### PR TITLE
Deployment-side audit trail for session creation (SUP-475)

### DIFF
--- a/docs/cross-client-auth.md
+++ b/docs/cross-client-auth.md
@@ -148,15 +148,26 @@ and would make the exchange look anomalous. All paths land in the one
 
 | Field | Value |
 | --- | --- |
-| `method` | `password` (`/sign-in/email`, `/sign-up/email`), `oidc` (`/callback/:id`, `/oauth2/callback/:providerId`), `impersonation` (`/admin/impersonate-user`), `token-exchange`, or `unknown` |
+| `method` | `password` (`/sign-in/email`, `/sign-up/email`), `oidc` (`/callback/:id`, `/oauth2/callback/:providerId`), `impersonation`, `token-exchange`, or `unknown` |
 | `orgId` | Only for `token-exchange` — the grant's `org_id`. Omitted otherwise |
+| `targetUserId` | Only for `impersonation` — the impersonated user (see below) |
 
 No token, assertion, `jti`, email, name, IP, or user-agent ever reaches
-`details`. The user is identified by the row's `userId` foreign key; the
+`details`. People are identified by id (foreign keys the audit UI resolves); the
 user-agent already lives on the session row for the sessions list, and copying
 attacker-controlled text into a durable trail would add surface without adding
 information. `method` is also the client distinction — it is the granularity we
 can actually verify, unlike a label parsed out of a `User-Agent` string.
+
+**Impersonation inverts actor and subject.** Better Auth puts the impersonated
+user on `session.userId` and the admin who initiated it on
+`session.impersonatedBy`. Every other audit row treats `userId` as the actor, so
+recording the session as-is would blame the target for a privileged action taken
+against them — and revoking the session would take the only trace of who did it
+with it. The audit row therefore records the **admin** as `userId` and the target
+as `details.targetUserId`. The `impersonatedBy` column, not the endpoint path, is
+what identifies these: it is what the plugin actually wrote, and it carries the
+actor the path cannot.
 
 Endpoint paths are matched **exactly**, against the registered path templates
 Better Auth puts on the hook context. A path that stops minting sessions

--- a/docs/cross-client-auth.md
+++ b/docs/cross-client-auth.md
@@ -132,6 +132,44 @@ exists before a session is minted.
 Exchanged sessions record the caller's `User-Agent` and IP, so they are
 distinguishable and revocable in the admin sessions list.
 
