### PR TITLE
feat: host-wide in-memory activity clock for AutoSleep (SUP-474)

### DIFF
--- a/src/shared/lib/container/agent-activity-clock.test.ts
+++ b/src/shared/lib/container/agent-activity-clock.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  touchAgentActivity,
+  getAgentLastActivity,
+  clearAgentActivity,
+  clearAllAgentActivity,
+} from './agent-activity-clock'
+
+describe('agent-activity-clock', () => {
+  beforeEach(() => {
+    clearAllAgentActivity()
+  })
+
+  it('touch then get returns the timestamp', () => {
+    touchAgentActivity('a1', 1000)
+    expect(getAgentLastActivity('a1')).toBe(1000)
+  })
+
+  it('touch only advances (ignores older timestamps)', () => {
+    touchAgentActivity('a1', 2000)
+    touchAgentActivity('a1', 1000)
+    expect(getAgentLastActivity('a1')).toBe(2000)
+  })
+
+  it('clear removes one agent', () => {
+    touchAgentActivity('a1', 1000)
+    touchAgentActivity('a2', 2000)
+    clearAgentActivity('a1')
+    expect(getAgentLastActivity('a1')).toBeUndefined()
+    expect(getAgentLastActivity('a2')).toBe(2000)
+  })
+
+  it('clearAll removes every agent', () => {
+    touchAgentActivity('a1', 1000)
+    touchAgentActivity('a2', 2000)
+    clearAllAgentActivity()
+    expect(getAgentLastActivity('a1')).toBeUndefined()
+    expect(getAgentLastActivity('a2')).toBeUndefined()
+  })
+})

--- a/src/shared/lib/container/agent-activity-clock.ts
+++ b/src/shared/lib/container/agent-activity-clock.ts
@@ -1,0 +1,23 @@
+// Host-wide in-memory last-activity timestamps for AutoSleepMonitor.
+// Separate module to avoid import cycles with message-persister / container-manager.
+
+const lastActivityAt = new Map<string, number>()
+
+export function touchAgentActivity(agentId: string, atMs: number = Date.now()): void {
+  const prev = lastActivityAt.get(agentId)
+  if (prev === undefined || atMs > prev) {
+    lastActivityAt.set(agentId, atMs)
+  }
+}
+
+export function getAgentLastActivity(agentId: string): number | undefined {
+  return lastActivityAt.get(agentId)
+}
+
+export function clearAgentActivity(agentId: string): void {
+  lastActivityAt.delete(agentId)
+}
+
+export function clearAllAgentActivity(): void {
+  lastActivityAt.clear()
+}

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -1059,6 +1059,32 @@ describe('containerManager.syncAgentStatus', () => {
 
     expect(messagePersister.markAllSessionsInactiveForAgent).toHaveBeenCalledWith('sync-agent')
   })
+
+  it('seeds containerStartedAt when sync finds running without a start time', async () => {
+    const before = Date.now()
+    containerManager.getClient('sync-agent')
+    mockGetInfoFromRuntime.mockResolvedValue({ status: 'running', port: 4005 })
+
+    expect(containerManager.getContainerStartTime('sync-agent')).toBeUndefined()
+
+    await containerManager.syncAgentStatus('sync-agent')
+
+    const seeded = containerManager.getContainerStartTime('sync-agent')
+    expect(seeded).toBeDefined()
+    expect(seeded!).toBeGreaterThanOrEqual(before)
+  })
+
+  it('does not overwrite an existing containerStartedAt on sync', async () => {
+    containerManager.getClient('sync-agent')
+    mockGetInfoFromRuntime.mockResolvedValue({ status: 'running', port: 4005 })
+    await containerManager.syncAgentStatus('sync-agent')
+    const first = containerManager.getContainerStartTime('sync-agent')!
+
+    await new Promise((r) => setTimeout(r, 5))
+    await containerManager.syncAgentStatus('sync-agent')
+
+    expect(containerManager.getContainerStartTime('sync-agent')).toBe(first)
+  })
 })
 
 // ============================================================================
