### PR TITLE
fix: host-owned MicroVM idle stop and suspended UI status (SUP-474)

### DIFF
--- a/src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
@@ -71,18 +71,19 @@ describe.skipIf(!enabled)('LambdaMicroVmRuntimeClient e2e (real AWS)', () => {
       expect((await client.getInfoFromRuntime()).status).toBe('running')
 
       await client.stop() // plain stop -> suspend (default)
-      // Let the suspend settle (SuspendMicrovm completes in ~1s); the client maps
-      // SUSPENDED/SUSPENDING to 'running' since the VM auto-resumes on demand.
+      // Let the suspend settle (SuspendMicrovm completes in ~1s); UI maps
+      // SUSPENDED/SUSPENDING to stopped while the local proxy is kept for warm resume.
       await new Promise((r) => setTimeout(r, 10_000))
-      expect((await client.getInfoFromRuntime()).status).toBe('running')
+      expect((await client.getInfoFromRuntime()).status).toBe('stopped')
 
-      // No waitForHealthy kick: a normal request resumes + succeeds via the proxy.
+      // Transparent auto-resume via the proxy (no new RunMicrovm).
       const t0 = Date.now()
       const res = await client.fetch('/health')
       const resumeMs = Date.now() - t0
       expect(res.ok).toBe(true)
       console.log(`[E2E-RESUME] suspend -> /health ok (transparent auto-resume): ${resumeMs}ms`)
       expect(resumeMs).toBeLessThan(15_000)
+      expect((await client.getInfoFromRuntime()).status).toBe('running')
     } finally {
       await client.stop()
     }

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -59,7 +59,6 @@ import {
   resolveMicrovmRuntimeConfigOrNull,
   isMicrovmRuntimeConfigured,
   getMicrovmRuntimeConfig,
-  resolveIdleSeconds,
 } from './lambda-microvm-runtime'
 import { readBootstrapEnv, resetBootstrapEnvStoreForTests } from './agent-bootstrap-env-store'
 
@@ -168,29 +167,6 @@ describe('microvm runtime config', () => {
   })
 })
 
