### PR TITLE
Bearer auth + RFC 7523 JWT-grant token endpoint for auth-mode deployments

### DIFF
--- a/docs/cross-client-auth.md
+++ b/docs/cross-client-auth.md
@@ -1,0 +1,158 @@
+# Cross-client auth: bearer tokens + RFC 7523 token exchange
+
+How non-browser clients (desktop app, iOS/watch companions) obtain and use
+user-scoped access tokens for an **auth-mode (cloud) deployment** of this app,
+without an interactive login round-trip.
+
+This is the deployment-side half of the mechanism. The platform-side half
+(RFC 8693 grant issuance + deployment discovery) is documented in the platform
+repo at `docs/cross-client-auth.md`.
+
+## Mechanism overview
+
+The design follows the OAuth *identity and authorization chaining* pattern:
+[RFC 8693](https://www.rfc-editor.org/rfc/rfc8693.html) token exchange at the
+upstream Authorization Server (the platform), followed by an
+[RFC 7523](https://www.rfc-editor.org/rfc/rfc7523.html) JWT bearer grant at the
+downstream Authorization Server (this deployment).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client (desktop / watch)
+    participant P as Platform (upstream AS)
+    participant D as This deployment (downstream AS + API)
+
+    Note over C: Holds a member-bound platform credential<br/>(plat_sa_ key or platform user session)
+    C->>P: GET /v1/me/deployments (discovery)
+    P-->>C: deployment_url + authorization_server
+    C->>P: POST /token/deployment-assertion (RFC 8693)
+    P-->>C: JWT authorization grant (RS256, 120s, single-use jti,<br/>aud = this deployment)
+    C->>D: POST /api/auth/token/exchange (RFC 7523)
+    D->>D: Verify grant · burn jti · resolve/provision user ·<br/>create Better Auth session
+    D-->>C: { access_token, token_type: Bearer, expires_in }
+    C->>D: API calls with Authorization: Bearer <access_token>
+```
+
+Key properties:
+
+- The deployment is the **sole authority for its own tokens**. The platform
+  never receives or mints a deployment token; it only signs a short-lived
+  grant that this deployment chooses to honor.
+- Re-auth is silent: on any 401 the client repeats the two hops. Grants are
+  cheap and single-use; the long-lived root credential stays at the platform.
+- The exchanged session is a completely ordinary Better Auth session — every
+  ACL helper behind `Authenticated()` works unchanged.
+
+## Deployment-side pieces
+
+### 1. Bearer authentication (Better Auth `bearer` plugin)
+
+`src/shared/lib/auth/index.ts` registers the `bearer()` plugin, so
+`auth.api.getSession({ headers })` honors `Authorization: Bearer
+<session-token>` in addition to cookies. `Authenticated()`
+(`src/api/middleware/auth.ts`) needed no changes. Any endpoint behind it —
+agents, sessions, STT — is therefore reachable by token-holding clients.
+
+The plugin also echoes the session token in a JS-readable `set-auth-token`
+response header on every sign-in. This app's browser client is cookie-only and
+token clients get their token from the exchange endpoint's JSON body, so that
+header is never consumed — a middleware in `src/api/index.ts` strips it from
+`/api/auth/*` responses to keep the session credential out of reach of a
+renderer XSS. (The bearer plugin exposes no option to suppress the header.)
+
+### 2. Token endpoint — `POST /api/auth/token/exchange`
+
+Route: `src/api/routes/token-exchange.ts` (mounted in `src/api/index.ts`
+*before* the Better Auth wildcard, behind the `/api/auth/*` rate limiter).
+Logic: `src/shared/lib/auth/token-exchange.ts`; wire schemas:
+`src/shared/lib/auth/token-exchange-schema.ts`.
+
+Request (`application/x-www-form-urlencoded`, single-valued params):
+
+```text
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+&assertion=<JWT authorization grant>
+```
+
+Success (`200`, `Cache-Control: no-store`):
+
+```json
+{ "access_token": "<session token>", "token_type": "Bearer", "expires_in": 86400 }
+```
+
+Errors are OAuth JSON (`invalid_request`, `unsupported_grant_type`,
+`invalid_grant`) with no identity-revealing detail; unexpected failures are
+`500 server_error`.
+
+### 3. Grant validation
+
+A grant is accepted only if **all** of the following hold:
+
+| Check | Source of truth |
+|---|---|
+| RS256 signature | Platform JWKS (`verifyOidcJwt`, issuer from the `platform` entry in `AUTH_PROVIDERS_JSON`) |
+| `typ` header | Must be `deployment-assertion+jwt` (cannot be confused with `PLATFORM_TOKEN` org JWTs) |
+| `iss` | Platform issuer (as above) |
+| `aud` | Must equal this deployment's configured base URL **exactly** (single string; arrays rejected). See “Audience configuration” below |
+| `exp` | Valid and no more than ~5 minutes out; `iat` not in the future |
+| `jti` | Never seen before — atomically consumed (below) |
+| `org_id` | Equals the org pinned by `PLATFORM_TOKEN` (same gate as browser OIDC login) |
+| `email` / `email_verified` | Well-formed email with `email_verified == true` |
+
+### 4. Replay prevention
+
+`token_exchange_jti` (`src/shared/lib/db/schema.ts`) stores each consumed
+`jti` with the grant's expiry. The primary-key `INSERT … ON CONFLICT DO
+NOTHING` is the gate: only the request whose insert lands may mint a session.
+Expired rows are pruned opportunistically on each exchange.
+
+### 5. Identity resolution & provisioning
+
+Stable-identity contract:
+
+1. An existing `account` row with `(providerId='platform', accountId=<grant
+   sub>)` wins — even over a later email change. The pair is enforced by a
+   unique index (`account_provider_account_unique`).
+2. Otherwise the verified, normalized (lowercased) email resolves to the
+   existing user (the platform identity is linked, honoring account-linking
+   policy) or a new user is provisioned.
+
+All writes go through Better Auth's internal adapter, so database hooks run
+exactly as for browser OIDC login: first-user-becomes-admin bootstrap,
+pending-admin-approval banning, and max-concurrent-session enforcement.
+Banned/pending users are rejected (`invalid_grant`) before any session is
+created — checked explicitly because the admin plugin's ban hook only runs
+inside HTTP endpoint contexts. Concurrent first exchanges are safe: unique
+races are resolved by reloading the winner and asserting the subject mapping
+exists before a session is minted.
+
+### 6. Session hygiene
+
+Exchanged sessions record the caller's `User-Agent` and IP, so they are
+distinguishable and revocable in the admin sessions list.
+
+## Audience configuration (important for cloud deployments)
+
+The endpoint verifies `aud` against `getAppBaseUrl()`
+(`src/shared/lib/auth/config.ts`) — **never** against request headers. The
+resolution order is:
+
+1. `TRUSTED_ORIGINS` env var (first entry) — the documented cloud interface,
+2. `settings.auth.trustedOrigins` (first entry),
+3. `http(s)://$HOST:$PORT` fallback.
+
+For the exchange to work, this value must equal the canonical
+`org_deployment.deployment_url` the platform has on record for the deployment
+(compared with no trailing slash). A mismatch makes every exchange fail with
+`invalid_grant`.
+
+## Testing
+
+- Integration suite: `src/shared/lib/auth/token-exchange.integration.test.ts`
+  (real Better Auth + real SQLite: contract, replay/concurrency, provisioning,
+  ban/pending, bearer-through-`Authenticated()`).
+- Config precedence: `src/shared/lib/auth/config.test.ts`.
+- Live two-service chain: seed the platform repo's local stack and drive
+  discovery → RFC 8693 → RFC 7523 → bearer calls; see the platform repo's
+  `docs/cross-client-auth.md` for the walkthrough.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -36,6 +36,7 @@ import auditLogRouter from './routes/audit-log'
 import connectionLogsRouter from './routes/connection-logs'
 import debugRouter from './routes/debug'
 import platformAuth from './routes/platform-auth'
+import tokenExchange from './routes/token-exchange'
 import agentBootstrap from './routes/agent-bootstrap'
 import activityRouter from './routes/activity'
 import { initializeServices } from '@shared/lib/startup'
@@ -112,6 +113,26 @@ if (isAuthMode()) {
 // Auth enforcement middleware (signup mode, password policy, account lockout)
 if (isAuthMode()) {
   app.use('/api/auth/*', authEnforcementMiddleware)
+}
+
+// The bearer plugin echoes the session token in a JS-readable `set-auth-token`
+// response header on every sign-in. This app's browser client is cookie-only
+// and token clients receive their token from the exchange endpoint's JSON body,
+// so the header is never consumed — strip it to keep the session credential out
+// of reach of a renderer XSS. (The bearer plugin has no option to suppress it.)
+if (isAuthMode()) {
+  app.use('/api/auth/*', async (c, next) => {
+    await next()
+    if (c.res.headers.has('set-auth-token')) {
+      c.res.headers.delete('set-auth-token')
+    }
+  })
+}
+
+// RFC 7523 token endpoint — registered before the Better Auth wildcard so it
+// wins the route match, after the rate limiter + enforcement middleware above.
+if (isAuthMode()) {
+  app.route('/api/auth/token', tokenExchange)
 }
 
 // Mount Better Auth handler (only when AUTH_MODE is enabled)

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -170,6 +170,7 @@ vi.mock('@shared/lib/db/schema', () => ({
   messageAuthor: {},
   xAgentPolicies: {},
   apiScopePolicies: {},
+  tokenExchangeJti: {},
 }))
 
 vi.mock('fs', () => ({

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -74,6 +74,7 @@ import {
   messageAuthor,
   xAgentPolicies,
   apiScopePolicies,
+  tokenExchangeJti,
 } from '@shared/lib/db/schema'
 import fs from 'fs'
 
@@ -191,6 +192,8 @@ const FACTORY_RESET_TABLES: SQLiteTable[] = [
   userSettings,
   // global app audit log
   auditLog,
+  // transient single-use jti replay guard for the token-exchange endpoint
+  tokenExchangeJti,
 ]
 
 // Custom model icons are used in regular model pickers, so any authenticated

--- a/src/api/routes/token-exchange.ts
+++ b/src/api/routes/token-exchange.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import type { Context } from 'hono'
+import { bodyLimit } from 'hono/body-limit'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { captureException } from '@shared/lib/error-reporting'
 import { JWT_BEARER_GRANT_TYPE, type TokenExchangeErrorCode } from '@shared/lib/auth/token-exchange-schema'
@@ -44,26 +45,25 @@ function singleParam(params: URLSearchParams, name: string): string | null {
  */
 const tokenExchange = new Hono()
 
-tokenExchange.post('/exchange', async (c) => {
+// Bound the request body by bytes before it is buffered. bodyLimit checks a
+// declared Content-Length up front and, for chunked bodies with none, aborts
+// mid-stream once the byte count is exceeded — so a body-less-Content-Length
+// request can't force us to buffer unbounded input.
+const limitBody = bodyLimit({
+  maxSize: MAX_FORM_BODY_BYTES,
+  onError: (c) => oauthError(c, 400, 'invalid_request'),
+})
+
+tokenExchange.post('/exchange', limitBody, async (c) => {
   const contentType = (c.req.header('content-type') ?? '').split(';')[0].trim().toLowerCase()
   if (contentType !== 'application/x-www-form-urlencoded') {
     return oauthError(c, 400, 'invalid_request', 'content type must be application/x-www-form-urlencoded')
-  }
-
-  // Reject oversized bodies before buffering when the client declares a
-  // length; the post-read check below still covers chunked encodings.
-  const declaredLength = Number(c.req.header('content-length'))
-  if (Number.isFinite(declaredLength) && declaredLength > MAX_FORM_BODY_BYTES) {
-    return oauthError(c, 400, 'invalid_request')
   }
 
   let rawBody: string
   try {
     rawBody = await c.req.text()
   } catch {
-    return oauthError(c, 400, 'invalid_request')
-  }
-  if (rawBody.length > MAX_FORM_BODY_BYTES) {
     return oauthError(c, 400, 'invalid_request')
   }
 

--- a/src/api/routes/token-exchange.ts
+++ b/src/api/routes/token-exchange.ts
@@ -1,0 +1,103 @@
+import { Hono } from 'hono'
+import type { Context } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { JWT_BEARER_GRANT_TYPE, type TokenExchangeErrorCode } from '@shared/lib/auth/token-exchange-schema'
+
+// Bound the raw form body and the assertion itself; a legitimate grant is a
+// small three-segment JWT.
+const MAX_FORM_BODY_BYTES = 16 * 1024
+const MAX_ASSERTION_LENGTH = 8 * 1024
+
+const NO_STORE_HEADERS = {
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache',
+} as const
+
+function oauthError(
+  c: Context,
+  status: ContentfulStatusCode,
+  error: TokenExchangeErrorCode | 'server_error',
+  description?: string,
+) {
+  return c.json(
+    { error, ...(description ? { error_description: description } : {}) },
+    status,
+    NO_STORE_HEADERS,
+  )
+}
+
+// Reads a required single-valued form parameter; null means the request is
+// malformed (missing or duplicated).
+function singleParam(params: URLSearchParams, name: string): string | null {
+  const values = params.getAll(name)
+  if (values.length !== 1) return null
+  return values[0]
+}
+
+/**
+ * RFC 7523 JWT bearer grant token endpoint (downstream Authorization Server).
+ * POST /api/auth/token/exchange — accepts a platform-issued JWT authorization
+ * grant and returns a deployment bearer access token backed by a Better Auth
+ * session. Mounted before the Better Auth wildcard; the /api/auth/* rate
+ * limiter applies.
+ */
+const tokenExchange = new Hono()
+
+tokenExchange.post('/exchange', async (c) => {
+  const contentType = (c.req.header('content-type') ?? '').split(';')[0].trim().toLowerCase()
+  if (contentType !== 'application/x-www-form-urlencoded') {
+    return oauthError(c, 400, 'invalid_request', 'content type must be application/x-www-form-urlencoded')
+  }
+
+  // Reject oversized bodies before buffering when the client declares a
+  // length; the post-read check below still covers chunked encodings.
+  const declaredLength = Number(c.req.header('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_FORM_BODY_BYTES) {
+    return oauthError(c, 400, 'invalid_request')
+  }
+
+  let rawBody: string
+  try {
+    rawBody = await c.req.text()
+  } catch {
+    return oauthError(c, 400, 'invalid_request')
+  }
+  if (rawBody.length > MAX_FORM_BODY_BYTES) {
+    return oauthError(c, 400, 'invalid_request')
+  }
+
+  const params = new URLSearchParams(rawBody)
+
+  const grantType = singleParam(params, 'grant_type')
+  if (!grantType) {
+    return oauthError(c, 400, 'invalid_request', 'grant_type is required')
+  }
+  if (grantType !== JWT_BEARER_GRANT_TYPE) {
+    return oauthError(c, 400, 'unsupported_grant_type')
+  }
+
+  const assertion = singleParam(params, 'assertion')
+  if (!assertion) {
+    return oauthError(c, 400, 'invalid_request', 'assertion is required exactly once')
+  }
+  if (assertion.length > MAX_ASSERTION_LENGTH) {
+    return oauthError(c, 400, 'invalid_request', 'assertion is too large')
+  }
+
+  const { exchangeDeploymentGrant, TokenExchangeError } = await import('@shared/lib/auth/token-exchange')
+  try {
+    const result = await exchangeDeploymentGrant(assertion, {
+      userAgent: c.req.header('user-agent'),
+      ipAddress: c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || '',
+    })
+    return c.json(result, 200, NO_STORE_HEADERS)
+  } catch (error) {
+    if (error instanceof TokenExchangeError) {
+      return oauthError(c, 400, error.code)
+    }
+    console.error('token exchange failed:', error)
+    return oauthError(c, 500, 'server_error')
+  }
+})
+
+export default tokenExchange

--- a/src/api/routes/token-exchange.ts
+++ b/src/api/routes/token-exchange.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import type { Context } from 'hono'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { captureException } from '@shared/lib/error-reporting'
 import { JWT_BEARER_GRANT_TYPE, type TokenExchangeErrorCode } from '@shared/lib/auth/token-exchange-schema'
 
 // Bound the raw form body and the assertion itself; a legitimate grant is a
@@ -93,9 +94,13 @@ tokenExchange.post('/exchange', async (c) => {
     return c.json(result, 200, NO_STORE_HEADERS)
   } catch (error) {
     if (error instanceof TokenExchangeError) {
+      // Expected OAuth denials are normal control flow — never reported.
+      // Internal failures masked as a denial are flagged by the service layer.
       return oauthError(c, 400, error.code)
     }
-    console.error('token exchange failed:', error)
+    // Genuinely unexpected failure. Report tags only — never the assertion,
+    // resulting token, jti, or any identity claim.
+    captureException(error, { tags: { component: 'token-exchange', operation: 'exchange' } })
     return oauthError(c, 500, 'server_error')
   }
 })

--- a/src/shared/lib/auth/config.test.ts
+++ b/src/shared/lib/auth/config.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Trusted-origins resolution: the TRUSTED_ORIGINS env var is the documented
+ * deployment interface and must win over settings.json — it feeds Better
+ * Auth's baseURL and the audience the token-exchange endpoint verifies
+ * grants against.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getAppBaseUrl, getTrustedOrigins } from './config'
+
+const mockSettings = vi.hoisted(() => ({ auth: {} as Record<string, unknown> }))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => mockSettings,
+}))
+
+const savedEnv: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const key of ['TRUSTED_ORIGINS', 'HOST', 'PORT', 'USE_HTTPS']) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+  mockSettings.auth = {}
+})
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+})
+
+describe('getTrustedOrigins', () => {
+  it('prefers the TRUSTED_ORIGINS env var over settings', () => {
+    process.env.TRUSTED_ORIGINS = 'https://cloud.example, https://second.example'
+    mockSettings.auth = { trustedOrigins: ['https://settings.example'] }
+    expect(getTrustedOrigins()).toEqual(['https://cloud.example', 'https://second.example'])
+  })
+
+  it('falls back to settings when the env var is unset or empty', () => {
+    mockSettings.auth = { trustedOrigins: ['https://settings.example'] }
+    expect(getTrustedOrigins()).toEqual(['https://settings.example'])
+    process.env.TRUSTED_ORIGINS = ' , '
+    expect(getTrustedOrigins()).toEqual(['https://settings.example'])
+  })
+})
+
+describe('getAppBaseUrl', () => {
+  it('uses the first TRUSTED_ORIGINS entry (the documented cloud contract)', () => {
+    process.env.TRUSTED_ORIGINS = 'https://cloud.example'
+    expect(getAppBaseUrl()).toBe('https://cloud.example')
+  })
+
+  it('falls back to HOST/PORT/USE_HTTPS when no origins are configured', () => {
+    process.env.HOST = 'deploy.example'
+    process.env.PORT = '8443'
+    process.env.USE_HTTPS = 'true'
+    expect(getAppBaseUrl()).toBe('https://deploy.example:8443')
+  })
+
+  it('defaults to localhost when nothing is configured', () => {
+    expect(getAppBaseUrl()).toBe('http://localhost:47891')
+  })
+})

