### PR TITLE
Permissions UI overhaul: card layout, group dropdowns, cascading group decisions

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "mock-web",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "export SUPERAGENT_DATA_DIR=\"${TMPDIR:-/tmp}/superagent-mock-web-data\" E2E_MOCK=true PORT=47899 VITE_CACHE_DIR=\"${TMPDIR:-/tmp}/superagent-mock-web-vite\"; node e2e/setup-e2e-data.js && npm run dev:web"
+      ],
+      "port": 47899
+    }
+  ]
+}

--- a/e2e/specs/scope-policy-grouping.spec.ts
+++ b/e2e/specs/scope-policy-grouping.spec.ts
@@ -53,14 +53,14 @@ test.describe('Scope Policy Editor — risk-label grouping', () => {
 
     // Each group header pre-fills the recommended baseline default.
     await expect(
-      page.locator('[data-testid="group-default-read"] [data-testid="policy-toggle-allow"]'),
-    ).toHaveAttribute('data-active', 'true')
+      page.locator('[data-testid="group-default-read"] [data-testid="policy-dropdown-trigger"]'),
+    ).toHaveAttribute('data-decision', 'allow')
     await expect(
-      page.locator('[data-testid="group-default-write"] [data-testid="policy-toggle-review"]'),
-    ).toHaveAttribute('data-active', 'true')
+      page.locator('[data-testid="group-default-write"] [data-testid="policy-dropdown-trigger"]'),
+    ).toHaveAttribute('data-decision', 'review')
     await expect(
-      page.locator('[data-testid="group-default-destructive"] [data-testid="policy-toggle-block"]'),
-    ).toHaveAttribute('data-active', 'true')
+      page.locator('[data-testid="group-default-destructive"] [data-testid="policy-dropdown-trigger"]'),
+    ).toHaveAttribute('data-decision', 'block')
 
     // Still display-only — nothing persisted until Save.
     const after = await (await request.get(`${API}/api/policies/scope/${account.id}`)).json()
@@ -85,13 +85,14 @@ test.describe('Scope Policy Editor — risk-label grouping', () => {
     // Settings → Connections → open the inline editor via the connection row.
     await openConnectionDetail(page, 'E2E Grouping Persist Slack')
 
-    const destAllow = () =>
-      page.locator('[data-testid="group-default-destructive"] [data-testid="policy-toggle-allow"]')
+    const destTrigger = () =>
+      page.locator('[data-testid="group-default-destructive"] [data-testid="policy-dropdown-trigger"]')
 
-    // Flip the Destructive group default from block → allow.
-    await expect(destAllow()).toHaveAttribute('data-active', 'false')
-    await destAllow().click()
-    await expect(destAllow()).toHaveAttribute('data-active', 'true')
+    // Flip the Destructive group default from block → allow via the dropdown.
+    await expect(destTrigger()).toHaveAttribute('data-decision', 'block')
+    await destTrigger().click()
+    await page.locator('[data-testid="policy-menu-allow"]').click()
+    await expect(destTrigger()).toHaveAttribute('data-decision', 'allow')
 
     // Save — the inline editor stays on screen; verify persistence via API.
     await page.locator('[data-testid="scope-policy-save"]').click()
@@ -112,6 +113,6 @@ test.describe('Scope Policy Editor — risk-label grouping', () => {
     })
     await expect(row).toBeVisible({ timeout: 5000 })
     await row.click()
-    await expect(destAllow()).toHaveAttribute('data-active', 'true', { timeout: 5000 })
+    await expect(destTrigger()).toHaveAttribute('data-decision', 'allow', { timeout: 5000 })
   })
 })

--- a/src/renderer/components/connections/connection-detail-page.tsx
+++ b/src/renderer/components/connections/connection-detail-page.tsx
@@ -4,7 +4,7 @@ import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { ConnectionAgentsList } from '@renderer/components/connections/connection-agents-list'
 import { IntegrationRowActions } from '@renderer/components/connections/integration-row-actions'
 import { ConnectionUsageCard } from '@renderer/components/connections/connection-usage-card'
