### PR TITLE
Registry consolidation: ReviewManager adapter, computer-use store, dead-subagent invalidation (Phase 5)

### DIFF
--- a/agent-container/src/tools/request-connected-account.test.ts
+++ b/agent-container/src/tools/request-connected-account.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { inputManager } from '../input-manager'
+
+describe('requestConnectedAccountTool', () => {
+  let originalAccounts: string | undefined
+
+  beforeEach(() => {
+    originalAccounts = process.env.CONNECTED_ACCOUNTS
+  })
+
+  afterEach(() => {
+    if (originalAccounts === undefined) {
+      delete process.env.CONNECTED_ACCOUNTS
+    } else {
+      process.env.CONNECTED_ACCOUNTS = originalAccounts
+    }
+  })
+
+  async function invokeTool(toolUseId: string) {
+    const { requestConnectedAccountTool } = await import('./request-connected-account')
+    const handler = (requestConnectedAccountTool as any).handler
+    inputManager.setCurrentToolUseId(toolUseId)
+    return handler({
+      toolkit: 'gmail',
+      reason: 'Allow access to Gmail to search for the shipping confirmation?',
+    }) as Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>
+  }
+
+  it('parks the pending request as connected_account, not secret', async () => {
+    const toolUseId = `ca-test-${Date.now()}-1`
+    const resultPromise = invokeTool(toolUseId)
+
+    await vi.waitFor(() => expect(inputManager.hasPending(toolUseId)).toBe(true))
+    const entry = inputManager.getAllPending().find((p) => p.toolUseId === toolUseId)
+    expect(entry?.inputType).toBe('connected_account')
+
+    inputManager.resolve(toolUseId, 'granted')
+    const result = await resultPromise
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0].text).toContain('gmail')
+  })
+
+  it('keeps the toolkit and reason on the pending metadata', async () => {
+    const toolUseId = `ca-test-${Date.now()}-2`
+    const resultPromise = invokeTool(toolUseId)
+
+    await vi.waitFor(() => expect(inputManager.hasPending(toolUseId)).toBe(true))
+    const entry = inputManager.getAllPending().find((p) => p.toolUseId === toolUseId)
+    expect(entry?.metadata).toMatchObject({
+      toolkit: 'gmail',
+      reason: 'Allow access to Gmail to search for the shipping confirmation?',
+    })
+
+    inputManager.resolve(toolUseId, 'granted')
+    await resultPromise
+  })
+
+  it('returns a declined message when the request is rejected', async () => {
+    const toolUseId = `ca-test-${Date.now()}-3`
+    const resultPromise = invokeTool(toolUseId)
+
+    await vi.waitFor(() => expect(inputManager.hasPending(toolUseId)).toBe(true))
+    inputManager.reject(toolUseId, 'User declined to provide access')
+
+    const result = await resultPromise
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('declined')
+  })
+})

--- a/agent-container/src/tools/request-connected-account.ts
+++ b/agent-container/src/tools/request-connected-account.ts
@@ -64,10 +64,10 @@ Common toolkits include gmail, slack, github, notion, linear, salesforce, and ma
     try {
       // This blocks until the user provides or declines access
       // The access tokens are set via /env endpoint before resolving
-      await inputManager.createPending(
+      await inputManager.createPendingWithType<string>(
         toolUseId,
-        `CONNECTED_ACCOUNT_${toolkitLower.toUpperCase()}`,
-        args.reason
+        'connected_account',
+        { toolkit: toolkitLower, reason: args.reason }
       )
 
       // If we get here, the user provided access

--- a/e2e/specs/subagent-browser-input-status.spec.ts
+++ b/e2e/specs/subagent-browser-input-status.spec.ts
@@ -63,6 +63,24 @@ test.describe('Subagent Browser Input Status', () => {
     await agentPage.waitForStatus('idle', 15000)
   })
 
+  test('a subagent that dies with a parked request drops the card and returns status to working', async ({ page }, testInfo) => {
+    await sessionPage.sendMessage(`dead subagent input ${uniqueSuffix(testInfo)}`)
+
+    // The subagent parks on browser input: card + awaiting, same as ever.
+    await expect(page.getByTestId('browser-input-request')).toBeVisible({ timeout: 15000 })
+    await agentPage.waitForStatus('awaiting_input', 15000)
+
+    // The subagent then dies (sidechain result, no tool_result). Nothing can
+    // answer the card anymore — the host must invalidate it: card gone and
+    // status back to working while the main turn is still open.
+    // Regression: the card sat orphaned until a turn boundary.
+    await expect(page.getByTestId('browser-input-request')).toHaveCount(0, { timeout: 10000 })
+    await agentPage.waitForStatus('working', 5000)
+
+    // …and the main turn settles on its own afterwards.
+    await agentPage.waitForStatus('idle', 15000)
+  })
+
   test('declining the subagent browser input request returns the agent to idle', async ({ page }, testInfo) => {
     await sessionPage.sendMessage(`subagent browser input ${uniqueSuffix(testInfo)}`)
 

--- a/e2e/specs/user-input-requests.spec.ts
+++ b/e2e/specs/user-input-requests.spec.ts
@@ -285,6 +285,35 @@ test.describe('User Input Requests', () => {
     await sessionPage.waitForInputEnabled(15000)
   })
 
+  test('parallel holdback: a declined request stays settled across reload', async ({ page }) => {
+    // Real-CLI parallel semantics: no tool_result reaches the transcript
+    // until BOTH siblings settle, so cleanup must come from the decision
+    // route's explicit settle. Regression: the declined secret stayed open in
+    // the registry — the snapshot kept serving it, a reload resurrected the
+    // card, and the stale card could save a value despite the decline.
+    await sessionPage.sendMessage('ask parallel holdback')
+
+    await sessionPage.waitForSecretRequest('DATABASE_URL')
+    await sessionPage.waitForQuestionRequest()
+
+    await sessionPage.declineSecret('DATABASE_URL')
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0, { timeout: 10000 })
+    // The sibling question is still parked — the turn is NOT over.
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(1)
+
+    // Reload mid-park: the still-open question must come back from the
+    // snapshot; the declined secret must NOT.
+    await page.reload()
+    await sessionPage.waitForQuestionRequest()
+    await expect(sessionPage.getSecretRequests()).toHaveCount(0)
+
+    // Answering the survivor releases the held sibling results and the turn
+    // completes normally.
+    await sessionPage.answerQuestion('AWS')
+    await expect(sessionPage.getQuestionRequests()).toHaveCount(0, { timeout: 10000 })
+    await sessionPage.waitForInputEnabled(15000)
+  })
+
   test('script run request: approve execution', async ({ page }) => {
     // No global toggle needed — permissions are now per-agent via ComputerUsePermissionManager
     // With no cached permission, the request will be shown to the user for approval

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -124,7 +124,10 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     subscribeToSession: vi.fn(),
     unsubscribeFromSession: vi.fn(),
     markSessionActive: vi.fn(),
+    markSessionInterrupted: vi.fn(),
     cancelAwaitingInput: vi.fn(),
+    completeInputRequest: vi.fn(),
+    getSettledInputRequests: vi.fn(() => new Map()),
     broadcastSessionEvent: vi.fn(),
   },
 }))
@@ -3194,6 +3197,109 @@ describe('DELETE /:id/sessions/:sessionId', () => {
 // Awaiting-input recovery from the persisted transcript
 // ============================================================================
 
+describe('decision routes settle their request immediately', () => {
+  // The transcript tool_result normally cleans up the stream store and
+  // registry, but parallel tool calls hold every sibling's result until the
+  // last one resolves. A successful decision must settle its own request NOW
+  // — otherwise the snapshot keeps serving it, a reload resurrects the card,
+  // and the stale card can act on a request that was already declined.
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockIsAuthMode.mockReturnValue(false)
+    mockContainerFetch.mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    )
+  })
+
+  const CASES: Array<{
+    label: string
+    url: string
+    body: Record<string, unknown>
+    outcome: 'answered' | 'declined'
+  }> = [
+    {
+      label: 'secret decline',
+      url: '/api/agents/test-agent/sessions/sess-1/provide-secret',
+      body: { toolUseId: 'tool-dec-1', secretName: 'K', decline: true },
+      outcome: 'declined',
+    },
+    {
+      label: 'question decline',
+      url: '/api/agents/test-agent/sessions/sess-1/answer-question',
+      body: { toolUseId: 'tool-dec-2', decline: true },
+      outcome: 'declined',
+    },
+    {
+      label: 'question answer',
+      url: '/api/agents/test-agent/sessions/sess-1/answer-question',
+      body: { toolUseId: 'tool-dec-3', answers: { 'Pick DB': 'sqlite' } },
+      outcome: 'answered',
+    },
+    {
+      label: 'browser input complete',
+      url: '/api/agents/test-agent/sessions/sess-1/complete-browser-input',
+      body: { toolUseId: 'tool-dec-4' },
+      outcome: 'answered',
+    },
+    {
+      label: 'browser input decline',
+      url: '/api/agents/test-agent/sessions/sess-1/complete-browser-input',
+      body: { toolUseId: 'tool-dec-5', decline: true },
+      outcome: 'declined',
+    },
+    {
+      label: 'script run deny',
+      url: '/api/agents/test-agent/sessions/sess-1/run-script',
+      body: { toolUseId: 'tool-dec-6', decline: true },
+      outcome: 'declined',
+    },
+    {
+      label: 'file decline',
+      url: '/api/agents/test-agent/sessions/sess-1/provide-file',
+      body: { toolUseId: 'tool-dec-7', decline: true },
+      outcome: 'declined',
+    },
+    {
+      label: 'connected account decline',
+      url: '/api/agents/test-agent/sessions/sess-1/provide-connected-account',
+      body: { toolUseId: 'tool-dec-8', toolkit: 'github', decline: true },
+      outcome: 'declined',
+    },
+    {
+      label: 'remote MCP decline',
+      url: '/api/agents/test-agent/sessions/sess-1/provide-remote-mcp',
+      body: { toolUseId: 'tool-dec-9', decline: true },
+      outcome: 'declined',
+    },
+  ]
+
+  it.each(CASES)('$label settles as $outcome', async ({ url, body, outcome }) => {
+    const res = await postJson(app, url, body)
+    expect(res.status).toBe(200)
+    expect(messagePersister.completeInputRequest).toHaveBeenCalledWith(
+      'sess-1',
+      body.toolUseId,
+      outcome,
+    )
+  })
+
+  it('a failed container reject does NOT settle the request', async () => {
+    mockContainerFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'no pending' }), { status: 404 }),
+    )
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/provide-secret', {
+      toolUseId: 'tool-dec-10',
+      secretName: 'K',
+      decline: true,
+    })
+    expect(res.status).toBe(500)
+    expect(messagePersister.completeInputRequest).not.toHaveBeenCalled()
+  })
+})
+
 describe('pending-requests snapshot — GET /:id/pending-requests', () => {
   let app: ReturnType<typeof createApp>
 
@@ -3350,6 +3456,45 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
 
     await getReq(app, URL)
     expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
+  })
+
+  it('a decision-settled request is stamped resolved and excluded from recovery', async () => {
+    // Parallel tool calls hold every sibling's transcript result until the
+    // last one settles — the declined call still looks unresolved here.
+    // Without the stamp, a reload resurrects its card (history fallback) and
+    // recovery re-asserts awaiting for a request nothing can answer anymore.
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
+      new Map([['tool-declined', 'declined']]),
+    )
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [
+          { id: 'tool-declined', name: 'mcp__user-input__request_secret', input: {} },
+          { id: 'tool-open', name: 'AskUserQuestion', input: {} },
+        ],
+      },
+    ])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Array<{
+      toolCalls?: Array<{ id: string; result?: string }>
+    }>
+    const toolCalls = body[0].toolCalls ?? []
+    expect(toolCalls.find((t) => t.id === 'tool-declined')?.result).toBe(
+      'User declined the request',
+    )
+    expect(toolCalls.find((t) => t.id === 'tool-open')?.result).toBeUndefined()
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }],
+    )
   })
 
   it('does not recover for an inactive session', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1713,6 +1713,27 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     // Discover subagent IDs for interrupted Task tool calls that have no result
     await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
 
+    // Parallel tool calls hold every sibling's transcript result until the
+    // LAST one resolves, so a request the user already decided still looks
+    // unresolved here. Stamp the settled outcome onto the transcript so every
+    // history consumer — the client's refresh fallback, the transcript card,
+    // and the recovery scan below — sees a completed call instead of
+    // resurrecting a decided one.
+    const settledRequests = messagePersister.getSettledInputRequests(sessionId)
+    if (settledRequests.size > 0) {
+      for (const item of transformed) {
+        if (item.type !== 'assistant') continue
+        for (const toolCall of item.toolCalls) {
+          if (toolCall.result !== undefined) continue
+          const outcome = settledRequests.get(toolCall.id)
+          if (outcome !== undefined) {
+            toolCall.result =
+              outcome === 'answered' ? 'User provided input' : 'User declined the request'
+          }
+        }
+      }
+    }
+
     if (messagePersister.isSessionActive(sessionId)) {
       const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
       if (unresolvedRequests.length > 0) {
@@ -2319,6 +2340,7 @@ agents.post('/:id/sessions/:sessionId/provide-secret', AgentUser(), async (c) =>
         return c.json({ error: 'Failed to reject secret request' }, 500)
       }
 
+      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'secret', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -2383,6 +2405,7 @@ agents.post('/:id/sessions/:sessionId/provide-secret', AgentUser(), async (c) =>
       return c.json({ error: 'Secret saved but failed to notify agent' }, 500)
     }
     console.log(`[provide-secret] Request ${toolUseId} resolved successfully`)
+    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
 
     return c.json({ success: true, saved: true })
   } catch (error) {
@@ -2427,6 +2450,7 @@ agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), a
         return c.json({ error: 'Failed to reject request' }, 500)
       }
 
+      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'connected_account', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -2562,6 +2586,7 @@ agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), a
     console.log(
       `[provide-connected-account] Request ${toolUseId} resolved successfully`
     )