--- a/src/shared/lib/auth/config.ts
+++ b/src/shared/lib/auth/config.ts
@@ -39,10 +39,21 @@ export function getAppBaseUrlFromRequest(c: Context): string {
 }
 
 /**
- * Get trusted origins from app settings.
- * Used for both CORS and Better Auth CSRF protection.
+ * Get trusted origins, env-first.
+ *
+ * The TRUSTED_ORIGINS env var is the documented deployment interface (README:
+ * "the first origin is also used as the app's base URL"), so it must win over
+ * settings.json — it feeds Better Auth's baseURL/CSRF config and the audience
+ * the RFC 7523 token endpoint verifies grants against.
  */
 export function getTrustedOrigins(): string[] {
+  const fromEnv = (process.env.TRUSTED_ORIGINS ?? '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+  if (fromEnv.length > 0) {
+    return fromEnv
+  }
   const settings = getSettings()
   return settings.auth?.trustedOrigins ?? []
 }

--- a/src/shared/lib/auth/index.ts
+++ b/src/shared/lib/auth/index.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
-import { admin, genericOAuth } from 'better-auth/plugins'
+import { admin, bearer, genericOAuth } from 'better-auth/plugins'
 import { and, eq, sql } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
 import * as schema from '@shared/lib/db/schema'
