### PR TITLE
Fix live connection refresh for running agents (SUP-470)

### DIFF
--- a/agent-container/src/claude-code-connections.test.ts
+++ b/agent-container/src/claude-code-connections.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type MockQueryCall = { options: Record<string, unknown> }
+const calls: MockQueryCall[] = []
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => {
+  function makeQuery(args: { options: Record<string, unknown> }) {
+    const abortController = args.options.abortController as AbortController
+    let resolvePending:
+      | ((result: IteratorResult<never>) => void)
+      | undefined
+    const finish = () => {
+      resolvePending?.({ value: undefined, done: true })
+      resolvePending = undefined
+    }
+    abortController.signal.addEventListener('abort', finish, { once: true })
+
+    const iterator: AsyncIterableIterator<never> & {
+      interrupt: () => Promise<void>
+      setModel: () => Promise<void>
+    } = {
+      [Symbol.asyncIterator]() {
+        return this
+      },
+      next() {
+        if (abortController.signal.aborted) {
+          return Promise.resolve({ value: undefined, done: true })
+        }
+        return new Promise<IteratorResult<never>>((resolve) => {
+          resolvePending = resolve
+        })
+      },
+      return() {
+        finish()
+        return Promise.resolve({ value: undefined, done: true })
+      },
+      throw(error?: unknown) {
+        return Promise.reject(error)
+      },
+      interrupt() {
+        return Promise.resolve()
+      },
+      setModel() {
+        return Promise.resolve()
+      },
+    }
+    return iterator
+  }
+
+  return {
+    query: vi.fn((args: { options: Record<string, unknown> }) => {
+      calls.push({ options: args.options })
+      return makeQuery(args)
+    }),
+  }
+})
+
+vi.mock('./mcp-server', () => ({
+  createUserInputMcpServer: () => ({}),
+  createBrowserMcpServer: () => ({}),
+  createComputerUseMcpServer: () => ({}),
+  createDashboardsMcpServer: () => ({}),
+  createAgentsMcpServer: () => ({}),
+  createChatMcpServer: () => ({}),
+}))
+
+vi.mock('./tools/browser', () => ({
+  createBrowserTools: () => [],
+}))
+
+vi.mock('./tools/computer-use', () => ({
+  computerUseTools: [],
+}))
+
+vi.mock('./file-hooks', () => ({
+  fileHooks: {},
+  resolveToolFilePath: () => '',
+}))
+
+vi.mock('./input-manager', () => ({
+  inputManager: {},
+  HUMAN_INPUT_TTL_MS: 24 * 60 * 60 * 1000,
+}))
+
+import { ClaudeCodeProcess } from './claude-code'
+
+describe('ClaudeCodeProcess runtime connection handling', () => {
+  let originalRemoteMcps: string | undefined
+  let originalConnectedAccounts: string | undefined
+  let claudeProcess: ClaudeCodeProcess | undefined
+
+  beforeEach(() => {
+    calls.length = 0
+    originalRemoteMcps = process.env.REMOTE_MCPS
+    originalConnectedAccounts = process.env.CONNECTED_ACCOUNTS
+    delete process.env.REMOTE_MCPS
+    delete process.env.CONNECTED_ACCOUNTS
+  })
+
+  afterEach(async () => {
+    await claudeProcess?.stop()
+    if (originalRemoteMcps === undefined) {
+      delete process.env.REMOTE_MCPS
+    } else {
+      process.env.REMOTE_MCPS = originalRemoteMcps
+    }
+    if (originalConnectedAccounts === undefined) {
+      delete process.env.CONNECTED_ACCOUNTS
+    } else {
+      process.env.CONNECTED_ACCOUNTS = originalConnectedAccounts
+    }
+  })
+
+  it('rebuilds a live query when Agent Settings changes MCPs or connected accounts', async () => {
+    claudeProcess = new ClaudeCodeProcess({
+      sessionId: 'test-runtime-connection-refresh',
+      workingDirectory: '/tmp',
+    })
+
+    await claudeProcess.start()
+    expect(calls).toHaveLength(1)
+    expect(calls[0].options.mcpServers).not.toHaveProperty('team_calendar')
+
+    process.env.REMOTE_MCPS = JSON.stringify([
+      {
+        id: 'mcp-calendar',
+        name: 'Team Calendar',
+        proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
+        tools: [{ name: 'list_events' }],
+      },
+    ])
+
+    await claudeProcess.sendMessage('List today’s events')
+
+    expect(calls).toHaveLength(2)
+    expect(calls[1].options.mcpServers).toMatchObject({
+      team_calendar: {
+        type: 'http',
+        url: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
+      },
+    })
+    expect(calls[1].options.allowedTools).toContain('mcp__team_calendar__*')
+    expect(calls[1].options.systemPrompt).toContain('Team Calendar')
+    expect(calls[1].options.systemPrompt).toContain('list_events')
+
+    process.env.REMOTE_MCPS = '[]'
+    await claudeProcess.sendMessage('Continue without the calendar')
+
+    expect(calls).toHaveLength(3)
+    expect(calls[2].options.mcpServers).not.toHaveProperty('team_calendar')
+    expect(calls[2].options.allowedTools).not.toContain('mcp__team_calendar__*')
+    expect(calls[2].options.systemPrompt).not.toContain('Team Calendar')
+
+    process.env.CONNECTED_ACCOUNTS = JSON.stringify({
+      gmail: [{ name: 'Work Gmail', id: 'account-gmail' }],
+    })
+    await claudeProcess.sendMessage('Check the connected Gmail account')
+
+    expect(calls).toHaveLength(4)
+    expect(calls[3].options.systemPrompt).toContain('Work Gmail')
+    expect(calls[3].options.systemPrompt).toContain('account-gmail')
+
+    process.env.CONNECTED_ACCOUNTS = '{}'
+    await claudeProcess.sendMessage('Continue without Gmail')
+
+    expect(calls).toHaveLength(5)
+    expect(calls[4].options.systemPrompt).not.toContain('Work Gmail')
+  })
+})

--- a/agent-container/src/claude-code-connections.test.ts
+++ b/agent-container/src/claude-code-connections.test.ts
@@ -166,4 +166,19 @@ describe('ClaudeCodeProcess runtime connection handling', () => {
     expect(calls).toHaveLength(5)
     expect(calls[4].options.systemPrompt).not.toContain('Work Gmail')
   })
+
+  it('treats unset and serialized empty projections as equivalent', async () => {
+    claudeProcess = new ClaudeCodeProcess({
+      sessionId: 'test-empty-runtime-connections',
+      workingDirectory: '/tmp',
+    })
+
+    await claudeProcess.start()
+    process.env.REMOTE_MCPS = '[]'
+    process.env.CONNECTED_ACCOUNTS = '{}'
+
+    await claudeProcess.sendMessage('Continue without connections')
+
+    expect(calls).toHaveLength(1)
+  })
 })

--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -160,6 +160,65 @@ describe('ClaudeCodeProcess effort handling', () => {
   })
 })
 
