### PR TITLE
Unified pending-request wire and client store (Phase 4)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -3240,13 +3240,13 @@ describe('pending-requests snapshot — GET /:id/pending-requests', () => {
     expect(body.requests.map((r) => r.id).sort()).toEqual(['req-mine', 'req-review'])
   })
 
-  it('recovery synthetics are excluded from the snapshot', async () => {
+  it('recovery synthetics stay in the snapshot — payload-less, but still blocking waits', async () => {
     park('req-live', 'sess-1')
     park('req-recovered', 'sess-1', { recovered: true })
 
     const res = await getReq(app, '/api/agents/test-agent/pending-requests?sessionId=sess-1')
     const body = (await res.json()) as { requests: Array<{ id: string }> }
-    expect(body.requests.map((r) => r.id)).toEqual(['req-live'])
+    expect(body.requests.map((r) => r.id).sort()).toEqual(['req-live', 'req-recovered'])
   })
 
   it("a sessionId belonging to a DIFFERENT agent leaks nothing through this agent's gate", async () => {

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -457,6 +457,7 @@ import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@s
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { listUserSecrets, setSecret, getSecret, keyToEnvVar, getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { readJsonFileStrict, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
@@ -3192,6 +3193,82 @@ describe('DELETE /:id/sessions/:sessionId', () => {
 // ============================================================================
 // Awaiting-input recovery from the persisted transcript
 // ============================================================================
+
+describe('pending-requests snapshot — GET /:id/pending-requests', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockIsAuthMode.mockReturnValue(false)
+    userInputRequestManager.reset()
+  })
+
+  afterEach(() => {
+    userInputRequestManager.reset()
+  })
+
+  function park(id: string, sessionId?: string, payload: Record<string, unknown> = { secretName: 'K' }) {
+    userInputRequestManager.register({
+      id,
+      kind: sessionId ? 'secret' : 'proxy_review',
+      scope: { agentSlug: 'test-agent', ...(sessionId ? { sessionId } : {}) },
+      blocking: true,
+      autoApproved: false,
+      payload,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+  }
+
+  it('a session view unions its own requests with the agent-scoped reviews', async () => {
+    park('req-mine', 'sess-1')
+    park('req-other-session', 'sess-2')
+    park('req-review')
+
+    const res = await getReq(app, '/api/agents/test-agent/pending-requests?sessionId=sess-1')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { requests: Array<{ id: string }> }
+    expect(body.requests.map((r) => r.id).sort()).toEqual(['req-mine', 'req-review'])
+  })
+
+  it('an agent view returns everything in the agent scope', async () => {
+    park('req-mine', 'sess-1')
+    park('req-review')
+
+    const res = await getReq(app, '/api/agents/test-agent/pending-requests')
+    const body = (await res.json()) as { requests: Array<{ id: string }> }
+    expect(body.requests.map((r) => r.id).sort()).toEqual(['req-mine', 'req-review'])
+  })
+
+  it('recovery synthetics are excluded from the snapshot', async () => {
+    park('req-live', 'sess-1')
+    park('req-recovered', 'sess-1', { recovered: true })
+
+    const res = await getReq(app, '/api/agents/test-agent/pending-requests?sessionId=sess-1')
+    const body = (await res.json()) as { requests: Array<{ id: string }> }
+    expect(body.requests.map((r) => r.id)).toEqual(['req-live'])
+  })
+
+  it("a sessionId belonging to a DIFFERENT agent leaks nothing through this agent's gate", async () => {
+    // AgentRead() authorizes :id only — the sessionId query param is caller
+    // input, so a foreign session must contribute zero entries to the view.
+    userInputRequestManager.register({
+      id: 'req-foreign',
+      kind: 'secret',
+      scope: { agentSlug: 'other-agent', sessionId: 'sess-foreign' },
+      blocking: true,
+      autoApproved: false,
+      payload: { secretName: 'OTHER_AGENTS_SECRET' },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+    park('req-review')
+
+    const res = await getReq(app, '/api/agents/test-agent/pending-requests?sessionId=sess-foreign')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { requests: Array<{ id: string }> }
+    expect(body.requests.map((r) => r.id)).toEqual(['req-review'])
+  })
+})
 
 describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', () => {
   let app: ReturnType<typeof createApp>

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -28,6 +28,7 @@ import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { guessMimeType } from '@shared/lib/utils/mime'
 import { parseByteRange } from '@shared/lib/utils/http-range'
 import { messagePersister } from '@shared/lib/container/message-persister'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import {
   listSessions,
   listSessionsByIds,
@@ -5392,6 +5393,24 @@ async function cleanupStaleUploads() {
 // Run cleanup on startup and every 30 minutes
 cleanupStaleUploads()
 setInterval(cleanupStaleUploads, 30 * 60 * 1000).unref()
+
+// =============================================================================
+// Pending user-input requests (unified wire)
+// =============================================================================
+
+// GET /api/agents/:id/pending-requests?sessionId= — snapshot of the open
+// user-input requests visible to the agent, optionally narrowed to a session's
+// view (its own requests plus the agent-scoped reviews that block every
+// session of the agent). This is the recovery source for the unified client
+// store: mount, reconnect, and invalidation refetch from here; live updates
+// arrive as user_request_created / user_request_resolved on the session and
+// global SSE streams. Legacy per-type events keep firing during the client
+// migration.
+agents.get('/:id/pending-requests', AgentRead(), (c) => {
+  const agentSlug = getAgentId(c)
+  const sessionId = c.req.query('sessionId') || undefined
+  return c.json({ requests: userInputRequestManager.getSnapshotForScope(agentSlug, sessionId) })
+})
 
 // =============================================================================
 // Proxy review endpoints

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -54,10 +54,17 @@ vi.mock('./insufficient-balance-card', () => ({
   InsufficientBalanceCard: () => <div data-testid="insufficient-balance-card" />,
 }))
 
-let mockProxyReviewsData: { reviews: Array<Record<string, unknown>> } = { reviews: [] }
-vi.mock('@renderer/hooks/use-proxy-reviews', () => ({
-  usePendingProxyReviews: () => ({ data: mockProxyReviewsData, refetch: vi.fn() }),
+// Mock the unified pending-request store — the indicator derives awaiting
+// from its blocking projection (same predicate as the server status).
+type MockPendingRequest = { id: string; kind: string; blocking: boolean; autoApproved: boolean }
+let mockPendingUserRequests: MockPendingRequest[] = []
+vi.mock('@renderer/hooks/use-pending-user-requests', () => ({
+  usePendingUserRequests: () => ({ data: mockPendingUserRequests }),
 }))
+
+function blockingRequest(kind: string, overrides: Partial<MockPendingRequest> = {}): MockPendingRequest {
+  return { id: `req-${kind}`, kind, blocking: true, autoApproved: false, ...overrides }
+}
 
 describe('AgentActivityIndicator', () => {
   beforeEach(() => {
@@ -79,7 +86,7 @@ describe('AgentActivityIndicator', () => {
       backgroundTasks: [],
     })
     mockMessages.length = 0
-    mockProxyReviewsData = { reviews: [] }
+    mockPendingUserRequests = []
   })
 
   it('returns null when not active and no error', () => {
@@ -196,7 +203,7 @@ describe('AgentActivityIndicator', () => {
   it('shows "Waiting for input..." when pending secret requests exist', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
-    mockStreamState.pendingSecretRequests = [{ toolUseId: 't1', secretName: 'API_KEY' }]
+    mockPendingUserRequests = [blockingRequest('secret')]
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
@@ -206,10 +213,7 @@ describe('AgentActivityIndicator', () => {
   it('shows "Waiting for input..." when pending question requests exist', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
-    mockStreamState.pendingQuestionRequests = [{
-      toolUseId: 't1',
-      questions: [{ question: 'Pick one', header: 'DB', options: [], multiSelect: false }],
-    }]
+    mockPendingUserRequests = [blockingRequest('question')]
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
@@ -218,7 +222,7 @@ describe('AgentActivityIndicator', () => {
   it('shows "Waiting for input..." when pending connected account requests exist', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
-    mockStreamState.pendingConnectedAccountRequests = [{ toolUseId: 't1', toolkit: 'github' }]
+    mockPendingUserRequests = [blockingRequest('connected_account')]
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
@@ -227,7 +231,7 @@ describe('AgentActivityIndicator', () => {
   it('shows "Waiting for input..." when pending file requests exist', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
-    mockStreamState.pendingFileRequests = [{ toolUseId: 't1', description: 'Upload CSV' }]
+    mockPendingUserRequests = [blockingRequest('file')]
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
@@ -236,7 +240,7 @@ describe('AgentActivityIndicator', () => {
   it('shows "Waiting for input..." when pending remote MCP requests exist', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
-    mockStreamState.pendingRemoteMcpRequests = [{ toolUseId: 't1', url: 'https://example.com' }]
+    mockPendingUserRequests = [blockingRequest('remote_mcp')]
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
@@ -245,7 +249,7 @@ describe('AgentActivityIndicator', () => {
   it('shows "Waiting for input..." when pending browser input requests exist', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
-    mockStreamState.pendingBrowserInputRequests = [{ toolUseId: 't1', message: 'Login', requirements: [] }]
+    mockPendingUserRequests = [blockingRequest('browser_input')]
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
@@ -264,27 +268,49 @@ describe('AgentActivityIndicator', () => {
   it('shows "Waiting for input..." when a proxy review is pending', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
-    mockProxyReviewsData = {
-      reviews: [{
-        id: 'r-1',
-        agentSlug: 'agent-1',
-        accountId: 'a1',
-        toolkit: 'gmail',
-        method: 'POST',
-        targetPath: '/send',
-        matchedScopes: ['GMAIL_SEND_EMAIL'],
-        scopeDescriptions: {},
-      }],
-    }
+    mockPendingUserRequests = [blockingRequest('proxy_review')]
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
     expect(screen.queryByText('Working...')).not.toBeInTheDocument()
   })
 
+  it.each(['script_run', 'computer_use', 'capability_review'])(
+    'shows "Waiting for input..." for %s — kinds the per-type list used to omit',
+    (kind) => {
+      mockStreamState.isActive = true
+      mockStreamState.activeStartTime = Date.now()
+      mockPendingUserRequests = [blockingRequest(kind)]
+
+      render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
+      expect(screen.queryByText('Working...')).not.toBeInTheDocument()
+    },
+  )
+
+  it('a non-blocking entry is not a wait — the indicator keeps "Working..."', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockPendingUserRequests = [blockingRequest('secret', { blocking: false })]
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('Working...')).toBeInTheDocument()
+    expect(screen.queryByText('Waiting for input...')).not.toBeInTheDocument()
+  })
+
+  it('an auto-approved entry is not a wait — the indicator keeps "Working..."', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockPendingUserRequests = [blockingRequest('script_run', { autoApproved: true })]
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByText('Working...')).toBeInTheDocument()
+    expect(screen.queryByText('Waiting for input...')).not.toBeInTheDocument()
+  })
+
   it('does not show "Waiting for input..." when not active even if pending requests exist', () => {
     mockStreamState.isActive = false
-    mockStreamState.pendingSecretRequests = [{ toolUseId: 't1', secretName: 'KEY' }]
+    mockPendingUserRequests = [blockingRequest('secret')]
 
     const { container } = render(
       <AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />
@@ -331,7 +357,7 @@ describe('AgentActivityIndicator', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
     mockStreamState.isCompacting = true
-    mockStreamState.pendingSecretRequests = [{ toolUseId: 't1', secretName: 'KEY' }]
+    mockPendingUserRequests = [blockingRequest('secret')]
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
@@ -341,7 +367,7 @@ describe('AgentActivityIndicator', () => {
   it('"Waiting for input..." takes priority over TodoWrite activeForm', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
-    mockStreamState.pendingSecretRequests = [{ toolUseId: 't1', secretName: 'KEY' }]
+    mockPendingUserRequests = [blockingRequest('secret')]
     mockMessages.push({
       id: 'msg-1',
       type: 'assistant',

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -2,7 +2,7 @@
 import { useMessages } from '@renderer/hooks/use-messages'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
-import { usePendingProxyReviews } from '@renderer/hooks/use-proxy-reviews'
+import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-requests'
 import { apiFetch } from '@renderer/lib/api'
 import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
 import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-balance-card'
@@ -22,13 +22,10 @@ interface AgentActivityIndicatorProps {
 export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIndicatorProps) {
   const {
     isActive, error, apiErrorCode, activeStartTime, isCompacting, activeSubagents, completedSubagents,
-    pendingSecretRequests, pendingConnectedAccountRequests, pendingQuestionRequests,
-    pendingFileRequests, pendingRemoteMcpRequests, pendingBrowserInputRequests,
     apiRetry, computerUseApp, computerUseAppIcon, backgroundTasks,
     isThinking,
   } = useMessageStream(sessionId, agentSlug)
-  const { data: proxyReviewsData } = usePendingProxyReviews(agentSlug)
-  const pendingProxyReviewCount = proxyReviewsData?.reviews?.length ?? 0
+  const { data: pendingUserRequests } = usePendingUserRequests(agentSlug, sessionId)
 
   const [revoking, setRevoking] = useState(false)
   const [revokeError, setRevokeError] = useState(false)
@@ -50,15 +47,13 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     }
   }, [agentSlug, sessionId])
 
-  const isAwaitingInput = isActive && (
-    pendingSecretRequests.length > 0 ||
-    pendingConnectedAccountRequests.length > 0 ||
-    pendingQuestionRequests.length > 0 ||
-    pendingFileRequests.length > 0 ||
-    pendingRemoteMcpRequests.length > 0 ||
-    pendingBrowserInputRequests.length > 0 ||
-    pendingProxyReviewCount > 0
-  )
+  // The unified store's blocking predicate is the SAME one the server derives
+  // the session's awaiting status from, so this indicator can no longer
+  // disagree with the sidebar/header. It also covers the kinds the old
+  // per-type list silently omitted: script_run, computer_use, and
+  // capability_review used to read as "Working…" while a card was parked.
+  const isAwaitingInput = isActive &&
+    (pendingUserRequests ?? []).some((r) => r.blocking && !r.autoApproved)
   const { data: messages } = useMessages(sessionId, agentSlug)
 
   // Use activeStartTime from SSE (set when session_active fires) as primary source.

--- a/src/renderer/components/messages/use-pending-requests.test.tsx
+++ b/src/renderer/components/messages/use-pending-requests.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { usePendingRequests, type PendingRequestDescriptor } from './use-pending-requests'
 import { createAssistantMessage, createUserMessage, createToolCall } from '@renderer/test/factories'
 import type { ApiMessageOrBoundary } from '@shared/lib/types/api'
+import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
 
 // Mock useMessages
 const mockMessagesData: { data: ApiMessageOrBoundary[] | undefined; isLoading: boolean } = {
@@ -15,18 +16,10 @@ vi.mock('@renderer/hooks/use-messages', () => ({
   useMessages: () => mockMessagesData,
 }))
 
-// Mock useMessageStream
+// Mock useMessageStream — the hook only reads lifecycle/streaming state from it
+// now; the per-kind pending arrays moved to the unified store.
 const mockStreamState = {
   isActive: false,
-  pendingSecretRequests: [] as Array<{ toolUseId: string; secretName: string; reason?: string }>,
-  pendingConnectedAccountRequests: [] as Array<{ toolUseId: string; toolkit: string; reason?: string }>,
-  pendingRemoteMcpRequests: [] as Array<{ toolUseId: string; url: string; name?: string; reason?: string; authHint?: 'oauth' | 'bearer' }>,
-  pendingQuestionRequests: [] as Array<{ toolUseId: string; questions: Array<{ question: string; header: string; options: Array<{ label: string; description: string }>; multiSelect: boolean }> }>,
-  pendingFileRequests: [] as Array<{ toolUseId: string; description: string; fileTypes?: string }>,
-  pendingBrowserInputRequests: [] as Array<{ toolUseId: string; message: string; requirements: string[] }>,
-  pendingScriptRunRequests: [] as Array<{ toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }>,
-  pendingComputerUseRequests: [] as Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }>,
-  pendingCapabilityReviewRequests: [] as Array<{ toolUseId: string; capability: 'subagents' | 'workflows'; toolName: string; input: Record<string, unknown> }>,
   streamingToolUses: [] as Array<{ id: string; name: string; partialInput: string; ready?: boolean }>,
   autoApprovedScriptRunIds: new Set<string>(),
   autoApprovedComputerUseIds: new Set<string>(),
@@ -57,29 +50,38 @@ vi.mock('@renderer/hooks/use-message-stream', () => ({
   removeCapabilityReviewRequest: (...args: unknown[]) => mockRemovers.removeCapabilityReviewRequest(...args),
 }))
 
-// Mock proxy reviews — mutable per test
-type ProxyReviewMock = {
-  id: string
-  agentSlug: string
-  accountId: string
-  toolkit: string
-  method: string
-  targetPath: string
-  matchedScopes: string[]
-  scopeDescriptions: Record<string, string>
-  displayText?: string
-  xAgent?: {
-    targetAgentSlug: string
-    targetAgentName: string
-    operation: 'list' | 'read' | 'invoke' | 'create'
-    preview?: string
-  }
-}
-const mockProxyReviewsData: { reviews: ProxyReviewMock[] } = { reviews: [] }
-const mockRefetchProxyReviews = vi.fn()
-vi.mock('@renderer/hooks/use-proxy-reviews', () => ({
-  usePendingProxyReviews: () => ({ data: mockProxyReviewsData, refetch: mockRefetchProxyReviews }),
+// Mock the unified pending-request store — mutable per test.
+const mockUnified: { data: PendingUserInputRequest[] | undefined } = { data: [] }
+vi.mock('@renderer/hooks/use-pending-user-requests', () => ({
+  usePendingUserRequests: () => ({ data: mockUnified.data }),
 }))
+
+// The hook uses the query client only to invalidate on review completion —
+// keep the real module surface (spread) so new exports don't break the mock.
+const mockInvalidateQueries = vi.fn()
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}))
+
+/** Build a unified registry envelope the way the server snapshot returns it. */
+function unified(
+  kind: PendingUserInputRequest['kind'],
+  id: string,
+  payload: Record<string, unknown>,
+  opts: { autoApproved?: boolean; agentScoped?: boolean } = {},
+): PendingUserInputRequest {
+  return {
+    id,
+    kind,
+    scope: opts.agentScoped
+      ? { agentSlug: 'agent-1' }
+      : { agentSlug: 'agent-1', sessionId: 's-1' },
+    blocking: true,
+    autoApproved: opts.autoApproved ?? false,
+    payload,
+  } as unknown as PendingUserInputRequest
+}
 
 const defaultArgs = {
   sessionId: 's-1',
@@ -98,29 +100,19 @@ describe('usePendingRequests', () => {
     vi.clearAllMocks()
     mockMessagesData.data = undefined
     mockMessagesData.isLoading = false
-    mockProxyReviewsData.reviews = []
+    mockUnified.data = []
     Object.assign(mockStreamState, {
       isActive: false,
-      pendingSecretRequests: [],
-      pendingConnectedAccountRequests: [],
-      pendingRemoteMcpRequests: [],
-      pendingQuestionRequests: [],
-      pendingFileRequests: [],
-      pendingBrowserInputRequests: [],
-      pendingScriptRunRequests: [],
-      pendingComputerUseRequests: [],
-      pendingCapabilityReviewRequests: [],
       streamingToolUses: [],
       autoApprovedScriptRunIds: new Set<string>(),
       autoApprovedComputerUseIds: new Set<string>(),
     })
   })
 
-  it('returns SSE-based pending secret requests', () => {
+  it('returns unified-store pending secret requests', () => {
+    mockStreamState.isActive = true
     mockMessagesData.data = []
-    mockStreamState.pendingSecretRequests = [
-      { toolUseId: 'tu-1', secretName: 'API_KEY' },
-    ]
+    mockUnified.data = [unified('secret', 'tu-1', { secretName: 'API_KEY' })]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
 
@@ -130,11 +122,11 @@ describe('usePendingRequests', () => {
     expect(matches[0].secretName).toBe('API_KEY')
   })
 
-  it('returns SSE-based pending question requests', () => {
+  it('returns unified-store pending question requests', () => {
+    mockStreamState.isActive = true
     mockMessagesData.data = []
-    mockStreamState.pendingQuestionRequests = [
-      {
-        toolUseId: 'tu-q1',
+    mockUnified.data = [
+      unified('question', 'tu-q1', {
         questions: [
           {
             question: 'Which DB?',
@@ -143,7 +135,7 @@ describe('usePendingRequests', () => {
             multiSelect: false,
           },
         ],
-      },
+      }),
     ]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
@@ -154,11 +146,10 @@ describe('usePendingRequests', () => {
     expect(matches[0].toolUseId).toBe('tu-q1')
   })
 
-  it('returns SSE-based pending file requests', () => {
+  it('returns unified-store pending file requests', () => {
+    mockStreamState.isActive = true
     mockMessagesData.data = []
-    mockStreamState.pendingFileRequests = [
-      { toolUseId: 'tu-f1', description: 'Upload config file' },
-    ]
+    mockUnified.data = [unified('file', 'tu-f1', { description: 'Upload config file' })]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
 
@@ -168,10 +159,11 @@ describe('usePendingRequests', () => {
     expect(matches[0].description).toBe('Upload config file')
   })
 
-  it('returns SSE-based pending connected account requests', () => {
+  it('returns unified-store pending connected account requests', () => {
+    mockStreamState.isActive = true
     mockMessagesData.data = []
-    mockStreamState.pendingConnectedAccountRequests = [
-      { toolUseId: 'tu-ca-1', toolkit: 'slack', reason: 'Need access' },
+    mockUnified.data = [
+      unified('connected_account', 'tu-ca-1', { toolkit: 'slack', reason: 'Need access' }),
     ]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
@@ -182,10 +174,11 @@ describe('usePendingRequests', () => {
     expect(matches[0].toolkit).toBe('slack')
   })
 
-  it('returns SSE-based pending remote MCP requests', () => {
+  it('returns unified-store pending remote MCP requests', () => {
+    mockStreamState.isActive = true
     mockMessagesData.data = []
-    mockStreamState.pendingRemoteMcpRequests = [
-      { toolUseId: 'tu-mcp-1', url: 'https://mcp.test.com', name: 'Test MCP' },
+    mockUnified.data = [
+      unified('remote_mcp', 'tu-mcp-1', { url: 'https://mcp.test.com', name: 'Test MCP' }),
     ]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
@@ -194,6 +187,77 @@ describe('usePendingRequests', () => {
     const matches = ofKind(result.current.items, 'remote_mcp')
     expect(matches).toHaveLength(1)
     expect(matches[0].url).toBe('https://mcp.test.com')
+  })
+
+  it('normalizes malformed questions on a unified envelope — a question without options still renders', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    // The model can omit `options` (or emit garbage). The card indexes
+    // options unconditionally, so the projection must run the same
+    // normalizer the message-history recovery path uses — raw passthrough
+    // crashes the card, and (unlike legacy) a reload would not heal it
+    // because the unified bucket wins the dedupe.
+    mockUnified.data = [
+      unified('question', 'tu-q-bad', {
+        questions: [{ question: 'Pick one?', header: 'DB', multiSelect: false }],
+      }),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'question')
+    expect(matches).toHaveLength(1)
+    expect(matches[0].questions[0].options).toEqual([])
+  })
+
+  it('onComplete hides the card synchronously — before any store refetch settles it', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockUnified.data = [unified('secret', 'tu-sync', { secretName: 'A' })]
+
+    const { result, rerender } = renderHook(() => usePendingRequests(defaultArgs))
+    expect(result.current.count).toBe(1)
+
+    // Answer the card but leave EVERY source untouched: the unified store
+    // still lists the entry (the settle is a server round trip away). The
+    // dismissal alone must remove it — this is the state-not-ref property;
+    // a ref here would leave the answered card up until the refetch lands.
+    act(() => {
+      ofKind(result.current.items, 'secret')[0].onComplete()
+    })
+    rerender()
+    expect(result.current.count).toBe(0)
+  })
+
+  it('a lenient envelope missing its card-critical field renders nothing (no broken card)', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    // The server accepts malformed tool input rather than dropping the wait;
+    // the projection must re-validate instead of drawing a crashing card.
+    mockUnified.data = [unified('secret', 'tu-bad', { reason: 'no name' })]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+    expect(result.current.count).toBe(0)
+  })
+
+  it('hides session-scoped unified entries while the session is idle, but keeps agent-scoped reviews', () => {
+    // e.g. an abandoned computer-use approval survives the idle boundary
+    // server-side for reconnect replay — rendering it on an idle session
+    // would gate the composer behind a dead card. Reviews outlive turns.
+    mockStreamState.isActive = false
+    mockUnified.data = [
+      unified('computer_use', 'tu-cu-idle', { method: 'click', params: {}, permissionLevel: 'use_application' }),
+      unified(
+        'proxy_review',
+        'review-live',
+        { accountId: 'a', toolkit: 'gh', method: 'GET', targetPath: '/x', matchedScopes: [], scopeDescriptions: {} },
+        { agentScoped: true },
+      ),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+    expect(ofKind(result.current.items, 'computer_use')).toHaveLength(0)
+    expect(ofKind(result.current.items, 'proxy_review')).toHaveLength(1)
   })
 
   it('derives pending secret request from message history when active', () => {
@@ -219,7 +283,7 @@ describe('usePendingRequests', () => {
     expect(matches[0].secretName).toBe('DB_PASSWORD')
   })
 
-  it('derives pending secret request from ready streaming tool use when SSE event is missed', () => {
+  it('derives pending secret request from ready streaming tool use when the event is missed', () => {
     mockStreamState.isActive = true
     mockMessagesData.data = []
     mockStreamState.streamingToolUses = [
@@ -283,11 +347,9 @@ describe('usePendingRequests', () => {
     expect(result.current.count).toBe(0)
   })
 
-  it('deduplicates SSE and message-based pending requests by toolUseId', () => {
+  it('deduplicates unified-store and message-based pending requests by toolUseId', () => {
     mockStreamState.isActive = true
-    mockStreamState.pendingSecretRequests = [
-      { toolUseId: 'tu-dup', secretName: 'API_KEY' },
-    ]
+    mockUnified.data = [unified('secret', 'tu-dup', { secretName: 'API_KEY' })]
     mockMessagesData.data = [
       createAssistantMessage({
         content: { text: '' },
@@ -525,6 +587,22 @@ describe('usePendingRequests', () => {
     expect(ofKind(result.current.items, 'computer_use')).toHaveLength(0)
   })
 
+  it('an auto-approved unified computer-use entry renders no approval card', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockUnified.data = [
+      unified(
+        'computer_use',
+        'tu-cu-auto',
+        { method: 'apps', params: {}, permissionLevel: 'list_apps_windows' },
+        { autoApproved: true },
+      ),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+    expect(ofKind(result.current.items, 'computer_use')).toHaveLength(0)
+  })
+
   it('coerces a non-array requirements to [] (model emitted a bare string)', () => {
     // Regression: the model can emit `requirements` as a string instead of a
     // string[]. The old `input.requirements || []` guard let a non-empty string
@@ -543,6 +621,20 @@ describe('usePendingRequests', () => {
           }),
         ],
       }),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'browser_input')
+    expect(matches).toHaveLength(1)
+    expect(matches[0].requirements).toEqual([])
+  })
+
+  it('coerces a non-array requirements to [] on a unified envelope too', () => {
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockUnified.data = [
+      unified('browser_input', 'tu-bi', { message: 'Log in', requirements: 'not-an-array' }),
     ]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
@@ -625,9 +717,7 @@ describe('usePendingRequests', () => {
 
   it('clears dismissed-request set when session transitions active → idle', () => {
     mockStreamState.isActive = true
-    mockStreamState.pendingSecretRequests = [
-      { toolUseId: 'tu-dismiss', secretName: 'API_KEY' },
-    ]
+    mockUnified.data = [unified('secret', 'tu-dismiss', { secretName: 'API_KEY' })]
     // Same request also derivable from messages (no result yet)
     mockMessagesData.data = [
       createAssistantMessage({
@@ -650,8 +740,8 @@ describe('usePendingRequests', () => {
     const item = ofKind(result.current.items, 'secret')[0]
     item.onComplete()
 
-    // SSE clears it; messages-based source would resurface, but dismissed blocks it
-    mockStreamState.pendingSecretRequests = []
+    // The store settles it; messages-based source would resurface, but dismissed blocks it
+    mockUnified.data = []
     rerender()
     expect(result.current.count).toBe(0)
 
@@ -670,12 +760,17 @@ describe('usePendingRequests', () => {
 
   // ---- Auto-approved script run filtering ----
 
-  it('filters out script run requests whose toolUseId is auto-approved', () => {
-    mockStreamState.pendingScriptRunRequests = [
-      { toolUseId: 'tu-script-1', script: 'echo hi', explanation: 'manual', scriptType: 'shell' },
-      { toolUseId: 'tu-script-2', script: 'echo bye', explanation: 'auto', scriptType: 'shell' },
+  it('filters out auto-approved script run entries (visible in the store, not a wait)', () => {
+    mockStreamState.isActive = true
+    mockUnified.data = [
+      unified('script_run', 'tu-script-1', { script: 'echo hi', explanation: 'manual', scriptType: 'shell' }),
+      unified(
+        'script_run',
+        'tu-script-2',
+        { script: 'echo bye', explanation: 'auto', scriptType: 'shell' },
+        { autoApproved: true },
+      ),
     ]
-    mockStreamState.autoApprovedScriptRunIds = new Set(['tu-script-2'])
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
 
@@ -684,21 +779,24 @@ describe('usePendingRequests', () => {
     expect(matches[0].toolUseId).toBe('tu-script-1')
   })
 
-  // ---- Proxy reviews ----
+  // ---- Proxy reviews (agent-scoped envelopes in the same store) ----
 
   it('emits a proxy_review descriptor for non-xAgent reviews', () => {
-    mockProxyReviewsData.reviews = [
-      {
-        id: 'review-1',
-        agentSlug: 'agent-1',
-        accountId: 'acct-1',
-        toolkit: 'github',
-        method: 'POST',
-        targetPath: '/repos/me/secret',
-        matchedScopes: ['repo:write'],
-        scopeDescriptions: { 'repo:write': 'Write to repos' },
-        displayText: 'Push to private repo',
-      },
+    mockUnified.data = [
+      unified(
+        'proxy_review',
+        'review-1',
+        {
+          accountId: 'acct-1',
+          toolkit: 'github',
+          method: 'POST',
+          targetPath: '/repos/me/secret',
+          matchedScopes: ['repo:write'],
+          scopeDescriptions: { 'repo:write': 'Write to repos' },
+          displayText: 'Push to private repo',
+        },
+        { agentScoped: true },
+      ),
     ]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
@@ -708,26 +806,29 @@ describe('usePendingRequests', () => {
     expect(matches).toHaveLength(1)
     expect(matches[0].reviewId).toBe('review-1')
     expect(matches[0].displayText).toBe('Push to private repo')
+    expect(matches[0].scopeDescriptions).toEqual({ 'repo:write': 'Write to repos' })
   })
 
   it('emits an x_agent_review descriptor when xAgent metadata is present', () => {
-    mockProxyReviewsData.reviews = [
-      {
-        id: 'review-x',
-        agentSlug: 'agent-1',
-        accountId: 'acct-x',
-        toolkit: 'x',
-        method: 'POST',
-        targetPath: '/agent',
-        matchedScopes: [],
-        scopeDescriptions: {},
-        displayText: 'Sub-agent review',
-        xAgent: {
-          targetAgentSlug: 'researcher',
-          targetAgentName: 'Researcher',
-          operation: 'invoke',
+    mockUnified.data = [
+      unified(
+        'x_agent_review',
+        'review-x',
+        {
+          accountId: 'acct-x',
+          toolkit: 'x',
+          method: 'POST',
+          targetPath: '/agent',
+          matchedScopes: [],
+          scopeDescriptions: {},
+          xAgent: {
+            targetAgentSlug: 'researcher',
+            targetAgentName: 'Researcher',
+            operation: 'invoke',
+          },
         },
-      },
+        { agentScoped: true },
+      ),
     ]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
@@ -737,29 +838,47 @@ describe('usePendingRequests', () => {
     expect(ofKind(result.current.items, 'proxy_review')).toHaveLength(0)
   })
 
-  it('proxy review onComplete triggers refetch', () => {
-    mockProxyReviewsData.reviews = [
-      {
-        id: 'review-r',
-        agentSlug: 'agent-1',
-        accountId: 'acct-r',
-        toolkit: 'gh',
-        method: 'GET',
-        targetPath: '/x',
-        matchedScopes: [],
-        scopeDescriptions: {},
-      },
+  it('an x_agent_review envelope with malformed xAgent metadata renders nothing', () => {
+    mockUnified.data = [
+      unified(
+        'x_agent_review',
+        'review-bad',
+        {
+          accountId: 'acct-x',
+          toolkit: 'x',
+          method: 'POST',
+          targetPath: '/agent',
+          xAgent: { operation: 'invoke' },
+        },
+        { agentScoped: true },
+      ),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+    expect(result.current.count).toBe(0)
+  })
+
+  it('proxy review onComplete invalidates the unified store (and the legacy review poll)', () => {
+    mockUnified.data = [
+      unified(
+        'proxy_review',
+        'review-r',
+        { accountId: 'acct-r', toolkit: 'gh', method: 'GET', targetPath: '/x', matchedScopes: [], scopeDescriptions: {} },
+        { agentScoped: true },
+      ),
     ]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'proxy_review')[0].onComplete()
-    expect(mockRefetchProxyReviews).toHaveBeenCalledTimes(1)
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['pending-user-requests'] })
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['proxy-reviews'] })
   })
 
-  // ---- SSE onComplete wiring: each kind's onComplete must call the matching remove* ----
+  // ---- onComplete wiring: each kind's onComplete must call the matching remove* ----
 
   it('secret onComplete calls removeSecretRequest with (sessionId, toolUseId)', () => {
-    mockStreamState.pendingSecretRequests = [{ toolUseId: 'tu-s', secretName: 'A' }]
+    mockStreamState.isActive = true
+    mockUnified.data = [unified('secret', 'tu-s', { secretName: 'A' })]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'secret')[0].onComplete()
     expect(mockRemovers.removeSecretRequest).toHaveBeenCalledTimes(1)
@@ -767,46 +886,53 @@ describe('usePendingRequests', () => {
   })
 
   it('connected_account onComplete calls removeConnectedAccountRequest', () => {
-    mockStreamState.pendingConnectedAccountRequests = [{ toolUseId: 'tu-c', toolkit: 'slack' }]
+    mockStreamState.isActive = true
+    mockUnified.data = [unified('connected_account', 'tu-c', { toolkit: 'slack' })]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'connected_account')[0].onComplete()
     expect(mockRemovers.removeConnectedAccountRequest).toHaveBeenCalledWith('s-1', 'tu-c')
   })
 
   it('remote_mcp onComplete calls removeRemoteMcpRequest', () => {
-    mockStreamState.pendingRemoteMcpRequests = [{ toolUseId: 'tu-m', url: 'https://x' }]
+    mockStreamState.isActive = true
+    mockUnified.data = [unified('remote_mcp', 'tu-m', { url: 'https://x' })]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'remote_mcp')[0].onComplete()
     expect(mockRemovers.removeRemoteMcpRequest).toHaveBeenCalledWith('s-1', 'tu-m')
   })
 
   it('question onComplete calls removeQuestionRequest', () => {
-    mockStreamState.pendingQuestionRequests = [{
-      toolUseId: 'tu-q',
-      questions: [{ question: 'Q?', header: 'H', options: [], multiSelect: false }],
-    }]
+    mockStreamState.isActive = true
+    mockUnified.data = [
+      unified('question', 'tu-q', {
+        questions: [{ question: 'Q?', header: 'H', options: [], multiSelect: false }],
+      }),
+    ]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'question')[0].onComplete()
     expect(mockRemovers.removeQuestionRequest).toHaveBeenCalledWith('s-1', 'tu-q')
   })
 
   it('file onComplete calls removeFileRequest', () => {
-    mockStreamState.pendingFileRequests = [{ toolUseId: 'tu-f', description: 'd' }]
+    mockStreamState.isActive = true
+    mockUnified.data = [unified('file', 'tu-f', { description: 'd' })]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'file')[0].onComplete()
     expect(mockRemovers.removeFileRequest).toHaveBeenCalledWith('s-1', 'tu-f')
   })
 
   it('browser_input onComplete calls removeBrowserInputRequest', () => {
-    mockStreamState.pendingBrowserInputRequests = [{ toolUseId: 'tu-b', message: 'm', requirements: [] }]
+    mockStreamState.isActive = true
+    mockUnified.data = [unified('browser_input', 'tu-b', { message: 'm', requirements: [] })]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'browser_input')[0].onComplete()
     expect(mockRemovers.removeBrowserInputRequest).toHaveBeenCalledWith('s-1', 'tu-b')
   })
 
   it('script_run onComplete calls removeScriptRunRequest', () => {
-    mockStreamState.pendingScriptRunRequests = [
-      { toolUseId: 'tu-r', script: 'echo', explanation: '', scriptType: 'shell' },
+    mockStreamState.isActive = true
+    mockUnified.data = [
+      unified('script_run', 'tu-r', { script: 'echo', explanation: '', scriptType: 'shell' }),
     ]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'script_run')[0].onComplete()
@@ -814,8 +940,9 @@ describe('usePendingRequests', () => {
   })
 
   it('computer_use onComplete calls removeComputerUseRequest', () => {
-    mockStreamState.pendingComputerUseRequests = [
-      { toolUseId: 'tu-cu', method: 'click', params: {}, permissionLevel: 'high' },
+    mockStreamState.isActive = true
+    mockUnified.data = [
+      unified('computer_use', 'tu-cu', { method: 'click', params: {}, permissionLevel: 'high' }),
     ]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
     ofKind(result.current.items, 'computer_use')[0].onComplete()
@@ -825,18 +952,18 @@ describe('usePendingRequests', () => {
   // ---- Arrival-order sort across mixed types ----
 
   it('sorts mixed-type requests by chronological arrival order across renders', () => {
+    mockStreamState.isActive = true
     // First batch: a single secret request arrives
-    mockStreamState.pendingSecretRequests = [
-      { toolUseId: 'tu-secret', secretName: 'A' },
-    ]
+    mockUnified.data = [unified('secret', 'tu-secret', { secretName: 'A' })]
 
     const { result, rerender } = renderHook(() => usePendingRequests(defaultArgs))
 
     expect(result.current.items.map((d) => d.key)).toEqual(['tu-secret'])
 
     // Second batch: a file request arrives later — should sort after the secret
-    mockStreamState.pendingFileRequests = [
-      { toolUseId: 'tu-file', description: 'Upload' },
+    mockUnified.data = [
+      unified('secret', 'tu-secret', { secretName: 'A' }),
+      unified('file', 'tu-file', { description: 'Upload' }),
     ]
     rerender()
 
@@ -844,9 +971,10 @@ describe('usePendingRequests', () => {
 
     // Third batch: another secret arrives last — sorts after both even though
     // the secret block comes first in the iteration order inside the hook.
-    mockStreamState.pendingSecretRequests = [
-      { toolUseId: 'tu-secret', secretName: 'A' },
-      { toolUseId: 'tu-secret-2', secretName: 'B' },
+    mockUnified.data = [
+      unified('secret', 'tu-secret', { secretName: 'A' }),
+      unified('file', 'tu-file', { description: 'Upload' }),
+      unified('secret', 'tu-secret-2', { secretName: 'B' }),
     ]
     rerender()
 
@@ -857,11 +985,15 @@ describe('usePendingRequests', () => {
     ])
   })
 
-  it('returns SSE-based capability review requests while active', () => {
+  it('returns unified-store capability review requests while active', () => {
     mockStreamState.isActive = true
     mockMessagesData.data = []
-    mockStreamState.pendingCapabilityReviewRequests = [
-      { toolUseId: 'tu-cap-1', capability: 'workflows', toolName: 'Workflow', input: { name: 'audit' } },
+    mockUnified.data = [
+      unified('capability_review', 'tu-cap-1', {
+        capability: 'workflows',
+        toolName: 'Workflow',
+        input: { name: 'audit' },
+      }),
     ]
 
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
@@ -870,6 +1002,20 @@ describe('usePendingRequests', () => {
     expect(matches).toHaveLength(1)
     expect(matches[0].capability).toBe('workflows')
     expect(matches[0].input).toEqual({ name: 'audit' })
+  })
+
+  it('hides capability reviews while the session is idle', () => {
+    mockStreamState.isActive = false
+    mockUnified.data = [
+      unified('capability_review', 'tu-cap-idle', {
+        capability: 'workflows',
+        toolName: 'Workflow',
+        input: {},
+      }),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+    expect(ofKind(result.current.items, 'capability_review')).toHaveLength(0)
   })
 
   it('does NOT derive capability reviews from message history — a running Task without a result is not an approval', () => {

--- a/src/renderer/components/messages/use-pending-requests.test.tsx
+++ b/src/renderer/components/messages/use-pending-requests.test.tsx
@@ -20,6 +20,9 @@ vi.mock('@renderer/hooks/use-messages', () => ({
 // now; the per-kind pending arrays moved to the unified store.
 const mockStreamState = {
   isActive: false,
+  // Kept as the cold-start fallback source for capability reviews (no
+  // message-history recovery exists for them) until the first snapshot lands.
+  pendingCapabilityReviewRequests: [] as Array<{ toolUseId: string; capability: 'subagents' | 'workflows'; toolName: string; input: Record<string, unknown> }>,
   streamingToolUses: [] as Array<{ id: string; name: string; partialInput: string; ready?: boolean }>,
   autoApprovedScriptRunIds: new Set<string>(),
   autoApprovedComputerUseIds: new Set<string>(),
@@ -54,6 +57,13 @@ vi.mock('@renderer/hooks/use-message-stream', () => ({
 const mockUnified: { data: PendingUserInputRequest[] | undefined } = { data: [] }
 vi.mock('@renderer/hooks/use-pending-user-requests', () => ({
   usePendingUserRequests: () => ({ data: mockUnified.data }),
+}))
+
+// Legacy review poll — consumed ONLY as the cold-start fallback while the
+// snapshot has never succeeded (data === undefined).
+const mockLegacyProxyReviews: { reviews: Array<Record<string, unknown>> } = { reviews: [] }
+vi.mock('@renderer/hooks/use-proxy-reviews', () => ({
+  usePendingProxyReviews: () => ({ data: mockLegacyProxyReviews }),
 }))
 
 // The hook uses the query client only to invalidate on review completion —
@@ -101,8 +111,10 @@ describe('usePendingRequests', () => {
     mockMessagesData.data = undefined
     mockMessagesData.isLoading = false
     mockUnified.data = []
+    mockLegacyProxyReviews.reviews = []
     Object.assign(mockStreamState, {
       isActive: false,
+      pendingCapabilityReviewRequests: [],
       streamingToolUses: [],
       autoApprovedScriptRunIds: new Set<string>(),
       autoApprovedComputerUseIds: new Set<string>(),
@@ -187,6 +199,78 @@ describe('usePendingRequests', () => {
     const matches = ofKind(result.current.items, 'remote_mcp')
     expect(matches).toHaveLength(1)
     expect(matches[0].url).toBe('https://mcp.test.com')
+  })
+
+  it('before the first snapshot, proxy reviews fall back to the legacy poll (blocked ≠ cardless)', () => {
+    // undefined = the snapshot has NEVER succeeded (cold fetch failure /
+    // still in flight) — distinct from a successful empty []. Reviews have
+    // no message-history or streaming recovery, so without this fallback a
+    // blocked agent has no card the user can approve until a retry lands.
+    mockUnified.data = undefined
+    mockLegacyProxyReviews.reviews = [
+      {
+        id: 'review-fb',
+        agentSlug: 'agent-1',
+        accountId: 'acct-1',
+        toolkit: 'github',
+        method: 'POST',
+        targetPath: '/repos/me/x',
+        matchedScopes: [],
+        scopeDescriptions: {},
+        displayText: 'Push to repo',
+      },
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'proxy_review')
+    expect(matches).toHaveLength(1)
+    expect(matches[0].reviewId).toBe('review-fb')
+  })
+
+  it('a successful snapshot is authoritative — the legacy poll no longer contributes reviews', () => {
+    mockUnified.data = []
+    mockLegacyProxyReviews.reviews = [
+      {
+        id: 'review-stale',
+        agentSlug: 'agent-1',
+        accountId: 'acct-1',
+        toolkit: 'github',
+        method: 'POST',
+        targetPath: '/x',
+        matchedScopes: [],
+        scopeDescriptions: {},
+      },
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+    expect(ofKind(result.current.items, 'proxy_review')).toHaveLength(0)
+  })
+
+  it('before the first snapshot, capability reviews fall back to the stream source', () => {
+    mockStreamState.isActive = true
+    mockUnified.data = undefined
+    mockStreamState.pendingCapabilityReviewRequests = [
+      { toolUseId: 'tu-cap-fb', capability: 'workflows', toolName: 'Workflow', input: { name: 'audit' } },
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    const matches = ofKind(result.current.items, 'capability_review')
+    expect(matches).toHaveLength(1)
+    expect(matches[0].toolUseId).toBe('tu-cap-fb')
+  })
+
+  it('a recovered synthetic envelope renders no card — the transcript covers it', () => {
+    // Recovered entries are now IN the snapshot (they are blocking waits the
+    // activity indicator must count) but carry no renderable payload; the
+    // per-kind guards must drop them rather than draw a broken card.
+    mockStreamState.isActive = true
+    mockMessagesData.data = []
+    mockUnified.data = [unified('secret', 'tu-recovered', { recovered: true })]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+    expect(result.current.count).toBe(0)
   })
 
   it('normalizes malformed questions on a unified envelope — a question without options still renders', () => {

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -14,7 +14,7 @@ import {
 } from '@renderer/hooks/use-message-stream'
 import { useMessages } from '@renderer/hooks/use-messages'
 import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-requests'
-import { type PendingReview } from '@renderer/hooks/use-proxy-reviews'
+import { usePendingProxyReviews, type PendingReview } from '@renderer/hooks/use-proxy-reviews'
 import { isTurnStartingUserMessage, type PendingMessage } from './pending-message'
 import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp } from '@shared/lib/computer-use/types'
 import { askUserQuestionDef } from '@shared/lib/tool-definitions/ask-user-question'
@@ -398,6 +398,7 @@ export function usePendingRequests({
   const { data: messages } = useMessages(sessionId, agentSlug)
   const {
     isActive,
+    pendingCapabilityReviewRequests: sseCapabilityReviewRequests,
     streamingToolUses,
     autoApprovedScriptRunIds,
     autoApprovedComputerUseIds,
@@ -406,9 +407,16 @@ export function usePendingRequests({
   // The unified store is the primary source for every kind — session-scoped
   // requests AND the agent-scoped reviews that used to arrive on a separate
   // poll. The streaming/message-history fallbacks below still cover the
-  // transcript-recovery path (the server deliberately keeps recovered entries
-  // off the wire — they carry no payload; the transcript renders them).
+  // transcript-recovery path (recovered entries are in the snapshot but carry
+  // no payload, so the per-kind guards drop them; the transcript renders them).
   const { data: unifiedRequestsData } = usePendingUserRequests(agentSlug, sessionId)
+  // undefined = the snapshot has NEVER succeeded (still in flight, or a cold
+  // fetch failure with nothing cached) — distinct from a successful empty [].
+  // Reviews have no message-history or streaming recovery, so until the first
+  // snapshot lands the legacy poll and stream arrays below keep those cards
+  // actionable; once a snapshot exists it is authoritative.
+  const hasSnapshot = unifiedRequestsData !== undefined
+  const { data: legacyProxyReviewsData } = usePendingProxyReviews(agentSlug)
   const unified = useMemo(() => {
     const requests = unifiedRequestsData ?? []
     // Session-scoped waits die with the turn for DISPLAY purposes — the legacy
@@ -421,7 +429,10 @@ export function usePendingRequests({
       isActive ? requests : requests.filter((r) => r.scope.sessionId === undefined),
     )
   }, [unifiedRequestsData, isActive])
-  const pendingProxyReviews = unified.reviews
+  const pendingProxyReviews = useMemo(
+    () => (hasSnapshot ? unified.reviews : legacyProxyReviewsData?.reviews ?? []),
+    [hasSnapshot, unified.reviews, legacyProxyReviewsData],
+  )
 
   // Derive pending requests from message history (for page refresh recovery).
   // Tool calls without a result are still pending, but only if there are no
@@ -610,14 +621,16 @@ export function usePendingRequests({
     return merged
   }, [unified.buckets.computerUseRequests, streamingBasedPendingRequests.computerUseRequests, messagesBasedPendingRequests.computerUseRequests, isActive, autoApprovedComputerUseIds, dismissedRequestIds])
 
-  // Capability reviews come from the unified store ONLY — no message-history
-  // or streaming recovery. A Task/Workflow call without a result usually means
-  // the launch is RUNNING (allow policy or an active session grant), not
-  // awaiting approval; only the host registry knows which.
+  // Capability reviews come from the unified store (with the stream source as
+  // the cold-start fallback) — no message-history or streaming recovery. A
+  // Task/Workflow call without a result usually means the launch is RUNNING
+  // (allow policy or an active session grant), not awaiting approval; only
+  // the host registry knows which.
   const pendingCapabilityReviewRequests = useMemo(() => {
     if (!isActive) return []
-    return unified.capabilityReviews.filter((r) => !dismissedRequestIds.has(r.toolUseId))
-  }, [unified.capabilityReviews, isActive, dismissedRequestIds])
+    const source = hasSnapshot ? unified.capabilityReviews : sseCapabilityReviewRequests
+    return source.filter((r) => !dismissedRequestIds.has(r.toolUseId))
+  }, [unified.capabilityReviews, sseCapabilityReviewRequests, hasSnapshot, isActive, dismissedRequestIds])
 
   // Track arrival order so the stack is chronological. Each id gets a
   // monotonically increasing sequence number the first time it appears.

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   useMessageStream,
   removeSecretRequest,
@@ -12,10 +13,12 @@ import {
   removeCapabilityReviewRequest,
 } from '@renderer/hooks/use-message-stream'
 import { useMessages } from '@renderer/hooks/use-messages'
-import { usePendingProxyReviews, type PendingReview } from '@renderer/hooks/use-proxy-reviews'
+import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-requests'
+import { type PendingReview } from '@renderer/hooks/use-proxy-reviews'
 import { isTurnStartingUserMessage, type PendingMessage } from './pending-message'
 import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp } from '@shared/lib/computer-use/types'
 import { askUserQuestionDef } from '@shared/lib/tool-definitions/ask-user-question'
+import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
 
 interface UsePendingRequestsArgs {
   sessionId: string
@@ -169,6 +172,202 @@ function addPendingRequestFromToolCall(buckets: PendingRequestBuckets, toolCall:
   }
 }
 
+type UnifiedCapabilityReview = {
+  toolUseId: string
+  capability: 'subagents' | 'workflows'
+  toolName: string
+  input: Record<string, unknown>
+}
+
+interface UnifiedProjection {
+  buckets: PendingRequestBuckets
+  capabilityReviews: UnifiedCapabilityReview[]
+  reviews: PendingReview[]
+}
+
+function isXAgentOperation(value: unknown): value is 'list' | 'read' | 'invoke' | 'create' {
+  return value === 'list' || value === 'read' || value === 'invoke' || value === 'create'
+}
+
+// Rebuild the legacy poll's PendingReview shape from a review envelope. The
+// payload carries the full ReviewDetails (plus the derived displayText), but
+// envelope payloads are lenient by design, so the card-critical fields are
+// re-validated here instead of trusted.
+function reviewFromEnvelope(
+  request: PendingUserInputRequest,
+  payload: Record<string, unknown>,
+): PendingReview | null {
+  if (
+    typeof payload.accountId !== 'string' ||
+    typeof payload.toolkit !== 'string' ||
+    typeof payload.method !== 'string' ||
+    typeof payload.targetPath !== 'string'
+  ) {
+    return null
+  }
+  let xAgent: PendingReview['xAgent']
+  if (request.kind === 'x_agent_review') {
+    const raw = payload.xAgent as Record<string, unknown> | undefined
+    if (
+      !raw ||
+      typeof raw.targetAgentSlug !== 'string' ||
+      typeof raw.targetAgentName !== 'string' ||
+      !isXAgentOperation(raw.operation)
+    ) {
+      return null
+    }
+    xAgent = {
+      targetAgentSlug: raw.targetAgentSlug,
+      targetAgentName: raw.targetAgentName,
+      operation: raw.operation,
+      preview: typeof raw.preview === 'string' ? raw.preview : undefined,
+    }
+  }
+  return {
+    id: request.id,
+    agentSlug: request.scope.agentSlug ?? '',
+    accountId: payload.accountId,
+    toolkit: payload.toolkit,
+    method: payload.method,
+    targetPath: payload.targetPath,
+    matchedScopes: Array.isArray(payload.matchedScopes)
+      ? payload.matchedScopes.filter((s): s is string => typeof s === 'string')
+      : [],
+    scopeDescriptions:
+      payload.scopeDescriptions && typeof payload.scopeDescriptions === 'object' && !Array.isArray(payload.scopeDescriptions)
+        ? (payload.scopeDescriptions as Record<string, string>)
+        : {},
+    displayText: typeof payload.displayText === 'string' ? payload.displayText : undefined,
+    ...(xAgent ? { xAgent } : {}),
+  }
+}
+
+// Project unified registry envelopes onto the same per-kind shapes the legacy
+// SSE events carried, so the descriptor builder (and every card) is untouched
+// by the wire migration. Envelope payloads are lenient by design (the server
+// keeps a wait alive even for malformed tool input), so each kind re-applies
+// the exact guards the legacy handlers used before rendering.
+function projectUnifiedRequests(requests: PendingUserInputRequest[]): UnifiedProjection {
+  const buckets = createPendingRequestBuckets()
+  const capabilityReviews: UnifiedCapabilityReview[] = []
+  const reviews: PendingReview[] = []
+
+  for (const request of requests) {
+    const payload = request.payload as Record<string, unknown>
+    switch (request.kind) {
+      case 'secret':
+        if (typeof payload.secretName === 'string') {
+          buckets.secretRequests.push({
+            toolUseId: request.id,
+            secretName: payload.secretName,
+            reason: typeof payload.reason === 'string' ? payload.reason : undefined,
+          })
+        }
+        break
+      case 'connected_account':
+        if (typeof payload.toolkit === 'string') {
+          buckets.connectedAccountRequests.push({
+            toolUseId: request.id,
+            toolkit: payload.toolkit,
+            reason: typeof payload.reason === 'string' ? payload.reason : undefined,
+          })
+        }
+        break
+      case 'question': {
+        // Same normalizer as the message-history path: the card indexes
+        // options unconditionally, and this bucket wins the dedupe — a raw
+        // passthrough would crash the card with no reload escape.
+        const questions = normalizePendingQuestions(payload)
+        if (questions.length) {
+          buckets.questionRequests.push({
+            toolUseId: request.id,
+            questions,
+          })
+        }
+        break
+      }
+      case 'file':
+        if (typeof payload.description === 'string') {
+          buckets.fileRequests.push({
+            toolUseId: request.id,
+            description: payload.description,
+            fileTypes: typeof payload.fileTypes === 'string' ? payload.fileTypes : undefined,
+          })
+        }
+        break
+      case 'remote_mcp':
+        if (typeof payload.url === 'string') {
+          buckets.remoteMcpRequests.push({
+            toolUseId: request.id,
+            url: payload.url,
+            name: typeof payload.name === 'string' ? payload.name : undefined,
+            reason: typeof payload.reason === 'string' ? payload.reason : undefined,
+            authHint: payload.authHint === 'oauth' || payload.authHint === 'bearer' ? payload.authHint : undefined,
+          })
+        }
+        break
+      case 'browser_input':
+        if (typeof payload.message === 'string') {
+          buckets.browserInputRequests.push({
+            toolUseId: request.id,
+            message: payload.message,
+            requirements: Array.isArray(payload.requirements) ? payload.requirements : [],
+          })
+        }
+        break
+      case 'script_run':
+        // Auto-approved scripts are already executing server-side; the entry
+        // exists so recovery paths can tell "granted" from "waiting".
+        if (request.autoApproved) break
+        if (typeof payload.script === 'string' && isScriptType(payload.scriptType)) {
+          buckets.scriptRunRequests.push({
+            toolUseId: request.id,
+            script: payload.script,
+            explanation: typeof payload.explanation === 'string' ? payload.explanation : '',
+            scriptType: payload.scriptType,
+          })
+        }
+        break
+      case 'computer_use':
+        if (request.autoApproved) break
+        if (typeof payload.method === 'string' && typeof payload.permissionLevel === 'string') {
+          buckets.computerUseRequests.push({
+            toolUseId: request.id,
+            method: payload.method,
+            params:
+              payload.params && typeof payload.params === 'object' && !Array.isArray(payload.params)
+                ? (payload.params as Record<string, unknown>)
+                : {},
+            permissionLevel: payload.permissionLevel,
+            appName: typeof payload.appName === 'string' ? payload.appName : undefined,
+          })
+        }
+        break
+      case 'capability_review':
+        if (
+          (payload.capability === 'subagents' || payload.capability === 'workflows') &&
+          typeof payload.toolName === 'string'
+        ) {
+          capabilityReviews.push({
+            toolUseId: request.id,
+            capability: payload.capability,
+            toolName: payload.toolName,
+            input: recordFromInput(payload.input),
+          })
+        }
+        break
+      case 'proxy_review':
+      case 'x_agent_review': {
+        const review = reviewFromEnvelope(request, payload)
+        if (review) reviews.push(review)
+        break
+      }
+    }
+  }
+
+  return { buckets, capabilityReviews, reviews }
+}
+
 export type PendingRequestDescriptor =
   | { kind: 'secret'; key: string; toolUseId: string; secretName: string; reason?: string; onComplete: () => void }
   | { kind: 'connected_account'; key: string; toolUseId: string; toolkit: string; reason?: string; onComplete: () => void }
@@ -195,25 +394,34 @@ export function usePendingRequests({
   // Only turn-starting sends mean the user "moved past" a request; queued
   // (mid-turn) messages leave the agent blocked on it.
   const hasPendingUserMessage = !!pendingUserMessages?.some((p) => !p.queued)
+  const queryClient = useQueryClient()
   const { data: messages } = useMessages(sessionId, agentSlug)
   const {
     isActive,
-    pendingSecretRequests: sseSecretRequests,
-    pendingConnectedAccountRequests: sseConnectedAccountRequests,
-    pendingRemoteMcpRequests: sseRemoteMcpRequests,
-    pendingQuestionRequests: sseQuestionRequests,
-    pendingFileRequests: sseFileRequests,
-    pendingBrowserInputRequests: sseBrowserInputRequests,
-    pendingScriptRunRequests: sseScriptRunRequests,
-    pendingComputerUseRequests: sseComputerUseRequests,
-    pendingCapabilityReviewRequests: sseCapabilityReviewRequests,
     streamingToolUses,
     autoApprovedScriptRunIds,
     autoApprovedComputerUseIds,
   } = useMessageStream(sessionId, agentSlug)
 
-  const { data: proxyReviewsData, refetch: refetchProxyReviews } = usePendingProxyReviews(agentSlug)
-  const pendingProxyReviews = useMemo(() => proxyReviewsData?.reviews ?? [], [proxyReviewsData])
+  // The unified store is the primary source for every kind — session-scoped
+  // requests AND the agent-scoped reviews that used to arrive on a separate
+  // poll. The streaming/message-history fallbacks below still cover the
+  // transcript-recovery path (the server deliberately keeps recovered entries
+  // off the wire — they carry no payload; the transcript renders them).
+  const { data: unifiedRequestsData } = usePendingUserRequests(agentSlug, sessionId)
+  const unified = useMemo(() => {
+    const requests = unifiedRequestsData ?? []
+    // Session-scoped waits die with the turn for DISPLAY purposes — the legacy
+    // arrays were cleared on session_idle, and e.g. an abandoned computer-use
+    // approval deliberately survives the idle boundary server-side for
+    // reconnect replay. Rendering it on an idle session would gate the
+    // composer behind a dead card. Agent-scoped reviews render regardless:
+    // they outlive any one turn.
+    return projectUnifiedRequests(
+      isActive ? requests : requests.filter((r) => r.scope.sessionId === undefined),
+    )
+  }, [unifiedRequestsData, isActive])
+  const pendingProxyReviews = unified.reviews
 
   // Derive pending requests from message history (for page refresh recovery).
   // Tool calls without a result are still pending, but only if there are no
@@ -266,15 +474,21 @@ export function usePendingRequests({
     return buckets
   }, [streamingToolUses])
 
-  // Track toolUseIds the user has already answered, so the message-based
-  // recovery source doesn't re-surface them before the tool result is persisted.
-  const dismissedRequestIds = useRef(new Set<string>())
+  // Track toolUseIds the user has already answered, so no source re-surfaces
+  // them before the settlement lands. State (not a ref): the merge memos
+  // filter on this set, and completion must recompute them SYNCHRONOUSLY —
+  // an answered card leaves the stack immediately, not a server round trip
+  // later when the store refetch settles it.
+  const [dismissedRequestIds, setDismissedRequestIds] = useState<ReadonlySet<string>>(new Set())
+  const dismissRequest = useCallback((toolUseId: string) => {
+    setDismissedRequestIds((prev) => new Set(prev).add(toolUseId))
+  }, [])
 
   // Clear dismissed set when session transitions from active → idle.
   const prevIsActive = useRef(isActive)
   useEffect(() => {
     if (prevIsActive.current && !isActive) {
-      dismissedRequestIds.current.clear()
+      setDismissedRequestIds(new Set())
     }
     prevIsActive.current = isActive
   }, [isActive])
@@ -287,124 +501,123 @@ export function usePendingRequests({
     const merged: { toolUseId: string; secretName: string; reason?: string }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.secretRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.secretRequests : []
-    for (const req of [...sseSecretRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+    for (const req of [...unified.buckets.secretRequests, ...streamingBased, ...messageBased]) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseSecretRequests, streamingBasedPendingRequests.secretRequests, messagesBasedPendingRequests.secretRequests, isActive])
+  }, [unified.buckets.secretRequests, streamingBasedPendingRequests.secretRequests, messagesBasedPendingRequests.secretRequests, isActive, dismissedRequestIds])
 
   const pendingConnectedAccountRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; toolkit: string; reason?: string }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.connectedAccountRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.connectedAccountRequests : []
-    for (const req of [...sseConnectedAccountRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+    for (const req of [...unified.buckets.connectedAccountRequests, ...streamingBased, ...messageBased]) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseConnectedAccountRequests, streamingBasedPendingRequests.connectedAccountRequests, messagesBasedPendingRequests.connectedAccountRequests, isActive])
+  }, [unified.buckets.connectedAccountRequests, streamingBasedPendingRequests.connectedAccountRequests, messagesBasedPendingRequests.connectedAccountRequests, isActive, dismissedRequestIds])
 
   const pendingQuestionRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; questions: Question[] }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.questionRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.questionRequests : []
-    for (const req of [...sseQuestionRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+    for (const req of [...unified.buckets.questionRequests, ...streamingBased, ...messageBased]) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseQuestionRequests, streamingBasedPendingRequests.questionRequests, messagesBasedPendingRequests.questionRequests, isActive])
+  }, [unified.buckets.questionRequests, streamingBasedPendingRequests.questionRequests, messagesBasedPendingRequests.questionRequests, isActive, dismissedRequestIds])
 
   const pendingFileRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; description: string; fileTypes?: string }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.fileRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.fileRequests : []
-    for (const req of [...sseFileRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+    for (const req of [...unified.buckets.fileRequests, ...streamingBased, ...messageBased]) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseFileRequests, streamingBasedPendingRequests.fileRequests, messagesBasedPendingRequests.fileRequests, isActive])
+  }, [unified.buckets.fileRequests, streamingBasedPendingRequests.fileRequests, messagesBasedPendingRequests.fileRequests, isActive, dismissedRequestIds])
 
   const pendingRemoteMcpRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; url: string; name?: string; reason?: string; authHint?: 'oauth' | 'bearer' }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.remoteMcpRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.remoteMcpRequests : []
-    for (const req of [...sseRemoteMcpRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+    for (const req of [...unified.buckets.remoteMcpRequests, ...streamingBased, ...messageBased]) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseRemoteMcpRequests, streamingBasedPendingRequests.remoteMcpRequests, messagesBasedPendingRequests.remoteMcpRequests, isActive])
+  }, [unified.buckets.remoteMcpRequests, streamingBasedPendingRequests.remoteMcpRequests, messagesBasedPendingRequests.remoteMcpRequests, isActive, dismissedRequestIds])
 
   const pendingBrowserInputRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; message: string; requirements: string[] }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.browserInputRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.browserInputRequests : []
-    for (const req of [...sseBrowserInputRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+    for (const req of [...unified.buckets.browserInputRequests, ...streamingBased, ...messageBased]) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseBrowserInputRequests, streamingBasedPendingRequests.browserInputRequests, messagesBasedPendingRequests.browserInputRequests, isActive])
+  }, [unified.buckets.browserInputRequests, streamingBasedPendingRequests.browserInputRequests, messagesBasedPendingRequests.browserInputRequests, isActive, dismissedRequestIds])
 
   const pendingScriptRunRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.scriptRunRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.scriptRunRequests : []
-    for (const req of [...sseScriptRunRequests, ...streamingBased, ...messageBased]) {
+    for (const req of [...unified.buckets.scriptRunRequests, ...streamingBased, ...messageBased]) {
       if (autoApprovedScriptRunIds.has(req.toolUseId)) continue
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseScriptRunRequests, streamingBasedPendingRequests.scriptRunRequests, messagesBasedPendingRequests.scriptRunRequests, isActive, autoApprovedScriptRunIds])
+  }, [unified.buckets.scriptRunRequests, streamingBasedPendingRequests.scriptRunRequests, messagesBasedPendingRequests.scriptRunRequests, isActive, autoApprovedScriptRunIds, dismissedRequestIds])
 
   const pendingComputerUseRequests = useMemo(() => {
     const seen = new Set<string>()
     const merged: { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }[] = []
     const messageBased = isActive ? messagesBasedPendingRequests.computerUseRequests : []
     const streamingBased = isActive ? streamingBasedPendingRequests.computerUseRequests : []
-    for (const req of [...sseComputerUseRequests, ...streamingBased, ...messageBased]) {
+    for (const req of [...unified.buckets.computerUseRequests, ...streamingBased, ...messageBased]) {
       if (autoApprovedComputerUseIds.has(req.toolUseId)) continue
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.current.has(req.toolUseId)) {
+      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
         seen.add(req.toolUseId)
         merged.push(req)
       }
     }
     return merged
-  }, [sseComputerUseRequests, streamingBasedPendingRequests.computerUseRequests, messagesBasedPendingRequests.computerUseRequests, isActive, autoApprovedComputerUseIds])
+  }, [unified.buckets.computerUseRequests, streamingBasedPendingRequests.computerUseRequests, messagesBasedPendingRequests.computerUseRequests, isActive, autoApprovedComputerUseIds, dismissedRequestIds])
 
-  // Capability reviews come from SSE (+ the server's reconnect replay map)
-  // ONLY — no message-history or streaming recovery. A Task/Workflow call
-  // without a result usually means the launch is RUNNING (allow policy or an
-  // active session grant), not awaiting approval; only the host knows which,
-  // and its replay map already covers refresh/reconnect.
+  // Capability reviews come from the unified store ONLY — no message-history
+  // or streaming recovery. A Task/Workflow call without a result usually means
+  // the launch is RUNNING (allow policy or an active session grant), not
+  // awaiting approval; only the host registry knows which.
   const pendingCapabilityReviewRequests = useMemo(() => {
     if (!isActive) return []
-    return sseCapabilityReviewRequests.filter((r) => !dismissedRequestIds.current.has(r.toolUseId))
-  }, [sseCapabilityReviewRequests, isActive])
+    return unified.capabilityReviews.filter((r) => !dismissedRequestIds.has(r.toolUseId))
+  }, [unified.capabilityReviews, isActive, dismissedRequestIds])
 
   // Track arrival order so the stack is chronological. Each id gets a
   // monotonically increasing sequence number the first time it appears.
@@ -454,53 +667,57 @@ export function usePendingRequests({
   }, [])
 
   const handleSecretRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeSecretRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleConnectedAccountRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeConnectedAccountRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleQuestionRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeQuestionRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleRemoteMcpRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeRemoteMcpRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleFileRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeFileRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleScriptRunRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeScriptRunRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleComputerUseRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeComputerUseRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleBrowserInputRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeBrowserInputRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleCapabilityReviewRequestComplete = useCallback((toolUseId: string) => {
-    dismissedRequestIds.current.add(toolUseId)
+    dismissRequest(toolUseId)
     removeCapabilityReviewRequest(sessionId, toolUseId)
-  }, [sessionId])
+  }, [sessionId, dismissRequest])
 
   const handleProxyReviewComplete = useCallback(() => {
-    refetchProxyReviews()
-  }, [refetchProxyReviews])
+    // The decision routes settle the registry entry, which broadcasts
+    // user_request_resolved → this invalidation is the immediate local echo
+    // (and keeps the dashboard's legacy review poll coherent).
+    queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
+    queryClient.invalidateQueries({ queryKey: ['proxy-reviews'] })
+  }, [queryClient])
 
   const items = useMemo<PendingRequestDescriptor[]>(() => {
     const all: PendingRequestDescriptor[] = []

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -216,6 +216,44 @@ describe('GlobalNotificationHandler — proxy review SSE pathway', () => {
     expect(proxyReviewCalls.length).toBe(1)
   })
 
+  it('user_request_created/resolved invalidate the unified store AND the legacy review poll', () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    const es = getLatestEventSource()
+
+    // A dashboard-triggered review can exist with NO session anywhere — this
+    // global event is its only push signal, so it must nudge both the unified
+    // store and the dashboard panel's legacy poll (still unmigrated).
+    simulateSSEMessage(es, {
+      type: 'user_request_created',
+      request: {
+        id: 'rev-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'my-agent' },
+        blocking: true,
+        autoApproved: false,
+        payload: {},
+      },
+    })
+    simulateSSEMessage(es, {
+      type: 'user_request_resolved',
+      requestId: 'rev-1',
+      kind: 'proxy_review',
+      outcome: 'answered',
+      scope: { agentSlug: 'my-agent' },
+    })
+
+    const keys = invalidateSpy.mock.calls.map((call) => (call[0] as { queryKey?: unknown[] }).queryKey?.[0])
+    expect(keys.filter((k) => k === 'pending-user-requests')).toHaveLength(2)
+    expect(keys.filter((k) => k === 'proxy-reviews')).toHaveLength(2)
+  })
+
   // SECURITY: focus-aware gate — when an actionable session_waiting fires
   // while the window is visible-but-unfocused (jsdom: hasFocus() === false),
   // the OS notification should still fire because the user is effectively

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -354,6 +354,22 @@ export function GlobalNotificationHandler() {
             break
           }
 
+          case 'user_request_created':
+          case 'user_request_resolved':
+            // Unified pending-request wire. Invalidation, not data: the
+            // refetch reads the server registry snapshot. This is the live
+            // path for agent-scoped reviews (they have no session stream) and
+            // the cross-tab/cross-session sync for everything else; the
+            // store's interval refetch is the safety net for a missed event.
+            queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
+            // The dashboard's pending-reviews panel still reads the legacy
+            // poll (its store migration is a later phase). Nudging it here
+            // makes dashboard-triggered reviews — which may have NO session
+            // anywhere — appear/settle on creation, decision, timeout, and
+            // auto-deny instead of on the next 30s poll tick.
+            queryClient.invalidateQueries({ queryKey: ['proxy-reviews'] })
+            break
+
           case 'agent_status_changed':
             // Agent started/stopped - update agent list and artifacts
             queryClient.invalidateQueries({ queryKey: ['agents'] })

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -440,6 +440,10 @@ function getOrCreateEventSource(
         // safety-net poll. Without this, a late join only recovers on the next poll
         // tick, which races the assertion timeout in tests and shows a stale UI in prod.
         queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        // Resync the unified pending-request store too: its create/resolve
+        // events are one-shot, so anything settled or opened while this
+        // stream was down must be recovered from the snapshot endpoint.
+        queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
         // Fetch current browser status to sync state (handles missed events)
         fetch(`${baseUrl}/api/agents/${agentSlug}/browser/status`)
           .then((res) => res.json())
@@ -1000,6 +1004,13 @@ function getOrCreateEventSource(
         if (t) {
           sessionThinking.set(sessionId, { blocks: closeOpenThinkingBlocks(t.blocks), isThinking: false })
         }
+      }
+      else if (data.type === 'user_request_created' || data.type === 'user_request_resolved') {
+        // Unified wire: the event is an invalidation trigger, not a data
+        // carrier — the refetch reads the server registry snapshot, so a
+        // burst of events collapses into one consistent read and a stale
+        // in-flight response can never overwrite a newer one.
+        queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
       }
       else if (data.type === 'secret_request') {
         // Agent is requesting a secret from the user

--- a/src/renderer/hooks/use-pending-user-requests.test.tsx
+++ b/src/renderer/hooks/use-pending-user-requests.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { usePendingUserRequests } from './use-pending-user-requests'
+
+const mockApiFetch = vi.fn()
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}))
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useAgents: () => ({ data: [] }),
+  resolveRouteAgentId: (slug: string) => slug,
+}))
+
+const validEnvelope = {
+  id: 'req-1',
+  kind: 'secret',
+  scope: { agentSlug: 'agent-1', sessionId: 's-1' },
+  blocking: true,
+  autoApproved: false,
+  payload: { secretName: 'API_KEY' },
+}
+
+function okResponse(requests: unknown[]) {
+  return { ok: true, json: async () => ({ requests }) }
+}
+
+describe('usePendingUserRequests', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+  })
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  it('fetches the scoped snapshot and returns the parsed envelopes', async () => {
+    mockApiFetch.mockResolvedValue(okResponse([validEnvelope]))
+
+    const { result } = renderHook(() => usePendingUserRequests('agent-1', 's-1'), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1))
+    expect(result.current.data?.[0].id).toBe('req-1')
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/agents/agent-1/pending-requests?sessionId=s-1')
+  })
+
+  it('omits the sessionId query for the agent-wide view', async () => {
+    mockApiFetch.mockResolvedValue(okResponse([]))
+
+    const { result } = renderHook(() => usePendingUserRequests('agent-1'), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toEqual([]))
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/agents/agent-1/pending-requests')
+  })
+
+  it('a failed fetch is an ERROR that keeps the last snapshot — never an empty success', async () => {
+    // Returning [] on !res.ok would cache "no requests" as truth: every card
+    // vanishes (capability reviews have no fallback source) and the activity
+    // indicator flips to "Working..." while the agent is actually blocked,
+    // until the next poll tick. An error keeps data and retries instead.
+    mockApiFetch.mockResolvedValueOnce(okResponse([validEnvelope]))
+
+    // Destructure INSIDE render, like production consumers: React Query only
+    // notifies on changes to properties a render has already read.
+    const { result } = renderHook(
+      () => {
+        const { data, isError, refetch } = usePendingUserRequests('agent-1', 's-1')
+        return { data, isError, refetch }
+      },
+      { wrapper },
+    )
+    await waitFor(() => expect(result.current.data).toHaveLength(1))
+
+    mockApiFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(mockApiFetch).toHaveBeenCalledTimes(2)
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data?.[0].id).toBe('req-1')
+  })
+})

--- a/src/renderer/hooks/use-pending-user-requests.ts
+++ b/src/renderer/hooks/use-pending-user-requests.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+import { apiFetch } from '@renderer/lib/api'
+import { useAgents, resolveRouteAgentId } from '@renderer/hooks/use-agents'
+import {
+  pendingUserInputRequestSchema,
+  type PendingUserInputRequest,
+} from '@shared/lib/user-input/request-schema'
+
+const snapshotSchema = z.object({ requests: z.array(pendingUserInputRequestSchema) })
+
+/**
+ * The unified pending user-input request store: every open request visible in
+ * a scope — all session-scoped kinds plus the agent-scoped reviews that block
+ * every session of the agent — as one typed list from one snapshot endpoint.
+ *
+ * Events are invalidation triggers, not data carriers: user_request_created /
+ * user_request_resolved on the session and global SSE streams invalidate this
+ * query, and the refetch reads the server's registry — the same projection
+ * that drives the awaiting-input status. The interval refetch is the safety
+ * net for a missed event (matching the legacy proxy-review poll).
+ */
+export function usePendingUserRequests(agentSlug: string, sessionId?: string) {
+  // Key on the CANONICAL agent id: the URL carries the display slug, but SSE
+  // invalidations are broad (['pending-user-requests']) and the snapshot URL
+  // must hit one stable cache entry per agent regardless of the slug form the
+  // caller happened to hold (same reasoning as usePendingProxyReviews).
+  const { data: agents } = useAgents()
+  const resolvedSlug = resolveRouteAgentId(agentSlug, agents) ?? agentSlug
+  return useQuery<PendingUserInputRequest[]>({
+    queryKey: ['pending-user-requests', resolvedSlug, sessionId ?? null],
+    queryFn: async () => {
+      const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : ''
+      const res = await apiFetch(`/api/agents/${resolvedSlug}/pending-requests${query}`)
+      if (!res.ok) {
+        // A failed fetch must be an ERROR, not an empty success: returning []
+        // would overwrite good cached data — every card vanishes and the
+        // activity indicator reads "Working..." while the agent is blocked.
+        // Throwing keeps the last snapshot and lets React Query retry.
+        throw new Error(`Pending-requests snapshot failed: ${res.status}`)
+      }
+      return snapshotSchema.parse(await res.json()).requests
+    },
+    refetchInterval: 30000,
+  })
+}

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -1366,6 +1366,41 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(resolved[0].outcome).toBe('declined')
     })
 
+    it('a request without a verified agentSlug never reaches the global stream (fail closed)', () => {
+      // The global-stream ACL filter forwards events without a top-level
+      // agentSlug to EVERY authenticated user. The scope schema types the
+      // slug as optional, so the broadcast boundary must fail closed rather
+      // than trust that every registration path populated it. The session
+      // stream still gets the event — its subscribers are AgentRead-gated.
+      userInputRequestManager.register({
+        id: 'wire-noslug-1',
+        kind: 'secret',
+        scope: { sessionId: SESSION_ID },
+        blocking: true,
+        autoApproved: false,
+        payload: { secretName: 'K' },
+      })
+      // An empty-string slug is just as fail-open: the filter's truthiness
+      // check skips it exactly like a missing one.
+      userInputRequestManager.register({
+        id: 'wire-noslug-2',
+        kind: 'secret',
+        scope: { agentSlug: '', sessionId: SESSION_ID },
+        blocking: true,
+        autoApproved: false,
+        payload: { secretName: 'K2' },
+      })
+
+      expect(createdFor(globalEvents, 'wire-noslug-1')).toHaveLength(0)
+      expect(createdFor(globalEvents, 'wire-noslug-2')).toHaveLength(0)
+      expect(createdFor(sseEvents, 'wire-noslug-1')).toHaveLength(1)
+      expect(createdFor(sseEvents, 'wire-noslug-2')).toHaveLength(1)
+
+      userInputRequestManager.resolve('wire-noslug-1', 'answered')
+      expect(resolvedFor(globalEvents, 'wire-noslug-1')).toHaveLength(0)
+      expect(resolvedFor(sseEvents, 'wire-noslug-1')).toHaveLength(1)
+    })
+
     it('recovery synthetics never hit the wire — the transcript renders those cards', () => {
       messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
         { toolUseId: 'wire-recovered-1', toolName: 'AskUserQuestion' },

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -1264,4 +1264,140 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
     })
   })
+
+  // ==========================================================================
+  // Unified wire: every registry transition broadcasts ONE typed event —
+  // user_request_created / user_request_resolved — alongside the legacy
+  // per-type events, to the global stream always and the session stream when
+  // session-scoped. Whatever mutation path drives the transition, the wire
+  // sees it: that is the property that makes silent settles impossible here.
+  // ==========================================================================
+
+  describe('unified wire broadcasts', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let globalEvents: any[]
+    let globalCleanup: () => void
+
+    beforeEach(() => {
+      globalEvents = []
+      globalCleanup = messagePersister.addGlobalNotificationClient((data) => {
+        globalEvents.push(data)
+      })
+    })
+
+    afterEach(() => {
+      globalCleanup()
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const createdFor = (events: any[], id: string) =>
+      events.filter((e) => e.type === 'user_request_created' && e.request?.id === id)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const resolvedFor = (events: any[], id: string) =>
+      events.filter((e) => e.type === 'user_request_resolved' && e.requestId === id)
+
+    it('a stream kind emits created on BOTH streams and resolved on its tool_result', () => {
+      simulateToolUse('mcp__user-input__request_secret', 'wire-secret-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+
+      const created = createdFor(globalEvents, 'wire-secret-1')
+      expect(created).toHaveLength(1)
+      expect(created[0].request.kind).toBe('secret')
+      expect(created[0].request.scope).toEqual({ agentSlug: AGENT_SLUG, sessionId: SESSION_ID })
+      expect(created[0].request.payload.secretName).toBe('API_KEY')
+      expect(createdFor(sseEvents, 'wire-secret-1')).toHaveLength(1)
+
+      sendToolResult('wire-secret-1')
+      const resolved = resolvedFor(globalEvents, 'wire-secret-1')
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0].outcome).toBe('answered')
+      expect(resolved[0].kind).toBe('secret')
+      expect(resolvedFor(sseEvents, 'wire-secret-1')).toHaveLength(1)
+    })
+
+    it('a turn boundary settles parked entries onto the wire (no silent clears)', () => {
+      simulateToolUse('mcp__user-input__request_secret', 'wire-boundary-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      // The idle boundary cancels the parked ask; the wire must say so.
+      mockClient._sendMessage({ type: 'result', subtype: 'success', num_turns: 1 })
+      const resolved = resolvedFor(globalEvents, 'wire-boundary-1')
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0].outcome).toBe('cancelled')
+    })
+
+    it('wire events carry a top-level agentSlug — the global-stream ACL filter reads only that', () => {
+      // notifications.ts filters global events by the TOP-LEVEL agentSlug and
+      // forwards anything without one to every authenticated user. Nesting
+      // the slug inside request.scope/scope would broadcast full request
+      // payloads (secret names, scripts, review details) tenant-wide.
+      simulateToolUse('mcp__user-input__request_secret', 'wire-acl-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      const created = createdFor(globalEvents, 'wire-acl-1')
+      expect(created).toHaveLength(1)
+      expect(created[0].agentSlug).toBe(AGENT_SLUG)
+
+      sendToolResult('wire-acl-1')
+      const resolved = resolvedFor(globalEvents, 'wire-acl-1')
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0].agentSlug).toBe(AGENT_SLUG)
+    })
+
+    it('an agent-scoped review emits on the global stream only (it has no session stream)', () => {
+      userInputRequestManager.register({
+        id: 'wire-review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: AGENT_SLUG },
+        blocking: true,
+        autoApproved: false,
+        payload: { toolkit: 'slack' },
+      })
+      expect(createdFor(globalEvents, 'wire-review-1')).toHaveLength(1)
+      expect(createdFor(sseEvents, 'wire-review-1')).toHaveLength(0)
+
+      userInputRequestManager.resolve('wire-review-1', 'declined')
+      const resolved = resolvedFor(globalEvents, 'wire-review-1')
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0].outcome).toBe('declined')
+    })
+
+    it('recovery synthetics never hit the wire — the transcript renders those cards', () => {
+      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
+        { toolUseId: 'wire-recovered-1', toolName: 'AskUserQuestion' },
+      ])
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(createdFor(globalEvents, 'wire-recovered-1')).toHaveLength(0)
+      expect(createdFor(sseEvents, 'wire-recovered-1')).toHaveLength(0)
+    })
+
+    it('the snapshot a reconnecting client fetches matches the wire it missed', () => {
+      simulateToolUse('mcp__user-input__request_secret', 'wire-snap-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      userInputRequestManager.register({
+        id: 'wire-snap-review',
+        kind: 'proxy_review',
+        scope: { agentSlug: AGENT_SLUG },
+        blocking: true,
+        autoApproved: false,
+        payload: { toolkit: 'slack' },
+      })
+
+      const ids = userInputRequestManager
+        .getSnapshotForScope(AGENT_SLUG, SESSION_ID)
+        .map((r) => r.id)
+        .sort()
+      expect(ids).toEqual(['wire-snap-1', 'wire-snap-review'])
+
+      userInputRequestManager.resolve('wire-snap-review', 'answered')
+      sendToolResult('wire-snap-1')
+      expect(userInputRequestManager.getSnapshotForScope(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
+    })
+  })
 })

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -295,7 +295,14 @@ class MessagePersister {
             outcome: transition.outcome,
             scope: request.scope,
           }
-    this.broadcastGlobal(event)
+    // Fail closed: the schema types scope.agentSlug as optional (and '' is
+    // possible), and the ACL filter forwards slug-less events to EVERY
+    // authenticated user — so a request without a verified slug must never
+    // reach the global stream. Its session stream still gets it: those
+    // subscribers are AgentRead-gated per session.
+    if (request.scope.agentSlug) {
+      this.broadcastGlobal(event)
+    }
     if (request.scope.sessionId) {
       this.broadcastToSSE(request.scope.sessionId, event)
     }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -8,8 +8,12 @@ import type { RequestRemoteMcpInput } from '@shared/lib/tool-definitions/request
 import type { RequestBrowserInputInput } from '@shared/lib/tool-definitions/request-browser-input'
 import type { RequestScriptRunInput } from '@shared/lib/tool-definitions/request-script-run'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
-import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
-import { streamEventToPendingRequest, type UserInputRequestOutcome } from '@shared/lib/user-input/request-schema'
+import { userInputRequestManager, type UserInputRequestTransition } from '@shared/lib/user-input/request-manager'
+import {
+  isReplayableUserInputRequest,
+  streamEventToPendingRequest,
+  type UserInputRequestOutcome,
+} from '@shared/lib/user-input/request-schema'
 import { classifyResult } from './result-classification'
 import { parseBackgroundTasksChanged } from './background-tasks-changed'
 import { parseCommandLifecycle } from './command-lifecycle'
@@ -260,6 +264,42 @@ class MessagePersister {
   // subscribeToSession() calls for the same session share the underlying
   // promise so we don't double-install listeners or double-tear-down state.
   private subscribingNow: Map<string, Promise<void>> = new Map()
+
+  constructor() {
+    // Unified wire: every registry transition — no matter which of the many
+    // mutation paths drove it — broadcasts ONE typed event, alongside the
+    // legacy per-type events, to the global stream always and to the session
+    // stream when session-scoped. Emitting from the registry's single funnel
+    // (instead of per-callsite) is what makes a silent settle impossible on
+    // this wire. Legacy events keep firing during the client migration.
+    userInputRequestManager.onTransition((transition) => {
+      this.broadcastRequestTransition(transition)
+    })
+  }
+
+  private broadcastRequestTransition(transition: UserInputRequestTransition): void {
+    const { request } = transition
+    if (!isReplayableUserInputRequest(request)) return
+    // agentSlug MUST be at the top level: the global-stream ACL filter
+    // (notifications.ts) reads only that field and forwards events without
+    // one to every authenticated user — nesting the slug inside scope would
+    // broadcast request payloads tenant-wide in auth mode.
+    const event =
+      transition.type === 'created'
+        ? { type: 'user_request_created', agentSlug: request.scope.agentSlug, request }
+        : {
+            type: 'user_request_resolved',
+            agentSlug: request.scope.agentSlug,
+            requestId: request.id,
+            kind: request.kind,
+            outcome: transition.outcome,
+            scope: request.scope,
+          }
+    this.broadcastGlobal(event)
+    if (request.scope.sessionId) {
+      this.broadcastToSSE(request.scope.sessionId, event)
+    }
+  }
 
   // Subscribe to a session's messages for SSE streaming.
   // Returns a promise that resolves when the WebSocket connection is ready.

--- a/src/shared/lib/proxy/review-manager.test.ts
+++ b/src/shared/lib/proxy/review-manager.test.ts
@@ -68,6 +68,32 @@ describe('ReviewManager', () => {
     expect(result).toBe(false)
   })
 
+  it('registers the review envelope with the full details plus the derived displayText', async () => {
+    const promise = manager.requestReview({
+      agentSlug: 'agent-1',
+      accountId: 'acc-1',
+      toolkit: 'gmail',
+      method: 'GET',
+      targetPath: '/gmail/v1/users/me/messages',
+      matchedScopes: ['gmail.readonly'],
+      scopeDescriptions: { 'gmail.readonly': 'Read email' },
+    })
+
+    // The unified wire renders review cards from this envelope alone — it must
+    // carry everything the legacy poll response carried, displayText included.
+    const [entry] = userInputRequestManager.getAgentScopedRequests('agent-1')
+    expect(entry.kind).toBe('proxy_review')
+    const payload = entry.payload as Record<string, unknown>
+    expect(payload.toolkit).toBe('gmail')
+    expect(payload.targetPath).toBe('/gmail/v1/users/me/messages')
+    expect(payload.scopeDescriptions).toEqual({ 'gmail.readonly': 'Read email' })
+    expect(typeof payload.displayText).toBe('string')
+    expect((payload.displayText as string).length).toBeGreaterThan(0)
+
+    manager.submitDecision(entry.id, 'deny')
+    await promise
+  })
+
   it('resolveMatchingPendingByLabel resolves sibling reviews sharing the risk label', async () => {
     // Two write-labelled requests (gmail.send, gmail.compose) + one read (gmail.readonly).
     const send = manager.requestReview({

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -165,18 +165,6 @@ export class ReviewManager {
       }
 
       this.pending.set(id, { id, details, resolve, reject, timer })
-      // Reviews are agent-scoped — no sessionId in the proxied call, so the
-      // envelope carries agentSlug only. The registry entry is what makes the
-      // agent's sessions read as awaiting while the review is parked.
-      userInputRequestManager.register({
-        id,
-        kind: details.xAgent ? 'x_agent_review' : 'proxy_review',
-        scope: { agentSlug: details.agentSlug },
-        blocking: true,
-        autoApproved: false,
-        payload: { ...details },
-      })
-      this.shadowRegistryCheck(details.agentSlug, 'requestReview')
 
       const displayText = generateReviewDisplayText(
         details.toolkit,
@@ -185,6 +173,21 @@ export class ReviewManager {
         details.scopeDescriptions,
         details.endpointDescription,
       )
+
+      // Reviews are agent-scoped — no sessionId in the proxied call, so the
+      // envelope carries agentSlug only. The registry entry is what makes the
+      // agent's sessions read as awaiting while the review is parked. The
+      // payload carries the full details plus the derived display text so the
+      // unified wire can render the review card without the legacy poll.
+      userInputRequestManager.register({
+        id,
+        kind: details.xAgent ? 'x_agent_review' : 'proxy_review',
+        scope: { agentSlug: details.agentSlug },
+        blocking: true,
+        autoApproved: false,
+        payload: { ...details, displayText },
+      })
+      this.shadowRegistryCheck(details.agentSlug, 'requestReview')
 
       // Broadcast review request to agent's active sessions
       broadcastReview(details.agentSlug, {

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -285,11 +285,16 @@ describe('UserInputRequestManager', () => {
       expect(ids).toEqual(['mine-1', 'review-1'])
     })
 
-    it('recovery synthetics are excluded — they carry no renderable payload', () => {
+    it('recovery synthetics ARE in the snapshot — a recovered wait is still a blocking wait', () => {
+      // They stay off the WIRE (no renderable payload to push), but the
+      // snapshot is the awaiting-status source for clients: excluding them
+      // made the activity indicator read "Working…" while the server and the
+      // transcript-rendered card both said awaiting input. The per-kind card
+      // guards drop the payload-less entries, so no broken card renders.
       manager.register(secretRequest({ id: 'live-1' }))
       manager.register(secretRequest({ id: 'recovered-1', payload: { recovered: true } }))
-      const ids = manager.getSnapshotForScope('agent-a', 'session-1').map((r) => r.id)
-      expect(ids).toEqual(['live-1'])
+      const ids = manager.getSnapshotForScope('agent-a', 'session-1').map((r) => r.id).sort()
+      expect(ids).toEqual(['live-1', 'recovered-1'])
     })
   })
 

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -169,6 +169,130 @@ describe('UserInputRequestManager', () => {
     })
   })
 
+  describe('transition listeners (unified wire feed)', () => {
+    it('emits exactly one created per accepted registration and one resolved per settlement', () => {
+      const transitions: Array<{ type: string; id: string; outcome?: string }> = []
+      manager.onTransition((t) => transitions.push({ type: t.type, id: t.request.id, outcome: t.outcome }))
+
+      manager.register(secretRequest())
+      // First-delivery-wins duplicate must NOT re-emit.
+      manager.register(secretRequest({ payload: { secretName: 'DUP' } }))
+      manager.resolve('tool-1', 'answered')
+      // Idempotent resolve of an unknown id must not emit.
+      manager.resolve('tool-1', 'answered')
+
+      expect(transitions).toEqual([
+        { type: 'created', id: 'tool-1', outcome: undefined },
+        { type: 'resolved', id: 'tool-1', outcome: 'answered' },
+      ])
+    })
+
+    it('a malformed registration emits nothing', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const transitions: string[] = []
+      manager.onTransition((t) => transitions.push(t.type))
+      manager.register({ id: '', kind: 'secret', scope: {}, blocking: true, payload: {} } as PendingUserInputRequestInput)
+      expect(transitions).toEqual([])
+    })
+
+    it('store-scoped clears emit resolved with the boundary outcome', () => {
+      const outcomes: Array<{ id: string; outcome?: string }> = []
+      manager.onTransition((t) => {
+        if (t.type === 'resolved') outcomes.push({ id: t.request.id, outcome: t.outcome })
+      })
+      manager.register(secretRequest({ id: 'clear-1' }))
+      manager.register(secretRequest({ id: 'clear-2' }))
+      manager.clearSessionStreamRequests('session-1', 'superseded')
+      expect(outcomes).toEqual([
+        { id: 'clear-1', outcome: 'superseded' },
+        { id: 'clear-2', outcome: 'superseded' },
+      ])
+    })
+
+    it('a throwing listener is swallowed and does not break the mutation or other listeners', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const seen: string[] = []
+      manager.onTransition(() => {
+        throw new Error('listener boom')
+      })
+      manager.onTransition((t) => seen.push(t.type))
+      const stored = manager.register(secretRequest())
+      expect(stored).not.toBeNull()
+      expect(seen).toEqual(['created'])
+    })
+
+    it('unsubscribe stops delivery', () => {
+      const seen: string[] = []
+      const unsubscribe = manager.onTransition((t) => seen.push(t.type))
+      unsubscribe()
+      manager.register(secretRequest())
+      expect(seen).toEqual([])
+    })
+  })
+
+  describe('getSnapshotForScope', () => {
+    it("a session scope unions its own requests with the agent's agent-scoped reviews", () => {
+      manager.register(secretRequest({ id: 'mine-1' }))
+      manager.register(secretRequest({ id: 'other-1', scope: { agentSlug: 'agent-a', sessionId: 'session-other' } }))
+      manager.register({
+        id: 'review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'agent-a' },
+        blocking: true,
+        payload: { toolkit: 'slack' },
+      } as PendingUserInputRequestInput)
+      manager.register({
+        id: 'review-b',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'agent-b' },
+        blocking: true,
+        payload: { toolkit: 'github' },
+      } as PendingUserInputRequestInput)
+
+      const ids = manager.getSnapshotForScope('agent-a', 'session-1').map((r) => r.id).sort()
+      expect(ids).toEqual(['mine-1', 'review-1'])
+    })
+
+    it("a session view never crosses agents — another agent's sessionId returns none of its requests", () => {
+      // The sessionId reaches getSnapshotForScope from an unvalidated query
+      // param behind an AgentRead gate on the AGENT only; matching on
+      // sessionId alone would hand agent-a's viewer agent-b's payloads.
+      manager.register(
+        secretRequest({ id: 'foreign-1', scope: { agentSlug: 'agent-b', sessionId: 'session-b' } }),
+      )
+      manager.register({
+        id: 'review-a',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'agent-a' },
+        blocking: true,
+        payload: { toolkit: 'slack' },
+      } as PendingUserInputRequestInput)
+
+      const ids = manager.getSnapshotForScope('agent-a', 'session-b').map((r) => r.id)
+      expect(ids).toEqual(['review-a'])
+    })
+
+    it('an agent scope returns everything in the agent, sessions included', () => {
+      manager.register(secretRequest({ id: 'mine-1' }))
+      manager.register({
+        id: 'review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'agent-a' },
+        blocking: true,
+        payload: { toolkit: 'slack' },
+      } as PendingUserInputRequestInput)
+      const ids = manager.getSnapshotForScope('agent-a').map((r) => r.id).sort()
+      expect(ids).toEqual(['mine-1', 'review-1'])
+    })
+
+    it('recovery synthetics are excluded — they carry no renderable payload', () => {
+      manager.register(secretRequest({ id: 'live-1' }))
+      manager.register(secretRequest({ id: 'recovered-1', payload: { recovered: true } }))
+      const ids = manager.getSnapshotForScope('agent-a', 'session-1').map((r) => r.id)
+      expect(ids).toEqual(['live-1'])
+    })
+  })
+
   describe('shadow diagnostics', () => {
     it('verifyStoreParity passes silently when both stores match', () => {
       manager.register(secretRequest({ id: 'stream-1' }))

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -1,4 +1,5 @@
 import {
+  isReplayableUserInputRequest,
   pendingUserInputRequestSchema,
   storeForKind,
   type PendingUserInputRequest,
@@ -19,8 +20,23 @@ import {
  * calls (and their split-brains: parallel requests, direct-clear doors,
  * review blockers) are gone.
  */
+/**
+ * A registry transition: exactly one 'created' per accepted registration and
+ * one 'resolved' per settlement, no matter which of the many mutation paths
+ * drove it. This is the single feed for the unified wire events
+ * (user_request_created / user_request_resolved) — emitting from here instead
+ * of per-callsite is what makes silent-exit bugs structurally impossible.
+ */
+export interface UserInputRequestTransition {
+  type: 'created' | 'resolved'
+  request: PendingUserInputRequest
+  outcome?: UserInputRequestOutcome
+}
+
 export class UserInputRequestManager {
   private requests = new Map<string, PendingUserInputRequest>()
+
+  private transitionListeners = new Set<(transition: UserInputRequestTransition) => void>()
 
   /** Bounded trail of recent settlements, for shadow-mode debugging and tests. */
   private recentResolutions: Array<{
@@ -51,6 +67,7 @@ export class UserInputRequestManager {
       return null
     }
     this.requests.set(parsed.data.id, parsed.data)
+    this.emitTransition({ type: 'created', request: parsed.data })
     return parsed.data
   }
 
@@ -61,7 +78,27 @@ export class UserInputRequestManager {
     this.requests.delete(id)
     this.recentResolutions.push({ id, kind: request.kind, outcome })
     if (this.recentResolutions.length > 100) this.recentResolutions.shift()
+    this.emitTransition({ type: 'resolved', request, outcome })
     return request
+  }
+
+  /**
+   * Subscribe to registry transitions. Listener errors are swallowed: wire
+   * fan-out must never break the mutation path that triggered it.
+   */
+  onTransition(listener: (transition: UserInputRequestTransition) => void): () => void {
+    this.transitionListeners.add(listener)
+    return () => this.transitionListeners.delete(listener)
+  }
+
+  private emitTransition(transition: UserInputRequestTransition): void {
+    for (const listener of this.transitionListeners) {
+      try {
+        listener(transition)
+      } catch (error) {
+        console.error('[UserInputRequestManager] transition listener failed:', error)
+      }
+    }
   }
 
   /**
@@ -111,6 +148,27 @@ export class UserInputRequestManager {
     return [...this.requests.values()].filter(
       (r) => r.scope.agentSlug === agentSlug && r.scope.sessionId === undefined,
     )
+  }
+
+  /**
+   * Wire snapshot for a scope. A session's view is its own requests plus the
+   * agent-scoped requests of its agent (a parked review blocks — and renders
+   * in — every session of the agent); an agent's view is everything in its
+   * scope. Recovery synthetics are excluded (no renderable payload).
+   */
+  getSnapshotForScope(agentSlug: string, sessionId?: string): PendingUserInputRequest[] {
+    return [...this.requests.values()].filter((r) => {
+      if (!isReplayableUserInputRequest(r)) return false
+      // Agent check FIRST, unconditionally: sessionId arrives from an
+      // unvalidated query param behind an AgentRead gate on the agent alone,
+      // so matching on sessionId by itself would hand this agent's viewer
+      // another agent's session-scoped payloads.
+      if (r.scope.agentSlug !== agentSlug) return false
+      if (sessionId !== undefined) {
+        return r.scope.sessionId === sessionId || r.scope.sessionId === undefined
+      }
+      return true
+    })
   }
 
   getStoreIdsForSession(sessionId: string, store: UserInputRequestStore): string[] {

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -1,5 +1,4 @@
 import {
-  isReplayableUserInputRequest,
   pendingUserInputRequestSchema,
   storeForKind,
   type PendingUserInputRequest,
@@ -154,11 +153,14 @@ export class UserInputRequestManager {
    * Wire snapshot for a scope. A session's view is its own requests plus the
    * agent-scoped requests of its agent (a parked review blocks — and renders
    * in — every session of the agent); an agent's view is everything in its
-   * scope. Recovery synthetics are excluded (no renderable payload).
+   * scope. Recovery synthetics are INCLUDED: they are real blocking waits and
+   * the snapshot is the clients' awaiting-status source — excluding them made
+   * the activity indicator read "Working…" against a visible recovered card.
+   * They carry no renderable payload, so the per-kind card guards drop them
+   * (the transcript renders the card); only the wire EVENTS filter them.
    */
   getSnapshotForScope(agentSlug: string, sessionId?: string): PendingUserInputRequest[] {
     return [...this.requests.values()].filter((r) => {
-      if (!isReplayableUserInputRequest(r)) return false
       // Agent check FIRST, unconditionally: sessionId arrives from an
       // unvalidated query param behind an AgentRead gate on the agent alone,
       // so matching on sessionId by itself would hand this agent's viewer

--- a/src/shared/lib/user-input/request-schema.ts
+++ b/src/shared/lib/user-input/request-schema.ts
@@ -156,6 +156,15 @@ export type PendingUserInputRequestInput = z.input<typeof pendingUserInputReques
  */
 export type UserInputRequestStore = 'stream' | 'computer_use' | 'review'
 
+/**
+ * Whether a request may be sent to clients (wire events, snapshots). Entries
+ * synthesized by transcript recovery carry no renderable payload — sending one
+ * would draw a broken card; the transcript renders those instead.
+ */
+export function isReplayableUserInputRequest(request: PendingUserInputRequest): boolean {
+  return (request.payload as Record<string, unknown>).recovered !== true
+}
+
 export function storeForKind(kind: UserInputRequestKind): UserInputRequestStore {
   if (kind === 'computer_use') return 'computer_use'
   if (kind === 'proxy_review' || kind === 'x_agent_review') return 'review'


### PR DESCRIPTION
Phase 4 of the pending user-input request rearchitecture (`user-input-requests-rearchitecture.md` §3.4). Phases 0–3: #560, #562, #566, #578.

## Server: one wire for every request kind

- `UserInputRequestManager.onTransition()` — the registry's single funnel emits exactly one `created` per accepted registration and one `resolved` per settlement, no matter which mutation path drove it. Emitting from the funnel (instead of per-callsite) is what makes silent settles structurally impossible on this wire. Duplicate registrations, idempotent re-resolves, and malformed drops emit nothing; listener errors are swallowed.
- The persister broadcasts `user_request_created` / `user_request_resolved` — global notification stream always, session SSE stream when session-scoped. Both events carry a **top-level `agentSlug`** for the global stream's per-user ACL filter. Recovery synthetics (`payload.recovered === true`) never hit the wire (`isReplayableUserInputRequest`).
- New `GET /api/agents/:id/pending-requests?sessionId=` snapshot behind `AgentRead()`. A session's view is its own requests ∪ the agent-scoped reviews; the agent view is everything in scope. The filter checks the agent **before** matching sessionId — the session param is caller input.
- Review envelopes now carry the full details plus the derived `displayText`, so review cards render from the envelope alone.

## Client: events invalidate, the snapshot is the truth

- New `usePendingUserRequests` store (React Query, canonical-slug key, 30s safety poll). The wire events are **invalidation triggers only** — the refetch reads the registry snapshot, so event bursts collapse into one consistent read, cross-stream ordering is irrelevant, and a stale in-flight response can never overwrite a newer one. A failed fetch throws (keeps last snapshot + retries) rather than caching an empty success.
- `use-pending-requests` now projects unified envelopes onto the legacy per-kind card shapes — descriptors, cards, and the renderer are untouched. The projection re-validates the lenient payloads (questions go through the same normalizer as the recovery path). Two properties are pinned by tests:
  - session-scoped entries are display-gated on `isActive` (an abandoned computer-use approval survives idle server-side for replay and must not gate the composer behind a dead card; agent-scoped reviews render regardless)
  - `dismissedRequestIds` is React state, not a ref — answering a card removes it synchronously, not a refetch round-trip later
- The activity indicator derives awaiting from the server's own predicate (`blocking && !autoApproved`), fixing the kinds the old per-type list omitted: script_run, computer_use, and capability_review used to read "Working…" while a card was parked.
- The global handler also nudges the dashboard's legacy `['proxy-reviews']` poll, so sessionless dashboard-triggered reviews appear/settle on push instead of the next 30s tick — previously they had no push signal at all.

## Kept live / deferred

Legacy per-type SSE events, the stream arrays, and the dashboard review poll all stay during the migration window. Deferred to Phase 5: decision-endpoint consolidation, ReviewManager→adapter, dashboard panel store migration, dead-array cleanup (the browser tray still reads `pendingBrowserInputRequests` — that array must survive the cleanup), container-emitted `pending_request_opened/settled` protocol, and `register()` upgrading a recovered synthetic when the real registration replays.

## Pre-PR review round

A 4-reviewer fan-out (server wire, client store, parity/consumers, test quality) ran before this PR; every fix below was proven red first:

- **P1** — global-stream ACL bypass: the notifications filter reads only a top-level `agentSlug` and forwards slug-less events to every authenticated user in auth mode; the events nested it inside `scope`. Now top-level on both frames.
- **P1** — cross-agent snapshot leak: `getSnapshotForScope` matched `sessionId` without an agent constraint, so `/api/agents/A/pending-requests?sessionId=<agent-B-session>` returned B's payloads. Agent check now comes first, unconditionally.
- **P2** — question projection raw-cast `payload.questions`; a question without `options` crashed the card with no reload escape (the unified bucket wins the dedupe against the normalized recovery copy). Now normalized.
- **P2** — `!res.ok → []` cached failures as success-empty, blanking every card and flipping the indicator to "Working…" until the next poll. Now throws.

Accepted transients (parity with or better than legacy): card appearance rides one invalidate→refetch round-trip; ~1-RTT indicator flash at turn start if a computer-use entry survived idle; strict snapshot parsing means a version-skewed envelope errors the query (keeps last data) rather than degrading per-kind.

## Validation

- Full unit suite: 7,775 passed (new: manager transitions/snapshot, persister wire incl. top-level-slug + cross-agent tests, route snapshot ×4, review displayText, hook test file, projection/dismissal/indicator pinning tests)
- E2E: 74/74 across the 13-spec acceptance set (user-input, mixed-pending, computer-use, reconnect, concurrent-tabs, proxy-review ×2, awaiting-status, capability, subagent-browser-input, connected-accounts, mcp-policy, message-queueing)
- `tsc --noEmit` clean; eslint clean (pre-existing warnings only)

https://claude.ai/code/session_01DLw9AJ5VXVQPzBAz87nNAA