-describe('resolveIdleSeconds', () => {
-  beforeEach(() => {
-    Object.assign(process.env, REQUIRED_ENV)
-  })
-
-  it('derives the idle window from the app auto-sleep setting (single source of truth)', () => {
-    autoSleepTimeoutMinutes.mockReturnValue(30)
-    expect(resolveIdleSeconds(getMicrovmRuntimeConfig())).toBe(1_800)
-  })
-
-  it('never idle-suspends (falls back to the lifetime cap) when auto-sleep is disabled', () => {
-    autoSleepTimeoutMinutes.mockReturnValue(0)
-    const config = getMicrovmRuntimeConfig()
-    expect(resolveIdleSeconds(config)).toBe(config.maxDurationSeconds)
-  })
-
-  it('clamps an app setting longer than the lifetime cap to maxDurationSeconds', () => {
-    autoSleepTimeoutMinutes.mockReturnValue(600) // 10h > 8h cap
-    const config = getMicrovmRuntimeConfig()
-    expect(resolveIdleSeconds(config)).toBe(config.maxDurationSeconds)
-  })
-})
-
 describe('LambdaMicroVmRuntimeClient eligibility', () => {
   it('isEligible only when runtime env is configured', () => {
     Object.assign(process.env, FULL_ENV)
@@ -259,8 +235,8 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(input.executionRoleArn).toBe('arn:exec')
     expect(input.egressNetworkConnectors).toEqual(['arn:egress'])
     expect(input.idlePolicy.autoResumeEnabled).toBe(true)
-    // idle tracks the app auto-sleep setting (30m); suspend/lifetime hit the 8h cap.
-    expect(input.idlePolicy.maxIdleDurationSeconds).toBe(1_800)
+    // Host owns product idle; AWS maxIdle = lifetime (not autoSleepTimeoutMinutes).
+    expect(input.idlePolicy.maxIdleDurationSeconds).toBe(28_800)
     expect(input.idlePolicy.suspendedDurationSeconds).toBe(28_800)
     expect(input.maximumDurationInSeconds).toBe(28_800)
     expect(typeof input.clientToken).toBe('string')
@@ -408,11 +384,18 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(await newClient().getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
-  it('getInfoFromRuntime treats SUSPENDED as running (auto-resume on request)', async () => {
+  it('getInfoFromRuntime treats SUSPENDED as stopped (host-owned sleep; proxy kept)', async () => {
     const client = newClient()
     await client.start()
     responses.getState = 'SUSPENDED'
-    expect((await client.getInfoFromRuntime()).status).toBe('running')
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+  })
+
+  it('getInfoFromRuntime treats SUSPENDING as stopped', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'SUSPENDING'
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
   it('getInfoFromRuntime reports stopped when the VM is TERMINATED and cleans up local state', async () => {
@@ -466,12 +449,13 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     stopSpy.mockRestore()
   })
 
-  it('background auto-sleep (escalateToForceStop:false) is a no-op — idlePolicy owns idle', async () => {
+  it('background auto-sleep (escalateToForceStop:false) suspends — host owns idle', async () => {
     const client = newClient()
     await client.start()
     sendMock.mockClear()
-    await client.stop({ escalateToForceStop: false })
-    expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(false)
+    const result = await client.stop({ escalateToForceStop: false })
+    expect(result).toEqual({ forceStopUsed: false, stopped: true })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(true)
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
   })
 
@@ -487,7 +471,7 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(suspendCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
 
-    // State is preserved: a subsequent start() short-circuits (no new RunMicrovm).
+    // State is preserved: a subsequent start() warm-resumes (no new RunMicrovm).
     sendMock.mockClear()
     responses.getState = 'SUSPENDED'
     await client.start()

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -19,7 +19,6 @@ import type {
 } from '@aws-sdk/client-lambda-microvms'
 import { BaseContainerClient, CONTAINER_INTERNAL_PORT } from './base-container-client'
 import type { ContainerConfig, ContainerInfo, ContainerStats, StartOptions, StopOptions, StopResult } from './types'
-import { getSettings } from '@shared/lib/config/settings'
 import { captureException } from '@shared/lib/error-reporting'
 import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
 
@@ -195,13 +194,6 @@ async function resolveHostApiBaseUrlForMicrovm(): Promise<string> {
 
   const port = hostAppPortSchema.parse(process.env.PORT)
   return `http://${privateIp}:${port}`
-}
-
-// Idle→suspend window: app settings are the single source of truth.
-export function resolveIdleSeconds(config: MicrovmRuntimeConfig): number {
-  const minutes = getSettings().app?.autoSleepTimeoutMinutes ?? 30
-  if (minutes <= 0) return config.maxDurationSeconds
-  return Math.min(minutes * 60, config.maxDurationSeconds)
 }
 
 // ---------------------------------------------------------------------------
@@ -462,8 +454,8 @@ export class LocalAuthForwardProxy {
 
 // MicroVM ids are AWS-generated (no deterministic name, no tag-filtered lookup),
 // so the agentId→microvm mapping + its loopback proxy live in process memory.
-// Lost on host-app restart: the orphaned VM is reclaimed by its idlePolicy
-// (idle→suspend→suspended-timeout→terminate) and the next start() re-runs.
+// Lost on host-app restart: the orphaned VM is reclaimed by suspendedDuration
+// (suspended-timeout→terminate) and the next start() re-runs.
 interface AgentMicrovmState {
   microvmId: string
   endpoint: string
@@ -541,8 +533,11 @@ async function runMicrovm(
   config: MicrovmRuntimeConfig,
   opts: { runHookPayload: string; clientToken: string; logStream: string },
 ): Promise<{ microvmId: string; endpoint: string }> {
+  // AWS IdlePolicy is all-or-nothing (idle + resume + suspended retention).
+  // Host AutoSleep owns product idle (explicit Suspend); maxIdle = lifetime so
+  // AWS is not a second product-sleep owner. Keep auto-resume + suspended GC.
   const idlePolicy = {
-    maxIdleDurationSeconds: resolveIdleSeconds(config),
+    maxIdleDurationSeconds: config.maxDurationSeconds,
     suspendedDurationSeconds: config.suspendedSeconds,
     autoResumeEnabled: true,
   }
@@ -667,7 +662,8 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   }
 
   async start(options?: StartOptions): Promise<void> {
-    if ((await this.getInfoFromRuntime()).status === 'running') return
+    // Warm path: same VM still SUSPENDED/RUNNING with local proxy — no RunMicrovm.
+    if (await this.tryWarmResume()) return
 
     const config = getMicrovmRuntimeConfig()
     // Full env exceeds the 4096-byte payload cap, so stash it host-side and pass the
@@ -739,19 +735,16 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
   // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
 
-  async stop(options?: StopOptions): Promise<StopResult> {
+  async stop(_options?: StopOptions): Promise<StopResult> {
     this.terminateWebSocketConnections()
-    // Auto-sleep is handled by AWS idlePolicy; the host-app sweep is a no-op.
-    if (options?.escalateToForceStop === false) {
-      return { forceStopUsed: false, stopped: true }
-    }
+    // Host owns product sleep (manual stop + AutoSleep); always Suspend.
     await this.suspend()
     return { forceStopUsed: false, stopped: true }
   }
 
   stopSync(): void {
     // Terminate uses the async AWS API; sync shutdown only tears down WS + proxy.
-    // The VM itself is reclaimed by its idlePolicy.
+    // The VM itself is reclaimed by suspendedDurationSeconds.
     this.terminateWebSocketConnections()
     this.cleanupLocal()
   }
@@ -762,10 +755,12 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const config = getMicrovmRuntimeConfig()
     try {
       const mvm = await getMicrovm(config.region, state.microvmId)
-      // SUSPENDED is "running on demand": idlePolicy.autoResumeEnabled wakes it
-      // on the next request through the proxy.
-      if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+      if (mvm.state === 'RUNNING') {
         return { status: 'running', port: state.proxyPort }
+      }
+      // Host-owned sleep: UI shows stopped; keep local proxy for warm resume.
+      if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+        return { status: 'stopped', port: null }
       }
       // Terminal: VM is gone — drop state + proxy (mirror NotFound) so it isn't leaked.
       this.cleanupLocal()
@@ -799,6 +794,32 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   private async mintToken(microvmId: string): Promise<MicrovmAuthToken> {
     const config = getMicrovmRuntimeConfig()
     return createMicrovmAuthToken(config.region, microvmId, [config.agentPort], AUTH_TOKEN_EXPIRATION_MINUTES)
+  }
+
+  // Resume an already-tracked VM (RUNNING / SUSPENDED) without RunMicrovm.
+  private async tryWarmResume(): Promise<boolean> {
+    const state = agentStates.get(this.config.agentId)
+    if (!state) return false
+    const config = getMicrovmRuntimeConfig()
+    try {
+      const mvm = await getMicrovm(config.region, state.microvmId)
+      if (mvm.state === 'RUNNING') return true
+      if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+        // Proxy /health kicks autoResumeEnabled; no new RunMicrovm.
+        if (!(await this.waitForHealthy(120_000, state.proxyPort))) {
+          throw new Error(`MicroVM agent ${state.microvmId} failed to resume`)
+        }
+        return true
+      }
+      this.cleanupLocal()
+      return false
+    } catch (error) {
+      if (isNotFound(error)) {
+        this.cleanupLocal()
+        return false
+      }
+      throw error
+    }
   }
 
   private async waitForRunning(region: string, microvmId: string, timeoutMs: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Host `stop()` / AutoSleep always Suspend (drop the auto-sleep no-op that left AWS as the only idle owner).
- Neutralize AWS product-idle: `maxIdleDurationSeconds` = lifetime cap (not `autoSleepTimeoutMinutes`); keep auto-resume + suspended retention (AWS IdlePolicy is all-or-nothing).
- Map `SUSPENDED` / `SUSPENDING` to UI `stopped`; warm-resume the same VM on `start()` / `/health` without a new `RunMicrovm`.

Stacked on #575 (activity clock) so AutoSleep’s RAM path actually drives MicroVM suspend.

**Supersedes** https://github.com/SkillfulAgents/SuperAgent/pull/568 (together with #575).

## Test plan
- [x] `vitest` — `lambda-microvm-runtime.test.ts` (suspend on auto-sleep stop, SUSPENDED→stopped, warm start)
- [ ] E2E (optional): suspend → UI stopped → `/health` auto-resumes without RunMicrovm
- [ ] Manual: auto-sleep stops a MicroVM agent; dashboard start warm-resumes