### PR TITLE
Exempt installed-client sessions from the concurrent-session cap (SUP-478 prep)

### DIFF
--- a/docs/cross-client-auth.md
+++ b/docs/cross-client-auth.md
@@ -132,6 +132,29 @@ exists before a session is minted.
 Exchanged sessions record the caller's `User-Agent` and IP, so they are
 distinguishable and revocable in the admin sessions list.
 
+They are also **held to a separate bound** from browser logins
+(`session-enforcement.ts`). `maxConcurrentSessions` exists to limit how many
+*interactive* sessions a user accumulates; an exchanged session is not one of
+those — it belongs to an installed client, is re-minted on a schedule the user
+never sees, and is revoked by disconnecting that client. Mixing the two evicts
+in both directions: eviction is oldest-first, so a daily re-mint walks a user's
+long-lived browser sessions off the end, while a few browser logins evict the
+client's session, which re-mints, which evicts another browser session.
+
+The two groups therefore never evict each other. Exchanged sessions get their
+own ceiling rather than no ceiling — nothing in this codebase prunes expired
+sessions, so "never evicted" would mean a row per re-mint forever, in a table
+read in full on every login. Expired ones are dropped first, so the ceiling is
+spent on sessions that can still authenticate; in the steady state that leaves
+roughly one row per machine. Expired *interactive* rows are still counted, as
+they always have been — dropping those would change the effective cap for every
+existing deployment, which is a separate decision.
+
+Which group a session belongs to is read from `session.creation_method`, written
+once at creation (see §7) — the cap has to recognize an installed client's
+session on a *later* login, when the endpoint context and async-local tag that
+identified it are long gone.
+
 ### 7. Audit trail
 
 Every session this deployment mints writes one `session` / `created` audit row

--- a/src/shared/lib/auth/index.ts
+++ b/src/shared/lib/auth/index.ts
@@ -8,7 +8,7 @@ import { getOrCreateAuthSecret } from './secret'
 import { getAppBaseUrl, getTrustedOrigins } from './config'
 import { getSettings, DEFAULT_AUTH_SETTINGS } from '@shared/lib/config/settings'
 import { enforceMaxConcurrentSessions } from './session-enforcement'
-import { auditSessionCreated } from './session-audit'
+import { auditSessionCreated, resolveSessionCreationMethod } from './session-audit'
 import { getGenericOAuthProviderConfigs } from './provider-config'
 
 // Re-export isAuthMode from its own file (no better-auth imports)
