### PR TITLE
Fix stuck Working after lost settle signals (SUP-468)

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -1,6 +1,6 @@
 import { query, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { UUID } from 'crypto';
+import { randomUUID, type UUID } from 'crypto';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -29,6 +29,14 @@ import { fileHooks, resolveToolFilePath } from './file-hooks';
 type QueryWithAsyncCancel = Query & {
   cancelAsyncMessage(messageUuid: string): Promise<boolean>;
 };
+
+function isNewTurnEvidence(message: SDKMessage): boolean {
+  if (message.type !== 'system' || !('subtype' in message)) return false;
+  if (message.subtype === 'session_state_changed') {
+    return 'state' in message && message.state === 'running';
+  }
+  return message.subtype === 'status' && 'status' in message && message.status === 'requesting';
+}
 
 /** Generate prefixed MCP tool names from a tools array, optionally excluding some by name. */
 function mcpToolNames(
@@ -474,6 +482,7 @@ export class ClaudeCodeProcess extends EventEmitter {
   private lastTurnInformationals: SDKMessage[] = [];
   private lastResultMessage: SDKMessage | null = null;
   private lastSessionState: string | null = null;
+  private lastPostResultNewTurnEvidence: SDKMessage | null = null;
   // Latest authoritative background-task snapshot for late-join replay. A
   // reconnecting host that only sees result+idle would otherwise keep a stale
   // local task hold forever (the live consumer self-heals when this arrives).
@@ -951,6 +960,13 @@ export class ClaudeCodeProcess extends EventEmitter {
     // a task id carried across the replacement would pin the session
     // unevictable forever (no terminal signal or snapshot ever comes).
     this.emit('query-start');
+    this.emitTrackedMessage({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [],
+      session_id: this.claudeSessionId || this.sessionId,
+      uuid: randomUUID(),
+    });
   }
 
   async start(): Promise<void> {
@@ -988,6 +1004,10 @@ export class ClaudeCodeProcess extends EventEmitter {
 
     try {
       for await (const message of this.queryInstance) {
+        if (isNewTurnEvidence(message)) {
+          lastResultWasError = false;
+        }
+
         // Capture Claude session ID from init message
         if (message.type === 'system' && message.subtype === 'init' && message.session_id) {
           this.claudeSessionId = message.session_id;
@@ -1385,17 +1405,25 @@ export class ClaudeCodeProcess extends EventEmitter {
 
   /** Record the frames a late-joining WebSocket subscriber must not miss. */
   private trackForLateJoinReplay(message: SDKMessage): void {
-    const msg = message as { type: string; subtype?: string; state?: string };
-    if (msg.type === 'system' && msg.subtype === 'informational') {
+    if (isNewTurnEvidence(message) && this.lastResultMessage) {
+      this.lastPostResultNewTurnEvidence = message;
+      this.lastResultMessage = null;
+      this.lastTurnInformationals = [];
+    }
+    if (message.type === 'system' && message.subtype === 'informational') {
       this.currentTurnInformationals.push(message);
-    } else if (msg.type === 'result') {
+    } else if (message.type === 'result') {
       this.lastResultMessage = message;
       this.lastTurnInformationals = this.currentTurnInformationals;
       this.currentTurnInformationals = [];
-    } else if (msg.type === 'system' && msg.subtype === 'background_tasks_changed') {
+      this.lastPostResultNewTurnEvidence = null;
+    } else if (message.type === 'system' && message.subtype === 'background_tasks_changed') {
       this.lastBackgroundTasksChanged = message;
-    } else if (msg.type === 'system' && msg.subtype === 'session_state_changed') {
-      this.lastSessionState = msg.state ?? null;
+    } else if (message.type === 'system' && message.subtype === 'session_state_changed') {
+      this.lastSessionState = message.state ?? null;
+      if (message.state === 'idle') {
+        this.lastPostResultNewTurnEvidence = null;
+      }
     }
   }
 
@@ -1418,6 +1446,9 @@ export class ClaudeCodeProcess extends EventEmitter {
    * the host can ignore the catch-up when it already saw the live copies.
    */
   getLateJoinReplay(): unknown[] {
+    if (this.lastPostResultNewTurnEvidence) {
+      return [{ ...this.lastPostResultNewTurnEvidence, replayed: true }];
+    }
     if (this.lastSessionState !== 'idle' || !this.lastResultMessage) {
       return [];
     }

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -474,6 +474,10 @@ export class ClaudeCodeProcess extends EventEmitter {
   private lastTurnInformationals: SDKMessage[] = [];
   private lastResultMessage: SDKMessage | null = null;
   private lastSessionState: string | null = null;
+  // Latest authoritative background-task snapshot for late-join replay. A
+  // reconnecting host that only sees result+idle would otherwise keep a stale
+  // local task hold forever (the live consumer self-heals when this arrives).
+  private lastBackgroundTasksChanged: SDKMessage | null = null;
   public slashCommands: { name: string; description: string; argumentHint: string }[] = [];
 
   constructor(options: ClaudeCodeProcessOptions) {
@@ -1043,6 +1047,20 @@ export class ClaudeCodeProcess extends EventEmitter {
 
       if (isAbortError) {
         console.log(`[Session ${this.sessionId}] Query aborted`);
+        // Terminal idle on abort ONLY when this loop is exiting with no
+        // successor query. interrupt() restarts via initializeQuery() unless
+        // stop()/dispose set `stopping` first — emitting idle on a settings-
+        // change interrupt would falsely settle a continuing session. When
+        // stopping, the host usually settles via markSessionInterrupted; the
+        // frame here is for live symmetry and late-join replay.
+        if (this.stopping && generation === this.queryGeneration) {
+          this.emitTrackedMessage({
+            type: 'system',
+            subtype: 'session_state_changed',
+            state: 'idle',
+            session_id: this.claudeSessionId || this.sessionId,
+          } as SDKMessage);
+        }
       } else {
         console.error(`[Session ${this.sessionId}] Query error:`, error);
         // Only emit a synthetic result if the SDK hasn't already reported this
@@ -1062,15 +1080,27 @@ export class ClaudeCodeProcess extends EventEmitter {
             userError = errorMsg || 'An unexpected error occurred';
           }
           // Emit synthetic result so downstream (WebSocket → message-persister → UI)
-          // knows the query failed and can transition to error state
+          // knows the query failed and can transition to error state. Route
+          // through trackForLateJoinReplay so a reconnecting host can recover
+          // the turn end (the live path already settles on isError).
           const isFatal = errorMsg.includes('SIGKILL') || errorMsg.includes('SIGTERM');
-          this.emit('message', {
+          this.emitTrackedMessage({
             type: 'result',
             subtype: 'error',
             error: userError,
             session_id: this.claudeSessionId || this.sessionId,
             ...(isFatal && { fatal: true }),
-          });
+          } as SDKMessage);
+        }
+        // Always announce turn-over after an abnormal exit so replay and live
+        // consumers see a terminal idle (host live path also settles on error).
+        if (generation === this.queryGeneration) {
+          this.emitTrackedMessage({
+            type: 'system',
+            subtype: 'session_state_changed',
+            state: 'idle',
+            session_id: this.claudeSessionId || this.sessionId,
+          } as SDKMessage);
         }
         // Only emit if there are listeners to prevent crash
         if (this.listenerCount('error') > 0) {
@@ -1362,9 +1392,17 @@ export class ClaudeCodeProcess extends EventEmitter {
       this.lastResultMessage = message;
       this.lastTurnInformationals = this.currentTurnInformationals;
       this.currentTurnInformationals = [];
+    } else if (msg.type === 'system' && msg.subtype === 'background_tasks_changed') {
+      this.lastBackgroundTasksChanged = message;
     } else if (msg.type === 'system' && msg.subtype === 'session_state_changed') {
       this.lastSessionState = msg.state ?? null;
     }
+  }
+
+  /** Track then emit — used for synthetic terminal frames outside the SDK loop. */
+  private emitTrackedMessage(message: SDKMessage): void {
+    this.trackForLateJoinReplay(message);
+    this.emit('message', message);
   }
 
   /**
@@ -1386,6 +1424,7 @@ export class ClaudeCodeProcess extends EventEmitter {
     return [
       ...this.lastTurnInformationals,
       this.lastResultMessage,
+      ...(this.lastBackgroundTasksChanged ? [this.lastBackgroundTasksChanged] : []),
       {
         type: 'system',
         subtype: 'session_state_changed',

--- a/agent-container/src/terminal-frames.test.ts
+++ b/agent-container/src/terminal-frames.test.ts
@@ -5,23 +5,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 type Frame = Record<string, unknown>
 
-let queryFactory: () => ReturnType<typeof makeThrowingQuery> = () => makeThrowingQuery()
-
-function makeThrowingQuery() {
-  let step = 0
+function makeQuery(frames: Frame[], terminalError?: Error) {
+  let index = 0
   return {
     [Symbol.asyncIterator]() {
       return this
     },
     next() {
-      step++
-      if (step === 1) {
-        return Promise.resolve({
-          value: { type: 'system', subtype: 'session_state_changed', state: 'running' },
-          done: false,
-        })
+      if (index < frames.length) {
+        return Promise.resolve({ value: frames[index++], done: false })
       }
-      return Promise.reject(new Error('sdk transport exploded'))
+      if (terminalError) return Promise.reject(terminalError)
+      return Promise.resolve({ value: undefined, done: true })
     },
     return() {
       return Promise.resolve({ value: undefined, done: true })
@@ -34,45 +29,46 @@ function makeThrowingQuery() {
   }
 }
 
+function replayFrames(proc: ClaudeCodeProcess): Frame[] {
+  return proc.getLateJoinReplay().filter(
+    (frame): frame is Frame => typeof frame === 'object' && frame !== null
+  )
+}
+
+const running = { type: 'system', subtype: 'session_state_changed', state: 'running' }
+const idle = { type: 'system', subtype: 'session_state_changed', state: 'idle' }
+const successResult = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 10,
+  num_turns: 1,
+  usage: { input_tokens: 0, output_tokens: 0 },
+}
+const errorResult = {
+  type: 'result',
+  subtype: 'error_during_execution',
+  is_error: true,
+  duration_ms: 10,
+  num_turns: 1,
+  usage: { input_tokens: 0, output_tokens: 0 },
+}
+
+let queryFactory: () => ReturnType<typeof makeQuery> = () =>
+  makeQuery([running], new Error('sdk transport exploded'))
+
 function makeTurnWithBackgroundSnapshotQuery() {
-  const frames: Frame[] = [
-    { type: 'system', subtype: 'session_state_changed', state: 'running' },
+  return makeQuery([
+    running,
     {
       type: 'system',
       subtype: 'background_tasks_changed',
       tasks: [{ task_id: 'wf-1' }],
     },
-    {
-      type: 'result',
-      subtype: 'success',
-      is_error: false,
-      duration_ms: 10,
-      num_turns: 1,
-      usage: { input_tokens: 0, output_tokens: 0 },
-    },
+    successResult,
     { type: 'system', subtype: 'background_tasks_changed', tasks: [] },
-    { type: 'system', subtype: 'session_state_changed', state: 'idle' },
-  ]
-  let i = 0
-  return {
-    [Symbol.asyncIterator]() {
-      return this
-    },
-    next() {
-      if (i < frames.length) {
-        return Promise.resolve({ value: frames[i++], done: false })
-      }
-      return Promise.resolve({ value: undefined, done: true })
-    },
-    return() {
-      return Promise.resolve({ value: undefined, done: true })
-    },
-    throw(err?: unknown) {
-      return Promise.reject(err)
-    },
-    interrupt: () => Promise.resolve(),
-    setModel: () => Promise.resolve(),
-  }
+    idle,
+  ])
 }
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
@@ -110,7 +106,7 @@ async function runToAbnormalExit(): Promise<{ frames: Frame[]; proc: ClaudeCodeP
 
 describe('abnormal-exit terminal frames', () => {
   beforeEach(() => {
-    queryFactory = () => makeThrowingQuery()
+    queryFactory = () => makeQuery([running], new Error('sdk transport exploded'))
   })
 
   it('emits a terminal session_state_changed after the synthetic error result', async () => {
@@ -124,11 +120,33 @@ describe('abnormal-exit terminal frames', () => {
 
   it('makes the synthetic error result recoverable via late-join replay', async () => {
     const { proc } = await runToAbnormalExit()
-    const replay = proc.getLateJoinReplay() as Frame[]
+    const replay = replayFrames(proc)
     expect(replay.some((f) => f.type === 'result')).toBe(true)
     expect(
       replay.some((f) => f.type === 'system' && f.subtype === 'session_state_changed' && f.state === 'idle')
     ).toBe(true)
+  })
+
+  it('emits a synthetic result when a new turn throws after the prior turn reported an error', async () => {
+    queryFactory = () =>
+      makeQuery([running, errorResult, running], new Error('second turn transport exploded'))
+    const proc = new ClaudeCodeProcess({ sessionId: 'consecutive-errors', workingDirectory: '/tmp' })
+    const frames: Frame[] = []
+    proc.on('message', (message: Frame) => frames.push(message))
+
+    await proc.start()
+    await vi.waitFor(
+      () => {
+        expect(
+          frames.some((frame) =>
+            frame.type === 'system' && frame.subtype === 'session_state_changed' && frame.state === 'idle'
+          )
+        ).toBe(true)
+      },
+      { timeout: 3000 }
+    )
+
+    expect(frames.filter((frame) => frame.type === 'result')).toHaveLength(2)
   })
 })
 
@@ -148,7 +166,7 @@ describe('late-join replay background task snapshot', () => {
       { timeout: 3000 }
     )
 
-    const replay = proc.getLateJoinReplay() as Frame[]
+    const replay = replayFrames(proc)
     const snapIdx = replay.findIndex((f) => f.type === 'system' && f.subtype === 'background_tasks_changed')
     const idleIdx = replay.findIndex(
       (f) => f.type === 'system' && f.subtype === 'session_state_changed' && f.state === 'idle'
@@ -158,5 +176,51 @@ describe('late-join replay background task snapshot', () => {
     expect(snapIdx).toBeGreaterThan(resultIdx)
     expect(idleIdx).toBeGreaterThan(snapIdx)
     expect((replay[snapIdx].tasks as unknown[]).length).toBe(0)
+  })
+
+  it('clears a dead process background-task snapshot when the query is replaced', async () => {
+    queryFactory = () =>
+      makeQuery([
+        running,
+        { type: 'system', subtype: 'background_tasks_changed', tasks: [{ task_id: 'dead-task' }] },
+        successResult,
+        idle,
+      ])
+    const proc = new ClaudeCodeProcess({ sessionId: 'query-replacement-bg', workingDirectory: '/tmp' })
+    const frames: Frame[] = []
+    proc.on('message', (message: Frame) => frames.push(message))
+    await proc.start()
+    await vi.waitFor(() => expect(proc.isRunning()).toBe(false))
+
+    queryFactory = () => makeQuery([running, successResult, idle])
+    await proc.sendMessage('start the replacement query')
+    await vi.waitFor(() => expect(proc.isRunning()).toBe(false))
+
+    const snapshots = frames.filter(
+      (frame) => frame.type === 'system' && frame.subtype === 'background_tasks_changed'
+    )
+    expect(snapshots.at(-1)?.tasks).toEqual([])
+    const replaySnapshot = replayFrames(proc).find(
+      (frame) => frame.type === 'system' && frame.subtype === 'background_tasks_changed'
+    )
+    expect(replaySnapshot?.tasks).toEqual([])
+  })
+})
+
+describe('late-join replay new-turn evidence', () => {
+  it('replays running when a successor turn started after the previous result', async () => {
+    queryFactory = () => makeQuery([running, successResult, running])
+    const proc = new ClaudeCodeProcess({ sessionId: 'replay-successor-running', workingDirectory: '/tmp' })
+    await proc.start()
+    await vi.waitFor(() => expect(proc.isRunning()).toBe(false))
+
+    expect(proc.getLateJoinReplay()).toEqual([
+      expect.objectContaining({
+        type: 'system',
+        subtype: 'session_state_changed',
+        state: 'running',
+        replayed: true,
+      }),
+    ])
   })
 })

--- a/agent-container/src/terminal-frames.test.ts
+++ b/agent-container/src/terminal-frames.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Abnormal-exit terminal frames + late-join replay of result, task snapshot, idle.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+type Frame = Record<string, unknown>
+
+let queryFactory: () => ReturnType<typeof makeThrowingQuery> = () => makeThrowingQuery()
+
+function makeThrowingQuery() {
+  let step = 0
+  return {
+    [Symbol.asyncIterator]() {
+      return this
+    },
+    next() {
+      step++
+      if (step === 1) {
+        return Promise.resolve({
+          value: { type: 'system', subtype: 'session_state_changed', state: 'running' },
+          done: false,
+        })
+      }
+      return Promise.reject(new Error('sdk transport exploded'))
+    },
+    return() {
+      return Promise.resolve({ value: undefined, done: true })
+    },
+    throw(err?: unknown) {
+      return Promise.reject(err)
+    },
+    interrupt: () => Promise.resolve(),
+    setModel: () => Promise.resolve(),
+  }
+}
+
+function makeTurnWithBackgroundSnapshotQuery() {
+  const frames: Frame[] = [
+    { type: 'system', subtype: 'session_state_changed', state: 'running' },
+    {
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [{ task_id: 'wf-1' }],
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      duration_ms: 10,
+      num_turns: 1,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    },
+    { type: 'system', subtype: 'background_tasks_changed', tasks: [] },
+    { type: 'system', subtype: 'session_state_changed', state: 'idle' },
+  ]
+  let i = 0
+  return {
+    [Symbol.asyncIterator]() {
+      return this
+    },
+    next() {
+      if (i < frames.length) {
+        return Promise.resolve({ value: frames[i++], done: false })
+      }
+      return Promise.resolve({ value: undefined, done: true })
+    },
+    return() {
+      return Promise.resolve({ value: undefined, done: true })
+    },
+    throw(err?: unknown) {
+      return Promise.reject(err)
+    },
+    interrupt: () => Promise.resolve(),
+    setModel: () => Promise.resolve(),
+  }
+}
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(() => queryFactory()),
+}))
+
+vi.mock('./mcp-server', () => ({
+  createUserInputMcpServer: () => ({}),
+  createBrowserMcpServer: () => ({}),
+  createComputerUseMcpServer: () => ({}),
+  createDashboardsMcpServer: () => ({}),
+  createAgentsMcpServer: () => ({}),
+  createChatMcpServer: () => ({}),
+}))
+vi.mock('./tools/browser', () => ({ createBrowserTools: () => [] }))
+vi.mock('./tools/computer-use', () => ({ computerUseTools: [] }))
+vi.mock('./file-hooks', () => ({ fileHooks: {}, resolveToolFilePath: () => '' }))
+vi.mock('./input-manager', () => ({ inputManager: {}, HUMAN_INPUT_TTL_MS: 24 * 60 * 60 * 1000 }))
+
+import { ClaudeCodeProcess } from './claude-code'
+
+async function runToAbnormalExit(): Promise<{ frames: Frame[]; proc: ClaudeCodeProcess }> {
+  const proc = new ClaudeCodeProcess({ sessionId: 'terminal-frames', workingDirectory: '/tmp' })
+  const frames: Frame[] = []
+  proc.on('message', (m: Frame) => frames.push(m))
+  await proc.start()
+  await vi.waitFor(
+    () => {
+      expect(frames.some((f) => f.type === 'result')).toBe(true)
+    },
+    { timeout: 3000 }
+  )
+  return { frames, proc }
+}
+
+describe('abnormal-exit terminal frames', () => {
+  beforeEach(() => {
+    queryFactory = () => makeThrowingQuery()
+  })
+
+  it('emits a terminal session_state_changed after the synthetic error result', async () => {
+    const { frames } = await runToAbnormalExit()
+    const resultIdx = frames.findIndex((f) => f.type === 'result')
+    const terminalAfter = frames
+      .slice(resultIdx + 1)
+      .some((f) => f.type === 'system' && f.subtype === 'session_state_changed' && f.state === 'idle')
+    expect(terminalAfter).toBe(true)
+  })
+
+  it('makes the synthetic error result recoverable via late-join replay', async () => {
+    const { proc } = await runToAbnormalExit()
+    const replay = proc.getLateJoinReplay() as Frame[]
+    expect(replay.some((f) => f.type === 'result')).toBe(true)
+    expect(
+      replay.some((f) => f.type === 'system' && f.subtype === 'session_state_changed' && f.state === 'idle')
+    ).toBe(true)
+  })
+})
+
+describe('late-join replay background task snapshot', () => {
+  it('includes the latest background_tasks_changed before idle', async () => {
+    queryFactory = () => makeTurnWithBackgroundSnapshotQuery()
+    const proc = new ClaudeCodeProcess({ sessionId: 'replay-bg', workingDirectory: '/tmp' })
+    const frames: Frame[] = []
+    proc.on('message', (m: Frame) => frames.push(m))
+    await proc.start()
+    await vi.waitFor(
+      () => {
+        expect(
+          frames.some((f) => f.type === 'system' && f.subtype === 'session_state_changed' && f.state === 'idle')
+        ).toBe(true)
+      },
+      { timeout: 3000 }
+    )
+
+    const replay = proc.getLateJoinReplay() as Frame[]
+    const snapIdx = replay.findIndex((f) => f.type === 'system' && f.subtype === 'background_tasks_changed')
+    const idleIdx = replay.findIndex(
+      (f) => f.type === 'system' && f.subtype === 'session_state_changed' && f.state === 'idle'
+    )
+    const resultIdx = replay.findIndex((f) => f.type === 'result')
+    expect(resultIdx).toBeGreaterThanOrEqual(0)
+    expect(snapIdx).toBeGreaterThan(resultIdx)
+    expect(idleIdx).toBeGreaterThan(snapIdx)
+    expect((replay[snapIdx].tasks as unknown[]).length).toBe(0)
+  })
+})

--- a/src/shared/lib/container/message-persister.settle-loss.test.ts
+++ b/src/shared/lib/container/message-persister.settle-loss.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Settle-signal loss: re-subscribe must keep reply memory, and a grace-after-
+ * result backstop must settle only when nothing is genuinely pending.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { ContainerClient, StreamMessage } from './types'
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  createScheduledTask: vi.fn(),
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+  finalizeAutomationStatus: vi.fn(() => Promise.resolve('not-automation')),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({}),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+vi.mock('@shared/lib/computer-use/permission-manager', () => ({
+  computerUsePermissionManager: {
+    checkPermission: vi.fn(() => 'prompt_needed'),
+    getGrabbedApp: vi.fn(() => undefined),
+    setGrabbedApp: vi.fn(),
+    clearGrabbedApp: vi.fn(),
+    consumeOnceGrant: vi.fn(),
+  },
+}))
+vi.mock('@shared/lib/computer-use/types', () => ({
+  getRequiredPermissionLevel: vi.fn(() => 'use_application'),
+  resolveTargetApp: vi.fn(() => undefined),
+  READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
+  TIMED_GRANT_DURATION_MS: 15 * 60 * 1000,
+}))
+vi.mock('@shared/lib/computer-use/executor', () => ({
+  resolveAppFromWindowRef: vi.fn(() => undefined),
+}))
+vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
+  createWebhookTrigger: vi.fn(() => Promise.resolve('trigger_new_id')),
+  listActiveWebhookTriggers: vi.fn(() => Promise.resolve([])),
+  cancelWebhookTriggerWithCleanup: vi.fn(() => Promise.resolve(true)),
+}))
+vi.mock('@shared/lib/composio/triggers', () => ({
+  getAvailableTriggers: vi.fn(() => Promise.resolve([])),
+  enableComposioTrigger: vi.fn(() => Promise.resolve('composio_trigger_id')),
+  deleteComposioTrigger: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/composio/client', () => ({
+  isPlatformComposioActive: vi.fn(() => true),
+}))
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: vi.fn(() => Promise.resolve('UTC')),
+}))
+vi.mock('@shared/lib/analytics/server-analytics', () => ({
+  trackServerEvent: vi.fn(),
+}))
+vi.mock('@shared/lib/db', () => ({ db: {} }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn() }))
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getAgentSessionsDir: (_agentSlug: string) => '/nonexistent',
+}))
+
+const SESSION_ID = 'settle-loss-session'
+const AGENT_SLUG = 'settle-loss-agent'
+
+function makeClient(): { client: ContainerClient; send: (content: Record<string, unknown>) => void } {
+  let callback: ((message: StreamMessage) => void) | null = null
+  const client = {
+    subscribeToStream: vi.fn((_sid: string, cb: (message: StreamMessage) => void) => {
+      callback = cb
+      return { unsubscribe: vi.fn(), ready: Promise.resolve() }
+    }),
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopSync: vi.fn(),
+    getInfoFromRuntime: vi.fn(),
+    getInfo: vi.fn(),
+    fetch: vi.fn(),
+    waitForHealthy: vi.fn(),
+    isHealthy: vi.fn(),
+    getStats: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)),
+    deleteSession: vi.fn(),
+    sendMessage: vi.fn(),
+    interruptSession: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as ContainerClient
+  return {
+    client,
+    send: (content) =>
+      callback?.({ type: 'message', content, timestamp: new Date(), sessionId: SESSION_ID } as StreamMessage),
+  }
+}
+
+async function freshPersister() {
+  vi.resetModules()
+  const { messagePersister, RESULT_IDLE_GRACE_MS } = await import('./message-persister')
+  return { persister: messagePersister, RESULT_IDLE_GRACE_MS }
+}
+
+const capabilities = { type: 'system', subtype: 'capabilities', session_state_events: true }
+const successResult = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 100,
+  num_turns: 1,
+  usage: { input_tokens: 0, output_tokens: 0 },
+}
+const idle = { type: 'system', subtype: 'session_state_changed', state: 'idle' }
+const running = { type: 'system', subtype: 'session_state_changed', state: 'running' }
+const streamEvent = {
+  type: 'stream_event',
+  event: { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('message-persister settle-signal loss', () => {
+  it('settles when idle arrives after an external re-subscribe that followed a result', async () => {
+    const { persister } = await freshPersister()
+    const first = makeClient()
+    await persister.subscribeToSession(SESSION_ID, first.client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    first.send(capabilities)
+    first.send(successResult)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+
+    // Socket died between result and idle; consumer re-subscribes before the
+    // container records idle, so attach gets no replay and idle arrives live.
+    const second = makeClient()
+    await persister.subscribeToSession(SESSION_ID, second.client, SESSION_ID, AGENT_SLUG)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+
+    second.send(idle)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(false)
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('settles within grace when a result was seen and idle never arrives', async () => {
+    vi.useFakeTimers()
+    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+    const { client, send } = makeClient()
+    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    send(capabilities)
+    send(successResult)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(false)
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  // Anchor regression: turn-1 result arms grace; queued turn-2 emits running
+  // while host isActive is still true (self-heal no-ops); stale timer must not
+  // settle on turn 1's result. Turn-2 result + idle settles normally.
+  it('does not false-settle mid-turn when running arrives while still active after a result', async () => {
+    vi.useFakeTimers()
+    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+    const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+    vi.mocked(notificationManager.triggerSessionComplete).mockClear()
+    const { client, send } = makeClient()
+    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    send(capabilities)
+    send(successResult)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+
+    send(running)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+    expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
+
+    send(successResult)
+    send(idle)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('cancels grace on stream_event activity without settling', async () => {
+    vi.useFakeTimers()
+    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+    const { client, send } = makeClient()
+    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    send(capabilities)
+    send(successResult)
+    send(streamEvent)
+
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('does not false-settle a quiet tool after cancel (timer stays disarmed)', async () => {
+    vi.useFakeTimers()
+    const { persister } = await freshPersister()
+    const { client, send } = makeClient()
+    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    send(capabilities)
+    send(successResult)
+    send(running)
+    send(streamEvent)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('fires completion notification exactly once when idle finalizes before grace', async () => {
+    vi.useFakeTimers()
+    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+    const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+    vi.mocked(notificationManager.triggerSessionComplete).mockClear()
+    const { client, send } = makeClient()
+    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    send(capabilities)
+    send(successResult)
+    send(idle)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('does not settle on the grace timer while background work is open', async () => {
+    vi.useFakeTimers()
+    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+    const { client, send } = makeClient()
+    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    send(capabilities)
+    // Same registration path the suite uses for background Bash holds.
+    send({
+      type: 'user',
+      tool_use_result: { backgroundTaskId: 'bg-1' },
+      message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running in background' }] },
+    })
+    send(successResult)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('does not settle on the grace timer while an awaiting shelf is open', async () => {
+    vi.useFakeTimers()
+    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+    const { client, send } = makeClient()
+    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    send(capabilities)
+    send(successResult)
+    persister.markAwaitingInput(SESSION_ID)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+
+  it('does not settle on the grace timer while an external review blocker is open', async () => {
+    vi.useFakeTimers()
+    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+    const { client, send } = makeClient()
+    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
+    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    send(capabilities)
+    send(successResult)
+    const unregister = persister.registerAwaitingBlockerSource((slug) => slug === AGENT_SLUG)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
+    unregister()
+    persister.unsubscribeFromSession(SESSION_ID)
+  })
+})

--- a/src/shared/lib/container/message-persister.settle-loss.test.ts
+++ b/src/shared/lib/container/message-persister.settle-loss.test.ts
@@ -33,6 +33,9 @@ vi.mock('@shared/lib/computer-use/permission-manager', () => ({
   },
 }))
 vi.mock('@shared/lib/computer-use/types', () => ({
+  computerUseMethodFromToolName: vi.fn((toolName: string) =>
+    toolName.replace('mcp__computer-use__computer_', '')
+  ),
   getRequiredPermissionLevel: vi.fn(() => 'use_application'),
   resolveTargetApp: vi.fn(() => undefined),
   READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
@@ -118,9 +121,46 @@ const successResult = {
 }
 const idle = { type: 'system', subtype: 'session_state_changed', state: 'idle' }
 const running = { type: 'system', subtype: 'session_state_changed', state: 'running' }
+const requesting = { type: 'system', subtype: 'status', status: 'requesting' }
 const streamEvent = {
   type: 'stream_event',
   event: { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+}
+
+function sendToolUse(
+  send: (content: Record<string, unknown>) => void,
+  toolName: string,
+  toolId: string,
+  input: Record<string, unknown>
+): void {
+  send({
+    type: 'stream_event',
+    event: {
+      type: 'content_block_start',
+      content_block: { type: 'tool_use', id: toolId, name: toolName },
+    },
+  })
+  send({
+    type: 'stream_event',
+    event: {
+      type: 'content_block_delta',
+      delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+    },
+  })
+  send({
+    type: 'stream_event',
+    event: { type: 'content_block_stop' },
+  })
+}
+
+async function startActiveSession() {
+  vi.useFakeTimers()
+  const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+  const connection = makeClient()
+  await persister.subscribeToSession(SESSION_ID, connection.client, SESSION_ID, AGENT_SLUG)
+  persister.markSessionActive(SESSION_ID, AGENT_SLUG)
+  connection.send(capabilities)
+  return { persister, RESULT_IDLE_GRACE_MS, ...connection }
 }
 
 afterEach(() => {
@@ -129,7 +169,10 @@ afterEach(() => {
 
 describe('message-persister settle-signal loss', () => {
   it('settles when idle arrives after an external re-subscribe that followed a result', async () => {
-    const { persister } = await freshPersister()
+    vi.useFakeTimers()
+    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+    const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+    vi.mocked(notificationManager.triggerSessionComplete).mockClear()
     const first = makeClient()
     await persister.subscribeToSession(SESSION_ID, first.client, SESSION_ID, AGENT_SLUG)
     persister.markSessionActive(SESSION_ID, AGENT_SLUG)
@@ -145,43 +188,42 @@ describe('message-persister settle-signal loss', () => {
 
     second.send(idle)
     expect(persister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
     persister.unsubscribeFromSession(SESSION_ID)
   })
 
   it('settles within grace when a result was seen and idle never arrives', async () => {
-    vi.useFakeTimers()
-    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
-    const { client, send } = makeClient()
-    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    send(capabilities)
+    const { persister, RESULT_IDLE_GRACE_MS, send } = await startActiveSession()
+    const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
+    vi.mocked(notificationManager.triggerSessionComplete).mockClear()
     send(successResult)
     expect(persister.isSessionActive(SESSION_ID)).toBe(true)
 
     await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
     expect(persister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
     persister.unsubscribeFromSession(SESSION_ID)
   })
 
-  // Anchor regression: turn-1 result arms grace; queued turn-2 emits running
-  // while host isActive is still true (self-heal no-ops); stale timer must not
-  // settle on turn 1's result. Turn-2 result + idle settles normally.
-  it('does not false-settle mid-turn when running arrives while still active after a result', async () => {
-    vi.useFakeTimers()
-    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
+  it.each([
+    ['running', running],
+    ['requesting', requesting],
+    ['replayed running after reconnect', { ...running, replayed: true }],
+  ])('does not false-settle after %s proves a successor turn started', async (_label, newTurnFrame) => {
+    const { persister, send } = await startActiveSession()
     const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
     vi.mocked(notificationManager.triggerSessionComplete).mockClear()
-    const { client, send } = makeClient()
-    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    send(capabilities)
     send(successResult)
     expect(persister.isSessionActive(SESSION_ID)).toBe(true)
 
-    send(running)
+    send(newTurnFrame)
     expect(persister.isSessionActive(SESSION_ID)).toBe(true)
 
-    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
+    await vi.advanceTimersByTimeAsync(60_000)
     expect(persister.isSessionActive(SESSION_ID)).toBe(true)
     expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
 
@@ -192,107 +234,51 @@ describe('message-persister settle-signal loss', () => {
     persister.unsubscribeFromSession(SESSION_ID)
   })
 
-  it('cancels grace on stream_event activity without settling', async () => {
-    vi.useFakeTimers()
-    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
-    const { client, send } = makeClient()
-    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    send(capabilities)
+  it('cancels grace on output activity without clearing the observed result', async () => {
+    const { persister, RESULT_IDLE_GRACE_MS, send } = await startActiveSession()
     send(successResult)
     send(streamEvent)
 
     await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
     expect(persister.isSessionActive(SESSION_ID)).toBe(true)
-    persister.unsubscribeFromSession(SESSION_ID)
-  })
-
-  it('does not false-settle a quiet tool after cancel (timer stays disarmed)', async () => {
-    vi.useFakeTimers()
-    const { persister } = await freshPersister()
-    const { client, send } = makeClient()
-    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    send(capabilities)
-    send(successResult)
-    send(running)
-    send(streamEvent)
-
-    await vi.advanceTimersByTimeAsync(60_000)
-    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
-    persister.unsubscribeFromSession(SESSION_ID)
-  })
-
-  it('fires completion notification exactly once when idle finalizes before grace', async () => {
-    vi.useFakeTimers()
-    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
-    const { notificationManager } = await import('@shared/lib/notifications/notification-manager')
-    vi.mocked(notificationManager.triggerSessionComplete).mockClear()
-    const { client, send } = makeClient()
-    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    send(capabilities)
-    send(successResult)
     send(idle)
     expect(persister.isSessionActive(SESSION_ID)).toBe(false)
-    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
-
-    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
-    expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
     persister.unsubscribeFromSession(SESSION_ID)
   })
 
-  it('does not settle on the grace timer while background work is open', async () => {
-    vi.useFakeTimers()
-    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
-    const { client, send } = makeClient()
-    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    send(capabilities)
-    // Same registration path the suite uses for background Bash holds.
-    send({
-      type: 'user',
-      tool_use_result: { backgroundTaskId: 'bg-1' },
-      message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running in background' }] },
-    })
+  it.each([
+    'incremental background work',
+    'snapshot-only background work',
+    'awaiting input',
+    'pending request after result clears awaiting',
+    'external review blocker',
+  ])('does not settle on grace while blocked by %s', async (blocker) => {
+    const { persister, RESULT_IDLE_GRACE_MS, send } = await startActiveSession()
+    let cleanup = () => {}
+    if (blocker === 'incremental background work') {
+      send({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-1' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+    } else if (blocker === 'pending request after result clears awaiting') {
+      sendToolUse(send, 'mcp__user-input__request_secret', 'secret-1', { secretName: 'API_KEY' })
+    }
     send(successResult)
-    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
-
+    if (blocker === 'snapshot-only background work') {
+      send({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 'snapshot-only' }],
+      })
+    } else if (blocker === 'awaiting input') {
+      persister.markAwaitingInput(SESSION_ID)
+    } else if (blocker === 'external review blocker') {
+      cleanup = persister.registerAwaitingBlockerSource((slug) => slug === AGENT_SLUG)
+    }
     await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
     expect(persister.isSessionActive(SESSION_ID)).toBe(true)
-    persister.unsubscribeFromSession(SESSION_ID)
-  })
-
-  it('does not settle on the grace timer while an awaiting shelf is open', async () => {
-    vi.useFakeTimers()
-    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
-    const { client, send } = makeClient()
-    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    send(capabilities)
-    send(successResult)
-    persister.markAwaitingInput(SESSION_ID)
-    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
-
-    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
-    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
-    persister.unsubscribeFromSession(SESSION_ID)
-  })
-
-  it('does not settle on the grace timer while an external review blocker is open', async () => {
-    vi.useFakeTimers()
-    const { persister, RESULT_IDLE_GRACE_MS } = await freshPersister()
-    const { client, send } = makeClient()
-    await persister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-    persister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    send(capabilities)
-    send(successResult)
-    const unregister = persister.registerAwaitingBlockerSource((slug) => slug === AGENT_SLUG)
-    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
-
-    await vi.advanceTimersByTimeAsync(RESULT_IDLE_GRACE_MS)
-    expect(persister.isSessionActive(SESSION_ID)).toBe(true)
-    unregister()
+    cleanup()
     persister.unsubscribeFromSession(SESSION_ID)
   })
 })

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -231,8 +231,15 @@ export function redactStreamedToolInput(toolName: string | undefined, partialInp
 }
 
 // TODO this file is too big, this class is HUGE. Needs breaking up
+/** Grace after an observed result before self-settling when idle is lost. */
+export const RESULT_IDLE_GRACE_MS = 5_000
+
 class MessagePersister {
   private streamingStates: Map<string, StreamingState> = new Map()
+  // Single-shot per-session backstop: armed when a result is seen under
+  // state-events authority and the idle may still be lost on a dead socket.
+  // Never settles a turn whose result was not seen (#339 honesty).
+  private resultIdleGraceTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   // "Allow for this session" capability grants, keyed by sessionId. Display
   // bookkeeping ONLY — enforcement lives in the container (which persists its
   // copy with the session). Once granted, launches auto-allow container-side
@@ -291,6 +298,11 @@ class MessagePersister {
     const priorIsActive = prior?.isActive ?? false
     const priorIsAwaitingInput = prior?.isAwaitingInput ?? false
     const priorBackgroundTasks = prior?.activeBackgroundTasks ?? new Map()
+    // Settle-relevant reply memory must survive external re-subscribe (SSE /
+    // chat bridge). Resetting these made a post-reconnect idle look stale and
+    // left the session busy forever when the drop raced the container's idle.
+    const priorLastResultSubtype = prior?.lastResultSubtype ?? null
+    const priorLastResultCleanSuccess = prior?.lastResultCleanSuccess ?? false
 
     // Unsubscribe if already subscribed (this also clears state, which is why
     // we captured the flags above)
@@ -320,10 +332,16 @@ class MessagePersister {
       bgTasksSnapshot: prior?.bgTasksSnapshot ?? null,
       pendingDeliverFiles: new Map(),
       stateEventsAuthority: prior?.stateEventsAuthority ?? false,
-      lastResultSubtype: null,
-      lastResultCleanSuccess: false,
+      lastResultSubtype: priorLastResultSubtype,
+      lastResultCleanSuccess: priorLastResultCleanSuccess,
       isRetrying: false,
     })
+
+    // Re-arm the grace backstop when a re-subscribe preserved an in-flight
+    // turn that already saw a result (unsubscribe tears the previous timer down).
+    if (priorIsActive && priorLastResultSubtype !== null) {
+      this.armResultIdleGrace(sessionId)
+    }
 
     // Store container client for reconnection checks
     this.containerClients.set(sessionId, client)
@@ -348,6 +366,7 @@ class MessagePersister {
 
   // Unsubscribe from a session
   unsubscribeFromSession(sessionId: string): void {
+    this.cancelResultIdleGrace(sessionId)
     const unsubscribe = this.subscriptions.get(sessionId)
     if (unsubscribe) {
       unsubscribe()
@@ -362,10 +381,66 @@ class MessagePersister {
     this.sessionCapabilityGrants.delete(sessionId)
   }
 
+  private cancelResultIdleGrace(sessionId: string): void {
+    const timer = this.resultIdleGraceTimers.get(sessionId)
+    if (!timer) return
+    clearTimeout(timer)
+    this.resultIdleGraceTimers.delete(sessionId)
+  }
+
+  // Post-result stream activity: cancel the grace timer. Tier-1 new-turn
+  // evidence also clears result memory so the honesty gate itself rejects
+  // settling turn N+1 on turn N's stale result. Never re-arms here.
+  private noteLiveStreamActivity(
+    sessionId: string,
+    state: StreamingState,
+    options: { newTurnEvidence?: boolean } = {}
+  ): void {
+    this.cancelResultIdleGrace(sessionId)
+    if (options.newTurnEvidence) {
+      state.lastResultSubtype = null
+      state.lastResultCleanSuccess = false
+    }
+  }
+
+  private armResultIdleGrace(sessionId: string): void {
+    this.cancelResultIdleGrace(sessionId)
+    const timer = setTimeout(() => {
+      this.resultIdleGraceTimers.delete(sessionId)
+      this.fireResultIdleGrace(sessionId)
+    }, RESULT_IDLE_GRACE_MS)
+    this.resultIdleGraceTimers.set(sessionId, timer)
+  }
+
+  private fireResultIdleGrace(sessionId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (!state) return
+    // Full settle gate — never settle a turn whose result was not seen, and
+    // never while background work / any awaiting shelf / an external review
+    // blocker is open. Gate fails → do nothing (no re-arm; other roads own recovery).
+    if (
+      !state.isActive ||
+      state.lastResultSubtype === null ||
+      this.openBackgroundWorkCount(state) > 0 ||
+      state.isAwaitingInput ||
+      this.hasBlockingPendingRequests(state) ||
+      this.hasExternalAwaitingBlocker(state.agentSlug)
+    ) {
+      return
+    }
+    this.finalizeIdle(sessionId, state)
+    if (state.lastResultSubtype === 'success' && state.agentSlug) {
+      notificationManager.triggerSessionComplete(sessionId, state.agentSlug).catch((err) => {
+        console.error('[MessagePersister] Failed to trigger session complete notification:', err)
+      })
+    }
+  }
+
   // Single idle finalizer — flips state and broadcasts to session + global
   // listeners. Used by the result handler (legacy result-driven idle), the
   // session_state_changed handler (authoritative idle), and markSessionInactive.
   private finalizeIdle(sessionId: string, state: StreamingState): void {
+    this.cancelResultIdleGrace(sessionId)
     // The session is truly settled: persist the automation outcome for a turn
     // that ended in a clean success. (Failures were already persisted at their
     // result — an error ends the turn immediately. Interrupts never set the
@@ -760,6 +835,7 @@ class MessagePersister {
 
   // Mark a session as interrupted (not active)
   async markSessionInterrupted(sessionId: string): Promise<void> {
+    this.cancelResultIdleGrace(sessionId)
     const state = this.streamingStates.get(sessionId)
 
     // Set interrupted flag FIRST to prevent race conditions with incoming events
@@ -852,6 +928,7 @@ class MessagePersister {
         this.capture.recordNote(sessionId, 'state_created', { agentSlug }).catch(() => {})
       }
     }
+    this.cancelResultIdleGrace(sessionId)
     state.isActive = true
     state.isInterrupted = false // Reset interrupted flag on new message
     state.isAwaitingInput = false // Reset awaiting input on new message
@@ -1220,6 +1297,7 @@ class MessagePersister {
 
     switch (content.type) {
       case 'assistant': {
+        this.noteLiveStreamActivity(sessionId, state)
         // Complete assistant message - JSONL is the source of truth
         // Track SDK error code from assistant message (e.g., 'authentication_failed', 'rate_limit')
         if (content.error) {
@@ -1249,6 +1327,7 @@ class MessagePersister {
       }
 
       case 'user':
+        this.noteLiveStreamActivity(sessionId, state)
         // Detect subagent completion: check if this user message contains tool_results
         // for any active subagent tool calls (meaning the subagent finished and returned its result)
         if (state.activeSubagents.size > 0) {
@@ -1422,6 +1501,8 @@ class MessagePersister {
             this.broadcastToSSE(sessionId, { type: 'compact_start' })
           }
           if (content.status === 'requesting') {
+            // Earliest queued-turn signal: CLI draining its command queue.
+            this.noteLiveStreamActivity(sessionId, state, { newTurnEvidence: true })
             // The CLI is composing the next model request — the moment it
             // drains its command queue. Queued (mid-turn) messages picked up
             // here are persisted as queued_command attachments with no stream
@@ -1627,17 +1708,23 @@ class MessagePersister {
                 }
               }
             }
-          } else if (content.state === 'running' && !state.isActive) {
-            // The runtime started a turn we didn't initiate via POST (e.g. a
-            // queued message picked up after an out-of-order idle) — self-heal.
-            state.isActive = true
-            this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true })
-            this.broadcastGlobal({
-              type: 'session_active',
-              sessionId,
-              agentSlug: state.agentSlug,
-              isActive: true,
-            })
+          } else if (content.state === 'running') {
+            // Unambiguous new-turn evidence — cancel grace + clear result memory
+            // even while isActive is still true (queued follow-up; self-heal
+            // below only covers the inactive case).
+            this.noteLiveStreamActivity(sessionId, state, { newTurnEvidence: true })
+            if (!state.isActive) {
+              // The runtime started a turn we didn't initiate via POST (e.g. a
+              // queued message picked up after an out-of-order idle) — self-heal.
+              state.isActive = true
+              this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true })
+              this.broadcastGlobal({
+                type: 'session_active',
+                sessionId,
+                agentSlug: state.agentSlug,
+                isActive: true,
+              })
+            }
           }
         } else if (content.subtype === 'background_tasks_changed') {
           // Authoritative full snapshot of the session's live background tasks
@@ -1809,8 +1896,11 @@ class MessagePersister {
         // when the session is settled — a result alone doesn't: queued
         // (mid-turn) messages or background work may keep it running, and the
         // runtime holds that state, not us. session_state_changed:'idle'
-        // finalizes (and fires the completion notification).
+        // finalizes (and fires the completion notification). Arm a grace
+        // backstop so a lost idle (dead socket) still settles once nothing is
+        // pending — never before a result was seen.
         if (state.stateEventsAuthority) {
+          this.armResultIdleGrace(sessionId)
           break
         }
 
@@ -1865,6 +1955,7 @@ class MessagePersister {
         break
 
       case 'stream_event':
+        this.noteLiveStreamActivity(sessionId, state)
         // Handle stream events for SSE broadcasting
         if (content.event) {
           this.handleStreamEvent(sessionId, content.event, state)
@@ -1931,6 +2022,7 @@ class MessagePersister {
 
   // Mark a session as inactive and broadcast the update
   private markSessionInactive(sessionId: string, state: StreamingState): void {
+    this.cancelResultIdleGrace(sessionId)
     // A session that was mid-turn (user message sent, no result yet) and not
     // deliberately interrupted didn't finish — its runtime vanished (container
     // crash, guest OOM kill of the agent process, VM death). Surface that as an

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -238,7 +238,7 @@ class MessagePersister {
   private streamingStates: Map<string, StreamingState> = new Map()
   // Single-shot per-session backstop: armed when a result is seen under
   // state-events authority and the idle may still be lost on a dead socket.
-  // Never settles a turn whose result was not seen (#339 honesty).
+  // Never settles a turn whose result was not seen.
   private resultIdleGraceTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   // "Allow for this session" capability grants, keyed by sessionId. Display
   // bookkeeping ONLY — enforcement lives in the container (which persists its


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-468/fix-stuck-working-settle-signal-loss-class-liveness-replay-backstop

## Why

Telegram shows Working while the host considers a session active.

A normal turn ends with a result followed by an idle signal.
If the idle signal is lost because the socket attached late, disconnected, or the query process died, the reply can be complete while the host remains active forever.
Reconnect recovery could also replay the previous turn after a successor turn had started, or preserve background tasks from a dead process.

## What

Normal and fallback settlement now follow the same rule:

```text
normal:     running → result → idle → settled
lost idle:  running → result → 5s grace → clean gate → settled
                                         └─ blocked → stay active
```

Post-result activity prevents an old result from settling new work:

```text
post-result frame
├─ output only        → cancel grace, keep result for a later real idle
├─ running/requesting → cancel grace, forget the previous result
└─ no activity        → settle after grace only when every blocker is clear
```

### Cases fixed

1. **Idle is lost after a result**
   - The host starts a single five-second grace period after observing the result.
   - When it expires, the host settles only if no background task, input request, pending blocking request, or external review is open.

2. **The subscriber attaches after an instant turn already finished**
   - The container replays the latest result, authoritative background-task snapshot, and idle state.
   - Replayed frames are marked so a host that already saw the live frames does not process them twice.

3. **The query exits abnormally**
   - The container emits a synthetic error result followed by idle, and records both for late-join replay.
   - New-turn evidence resets prior error suppression, so consecutive failed turns each receive their own terminal frames.

4. **A dead query leaves background tasks behind**
   - Starting a replacement query emits an empty task snapshot.
   - The host cannot remain pinned by task IDs owned by the dead process.

5. **A successor turn starts before a reconnect**
   - The container replays running or requesting evidence for the successor turn instead of the previous turn's result and idle.
   - The host keeps the live turn active.

## Safety rules

- Never infer completion without first observing a result.
- Never settle while background work, user input, a pending blocking request, or external review is open.
- Any output cancels the fallback timer.
- Running or requesting proves a new turn and invalidates the previous result.
- Completion state and notifications finalize once.

## Scope

- 4 files
- Implementation: +185 / -23 lines
- Regression tests: +510 lines

## Verification

- [x] Root TypeScript typecheck
- [x] Agent-container TypeScript typecheck
- [x] Lint with zero errors
- [x] Root unit suite: 7,741 passed
- [x] Agent-container unit suite: 746 passed
- [x] Telegram normal completion: reply delivered and Working cleared
- [x] Telegram forced container stop: Working cleared within one second, with no leaked `done` output