@@ -90,6 +90,9 @@ function createAuthInstance() {
       },
     },
     plugins: [
+      // Accepts the session token via `Authorization: Bearer` so non-browser
+      // clients (desktop app, watch) can call Authenticated() routes.
+      bearer(),
       admin({
         defaultRole: authSettings.defaultUserRole === 'admin' ? 'admin' : 'user',
       }),

--- a/src/shared/lib/auth/provider-config.ts
+++ b/src/shared/lib/auth/provider-config.ts
@@ -208,6 +208,13 @@ export function getPublicAuthProviders(
   return getEnabledProviderDefinitions(providers).map((definition) => definition.toPublicConfig())
 }
 
+// Whether the named provider is present and not explicitly disabled. Used to
+// gate flows (e.g. token exchange) that must not run when platform login has
+// been turned off, matching the interactive-login surface.
+export function isAuthProviderEnabled(id: string): boolean {
+  return resolveEnvAuthProviders().some((p) => p.id === id && p.enabled !== false)
+}
+
 // Issuer for the named provider, derived from `issuer` or `discoveryUrl`.
 export function getAuthProviderIssuer(id: string): string | undefined {
   const providers = resolveEnvAuthProviders()

--- a/src/shared/lib/auth/token-exchange-schema.ts
+++ b/src/shared/lib/auth/token-exchange-schema.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+// RFC 7523 JWT bearer authorization grant URN (RFC 7523 §2.1).
+export const JWT_BEARER_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+
+// Explicit token type for the platform-issued JWT authorization grant.
+// Distinct from `PLATFORM_TOKEN` org JWTs (typ JWT, aud platform-org-runtime)
+// so the two can never be confused.
+export const DEPLOYMENT_ASSERTION_TYP = 'deployment-assertion+jwt'
+
+// Grants must be short-lived; reject anything expiring further out than this.
+export const MAX_GRANT_LIFETIME_SEC = 300
+
+// Decoded JWT authorization-grant payload, validated after JOSE signature
+// verification. jose already enforced iss/aud/exp; this pins the shape of
+// everything the exchange logic consumes.
+export const DeploymentGrantClaimsSchema = z
+  .object({
+    iss: z.string().min(1),
+    sub: z.string().min(1).max(256),
+    aud: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]),
+    iat: z.number().int(),
+    exp: z.number().int(),
+    jti: z.string().min(1).max(256),
+    org_id: z.string().min(1).max(256),
+    user_id: z.string().min(1).max(256).optional(),
+    email: z.email().max(320),
+    email_verified: z.boolean(),
+    name: z.string().max(512).optional(),
+    role: z.string().max(64).optional(),
+  })
+  .passthrough()
+
+export type DeploymentGrantClaims = z.infer<typeof DeploymentGrantClaimsSchema>
+
+// OAuth token endpoint success payload (RFC 6749 §5.1). The access token is
+// a Better Auth session token, but that is an implementation detail — the
+// wire contract is a plain OAuth bearer response.
+export const TokenExchangeSuccessSchema = z.object({
+  access_token: z.string().min(1),
+  token_type: z.literal('Bearer'),
+  expires_in: z.number().int().nonnegative(),
+})
+
+export type TokenExchangeSuccess = z.infer<typeof TokenExchangeSuccessSchema>
+
+export type TokenExchangeErrorCode =
+  | 'invalid_request'
+  | 'unsupported_grant_type'
+  | 'invalid_grant'

--- a/src/shared/lib/auth/token-exchange.integration.test.ts
+++ b/src/shared/lib/auth/token-exchange.integration.test.ts
@@ -9,13 +9,20 @@
  * the issued access token authenticates through Authenticated() via the
  * bearer plugin.
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import crypto from 'crypto'
 import { Hono } from 'hono'
 import { generateKeyPair, exportJWK, SignJWT, createLocalJWKSet, type JWTPayload } from 'jose'
+
+// Spy on Sentry reporting while keeping every other export real.
+const captureExceptionMock = vi.hoisted(() => vi.fn())
+vi.mock('@shared/lib/error-reporting', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shared/lib/error-reporting')>()),
+  captureException: captureExceptionMock,
+}))
 
 const TEST_ISSUER = 'https://auth.test.example'
 const TEST_ORG = 'org_test_123'
