### PR TITLE
Derive session awaiting-input from the request registry (Phase 3)

### DIFF
--- a/e2e/specs/awaiting-input-status.spec.ts
+++ b/e2e/specs/awaiting-input-status.spec.ts
@@ -8,6 +8,8 @@ import {
   gotoAgentHome,
   uniqueName,
   uniqueSuffix,
+  waitForCurrentSessionId,
+  waitForPendingProxyReview,
   type TestAgent,
   type TestSession,
 } from '../helpers/agents'
@@ -150,6 +152,49 @@ test.describe('Awaiting Input Status', () => {
     // Session should complete — status should clear
     await sessionPage.waitForInputEnabled(15000)
     await agentPage.waitForStatus('idle', 15000)
+  })
+
+  test('a parked proxy review flags a session that starts after it', async ({ page, request }, testInfo) => {
+    // Session 1 parks an agent-scoped proxy review (real ReviewManager).
+    // The review scenario persists its user message only after the decision,
+    // so wait on the session id from the URL, not on the transcript.
+    await sessionPage.sendMessage(`proxy review ${uniqueSuffix(testInfo)}`)
+    await waitForCurrentSessionId(page)
+    const review = await waitForPendingProxyReview(request, agent, {
+      xAgent: false,
+      toolkit: 'slack',
+      targetPath: 'api/chat.postMessage',
+    })
+    await agentPage.waitForStatus('awaiting_input', 15000)
+
+    // Start a NEW session while the review is still parked. The review is
+    // agent-scoped, so the fresh session must read as waiting on the human
+    // from its first moment — the waiting status derives from the open
+    // request, not from which sessions happened to be active when the review
+    // was raised. Assert via the sessions route (the status source for the
+    // sidebar and header): the slow-work turn holds the session active for
+    // ~5s, so the poll must land inside that window.
+    await gotoAgentHome(page, agent)
+    const session2 = await sendScenarioMessage(page, request, testInfo, 'work slowly')
+    await expect
+      .poll(async () => {
+        const res = await request.get(`/api/agents/${agent.slug}/sessions`)
+        if (!res.ok()) return undefined
+        const sessions = (await res.json()) as Array<{ id: string; isAwaitingInput: boolean }>
+        return sessions.find((s) => s.id === session2.id)?.isAwaitingInput
+      }, { timeout: 4000 })
+      .toBe(true)
+
+    // The agent keeps reading awaiting — session 1 is still parked on the
+    // review, whose card renders here too (it is agent-scoped). The composer
+    // stays gated behind the card, so allow FIRST, then expect the settle.
+    await agentPage.waitForStatus('awaiting_input', 15000)
+    await sessionPage.waitForProxyReviewRequestById(review.id, 35000)
+    await sessionPage.allowProxyReview(review.id)
+
+    // Session 1 unwinds and the whole agent settles.
+    await sessionPage.waitForInputEnabled(20000)
+    await agentPage.waitForStatus('idle', 20000)
   })
 
   test('sidebar session shows question mark icon when awaiting input', async ({ page, request }, testInfo) => {

--- a/e2e/specs/computer-use.spec.ts
+++ b/e2e/specs/computer-use.spec.ts
@@ -43,6 +43,29 @@ test.describe('Computer Use requests', () => {
     await sessionPage.expectAssistantMessage('Thank you for providing the information.', 1, 15000)
   })
 
+  test('an abandoned approval does not survive into the next turn', async ({ page }) => {
+    // Park a computer-use approval, then stop the turn with the card unresolved.
+    await sessionPage.sendMessage('use computer')
+    await sessionPage.waitForComputerUseRequest()
+    await sessionPage.stopSessionFromRequest()
+    await sessionPage.waitForInputEnabled(15000)
+
+    // A new message starts a fresh turn, which supersedes the abandoned
+    // approval server-side. (The computer-use store deliberately survives an
+    // IDLE boundary so a reconnect can replay a still-parked card — but a new
+    // turn must wipe it, or the stale entry reads as a live wait.)
+    await sessionPage.sendMessage('carry on without the computer')
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expectAssistantMessage('This is a mock response from the E2E test container.', 1, 15000)
+
+    // Reload: the /stream replay must NOT resurrect the abandoned approval
+    // card, and the agent must read idle — not needing input.
+    await page.reload()
+    await sessionPage.expectAssistantMessage('This is a mock response from the E2E test container.', 1, 15000)
+    await expect(sessionPage.getComputerUseRequests()).toHaveCount(0)
+    await agentPage.waitForStatus('idle', 15000)
+  })
+
   test('computer use request: deny', async () => {
     await sessionPage.sendMessage('use computer')
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -116,6 +116,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     markAllSessionsInactiveForAgent: vi.fn(),
     isSessionActive: vi.fn(() => false),
     isSessionAwaitingInput: vi.fn(() => false),
+    recoverSessionAwaitingInput: vi.fn(),
     getActiveSessionIdsForAgent: vi.fn(() => [] as string[]),
     hasActiveSessionsForAgent: vi.fn(() => false),
     hasSessionsAwaitingInputForAgent: vi.fn(() => false),
@@ -3189,6 +3190,109 @@ describe('DELETE /:id/sessions/:sessionId', () => {
 })
 
 // ============================================================================
+// Awaiting-input recovery from the persisted transcript
+// ============================================================================
+
+describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', () => {
+  let app: ReturnType<typeof createApp>
+  const URL = '/api/agents/test-agent/sessions/sess-1/messages'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockIsAuthMode.mockReturnValue(false)
+    vi.mocked(sessionExists).mockResolvedValue(true)
+    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
+  })
+
+  it('re-establishes the missed blocking requests of the trailing turn for an active session', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'm1', type: 'user', content: { text: 'go' }, toolCalls: [], createdAt: new Date() },
+      {
+        id: 'm2',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [
+          // Resolved call: not recoverable.
+          { id: 'tool-done', name: 'Bash', input: {}, result: 'ok' },
+          // The missed blocking ask this fallback exists for.
+          { id: 'tool-q', name: 'AskUserQuestion', input: {} },
+          // script_run is excluded from isBlockingUserInputToolName (its
+          // handler decides blocking per-grant) — must not be recovered here.
+          { id: 'tool-sr', name: 'mcp__user-input__request_script_run', input: {} },
+        ],
+      },
+    ])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }],
+    )
+  })
+
+  it('a trailing QUEUED user message does not end the turn scan', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'mcp__user-input__request_secret', input: {} }],
+      },
+      // Queued mid-turn message: the turn is still the same one that parked.
+      { id: 'm2', type: 'user', queued: true, content: { text: 'also…' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    await getReq(app, URL)
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }],
+    )
+  })
+
+  it('does not recover when a later user message started a fresh turn', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
+      },
+      // A real (non-queued) user message supersedes the parked ask.
+      { id: 'm2', type: 'user', content: { text: 'never mind' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    await getReq(app, URL)
+    expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
+  })
+
+  it('does not recover for an inactive session', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(false)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
+      },
+    ])
+
+    await getReq(app, URL)
+    expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
+  })
+})
+
+// ============================================================================
 // User Message Broadcast & Typing Indicator Tests
 // ============================================================================
 
@@ -4531,19 +4635,22 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
     expect(body[1].hasUnreadNotifications).toBe(true)
   })
 
-  it('marks active sessions awaiting input when agent-level reviews are pending', async () => {
+  it('reports the persister awaiting status per session verbatim', async () => {
     vi.mocked(listSessionsByIds).mockResolvedValue([
       sessionInfo('s-live', '2026-01-02T10:00:00Z'),
       sessionInfo('s-idle', '2026-01-02T11:00:00Z'),
     ])
     vi.mocked(messagePersister.isSessionActive).mockImplementation((id: string) => id === 's-live')
-    mockGetPendingReviewsForAgent.mockReturnValue([{ id: 'review-1' }])
+    // Agent-level reviews are already folded into the persister's derived
+    // awaiting projection (they flag every active session of the agent) —
+    // the route adds no special-case of its own anymore.
+    vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
+      (id: string) => id === 's-live',
+    )
 
     const res = await getReq(app, NOTABLE_URL)
     const body = await res.json() as Array<{ id: string; isAwaitingInput: boolean }>
     const bySessionId = new Map(body.map((s) => [s.id, s]))
-    // Agent-level review only flags LIVE sessions — idle ones can't be the
-    // session the review is waiting on.
     expect(bySessionId.get('s-live')?.isAwaitingInput).toBe(true)
     expect(bySessionId.get('s-idle')?.isAwaitingInput).toBe(false)
   })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -466,20 +466,26 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
   )
 }
 
