### PR TITLE
Add Spotlight alternate names to mac bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,6 +255,14 @@
       "gatekeeperAssess": false,
       "notarize": true,
       "extendInfo": {
+        "CFBundleAlternateNames": [
+          "Gamut",
+          "Superagent",
+          "SuperAgent",
+          "Claude",
+          "Codex",
+          "ChatGPT"
+        ],
         "CFBundleDocumentTypes": [
           {
             "CFBundleTypeName": "Any File",


### PR DESCRIPTION
## Summary
- Adds `CFBundleAlternateNames` to `build.mac.extendInfo` so Spotlight matches the app under additional search terms: **Gamut, Superagent, SuperAgent, Claude, Codex, ChatGPT**
- macOS indexes this Info.plist array into `kMDItemAlternateNames`; Spotlight prefix-matches alternate names the same way it matches the app name, while results still display the real app name and icon. Same mechanism ChatGPT.app uses to answer to "Codex" (verified via `mdls` locally)
- Supports the bridge-first rebrand: users typing "superagent" still find Gamut.app

## Notes
- `CFBundleAlternateNames` is undocumented by Apple but used by Apple's own apps (System Settings ⇒ "System Preferences") and major third parties; stable across recent macOS versions
- Applied at package time by electron-builder — no effect on dev runs. Verify on a dist build with `mdls -name kMDItemAlternateNames /Applications/Gamut.app`
- Existing installs pick this up when the bundle is replaced on next update (Spotlight reindexes then)
- Includes competitor brand names (Claude/Codex/ChatGPT) as aliases per request — visible-but-adjacent in results, not impersonation, though worth a second pair of eyes given trademark optics

## Test plan
- [ ] `npx tsc --noEmit` unaffected (config-only change); JSON validated with a parse check
- [ ] After next mac dist build: `mdls -name kMDItemAlternateNames` lists all six aliases
- [ ] Spotlight search for "superagent" and "claude" surfaces Gamut.app

https://claude.ai/code/session_01UtGm22cJy3JB5av9YoR2sw