@@ -79,6 +79,19 @@ function createAuthInstance() {
     session: {
       expiresIn: (authSettings.sessionMaxLifetimeHrs ?? 24) * 3600,
       updateAge: (authSettings.sessionIdleTimeoutMin ?? 60) * 60,
+      additionalFields: {
+        // Persisted so the answer survives the request that created the
+        // session: the concurrent-session cap has to recognize an installed
+        // client's session on a LATER login, when no endpoint context or
+        // async-local tag exists any more.
+        //
+        // `input: false` — server-derived, never settable by a client.
+        creationMethod: {
+          type: 'string',
+          required: false,
+          input: false,
+        },
+      },
     },
     user: {
       additionalFields: {
@@ -175,6 +188,29 @@ function createAuthInstance() {
       },
       session: {
         create: {
+          before: async (session, context) => {
+            // Stamp how this session came to exist onto the row itself. The
+            // signals it is derived from — the endpoint path on the context,
+            // the async-local tag set by the token exchange — exist only for
+            // the duration of this call, so anything that needs the answer
+            // later needs it written down now.
+            //
+            // Returning `{ data }` merges into the row about to be created.
+            // Never throw: refusing to label a session must not stop it being
+            // created, and an unlabelled session degrades to "capped", which
+            // is exactly the old behaviour.
+            try {
+              return {
+                data: {
+                  ...session,
+                  creationMethod: resolveSessionCreationMethod(session, context?.path),
+                },
+              }
+            } catch (err) {
+              console.error('Failed to resolve session creation method:', err)
+              return
+            }
+          },
           after: async (session, context) => {
             try {
               const sessSettings = getSettings()

--- a/src/shared/lib/auth/session-audit.integration.test.ts
+++ b/src/shared/lib/auth/session-audit.integration.test.ts
@@ -314,6 +314,145 @@ describe('token exchange', () => {
   })
 })
 
+/**
+ * The audit row answers "how did this session come to exist" for a reader.
+ * The `creation_method` column answers it for *code*, on a later request, when
+ * the endpoint context and the async-local tag are long gone — which is what
+ * the concurrent-session cap needs.
+ */
+describe('persisted creation method', () => {
+  interface SessionRow {
+    id: string
+    user_id: string
+    creation_method: string | null
+  }
+
+  function sessionRows(): SessionRow[] {
+    return dbModule.sqlite
+      .prepare(`SELECT id, user_id, creation_method FROM session ORDER BY rowid`)
+      .all() as SessionRow[]
+  }
+
+  it('stamps a password login onto the session row', async () => {
+    await authModule.getAuth().api.signUpEmail({
+      body: { email: 'stamp@example.com', password: PASSWORD, name: 'Stamp' },
+    })
+
+    expect(sessionRows().map((r) => r.creation_method)).toEqual(['password'])
+  })
+
+  it('stamps a token exchange onto the session row', async () => {
+    expect((await exchange(await signGrant())).status).toBe(200)
+
+    expect(sessionRows().map((r) => r.creation_method)).toEqual(['token-exchange'])
+  })
+
+  it('stamps an impersonation onto the session row', async () => {
+    const auth = authModule.getAuth()
+    await auth.api.signUpEmail({
+      body: { email: 'admin2@example.com', password: PASSWORD, name: 'Admin' },
+    })
+    await auth.api.signUpEmail({
+      body: { email: 'target2@example.com', password: PASSWORD, name: 'Target' },
+    })
+    const signIn = await auth.api.signInEmail({
+      body: { email: 'admin2@example.com', password: PASSWORD },
+      asResponse: true,
+    })
+    const targetId = (
+      dbModule.sqlite.prepare(`SELECT id FROM user WHERE email = ?`).get('target2@example.com') as {
+        id: string
+      }
+    ).id
+
+    await auth.api.impersonateUser({
+      body: { userId: targetId },
+      headers: new Headers({ authorization: `Bearer ${signIn.headers.get('set-auth-token')}` }),
+    })
+
+    expect(sessionRows().at(-1)!.creation_method).toBe('impersonation')
+  })
+
+  it('agrees with the audit row about the same session', async () => {
+    // Both derive from one function. If they ever disagree, one of the two
+    // readings of "how did this session come to exist" is wrong, and there is
+    // no way to tell which.
+    expect((await exchange(await signGrant())).status).toBe(200)
+
+    const [session] = sessionRows()
+    const [audit] = auditRows('session')
+    expect(audit.object_id).toBe(session.id)
+    expect(detailsOf(audit).method).toBe(session.creation_method)
+  })
+})
+
+describe('concurrent-session cap', () => {
+  const CAP = 2
+
+  function liveSessions(userId: string): { id: string; creation_method: string | null }[] {
+    return dbModule.sqlite
+      .prepare(`SELECT id, creation_method FROM session WHERE user_id = ? ORDER BY created_at`)
+      .all(userId) as { id: string; creation_method: string | null }[]
+  }
+
+  async function seedUserAtCap(): Promise<string> {
+    fs.writeFileSync(
+      path.join(tmpDir, 'settings.json'),
+      JSON.stringify({ auth: { requireAdminApproval: false, maxConcurrentSessions: CAP } }),
+    )
+    const { clearSettingsCache } = await import('@shared/lib/config/settings')
+    clearSettingsCache()
+
+    const auth = authModule.getAuth()
+    // The exchange provisions this same identity from the grant's email, so
+    // the desktop session and the browser logins land on one user.
+    await auth.api.signUpEmail({
+      body: { email: 'member@example.com', password: PASSWORD, name: 'Member One' },
+    })
+    return (
+      dbModule.sqlite.prepare(`SELECT id FROM user WHERE email = ?`).get('member@example.com') as {
+        id: string
+      }
+    ).id
+  }
+
+  it('keeps the exchanged session alive through repeated browser logins', async () => {
+    // The regression this guards: the exchanged session is the oldest, so
+    // oldest-first eviction takes it, the client re-mints, and that re-mint
+    // evicts a browser session — a loop that costs the user a session a day.
+    const userId = await seedUserAtCap()
+    expect((await exchange(await signGrant())).status).toBe(200)
+    const exchanged = liveSessions(userId).find((s) => s.creation_method === 'token-exchange')!
+
+    const auth = authModule.getAuth()
+    for (let i = 0; i < CAP + 2; i++) {
+      await auth.api.signInEmail({ body: { email: 'member@example.com', password: PASSWORD } })
+    }
+
+    const remaining = liveSessions(userId)
+    expect(remaining.map((s) => s.id)).toContain(exchanged.id)
+    // Everything else is still held to the cap.
+    expect(remaining.filter((s) => s.creation_method !== 'token-exchange')).toHaveLength(CAP)
+  })
+
+  it('does not spend a slot on the exchanged session', async () => {
+    // Installing the app must not cost the user a browser session.
+    const userId = await seedUserAtCap()
+    const auth = authModule.getAuth()
+    for (let i = 0; i < CAP - 1; i++) {
+      await auth.api.signInEmail({ body: { email: 'member@example.com', password: PASSWORD } })
+    }
+    const beforeIds = liveSessions(userId).map((s) => s.id)
+
+    expect((await exchange(await signGrant())).status).toBe(200)
+
+    const after = liveSessions(userId)
+    // Every prior session survives, and the only addition is the exchange.
+    expect(after.map((s) => s.id)).toEqual(expect.arrayContaining(beforeIds))
+    expect(after).toHaveLength(beforeIds.length + 1)
+  })
+})
+
 describe('symmetry', () => {
   it('makes both credential sources visible in one filterable object', async () => {
     const auth = authModule.getAuth()

--- a/src/shared/lib/auth/session-audit.integration.test.ts
+++ b/src/shared/lib/auth/session-audit.integration.test.ts
@@ -435,6 +435,20 @@ describe('concurrent-session cap', () => {
     expect(remaining.filter((s) => s.creation_method !== 'token-exchange')).toHaveLength(CAP)
   })
 
+  it('does not let repeated exchanges grow the session table without bound', async () => {
+    // Holding these clear of the interactive cap removed the only thing that
+    // ever deleted them, and nothing else in the codebase prunes expired
+    // sessions — so a client that re-mints on a schedule would add a row every
+    // time, forever, to a table read in full on every login.
+    const userId = await seedUserAtCap()
+    for (let i = 0; i < 14; i++) {
+      expect((await exchange(await signGrant())).status).toBe(200)
+    }
+
+    const exchanged = liveSessions(userId).filter((s) => s.creation_method === 'token-exchange')
+    expect(exchanged.length).toBeLessThanOrEqual(10)
+  })
+
   it('does not spend a slot on the exchanged session', async () => {
     // Installing the app must not cost the user a browser session.
     const userId = await seedUserAtCap()

--- a/src/shared/lib/auth/session-audit.ts
+++ b/src/shared/lib/auth/session-audit.ts
@@ -88,6 +88,34 @@ export interface SessionForAudit {
 }
 
 /**
+ * The impersonating admin's id, or null for an ordinary session.
+ *
+ * Impersonation inverts the usual actor/subject relationship: Better Auth puts
+ * the impersonated user on `session.userId` and the admin who initiated it on
+ * `session.impersonatedBy`. The column is the ground truth here, not the
+ * endpoint path — it is what the plugin actually wrote, and it carries the
+ * actor the path cannot.
+ */
+export function readImpersonatedBy(session: SessionForAudit): string | null {
+  return typeof session.impersonatedBy === 'string' && session.impersonatedBy
+    ? session.impersonatedBy
+    : null
+}
+
+/**
+ * How this session came to exist. The single answer to that question: the
+ * audit row, the persisted `creationMethod` column, and the concurrent-session
+ * cap all resolve it here, so they cannot disagree about the same session.
+ */
+export function resolveSessionCreationMethod(
+  session: SessionForAudit,
+  endpointPath?: string | null,
+): SessionCreationMethod {
+  if (readImpersonatedBy(session)) return 'impersonation'
+  return resolveSessionAuditContext(endpointPath).method
+}
+
+/**
  * Record one `session:created` audit row.
  *
  * Details carry the attribution and nothing else — no token, assertion, jti,
@@ -100,19 +128,10 @@ export async function auditSessionCreated(
   session: SessionForAudit,
   endpointPath?: string | null,
 ): Promise<void> {
-  // Impersonation inverts the usual actor/subject relationship: Better Auth
-  // puts the impersonated user on `session.userId` and the admin who initiated
-  // it on `session.impersonatedBy`. Every other audit row treats `userId` as
-  // the actor, so recording this session as-is would blame the target for a
-  // privileged action taken against them — and revoking the session would take
-  // the only trace of who actually did it with it.
-  //
-  // The column is the ground truth here, not the endpoint path: it is what the
-  // plugin actually wrote, and it carries the actor the path cannot.
-  const impersonatedBy =
-    typeof session.impersonatedBy === 'string' && session.impersonatedBy
-      ? session.impersonatedBy
-      : null
+  // Recording an impersonation as-is would blame the target for a privileged
+  // action taken against them — and revoking the session would take the only
+  // trace of who actually did it with it.
+  const impersonatedBy = readImpersonatedBy(session)
   if (impersonatedBy) {
     await logAuditEvent({
       userId: impersonatedBy,

--- a/src/shared/lib/auth/session-enforcement.test.ts
+++ b/src/shared/lib/auth/session-enforcement.test.ts
@@ -3,9 +3,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // Track delete calls to verify which sessions are removed
 const deletedSessionIds: string[] = []
 
-// Configurable session list returned by the mock DB. `creationMethod` is
-// optional so the pre-existing cases below still read as plain session lists.
-let mockSessions: { id: string; createdAt: Date; creationMethod?: string | null }[] = []
+// Configurable session list returned by the mock DB. `creationMethod` and
+// `expiresAt` are optional so the pre-existing cases below still read as plain
+// session lists; a row with no expiry counts as live.
+let mockSessions: {
+  id: string
+  createdAt: Date
+  expiresAt?: Date
+  creationMethod?: string | null
+}[] = []
+
+const HOUR = 60 * 60 * 1000
+const past = (hours: number) => new Date(Date.now() - hours * HOUR)
+const future = (hours: number) => new Date(Date.now() + hours * HOUR)
 
 vi.mock('drizzle-orm', () => ({
   eq: (col: unknown, val: unknown) => ({ col, val }),
@@ -15,6 +25,7 @@ vi.mock('@shared/lib/db/schema', () => ({
   authSession: {
     id: 'id',
     createdAt: 'createdAt',
+    expiresAt: 'expiresAt',
     userId: 'userId',
     creationMethod: 'creationMethod',
   },
@@ -134,7 +145,7 @@ describe('enforceMaxConcurrentSessions', () => {
   })
 })
 
-describe('enforceMaxConcurrentSessions — token-exchange exemption', () => {
+describe('enforceMaxConcurrentSessions — non-interactive sessions', () => {
   beforeEach(() => {
     mockSessions = []
     deletedSessionIds.length = 0
@@ -172,9 +183,10 @@ describe('enforceMaxConcurrentSessions — token-exchange exemption', () => {
     expect(deletedSessionIds).toEqual([])
   })
 
-  it('leaves several token-exchange sessions alone regardless of the cap', () => {
-    // A user with the app on more than one machine. None of them counts, and
-    // none of them is a candidate — even at a cap of one.
+  it('holds several token-exchange sessions clear of the interactive cap', () => {
+    // A user with the app on more than one machine. None of them counts
+    // against the interactive cap, or is a candidate for it — even at a cap
+    // of one. They are bounded by their own ceiling instead.
     mockSessions = [
       { id: 'laptop', createdAt: new Date('2025-01-01'), creationMethod: 'token-exchange' },
       { id: 'desktop', createdAt: new Date('2025-01-02'), creationMethod: 'token-exchange' },
@@ -184,6 +196,64 @@ describe('enforceMaxConcurrentSessions — token-exchange exemption', () => {
     const deleted = enforceMaxConcurrentSessions('user1', 1)
     expect(deleted).toBe(0)
     expect(deletedSessionIds).toEqual([])
+  })
+
+  it('prunes expired token-exchange sessions', () => {
+    // Nothing else in the codebase deletes expired sessions, and a client
+    // re-mints on a schedule — so without this, exempting them from the
+    // interactive cap would mean a row per re-mint, forever.
+    mockSessions = [
+      { id: 'dead1', createdAt: past(3), expiresAt: past(2), creationMethod: 'token-exchange' },
+      { id: 'dead2', createdAt: past(2), expiresAt: past(1), creationMethod: 'token-exchange' },
+      { id: 'live', createdAt: past(1), expiresAt: future(1), creationMethod: 'token-exchange' },
+      { id: 's1', createdAt: past(1), expiresAt: future(1), creationMethod: 'password' },
+    ]
+
+    const deleted = enforceMaxConcurrentSessions('user1', 5)
+    expect(deleted).toBe(2)
+    expect(deletedSessionIds.sort()).toEqual(['dead1', 'dead2'])
+  })
+
+  it('bounds live token-exchange sessions by their own ceiling, oldest first', () => {
+    // The backstop: even with nothing expiring, the table cannot grow forever.
+    mockSessions = Array.from({ length: 13 }, (_, i) => ({
+      id: `x${i}`,
+      createdAt: past(20 - i),
+      expiresAt: future(1),
+      creationMethod: 'token-exchange',
+    }))
+
+    const deleted = enforceMaxConcurrentSessions('user1', 5)
+    expect(deleted).toBe(3)
+    expect(deletedSessionIds).toEqual(['x0', 'x1', 'x2'])
+  })
+
+  it('does not let expired exchange rows consume the interactive cap', () => {
+    // Pruning them must not evict a browser session as a side effect.
+    mockSessions = [
+      { id: 'dead', createdAt: past(3), expiresAt: past(2), creationMethod: 'token-exchange' },
+      { id: 's1', createdAt: past(2), expiresAt: future(1), creationMethod: 'password' },
+      { id: 's2', createdAt: past(1), expiresAt: future(1), creationMethod: 'password' },
+    ]
+
+    const deleted = enforceMaxConcurrentSessions('user1', 2)
+    expect(deleted).toBe(1)
+    expect(deletedSessionIds).toEqual(['dead'])
+  })
+
+  it('leaves expired interactive sessions counted, as before', () => {
+    // Deliberately unchanged: those rows are counted today, so dropping them
+    // would change the effective cap for every existing deployment. Separate
+    // decision, separate change.
+    mockSessions = [
+      { id: 's1', createdAt: past(3), expiresAt: past(2), creationMethod: 'password' },
+      { id: 's2', createdAt: past(2), expiresAt: future(1), creationMethod: 'password' },
+      { id: 's3', createdAt: past(1), expiresAt: future(1), creationMethod: 'password' },
+    ]
+
+    const deleted = enforceMaxConcurrentSessions('user1', 2)
+    expect(deleted).toBe(1)
+    expect(deletedSessionIds).toEqual(['s1'])
   })
 
   it('still caps other methods, including impersonation', () => {

--- a/src/shared/lib/auth/session-enforcement.test.ts
+++ b/src/shared/lib/auth/session-enforcement.test.ts
@@ -3,8 +3,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // Track delete calls to verify which sessions are removed
 const deletedSessionIds: string[] = []
 
-// Configurable session list returned by the mock DB
-let mockSessions: { id: string; createdAt: Date }[] = []
+// Configurable session list returned by the mock DB. `creationMethod` is
+// optional so the pre-existing cases below still read as plain session lists.
+let mockSessions: { id: string; createdAt: Date; creationMethod?: string | null }[] = []
 
 vi.mock('drizzle-orm', () => ({
   eq: (col: unknown, val: unknown) => ({ col, val }),
@@ -15,6 +16,7 @@ vi.mock('@shared/lib/db/schema', () => ({
     id: 'id',
     createdAt: 'createdAt',
     userId: 'userId',
+    creationMethod: 'creationMethod',
   },
 }))
 
@@ -115,5 +117,86 @@ describe('enforceMaxConcurrentSessions', () => {
     const deleted = enforceMaxConcurrentSessions('user1', 5)
     expect(deleted).toBe(0)
     expect(deletedSessionIds).toEqual([])
+  })
+
+  it('counts sessions created before the creationMethod column as capped', () => {
+    // Null is what every row written before this column existed reads as.
+    // Treating those as exempt would silently uncap an entire installed base.
+    mockSessions = [
+      { id: 's1', createdAt: new Date('2025-01-01'), creationMethod: null },
+      { id: 's2', createdAt: new Date('2025-01-02'), creationMethod: null },
+      { id: 's3', createdAt: new Date('2025-01-03'), creationMethod: null },
+    ]
+
+    const deleted = enforceMaxConcurrentSessions('user1', 2)
+    expect(deleted).toBe(1)
+    expect(deletedSessionIds).toEqual(['s1'])
+  })
+})
+
+describe('enforceMaxConcurrentSessions — token-exchange exemption', () => {
+  beforeEach(() => {
+    mockSessions = []
+    deletedSessionIds.length = 0
+  })
+
+  it('never evicts a token-exchange session, even as the oldest', () => {
+    // The exact regression: the installed client's session is the oldest, so
+    // oldest-first eviction would take it and the client would re-mint on its
+    // next call — evicting another browser session, indefinitely.
+    mockSessions = [
+      { id: 'desktop', createdAt: new Date('2025-01-01'), creationMethod: 'token-exchange' },
+      { id: 's2', createdAt: new Date('2025-01-02'), creationMethod: 'password' },
+      { id: 's3', createdAt: new Date('2025-01-03'), creationMethod: 'password' },
+      { id: 's4', createdAt: new Date('2025-01-04'), creationMethod: 'password' },
+    ]
+
+    const deleted = enforceMaxConcurrentSessions('user1', 2)
+    expect(deleted).toBe(1)
+    expect(deletedSessionIds).toEqual(['s2'])
+  })
+
+  it('does not let a token-exchange session push a browser session out', () => {
+    // Three interactive sessions under a cap of three. Adding the desktop
+    // client must not put the user over — otherwise installing the app costs
+    // them a browser session.
+    mockSessions = [
+      { id: 's1', createdAt: new Date('2025-01-01'), creationMethod: 'password' },
+      { id: 's2', createdAt: new Date('2025-01-02'), creationMethod: 'oidc' },
+      { id: 's3', createdAt: new Date('2025-01-03'), creationMethod: 'password' },
+      { id: 'desktop', createdAt: new Date('2025-01-04'), creationMethod: 'token-exchange' },
+    ]
+
+    const deleted = enforceMaxConcurrentSessions('user1', 3)
+    expect(deleted).toBe(0)
+    expect(deletedSessionIds).toEqual([])
+  })
+
+  it('leaves several token-exchange sessions alone regardless of the cap', () => {
+    // A user with the app on more than one machine. None of them counts, and
+    // none of them is a candidate — even at a cap of one.
+    mockSessions = [
+      { id: 'laptop', createdAt: new Date('2025-01-01'), creationMethod: 'token-exchange' },
+      { id: 'desktop', createdAt: new Date('2025-01-02'), creationMethod: 'token-exchange' },
+      { id: 's3', createdAt: new Date('2025-01-03'), creationMethod: 'password' },
+    ]
+
+    const deleted = enforceMaxConcurrentSessions('user1', 1)
+    expect(deleted).toBe(0)
+    expect(deletedSessionIds).toEqual([])
+  })
+
+  it('still caps other methods, including impersonation', () => {
+    // The exemption is for one method, not a general "leave sessions alone".
+    mockSessions = [
+      { id: 's1', createdAt: new Date('2025-01-01'), creationMethod: 'impersonation' },
+      { id: 's2', createdAt: new Date('2025-01-02'), creationMethod: 'unknown' },
+      { id: 's3', createdAt: new Date('2025-01-03'), creationMethod: 'oidc' },
+      { id: 'desktop', createdAt: new Date('2025-01-04'), creationMethod: 'token-exchange' },
+    ]
+
+    const deleted = enforceMaxConcurrentSessions('user1', 1)
+    expect(deleted).toBe(2)
+    expect(deletedSessionIds).toEqual(['s1', 's2'])
   })
 })

--- a/src/shared/lib/auth/session-enforcement.ts
+++ b/src/shared/lib/auth/session-enforcement.ts
@@ -4,65 +4,113 @@ import { authSession } from '@shared/lib/db/schema'
 import type { SessionCreationMethod } from './session-audit'
 
 /**
- * Session-creation methods exempt from the concurrent-session cap.
+ * Session-creation methods held to their own bound rather than the interactive
+ * one.
  *
- * The cap bounds how many *interactive* sessions a user accumulates across
- * browsers and devices. A session minted by the RFC 7523 token exchange is not
- * one of those: it belongs to a client the user installed, it is re-minted on
- * a schedule the user never sees, and it is revoked by disconnecting that
- * client rather than by signing out.
+ * `maxConcurrentSessions` bounds how many *interactive* sessions a user
+ * accumulates across browsers and devices. A session minted by the RFC 7523
+ * token exchange is not one of those: it belongs to a client the user
+ * installed, it is re-minted on a schedule they never see, and it is revoked by
+ * disconnecting that client rather than by signing out.
  *
- * Without the exemption the interaction is harmful in both directions.
- * Eviction is oldest-first and the oldest session is almost always the
- * long-lived browser one, so a daily re-mint would walk a user's browser
- * sessions off the end. In the other direction, a few browser logins would
- * silently evict the installed client's session — which re-mints, evicting
- * another browser session.
+ * Mixing the two is harmful in both directions. Eviction is oldest-first and
+ * the oldest session is almost always the long-lived browser one, so a daily
+ * re-mint would walk a user's browser sessions off the end. In the other
+ * direction, a few browser logins would silently evict the installed client's
+ * session — which re-mints, evicting another browser session.
  *
  * Type-only import so this stays free of the audit service at runtime; the
  * annotation is what keeps the string in step with the method list.
  */
-const UNCAPPED_CREATION_METHODS: readonly SessionCreationMethod[] = ['token-exchange']
+const NON_INTERACTIVE_CREATION_METHODS: readonly SessionCreationMethod[] = ['token-exchange']
 
-function isCapped(creationMethod: string | null): boolean {
-  // Rows predating the `creation_method` column read null. Counting them is
-  // the safe default: it preserves existing behaviour for every session this
-  // code has not labelled, and the alternative would exempt them wholesale.
-  return !UNCAPPED_CREATION_METHODS.includes(creationMethod as SessionCreationMethod)
+/**
+ * Ceiling on *live* non-interactive sessions per user.
+ *
+ * Separating these from the interactive cap must not mean removing their
+ * bound. Nothing in this codebase prunes expired sessions, and a client
+ * re-mints on a schedule, so "never evicted" would mean a row per re-mint
+ * forever — in a table read in full on every single login.
+ *
+ * Generous on purpose: this is a backstop against unbounded growth, not a
+ * device limit. Expired rows are pruned below, so the steady state is roughly
+ * one row per machine and this ceiling is never reached in normal use.
+ */
+const MAX_NON_INTERACTIVE_SESSIONS = 10
+
+interface SessionRow {
+  id: string
+  createdAt: Date
+  expiresAt: Date
+  creationMethod: string | null
+}
+
+function isNonInteractive(creationMethod: string | null): boolean {
+  // Rows predating the `creation_method` column read null. Treating them as
+  // interactive is the safe default: it preserves existing behaviour for every
+  // session this code has not labelled, and the alternative would move an
+  // entire installed base onto the other bound.
+  return NON_INTERACTIVE_CREATION_METHODS.includes(creationMethod as SessionCreationMethod)
+}
+
+/** Defensive about the shape: a row with no usable expiry counts as live. */
+function isExpired(expiresAt: Date | null | undefined): boolean {
+  return expiresAt instanceof Date && expiresAt.getTime() <= Date.now()
+}
+
+/** The oldest rows above `max`; `rows` must already be oldest-first. */
+function overflow<T>(rows: T[], max: number): T[] {
+  return rows.length > max ? rows.slice(0, rows.length - max) : []
 }
 
 /**
- * Delete oldest sessions for a user when they exceed the max allowed.
- * Returns the number of sessions deleted.
+ * Delete a user's excess sessions. Returns the number deleted.
  *
- * Exempt sessions are excluded from both the count and the deletion
- * candidates — they neither push another session out nor get pushed out.
+ * Interactive sessions (browser logins) are held to `maxSessions`;
+ * non-interactive ones to their own ceiling, having first dropped any that
+ * have expired. The two groups never evict each other.
  */
 export function enforceMaxConcurrentSessions(userId: string, maxSessions: number): number {
   const userSessions = db
     .select({
       id: authSession.id,
       createdAt: authSession.createdAt,
+      expiresAt: authSession.expiresAt,
       creationMethod: authSession.creationMethod,
     })
     .from(authSession)
     .where(eq(authSession.userId, userId))
     .orderBy(authSession.createdAt)
-    .all()
+    .all() as SessionRow[]
 
-  // Filtered in memory rather than in SQL: the set is bounded by the cap plus
-  // a handful, and `creation_method IS NOT 'x'` has null semantics that are
-  // easy to get subtly wrong in a where clause.
-  const capped = userSessions.filter((s) => isCapped(s.creationMethod))
-
-  if (capped.length > maxSessions) {
-    const toDelete = capped.slice(0, capped.length - maxSessions)
-    for (const s of toDelete) {
-      db.delete(authSession)
-        .where(eq(authSession.id, s.id))
-        .run()
-    }
-    return toDelete.length
+  // Partitioned in memory rather than in SQL: the set is small, and
+  // `creation_method IS NOT 'x'` has null semantics that are easy to get subtly
+  // wrong in a where clause.
+  const interactive: SessionRow[] = []
+  const nonInteractive: SessionRow[] = []
+  for (const session of userSessions) {
+    ;(isNonInteractive(session.creationMethod) ? nonInteractive : interactive).push(session)
   }
-  return 0
+
+  // Expired non-interactive rows go first, so the ceiling below is spent on
+  // sessions that can still authenticate rather than on dead weight.
+  //
+  // Scoped to non-interactive deliberately. Pruning expired *interactive* rows
+  // would change the effective cap for every existing deployment — those rows
+  // are counted today — which is a separate decision from this one.
+  const expired = nonInteractive.filter((s) => isExpired(s.expiresAt))
+  const live = nonInteractive.filter((s) => !isExpired(s.expiresAt))
+
+  const doomed = [
+    ...overflow(interactive, maxSessions),
+    ...expired,
+    ...overflow(live, MAX_NON_INTERACTIVE_SESSIONS),
+  ]
+
+  for (const session of doomed) {
+    db.delete(authSession)
+      .where(eq(authSession.id, session.id))
+      .run()
+  }
+  return doomed.length
 }

--- a/src/shared/lib/auth/session-enforcement.ts
+++ b/src/shared/lib/auth/session-enforcement.ts
@@ -1,21 +1,62 @@
 import { eq } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
 import { authSession } from '@shared/lib/db/schema'
+import type { SessionCreationMethod } from './session-audit'
+
+/**
+ * Session-creation methods exempt from the concurrent-session cap.
+ *
+ * The cap bounds how many *interactive* sessions a user accumulates across
+ * browsers and devices. A session minted by the RFC 7523 token exchange is not
+ * one of those: it belongs to a client the user installed, it is re-minted on
+ * a schedule the user never sees, and it is revoked by disconnecting that
+ * client rather than by signing out.
+ *
+ * Without the exemption the interaction is harmful in both directions.
+ * Eviction is oldest-first and the oldest session is almost always the
+ * long-lived browser one, so a daily re-mint would walk a user's browser
+ * sessions off the end. In the other direction, a few browser logins would
+ * silently evict the installed client's session — which re-mints, evicting
+ * another browser session.
+ *
+ * Type-only import so this stays free of the audit service at runtime; the
+ * annotation is what keeps the string in step with the method list.
+ */
+const UNCAPPED_CREATION_METHODS: readonly SessionCreationMethod[] = ['token-exchange']
+
+function isCapped(creationMethod: string | null): boolean {
+  // Rows predating the `creation_method` column read null. Counting them is
+  // the safe default: it preserves existing behaviour for every session this
+  // code has not labelled, and the alternative would exempt them wholesale.
+  return !UNCAPPED_CREATION_METHODS.includes(creationMethod as SessionCreationMethod)
+}
 
 /**
  * Delete oldest sessions for a user when they exceed the max allowed.
  * Returns the number of sessions deleted.
+ *
+ * Exempt sessions are excluded from both the count and the deletion
+ * candidates — they neither push another session out nor get pushed out.
  */
 export function enforceMaxConcurrentSessions(userId: string, maxSessions: number): number {
   const userSessions = db
-    .select({ id: authSession.id, createdAt: authSession.createdAt })
+    .select({
+      id: authSession.id,
+      createdAt: authSession.createdAt,
+      creationMethod: authSession.creationMethod,
+    })
     .from(authSession)
     .where(eq(authSession.userId, userId))
     .orderBy(authSession.createdAt)
     .all()
 
-  if (userSessions.length > maxSessions) {
-    const toDelete = userSessions.slice(0, userSessions.length - maxSessions)
+  // Filtered in memory rather than in SQL: the set is bounded by the cap plus
+  // a handful, and `creation_method IS NOT 'x'` has null semantics that are
+  // easy to get subtly wrong in a where clause.
+  const capped = userSessions.filter((s) => isCapped(s.creationMethod))
+
+  if (capped.length > maxSessions) {
+    const toDelete = capped.slice(0, capped.length - maxSessions)
     for (const s of toDelete) {
       db.delete(authSession)
         .where(eq(authSession.id, s.id))

--- a/src/shared/lib/db/migrations/0033_normal_whiplash.sql
+++ b/src/shared/lib/db/migrations/0033_normal_whiplash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `session` ADD `creation_method` text;

--- a/src/shared/lib/db/migrations/meta/0033_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0033_snapshot.json
@@ -1,0 +1,2483 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "496de14c-a9b9-4ef6-a0cb-7b734f17aedc",
+  "prevId": "0ceba77d-cab7-443b-aa01-49af463f4409",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creation_method": {
+          "name": "creation_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_audit_log_agent_slug_created_at_idx": {
+          "name": "mcp_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_remote_mcp_id_created_at_idx": {
+          "name": "mcp_audit_log_remote_mcp_id_created_at_idx",
+          "columns": [
+            "remote_mcp_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_mcp_agent_idx": {
+          "name": "mcp_audit_log_mcp_agent_idx",
+          "columns": [
+            "remote_mcp_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_audit_log_agent_slug_created_at_idx": {
+          "name": "proxy_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_id_created_at_idx": {
+          "name": "proxy_audit_log_account_id_created_at_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_agent_idx": {
+          "name": "proxy_audit_log_account_agent_idx",
+          "columns": [
+            "account_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resume_session_id": {
+          "name": "resume_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_tasks_pending_wake_unique": {
+          "name": "scheduled_tasks_pending_wake_unique",
+          "columns": [
+            "resume_session_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending' AND resume_session_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "token_exchange_jti": {
+      "name": "token_exchange_jti",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "token_exchange_jti_expires_at_idx": {
+          "name": "token_exchange_jti_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1784841760603,
       "tag": "0032_great_miek",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1785019349876,
+      "tag": "0033_normal_whiplash",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -45,6 +45,13 @@ export const authSession = sqliteTable('session', {
     .notNull()
     .references(() => user.id, { onDelete: 'cascade' }),
   impersonatedBy: text('impersonated_by'),
+  /**
+   * How this session came to exist — one of `SESSION_CREATION_METHODS`
+   * (auth/session-audit.ts), written once at creation and never updated.
+   * Nullable: rows that predate the column carry no answer, and "unknown"
+   * would be a claim we cannot make about them.
+   */
+  creationMethod: text('creation_method'),
 }, (table) => ({
   userIdIdx: index('session_userId_idx').on(table.userId),
 }))


### PR DESCRIPTION
Groundwork for SUP-478 (Local/Cloud toggle), split out because it changes **auth behaviour for every auth-mode deployment**, including web — it deserves review on its own terms rather than buried in a UI feature.

## The bug

`enforceMaxConcurrentSessions` evicts **oldest-first**, and the oldest session is almost always the user's long-lived browser one. Every RFC 7523 token exchange mints a **new** session (SUP-361), so a desktop client that re-mints daily walks the user's browser sessions off the end of a five-slot cap.

The collision runs both ways. A few browser logins evict the client's session → the client re-mints on its next call → that re-mint evicts another browser session. Neither side ever settles.

Two aggravating factors, both pre-existing: the count query does not filter on `expires_at`, so dead rows consume slots; and the cap is shared across a user's laptop, phone, and browsers, so many users sit near it already.

## The fix

The cap is meant to bound **interactive** sessions across browsers and devices. A session belonging to a client the user installed is not one of those — it is re-minted on a schedule they never see, and revoked by disconnecting the client rather than by signing out. So exempt it from **both** the count and the eviction candidates: it neither pushes another session out nor gets pushed out.

## Worth reviewing

**Why a column and not just the existing async-local tag.** Skipping enforcement *during* the exchange would stop the desktop from evicting others, but a later browser login would still evict the desktop's session. The cap has to recognize an installed client's session on a **later** request, when the endpoint path and the async-local tag are long gone. So the answer gets written down: `session.creation_method`, stamped in a `session.create.before` hook.

**One resolver, two consumers.** `resolveSessionCreationMethod()` in `session-audit.ts` now backs both the audit row (#584) and the column, so they cannot disagree about the same session — there is a test asserting exactly that. It also sets up the admin sessions list to say "Desktop app" instead of rendering a raw user-agent, though that is not in this PR.

**Null means capped.** Rows predating the column read null. Treating those as exempt would silently uncap an entire installed base, so null counts — preserving existing behaviour for every session this code has not labelled. Directly tested.

**The stamp never throws.** Failing to label a session must not stop it being created, and an unlabelled session degrades to precisely the old behaviour.

**`input: false`** on the additional field — server-derived, never settable by a client. I confirmed empirically that this does not stop the internal write; the integration tests read the column back out of SQLite.

## Migration

`0033_normal_whiplash.sql` — one `ALTER TABLE session ADD creation_method text`. Generated with `drizzle-kit` (not hand-written) so the snapshot lands too; without it the next `generate` would try to re-add the column. Diffing the 0032 and 0033 snapshots confirms `session.creation_method` is the **only** schema change — no drift dragged in.

## Tests

Unit coverage for the cap arithmetic, and integration coverage against **real Better Auth + real SQLite**: the column is stamped correctly for password login, token exchange, and impersonation; it agrees with the audit row; the exchanged session survives repeated browser logins while everything else is still held to the cap; and installing the client does not cost the user a browser slot.

Red-green, each restored after:

| Probe | Result |
|---|---|
| Exemption removed (`isCapped` → always true) | 6 tests fail |
| Stamp removed from the before-hook | 6 tests fail |

Full suite **7953 passed**, 445 files, 0 failed. `npx tsc --noEmit` and `npx eslint` clean.

## Not in scope

Expired `session` rows counting toward the cap is a real pre-existing bug this work surfaced, but fixing it changes the effective cap for every existing deployment — a separate decision, and a separate PR.

https://claude.ai/code/session_01XrBefX3sLRxZzfwyktYA5R