-function hasUnresolvedBlockingInputRequest(items: TransformedItem[]): boolean {
+// Unresolved blocking user-input tool calls in the current (trailing) turn —
+// the recovery input for messagePersister.recoverSessionAwaitingInput when the
+// one-shot request stream event was missed.
+function getUnresolvedBlockingInputRequests(
+  items: TransformedItem[],
+): Array<{ toolUseId: string; toolName: string }> {
+  const unresolved: Array<{ toolUseId: string; toolName: string }> = []
   for (let i = items.length - 1; i >= 0; i--) {
     const item = items[i]
-    if (item.type === 'user' && !item.queued) return false
+    if (item.type === 'user' && !item.queued) break
     if (item.type !== 'assistant') continue
 
     for (const toolCall of item.toolCalls) {
       if (toolCall.result === undefined && isBlockingUserInputToolName(toolCall.name)) {
-        return true
+        unresolved.push({ toolUseId: toolCall.id, toolName: toolCall.name })
       }
     }
   }
 
-  return false
+  return unresolved
 }
 
 /**
@@ -1507,7 +1513,6 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
       const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.trunc(limitRaw), 100) : 25
       const unreadIds = await getSessionIdsWithUnreadNotifications(slug)
       const activeIds = messagePersister.getActiveSessionIdsForAgent(slug)
-      const hasAgentLevelReviews = reviewManager.getPendingReviewsForAgent(slug).length > 0
       const infos = await listSessionsByIds(slug, [...new Set([...activeIds, ...unreadIds])], {
         excludeAutomated: true,
       })
@@ -1516,8 +1521,9 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
         return {
           ...session,
           isActive,
-          isAwaitingInput:
-            messagePersister.isSessionAwaitingInput(session.id) || (isActive && hasAgentLevelReviews),
+          // The awaiting projection already counts agent-scoped reviews
+          // against every active session of the agent — no review special-case.
+          isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id),
           hasUnreadNotifications: unreadIds.has(session.id),
         }
       })
@@ -1533,7 +1539,6 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
 
     const sessionList = await listSessions(slug, { excludeAutomated: true })
     const unreadSessionIds = await getSessionIdsWithUnreadNotifications(slug)
-    const hasAgentLevelReviews = reviewManager.getPendingReviewsForAgent(slug).length > 0
     const pendingWakes = await listPendingWakesByAgent(slug)
     const wakesBySession = new Map(pendingWakes.map((w) => [w.resumeSessionId!, w]))
     const sessionsWithStatus = sessionList.map((session) => {
@@ -1542,7 +1547,9 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
       return {
         ...session,
         isActive,
-        isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id) || (isActive && hasAgentLevelReviews),
+        // The awaiting projection already counts agent-scoped reviews against
+        // every active session of the agent — no review special-case.
+        isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id),
         hasUnreadNotifications: unreadSessionIds.has(session.id),
         ...(wake
           ? {
@@ -1705,14 +1712,14 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     // Discover subagent IDs for interrupted Task tool calls that have no result
     await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
 
-    if (
-      messagePersister.isSessionActive(sessionId) &&
-      hasUnresolvedBlockingInputRequest(transformed)
-    ) {
-      // If the request-specific stream event was missed, persisted messages are
-      // the fallback source of truth. A stale transcript can briefly re-assert
-      // awaiting input, but the next stream result/idle event clears it.
-      messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug)
+    if (messagePersister.isSessionActive(sessionId)) {
+      const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
+      if (unresolvedRequests.length > 0) {
+        // If the request-specific stream event was missed, persisted messages are
+        // the fallback source of truth. A stale transcript can briefly re-assert
+        // awaiting input, but the next stream result/idle event clears it.
+        messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
+      }
     }
 
     // In auth mode, annotate user messages with sender info

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -1108,4 +1108,160 @@ describe('pending user-input request lifecycle (characterization)', () => {
       ).toEqual(['invalidated', 'invalidated'])
     })
   })
+
+  // ==========================================================================
+  // Turn-boundary and transport crossings: the awaiting projection must hold
+  // where a request's lifetime crosses a result, a runtime-started turn, a
+  // transport reattach, or a recovery→cancel sequence — the seams where the
+  // cache and its source of truth can drift apart.
+  // ==========================================================================
+
+  describe('turn-boundary and transport crossings', () => {
+    function parkAgentReview(id: string) {
+      userInputRequestManager.register({
+        id,
+        kind: 'proxy_review',
+        scope: { agentSlug: AGENT_SLUG },
+        blocking: true,
+        autoApproved: false,
+        payload: { toolkit: 'slack' },
+      })
+      messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
+    }
+
+    it('cancelAwaitingInput rejects recovered entries on the container despite the replay filter', async () => {
+      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
+        { toolUseId: 'rec-cancel-1', toolName: 'AskUserQuestion' },
+      ])
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      // The replay filter hides the synthesized entry from reconnecting clients…
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+
+      // …but a replacement message must still clean it up container-side: the
+      // recovered ask is exactly the one whose container pending may still be
+      // live, and a late answer must not land on the abandoned turn.
+      await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+
+      const rejectedUrls = mockContainerClientFetch.mock.calls
+        .map((call) => call[0])
+        .filter((url): url is string => typeof url === 'string' && url.endsWith('/reject'))
+      expect(rejectedUrls).toContain('/inputs/rec-cancel-1/reject')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+    })
+
+    it('a clean success mid-turn re-derives awaiting instead of blind-clearing it', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const globalEvents: any[] = []
+      const cleanup = messagePersister.addGlobalNotificationClient((data) => {
+        globalEvents.push(data)
+      })
+      try {
+        // The runtime announces state-event authority: a result alone no
+        // longer settles the session.
+        mockClient._sendMessage({
+          type: 'system',
+          subtype: 'capabilities',
+          session_state_events: true,
+        })
+        parkAgentReview('boundary-review-1')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+        mockClient._sendMessage({ type: 'result', subtype: 'success', num_turns: 1 })
+
+        // Still active (the runtime owns idle) and the review is still open —
+        // the session keeps reading awaiting, and no falling edge fires.
+        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(globalEvents.filter((e) => e.type === 'session_input_provided')).toHaveLength(0)
+
+        // The review settles → the falling edge fires now, not never.
+        userInputRequestManager.resolve('boundary-review-1', 'answered')
+        messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(globalEvents.filter((e) => e.type === 'session_input_provided')).toHaveLength(1)
+      } finally {
+        cleanup()
+      }
+    })
+
+    it('a runtime-started turn picks up an already-parked agent review', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const globalEvents: any[] = []
+      const cleanup = messagePersister.addGlobalNotificationClient((data) => {
+        globalEvents.push(data)
+      })
+      try {
+        // End the current turn (result-driven idle — no authority announced).
+        mockClient._sendMessage({ type: 'result', subtype: 'success', num_turns: 1 })
+        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+
+        // A review parks while the session is idle: an inactive session never
+        // reads awaiting.
+        parkAgentReview('boundary-review-2')
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+
+        // The runtime starts the next (queued) turn itself — no POST, no
+        // markSessionActive. The self-heal must sync the projection too.
+        mockClient._sendMessage({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'running',
+        })
+        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(globalEvents.filter((e) => e.type === 'session_awaiting_input')).toHaveLength(1)
+      } finally {
+        cleanup()
+      }
+    })
+
+    it('a transport re-subscribe preserves parked requests, their registry entries, and replay', async () => {
+      simulateToolUse('mcp__user-input__request_secret', 'resub-secret-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      // Reattach the stream (reconnect of an in-flight session). Only the
+      // transport may turn over — the wait itself is still parked.
+      const secondClient = createMockClient()
+      await messagePersister.subscribeToSession(SESSION_ID, secondClient, SESSION_ID, AGENT_SLUG)
+
+      // Replay store, registry entry, and cache all still agree, so a later
+      // sync must NOT clear the genuinely parked ask.
+      expect(
+        messagePersister.getPendingInputRequests(SESSION_ID).map((r) => r.toolUseId)
+      ).toEqual(['resub-secret-1'])
+      expect(
+        userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+      ).toContain('resub-secret-1')
+      messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      // The parked ask resolves over the NEW transport and settles normally.
+      secondClient._sendMessage({
+        type: 'user',
+        message: {
+          content: [
+            { type: 'tool_result', tool_use_id: 'resub-secret-1', content: 'resolved' },
+          ],
+        },
+      })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+    })
+
+    it('the markSessionIdle revert clears the awaiting cache an agent review had set', () => {
+      parkAgentReview('boundary-review-3')
+      // markSessionActive's trailing sync picks up the open review.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      // The optimistic send fails → revert. An inactive session is never
+      // awaiting, review or not — the cache resets with isActive.
+      messagePersister.markSessionIdle(SESSION_ID)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+    })
+  })
 })

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -6,12 +6,15 @@
  * awaiting → notify exactly once → resolve → drop the replay entry → clear
  * awaiting only when it was the last blocking wait.
  *
- * This file pins CURRENT behavior — including the known divergences it
- * documents inline (computer-use's separate store, capability review's early
- * clear). The sidechain matrix at the bottom is the acceptance table for the
- * unified dispatcher: every kind must surface from every delivery path. Rows
- * were `surfacesToday: false` before the dispatcher landed — those kinds hung
- * silently when a subagent called them.
+ * This file pins CURRENT behavior. The awaiting status is DERIVED from the
+ * userInputRequestManager registry (Phase 3): the split-brains this suite
+ * originally pinned as known-wrong — the first of two parallel requests
+ * dropping the waiting light, the computer-use and capability-review clear
+ * doors leaving the bit stuck — are fixed, and their tests now assert the
+ * correct arithmetic. The sidechain matrix at the bottom is the acceptance
+ * table for the unified dispatcher: every kind must surface from every
+ * delivery path. Rows were `surfacesToday: false` before the dispatcher
+ * landed — those kinds hung silently when a subagent called them.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { ContainerClient, StreamMessage } from './types'
@@ -290,8 +293,16 @@ describe('pending user-input request lifecycle (characterization)', () => {
     originalE2eMock = process.env.E2E_MOCK
     process.env.E2E_MOCK = 'true'
 
+    // Agent-scoped entries (reviews) are not dropped by unsubscribe — wipe the
+    // registry so one test's review can't keep a later test's session awaiting.
+    userInputRequestManager.reset()
+
     mockClient = createMockClient()
     await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+    // Requests park mid-turn: production always has markSessionActive before
+    // any request event arrives, and the derived awaiting projection is gated
+    // on an active turn (an inactive session is never awaiting).
+    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const events: any[] = []
@@ -396,13 +407,12 @@ describe('pending user-input request lifecycle (characterization)', () => {
         expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(2)
 
         sendToolResult('tool-par-1')
-        // KNOWN SPLIT-BRAIN (pinned, not desired): the main-path user-message
-        // handler clears awaiting without consulting the stream stores — it
-        // only defers to external review blockers. The second request's
-        // replay entry is still parked (the card stack still shows it), but
-        // the sidebar/header bit already reads "not waiting". Derived
-        // awaiting state flips this expectation to `true`.
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        // Derived awaiting: the projection consults what is actually still
+        // open, so answering the first request keeps the waiting light on
+        // while the second card is parked. (This was the pinned parallel-
+        // request split-brain before the flip: the imperative clear dropped
+        // the bit on the first tool_result.)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
         expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
 
         sendToolResult('tool-par-2')
@@ -441,24 +451,24 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(call.slice(0, 3)).toEqual([SESSION_ID, AGENT_SLUG, 'computer_use'])
     })
 
-    it('a tool_result alone does NOT drop the parked entry, yet it DOES clear awaiting', () => {
+    it('a tool_result alone does NOT drop the parked entry — and awaiting stays on with it', () => {
       simulateToolUse(TOOL, 'cu-clear-1', { x: 1, y: 2 })
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-      // KNOWN SPLIT-BRAIN (pinned, not desired): the computer-use store is
-      // cleared only via the decision route's explicit call, so the entry
-      // survives the tool_result — but the main-path user-message handler
-      // still clears the awaiting bit without consulting this store. Card
-      // parked, light off. Derived awaiting state flips the second
-      // expectation to `true`.
+      // The computer-use store is cleared only via the decision route's
+      // explicit call, so the entry survives a stray tool_result. Derived
+      // awaiting reads that store: card parked, light ON. (Before the flip
+      // this was a pinned split-brain — the imperative clear dropped the bit
+      // without consulting this store.)
       sendToolResult('cu-clear-1')
       expect(
         messagePersister.getPendingComputerUseRequests(SESSION_ID).map((r) => r.toolUseId)
       ).toContain('cu-clear-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
       messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-1')
       expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
     })
 
     it('the route clear flips awaiting and broadcasts when it was the last blocking wait', () => {
@@ -534,7 +544,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(call.slice(0, 3)).toEqual([SESSION_ID, AGENT_SLUG, 'capability_review_workflows'])
     })
 
-    it('completeCapabilityReview drops the replay entry and broadcasts, but never flips the awaiting bit', async () => {
+    it('completeCapabilityReview drops the replay entry, broadcasts, and clears awaiting', async () => {
       simulateToolUse('Workflow', 'wf-lifecycle-2', { script: 'export const meta = {}' })
       await vi.waitFor(() => {
         expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(1)
@@ -544,82 +554,78 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
       expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
       expect(sseEvents.filter((e) => e.type === 'capability_review_resolved')).toHaveLength(1)
-      // KNOWN SPLIT-BRAIN (pinned, not desired): like the computer-use route
-      // clear, this door empties its store and broadcasts but leaves the
-      // awaiting bit set — it stays true until later stream traffic (the
-      // launched tool's own lifecycle) clears it.
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      // Derived awaiting: settling the review settles the wait. (Before the
+      // flip this door emptied its store and broadcast but left the bit stuck
+      // until later stream traffic cleared it — a pinned split-brain.)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
     })
   })
 
   // ==========================================================================
-  // Cross-store awaiting arithmetic: input store + computer-use store +
-  // external blocker source (the ReviewManager seam). Awaiting must survive
-  // until the LAST wait across all three resolves.
+  // Cross-store awaiting arithmetic: stream store + computer-use store +
+  // agent-scoped reviews (the ReviewManager seam — an agent-scoped registry
+  // entry). Awaiting must survive until the LAST wait across all three
+  // resolves. There is no side-channel: whatever is open in the registry IS
+  // the projection.
   // ==========================================================================
 
   describe('cross-store awaiting arithmetic', () => {
-    it('a held external blocker keeps awaiting alive through tool_results; the agent door releases it', () => {
-      let blockerHeld = true
-      const unregister = messagePersister.registerAwaitingBlockerSource(
-        (agentSlug) => agentSlug === AGENT_SLUG && blockerHeld
-      )
+    // What ReviewManager.requestReview writes through: an agent-scoped
+    // blocking entry (no sessionId — the proxied call has none).
+    function parkAgentReview(id: string) {
+      userInputRequestManager.register({
+        id,
+        kind: 'proxy_review',
+        scope: { agentSlug: AGENT_SLUG },
+        blocking: true,
+        autoApproved: false,
+        payload: { toolkit: 'slack' },
+      })
+      messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
+    }
 
-      try {
-        simulateToolUse('mcp__user-input__request_secret', 'mix-secret-1', {
-          secretName: 'API_KEY',
-          reason: 'Need it',
-        })
-        simulateToolUse('mcp__computer-use__computer_click', 'mix-cu-1', { x: 1, y: 2 })
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+    it('a parked agent-scoped review keeps awaiting alive through tool_results and the cu clear', () => {
+      parkAgentReview('mix-review-1')
 
-        // The user-message clear defers to a held external blocker — this is
-        // the ONLY thing that saves the awaiting bit here: the still-parked
-        // computer-use entry would not (see the split-brain pins above).
-        sendToolResult('mix-secret-1')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      simulateToolUse('mcp__user-input__request_secret', 'mix-secret-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      simulateToolUse('mcp__computer-use__computer_click', 'mix-cu-1', { x: 1, y: 2 })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        // The computer-use route clear defers to the held external blocker
-        // (same waiting-light rule), so awaiting survives it too.
-        messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'mix-cu-1')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      // The secret resolves, but the cu entry AND the review are still open.
+      sendToolResult('mix-secret-1')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        // Once the blocker releases, the agent-level door clears it: both
-        // stream stores are empty by now.
-        blockerHeld = false
-        messagePersister.clearAwaitingInputForAgentIfUnblocked(AGENT_SLUG)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
-      } finally {
-        unregister()
-      }
+      // The cu entry resolves, but the review is still open.
+      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'mix-cu-1')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      // The review settles — nothing is open anymore.
+      userInputRequestManager.resolve('mix-review-1', 'answered')
+      messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
     })
 
-    it('the agent-level door checks stream stores only — external blockers are the CALLER\'s contract', () => {
-      let blockerHeld = true
-      const unregister = messagePersister.registerAwaitingBlockerSource(
-        (agentSlug) => agentSlug === AGENT_SLUG && blockerHeld
-      )
+    it('the agent-wide sync cannot clear awaiting while a review remains open', () => {
+      parkAgentReview('mix-review-2')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-      try {
-        messagePersister.markAwaitingInput(SESSION_ID)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      // Before the derived flip, the agent-level clear door trusted its
+      // caller to verify no reviews remained — a caller that forgot cleared
+      // awaiting under a live review. The projection makes that impossible:
+      // sync recomputes from the registry, and the review is still in it.
+      messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        // A held user-message clear defers to the blocker source…
-        sendToolResult('unknown-tool-id')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      // A stray tool_result on the session doesn't drop it either.
+      sendToolResult('unknown-tool-id')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        // …but clearAwaitingInputForAgentIfUnblocked does NOT consult
-        // external blocker sources. Its documented contract is that the
-        // caller (ReviewManager) verifies no reviews remain before calling.
-        // Pinned: a caller that forgets this check clears awaiting while a
-        // review is still parked — nothing in the persister stops it.
-        messagePersister.clearAwaitingInputForAgentIfUnblocked(AGENT_SLUG)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
-
-        blockerHeld = false
-      } finally {
-        unregister()
-      }
+      userInputRequestManager.resolve('mix-review-2', 'declined')
+      messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
     })
   })
 
@@ -886,47 +892,45 @@ describe('pending user-input request lifecycle (characterization)', () => {
       }
     })
 
-    it('the sidechain resolve defers to a held external blocker (parked proxy/x-agent review)', () => {
-      let blockerHeld = true
-      const unregister = messagePersister.registerAwaitingBlockerSource(
-        (agentSlug) => agentSlug === AGENT_SLUG && blockerHeld
+    it('the sidechain resolve keeps awaiting on while a proxy/x-agent review is parked', () => {
+      userInputRequestManager.register({
+        id: 'side-review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: AGENT_SLUG },
+        blocking: true,
+        autoApproved: false,
+        payload: { toolkit: 'slack' },
+      })
+      sendSidechainToolUse(
+        'mcp__user-input__request_secret',
+        'side-blk-1',
+        { secretName: 'BLK_KEY', reason: 'Blocked resolve' },
+        'parent-blk',
+        'complete'
       )
-      try {
-        sendSidechainToolUse(
-          'mcp__user-input__request_secret',
-          'side-blk-1',
-          { secretName: 'BLK_KEY', reason: 'Blocked resolve' },
-          'parent-blk',
-          'complete'
-        )
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        // The subagent's ask resolves, but the review is still parked — the
-        // waiting light must stay on.
-        sendSidechainToolResult('side-blk-1', 'parent-blk')
-        expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      // The subagent's ask resolves, but the review is still parked — the
+      // waiting light must stay on.
+      sendSidechainToolResult('side-blk-1', 'parent-blk')
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        blockerHeld = false
-        messagePersister.clearAwaitingInputForAgentIfUnblocked(AGENT_SLUG)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
-      } finally {
-        unregister()
-      }
+      userInputRequestManager.resolve('side-review-1', 'answered')
+      messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
     })
   })
 
   // ==========================================================================
-  // Phase 2 shadow registry: every store mutation writes through to the
+  // Shadow registry: every store mutation writes through to the
   // UserInputRequestManager, whose per-store view must mirror the legacy
   // stores exactly (the persister asserts this inline at every mutation —
-  // storeMismatches must stay 0). Its DERIVED awaiting projection is compared
-  // against the imperative bit: where the pinned split-brains make the bit
-  // wrong, the projection is right, and the divergence counter is the
-  // telemetry that sizes the Phase 3 flip.
+  // storeMismatches must stay 0). Its derived awaiting projection is what the
+  // persister's isSessionAwaitingInput now reports.
   // ==========================================================================
 
-  describe('shadow registry equivalence (Phase 2)', () => {
+  describe('shadow registry equivalence', () => {
     const KIND_BY_SSE_TYPE: Record<string, string> = {
       secret_request: 'secret',
       user_question_request: 'question',
@@ -936,19 +940,6 @@ describe('pending user-input request lifecycle (characterization)', () => {
       browser_input_request: 'browser_input',
       script_run_request: 'script_run',
     }
-
-    let consoleWarnSpy: ReturnType<typeof vi.spyOn>
-
-    beforeEach(() => {
-      userInputRequestManager.reset()
-      // Divergence telemetry warns on purpose in the split-brain tests below —
-      // keep the test output clean.
-      consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    })
-
-    afterEach(() => {
-      consoleWarnSpy.mockRestore()
-    })
 
     it('every standard kind registers a typed entry mirroring the replay store, and settles with it', async () => {
       for (const kindCase of STANDARD_KINDS) {
@@ -1013,7 +1004,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(userInputRequestManager.stats.storeMismatches).toBe(0)
     })
 
-    it('parallel requests: the projection stays awaiting while the bit drops early (split-brain telemetry)', async () => {
+    it('parallel requests: the reported status tracks the projection across partial resolves', () => {
       simulateToolUse('mcp__user-input__request_secret', 'shadow-par-1', {
         secretName: 'API_KEY',
         reason: 'Need it',
@@ -1024,25 +1015,20 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(true)
 
-      // KNOWN SPLIT-BRAIN (pinned at the main-path user-message handler): the
-      // first tool_result clears the bit while the second card is still
-      // parked. The derived projection keeps the light on — this is the
-      // behavior Phase 3 promotes to authoritative.
+      // The first tool_result settles one request; the second card is still
+      // parked, so bit and projection both stay on — the persister's status
+      // IS the projection now.
       sendToolResult('shadow-par-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(true)
-
-      // The divergence check is deferred a microtask past the mutation.
-      await vi.waitFor(() => {
-        expect(userInputRequestManager.stats.awaitingDivergences).toBeGreaterThan(0)
-      })
 
       sendToolResult('shadow-par-2')
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
       expect(userInputRequestManager.stats.storeMismatches).toBe(0)
     })
 
-    it('capability review: the registry settles on complete; the stuck bit is divergence telemetry', async () => {
+    it('capability review: complete settles the registry entry and the reported status together', async () => {
       mockAgentCapabilities.subagents = 'allow'
       mockAgentCapabilities.workflows = 'review'
       vi.mocked(mockClient.fetch).mockResolvedValue({
@@ -1063,12 +1049,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       messagePersister.completeCapabilityReview(SESSION_ID, 'shadow-cap-1')
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
-      // Pinned: the early-clear door empties its store but never flips the
-      // bit. Projection right, bit wrong — counted, not thrown.
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
-      await vi.waitFor(() => {
-        expect(userInputRequestManager.stats.awaitingDivergences).toBeGreaterThan(0)
-      })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
       expect(userInputRequestManager.stats.storeMismatches).toBe(0)
     })
 

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -170,6 +170,7 @@ vi.mock('./container-manager', () => ({
 
 // Import after mocks are set up
 import { messagePersister, redactStreamedToolInput } from './message-persister'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { finalizeAutomationStatus, getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 
 describe('redactStreamedToolInput', () => {
@@ -2559,6 +2560,13 @@ describe('MessagePersister', () => {
   // ============================================================================
 
   describe('awaiting input status tracking', () => {
+    beforeEach(() => {
+      // Requests park mid-turn: production always has markSessionActive before
+      // a request event arrives, and the derived awaiting projection is gated
+      // on an active turn (an inactive session is never awaiting).
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    })
+
     // Helper to collect global notification events
     function collectGlobalEvents(): { events: any[]; cleanup: () => void } {
       const events: any[] = []
@@ -2621,7 +2629,9 @@ describe('MessagePersister', () => {
       const { events: globalEvents, cleanup: globalCleanup } = collectGlobalEvents()
 
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG)
+      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
+        { toolUseId: 'recovered-1', toolName: 'mcp__user-input__request_secret' },
+      ])
 
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
       expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(true)
@@ -2631,14 +2641,32 @@ describe('MessagePersister', () => {
       expect(awaitingEvents[0].sessionId).toBe(SESSION_ID)
       expect(awaitingEvents[0].agentSlug).toBe(AGENT_SLUG)
 
+      // Recovered entries are synthesized (never broadcast, no payload) — the
+      // SSE replay must skip them; clients render the card from the transcript.
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+
+      // Its tool_result settles the recovered wait like any other request.
+      mockClient._sendMessage({
+        type: 'user',
+        message: {
+          content: [
+            { type: 'tool_result', tool_use_id: 'recovered-1', content: 'secret-value' },
+          ],
+        },
+      })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+
       globalCleanup()
     })
 
     it('does not recover awaiting input for an inactive session', () => {
-      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG)
+      // A session with no active turn (here: no streaming state at all — the
+      // post-restart shape this fallback exists for) must not be recovered.
+      messagePersister.recoverSessionAwaitingInput('inactive-session-1', AGENT_SLUG, [
+        { toolUseId: 'recovered-2', toolName: 'mcp__user-input__request_secret' },
+      ])
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
-      expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput('inactive-session-1')).toBe(false)
     })
 
     it('sets isAwaitingInput after AskUserQuestion tool fires', () => {
@@ -2923,18 +2951,23 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
     })
 
-    it('keeps isAwaitingInput on tool result while an external blocker (parked review) is active', () => {
+    it('keeps isAwaitingInput on tool result while a parked review is open', () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
 
-      // A parked proxy/x-agent review keeps the agent awaiting even as an unrelated
-      // tool result lands. The review lives outside the stream maps, so it registers
-      // a blocker source rather than being visible in pendingInputRequests.
-      let reviewPending = true
-      // The persister singleton is shared across tests; unregister in finally so a
-      // failing assertion can't leak this predicate into later tests' blocker set.
-      const unregister = messagePersister.registerAwaitingBlockerSource(
-        (slug) => slug === AGENT_SLUG && reviewPending,
-      )
+      // A parked proxy/x-agent review keeps the agent awaiting even as an
+      // unrelated tool result lands. The review lives outside the stream maps
+      // as an agent-scoped registry entry — exactly what ReviewManager writes
+      // through on requestReview.
+      // The registry singleton is shared across tests; resolve in finally so a
+      // failing assertion can't leak this review into later tests.
+      userInputRequestManager.register({
+        id: 'blocker-review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: AGENT_SLUG },
+        blocking: true,
+        autoApproved: false,
+        payload: { toolkit: 'slack' },
+      })
 
       try {
         simulateToolUse('mcp__user-input__request_secret', 'tool-1', { secretName: 'KEY' })
@@ -2950,22 +2983,15 @@ describe('MessagePersister', () => {
           },
         })
 
-        // Must stay awaiting — the review blocker is still active.
+        // Must stay awaiting — the review is still open.
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
-        // Once the review resolves, a later tool result settles the session normally.
-        reviewPending = false
-        mockClient._sendMessage({
-          type: 'user',
-          message: {
-            content: [
-              { type: 'tool_result', tool_use_id: 'tool-2', content: 'done' },
-            ],
-          },
-        })
+        // Once the review resolves, the agent-wide sync settles the session.
+        userInputRequestManager.resolve('blocker-review-1', 'answered')
+        messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
       } finally {
-        unregister()
+        userInputRequestManager.resolve('blocker-review-1', 'cancelled')
       }
     })
 
@@ -3393,6 +3419,12 @@ describe('MessagePersister', () => {
   // ============================================================================
 
   describe('automated session promotion', () => {
+    beforeEach(() => {
+      // Promotion fires on the awaiting rising edge, which requires an active
+      // turn — as in production, where the automated send marks active first.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    })
+
     function collectGlobalEvents(): { events: any[]; cleanup: () => void } {
       const events: any[] = []
       const cleanup = messagePersister.addGlobalNotificationClient((data) => {
@@ -3705,6 +3737,12 @@ describe('MessagePersister', () => {
   // ============================================================================
 
   describe('Script run request detection', () => {
+    beforeEach(() => {
+      // Awaiting is derived and gated on an active turn — mark active as the
+      // real message send would before any request event arrives.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    })
+
     // Use existing simulateToolUse helper (already defined above in awaiting input tests)
     // Re-define locally since the other is scoped to that describe block
     function simulateToolUse(toolName: string, toolId: string, input: Record<string, unknown>) {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -110,11 +110,16 @@ interface StreamingState {
   // Per-subagent streaming state, keyed by parent tool_use ID (supports concurrent background agents)
   activeSubagents: Map<string, SubagentStreamingState>
   slashCommands: SlashCommandInfo[] // Available slash commands from SDK
-  isAwaitingInput: boolean // True when session is waiting for user input (e.g., secret, file, question)
+  // Cache of the registry's derived awaiting projection (userInputRequestManager.isSessionAwaiting,
+  // gated on isActive), maintained by syncSessionAwaiting for edge-triggered broadcasts. Do not
+  // set imperatively — turn-boundary teardown paths reset it to false alongside isActive; every
+  // other transition must go through syncSessionAwaiting.
+  isAwaitingInput: boolean
   // TODO: computer-use and the other input requests are tracked in two separate maps with
-  // divergent clearing rules (this one is cleared only via explicit route calls; pendingInputRequests
-  // below is cleared on tool_result + turn boundaries — so e.g. interrupt clears one but not the
-  // other). Unify into a single store + single SSE replay loop. Tracked: SUP-213 (sibling of SUP-163).
+  // divergent clearing rules (this one survives an idle boundary for SSE replay and is cleared
+  // on session_active / decision routes / cancelAwaitingInput; pendingInputRequests below is
+  // cleared on tool_result + both turn boundaries). Unify into a single store + single SSE
+  // replay loop. Tracked: SUP-213 (sibling of SUP-163).
   pendingComputerUseRequests: Map<string, { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> // Pending computer use requests awaiting user approval (keyed by toolUseId)
   // Pending user-input request broadcasts (secret/connected_account/question/file/remote_mcp/
   // script_run/browser_input), keyed by toolUseId. These are one-shot SSE events, so a client
@@ -519,10 +524,13 @@ class MessagePersister {
 
   // Get pending user-input request broadcasts for a session (for SSE replay on (re)connect).
   // Returns the exact event payloads that were broadcast, so the route can re-send them verbatim.
+  // Entries synthesized by recoverSessionAwaitingInput are excluded: they were never broadcast
+  // and carry no payload — replaying one would render a broken card. Clients get those from
+  // the transcript instead.
   getPendingInputRequests(sessionId: string): Array<{ type: string; toolUseId: string; [k: string]: unknown }> {
     const state = this.streamingStates.get(sessionId)
     if (!state) return []
-    return Array.from(state.pendingInputRequests.values())
+    return Array.from(state.pendingInputRequests.values()).filter((r) => r.recovered !== true)
   }
 
   // Record an "Allow for this session" capability grant (decision route calls
@@ -554,13 +562,7 @@ class MessagePersister {
     userInputRequestManager.resolveIfInStore(toolUseId, 'stream', outcome)
     this.shadowRegistryCheck(sessionId, 'completeCapabilityReview')
     this.broadcastToSSE(sessionId, { type: 'capability_review_resolved', toolUseId })
-    if (state.pendingInputRequests.size === 0) {
-      this.broadcastGlobal({
-        type: 'session_input_provided',
-        sessionId,
-        agentSlug: state.agentSlug,
-      })
-    }
+    this.syncSessionAwaiting(sessionId)
   }
 
   // Clear a pending computer use request (after approval/rejection)
@@ -574,21 +576,7 @@ class MessagePersister {
       state.pendingComputerUseRequests.delete(toolUseId)
       userInputRequestManager.resolveIfInStore(toolUseId, 'computer_use', outcome)
       this.shadowRegistryCheck(sessionId, 'clearPendingComputerUseRequest')
-      // Same waiting-light rule as the sidechain input clear: both stores,
-      // skip auto-approved — and defer to a parked proxy/x-agent review
-      // (external blocker), which is also a real wait.
-      if (
-        state.isAwaitingInput &&
-        !this.hasBlockingPendingRequests(state) &&
-        !this.hasExternalAwaitingBlocker(state.agentSlug)
-      ) {
-        state.isAwaitingInput = false
-        this.broadcastGlobal({
-          type: 'session_input_provided',
-          sessionId,
-          agentSlug: state.agentSlug,
-        })
-      }
+      this.syncSessionAwaiting(sessionId)
     }
   }
 
@@ -881,13 +869,30 @@ class MessagePersister {
       agentSlug: state.agentSlug,
       isActive: true,
     })
+
+    // The session_active broadcast above wiped the previous turn's parked
+    // requests, so the projection here reflects only waits that genuinely
+    // survive a new message — an agent-scoped proxy/x-agent review. Syncing
+    // makes a session that joins mid-review show awaiting immediately (the
+    // review used to mark only the sessions active at request time).
+    this.syncSessionAwaiting(sessionId)
   }
 
-  // Mark session as awaiting user input and broadcast globally
-  private markSessionAwaitingInput(sessionId: string): void {
+  // Recompute the derived awaiting projection for a session and broadcast on
+  // the edges. `state.isAwaitingInput` is only a cache of the registry's
+  // `isSessionAwaiting` projection — this is the ONE place that flips it in
+  // response to requests opening/settling (turn-boundary teardown paths reset
+  // it directly, alongside isActive, without broadcasting). An inactive
+  // session is never awaiting: its parked requests died with the turn, even
+  // when a stale entry (or an agent-scoped review) is still open.
+  private syncSessionAwaiting(sessionId: string): void {
     const state = this.streamingStates.get(sessionId)
-    if (state && !state.isAwaitingInput) {
-      state.isAwaitingInput = true
+    if (!state) return
+    const derived =
+      state.isActive && userInputRequestManager.isSessionAwaiting(sessionId, state.agentSlug)
+    if (derived === state.isAwaitingInput) return
+    state.isAwaitingInput = derived
+    if (derived) {
       this.broadcastGlobal({
         type: 'session_awaiting_input',
         sessionId,
@@ -898,31 +903,7 @@ class MessagePersister {
           console.error('[MessagePersister] Failed to promote automated session:', err)
         })
       }
-    }
-  }
-
-  // Public door for host-owned waits that park outside the tool_use stream
-  // (proxy / MCP / x-agent review). Same bit as markSessionAwaitingInput.
-  markAwaitingInput(sessionId: string): void {
-    this.markSessionAwaitingInput(sessionId)
-  }
-
-  // Real waits only: non-auto pocket-A asks + any pocket-B computer-use approval.
-  // Proxy reviews live in ReviewManager and are gated by the caller before this runs.
-  private hasBlockingPendingRequests(state: StreamingState): boolean {
-    return (
-      [...state.pendingInputRequests.values()].some((r) => r.autoApproved !== true) ||
-      state.pendingComputerUseRequests.size > 0
-    )
-  }
-
-  // Clear awaiting on every session for an agent that has no remaining stream
-  // blockers. Caller must ensure no proxy reviews remain for the agent first.
-  clearAwaitingInputForAgentIfUnblocked(agentSlug: string): void {
-    for (const [sessionId, state] of this.streamingStates) {
-      if (state.agentSlug !== agentSlug || !state.isAwaitingInput) continue
-      if (this.hasBlockingPendingRequests(state)) continue
-      state.isAwaitingInput = false
+    } else {
       this.broadcastGlobal({
         type: 'session_input_provided',
         sessionId,
@@ -931,34 +912,19 @@ class MessagePersister {
     }
   }
 
-  // External "still waiting on the human" signals that live outside the stream's
-  // pending maps — proxy / x-agent reviews own their store in ReviewManager, which
-  // already imports this module, so it registers a source here rather than being
-  // imported back (that would cycle). Returns an unregister fn, mirroring
-  // addGlobalNotificationClient.
-  private awaitingBlockerSources = new Set<(agentSlug: string) => boolean>()
-
-  registerAwaitingBlockerSource(fn: (agentSlug: string) => boolean): () => void {
-    this.awaitingBlockerSources.add(fn)
-    return () => {
-      this.awaitingBlockerSources.delete(fn)
+  // Agent-wide recompute: agent-scoped requests (proxy / x-agent reviews) block
+  // every session of the agent, so ReviewManager calls this after each review
+  // opens or settles. Replaces the registerAwaitingBlockerSource predicate and
+  // the mark/clear pair ReviewManager used to drive imperatively.
+  syncAgentSessionsAwaiting(agentSlug: string): void {
+    for (const [sessionId, state] of this.streamingStates) {
+      if (state.agentSlug === agentSlug) this.syncSessionAwaiting(sessionId)
     }
   }
 
-  private hasExternalAwaitingBlocker(agentSlug: string | undefined): boolean {
-    if (!agentSlug) return false
-    for (const isBlocking of this.awaitingBlockerSources) {
-      if (isBlocking(agentSlug)) return true
-    }
-    return false
-  }
-
-  // Phase 2 shadow-registry parity (dev/test only, skipped in production).
-  // Store comparison runs synchronously — every mutation site writes through to
-  // the registry adjacent to the store mutation, so the two must already agree
-  // here. The awaiting-bit comparison is deferred a microtask: the imperative
-  // mark/clear that follows a store mutation lands later in the same
-  // synchronous stretch, and comparing early would report phantom divergence.
+  // Shadow-registry parity (dev/test only, skipped in production). Every store
+  // mutation site writes through to the registry adjacent to the store
+  // mutation, so the two must agree here.
   private shadowRegistryCheck(sessionId: string, context: string): void {
     if (process.env.NODE_ENV === 'production') return
     const state = this.streamingStates.get(sessionId)
@@ -968,16 +934,6 @@ class MessagePersister {
       context,
       streamStoreIds: [...state.pendingInputRequests.keys()],
       computerUseStoreIds: [...state.pendingComputerUseRequests.keys()],
-    })
-    queueMicrotask(() => {
-      const current = this.streamingStates.get(sessionId)
-      if (!current) return
-      userInputRequestManager.compareAwaitingProjection({
-        sessionId,
-        context,
-        agentSlug: current.agentSlug,
-        isAwaitingInput: current.isAwaitingInput,
-      })
     })
   }
 
@@ -1010,23 +966,56 @@ class MessagePersister {
 
     // Only tools with 'request_' prefix actually block waiting for user response
     // (schedule_task, deliver_file, search_* resolve immediately and don't block).
-    // computer-use AND request_script_run mark awaiting in their own handlers,
-    // which only do so when user approval is actually needed (not when
-    // auto-executed against a cached permission grant).
+    // computer-use AND request_script_run sync awaiting in their own handlers.
+    // The handler above already broadcast the request event, which registered
+    // it — the sync just picks the new entry up.
     if (isBlockingUserInputToolName(toolName)) {
-      this.markSessionAwaitingInput(sessionId)
+      this.syncSessionAwaiting(sessionId)
     }
+  }
+
+  // Blocking user-input tool name → the request event type its handler
+  // broadcasts. Recovery synthesizes store entries in this shape when the
+  // original one-shot event was missed. Keep in sync with the handlers'
+  // broadcast types (INPUT_REQUEST_TYPES).
+  private static readonly REQUEST_EVENT_TYPE_BY_TOOL_NAME: Record<string, string> = {
+    AskUserQuestion: 'user_question_request',
+    'mcp__user-input__request_secret': 'secret_request',
+    'mcp__user-input__request_connected_account': 'connected_account_request',
+    'mcp__user-input__request_file': 'file_request',
+    'mcp__user-input__request_remote_mcp': 'remote_mcp_request',
+    'mcp__user-input__request_browser_input': 'browser_input_request',
   }
 
   // Recover awaiting-input state from persisted messages when the one-shot
   // request stream event was missed but the unresolved tool call is visible.
-  recoverSessionAwaitingInput(sessionId: string, agentSlug?: string): void {
+  // Re-establishes the missed requests in the stream store and the registry
+  // (the derived awaiting projection needs real entries — there is no forced
+  // bit anymore), then recomputes awaiting. Entries are marked `recovered` so
+  // SSE replay skips them: they carry no payload, and connected clients render
+  // the card from the transcript that triggered this recovery in the first
+  // place. Resolution needs no special path — their tool_result (or the next
+  // turn boundary) clears them like any other stream-store entry.
+  recoverSessionAwaitingInput(
+    sessionId: string,
+    agentSlug: string | undefined,
+    unresolved: Array<{ toolUseId: string; toolName: string }>,
+  ): void {
     const state = this.streamingStates.get(sessionId)
     if (!state?.isActive) return
     if (agentSlug && !state.agentSlug) {
       state.agentSlug = agentSlug
     }
-    this.markSessionAwaitingInput(sessionId)
+    for (const { toolUseId, toolName } of unresolved) {
+      const type = MessagePersister.REQUEST_EVENT_TYPE_BY_TOOL_NAME[toolName]
+      if (!type || state.pendingInputRequests.has(toolUseId)) continue
+      const evt = { type, toolUseId, agentSlug: state.agentSlug, recovered: true }
+      state.pendingInputRequests.set(toolUseId, evt)
+      const shadow = streamEventToPendingRequest(sessionId, evt)
+      if (shadow) userInputRequestManager.register(shadow)
+      this.shadowRegistryCheck(sessionId, 'recoverSessionAwaitingInput')
+    }
+    this.syncSessionAwaiting(sessionId)
   }
 
   // Promote an automated session (cron/webhook/chat) to a regular session so it
@@ -1138,12 +1127,25 @@ class MessagePersister {
       if (state) {
         if (evt.type === 'session_active' || evt.type === 'session_idle') {
           state.pendingInputRequests.clear()
-          // Shadow registry (Phase 2): mirror the turn-boundary wipe. A new
-          // turn supersedes parked asks; an idle boundary cancels them.
+          // Mirror the turn-boundary wipe in the registry. A new turn
+          // supersedes parked asks; an idle boundary cancels them.
           userInputRequestManager.clearSessionStreamRequests(
             sessionId,
             evt.type === 'session_active' ? 'superseded' : 'cancelled',
           )
+          if (evt.type === 'session_active') {
+            // A new turn also supersedes computer-use approvals left over from
+            // a previous one. Historically this store was never cleared at
+            // turn boundaries (only by a decision or cancelAwaitingInput), so
+            // stale entries could survive an idle/interrupt — harmless when
+            // awaiting was an imperative bit, but the derived projection would
+            // read them as a live wait and flag the fresh turn as awaiting.
+            // (Idle keeps them for SSE replay of a still-parked approval.)
+            for (const id of state.pendingComputerUseRequests.keys()) {
+              userInputRequestManager.resolveIfInStore(id, 'computer_use', 'superseded')
+            }
+            state.pendingComputerUseRequests.clear()
+          }
           this.shadowRegistryCheck(sessionId, `broadcast:${evt.type}`)
         } else if (MessagePersister.INPUT_REQUEST_TYPES.has(evt.type) && typeof evt.toolUseId === 'string') {
           state.pendingInputRequests.set(evt.toolUseId, evt as { type: string; toolUseId: string })
@@ -1381,19 +1383,10 @@ class MessagePersister {
           this.broadcastToSSE(sessionId, { type: 'messages_updated' })
           break
         }
-        // Clear awaiting input when tool results arrive (user provided input),
-        // unless a proxy / x-agent review is still parked for this agent. Those
-        // reviews live in ReviewManager, outside the stream's pending maps, so we
-        // ask via a registered blocker source instead of clearing blindly.
-        if (state.isAwaitingInput && !this.hasExternalAwaitingBlocker(state.agentSlug)) {
-          state.isAwaitingInput = false
-          this.broadcastGlobal({
-            type: 'session_input_provided',
-            sessionId,
-            agentSlug: state.agentSlug,
-          })
-        }
-        // Tool results come as 'user' type messages
+        // Tool results come as 'user' type messages. handleToolResults settles
+        // each answered request in the registry and recomputes awaiting from
+        // what actually remains open — answering one of several parallel
+        // requests no longer drops the waiting light while siblings are parked.
         this.handleToolResults(sessionId, content)
         // Broadcast refresh so frontend can detect the persisted user message
         // and clear the optimistic pending copy promptly.
@@ -4037,7 +4030,7 @@ ${continuation}`
         input,
         agentSlug,
       })
-      this.markSessionAwaitingInput(sessionId)
+      this.syncSessionAwaiting(sessionId)
 
       if (agentSlug) {
         notificationManager.triggerSessionWaitingInput(
@@ -4173,7 +4166,7 @@ ${continuation}`
       // handler) covers SUBAGENT-originated requests, whose sidechain paths
       // bypass that handler — without this the orange awaiting-input status
       // never flips and the agent shows "working" while parked on the user.
-      this.markSessionAwaitingInput(sessionId)
+      this.syncSessionAwaiting(sessionId)
 
       // Renderer-side gate handles suppression; see session_complete trigger.
       if (agentSlug) {
@@ -4261,7 +4254,7 @@ ${continuation}`
       // Only flip the global "awaiting input" status (which drives the orange agent-status
       // pill in the sidebar / tray) when the user actually has to respond.
       if (!autoApproved) {
-        this.markSessionAwaitingInput(sessionId)
+        this.syncSessionAwaiting(sessionId)
         // Renderer-side gate handles suppression; see session_complete trigger.
         if (agentSlug) {
           notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'script_run').catch((err) => {
@@ -4360,7 +4353,7 @@ ${continuation}`
         }
         this.shadowRegistryCheck(sessionId, 'handleComputerUseRequestTool')
       }
-      this.markSessionAwaitingInput(sessionId)
+      this.syncSessionAwaiting(sessionId)
 
       this.broadcastToSSE(sessionId, {
         type: 'computer_use_request',
@@ -4558,12 +4551,10 @@ ${continuation}`
   // Handle tool results - broadcast to SSE clients
   // Sidechain counterpart of handleToolResults, scoped to tracked input
   // requests only: ordinary subagent tool results (Bash, Read, …) stream
-  // constantly and must not broadcast main-path `tool_result` events or touch
-  // the awaiting flag. Unlike the main path's unconditional clear, awaiting is
-  // cleared only when no OTHER blocking request remains (the shared both-stores
-  // rule) — a main-agent question or a pending computer-use can be open in
-  // parallel with a subagent's browser_input — and never while a proxy/x-agent
-  // review is still parked for this agent.
+  // constantly and must not broadcast main-path `tool_result` events. The
+  // trailing sync recomputes awaiting from what remains open — a main-agent
+  // question, a pending computer-use, or a parked proxy/x-agent review keeps
+  // the session waiting even after a subagent's browser_input resolves.
   private resolveSidechainInputRequests(
     sessionId: string,
     state: StreamingState,
@@ -4590,18 +4581,7 @@ ${continuation}`
         isError: block.is_error || false,
       })
     }
-    if (
-      state.isAwaitingInput &&
-      !this.hasBlockingPendingRequests(state) &&
-      !this.hasExternalAwaitingBlocker(state.agentSlug)
-    ) {
-      state.isAwaitingInput = false
-      this.broadcastGlobal({
-        type: 'session_input_provided',
-        sessionId,
-        agentSlug: state.agentSlug,
-      })
-    }
+    this.syncSessionAwaiting(sessionId)
   }
 
   private handleToolResults(
@@ -4652,6 +4632,7 @@ ${continuation}`
           }
         }
       }
+      this.syncSessionAwaiting(sessionId)
     } catch (error) {
       console.error('Failed to handle tool results:', error)
     }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -288,18 +288,28 @@ class MessagePersister {
     containerSessionId: string,
     agentSlug?: string
   ): Promise<void> {
-    // Preserve session-lifecycle flags across (re-)subscribe so callers that
+    // Preserve session-lifecycle state across (re-)subscribe so callers that
     // markSessionActive *before* subscribing (e.g. x-agent sync invoke) and
     // SSE reconnects of in-flight sessions don't lose their "currently busy"
-    // state when the listener reattaches.
+    // state when the listener reattaches. The pending-request stores carry
+    // over too: the awaiting cache is only meaningful while its source of
+    // truth survives — recreating the stores empty would let the next sync
+    // clear a genuinely parked wait, and would lose the reconnect replay data.
     const prior = this.streamingStates.get(sessionId)
     const priorIsActive = prior?.isActive ?? false
     const priorIsAwaitingInput = prior?.isAwaitingInput ?? false
     const priorBackgroundTasks = prior?.activeBackgroundTasks ?? new Map()
+    const priorPendingInputRequests = prior?.pendingInputRequests ?? new Map()
+    const priorPendingComputerUseRequests = prior?.pendingComputerUseRequests ?? new Map()
 
-    // Unsubscribe if already subscribed (this also clears state, which is why
-    // we captured the flags above)
-    this.unsubscribeFromSession(sessionId)
+    // Detach only the transport if already subscribed. NOT unsubscribeFromSession:
+    // that is a full teardown — it drops the session's registry entries, which
+    // must outlive a transport reattach for the same live session.
+    const existingUnsubscribe = this.subscriptions.get(sessionId)
+    if (existingUnsubscribe) {
+      existingUnsubscribe()
+      this.subscriptions.delete(sessionId)
+    }
 
     // Initialize state
     this.streamingStates.set(sessionId, {
@@ -317,8 +327,8 @@ class MessagePersister {
       activeSubagents: new Map(),
       slashCommands: [],
       isAwaitingInput: priorIsAwaitingInput,
-      pendingComputerUseRequests: new Map(),
-      pendingInputRequests: new Map(),
+      pendingComputerUseRequests: priorPendingComputerUseRequests,
+      pendingInputRequests: priorPendingInputRequests,
       cancelledCapabilityReviews: new Set(),
       lastApiErrorCode: null,
       activeBackgroundTasks: priorBackgroundTasks,
@@ -380,6 +390,12 @@ class MessagePersister {
       this.persistAutomationStatus(sessionId, state, 'succeeded')
     }
     state.isActive = false
+    // Teardown resets the awaiting cache silently alongside isActive (an
+    // inactive session is never awaiting). isSessionAwaitingInput reports this
+    // bit raw, so leaving it set would strand "needs input" on an idle session
+    // — e.g. the markSessionIdle revert after markSessionActive's sync picked
+    // up an open agent-scoped review.
+    state.isAwaitingInput = false
     this.broadcastToSSE(sessionId, { type: 'session_idle', isActive: false })
     this.broadcastGlobal({
       type: 'session_idle',
@@ -601,10 +617,15 @@ class MessagePersister {
   async cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void> {
     if (!this.isSessionAwaitingInput(sessionId)) return
 
+    const state = this.streamingStates.get(sessionId)
+
     // Snapshot the pending tool ids from BOTH maps before interrupting. pendingInputRequests holds
     // the broadcast types (cleared by markSessionInterrupted's session_idle); computer_use lives in
-    // its own pendingComputerUseRequests map, which that broadcast does NOT clear.
-    const inputRequestIds = this.getPendingInputRequests(sessionId).map((r) => r.toolUseId)
+    // its own pendingComputerUseRequests map, which that broadcast does NOT clear. Read the store
+    // RAW — not getPendingInputRequests, whose replay filter hides recovered entries. Those are
+    // exactly the ones whose container-side pending may still be live (the host missed the original
+    // events), so skipping them would leave an abandoned request for a late click to land on.
+    const inputRequestIds = Array.from(state?.pendingInputRequests.values() ?? []).map((r) => r.toolUseId)
     const computerUseIds = this.getPendingComputerUseRequests(sessionId).map((r) => r.toolUseId)
 
     // Interrupt FIRST: abort the parked query so it can never resume into a filler reply.
@@ -615,7 +636,6 @@ class MessagePersister {
 
     // Clear the host-side computer_use bookkeeping explicitly — session_idle only clears
     // pendingInputRequests, so a leftover entry would replay a phantom approval card on reconnect.
-    const state = this.streamingStates.get(sessionId)
     for (const id of computerUseIds) {
       state?.pendingComputerUseRequests.delete(id)
       if (state) userInputRequestManager.resolveIfInStore(id, 'computer_use', 'superseded')
@@ -1631,6 +1651,12 @@ class MessagePersister {
               agentSlug: state.agentSlug,
               isActive: true,
             })
+            // Same trailing sync as markSessionActive: the session_active
+            // broadcast above wiped the previous turn's parked requests, so
+            // this picks up only waits that survive a new turn — an
+            // agent-scoped review that was already parked when the runtime
+            // started this one.
+            this.syncSessionAwaiting(sessionId)
           }
         } else if (content.subtype === 'background_tasks_changed') {
           // Authoritative full snapshot of the session's live background tasks
@@ -1689,13 +1715,27 @@ class MessagePersister {
         const classification = classifyResult(content)
         const isError = classification.isError
         state.isStreaming = false
-        state.isAwaitingInput = false
         // On error the turn ends here, so settle isActive too BEFORE the single
         // emit. Collapsing every terminal flag change into ONE emit (reflecting
         // the final state) avoids a spurious working(true)→(false) pair — the
         // intermediate "isActive still true, streaming just cleared" snapshot
         // would read working=true and race connectors into a stuck indicator.
-        if (isError || classification.isInterrupt) state.isActive = false
+        // The awaiting cache follows the same rule: silent-clear ONLY where the
+        // session is actually settling (error/interrupt here, finalizeIdle
+        // below). A clean success can leave the session ACTIVE — the runtime
+        // owns idle under state-event authority, or background work remains —
+        // and an open agent-scoped review still blocks every active session,
+        // so re-derive instead: a blind clear would misreport "working" AND
+        // eat the falling edge (the review's later settle would see
+        // cache == derived and never broadcast session_input_provided).
+        if (isError || classification.isInterrupt) {
+          state.isActive = false
+          state.isAwaitingInput = false
+        } else if (state.stateEventsAuthority || this.openBackgroundWorkCount(state) > 0) {
+          this.syncSessionAwaiting(sessionId)
+        } else {
+          state.isAwaitingInput = false // finalizeIdle below settles the turn
+        }
         state.currentText = ''
         state.lastResultSubtype = typeof content.subtype === 'string' ? content.subtype : null
 

--- a/src/shared/lib/proxy/proxy-review-session-awaiting.test.ts
+++ b/src/shared/lib/proxy/proxy-review-session-awaiting.test.ts
@@ -6,6 +6,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { messagePersister } from '@shared/lib/container/message-persister'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { ReviewManager } from './review-manager'
 
 const SESSION_ID = 'proxy-review-awaiting-session'
@@ -106,10 +107,20 @@ describe('proxy review session awaiting', () => {
     const promise = manager.requestReview(reviewDetails())
     expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
 
+    // Park a secret request the way the persister's broadcast funnel does:
+    // store entry + registry write-through (awaiting derives from the latter).
     const state = streamState()
     state?.pendingInputRequests.set('secret-1', {
-      type: 'request_secret',
+      type: 'secret_request',
       toolUseId: 'secret-1',
+    })
+    userInputRequestManager.register({
+      id: 'secret-1',
+      kind: 'secret',
+      scope: { agentSlug: AGENT_SLUG, sessionId: SESSION_ID },
+      blocking: true,
+      autoApproved: false,
+      payload: { secretName: 'API_KEY' },
     })
 
     const id = manager.getPendingReviewsForAgent(AGENT_SLUG)[0].id
@@ -118,5 +129,8 @@ describe('proxy review session awaiting', () => {
 
     expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
     expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('awaiting')
+
+    state?.pendingInputRequests.delete('secret-1')
+    userInputRequestManager.resolve('secret-1', 'cancelled')
   })
 })

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -107,37 +107,13 @@ interface PendingReview {
 
 export class ReviewManager {
   private pending: Map<string, PendingReview> = new Map()
-  private awaitingBlockerRegistered = false
 
-  // Teach MessagePersister that a parked review counts as "still waiting on the
-  // human", so its tool-result clear won't drop the awaiting bit while a review is
-  // up. Registered lazily on first review (not at module load): review-manager and
-  // message-persister form an import cycle, so the persister singleton isn't ready
-  // at module-eval time — mirrors container-manager wiring its callback at startup.
-  private ensureAwaitingBlockerRegistered(): void {
-    if (this.awaitingBlockerRegistered) return
-    this.awaitingBlockerRegistered = true
-    messagePersister.registerAwaitingBlockerSource(
-      (agentSlug) => this.getPendingReviewsForAgent(agentSlug).length > 0,
-    )
-  }
-
-  private markAgentSessionsAwaiting(agentSlug: string): void {
-    for (const sessionId of messagePersister.getActiveSessionIdsForAgent(agentSlug)) {
-      messagePersister.markAwaitingInput(sessionId)
-    }
-  }
-
-  // Caller deletes the review from `pending` first. No-op while any review remains.
-  private clearAgentSessionsAwaitingIfIdle(agentSlug: string): void {
-    if (this.getPendingReviewsForAgent(agentSlug).length > 0) return
-    messagePersister.clearAwaitingInputForAgentIfUnblocked(agentSlug)
-  }
-
-  // Phase 2 shadow-registry parity (dev/test only): after every mutation of
+  // Shadow-registry parity (dev/test only): after every mutation of
   // `pending`, the registry's agent-scoped review view must mirror this store
   // exactly — a missed or malformed write-through fails tests / logs in dev
-  // instead of silently diverging.
+  // instead of silently diverging. This matters doubly now that the awaiting
+  // status is DERIVED from the registry: a review that misses its write-through
+  // would no longer light the waiting indicator at all.
   private shadowRegistryCheck(agentSlug: string, context: string): void {
     if (process.env.NODE_ENV === 'production') return
     const reviewStoreIds = [...this.pending.values()]
@@ -147,7 +123,6 @@ export class ReviewManager {
   }
 
   requestReview(details: ReviewDetails, signal?: AbortSignal): Promise<'allow' | 'deny'> {
-    this.ensureAwaitingBlockerRegistered()
     const id = crypto.randomUUID()
 
     return new Promise<'allow' | 'deny'>((resolve, reject) => {
@@ -161,7 +136,7 @@ export class ReviewManager {
           reviewId: id,
           decision: 'deny',
         })
-        this.clearAgentSessionsAwaitingIfIdle(details.agentSlug)
+        messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
         reject(new Error('Review timeout'))
       }
 
@@ -177,7 +152,7 @@ export class ReviewManager {
           reviewId: id,
           decision: 'deny',
         })
-        this.clearAgentSessionsAwaitingIfIdle(details.agentSlug)
+        messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
       }
 
       // If the request is aborted (e.g. task stopped), clean up the orphaned review
@@ -190,8 +165,9 @@ export class ReviewManager {
       }
 
       this.pending.set(id, { id, details, resolve, reject, timer })
-      // Shadow registry (Phase 2): reviews are agent-scoped — no sessionId in
-      // the proxied call, so the envelope carries agentSlug only.
+      // Reviews are agent-scoped — no sessionId in the proxied call, so the
+      // envelope carries agentSlug only. The registry entry is what makes the
+      // agent's sessions read as awaiting while the review is parked.
       userInputRequestManager.register({
         id,
         kind: details.xAgent ? 'x_agent_review' : 'proxy_review',
@@ -224,15 +200,16 @@ export class ReviewManager {
         ...(details.xAgent ? { xAgent: details.xAgent } : {}),
       })
 
-      // Mark active sessions awaiting so chat tick / activity strip stop lying
-      // "Working…" while the Allow/Deny card is up.
-      this.markAgentSessionsAwaiting(details.agentSlug)
+      // Recompute awaiting for the agent's sessions so chat tick / activity
+      // strip stop lying "Working…" while the Allow/Deny card is up — the
+      // registry entry registered above is what flips them.
+      messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
 
       // Fire ONE OS notification per review, attributed to the first active
       // session of this agent. The proxy call is agent-scoped (no sessionId
       // in the request), so we pick an active session — same attribution
-      // heuristic the sidebar uses for its orange dot (agents.ts:
-      // isActive && hasAgentLevelReviews). Whether the OS popup actually
+      // heuristic the awaiting projection applies (an agent-scoped review
+      // blocks the agent's active sessions). Whether the OS popup actually
       // shows is the renderer's call — it knows OS focus + per-user viewing
       // + `notifyWhenUnfocused`. An open SSE connection ≠ actively looking
       // at the screen.
@@ -278,7 +255,7 @@ export class ReviewManager {
       reviewId: id,
       decision,
     })
-    this.clearAgentSessionsAwaitingIfIdle(review.details.agentSlug)
+    messagePersister.syncAgentSessionsAwaiting(review.details.agentSlug)
 
     return true
   }
@@ -306,7 +283,7 @@ export class ReviewManager {
       }
     }
     this.shadowRegistryCheck(agentSlug, 'resolveMatchingPending')
-    this.clearAgentSessionsAwaitingIfIdle(agentSlug)
+    messagePersister.syncAgentSessionsAwaiting(agentSlug)
   }
 
   /**
@@ -338,7 +315,7 @@ export class ReviewManager {
       })
     }
     this.shadowRegistryCheck(agentSlug, 'resolveMatchingPendingByLabel')
-    this.clearAgentSessionsAwaitingIfIdle(agentSlug)
+    messagePersister.syncAgentSessionsAwaiting(agentSlug)
   }
 
   /**
@@ -370,7 +347,7 @@ export class ReviewManager {
       }
     }
     this.shadowRegistryCheck(agentSlug, 'resolveMatchingXAgentByOperation')
-    this.clearAgentSessionsAwaitingIfIdle(agentSlug)
+    messagePersister.syncAgentSessionsAwaiting(agentSlug)
   }
 
   getPendingReviewsForAgent(
@@ -455,7 +432,7 @@ export class ReviewManager {
       })
     }
     this.shadowRegistryCheck(agentSlug, 'denyAllForAgent')
-    this.clearAgentSessionsAwaitingIfIdle(agentSlug)
+    messagePersister.syncAgentSessionsAwaiting(agentSlug)
   }
 
   rejectAll(): void {
@@ -474,15 +451,16 @@ export class ReviewManager {
     }
     for (const agentSlug of agentSlugs) {
       this.shadowRegistryCheck(agentSlug, 'rejectAll')
-      this.clearAgentSessionsAwaitingIfIdle(agentSlug)
+      messagePersister.syncAgentSessionsAwaiting(agentSlug)
     }
   }
 }
 
 // Use globalThis to persist across Next.js hot reloads in development, matching
-// messagePersister. The two are coupled: reviewManager registers an awaiting-blocker
-// source on the persister, and the persister survives reloads — so reviewManager must
-// too, or each reload leaks a new stale predicate into the persister's blocker set.
+// messagePersister. The two are coupled: pending reviews write through to the
+// userInputRequestManager registry (which drives the persister's awaiting
+// projection), and both singletons survive reloads — so reviewManager must too,
+// or a reload would strand its pending reviews in a stale instance.
 const globalForReviewManager = globalThis as unknown as {
   reviewManager: ReviewManager | undefined
 }

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -226,29 +226,6 @@ describe('UserInputRequestManager', () => {
       expect(manager.stats.storeMismatches).toBe(1)
     })
 
-    it('compareAwaitingProjection counts divergence and warns once per episode', () => {
-      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      manager.register(secretRequest())
-
-      // Bit says false while a real wait is open: diverged. Two checks in the
-      // same episode → two counts, ONE warn.
-      const diverged = {
-        sessionId: 'session-1',
-        context: 'test',
-        agentSlug: 'agent-a',
-        isAwaitingInput: false,
-      }
-      manager.compareAwaitingProjection(diverged)
-      manager.compareAwaitingProjection(diverged)
-      expect(manager.stats.awaitingDivergences).toBe(2)
-      expect(consoleWarn).toHaveBeenCalledTimes(1)
-
-      // Convergence closes the episode; the next divergence warns again.
-      manager.compareAwaitingProjection({ ...diverged, isAwaitingInput: true })
-      manager.compareAwaitingProjection(diverged)
-      expect(consoleWarn).toHaveBeenCalledTimes(2)
-    })
-
     it('reset wipes requests and diagnostics', () => {
       manager.register(secretRequest())
       manager.resolve('tool-1', 'answered')
@@ -256,7 +233,6 @@ describe('UserInputRequestManager', () => {
       expect(manager.stats).toEqual({
         open: 0,
         storeMismatches: 0,
-        awaitingDivergences: 0,
         recentResolutions: [],
       })
     })

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -11,13 +11,13 @@ import {
  * Host-side registry of every pending user-input request, regardless of which
  * legacy store owns it (persister stream store, computer-use map, ReviewManager).
  *
- * Phase 2 — SHADOW MODE: the legacy stores stay authoritative and every
- * mutation writes through to this registry; nothing reads it for behavior.
- * `verifyStoreParity` asserts the mirror is exact at every store mutation
- * (throws under vitest, logs otherwise), and `compareAwaitingProjection`
- * counts divergence between the imperative awaiting bit and the projection
- * this registry derives — the known split-brains Phase 3 replaces the bit
- * to fix.
+ * Phase 3: the legacy stores stay authoritative for request CONTENTS (and
+ * every mutation still writes through, with `verifyStoreParity` asserting the
+ * mirror is exact), but the session "awaiting input" status is now DERIVED
+ * from this registry via `isSessionAwaiting` — the persister's bit is just an
+ * edge-detection cache of that projection. The imperative per-path mark/clear
+ * calls (and their split-brains: parallel requests, direct-clear doors,
+ * review blockers) are gone.
  */
 export class UserInputRequestManager {
   private requests = new Map<string, PendingUserInputRequest>()
@@ -30,10 +30,6 @@ export class UserInputRequestManager {
   }> = []
 
   private storeMismatchCount = 0
-  private awaitingDivergenceCount = 0
-  // Sessions currently known-diverged, so we warn once per divergence episode
-  // instead of on every mutation while it persists.
-  private divergedSessions = new Set<string>()
 
   /**
    * Register a pending request. First delivery wins: re-registering an id that
@@ -130,9 +126,9 @@ export class UserInputRequestManager {
   /**
    * Derived awaiting projection for a session: any open real wait scoped to
    * the session, plus any agent-scoped real wait of its agent (a parked review
-   * blocks every session of the agent — same semantics the imperative bit
-   * approximates today). Phase 3 flips the persister onto this; Phase 2 only
-   * compares it against the bit.
+   * blocks every session of the agent). This is the source of truth for
+   * "awaiting input" — the persister recomputes it after every registry
+   * transition and broadcasts on the edges.
    */
   isSessionAwaiting(sessionId: string, agentSlug?: string): boolean {
     for (const request of this.requests.values()) {
@@ -233,36 +229,9 @@ export class UserInputRequestManager {
     this.reportStoreMismatch(`agent=${check.agentSlug}`, check.context, [mismatch])
   }
 
-  /**
-   * Soft comparison of the imperative awaiting bit vs the derived projection.
-   * Never throws: the Phase 0 characterization suite pinned real split-brains
-   * where the bit is wrong, and this counter is the telemetry that sizes them.
-   * Warns once per divergence episode per session.
-   */
-  compareAwaitingProjection(check: {
-    sessionId: string
-    context: string
-    agentSlug: string | undefined
-    isAwaitingInput: boolean
-  }): void {
-    const projected = this.isSessionAwaiting(check.sessionId, check.agentSlug)
-    if (projected === check.isAwaitingInput) {
-      this.divergedSessions.delete(check.sessionId)
-      return
-    }
-    this.awaitingDivergenceCount++
-    if (this.divergedSessions.has(check.sessionId)) return
-    this.divergedSessions.add(check.sessionId)
-    console.warn(
-      `[UserInputRequestManager] awaiting divergence (session=${check.sessionId}, ` +
-        `context=${check.context}): bit=${check.isAwaitingInput} projection=${projected}`,
-    )
-  }
-
   get stats(): {
     open: number
     storeMismatches: number
-    awaitingDivergences: number
     recentResolutions: Array<{
       id: string
       kind: PendingUserInputRequest['kind']
@@ -272,7 +241,6 @@ export class UserInputRequestManager {
     return {
       open: this.requests.size,
       storeMismatches: this.storeMismatchCount,
-      awaitingDivergences: this.awaitingDivergenceCount,
       recentResolutions: [...this.recentResolutions],
     }
   }
@@ -282,8 +250,6 @@ export class UserInputRequestManager {
     this.requests.clear()
     this.recentResolutions = []
     this.storeMismatchCount = 0
-    this.awaitingDivergenceCount = 0
-    this.divergedSessions.clear()
   }
 }
 


### PR DESCRIPTION
Phase 3 of the user-input request rearchitecture (follows #560, #562, #566): the session "awaiting input" status stops being an imperative per-path bit and becomes a **derived projection** of the `userInputRequestManager` registry.

## What changed

- **One flip point.** `state.isAwaitingInput` is now an edge-detection cache of `isSessionAwaiting(sessionId, agentSlug)`, gated on an active turn. A new private `syncSessionAwaiting` recomputes it after every registry transition and broadcasts on the edges (`session_awaiting_input` + automated-session promotion on rise, `session_input_provided` on fall). Turn-boundary teardowns still reset silently alongside `isActive`, exactly as before.
- **Deleted the imperative machinery:** `markSessionAwaitingInput`/`markAwaitingInput`, `clearAwaitingInputForAgentIfUnblocked`, `hasBlockingPendingRequests`, the `registerAwaitingBlockerSource` predicate set (the #528 hack), the now-tautological `compareAwaitingProjection` divergence telemetry, and both per-session `|| (isActive && hasAgentLevelReviews)` hacks in agents.ts (the agent-list one stays — it covers dashboard reviews with no session).
- **ReviewManager** now calls `messagePersister.syncAgentSessionsAwaiting(agentSlug)` after registering/settling a review — the agent-scoped registry entry is what blocks the agent's sessions. A session that starts *while* a review is parked now reads as awaiting immediately (previously only sessions active at request time were marked).
- **Split-brains fixed** (the Phase 0 pins now assert the correct behavior): answering one of several parallel requests keeps the waiting light on; `completeCapabilityReview`/`clearPendingComputerUseRequest` flip the bit and broadcast together; a stray tool_result on a parked computer-use approval no longer drops the light; an agent-wide sync cannot clear awaiting under a live review.
- **`session_active` supersedes stale computer-use entries** (partial SUP-213). Required here: the projection would read a pre-idle leftover approval as a live wait on the fresh turn. `session_idle` still keeps them for SSE replay of a genuinely parked card.
- **`recoverSessionAwaitingInput` changed signature** — with no forced bit, recovery re-establishes the actual missed requests (store + registry, marked `recovered` and excluded from SSE replay since they carry no payload; clients render the card from the transcript). agents.ts passes the unresolved tool calls it already scans for.

## Validation

- Full unit suite green (the 245KB persister matrix is the phase's acceptance suite; ~25 harness fixes, all the same shape — mark the session active before simulating request events, as production always does). Store-parity assertions stayed armed throughout.
- 78/78 mock E2E across the 14 awaiting-adjacent specs (request lifecycles, parallel requests, capability/proxy reviews, computer use, reconnect replay, message queueing, mixed pending, status indicators).
- 3 scripted live-container repros against a real model: park → answer → keep working, two-turn with background bash, and a wire tap proving both awaiting edges fire while sampling route truth every 2s.

## New gap-closure tests

- E2E: a parked proxy review flags a session that starts after it (asserted via the sessions route inside the slow-work window).
- E2E: an abandoned computer-use approval does not survive into the next turn — reload replay must not resurrect it (red on main, green here).
- Route tests (×4): awaiting-input recovery — trailing-turn extraction, script_run exclusion, queued-message handling, inactive-session no-op.

https://claude.ai/code/session_01DLw9AJ5VXVQPzBAz87nNAA