+describe('ClaudeCodeProcess remote MCP handling', () => {
+  let originalRemoteMcps: string | undefined
+
+  beforeEach(() => {
+    calls.length = 0
+    originalRemoteMcps = process.env.REMOTE_MCPS
+    delete process.env.REMOTE_MCPS
+  })
+
+  afterEach(() => {
+    if (originalRemoteMcps === undefined) {
+      delete process.env.REMOTE_MCPS
+    } else {
+      process.env.REMOTE_MCPS = originalRemoteMcps
+    }
+  })
+
+  it('rebuilds a live query when Agent Settings adds or removes an MCP', { timeout: 20000 }, async () => {
+    const claudeProcess = new ClaudeCodeProcess({
+      sessionId: 'test-remote-mcp-refresh',
+      workingDirectory: '/tmp',
+    })
+
+    await claudeProcess.start()
+    expect(calls).toHaveLength(1)
+    expect(calls[0].options.mcpServers).not.toHaveProperty('team_calendar')
+
+    process.env.REMOTE_MCPS = JSON.stringify([
+      {
+        id: 'mcp-calendar',
+        name: 'Team Calendar',
+        proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
+        tools: [{ name: 'list_events' }],
+      },
+    ])
+
+    await claudeProcess.sendMessage('List today’s events')
+
+    expect(calls).toHaveLength(2)
+    expect(calls[1].options.mcpServers).toMatchObject({
+      team_calendar: {
+        type: 'http',
+        url: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
+      },
+    })
+    expect(calls[1].options.allowedTools).toContain('mcp__team_calendar__*')
+    expect(calls[1].options.systemPrompt).toContain('Team Calendar')
+    expect(calls[1].options.systemPrompt).toContain('list_events')
+
+    process.env.REMOTE_MCPS = '[]'
+    await claudeProcess.sendMessage('Continue without the calendar')
+
+    expect(calls).toHaveLength(3)
+    expect(calls[2].options.mcpServers).not.toHaveProperty('team_calendar')
+    expect(calls[2].options.allowedTools).not.toContain('mcp__team_calendar__*')
+    expect(calls[2].options.systemPrompt).not.toContain('Team Calendar')
+  })
+})
+
 describe('ClaudeCodeProcess speed handling', () => {
   beforeEach(() => {
     calls.length = 0

--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -160,13 +160,16 @@ describe('ClaudeCodeProcess effort handling', () => {
   })
 })
 
-describe('ClaudeCodeProcess remote MCP handling', () => {
+describe('ClaudeCodeProcess runtime connection handling', () => {
   let originalRemoteMcps: string | undefined
+  let originalConnectedAccounts: string | undefined
 
   beforeEach(() => {
     calls.length = 0
     originalRemoteMcps = process.env.REMOTE_MCPS
+    originalConnectedAccounts = process.env.CONNECTED_ACCOUNTS
     delete process.env.REMOTE_MCPS
+    delete process.env.CONNECTED_ACCOUNTS
   })
 
   afterEach(() => {
@@ -175,9 +178,14 @@ describe('ClaudeCodeProcess remote MCP handling', () => {
     } else {
       process.env.REMOTE_MCPS = originalRemoteMcps
     }
+    if (originalConnectedAccounts === undefined) {
+      delete process.env.CONNECTED_ACCOUNTS
+    } else {
+      process.env.CONNECTED_ACCOUNTS = originalConnectedAccounts
+    }
   })
 
-  it('rebuilds a live query when Agent Settings adds or removes an MCP', { timeout: 20000 }, async () => {
+  it('rebuilds a live query when Agent Settings changes MCPs or connected accounts', { timeout: 30000 }, async () => {
     const claudeProcess = new ClaudeCodeProcess({
       sessionId: 'test-remote-mcp-refresh',
       workingDirectory: '/tmp',
@@ -216,6 +224,21 @@ describe('ClaudeCodeProcess remote MCP handling', () => {
     expect(calls[2].options.mcpServers).not.toHaveProperty('team_calendar')
     expect(calls[2].options.allowedTools).not.toContain('mcp__team_calendar__*')
     expect(calls[2].options.systemPrompt).not.toContain('Team Calendar')
+
+    process.env.CONNECTED_ACCOUNTS = JSON.stringify({
+      gmail: [{ name: 'Work Gmail', id: 'account-gmail' }],
+    })
+    await claudeProcess.sendMessage('Check the connected Gmail account')
+
+    expect(calls).toHaveLength(4)
+    expect(calls[3].options.systemPrompt).toContain('Work Gmail')
+    expect(calls[3].options.systemPrompt).toContain('account-gmail')
+
+    process.env.CONNECTED_ACCOUNTS = '{}'
+    await claudeProcess.sendMessage('Continue without Gmail')
+
+    expect(calls).toHaveLength(5)
+    expect(calls[4].options.systemPrompt).not.toContain('Work Gmail')
   })
 })
 

--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -9,7 +9,7 @@
  *     as the current level (so the first post-upgrade message with effort='high'
  *     does not trigger a spurious restart).
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 type MockQueryCall = { options: Record<string, unknown> }
 const calls: MockQueryCall[] = []
@@ -17,9 +17,20 @@ const setModelCalls: (string | undefined)[] = []
 
 // Stub the SDK before importing ClaudeCodeProcess.
 vi.mock('@anthropic-ai/claude-agent-sdk', () => {
-  // Returns an async iterator that never yields until aborted — good enough to
-  // model a running session for the purposes of this test.
-  function makeQuery(_args: { prompt: unknown; options: Record<string, unknown> }) {
+  // Model a running SDK iterator that actually honors the AbortController.
+  // This lets interrupt() observe processMessages() unwind immediately instead
+  // of paying its 5-second hung-SDK fallback in every restart test.
+  function makeQuery(args: { prompt: unknown; options: Record<string, unknown> }) {
+    const abortController = args.options.abortController as AbortController
+    let resolvePending:
+      | ((result: IteratorResult<never>) => void)
+      | undefined
+    const finish = () => {
+      resolvePending?.({ value: undefined, done: true })
+      resolvePending = undefined
+    }
+    abortController.signal.addEventListener('abort', finish, { once: true })
+
     const iter: AsyncIterableIterator<never> & {
       interrupt: () => Promise<void>
       setModel: (model?: string) => Promise<void>
@@ -28,11 +39,15 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
         return this
       },
       next() {
-        return new Promise<IteratorResult<never>>(() => {
-          /* pending forever — real abort handled via AbortController in process */
+        if (abortController.signal.aborted) {
+          return Promise.resolve({ value: undefined, done: true })
+        }
+        return new Promise<IteratorResult<never>>((resolve) => {
+          resolvePending = resolve
         })
       },
       return() {
+        finish()
         return Promise.resolve({ value: undefined, done: true } as IteratorResult<never>)
       },
       throw(err?: unknown) {
@@ -92,14 +107,7 @@ describe('ClaudeCodeProcess effort handling', () => {
     calls.length = 0
   })
 
-  afterEach(async () => {
-    // Nothing to tear down — process.stop() triggers abort which our stub ignores.
-  })
-
-  // Interrupt's wait-for-stop polls up to 5 s before falling through; our mock
-  // doesn't honor the abort signal, so each effort-change test waits that full
-  // window. Raise the per-test timeout accordingly.
-  it('rebuilds the query with the new effort when effort changes', { timeout: 15000 }, async () => {
+  it('rebuilds the query with the new effort when effort changes', async () => {
     const process = new ClaudeCodeProcess({
       sessionId: 'test-session-1',
       workingDirectory: '/tmp',
@@ -135,7 +143,7 @@ describe('ClaudeCodeProcess effort handling', () => {
     expect(calls).toHaveLength(1)
   })
 
-  it('treats undefined stored effort as high so first high message does not restart', { timeout: 15000 }, async () => {
+  it('treats undefined stored effort as high so first high message does not restart', async () => {
     // Simulates a session created before this feature (no persisted effort).
     const process = new ClaudeCodeProcess({
       sessionId: 'test-session-3',
@@ -157,88 +165,6 @@ describe('ClaudeCodeProcess effort handling', () => {
     await process.sendMessage('hello again', undefined, { effort: 'low' })
     expect(calls).toHaveLength(2)
     expect(calls[1].options.effort).toBe('low')
-  })
-})
-
-describe('ClaudeCodeProcess runtime connection handling', () => {
-  let originalRemoteMcps: string | undefined
-  let originalConnectedAccounts: string | undefined
-
-  beforeEach(() => {
-    calls.length = 0
-    originalRemoteMcps = process.env.REMOTE_MCPS
-    originalConnectedAccounts = process.env.CONNECTED_ACCOUNTS
-    delete process.env.REMOTE_MCPS
-    delete process.env.CONNECTED_ACCOUNTS
-  })
-
-  afterEach(() => {
-    if (originalRemoteMcps === undefined) {
-      delete process.env.REMOTE_MCPS
-    } else {
-      process.env.REMOTE_MCPS = originalRemoteMcps
-    }
-    if (originalConnectedAccounts === undefined) {
-      delete process.env.CONNECTED_ACCOUNTS
-    } else {
-      process.env.CONNECTED_ACCOUNTS = originalConnectedAccounts
-    }
-  })
-
-  it('rebuilds a live query when Agent Settings changes MCPs or connected accounts', { timeout: 30000 }, async () => {
-    const claudeProcess = new ClaudeCodeProcess({
-      sessionId: 'test-remote-mcp-refresh',
-      workingDirectory: '/tmp',
-    })
-
-    await claudeProcess.start()
-    expect(calls).toHaveLength(1)
-    expect(calls[0].options.mcpServers).not.toHaveProperty('team_calendar')
-
-    process.env.REMOTE_MCPS = JSON.stringify([
-      {
-        id: 'mcp-calendar',
-        name: 'Team Calendar',
-        proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
-        tools: [{ name: 'list_events' }],
-      },
-    ])
-
-    await claudeProcess.sendMessage('List today’s events')
-
-    expect(calls).toHaveLength(2)
-    expect(calls[1].options.mcpServers).toMatchObject({
-      team_calendar: {
-        type: 'http',
-        url: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
-      },
-    })
-    expect(calls[1].options.allowedTools).toContain('mcp__team_calendar__*')
-    expect(calls[1].options.systemPrompt).toContain('Team Calendar')
-    expect(calls[1].options.systemPrompt).toContain('list_events')
-
-    process.env.REMOTE_MCPS = '[]'
-    await claudeProcess.sendMessage('Continue without the calendar')
-
-    expect(calls).toHaveLength(3)
-    expect(calls[2].options.mcpServers).not.toHaveProperty('team_calendar')
-    expect(calls[2].options.allowedTools).not.toContain('mcp__team_calendar__*')
-    expect(calls[2].options.systemPrompt).not.toContain('Team Calendar')
-
-    process.env.CONNECTED_ACCOUNTS = JSON.stringify({
-      gmail: [{ name: 'Work Gmail', id: 'account-gmail' }],
-    })
-    await claudeProcess.sendMessage('Check the connected Gmail account')
-
-    expect(calls).toHaveLength(4)
-    expect(calls[3].options.systemPrompt).toContain('Work Gmail')
-    expect(calls[3].options.systemPrompt).toContain('account-gmail')
-
-    process.env.CONNECTED_ACCOUNTS = '{}'
-    await claudeProcess.sendMessage('Continue without Gmail')
-
-    expect(calls).toHaveLength(5)
-    expect(calls[4].options.systemPrompt).not.toContain('Work Gmail')
   })
 })
 

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -429,6 +429,12 @@ export class ClaudeCodeProcess extends EventEmitter {
   private effort: EffortLevel | undefined;
   private speed: SpeedLevel | undefined;
   private capabilityPolicies: AgentCapabilityPolicies | undefined;
+  // REMOTE_MCPS is mutable at runtime when Agent Settings connections change,
+  // but the SDK snapshots MCP servers, allowed tool patterns, and the system
+  // prompt when query() is created. Track the exact env value baked into the
+  // current query so the next user message can refresh a stale query before it
+  // is delivered.
+  private remoteMcpConfigSnapshot = '';
   // Session-scoped review grants ("Allow for this session"). Scoped to the
   // SESSION, not the process: they must survive idle-eviction + resume (the
   // session-manager persists them via the 'capability-grant' event), or the
@@ -571,6 +577,7 @@ export class ClaudeCodeProcess extends EventEmitter {
   private createQuery(): Query {
     const remoteMcpConfigs = this.buildRemoteMcpServers();
     const remoteMcpToolPatterns = Object.keys(remoteMcpConfigs).map(name => `mcp__${name}__*`);
+    this.remoteMcpConfigSnapshot = process.env.REMOTE_MCPS ?? '';
 
     // Browser tools are bound per-session via a getter read on every request:
     // this.sessionId changes when the query (re)starts, and a module-global id
@@ -1093,6 +1100,21 @@ export class ClaudeCodeProcess extends EventEmitter {
     const effort = options?.effort;
     const speed = options?.speed;
     const model = options?.model;
+    const remoteMcpConfigChanged =
+      (process.env.REMOTE_MCPS ?? '') !== this.remoteMcpConfigSnapshot;
+
+    if (remoteMcpConfigChanged) {
+      // The prompt's "Remote MCP Servers (Available)" section is generated
+      // from REMOTE_MCPS too, so refresh it alongside the query tool config.
+      this.systemPrompt = generateSystemPrompt(
+        this.availableEnvVars,
+        this.userSystemPrompt,
+        this.modelPromptHints,
+        this.webSearchProvider,
+        this.webFetchProvider,
+        this.capabilityPolicies
+      );
+    }
 
     // Treat undefined stored effort as 'high' so pre-existing sessions (created before
     // this feature) don't trigger a spurious restart on their first post-upgrade message.
@@ -1149,7 +1171,7 @@ export class ClaudeCodeProcess extends EventEmitter {
         await this.currentStop.catch(() => undefined);
       }
       await this.restart();
-    } else if (effortChanged || speedChanged || capabilityBlockChanged) {
+    } else if (effortChanged || speedChanged || capabilityBlockChanged || remoteMcpConfigChanged) {
       // Effort can only be set at query creation time — the SDK has no setEffort
       // facility — so any effort change forces an interrupt + re-query. Speed
       // lives in the query env (ANTHROPIC_CUSTOM_HEADERS), which is likewise
@@ -1160,6 +1182,7 @@ export class ClaudeCodeProcess extends EventEmitter {
       if (effortChanged) reasons.push(`effort ${currentEffort} -> ${effort}`);
       if (speedChanged) reasons.push(`speed ${currentSpeed} -> ${speed}`);
       if (capabilityBlockChanged) reasons.push('capability block boundary changed');
+      if (remoteMcpConfigChanged) reasons.push('remote MCP configuration changed');
       if (modelChanged) reasons.push(`model -> ${this.model}`);
       console.log(`[Session ${this.sessionId}] Restarting query (${reasons.join(', ')})`);
       await this.interrupt();

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -124,8 +124,8 @@ function parseRemoteMcps(): RemoteMcpConfig[] {
 
 function runtimeConnectionConfigSnapshot(): string {
   return JSON.stringify([
-    process.env.CONNECTED_ACCOUNTS ?? '',
-    process.env.REMOTE_MCPS ?? '',
+    process.env.CONNECTED_ACCOUNTS || '{}',
+    process.env.REMOTE_MCPS || '[]',
   ])
 }
 

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -122,6 +122,13 @@ function parseRemoteMcps(): RemoteMcpConfig[] {
   }
 }
 
+function runtimeConnectionConfigSnapshot(): string {
+  return JSON.stringify([
+    process.env.CONNECTED_ACCOUNTS ?? '',
+    process.env.REMOTE_MCPS ?? '',
+  ])
+}
+
 /**
  * Parses connected accounts metadata from the CONNECTED_ACCOUNTS env var.
  * Format: {"toolkit": [{"name": "Display Name", "id": "uuid"}, ...]}
@@ -429,12 +436,11 @@ export class ClaudeCodeProcess extends EventEmitter {
   private effort: EffortLevel | undefined;
   private speed: SpeedLevel | undefined;
   private capabilityPolicies: AgentCapabilityPolicies | undefined;
-  // REMOTE_MCPS is mutable at runtime when Agent Settings connections change,
-  // but the SDK snapshots MCP servers, allowed tool patterns, and the system
-  // prompt when query() is created. Track the exact env value baked into the
-  // current query so the next user message can refresh a stale query before it
-  // is delivered.
-  private remoteMcpConfigSnapshot = '';
+  // Connection metadata is mutable at runtime when Agent Settings changes.
+  // The SDK snapshots MCP servers, allowed tool patterns, and the system prompt
+  // when query() is created, so the next user message must refresh a stale
+  // query before it is delivered.
+  private runtimeConnectionSnapshot = '';
   // Session-scoped review grants ("Allow for this session"). Scoped to the
   // SESSION, not the process: they must survive idle-eviction + resume (the
   // session-manager persists them via the 'capability-grant' event), or the
@@ -577,7 +583,7 @@ export class ClaudeCodeProcess extends EventEmitter {
   private createQuery(): Query {
     const remoteMcpConfigs = this.buildRemoteMcpServers();
     const remoteMcpToolPatterns = Object.keys(remoteMcpConfigs).map(name => `mcp__${name}__*`);
-    this.remoteMcpConfigSnapshot = process.env.REMOTE_MCPS ?? '';
+    this.runtimeConnectionSnapshot = runtimeConnectionConfigSnapshot();
 
     // Browser tools are bound per-session via a getter read on every request:
     // this.sessionId changes when the query (re)starts, and a module-global id
@@ -1100,12 +1106,12 @@ export class ClaudeCodeProcess extends EventEmitter {
     const effort = options?.effort;
     const speed = options?.speed;
     const model = options?.model;
-    const remoteMcpConfigChanged =
-      (process.env.REMOTE_MCPS ?? '') !== this.remoteMcpConfigSnapshot;
+    const runtimeConnectionConfigChanged =
+      runtimeConnectionConfigSnapshot() !== this.runtimeConnectionSnapshot;
 
-    if (remoteMcpConfigChanged) {
-      // The prompt's "Remote MCP Servers (Available)" section is generated
-      // from REMOTE_MCPS too, so refresh it alongside the query tool config.
+    if (runtimeConnectionConfigChanged) {
+      // The prompt's connected-account and remote-MCP sections are generated
+      // from runtime env metadata, so refresh them alongside the query config.
       this.systemPrompt = generateSystemPrompt(
         this.availableEnvVars,
         this.userSystemPrompt,
@@ -1171,7 +1177,7 @@ export class ClaudeCodeProcess extends EventEmitter {
         await this.currentStop.catch(() => undefined);
       }
       await this.restart();
-    } else if (effortChanged || speedChanged || capabilityBlockChanged || remoteMcpConfigChanged) {
+    } else if (effortChanged || speedChanged || capabilityBlockChanged || runtimeConnectionConfigChanged) {
       // Effort can only be set at query creation time — the SDK has no setEffort
       // facility — so any effort change forces an interrupt + re-query. Speed
       // lives in the query env (ANTHROPIC_CUSTOM_HEADERS), which is likewise
@@ -1182,7 +1188,7 @@ export class ClaudeCodeProcess extends EventEmitter {
       if (effortChanged) reasons.push(`effort ${currentEffort} -> ${effort}`);
       if (speedChanged) reasons.push(`speed ${currentSpeed} -> ${speed}`);
       if (capabilityBlockChanged) reasons.push('capability block boundary changed');
-      if (remoteMcpConfigChanged) reasons.push('remote MCP configuration changed');
+      if (runtimeConnectionConfigChanged) reasons.push('runtime connection configuration changed');
       if (modelChanged) reasons.push(`model -> ${this.model}`);
       console.log(`[Session ${this.sessionId}] Restarting query (${reasons.join(', ')})`);
       await this.interrupt();

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -360,6 +360,81 @@ function toSkillsetRef(config: Pick<SkillsetConfig, 'id' | 'url' | 'name' | 'pro
   }
 }
 
+type RemoteMcpRuntimeClient = Pick<
+  ReturnType<typeof containerManager.getClient>,
+  'fetch' | 'getHostApiBaseUrl'
+>
+
+/**
+ * Rebuild the container's runtime MCP catalog from the database.
+ *
+ * The mapping table is the source of truth, while REMOTE_MCPS is the live
+ * container projection consumed when each SDK query is created. Keeping this
+ * in one helper ensures Agent Settings mutations and in-session approvals
+ * produce the same proxy URLs and tool catalog.
+ */
+async function updateRemoteMcpEnvironment(
+  agentSlug: string,
+  client: RemoteMcpRuntimeClient,
+): Promise<Response> {
+  const hostApiBaseUrl = await client.getHostApiBaseUrl()
+  const mcpMappings = await db
+    .select({ mcp: remoteMcpServers })
+    .from(agentRemoteMcps)
+    .innerJoin(remoteMcpServers, eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id))
+    .where(eq(agentRemoteMcps.agentSlug, agentSlug))
+
+  const mcpConfigs = mcpMappings
+    .filter(({ mcp }) => mcp.status === 'active')
+    .map(({ mcp }) => {
+      // Only pass tool names (not full schemas) to keep env var size small.
+      let toolNames: Array<{ name: string }> = []
+      if (mcp.toolsJson) {
+        try {
+          toolNames = JSON.parse(mcp.toolsJson).map((tool: { name: string }) => ({ name: tool.name }))
+        } catch {
+          // A malformed cached tool catalog must not prevent the connection
+          // itself from reaching the runtime; discovery can repair it later.
+        }
+      }
+      return {
+        id: mcp.id,
+        name: mcp.name,
+        proxyUrl: `${hostApiBaseUrl}/api/mcp-proxy/${agentSlug}/${mcp.id}`,
+        tools: toolNames,
+      }
+    })
+
+  return client.fetch('/env', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key: 'REMOTE_MCPS', value: JSON.stringify(mcpConfigs) }),
+  })
+}
+
+async function syncRemoteMcpsToRunningContainer(agentSlug: string): Promise<boolean> {
+  if (containerManager.getCachedInfo(agentSlug).status !== 'running') {
+    // Container startup rebuilds REMOTE_MCPS from the same mapping table.
+    return true
+  }
+  try {
+    const response = await updateRemoteMcpEnvironment(
+      agentSlug,
+      containerManager.getClient(agentSlug),
+    )
+    if (!response.ok) {
+      console.error(
+        `Failed to update REMOTE_MCPS for running agent ${agentSlug}:`,
+        await response.text(),
+      )
+    }
+    return response.ok
+  } catch (error) {
+    console.error(`Failed to sync REMOTE_MCPS for running agent ${agentSlug}:`, error)
+    return false
+  }
+}
+
 /**
  * Enrich an array of ApiAgent objects with summary fields:
  * active/awaiting sessions, last activity, scheduled tasks, dashboards.
@@ -3550,6 +3625,9 @@ agents.post('/:id/remote-mcps', AgentUser(), async (c) => {
     await db.insert(agentRemoteMcps).values(values).onConflictDoNothing()
 
     for (const mcpId of newMcpIds) { logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: mcpId, action: 'assigned', details: { agentSlug: slug } }) }
+    if (!(await syncRemoteMcpsToRunningContainer(slug))) {
+      return c.json({ error: 'MCP assignment was saved, but the live agent session could not be refreshed' }, 502)
+    }
     return c.json({ success: true, added: newMcpIds.length })
   } catch (error) {
     console.error('Failed to assign remote MCPs to agent:', error)
@@ -3584,6 +3662,9 @@ agents.delete('/:id/remote-mcps/:mcpId', AgentUser(), async (c) => {
 
     await db.delete(agentRemoteMcps).where(eq(agentRemoteMcps.id, mapping.id))
     logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: mcpId, action: 'unassigned', details: { agentSlug: slug } })
+    if (!(await syncRemoteMcpsToRunningContainer(slug))) {
+      return c.json({ error: 'MCP removal was saved, but the live agent session could not be refreshed' }, 502)
+    }
     return c.body(null, 204)
   } catch (error) {
     console.error('Failed to remove remote MCP from agent:', error)
@@ -3700,36 +3781,8 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
       await db.insert(agentRemoteMcps).values(newMappings)
     }
 
-    // Same talk-back base as container start — not getContainerHostUrl().
-    const hostApiBaseUrl = await client.getHostApiBaseUrl()
-    const mcpMappings = await db
-      .select({ mcp: remoteMcpServers })
-      .from(agentRemoteMcps)
-      .innerJoin(remoteMcpServers, eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id))
-      .where(eq(agentRemoteMcps.agentSlug, slug))
-
-    const mcpConfigs = mcpMappings
-      .filter(({ mcp }) => mcp.status === 'active')
-      .map(({ mcp }) => {
-        // Only pass tool names (not full schemas) to keep env var size small
-        let toolNames: Array<{ name: string }> = []
-        if (mcp.toolsJson) {
-          try { toolNames = JSON.parse(mcp.toolsJson).map((t: any) => ({ name: t.name })) } catch { /* ignore */ }
-        }
-        return {
-          id: mcp.id,
-          name: mcp.name,
-          proxyUrl: `${hostApiBaseUrl}/api/mcp-proxy/${slug}/${mcp.id}`,
-          tools: toolNames,
-        }
-      })
-
     // Update container env var
-    const envResponse = await client.fetch('/env', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ key: 'REMOTE_MCPS', value: JSON.stringify(mcpConfigs) }),
-    })
+    const envResponse = await updateRemoteMcpEnvironment(slug, client)
     if (!envResponse.ok) {
       console.error('Failed to update REMOTE_MCPS env var:', await envResponse.text())
       return c.json({ error: 'Failed to update container environment' }, 502)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -19,6 +19,11 @@ import {
   AgentContainerStopError,
 } from '@shared/lib/services/agent-service'
 import { containerManager } from '@shared/lib/container/container-manager'
+import {
+  syncAgentConnectionEnvironment,
+  updateConnectedAccountsEnvironment,
+  updateRemoteMcpEnvironment,
+} from '@shared/lib/container/connection-runtime-sync'
 import { parseRuntimeOptions } from '@shared/lib/container/runtime-options'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 import { listWebhookTriggers, listActiveWebhookTriggers, listCancelledWebhookTriggers } from '@shared/lib/services/webhook-trigger-service'
@@ -357,81 +362,6 @@ function toSkillsetRef(config: Pick<SkillsetConfig, 'id' | 'url' | 'name' | 'pro
     provider: config.provider,
     skillsetName: config.name,
     providerData: provider.normalizeProviderData(config),
-  }
-}
-
-type RemoteMcpRuntimeClient = Pick<
-  ReturnType<typeof containerManager.getClient>,
-  'fetch' | 'getHostApiBaseUrl'
->
-
-/**
- * Rebuild the container's runtime MCP catalog from the database.
- *
- * The mapping table is the source of truth, while REMOTE_MCPS is the live
- * container projection consumed when each SDK query is created. Keeping this
- * in one helper ensures Agent Settings mutations and in-session approvals
- * produce the same proxy URLs and tool catalog.
- */
-async function updateRemoteMcpEnvironment(
-  agentSlug: string,
-  client: RemoteMcpRuntimeClient,
-): Promise<Response> {
-  const hostApiBaseUrl = await client.getHostApiBaseUrl()
-  const mcpMappings = await db
-    .select({ mcp: remoteMcpServers })
-    .from(agentRemoteMcps)
-    .innerJoin(remoteMcpServers, eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id))
-    .where(eq(agentRemoteMcps.agentSlug, agentSlug))
-
-  const mcpConfigs = mcpMappings
-    .filter(({ mcp }) => mcp.status === 'active')
-    .map(({ mcp }) => {
-      // Only pass tool names (not full schemas) to keep env var size small.
-      let toolNames: Array<{ name: string }> = []
-      if (mcp.toolsJson) {
-        try {
-          toolNames = JSON.parse(mcp.toolsJson).map((tool: { name: string }) => ({ name: tool.name }))
-        } catch {
-          // A malformed cached tool catalog must not prevent the connection
-          // itself from reaching the runtime; discovery can repair it later.
-        }
-      }
-      return {
-        id: mcp.id,
-        name: mcp.name,
-        proxyUrl: `${hostApiBaseUrl}/api/mcp-proxy/${agentSlug}/${mcp.id}`,
-        tools: toolNames,
-      }
-    })
-
-  return client.fetch('/env', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ key: 'REMOTE_MCPS', value: JSON.stringify(mcpConfigs) }),
-  })
-}
-
-async function syncRemoteMcpsToRunningContainer(agentSlug: string): Promise<boolean> {
-  if (containerManager.getCachedInfo(agentSlug).status !== 'running') {
-    // Container startup rebuilds REMOTE_MCPS from the same mapping table.
-    return true
-  }
-  try {
-    const response = await updateRemoteMcpEnvironment(
-      agentSlug,
-      containerManager.getClient(agentSlug),
-    )
-    if (!response.ok) {
-      console.error(
-        `Failed to update REMOTE_MCPS for running agent ${agentSlug}:`,
-        await response.text(),
-      )
-    }
-    return response.ok
-  } catch (error) {
-    console.error(`Failed to sync REMOTE_MCPS for running agent ${agentSlug}:`, error)
-    return false
   }
 }
 
@@ -2542,40 +2472,11 @@ agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), a
       }
     }
 
-    // Build updated account metadata for the container (no tokens, just names + IDs)
-    const allMappings = await db
-      .select({ account: connectedAccounts })
-      .from(agentConnectedAccounts)
-      .innerJoin(
-        connectedAccounts,
-        eq(agentConnectedAccounts.connectedAccountId, connectedAccounts.id)
-      )
-      .where(eq(agentConnectedAccounts.agentSlug, agentSlug))
-
-    const metadata: Record<string, Array<{ name: string; id: string }>> = {}
-    for (const { account } of allMappings) {
-      if (account.status !== 'active') continue
-      if (!metadata[account.toolkitSlug]) {
-        metadata[account.toolkitSlug] = []
-      }
-      metadata[account.toolkitSlug].push({
-        name: account.displayName,
-        id: account.id,
-      })
-    }
-
     // Update CONNECTED_ACCOUNTS metadata in container (no raw tokens)
     console.log(
       `[provide-connected-account] Updating CONNECTED_ACCOUNTS metadata in container`
     )
-    const envResponse = await client.fetch('/env', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        key: 'CONNECTED_ACCOUNTS',
-        value: JSON.stringify(metadata),
-      }),
-    })
+    const envResponse = await updateConnectedAccountsEnvironment(agentSlug, client)
 
     if (!envResponse.ok) {
       let errorDetails = 'Unknown error'
@@ -3508,7 +3409,8 @@ agents.post('/:id/connected-accounts', AgentUser(), async (c) => {
       ))
 
     for (const accountId of insertedAccountIds) { logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: accountId, action: 'assigned', details: { agentSlug: slug } }) }
-    return c.json({ accounts })
+    const liveRefresh = await syncAgentConnectionEnvironment(slug, 'connected-accounts')
+    return c.json({ accounts, liveRefresh })
   } catch (error) {
     console.error('Failed to map connected accounts to agent:', error)
     return c.json({ error: 'Failed to map connected accounts to agent' }, 500)
@@ -3544,7 +3446,10 @@ agents.delete('/:id/connected-accounts/:accountId', AgentUser(), async (c) => {
       .where(eq(agentConnectedAccounts.id, found.id))
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: accountId, action: 'unassigned', details: { agentSlug: slug } })
-    return c.body(null, 204)
+    const liveRefresh = await syncAgentConnectionEnvironment(slug, 'connected-accounts')
+    return c.body(null, 204, {
+      'X-Superagent-Live-Refresh': String(liveRefresh),
+    })
   } catch (error) {
     console.error('Failed to remove account mapping:', error)
     return c.json({ error: 'Failed to remove account mapping' }, 500)
@@ -3625,10 +3530,8 @@ agents.post('/:id/remote-mcps', AgentUser(), async (c) => {
     await db.insert(agentRemoteMcps).values(values).onConflictDoNothing()
 
     for (const mcpId of newMcpIds) { logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: mcpId, action: 'assigned', details: { agentSlug: slug } }) }
-    if (!(await syncRemoteMcpsToRunningContainer(slug))) {
-      return c.json({ error: 'MCP assignment was saved, but the live agent session could not be refreshed' }, 502)
-    }
-    return c.json({ success: true, added: newMcpIds.length })
+    const liveRefresh = await syncAgentConnectionEnvironment(slug, 'remote-mcps')
+    return c.json({ success: true, added: newMcpIds.length, liveRefresh })
   } catch (error) {
     console.error('Failed to assign remote MCPs to agent:', error)
     return c.json({ error: 'Failed to assign remote MCPs to agent' }, 500)
@@ -3662,10 +3565,10 @@ agents.delete('/:id/remote-mcps/:mcpId', AgentUser(), async (c) => {
 
     await db.delete(agentRemoteMcps).where(eq(agentRemoteMcps.id, mapping.id))
     logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: mcpId, action: 'unassigned', details: { agentSlug: slug } })
-    if (!(await syncRemoteMcpsToRunningContainer(slug))) {
-      return c.json({ error: 'MCP removal was saved, but the live agent session could not be refreshed' }, 502)
-    }
-    return c.body(null, 204)
+    const liveRefresh = await syncAgentConnectionEnvironment(slug, 'remote-mcps')
+    return c.body(null, 204, {
+      'X-Superagent-Live-Refresh': String(liveRefresh),
+    })
   } catch (error) {
     console.error('Failed to remove remote MCP from agent:', error)
     return c.json({ error: 'Failed to remove remote MCP from agent' }, 500)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -3447,9 +3447,7 @@ agents.delete('/:id/connected-accounts/:accountId', AgentUser(), async (c) => {
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: accountId, action: 'unassigned', details: { agentSlug: slug } })
     const liveRefresh = await syncAgentConnectionEnvironment(slug, 'connected-accounts')
-    return c.body(null, 204, {
-      'X-Superagent-Live-Refresh': String(liveRefresh),
-    })
+    return c.json({ success: true, liveRefresh })
   } catch (error) {
     console.error('Failed to remove account mapping:', error)
     return c.json({ error: 'Failed to remove account mapping' }, 500)
@@ -3566,9 +3564,7 @@ agents.delete('/:id/remote-mcps/:mcpId', AgentUser(), async (c) => {
     await db.delete(agentRemoteMcps).where(eq(agentRemoteMcps.id, mapping.id))
     logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: mcpId, action: 'unassigned', details: { agentSlug: slug } })
     const liveRefresh = await syncAgentConnectionEnvironment(slug, 'remote-mcps')
-    return c.body(null, 204, {
-      'X-Superagent-Live-Refresh': String(liveRefresh),
-    })
+    return c.json({ success: true, liveRefresh })
   } catch (error) {
     console.error('Failed to remove remote MCP from agent:', error)
     return c.json({ error: 'Failed to remove remote MCP from agent' }, 500)

--- a/src/api/routes/connected-accounts.test.ts
+++ b/src/api/routes/connected-accounts.test.ts
@@ -122,10 +122,23 @@ vi.mock('@shared/lib/services/audit-log-service', () => ({
 
 const mockCountActiveTriggersPerAccount = vi.fn()
 const mockCancelTriggersForConnectedAccount = vi.fn()
+const mockFindAgentsAssignedConnectedAccount = vi.fn()
+  .mockResolvedValue(['agent-a'])
+const mockSyncAgentsAssignedConnectedAccount = vi.fn().mockResolvedValue(true)
+const mockSyncConnectedAccountAgents = vi.fn().mockResolvedValue(true)
 
 vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
   countActiveTriggersPerAccount: (...args: unknown[]) => mockCountActiveTriggersPerAccount(...args),
   cancelTriggersForConnectedAccount: (...args: unknown[]) => mockCancelTriggersForConnectedAccount(...args),
+}))
+
+vi.mock('@shared/lib/container/connection-runtime-sync', () => ({
+  findAgentsAssignedConnectedAccount: (...args: unknown[]) =>
+    mockFindAgentsAssignedConnectedAccount(...args),
+  syncAgentsAssignedConnectedAccount: (...args: unknown[]) =>
+    mockSyncAgentsAssignedConnectedAccount(...args),
+  syncConnectedAccountAgents: (...args: unknown[]) =>
+    mockSyncConnectedAccountAgents(...args),
 }))
 
 import connectedAccountsRouter from './connected-accounts'
@@ -217,6 +230,10 @@ describe('connected-accounts reconnect flow', () => {
         displayName: 'My GitHub',
       }))
       expect(mockDbInsertValues).not.toHaveBeenCalled()
+      expect(await res.json()).toMatchObject({ liveRefresh: true })
+      expect(mockSyncAgentsAssignedConnectedAccount).toHaveBeenCalledWith(
+        'existing-acc',
+      )
     })
 
     it('deletes old remote connection after reconnect', async () => {
@@ -310,6 +327,11 @@ describe('connected-accounts reconnect flow', () => {
         .toBeLessThan(mockDeleteConnection.mock.invocationCallOrder[0])
       expect(mockDeleteConnection.mock.invocationCallOrder[0])
         .toBeLessThan(mockDbDeleteWhere.mock.invocationCallOrder[0])
+      expect(mockFindAgentsAssignedConnectedAccount).toHaveBeenCalledWith(
+        'existing-acc',
+      )
+      expect(mockSyncConnectedAccountAgents).toHaveBeenCalledWith(['agent-a'])
+      expect(res.headers.get('X-Superagent-Live-Refresh')).toBe('true')
     })
 
     it('still deletes the local row when remote provider cleanup fails', async () => {

--- a/src/api/routes/connected-accounts.test.ts
+++ b/src/api/routes/connected-accounts.test.ts
@@ -295,6 +295,9 @@ describe('connected-accounts reconnect flow', () => {
       expect(res.status).toBe(200)
       expect(mockDbInsertValues).toHaveBeenCalled()
       expect(mockDbUpdateSet).not.toHaveBeenCalled()
+      expect(mockSyncAgentsAssignedConnectedAccount).toHaveBeenCalledWith(
+        expect.any(String),
+      )
     })
   })
 

--- a/src/api/routes/connected-accounts.test.ts
+++ b/src/api/routes/connected-accounts.test.ts
@@ -311,7 +311,8 @@ describe('connected-accounts reconnect flow', () => {
         method: 'DELETE',
       })
 
-      expect(res.status).toBe(204)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ success: true, liveRefresh: true })
       expect(mockCancelTriggersForConnectedAccount).toHaveBeenCalledWith('existing-acc')
       expect(mockDeleteConnection).toHaveBeenCalledWith('remote-conn', 'github')
       expect(mockDbDeleteWhere).toHaveBeenCalledWith({ col: 'id', val: 'existing-acc' })
@@ -331,7 +332,6 @@ describe('connected-accounts reconnect flow', () => {
         'existing-acc',
       )
       expect(mockSyncConnectedAccountAgents).toHaveBeenCalledWith(['agent-a'])
-      expect(res.headers.get('X-Superagent-Live-Refresh')).toBe('true')
     })
 
     it('still deletes the local row when remote provider cleanup fails', async () => {
@@ -349,7 +349,8 @@ describe('connected-accounts reconnect flow', () => {
         method: 'DELETE',
       })
 
-      expect(res.status).toBe(204)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ success: true, liveRefresh: true })
       expect(mockCancelTriggersForConnectedAccount).toHaveBeenCalledWith('existing-acc')
       expect(mockDbDeleteWhere).toHaveBeenCalledWith({ col: 'id', val: 'existing-acc' })
       expect(warnSpy).toHaveBeenCalledWith('Failed to delete connection from provider:', expect.any(Error))

--- a/src/api/routes/connected-accounts.ts
+++ b/src/api/routes/connected-accounts.ts
@@ -17,6 +17,11 @@ import { Authenticated, OwnsAccount, IsAdmin, Or } from '../middleware/auth'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 import { countActiveTriggersPerAccount, cancelTriggersForConnectedAccount } from '@shared/lib/services/webhook-trigger-service'
+import {
+  findAgentsAssignedConnectedAccount,
+  syncAgentsAssignedConnectedAccount,
+  syncConnectedAccountAgents,
+} from '@shared/lib/container/connection-runtime-sync'
 
 const connectedAccountsRouter = new Hono()
 
@@ -295,8 +300,13 @@ connectedAccountsRouter.post('/complete', async (c) => {
       logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: id, action: 'connected', details: { toolkitSlug } })
     }
 
+    const liveRefresh = reconnectAccountId
+      ? await syncAgentsAssignedConnectedAccount(id)
+      : true
+
     return c.json({
       success: true,
+      liveRefresh,
       account: {
         id,
         providerConnectionId: connectionId,
@@ -420,6 +430,10 @@ connectedAccountsRouter.get('/callback', async (c) => {
       logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: id, action: 'connected', details: { toolkitSlug } })
     }
 
+    if (reconnectAccountId) {
+      await syncAgentsAssignedConnectedAccount(id)
+    }
+
     return c.html(
       generateCallbackHtml({
         success: true,
@@ -521,8 +535,10 @@ connectedAccountsRouter.patch('/:id', Or(OwnsAccount(), IsAdmin()), async (c) =>
       .where(eq(connectedAccounts.id, id))
       .limit(1)
 
+    const liveRefresh = await syncAgentsAssignedConnectedAccount(id)
     return c.json({
       account: { ...updated, provider: getProvider(updated.toolkitSlug) },
+      liveRefresh,
     })
   } catch (error) {
     console.error('Failed to update connected account:', error)
@@ -558,11 +574,22 @@ connectedAccountsRouter.delete('/:id', Or(OwnsAccount(), IsAdmin()), async (c) =
       console.warn('Failed to delete connection from provider:', error)
     }
 
+    let assignedAgentSlugs: string[] | null = null
+    try {
+      assignedAgentSlugs = await findAgentsAssignedConnectedAccount(id)
+    } catch (error) {
+      console.warn(`Failed to resolve agents assigned account ${id} before delete:`, error)
+    }
     await db.delete(connectedAccounts).where(eq(connectedAccounts.id, id))
+    const liveRefresh = assignedAgentSlugs
+      ? await syncConnectedAccountAgents(assignedAgentSlugs)
+      : false
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: id, action: 'disconnected', details: { toolkitSlug: existing.toolkitSlug } })
 
-    return c.body(null, 204)
+    return c.body(null, 204, {
+      'X-Superagent-Live-Refresh': String(liveRefresh),
+    })
   } catch (error) {
     console.error('Failed to delete connected account:', error)
     return c.json({ error: 'Failed to delete connected account' }, 500)

--- a/src/api/routes/connected-accounts.ts
+++ b/src/api/routes/connected-accounts.ts
@@ -587,9 +587,7 @@ connectedAccountsRouter.delete('/:id', Or(OwnsAccount(), IsAdmin()), async (c) =
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: id, action: 'disconnected', details: { toolkitSlug: existing.toolkitSlug } })
 
-    return c.body(null, 204, {
-      'X-Superagent-Live-Refresh': String(liveRefresh),
-    })
+    return c.json({ success: true, liveRefresh })
   } catch (error) {
     console.error('Failed to delete connected account:', error)
     return c.json({ error: 'Failed to delete connected account' }, 500)

--- a/src/api/routes/connected-accounts.ts
+++ b/src/api/routes/connected-accounts.ts
@@ -300,9 +300,7 @@ connectedAccountsRouter.post('/complete', async (c) => {
       logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: id, action: 'connected', details: { toolkitSlug } })
     }
 
-    const liveRefresh = reconnectAccountId
-      ? await syncAgentsAssignedConnectedAccount(id)
-      : true
+    const liveRefresh = await syncAgentsAssignedConnectedAccount(id)
 
     return c.json({
       success: true,
@@ -430,9 +428,9 @@ connectedAccountsRouter.get('/callback', async (c) => {
       logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: id, action: 'connected', details: { toolkitSlug } })
     }
 
-    if (reconnectAccountId) {
-      await syncAgentsAssignedConnectedAccount(id)
-    }
+    // This HTML callback has no renderer response channel for a refresh
+    // warning. The sync remains best-effort and logs failures server-side.
+    await syncAgentsAssignedConnectedAccount(id)
 
     return c.html(
       generateCallbackHtml({

--- a/src/api/routes/provide-remote-mcp.test.ts
+++ b/src/api/routes/provide-remote-mcp.test.ts
@@ -451,3 +451,95 @@ describe('provide-remote-mcp handler', () => {
     expect(mockContainerFetch).not.toHaveBeenCalled()
   })
 })
+
+describe('Agent Settings remote MCP live sync', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockGetHostApiBaseUrl.mockResolvedValue('http://10.20.107.8:3000')
+  })
+
+  it('updates REMOTE_MCPS in a running container after assignment', async () => {
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined)
+    mockInsertValues.mockReturnValueOnce({ onConflictDoNothing })
+
+    // Existing assignments lookup → none.
+    mockSelectFrom.mockReturnValueOnce({
+      where: vi.fn().mockResolvedValue([]),
+    })
+    // Runtime projection after insert.
+    mockSelectFrom.mockReturnValueOnce({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            mcp: {
+              id: 'mcp-1',
+              name: 'Calendar',
+              status: 'active',
+              toolsJson: JSON.stringify([{ name: 'list_events' }]),
+            },
+          },
+        ]),
+      }),
+    })
+    mockContainerFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => '',
+    })
+
+    const res = await app.request('http://localhost/api/agents/test-agent/remote-mcps', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mcpIds: ['mcp-1'] }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(onConflictDoNothing).toHaveBeenCalledOnce()
+    const envCall = mockContainerFetch.mock.calls.find(([path]) => path === '/env')
+    expect(envCall).toBeDefined()
+    const envBody = JSON.parse(envCall![1].body as string)
+    const configs = JSON.parse(envBody.value)
+    expect(configs).toEqual([
+      {
+        id: 'mcp-1',
+        name: 'Calendar',
+        proxyUrl: 'http://10.20.107.8:3000/api/mcp-proxy/test-agent/mcp-1',
+        tools: [{ name: 'list_events' }],
+      },
+    ])
+  })
+
+  it('updates REMOTE_MCPS in a running container after removal', async () => {
+    // Mapping ownership lookup.
+    mockSelectFrom.mockReturnValueOnce({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'mapping-1' }]),
+        }),
+      }),
+    })
+    // Runtime projection after delete → empty.
+    mockSelectFrom.mockReturnValueOnce({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    })
+    mockContainerFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => '',
+    })
+
+    const res = await app.request(
+      'http://localhost/api/agents/test-agent/remote-mcps/mcp-1',
+      { method: 'DELETE' },
+    )
+
+    expect(res.status).toBe(204)
+    const envCall = mockContainerFetch.mock.calls.find(([path]) => path === '/env')
+    expect(envCall).toBeDefined()
+    const envBody = JSON.parse(envCall![1].body as string)
+    expect(JSON.parse(envBody.value)).toEqual([])
+  })
+})