+    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
 
     return c.json({
       success: true,
@@ -2609,6 +2634,7 @@ agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) =
         return c.json({ error: 'Failed to reject question request' }, 500)
       }
 
+      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'question', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -2640,6 +2666,7 @@ agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) =
       return c.json({ error: 'Failed to submit answers' }, 500)
     }
     console.log(`[answer-question] Request ${toolUseId} resolved successfully`)
+    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
 
     return c.json({ success: true })
   } catch (error) {
@@ -2765,8 +2792,10 @@ agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), asyn
         return c.json({ error: 'Failed to reject browser input request' }, 500)
       }
 
-      // Interrupt the session so the user can chat directly with the agent
       const sessionId = c.req.param('sessionId')
+      messagePersister.completeInputRequest(sessionId, toolUseId, 'declined')
+
+      // Interrupt the session so the user can chat directly with the agent
       try {
         await client.interruptSession(sessionId)
       } catch (e) {
@@ -2800,6 +2829,7 @@ agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), asyn
       return c.json({ error: 'Failed to complete browser input request' }, 500)
     }
 
+    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
     return c.json({ success: true })
   } catch (error) {
     console.error('Failed to complete browser input:', error)
@@ -2844,6 +2874,7 @@ agents.post('/:id/sessions/:sessionId/run-script', AgentUser(), async (c) => {
         return c.json({ error: 'Failed to reject script run request' }, 500)
       }
 
+      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'script_run', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -2930,6 +2961,7 @@ agents.post('/:id/sessions/:sessionId/run-script', AgentUser(), async (c) => {
       return c.json({ error: 'Failed to resolve script run request' }, 500)
     }
 
+    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
     trackServerEvent('script_executed', { scriptType, exitCode })
     return c.json({ success: true })
   } catch (error) {
@@ -3656,6 +3688,7 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
         console.error('Failed to reject remote MCP request:', await rejectResponse.text())
         return c.json({ error: 'Failed to decline the request in container' }, 502)
       }
+      messagePersister.completeInputRequest(c.req.param('sessionId'), body.toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'remote_mcp', withReason: !!body.declineReason })
       return c.json({ success: true, status: 'declined' })
     }
@@ -3756,6 +3789,7 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
       return c.json({ error: 'Failed to resolve the request in container' }, 502)
     }
 
+    messagePersister.completeInputRequest(c.req.param('sessionId'), body.toolUseId, 'answered')
     return c.json({ success: true, status: 'provided' })
   } catch (error) {
     console.error('Failed to provide remote MCP:', error)
@@ -4940,6 +4974,7 @@ agents.post('/:id/sessions/:sessionId/provide-file', AgentUser(), async (c) => {
         return c.json({ error: 'Failed to reject file request' }, 500)
       }
 
+      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'file', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -4971,6 +5006,7 @@ agents.post('/:id/sessions/:sessionId/provide-file', AgentUser(), async (c) => {
       return c.json({ error: 'Failed to notify agent of uploaded file' }, 500)
     }
     console.log(`[provide-file] Request ${toolUseId} resolved successfully`)
+    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
 
     return c.json({ success: true, filePath })
   } catch (error) {

--- a/src/api/routes/provide-connected-account.test.ts
+++ b/src/api/routes/provide-connected-account.test.ts
@@ -35,6 +35,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     broadcastGlobal: vi.fn(),
     persistMessage: vi.fn(),
     markAllSessionsInactiveForAgent: vi.fn(),
+    completeInputRequest: vi.fn(),
   },
 }))
 

--- a/src/api/routes/provide-remote-mcp.test.ts
+++ b/src/api/routes/provide-remote-mcp.test.ts
@@ -33,6 +33,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     broadcastGlobal: vi.fn(),
     persistMessage: vi.fn(),
     markAllSessionsInactiveForAgent: vi.fn(),
+    completeInputRequest: vi.fn(),
   },
 }))
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1648,6 +1648,11 @@ class ChatIntegrationManager {
           const text = await resolveResponse.text().catch(() => '')
           console.error(`[ChatIntegrationManager] Failed to resolve question ${toolUseId}:`, text)
           reportError(new Error(`Resolve question failed: ${resolveResponse.status}`), 'resolve-input', { integrationId, toolUseId, status: resolveResponse.status })
+        } else {
+          // Settle immediately — parallel tool calls hold the transcript
+          // tool_result until every sibling resolves. The registry entry's
+          // scope supplies the session.
+          messagePersister.completeInputRequest(undefined, toolUseId, 'answered')
         }
         return
       }
@@ -1664,6 +1669,8 @@ class ChatIntegrationManager {
         const text = await resolveResponse.text().catch(() => '')
         console.error(`[ChatIntegrationManager] Failed to resolve input ${toolUseId}:`, text)
         reportError(new Error(`Resolve input failed: ${resolveResponse.status}`), 'resolve-input', { integrationId, toolUseId, status: resolveResponse.status })
+      } else {
+        messagePersister.completeInputRequest(undefined, toolUseId, 'answered')
       }
     } catch (err) {
       console.error(`[ChatIntegrationManager] Failed to handle interactive response:`, err)

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -1267,6 +1267,97 @@ describe('pending user-input request lifecycle (characterization)', () => {
   })
 
   // ==========================================================================
+  // Decision-route settle: a successful decision must settle its request
+  // immediately. The transcript tool_result normally does the cleanup, but
+  // parallel tool calls hold every sibling's result until the LAST one
+  // resolves — without an explicit settle, the decided entry stays open, the
+  // snapshot keeps serving it, a reload resurrects the card, and the stale
+  // card can act on a request that was already declined.
+  // ==========================================================================
+
+  describe('decision settle under parallel tool calls', () => {
+    it('completeInputRequest settles one of two parallel asks without waiting for its tool_result', () => {
+      simulateToolUse('mcp__user-input__request_secret', 'par-secret-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      simulateToolUse('AskUserQuestion', 'par-question-1', {
+        questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
+      })
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(2)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      messagePersister.completeInputRequest(SESSION_ID, 'par-secret-1', 'declined')
+
+      // Registry and replay store both drop the declined ask NOW — a reload
+      // must not resurrect it. The surviving question keeps the light on.
+      expect(
+        userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id),
+      ).toEqual(['par-question-1'])
+      expect(messagePersister.getPendingInputRequests(SESSION_ID).map((r) => r.toolUseId)).toEqual(
+        ['par-question-1'],
+      )
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(
+        userInputRequestManager.stats.recentResolutions.find((r) => r.id === 'par-secret-1')
+          ?.outcome,
+      ).toBe('declined')
+
+      // Other tabs drop the card off the same broadcast the tool_result path
+      // emits.
+      const toolResults = sseEvents.filter(
+        (e) => e.type === 'tool_result' && e.toolUseId === 'par-secret-1',
+      )
+      expect(toolResults).toHaveLength(1)
+      expect(toolResults[0].isError).toBe(true)
+
+      // When the CLI finally releases the parallel siblings' results, the
+      // already-settled ask is a no-op — no double resolution.
+      sendToolResult('par-secret-1')
+      expect(
+        userInputRequestManager.stats.recentResolutions.filter((r) => r.id === 'par-secret-1'),
+      ).toHaveLength(1)
+
+      sendToolResult('par-question-1')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+    })
+
+    it('the settled outcome is stamped for the messages route until the turn boundary clears it', () => {
+      // The transcript still shows the declined call as unresolved while its
+      // sibling holds the results back — the messages route stamps this
+      // outcome so history consumers see a completed call.
+      simulateToolUse('mcp__user-input__request_secret', 'par-stamp-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      messagePersister.completeInputRequest(SESSION_ID, 'par-stamp-1', 'declined')
+      expect(messagePersister.getSettledInputRequests(SESSION_ID).get('par-stamp-1')).toBe(
+        'declined',
+      )
+
+      // The turn boundary lands the real results in the transcript — the
+      // stamp expires with it.
+      mockClient._sendMessage({ type: 'result', subtype: 'success', num_turns: 1 })
+      expect(messagePersister.getSettledInputRequests(SESSION_ID).size).toBe(0)
+    })
+
+    it('settling the last parked ask clears awaiting, and callers without a sessionId derive it', () => {
+      simulateToolUse('mcp__user-input__request_secret', 'par-solo-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+
+      // Chat connectors know only the toolUseId — the registry entry's scope
+      // supplies the session.
+      messagePersister.completeInputRequest(undefined, 'par-solo-1', 'answered')
+
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+    })
+  })
+
+  // ==========================================================================
   // Dead-subagent invalidation: a subagent that terminates with a parked
   // request leaves an unanswerable card. Its registry entries are linked by
   // parentToolUseId at dispatch, and subagent completion invalidates them —

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -1328,6 +1328,45 @@ describe('pending user-input request lifecycle (characterization)', () => {
       })
     })
 