@@ -465,5 +472,40 @@ describe('approval and ban enforcement', () => {
     expect(res.status).toBe(200)
     const user = dbModule.sqlite.prepare(`SELECT banned FROM user`).get() as { banned: number }
     expect(user.banned).toBe(0)
+  })
+})
+
+describe('observability', () => {
+  beforeEach(() => captureExceptionMock.mockClear())
+
+  it('does not report expected OAuth denials to Sentry', async () => {
+    const res = await exchangeRequest(await signGrant({ audience: 'https://other.example' }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+    expect(captureExceptionMock).not.toHaveBeenCalled()
+  })
+
+  it('reports an unexpected replay-table failure while still denying the client', async () => {
+    // Drop the replay table so jti consumption hits a real DB error (not a
+    // normal replay conflict). The client still sees a generic denial.
+    dbModule.sqlite.prepare(`DROP TABLE token_exchange_jti`).run()
+    try {
+      const res = await exchangeRequest(await signGrant())
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toBe('invalid_grant')
+      expect(captureExceptionMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          tags: expect.objectContaining({ component: 'token-exchange', operation: 'jti-consume' }),
+        }),
+      )
+    } finally {
+      dbModule.sqlite
+        .prepare('CREATE TABLE `token_exchange_jti` (`jti` text PRIMARY KEY NOT NULL, `expires_at` integer NOT NULL)')
+        .run()
+      dbModule.sqlite
+        .prepare('CREATE INDEX `token_exchange_jti_expires_at_idx` ON `token_exchange_jti` (`expires_at`)')
+        .run()
+    }
   })
 })

--- a/src/shared/lib/auth/token-exchange.integration.test.ts
+++ b/src/shared/lib/auth/token-exchange.integration.test.ts
@@ -307,6 +307,28 @@ describe('grant verification', () => {
     expect((await res.json()).error).toBe('invalid_grant')
   })
 