+### 7. Audit trail
+
+Every session this deployment mints writes one `session` / `created` audit row
+(`src/shared/lib/auth/session-audit.ts`), so credential issuance survives the
+session itself being revoked or expiring — a deployment-owned record that does
+not require reading platform logs across the trust boundary.
+
+Auditing is deliberately **uniform across every path**, not exchange-only: a
+trail that showed headless exchanges but not browser logins would read as a bug
+and would make the exchange look anomalous. All paths land in the one
+`session.create.after` database hook in `src/shared/lib/auth/index.ts`.
+
+`details` carries the attribution and nothing else:
+
+| Field | Value |
+| --- | --- |
+| `method` | `password` (`/sign-in/email`, `/sign-up/email`), `oidc` (`/callback/:id`, `/oauth2/callback/:providerId`), `impersonation` (`/admin/impersonate-user`), `token-exchange`, or `unknown` |
+| `orgId` | Only for `token-exchange` — the grant's `org_id`. Omitted otherwise |
+
+No token, assertion, `jti`, email, name, IP, or user-agent ever reaches
+`details`. The user is identified by the row's `userId` foreign key; the
+user-agent already lives on the session row for the sessions list, and copying
+attacker-controlled text into a durable trail would add surface without adding
+information. `method` is also the client distinction — it is the granularity we
+can actually verify, unlike a label parsed out of a `User-Agent` string.
+
+Endpoint paths are matched **exactly**, against the registered path templates
+Better Auth puts on the hook context. A path that stops minting sessions
+upstream just stops appearing; a new one that starts is recorded as `unknown`
+until it is added — the safe direction to be wrong in. The token exchange is
+not an endpoint, so it has no path: it tags its `createSession` call through an
+`AsyncLocalStorage` scope (async-local rather than a module flag so two
+concurrent exchanges cannot read each other's tag).
+
+Revocation is **not** audited yet. It would have to cover sign-out, admin
+revoke, and the concurrent-session reaper in one change or it would reproduce
+exactly the asymmetry this closed.
+
 ## Audience configuration (important for cloud deployments)
 
 The endpoint verifies `aud` against `getAppBaseUrl()`
@@ -152,6 +190,9 @@ For the exchange to work, this value must equal the canonical
 - Integration suite: `src/shared/lib/auth/token-exchange.integration.test.ts`
   (real Better Auth + real SQLite: contract, replay/concurrency, provisioning,
   ban/pending, bearer-through-`Authenticated()`).
+- Audit trail: `src/shared/lib/auth/session-audit.integration.test.ts` (real
+  password login and real exchange, side by side, asserting one row each and no
+  sensitive fields) plus `session-audit.test.ts` for the mapping itself.
 - Config precedence: `src/shared/lib/auth/config.test.ts`.
 - Live two-service chain: seed the platform repo's local stack and drive
   discovery → RFC 8693 → RFC 7523 → bearer calls; see the platform repo's

--- a/src/shared/lib/auth/index.ts
+++ b/src/shared/lib/auth/index.ts
@@ -8,6 +8,7 @@ import { getOrCreateAuthSecret } from './secret'
 import { getAppBaseUrl, getTrustedOrigins } from './config'
 import { getSettings, DEFAULT_AUTH_SETTINGS } from '@shared/lib/config/settings'
 import { enforceMaxConcurrentSessions } from './session-enforcement'
+import { auditSessionCreated } from './session-audit'
 import { getGenericOAuthProviderConfigs } from './provider-config'
 
 // Re-export isAuthMode from its own file (no better-auth imports)
@@ -174,13 +175,26 @@ function createAuthInstance() {
       },
       session: {
         create: {
-          after: async (session) => {
+          after: async (session, context) => {
             try {
               const sessSettings = getSettings()
               const sessAuth = { ...DEFAULT_AUTH_SETTINGS, ...sessSettings.auth }
               enforceMaxConcurrentSessions(session.userId, sessAuth.maxConcurrentSessions ?? 5)
             } catch (err) {
               console.error('Failed to enforce max concurrent sessions:', err)
+            }
+            // Every session-creation path lands here — browser password login,
+            // platform OIDC, admin impersonation, and the RFC 7523 token
+            // exchange — so one audit row per session comes from one place.
+            // Its own try/catch: enforcement failing must not swallow the
+            // record of the credential that was just issued.
+            try {
+              // Declared as GenericEndpointContext, but the object Better Auth
+              // actually stores is a Partial — outside an endpoint it is null,
+              // and `path` can be absent even when it is not.
+              await auditSessionCreated(session, context?.path)
+            } catch (err) {
+              console.error('Failed to audit session creation:', err)
             }
           },
         },

--- a/src/shared/lib/auth/session-audit.integration.test.ts
+++ b/src/shared/lib/auth/session-audit.integration.test.ts
@@ -183,6 +183,84 @@ describe('browser password login', () => {
   })
 })
 
+describe('admin impersonation', () => {
+  /** Sign a user in and return a bearer usable as that user's credentials. */
+  async function signInAs(email: string): Promise<string> {
+    const res = await authModule.getAuth().api.signInEmail({
+      body: { email, password: PASSWORD },
+      asResponse: true,
+    })
+    const token = res.headers.get('set-auth-token')
+    expect(token).toBeTruthy()
+    return token!
+  }
+
+  async function seedAdminAndTarget(): Promise<{ adminId: string; targetId: string }> {
+    const auth = authModule.getAuth()
+    // First user is promoted to admin by the user.create.after hook.
+    await auth.api.signUpEmail({
+      body: { email: 'admin@example.com', password: PASSWORD, name: 'Admin' },
+    })
+    await auth.api.signUpEmail({
+      body: { email: 'target@example.com', password: PASSWORD, name: 'Target' },
+    })
+    const row = (email: string) =>
+      (dbModule.sqlite.prepare(`SELECT id FROM user WHERE email = ?`).get(email) as { id: string })
+        .id
+    return { adminId: row('admin@example.com'), targetId: row('target@example.com') }
+  }
+
+  it('credits the impersonating admin as the actor and keeps the target in details', async () => {
+    const { adminId, targetId } = await seedAdminAndTarget()
+    const adminToken = await signInAs('admin@example.com')
+    dbModule.sqlite.prepare(`DELETE FROM audit_log`).run()
+
+    await authModule.getAuth().api.impersonateUser({
+      body: { userId: targetId },
+      headers: new Headers({ authorization: `Bearer ${adminToken}` }),
+    })
+
+    const rows = auditRows('session')
+    expect(rows).toHaveLength(1)
+    // Better Auth puts the target on session.userId and the admin on
+    // session.impersonatedBy; the audit row must invert that, or the UI blames
+    // the victim for the admin's action.
+    expect(rows[0].user_id).toBe(adminId)
+    expect(detailsOf(rows[0])).toEqual({ method: 'impersonation', targetUserId: targetId })
+  })
+
+  it('survives revocation of the impersonation session', async () => {
+    const { adminId, targetId } = await seedAdminAndTarget()
+    const adminToken = await signInAs('admin@example.com')
+    dbModule.sqlite.prepare(`DELETE FROM audit_log`).run()
+
+    await authModule.getAuth().api.impersonateUser({
+      body: { userId: targetId },
+      headers: new Headers({ authorization: `Bearer ${adminToken}` }),
+    })
+
+    const [row] = auditRows('session')
+    dbModule.sqlite.prepare(`DELETE FROM session WHERE id = ?`).run(row.object_id)
+
+    // The whole point of the trail: with the session gone, who did it and to
+    // whom is still on record.
+    const [after] = auditRows('session')
+    expect(after.user_id).toBe(adminId)
+    expect(detailsOf(after).targetUserId).toBe(targetId)
+  })
+
+  it('does not confuse an ordinary login by the same admin with impersonation', async () => {
+    const { adminId } = await seedAdminAndTarget()
+    dbModule.sqlite.prepare(`DELETE FROM audit_log`).run()
+
+    await signInAs('admin@example.com')
+
+    const [row] = auditRows('session')
+    expect(row.user_id).toBe(adminId)
+    expect(detailsOf(row)).toEqual({ method: 'password' })
+  })
+})
+
 describe('token exchange', () => {
   it('writes one session:created row tagged token-exchange with the grant org', async () => {
     const res = await exchange(await signGrant())

--- a/src/shared/lib/auth/session-audit.integration.test.ts
+++ b/src/shared/lib/auth/session-audit.integration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Integration coverage for the deployment-side session audit trail, against a
+ * real Better Auth instance and a real SQLite database in a temp data dir.
+ *
+ * The point of these tests is symmetry: a browser password login and a headless
+ * RFC 7523 token exchange must each leave exactly one `session:created` row,
+ * distinguishable by `method`, with nothing sensitive in `details`. Unit tests
+ * can prove the mapping, but only a real dispatch proves the endpoint paths the
+ * mapping is keyed on are the ones Better Auth actually reports.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import { Hono } from 'hono'
+import { generateKeyPair, exportJWK, SignJWT, createLocalJWKSet } from 'jose'
+
+const TEST_ISSUER = 'https://auth.test.example'
+const TEST_ORG = 'org_audit_123'
+const SIGNING_KID = 'platform-oidc-main'
+const GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+const PASSWORD = 'correct-horse-battery-staple'
+
+let tmpDir: string
+let privateKey: CryptoKey
+let audience: string
+let dbModule: typeof import('@shared/lib/db')
+let authModule: typeof import('./index')
+let app: Hono
+
+interface AuditRow {
+  object: string
+  action: string
+  object_id: string
+  user_id: string | null
+  details: string | null
+}
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj)).toString('base64url')
+}
+
+function auditRows(object?: string): AuditRow[] {
+  const sql = object
+    ? `SELECT object, action, object_id, user_id, details FROM audit_log WHERE object = ? ORDER BY rowid`
+    : `SELECT object, action, object_id, user_id, details FROM audit_log ORDER BY rowid`
+  const stmt = dbModule.sqlite.prepare(sql)
+  return (object ? stmt.all(object) : stmt.all()) as AuditRow[]
+}
+
+function detailsOf(row: AuditRow): Record<string, unknown> {
+  return JSON.parse(row.details ?? '{}')
+}
+
+async function signGrant(payload: Record<string, unknown> = {}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000)
+  return new SignJWT({
+    sub: 'sub_member_1',
+    org_id: TEST_ORG,
+    user_id: 'platform-user-uuid-1',
+    email: 'member@example.com',
+    email_verified: true,
+    name: 'Member One',
+    role: 'member',
+    jti: crypto.randomUUID(),
+    ...payload,
+  })
+    .setProtectedHeader({ alg: 'RS256', typ: 'deployment-assertion+jwt', kid: SIGNING_KID })
+    .setIssuer(TEST_ISSUER)
+    .setAudience(audience)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 120)
+    .sign(privateKey)
+}
+
+function exchange(assertion: string) {
+  return app.request('/api/auth/token/exchange', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: GRANT_TYPE, assertion }).toString(),
+  })
+}
+
+beforeAll(async () => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'session-audit-')))
+  process.env.SUPERAGENT_DATA_DIR = tmpDir
+  process.env.AUTH_MODE = 'true'
+  process.env.BETTER_AUTH_SECRET = 'test-secret-0123456789abcdef0123456789abcdef'
+  process.env.PLATFORM_TOKEN = `${b64url({ alg: 'RS256' })}.${b64url({ orgId: TEST_ORG })}.sig`
+  process.env.AUTH_PROVIDERS_JSON = JSON.stringify([
+    { id: 'platform', type: 'oidc', issuer: TEST_ISSUER, clientId: 'superagent-org-audit' },
+  ])
+
+  const pair = await generateKeyPair('RS256')
+  privateKey = pair.privateKey as CryptoKey
+  const jwk = await exportJWK(pair.publicKey)
+  jwk.kid = SIGNING_KID
+  jwk.alg = 'RS256'
+  const { _setOidcJwksResolverForTest } = await import('./oidc-jwt')
+  _setOidcJwksResolverForTest(createLocalJWKSet({ keys: [jwk] }) as never)
+
+  const { getAppBaseUrl } = await import('./config')
+  audience = getAppBaseUrl()
+
+  dbModule = await import('@shared/lib/db')
+  authModule = await import('./index')
+
+  const tokenExchangeRoute = (await import('../../../api/routes/token-exchange')).default
+  app = new Hono()
+  app.route('/api/auth/token', tokenExchangeRoute)
+})
+
+afterAll(async () => {
+  const { _setOidcJwksResolverForTest } = await import('./oidc-jwt')
+  _setOidcJwksResolverForTest(null)
+  delete process.env.SUPERAGENT_DATA_DIR
+  delete process.env.AUTH_MODE
+  delete process.env.PLATFORM_TOKEN
+  delete process.env.AUTH_PROVIDERS_JSON
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+beforeEach(async () => {
+  for (const table of ['session', 'account', 'user', 'token_exchange_jti', 'audit_log']) {
+    dbModule.sqlite.prepare(`DELETE FROM ${table}`).run()
+  }
+  // Approval defaults to on, which bans every user after the first and would
+  // make "two users, two methods" fail for a reason that has nothing to do
+  // with auditing.
+  fs.writeFileSync(
+    path.join(tmpDir, 'settings.json'),
+    JSON.stringify({ auth: { requireAdminApproval: false } }),
+  )
+  const { clearSettingsCache } = await import('@shared/lib/config/settings')
+  clearSettingsCache()
+})
+
+describe('browser password login', () => {
+  it('writes one session:created row per sign-up and sign-in', async () => {
+    const auth = authModule.getAuth()
+    const email = 'browser-user@example.com'
+
+    // Registration auto-signs-in, so this is itself a session-creation path.
+    await auth.api.signUpEmail({ body: { email, password: PASSWORD, name: 'Browser User' } })
+    expect(auditRows('session')).toHaveLength(1)
+
+    await auth.api.signInEmail({ body: { email, password: PASSWORD } })
+
+    const rows = auditRows('session')
+    expect(rows).toHaveLength(2)
+    for (const row of rows) {
+      expect(row.action).toBe('created')
+      expect(detailsOf(row)).toEqual({ method: 'password' })
+    }
+  })
+
+  it('attributes the row to the signed-in user and the session it created', async () => {
+    const auth = authModule.getAuth()
+    const email = 'attributed@example.com'
+    await auth.api.signUpEmail({ body: { email, password: PASSWORD, name: 'Attributed' } })
+
+    const [row] = auditRows('session')
+    const session = dbModule.sqlite
+      .prepare(`SELECT id, user_id FROM session WHERE id = ?`)
+      .get(row.object_id) as { id: string; user_id: string } | undefined
+
+    expect(session).toBeDefined()
+    expect(row.user_id).toBe(session!.user_id)
+  })
+
+  it('writes no session row for a failed password attempt', async () => {
+    const auth = authModule.getAuth()
+    const email = 'wrong-password@example.com'
+    await auth.api.signUpEmail({ body: { email, password: PASSWORD, name: 'Wrong Password' } })
+
+    await expect(
+      auth.api.signInEmail({ body: { email, password: 'not-the-password-at-all' } }),
+    ).rejects.toThrow()
+
+    // Only the sign-up's session — the rejected attempt minted nothing.
+    expect(auditRows('session')).toHaveLength(1)
+  })
+})
+
+describe('token exchange', () => {
+  it('writes one session:created row tagged token-exchange with the grant org', async () => {
+    const res = await exchange(await signGrant())
+    expect(res.status).toBe(200)
+
+    const rows = auditRows('session')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].action).toBe('created')
+    expect(detailsOf(rows[0])).toEqual({ method: 'token-exchange', orgId: TEST_ORG })
+  })
+
+  it('attributes the row to the provisioned user and the minted session', async () => {
+    const res = await exchange(await signGrant())
+    const body = await res.json()
+
+    const [row] = auditRows('session')
+    const session = dbModule.sqlite
+      .prepare(`SELECT id, user_id FROM session WHERE token = ?`)
+      .get(body.access_token) as { id: string; user_id: string }
+
+    expect(row.object_id).toBe(session.id)
+    expect(row.user_id).toBe(session.user_id)
+  })
+
+  it('leaks no assertion, token, jti, email, or name into details', async () => {
+    const jti = crypto.randomUUID()
+    const assertion = await signGrant({ jti })
+    const res = await exchange(assertion)
+    const body = await res.json()
+
+    const [row] = auditRows('session')
+    const serialized = row.details ?? ''
+    for (const secret of [assertion, body.access_token, jti, 'member@example.com', 'Member One']) {
+      expect(serialized).not.toContain(secret)
+    }
+    expect(Object.keys(detailsOf(row)).sort()).toEqual(['method', 'orgId'])
+  })
+
+  it('writes no session row for a rejected grant', async () => {
+    const res = await exchange(await signGrant({ org_id: 'org_someone_else' }))
+    expect(res.status).toBe(400)
+    expect(auditRows('session')).toHaveLength(0)
+  })
+
+  it('records one row per exchange, not one per replay attempt', async () => {
+    const assertion = await signGrant()
+    expect((await exchange(assertion)).status).toBe(200)
+    expect((await exchange(assertion)).status).toBe(400)
+
+    expect(auditRows('session')).toHaveLength(1)
+  })
+})
+
+describe('symmetry', () => {
+  it('makes both credential sources visible in one filterable object', async () => {
+    const auth = authModule.getAuth()
+    await auth.api.signUpEmail({
+      body: { email: 'both@example.com', password: PASSWORD, name: 'Both' },
+    })
+    expect((await exchange(await signGrant())).status).toBe(200)
+
+    const methods = auditRows('session').map((row) => detailsOf(row).method)
+    expect(methods.sort()).toEqual(['password', 'token-exchange'])
+  })
+})