--- a/src/api/routes/provide-remote-mcp.test.ts
+++ b/src/api/routes/provide-remote-mcp.test.ts
@@ -536,7 +536,8 @@ describe('Agent Settings remote MCP live sync', () => {
       { method: 'DELETE' },
     )
 
-    expect(res.status).toBe(204)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, liveRefresh: true })
     const envCall = mockContainerFetch.mock.calls.find(([path]) => path === '/env')
     expect(envCall).toBeDefined()
     const envBody = JSON.parse(envCall![1].body as string)

--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -44,6 +44,9 @@ const mockInitiateNewServerOAuth = vi.fn()
 const mockCompleteOAuthFlow = vi.fn()
 const mockDiscoverOAuthMetadata = vi.fn()
 const mockValidateAndConsumeOAuthErrorResponse = vi.fn()
+const mockFindAgentsAssignedRemoteMcp = vi.fn().mockResolvedValue(['agent-a'])
+const mockSyncAgentsAssignedRemoteMcp = vi.fn().mockResolvedValue(true)
+const mockSyncRemoteMcpAgents = vi.fn().mockResolvedValue(true)
 
 vi.mock('@shared/lib/mcp/oauth', () => ({
   McpOAuthSetupError: class McpOAuthSetupError extends Error {},
@@ -53,6 +56,15 @@ vi.mock('@shared/lib/mcp/oauth', () => ({
   validateAndConsumeOAuthErrorResponse: (...args: unknown[]) =>
     mockValidateAndConsumeOAuthErrorResponse(...args),
   discoverOAuthMetadata: (...args: unknown[]) => mockDiscoverOAuthMetadata(...args),
+}))
+
+vi.mock('@shared/lib/container/connection-runtime-sync', () => ({
+  findAgentsAssignedRemoteMcp: (...args: unknown[]) =>
+    mockFindAgentsAssignedRemoteMcp(...args),
+  syncAgentsAssignedRemoteMcp: (...args: unknown[]) =>
+    mockSyncAgentsAssignedRemoteMcp(...args),
+  syncRemoteMcpAgents: (...args: unknown[]) =>
+    mockSyncRemoteMcpAgents(...args),
 }))
 
 // Mock DB with chainable query builder
@@ -1089,7 +1101,44 @@ describe('SSRF protection', () => {
       })
 
       expect(res.status).toBe(200)
+      expect(await res.json()).toMatchObject({ liveRefresh: true })
+      expect(mockSyncAgentsAssignedRemoteMcp).toHaveBeenCalledWith('mcp-1')
     })
+  })
+})
+
+describe('remote MCP runtime propagation', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockDeleteWhere.mockResolvedValue(undefined)
+  })
+
+  it('refreshes previously assigned agents after deleting the MCP row', async () => {
+    mockDbFrom.mockReturnValue({ where: mockWhere })
+    mockWhere.mockReturnValue({ limit: mockLimit })
+    mockLimit.mockResolvedValue([
+      {
+        id: 'mcp-1',
+        name: 'Calendar',
+        url: 'https://mcp.example.com',
+      },
+    ])
+
+    const res = await app.request('http://localhost/api/remote-mcps/mcp-1', {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, liveRefresh: true })
+    expect(mockFindAgentsAssignedRemoteMcp).toHaveBeenCalledWith('mcp-1')
+    expect(mockDeleteWhere).toHaveBeenCalled()
+    expect(mockSyncRemoteMcpAgents).toHaveBeenCalledWith(['agent-a'])
+    expect(
+      mockDeleteWhere.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockSyncRemoteMcpAgents.mock.invocationCallOrder[0])
   })
 })
 
