### PR TITLE
Wait for the remote MCP handshake before delivering the next message

### DIFF
--- a/agent-container/src/claude-code-connections.test.ts
+++ b/agent-container/src/claude-code-connections.test.ts
@@ -1,7 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type MockQueryCall = { options: Record<string, unknown> }
+type MockMcpStatus = { name: string; status: string }
 const calls: MockQueryCall[] = []
+
+// Per-test override for the mcpServerStatus() control request. Left null, every
+// server configured on the most recent query reports 'connected' immediately, so
+// tests that are not about the handshake gate never wait on it.
+let mcpServerStatusImpl: (() => Promise<MockMcpStatus[]>) | null = null
+let mcpServerStatusCalls = 0
+
+function allConnected(): MockMcpStatus[] {
+  const servers = (calls[calls.length - 1]?.options.mcpServers ?? {}) as Record<string, unknown>
+  return Object.keys(servers).map((name) => ({ name, status: 'connected' }))
+}
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => {
   function makeQuery(args: { options: Record<string, unknown> }) {
@@ -18,6 +30,7 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
     const iterator: AsyncIterableIterator<never> & {
       interrupt: () => Promise<void>
       setModel: () => Promise<void>
+      mcpServerStatus: () => Promise<MockMcpStatus[]>
     } = {
       [Symbol.asyncIterator]() {
         return this
@@ -42,6 +55,10 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
       },
       setModel() {
         return Promise.resolve()
+      },
+      mcpServerStatus() {
+        mcpServerStatusCalls++
+        return (mcpServerStatusImpl ?? (async () => allConnected()))()
       },
     }
     return iterator
@@ -91,6 +108,8 @@ describe('ClaudeCodeProcess runtime connection handling', () => {
 
   beforeEach(() => {
     calls.length = 0
+    mcpServerStatusImpl = null
+    mcpServerStatusCalls = 0
     originalRemoteMcps = process.env.REMOTE_MCPS
     originalConnectedAccounts = process.env.CONNECTED_ACCOUNTS
     delete process.env.REMOTE_MCPS
@@ -180,5 +199,139 @@ describe('ClaudeCodeProcess runtime connection handling', () => {
     await claudeProcess.sendMessage('Continue without connections')
 
     expect(calls).toHaveLength(1)
+  })
+})
+
+describe('ClaudeCodeProcess remote MCP handshake gate', () => {
+  let originalRemoteMcps: string | undefined
+  let originalConnectedAccounts: string | undefined
+  let claudeProcess: ClaudeCodeProcess | undefined
+
+  const CALENDAR = JSON.stringify([
+    {
+      id: 'mcp-calendar',
+      name: 'Team Calendar',
+      proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
+      tools: [{ name: 'list_events' }],
+    },
+  ])
+
+  async function startProcess(sessionId: string): Promise<ClaudeCodeProcess> {
+    claudeProcess = new ClaudeCodeProcess({ sessionId, workingDirectory: '/tmp' })
+    await claudeProcess.start()
+    return claudeProcess
+  }
+
+  beforeEach(() => {
+    calls.length = 0
+    mcpServerStatusImpl = null
+    mcpServerStatusCalls = 0
+    originalRemoteMcps = process.env.REMOTE_MCPS
+    originalConnectedAccounts = process.env.CONNECTED_ACCOUNTS
+    delete process.env.REMOTE_MCPS
+    delete process.env.CONNECTED_ACCOUNTS
+  })
+
+  afterEach(async () => {
+    await claudeProcess?.stop()
+    claudeProcess = undefined
+    if (originalRemoteMcps === undefined) delete process.env.REMOTE_MCPS
+    else process.env.REMOTE_MCPS = originalRemoteMcps
+    if (originalConnectedAccounts === undefined) delete process.env.CONNECTED_ACCOUNTS
+    else process.env.CONNECTED_ACCOUNTS = originalConnectedAccounts
+  })
+
+  it('holds the message until a newly connected server finishes its handshake', async () => {
+    const claude = await startProcess('test-handshake-gate-waits')
+
+    // Two polls report the SDK still connecting, the third reports it done.
+    let poll = 0
+    mcpServerStatusImpl = async () => [
+      { name: 'team_calendar', status: ++poll < 3 ? 'pending' : 'connected' },
+    ]
+
+    process.env.REMOTE_MCPS = CALENDAR
+    await claude.sendMessage('List today’s events')
+
+    // The query was rebuilt AND the send waited through the pending polls
+    // rather than delivering into a half-connected session.
+    expect(calls).toHaveLength(2)
+    expect(mcpServerStatusCalls).toBe(3)
+  })
+
+  it('does not wait on MCP servers from other setting scopes', async () => {
+    const claude = await startProcess('test-handshake-gate-foreign')
+
+    // createQuery passes settingSources ['user','project'], so the status list
+    // carries servers this agent never configured. A slow one of those must not
+    // hold up the user's turn.
+    mcpServerStatusImpl = async () => [
+      { name: 'team_calendar', status: 'connected' },
+      { name: 'some-user-scoped-server', status: 'pending' },
+    ]
+
+    process.env.REMOTE_MCPS = CALENDAR
+    await claude.sendMessage('List today’s events')
+
+    expect(mcpServerStatusCalls).toBe(1)
+  })
+
+  it('stops waiting at a server that will never become connected', async () => {
+    const claude = await startProcess('test-handshake-gate-failed')
+
+    // 'failed' is terminal — polling to the timeout would just delay the turn.
+    mcpServerStatusImpl = async () => [{ name: 'team_calendar', status: 'failed' }]
+
+    process.env.REMOTE_MCPS = CALENDAR
+    await claude.sendMessage('List today’s events')
+
+    expect(mcpServerStatusCalls).toBe(1)
+    expect(calls).toHaveLength(2)
+  })
+
+  it('delivers the message when the control channel is unavailable', async () => {
+    const claude = await startProcess('test-handshake-gate-no-channel')
+
+    // Older CLI without the control request, or a query already torn down.
+    mcpServerStatusImpl = async () => {
+      throw new Error('control request not supported')
+    }
+
+    process.env.REMOTE_MCPS = CALENDAR
+    await claude.sendMessage('List today’s events')
+
+    expect(mcpServerStatusCalls).toBe(1)
+    expect(calls).toHaveLength(2)
+  })
+
+  it('skips the probe entirely when the change left no remote MCPs configured', async () => {
+    const claude = await startProcess('test-handshake-gate-accounts-only')
+
+    // A connected-account-only change still re-queries, but there is no remote
+    // MCP handshake to wait on.
+    process.env.CONNECTED_ACCOUNTS = JSON.stringify({
+      gmail: [{ name: 'Work Gmail', id: 'account-gmail' }],
+    })
+    await claude.sendMessage('Check the connected Gmail account')
+
+    expect(calls).toHaveLength(2)
+    expect(mcpServerStatusCalls).toBe(0)
+  })
+
+  it('gives up after the timeout instead of blocking the turn forever', async () => {
+    const claude = await startProcess('test-handshake-gate-timeout')
+    process.env.REMOTE_MCPS = CALENDAR
+
+    mcpServerStatusImpl = async () => [{ name: 'team_calendar', status: 'pending' }]
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Exercised directly so the test does not sit out the production timeout.
+    await (
+      claude as unknown as { waitForRemoteMcpsReady(ms: number): Promise<void> }
+    ).waitForRemoteMcpsReady(600)
+
+    expect(mcpServerStatusCalls).toBeGreaterThan(1)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('still pending'))
+    warn.mockRestore()
   })
 })

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -59,6 +59,13 @@ import { createCapabilityGateHook, CAPABILITY_REVIEW_HOOK_TIMEOUT_S } from './ca
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
 const SYSTEM_MESSAGE_PREFIX = '[SYSTEM] ';
 
+// Upper bound on how long a message waits for freshly (re)connected remote MCP
+// servers to finish their handshake. Comfortably inside the 5-minute interactive
+// idle eviction, and the same order as the interrupt() teardown the send path
+// already awaits.
+const REMOTE_MCP_READY_TIMEOUT_MS = 8_000;
+const REMOTE_MCP_READY_POLL_MS = 250;
+
 export const AGENT_BROWSER_BASH_WARNING =
   'STRONG WARNING: This Bash command is probably bypassing Gamut\'s browser integration. For website work, use the dedicated mcp__browser__browser_* tools; if they are deferred, load their exact full names with ToolSearch. The Bash command is still allowed, but continue with agent-browser only when the dedicated browser tools genuinely cannot perform the operation.';
 
@@ -579,6 +586,59 @@ export class ClaudeCodeProcess extends EventEmitter {
     }
 
     return configs;
+  }
+
+  /**
+   * Hold the next message until the remote MCP servers this query just
+   * (re)connected have finished their handshake.
+   *
+   * createQuery() reconnects every MCP server from scratch, and the SDK runs
+   * that handshake CONCURRENTLY with the first turn. Meanwhile the system
+   * prompt — regenerated from the same REMOTE_MCPS — already tells the model
+   * the servers "are connected and their tools are available for use". The
+   * model believes it, calls mcp__<server>__<tool>, and gets "No such tool
+   * available": the exact symptom of a connection that never arrived.
+   *
+   * Only the connection-config-changed path calls this. An unchanged config
+   * means no re-query at all, hence no handshake in flight and nothing to wait
+   * for. The other re-query triggers (effort/speed/capability change, cold-start
+   * restart) race the same handshake, but there the user has not just connected
+   * a server they are about to ask about — and gating every wake-from-idle would
+   * tax a far more common path for a far rarer payoff.
+   */
+  private async waitForRemoteMcpsReady(
+    timeoutMs: number = REMOTE_MCP_READY_TIMEOUT_MS
+  ): Promise<void> {
+    // Keys are already sanitized, and they are exactly the keys handed to
+    // query() as mcpServers — so they match the names the SDK reports back.
+    const expected = Object.keys(this.buildRemoteMcpServers());
+    if (expected.length === 0 || !this.queryInstance) return;
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const statuses = await this.queryInstance.mcpServerStatus().catch(() => null);
+      // No control channel (older CLI, or a query already torn down): the turn
+      // must never hang on a diagnostic.
+      if (!statuses) return;
+
+      // Scoped to OUR servers by name. createQuery passes settingSources
+      // ['user','project'], so this list also carries user- and project-scoped
+      // servers whose health is not ours to block a turn on. A server missing
+      // from the list entirely is still starting up — keep waiting.
+      const settled = expected.every((name) => {
+        const status = statuses.find((s) => s.name === name)?.status;
+        // 'failed' | 'needs-auth' | 'disabled' never become 'connected'; waiting
+        // past them would burn the whole timeout on a server that is simply down.
+        return status !== undefined && status !== 'pending';
+      });
+      if (settled) return;
+
+      await new Promise((resolve) => setTimeout(resolve, REMOTE_MCP_READY_POLL_MS));
+    }
+
+    console.warn(
+      `[Session ${this.sessionId}] Remote MCP handshake still pending after ${timeoutMs}ms — delivering the message anyway`
+    );
   }
 
   /**
@@ -1216,6 +1276,14 @@ export class ClaudeCodeProcess extends EventEmitter {
         console.warn(`[Session ${this.sessionId}] setModel failed, falling back to restart:`, err);
         await this.interrupt();
       }
+    }
+
+    // Deliberately outside the branch chain above: BOTH the cold-session
+    // restart() and the interrupt() re-query rebuild the query with the new
+    // connection set, so both race the handshake. Guarded by the flag rather
+    // than by the branch, so an effort- or speed-only re-query pays nothing.
+    if (runtimeConnectionConfigChanged) {
+      await this.waitForRemoteMcpsReady();
     }
 
     // Create SDK user message format


### PR DESCRIPTION
Follow-up to #571 (SUP-470).

## Problem

#571 makes a newly connected MCP reach a running container, but the re-query is synchronous with message delivery, so the SDK's MCP handshake races the first turn.

The system prompt is regenerated from `REMOTE_MCPS` and states the servers "are connected and their tools are available for use" — while the SDK still has them in `pendingMcpServers` with their tools deferred. The model believes the prompt, calls `mcp__<server>__<tool>`, and gets `No such tool available`.

Observed against a live Cal.com MCP, on the exact flow from the ticket (send a message, connect the MCP, ask about it):

| Time | Event |
|---|---|
| `+0.0s` | message delivered, query recreated, `cal_com` **pending** |
| `+3.5s` | model calls `mcp__cal_com__get_me` → `No such tool available` |
| `+6.7s` | handshake completes, 58 tools register |
| `+12.3s` | retry succeeds |

That model recovered on its own via `ToolSearch`. One that doesn't reports "I can't find the Cal MCP tools" — the verbatim symptom of SUP-470 itself, so the fix looks like it didn't take.

Cost per occurrence: a failed tool call, an extra round-trip, and a *second* cache invalidation in the same turn (`tools_changed`, 41,393 tokens) on top of the unavoidable `system_changed` one.

## Fix

Gate the send on `Query.mcpServerStatus()` until the remote servers this query configured are no longer `pending`.

## Why not the init frame

`system/init` carries `mcp_servers: [{name, status}]`, but it is emitted **after** the first user message is sent — `session-manager.ts` says so explicitly (`"emitted after first message is sent"` / `"Send the initial message - this triggers Claude to emit the session ID"`). Gating on it deadlocks. `mcpServerStatus()` is a control request and has no such ordering constraint.

## Validated experimentally

Probed with a local HTTP MCP server that stalls `initialize` for 6s, mirroring `claude-code.ts` exactly — query created, background `for await` driving it, **no message pushed**:

```
[+   30ms] >>> calling mcpServerStatus() with NO message pushed
[+  912ms] MCP server: got initialize, stalling 6000ms
[+ 1306ms] RESOLVED pre-message: [... "slowmcp", status: "pending" ...]
[+ 6913ms] MCP server: replying to initialize
[+ 7351ms] poll: slowmcp=connected   >>> settled
[+ 7351ms] initialize calls received by MCP server: 1
```

Three findings that shaped the implementation:

- **Scope the wait to our own server names.** `createQuery` passes `settingSources: ['user','project']`, so the status list also carried `Sanity[user]`, `claude.ai Gmail[claudeai]`, etc. Waiting on "nothing is pending" would let an unrelated user-scoped server gate the turn.
- **`failed`/`needs-auth`/`disabled` count as settled.** An unreachable server reports `failed` in ~1.2s rather than hanging at `pending`, so waiting past those would only burn the timeout.
- **In-process SDK servers never appear.** Passing `user-input` via `createSdkMcpServer` produced no entry at all — only transport-based servers are listed, so `browser`/`dashboards`/`agents`/`chat` cannot cause a false pending.

The single `initialize` at `+912ms` with no message pushed also confirms the root cause: the handshake starts at query creation and runs concurrently with the first turn.

## Scope

Only the connection-config-changed path waits — an unchanged config means no re-query, hence no handshake in flight and nothing to wait for. **Zero added latency on an ordinary message**, structurally rather than by flag.

Deliberately *not* applied to the other re-query triggers (effort/speed/capability change, cold-start restart). Those race the same handshake, but there the user hasn't just connected a server they're about to ask about, and gating every wake-from-idle would tax a far more common path. Noted in the code so the narrower scope reads as intentional rather than missed.

The call sits outside the branch chain so it covers both the cold-session `restart()` and the `interrupt()` re-query — a guard inside the `else if` would miss "session idle-evicted, user connects an MCP, user messages", and would also fire on effort-only changes.

## Trade

The first message after connecting waits out the handshake (~6.7s in the trace above, of which ~3.2s is genuinely additive — the model would have spent the rest thinking before its first tool call anyway). A spinner instead of a red failed tool call. Bounded at 8s and non-fatal: a wedged server logs a warning and the message goes through. Comfortably inside the 5-minute interactive idle eviction, and the same order as the `interrupt()` teardown the send path already awaits.

## Validation

- `vitest run src/claude-code-connections.test.ts` — 8 passed (6 new)
- **Red→green proven**: with the call site disabled, 4 of the 6 new tests fail. The other two are by design independent of it — the timeout test exercises the helper directly, and the "skips the probe" test asserts an absence.
- agent-container full suite — 48 files, 748 passed, 8 skipped
- agent-container `tsc --noEmit`, host `tsc --noEmit`
- ESLint on both changed files

## Resumed queries — validated

`createQuery()` always passes `resume: this.claudeSessionId`, so the production restart path is *always* a resume, while the probe above used a fresh query. Re-ran it end to end: a real API turn to mint a genuine resumable session, then a **new** query with `resume:<id>` + the slow MCP server and **no message pushed**.

```
[+ 1240ms] init frame - session_id: ce1ae44e-2915-4046-894d-055827849917
[+ 2125ms] turn finished: success
[+ 3165ms] transcript on disk: yes (14256 bytes)
[+ 3172ms] PHASE 2: resume:ce1ae44e-... + slow MCP, NO message pushed
[+ 3474ms] MCP server: initialize received, stalling 6000ms
[+ 3492ms] RESOLVED pre-message on resume: ["slowmcp=pending"]
[+ 9475ms] MCP server: replying to initialize
[+ 9524ms] poll: ["slowmcp=connected"]   >>> settled
```

The control request answered ~320ms after query creation — faster than on a fresh query, not slower — and the `pending -> connected` transition tracked the server exactly. The handshake also starts at query creation on a resume (`initialize` arrived ~300ms in, with no message pushed), so the race this PR closes is present on the production path too.

## Not included

A cheaper, complementary mitigation not included here: the `## Remote MCP Servers (Available)` block in `system-prompt.md` asserts availability with no mention of deferral. A one-line `ToolSearch` hint there — mirroring the browser-tools warning in `claude-code.ts` — would make recovery reliable even when the gate times out. Happy to add it here or separately.

https://claude.ai/code/session_013W5TVSA7M519k7fKwFMg3r
