### PR TITLE
Pre-warm the agent CLI subprocess so session creation doesn't wait on its boot

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -1,4 +1,4 @@
-import { query, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import { query, startup, Options, Query, WarmQuery, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { UUID } from 'crypto';
 import { EventEmitter } from 'events';
@@ -474,6 +474,10 @@ export class ClaudeCodeProcess extends EventEmitter {
   private lastTurnInformationals: SDKMessage[] = [];
   private lastResultMessage: SDKMessage | null = null;
   private lastSessionState: string | null = null;
+  // Pre-spawned CLI subprocess from prewarm(), waiting for a prompt. Claimed
+  // (once) by the next createQuery; see prewarm() for why the handle lives on
+  // the process rather than in a detached pool.
+  private warmHandle: WarmQuery | null = null;
   public slashCommands: { name: string; description: string; argumentHint: string }[] = [];
 
   constructor(options: ClaudeCodeProcessOptions) {
@@ -572,8 +576,49 @@ export class ClaudeCodeProcess extends EventEmitter {
   /**
    * Creates a new query instance with the standard configuration.
    * Used by start(), restart(), and interrupt() to avoid duplication.
+   *
+   * Claims the pre-warmed subprocess when prewarm() left one: its CLI is
+   * already spawned and past the initialize handshake, so the `init` message
+   * (and with it the canonical session id) lands in milliseconds instead of
+   * the ~1-3s a cold spawn costs. The handle is single-use — the SDK closes
+   * over the prompt stream we hand it here — so it is cleared on claim.
    */
   private createQuery(): Query {
+    const warm = this.warmHandle;
+    if (warm) {
+      this.warmHandle = null;
+      console.log(`[Session ${this.sessionId}] createQuery: claiming pre-warmed subprocess`);
+      return warm.query(this.messageQueue!);
+    }
+    return query({ prompt: this.messageQueue!, options: this.buildQueryOptions() });
+  }
+
+  /**
+   * Pre-spawn the CLI subprocess and complete its initialize handshake before
+   * a prompt exists, so the next start() pays no boot cost.
+   *
+   * The warm handle lives on the process (not in a detached pool of bare
+   * option sets) because the options bake in this instance's closures — the
+   * `canUseTool` callback, every hook, and the browser/agents/chat MCP servers
+   * all resolve `this.sessionId` at call time. A handle warmed against one
+   * process could therefore never be handed to another without misrouting
+   * those callbacks. The session manager pools whole pre-warmed processes
+   * instead, and only hands one to a request whose parameters match.
+   */
+  async prewarm(): Promise<void> {
+    if (this.disposed || this.warmHandle || this.queryInstance) return;
+    // Baked into the warm subprocess's options, so initializeQuery must not
+    // replace it on claim or the warm process would be unstoppable.
+    this.abortController = new AbortController();
+    this.warmHandle = await startup({ options: this.buildQueryOptions() });
+  }
+
+  /** Whether a pre-warmed subprocess is parked on this process, unclaimed. */
+  isPrewarmed(): boolean {
+    return this.warmHandle !== null;
+  }
+
+  private buildQueryOptions(): Options {
     const remoteMcpConfigs = this.buildRemoteMcpServers();
     const remoteMcpToolPatterns = Object.keys(remoteMcpConfigs).map(name => `mcp__${name}__*`);
 
@@ -601,345 +646,353 @@ export class ClaudeCodeProcess extends EventEmitter {
       ],
     });
 
-    return query({
-      prompt: this.messageQueue!,
-      options: {
-        model: this.model,
-        cwd: this.workingDirectory,
-        abortController: this.abortController!,
-        resume: this.claudeSessionId || undefined,
-        permissionMode: 'bypassPermissions',
-        includePartialMessages: true,
-        agentProgressSummaries: true,
-        // Expose the dynamic-workflows `Workflow` tool. In headless/SDK mode the
-        // feature is hidden unless explicitly opted in (there is no interactive
-        // /config to record consent, so the SDK defaults it OFF). There is no
-        // enable env var — only CLAUDE_CODE_DISABLE_WORKFLOWS — so we set it via
-        // the `settings` flag layer (`enableWorkflows` is a Settings field, not a
-        // top-level Option). Without it the model can't see a Workflow tool at all
-        // and falls back to simulating with Agent subagents.
-        settings: { enableWorkflows: capabilityTools.enableWorkflows },
-        settingSources: ['user', 'project'],
-        allowedTools: capabilityTools.allowedTools,
-        disallowedTools: capabilityTools.disallowedTools,
-        // Request summarized thinking so reasoning text streams to the UI. Without an
-        // explicit `display`, Opus 4.8/4.7 default to `omitted` — thinking_delta events
-        // arrive empty (only a signature), so the UI can show "Thinking" but no text.
-        thinking: this.maxThinkingTokens
-          ? { type: 'enabled', budgetTokens: this.maxThinkingTokens, display: 'summarized' }
-          : { type: 'adaptive', display: 'summarized' },
-        ...(this.maxTurns && { maxTurns: this.maxTurns }),
-        ...(this.maxBudgetUsd && { maxBudgetUsd: this.maxBudgetUsd }),
-        ...(this.effort && { effort: this.effort }),
-        // withAgentAttributionHeaders folds the host-injected agent identity env
-        // vars into ANTHROPIC_CUSTOM_HEADERS (composed here, after the custom-env
-        // merge, so a user-set ANTHROPIC_CUSTOM_HEADERS is appended to, not lost).
-        // withSpeedHeader then appends X-Superagent-Speed for non-normal tiers.
-        env: withSpeedHeader(withAgentAttributionHeaders({
-          // Agent SDK 0.2.113+ replaces process.env with options.env instead of
-          // overlaying it, so we must spread process.env explicitly or the Claude
-          // subprocess loses PATH, HOME, ANTHROPIC_API_KEY, connected-account env
-          // vars, and anything else set on the container.
-          ...process.env,
-          ...this.customEnvVars,
-          // Emit `session_state_changed` system events (idle/running/requires_action).
-          // The host treats `idle` as the authoritative end-of-session signal (a
-          // 'result' alone doesn't end it — queued messages can keep the run going).
-          // server.ts announces this capability on WebSocket connect — keep the two
-          // in sync. See message-persister.ts.
-          CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
-          // CLI 2.1.212+ moves MCP tool calls that run >2min to a background
-          // task. Our blocking user-input tools (request_user_input et al.)
-          // legitimately block far longer than that waiting on a human, and
-          // the pending-request lifecycle depends on the call staying
-          // foreground until resolved — so disable auto-backgrounding.
-          CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS: '0',
-          // Explicit maxOutputTokens setting takes precedence over custom env var
-          ...(this.maxOutputTokens && { CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(this.maxOutputTokens) }),
-        }), this.speed),
-        mcpServers: {
-          'user-input': createUserInputMcpServer(),
-          'browser': createBrowserMcpServer(browserMcpTools),
-          'dashboards': createDashboardsMcpServer(),
-          'agents': createAgentsMcpServer(() => this.sessionId),
-          'chat': createChatMcpServer(() => this.sessionId),
-          ...((this.webSearchProvider || this.webFetchProvider)
-            ? { 'web': createWebMcpServer({ search: !!this.webSearchProvider, fetch: !!this.webFetchProvider }) }
-            : {}),
-          ...(isComputerUseHost() ? { 'computer-use': createComputerUseMcpServer() } : {}),
-          ...remoteMcpConfigs,
+    return {
+      model: this.model,
+      cwd: this.workingDirectory,
+      abortController: this.abortController!,
+      resume: this.claudeSessionId || undefined,
+      permissionMode: 'bypassPermissions',
+      includePartialMessages: true,
+      agentProgressSummaries: true,
+      // Expose the dynamic-workflows `Workflow` tool. In headless/SDK mode the
+      // feature is hidden unless explicitly opted in (there is no interactive
+      // /config to record consent, so the SDK defaults it OFF). There is no
+      // enable env var — only CLAUDE_CODE_DISABLE_WORKFLOWS — so we set it via
+      // the `settings` flag layer (`enableWorkflows` is a Settings field, not a
+      // top-level Option). Without it the model can't see a Workflow tool at all
+      // and falls back to simulating with Agent subagents.
+      settings: { enableWorkflows: capabilityTools.enableWorkflows },
+      settingSources: ['user', 'project'],
+      allowedTools: capabilityTools.allowedTools,
+      disallowedTools: capabilityTools.disallowedTools,
+      // Request summarized thinking so reasoning text streams to the UI. Without an
+      // explicit `display`, Opus 4.8/4.7 default to `omitted` — thinking_delta events
+      // arrive empty (only a signature), so the UI can show "Thinking" but no text.
+      thinking: this.maxThinkingTokens
+        ? { type: 'enabled', budgetTokens: this.maxThinkingTokens, display: 'summarized' }
+        : { type: 'adaptive', display: 'summarized' },
+      ...(this.maxTurns && { maxTurns: this.maxTurns }),
+      ...(this.maxBudgetUsd && { maxBudgetUsd: this.maxBudgetUsd }),
+      ...(this.effort && { effort: this.effort }),
+      // withAgentAttributionHeaders folds the host-injected agent identity env
+      // vars into ANTHROPIC_CUSTOM_HEADERS (composed here, after the custom-env
+      // merge, so a user-set ANTHROPIC_CUSTOM_HEADERS is appended to, not lost).
+      // withSpeedHeader then appends X-Superagent-Speed for non-normal tiers.
+      env: withSpeedHeader(withAgentAttributionHeaders({
+        // Agent SDK 0.2.113+ replaces process.env with options.env instead of
+        // overlaying it, so we must spread process.env explicitly or the Claude
+        // subprocess loses PATH, HOME, ANTHROPIC_API_KEY, connected-account env
+        // vars, and anything else set on the container.
+        ...process.env,
+        ...this.customEnvVars,
+        // Emit `session_state_changed` system events (idle/running/requires_action).
+        // The host treats `idle` as the authoritative end-of-session signal (a
+        // 'result' alone doesn't end it — queued messages can keep the run going).
+        // server.ts announces this capability on WebSocket connect — keep the two
+        // in sync. See message-persister.ts.
+        CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
+        // CLI 2.1.212+ moves MCP tool calls that run >2min to a background
+        // task. Our blocking user-input tools (request_user_input et al.)
+        // legitimately block far longer than that waiting on a human, and
+        // the pending-request lifecycle depends on the call staying
+        // foreground until resolved — so disable auto-backgrounding.
+        CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS: '0',
+        // Boot-path network work we never benefit from: the CLI fetches
+        // feature flags and posts telemetry/error reports before the first
+        // turn, which measured ~400ms of the session-start wait and can hang
+        // far longer when egress is restricted. One switch covers the
+        // auto-updater, /bug uploads, error reporting and telemetry.
+        // Trade-off: it also stops remote feature-flag evaluation, so
+        // server-side flags and killswitches no longer reach our sessions —
+        // acceptable because the CLI version is pinned by the image, not
+        // self-updated. Pinned like the other vars here: customEnvVars is
+        // spread above, so an agent cannot turn this back on.
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+        // Explicit maxOutputTokens setting takes precedence over custom env var
+        ...(this.maxOutputTokens && { CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(this.maxOutputTokens) }),
+      }), this.speed),
+      mcpServers: {
+        'user-input': createUserInputMcpServer(),
+        'browser': createBrowserMcpServer(browserMcpTools),
+        'dashboards': createDashboardsMcpServer(),
+        'agents': createAgentsMcpServer(() => this.sessionId),
+        'chat': createChatMcpServer(() => this.sessionId),
+        ...((this.webSearchProvider || this.webFetchProvider)
+          ? { 'web': createWebMcpServer({ search: !!this.webSearchProvider, fetch: !!this.webFetchProvider }) }
+          : {}),
+        ...(isComputerUseHost() ? { 'computer-use': createComputerUseMcpServer() } : {}),
+        ...remoteMcpConfigs,
+      },
+      agents: {
+        'web-browser': {
+          description: 'Web browsing specialist. Delegate any task that requires interacting with websites — navigating pages, filling forms, clicking buttons, extracting information, searching for products, changing settings on web services, or any multi-step web interaction. The browser should already be open (use browser_open first). This agent runs on a cheaper model and handles all browser interactions autonomously.',
+          // Host-resolved concrete wire id for the browser model (any provider/
+          // model the user configured); AgentDefinition.model is a plain string.
+          // Fall back to the main model — never a hardcoded Claude alias, which
+          // would force Anthropic on non-Anthropic providers.
+          model: this.browserModel || this.model,
+          tools: [
+            ...mcpToolNames('browser', browserMcpTools),
+            // The subagent hard-codes its tools, so swap native WebSearch for the vendor tool
+            // when one is active (native is Anthropic-server-side, absent on non-Claude models).
+            ...(this.webSearchProvider ? ['mcp__web__web_search'] : ['WebSearch']),
+            'Read',
+            'mcp__user-input__request_file',
+            'mcp__user-input__request_browser_input',
+          ],
+          prompt: WEB_BROWSER_AGENT_PROMPT,
+          maxTurns: 500,
         },
-        agents: {
-          'web-browser': {
-            description: 'Web browsing specialist. Delegate any task that requires interacting with websites — navigating pages, filling forms, clicking buttons, extracting information, searching for products, changing settings on web services, or any multi-step web interaction. The browser should already be open (use browser_open first). This agent runs on a cheaper model and handles all browser interactions autonomously.',
-            // Host-resolved concrete wire id for the browser model (any provider/
-            // model the user configured); AgentDefinition.model is a plain string.
-            // Fall back to the main model — never a hardcoded Claude alias, which
-            // would force Anthropic on non-Anthropic providers.
+        'dashboard-builder': {
+          description: 'Dashboard building specialist. Delegate any task that involves creating, editing, or debugging dashboards (artifacts) — designing layouts, writing HTML/CSS/JS or React code, adding charts, connecting to data sources, fixing visual issues, or iterating on dashboard design. This agent handles the full build cycle: scaffolding, coding, starting, and verifying via screenshots.',
+          // Host-resolved dashboard-builder model (its own setting); falls back to
+          // the main model rather than a hardcoded Claude alias.
+          model: this.dashboardBuilderModel || this.model,
+          tools: [
+            'mcp__dashboards__create_dashboard',
+            'mcp__dashboards__start_dashboard',
+            'mcp__dashboards__list_dashboards',
+            'mcp__dashboards__get_dashboard_logs',
+            'Read',
+            'Write',
+            'Edit',
+            'Bash',
+          ],
+          prompt: DASHBOARD_BUILDER_AGENT_PROMPT,
+          maxTurns: 200,
+        },
+        ...(isComputerUseHost() ? {
+          'computer-use': {
+            description: 'Desktop automation specialist for macOS and Windows. Delegate any task that requires interacting with native applications — clicking buttons, filling forms, reading screen content, navigating menus, or any multi-step app interaction. The app should already be launched and grabbed (use computer_launch first). This agent runs on a cheaper model and handles all app interactions autonomously.',
+            // Cheap tier (browser model); falls back to the main model — never a
+            // hardcoded Claude alias.
             model: this.browserModel || this.model,
             tools: [
-              ...mcpToolNames('browser', browserMcpTools),
-              // The subagent hard-codes its tools, so swap native WebSearch for the vendor tool
-              // when one is active (native is Anthropic-server-side, absent on non-Claude models).
-              ...(this.webSearchProvider ? ['mcp__web__web_search'] : ['WebSearch']),
+              ...mcpToolNames('computer-use', computerUseTools, ['computer_launch', 'computer_quit', 'computer_ungrab']),
               'Read',
-              'mcp__user-input__request_file',
-              'mcp__user-input__request_browser_input',
             ],
-            prompt: WEB_BROWSER_AGENT_PROMPT,
+            prompt: COMPUTER_USE_AGENT_PROMPT,
             maxTurns: 500,
           },
-          'dashboard-builder': {
-            description: 'Dashboard building specialist. Delegate any task that involves creating, editing, or debugging dashboards (artifacts) — designing layouts, writing HTML/CSS/JS or React code, adding charts, connecting to data sources, fixing visual issues, or iterating on dashboard design. This agent handles the full build cycle: scaffolding, coding, starting, and verifying via screenshots.',
-            // Host-resolved dashboard-builder model (its own setting); falls back to
-            // the main model rather than a hardcoded Claude alias.
-            model: this.dashboardBuilderModel || this.model,
-            tools: [
-              'mcp__dashboards__create_dashboard',
-              'mcp__dashboards__start_dashboard',
-              'mcp__dashboards__list_dashboards',
-              'mcp__dashboards__get_dashboard_logs',
-              'Read',
-              'Write',
-              'Edit',
-              'Bash',
+        } : {}),
+      },
+      // Handle AskUserQuestion via canUseTool callback (per SDK docs)
+      canUseTool: async (toolName: string, toolInput: Record<string, unknown>, options: { toolUseID: string; signal: AbortSignal }) => {
+        if (toolName === 'AskUserQuestion') {
+          console.log('[canUseTool] AskUserQuestion called, toolUseID:', options.toolUseID);
+
+          const questions = toolInput.questions as Array<{
+            question: string;
+            header: string;
+            options: Array<{ label: string; description: string }>;
+            multiSelect: boolean;
+          }> | undefined;
+
+          if (!questions?.length) {
+            console.log('[canUseTool] No questions, allowing tool to proceed');
+            return { behavior: 'allow' as const, updatedInput: toolInput };
+          }
+
+          const requestId = options.toolUseID || `ask-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+          console.log('[canUseTool] Creating pending request:', requestId);
+
+          try {
+            // Block until user answers via our UI
+            const answers = await inputManager.createPendingWithType<Record<string, string>>(
+              requestId,
+              'question',
+              questions,
+              this.sessionId
+            );
+
+            console.log('[canUseTool] Got answers:', JSON.stringify(answers));
+
+            // Return answers to Claude
+            return {
+              behavior: 'allow' as const,
+              updatedInput: { questions, answers },
+            };
+          } catch (error) {
+            console.log('[canUseTool] User declined:', error);
+            return {
+              behavior: 'deny' as const,
+              message: error instanceof Error ? error.message : 'User declined to answer',
+            };
+          }
+        }
+
+        // For MCP user-input tools called by subagents, set the toolUseId
+        // so the tool handler can consume it. PreToolUse hooks may not fire
+        // for subagent tool calls, so we set it here as well.
+        // TODO: Race condition — if both canUseTool and PreToolUse fire for
+        // the same tool call, the last write wins (setCurrentToolUseId is
+        // not additive). This is acceptable because they write the same ID,
+        // but if two user-input tools fire concurrently the first ID could
+        // be overwritten before consumeCurrentToolUseId is called.
+        if ((toolName.startsWith('mcp__user-input__') || toolName.startsWith('mcp__computer-use__')) && options.toolUseID) {
+          inputManager.setCurrentToolUseId(options.toolUseID, this.sessionId);
+        }
+
+        // Auto-approve other tools (we're in bypassPermissions mode)
+        return { behavior: 'allow' as const, updatedInput: toolInput };
+      },
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'mcp__user-input__.*',
+            hooks: [
+              async (_input, toolUseId) => {
+                if (toolUseId) {
+                  inputManager.setCurrentToolUseId(toolUseId, this.sessionId);
+                }
+                return {};
+              },
             ],
-            prompt: DASHBOARD_BUILDER_AGENT_PROMPT,
-            maxTurns: 200,
           },
-          ...(isComputerUseHost() ? {
-            'computer-use': {
-              description: 'Desktop automation specialist for macOS and Windows. Delegate any task that requires interacting with native applications — clicking buttons, filling forms, reading screen content, navigating menus, or any multi-step app interaction. The app should already be launched and grabbed (use computer_launch first). This agent runs on a cheaper model and handles all app interactions autonomously.',
-              // Cheap tier (browser model); falls back to the main model — never a
-              // hardcoded Claude alias.
-              model: this.browserModel || this.model,
-              tools: [
-                ...mcpToolNames('computer-use', computerUseTools, ['computer_launch', 'computer_quit', 'computer_ungrab']),
-                'Read',
-              ],
-              prompt: COMPUTER_USE_AGENT_PROMPT,
-              maxTurns: 500,
-            },
-          } : {}),
-        },
-        // Handle AskUserQuestion via canUseTool callback (per SDK docs)
-        canUseTool: async (toolName: string, toolInput: Record<string, unknown>, options: { toolUseID: string; signal: AbortSignal }) => {
-          if (toolName === 'AskUserQuestion') {
-            console.log('[canUseTool] AskUserQuestion called, toolUseID:', options.toolUseID);
-
-            const questions = toolInput.questions as Array<{
-              question: string;
-              header: string;
-              options: Array<{ label: string; description: string }>;
-              multiSelect: boolean;
-            }> | undefined;
-
-            if (!questions?.length) {
-              console.log('[canUseTool] No questions, allowing tool to proceed');
-              return { behavior: 'allow' as const, updatedInput: toolInput };
-            }
-
-            const requestId = options.toolUseID || `ask-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
-            console.log('[canUseTool] Creating pending request:', requestId);
-
-            try {
-              // Block until user answers via our UI
-              const answers = await inputManager.createPendingWithType<Record<string, string>>(
-                requestId,
-                'question',
-                questions,
-                this.sessionId
-              );
-
-              console.log('[canUseTool] Got answers:', JSON.stringify(answers));
-
-              // Return answers to Claude
-              return {
-                behavior: 'allow' as const,
-                updatedInput: { questions, answers },
-              };
-            } catch (error) {
-              console.log('[canUseTool] User declined:', error);
-              return {
-                behavior: 'deny' as const,
-                message: error instanceof Error ? error.message : 'User declined to answer',
-              };
-            }
-          }
-
-          // For MCP user-input tools called by subagents, set the toolUseId
-          // so the tool handler can consume it. PreToolUse hooks may not fire
-          // for subagent tool calls, so we set it here as well.
-          // TODO: Race condition — if both canUseTool and PreToolUse fire for
-          // the same tool call, the last write wins (setCurrentToolUseId is
-          // not additive). This is acceptable because they write the same ID,
-          // but if two user-input tools fire concurrently the first ID could
-          // be overwritten before consumeCurrentToolUseId is called.
-          if ((toolName.startsWith('mcp__user-input__') || toolName.startsWith('mcp__computer-use__')) && options.toolUseID) {
-            inputManager.setCurrentToolUseId(options.toolUseID, this.sessionId);
-          }
-
-          // Auto-approve other tools (we're in bypassPermissions mode)
-          return { behavior: 'allow' as const, updatedInput: toolInput };
-        },
-        hooks: {
-          PreToolUse: [
-            {
-              matcher: 'mcp__user-input__.*',
-              hooks: [
-                async (_input, toolUseId) => {
-                  if (toolUseId) {
-                    inputManager.setCurrentToolUseId(toolUseId, this.sessionId);
-                  }
-                  return {};
+          {
+            matcher: 'mcp__computer-use__.*',
+            hooks: [
+              async (_input, toolUseId) => {
+                if (toolUseId) {
+                  inputManager.setCurrentToolUseId(toolUseId, this.sessionId);
+                }
+                return {};
+              },
+            ],
+          },
+          {
+            matcher: 'Bash',
+            hooks: [
+              async (input) => {
+                const toolInput = (input as any).tool_input as Record<string, unknown> | undefined;
+                if (!startsWithAgentBrowserCommand(toolInput?.command)) return {};
+                return {
+                  hookSpecificOutput: {
+                    hookEventName: 'PreToolUse' as const,
+                    additionalContext: AGENT_BROWSER_BASH_WARNING,
+                  },
+                };
+              },
+            ],
+          },
+          {
+            // Launch-policy gate for subagents/workflows — see
+            // createCapabilityGateHook for why this is a hook and not
+            // canUseTool.
+            matcher: '^(Task|Agent|Workflow)$',
+            timeout: CAPABILITY_REVIEW_HOOK_TIMEOUT_S,
+            hooks: [
+              createCapabilityGateHook({
+                sessionId: this.sessionId,
+                getPolicies: () => this.capabilityPolicies,
+                getSessionGrants: () => this.sessionCapabilityGrants,
+                onSessionGrant: (capability) => {
+                  this.sessionCapabilityGrants.add(capability);
+                  // Session-manager persists it so the grant survives eviction+resume.
+                  this.emit('capability-grant', { capability });
                 },
-              ],
-            },
-            {
-              matcher: 'mcp__computer-use__.*',
-              hooks: [
-                async (_input, toolUseId) => {
-                  if (toolUseId) {
-                    inputManager.setCurrentToolUseId(toolUseId, this.sessionId);
-                  }
-                  return {};
+                onReviewCancelled: (cancelledToolUseId, capability) => {
+                  // Same relay as SDK frames (persister → SSE → renderer),
+                  // so the host closes the orphaned approval card.
+                  this.emit('message', {
+                    type: 'capability_review_cancelled',
+                    toolUseId: cancelledToolUseId,
+                    capability,
+                    session_id: this.claudeSessionId || this.sessionId,
+                  });
                 },
-              ],
-            },
-            {
-              matcher: 'Bash',
-              hooks: [
-                async (input) => {
-                  const toolInput = (input as any).tool_input as Record<string, unknown> | undefined;
-                  if (!startsWithAgentBrowserCommand(toolInput?.command)) return {};
+              }),
+            ],
+          },
+          {
+            matcher: 'mcp__agents__create_agent',
+            hooks: [
+              async () => {
+                if (this.userMessageCount <= 1 && !this.isResumedSession) {
                   return {
                     hookSpecificOutput: {
                       hookEventName: 'PreToolUse' as const,
-                      additionalContext: AGENT_BROWSER_BASH_WARNING,
+                      permissionDecision: 'deny' as const,
+                      permissionDecisionReason:
+                        'This is the first message in the session. When users say "create an agent to..." they almost always mean they want YOU (the current agent) to to be this agent. Please re-read the user\'s message — they are likely asking you to build this agent in your current workspace - not as a seperate one. Only create a new agent if the user explicitly and unambiguously asks to set up a separate, reusable agent definition.',
                     },
                   };
-                },
-              ],
-            },
-            {
-              // Launch-policy gate for subagents/workflows — see
-              // createCapabilityGateHook for why this is a hook and not
-              // canUseTool.
-              matcher: '^(Task|Agent|Workflow)$',
-              timeout: CAPABILITY_REVIEW_HOOK_TIMEOUT_S,
-              hooks: [
-                createCapabilityGateHook({
-                  sessionId: this.sessionId,
-                  getPolicies: () => this.capabilityPolicies,
-                  getSessionGrants: () => this.sessionCapabilityGrants,
-                  onSessionGrant: (capability) => {
-                    this.sessionCapabilityGrants.add(capability);
-                    // Session-manager persists it so the grant survives eviction+resume.
-                    this.emit('capability-grant', { capability });
-                  },
-                  onReviewCancelled: (cancelledToolUseId, capability) => {
-                    // Same relay as SDK frames (persister → SSE → renderer),
-                    // so the host closes the orphaned approval card.
-                    this.emit('message', {
-                      type: 'capability_review_cancelled',
-                      toolUseId: cancelledToolUseId,
-                      capability,
-                      session_id: this.claudeSessionId || this.sessionId,
-                    });
-                  },
-                }),
-              ],
-            },
-            {
-              matcher: 'mcp__agents__create_agent',
-              hooks: [
-                async () => {
-                  if (this.userMessageCount <= 1 && !this.isResumedSession) {
-                    return {
-                      hookSpecificOutput: {
-                        hookEventName: 'PreToolUse' as const,
-                        permissionDecision: 'deny' as const,
-                        permissionDecisionReason:
-                          'This is the first message in the session. When users say "create an agent to..." they almost always mean they want YOU (the current agent) to to be this agent. Please re-read the user\'s message — they are likely asking you to build this agent in your current workspace - not as a seperate one. Only create a new agent if the user explicitly and unambiguously asks to set up a separate, reusable agent definition.',
-                      },
-                    };
+                }
+                return {};
+              },
+            ],
+          },
+          {
+            matcher: 'Write',
+            hooks: [
+              async (input) => {
+                const toolInput = (input as any).tool_input as Record<string, unknown>;
+                const filePath = resolveToolFilePath(toolInput, this.workingDirectory);
+                if (!filePath) return {};
+                for (const hook of fileHooks) {
+                  if (!hook.matches(filePath)) continue;
+                  const result = hook.onWrite(filePath, toolInput.content as string);
+                  if (result.error) {
+                    return { hookSpecificOutput: { hookEventName: 'PreToolUse' as const, permissionDecision: 'deny' as const, permissionDecisionReason: result.error } };
                   }
-                  return {};
-                },
-              ],
-            },
-            {
-              matcher: 'Write',
-              hooks: [
-                async (input) => {
-                  const toolInput = (input as any).tool_input as Record<string, unknown>;
-                  const filePath = resolveToolFilePath(toolInput, this.workingDirectory);
-                  if (!filePath) return {};
-                  for (const hook of fileHooks) {
-                    if (!hook.matches(filePath)) continue;
-                    const result = hook.onWrite(filePath, toolInput.content as string);
+                  if (result.warning) {
+                    return { hookSpecificOutput: { hookEventName: 'PreToolUse' as const, additionalContext: result.warning } };
+                  }
+                }
+                return {};
+              },
+            ],
+          },
+        ],
+        PostToolUse: [
+          {
+            matcher: 'Read',
+            hooks: [
+              async (input) => {
+                const toolInput = (input as any).tool_input as Record<string, unknown>;
+                const filePath = resolveToolFilePath(toolInput, this.workingDirectory);
+                if (!filePath) return {};
+                for (const hook of fileHooks) {
+                  if (!hook.matches(filePath)) continue;
+                  const result = hook.onRead(filePath);
+                  if (result.additionalContext) {
+                    return { hookSpecificOutput: { hookEventName: 'PostToolUse' as const, additionalContext: result.additionalContext } };
+                  }
+                }
+                return {};
+              },
+            ],
+          },
+          {
+            matcher: 'Edit',
+            hooks: [
+              async (input) => {
+                const toolInput = (input as any).tool_input as Record<string, unknown>;
+                const filePath = resolveToolFilePath(toolInput, this.workingDirectory);
+                if (!filePath) return {};
+                for (const hook of fileHooks) {
+                  if (!hook.matches(filePath)) continue;
+                  try {
+                    const content = await fs.promises.readFile(filePath, 'utf-8');
+                    const result = hook.onEdit(filePath, content);
                     if (result.error) {
-                      return { hookSpecificOutput: { hookEventName: 'PreToolUse' as const, permissionDecision: 'deny' as const, permissionDecisionReason: result.error } };
+                      return { hookSpecificOutput: { hookEventName: 'PostToolUse' as const, additionalContext: `Warning: ${result.error}` } };
                     }
                     if (result.warning) {
-                      return { hookSpecificOutput: { hookEventName: 'PreToolUse' as const, additionalContext: result.warning } };
+                      return { hookSpecificOutput: { hookEventName: 'PostToolUse' as const, additionalContext: result.warning } };
                     }
+                  } catch {
+                    // File may not exist yet after edit — skip
                   }
-                  return {};
-                },
-              ],
-            },
-          ],
-          PostToolUse: [
-            {
-              matcher: 'Read',
-              hooks: [
-                async (input) => {
-                  const toolInput = (input as any).tool_input as Record<string, unknown>;
-                  const filePath = resolveToolFilePath(toolInput, this.workingDirectory);
-                  if (!filePath) return {};
-                  for (const hook of fileHooks) {
-                    if (!hook.matches(filePath)) continue;
-                    const result = hook.onRead(filePath);
-                    if (result.additionalContext) {
-                      return { hookSpecificOutput: { hookEventName: 'PostToolUse' as const, additionalContext: result.additionalContext } };
-                    }
-                  }
-                  return {};
-                },
-              ],
-            },
-            {
-              matcher: 'Edit',
-              hooks: [
-                async (input) => {
-                  const toolInput = (input as any).tool_input as Record<string, unknown>;
-                  const filePath = resolveToolFilePath(toolInput, this.workingDirectory);
-                  if (!filePath) return {};
-                  for (const hook of fileHooks) {
-                    if (!hook.matches(filePath)) continue;
-                    try {
-                      const content = await fs.promises.readFile(filePath, 'utf-8');
-                      const result = hook.onEdit(filePath, content);
-                      if (result.error) {
-                        return { hookSpecificOutput: { hookEventName: 'PostToolUse' as const, additionalContext: `Warning: ${result.error}` } };
-                      }
-                      if (result.warning) {
-                        return { hookSpecificOutput: { hookEventName: 'PostToolUse' as const, additionalContext: result.warning } };
-                      }
-                    } catch {
-                      // File may not exist yet after edit — skip
-                    }
-                  }
-                  return {};
-                },
-              ],
-            },
-          ],
-        },
-        systemPrompt: this.systemPrompt,
+                }
+                return {};
+              },
+            ],
+          },
+        ],
       },
-    });
+      systemPrompt: this.systemPrompt,
+    };
   }
 
   /**
@@ -949,7 +1002,12 @@ export class ClaudeCodeProcess extends EventEmitter {
     // New query generation: a stale processMessages loop from a previous
     // query must not clobber this one's state when it finally unwinds.
     this.queryGeneration++;
-    this.abortController = new AbortController();
+    // A pre-warmed subprocess was spawned with prewarm()'s AbortController
+    // already baked into its options; replacing it here would leave that
+    // subprocess with no way to be aborted.
+    if (!this.warmHandle) {
+      this.abortController = new AbortController();
+    }
     this.messageQueue = new MessageQueue();
     this.queryInstance = this.createQuery();
     this.isReady = true;
@@ -1319,6 +1377,14 @@ export class ClaudeCodeProcess extends EventEmitter {
   private async performStop(options?: { graceful?: boolean; graceMs?: number }): Promise<void> {
     console.log(`[Session ${this.sessionId}] Stopping session${options?.graceful ? ' (graceful)' : ''}`);
     this.stopping = true;
+
+    // An unclaimed warm subprocess has no prompt stream and no message loop —
+    // nothing below would ever reach it, so it would outlive the session as an
+    // orphan. close() is the SDK's discard path for exactly this.
+    if (this.warmHandle) {
+      this.warmHandle.close();
+      this.warmHandle = null;
+    }
 
     // Close the message queue to signal end of input
     if (this.messageQueue) {

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -379,12 +379,6 @@ export class MessageQueue {
   }
 }
 
-// Module-level reference to the current process (one per container)
-let currentProcess: ClaudeCodeProcess | null = null;
-export function getCurrentProcess(): ClaudeCodeProcess | null {
-  return currentProcess;
-}
-
 export interface ClaudeCodeProcessOptions {
   sessionId: string;
   workingDirectory: string;
@@ -514,8 +508,6 @@ export class ClaudeCodeProcess extends EventEmitter {
       options.webFetchProvider,
       options.capabilityPolicies
     );
-    // Set module-level reference for tools that need access to the process
-    currentProcess = this;
   }
 
   /**
@@ -712,7 +704,7 @@ export class ClaudeCodeProcess extends EventEmitter {
         ...(this.maxOutputTokens && { CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(this.maxOutputTokens) }),
       }), this.speed),
       mcpServers: {
-        'user-input': createUserInputMcpServer(),
+        'user-input': createUserInputMcpServer(() => this),
         'browser': createBrowserMcpServer(browserMcpTools),
         'dashboards': createDashboardsMcpServer(),
         'agents': createAgentsMcpServer(() => this.sessionId),

--- a/agent-container/src/mcp-server.ts
+++ b/agent-container/src/mcp-server.ts
@@ -11,7 +11,7 @@ import { webFetchTool } from './tools/web/web-fetch'
 import { requestSecretTool } from './tools/request-secret'
 import { requestConnectedAccountTool } from './tools/request-connected-account'
 import { searchConnectedAccountServicesTool } from './tools/search-connected-account-services'
-import { requestRemoteMcpTool } from './tools/request-remote-mcp'
+import { createRequestRemoteMcpTool, type RemoteMcpInjectionTarget } from './tools/request-remote-mcp'
 import { searchRemoteMcpServicesTool } from './tools/search-remote-mcp-services'
 import {
   scheduleTaskTool,
@@ -61,7 +61,7 @@ import { makeSendChatMessageTool } from './tools/chat/send-chat-message'
  * one transport connection per server at a time. Reusing singletons across
  * sessions causes "Already connected to a transport" errors.
  */
-export function createUserInputMcpServer() {
+export function createUserInputMcpServer(getProcess: () => RemoteMcpInjectionTarget | null = () => null) {
   // Only expose script execution tool on supported host platforms (macOS/Windows)
   const hostPlatform = process.env.HOST_PLATFORM
   const includeScriptRun = hostPlatform === 'darwin' || hostPlatform === 'win32'
@@ -78,7 +78,7 @@ export function createUserInputMcpServer() {
     version: '1.0.0',
     tools: [
       requestSecretTool, requestConnectedAccountTool, searchConnectedAccountServicesTool,
-      requestRemoteMcpTool, searchRemoteMcpServicesTool,
+      createRequestRemoteMcpTool(getProcess), searchRemoteMcpServicesTool,
       scheduleTaskTool, scheduleResumeTool, listScheduledTasksTool, cancelScheduledTaskTool,
       pauseScheduledTaskTool, resumeScheduledTaskTool,
       deliverFileTool, deliverSessionTool, requestFileTool, requestBrowserInputTool,

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -450,14 +450,18 @@ app.post('/env', async (c) => {
     process.env[body.key] = body.value;
     console.log(`[ENV] Set environment variable: ${body.key} (${body.value.length} chars)`);
 
+    // A pre-warmed subprocess captured the old env when it spawned (REMOTE_MCPS
+    // in particular is read while building its query options), so it would run
+    // the next session against a stale view. Invalidated here — immediately
+    // after the env changes and BEFORE the awaited file write below — so a
+    // session arriving in that window cannot claim the stale process. The
+    // generation bump inside is synchronous and also rejects a warm-up that is
+    // still spawning; the next createSession re-warms from the current env.
+    const discarded = sessionManager.discardPrewarmed(`env var ${body.key} changed`);
+
     // Also write to .env file (for uv/python scripts)
     await updateEnvFile(body.key, body.value);
-
-    // A parked pre-warmed subprocess captured the old env when it spawned
-    // (REMOTE_MCPS in particular is read while building its query options), so
-    // it would run the next session against a stale view. Drop it and let the
-    // next createSession re-warm from the current env.
-    await sessionManager.discardPrewarmed(`env var ${body.key} changed`);
+    await discarded;
 
     // Verify it was set in process.env
     if (process.env[body.key] !== body.value) {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -453,6 +453,12 @@ app.post('/env', async (c) => {
     // Also write to .env file (for uv/python scripts)
     await updateEnvFile(body.key, body.value);
 
+    // A parked pre-warmed subprocess captured the old env when it spawned
+    // (REMOTE_MCPS in particular is read while building its query options), so
+    // it would run the next session against a stale view. Drop it and let the
+    // next createSession re-warm from the current env.
+    await sessionManager.discardPrewarmed(`env var ${body.key} changed`);
+
     // Verify it was set in process.env
     if (process.env[body.key] !== body.value) {
       console.error(`[ENV] Failed to verify env var was set: ${body.key}`);
@@ -2566,6 +2572,13 @@ function handleBrowserStreamConnection(ws: WebSocket) {
     if (cdpScreencast?.clientWs === ws) cleanupCdpScreencast();
   });
 }
+
+// Spawn a CLI subprocess for the shape of the last session this workspace ran,
+// so the first session after a wake doesn't pay the boot cost inline. No-op
+// until a session has been created here at least once. Kicked off before the
+// dashboard scan below: on a cold container the two compete for the same two
+// CPUs, and only this one is in front of a waiting user.
+sessionManager.prewarmFromLastProfile();
 
 // Start dashboard processes asynchronously (don't block server startup)
 dashboardManager.scanAndStartAll().catch((error) => {

--- a/agent-container/src/session-gc-durability.e2e.test.ts
+++ b/agent-container/src/session-gc-durability.e2e.test.ts
@@ -149,6 +149,7 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
     'turns from a resumed (post-eviction) query survive on disk and across a manager restart',
     async () => {
       const manager = new SessionManager(workDir, {
+      prewarmEnabled: false,
         idleEvictionMs: 0,
         automatedIdleEvictionMs: 0,
         evictionPollMs: 500,
@@ -180,6 +181,7 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
       // Fresh manager = container restart.
       await manager.stopAll();
       const manager2 = new SessionManager(workDir, {
+      prewarmEnabled: false,
         idleEvictionMs: 60 * 60_000,
         automatedIdleEvictionMs: 60 * 60_000,
         evictionPollMs: 60_000,
@@ -208,6 +210,7 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
     'a shouldQuery:false append into a cold automated session reaches disk despite instant eviction',
     async () => {
       const manager = new SessionManager(workDir, {
+      prewarmEnabled: false,
         idleEvictionMs: 0,
         automatedIdleEvictionMs: 0,
         evictionPollMs: 250,
@@ -266,6 +269,7 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
       // queued follow-up. If a future CLI/SDK does, a threshold-0 sweep
       // landing in that gap would evict and silently kill the queued message.
       const manager = new SessionManager(workDir, {
+      prewarmEnabled: false,
         idleEvictionMs: 0, // human promotion flips class → keep both classes at 0
         automatedIdleEvictionMs: 0,
         evictionPollMs: 250,
@@ -302,6 +306,7 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
       // and workflows ride the same type-agnostic task_id bookkeeping and
       // are covered by the fixture replays.
       const manager = new SessionManager(workDir, {
+      prewarmEnabled: false,
         idleEvictionMs: 60 * 60_000,
         automatedIdleEvictionMs: 0, // most aggressive class
         evictionPollMs: 500,
@@ -356,6 +361,7 @@ describe.skipIf(!ENABLED)('session GC durability (live, disk forensics)', () => 
       // the fresh parked query gets reaped. If an SDK change stops emitting
       // those frames, every user Stop would pin a ~250MB subprocess forever.
       const manager = new SessionManager(workDir, {
+      prewarmEnabled: false,
         idleEvictionMs: 3_000,
         automatedIdleEvictionMs: -1,
         evictionPollMs: 500,

--- a/agent-container/src/session-gc.e2e.test.ts
+++ b/agent-container/src/session-gc.e2e.test.ts
@@ -128,6 +128,7 @@ describe.skipIf(!ENABLED)('session GC end-to-end (real CLI subprocesses)', () =>
       // class, so the re-reap at the end exercises the promoted (interactive)
       // path — the first reap exercises the automated (threshold 0) path.
       const manager = new SessionManager(workDir, {
+      prewarmEnabled: false,
         idleEvictionMs: 5_000,
         automatedIdleEvictionMs: 0,
         evictionPollMs: 1_000,
@@ -183,6 +184,7 @@ describe.skipIf(!ENABLED)('session GC end-to-end (real CLI subprocesses)', () =>
     async () => {
       const IDLE_MS = 6_000;
       const manager = new SessionManager(workDir, {
+      prewarmEnabled: false,
         idleEvictionMs: IDLE_MS,
         automatedIdleEvictionMs: 0,
         evictionPollMs: 1_000,

--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -137,6 +137,7 @@ describe('SessionManager idle eviction', () => {
     nextStartDelayMs = 0
     // Interactive waits IDLE_MS; automated (cron/webhook) evicts immediately when idle.
     manager = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: IDLE_MS,
       automatedIdleEvictionMs: 0,
     })
@@ -266,6 +267,7 @@ describe('SessionManager idle eviction', () => {
     // the single final idle. A threshold-0 sweep landing after result #1
     // must not kill the queued turns.
     const promoOff = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: 0,
       automatedIdleEvictionMs: 0,
     })
@@ -417,6 +419,7 @@ describe('SessionManager idle eviction', () => {
   it('holds through the completion-wake gap and evicts only after the wake turn settles', async () => {
     // Automated threshold 0 — the exact class exposed to the wake-gap race.
     const gapManager = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: IDLE_MS,
       automatedIdleEvictionMs: 0,
       wakeGraceMs: 60_000,
@@ -445,6 +448,7 @@ describe('SessionManager idle eviction', () => {
 
   it('settles after the wake grace expires when no wake ever comes', async () => {
     const graceManager = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: IDLE_MS,
       automatedIdleEvictionMs: 0,
       wakeGraceMs: 5,
@@ -481,6 +485,7 @@ describe('SessionManager idle eviction', () => {
     // Resume via a bare getSession — a human message would (correctly)
     // promote the session to interactive instead.
     const restarted = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: 60 * 60_000,
       automatedIdleEvictionMs: 0,
     })
@@ -498,6 +503,7 @@ describe('SessionManager idle eviction', () => {
 
   it('a human message promotes an automated session to the interactive class', async () => {
     const promoManager = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: 60 * 60_000, // interactive effectively off
       automatedIdleEvictionMs: 0,
     })
@@ -591,6 +597,7 @@ describe('SessionManager idle eviction', () => {
     await manager.stopAll()
 
     const restarted = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: IDLE_MS,
       automatedIdleEvictionMs: 0,
     })
@@ -614,6 +621,7 @@ describe('SessionManager idle eviction', () => {
     await manager.stopAll()
 
     const restarted = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: IDLE_MS,
       automatedIdleEvictionMs: 0,
     })
@@ -643,6 +651,7 @@ describe('SessionManager idle eviction', () => {
     await manager.stopAll()
 
     const restarted = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: IDLE_MS,
       automatedIdleEvictionMs: 0,
     })
@@ -682,6 +691,7 @@ describe('SessionManager idle eviction', () => {
 
   it('a shouldQuery:false append does NOT promote an automated session', async () => {
     const promoManager = new SessionManager(workDir, {
+      prewarmEnabled: false,
       idleEvictionMs: 60 * 60_000,
       automatedIdleEvictionMs: 0,
     })

--- a/agent-container/src/session-manager-prewarm.test.ts
+++ b/agent-container/src/session-manager-prewarm.test.ts
@@ -243,6 +243,55 @@ describe('SessionManager pre-warm pool', () => {
     expect(session.id).not.toBe(warmed.sessionId)
   })
 
+  // Nested profile fields decide what the process is BUILT with, so they have
+  // to reach the key. A block-policy session claiming a process warmed under
+  // allow would run with the capability tools baked into its query.
+  it('does not share a warm process across differing capability policies', async () => {
+    await manager.createSession({
+      ...baseRequest,
+      capabilityPolicies: { subagents: 'allow', workflows: 'allow' },
+    })
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+
+    const session = await manager.createSession({
+      ...baseRequest,
+      capabilityPolicies: { subagents: 'block', workflows: 'block' },
+    })
+
+    expect(session.id).not.toBe(warmed.sessionId)
+    expect(warmed.disposeCalls).toBe(1)
+  })
+
+  it('does not share a warm process across differing custom env vars', async () => {
+    await manager.createSession({ ...baseRequest, customEnvVars: { API_BASE: 'one' } })
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+
+    const session = await manager.createSession({ ...baseRequest, customEnvVars: { API_BASE: 'two' } })
+
+    expect(session.id).not.toBe(warmed.sessionId)
+    expect(warmed.disposeCalls).toBe(1)
+  })
+
+  // The process is spawned with a snapshot of the environment, so one that is
+  // still spawning when /env writes is just as stale as a parked one — and its
+  // profile is unchanged, so nothing else would reject it.
+  it('rejects a warm-up that was already spawning when the environment changed', async () => {
+    let release!: () => void
+    prewarmGate = new Promise<void>((r) => (release = r))
+
+    await manager.createSession(baseRequest)
+    const inFlight = MockClaudeProcess.spawned.at(-1)!
+
+    await manager.discardPrewarmed('env var REMOTE_MCPS changed')
+    release()
+
+    await vi.waitFor(() => expect(inFlight.disposeCalls).toBe(1))
+    // And nothing stale is left parked for the next session to claim.
+    prewarmGate = null
+    const session = await manager.createSession(baseRequest)
+    expect(session.id).not.toBe(inFlight.sessionId)
+  })
+
   // Otherwise a CLI nobody can use sits on memory until the next createSession.
   it('disposes a warm-up that finishes after a session asked for something else', async () => {
     let release!: () => void

--- a/agent-container/src/session-manager-prewarm.test.ts
+++ b/agent-container/src/session-manager-prewarm.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Pre-warmed subprocess pool.
+ *
+ * A parked, already-initialized CLI is what removes the multi-second wait from
+ * session creation, so what matters here is that it is only ever handed to a
+ * session whose query options would be identical, and that it can never be
+ * left running with nothing pointing at it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'events'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+vi.mock('./browser-state', () => ({
+  releaseBrowserLock: vi.fn(),
+  renameBrowserSession: vi.fn(),
+}))
+
+const persistedSessions = new Map<string, unknown>()
+vi.mock('./session-persistence', () => ({
+  SessionPersistence: class {
+    saveSession(data: { sessionId: string }) {
+      persistedSessions.set(data.sessionId, data)
+    }
+    getSession(id: string) {
+      return persistedSessions.get(id)
+    }
+    getAllSessions() {
+      return Array.from(persistedSessions.values())
+    }
+    updateSession() {}
+    deleteSession(id: string) {
+      persistedSessions.delete(id)
+    }
+    addSessionCapabilityGrant() {}
+    getSessionCapabilityGrants() {
+      return []
+    }
+  },
+}))
+
+// Set to park every in-flight prewarm() until the test releases it.
+let prewarmGate: Promise<void> | null = null
+
+class MockClaudeProcess extends EventEmitter {
+  static spawned: MockClaudeProcess[] = []
+  prewarmCalls = 0
+  disposeCalls = 0
+  warm = false
+  readonly options: Record<string, unknown>
+
+  constructor(options: { sessionId: string } & Record<string, unknown>) {
+    super()
+    this.options = options
+    MockClaudeProcess.spawned.push(this)
+  }
+
+  get sessionId(): string {
+    return this.options.sessionId as string
+  }
+
+  async prewarm(): Promise<void> {
+    if (prewarmGate) await prewarmGate
+    this.prewarmCalls++
+    this.warm = true
+  }
+
+  isPrewarmed(): boolean {
+    return this.warm
+  }
+
+  async start(): Promise<void> {}
+
+  async sendMessage(): Promise<void> {
+    this.emit('claude-session-id', this.sessionId)
+    this.emit('init-complete')
+  }
+
+  async stop(): Promise<void> {}
+
+  async dispose(): Promise<void> {
+    this.disposeCalls++
+    this.warm = false
+  }
+
+  isRunning(): boolean {
+    return true
+  }
+
+  get slashCommands() {
+    return []
+  }
+}
+
+// The factory is hoisted above the class declaration, so the reference has to
+// happen at construction time rather than at factory-evaluation time.
+vi.mock('./claude-code', () => ({
+  ClaudeCodeProcess: class {
+    constructor(options: { sessionId: string } & Record<string, unknown>) {
+      return new MockClaudeProcess(options)
+    }
+  },
+}))
+
+import { SessionManager } from './session-manager'
+
+const baseRequest = {
+  initialMessage: 'hello',
+  model: 'claude-opus-4-8',
+  effort: 'high' as const,
+}
+
+describe('SessionManager pre-warm pool', () => {
+  let manager: SessionManager
+  let workDir: string
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prewarm-test-'))
+    MockClaudeProcess.spawned = []
+    persistedSessions.clear()
+    prewarmGate = null
+    manager = new SessionManager(workDir, { idleEvictionMs: -1, automatedIdleEvictionMs: -1 })
+  })
+
+  afterEach(async () => {
+    await manager.stopAll()
+    fs.rmSync(workDir, { recursive: true, force: true })
+  })
+
+  // The whole point: the second session skips the boot the first one paid for.
+  it('serves the next matching session from the pre-warmed process', async () => {
+    await manager.createSession(baseRequest)
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+    expect(warmed.prewarmCalls).toBe(1)
+
+    const spawnedBefore = MockClaudeProcess.spawned.length
+    const session = await manager.createSession(baseRequest)
+
+    // The mock adopts its own temp id as the session id, so an id match proves
+    // the warm process served this session — no second cold spawn.
+    expect(session.id).toBe(warmed.sessionId)
+    expect(warmed.disposeCalls).toBe(0)
+    // Only the refill for the session AFTER this one was spawned.
+    expect(MockClaudeProcess.spawned.length).toBe(spawnedBefore + 1)
+  })
+
+  // The composer only sends a model when the user explicitly picks one, so the
+  // next session almost always arrives on the agent default. Warming for the
+  // one-off pick instead would cost a wasted spawn AND a cold start.
+  it('warms for the host-supplied default, not the model this session picked', async () => {
+    const defaults = { model: 'claude-opus-4-8', effort: 'high' as const, speed: undefined }
+
+    // A one-off pick: this session runs Sonnet, but the default is Opus.
+    await manager.createSession({
+      ...baseRequest,
+      model: 'claude-sonnet-5',
+      prewarmDefaults: defaults,
+    })
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+    expect(warmed.options.model).toBe('claude-opus-4-8')
+
+    // Back to the default — it gets the warm process.
+    const session = await manager.createSession({ ...baseRequest, prewarmDefaults: defaults })
+    expect(session.id).toBe(warmed.sessionId)
+    expect(warmed.disposeCalls).toBe(0)
+  })
+
+  // The boot warm-up uses the previous container's profile, so a default that
+  // changed in between leaves a parked process nothing will ever claim.
+  it('replaces a parked process when the wanted profile changes', async () => {
+    await manager.createSession({ ...baseRequest, prewarmDefaults: { model: 'claude-opus-4-8' } })
+    const stale = MockClaudeProcess.spawned.at(-1)!
+    expect(stale.options.model).toBe('claude-opus-4-8')
+
+    // Next session reports a different default (the agent's default changed).
+    await manager.createSession({ ...baseRequest, prewarmDefaults: { model: 'claude-sonnet-5' } })
+
+    expect(stale.disposeCalls).toBe(1)
+    const replacement = MockClaudeProcess.spawned.at(-1)!
+    expect(replacement.options.model).toBe('claude-sonnet-5')
+    expect(replacement.prewarmCalls).toBe(1)
+  })
+
+  // Without a hint (cron, chat, cross-agent) the session's own shape is still
+  // the best available guess.
+  it('falls back to this session shape when the host sends no default', async () => {
+    await manager.createSession({ ...baseRequest, model: 'claude-sonnet-5' })
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+
+    expect(warmed.options.model).toBe('claude-sonnet-5')
+  })
+
+  // A warm process bakes in model/effort/prompt: handing it to a request that
+  // asked for something else would silently run the wrong configuration.
+  it('discards the pre-warmed process when the next session asks for different parameters', async () => {
+    await manager.createSession(baseRequest)
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+
+    const session = await manager.createSession({ ...baseRequest, model: 'claude-sonnet-5' })
+
+    expect(session.id).not.toBe(warmed.sessionId)
+    expect(warmed.disposeCalls).toBe(1)
+  })
+
+  // Absent/parsed-default values must not read as a different configuration.
+  it('treats an omitted capability policy as the parsed default, not a mismatch', async () => {
+    await manager.createSession(baseRequest)
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+
+    const session = await manager.createSession({ ...baseRequest, capabilityPolicies: undefined })
+
+    expect(session.id).toBe(warmed.sessionId)
+  })
+
+  // The first session after a container wake is the slow one, so the profile
+  // has to survive the restart.
+  it('pre-warms at boot from the profile persisted by the previous container', async () => {
+    await manager.createSession(baseRequest)
+    await manager.stopAll()
+
+    MockClaudeProcess.spawned = []
+    const restarted = new SessionManager(workDir, { idleEvictionMs: -1, automatedIdleEvictionMs: -1 })
+    restarted.prewarmFromLastProfile()
+    await vi.waitFor(() => expect(MockClaudeProcess.spawned.length).toBe(1))
+    const warmed = MockClaudeProcess.spawned[0]
+    await vi.waitFor(() => expect(warmed.prewarmCalls).toBe(1))
+
+    const session = await restarted.createSession(baseRequest)
+    expect(session.id).toBe(warmed.sessionId)
+    await restarted.stopAll()
+  })
+
+  // The warm process captured the old REMOTE_MCPS when it spawned.
+  it('discards the pre-warmed process when the environment changes', async () => {
+    await manager.createSession(baseRequest)
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+
+    await manager.discardPrewarmed('env var REMOTE_MCPS changed')
+
+    expect(warmed.disposeCalls).toBe(1)
+    const session = await manager.createSession(baseRequest)
+    expect(session.id).not.toBe(warmed.sessionId)
+  })
+
+  // Otherwise a CLI nobody can use sits on memory until the next createSession.
+  it('disposes a warm-up that finishes after a session asked for something else', async () => {
+    let release!: () => void
+    prewarmGate = new Promise<void>((r) => (release = r))
+
+    // The refill for this session is now parked mid-spawn.
+    await manager.createSession(baseRequest)
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+
+    // A session with different parameters arrives first and starts cold.
+    prewarmGate = null
+    const session = await manager.createSession({ ...baseRequest, model: 'claude-sonnet-5' })
+    expect(session.id).not.toBe(warmed.sessionId)
+
+    release()
+    await vi.waitFor(() => expect(warmed.disposeCalls).toBe(1))
+  })
+
+  // Nothing references the parked process, so only shutdown can reap it.
+  it('disposes the parked process on shutdown instead of orphaning it', async () => {
+    await manager.createSession(baseRequest)
+    const warmed = MockClaudeProcess.spawned.at(-1)!
+
+    await manager.stopAll()
+
+    expect(warmed.disposeCalls).toBe(1)
+  })
+
+  it('does not pre-warm when disabled', async () => {
+    const off = new SessionManager(workDir, {
+      idleEvictionMs: -1,
+      automatedIdleEvictionMs: -1,
+      prewarmEnabled: false,
+    })
+    MockClaudeProcess.spawned = []
+
+    await off.createSession(baseRequest)
+
+    expect(MockClaudeProcess.spawned).toHaveLength(1)
+    expect(MockClaudeProcess.spawned[0].prewarmCalls).toBe(0)
+    await off.stopAll()
+  })
+})

--- a/agent-container/src/session-manager-prewarm.test.ts
+++ b/agent-container/src/session-manager-prewarm.test.ts
@@ -104,6 +104,8 @@ vi.mock('./claude-code', () => ({
 }))
 
 import { SessionManager } from './session-manager'
+import { nextWarmProfileFromRequest } from './warm-profile'
+import { agentCapabilityPoliciesSchema, speedLevelSchema } from './capability-policies'
 
 const baseRequest = {
   initialMessage: 'hello',
@@ -114,6 +116,18 @@ const baseRequest = {
 describe('SessionManager pre-warm pool', () => {
   let manager: SessionManager
   let workDir: string
+
+  // Built through the same normalization createSession uses, so a profile
+  // handed to prewarm() directly keys identically to one derived from a
+  // request — otherwise the claim would miss for reasons unrelated to the test.
+  const profileFor = (model: string) =>
+    nextWarmProfileFromRequest({
+      ...baseRequest,
+      model,
+      workingDirectory: workDir,
+      speed: speedLevelSchema.parse(undefined),
+      capabilityPolicies: agentCapabilityPoliciesSchema.parse(undefined),
+    })
 
   beforeEach(() => {
     workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prewarm-test-'))
@@ -180,6 +194,31 @@ describe('SessionManager pre-warm pool', () => {
     const replacement = MockClaudeProcess.spawned.at(-1)!
     expect(replacement.options.model).toBe('claude-sonnet-5')
     expect(replacement.prewarmCalls).toBe(1)
+    // Spawning it is not enough — it has to survive to be claimed. Discarding
+    // the stale process bumps the warm generation, so a replacement that
+    // captured the generation too early rejects itself on the way in and the
+    // next session pays a cold start anyway.
+    expect(replacement.disposeCalls).toBe(0)
+  })
+
+  // Reachable when two session creations overlap and refill for different
+  // profiles: the second refill finds the first one's process already parked.
+  it('parks a replacement that was spawned while another profile was parked', async () => {
+    await manager.prewarm(profileFor('claude-opus-4-8'))
+    const stale = MockClaudeProcess.spawned.at(-1)!
+
+    await manager.prewarm(profileFor('claude-sonnet-5'))
+    const replacement = MockClaudeProcess.spawned.at(-1)!
+
+    expect(stale.disposeCalls).toBe(1)
+    expect(replacement.disposeCalls).toBe(0)
+    // Claimable: the session it was warmed for gets it instead of starting cold.
+    const session = await manager.createSession({
+      ...baseRequest,
+      prewarmDefaults: { model: 'claude-sonnet-5' },
+      model: 'claude-sonnet-5',
+    })
+    expect(session.id).toBe(replacement.sessionId)
   })
 
   // Without a hint (cron, chat, cross-agent) the session's own shape is still

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -425,7 +425,6 @@ export class SessionManager extends EventEmitter {
     if (!this.prewarmEnabled || this.shuttingDown) return;
 
     const key = warmProfileKey(profile);
-    const generation = this.warmGeneration;
     // Recorded even when a warm-up is already in flight, so that one can see
     // it has been superseded and hand over to this profile when it lands.
     this.desiredWarmKey = key;
@@ -440,6 +439,11 @@ export class SessionManager extends EventEmitter {
       await this.discardPrewarmed('wanted profile changed');
     }
     if (this.warming) return;
+
+    // Captured here, AFTER any discard above: discardPrewarmed bumps the
+    // generation, so reading it earlier would make this spawn reject itself on
+    // arrival and leave the next session cold.
+    const generation = this.warmGeneration;
     const promise = (async () => {
       const process = new ClaudeCodeProcess({
         sessionId: uuidv4(),

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -9,6 +9,13 @@ import * as fs from 'fs';
 import { releaseBrowserLock } from './browser-state';
 import { claudeSettingsSchema, SESSION_RETENTION_DAYS } from './claude-settings-schema';
 import { SessionSettlementTracker } from './session-settlement';
+import {
+  WarmProfileStore,
+  nextWarmProfileFromRequest,
+  sessionProfileFromRequest,
+  warmProfileKey,
+  type WarmProfile,
+} from './warm-profile';
 
 interface SessionData {
   session: Session;
@@ -60,6 +67,21 @@ export class SessionManager extends EventEmitter {
   private readonly automatedIdleEvictionMs: number;
   private readonly wakeGraceMs: number | undefined;
   private evictionTimer: ReturnType<typeof setInterval> | null = null;
+  // A CLI subprocess spawned ahead of demand, parked past its initialize
+  // handshake. Keyed by the profile it was built for — it may only serve a
+  // request whose options would be identical. See claimPrewarmed().
+  private warm: { key: string; process: ClaudeCodeProcess } | null = null;
+  private warming: { key: string; promise: Promise<void> } | null = null;
+  // Key of the profile we currently want parked. A warm-up that resolves after
+  // this has moved on (a later session changed the default) disposes itself
+  // instead of parking a process nobody will accept.
+  private desiredWarmKey: string | null = null;
+  private pendingProfile: WarmProfile | null = null;
+  private shuttingDown = false;
+  private readonly warmProfileStore: WarmProfileStore;
+  // Kill switch for the parked subprocess, so a container can fall back to
+  // cold starts (SESSION_PREWARM=0) without a redeploy.
+  private readonly prewarmEnabled: boolean;
 
   constructor(
     baseWorkingDirectory: string = '/workspace',
@@ -68,11 +90,15 @@ export class SessionManager extends EventEmitter {
       automatedIdleEvictionMs?: number;
       wakeGraceMs?: number;
       evictionPollMs?: number;
+      prewarmEnabled?: boolean;
     }
   ) {
     super();
     this.baseWorkingDirectory = baseWorkingDirectory;
     this.persistence = new SessionPersistence();
+    this.warmProfileStore = new WarmProfileStore(baseWorkingDirectory);
+    this.prewarmEnabled =
+      options?.prewarmEnabled ?? !['0', 'false'].includes((process.env.SESSION_PREWARM ?? '').trim().toLowerCase());
     this.wakeGraceMs = options?.wakeGraceMs;
     this.idleEvictionMs =
       options?.idleEvictionMs ??
@@ -181,26 +207,36 @@ export class SessionManager extends EventEmitter {
       fs.mkdirSync(workingDirectory, { recursive: true });
     }
 
-    const process = new ClaudeCodeProcess({
-      sessionId: tempSessionId,
-      workingDirectory,
-      userSystemPrompt: request.systemPrompt,
-      modelPromptHints: request.modelPromptHints,
-      availableEnvVars: request.availableEnvVars,
-      model: request.model,
-      browserModel: request.browserModel,
-      dashboardBuilderModel: request.dashboardBuilderModel,
-      webSearchProvider: request.webSearchProvider,
-      webFetchProvider: request.webFetchProvider,
-      maxOutputTokens: request.maxOutputTokens,
-      maxThinkingTokens: request.maxThinkingTokens,
-      maxTurns: request.maxTurns,
-      maxBudgetUsd: request.maxBudgetUsd,
-      customEnvVars: request.customEnvVars,
-      effort: request.effort,
-      speed,
-      capabilityPolicies,
-    });
+    // Normalized before the profiles are derived so a key matches what the
+    // process is actually built with (an absent policy/speed and its parsed
+    // default must not look like two different profiles). The session's own
+    // shape decides whether a parked process fits; the host's default shape
+    // decides what to warm next.
+    const normalized = { ...request, speed, capabilityPolicies, workingDirectory };
+    const sessionProfile = sessionProfileFromRequest(normalized);
+    const nextProfile = nextWarmProfileFromRequest(normalized);
+    const process =
+      (await this.claimPrewarmed(sessionProfile)) ??
+      new ClaudeCodeProcess({
+        sessionId: tempSessionId,
+        workingDirectory,
+        userSystemPrompt: request.systemPrompt,
+        modelPromptHints: request.modelPromptHints,
+        availableEnvVars: request.availableEnvVars,
+        model: request.model,
+        browserModel: request.browserModel,
+        dashboardBuilderModel: request.dashboardBuilderModel,
+        webSearchProvider: request.webSearchProvider,
+        webFetchProvider: request.webFetchProvider,
+        maxOutputTokens: request.maxOutputTokens,
+        maxThinkingTokens: request.maxThinkingTokens,
+        maxTurns: request.maxTurns,
+        maxBudgetUsd: request.maxBudgetUsd,
+        customEnvVars: request.customEnvVars,
+        effort: request.effort,
+        speed,
+        capabilityPolicies,
+      });
 
     // Promise to capture Claude's session ID and slash commands (emitted after first message is sent)
     const initCompletePromise = new Promise<string>((resolve, reject) => {
@@ -334,8 +370,145 @@ export class SessionManager extends EventEmitter {
 
     this.sessions.set(sessionId, sessionData);
 
+    // Refill for the next session, and remember the shape across restarts.
+    // Deliberately after the session is live: the warm spawn costs ~1s of CPU
+    // and must never sit in front of the request that triggered it.
+    this.warmProfileStore.write(nextProfile);
+    void this.prewarm(nextProfile);
+
     console.log(`Created session ${sessionId} with working directory ${workingDirectory}`);
     return session;
+  }
+
+  /**
+   * Take the pre-warmed process for this profile, if one is ready or on its
+   * way. A warm process has its CLI already spawned and initialized, so the
+   * session's `init` (and canonical id) arrives in milliseconds.
+   *
+   * Awaiting an in-flight warm-up for the SAME profile is never worse than
+   * spawning cold — both pay one boot, and this way we don't run two. A
+   * MISMATCHED warm process is discarded rather than kept: its options bake in
+   * the wrong model/effort/prompt, and the profile that just arrived is the
+   * better predictor of the next one.
+   */
+  private async claimPrewarmed(profile: WarmProfile): Promise<ClaudeCodeProcess | null> {
+    const key = warmProfileKey(profile);
+
+    if (this.warming && this.warming.key === key) {
+      await this.warming.promise.catch(() => undefined);
+    }
+
+    const warm = this.warm;
+    if (!warm) return null;
+    this.warm = null;
+
+    if (warm.key !== key) {
+      console.log('[SessionManager] Discarding pre-warmed process: session parameters changed');
+      await warm.process.dispose().catch(() => undefined);
+      return null;
+    }
+
+    console.log('[SessionManager] Using pre-warmed process for new session');
+    return warm.process;
+  }
+
+  /**
+   * Spawn a CLI subprocess for `profile` and park it, initialized, until the
+   * next matching createSession. Best-effort throughout: any failure here just
+   * means the next session starts cold, so it must never reject into a caller.
+   */
+  async prewarm(profile: WarmProfile): Promise<void> {
+    if (!this.prewarmEnabled || this.shuttingDown) return;
+
+    const key = warmProfileKey(profile);
+    // Recorded even when a warm-up is already in flight, so that one can see
+    // it has been superseded and hand over to this profile when it lands.
+    this.desiredWarmKey = key;
+    this.pendingProfile = profile;
+
+    if (this.warm) {
+      if (this.warm.key === key) return;
+      // Parked for a profile we no longer expect — e.g. the boot warm-up used
+      // the last container's profile and the agent's default has since
+      // changed. Leaving it would strand every future session on a cold start
+      // while an unusable CLI holds memory.
+      await this.discardPrewarmed('wanted profile changed');
+    }
+    if (this.warming) return;
+    const promise = (async () => {
+      const process = new ClaudeCodeProcess({
+        sessionId: uuidv4(),
+        workingDirectory: profile.workingDirectory || this.baseWorkingDirectory,
+        userSystemPrompt: profile.systemPrompt,
+        modelPromptHints: profile.modelPromptHints,
+        availableEnvVars: profile.availableEnvVars,
+        model: profile.model,
+        browserModel: profile.browserModel,
+        dashboardBuilderModel: profile.dashboardBuilderModel,
+        webSearchProvider: profile.webSearchProvider,
+        webFetchProvider: profile.webFetchProvider,
+        maxOutputTokens: profile.maxOutputTokens,
+        maxThinkingTokens: profile.maxThinkingTokens,
+        maxTurns: profile.maxTurns,
+        maxBudgetUsd: profile.maxBudgetUsd,
+        customEnvVars: profile.customEnvVars,
+        effort: profile.effort,
+        speed: profile.speed,
+        capabilityPolicies: profile.capabilityPolicies,
+      });
+      try {
+        await process.prewarm();
+        // The wanted profile may have changed while this was spawning (a
+        // session switched the agent default). Parking this one would leave a
+        // CLI nobody can accept holding memory, so drop it and warm for what
+        // is wanted now.
+        if (this.shuttingDown || this.desiredWarmKey !== key) {
+          await process.dispose().catch(() => undefined);
+          return;
+        }
+        this.warm = { key, process };
+        console.log('[SessionManager] Pre-warmed a CLI subprocess for the next session');
+      } catch (error) {
+        console.error('[SessionManager] Pre-warm failed (next session starts cold):', error);
+        await process.dispose().catch(() => undefined);
+      }
+    })().finally(() => {
+      if (this.warming?.key === key) this.warming = null;
+    });
+
+    this.warming = { key, promise };
+    await promise;
+
+    // A profile that arrived mid-spawn was recorded but not acted on (this
+    // call held the in-flight slot), so pick it up now that the slot is free.
+    if (!this.warm && this.desiredWarmKey !== null && this.desiredWarmKey !== key && !this.shuttingDown) {
+      const wanted = this.pendingProfile;
+      if (wanted) void this.prewarm(wanted);
+    }
+  }
+
+  /**
+   * Pre-warm from the last persisted profile. Called at boot so the first
+   * session after a container wake — the slowest one, with nothing in page
+   * cache — is also served warm.
+   */
+  prewarmFromLastProfile(): void {
+    const profile = this.warmProfileStore.read();
+    if (!profile) return;
+    void this.prewarm(profile);
+  }
+
+  /**
+   * Drop the parked process. Its options bake in a snapshot of the remote-MCP
+   * env, so anything that rewrites that env must invalidate it or the next
+   * session would silently run against the old MCP set.
+   */
+  async discardPrewarmed(reason: string): Promise<void> {
+    const warm = this.warm;
+    if (!warm) return;
+    this.warm = null;
+    console.log(`[SessionManager] Discarding pre-warmed process: ${reason}`);
+    await warm.process.dispose().catch(() => undefined);
   }
 
   /**
@@ -732,6 +905,11 @@ export class SessionManager extends EventEmitter {
       clearInterval(this.evictionTimer);
       this.evictionTimer = null;
     }
+    // Latches before the in-flight warm-up is awaited so a spawn that lands
+    // mid-shutdown disposes itself instead of parking an orphan subprocess.
+    this.shuttingDown = true;
+    await this.warming?.promise.catch(() => undefined);
+    await this.discardPrewarmed('container shutting down');
     const sessionIds = Array.from(this.sessions.keys());
     console.log(`Stopping ${sessionIds.length} active session(s)...`);
 

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -77,6 +77,10 @@ export class SessionManager extends EventEmitter {
   // instead of parking a process nobody will accept.
   private desiredWarmKey: string | null = null;
   private pendingProfile: WarmProfile | null = null;
+  // Bumped by discardPrewarmed. A warm-up captures the value at spawn time and
+  // disposes itself if it no longer matches, which is the only way to reject a
+  // process that was already spawning when the environment changed.
+  private warmGeneration = 0;
   private shuttingDown = false;
   private readonly warmProfileStore: WarmProfileStore;
   // Kill switch for the parked subprocess, so a container can fall back to
@@ -421,6 +425,7 @@ export class SessionManager extends EventEmitter {
     if (!this.prewarmEnabled || this.shuttingDown) return;
 
     const key = warmProfileKey(profile);
+    const generation = this.warmGeneration;
     // Recorded even when a warm-up is already in flight, so that one can see
     // it has been superseded and hand over to this profile when it lands.
     this.desiredWarmKey = key;
@@ -462,7 +467,7 @@ export class SessionManager extends EventEmitter {
         // session switched the agent default). Parking this one would leave a
         // CLI nobody can accept holding memory, so drop it and warm for what
         // is wanted now.
-        if (this.shuttingDown || this.desiredWarmKey !== key) {
+        if (this.shuttingDown || this.desiredWarmKey !== key || this.warmGeneration !== generation) {
           await process.dispose().catch(() => undefined);
           return;
         }
@@ -504,6 +509,11 @@ export class SessionManager extends EventEmitter {
    * session would silently run against the old MCP set.
    */
   async discardPrewarmed(reason: string): Promise<void> {
+    // Bumped synchronously, before any await and whether or not a process is
+    // parked right now: a warm-up still spawning captured the OLD environment
+    // when it built its query options, so it must be invalidated too. Its
+    // profile is unchanged, so desiredWarmKey would happily park it.
+    this.warmGeneration++;
     const warm = this.warm;
     if (!warm) return;
     this.warm = null;

--- a/agent-container/src/tools/request-remote-mcp.test.ts
+++ b/agent-container/src/tools/request-remote-mcp.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { inputManager } from '../input-manager'
 
+// The tool is built against its owning process, so the test supplies one
+// rather than stubbing a module global.
 const mockAddRemoteMcpServer = vi.fn()
-vi.mock('../claude-code', () => ({
-  getCurrentProcess: () => ({
-    addRemoteMcpServer: (...args: unknown[]) => mockAddRemoteMcpServer(...args),
-  }),
-}))
+const owningProcess = {
+  addRemoteMcpServer: (...args: unknown[]) => mockAddRemoteMcpServer(...args),
+}
 
 const GRANOLA_MCP = {
   id: 'mcp-granola-1',
@@ -32,8 +32,8 @@ describe('requestRemoteMcpTool', () => {
   })
 
   async function invokeTool() {
-    const { requestRemoteMcpTool } = await import('./request-remote-mcp')
-    const handler = (requestRemoteMcpTool as any).handler
+    const { createRequestRemoteMcpTool } = await import('./request-remote-mcp')
+    const handler = (createRequestRemoteMcpTool(() => owningProcess) as any).handler
     return handler({ url: 'https://mcp.granola.ai/mcp', name: 'Granola', authHint: 'oauth' })
   }
 
@@ -91,5 +91,48 @@ describe('requestRemoteMcpTool', () => {
 
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toContain('declined')
+  })
+
+
+  // Regression: the injection target used to come from a module global set in
+  // the ClaudeCodeProcess constructor, so the most recently CONSTRUCTED process
+  // won. Once the container pre-warms a process for the next session, that
+  // global points at the parked process from the moment a session starts — the
+  // approved MCP would be injected into a query nobody is talking to, and the
+  // asking session would never see the tools.
+  it('injects into the owning process, never the pre-warmed one built after it', async () => {
+    process.env.REMOTE_MCPS = JSON.stringify([GRANOLA_MCP])
+    const parkedInjections: string[] = []
+    const { createRequestRemoteMcpTool } = await import('./request-remote-mcp')
+    // Built for the live session; the parked process is created afterwards.
+    const tool = createRequestRemoteMcpTool(() => owningProcess) as any
+    const parked = { addRemoteMcpServer: (name: string) => parkedInjections.push(name) }
+    void parked
+
+    const toolUseId = `mcp-test-${Date.now()}-5`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.resolve(toolUseId, GRANOLA_MCP.id)
+    await tool.handler({ url: 'https://mcp.granola.ai/mcp', name: 'Granola' })
+
+    expect(mockAddRemoteMcpServer).toHaveBeenCalledWith(GRANOLA_MCP.name)
+    expect(parkedInjections).toEqual([])
+  })
+
+  // The owning process object is replaced on interrupt/restart, so the target
+  // has to be read when the tool runs rather than captured at build time.
+  it('resolves the owning process at call time', async () => {
+    process.env.REMOTE_MCPS = JSON.stringify([GRANOLA_MCP])
+    const injections: string[] = []
+    let current = { addRemoteMcpServer: (_: string) => { throw new Error('stale process was used') } }
+    const { createRequestRemoteMcpTool } = await import('./request-remote-mcp')
+    const tool = createRequestRemoteMcpTool(() => current) as any
+    current = { addRemoteMcpServer: (name: string) => injections.push(name) }
+
+    const toolUseId = `mcp-test-${Date.now()}-6`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.resolve(toolUseId, GRANOLA_MCP.id)
+    await tool.handler({ url: 'https://mcp.granola.ai/mcp', name: 'Granola' })
+
+    expect(injections).toEqual([GRANOLA_MCP.name])
   })
 })

--- a/agent-container/src/tools/request-remote-mcp.ts
+++ b/agent-container/src/tools/request-remote-mcp.ts
@@ -9,10 +9,26 @@
 import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { z } from 'zod'
 import { inputManager } from '../input-manager'
-import { getCurrentProcess } from '../claude-code'
 import { sanitizeMcpName } from '../sanitize-mcp-name'
 
-export const requestRemoteMcpTool = tool(
+/**
+ * The one capability this tool needs from the process that owns the query it
+ * is running inside. Structural rather than the ClaudeCodeProcess type so the
+ * tool module doesn't import back into claude-code.ts.
+ */
+export interface RemoteMcpInjectionTarget {
+  addRemoteMcpServer(name: string): void
+}
+
+/**
+ * Bound to its OWNING process, not to a module global. The container can hold
+ * processes that are not the caller — other live sessions, and the pre-warmed
+ * one parked for the next session — and injecting the approved MCP into any of
+ * them would leave the session that asked for it without the tools, because
+ * only the owning query restarts.
+ */
+export function createRequestRemoteMcpTool(getProcess: () => RemoteMcpInjectionTarget | null) {
+  return tool(
   'request_remote_mcp',
   `Request access to a remote MCP server. The user will be prompted to connect the MCP server (potentially going through OAuth), then assign it to this agent. After approval, the MCP tools become available.
 
@@ -90,7 +106,7 @@ Use this when you need to interact with an MCP server that hasn't been configure
             mcpInfo = `\n\n${mcpBlocks.join('\n\n')}`
 
             // Trigger interrupt + restart so the new query picks up the MCP from env var.
-            const proc = getCurrentProcess()
+            const proc = getProcess()
             if (proc) {
               matchingMcps.forEach((matchingMcp) => proc.addRemoteMcpServer(matchingMcp.name))
             } else {
@@ -150,3 +166,4 @@ Use this when you need to interact with an MCP server that hasn't been configure
     }
   }
 )
+}

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -91,6 +91,16 @@ export interface CreateSessionRequest {
   effort?: EffortLevel; // Initial thinking effort level
   speed?: SpeedLevel; // Initial processing-speed tier (emitted as X-Superagent-Speed)
   capabilityPolicies?: AgentCapabilityPolicies; // Launch policies for subagents/workflows (absent = allow)
+  // What the host expects the NEXT session to ask for (agent default model/
+  // effort/speed with the global fallback applied), as opposed to this
+  // session's own possibly one-off pick. Used to pre-warm a CLI subprocess for
+  // the right configuration; absent on non-interactive callers.
+  prewarmDefaults?: {
+    model?: string;
+    modelPromptHints?: string[];
+    effort?: EffortLevel;
+    speed?: SpeedLevel;
+  };
 }
 
 export interface SendMessageRequest {

--- a/agent-container/src/warm-profile.test.ts
+++ b/agent-container/src/warm-profile.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Profile keying.
+ *
+ * The key is the entire safety argument for handing a pre-warmed process to a
+ * session: equal keys are treated as "these two sessions would build an
+ * identical query". Anything that reaches the query but not the key is a way
+ * for a session to run under a configuration it did not ask for.
+ */
+import { describe, it, expect } from 'vitest'
+import { warmProfileKey, warmProfileSchema } from './warm-profile'
+
+const base = warmProfileSchema.parse({ model: 'claude-opus-4-8', effort: 'high' })
+
+describe('warmProfileKey', () => {
+  // Regression: JSON.stringify's array-replacer form is a whitelist applied at
+  // every depth, so nested objects collapsed to `{}` and an allow-policy
+  // profile keyed identically to a block-policy one.
+  it('separates profiles that differ only in a nested capability policy', () => {
+    const allow = warmProfileKey(
+      warmProfileSchema.parse({ ...base, capabilityPolicies: { subagents: 'allow', workflows: 'allow' } })
+    )
+    const block = warmProfileKey(
+      warmProfileSchema.parse({ ...base, capabilityPolicies: { subagents: 'block', workflows: 'block' } })
+    )
+
+    expect(allow).not.toBe(block)
+  })
+
+  it('separates profiles that differ only in a nested custom env var', () => {
+    const one = warmProfileKey(warmProfileSchema.parse({ ...base, customEnvVars: { API_BASE: 'one' } }))
+    const two = warmProfileKey(warmProfileSchema.parse({ ...base, customEnvVars: { API_BASE: 'two' } }))
+
+    expect(one).not.toBe(two)
+  })
+
+  it('keys the same configuration identically regardless of insertion order', () => {
+    const a = warmProfileKey(
+      warmProfileSchema.parse({ model: 'm', effort: 'high', customEnvVars: { A: '1', B: '2' } })
+    )
+    const b = warmProfileKey(
+      warmProfileSchema.parse({ customEnvVars: { B: '2', A: '1' }, effort: 'high', model: 'm' })
+    )
+
+    expect(a).toBe(b)
+  })
+
+  // Array order is meaningful — the hints are concatenated into the prompt.
+  it('separates profiles whose prompt hints differ only in order', () => {
+    const a = warmProfileKey(warmProfileSchema.parse({ ...base, modelPromptHints: ['one', 'two'] }))
+    const b = warmProfileKey(warmProfileSchema.parse({ ...base, modelPromptHints: ['two', 'one'] }))
+
+    expect(a).not.toBe(b)
+  })
+
+  it('treats an absent field and an explicitly undefined one as the same profile', () => {
+    const absent = warmProfileKey(warmProfileSchema.parse({ model: 'm' }))
+    const undef = warmProfileKey(warmProfileSchema.parse({ model: 'm', effort: undefined, speed: undefined }))
+
+    expect(absent).toBe(undef)
+  })
+})

--- a/agent-container/src/warm-profile.ts
+++ b/agent-container/src/warm-profile.ts
@@ -1,0 +1,125 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { z } from 'zod';
+import { agentCapabilityPoliciesSchema, speedLevelSchema } from './capability-policies';
+import type { CreateSessionRequest } from './types';
+
+/**
+ * The subset of a create-session request that a pre-warmed CLI subprocess
+ * bakes in: everything the query options (and the rendered system prompt)
+ * are derived from. Two requests with the same profile can be served by the
+ * same warm process; anything else must spawn cold.
+ *
+ * Deliberately excludes the per-session parts — initialMessage, its uuid,
+ * metadata, envVars — which are supplied after the process is claimed.
+ */
+export const warmProfileSchema = z.object({
+  workingDirectory: z.string().optional(),
+  systemPrompt: z.string().optional(),
+  modelPromptHints: z.array(z.string()).optional(),
+  availableEnvVars: z.array(z.string()).optional(),
+  model: z.string().optional(),
+  browserModel: z.string().optional(),
+  dashboardBuilderModel: z.string().optional(),
+  webSearchProvider: z.string().optional(),
+  webFetchProvider: z.string().optional(),
+  maxOutputTokens: z.number().optional(),
+  maxThinkingTokens: z.number().optional(),
+  maxTurns: z.number().optional(),
+  maxBudgetUsd: z.number().optional(),
+  customEnvVars: z.record(z.string(), z.string()).optional(),
+  effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
+  speed: speedLevelSchema,
+  capabilityPolicies: agentCapabilityPoliciesSchema,
+});
+
+export type WarmProfile = z.infer<typeof warmProfileSchema>;
+
+/** The shape THIS session runs with — what a parked process must match. */
+export function sessionProfileFromRequest(request: CreateSessionRequest): WarmProfile {
+  return buildProfile(request, undefined);
+}
+
+/**
+ * The shape to pre-warm for AFTER serving `request`.
+ *
+ * Prefers the host's `prewarmDefaults` — the agent default model/effort/speed
+ * — over what this session happened to run with. The composer only puts
+ * model/effort/speed on the wire when the user explicitly picks one, so the
+ * default is what the next session will almost always ask for; warming for a
+ * one-off pick instead would cost both a wasted spawn and a cold start.
+ * Callers that send no hint (cron, chat, cross-agent) fall back to this
+ * session's own shape.
+ */
+export function nextWarmProfileFromRequest(request: CreateSessionRequest): WarmProfile {
+  return buildProfile(request, request.prewarmDefaults);
+}
+
+function buildProfile(
+  request: CreateSessionRequest,
+  defaults: CreateSessionRequest['prewarmDefaults']
+): WarmProfile {
+  return warmProfileSchema.parse({
+    workingDirectory: request.workingDirectory,
+    systemPrompt: request.systemPrompt,
+    modelPromptHints: defaults ? defaults.modelPromptHints : request.modelPromptHints,
+    availableEnvVars: request.availableEnvVars,
+    model: defaults ? defaults.model : request.model,
+    browserModel: request.browserModel,
+    dashboardBuilderModel: request.dashboardBuilderModel,
+    webSearchProvider: request.webSearchProvider,
+    webFetchProvider: request.webFetchProvider,
+    maxOutputTokens: request.maxOutputTokens,
+    maxThinkingTokens: request.maxThinkingTokens,
+    maxTurns: request.maxTurns,
+    maxBudgetUsd: request.maxBudgetUsd,
+    customEnvVars: request.customEnvVars,
+    effort: defaults ? defaults.effort : request.effort,
+    speed: defaults ? defaults.speed : request.speed,
+    capabilityPolicies: request.capabilityPolicies,
+  });
+}
+
+/**
+ * Stable identity for a profile. Key equality is the whole safety argument
+ * for handing a warm process to a request, so it is computed from a
+ * key-sorted serialization rather than plain JSON.stringify (whose output
+ * depends on insertion order).
+ */
+export function warmProfileKey(profile: WarmProfile): string {
+  return JSON.stringify(profile, Object.keys(profile).sort());
+}
+
+/**
+ * The last-used profile, persisted so a container that just booted can warm a
+ * subprocess for the session that is about to arrive. Without it the first
+ * session after a wake — the slowest case, since nothing is in page cache —
+ * would be the one case that never gets a warm process.
+ */
+export class WarmProfileStore {
+  private readonly filePath: string;
+
+  constructor(baseWorkingDirectory: string) {
+    this.filePath = path.join(baseWorkingDirectory, '.superagent-warm-profile.json');
+  }
+
+  read(): WarmProfile | null {
+    try {
+      if (!fs.existsSync(this.filePath)) return null;
+      return warmProfileSchema.parse(JSON.parse(fs.readFileSync(this.filePath, 'utf-8')));
+    } catch (error) {
+      // A stale or hand-edited file must never block session creation: the
+      // worst case of ignoring it is one cold start.
+      console.error('[WarmProfile] Ignoring unreadable warm profile:', error);
+      return null;
+    }
+  }
+
+  write(profile: WarmProfile): void {
+    try {
+      fs.writeFileSync(this.filePath, JSON.stringify(warmProfileSchema.parse(profile), null, 2));
+    } catch (error) {
+      console.error('[WarmProfile] Failed to persist warm profile:', error);
+    }
+  }
+}

--- a/agent-container/src/warm-profile.ts
+++ b/agent-container/src/warm-profile.ts
@@ -81,13 +81,29 @@ function buildProfile(
 }
 
 /**
- * Stable identity for a profile. Key equality is the whole safety argument
- * for handing a warm process to a request, so it is computed from a
- * key-sorted serialization rather than plain JSON.stringify (whose output
- * depends on insertion order).
+ * Stable identity for a profile. Key equality is the whole safety argument for
+ * handing a warm process to a request, so every field has to reach the key at
+ * every depth.
+ *
+ * Hand-rolled rather than `JSON.stringify(profile, sortedKeys)`: that replacer
+ * form is a whitelist applied at EVERY level, so nested objects
+ * (capabilityPolicies, customEnvVars) collapse to `{}` — an allow-policy
+ * profile and a block-policy one would share a key, and a restricted session
+ * could claim a process warmed with the capability tools baked in.
  */
 export function warmProfileKey(profile: WarmProfile): string {
-  return JSON.stringify(profile, Object.keys(profile).sort());
+  return stableStringify(profile);
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  // Arrays are order-significant (modelPromptHints, availableEnvVars): a
+  // different order really is a different prompt, so don't sort them.
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(',')}}`;
 }
 
 /**

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1618,6 +1618,15 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
       maxBrowserTabs: getSettings().app?.maxBrowserTabs,
       effort: runtimeOptions.effort ?? agentPrefs.defaultEffort,
       speed: runtimeOptions.speed ?? agentPrefs.defaultSpeed,
+      // Same preference chain MINUS the per-session pick: this is what the
+      // composer will send next time (it only puts model/effort/speed on the
+      // wire when the user explicitly chooses one), so it is what the
+      // container should pre-warm for.
+      prewarmDefaults: {
+        model: agentPrefs.defaultModel ?? getEffectiveModels().agentModel,
+        effort: agentPrefs.defaultEffort,
+        speed: agentPrefs.defaultSpeed,
+      },
     })
     const sessionId = containerSession.id
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1101,6 +1101,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     // Resolve stored selections (bare aliases or concrete ids) to the active
     // provider's concrete wire id before the container ever sees them.
     const resolvedModel = resolveContainerModel(options.model, 'agent')
+    // Resolved on the same path as the session's own model, so the prompt
+    // hints the container pre-warms with match what a default session would
+    // actually be built with.
+    const resolvedPrewarmModel = resolveContainerModel(options.prewarmDefaults?.model, 'agent')
+    const prewarmPromptHints = getContainerModelPromptHints(resolvedPrewarmModel)
     const resolvedBrowserModel = resolveContainerModel(options.browserModel, 'browser')
     const resolvedDashboardBuilderModel = resolveContainerModel(options.dashboardBuilderModel, 'dashboard')
     const modelPromptHints = getContainerModelPromptHints(resolvedModel)
@@ -1146,6 +1151,12 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           effort: options.effort,
           speed: options.speed,
           capabilityPolicies,
+          prewarmDefaults: options.prewarmDefaults && {
+            model: resolvedPrewarmModel,
+            modelPromptHints: prewarmPromptHints.length > 0 ? prewarmPromptHints : undefined,
+            effort: options.prewarmDefaults.effort,
+            speed: options.prewarmDefaults.speed,
+          },
         }),
         signal: controller.signal,
       })

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -64,6 +64,21 @@ export interface CreateSessionOptions {
   maxBrowserTabs?: number // Max browser tabs allowed (default 10)
   effort?: EffortLevel // Initial thinking effort level
   speed?: SpeedLevel // Initial processing speed tier
+  /**
+   * What the NEXT session on this agent will most likely ask for: the agent's
+   * default model/effort/speed with the global fallback applied, ignoring any
+   * per-session pick in `model`/`effort`/`speed` above.
+   *
+   * The container pre-warms a CLI subprocess for this shape. Without it the
+   * container can only guess from the session it just ran, so a single one-off
+   * model pick would leave it warmed for the wrong configuration — the next
+   * default session would discard that process and start cold.
+   */
+  prewarmDefaults?: {
+    model?: string
+    effort?: EffortLevel
+    speed?: SpeedLevel
+  }
 }
 
 export interface StartOptions {


### PR DESCRIPTION
Starting a session took a few seconds before anything appeared, and it had been getting worse. This removes the largest fixed piece of that wait.

## Where the time went

`POST /api/agents/:id/sessions` is synchronous end to end and the UI is blocked for all of it: the composer stays disabled and navigation only happens once the mutation resolves (`agent-home.tsx:192` → `agent-shell.tsx:129`). The host's own work is ~30ms — `getAgent`, `ensureRunning` (cached), secrets, prefs and `registerSession` all measured 1–37ms. Effectively all of the wait was `client.createSession`, which blocks until the container's CLI has spawned and emitted `system init`, because that message carries the canonical session id.

Ruled out as causes, with measurements: the CLI/SDK version (benched 0.2.118 / 0.3.181 / 0.3.197 / 0.3.206 / 0.3.219 — all ~1.4–2.0s to init, no trend), our `query()` options (cumulative bisect over settingSources, hooks, subagents, the 63k system prompt, 5–6 SDK MCP servers, 92 tools — flat throughout), and time-to-first-token (median 2.5–3.6s per month across 745 real transcripts, Feb→Jul, flat). What does vary is machine load: the same probe swung between 1.1s and 7.5s depending on what else was running.

## What this does

**Pre-warm a CLI subprocess** using the SDK's `startup()`/`WarmQuery`. This is the officially recommended approach for our deployment shape — the [hosting guide](https://code.claude.com/docs/en/agent-sdk/hosting), under "Long-running sessions", says to "use `streamInput()` to add turns to an active session and `startup()` to pre-warm subprocesses ahead of incoming traffic". `createQuery()` claims the parked handle instead of spawning; `buildQueryOptions()` was split out of `createQuery()` so both paths build identical options.

The pooling layer on top is ours — Anthropic documents the primitive but gives no guidance on matching or pool depth. It holds **whole pre-warmed processes**, not detached option sets: the options bake in `canUseTool`, every hook, and the browser/agents/chat MCP servers, all of which resolve `this.sessionId` at call time, so a handle warmed against one process could never be safely handed to another. A warm process is used only when the incoming request's profile key matches exactly; a mismatch discards it and starts cold.

**The host decides what to warm for.** `prewarmDefaults` carries the same preference chain minus the per-session pick — `agentPrefs.defaultModel ?? getEffectiveModels().agentModel`, plus default effort/speed — resolved through `resolveContainerModel` to a concrete wire id. This matters: the agent default is stored as the alias `"opus"` and only becomes `claude-opus-5` after resolution, so keying on the raw value would never match. The composer only puts a model on the wire when the user explicitly picks one (`composer-options.tsx:243`), so keying on last-used would let a single one-off pick cost the next session both a wasted spawn and a cold start. Callers without a hint (cron, chat, cross-agent) fall back to the session's own shape.

**Drop the CLI's boot-path telemetry and feature-flag fetch.** Measured on its own this is 2% — noise (see the table below). It is kept only as insurance for restricted-egress deployments, where that fetch has been reported to hang startup ([#16590](https://github.com/anthropics/claude-code/issues/16590), [#55623](https://github.com/anthropics/claude-code/issues/55623)). It does stop remote flags and killswitches from reaching our sessions, which is acceptable because the image pins the CLI version rather than self-updating.

Lifecycle: refill happens after the session is live, never in front of it; the profile is persisted so a booting container warms for the session about to arrive (kicked off before the dashboard scan — on 2 CPUs they compete); `POST /env` discards the parked process because it captured the old `REMOTE_MCPS`; `stopAll()` disposes it; and a warm-up that resolves after the wanted profile changed disposes itself rather than parking something nothing will claim.

**Pool depth is one.** A parked process holds ~232MB RSS (measured), so a deeper pool would reserve ~700MB per awake agent against a 4GB limit. A second session arriving mid-refill awaits the in-flight warm-up rather than racing it with a cold spawn, so bursts degrade to today's behaviour instead of contending for 2 CPUs. `SESSION_PREWARM=0` (or `prewarmEnabled: false`) disables it.

## Measurements

Three images built from the same commit, interleaved rounds, real containers and real LLM turns, 2 CPU / 4GB. Median `POST /sessions`:

| arm | idle container (n=12) | sleeping container (n=6) |
|---|---|---|
| baseline | 0.635s (p90 0.663) | 1.786s |
| telemetry flag only | 0.623s — **2%, noise** | 1.768s |
| pre-warm pool | **0.197s (p90 0.267) — 69%** | **1.427s — 20%** |

For the sleeping case the CLI cost is gone too — container logs show the boot warm-up landing and the request claiming it 0.3ms later, with `init` at +77ms. The remaining ~1.4s is `docker start` plus the health wait, which this doesn't touch.

One-off override behaviour, verified live: default cold 0.751s → default **0.188s** → one-off Haiku pick 0.521s (correctly not served a mismatched process) → default **0.183s** (pool stayed on the default) → default **0.197s**. Persisted profile after the Haiku session is `claude-opus-5`.

## Testing

- 761 container tests, 1862 host tests, both typechecks, eslint clean on changed files.
- 14 pool tests plus 5 profile-key tests and 2 process-binding tests: claim-on-match, discard-on-mismatch, parsed-default equivalence, warms-for-host-default-not-this-session's-pick, replaces-a-parked-stale-process, no-hint fallback, boot warm from persisted profile, env-change invalidation, stale warm-up self-disposal, shutdown disposal, kill switch.
- End to end through the real app: warm-claimed sessions return correct transcripts, and a model switch discards the warm process and still answers.
- Existing SessionManager suites pass `prewarmEnabled: false` — they mock the process class entirely and shouldn't have to model pre-warming.

## Review notes

`claude-code.ts` shows ~700 changed lines but only ~78 are real — the rest is re-indentation from unnesting the options object. Review with `git diff -w`.

Two bugs found by running against a real container that the unit tests missed, both fixed here: the staleness guard compared against the session's profile rather than the refill target (so every refill disposed itself), and a parked stale process was never replaced (so a boot warm-up built from the previous container's profile stranded every later session on a cold start).

Not addressed: a message into an idle-evicted session still pays a full cold boot, since a warm process can't serve it (`resume: <sessionId>` is baked into the options). That's the other half of the "existing sessions feel slower" report and wants its own change.

https://claude.ai/code/session_01FT8YFrqoNfy3wJSQ89UKFG