--- a/src/shared/lib/auth/session-audit.test.ts
+++ b/src/shared/lib/auth/session-audit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit coverage for session-creation attribution. The integration suite proves
+ * the real endpoints land on the right paths; this proves the mapping itself,
+ * the async-local tag, and that nothing but the attribution reaches `details`.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const logAuditEventMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock('@shared/lib/services/audit-log-service', () => ({
+  logAuditEvent: logAuditEventMock,
+}))
+
+import {
+  auditSessionCreated,
+  resolveSessionAuditContext,
+  withSessionAuditContext,
+} from './session-audit'
+
+const SESSION = { id: 'sess_1', userId: 'user_1' }
+
+beforeEach(() => {
+  logAuditEventMock.mockClear()
+})
+
+describe('resolveSessionAuditContext', () => {
+  it.each([
+    ['/sign-in/email', 'password'],
+    ['/sign-up/email', 'password'],
+    ['/callback/:id', 'oidc'],
+    ['/oauth2/callback/:providerId', 'oidc'],
+    ['/admin/impersonate-user', 'impersonation'],
+  ])('maps %s to %s', (path, method) => {
+    expect(resolveSessionAuditContext(path).method).toBe(method)
+  })
+
+  it('reports an unrecognized endpoint path as unknown rather than guessing', () => {
+    expect(resolveSessionAuditContext('/sign-in/passkey').method).toBe('unknown')
+  })
+
+  it('reports a session with no endpoint context as unknown', () => {
+    expect(resolveSessionAuditContext(undefined).method).toBe('unknown')
+    expect(resolveSessionAuditContext(null).method).toBe('unknown')
+  })
+
+  it('lets an explicit tag win over the endpoint path', () => {
+    withSessionAuditContext({ method: 'token-exchange', orgId: 'org_1' }, () => {
+      expect(resolveSessionAuditContext('/sign-in/email')).toEqual({
+        method: 'token-exchange',
+        orgId: 'org_1',
+      })
+    })
+  })
+
+  it('does not leak a tag outside its scope', () => {
+    withSessionAuditContext({ method: 'token-exchange' }, () => {})
+    expect(resolveSessionAuditContext(undefined).method).toBe('unknown')
+  })
+
+  it('keeps concurrent tags isolated from each other', async () => {
+    const seen: string[] = []
+    const tagged = (orgId: string, delayMs: number) =>
+      withSessionAuditContext({ method: 'token-exchange', orgId }, async () => {
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+        seen.push(resolveSessionAuditContext(undefined).orgId!)
+      })
+
+    await Promise.all([tagged('org_a', 10), tagged('org_b', 0)])
+
+    expect(seen.sort()).toEqual(['org_a', 'org_b'])
+  })
+})
+
+describe('auditSessionCreated', () => {
+  it('writes exactly one session:created row attributed to the session user', async () => {
+    await auditSessionCreated(SESSION, '/sign-in/email')
+
+    expect(logAuditEventMock).toHaveBeenCalledOnce()
+    expect(logAuditEventMock).toHaveBeenCalledWith({
+      userId: 'user_1',
+      object: 'session',
+      objectId: 'sess_1',
+      action: 'created',
+      details: { method: 'password' },
+    })
+  })
+
+  it('records the grant org for a tagged token exchange', async () => {
+    await withSessionAuditContext({ method: 'token-exchange', orgId: 'org_9' }, () =>
+      auditSessionCreated(SESSION),
+    )
+
+    expect(logAuditEventMock.mock.calls[0][0].details).toEqual({
+      method: 'token-exchange',
+      orgId: 'org_9',
+    })
+  })
+
+  it('omits orgId entirely when the path did not name one', async () => {
+    await auditSessionCreated(SESSION, '/callback/:id')
+
+    expect(Object.keys(logAuditEventMock.mock.calls[0][0].details)).toEqual(['method'])
+  })
+
+  it('never carries anything beyond the attribution into details', async () => {
+    await auditSessionCreated(SESSION, '/oauth2/callback/:providerId')
+
+    const details = logAuditEventMock.mock.calls[0][0].details as Record<string, unknown>
+    expect(Object.keys(details).every((key) => key === 'method' || key === 'orgId')).toBe(true)
+  })
+})