@@ -1257,6 +1306,8 @@ describe('OAuth callback — postMessage origin', () => {
     const html = await res.text()
     expect(html).toContain('window.location.origin')
     expect(html).not.toContain("'*'")
+    expect(mockFindAgentsAssignedRemoteMcp).toHaveBeenCalledWith('mcp-new')
+    expect(mockSyncRemoteMcpAgents).toHaveBeenCalledWith(['agent-a'])
   })
 
   it('emits callback fallbacks for web popups whose opener was severed', async () => {

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -426,6 +426,8 @@ remoteMcps.get('/oauth-callback', async (c) => {
         })
         .where(eq(remoteMcpServers.id, result.mcpId))
     }
+    // This HTML callback has no renderer response channel for a refresh
+    // warning. The sync remains best-effort and logs failures server-side.
     if (assignedAgentSlugs) await syncRemoteMcpAgents(assignedAgentSlugs)
   } catch (err: any) {
     // Tool discovery failed — delete the server so we don't leave a broken entry

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -20,6 +20,11 @@ import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 import { mcpSafeFetch } from '@shared/lib/mcp/mcp-safe-fetch'
 import { validateMcpDiscoveryUrl } from '@shared/lib/utils/url-safety'
 import { discoverTools } from '@shared/lib/mcp/discover-tools'
+import {
+  findAgentsAssignedRemoteMcp,
+  syncAgentsAssignedRemoteMcp,
+  syncRemoteMcpAgents,
+} from '@shared/lib/container/connection-runtime-sync'
 
 function safeParseTools(json: string | null): McpToolInfo[] {
   if (!json) return []
@@ -396,6 +401,12 @@ remoteMcps.get('/oauth-callback', async (c) => {
 
   // Discover tools to verify the connection works
   let serverUrl: string | undefined
+  let assignedAgentSlugs: string[] | null = null
+  try {
+    assignedAgentSlugs = await findAgentsAssignedRemoteMcp(result.mcpId)
+  } catch (error) {
+    console.warn('Failed to resolve agents assigned to OAuth MCP:', error)
+  }
   try {
     const [server] = await db
       .select()
@@ -415,9 +426,11 @@ remoteMcps.get('/oauth-callback', async (c) => {
         })
         .where(eq(remoteMcpServers.id, result.mcpId))
     }
+    if (assignedAgentSlugs) await syncRemoteMcpAgents(assignedAgentSlugs)
   } catch (err: any) {
     // Tool discovery failed — delete the server so we don't leave a broken entry
     await db.delete(remoteMcpServers).where(eq(remoteMcpServers.id, result.mcpId))
+    if (assignedAgentSlugs) await syncRemoteMcpAgents(assignedAgentSlugs)
     const errorMsg = err.message || 'Tool discovery failed'
     return c.html(mcpOAuthCallbackBody(
       {
@@ -519,9 +532,11 @@ remoteMcps.patch('/:id', Or(UsersMcpServer(), IsAdmin()), async (c) => {
     .limit(1)
 
   logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: id, action: 'updated' })
+  const liveRefresh = await syncAgentsAssignedRemoteMcp(id)
 
   return c.json({
     server: sanitizeServer(updated),
+    liveRefresh,
   })
 })
 
@@ -539,11 +554,20 @@ remoteMcps.delete('/:id', Or(UsersMcpServer(), IsAdmin()), async (c) => {
     return c.json({ error: 'MCP server not found' }, 404)
   }
 
+  let assignedAgentSlugs: string[] | null = null
+  try {
+    assignedAgentSlugs = await findAgentsAssignedRemoteMcp(id)
+  } catch (error) {
+    console.warn(`Failed to resolve agents assigned MCP ${id} before delete:`, error)
+  }
   await db.delete(remoteMcpServers).where(eq(remoteMcpServers.id, id))
+  const liveRefresh = assignedAgentSlugs
+    ? await syncRemoteMcpAgents(assignedAgentSlugs)
+    : false
 
   logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: id, action: 'deleted', details: { name: existing.name } })
 
-  return c.json({ success: true })
+  return c.json({ success: true, liveRefresh })
 })
 
 // Discover tools from an MCP server
@@ -575,7 +599,8 @@ remoteMcps.post('/:id/discover-tools', Or(UsersMcpServer(), IsAdmin()), async (c
       })
       .where(eq(remoteMcpServers.id, id))
 
-    return c.json({ tools })
+    const liveRefresh = await syncAgentsAssignedRemoteMcp(id)
+    return c.json({ tools, liveRefresh })
   } catch (error: any) {
     const errorMessage = error.message || 'Tool discovery failed'
     await db
@@ -587,7 +612,8 @@ remoteMcps.post('/:id/discover-tools', Or(UsersMcpServer(), IsAdmin()), async (c
       })
       .where(eq(remoteMcpServers.id, id))
 
-    return c.json({ error: errorMessage }, 502)
+    const liveRefresh = await syncAgentsAssignedRemoteMcp(id)
+    return c.json({ error: errorMessage, liveRefresh }, 502)
   }
 })
 