+  it('rejects a still-valid grant whose total lifetime exceeds the max', async () => {
+    // Old iat, near-future exp: not yet expired, but claims a >5min lifetime.
+    const now = Math.floor(Date.now() / 1000)
+    const res = await exchangeRequest(await signGrant({ iat: now - 3600, exp: now + 120 }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('refuses to exchange when the deployment org pin is unavailable', async () => {
+    const pinned = process.env.PLATFORM_TOKEN
+    delete process.env.PLATFORM_TOKEN
+    try {
+      // A correctly-signed grant for the right org must still be rejected:
+      // without a verified org pin the exchange fails closed.
+      const res = await exchangeRequest(await signGrant())
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toBe('invalid_grant')
+    } finally {
+      process.env.PLATFORM_TOKEN = pinned
+    }
+  })
+
   it('rejects a grant whose email is not an email address', async () => {
     const res = await exchangeRequest(
       await signGrant({ payload: { email: 'not-an-email' } }),
@@ -337,6 +359,27 @@ describe('grant verification', () => {
         'content-length': String(64 * 1024),
       },
       body: new URLSearchParams({ grant_type: GRANT_TYPE, assertion: 'x' }).toString(),
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_request')
+  })
+
+  it('rejects an oversized chunked body that declares no content-length', async () => {
+    // A streamed body has no Content-Length, so the pre-check can't see it;
+    // bodyLimit must abort mid-stream by byte count.
+    const oversized = 'a'.repeat(20 * 1024)
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(oversized))
+        controller.close()
+      },
+    })
+    const res = await app.request('/api/auth/token/exchange', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: stream,
+      // @ts-expect-error duplex is required for a streaming request body
+      duplex: 'half',
     })
     expect(res.status).toBe(400)
     expect((await res.json()).error).toBe('invalid_request')

--- a/src/shared/lib/auth/token-exchange.integration.test.ts
+++ b/src/shared/lib/auth/token-exchange.integration.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Integration tests for the RFC 7523 token endpoint + bearer plugin, against
+ * a real Better Auth instance and a real SQLite database in a temp data dir.
+ *
+ * Proves the full contract: form parsing, grant verification (signature,
+ * issuer, audience, typ, lifetime, org gate, email_verified), atomic jti
+ * replay, provisioning through Better Auth (first-user bootstrap, pending
+ * approval, banned users, account linking, stable subject mapping), and that
+ * the issued access token authenticates through Authenticated() via the
+ * bearer plugin.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import { Hono } from 'hono'
+import { generateKeyPair, exportJWK, SignJWT, createLocalJWKSet, type JWTPayload } from 'jose'
+
+const TEST_ISSUER = 'https://auth.test.example'
+const TEST_ORG = 'org_test_123'
+const SIGNING_KID = 'platform-oidc-main'
+const GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+
+let tmpDir: string
+let privateKey: CryptoKey
+let audience: string
+// Deferred imports (must happen after env setup)
+let dbModule: typeof import('@shared/lib/db')
+let app: Hono
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj)).toString('base64url')
+}
+
+interface GrantOptions {
+  payload?: Partial<JWTPayload> & Record<string, unknown>
+  typ?: string
+  issuer?: string
+  audience?: string | string[]
+  iat?: number
+  exp?: number
+}
+
+async function signGrant(options: GrantOptions = {}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000)
+  const payload: Record<string, unknown> = {
+    sub: 'sub_member_1',
+    org_id: TEST_ORG,
+    user_id: 'platform-user-uuid-1',
+    email: 'member@example.com',
+    email_verified: true,
+    name: 'Member One',
+    role: 'member',
+    jti: crypto.randomUUID(),
+    ...options.payload,
+  }
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'RS256', typ: options.typ ?? 'deployment-assertion+jwt', kid: SIGNING_KID })
+    .setIssuer(options.issuer ?? TEST_ISSUER)
+    .setAudience(options.audience ?? audience)
+    .setIssuedAt(options.iat ?? now)
+    .setExpirationTime(options.exp ?? now + 120)
+    .sign(privateKey)
+}
+
+function exchangeRequest(assertion: string, overrides: {
+  grantType?: string
+  contentType?: string
+  rawBody?: string
+  headers?: Record<string, string>
+} = {}) {
+  const body =
+    overrides.rawBody ??
+    new URLSearchParams({
+      grant_type: overrides.grantType ?? GRANT_TYPE,
+      assertion,
+    }).toString()
+  return app.request('/api/auth/token/exchange', {
+    method: 'POST',
+    headers: {
+      'content-type': overrides.contentType ?? 'application/x-www-form-urlencoded',
+      ...overrides.headers,
+    },
+    body,
+  })
+}
+
+function countRows(table: string): number {
+  const row = dbModule.sqlite.prepare(`SELECT count(*) AS n FROM ${table}`).get() as { n: number }
+  return row.n
+}
+
+function wipeAuthTables(): void {
+  for (const table of ['session', 'account', 'user', 'token_exchange_jti']) {
+    dbModule.sqlite.prepare(`DELETE FROM ${table}`).run()
+  }
+}
+
+async function writeAuthSettings(auth: Record<string, unknown>): Promise<void> {
+  const settingsPath = path.join(tmpDir, 'settings.json')
+  const current = fs.existsSync(settingsPath)
+    ? JSON.parse(fs.readFileSync(settingsPath, 'utf-8'))
+    : {}
+  fs.writeFileSync(settingsPath, JSON.stringify({ ...current, auth }))
+  const { clearSettingsCache } = await import('@shared/lib/config/settings')
+  clearSettingsCache()
+}
+
+beforeAll(async () => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'token-exchange-')))
+  process.env.SUPERAGENT_DATA_DIR = tmpDir
+  process.env.AUTH_MODE = 'true'
+  process.env.BETTER_AUTH_SECRET = 'test-secret-0123456789abcdef0123456789abcdef'
+  // Org-pinned deployment: unverified decode of the orgId claim is all the
+  // org gate needs, so an unsigned JWT-shaped token is fine here.
+  process.env.PLATFORM_TOKEN = `${b64url({ alg: 'RS256' })}.${b64url({ orgId: TEST_ORG })}.sig`
+  process.env.AUTH_PROVIDERS_JSON = JSON.stringify([
+    { id: 'platform', type: 'oidc', issuer: TEST_ISSUER, clientId: 'superagent-org-test' },
+  ])
+
+  const pair = await generateKeyPair('RS256')
+  privateKey = pair.privateKey as CryptoKey
+  const jwk = await exportJWK(pair.publicKey)
+  jwk.kid = SIGNING_KID
+  jwk.alg = 'RS256'
+  const { _setOidcJwksResolverForTest } = await import('./oidc-jwt')
+  _setOidcJwksResolverForTest(createLocalJWKSet({ keys: [jwk] }) as never)
+
+  const { getAppBaseUrl } = await import('./config')
+  audience = getAppBaseUrl()
+
+  dbModule = await import('@shared/lib/db')
+
+  const tokenExchangeRoute = (await import('../../../api/routes/token-exchange')).default
+  const { Authenticated } = await import('../../../api/middleware/auth')
+  app = new Hono()
+  app.route('/api/auth/token', tokenExchangeRoute)
+  app.get('/api/protected', Authenticated(), (c) =>
+    c.json({ userId: (c.get('user' as never) as { id: string }).id }),
+  )
+})
+
+afterAll(async () => {
+  const { _setOidcJwksResolverForTest } = await import('./oidc-jwt')
+  _setOidcJwksResolverForTest(null)
+  delete process.env.SUPERAGENT_DATA_DIR
+  delete process.env.AUTH_MODE
+  delete process.env.PLATFORM_TOKEN
+  delete process.env.AUTH_PROVIDERS_JSON
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+beforeEach(async () => {
+  wipeAuthTables()
+  await writeAuthSettings({})
+})
+
+describe('request validation', () => {
+  it('rejects a non-form content type', async () => {
+    const res = await exchangeRequest('x', { contentType: 'application/json' })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_request')
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(res.headers.get('pragma')).toBe('no-cache')
+  })
+
+  it('rejects a missing grant_type', async () => {
+    const res = await exchangeRequest('x', { rawBody: `assertion=x` })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_request')
+  })
+
+  it('rejects a wrong grant_type with unsupported_grant_type', async () => {
+    const res = await exchangeRequest('x', { grantType: 'authorization_code' })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('unsupported_grant_type')
+  })
+
+  it('rejects a missing assertion', async () => {
+    const res = await exchangeRequest('', {
+      rawBody: `grant_type=${encodeURIComponent(GRANT_TYPE)}`,
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_request')
+  })
+
+  it('rejects a duplicated assertion parameter', async () => {
+    const grant = await signGrant()
+    const res = await exchangeRequest('', {
+      rawBody: `grant_type=${encodeURIComponent(GRANT_TYPE)}&assertion=${grant}&assertion=${grant}`,
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_request')
+  })
+
+  it('rejects an oversized assertion', async () => {
+    const res = await exchangeRequest('a'.repeat(9000))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_request')
+  })
+})
+
+describe('grant verification', () => {
+  it('exchanges a valid grant for a working bearer token', async () => {
+    const res = await exchangeRequest(await signGrant(), {
+      headers: { 'user-agent': 'SuperagentDesktop/1.0' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    const body = await res.json()
+    expect(body.token_type).toBe('Bearer')
+    expect(body.expires_in).toBeGreaterThan(0)
+    expect(typeof body.access_token).toBe('string')
+
+    // The token authenticates through Authenticated() via the bearer plugin.
+    const protectedRes = await app.request('/api/protected', {
+      headers: { authorization: `Bearer ${body.access_token}` },
+    })
+    expect(protectedRes.status).toBe(200)
+    const who = await protectedRes.json()
+    expect(typeof who.userId).toBe('string')
+
+    // Session hygiene: userAgent recorded for the sessions list.
+    const session = dbModule.sqlite
+      .prepare(`SELECT user_agent FROM session WHERE token = ?`)
+      .get(body.access_token) as { user_agent: string }
+    expect(session.user_agent).toBe('SuperagentDesktop/1.0')
+  })
+
+  it('rejects a garbage bearer token on protected routes', async () => {
+    const res = await app.request('/api/protected', {
+      headers: { authorization: 'Bearer not-a-real-token' },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects a grant with the wrong audience', async () => {
+    const res = await exchangeRequest(await signGrant({ audience: 'https://other.example' }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a grant with the wrong issuer', async () => {
+    const res = await exchangeRequest(await signGrant({ issuer: 'https://evil.example' }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a grant without the deployment-assertion typ (org JWT confusion)', async () => {
+    const res = await exchangeRequest(await signGrant({ typ: 'JWT' }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects an expired grant', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const res = await exchangeRequest(await signGrant({ iat: now - 300, exp: now - 60 }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a grant living longer than five minutes', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const res = await exchangeRequest(await signGrant({ exp: now + 3600 }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a grant for another organization', async () => {
+    const res = await exchangeRequest(await signGrant({ payload: { org_id: 'org_other' } }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a grant with an unverified email', async () => {
+    const res = await exchangeRequest(await signGrant({ payload: { email_verified: false } }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a grant missing required claims', async () => {
+    const res = await exchangeRequest(await signGrant({ payload: { jti: undefined } }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a multi-valued audience even when it contains this deployment', async () => {
+    const res = await exchangeRequest(
+      await signGrant({ audience: [audience, 'https://other.example'] }),
+    )
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a grant issued in the future', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const res = await exchangeRequest(await signGrant({ iat: now + 120, exp: now + 240 }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('rejects a grant whose email is not an email address', async () => {
+    const res = await exchangeRequest(
+      await signGrant({ payload: { email: 'not-an-email' } }),
+    )
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('refuses to exchange when the platform provider is disabled', async () => {
+    const enabled = process.env.AUTH_PROVIDERS_JSON
+    process.env.AUTH_PROVIDERS_JSON = JSON.stringify([
+      { id: 'platform', type: 'oidc', issuer: TEST_ISSUER, clientId: 'superagent-org-test', enabled: false },
+    ])
+    try {
+      const res = await exchangeRequest(await signGrant())
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toBe('invalid_grant')
+    } finally {
+      process.env.AUTH_PROVIDERS_JSON = enabled
+    }
+  })
+
+  it('rejects an oversized declared content-length up front', async () => {
+    const res = await app.request('/api/auth/token/exchange', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'content-length': String(64 * 1024),
+      },
+      body: new URLSearchParams({ grant_type: GRANT_TYPE, assertion: 'x' }).toString(),
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_request')
+  })
+})
+
+describe('replay prevention', () => {
+  it('rejects a replayed jti', async () => {
+    const grant = await signGrant()
+    const first = await exchangeRequest(grant)
+    expect(first.status).toBe(200)
+    const second = await exchangeRequest(grant)
+    expect(second.status).toBe(400)
+    expect((await second.json()).error).toBe('invalid_grant')
+  })
+
+  it('lets exactly one of two concurrent redemptions win', async () => {
+    const grant = await signGrant()
+    const [a, b] = await Promise.all([exchangeRequest(grant), exchangeRequest(grant)])
+    const statuses = [a.status, b.status].sort()
+    expect(statuses).toEqual([200, 400])
+    expect(countRows('session')).toBe(1)
+  })
+})
+
+describe('provisioning and identity mapping', () => {
+  it('promotes the first exchanged user to admin', async () => {
+    const res = await exchangeRequest(await signGrant())
+    expect(res.status).toBe(200)
+    const user = dbModule.sqlite
+      .prepare(`SELECT role, email, email_verified FROM user`)
+      .get() as { role: string; email: string; email_verified: number }
+    expect(user.role).toBe('admin')
+    expect(user.email).toBe('member@example.com')
+    expect(user.email_verified).toBe(1)
+  })
+
+  it('keeps the (providerId, sub) mapping stable across email changes', async () => {
+    const first = await exchangeRequest(await signGrant())
+    expect(first.status).toBe(200)
+    const originalUserId = (dbModule.sqlite.prepare(`SELECT id FROM user`).get() as { id: string }).id
+
+    const second = await exchangeRequest(
+      await signGrant({ payload: { email: 'renamed@example.com' } }),
+    )
+    expect(second.status).toBe(200)
+    expect(countRows('user')).toBe(1)
+    const sessions = dbModule.sqlite
+      .prepare(`SELECT DISTINCT user_id FROM session`)
+      .all() as { user_id: string }[]
+    expect(sessions).toEqual([{ user_id: originalUserId }])
+  })
+
+  it('links the platform identity to an existing user with the same email', async () => {
+    const { getAuth } = await import('./index')
+    await getAuth().api.signUpEmail({
+      body: {
+        email: 'member@example.com',
+        password: 'CorrectHorseBattery1!',
+        name: 'Local Member',
+      },
+    })
+    expect(countRows('user')).toBe(1)
+
+    const res = await exchangeRequest(await signGrant())
+    expect(res.status).toBe(200)
+    expect(countRows('user')).toBe(1)
+    const accounts = dbModule.sqlite
+      .prepare(`SELECT provider_id FROM account ORDER BY provider_id`)
+      .all() as { provider_id: string }[]
+    expect(accounts.map((a) => a.provider_id)).toEqual(['credential', 'platform'])
+  })
+
+  it('creates one user and one mapping for concurrent first exchanges', async () => {
+    const [a, b] = await Promise.all([
+      exchangeRequest(await signGrant()),
+      exchangeRequest(await signGrant()),
+    ])
+    expect(a.status).toBe(200)
+    expect(b.status).toBe(200)
+    expect(countRows('user')).toBe(1)
+    const mappings = dbModule.sqlite
+      .prepare(`SELECT count(*) AS n FROM account WHERE provider_id = 'platform'`)
+      .get() as { n: number }
+    expect(mappings.n).toBe(1)
+    expect(countRows('session')).toBe(2)
+  })
+})
+
+describe('approval and ban enforcement', () => {
+  it('refuses a session for a user pending admin approval', async () => {
+    // Seed a first user so the exchanged user is not the bootstrap admin.
+    const first = await exchangeRequest(await signGrant())
+    expect(first.status).toBe(200)
+
+    await writeAuthSettings({ requireAdminApproval: true })
+    const res = await exchangeRequest(
+      await signGrant({ payload: { sub: 'sub_member_2', email: 'second@example.com' } }),
+    )
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+
+    // User row exists (pending), but no session was minted for it.
+    const pending = dbModule.sqlite
+      .prepare(`SELECT id, banned, ban_reason FROM user WHERE email = 'second@example.com'`)
+      .get() as { id: string; banned: number; ban_reason: string }
+    expect(pending.banned).toBe(1)
+    expect(pending.ban_reason).toBe('Pending admin approval')
+    const sessions = dbModule.sqlite
+      .prepare(`SELECT count(*) AS n FROM session WHERE user_id = ?`)
+      .get(pending.id) as { n: number }
+    expect(sessions.n).toBe(0)
+  })
+
+  it('refuses a session for a banned user', async () => {
+    const first = await exchangeRequest(await signGrant())
+    expect(first.status).toBe(200)
+    dbModule.sqlite.prepare(`UPDATE user SET banned = 1, ban_reason = 'nope'`).run()
+
+    const res = await exchangeRequest(await signGrant())
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('invalid_grant')
+  })
+
+  it('auto-unbans when the ban has expired', async () => {
+    const first = await exchangeRequest(await signGrant())
+    expect(first.status).toBe(200)
+    dbModule.sqlite
+      .prepare(`UPDATE user SET banned = 1, ban_expires = ?`)
+      .run(Date.now() - 60_000)
+
+    const res = await exchangeRequest(await signGrant())
+    expect(res.status).toBe(200)
+    const user = dbModule.sqlite.prepare(`SELECT banned FROM user`).get() as { banned: number }
+    expect(user.banned).toBe(0)
+  })
+})

--- a/src/shared/lib/auth/token-exchange.ts
+++ b/src/shared/lib/auth/token-exchange.ts
@@ -83,11 +83,19 @@ async function verifyGrant(assertion: string): Promise<DeploymentGrantClaims> {
   const claims = parsed.data
 
   const nowSec = Math.floor(Date.now() / 1000)
-  if (claims.exp > nowSec + MAX_GRANT_LIFETIME_SEC + CLOCK_SKEW_SEC) {
-    throw new TokenExchangeError('invalid_grant')
-  }
   // Not issued in the future (jose does not check iat by default).
   if (claims.iat > nowSec + CLOCK_SKEW_SEC) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+  // Positive, bounded total lifetime — enforce the documented ≤5-min contract
+  // against iat directly, not just how far exp sits from now. A grant claiming
+  // a long lifetime (old iat, near-future exp) is rejected even if it hasn't
+  // expired yet.
+  if (claims.exp <= claims.iat || claims.exp - claims.iat > MAX_GRANT_LIFETIME_SEC) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+  // And it must still be fresh relative to now.
+  if (claims.exp > nowSec + MAX_GRANT_LIFETIME_SEC + CLOCK_SKEW_SEC) {
     throw new TokenExchangeError('invalid_grant')
   }
   // Exactly this deployment as the sole audience: jose accepts any array
@@ -96,10 +104,14 @@ async function verifyGrant(assertion: string): Promise<DeploymentGrantClaims> {
     throw new TokenExchangeError('invalid_grant')
   }
 
-  // Org gate: identical to interactive login — a grant minted for another
-  // org's deployment can never create a session here.
+  // Org gate — fail closed. The browser-login gate allows a non-org-pinned
+  // deployment (no PLATFORM_TOKEN → any org), but a headless token exchange
+  // must not: a missing or malformed deployment org pin is a misconfiguration,
+  // and minting a session for an unverified org would be a fail-open. Every
+  // real auth-mode deployment carries PLATFORM_TOKEN, so this only rejects the
+  // broken case.
   const deploymentOrg = decodeOrgIdFromToken(process.env.PLATFORM_TOKEN ?? '')
-  if (deploymentOrg && claims.org_id !== deploymentOrg) {
+  if (!deploymentOrg || claims.org_id !== deploymentOrg) {
     throw new TokenExchangeError('invalid_grant')
   }
 

--- a/src/shared/lib/auth/token-exchange.ts
+++ b/src/shared/lib/auth/token-exchange.ts
@@ -1,4 +1,5 @@
 import { lt } from 'drizzle-orm'
+import { captureException } from '@shared/lib/error-reporting'
 import { db } from '@shared/lib/db'
 import { tokenExchangeJti } from '@shared/lib/db/schema'
 import { decodeOrgIdFromToken } from '@shared/lib/platform-auth/decode-org-id'
@@ -127,7 +128,9 @@ function consumeJti(jti: string, expSec: number): void {
     }
   } catch (error) {
     if (error instanceof TokenExchangeError) throw error
-    console.error('token exchange: jti consumption failed:', error)
+    // Replay is a normal conflict (handled above); reaching here means the
+    // replay table itself is failing — report it (never the jti value).
+    captureException(error, { tags: { component: 'token-exchange', operation: 'jti-consume' } })
     throw new TokenExchangeError('invalid_grant')
   }
 }
@@ -270,6 +273,12 @@ export async function exchangeDeploymentGrant(
   // auto-unban.
   const fresh = await ctx.internalAdapter.findUserById(user.id)
   if (!fresh) {
+    // Invariant violation: resolveUser just produced this user. Masked to the
+    // client as a generic denial, but a systemic occurrence must be visible.
+    captureException(new Error('token exchange: resolved user missing after provisioning'), {
+      tags: { component: 'token-exchange', operation: 'user-missing' },
+      extra: { userId: user.id },
+    })
     throw new TokenExchangeError('invalid_grant')
   }
   const banned = fresh as typeof fresh & { banned?: boolean | null; banExpires?: Date | null }
@@ -292,6 +301,10 @@ export async function exchangeDeploymentGrant(
     ipAddress: meta.ipAddress ?? '',
   })
   if (!session) {
+    captureException(new Error('token exchange: session creation returned no session'), {
+      tags: { component: 'token-exchange', operation: 'session-create' },
+      extra: { userId: fresh.id },
+    })
     throw new TokenExchangeError('invalid_grant')
   }
 

--- a/src/shared/lib/auth/token-exchange.ts
+++ b/src/shared/lib/auth/token-exchange.ts
@@ -1,0 +1,308 @@
+import { lt } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { tokenExchangeJti } from '@shared/lib/db/schema'
+import { decodeOrgIdFromToken } from '@shared/lib/platform-auth/decode-org-id'
+import { PLATFORM_AUTH_PROVIDER_ID } from '@shared/lib/services/platform-auth-service'
+import { getAuth } from './index'
+import { getAppBaseUrl } from './config'
+import { verifyOidcJwt } from './oidc-jwt'
+import { getAuthProviderIssuer, isAuthProviderEnabled } from './provider-config'
+import {
+  DEPLOYMENT_ASSERTION_TYP,
+  DeploymentGrantClaimsSchema,
+  MAX_GRANT_LIFETIME_SEC,
+  type DeploymentGrantClaims,
+  type TokenExchangeErrorCode,
+  type TokenExchangeSuccess,
+} from './token-exchange-schema'
+
+// Allow small clock drift between platform and deployment when checking
+// the grant's maximum lifetime.
+const CLOCK_SKEW_SEC = 5
+
+/**
+ * OAuth error for the token endpoint. `description` must never disclose
+ * whether an email, membership, account mapping, or jti exists.
+ */
+export class TokenExchangeError extends Error {
+  constructor(
+    public readonly code: TokenExchangeErrorCode,
+    public readonly description?: string,
+  ) {
+    super(description ?? code)
+    this.name = 'TokenExchangeError'
+  }
+}
+
+export interface TokenExchangeRequestMeta {
+  userAgent?: string
+  ipAddress?: string
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const code = (error as { code?: string }).code
+  if (code === 'SQLITE_CONSTRAINT_UNIQUE' || code === 'SQLITE_CONSTRAINT_PRIMARYKEY') return true
+  return /unique constraint/i.test(error.message)
+}
+
+/**
+ * Verify the platform-signed JWT authorization grant: signature via the
+ * platform JWKS, issuer, audience (this deployment's configured base URL —
+ * never derived from request headers), explicit typ, and payload shape.
+ */
+async function verifyGrant(assertion: string): Promise<DeploymentGrantClaims> {
+  // Gate on the same provider that backs interactive login: if platform login
+  // is unconfigured or explicitly disabled, no session may be minted here.
+  const issuer = getAuthProviderIssuer(PLATFORM_AUTH_PROVIDER_ID)
+  if (!issuer || !isAuthProviderEnabled(PLATFORM_AUTH_PROVIDER_ID)) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+  // Same canonical form the platform signs (origin + path, no trailing
+  // slash), so an operator-supplied trailing slash can't break verification.
+  const audience = getAppBaseUrl().replace(/\/+$/, '')
+
+  let payload: unknown
+  try {
+    const result = await verifyOidcJwt(assertion, {
+      issuer,
+      audience,
+      algorithms: ['RS256'],
+      typ: DEPLOYMENT_ASSERTION_TYP,
+    })
+    payload = result.payload
+  } catch {
+    throw new TokenExchangeError('invalid_grant')
+  }
+
+  const parsed = DeploymentGrantClaimsSchema.safeParse(payload)
+  if (!parsed.success) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+  const claims = parsed.data
+
+  const nowSec = Math.floor(Date.now() / 1000)
+  if (claims.exp > nowSec + MAX_GRANT_LIFETIME_SEC + CLOCK_SKEW_SEC) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+  // Not issued in the future (jose does not check iat by default).
+  if (claims.iat > nowSec + CLOCK_SKEW_SEC) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+  // Exactly this deployment as the sole audience: jose accepts any array
+  // containing the value, but a grant is minted for one deployment only.
+  if (claims.aud !== audience) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+
+  // Org gate: identical to interactive login — a grant minted for another
+  // org's deployment can never create a session here.
+  const deploymentOrg = decodeOrgIdFromToken(process.env.PLATFORM_TOKEN ?? '')
+  if (deploymentOrg && claims.org_id !== deploymentOrg) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+
+  if (claims.email_verified !== true) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+
+  return claims
+}
+
+/**
+ * Atomically consume the grant's jti. The INSERT's primary-key constraint is
+ * the replay gate: only the request whose insert lands may continue.
+ */
+function consumeJti(jti: string, expSec: number): void {
+  try {
+    // Opportunistic TTL cleanup keeps the table bounded.
+    db.delete(tokenExchangeJti).where(lt(tokenExchangeJti.expiresAt, new Date())).run()
+    const result = db
+      .insert(tokenExchangeJti)
+      .values({ jti, expiresAt: new Date(expSec * 1000) })
+      .onConflictDoNothing()
+      .run()
+    if (result.changes === 0) {
+      throw new TokenExchangeError('invalid_grant')
+    }
+  } catch (error) {
+    if (error instanceof TokenExchangeError) throw error
+    console.error('token exchange: jti consumption failed:', error)
+    throw new TokenExchangeError('invalid_grant')
+  }
+}
+
+type AuthContext = Awaited<ReturnType<typeof getAuth>['$context']>
+
+/**
+ * Resolve the Better Auth user for the grant, provisioning on first exchange.
+ *
+ * Resolution order (per the stable-identity contract):
+ *  1. Existing `(providerId, accountId)` account mapping wins — even over a
+ *     later email change on the platform side.
+ *  2. Otherwise the verified, normalized email resolves to the existing user
+ *     (linking the platform identity) or provisions a new user.
+ *
+ * All writes go through Better Auth's internal adapter so database hooks run:
+ * first-user bootstrap, pending-approval banning, and session limits behave
+ * exactly as they do for browser OIDC login.
+ */
+async function resolveUser(ctx: AuthContext, claims: DeploymentGrantClaims) {
+  const providerId = PLATFORM_AUTH_PROVIDER_ID
+  const email = claims.email.trim().toLowerCase()
+
+  type FoundUser = NonNullable<
+    Awaited<ReturnType<AuthContext['internalAdapter']['findOAuthUser']>>
+  >['user']
+
+  // Link the platform identity to an existing user, honoring the app's
+  // account-linking policy.
+  // Widen: the inferred options type only carries the literal keys set in
+  // our config, but the runtime policy honors all linking options.
+  const linkPlatformMapping = async (user: FoundUser) => {
+    const linking = ctx.options.account?.accountLinking as
+      | {
+          enabled?: boolean
+          disableImplicitLinking?: boolean
+          requireLocalEmailVerified?: boolean
+        }
+      | undefined
+    if (linking?.enabled === false || linking?.disableImplicitLinking === true) {
+      throw new TokenExchangeError('invalid_grant')
+    }
+    if ((linking?.requireLocalEmailVerified ?? true) && !user.emailVerified) {
+      throw new TokenExchangeError('invalid_grant')
+    }
+    await ctx.internalAdapter.linkAccount({
+      providerId,
+      accountId: claims.sub,
+      userId: user.id,
+    })
+  }
+
+  const attempt = async () => {
+    const found = await ctx.internalAdapter.findOAuthUser(email, claims.sub, providerId)
+    if (found?.linkedAccount) {
+      return found.user
+    }
+
+    if (found) {
+      // User exists by email but has no platform mapping yet.
+      await linkPlatformMapping(found.user)
+      if (!found.user.emailVerified && found.user.email === email) {
+        await ctx.internalAdapter.updateUser(found.user.id, { emailVerified: true })
+      }
+      return found.user
+    }
+
+    const created = await ctx.internalAdapter.createOAuthUser(
+      {
+        email,
+        name: claims.name?.trim() || email,
+        emailVerified: true,
+      },
+      {
+        providerId,
+        accountId: claims.sub,
+      },
+    )
+    if (!created?.user) {
+      throw new TokenExchangeError('invalid_grant')
+    }
+    return created.user
+  }
+
+  try {
+    return await attempt()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+    // A concurrent exchange won an insert race. Two cases:
+    //  - same subject: the winner persisted our (providerId, sub) mapping;
+    //  - different subject, same email: the winner created the user, and
+    //    this subject's mapping does not exist yet.
+    // Either way, reload and make sure THIS subject's mapping is persisted
+    // before any session is minted for it.
+    const winner = await ctx.internalAdapter.findOAuthUser(email, claims.sub, providerId)
+    if (!winner) {
+      throw new TokenExchangeError('invalid_grant')
+    }
+    if (winner.linkedAccount) {
+      return winner.user
+    }
+    try {
+      await linkPlatformMapping(winner.user)
+    } catch (linkError) {
+      // Yet another concurrent linker may have won; anything else is real.
+      if (linkError instanceof TokenExchangeError) throw linkError
+      if (!isUniqueConstraintError(linkError)) throw linkError
+    }
+    const final = await ctx.internalAdapter.findOAuthUser(email, claims.sub, providerId)
+    if (!final?.linkedAccount) {
+      throw new TokenExchangeError('invalid_grant')
+    }
+    return final.user
+  }
+}
+
+/**
+ * RFC 7523 exchange: verify a platform-issued JWT authorization grant,
+ * atomically consume its jti, resolve/provision the Better Auth user, and
+ * return an OAuth bearer response backed by a Better Auth session.
+ */
+export async function exchangeDeploymentGrant(
+  assertion: string,
+  meta: TokenExchangeRequestMeta = {},
+): Promise<TokenExchangeSuccess> {
+  const claims = await verifyGrant(assertion)
+
+  // Only after full cryptographic + claim validation: burn the jti.
+  consumeJti(claims.jti, claims.exp)
+
+  const auth = getAuth()
+  const ctx = await auth.$context
+
+  const user = await resolveUser(ctx, claims)
+
+  // Banned/pending enforcement. The admin plugin's session.create.before hook
+  // only runs inside an endpoint context, so enforce here explicitly —
+  // including the pending-approval ban applied by the user.create.after hook
+  // during first-exchange provisioning. Mirrors the plugin's banExpires
+  // auto-unban.
+  const fresh = await ctx.internalAdapter.findUserById(user.id)
+  if (!fresh) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+  const banned = fresh as typeof fresh & { banned?: boolean | null; banExpires?: Date | null }
+  if (banned.banned) {
+    if (banned.banExpires && new Date(banned.banExpires).getTime() < Date.now()) {
+      await ctx.internalAdapter.updateUser(fresh.id, {
+        banned: false,
+        banReason: null,
+        banExpires: null,
+      })
+    } else {
+      throw new TokenExchangeError('invalid_grant')
+    }
+  }
+
+  // Session hygiene: record where this session came from so users can see
+  // and revoke it in the sessions list.
+  const session = await ctx.internalAdapter.createSession(fresh.id, false, {
+    userAgent: meta.userAgent?.slice(0, 512) || 'token-exchange',
+    ipAddress: meta.ipAddress ?? '',
+  })
+  if (!session) {
+    throw new TokenExchangeError('invalid_grant')
+  }
+
+  const expiresIn = Math.max(
+    0,
+    Math.floor((new Date(session.expiresAt).getTime() - Date.now()) / 1000),
+  )
+
+  return {
+    access_token: session.token,
+    token_type: 'Bearer',
+    expires_in: expiresIn,
+  }
+}

--- a/src/shared/lib/db/migrations/0032_great_miek.sql
+++ b/src/shared/lib/db/migrations/0032_great_miek.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `token_exchange_jti` (
+	`jti` text PRIMARY KEY NOT NULL,
+	`expires_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `token_exchange_jti_expires_at_idx` ON `token_exchange_jti` (`expires_at`);--> statement-breakpoint
+DELETE FROM `account` WHERE `rowid` NOT IN (SELECT MIN(`rowid`) FROM `account` GROUP BY `provider_id`, `account_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `account_provider_account_unique` ON `account` (`provider_id`,`account_id`);

--- a/src/shared/lib/db/migrations/meta/0032_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0032_snapshot.json
@@ -1,0 +1,2476 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0ceba77d-cab7-443b-aa01-49af463f4409",
+  "prevId": "127e87a1-bdd9-4e34-8272-feadf83eb384",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_audit_log_agent_slug_created_at_idx": {
+          "name": "mcp_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_remote_mcp_id_created_at_idx": {
+          "name": "mcp_audit_log_remote_mcp_id_created_at_idx",
+          "columns": [
+            "remote_mcp_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_mcp_agent_idx": {
+          "name": "mcp_audit_log_mcp_agent_idx",
+          "columns": [
+            "remote_mcp_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_audit_log_agent_slug_created_at_idx": {
+          "name": "proxy_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_id_created_at_idx": {
+          "name": "proxy_audit_log_account_id_created_at_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_agent_idx": {
+          "name": "proxy_audit_log_account_agent_idx",
+          "columns": [
+            "account_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resume_session_id": {
+          "name": "resume_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_tasks_pending_wake_unique": {
+          "name": "scheduled_tasks_pending_wake_unique",
+          "columns": [
+            "resume_session_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending' AND resume_session_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "token_exchange_jti": {
+      "name": "token_exchange_jti",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "token_exchange_jti_expires_at_idx": {
+          "name": "token_exchange_jti_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1784233277152,
       "tag": "0031_misty_sumo",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1784841760603,
+      "tag": "0032_great_miek",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -71,6 +71,19 @@ export const authAccount = sqliteTable('account', {
     .notNull(),
 }, (table) => ({
   userIdIdx: index('account_userId_idx').on(table.userId),
+  // One stable mapping per external identity: (providerId, accountId) is the
+  // durable lookup for token-exchange provisioning and must never fork.
+  providerAccountIdx: uniqueIndex('account_provider_account_unique').on(table.providerId, table.accountId),
+}))
+
+// Single-use `jti` replay guard for the RFC 7523 token-exchange endpoint.
+// The primary key makes consumption atomic: only the request whose INSERT
+// lands may mint a session for that grant. Rows expire with the grant's exp.
+export const tokenExchangeJti = sqliteTable('token_exchange_jti', {
+  jti: text('jti').primaryKey(),
+  expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+}, (table) => ({
+  expiresAtIdx: index('token_exchange_jti_expires_at_idx').on(table.expiresAt),
 }))
 
 export const verification = sqliteTable('verification', {

--- a/src/shared/lib/services/platform-auth-service.ts
+++ b/src/shared/lib/services/platform-auth-service.ts
@@ -22,7 +22,7 @@ export type PlatformAuthSource = 'settings' | 'env' | null
 const PLATFORM_ORG_ACCESS_TOKEN_AUDIENCE = 'platform-org-runtime'
 const PLATFORM_ORG_ACCESS_TOKEN_ALG = 'RS256'
 const PLATFORM_ORG_ACCESS_TOKEN_TYP = 'JWT'
-const PLATFORM_AUTH_PROVIDER_ID = 'platform'
+export const PLATFORM_AUTH_PROVIDER_ID = 'platform'
 
 export interface VerifiedPlatformOrgAccessToken {
   orgId: string


### PR DESCRIPTION
Deployment-side of the cross-client token-minting flow (**SUP-361**, part of SUP-360). Lets non-browser clients — the desktop app, and later watch/iOS companions — obtain a user-scoped session token for an **auth-mode cloud deployment** without an interactive login round-trip.

Pairs with the platform-side PR (`SkillfulAgents/platform`: RFC 8693 grant + discovery). Design doc: `docs/cross-client-auth.md`.

## What this adds

**1. Bearer authentication** — registers Better Auth's `bearer` plugin, so `Authenticated()` honors `Authorization: Bearer <session-token>` as well as cookies; every endpoint behind it (agents, sessions, STT) is reachable by token clients. The plugin's `set-auth-token` response header is stripped on `/api/auth/*` so a renderer XSS can't read the session credential (the browser client is cookie-only; token clients get their token from the exchange body).

**2. `POST /api/auth/token/exchange`** (RFC 7523 JWT bearer grant) — verifies a platform-signed *deployment-assertion* grant:
- RS256 signature via the platform JWKS; `iss`, exact single `aud` = this deployment's base URL, `typ=deployment-assertion+jwt`, future-`iat` rejected, ≤5-min lifetime, `org_id` gate (same as browser login), verified email.
- Atomic single-use `jti` via a PK-insert replay table.
- User resolution through Better Auth's internal adapter, so first-user bootstrap, pending-approval banning, account linking, and max-session limits all run; stable `(providerId, accountId)` mapping with a unique index; concurrent first-exchange races link and assert the mapping before minting.
- OAuth JSON errors with no identity disclosure; `no-store`.

**3. Config & migration** — the verified audience resolves env-first from `TRUSTED_ORIGINS` (the documented cloud interface); the exchange is gated on the platform provider being enabled. Migration `0032` adds the `token_exchange_jti` table + unique `account(provider_id, account_id)`, with a dedupe pass so index creation can't fatally fail on a DB with pre-existing duplicates.

## Testing

- Integration suite against **real Better Auth + real SQLite**: contract, replay/concurrency, provisioning, ban/pending, disabled-provider gate, bearer-through-`Authenticated()`.
- Config-precedence unit tests.
- Proven **end-to-end** against a live local platform (discovery → RFC 8693 → RFC 7523 → bearer API calls, plus the negative matrix); `set-auth-token` stripping verified on a live sign-in.
- Full app suite green (7,724 passing), tsc + lint clean.

https://claude.ai/code/session_01XrBefX3sLRxZzfwyktYA5R