--- a/src/shared/lib/auth/session-audit.test.ts
+++ b/src/shared/lib/auth/session-audit.test.ts
@@ -101,6 +101,39 @@ describe('auditSessionCreated', () => {
     expect(Object.keys(logAuditEventMock.mock.calls[0][0].details)).toEqual(['method'])
   })
 
+  it('credits the impersonating admin as the actor, not the impersonated user', async () => {
+    await auditSessionCreated(
+      { id: 'sess_imp', userId: 'target_user', impersonatedBy: 'admin_user' },
+      '/admin/impersonate-user',
+    )
+
+    expect(logAuditEventMock).toHaveBeenCalledWith({
+      userId: 'admin_user',
+      object: 'session',
+      objectId: 'sess_imp',
+      action: 'created',
+      details: { method: 'impersonation', targetUserId: 'target_user' },
+    })
+  })
+
+  it('recognizes impersonation from the session column even without the path', async () => {
+    await auditSessionCreated({ id: 'sess_imp', userId: 'target', impersonatedBy: 'admin' })
+
+    const call = logAuditEventMock.mock.calls[0][0]
+    expect(call.userId).toBe('admin')
+    expect(call.details.method).toBe('impersonation')
+  })
+
+  it('treats an absent or blank impersonatedBy as an ordinary session', async () => {
+    await auditSessionCreated({ ...SESSION, impersonatedBy: '' }, '/sign-in/email')
+    await auditSessionCreated({ ...SESSION, impersonatedBy: null }, '/sign-in/email')
+
+    for (const [call] of logAuditEventMock.mock.calls) {
+      expect(call.userId).toBe('user_1')
+      expect(call.details).toEqual({ method: 'password' })
+    }
+  })
+
   it('never carries anything beyond the attribution into details', async () => {
     await auditSessionCreated(SESSION, '/oauth2/callback/:providerId')
 

--- a/src/shared/lib/auth/session-audit.ts
+++ b/src/shared/lib/auth/session-audit.ts
@@ -1,0 +1,97 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { logAuditEvent } from '@shared/lib/services/audit-log-service'
+
+/**
+ * How a session came to exist. Every path that mints a Better Auth session on
+ * this deployment resolves to exactly one of these, so the audit trail can
+ * answer "where did this credential come from" without a read across the trust
+ * boundary into platform logs.
+ *
+ * `unknown` is deliberate, not a fallback bug: a session created outside any
+ * known path is more interesting than one we can name, and silently dropping it
+ * would leave a hole exactly where an unexpected issuer would show up.
+ */
+export const SESSION_CREATION_METHODS = [
+  'password',
+  'oidc',
+  'token-exchange',
+  'impersonation',
+  'unknown',
+] as const
+
+export type SessionCreationMethod = (typeof SESSION_CREATION_METHODS)[number]
+
+export interface SessionAuditContext {
+  method: SessionCreationMethod
+  /** Present only where the credential itself named an org (the RFC 7523 grant). */
+  orgId?: string
+}
+
+/**
+ * Better Auth endpoint paths that end in a session, keyed by the registered
+ * path template (`dispatchAuthEndpoint` puts `endpoint.path` on the context, so
+ * these are the literal templates, not concrete request URLs).
+ *
+ * Matched exactly. A path that stops minting sessions upstream simply stops
+ * appearing here; a new one that starts is recorded as `unknown` until it is
+ * added, which is the safe direction to be wrong in.
+ */
+const METHOD_BY_ENDPOINT_PATH: Record<string, SessionCreationMethod> = {
+  '/sign-in/email': 'password',
+  // Auto sign-in on registration mints a session on the sign-up endpoint.
+  '/sign-up/email': 'password',
+  '/callback/:id': 'oidc',
+  '/oauth2/callback/:providerId': 'oidc',
+  '/admin/impersonate-user': 'impersonation',
+}
+
+/**
+ * Sessions minted outside a Better Auth endpoint carry no endpoint context, so
+ * the caller tags them here instead. Async-local rather than a module flag: two
+ * concurrent exchanges must not be able to read each other's tag.
+ */
+const auditContextStore = new AsyncLocalStorage<SessionAuditContext>()
+
+/**
+ * Run `fn` with an explicit attribution for any session it creates. Must wrap
+ * the `createSession` call itself — the database hook that reads it runs
+ * synchronously within that call.
+ */
+export function withSessionAuditContext<T>(context: SessionAuditContext, fn: () => T): T {
+  return auditContextStore.run(context, fn)
+}
+
+/**
+ * An explicit tag always wins: a caller that knows how the session was minted
+ * knows better than an endpoint path, and a tagged call reaching this from
+ * inside an endpoint context is still that caller's session.
+ */
+export function resolveSessionAuditContext(endpointPath?: string | null): SessionAuditContext {
+  const tagged = auditContextStore.getStore()
+  if (tagged) return tagged
+  const method = endpointPath ? METHOD_BY_ENDPOINT_PATH[endpointPath] : undefined
+  return { method: method ?? 'unknown' }
+}
+
+/**
+ * Record one `session:created` audit row.
+ *
+ * Details carry the attribution and nothing else — no token, assertion, jti,
+ * email, name, IP, or user-agent. The user is identified by `userId` (a foreign
+ * key the audit UI resolves), and the session row itself already holds the
+ * user-agent for the sessions list, so copying attacker-controlled text into a
+ * durable trail would add surface without adding information.
+ */
+export async function auditSessionCreated(
+  session: { id: string; userId: string },
+  endpointPath?: string | null,
+): Promise<void> {
+  const { method, orgId } = resolveSessionAuditContext(endpointPath)
+  await logAuditEvent({
+    userId: session.userId,
+    object: 'session',
+    objectId: session.id,
+    action: 'created',
+    details: { method, ...(orgId ? { orgId } : {}) },
+  })
+}

--- a/src/shared/lib/auth/session-audit.ts
+++ b/src/shared/lib/auth/session-audit.ts
@@ -42,6 +42,9 @@ const METHOD_BY_ENDPOINT_PATH: Record<string, SessionCreationMethod> = {
   '/sign-up/email': 'password',
   '/callback/:id': 'oidc',
   '/oauth2/callback/:providerId': 'oidc',
+  // Belt and braces. Impersonation is normally recognized from the session's
+  // `impersonatedBy` column, which also names the actor; this only keeps the
+  // label right if that column is ever absent.
   '/admin/impersonate-user': 'impersonation',
 }
 
@@ -73,19 +76,54 @@ export function resolveSessionAuditContext(endpointPath?: string | null): Sessio
   return { method: method ?? 'unknown' }
 }
 
+export interface SessionForAudit {
+  id: string
+  userId: string
+  /**
+   * Set by the admin plugin when the session is an impersonation. Typed loose
+   * on purpose: the database hook hands us `Session & Record<string, unknown>`,
+   * so the field arrives as `unknown` and is narrowed at runtime.
+   */
+  impersonatedBy?: unknown
+}
+
 /**
  * Record one `session:created` audit row.
  *
  * Details carry the attribution and nothing else — no token, assertion, jti,
- * email, name, IP, or user-agent. The user is identified by `userId` (a foreign
- * key the audit UI resolves), and the session row itself already holds the
- * user-agent for the sessions list, so copying attacker-controlled text into a
- * durable trail would add surface without adding information.
+ * email, name, IP, or user-agent. People are identified by id (foreign keys the
+ * audit UI resolves), and the session row itself already holds the user-agent
+ * for the sessions list, so copying attacker-controlled text into a durable
+ * trail would add surface without adding information.
  */
 export async function auditSessionCreated(
-  session: { id: string; userId: string },
+  session: SessionForAudit,
   endpointPath?: string | null,
 ): Promise<void> {
+  // Impersonation inverts the usual actor/subject relationship: Better Auth
+  // puts the impersonated user on `session.userId` and the admin who initiated
+  // it on `session.impersonatedBy`. Every other audit row treats `userId` as
+  // the actor, so recording this session as-is would blame the target for a
+  // privileged action taken against them — and revoking the session would take
+  // the only trace of who actually did it with it.
+  //
+  // The column is the ground truth here, not the endpoint path: it is what the
+  // plugin actually wrote, and it carries the actor the path cannot.
+  const impersonatedBy =
+    typeof session.impersonatedBy === 'string' && session.impersonatedBy
+      ? session.impersonatedBy
+      : null
+  if (impersonatedBy) {
+    await logAuditEvent({
+      userId: impersonatedBy,
+      object: 'session',
+      objectId: session.id,
+      action: 'created',
+      details: { method: 'impersonation', targetUserId: session.userId },
+    })
+    return
+  }
+
   const { method, orgId } = resolveSessionAuditContext(endpointPath)
   await logAuditEvent({
     userId: session.userId,

--- a/src/shared/lib/auth/token-exchange.ts
+++ b/src/shared/lib/auth/token-exchange.ts
@@ -8,6 +8,7 @@ import { getAuth } from './index'
 import { getAppBaseUrl } from './config'
 import { verifyOidcJwt } from './oidc-jwt'
 import { getAuthProviderIssuer, isAuthProviderEnabled } from './provider-config'
+import { withSessionAuditContext } from './session-audit'
 import {
   DEPLOYMENT_ASSERTION_TYP,
   DeploymentGrantClaimsSchema,
@@ -308,10 +309,18 @@ export async function exchangeDeploymentGrant(
 
   // Session hygiene: record where this session came from so users can see
   // and revoke it in the sessions list.
-  const session = await ctx.internalAdapter.createSession(fresh.id, false, {
-    userAgent: meta.userAgent?.slice(0, 512) || 'token-exchange',
-    ipAddress: meta.ipAddress ?? '',
-  })
+  //
+  // Wrapped so the session.create.after hook can attribute the audit row: this
+  // call is not a Better Auth endpoint, so there is no endpoint path for the
+  // hook to read, and the grant's org is only known here.
+  const session = await withSessionAuditContext(
+    { method: 'token-exchange', orgId: claims.org_id },
+    () =>
+      ctx.internalAdapter.createSession(fresh.id, false, {
+        userAgent: meta.userAgent?.slice(0, 512) || 'token-exchange',
+        ipAddress: meta.ipAddress ?? '',
+      }),
+  )
   if (!session) {
     captureException(new Error('token exchange: session creation returned no session'), {
       tags: { component: 'token-exchange', operation: 'session-create' },

--- a/src/shared/lib/services/audit-log-service.ts
+++ b/src/shared/lib/services/audit-log-service.ts
@@ -19,6 +19,11 @@ export const AUDIT_EVENT_MAP = {
   settings:         ['updated', 'factory_reset'],
   policy:           ['updated'],
   user:             ['invited', 'reset_password'],
+  // Authentication events. Every path that mints a session records `created`
+  // with a `method` detail — see auth/session-audit.ts. Revocation is not
+  // audited yet; it would have to cover sign-out, admin revoke, and the
+  // concurrent-session reaper together or it would read as a gap.
+  session:          ['created'],
 } as const satisfies Record<string, readonly string[]>
 
 export type AuditObject = keyof typeof AUDIT_EVENT_MAP


### PR DESCRIPTION
Closes SUP-475. Last of the SUP-360 series (follows #573 token exchange, #581 cloud workspace).

## The gap

The deployment audit trail covers resource and config mutations but recorded **nothing about authentication**. No path to a session was audited: browser password login and platform OIDC login mint Better Auth sessions and wrote nothing (`session.create.after` only ran `enforceMaxConcurrentSessions`), and the RFC 7523 token exchange wrote nothing either.

What this closes is a **persistent, deployment-owned record of credential issuance that survives the session being revoked or expiring** — without reading platform logs across the trust boundary. Grant issuance is already audited platform-side (SUP-363), exchanged sessions are already revocable in the admin sessions list, and failures already report to Sentry; none of those is a durable local record.

## Approach

One `session` / `created` audit object, written from the **single** `session.create.after` database hook, so every session-minting path shares one code path. An exchange-only event was explicitly rejected: exchanged sessions appearing in the trail while ordinary logins did not reads as a bug, and makes the exchange look anomalous.

`details` carries the attribution and nothing else:

| Field | Value |
| --- | --- |
| `method` | `password` (`/sign-in/email`, `/sign-up/email`), `oidc` (`/callback/:id`, `/oauth2/callback/:providerId`), `impersonation`, `token-exchange`, `unknown` |
| `orgId` | Only for `token-exchange` — the grant's `org_id`. Omitted otherwise |
| `targetUserId` | Only for `impersonation` — the impersonated user |

No token, assertion, `jti`, email, name, IP, or user-agent. People are identified by id (foreign keys the audit UI resolves); the user-agent already lives on the session row for the sessions list, and copying attacker-controlled text into a durable trail adds surface without adding information.

## Three things worth reviewing

**Impersonation inverts actor and subject.** Better Auth puts the impersonated user on `session.userId` and the initiating admin on `session.impersonatedBy`. Every other audit row treats `userId` as the actor, so recording the session as-is would blame the target for a privileged action taken against them — and revoking the session would take the only trace of who did it with it. The row records the **admin** as `userId` and the target as `details.targetUserId`. Recognition is driven by the `impersonatedBy` column, not the endpoint path: it is what the plugin actually wrote, and it is the only thing carrying the actor.

**Path matching is exact**, against the registered path templates `dispatchAuthEndpoint` puts on the hook context (`/oauth2/callback/:providerId`, not a concrete URL). A path that stops minting sessions upstream just stops appearing; a new one that starts is recorded as `unknown` until it is added. `unknown` is deliberate, not a fallback bug — an unattributable session is the most interesting row in the table.

**The exchange is not an endpoint**, so it has no path to read. It tags its `createSession` call through an `AsyncLocalStorage` scope. Async-local rather than a module flag so two concurrent exchanges cannot read each other's tag; the hook runs synchronously within that call (`queueAfterTransactionHook` executes inline when there is no adapter store), so the scope is live when it reads.

## Deviations from the ticket

- **No `client` (Desktop/Watch) label.** There is no trustworthy client signal — it would have to be parsed out of a `User-Agent` string. `method` already carries the distinction at the granularity we can actually verify, and the raw UA is on the session row.
- **`impersonation` added** to the proposed `token-exchange | oidc | password`. `/admin/impersonate-user` mints a session; without it that would log as `unknown` — and, as above, with the wrong actor.
- **`revoked` deferred**, as the ticket permits. It would have to cover sign-out, admin revoke, and the concurrent-session reaper (which deletes rows through drizzle directly, bypassing hooks) in one change, or it would reproduce exactly the asymmetry this closes.

## UI and schema

No renderer change and no migration. `AUDIT_EVENT_MAP` drives `/audit-log/filters`, which drives both filter dropdowns; `audit_log.object`/`action` are free-text columns.

## Testing

- `session-audit.integration.test.ts` — real Better Auth + real SQLite. A password sign-up/sign-in, a real admin impersonation, and a real token exchange side by side: exactly one row each, correct `method`, correct `userId`/`objectId` against the actual session row, no row for a failed password attempt or a rejected/replayed grant, and an assertion that neither the assertion, the issued token, the `jti`, the email, nor the name appears anywhere in `details`. The impersonation case deletes the session afterwards and asserts both actor and target are still on record.
- `session-audit.test.ts` — the mapping itself, tag-beats-path precedence, no leakage outside a tag's scope, concurrent tags staying isolated, and the impersonation actor swap.
- Red-green verified: **8 of 9** integration tests fail with the hook call removed; **3 of 9** with just the exchange tag removed; **4** fail with the impersonation branch removed.
- Full unit suite green (7934 passed), typecheck and lint clean.

https://claude.ai/code/session_01XrBefX3sLRxZzfwyktYA5R