+    it('a dead subagent also invalidates its parked script_run approval', () => {
+      // script_run is dispatched ADJACENT to the blocking-tool funnel (its own
+      // handler call at the sidechain sites), so its parent threading is a
+      // separate seam from the six funnel kinds — and unlike capability
+      // reviews it has no container-side cancelled-frame cleanup to fall
+      // back on.
+      mockClient._sendMessage({
+        type: 'assistant',
+        parent_tool_use_id: 'parent-script-1',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'side-script-1',
+              name: 'mcp__user-input__request_script_run',
+              input: { script: 'sw_vers', explanation: 'Version', scriptType: 'shell' },
+            },
+          ],
+        },
+      })
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(
+        userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id),
+      ).toEqual(['side-script-1'])
+
+      mockClient._sendMessage({
+        type: 'result',
+        parent_tool_use_id: 'parent-script-1',
+        subtype: 'success',
+      })
+
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(
+        userInputRequestManager.stats.recentResolutions.find((r) => r.id === 'side-script-1')
+          ?.outcome,
+      ).toBe('invalidated')
+    })
+
     it("a sibling subagent's death leaves another subagent's parked request open", () => {
       sendSidechainToolUse('parent-alive-1', 'side-kept-1')
       sendSidechainToolUse('parent-dying-1', 'side-dropped-1')

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -423,11 +423,12 @@ describe('pending user-input request lifecycle (characterization)', () => {
   )
 
   // ==========================================================================
-  // Documented divergence: computer-use lives in a separate store with
-  // route-driven clearing (the two-store split this suite exists to pin down)
+  // Documented divergence: computer-use has route-driven clearing and
+  // survives idle boundaries — the registry expresses this as a distinct
+  // store label (storeForKind), no longer as a separate map
   // ==========================================================================
 
-  describe('main stream: computer use (divergent two-store lifecycle)', () => {
+  describe('main stream: computer use (divergent clearing rules)', () => {
     const TOOL = 'mcp__computer-use__computer_click'
 
     it('opens into the computer-use store, NOT the input-request store', async () => {
@@ -1266,6 +1267,101 @@ describe('pending user-input request lifecycle (characterization)', () => {
   })
 
   // ==========================================================================
+  // Dead-subagent invalidation: a subagent that terminates with a parked
+  // request leaves an unanswerable card. Its registry entries are linked by
+  // parentToolUseId at dispatch, and subagent completion invalidates them —
+  // registry, replay store, container pending, and awaiting status together.
+  // ==========================================================================
+
+  describe('dead-subagent request invalidation', () => {
+    function sendSidechainToolUse(parentToolId: string, toolId: string) {
+      mockClient._sendMessage({
+        type: 'assistant',
+        parent_tool_use_id: parentToolId,
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: toolId,
+              name: 'mcp__user-input__request_browser_input',
+              input: { message: 'Log in', requirements: [] },
+            },
+          ],
+        },
+      })
+    }
+
+    it('a subagent that dies with a parked request invalidates it everywhere', async () => {
+      sendSidechainToolUse('parent-dead-1', 'side-orphan-1')
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(1)
+
+      // The subagent finishes WITHOUT a tool_result for the parked ask
+      // (killed, errored, or torn down) — sidechain 'result' is its terminal
+      // frame. Nothing can answer the request anymore.
+      mockClient._sendMessage({
+        type: 'result',
+        parent_tool_use_id: 'parent-dead-1',
+        subtype: 'success',
+      })
+
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.getPendingInputRequests(SESSION_ID)).toHaveLength(0)
+      expect(
+        userInputRequestManager.stats.recentResolutions.find((r) => r.id === 'side-orphan-1')
+          ?.outcome,
+      ).toBe('invalidated')
+      // The unified wire tells clients the card is dead.
+      const resolved = sseEvents.filter(
+        (e) => e.type === 'user_request_resolved' && e.requestId === 'side-orphan-1',
+      )
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0].outcome).toBe('invalidated')
+      // The container-side pending is rejected so a late click can't land.
+      await vi.waitFor(() => {
+        expect(
+          mockContainerClientFetch.mock.calls.some(
+            (c) => c[0] === '/inputs/side-orphan-1/reject',
+          ),
+        ).toBe(true)
+      })
+    })
+
+    it("a sibling subagent's death leaves another subagent's parked request open", () => {
+      sendSidechainToolUse('parent-alive-1', 'side-kept-1')
+      sendSidechainToolUse('parent-dying-1', 'side-dropped-1')
+      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(2)
+
+      mockClient._sendMessage({
+        type: 'result',
+        parent_tool_use_id: 'parent-dying-1',
+        subtype: 'success',
+      })
+
+      const open = userInputRequestManager.getOpenRequestsForSession(SESSION_ID)
+      expect(open.map((r) => r.id)).toEqual(['side-kept-1'])
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+    })
+
+    it("a main-agent request has no parent linkage and survives subagent completions", () => {
+      simulateToolUse('mcp__user-input__request_secret', 'main-secret-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+      mockClient._sendMessage({
+        type: 'result',
+        parent_tool_use_id: 'parent-unrelated-1',
+        subtype: 'success',
+      })
+      expect(
+        userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id),
+      ).toEqual(['main-secret-1'])
+      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+    })
+  })
+
+  // ==========================================================================
   // Unified wire: every registry transition broadcasts ONE typed event —
   // user_request_created / user_request_resolved — alongside the legacy
   // per-type events, to the global stream always and the session stream when
@@ -1408,6 +1504,33 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
       expect(createdFor(globalEvents, 'wire-recovered-1')).toHaveLength(0)
       expect(createdFor(sseEvents, 'wire-recovered-1')).toHaveLength(0)
+    })
+
+    it('the real registration upgrades a recovered synthetic and finally hits the wire', () => {
+      // Recovery beat the stream event (the GET-messages read raced the
+      // container stream). Without the upgrade, the payload-less stub blocks
+      // the real registration forever: clients never receive a renderable
+      // user_request_created and the snapshot serves a stub the card guards
+      // drop.
+      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
+        { toolUseId: 'wire-upgrade-1', toolName: 'mcp__user-input__request_secret' },
+      ])
+      expect(createdFor(globalEvents, 'wire-upgrade-1')).toHaveLength(0)
+
+      simulateToolUse('mcp__user-input__request_secret', 'wire-upgrade-1', {
+        secretName: 'API_KEY',
+        reason: 'Need it',
+      })
+
+      const created = createdFor(globalEvents, 'wire-upgrade-1')
+      expect(created).toHaveLength(1)
+      expect(created[0].request.payload.secretName).toBe('API_KEY')
+
+      const entry = userInputRequestManager
+        .getSnapshotForScope(AGENT_SLUG, SESSION_ID)
+        .find((r) => r.id === 'wire-upgrade-1')
+      expect((entry?.payload as { recovered?: boolean }).recovered).toBeUndefined()
+      expect((entry?.payload as { secretName?: string }).secretName).toBe('API_KEY')
     })
 
     it('the snapshot a reconnecting client fetches matches the wire it missed', () => {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3113,7 +3113,7 @@ describe('MessagePersister', () => {
         expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
       })
 
-      it('sweeps pendingComputerUseRequests (the separate map) and interrupts', async () => {
+      it('sweeps the pending computer-use entries and interrupts', async () => {
         vi.stubEnv('E2E_MOCK', 'true') // skip the host platform gate so the request goes pending
         try {
           messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -2174,7 +2174,7 @@ class MessagePersister {
               parentToolId,
             )
             if (block.name === 'mcp__user-input__request_script_run') {
-              this.handleScriptRunRequestTool(sessionId, block.id, input, state.agentSlug)
+              this.handleScriptRunRequestTool(sessionId, block.id, input, state.agentSlug, parentToolId)
             }
             if (block.name.startsWith('mcp__computer-use__')) {
               this.handleComputerUseRequestTool(
@@ -2479,7 +2479,8 @@ class MessagePersister {
               sessionId,
               sub.currentToolUse.id,
               sub.currentToolInput,
-              state.agentSlug
+              state.agentSlug,
+              parentToolId
             )
           }
 
@@ -4350,7 +4351,8 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug?: string,
+    parentToolUseId?: string
   ): void {
     try {
       let input: RequestScriptRunInput = {}
@@ -4400,6 +4402,7 @@ ${continuation}`
         scriptType: input.scriptType,
         agentSlug,
         autoApproved,
+        ...(parentToolUseId ? { parentToolUseId } : {}),
       })
 
       // Only flip the global "awaiting input" status (which drives the orange agent-status

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -119,12 +119,11 @@ interface StreamingState {
   // set imperatively — turn-boundary teardown paths reset it to false alongside isActive; every
   // other transition must go through syncSessionAwaiting.
   isAwaitingInput: boolean
-  // TODO: computer-use and the other input requests are tracked in two separate maps with
-  // divergent clearing rules (this one survives an idle boundary for SSE replay and is cleared
-  // on session_active / decision routes / cancelAwaitingInput; pendingInputRequests below is
-  // cleared on tool_result + both turn boundaries). Unify into a single store + single SSE
-  // replay loop. Tracked: SUP-213 (sibling of SUP-163).
-  pendingComputerUseRequests: Map<string, { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> // Pending computer use requests awaiting user approval (keyed by toolUseId)
+  // Computer-use requests live ONLY in userInputRequestManager (kind
+  // 'computer_use'), not here: their clearing rules diverge from the stream
+  // store (they survive an idle boundary for SSE replay; cleared on
+  // session_active / decision routes / cancelAwaitingInput), which the
+  // registry expresses via storeForKind — see getPendingComputerUseRequests.
   // Pending user-input request broadcasts (secret/connected_account/question/file/remote_mcp/
   // script_run/browser_input), keyed by toolUseId. These are one-shot SSE events, so a client
   // that connects AFTER they fire would never see them; we store the exact payloads here and the
@@ -347,7 +346,6 @@ class MessagePersister {
     const priorIsAwaitingInput = prior?.isAwaitingInput ?? false
     const priorBackgroundTasks = prior?.activeBackgroundTasks ?? new Map()
     const priorPendingInputRequests = prior?.pendingInputRequests ?? new Map()
-    const priorPendingComputerUseRequests = prior?.pendingComputerUseRequests ?? new Map()
 
     // Detach only the transport if already subscribed. NOT unsubscribeFromSession:
     // that is a full teardown — it drops the session's registry entries, which
@@ -374,7 +372,6 @@ class MessagePersister {
       activeSubagents: new Map(),
       slashCommands: [],
       isAwaitingInput: priorIsAwaitingInput,
-      pendingComputerUseRequests: priorPendingComputerUseRequests,
       pendingInputRequests: priorPendingInputRequests,
       cancelledCapabilityReviews: new Set(),
       lastApiErrorCode: null,
@@ -578,11 +575,30 @@ class MessagePersister {
     return state ? this.computeActivity(state) : 'idle'
   }
 
-  // Get pending computer use requests for a session (for SSE replay on reconnect)
+  // Get pending computer use requests for a session (for SSE replay on reconnect).
+  // Sourced from the registry — the persister no longer keeps its own
+  // computer-use map. The legacy event shape is rebuilt from the envelope for
+  // the replay route and the decision endpoints.
   getPendingComputerUseRequests(sessionId: string): Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> {
-    const state = this.streamingStates.get(sessionId)
-    if (!state) return []
-    return Array.from(state.pendingComputerUseRequests.values())
+    return userInputRequestManager
+      .getOpenRequestsForSession(sessionId)
+      .filter((r) => r.kind === 'computer_use')
+      .map((r) => {
+        const payload = r.payload as {
+          method?: string
+          params?: Record<string, unknown>
+          permissionLevel?: string
+          appName?: string
+        }
+        return {
+          toolUseId: r.id,
+          method: payload.method ?? '',
+          params: payload.params ?? {},
+          permissionLevel: payload.permissionLevel ?? '',
+          appName: payload.appName,
+          agentSlug: r.scope.agentSlug,
+        }
+      })
   }
 
   // Get pending user-input request broadcasts for a session (for SSE replay on (re)connect).
@@ -634,13 +650,8 @@ class MessagePersister {
     toolUseId: string,
     outcome: UserInputRequestOutcome = 'answered',
   ): void {
-    const state = this.streamingStates.get(sessionId)
-    if (state) {
-      state.pendingComputerUseRequests.delete(toolUseId)
-      userInputRequestManager.resolveIfInStore(toolUseId, 'computer_use', outcome)
-      this.shadowRegistryCheck(sessionId, 'clearPendingComputerUseRequest')
-      this.syncSessionAwaiting(sessionId)
-    }
+    userInputRequestManager.resolveIfInStore(toolUseId, 'computer_use', outcome)
+    this.syncSessionAwaiting(sessionId)
   }
 
   // When a new message arrives while the session is awaiting user input, cancel the
@@ -666,9 +677,9 @@ class MessagePersister {
 
     const state = this.streamingStates.get(sessionId)
 
-    // Snapshot the pending tool ids from BOTH maps before interrupting. pendingInputRequests holds
-    // the broadcast types (cleared by markSessionInterrupted's session_idle); computer_use lives in
-    // its own pendingComputerUseRequests map, which that broadcast does NOT clear. Read the store
+    // Snapshot the pending tool ids from BOTH stores before interrupting. pendingInputRequests
+    // holds the broadcast types (cleared by markSessionInterrupted's session_idle); computer_use
+    // lives only in the registry, which that broadcast does NOT clear. Read the stream store
     // RAW — not getPendingInputRequests, whose replay filter hides recovered entries. Those are
     // exactly the ones whose container-side pending may still be live (the host missed the original
     // events), so skipping them would leave an abandoned request for a late click to land on.
@@ -682,10 +693,9 @@ class MessagePersister {
     await this.markSessionInterrupted(sessionId)
 
     // Clear the host-side computer_use bookkeeping explicitly — session_idle only clears
-    // pendingInputRequests, so a leftover entry would replay a phantom approval card on reconnect.
+    // the stream store, so a leftover entry would replay a phantom approval card on reconnect.
     for (const id of computerUseIds) {
-      state?.pendingComputerUseRequests.delete(id)
-      if (state) userInputRequestManager.resolveIfInStore(id, 'computer_use', 'superseded')
+      userInputRequestManager.resolveIfInStore(id, 'computer_use', 'superseded')
     }
     this.shadowRegistryCheck(sessionId, 'cancelAwaitingInput')
 
@@ -888,7 +898,6 @@ class MessagePersister {
         activeSubagents: new Map(),
         slashCommands: [],
         isAwaitingInput: false,
-        pendingComputerUseRequests: new Map(),
         pendingInputRequests: new Map(),
         cancelledCapabilityReviews: new Set(),
         lastApiErrorCode: null,
@@ -1000,7 +1009,6 @@ class MessagePersister {
       sessionId,
       context,
       streamStoreIds: [...state.pendingInputRequests.keys()],
-      computerUseStoreIds: [...state.pendingComputerUseRequests.keys()],
     })
   }
 
@@ -1013,22 +1021,31 @@ class MessagePersister {
     toolUseId: string,
     toolInput: string,
     agentSlug?: string,
+    parentToolUseId?: string,
   ): void {
     const state = this.streamingStates.get(sessionId)
-    if (state?.pendingInputRequests.has(toolUseId)) return
+    // A recovered stub does NOT dedupe: transcript recovery can synthesize a
+    // payload-less entry before the stream event lands, and the real dispatch
+    // must go through to re-broadcast the event and upgrade the registry entry
+    // (register() replaces recovered synthetics; clients never got a
+    // renderable event for the stub).
+    const existing = state?.pendingInputRequests.get(toolUseId) as
+      | { recovered?: boolean }
+      | undefined
+    if (existing && existing.recovered !== true) return
 
     if (toolName === 'AskUserQuestion') {
-      this.handleAskUserQuestionTool(sessionId, toolUseId, toolInput, agentSlug)
+      this.handleAskUserQuestionTool(sessionId, toolUseId, toolInput, agentSlug, parentToolUseId)
     } else if (toolName === 'mcp__user-input__request_secret') {
-      this.handleSecretRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+      this.handleSecretRequestTool(sessionId, toolUseId, toolInput, agentSlug, parentToolUseId)
     } else if (toolName === 'mcp__user-input__request_connected_account') {
-      this.handleConnectedAccountRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+      this.handleConnectedAccountRequestTool(sessionId, toolUseId, toolInput, agentSlug, parentToolUseId)
     } else if (toolName === 'mcp__user-input__request_file') {
-      this.handleFileRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+      this.handleFileRequestTool(sessionId, toolUseId, toolInput, agentSlug, parentToolUseId)
     } else if (toolName === 'mcp__user-input__request_remote_mcp') {
-      this.handleRemoteMcpRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+      this.handleRemoteMcpRequestTool(sessionId, toolUseId, toolInput, agentSlug, parentToolUseId)
     } else if (toolName === 'mcp__user-input__request_browser_input') {
-      this.handleBrowserInputRequestTool(sessionId, toolUseId, toolInput, agentSlug)
+      this.handleBrowserInputRequestTool(sessionId, toolUseId, toolInput, agentSlug, parentToolUseId)
     }
 
     // Only tools with 'request_' prefix actually block waiting for user response
@@ -1202,16 +1219,15 @@ class MessagePersister {
           )
           if (evt.type === 'session_active') {
             // A new turn also supersedes computer-use approvals left over from
-            // a previous one. Historically this store was never cleared at
-            // turn boundaries (only by a decision or cancelAwaitingInput), so
+            // a previous one. Historically these were never cleared at turn
+            // boundaries (only by a decision or cancelAwaitingInput), so
             // stale entries could survive an idle/interrupt — harmless when
             // awaiting was an imperative bit, but the derived projection would
             // read them as a live wait and flag the fresh turn as awaiting.
             // (Idle keeps them for SSE replay of a still-parked approval.)
-            for (const id of state.pendingComputerUseRequests.keys()) {
+            for (const id of userInputRequestManager.getStoreIdsForSession(sessionId, 'computer_use')) {
               userInputRequestManager.resolveIfInStore(id, 'computer_use', 'superseded')
             }
-            state.pendingComputerUseRequests.clear()
           }
           this.shadowRegistryCheck(sessionId, `broadcast:${evt.type}`)
         } else if (MessagePersister.INPUT_REQUEST_TYPES.has(evt.type) && typeof evt.toolUseId === 'string') {
@@ -2155,6 +2171,7 @@ class MessagePersister {
               block.id,
               input,
               state.agentSlug,
+              parentToolId,
             )
             if (block.name === 'mcp__user-input__request_script_run') {
               this.handleScriptRunRequestTool(sessionId, block.id, input, state.agentSlug)
@@ -2166,6 +2183,7 @@ class MessagePersister {
                 block.name,
                 input,
                 state.agentSlug,
+                parentToolId,
               )
             }
           }
@@ -2345,6 +2363,38 @@ class MessagePersister {
       state.completedSubagentIds.add(sub.agentId)
     }
     state.activeSubagents.delete(parentToolId)
+    this.invalidateSubagentRequests(sessionId, state, parentToolId)
+  }
+
+  // A terminated subagent can leave a parked request nothing will ever answer
+  // (it died before its tool_result). Settle its registry entries, drop the
+  // replay mirrors, reject the container-side pendings so a late click can't
+  // land, and recompute awaiting. A subagent that resolved its requests
+  // normally has no entries left under its parent — this is then a no-op.
+  private invalidateSubagentRequests(
+    sessionId: string,
+    state: StreamingState,
+    parentToolId: string,
+  ): void {
+    const orphaned = userInputRequestManager.resolveRequestsByParent(parentToolId, 'invalidated')
+    if (orphaned.length === 0) return
+    for (const request of orphaned) {
+      state.pendingInputRequests.delete(request.id)
+      if (state.agentSlug) {
+        this.rejectContainerInput(
+          state.agentSlug,
+          request.id,
+          'The subagent that asked for this input was terminated.',
+        ).catch((e) =>
+          console.error(
+            `[MessagePersister] dead-subagent reject failed for ${request.id}:`,
+            e,
+          ),
+        )
+      }
+    }
+    this.shadowRegistryCheck(sessionId, 'invalidateSubagentRequests')
+    this.syncSessionAwaiting(sessionId)
   }
 
   // Handle subagent stream events — mirrors handleStreamEvent but with subagent_ prefixed SSE events
@@ -2421,6 +2471,7 @@ class MessagePersister {
             sub.currentToolUse.id,
             sub.currentToolInput,
             state.agentSlug,
+            parentToolId,
           )
 
           if (sub.currentToolUse.name === 'mcp__user-input__request_script_run') {
@@ -2438,7 +2489,8 @@ class MessagePersister {
               sub.currentToolUse.id,
               sub.currentToolUse.name,
               sub.currentToolInput,
-              state.agentSlug
+              state.agentSlug,
+              parentToolId,
             )
           }
 
@@ -2774,7 +2826,8 @@ class MessagePersister {
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug?: string,
+    parentToolUseId?: string
   ): void {
     try {
       // Parse the tool input to get secretName and reason
@@ -2798,6 +2851,7 @@ class MessagePersister {
         secretName: input.secretName,
         reason: input.reason,
         agentSlug,
+        ...(parentToolUseId ? { parentToolUseId } : {}),
       })
 
       // Renderer's notification gate decides whether to show the OS popup
@@ -2817,7 +2871,8 @@ class MessagePersister {
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug?: string,
+    parentToolUseId?: string
   ): void {
     try {
       // Parse the tool input to get toolkit and reason
@@ -2841,6 +2896,7 @@ class MessagePersister {
         toolkit: input.toolkit.toLowerCase(),
         reason: input.reason,
         agentSlug,
+        ...(parentToolUseId ? { parentToolUseId } : {}),
       })
 
       // Renderer-side gate handles suppression; see session_complete trigger.
@@ -4014,7 +4070,8 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug?: string,
+    parentToolUseId?: string
   ): void {
     try {
       // Parse the tool input to get questions
@@ -4037,6 +4094,7 @@ ${continuation}`
         toolUseId,
         questions: input.questions,
         agentSlug,
+        ...(parentToolUseId ? { parentToolUseId } : {}),
       })
 
       // Renderer-side gate handles suppression; see session_complete trigger.
@@ -4138,7 +4196,8 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug?: string,
+    parentToolUseId?: string
   ): void {
     try {
       let input: RequestFileInput = {}
@@ -4161,6 +4220,7 @@ ${continuation}`
         description: input.description,
         fileTypes: input.fileTypes,
         agentSlug,
+        ...(parentToolUseId ? { parentToolUseId } : {}),
       })
 
       // Renderer-side gate handles suppression; see session_complete trigger.
@@ -4179,7 +4239,8 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug?: string,
+    parentToolUseId?: string
   ): void {
     try {
       let input: RequestRemoteMcpInput = {}
@@ -4204,6 +4265,7 @@ ${continuation}`
         reason: input.reason,
         authHint: input.authHint,
         agentSlug,
+        ...(parentToolUseId ? { parentToolUseId } : {}),
       })
 
       // Renderer-side gate handles suppression; see session_complete trigger.
@@ -4222,7 +4284,8 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug?: string,
+    parentToolUseId?: string
   ): void {
     try {
       let input: RequestBrowserInputInput = {}
@@ -4246,6 +4309,7 @@ ${continuation}`
         // string) to [] so the renderer never calls `.map()` on a non-array.
         requirements: Array.isArray(input.requirements) ? input.requirements : [],
         agentSlug,
+        ...(parentToolUseId ? { parentToolUseId } : {}),
       })
 
       // The request always blocks on the user, no matter which stream it came
@@ -4363,6 +4427,7 @@ ${continuation}`
     toolName: string,
     toolInput: string,
     agentSlug?: string,
+    parentToolUseId?: string,
   ): Promise<void> {
     try {
       // Extract AC method from tool name: mcp__computer-use__computer_launch -> launch.
@@ -4423,23 +4488,18 @@ ${continuation}`
         }
       }
 
-      // Permission needed — track and broadcast to UI for user approval
-      const state = this.streamingStates.get(sessionId)
-      if (state) {
-        // Guard against duplicate entries (e.g., SSE event replayed)
-        if (!state.pendingComputerUseRequests.has(toolUseId)) {
-          state.pendingComputerUseRequests.set(toolUseId, { toolUseId, method, params, permissionLevel, appName, agentSlug })
-          userInputRequestManager.register({
-            id: toolUseId,
-            kind: 'computer_use',
-            scope: { agentSlug, sessionId },
-            blocking: true,
-            autoApproved: false,
-            payload: { method, params, permissionLevel, appName },
-          })
-        }
-        this.shadowRegistryCheck(sessionId, 'handleComputerUseRequestTool')
-      }
+      // Permission needed — register and broadcast to UI for user approval.
+      // register() is first-delivery-wins, so a duplicate delivery (e.g. an
+      // SSE event replayed) cannot double-enter the registry.
+      userInputRequestManager.register({
+        id: toolUseId,
+        kind: 'computer_use',
+        scope: { agentSlug, sessionId },
+        blocking: true,
+        autoApproved: false,
+        parentToolUseId,
+        payload: { method, params, permissionLevel, appName },
+      })
       this.syncSessionAwaiting(sessionId)
 
       this.broadcastToSSE(sessionId, {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -129,6 +129,14 @@ interface StreamingState {
   // that connects AFTER they fire would never see them; we store the exact payloads here and the
   // /stream route replays them on (re)connect. Cleared at turn boundaries (session_active/idle).
   pendingInputRequests: Map<string, { type: string; toolUseId: string; [k: string]: unknown }>
+  // Requests settled by a decision route while their transcript tool_result is
+  // still HELD BACK (parallel tool calls release every sibling's result only
+  // when the last one settles). The messages route stamps these outcomes onto
+  // the transcript so history consumers — the client's refresh fallback, the
+  // transcript card, the recovery scan — see a completed call instead of
+  // resurrecting a decided one. Cleared at turn boundaries, when the real
+  // results are in the transcript.
+  settledInputRequests: Map<string, UserInputRequestOutcome>
   // Tombstones for capability reviews cancelled BEFORE their card was stored:
   // handleCapabilityReviewTool awaits a container grant lookup before it
   // broadcasts, so a capability_review_cancelled frame can win that race —
@@ -346,6 +354,7 @@ class MessagePersister {
     const priorIsAwaitingInput = prior?.isAwaitingInput ?? false
     const priorBackgroundTasks = prior?.activeBackgroundTasks ?? new Map()
     const priorPendingInputRequests = prior?.pendingInputRequests ?? new Map()
+    const priorSettledInputRequests = prior?.settledInputRequests ?? new Map()
 
     // Detach only the transport if already subscribed. NOT unsubscribeFromSession:
     // that is a full teardown — it drops the session's registry entries, which
@@ -373,6 +382,7 @@ class MessagePersister {
       slashCommands: [],
       isAwaitingInput: priorIsAwaitingInput,
       pendingInputRequests: priorPendingInputRequests,
+      settledInputRequests: priorSettledInputRequests,
       cancelledCapabilityReviews: new Set(),
       lastApiErrorCode: null,
       activeBackgroundTasks: priorBackgroundTasks,
@@ -601,6 +611,13 @@ class MessagePersister {
       })
   }
 
+  // Requests a decision route settled while their transcript tool_result is
+  // still held back by parallel siblings. The messages route stamps these
+  // outcomes onto the transcript.
+  getSettledInputRequests(sessionId: string): Map<string, UserInputRequestOutcome> {
+    return this.streamingStates.get(sessionId)?.settledInputRequests ?? new Map()
+  }
+
   // Get pending user-input request broadcasts for a session (for SSE replay on (re)connect).
   // Returns the exact event payloads that were broadcast, so the route can re-send them verbatim.
   // Entries synthesized by recoverSessionAwaitingInput are excluded: they were never broadcast
@@ -642,6 +659,45 @@ class MessagePersister {
     this.shadowRegistryCheck(sessionId, 'completeCapabilityReview')
     this.broadcastToSSE(sessionId, { type: 'capability_review_resolved', toolUseId })
     this.syncSessionAwaiting(sessionId)
+  }
+
+  // Settle a stream-store request the moment its decision succeeds. The
+  // transcript tool_result normally does this cleanup, but parallel tool
+  // calls hold every sibling's result until the LAST one resolves — without
+  // an explicit settle the decided entry stays open: the snapshot keeps
+  // serving it, a reload resurrects the card, and the stale card can act on
+  // a request that was already declined. Mirrors completeCapabilityReview;
+  // the real tool_result arriving later is a no-op. Callers that only know
+  // the toolUseId (chat connectors) pass sessionId undefined — the registry
+  // entry's scope supplies it.
+  completeInputRequest(
+    sessionId: string | undefined,
+    toolUseId: string,
+    outcome: UserInputRequestOutcome,
+  ): void {
+    const scopeSessionId =
+      sessionId ?? userInputRequestManager.getOpenRequest(toolUseId)?.scope.sessionId
+    if (!scopeSessionId) return
+    const state = this.streamingStates.get(scopeSessionId)
+    const hadStoreEntry = state?.pendingInputRequests.delete(toolUseId) ?? false
+    const settled = userInputRequestManager.resolveIfInStore(toolUseId, 'stream', outcome)
+    if (state && (hadStoreEntry || settled)) {
+      state.settledInputRequests.set(toolUseId, outcome)
+    }
+    if (state) this.shadowRegistryCheck(scopeSessionId, 'completeInputRequest')
+    if (hadStoreEntry || settled) {
+      // Same broadcast the tool_result path emits — the resolving tab already
+      // removed its card optimistically; every other tab drops it off this
+      // event. Card removal is idempotent, so the later real tool_result
+      // broadcasting again is harmless.
+      this.broadcastToSSE(scopeSessionId, {
+        type: 'tool_result',
+        toolUseId,
+        result: outcome === 'answered' ? 'User provided input' : 'User declined the request',
+        isError: outcome !== 'answered',
+      })
+    }
+    this.syncSessionAwaiting(scopeSessionId)
   }
 
   // Clear a pending computer use request (after approval/rejection)
@@ -899,6 +955,7 @@ class MessagePersister {
         slashCommands: [],
         isAwaitingInput: false,
         pendingInputRequests: new Map(),
+        settledInputRequests: new Map(),
         cancelledCapabilityReviews: new Set(),
         lastApiErrorCode: null,
         activeBackgroundTasks: new Map(),
@@ -1211,6 +1268,9 @@ class MessagePersister {
       if (state) {
         if (evt.type === 'session_active' || evt.type === 'session_idle') {
           state.pendingInputRequests.clear()
+          // The turn boundary lands the held-back sibling results in the
+          // transcript — the settled-outcome stamps are no longer needed.
+          state.settledInputRequests.clear()
           // Mirror the turn-boundary wipe in the registry. A new turn
           // supersedes parked asks; an idle boundary cancels them.
           userInputRequestManager.clearSessionStreamRequests(

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -668,7 +668,10 @@ export interface UserInputTool {
 }
 
 export class UserInputRequestScenario implements MockScenario {
-  constructor(private tools: UserInputTool[]) {}
+  constructor(
+    private tools: UserInputTool[],
+    private opts?: { holdResultsUntilAll?: boolean },
+  ) {}
 
   execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
     let delay = 10
@@ -685,7 +688,9 @@ export class UserInputRequestScenario implements MockScenario {
 
     // Register pending inputs BEFORE emitting any events, so that
     // resolve/reject calls from the API can find and decrement the count.
-    client.registerPendingInputs(sessionId, tools.length)
+    client.registerPendingInputs(sessionId, tools.length, {
+      holdResultsUntilAll: this.opts?.holdResultsUntilAll,
+    })
 
     // Write the user message entry immediately so the JSONL file exists on disk.
     // The backend's getSession() checks fileExists(jsonlPath) and returns 404 if
@@ -1618,6 +1623,32 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
         input: { method: 'apps', params: {}, permissionLevel: 'list_apps_windows' },
       },
     ])],
+    // Same request pair as 'ask parallel' below, but with real-CLI parallel
+    // semantics: no tool_result reaches the transcript until BOTH siblings
+    // settle. Pins the decision-route settle — without it a decided request
+    // stays open and a reload resurrects its card. Listed BEFORE 'ask
+    // parallel': scenario matching is first-substring-wins, and this key
+    // contains that one.
+    ['ask parallel holdback', new UserInputRequestScenario([
+      {
+        name: 'mcp__user-input__request_secret',
+        input: { secretName: 'DATABASE_URL', reason: 'Connection string for the database' },
+      },
+      {
+        name: 'AskUserQuestion',
+        input: {
+          questions: [{
+            question: 'Which cloud provider do you prefer?',
+            header: 'Cloud',
+            options: [
+              { label: 'AWS', description: 'Amazon Web Services' },
+              { label: 'GCP', description: 'Google Cloud Platform' },
+            ],
+            multiSelect: false,
+          }],
+        },
+      },
+    ], { holdResultsUntilAll: true })],
     ['ask parallel', new UserInputRequestScenario([
       {
         name: 'mcp__user-input__request_secret',
@@ -1869,6 +1900,11 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   // session (default 50ms). Scenarios that must expose the post-resolve window
   // (agent resumed, not yet settled) register a longer one.
   private inputCompletionDelays: Map<string, number> = new Map()
+
+  // Sessions whose parallel tool results are HELD until the last sibling
+  // resolves (matching the real CLI), plus the buffered result blocks.
+  private holdResultsSessions: Set<string> = new Set()
+  private heldToolResults: Map<string, Array<Record<string, unknown>>> = new Map()
   // toolUseId → parent_tool_use_id for input requests that a SUBAGENT issued.
   // The real SDK returns their tool_results on the sidechain (parent id set),
   // which the persister routes through handleSidechainMessage — a top-level
@@ -1972,10 +2008,20 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
    * `completionDelayMs` stretches the gap between the last resolve and that
    * result, for tests that assert the agent-resumed-but-not-settled window.
    */
-  registerPendingInputs(sessionId: string, count: number, opts?: { completionDelayMs?: number }): void {
+  registerPendingInputs(
+    sessionId: string,
+    count: number,
+    opts?: { completionDelayMs?: number; holdResultsUntilAll?: boolean },
+  ): void {
     this.pendingInputCounts.set(sessionId, count)
     if (opts?.completionDelayMs !== undefined) {
       this.inputCompletionDelays.set(sessionId, opts.completionDelayMs)
+    }
+    if (opts?.holdResultsUntilAll) {
+      // Parallel-sibling fidelity: the real CLI holds every parallel tool
+      // call's result until the LAST one resolves — the immediate-emit
+      // default hid the decided-but-unsettled window from E2E entirely.
+      this.holdResultsSessions.add(sessionId)
     }
     console.log(`[MockContainerClient] Registered ${count} pending inputs for session ${sessionId}`)
   }
@@ -2239,6 +2285,28 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
                 message: { content: toolResultBlocks },
               },
             })
+          } else if (this.holdResultsSessions.has(sessionId)) {
+            // Parallel-sibling fidelity: hold this result until the last
+            // sibling settles, then release them all in ONE user message —
+            // the real CLI does not stream results for parallel tool calls
+            // individually. Host-side cleanup between decision and release
+            // must come from the decision routes' explicit settle.
+            const held = this.heldToolResults.get(sessionId) ?? []
+            held.push(...toolResultBlocks)
+            this.heldToolResults.set(sessionId, held)
+            if (remaining === 0) {
+              this.holdResultsSessions.delete(sessionId)
+              this.heldToolResults.delete(sessionId)
+              this.writeJsonlEntry(sessionId, {
+                type: 'user',
+                message: { content: held },
+                timestamp: new Date().toISOString(),
+              })
+              this.emitStreamMessage(sessionId, {
+                type: 'user',
+                content: { type: 'user', message: { content: held } },
+              })
+            }
           } else {
             this.writeJsonlEntry(sessionId, {
               type: 'user',

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -861,6 +861,87 @@ export class SubagentBrowserInputScenario implements MockScenario {
   }
 }
 
+/**
+ * A background subagent parks on request_browser_input and then DIES — its
+ * sidechain 'result' arrives with no tool_result for the parked ask — while
+ * the main turn keeps running. The host must invalidate the orphaned request
+ * (card gone, status back to working) instead of leaving an unanswerable card
+ * until a turn boundary. The main turn ends on its own afterwards.
+ */
+export class DeadSubagentInputScenario implements MockScenario {
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    const parentToolId = `agent_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
+    const subToolId = `subtool_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
+
+    client.writeJsonlEntry(sessionId, {
+      type: 'user',
+      message: { content: userMessage },
+      timestamp: new Date().toISOString(),
+    })
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_start' } },
+      })
+    }, 10)
+
+    // The subagent's request arrives as a complete sidechain assistant message.
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'assistant',
+        content: {
+          type: 'assistant',
+          parent_tool_use_id: parentToolId,
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: subToolId,
+                name: 'mcp__user-input__request_browser_input',
+                input: {
+                  message: 'Log in to GitHub to finish the submission.',
+                  requirements: ['Log in to GitHub'],
+                },
+              },
+            ],
+          },
+        },
+      })
+    }, 60)
+
+    // The subagent dies ~2.5s later: its terminal sidechain 'result' frame
+    // arrives while the browser_input has no tool_result. Long enough for a
+    // spec to assert the card + awaiting window first.
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: {
+          type: 'result',
+          parent_tool_use_id: parentToolId,
+          subtype: 'success',
+        },
+      })
+    }, 2500)
+
+    // The main turn continues briefly, then settles on its own — the parked
+    // ask must NOT be what ends it.
+    setTimeout(() => {
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'The subagent stopped; continuing without it.' }],
+        },
+        timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: { type: 'result', subtype: 'success' },
+      })
+    }, 5000)
+  }
+}
+
 function getMessageParam(userMessage: string, key: string): string | undefined {
   const prefix = `${key}=`
   const rawValue = userMessage
@@ -1589,6 +1670,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       },
     ])],
     ['subagent browser input', new SubagentBrowserInputScenario()],
+    ['dead subagent input', new DeadSubagentInputScenario()],
     // Proxy review scenario for E2E tests
     // Cross-store mix: container input asks + a parked ReviewManager review
     ['mixed pending', new MixedPendingRequestsScenario()],

--- a/src/shared/lib/proxy/review-manager.test.ts
+++ b/src/shared/lib/proxy/review-manager.test.ts
@@ -805,3 +805,99 @@ describe('ReviewManager shadow registry write-through (Phase 2)', () => {
     expect(userInputRequestManager.stats.recentResolutions.at(-1)?.outcome).toBe('cancelled')
   })
 })
+
+describe('ReviewManager as registry adapter (Phase 5)', () => {
+  let manager: ReviewManager
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    manager = new ReviewManager()
+    userInputRequestManager.reset()
+  })
+
+  afterEach(() => {
+    manager.rejectAll()
+    vi.useRealTimers()
+  })
+
+  // A review entry that exists only in the registry (no blocked promise —
+  // e.g. one restored by a future recovery path, or registered by another
+  // feeder). The adapter must treat the registry as the pending store, so
+  // these are visible, decidable, and sweepable exactly like promise-backed
+  // ones.
+  function registerRegistryOnlyReview(id: string, agentSlug = 'adapter-agent') {
+    userInputRequestManager.register({
+      id,
+      kind: 'proxy_review',
+      scope: { agentSlug },
+      blocking: true,
+      autoApproved: false,
+      payload: {
+        agentSlug,
+        accountId: 'acc-1',
+        toolkit: 'gmail',
+        method: 'GET',
+        targetPath: '/gmail/v1/users/me/messages',
+        matchedScopes: ['gmail.readonly'],
+        scopeDescriptions: { 'gmail.readonly': 'Read email' },
+        displayText: 'Allow reading email?',
+      },
+    })
+  }
+
+  it('getPendingReviewsForAgent reads the registry, not a private copy', () => {
+    registerRegistryOnlyReview('registry-review-1')
+    const pending = manager.getPendingReviewsForAgent('adapter-agent')
+    expect(pending).toHaveLength(1)
+    expect(pending[0].id).toBe('registry-review-1')
+    expect(pending[0].toolkit).toBe('gmail')
+    expect(pending[0].matchedScopes).toEqual(['gmail.readonly'])
+    expect(pending[0].displayText).toBe('Allow reading email?')
+  })
+
+  it('submitDecision settles a registry-only review entry', () => {
+    registerRegistryOnlyReview('registry-review-2')
+    expect(manager.submitDecision('registry-review-2', 'allow')).toBe(true)
+    expect(userInputRequestManager.getAgentScopedRequests('adapter-agent')).toHaveLength(0)
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+      id: 'registry-review-2',
+      kind: 'proxy_review',
+      outcome: 'answered',
+    })
+    expect(mockBroadcastReview).toHaveBeenCalledWith(
+      'adapter-agent',
+      expect.objectContaining({ type: 'proxy_review_resolved', reviewId: 'registry-review-2' }),
+    )
+  })
+
+  it('denyAllForAgent sweeps registry-only review entries', () => {
+    registerRegistryOnlyReview('registry-review-3')
+    registerRegistryOnlyReview('registry-review-4')
+    manager.denyAllForAgent('adapter-agent')
+    expect(userInputRequestManager.getAgentScopedRequests('adapter-agent')).toHaveLength(0)
+  })
+
+  it('SECURITY: submitDecision refuses to settle a non-review registry entry', () => {
+    // The decision routes accept a caller-supplied id. If the adapter resolved
+    // whatever the registry holds under that id, a review decision could
+    // settle a parked secret/question/computer-use wait out from under its
+    // own decision flow.
+    userInputRequestManager.register({
+      id: 'stream-tool-1',
+      kind: 'secret',
+      scope: { agentSlug: 'adapter-agent', sessionId: 'session-1' },
+      blocking: true,
+      autoApproved: false,
+      payload: { secretName: 'API_KEY' },
+    })
+    expect(manager.submitDecision('stream-tool-1', 'allow')).toBe(false)
+    expect(userInputRequestManager.getOpenRequestsForSession('session-1')).toHaveLength(1)
+  })
+
+  it('SECURITY: expectedAgentSlug still gates registry-only entries', () => {
+    registerRegistryOnlyReview('registry-review-5')
+    expect(manager.submitDecision('registry-review-5', 'allow', 'other-agent')).toBe(false)
+    expect(userInputRequestManager.getAgentScopedRequests('adapter-agent')).toHaveLength(1)
+  })
+})

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -4,6 +4,7 @@ import { getScopeLabel, type ScopeLabel } from './scope-metadata'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
 
 const REVIEW_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
@@ -97,29 +98,100 @@ export function generateReviewDisplayText(
   return `Allow ${method} request to ${toolkitDisplay}?`
 }
 
-interface PendingReview {
-  id: string
-  details: ReviewDetails
+interface ReviewSettler {
   resolve: (decision: 'allow' | 'deny') => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
 }
 
-export class ReviewManager {
-  private pending: Map<string, PendingReview> = new Map()
+type ReviewRegistryEntry = Extract<
+  PendingUserInputRequest,
+  { kind: 'proxy_review' | 'x_agent_review' }
+>
 
-  // Shadow-registry parity (dev/test only): after every mutation of
-  // `pending`, the registry's agent-scoped review view must mirror this store
-  // exactly — a missed or malformed write-through fails tests / logs in dev
-  // instead of silently diverging. This matters doubly now that the awaiting
-  // status is DERIVED from the registry: a review that misses its write-through
-  // would no longer light the waiting indicator at all.
-  private shadowRegistryCheck(agentSlug: string, context: string): void {
+export class ReviewManager {
+  // The registry (userInputRequestManager) IS the pending-review store — each
+  // envelope's payload carries the full ReviewDetails plus displayText. This
+  // map holds only what an envelope cannot: the blocked proxied call's promise
+  // settlers and the auto-deny timer. An entry without a settler is still a
+  // real review (visible, decidable, sweepable); a settler without an entry is
+  // a leak the shadow check flags.
+  private settlers: Map<string, ReviewSettler> = new Map()
+
+  private shadowSettlerCheck(context: string): void {
     if (process.env.NODE_ENV === 'production') return
-    const reviewStoreIds = [...this.pending.values()]
-      .filter((review) => review.details.agentSlug === agentSlug)
-      .map((review) => review.id)
-    userInputRequestManager.verifyReviewStoreParity({ agentSlug, context, reviewStoreIds })
+    userInputRequestManager.verifyReviewSettlerParity({
+      context,
+      settlerIds: [...this.settlers.keys()],
+    })
+  }
+
+  private static isReviewEntry(r: PendingUserInputRequest): r is ReviewRegistryEntry {
+    return r.kind === 'proxy_review' || r.kind === 'x_agent_review'
+  }
+
+  private reviewEntriesForAgent(agentSlug: string): ReviewRegistryEntry[] {
+    return userInputRequestManager
+      .getAgentScopedRequests(agentSlug)
+      .filter(ReviewManager.isReviewEntry)
+  }
+
+  // Rebuild ReviewDetails from an envelope payload. The payload schema is
+  // deliberately lenient, so every field gets a safe default; displayText is
+  // recomputed when the envelope predates it.
+  private static detailsOf(entry: ReviewRegistryEntry): ReviewDetails & { displayText: string } {
+    const p = entry.payload as Record<string, unknown>
+    const toolkit = typeof p.toolkit === 'string' ? p.toolkit : ''
+    const method = typeof p.method === 'string' ? p.method : ''
+    const targetPath = typeof p.targetPath === 'string' ? p.targetPath : ''
+    const scopeDescriptions =
+      p.scopeDescriptions && typeof p.scopeDescriptions === 'object'
+        ? (p.scopeDescriptions as Record<string, string>)
+        : {}
+    const endpointDescription =
+      typeof p.endpointDescription === 'string' ? p.endpointDescription : undefined
+    const displayText =
+      typeof p.displayText === 'string' && p.displayText.length > 0
+        ? p.displayText
+        : generateReviewDisplayText(toolkit, method, targetPath, scopeDescriptions, endpointDescription)
+    return {
+      agentSlug: entry.scope.agentSlug ?? '',
+      accountId: typeof p.accountId === 'string' ? p.accountId : '',
+      toolkit,
+      method,
+      targetPath,
+      matchedScopes: Array.isArray(p.matchedScopes) ? (p.matchedScopes as string[]) : [],
+      scopeDescriptions,
+      ...(endpointDescription !== undefined ? { endpointDescription } : {}),
+      ...(p.xAgent && typeof p.xAgent === 'object'
+        ? { xAgent: p.xAgent as ReviewDetails['xAgent'] }
+        : {}),
+      displayText,
+    }
+  }
+
+  // The single exit: settles the registry entry, the parked promise (if one
+  // exists), the auto-deny timer, and the UI broadcast together, in that
+  // order — the registry must be settled before the promise resumes the
+  // proxied call, which can re-enter and request another review.
+  private settleReview(
+    entry: ReviewRegistryEntry,
+    outcome: 'answered' | 'declined' | 'cancelled' | 'timeout',
+    action: { type: 'resolve'; decision: 'allow' | 'deny' } | { type: 'reject'; error: Error },
+  ): void {
+    const settler = this.settlers.get(entry.id)
+    this.settlers.delete(entry.id)
+    if (settler) clearTimeout(settler.timer)
+    userInputRequestManager.resolve(entry.id, outcome)
+    if (settler) {
+      if (action.type === 'resolve') settler.resolve(action.decision)
+      else settler.reject(action.error)
+    }
+    broadcastReview(entry.scope.agentSlug ?? '', {
+      type: 'proxy_review_resolved',
+      reviewId: entry.id,
+      decision: action.type === 'resolve' ? action.decision : 'deny',
+    })
   }
 
   requestReview(details: ReviewDetails, signal?: AbortSignal): Promise<'allow' | 'deny'> {
@@ -127,10 +199,10 @@ export class ReviewManager {
 
     return new Promise<'allow' | 'deny'>((resolve, reject) => {
       const settleTimedOut = () => {
-        if (!this.pending.has(id)) return
-        this.pending.delete(id)
+        if (!this.settlers.has(id)) return
+        this.settlers.delete(id)
         userInputRequestManager.resolve(id, 'timeout')
-        this.shadowRegistryCheck(details.agentSlug, 'settleTimedOut')
+        this.shadowSettlerCheck('settleTimedOut')
         broadcastReview(details.agentSlug, {
           type: 'proxy_review_resolved',
           reviewId: id,
@@ -144,9 +216,9 @@ export class ReviewManager {
 
       const cleanup = () => {
         clearTimeout(timer)
-        this.pending.delete(id)
+        this.settlers.delete(id)
         userInputRequestManager.resolve(id, 'cancelled')
-        this.shadowRegistryCheck(details.agentSlug, 'abortCleanup')
+        this.shadowSettlerCheck('abortCleanup')
         broadcastReview(details.agentSlug, {
           type: 'proxy_review_resolved',
           reviewId: id,
@@ -158,13 +230,13 @@ export class ReviewManager {
       // If the request is aborted (e.g. task stopped), clean up the orphaned review
       if (signal) {
         signal.addEventListener('abort', () => {
-          if (!this.pending.has(id)) return // already resolved/timed out
+          if (!this.settlers.has(id)) return // already resolved/timed out
           cleanup()
           reject(new Error('Request aborted'))
         }, { once: true })
       }
 
-      this.pending.set(id, { id, details, resolve, reject, timer })
+      this.settlers.set(id, { resolve, reject, timer })
 
       const displayText = generateReviewDisplayText(
         details.toolkit,
@@ -175,11 +247,11 @@ export class ReviewManager {
       )
 
       // Reviews are agent-scoped — no sessionId in the proxied call, so the
-      // envelope carries agentSlug only. The registry entry is what makes the
-      // agent's sessions read as awaiting while the review is parked. The
-      // payload carries the full details plus the derived display text so the
-      // unified wire can render the review card without the legacy poll.
-      userInputRequestManager.register({
+      // envelope carries agentSlug only. The registry entry IS the pending
+      // review: it makes the agent's sessions read as awaiting, and its
+      // payload carries the full details plus the derived display text so
+      // every reader (unified wire, dashboard poll, sweeps) renders from it.
+      const registered = userInputRequestManager.register({
         id,
         kind: details.xAgent ? 'x_agent_review' : 'proxy_review',
         scope: { agentSlug: details.agentSlug },
@@ -187,7 +259,16 @@ export class ReviewManager {
         autoApproved: false,
         payload: { ...details, displayText },
       })
-      this.shadowRegistryCheck(details.agentSlug, 'requestReview')
+      if (!registered) {
+        // Can't happen with our own envelope construction, but if the registry
+        // ever drops it, fail the proxied call now — a review that exists
+        // nowhere would otherwise park until the timeout.
+        clearTimeout(timer)
+        this.settlers.delete(id)
+        reject(new Error('Failed to register review'))
+        return
+      }
+      this.shadowSettlerCheck('requestReview')
 
       // Broadcast review request to agent's active sessions
       broadcastReview(details.agentSlug, {
@@ -238,27 +319,26 @@ export class ReviewManager {
    * by agentSlug itself) may omit it.
    */
   submitDecision(id: string, decision: 'allow' | 'deny', expectedAgentSlug?: string): boolean {
-    const review = this.pending.get(id)
-    if (!review) return false
-    if (expectedAgentSlug !== undefined && review.details.agentSlug !== expectedAgentSlug) {
+    const entry = userInputRequestManager.getOpenRequest(id)
+    // The kind guard is load-bearing: the decision routes accept a
+    // caller-supplied id, and resolving whatever the registry holds under it
+    // would let a review decision settle a parked secret/question/computer-use
+    // wait out from under its own decision flow.
+    if (!entry || !ReviewManager.isReviewEntry(entry)) return false
+    if (expectedAgentSlug !== undefined && entry.scope.agentSlug !== expectedAgentSlug) {
       // Don't leak existence of the review to an unauthorized caller —
       // return the same `false` shape as "review not found".
       return false
     }
 
-    clearTimeout(review.timer)
-    this.pending.delete(id)
-    userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
-    this.shadowRegistryCheck(review.details.agentSlug, 'submitDecision')
-    review.resolve(decision)
-
-    // Broadcast resolution so UIs can dismiss the prompt
-    broadcastReview(review.details.agentSlug, {
-      type: 'proxy_review_resolved',
-      reviewId: id,
+    this.settleReview(entry, decision === 'allow' ? 'answered' : 'declined', {
+      type: 'resolve',
       decision,
     })
-    messagePersister.syncAgentSessionsAwaiting(review.details.agentSlug)
+    this.shadowSettlerCheck('submitDecision')
+    if (entry.scope.agentSlug) {
+      messagePersister.syncAgentSessionsAwaiting(entry.scope.agentSlug)
+    }
 
     return true
   }
@@ -268,24 +348,14 @@ export class ReviewManager {
     scope: string,
     decision: 'allow' | 'deny'
   ): void {
-    for (const [id, review] of this.pending) {
-      if (
-        review.details.agentSlug === agentSlug &&
-        review.details.matchedScopes.includes(scope)
-      ) {
-        clearTimeout(review.timer)
-        this.pending.delete(id)
-        userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
-        review.resolve(decision)
-
-        broadcastReview(agentSlug, {
-          type: 'proxy_review_resolved',
-          reviewId: id,
-          decision,
-        })
-      }
+    for (const entry of this.reviewEntriesForAgent(agentSlug)) {
+      if (!ReviewManager.detailsOf(entry).matchedScopes.includes(scope)) continue
+      this.settleReview(entry, decision === 'allow' ? 'answered' : 'declined', {
+        type: 'resolve',
+        decision,
+      })
     }
-    this.shadowRegistryCheck(agentSlug, 'resolveMatchingPending')
+    this.shadowSettlerCheck('resolveMatchingPending')
     messagePersister.syncAgentSessionsAwaiting(agentSlug)
   }
 
@@ -301,23 +371,18 @@ export class ReviewManager {
     label: ScopeLabel,
     decision: 'allow' | 'deny',
   ): void {
-    for (const [id, review] of this.pending) {
-      if (review.details.agentSlug !== agentSlug) continue
-      const hasLabel = review.details.matchedScopes.some(
-        (s) => getScopeLabel(review.details.toolkit, s) === label,
+    for (const entry of this.reviewEntriesForAgent(agentSlug)) {
+      const details = ReviewManager.detailsOf(entry)
+      const hasLabel = details.matchedScopes.some(
+        (s) => getScopeLabel(details.toolkit, s) === label,
       )
       if (!hasLabel) continue
-      clearTimeout(review.timer)
-      this.pending.delete(id)
-      userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
-      review.resolve(decision)
-      broadcastReview(agentSlug, {
-        type: 'proxy_review_resolved',
-        reviewId: id,
+      this.settleReview(entry, decision === 'allow' ? 'answered' : 'declined', {
+        type: 'resolve',
         decision,
       })
     }
-    this.shadowRegistryCheck(agentSlug, 'resolveMatchingPendingByLabel')
+    this.shadowSettlerCheck('resolveMatchingPendingByLabel')
     messagePersister.syncAgentSessionsAwaiting(agentSlug)
   }
 
@@ -332,44 +397,24 @@ export class ReviewManager {
     operation: 'list' | 'read' | 'invoke' | 'create',
     decision: 'allow' | 'deny',
   ): void {
-    for (const [id, review] of this.pending) {
-      if (
-        review.details.agentSlug === agentSlug &&
-        review.details.xAgent?.operation === operation
-      ) {
-        clearTimeout(review.timer)
-        this.pending.delete(id)
-        userInputRequestManager.resolve(id, decision === 'allow' ? 'answered' : 'declined')
-        review.resolve(decision)
-
-        broadcastReview(agentSlug, {
-          type: 'proxy_review_resolved',
-          reviewId: id,
-          decision,
-        })
-      }
+    for (const entry of this.reviewEntriesForAgent(agentSlug)) {
+      if (ReviewManager.detailsOf(entry).xAgent?.operation !== operation) continue
+      this.settleReview(entry, decision === 'allow' ? 'answered' : 'declined', {
+        type: 'resolve',
+        decision,
+      })
     }
-    this.shadowRegistryCheck(agentSlug, 'resolveMatchingXAgentByOperation')
+    this.shadowSettlerCheck('resolveMatchingXAgentByOperation')
     messagePersister.syncAgentSessionsAwaiting(agentSlug)
   }
 
   getPendingReviewsForAgent(
     agentSlug: string
   ): Array<{ id: string; displayText: string } & ReviewDetails> {
-    const results: Array<{ id: string; displayText: string } & ReviewDetails> = []
-    for (const review of this.pending.values()) {
-      if (review.details.agentSlug === agentSlug) {
-        const displayText = generateReviewDisplayText(
-          review.details.toolkit,
-          review.details.method,
-          review.details.targetPath,
-          review.details.scopeDescriptions,
-          review.details.endpointDescription,
-        )
-        results.push({ id: review.id, displayText, ...review.details })
-      }
-    }
-    return results
+    return this.reviewEntriesForAgent(agentSlug).map((entry) => ({
+      id: entry.id,
+      ...ReviewManager.detailsOf(entry),
+    }))
   }
 
   /**
@@ -421,39 +466,28 @@ export class ReviewManager {
   }
 
   denyAllForAgent(agentSlug: string): void {
-    for (const [id, review] of this.pending) {
-      if (review.details.agentSlug !== agentSlug) continue
-      clearTimeout(review.timer)
-      this.pending.delete(id)
-      userInputRequestManager.resolve(id, 'declined')
-      review.resolve('deny')
-
-      broadcastReview(agentSlug, {
-        type: 'proxy_review_resolved',
-        reviewId: id,
-        decision: 'deny',
-      })
+    for (const entry of this.reviewEntriesForAgent(agentSlug)) {
+      this.settleReview(entry, 'declined', { type: 'resolve', decision: 'deny' })
     }
-    this.shadowRegistryCheck(agentSlug, 'denyAllForAgent')
+    this.shadowSettlerCheck('denyAllForAgent')
     messagePersister.syncAgentSessionsAwaiting(agentSlug)
   }
 
   rejectAll(): void {
     const agentSlugs = new Set<string>()
-    for (const [id, review] of this.pending) {
-      clearTimeout(review.timer)
-      this.pending.delete(id)
-      userInputRequestManager.resolve(id, 'cancelled')
-      agentSlugs.add(review.details.agentSlug)
-      broadcastReview(review.details.agentSlug, {
-        type: 'proxy_review_resolved',
-        reviewId: id,
-        decision: 'deny',
-      })
-      review.reject(new Error('Review timeout'))
+    for (const entry of userInputRequestManager.getOpenRequestsForStore('review')) {
+      if (!ReviewManager.isReviewEntry(entry)) continue
+      if (entry.scope.agentSlug) agentSlugs.add(entry.scope.agentSlug)
+      this.settleReview(entry, 'cancelled', { type: 'reject', error: new Error('Review timeout') })
+    }
+    // Defensive: a settler whose registry entry vanished is still a parked
+    // proxied call — shutdown must never leave one hung.
+    for (const [id, settler] of this.settlers) {
+      clearTimeout(settler.timer)
+      this.settlers.delete(id)
+      settler.reject(new Error('Review timeout'))
     }
     for (const agentSlug of agentSlugs) {
-      this.shadowRegistryCheck(agentSlug, 'rejectAll')
       messagePersister.syncAgentSessionsAwaiting(agentSlug)
     }
   }

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -42,6 +42,44 @@ describe('UserInputRequestManager', () => {
       expect((open[0].payload as { secretName?: string }).secretName).toBe('FIRST')
     })
 
+    it('upgrades a recovered synthetic when the real registration replays', () => {
+      // GET-messages recovery can synthesize a payload-less stub before the
+      // stream event lands (the recovery read races the container stream).
+      // The real registration must replace the stub — and emit the 'created'
+      // transition, because the stub's was filtered off the wire, so this is
+      // the first event clients can actually render.
+      const transitions: Array<{ type: string; payload: unknown }> = []
+      manager.onTransition((t) => transitions.push({ type: t.type, payload: t.request.payload }))
+
+      manager.register(secretRequest({ payload: { recovered: true } }))
+      const upgraded = manager.register(
+        secretRequest({ payload: { secretName: 'API_KEY', reason: 'Need it' } }),
+      )
+
+      expect((upgraded!.payload as { secretName?: string }).secretName).toBe('API_KEY')
+      expect((upgraded!.payload as { recovered?: boolean }).recovered).toBeUndefined()
+      expect(manager.stats.open).toBe(1)
+      expect(transitions.map((t) => t.type)).toEqual(['created', 'created'])
+      expect((transitions[1].payload as { secretName?: string }).secretName).toBe('API_KEY')
+    })
+
+    it('never downgrades: a recovered synthetic cannot replace a real entry', () => {
+      const first = manager.register(secretRequest({ payload: { secretName: 'REAL' } }))
+      const second = manager.register(secretRequest({ payload: { recovered: true } }))
+      expect(second).toBe(first)
+      const third = manager.register(secretRequest({ payload: { recovered: true } }))
+      expect(third).toBe(first)
+    })
+
+    it('a second recovered synthetic does not re-emit over an existing one', () => {
+      const transitions: string[] = []
+      manager.onTransition((t) => transitions.push(t.type))
+      const first = manager.register(secretRequest({ payload: { recovered: true } }))
+      const second = manager.register(secretRequest({ payload: { recovered: true } }))
+      expect(second).toBe(first)
+      expect(transitions).toEqual(['created'])
+    })
+
     it('drops a malformed envelope without throwing (shadow mode must never break delivery)', () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
       const stored = manager.register({
@@ -305,7 +343,6 @@ describe('UserInputRequestManager', () => {
         sessionId: 'session-1',
         context: 'test',
         streamStoreIds: ['stream-1'],
-        computerUseStoreIds: [],
       })
       expect(manager.stats.storeMismatches).toBe(0)
     })
@@ -317,13 +354,12 @@ describe('UserInputRequestManager', () => {
           sessionId: 'session-1',
           context: 'test',
           streamStoreIds: ['stream-1', 'stream-2'],
-          computerUseStoreIds: [],
         }),
       ).toThrow(/shadow store mismatch/)
       expect(manager.stats.storeMismatches).toBe(1)
     })
 
-    it('verifyReviewStoreParity compares only agent-scoped review entries', () => {
+    it('verifyReviewSettlerParity accepts settlers backed by open review entries', () => {
       manager.register({
         id: 'review-1',
         kind: 'proxy_review',
@@ -331,26 +367,29 @@ describe('UserInputRequestManager', () => {
         blocking: true,
         payload: { toolkit: 'slack' },
       })
-      // Session-scoped stream noise for the same agent must not leak into the
-      // review comparison.
-      manager.register(secretRequest())
-
-      manager.verifyReviewStoreParity({
-        agentSlug: 'agent-a',
-        context: 'test',
-        reviewStoreIds: ['review-1'],
-      })
+      manager.verifyReviewSettlerParity({ context: 'test', settlerIds: ['review-1'] })
       expect(manager.stats.storeMismatches).toBe(0)
     })
 
-    it('verifyReviewStoreParity throws under vitest when a review write-through was missed', () => {
-      // ReviewManager holds a review the registry never saw.
+    it('verifyReviewSettlerParity accepts review entries without settlers', () => {
+      // Feeders other than requestReview own no promise — an entry without a
+      // settler is a legitimate pending review, not a mismatch.
+      manager.register({
+        id: 'review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: 'agent-a' },
+        blocking: true,
+        payload: { toolkit: 'slack' },
+      })
+      manager.verifyReviewSettlerParity({ context: 'test', settlerIds: [] })
+      expect(manager.stats.storeMismatches).toBe(0)
+    })
+
+    it('verifyReviewSettlerParity throws under vitest on an orphaned settler', () => {
+      // A settler without a registry entry is a parked proxied call no sweep
+      // can ever reach.
       expect(() =>
-        manager.verifyReviewStoreParity({
-          agentSlug: 'agent-a',
-          context: 'test',
-          reviewStoreIds: ['review-orphan'],
-        }),
+        manager.verifyReviewSettlerParity({ context: 'test', settlerIds: ['review-orphan'] }),
       ).toThrow(/shadow store mismatch/)
       expect(manager.stats.storeMismatches).toBe(1)
     })

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -51,23 +51,35 @@ export class UserInputRequestManager {
    * is still open returns the original entry unchanged (stream stop and
    * complete-assistant can both carry the same tool_use).
    *
+   * One exception: a real registration REPLACES a recovered synthetic for the
+   * same id. Transcript recovery can synthesize a payload-less stub before the
+   * stream event lands; the stub's 'created' transition is filtered off the
+   * wire, so the upgrade emits 'created' again — the first renderable event
+   * clients get for the id. A recovered input never replaces anything.
+   *
    * Never throws — a malformed envelope is logged and dropped so shadow-mode
    * registration can never break a production delivery path.
    */
   register(input: PendingUserInputRequestInput): PendingUserInputRequest | null {
     const existing = this.requests.get(input.id)
-    if (existing) return existing
+    if (existing && !UserInputRequestManager.isRecoveredSynthetic(existing)) return existing
     const parsed = pendingUserInputRequestSchema.safeParse(input)
     if (!parsed.success) {
+      if (existing) return existing
       console.error(
         `[UserInputRequestManager] Dropped malformed request registration (id=${input.id}):`,
         parsed.error.message,
       )
       return null
     }
+    if (existing && UserInputRequestManager.isRecoveredSynthetic(parsed.data)) return existing
     this.requests.set(parsed.data.id, parsed.data)
     this.emitTransition({ type: 'created', request: parsed.data })
     return parsed.data
+  }
+
+  private static isRecoveredSynthetic(request: PendingUserInputRequest): boolean {
+    return (request.payload as Record<string, unknown>).recovered === true
   }
 
   /** Settle and remove a request. Idempotent: unknown ids are a no-op (null). */
@@ -125,6 +137,24 @@ export class UserInputRequestManager {
     }
   }
 
+  /**
+   * Settle every open request registered under a parent Task tool_use — the
+   * dead-subagent sweep. Returns what was settled so the caller can clean up
+   * its mirrors (replay store, container pendings).
+   */
+  resolveRequestsByParent(
+    parentToolUseId: string,
+    outcome: UserInputRequestOutcome = 'invalidated',
+  ): PendingUserInputRequest[] {
+    const settled: PendingUserInputRequest[] = []
+    for (const request of [...this.requests.values()]) {
+      if (request.parentToolUseId !== parentToolUseId) continue
+      const resolved = this.resolve(request.id, outcome)
+      if (resolved) settled.push(resolved)
+    }
+    return settled
+  }
+
   /** Mirror of `streamingStates.delete` — every session-scoped entry dies with the state. */
   dropSessionRequests(sessionId: string, outcome: UserInputRequestOutcome = 'invalidated'): void {
     for (const request of [...this.requests.values()]) {
@@ -133,8 +163,18 @@ export class UserInputRequestManager {
     }
   }
 
+  /** Look up a single open request by id. */
+  getOpenRequest(id: string): PendingUserInputRequest | null {
+    return this.requests.get(id) ?? null
+  }
+
   getOpenRequestsForSession(sessionId: string): PendingUserInputRequest[] {
     return [...this.requests.values()].filter((r) => r.scope.sessionId === sessionId)
+  }
+
+  /** Every open request of a store, across all scopes (e.g. shutdown sweeps). */
+  getOpenRequestsForStore(store: UserInputRequestStore): PendingUserInputRequest[] {
+    return [...this.requests.values()].filter((r) => storeForKind(r.kind) === store)
   }
 
   /** Session-scoped AND agent-scoped entries for the agent. */
@@ -244,49 +284,30 @@ export class UserInputRequestManager {
     sessionId: string
     context: string
     streamStoreIds: string[]
-    computerUseStoreIds: string[]
   }): void {
-    const mismatches = [
-      UserInputRequestManager.describeIdMismatch(
-        'stream',
-        check.streamStoreIds,
-        this.getStoreIdsForSession(check.sessionId, 'stream'),
-      ),
-      UserInputRequestManager.describeIdMismatch(
-        'computer_use',
-        check.computerUseStoreIds,
-        this.getStoreIdsForSession(check.sessionId, 'computer_use'),
-      ),
-    ].filter((m): m is string => m !== null)
-    if (mismatches.length === 0) return
-    this.reportStoreMismatch(`session=${check.sessionId}`, check.context, mismatches)
+    const mismatch = UserInputRequestManager.describeIdMismatch(
+      'stream',
+      check.streamStoreIds,
+      this.getStoreIdsForSession(check.sessionId, 'stream'),
+    )
+    if (mismatch === null) return
+    this.reportStoreMismatch(`session=${check.sessionId}`, check.context, [mismatch])
   }
 
   /**
-   * Same invariant for the review store: the registry's agent-scoped review
-   * view must equal ReviewManager's pending store for the agent, at every
-   * review mutation point.
+   * Review-side invariant, one-directional: every promise settler ReviewManager
+   * holds must correspond to an open review-store entry — a settler without
+   * one is a parked proxied call no sweep can ever reach (the silent-exit bug
+   * class). The converse is NOT an invariant: registry entries without
+   * settlers are legitimate (feeders other than requestReview own no promise).
    */
-  verifyReviewStoreParity(check: {
-    agentSlug: string
-    context: string
-    reviewStoreIds: string[]
-  }): void {
-    const registryIds = [...this.requests.values()]
-      .filter(
-        (r) =>
-          r.scope.agentSlug === check.agentSlug &&
-          r.scope.sessionId === undefined &&
-          storeForKind(r.kind) === 'review',
-      )
-      .map((r) => r.id)
-    const mismatch = UserInputRequestManager.describeIdMismatch(
-      'review',
-      check.reviewStoreIds,
-      registryIds,
-    )
-    if (mismatch === null) return
-    this.reportStoreMismatch(`agent=${check.agentSlug}`, check.context, [mismatch])
+  verifyReviewSettlerParity(check: { context: string; settlerIds: string[] }): void {
+    const registryIds = new Set(this.getOpenRequestsForStore('review').map((r) => r.id))
+    const orphans = check.settlerIds.filter((id) => !registryIds.has(id))
+    if (orphans.length === 0) return
+    this.reportStoreMismatch('review-settlers', check.context, [
+      `orphaned settlers=[${[...orphans].sort().join(',')}]`,
+    ])
   }
 
   get stats(): {

--- a/src/shared/lib/user-input/request-schema.ts
+++ b/src/shared/lib/user-input/request-schema.ts
@@ -53,6 +53,13 @@ const baseRequest = z.object({
   blocking: z.boolean(),
   /** Auto-approved asks (e.g. allowlisted script_run) are visible but never block. */
   autoApproved: z.boolean().default(false),
+  /**
+   * The Task tool_use that spawned the asking subagent, when the request came
+   * from a sidechain. Subagent termination invalidates every open request
+   * registered under its parent — without this linkage a dead subagent's card
+   * is orphaned until a coarser boundary clears it.
+   */
+  parentToolUseId: z.string().optional(),
 })
 
 const lenientString = z.string().optional().catch(undefined)
@@ -194,7 +201,14 @@ export function streamEventToPendingRequest(
 ): PendingUserInputRequestInput | null {
   const kind = STREAM_EVENT_TYPE_TO_KIND[evt.type]
   if (!kind) return null
-  const { type: _type, toolUseId: _toolUseId, agentSlug, autoApproved, ...payload } = evt
+  const {
+    type: _type,
+    toolUseId: _toolUseId,
+    agentSlug,
+    autoApproved,
+    parentToolUseId,
+    ...payload
+  } = evt
   return {
     id: evt.toolUseId,
     kind,
@@ -204,6 +218,7 @@ export function streamEventToPendingRequest(
     },
     blocking: true,
     autoApproved: autoApproved === true,
+    parentToolUseId: typeof parentToolUseId === 'string' ? parentToolUseId : undefined,
     payload,
   } as PendingUserInputRequestInput
 }


### PR DESCRIPTION
Phase 5 of the user-input request rearchitecture (follows #560, #562, #566, #578, #583). The registry (`userInputRequestManager`) becomes the single pending store for reviews and computer-use, and gains resource invalidation for dead subagents.

## What changed

### 1. ReviewManager → registry adapter
The registry now owns the pending-review list (envelope payloads carry full `ReviewDetails` + `displayText` since Phase 4). ReviewManager keeps only a `settlers` map — the blocked proxied call's promise resolve/reject and the 5-minute auto-deny timer, keyed by id. All reads (`getPendingReviewsForAgent`, the three sweeps, `submitDecision`) re-source from the registry, so the dashboard poll endpoint and `hasAgentLevelReviews` gates work unchanged.

Two hardenings that fall out of the design:
- **`submitDecision` has a review-kind guard**: a caller-supplied id that resolves to a parked secret/question/computer-use entry returns `false` instead of settling a foreign wait.
- Registry-only review entries (from feeders other than `requestReview`) are now visible, decidable, and sweepable — previously they were invisible to every decision path.

The parity invariant flips to one-directional `verifyReviewSettlerParity`: a settler without a registry entry is a leak (a parked call no sweep can reach); an entry without a settler is legitimate.

### 2. Computer-use into the registry
`pendingComputerUseRequests` is deleted from `StreamingState`. `getPendingComputerUseRequests` rebuilds the legacy shape from registry envelopes for the SSE replay route and decision endpoints. The `session_active` supersede loop reads registry ids — closing a latent hole where registry entries could outlive the old map across a state recreation. The divergent clearing rules (survives idle for replay; cleared by decision routes / `cancelAwaitingInput` / new turn) are unchanged, now expressed only through `storeForKind`.

### 3. Dead-subagent invalidation (closes the #527 follow-up)
Envelopes gain an optional top-level `parentToolUseId`, populated on all sidechain dispatches (both delivery paths, all 6 blocking kinds + computer-use). `broadcastSubagentCompleted` settles every open request under the dead parent as `invalidated` — registry entry, replay store, container-side pending (`/inputs/:id/reject`), and awaiting status together. Previously a subagent that died mid-request orphaned its card until a coarser boundary or TTL.

### 4. Recovered-synthetic upgrade
`register()` now replaces a recovered stub when the real registration replays, re-emitting `created` — previously the stub blocked the real payload from ever entering the registry, so clients never received a renderable `user_request_created` for that id. The dispatch funnel's dedupe lets the real event through a recovered stub. Downgrades (recovered over real) are pinned impossible.

### 5. Container `connected_account` kind fix
`request-connected-account.ts` no longer stamps `inputType: 'secret'` via the legacy `createPending` wrapper. Verified no host code reads the container's `inputType`, so the change is contained to the container.

## Validation
- Red-proven where behavior changed: 7 tests observed red first across the three behavioral workstreams
- Typecheck + lint clean; full unit suite 7,833 green; container suite 743 green
- 13-spec request E2E set: 75/75 (incl. a new dead-subagent E2E — new mock scenario `dead subagent input`)
- **Live-validated** on an isolated dev instance (real Docker container, real Opus 5, real browser): (a) `request_secret` full cycle — card, awaiting indicator, reload-while-parked re-render, provide → resolve → idle; (b) the x-agent review chain through the adapter — parked list-review card re-rendered from the registry snapshot on fresh navigation, Allow Once unblocked the parked route via the settler, second invoke-review card allowed, cross-agent message delivered, idle

## Not in this PR (Phase 6 per plan §3.4)
Single decision endpoint, dashboard panel client migration, dead-array cleanup (`pendingBrowserInputRequests` must survive for the browser tray), legacy event removal, name normalization.

https://claude.ai/code/session_01DLw9AJ5VXVQPzBAz87nNAA