@@ -636,7 +662,13 @@ remoteMcps.post('/:id/test-connection', Or(UsersMcpServer(), IsAdmin()), async (
         .update(remoteMcpServers)
         .set({ status: 'auth_required', errorMessage: 'Authentication required', updatedAt: new Date() })
         .where(eq(remoteMcpServers.id, id))
-      return c.json({ success: false, error: 'Authentication required', needsAuth: true })
+      const liveRefresh = await syncAgentsAssignedRemoteMcp(id)
+      return c.json({
+        success: false,
+        error: 'Authentication required',
+        needsAuth: true,
+        liveRefresh,
+      })
     }
 
     if (!res.ok) {
@@ -648,14 +680,16 @@ remoteMcps.post('/:id/test-connection', Or(UsersMcpServer(), IsAdmin()), async (
       .set({ status: 'active', errorMessage: null, updatedAt: new Date() })
       .where(eq(remoteMcpServers.id, id))
 
-    return c.json({ success: true })
+    const liveRefresh = await syncAgentsAssignedRemoteMcp(id)
+    return c.json({ success: true, liveRefresh })
   } catch (error: any) {
     const errorMessage = error.message || 'Connection test failed'
     await db
       .update(remoteMcpServers)
       .set({ status: 'error', errorMessage, updatedAt: new Date() })
       .where(eq(remoteMcpServers.id, id))
-    return c.json({ success: false, error: errorMessage })
+    const liveRefresh = await syncAgentsAssignedRemoteMcp(id)
+    return c.json({ success: false, error: errorMessage, liveRefresh })
   }
 })
 

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -658,6 +658,10 @@ describe('SUP-199: remote MCP assignment ownership (AUTH_MODE)', () => {
     })
 
     expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({
+      success: true,
+      liveRefresh: false,
+    })
     expect(mockDbInsertValues).toHaveBeenCalledTimes(1)
     expect(mockDbInsertValues).toHaveBeenCalledWith([
       expect.objectContaining({ agentSlug: 'my-agent', remoteMcpId: 'my-mcp-id' }),
@@ -737,6 +741,7 @@ describe('unlink ownership: cross-user account/MCP unlink from a shared agent (A
       method: 'DELETE',
     })
     expect(res.status).toBe(204)
+    expect(res.headers.get('X-Superagent-Live-Refresh')).toBe('false')
     expect(mockDbDeleteWhere).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -722,7 +722,8 @@ describe('unlink ownership: cross-user account/MCP unlink from a shared agent (A
     const res = await appWithAgents().request('http://localhost/api/agents/my-agent/connected-accounts/my-account-id', {
       method: 'DELETE',
     })
-    expect(res.status).toBe(204)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, liveRefresh: false })
     expect(mockDbDeleteWhere).toHaveBeenCalledTimes(1)
   })
 
@@ -740,8 +741,8 @@ describe('unlink ownership: cross-user account/MCP unlink from a shared agent (A
     const res = await appWithAgents().request('http://localhost/api/agents/my-agent/remote-mcps/my-mcp-id', {
       method: 'DELETE',
     })
-    expect(res.status).toBe(204)
-    expect(res.headers.get('X-Superagent-Live-Refresh')).toBe('false')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, liveRefresh: false })
     expect(mockDbDeleteWhere).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/components/home/graph/graph-connections.test.ts
+++ b/src/renderer/components/home/graph/graph-connections.test.ts
@@ -15,12 +15,10 @@ function response(
   body: unknown,
   ok = true,
   status = 200,
-  headers: Record<string, string> = {},
 ): Response {
   return {
     ok,
     status,
-    headers: new Headers(headers),
     json: async () => body,
   } as Response
 }