-import { ScopePolicyEditorBody } from '@renderer/components/settings/scope-policy-editor'
+import { ScopePolicySection } from '@renderer/components/settings/scope-policy-editor'
 import { ToolPolicyEditorBody } from '@renderer/components/settings/tool-policy-editor'
 import {
   useHideSettingsHeader,
@@ -95,23 +95,27 @@ export function ConnectionDetailPage({ row, onBack, onViewLogs, backLabel = 'Con
         <div className="space-y-4 min-w-0">
           <ConnectionUsageCard row={row} onViewLogs={onViewLogs} />
 
-          <section className="space-y-2 min-w-0">
-            <h3 className="text-xs font-normal text-muted-foreground">Permissions</h3>
-            <div className="rounded-xl border bg-background p-3">
-              {row.type === 'oauth' && row.toolkit ? (
-                <ScopePolicyEditorBody accountId={row.id} toolkit={row.toolkit} />
-              ) : row.type === 'mcp' ? (
-                <ToolPolicyEditorBody
-                  mcpId={row.id}
-                  tools={row.mcpTools ?? []}
-                />
-              ) : (
-                <p className="text-sm text-muted-foreground py-4 text-center">
-                  No permissions configurable for this connection.
-                </p>
-              )}
-            </div>
-          </section>
+          {row.type === 'oauth' && row.toolkit ? (
+            <ScopePolicySection accountId={row.id} toolkit={row.toolkit} />
+          ) : (
+            <section className="space-y-2 min-w-0">
+              <h3 className="text-xs font-normal text-muted-foreground">Permissions</h3>
+              <div className="rounded-xl border bg-background py-2 overflow-hidden">
+                {row.type === 'mcp' ? (
+                  <div className="px-3">
+                    <ToolPolicyEditorBody
+                      mcpId={row.id}
+                      tools={row.mcpTools ?? []}
+                    />
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground py-4 text-center">
+                    No permissions configurable for this connection.
+                  </p>
+                )}
+              </div>
+            </section>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/components/settings/scope-policy-editor.test.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.test.tsx
@@ -18,8 +18,16 @@ vi.mock('@renderer/lib/api', () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...(args as [string, never])),
 }))
 
-const groupToggle = (group: string, decision: 'allow' | 'review' | 'block') =>
-  within(screen.getByTestId(`group-default-${group}`)).getByTestId(`policy-toggle-${decision}`)
+// Group headers use the dropdown variant: the trigger reports the current
+// decision via data-decision; picking a value goes through the portal menu.
+const groupDecision = (group: string) =>
+  within(screen.getByTestId(`group-default-${group}`)).getByTestId('policy-dropdown-trigger')
+
+const setGroupDecision = async (group: string, decision: 'allow' | 'review' | 'block' | 'default') => {
+  groupDecision(group).click()
+  const item = await screen.findByTestId(`policy-menu-${decision}`)
+  item.click()
+}
 
 describe('ScopePolicyEditor', () => {
   beforeEach(() => {
@@ -35,9 +43,9 @@ describe('ScopePolicyEditor', () => {
     )
     await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
 
-    expect(groupToggle('read', 'allow')).toHaveAttribute('data-active', 'true')
-    expect(groupToggle('write', 'review')).toHaveAttribute('data-active', 'true')
-    expect(groupToggle('destructive', 'block')).toHaveAttribute('data-active', 'true')
+    expect(groupDecision('read')).toHaveAttribute('data-decision', 'allow')
+    expect(groupDecision('write')).toHaveAttribute('data-decision', 'review')
+    expect(groupDecision('destructive')).toHaveAttribute('data-decision', 'block')
   })
 
   it('does NOT pre-fill baseline once the account has any saved policy (groups show "default")', async () => {
@@ -48,11 +56,9 @@ describe('ScopePolicyEditor', () => {
     )
     await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
 
-    // Every group default toggle is inactive (= inherit/default), NOT the baseline.
+    // Every group default is inherit/default, NOT the baseline.
     for (const group of ['read', 'write', 'destructive'] as const) {
-      for (const decision of ['allow', 'review', 'block'] as const) {
-        expect(groupToggle(group, decision)).toHaveAttribute('data-active', 'false')
-      }
+      expect(groupDecision(group)).toHaveAttribute('data-decision', 'default')
     }
   })
 
@@ -82,7 +88,7 @@ describe('ScopePolicyEditor', () => {
     expect(screen.getByTestId('scope-policy-save')).toBeDisabled()
 
     // Flip a risk-level default — now the editor differs from what's persisted.
-    groupToggle('read', 'allow').click()
+    await setGroupDecision('read', 'allow')
     await waitFor(() => expect(screen.getByTestId('scope-policy-save')).toBeEnabled())
   })
 
@@ -105,7 +111,7 @@ describe('ScopePolicyEditor', () => {
     )
     await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
 
-    groupToggle('read', 'allow').click()
+    await setGroupDecision('read', 'allow')
     await waitFor(() => expect(screen.getByTestId('scope-policy-save')).toBeEnabled())
 
     screen.getByTestId('scope-policy-save').click()

--- a/src/renderer/components/settings/scope-policy-editor.test.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.test.tsx
@@ -29,6 +29,16 @@ const setGroupDecision = async (group: string, decision: 'allow' | 'review' | 'b
   item.click()
 }
 
+/** A segment of a scope row's three-way toggle. */
+const scopeToggle = (scope: string, decision: 'allow' | 'review' | 'block') =>
+  within(screen.getByTestId(`scope-row-${scope}`)).getByTestId(`policy-toggle-${decision}`)
+
+/** Expands a risk group so its scope rows render. */
+const expandGroup = async (group: string) => {
+  screen.getByTestId(`scope-group-toggle-${group}`).click()
+  await waitFor(() => expect(screen.getByTestId('scope-row-gmail.readonly')).toBeInTheDocument())
+}
+
 describe('ScopePolicyEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -102,6 +112,115 @@ describe('ScopePolicyEditor', () => {
     await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
 
     expect(screen.getByTestId('scope-policy-save')).toBeEnabled()
+  })
+
+  it('shows the group decision on scopes that have no rule of their own', async () => {
+    policiesFixture = []
+    renderWithProviders(
+      <ScopePolicyEditor accountId="acc-7" toolkit="gmail" open onOpenChange={() => {}} />,
+    )
+    await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
+    await expandGroup('read')
+
+    // Read group is on the 'allow' baseline, so its scopes display allow —
+    // flagged as inherited, not as a rule set on the scope.
+    expect(scopeToggle('gmail.readonly', 'allow')).toHaveAttribute('data-active', 'true')
+    expect(scopeToggle('gmail.readonly', 'allow')).toHaveAttribute('data-inherited', 'true')
+    expect(scopeToggle('gmail.readonly', 'block')).toHaveAttribute('data-active', 'false')
+
+    // Moving the group moves what its scopes display.
+    await setGroupDecision('read', 'block')
+    await waitFor(() =>
+      expect(scopeToggle('gmail.readonly', 'block')).toHaveAttribute('data-active', 'true'),
+    )
+    expect(scopeToggle('gmail.readonly', 'allow')).toHaveAttribute('data-active', 'false')
+  })
+
+  it('a scope with its own rule keeps it, and shows it as explicit', async () => {
+    policiesFixture = [
+      { scope: '*read', decision: 'allow' },
+      { scope: 'gmail.readonly', decision: 'block' },
+    ]
+    renderWithProviders(
+      <ScopePolicyEditor accountId="acc-8" toolkit="gmail" open onOpenChange={() => {}} />,
+    )
+    await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
+    await expandGroup('read')
+
+    // The override wins over the group's allow, and reads as set-here.
+    expect(scopeToggle('gmail.readonly', 'block')).toHaveAttribute('data-active', 'true')
+    expect(scopeToggle('gmail.readonly', 'block')).toHaveAttribute('data-inherited', 'false')
+    // A sibling with no rule of its own inherits the group instead.
+    expect(scopeToggle('gmail.metadata', 'allow')).toHaveAttribute('data-inherited', 'true')
+  })
+
+  it('changing a group writes only its sentinel — never a row per scope', async () => {
+    policiesFixture = [{ scope: 'gmail.send', decision: 'block' }]
+    renderWithProviders(
+      <ScopePolicyEditor accountId="acc-9" toolkit="gmail" open onOpenChange={() => {}} />,
+    )
+    await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
+
+    await setGroupDecision('read', 'allow')
+    await waitFor(() => expect(screen.getByTestId('scope-policy-save')).toBeEnabled())
+    screen.getByTestId('scope-policy-save').click()
+
+    await waitFor(() => expect(lastPutBody).not.toBeNull())
+    const byScope = Object.fromEntries(lastPutBody!.policies.map((p) => [p.scope, p.decision]))
+    // The group sentinel plus the pre-existing override — the four other read
+    // scopes stay on inherit rather than being materialized as their own rows.
+    expect(byScope).toEqual({ '*read': 'allow', 'gmail.send': 'block' })
+  })
+
+  it('clicking an inherited scope pins it as that scope’s own rule', async () => {
+    policiesFixture = [{ scope: '*read', decision: 'allow' }]
+    renderWithProviders(
+      <ScopePolicyEditor accountId="acc-10" toolkit="gmail" open onOpenChange={() => {}} />,
+    )
+    await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
+    await expandGroup('read')
+
+    // Clicking the segment it already displays promotes inherit → explicit
+    // rather than deselecting (there is nothing of its own to remove yet).
+    expect(scopeToggle('gmail.readonly', 'allow')).toHaveAttribute('data-inherited', 'true')
+    scopeToggle('gmail.readonly', 'allow').click()
+    await waitFor(() =>
+      expect(scopeToggle('gmail.readonly', 'allow')).toHaveAttribute('data-inherited', 'false'),
+    )
+    expect(scopeToggle('gmail.readonly', 'allow')).toHaveAttribute('data-active', 'true')
+
+    // And now it can be cleared back to inherit.
+    scopeToggle('gmail.readonly', 'allow').click()
+    await waitFor(() =>
+      expect(scopeToggle('gmail.readonly', 'allow')).toHaveAttribute('data-inherited', 'true'),
+    )
+  })
+
+  it('Reset defaults restores the group baselines and the account fallback', async () => {
+    policiesFixture = [
+      { scope: '*', decision: 'block' },
+      { scope: '*read', decision: 'block' },
+      { scope: 'gmail.send', decision: 'allow' },
+    ]
+    renderWithProviders(
+      <ScopePolicyEditor accountId="acc-11" toolkit="gmail" open onOpenChange={() => {}} />,
+    )
+    await waitFor(() => expect(screen.getByTestId('group-default-read')).toBeInTheDocument())
+
+    screen.getByTestId('reset-recommended-defaults').click()
+    await waitFor(() => expect(groupDecision('read')).toHaveAttribute('data-decision', 'allow'))
+
+    screen.getByTestId('scope-policy-save').click()
+    await waitFor(() => expect(lastPutBody).not.toBeNull())
+    const byScope = Object.fromEntries(lastPutBody!.policies.map((p) => [p.scope, p.decision]))
+    // Baselines restored and the account '*' fallback cleared; the deliberate
+    // per-scope override is not a default, so it survives.
+    expect(byScope).toEqual({
+      '*read': 'allow',
+      '*write': 'review',
+      '*destructive': 'block',
+      'gmail.send': 'allow',
+    })
   })
 
   it('re-disables Save after a successful save', async () => {

--- a/src/renderer/components/settings/scope-policy-editor.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.tsx
@@ -52,6 +52,15 @@ const LABEL_GROUPS: Array<{
   { key: 'destructive', title: 'Destructive actions' },
 ]
 
+/** Every scope a toolkit declares, flattened. Empty when we have no scope map for it. */
+function toolkitScopes(toolkit: string): string[] {
+  const provider = SCOPE_MAPS[toolkit]
+  if (!provider) return []
+  return Array.isArray(provider.allScopes)
+    ? provider.allScopes
+    : Object.values(provider.allScopes).flat()
+}
+
 const emptyLabelDefaults: Record<ScopeLabel, PolicyDecision> = {
   read: 'default',
   write: 'default',
@@ -68,6 +77,19 @@ function serializePolicies(entries: Iterable<readonly [string, string]>): string
     [...entries].filter(([, decision]) => decision !== 'default').sort(([a], [b]) => a.localeCompare(b)),
   )
 }
+
+/**
+ * Decision-filter options. The wording tracks the toggle labels ("Always allow"
+ * / "Needs approval" / "Blocked") so the filter and the controls it filters
+ * speak the same language.
+ */
+const DECISION_FILTERS: Array<{ value: 'all' | PolicyDecision; label: string }> = [
+  { value: 'all', label: 'All scopes' },
+  { value: 'allow', label: 'Always allow' },
+  { value: 'review', label: 'Needs approval' },
+  { value: 'block', label: 'Blocked' },
+  { value: 'default', label: 'No rule set' },
+]
 
 export interface ScopePolicyFilters {
   textFilter: string
@@ -155,25 +177,32 @@ export function ScopePolicyFilterControls({
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="end" className="w-32 p-1">
-          {(['all', 'allow', 'review', 'block', 'default'] as const).map((v) => (
+        <PopoverContent align="end" className="w-44 p-1">
+          {/* Matches the rule saved on the scope itself, not what it displays —
+              a scope inheriting "always allow" from its group is "No rule set". */}
+          <p className="px-2 pb-1 pt-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+            Rule set on the scope
+          </p>
+          {DECISION_FILTERS.map(({ value, label }) => (
             <button
-              key={v}
+              key={value}
               type="button"
-              data-testid={`scope-filter-${v}`}
+              data-testid={`scope-filter-${value}`}
               onClick={() => {
-                setDecisionFilter(v)
+                setDecisionFilter(value)
                 setFilterMenuOpen(false)
               }}
               className={cn(
                 'flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted',
-                decisionFilter === v && 'bg-muted',
+                decisionFilter === value && 'bg-muted',
               )}
             >
-              {(v === 'allow' || v === 'review' || v === 'block') && (
-                <PolicyDecisionIcon decision={v} className="h-3 w-3" />
-              )}
-              <span className="capitalize">{v}</span>
+              {/* Fixed-size slot so the two option rows without a glyph
+                  ("All scopes", "No rule set") still align with the three that have one. */}
+              <span className="flex h-3 w-3 shrink-0 items-center justify-center">
+                {value !== 'all' && <PolicyDecisionIcon decision={value} className="h-3 w-3" />}
+              </span>
+              {label}
             </button>
           ))}
         </PopoverContent>
@@ -230,15 +259,7 @@ export function ScopePolicyEditorBody({
 
   // Get scopes from the scope map for this toolkit
   const provider = SCOPE_MAPS[toolkit]
-  const allScopes = useMemo(
-    () =>
-      provider
-        ? Array.isArray(provider.allScopes)
-          ? provider.allScopes
-          : Object.values(provider.allScopes).flat()
-        : [],
-    [provider],
-  )
+  const allScopes = useMemo(() => toolkitScopes(toolkit), [toolkit])
 
   // For each scope, prefer the curated description; otherwise borrow the
   // first endpoint description that mentions this scope.
@@ -343,14 +364,16 @@ export function ScopePolicyEditorBody({
     return groups
   }, [filteredPolicies, toolkit])
 
-  const setLabelDefault = (label: ScopeLabel, decision: PolicyDecision) => {
+  // Only the group sentinel moves. Scopes in the group have no rule of their
+  // own, so they inherit this and re-render — no per-scope rows are written,
+  // and an explicit override on a scope keeps winning.
+  const setLabelDefault = (label: ScopeLabel, decision: PolicyDecision) =>
     setLabelDefaults((prev) => ({ ...prev, [label]: decision }))
-    // Setting a group decision cascades to every scope in that group — including
-    // rows hidden by an active filter — so rows never silently diverge from the
-    // group control. Deselecting (back to 'default') clears them the same way.
-    setPolicies((prev) =>
-      prev.map((p) => (getScopeLabel(toolkit, p.scope) === label ? { ...p, decision } : p)),
-    )
+
+  /** What a scope in this group inherits, or undefined when the group is itself on 'default'. */
+  const inheritedFor = (label: ScopeLabel): 'allow' | 'review' | 'block' | undefined => {
+    const d = labelDefaults[label]
+    return d === 'default' ? undefined : d
   }
 
   const setOpenGroup = (key: string, open: boolean) =>
@@ -359,15 +382,16 @@ export function ScopePolicyEditorBody({
   // When the user is filtering, reveal matching groups regardless of collapse state.
   const filtering = textFilter.trim() !== '' || decisionFilter !== 'all'
 
+  // Restores every default this card shows: the three group baselines and the
+  // fallback below them. Explicit per-scope overrides are deliberate choices,
+  // not defaults, so they survive.
   const resetToRecommended = () => {
     setLabelDefaults({
       read: LABEL_DEFAULT_BASELINE.read,
       write: LABEL_DEFAULT_BASELINE.write,
       destructive: LABEL_DEFAULT_BASELINE.destructive,
     })
-    // "Recommended" is the pure-defaults state: group baselines with no
-    // per-scope overrides, so clear every row back to inherit.
-    setPolicies((prev) => prev.map((p) => ({ ...p, decision: 'default' as PolicyDecision })))
+    setAccountDefault('default')
   }
 
   // The non-default policies that a Save would write, keyed by scope.
@@ -420,7 +444,7 @@ export function ScopePolicyEditorBody({
     )
   }
 
-  const renderRow = (p: ScopePolicy) => (
+  const renderRow = (p: ScopePolicy, inherited?: 'allow' | 'review' | 'block') => (
     <div
       key={p.scope}
       data-testid={`scope-row-${p.scope}`}
@@ -436,7 +460,11 @@ export function ScopePolicyEditorBody({
           </p>
         )}
       </div>
-      <PolicyDecisionToggle value={p.decision} onChange={(v) => updateScopePolicy(p.scope, v)} />
+      <PolicyDecisionToggle
+        value={p.decision}
+        inheritedValue={inherited}
+        onChange={(v) => updateScopePolicy(p.scope, v)}
+      />
     </div>
   )
 
@@ -514,7 +542,7 @@ export function ScopePolicyEditorBody({
                     />
                   </div>
                   <CollapsibleContent className="divide-y divide-border/50">
-                    {rows.map(renderRow)}
+                    {rows.map((p) => renderRow(p, inheritedFor(g.key)))}
                   </CollapsibleContent>
                 </Collapsible>
               )
@@ -543,8 +571,10 @@ export function ScopePolicyEditorBody({
                     </span>
                   </CollapsibleTrigger>
                 </div>
+                {/* Unlabeled scopes belong to no risk group, so there is no
+                    group decision for them to inherit — they show only their own. */}
                 <CollapsibleContent className="divide-y divide-border/50">
-                  {groupedPolicies.other.map(renderRow)}
+                  {groupedPolicies.other.map((p) => renderRow(p))}
                 </CollapsibleContent>
               </Collapsible>
             )}
@@ -621,11 +651,15 @@ export function ScopePolicySection({
   className,
 }: ScopePolicySectionProps) {
   const filters = useScopePolicyFilters(accountId)
+  // Nothing to search or filter when the toolkit declares no scopes — the card
+  // shows only the fallback row, so the controls would be dead. Memoized: this
+  // re-renders on every keystroke in the search box.
+  const hasScopes = useMemo(() => toolkitScopes(toolkit).length > 0, [toolkit])
   return (
     <section className={cn('flex min-h-0 min-w-0 flex-col space-y-2', className)}>
       <div className="flex items-center justify-between gap-2">
         <h3 className="text-xs font-normal text-muted-foreground shrink-0">{title}</h3>
-        <ScopePolicyFilterControls filters={filters} className="flex-1" />
+        {hasScopes && <ScopePolicyFilterControls filters={filters} className="flex-1" />}
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border bg-background py-2">
         <ScopePolicyEditorBody

--- a/src/renderer/components/settings/scope-policy-editor.tsx
+++ b/src/renderer/components/settings/scope-policy-editor.tsx
@@ -1,16 +1,14 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@renderer/lib/api'
-import { Loader2, Search, AlertCircle, Eye, Pencil, Trash2, ChevronRight } from 'lucide-react'
+import { Loader2, Search, AlertCircle, ChevronRight, ListFilter, Undo2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@renderer/components/ui/select'
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@renderer/components/ui/popover'
 import {
   Dialog,
   DialogContent,
@@ -25,7 +23,11 @@ import {
   labelDefaultKey,
   LABEL_DEFAULT_BASELINE,
 } from '@shared/lib/proxy/policy-sentinels'
-import { PolicyDecisionToggle } from '@renderer/components/ui/policy-decision-toggle'
+import {
+  PolicyDecisionToggle,
+  PolicyDecisionDropdown,
+  PolicyDecisionIcon,
+} from '@renderer/components/ui/policy-decision-toggle'
 import { HighlightMatch } from '@renderer/components/ui/highlight-match'
 import {
   Collapsible,
@@ -44,17 +46,10 @@ interface ScopePolicy {
 const LABEL_GROUPS: Array<{
   key: ScopeLabel
   title: string
-  hint: string
-  Icon: typeof Eye
 }> = [
-  { key: 'read', title: 'Read', hint: 'View-only access', Icon: Eye },
-  { key: 'write', title: 'Write', hint: 'Create, update, edit, delete items', Icon: Pencil },
-  {
-    key: 'destructive',
-    title: 'Destructive',
-    hint: 'Irreversible deletion or admin/governance',
-    Icon: Trash2,
-  },
+  { key: 'read', title: 'Read actions' },
+  { key: 'write', title: 'Write/Delete actions' },
+  { key: 'destructive', title: 'Destructive actions' },
 ]
 
 const emptyLabelDefaults: Record<ScopeLabel, PolicyDecision> = {
@@ -74,6 +69,119 @@ function serializePolicies(entries: Iterable<readonly [string, string]>): string
   )
 }
 
+export interface ScopePolicyFilters {
+  textFilter: string
+  setTextFilter: (v: string) => void
+  decisionFilter: 'all' | PolicyDecision
+  setDecisionFilter: (v: 'all' | PolicyDecision) => void
+}
+
+/**
+ * Filter state for the scope list. Lives outside ScopePolicyEditorBody so a
+ * parent can host the filter controls (e.g. in its section title row) while
+ * the editor consumes the values. Resets when `resetKey` (e.g. the account id)
+ * changes.
+ */
+export function useScopePolicyFilters(resetKey?: string): ScopePolicyFilters {
+  const [textFilter, setTextFilter] = useState('')
+  const [decisionFilter, setDecisionFilter] = useState<'all' | PolicyDecision>('all')
+  useEffect(() => {
+    setTextFilter('')
+    setDecisionFilter('all')
+  }, [resetKey])
+  return { textFilter, setTextFilter, decisionFilter, setDecisionFilter }
+}
+
+/** Compact icon-button search + decision-filter controls for the scope list. */
+export function ScopePolicyFilterControls({
+  filters,
+  className,
+}: {
+  filters: ScopePolicyFilters
+  className?: string
+}) {
+  const { textFilter, setTextFilter, decisionFilter, setDecisionFilter } = filters
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false)
+  return (
+    <div className={cn('flex items-center justify-end gap-1 min-w-0', className)}>
+      {searchOpen ? (
+        <div className="relative w-44 max-w-full">
+          <Search className="absolute left-1.5 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+          <Input
+            autoFocus
+            placeholder="Filter scopes..."
+            value={textFilter}
+            onChange={(e) => setTextFilter(e.target.value)}
+            onBlur={() => {
+              if (!textFilter.trim()) setSearchOpen(false)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                setTextFilter('')
+                setSearchOpen(false)
+              }
+            }}
+            className="h-6 text-xs pl-6"
+          />
+        </div>
+      ) : (
+        <Button
+          variant="ghost"
+          size="xs"
+          className="h-6 w-6 px-0 text-muted-foreground"
+          aria-label="Search scopes"
+          data-testid="scope-search-toggle"
+          onClick={() => setSearchOpen(true)}
+        >
+          <Search className="h-3.5 w-3.5" />
+        </Button>
+      )}
+      <Popover open={filterMenuOpen} onOpenChange={setFilterMenuOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="xs"
+            className={cn(
+              'relative h-6 w-6 px-0',
+              decisionFilter === 'all' ? 'text-muted-foreground' : 'text-foreground',
+            )}
+            aria-label="Filter by decision"
+            data-testid="scope-filter-toggle"
+          >
+            <ListFilter className="h-3.5 w-3.5" />
+            {decisionFilter !== 'all' && (
+              <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-primary" />
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-32 p-1">
+          {(['all', 'allow', 'review', 'block', 'default'] as const).map((v) => (
+            <button
+              key={v}
+              type="button"
+              data-testid={`scope-filter-${v}`}
+              onClick={() => {
+                setDecisionFilter(v)
+                setFilterMenuOpen(false)
+              }}
+              className={cn(
+                'flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted',
+                decisionFilter === v && 'bg-muted',
+              )}
+            >
+              {(v === 'allow' || v === 'review' || v === 'block') && (
+                <PolicyDecisionIcon decision={v} className="h-3 w-3" />
+              )}
+              <span className="capitalize">{v}</span>
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
 interface ScopePolicyEditorBodyProps {
   accountId: string
   toolkit: string
@@ -83,6 +191,12 @@ interface ScopePolicyEditorBodyProps {
   onCancel?: () => void
   /** Hide the bottom action bar (Save/Cancel). When true, the parent is responsible for triggering save. */
   hideActions?: boolean
+  /**
+   * Externally-hosted filter state (from useScopePolicyFilters). When provided,
+   * the editor consumes these values and does NOT render its own filter
+   * toolbar — the parent renders ScopePolicyFilterControls wherever it wants.
+   */
+  filters?: ScopePolicyFilters
 }
 
 /**
@@ -95,6 +209,7 @@ export function ScopePolicyEditorBody({
   onSaved,
   onCancel,
   hideActions,
+  filters,
 }: ScopePolicyEditorBodyProps) {
   const queryClient = useQueryClient()
   const [policies, setPolicies] = useState<ScopePolicy[]>([])
@@ -106,8 +221,10 @@ export function ScopePolicyEditorBody({
   const [fetchError, setFetchError] = useState<string | null>(null)
   // Snapshot of the persisted (non-default) policies, for dirty detection.
   const [savedSnapshot, setSavedSnapshot] = useState('')
-  const [textFilter, setTextFilter] = useState('')
-  const [decisionFilter, setDecisionFilter] = useState<'all' | PolicyDecision>('all')
+  // Filter state: internal by default; a parent may host the controls and pass
+  // its own (see ScopePolicyEditorBodyProps.filters).
+  const internalFilters = useScopePolicyFilters(accountId)
+  const { textFilter, decisionFilter } = filters ?? internalFilters
   // Risk-label groups are accordions, collapsed by default.
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({})
 
@@ -142,8 +259,6 @@ export function ScopePolicyEditorBody({
   useEffect(() => {
     setLoading(true)
     setFetchError(null)
-    setTextFilter('')
-    setDecisionFilter('all')
     setOpenGroups({})
     apiFetch(`/api/policies/scope/${accountId}`)
       .then((res) => res.json())
@@ -228,8 +343,15 @@ export function ScopePolicyEditorBody({
     return groups
   }, [filteredPolicies, toolkit])
 
-  const setLabelDefault = (label: ScopeLabel, decision: PolicyDecision) =>
+  const setLabelDefault = (label: ScopeLabel, decision: PolicyDecision) => {
     setLabelDefaults((prev) => ({ ...prev, [label]: decision }))
+    // Setting a group decision cascades to every scope in that group — including
+    // rows hidden by an active filter — so rows never silently diverge from the
+    // group control. Deselecting (back to 'default') clears them the same way.
+    setPolicies((prev) =>
+      prev.map((p) => (getScopeLabel(toolkit, p.scope) === label ? { ...p, decision } : p)),
+    )
+  }
 
   const setOpenGroup = (key: string, open: boolean) =>
     setOpenGroups((prev) => ({ ...prev, [key]: open }))
@@ -237,12 +359,16 @@ export function ScopePolicyEditorBody({
   // When the user is filtering, reveal matching groups regardless of collapse state.
   const filtering = textFilter.trim() !== '' || decisionFilter !== 'all'
 
-  const resetToRecommended = () =>
+  const resetToRecommended = () => {
     setLabelDefaults({
       read: LABEL_DEFAULT_BASELINE.read,
       write: LABEL_DEFAULT_BASELINE.write,
       destructive: LABEL_DEFAULT_BASELINE.destructive,
     })
+    // "Recommended" is the pure-defaults state: group baselines with no
+    // per-scope overrides, so clear every row back to inherit.
+    setPolicies((prev) => prev.map((p) => ({ ...p, decision: 'default' as PolicyDecision })))
+  }
 
   // The non-default policies that a Save would write, keyed by scope.
   const currentBatch = useMemo(() => {
@@ -298,14 +424,14 @@ export function ScopePolicyEditorBody({
     <div
       key={p.scope}
       data-testid={`scope-row-${p.scope}`}
-      className="flex items-center justify-between rounded border px-2 py-1.5"
+      className="flex items-center justify-between gap-2 py-2 pl-8 pr-2"
     >
-      <div className="flex-1 min-w-0 mr-2">
+      <div className="flex-1 min-w-0">
         <span className="text-xs font-mono font-medium">
           <HighlightMatch text={p.scope} query={textFilter} />
         </span>
         {scopeDescriptions[p.scope] && (
-          <p className="text-xs text-muted-foreground truncate">
+          <p className="text-[11px] text-muted-foreground truncate">
             <HighlightMatch text={scopeDescriptions[p.scope]} query={textFilter} />
           </p>
         )}
@@ -325,70 +451,19 @@ export function ScopePolicyEditorBody({
   return (
     <div className="flex flex-col gap-3 min-h-0 flex-1">
       {fetchError && (
-        <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/50 rounded-md px-2 py-1.5">
+        <div className="mx-3 flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/50 rounded-md px-2 py-1.5">
           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
           {fetchError}
         </div>
       )}
 
-      {/* Account default */}
-      <div className="flex items-center justify-between rounded-md border p-2">
-        <div>
-          <span className="text-sm font-medium">Account Default</span>
-          <p className="text-xs text-muted-foreground">
-            Fallback for scopes without a per-scope or risk-level policy
-          </p>
-        </div>
-        <PolicyDecisionToggle
-          value={accountDefault}
-          onChange={(v) => setAccountDefault(v)}
-          size="md"
-        />
-      </div>
-
-      {/* Filters */}
-      {allScopes.length > 0 && (
-        <div className="flex gap-2">
-          <div className="relative flex-1">
-            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-            <Input
-              placeholder="Filter scopes..."
-              value={textFilter}
-              onChange={(e) => setTextFilter(e.target.value)}
-              className="h-8 text-xs pl-7"
-            />
-          </div>
-          <Select
-            value={decisionFilter}
-            onValueChange={(v) => setDecisionFilter(v as 'all' | PolicyDecision)}
-          >
-            <SelectTrigger className="w-[100px] h-8 text-xs shrink-0">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All</SelectItem>
-              <SelectItem value="allow">Allow</SelectItem>
-              <SelectItem value="review">Review</SelectItem>
-              <SelectItem value="block">Block</SelectItem>
-              <SelectItem value="default">Default</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      )}
-
-      {allScopes.length > 0 && (
-        <button
-          type="button"
-          onClick={resetToRecommended}
-          data-testid="reset-recommended-defaults"
-          className="self-start text-xs text-muted-foreground hover:text-foreground hover:underline underline-offset-2"
-        >
-          Reset risk-level defaults to recommended
-        </button>
+      {/* Filters — hidden when the parent hosts the controls (filters prop) */}
+      {allScopes.length > 0 && !filters && (
+        <ScopePolicyFilterControls filters={internalFilters} className="pl-3 pr-2" />
       )}
 
       {/* Per-scope policies, grouped by risk label */}
-      <div className="flex-1 overflow-y-auto min-h-0 space-y-3">
+      <div className="flex-1 overflow-y-auto min-h-0">
         {allScopes.length === 0 ? (
           <p className="text-sm text-muted-foreground py-4 text-center">
             No scopes defined for this API.
@@ -398,11 +473,10 @@ export function ScopePolicyEditorBody({
             No scopes match your filters.
           </p>
         ) : (
-          <>
+          <div className="divide-y divide-border/50">
             {LABEL_GROUPS.map((g) => {
               const rows = groupedPolicies[g.key]
               if (rows.length === 0) return null
-              const Icon = g.Icon
               // Collapsed by default; a filter reveals matches, but an explicit
               // collapse/expand by the user (sets openGroups[key]) always wins —
               // so the trigger never feels "dead" while filtering.
@@ -413,11 +487,11 @@ export function ScopePolicyEditorBody({
                   open={isOpen}
                   onOpenChange={(o) => setOpenGroup(g.key, o)}
                   data-testid={`scope-group-${g.key}`}
-                  className="space-y-1"
+                  className="divide-y divide-border/50"
                 >
                   <div
                     data-testid={`group-default-${g.key}`}
-                    className="flex items-center justify-between rounded-md bg-muted/40 px-2 py-1.5"
+                    className="flex items-center justify-between gap-2 bg-background py-2 pl-3 pr-2 transition-colors hover:bg-muted/30"
                   >
                     <CollapsibleTrigger
                       data-testid={`scope-group-toggle-${g.key}`}
@@ -429,19 +503,17 @@ export function ScopePolicyEditorBody({
                           isOpen && 'rotate-90',
                         )}
                       />
-                      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       <span className="text-xs font-medium">{g.title}</span>
-                      <span className="text-xs text-muted-foreground tabular-nums">
-                        ({rows.length})
+                      <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground tabular-nums">
+                        {rows.length}
                       </span>
-                      <span className="text-xs text-muted-foreground truncate">· {g.hint}</span>
                     </CollapsibleTrigger>
-                    <PolicyDecisionToggle
+                    <PolicyDecisionDropdown
                       value={labelDefaults[g.key]}
                       onChange={(v) => setLabelDefault(g.key, v)}
                     />
                   </div>
-                  <CollapsibleContent className="space-y-1 pl-1">
+                  <CollapsibleContent className="divide-y divide-border/50">
                     {rows.map(renderRow)}
                   </CollapsibleContent>
                 </Collapsible>
@@ -452,36 +524,62 @@ export function ScopePolicyEditorBody({
                 open={openGroups.other ?? filtering}
                 onOpenChange={(o) => setOpenGroup('other', o)}
                 data-testid="scope-group-other"
-                className="space-y-1"
+                className="divide-y divide-border/50"
               >
-                <CollapsibleTrigger
-                  data-testid="scope-group-toggle-other"
-                  className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left"
-                >
-                  <ChevronRight
-                    className={cn(
-                      'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
-                      (openGroups.other ?? filtering) && 'rotate-90',
-                    )}
-                  />
-                  <span className="text-xs font-medium">Other</span>
-                  <span className="text-xs text-muted-foreground tabular-nums">
-                    ({groupedPolicies.other.length})
-                  </span>
-                  <span className="text-xs text-muted-foreground truncate">
-                    · uses the account default
-                  </span>
-                </CollapsibleTrigger>
-                <CollapsibleContent className="space-y-1 pl-1">
+                <div className="flex items-center bg-background py-2 pl-3 pr-2 transition-colors hover:bg-muted/30">
+                  <CollapsibleTrigger
+                    data-testid="scope-group-toggle-other"
+                    className="flex flex-1 items-center gap-1.5 min-w-0 text-left"
+                  >
+                    <ChevronRight
+                      className={cn(
+                        'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+                        (openGroups.other ?? filtering) && 'rotate-90',
+                      )}
+                    />
+                    <span className="text-xs font-medium">Other actions</span>
+                    <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground tabular-nums">
+                      {groupedPolicies.other.length}
+                    </span>
+                  </CollapsibleTrigger>
+                </div>
+                <CollapsibleContent className="divide-y divide-border/50">
                   {groupedPolicies.other.map(renderRow)}
                 </CollapsibleContent>
               </Collapsible>
             )}
-          </>
+          </div>
         )}
       </div>
+
+      {/* Account default — the fallback tier, so it reads below the groups */}
+      {/* -mt-3 cancels the parent gap so the divider above sits in the same
+          16px rhythm as the list's divide-y hairlines */}
+      <div className="-mt-3 flex items-center justify-between gap-3 border-t border-border/50 py-3.5 pl-3 pr-2">
+        <span className="text-[11px] text-muted-foreground truncate min-w-0">
+          Fallback for scopes without a per-scope or risk-level policy
+        </span>
+        <div className="shrink-0">
+          <PolicyDecisionToggle
+            value={accountDefault}
+            onChange={(v) => setAccountDefault(v)}
+          />
+        </div>
+      </div>
       {!hideActions && (
-        <div className="flex justify-end gap-2 pt-2">
+        <div className="flex items-center justify-end gap-2 pl-3 pr-2">
+          {allScopes.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={resetToRecommended}
+              data-testid="reset-recommended-defaults"
+              className="mr-auto text-muted-foreground hover:text-foreground"
+            >
+              <Undo2 className="h-3.5 w-3.5 mr-1.5" />
+              Reset defaults
+            </Button>
+          )}
           {onCancel && (
             <Button variant="outline" size="sm" onClick={onCancel}>
               Cancel
@@ -489,11 +587,56 @@ export function ScopePolicyEditorBody({
           )}
           <Button data-testid="scope-policy-save" size="sm" onClick={handleSave} disabled={saving || !isDirty}>
             {saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
-            Save Policies
+            Save
           </Button>
         </div>
       )}
     </div>
+  )
+}
+
+interface ScopePolicySectionProps {
+  accountId: string
+  toolkit: string
+  /** Called after a successful save. */
+  onSaved?: () => void
+  /** Called when the user clicks Cancel. When omitted, no Cancel button renders. */
+  onCancel?: () => void
+  /** Section label; defaults to "Permissions". */
+  title?: React.ReactNode
+  className?: string
+}
+
+/**
+ * Self-contained "Permissions" panel: the muted section title with search/filter
+ * controls, and the bordered card holding the scope policy editor. Rendered
+ * identically on the connection detail page and inside the policy dialog.
+ */
+export function ScopePolicySection({
+  accountId,
+  toolkit,
+  onSaved,
+  onCancel,
+  title = 'Permissions',
+  className,
+}: ScopePolicySectionProps) {
+  const filters = useScopePolicyFilters(accountId)
+  return (
+    <section className={cn('flex min-h-0 min-w-0 flex-col space-y-2', className)}>
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-xs font-normal text-muted-foreground shrink-0">{title}</h3>
+        <ScopePolicyFilterControls filters={filters} className="flex-1" />
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border bg-background py-2">
+        <ScopePolicyEditorBody
+          accountId={accountId}
+          toolkit={toolkit}
+          filters={filters}
+          onSaved={onSaved}
+          onCancel={onCancel}
+        />
+      </div>
+    </section>
   )
 }
 
@@ -515,14 +658,22 @@ export function ScopePolicyEditor({
 }: ScopePolicyEditorProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg max-h-[80vh] overflow-hidden flex flex-col">
-        <DialogHeader>
-          {header ?? <DialogTitle className="capitalize">{toolkit} Scope Policies</DialogTitle>}
-          <DialogDescription className="sr-only">Configure per-scope access policies for {toolkit}</DialogDescription>
-        </DialogHeader>
-        <ScopePolicyEditorBody
+      {/* No visible dialog title or X — the section label carries the title and
+          Cancel handles dismissal. The sr-only title keeps the dialog labeled
+          for screen readers. */}
+      <DialogContent hideClose className="max-w-lg max-h-[80vh] overflow-hidden flex flex-col">
+        <DialogTitle className="sr-only">Agent permissions for {toolkit}</DialogTitle>
+        <DialogDescription className="sr-only">Configure per-scope access policies for {toolkit}</DialogDescription>
+        {header && <DialogHeader>{header}</DialogHeader>}
+        <ScopePolicySection
           accountId={accountId}
           toolkit={toolkit}
+          title={
+            <>
+              Agent permissions for <span className="capitalize">{toolkit}</span>
+            </>
+          }
+          className={cn('flex-1 min-h-0 mb-6', header ? 'mt-5' : 'mt-1')}
           onSaved={() => onOpenChange(false)}
           onCancel={() => onOpenChange(false)}
         />

--- a/src/renderer/components/ui/dialog.tsx
+++ b/src/renderer/components/ui/dialog.tsx
@@ -26,8 +26,11 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, onKeyDown, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    /** Omit the top-right X close button (e.g. when the dialog has its own Cancel). */
+    hideClose?: boolean
+  }
+>(({ className, children, onKeyDown, hideClose, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -43,10 +46,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideClose && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))

--- a/src/renderer/components/ui/policy-decision-toggle.tsx
+++ b/src/renderer/components/ui/policy-decision-toggle.tsx
@@ -1,4 +1,5 @@
-import { CircleCheck, Hand, Ban } from 'lucide-react'
+import { useState } from 'react'
+import { CircleCheckBig, Hand, Ban, ChevronDown, CircleDashed } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import {
   Tooltip,
@@ -6,6 +7,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@renderer/components/ui/tooltip'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@renderer/components/ui/popover'
 
 type PolicyDecision = 'allow' | 'review' | 'block' | 'default'
 
@@ -23,24 +29,24 @@ interface PolicyDecisionToggleProps {
 const options = [
   {
     value: 'allow' as const,
-    icon: CircleCheck,
+    icon: CircleCheckBig,
     label: 'Allow',
-    activeClasses: 'bg-green-600 text-white',
-    hoverClasses: 'hover:bg-green-100 dark:hover:bg-green-900/40 text-muted-foreground',
+    tooltip: 'Always allow',
+    activeColor: 'text-green-600 dark:text-green-400',
   },
   {
     value: 'review' as const,
     icon: Hand,
     label: 'Review',
-    activeClasses: 'bg-blue-600 text-white',
-    hoverClasses: 'hover:bg-blue-100 dark:hover:bg-blue-900/40 text-muted-foreground',
+    tooltip: 'Needs approval',
+    activeColor: 'text-blue-600 dark:text-blue-400',
   },
   {
     value: 'block' as const,
     icon: Ban,
     label: 'Block',
-    activeClasses: 'bg-orange-600 text-white',
-    hoverClasses: 'hover:bg-orange-100 dark:hover:bg-orange-900/40 text-muted-foreground',
+    tooltip: 'Blocked',
+    activeColor: 'text-orange-600 dark:text-orange-400',
   },
 ] as const
 
@@ -55,7 +61,7 @@ export function PolicyDecisionToggle({
 
   return (
     <TooltipProvider delayDuration={300}>
-      <div className="inline-flex items-center rounded-md border bg-muted/50 p-0.5 gap-0.5">
+      <div className="inline-flex items-center rounded-md bg-muted p-0.5 gap-0.5 text-muted-foreground">
         {options.map((opt) => {
           const isActive = value === opt.value
           const Icon = opt.icon
@@ -75,20 +81,105 @@ export function PolicyDecisionToggle({
                   className={cn(
                     'inline-flex items-center justify-center rounded-sm transition-colors',
                     btnSize,
-                    isActive ? opt.activeClasses : opt.hoverClasses
+                    isActive
+                      ? cn('bg-background shadow', opt.activeColor)
+                      : 'hover:text-foreground'
                   )}
                 >
                   <Icon className={iconSize} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="text-xs">
-                {isActive && allowDeselect ? `Remove ${opt.label.toLowerCase()} (set to default)` : opt.label}
+                {isActive && allowDeselect ? `Remove ${opt.label.toLowerCase()} (set to default)` : opt.tooltip}
               </TooltipContent>
             </Tooltip>
           )
         })}
       </div>
     </TooltipProvider>
+  )
+}
+
+/**
+ * Compact dropdown variant of the policy control: the trigger shows the current
+ * decision's icon and a chevron; the menu offers the three decisions plus
+ * "Default" (inherit). Used where a full segmented toggle is too heavy — e.g.
+ * scope-group headers.
+ */
+export function PolicyDecisionDropdown({
+  value,
+  onChange,
+  className,
+}: {
+  value: PolicyDecision
+  onChange: (value: PolicyDecision) => void
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const current = options.find((o) => o.value === value)
+  const CurrentIcon = current?.icon
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="policy-dropdown-trigger"
+          data-decision={value}
+          className={cn(
+            'flex h-7 w-36 items-center gap-1.5 whitespace-nowrap rounded-md border border-input bg-transparent px-2 text-xs shadow-sm focus:outline-none focus:ring-1 focus:ring-ring',
+            className,
+          )}
+        >
+          {current && CurrentIcon ? (
+            <CurrentIcon className={cn('h-3.5 w-3.5 shrink-0', current.activeColor)} />
+          ) : (
+            <CircleDashed className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )}
+          {current ? current.tooltip : 'Default'}
+          <ChevronDown className="ml-auto h-3.5 w-3.5 shrink-0 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-40 p-1">
+        {options.map((opt) => {
+          const Icon = opt.icon
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              data-testid={`policy-menu-${opt.value}`}
+              data-active={value === opt.value}
+              onClick={() => {
+                onChange(opt.value)
+                setOpen(false)
+              }}
+              className={cn(
+                'flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted',
+                value === opt.value && 'bg-muted',
+              )}
+            >
+              <Icon className={cn('h-3.5 w-3.5', opt.activeColor)} />
+              {opt.tooltip}
+            </button>
+          )
+        })}
+        <button
+          type="button"
+          data-testid="policy-menu-default"
+          data-active={value === 'default'}
+          onClick={() => {
+            onChange('default')
+            setOpen(false)
+          }}
+          className={cn(
+            'flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted',
+            value === 'default' && 'bg-muted',
+          )}
+        >
+          <CircleDashed className="h-3.5 w-3.5 text-muted-foreground" />
+          Default
+        </button>
+      </PopoverContent>
+    </Popover>
   )
 }
 
@@ -103,7 +194,7 @@ export function PolicyDecisionIcon({
   const iconClass = cn('h-3.5 w-3.5', className)
   switch (decision) {
     case 'allow':
-      return <CircleCheck className={cn(iconClass, 'text-green-600')} />
+      return <CircleCheckBig className={cn(iconClass, 'text-green-600')} />
     case 'review':
       return <Hand className={cn(iconClass, 'text-blue-600')} />
     case 'block':

--- a/src/renderer/components/ui/policy-decision-toggle.tsx
+++ b/src/renderer/components/ui/policy-decision-toggle.tsx
@@ -24,6 +24,13 @@ interface PolicyDecisionToggleProps {
    * 'default' — for strict three-way policies with no inherit tier.
    */
   allowDeselect?: boolean
+  /**
+   * What applies when `value` is 'default' — e.g. the risk-group decision for a
+   * scope row. Shown as a muted chip (colored glyph, no raised background) so
+   * "inherits allow" is legible without looking like a rule set on this row.
+   * Clicking any option while inheriting pins it as an explicit override.
+   */
+  inheritedValue?: Exclude<PolicyDecision, 'default'>
 }
 
 const options = [
@@ -55,15 +62,19 @@ export function PolicyDecisionToggle({
   onChange,
   size = 'sm',
   allowDeselect = true,
+  inheritedValue,
 }: PolicyDecisionToggleProps) {
   const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4'
   const btnSize = size === 'sm' ? 'h-6 w-7' : 'h-7 w-8'
+  // Nothing of its own → show what it inherits, if the caller told us.
+  const inheriting = value === 'default' && inheritedValue !== undefined
+  const shown = inheriting ? inheritedValue : value
 
   return (
     <TooltipProvider delayDuration={300}>
       <div className="inline-flex items-center rounded-md bg-muted p-0.5 gap-0.5 text-muted-foreground">
         {options.map((opt) => {
-          const isActive = value === opt.value
+          const isActive = shown === opt.value
           const Icon = opt.icon
           return (
             <Tooltip key={opt.value}>
@@ -72,9 +83,16 @@ export function PolicyDecisionToggle({
                   type="button"
                   data-testid={`policy-toggle-${opt.value}`}
                   data-active={isActive}
+                  data-inherited={isActive && inheriting}
                   aria-label={opt.label}
                   aria-pressed={isActive}
                   onClick={() => {
+                    // While inheriting there is nothing to deselect — any click
+                    // pins the clicked decision as this row's own rule.
+                    if (inheriting) {
+                      onChange(opt.value)
+                      return
+                    }
                     if (isActive && !allowDeselect) return
                     onChange(isActive ? 'default' : opt.value)
                   }}
@@ -82,7 +100,7 @@ export function PolicyDecisionToggle({
                     'inline-flex items-center justify-center rounded-sm transition-colors',
                     btnSize,
                     isActive
-                      ? cn('bg-background shadow', opt.activeColor)
+                      ? cn(inheriting ? 'opacity-60' : 'bg-background shadow', opt.activeColor)
                       : 'hover:text-foreground'
                   )}
                 >
@@ -90,7 +108,11 @@ export function PolicyDecisionToggle({
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="text-xs">
-                {isActive && allowDeselect ? `Remove ${opt.label.toLowerCase()} (set to default)` : opt.tooltip}
+                {isActive && inheriting
+                  ? `${opt.tooltip} — inherited. Click to set it here.`
+                  : isActive && allowDeselect
+                    ? `Remove ${opt.label.toLowerCase()} (set to default)`
+                    : opt.tooltip}
               </TooltipContent>
             </Tooltip>
           )


### PR DESCRIPTION
Reworks the scope-policy permissions UI (connection detail page + the policy dialog agents trigger from sessions) into the connections card design language, and simplifies the interaction model.

## Behavior changes (review attention here)

- **Group decisions are inherited, not copied.** A scope row renders `own_rule ?? group_rule ?? nothing`: with no rule of its own it displays whatever its risk group (Read / Write-Delete / Destructive) is set to, drawn as a muted chip — colored glyph, no raised background — so "inherits allow" reads differently from "allow was set here". Setting a group moves only its `*read`/`*write`/`*destructive` sentinel; **no per-scope rows are written**, and an explicit override on a scope keeps winning. Clicking a segment while inheriting pins that decision as the scope's own rule; clicking an explicit one clears it back to inherit. Resolution semantics in `policy-resolver` are untouched.
- **Reset defaults** restores every default the card shows: the three group baselines (allow/review/block) *and* the account fallback below them. Explicit per-scope overrides are deliberate choices rather than defaults, so they survive.
- **Decision filter matches the rule saved on the scope**, not what the row displays — a scope inheriting "always allow" from its group is "No rule set". The menu is labelled to say so.
- **Policy dialog chrome removed**: no dialog title or X close button — the section label ("Agent permissions for {toolkit}") carries the title and Cancel handles dismissal (Escape and click-outside still work). An sr-only DialogTitle keeps the dialog labeled for screen readers. Adds an opt-in `hideClose` prop to the shared `DialogContent` (no other dialogs affected).
- "Unsaved changes" hint removed from the action bar (Save's disabled state already communicates it).

## Visual / structural

- Scope editor flattened into a single card: hairline `divide-y` list with edge-to-edge dividers, grey count chips on group headers, Fallback as the list's footer row, `py-2` card construction matching `connections-tab`/`capabilities-tab`.
- Group headers use a new **`PolicyDecisionDropdown`** (select-style trigger: colored icon + label + chevron; menu: Always allow / Needs approval / Blocked / Default). Scope rows keep the segmented toggle.
- `PolicyDecisionToggle` restyled to the segmented-control recipe (`bg-muted` pill, white active chip with colored icon, no per-state fills); allow glyph switched `CircleCheck` → `CircleCheckBig`; tooltips renamed to "Always allow" / "Needs approval" / "Blocked". Gains an optional `inheritedValue` prop for the muted inherit state — callers that don't pass it (capabilities tab, connections defaults, agent policies, MCP tool editor) are unchanged.
- Search + decision filter collapsed behind small icon buttons hosted in the section title row (`useScopePolicyFilters` + `ScopePolicyFilterControls`); decision filter shows an active-dot indicator, and is hidden entirely for connections whose toolkit declares no scopes.
- New **`ScopePolicySection`** packages the title row + filter controls + bordered card, rendered identically on the connection detail page and in the dialog.
- Group titles renamed to "Read actions" / "Write/Delete actions" / "Destructive actions" (descriptions dropped); Save button label shortened from "Save Policies" to "Save"; Reset defaults is now a low-emphasis ghost button with an undo icon.

## Testing

- Unit: `scope-policy-editor.test.tsx` — 11 tests covering the dropdown control, inherited display, override-wins, "changing a group writes only its sentinel", inherit→explicit→inherit via clicks, and Reset. Full renderer suite green (1951 tests).
- E2E: `scope-policy-grouping`, `connections-page-policy-modal`, `policy-settings`, `capability-review` all green (15/15).
- Typecheck and `eslint 'src/**/*.{ts,tsx}'` clean.
- Manually verified in the browser preview (light + dark) on all three surfaces — post-connect popup, global connections detail, agent-home connections detail: inherited vs explicit rendering, moving a group with an override present, Reset, and the dialog connect flow.

## Known follow-ups (not addressed here)

- The dialog surface clips a long scope list with no scroll affordance.
- `handleSave` doesn't check `res.ok()`, so a rejected PUT closes the dialog as if it succeeded (pre-existing).
- `PolicyDecisionDropdown` and the filter menu are Popover-with-buttons rather than `Select`/`DropdownMenu` semantics.

Also adds `.claude/launch.json` with the `mock-web` preview config (isolated `E2E_MOCK` data dir) used to develop this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