@@ -1354,6 +1380,9 @@ describe('containerManager.stopContainer force stop recovery', () => {
     // Auto-sleep path: stop+kill timed out and force-stop was disabled, so the
     // container is still alive. We must NOT mark it stopped, broadcast a stop,
     // or trigger VM-restart recovery — the next sweep retries.
+    const { touchAgentActivity, getAgentLastActivity } = await import('./agent-activity-clock')
+    touchAgentActivity('stuck-agent', 12345)
+
     containerManager.getClient('stuck-agent')
     containerManager.getClient('other-agent')
     containerManager.updateCachedStatus('stuck-agent', 'running', 4001)
@@ -1367,6 +1396,9 @@ describe('containerManager.stopContainer force stop recovery', () => {
     expect(containerManager.getCachedInfo('stuck-agent')).toEqual({ status: 'running', port: 4001 })
     expect(containerManager.getCachedInfo('other-agent')).toEqual({ status: 'running', port: 4002 })
 
+    // Incomplete stop must not clear the activity clock
+    expect(getAgentLastActivity('stuck-agent')).toBe(12345)
+
     // No stopped broadcast for the stuck agent, no system_alert, no recovery
     const broadcasts = vi.mocked(messagePersister.broadcastGlobal).mock.calls
     const stoppedEvents = broadcasts.filter(
@@ -1376,6 +1408,19 @@ describe('containerManager.stopContainer force stop recovery', () => {
     expect(broadcasts.filter(([msg]: any) => msg.type === 'system_alert')).toHaveLength(0)
     expect(messagePersister.markAllSessionsInactiveForAgent).not.toHaveBeenCalledWith('stuck-agent')
     expect(mockClearRunnerAvailabilityCache).not.toHaveBeenCalled()
+  })
+
+  it('clears activity clock on successful stop', async () => {
+    const { touchAgentActivity, getAgentLastActivity } = await import('./agent-activity-clock')
+    touchAgentActivity('normal-agent', 99999)
+
+    containerManager.getClient('normal-agent')
+    containerManager.updateCachedStatus('normal-agent', 'running', 4001)
+    mockStop.mockResolvedValue({ forceStopUsed: false, stopped: true })
+
+    await containerManager.stopContainer('normal-agent')
+
+    expect(getAgentLastActivity('normal-agent')).toBeUndefined()
   })
 
   it('still cleans up even when stop() throws', async () => {

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -12,6 +12,10 @@ import { getSettings, mutateSettings } from '@shared/lib/config/settings'
 import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { copyChromeProfileData } from '@shared/lib/browser/chrome-profile'
 import { messagePersister } from './message-persister'
+import {
+  clearAgentActivity,
+  clearAllAgentActivity,
+} from './agent-activity-clock'
 import { ungrabAC } from '@shared/lib/computer-use/executor'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
 import { captureException, captureMessage, addErrorBreadcrumb } from '@shared/lib/error-reporting'
@@ -192,6 +196,7 @@ class ContainerManager {
       } else {
         // Update cached status
         this.markAsStopped(agentId)
+        clearAgentActivity(agentId)
 
         // Mark all sessions for this agent as inactive
         messagePersister.markAllSessionsInactiveForAgent(agentId)
@@ -218,6 +223,7 @@ class ContainerManager {
         for (const otherId of this.getRunningAgentIds()) {
           if (otherId === agentId) continue
           this.markAsStopped(otherId)
+          clearAgentActivity(otherId)
           messagePersister.markAllSessionsInactiveForAgent(otherId)
           messagePersister.broadcastGlobal({
             type: 'agent_status_changed',
@@ -266,6 +272,12 @@ class ContainerManager {
     if (this.startingAgents.has(agentId)) return info
 
     this.updateCachedStatus(agentId, info.status, info.port)
+
+    // Host restart / external reconcile: running without a start timestamp gets
+    // a full auto-sleep grace window from now (not exempt forever).
+    if (info.status === 'running' && !this.containerStartedAt.has(agentId)) {
+      this.containerStartedAt.set(agentId, Date.now())
+    }
 
     // Broadcast if status changed (e.g., container was stopped externally)
     if (previousStatus && previousStatus !== info.status) {
@@ -705,6 +717,7 @@ class ContainerManager {
     this.healthWarnings.delete(agentId)
     this.stoppingAgents.delete(agentId)
     this.startingAgents.delete(agentId)
+    clearAgentActivity(agentId)
   }
 
   // Clear all cached clients (e.g., when container runner setting changes).
@@ -717,6 +730,7 @@ class ContainerManager {
     this.healthWarnings.clear()
     this.stoppingAgents.clear()
     this.startingAgents.clear()
+    clearAllAgentActivity()
   }
 
   // Stop all containers (with per-container timeout to prevent blocking shutdown)
@@ -748,6 +762,7 @@ class ContainerManager {
     this.containerStatuses.clear()
     this.healthWarnings.clear()
     this.stoppingAgents.clear()
+    clearAllAgentActivity()
   }
 
   // Synchronous stop - used for exit handlers where async isn't available
@@ -767,6 +782,7 @@ class ContainerManager {
     this.lastKeepAliveAt.clear()
     this.containerStatuses.clear()
     this.healthWarnings.clear()
+    clearAllAgentActivity()
   }
 
   // Check if any agents have running containers (uses cached status)

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -1843,6 +1843,33 @@ describe('MessagePersister', () => {
     })
   })
 
+  describe('agent activity clock touches', () => {
+    it('markSessionActive touches the activity clock', async () => {
+      const { getAgentLastActivity, clearAgentActivity } = await import('./agent-activity-clock')
+      clearAgentActivity(AGENT_SLUG)
+      const before = Date.now()
+
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      const at = getAgentLastActivity(AGENT_SLUG)
+      expect(at).toBeDefined()
+      expect(at!).toBeGreaterThanOrEqual(before)
+    })
+
+    it('handleMessage touches the activity clock when agentSlug is known', async () => {
+      const { getAgentLastActivity, clearAgentActivity } = await import('./agent-activity-clock')
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      clearAgentActivity(AGENT_SLUG)
+      const before = Date.now()
+
+      mockClient._sendMessage({ type: 'assistant', content: [{ type: 'text', text: 'hi' }] })
+
+      const at = getAgentLastActivity(AGENT_SLUG)
+      expect(at).toBeDefined()
+      expect(at!).toBeGreaterThanOrEqual(before)
+    })
+  })
+
   // ============================================================================
   // schedule_resume tool handling
   // ============================================================================

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -13,6 +13,7 @@ import { streamEventToPendingRequest, type UserInputRequestOutcome } from '@shar
 import { classifyResult } from './result-classification'
 import { parseBackgroundTasksChanged } from './background-tasks-changed'
 import { parseCommandLifecycle } from './command-lifecycle'
+import { touchAgentActivity } from './agent-activity-clock'
 import { captureException } from '@shared/lib/error-reporting'
 import {
   createScheduledTask,
@@ -391,6 +392,7 @@ class MessagePersister {
   markSessionIdle(sessionId: string): void {
     const state = this.streamingStates.get(sessionId)
     if (!state?.isActive) return
+    if (state.agentSlug) touchAgentActivity(state.agentSlug)
     this.finalizeIdle(sessionId, state)
   }
 
@@ -775,6 +777,7 @@ class MessagePersister {
       state.activeSubagents.clear()
       state.activeBackgroundTasks.clear()
       this.stopAllWorkflowTailers(sessionId)
+      if (state.agentSlug) touchAgentActivity(state.agentSlug)
     }
 
     // Broadcast to session-specific clients
@@ -870,6 +873,7 @@ class MessagePersister {
     if (agentSlug) {
       state.agentSlug = agentSlug
     }
+    if (state.agentSlug) touchAgentActivity(state.agentSlug)
 
     // Broadcast to session-specific clients
     this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true })
@@ -1173,6 +1177,8 @@ class MessagePersister {
     this.capture?.recordInput(sessionId, message)
     const state = this.streamingStates.get(sessionId)
     if (!state) return
+
+    if (state.agentSlug) touchAgentActivity(state.agentSlug)
 
     // Skip processing if session was interrupted (prevents race conditions)
     // Allow 'result' through as it indicates the container actually stopped
@@ -1952,6 +1958,7 @@ class MessagePersister {
       // working=true and race connectors into a stuck indicator), and emit
       // session_error INSTEAD of session_idle — connectors finalize on either.
       state.isActive = false
+      if (state.agentSlug) touchAgentActivity(state.agentSlug)
       const errorMessage =
         'The agent stopped unexpectedly because the connection to its runtime was lost. ' +
         'The container may have crashed or run out of memory.'

--- a/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import type { SessionInfo } from '@shared/lib/types/agent'
 
 // ============================================================================
 // Mocks — must be declared before any import that triggers the module
@@ -27,10 +26,10 @@ vi.mock('@shared/lib/container/message-persister', () => ({
   },
 }))
 
-const mockListSessions = vi.fn<(slug: string) => Promise<SessionInfo[]>>()
+const mockGetAgentLastActivity = vi.fn<(id: string) => number | undefined>()
 
-vi.mock('@shared/lib/services/session-service', () => ({
-  listSessions: (slug: string) => mockListSessions(slug),
+vi.mock('@shared/lib/container/agent-activity-clock', () => ({
+  getAgentLastActivity: (id: string) => mockGetAgentLastActivity(id),
 }))
 
 const mockGetSettings = vi.fn()
@@ -48,17 +47,6 @@ import { autoSleepMonitor } from './auto-sleep-monitor'
 
 const THIRTY_MINUTES_MS = 30 * 60 * 1000
 
-function makeSession(id: string, lastActivityAt: Date): SessionInfo {
-  return {
-    id,
-    agentSlug: 'agent-1',
-    name: `Session ${id}`,
-    createdAt: new Date('2026-01-01'),
-    lastActivityAt,
-    messageCount: 1,
-  }
-}
-
 // ============================================================================
 // Tests
 // ============================================================================
@@ -70,9 +58,9 @@ describe('AutoSleepMonitor', () => {
 
     mockGetSettings.mockReturnValue({ app: { autoSleepTimeoutMinutes: 30 } })
     mockGetRunningAgentIds.mockReturnValue([])
-    mockListSessions.mockResolvedValue([])
     mockGetContainerStartTime.mockReturnValue(undefined)
     mockGetLastKeepAlive.mockReturnValue(undefined)
+    mockGetAgentLastActivity.mockReturnValue(undefined)
     mockStopContainer.mockResolvedValue(undefined)
   })
 
@@ -88,10 +76,8 @@ describe('AutoSleepMonitor', () => {
   it('stops idle agent after timeout', async () => {
     const now = Date.now()
     mockGetRunningAgentIds.mockReturnValue(['agent-1'])
-    mockListSessions.mockResolvedValue([
-      makeSession('s1', new Date(now - THIRTY_MINUTES_MS - 1000)),
-    ])
     mockGetContainerStartTime.mockReturnValue(now - THIRTY_MINUTES_MS - 1000)
+    mockGetAgentLastActivity.mockReturnValue(now - THIRTY_MINUTES_MS - 1000)
 
     await autoSleepMonitor.start()
     await tick()
@@ -104,14 +90,8 @@ describe('AutoSleepMonitor', () => {
   })
 
   it('never escalates to force-stopping the VM (escalateToForceStop: false)', async () => {
-    // Auto-sleep is a background sweep; force-stopping the shared Lima VM to
-    // reclaim one idle container would kill every running agent. The monitor
-    // must always opt out of escalation.
     const now = Date.now()
     mockGetRunningAgentIds.mockReturnValue(['agent-1'])
-    mockListSessions.mockResolvedValue([
-      makeSession('s1', new Date(now - THIRTY_MINUTES_MS - 1000)),
-    ])
     mockGetContainerStartTime.mockReturnValue(now - THIRTY_MINUTES_MS - 1000)
 
     await autoSleepMonitor.start()
@@ -122,13 +102,11 @@ describe('AutoSleepMonitor', () => {
     expect(options).toMatchObject({ escalateToForceStop: false })
   })
 
-  it('does not stop agent with recent session activity', async () => {
+  it('does not stop agent with recent activity clock', async () => {
     const now = Date.now()
     mockGetRunningAgentIds.mockReturnValue(['agent-1'])
-    mockListSessions.mockResolvedValue([
-      makeSession('s1', new Date(now - 5 * 60 * 1000)),
-    ])
     mockGetContainerStartTime.mockReturnValue(now - THIRTY_MINUTES_MS - 1000)
+    mockGetAgentLastActivity.mockReturnValue(now - 5 * 60 * 1000)
 
     await autoSleepMonitor.start()
     await tick()
@@ -136,14 +114,24 @@ describe('AutoSleepMonitor', () => {
     expect(mockStopContainer).not.toHaveBeenCalled()
   })
 
-  it('does not stop agent with recent keep-alive despite stale sessions', async () => {
+  it('does not stop agent with recent keep-alive despite stale clock', async () => {
     const now = Date.now()
     mockGetRunningAgentIds.mockReturnValue(['agent-1'])
-    mockListSessions.mockResolvedValue([
-      makeSession('s1', new Date(now - THIRTY_MINUTES_MS - 60_000)),
-    ])
     mockGetContainerStartTime.mockReturnValue(now - THIRTY_MINUTES_MS - 60_000)
+    mockGetAgentLastActivity.mockReturnValue(now - THIRTY_MINUTES_MS - 60_000)
     mockGetLastKeepAlive.mockReturnValue(now - 5 * 60 * 1000)
+
+    await autoSleepMonitor.start()
+    await tick()
+
+    expect(mockStopContainer).not.toHaveBeenCalled()
+  })
+
+  it('does not stop agent with recent container start floor', async () => {
+    const now = Date.now()
+    mockGetRunningAgentIds.mockReturnValue(['agent-1'])
+    mockGetContainerStartTime.mockReturnValue(now - 5 * 60 * 1000)
+    mockGetAgentLastActivity.mockReturnValue(now - THIRTY_MINUTES_MS - 60_000)
 
     await autoSleepMonitor.start()
     await tick()
@@ -154,10 +142,8 @@ describe('AutoSleepMonitor', () => {
   it('stops agent when keep-alive is also stale', async () => {
     const now = Date.now()
     mockGetRunningAgentIds.mockReturnValue(['agent-1'])
-    mockListSessions.mockResolvedValue([
-      makeSession('s1', new Date(now - THIRTY_MINUTES_MS - 60_000)),
-    ])
     mockGetContainerStartTime.mockReturnValue(now - THIRTY_MINUTES_MS - 60_000)
+    mockGetAgentLastActivity.mockReturnValue(now - THIRTY_MINUTES_MS - 60_000)
     mockGetLastKeepAlive.mockReturnValue(now - THIRTY_MINUTES_MS - 30_000)
 
     await autoSleepMonitor.start()
@@ -173,13 +159,12 @@ describe('AutoSleepMonitor', () => {
     await autoSleepMonitor.start()
     await tick()
 
-    expect(mockListSessions).not.toHaveBeenCalled()
+    expect(mockGetAgentLastActivity).not.toHaveBeenCalled()
     expect(mockStopContainer).not.toHaveBeenCalled()
   })
 
-  it('skips agent with no sessions', async () => {
+  it('skips agent with no activity signals', async () => {
     mockGetRunningAgentIds.mockReturnValue(['agent-1'])
-    mockListSessions.mockResolvedValue([])
 
     await autoSleepMonitor.start()
     await tick()

--- a/src/shared/lib/scheduler/auto-sleep-monitor.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.ts
@@ -7,8 +7,8 @@
  */
 
 import { containerManager } from '@shared/lib/container/container-manager'
+import { getAgentLastActivity } from '@shared/lib/container/agent-activity-clock'
 import { messagePersister } from '@shared/lib/container/message-persister'
-import { listSessions } from '@shared/lib/services/session-service'
 import { getSettings } from '@shared/lib/config/settings'
 
 class AutoSleepMonitor {
@@ -81,27 +81,21 @@ class AutoSleepMonitor {
             continue
           }
 
-          // Check last activity across all sessions
-          const sessions = await listSessions(agentId)
+          // Idle history is host RAM only (start / keep-alive / activity clock).
+          // No listSessions — session jsonl stats are expensive on network FS.
+          const signals = [
+            containerManager.getContainerStartTime(agentId),
+            containerManager.getLastKeepAlive(agentId),
+            getAgentLastActivity(agentId),
+          ].filter((t): t is number => t !== undefined)
 
-          // No sessions — container was just started, skip it
-          if (sessions.length === 0) {
+          // No signals — host just discovered the container; wait for grace seed
+          // or a touch before considering idle.
+          if (signals.length === 0) {
             continue
           }
 
-          // Use container start time as a floor — when an agent is woken up
-          // to view its dashboard, session timestamps are stale from before
-          // the previous sleep and would cause immediate re-sleep.
-          const containerStartTime =
-            containerManager.getContainerStartTime(agentId) ?? 0
-          const lastKeepAlive =
-            containerManager.getLastKeepAlive(agentId) ?? 0
-
-          const lastActivity = Math.max(
-            containerStartTime,
-            lastKeepAlive,
-            ...sessions.map((s) => s.lastActivityAt.getTime())
-          )
+          const lastActivity = Math.max(...signals)
 
           if (now - lastActivity > timeoutMs) {
             console.log(


### PR DESCRIPTION
## Summary
- Add a host-wide RAM activity clock (`agent-activity-clock`) touched from stream ingress and host session transitions.
- AutoSleepMonitor no longer calls `listSessions` / stats session jsonl; idle uses `max(start, keepAlive, clock)`.
- Seed `containerStartedAt` on reconcile when a running container has no start time; clear the clock only on successful stop paths.

Fixes the S3 Files / network-FS cost of every 60s idle sweep for all runtimes (Docker, K8s, MicroVM).

**Supersedes** https://github.com/SkillfulAgents/SuperAgent/pull/568 (together with #576).

## Test plan
- [x] `vitest` — `agent-activity-clock`, `auto-sleep-monitor`, container-manager grace/clear, message-persister touch coverage
- [ ] Manual: leave an idle agent past `autoSleepTimeoutMinutes` and confirm stop without session-dir scanning
- [ ] Manual: host restart with a still-running container gets a full timeout grace (not instant sleep)