@@ -80,9 +78,7 @@ describe('deleteGraphConnection — resource edges', () => {
 
   it('keeps the saved unlink and warns when the live refresh fails', async () => {
     apiFetchMock.mockResolvedValueOnce(
-      response(null, true, 204, {
-        'X-Superagent-Live-Refresh': 'false',
-      }),
+      response({ success: true, liveRefresh: false }),
     )
 
     const changed = await deleteGraphConnection({

--- a/src/renderer/components/home/graph/graph-connections.test.ts
+++ b/src/renderer/components/home/graph/graph-connections.test.ts
@@ -4,15 +4,25 @@ import type { GraphEdgeSpec } from './use-graph-data'
 
 vi.mock('@renderer/lib/api', () => ({ apiFetch: vi.fn() }))
 vi.mock('sonner', () => ({
-  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
 }))
 
 const { apiFetch } = await import('@renderer/lib/api')
 const { toast } = await import('sonner')
 const apiFetchMock = vi.mocked(apiFetch)
 
-function response(body: unknown, ok = true, status = 200): Response {
-  return { ok, status, json: async () => body } as Response
+function response(
+  body: unknown,
+  ok = true,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  return {
+    ok,
+    status,
+    headers: new Headers(headers),
+    json: async () => body,
+  } as Response
 }
 
 const permissionEdge = (a: string, b: string, policyCallers: string[]): GraphEdgeSpec => ({
@@ -66,6 +76,27 @@ describe('deleteGraphConnection — resource edges', () => {
     expect(apiFetchMock).toHaveBeenCalledWith('/api/agents/a/remote-mcps/m', { method: 'DELETE' })
     expect(toast.error).toHaveBeenCalled()
     expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('keeps the saved unlink and warns when the live refresh fails', async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      response(null, true, 204, {
+        'X-Superagent-Live-Refresh': 'false',
+      }),
+    )
+
+    const changed = await deleteGraphConnection({
+      id: 'agent:a->mcp:m',
+      source: 'agent:a',
+      target: 'mcp:m',
+      variant: 'resource',
+    })
+
+    expect(changed).toBe(true)
+    expect(toast.warning).toHaveBeenCalledWith(
+      expect.stringContaining('need a restart'),
+    )
+    expect(toast.error).not.toHaveBeenCalled()
   })
 })
 
@@ -163,6 +194,18 @@ describe('createDrawnConnection', () => {
     const [url, init] = apiFetchMock.mock.calls[0]
     expect(url).toBe('/api/agents/a/remote-mcps')
     expect(JSON.parse(init?.body as string)).toEqual({ mcpIds: ['m'] })
+  })
+
+  it('keeps the saved link and warns when the live refresh fails', async () => {
+    apiFetchMock.mockResolvedValueOnce(response({ liveRefresh: false }))
+
+    const changed = await createDrawnConnection('agent:a', 'account:acc')
+
+    expect(changed).toBe(true)
+    expect(toast.warning).toHaveBeenCalledWith(
+      expect.stringContaining('need a restart'),
+    )
+    expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('refuses undrawable pairs without a request', async () => {

--- a/src/renderer/components/home/graph/graph-connections.test.ts
+++ b/src/renderer/components/home/graph/graph-connections.test.ts
@@ -90,7 +90,7 @@ describe('deleteGraphConnection — resource edges', () => {
 
     expect(changed).toBe(true)
     expect(toast.warning).toHaveBeenCalledWith(
-      expect.stringContaining('need a restart'),
+      'One or more running agents need a restart to apply the latest connection state.',
     )
     expect(toast.error).not.toHaveBeenCalled()
   })
@@ -199,7 +199,7 @@ describe('createDrawnConnection', () => {
 
     expect(changed).toBe(true)
     expect(toast.warning).toHaveBeenCalledWith(
-      expect.stringContaining('need a restart'),
+      'One or more running agents need a restart to apply the latest connection state.',
     )
     expect(toast.error).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/home/graph/graph-connections.ts
+++ b/src/renderer/components/home/graph/graph-connections.ts
@@ -10,6 +10,7 @@
 
 import { toast } from 'sonner'
 import { apiFetch } from '@renderer/lib/api'
+import { warnIfLiveRefreshFailed } from '@renderer/lib/connection-live-refresh'
 import type { GraphEdgeSpec } from './use-graph-data'
 
 export function nodeKind(nodeId: string): string {
@@ -29,19 +30,6 @@ export function drawnConnectionKind(source: string, target: string): 'invoke' | 
 }
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' }
-
-function warnIfLiveRefreshFailed(result: unknown): void {
-  if (
-    typeof result === 'object' &&
-    result !== null &&
-    'liveRefresh' in result &&
-    result.liveRefresh === false
-  ) {
-    toast.warning(
-      'Connection saved, but one or more running agents need a restart to refresh it.',
-    )
-  }
-}
 
 /**
  * Remove the relationship behind an edge; true = something changed.

--- a/src/renderer/components/home/graph/graph-connections.ts
+++ b/src/renderer/components/home/graph/graph-connections.ts
@@ -43,12 +43,6 @@ function warnIfLiveRefreshFailed(result: unknown): void {
   }
 }
 
-function warnIfLiveRefreshHeaderFailed(response: Response): void {
-  if (response.headers?.get('X-Superagent-Live-Refresh') === 'false') {
-    warnIfLiveRefreshFailed({ liveRefresh: false })
-  }
-}
-
 /**
  * Remove the relationship behind an edge; true = something changed.
  * Resource edges unlink the account/MCP; agent↔agent edges revoke invoke
@@ -68,7 +62,6 @@ export async function deleteGraphConnection(edge: GraphEdgeSpec): Promise<boolea
         { method: 'DELETE' },
       )
       if (!res.ok) throw new Error(`Failed to unlink (${res.status})`)
-      warnIfLiveRefreshHeaderFailed(res)
       warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
       toast.success(resourceKind === 'account' ? 'Account unlinked' : 'MCP server unlinked')
       return true

--- a/src/renderer/components/home/graph/graph-connections.ts
+++ b/src/renderer/components/home/graph/graph-connections.ts
@@ -30,6 +30,25 @@ export function drawnConnectionKind(source: string, target: string): 'invoke' | 
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' }
 
+function warnIfLiveRefreshFailed(result: unknown): void {
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    'liveRefresh' in result &&
+    result.liveRefresh === false
+  ) {
+    toast.warning(
+      'Connection saved, but one or more running agents need a restart to refresh it.',
+    )
+  }
+}
+
+function warnIfLiveRefreshHeaderFailed(response: Response): void {
+  if (response.headers?.get('X-Superagent-Live-Refresh') === 'false') {
+    warnIfLiveRefreshFailed({ liveRefresh: false })
+  }
+}
+
 /**
  * Remove the relationship behind an edge; true = something changed.
  * Resource edges unlink the account/MCP; agent↔agent edges revoke invoke
@@ -49,6 +68,8 @@ export async function deleteGraphConnection(edge: GraphEdgeSpec): Promise<boolea
         { method: 'DELETE' },
       )
       if (!res.ok) throw new Error(`Failed to unlink (${res.status})`)
+      warnIfLiveRefreshHeaderFailed(res)
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
       toast.success(resourceKind === 'account' ? 'Account unlinked' : 'MCP server unlinked')
       return true
     }
@@ -134,6 +155,7 @@ export async function createDrawnConnection(source: string, target: string): Pro
             body: JSON.stringify({ mcpIds: [resourceId] }),
           })
     if (!res.ok) throw new Error(`Failed to link (${res.status})`)
+    warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     toast.success(kind === 'account' ? 'Account linked to agent' : 'MCP server linked to agent')
     return true
   } catch (error) {

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -2,6 +2,7 @@ import { apiFetch } from '@renderer/lib/api'
 
 import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import type { Provider } from '@shared/lib/account-providers/service-catalog'
 import type {
@@ -22,6 +23,25 @@ export interface ConnectedAccount {
 }
 
 export type AgentConnectedAccount = PublicAgentConnectedAccount
+
+function warnIfLiveRefreshFailed(result: unknown): void {
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    'liveRefresh' in result &&
+    result.liveRefresh === false
+  ) {
+    toast.warning(
+      'Connection saved, but one or more running agents need a restart to refresh it.',
+    )
+  }
+}
+
+function warnIfLiveRefreshHeaderFailed(response: Response): void {
+  if (response.headers?.get('X-Superagent-Live-Refresh') === 'false') {
+    warnIfLiveRefreshFailed({ liveRefresh: false })
+  }
+}
 
 interface ConnectedAccountsResponse {
   accounts: ConnectedAccount[]
@@ -121,6 +141,8 @@ export function useDeleteConnectedAccount() {
         const error = await res.json().catch(() => ({}))
         throw new Error(error.error || 'Failed to delete account')
       }
+      warnIfLiveRefreshHeaderFailed(res)
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, accountId) => {
       queryClient.invalidateQueries({ queryKey: ['connected-accounts'] })
@@ -152,6 +174,7 @@ export function useRenameConnectedAccount() {
       }
 
       const data = await res.json()
+      warnIfLiveRefreshFailed(data)
       return data.account
     },
     onSuccess: () => {
@@ -179,6 +202,7 @@ export function useAssignAccountsToAgent() {
         const error = await res.json().catch(() => ({}))
         throw new Error(error.error || 'Failed to assign accounts to agent')
       }
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, { accountIds }) => {
       // Bare prefix (not keyed on agentSlug): the agent-home Connections card keys
@@ -206,6 +230,8 @@ export function useRemoveAgentConnectedAccount() {
         method: 'DELETE',
       })
       if (!res.ok) throw new Error('Failed to remove account from agent')
+      warnIfLiveRefreshHeaderFailed(res)
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, { accountId }) => {
       // Bare prefix — see useAssignAccountsToAgent: reaches the id-keyed home card too.

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -1,8 +1,8 @@
 import { apiFetch } from '@renderer/lib/api'
+import { warnIfLiveRefreshFailed } from '@renderer/lib/connection-live-refresh'
 
 import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import type { Provider } from '@shared/lib/account-providers/service-catalog'
 import type {
@@ -23,19 +23,6 @@ export interface ConnectedAccount {
 }
 
 export type AgentConnectedAccount = PublicAgentConnectedAccount
-
-function warnIfLiveRefreshFailed(result: unknown): void {
-  if (
-    typeof result === 'object' &&
-    result !== null &&
-    'liveRefresh' in result &&
-    result.liveRefresh === false
-  ) {
-    toast.warning(
-      'Connection saved, but one or more running agents need a restart to refresh it.',
-    )
-  }
-}
 
 interface ConnectedAccountsResponse {
   accounts: ConnectedAccount[]

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -37,12 +37,6 @@ function warnIfLiveRefreshFailed(result: unknown): void {
   }
 }
 
-function warnIfLiveRefreshHeaderFailed(response: Response): void {
-  if (response.headers?.get('X-Superagent-Live-Refresh') === 'false') {
-    warnIfLiveRefreshFailed({ liveRefresh: false })
-  }
-}
-
 interface ConnectedAccountsResponse {
   accounts: ConnectedAccount[]
 }
@@ -141,7 +135,6 @@ export function useDeleteConnectedAccount() {
         const error = await res.json().catch(() => ({}))
         throw new Error(error.error || 'Failed to delete account')
       }
-      warnIfLiveRefreshHeaderFailed(res)
       warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, accountId) => {
@@ -230,7 +223,6 @@ export function useRemoveAgentConnectedAccount() {
         method: 'DELETE',
       })
       if (!res.ok) throw new Error('Failed to remove account from agent')
-      warnIfLiveRefreshHeaderFailed(res)
       warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, { accountId }) => {

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -2,6 +2,7 @@ import { apiFetch } from '@renderer/lib/api'
 
 import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import type {
   AgentRemoteMcpDto,
   PublicAgentRemoteMcp,
@@ -21,6 +22,25 @@ export interface RemoteMcpServer {
 }
 
 export type AgentRemoteMcp = PublicAgentRemoteMcp
+
+function warnIfLiveRefreshFailed(result: unknown): void {
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    'liveRefresh' in result &&
+    result.liveRefresh === false
+  ) {
+    toast.warning(
+      'Connection saved, but one or more running agents need a restart to refresh it.',
+    )
+  }
+}
+
+function warnIfLiveRefreshHeaderFailed(response: Response): void {
+  if (response.headers?.get('X-Superagent-Live-Refresh') === 'false') {
+    warnIfLiveRefreshFailed({ liveRefresh: false })
+  }
+}
 
 /**
  * Fetch all registered remote MCP servers
@@ -99,6 +119,7 @@ export function useRenameRemoteMcp() {
         const error = await res.json().catch(() => ({}))
         throw new Error(error.error || 'Failed to rename MCP server')
       }
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
@@ -124,6 +145,8 @@ export function useDeleteRemoteMcp() {
         const error = await res.json()
         throw new Error(error.error || 'Failed to delete MCP server')
       }
+      warnIfLiveRefreshHeaderFailed(res)
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, id) => {
       queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
@@ -152,6 +175,7 @@ export function useAssignMcpToAgent() {
         const error = await res.json()
         throw new Error(error.error || 'Failed to assign MCP to agent')
       }
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, { mcpIds }) => {
       // Bare prefix (not keyed on agentSlug): the agent-home Connections card keys
@@ -181,6 +205,8 @@ export function useRemoveMcpFromAgent() {
         const error = await res.json()
         throw new Error(error.error || 'Failed to remove MCP from agent')
       }
+      warnIfLiveRefreshHeaderFailed(res)
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, { mcpId }) => {
       // Bare prefix — see useAssignMcpToAgent: reaches the id-keyed home card too.
@@ -212,7 +238,7 @@ export function useDiscoverMcpTools() {
   const queryClient = useQueryClient()
 
   return useMutation<
-    { tools: Array<{ name: string; description?: string }> },
+    { tools: Array<{ name: string; description?: string }>; liveRefresh?: boolean },
     Error,
     string
   >({
@@ -225,7 +251,9 @@ export function useDiscoverMcpTools() {
         const error = await res.json()
         throw new Error(error.error || 'Failed to discover tools')
       }
-      return res.json()
+      const result = await res.json()
+      warnIfLiveRefreshFailed(result)
+      return result
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
@@ -240,7 +268,7 @@ export function useDiscoverMcpTools() {
 export function useTestMcpConnection() {
   const queryClient = useQueryClient()
 
-  return useMutation<{ success: boolean; error?: string; needsAuth?: boolean }, Error, string>({
+  return useMutation<{ success: boolean; error?: string; needsAuth?: boolean; liveRefresh?: boolean }, Error, string>({
     meta: { skipGlobalErrorToast: true },
     mutationFn: async (mcpId) => {
       const res = await apiFetch(`/api/remote-mcps/${mcpId}/test-connection`, {
@@ -250,7 +278,9 @@ export function useTestMcpConnection() {
         const error = await res.json()
         throw new Error(error.error || 'Connection test failed')
       }
-      return res.json()
+      const result = await res.json()
+      warnIfLiveRefreshFailed(result)
+      return result
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -1,8 +1,8 @@
 import { apiFetch } from '@renderer/lib/api'
+import { warnIfLiveRefreshFailed } from '@renderer/lib/connection-live-refresh'
 
 import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import type {
   AgentRemoteMcpDto,
   PublicAgentRemoteMcp,
@@ -22,19 +22,6 @@ export interface RemoteMcpServer {
 }
 
 export type AgentRemoteMcp = PublicAgentRemoteMcp
-
-function warnIfLiveRefreshFailed(result: unknown): void {
-  if (
-    typeof result === 'object' &&
-    result !== null &&
-    'liveRefresh' in result &&
-    result.liveRefresh === false
-  ) {
-    toast.warning(
-      'Connection saved, but one or more running agents need a restart to refresh it.',
-    )
-  }
-}
 
 /**
  * Fetch all registered remote MCP servers

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -36,12 +36,6 @@ function warnIfLiveRefreshFailed(result: unknown): void {
   }
 }
 
-function warnIfLiveRefreshHeaderFailed(response: Response): void {
-  if (response.headers?.get('X-Superagent-Live-Refresh') === 'false') {
-    warnIfLiveRefreshFailed({ liveRefresh: false })
-  }
-}
-
 /**
  * Fetch all registered remote MCP servers
  */
@@ -145,7 +139,6 @@ export function useDeleteRemoteMcp() {
         const error = await res.json()
         throw new Error(error.error || 'Failed to delete MCP server')
       }
-      warnIfLiveRefreshHeaderFailed(res)
       warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, id) => {
@@ -205,7 +198,6 @@ export function useRemoveMcpFromAgent() {
         const error = await res.json()
         throw new Error(error.error || 'Failed to remove MCP from agent')
       }
-      warnIfLiveRefreshHeaderFailed(res)
       warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
     },
     onSuccess: (_, { mcpId }) => {

--- a/src/renderer/lib/connection-live-refresh.ts
+++ b/src/renderer/lib/connection-live-refresh.ts
@@ -1,0 +1,14 @@
+import { toast } from 'sonner'
+
+export function warnIfLiveRefreshFailed(result: unknown): void {
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    'liveRefresh' in result &&
+    result.liveRefresh === false
+  ) {
+    toast.warning(
+      'One or more running agents need a restart to apply the latest connection state.',
+    )
+  }
+}

--- a/src/shared/lib/container/connection-runtime-projections.ts
+++ b/src/shared/lib/container/connection-runtime-projections.ts
@@ -1,0 +1,79 @@
+export interface ConnectedAccountProjectionSource {
+  id: string
+  toolkitSlug: string
+  displayName: string
+  status: string
+}
+
+export interface RemoteMcpProjectionSource {
+  id: string
+  name: string
+  status: string
+  toolsJson: string | null
+}
+
+export interface RemoteMcpRuntimeConfig {
+  id: string
+  name: string
+  proxyUrl: string
+  tools: Array<{ name: string }>
+}
+
+function parseToolNames(toolsJson: string | null): Array<{ name: string }> {
+  if (!toolsJson) return []
+  try {
+    const tools = JSON.parse(toolsJson) as unknown
+    if (!Array.isArray(tools)) return []
+    return tools.flatMap((tool) => {
+      if (
+        typeof tool === 'object' &&
+        tool !== null &&
+        'name' in tool &&
+        typeof tool.name === 'string'
+      ) {
+        return [{ name: tool.name }]
+      }
+      return []
+    })
+  } catch {
+    return []
+  }
+}
+
+export function buildConnectedAccountsProjection(
+  accounts: ConnectedAccountProjectionSource[],
+): Record<string, Array<{ name: string; id: string }>> {
+  const metadata: Record<string, Array<{ name: string; id: string }>> = {}
+  const activeAccounts = accounts
+    .filter((account) => account.status === 'active')
+    .sort((a, b) =>
+      a.toolkitSlug.localeCompare(b.toolkitSlug) ||
+      a.id.localeCompare(b.id),
+    )
+
+  for (const account of activeAccounts) {
+    metadata[account.toolkitSlug] ??= []
+    metadata[account.toolkitSlug].push({
+      name: account.displayName,
+      id: account.id,
+    })
+  }
+
+  return metadata
+}
+
+export function buildRemoteMcpProjection(
+  mcps: RemoteMcpProjectionSource[],
+  agentSlug: string,
+  hostApiBaseUrl: string,
+): RemoteMcpRuntimeConfig[] {
+  return mcps
+    .filter((mcp) => mcp.status === 'active')
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((mcp) => ({
+      id: mcp.id,
+      name: mcp.name,
+      proxyUrl: `${hostApiBaseUrl}/api/mcp-proxy/${agentSlug}/${mcp.id}`,
+      tools: parseToolNames(mcp.toolsJson),
+    }))
+}

--- a/src/shared/lib/container/connection-runtime-sync.test.ts
+++ b/src/shared/lib/container/connection-runtime-sync.test.ts
@@ -159,6 +159,17 @@ describe('connection runtime synchronization', () => {
     ).resolves.toBe(false)
   })
 
+  it('reports a rejected env update without throwing', async () => {
+    mockWhere.mockResolvedValue([])
+    mockFetch.mockResolvedValue(
+      new Response('container unavailable', { status: 502 }),
+    )
+
+    await expect(
+      syncAgentConnectionEnvironment('agent-1', 'connected-accounts'),
+    ).resolves.toBe(false)
+  })
+
   it('does not contact a stopped container because startup rebuilds the projection', async () => {
     mockGetCachedInfo.mockReturnValue({ status: 'stopped', port: null })
 

--- a/src/shared/lib/container/connection-runtime-sync.test.ts
+++ b/src/shared/lib/container/connection-runtime-sync.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockWhere = vi.fn()
+const mockFetch = vi.fn()
+const mockGetHostApiBaseUrl = vi.fn()
+const mockGetCachedInfo = vi.fn()
+
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({ where: (...args: unknown[]) => mockWhere(...args) }),
+        where: (...args: unknown[]) => mockWhere(...args),
+      }),
+    }),
+  },
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  connectedAccounts: { id: 'account_id' },
+  agentConnectedAccounts: {
+    agentSlug: 'account_agent_slug',
+    connectedAccountId: 'connected_account_id',
+  },
+  remoteMcpServers: { id: 'mcp_id' },
+  agentRemoteMcps: {
+    agentSlug: 'mcp_agent_slug',
+    remoteMcpId: 'remote_mcp_id',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: (column: string, value: string) => ({ column, value }),
+}))
+
+vi.mock('./container-manager', () => ({
+  containerManager: {
+    getCachedInfo: (...args: unknown[]) => mockGetCachedInfo(...args),
+    getClient: () => ({
+      fetch: (...args: unknown[]) => mockFetch(...args),
+      getHostApiBaseUrl: (...args: unknown[]) => mockGetHostApiBaseUrl(...args),
+    }),
+  },
+}))
+
+import {
+  syncAgentConnectionEnvironment,
+  updateConnectedAccountsEnvironment,
+  updateRemoteMcpEnvironment,
+} from './connection-runtime-sync'
+
+describe('connection runtime synchronization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCachedInfo.mockReturnValue({ status: 'running', port: 8080 })
+    mockGetHostApiBaseUrl.mockResolvedValue('http://10.20.30.40:3000')
+    mockFetch.mockResolvedValue(new Response(null, { status: 200 }))
+  })
+
+  it('writes the active remote MCP projection with stable ordering', async () => {
+    mockWhere.mockResolvedValue([
+      {
+        mcp: {
+          id: 'mcp-z',
+          name: 'Zed',
+          status: 'active',
+          toolsJson: JSON.stringify([{ name: 'search' }, { invalid: true }]),
+        },
+      },
+      {
+        mcp: {
+          id: 'mcp-disabled',
+          name: 'Disabled',
+          status: 'auth_required',
+          toolsJson: null,
+        },
+      },
+      {
+        mcp: {
+          id: 'mcp-a',
+          name: 'Alpha',
+          status: 'active',
+          toolsJson: JSON.stringify([{ name: 'list' }]),
+        },
+      },
+    ])
+
+    await updateRemoteMcpEnvironment('agent-1', {
+      fetch: mockFetch,
+      getHostApiBaseUrl: mockGetHostApiBaseUrl,
+    } as never)
+
+    const [, init] = mockFetch.mock.calls[0]
+    const payload = JSON.parse(init.body as string)
+    expect(payload.key).toBe('REMOTE_MCPS')
+    expect(JSON.parse(payload.value)).toEqual([
+      {
+        id: 'mcp-a',
+        name: 'Alpha',
+        proxyUrl: 'http://10.20.30.40:3000/api/mcp-proxy/agent-1/mcp-a',
+        tools: [{ name: 'list' }],
+      },
+      {
+        id: 'mcp-z',
+        name: 'Zed',
+        proxyUrl: 'http://10.20.30.40:3000/api/mcp-proxy/agent-1/mcp-z',
+        tools: [{ name: 'search' }],
+      },
+    ])
+  })
+
+  it('writes active connected-account metadata grouped by toolkit', async () => {
+    mockWhere.mockResolvedValue([
+      {
+        account: {
+          id: 'slack-1',
+          toolkitSlug: 'slack',
+          displayName: 'Work Slack',
+          status: 'active',
+        },
+      },
+      {
+        account: {
+          id: 'gmail-expired',
+          toolkitSlug: 'gmail',
+          displayName: 'Old Gmail',
+          status: 'expired',
+        },
+      },
+      {
+        account: {
+          id: 'gmail-1',
+          toolkitSlug: 'gmail',
+          displayName: 'Work Gmail',
+          status: 'active',
+        },
+      },
+    ])
+
+    await updateConnectedAccountsEnvironment('agent-1', {
+      fetch: mockFetch,
+      getHostApiBaseUrl: mockGetHostApiBaseUrl,
+    } as never)
+
+    const [, init] = mockFetch.mock.calls[0]
+    const payload = JSON.parse(init.body as string)
+    expect(payload.key).toBe('CONNECTED_ACCOUNTS')
+    expect(JSON.parse(payload.value)).toEqual({
+      gmail: [{ name: 'Work Gmail', id: 'gmail-1' }],
+      slack: [{ name: 'Work Slack', id: 'slack-1' }],
+    })
+  })
+
+  it('reports a live refresh failure without throwing or changing persistence semantics', async () => {
+    mockGetHostApiBaseUrl.mockRejectedValue(new Error('container unavailable'))
+
+    await expect(
+      syncAgentConnectionEnvironment('agent-1', 'remote-mcps'),
+    ).resolves.toBe(false)
+  })
+
+  it('does not contact a stopped container because startup rebuilds the projection', async () => {
+    mockGetCachedInfo.mockReturnValue({ status: 'stopped', port: null })
+
+    await expect(
+      syncAgentConnectionEnvironment('agent-1', 'connected-accounts'),
+    ).resolves.toBe(true)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/container/connection-runtime-sync.ts
+++ b/src/shared/lib/container/connection-runtime-sync.ts
@@ -7,6 +7,10 @@ import {
 } from '@shared/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { containerManager } from './container-manager'
+import {
+  buildConnectedAccountsProjection,
+  buildRemoteMcpProjection,
+} from './connection-runtime-projections'
 
 type RuntimeClient = Pick<
   ReturnType<typeof containerManager.getClient>,
@@ -14,27 +18,6 @@ type RuntimeClient = Pick<
 >
 
 export type ConnectionRuntimeKind = 'connected-accounts' | 'remote-mcps'
-
-function parseToolNames(toolsJson: string | null): Array<{ name: string }> {
-  if (!toolsJson) return []
-  try {
-    const tools = JSON.parse(toolsJson) as unknown
-    if (!Array.isArray(tools)) return []
-    return tools.flatMap((tool) => {
-      if (
-        typeof tool === 'object' &&
-        tool !== null &&
-        'name' in tool &&
-        typeof tool.name === 'string'
-      ) {
-        return [{ name: tool.name }]
-      }
-      return []
-    })
-  } catch {
-    return []
-  }
-}
 
 export async function updateConnectedAccountsEnvironment(
   agentSlug: string,
@@ -49,22 +32,9 @@ export async function updateConnectedAccountsEnvironment(
     )
     .where(eq(agentConnectedAccounts.agentSlug, agentSlug))
 
-  const metadata: Record<string, Array<{ name: string; id: string }>> = {}
-  const activeAccounts = mappings
-    .map(({ account }) => account)
-    .filter((account) => account.status === 'active')
-    .sort((a, b) =>
-      a.toolkitSlug.localeCompare(b.toolkitSlug) ||
-      a.id.localeCompare(b.id),
-    )
-
-  for (const account of activeAccounts) {
-    metadata[account.toolkitSlug] ??= []
-    metadata[account.toolkitSlug].push({
-      name: account.displayName,
-      id: account.id,
-    })
-  }
+  const metadata = buildConnectedAccountsProjection(
+    mappings.map(({ account }) => account),
+  )
 
   return client.fetch('/env', {
     method: 'POST',
@@ -90,16 +60,11 @@ export async function updateRemoteMcpEnvironment(
     )
     .where(eq(agentRemoteMcps.agentSlug, agentSlug))
 
-  const configs = mappings
-    .map(({ mcp }) => mcp)
-    .filter((mcp) => mcp.status === 'active')
-    .sort((a, b) => a.id.localeCompare(b.id))
-    .map((mcp) => ({
-      id: mcp.id,
-      name: mcp.name,
-      proxyUrl: `${hostApiBaseUrl}/api/mcp-proxy/${agentSlug}/${mcp.id}`,
-      tools: parseToolNames(mcp.toolsJson),
-    }))
+  const configs = buildRemoteMcpProjection(
+    mappings.map(({ mcp }) => mcp),
+    agentSlug,
+    hostApiBaseUrl,
+  )
 
   return client.fetch('/env', {
     method: 'POST',

--- a/src/shared/lib/container/connection-runtime-sync.ts
+++ b/src/shared/lib/container/connection-runtime-sync.ts
@@ -1,0 +1,211 @@
+import { db } from '@shared/lib/db'
+import {
+  agentConnectedAccounts,
+  agentRemoteMcps,
+  connectedAccounts,
+  remoteMcpServers,
+} from '@shared/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { containerManager } from './container-manager'
+
+type RuntimeClient = Pick<
+  ReturnType<typeof containerManager.getClient>,
+  'fetch' | 'getHostApiBaseUrl'
+>
+
+export type ConnectionRuntimeKind = 'connected-accounts' | 'remote-mcps'
+
+function parseToolNames(toolsJson: string | null): Array<{ name: string }> {
+  if (!toolsJson) return []
+  try {
+    const tools = JSON.parse(toolsJson) as unknown
+    if (!Array.isArray(tools)) return []
+    return tools.flatMap((tool) => {
+      if (
+        typeof tool === 'object' &&
+        tool !== null &&
+        'name' in tool &&
+        typeof tool.name === 'string'
+      ) {
+        return [{ name: tool.name }]
+      }
+      return []
+    })
+  } catch {
+    return []
+  }
+}
+
+export async function updateConnectedAccountsEnvironment(
+  agentSlug: string,
+  client: RuntimeClient,
+): Promise<Response> {
+  const mappings = await db
+    .select({ account: connectedAccounts })
+    .from(agentConnectedAccounts)
+    .innerJoin(
+      connectedAccounts,
+      eq(agentConnectedAccounts.connectedAccountId, connectedAccounts.id),
+    )
+    .where(eq(agentConnectedAccounts.agentSlug, agentSlug))
+
+  const metadata: Record<string, Array<{ name: string; id: string }>> = {}
+  const activeAccounts = mappings
+    .map(({ account }) => account)
+    .filter((account) => account.status === 'active')
+    .sort((a, b) =>
+      a.toolkitSlug.localeCompare(b.toolkitSlug) ||
+      a.id.localeCompare(b.id),
+    )
+
+  for (const account of activeAccounts) {
+    metadata[account.toolkitSlug] ??= []
+    metadata[account.toolkitSlug].push({
+      name: account.displayName,
+      id: account.id,
+    })
+  }
+
+  return client.fetch('/env', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      key: 'CONNECTED_ACCOUNTS',
+      value: JSON.stringify(metadata),
+    }),
+  })
+}
+
+export async function updateRemoteMcpEnvironment(
+  agentSlug: string,
+  client: RuntimeClient,
+): Promise<Response> {
+  const hostApiBaseUrl = await client.getHostApiBaseUrl()
+  const mappings = await db
+    .select({ mcp: remoteMcpServers })
+    .from(agentRemoteMcps)
+    .innerJoin(
+      remoteMcpServers,
+      eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id),
+    )
+    .where(eq(agentRemoteMcps.agentSlug, agentSlug))
+
+  const configs = mappings
+    .map(({ mcp }) => mcp)
+    .filter((mcp) => mcp.status === 'active')
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((mcp) => ({
+      id: mcp.id,
+      name: mcp.name,
+      proxyUrl: `${hostApiBaseUrl}/api/mcp-proxy/${agentSlug}/${mcp.id}`,
+      tools: parseToolNames(mcp.toolsJson),
+    }))
+
+  return client.fetch('/env', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      key: 'REMOTE_MCPS',
+      value: JSON.stringify(configs),
+    }),
+  })
+}
+
+export async function syncAgentConnectionEnvironment(
+  agentSlug: string,
+  kind: ConnectionRuntimeKind,
+): Promise<boolean> {
+  if (containerManager.getCachedInfo(agentSlug).status !== 'running') {
+    // Container startup rebuilds both projections from the mapping tables.
+    return true
+  }
+
+  try {
+    const client = containerManager.getClient(agentSlug)
+    const response = kind === 'remote-mcps'
+      ? await updateRemoteMcpEnvironment(agentSlug, client)
+      : await updateConnectedAccountsEnvironment(agentSlug, client)
+
+    if (!response.ok) {
+      console.warn(
+        `[ConnectionRuntimeSync] Failed to update ${kind} for ${agentSlug}:`,
+        await response.text(),
+      )
+    }
+    return response.ok
+  } catch (error) {
+    console.warn(
+      `[ConnectionRuntimeSync] Failed to sync ${kind} for ${agentSlug}:`,
+      error,
+    )
+    return false
+  }
+}
+
+async function syncAgents(
+  agentSlugs: string[],
+  kind: ConnectionRuntimeKind,
+): Promise<boolean> {
+  const results = await Promise.all(
+    [...new Set(agentSlugs)].map((slug) =>
+      syncAgentConnectionEnvironment(slug, kind),
+    ),
+  )
+  return results.every(Boolean)
+}
+
+export async function findAgentsAssignedRemoteMcp(mcpId: string): Promise<string[]> {
+  const mappings = await db
+    .select({ agentSlug: agentRemoteMcps.agentSlug })
+    .from(agentRemoteMcps)
+    .where(eq(agentRemoteMcps.remoteMcpId, mcpId))
+  return mappings.map(({ agentSlug }) => agentSlug)
+}
+
+export async function findAgentsAssignedConnectedAccount(
+  accountId: string,
+): Promise<string[]> {
+  const mappings = await db
+    .select({ agentSlug: agentConnectedAccounts.agentSlug })
+    .from(agentConnectedAccounts)
+    .where(eq(agentConnectedAccounts.connectedAccountId, accountId))
+  return mappings.map(({ agentSlug }) => agentSlug)
+}
+
+export async function syncRemoteMcpAgents(agentSlugs: string[]): Promise<boolean> {
+  return syncAgents(agentSlugs, 'remote-mcps')
+}
+
+export async function syncConnectedAccountAgents(
+  agentSlugs: string[],
+): Promise<boolean> {
+  return syncAgents(agentSlugs, 'connected-accounts')
+}
+
+export async function syncAgentsAssignedRemoteMcp(mcpId: string): Promise<boolean> {
+  try {
+    return syncRemoteMcpAgents(await findAgentsAssignedRemoteMcp(mcpId))
+  } catch (error) {
+    console.warn(
+      `[ConnectionRuntimeSync] Failed to resolve agents assigned MCP ${mcpId}:`,
+      error,
+    )
+    return false
+  }
+}
+
+export async function syncAgentsAssignedConnectedAccount(
+  accountId: string,
+): Promise<boolean> {
+  try {
+    return syncConnectedAccountAgents(
+      await findAgentsAssignedConnectedAccount(accountId),
+    )
+  } catch (error) {
+    console.warn(
+      `[ConnectionRuntimeSync] Failed to resolve agents assigned account ${accountId}:`,
+      error,
+    )
+    return false
+  }
+}

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -329,7 +329,12 @@ describe('containerManager.ensureRunning — env var construction', () => {
         { id: 'gmail-a', toolkitSlug: 'gmail', displayName: 'Gmail A', status: 'active', providerConnectionId: 'c1', providerName: 'composio' },
       ],
       [
-        { id: 'mcp-z', name: 'Zed', status: 'active', toolsJson: '[]' },
+        {
+          id: 'mcp-z',
+          name: 'Zed',
+          status: 'active',
+          toolsJson: JSON.stringify([{ name: 'search' }, { invalid: true }]),
+        },
         { id: 'mcp-disabled', name: 'Disabled', status: 'auth_required', toolsJson: null },
         { id: 'mcp-a', name: 'Alpha', status: 'active', toolsJson: '[]' },
       ],
@@ -345,8 +350,10 @@ describe('containerManager.ensureRunning — env var construction', () => {
       ],
       slack: [{ name: 'Slack Z', id: 'slack-z' }],
     })
-    expect(JSON.parse(envVars.REMOTE_MCPS).map((mcp: { id: string }) => mcp.id))
+    const mcpConfigs = JSON.parse(envVars.REMOTE_MCPS)
+    expect(mcpConfigs.map((mcp: { id: string }) => mcp.id))
       .toEqual(['mcp-a', 'mcp-z'])
+    expect(mcpConfigs[1].tools).toEqual([{ name: 'search' }])
   })
 
   it('sets TZ env var from resolveTimezoneForAgent', async () => {

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -211,7 +211,13 @@ describe('containerManager.ensureRunning — env var construction', () => {
       status: string
       providerConnectionId: string
       providerName: string
-    }>
+    }>,
+    mcps: Array<{
+      id: string
+      name: string
+      status: string
+      toolsJson: string | null
+    }> = [],
   ) {
     // First db.select().from() call: connected accounts
     mockDbInnerJoin.mockReturnValue({ where: mockDbWhere })
@@ -221,7 +227,7 @@ describe('containerManager.ensureRunning — env var construction', () => {
 
     // Second db.select().from() call: remote MCPs
     mockMcpInnerJoin.mockReturnValue({ where: mockMcpWhere })
-    mockMcpWhere.mockResolvedValue([])
+    mockMcpWhere.mockResolvedValue(mcps.map((mcp) => ({ mcp })))
   }
 
   it('sets PROXY_BASE_URL with correct format', async () => {
@@ -313,6 +319,34 @@ describe('containerManager.ensureRunning — env var construction', () => {
     expect(metadata.gmail).toHaveLength(1)
     expect(metadata.gmail[0].name).toBe('active@gmail.com')
     expect(metadata.slack).toBeUndefined()
+  })
+
+  it('serializes connection projections in stable id order', async () => {
+    setupAccountMocks(
+      [
+        { id: 'slack-z', toolkitSlug: 'slack', displayName: 'Slack Z', status: 'active', providerConnectionId: 'c3', providerName: 'composio' },
+        { id: 'gmail-z', toolkitSlug: 'gmail', displayName: 'Gmail Z', status: 'active', providerConnectionId: 'c2', providerName: 'composio' },
+        { id: 'gmail-a', toolkitSlug: 'gmail', displayName: 'Gmail A', status: 'active', providerConnectionId: 'c1', providerName: 'composio' },
+      ],
+      [
+        { id: 'mcp-z', name: 'Zed', status: 'active', toolsJson: '[]' },
+        { id: 'mcp-disabled', name: 'Disabled', status: 'auth_required', toolsJson: null },
+        { id: 'mcp-a', name: 'Alpha', status: 'active', toolsJson: '[]' },
+      ],
+    )
+
+    await containerManager.ensureRunning('test-agent')
+
+    const envVars = mockStart.mock.calls[0][0].envVars
+    expect(JSON.parse(envVars.CONNECTED_ACCOUNTS)).toEqual({
+      gmail: [
+        { name: 'Gmail A', id: 'gmail-a' },
+        { name: 'Gmail Z', id: 'gmail-z' },
+      ],
+      slack: [{ name: 'Slack Z', id: 'slack-z' }],
+    })
+    expect(JSON.parse(envVars.REMOTE_MCPS).map((mcp: { id: string }) => mcp.id))
+      .toEqual(['mcp-a', 'mcp-z'])
   })
 
   it('sets TZ env var from resolveTimezoneForAgent', async () => {

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -20,6 +20,10 @@ import { getMountsWithHealth } from '@shared/lib/services/mount-service'
 import { isPlatformComposioActive } from '@shared/lib/composio/client'
 import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
 import { mergeCustomEnvVars } from './reserved-env-vars'
+import {
+  buildConnectedAccountsProjection,
+  buildRemoteMcpProjection,
+} from './connection-runtime-projections'
 
 /** Interval for syncing container status with reality (in ms). Default: 300 seconds */
 const STATUS_SYNC_INTERVAL_MS = parseInt(
@@ -535,23 +539,9 @@ class ContainerManager {
         .where(eq(agentConnectedAccounts.agentSlug, agentId))
 
       // Build account metadata (names + IDs, no tokens)
-      const accountMetadata: Record<string, Array<{ name: string; id: string }>> = {}
-      const activeAccounts = accountMappings
-        .map(({ account }) => account)
-        .filter((account) => account.status === 'active')
-        .sort((a, b) =>
-          a.toolkitSlug.localeCompare(b.toolkitSlug) ||
-          a.id.localeCompare(b.id)
-        )
-      for (const account of activeAccounts) {
-        if (!accountMetadata[account.toolkitSlug]) {
-          accountMetadata[account.toolkitSlug] = []
-        }
-        accountMetadata[account.toolkitSlug].push({
-          name: account.displayName,
-          id: account.id,
-        })
-      }
+      const accountMetadata = buildConnectedAccountsProjection(
+        accountMappings.map(({ account }) => account),
+      )
       envVars['CONNECTED_ACCOUNTS'] = JSON.stringify(accountMetadata)
 
       // Fetch remote MCPs for this agent
@@ -561,23 +551,11 @@ class ContainerManager {
         .innerJoin(remoteMcpServers, eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id))
         .where(eq(agentRemoteMcps.agentSlug, agentId))
 
-      const mcpConfigs = mcpMappings
-        .map(({ mcp }) => mcp)
-        .filter((mcp) => mcp.status === 'active')
-        .sort((a, b) => a.id.localeCompare(b.id))
-        .map((mcp) => {
-          // Only pass tool names (not full schemas) to keep env var size small
-          let toolNames: Array<{ name: string }> = []
-          if (mcp.toolsJson) {
-            try { toolNames = JSON.parse(mcp.toolsJson).map((t: any) => ({ name: t.name })) } catch { /* ignore */ }
-          }
-          return {
-            id: mcp.id,
-            name: mcp.name,
-            proxyUrl: `${hostApiBaseUrl}/api/mcp-proxy/${agentId}/${mcp.id}`,
-            tools: toolNames,
-          }
-        })
+      const mcpConfigs = buildRemoteMcpProjection(
+        mcpMappings.map(({ mcp }) => mcp),
+        agentId,
+        hostApiBaseUrl,
+      )
 
       if (mcpConfigs.length > 0) {
         envVars['REMOTE_MCPS'] = JSON.stringify(mcpConfigs)

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -536,8 +536,14 @@ class ContainerManager {
 
       // Build account metadata (names + IDs, no tokens)
       const accountMetadata: Record<string, Array<{ name: string; id: string }>> = {}
-      for (const { account } of accountMappings) {
-        if (account.status !== 'active') continue
+      const activeAccounts = accountMappings
+        .map(({ account }) => account)
+        .filter((account) => account.status === 'active')
+        .sort((a, b) =>
+          a.toolkitSlug.localeCompare(b.toolkitSlug) ||
+          a.id.localeCompare(b.id)
+        )
+      for (const account of activeAccounts) {
         if (!accountMetadata[account.toolkitSlug]) {
           accountMetadata[account.toolkitSlug] = []
         }
@@ -556,8 +562,10 @@ class ContainerManager {
         .where(eq(agentRemoteMcps.agentSlug, agentId))
 
       const mcpConfigs = mcpMappings
-        .filter(({ mcp }) => mcp.status === 'active')
-        .map(({ mcp }) => {
+        .map(({ mcp }) => mcp)
+        .filter((mcp) => mcp.status === 'active')
+        .sort((a, b) => a.id.localeCompare(b.id))
+        .map((mcp) => {
           // Only pass tool names (not full schemas) to keep env var size small
           let toolNames: Array<{ name: string }> = []
           if (mcp.toolsJson) {
@@ -1176,4 +1184,3 @@ if (process.env.NODE_ENV !== 'production') {
 // Note: Graceful shutdown handlers are registered in the application entry point
 // (src/main/index.ts for Electron, src/web/server.ts for web)
 // This avoids side effects at module import time and allows proper cleanup coordination
-


### PR DESCRIPTION
## Summary

- rebuild both `REMOTE_MCPS` and `CONNECTED_ACCOUNTS` in already-running agent containers when Agent Settings assigns or unlinks a connection
- propagate MCP/account rename and delete operations, MCP OAuth completion, tool discovery, and connection status transitions to every assigned running agent
- treat live container refresh as best-effort after a successful database mutation: APIs preserve their successful 2xx contract and return `liveRefresh: false` in the JSON response instead of reporting a false 502 failure
- keep the saved UI state and show a non-destructive restart hint when a running container could not be refreshed
- recreate the Claude Agent SDK query before the next message whenever either runtime connection projection changes, refreshing MCP tools, allowed patterns, and connection prompt context
- build boot and live connection projections through the same pure, stable-sorted builders

## Root cause

Agent Settings only changed database mappings. Running containers retained their boot-time connection environment, and each Claude Agent SDK query snapshots MCP configuration and the system prompt when it is created. OAuth completion, discovery, rename, and delete paths also changed the source-of-truth rows without updating assigned running agents.

The first implementation additionally returned 502 after a successful mapping write when live refresh failed. That caused the UI to revert its optimistic state even though the database mutation had committed.

## Impact

Existing sessions pick up MCP and connected-account additions, removals, authorization, discovery, rename, and deletion on the next message without a container restart when live refresh succeeds. If refresh is temporarily unavailable, the persisted state remains visible and the UI tells the user that running agents need a restart.

## Review follow-up

- return `200 { success: true, liveRefresh }` from all unlink/account-delete routes so Electron can read the signal without relying on non-exposed CORS response headers
- share pure projection builders between container boot and live sync, including identical malformed-tool filtering and deterministic ordering
- normalize unset and serialized-empty connection projections so an inactive assignment does not cause a semantic no-op query restart
- centralize renderer refresh warnings with neutral copy that also fits discovery and connection tests
- sync account completion unconditionally; HTML OAuth callbacks remain intentionally best-effort because they have no renderer warning channel
- move runtime connection query tests into `claude-code-connections.test.ts` and make SDK iterator mocks honor aborts
- explicitly cover stopped containers, thrown refreshes, rejected `/env` responses, successful writes with `liveRefresh: false`, and empty-projection normalization

## Validation

- `vitest run src/api/routes` — 36 files passed; 950 tests passed, 19 skipped
- full agent-container suite — 48 files passed, 3 skipped; 742 tests passed, 8 skipped
- targeted projection, OAuth, and renderer suite — 5 files and 162 tests passed
- host and agent-container `tsc --noEmit`
- ESLint on all changed TypeScript/TSX files
- `git diff --check`

Linear: SUP-470
