### PR TITLE
Idempotent decision routes, transition-driven notifications, dead store cleanup (Phase 6)

### DIFF
--- a/e2e/specs/connected-accounts.spec.ts
+++ b/e2e/specs/connected-accounts.spec.ts
@@ -390,10 +390,20 @@ test.describe('Remote MCP - Full Connection Flow', () => {
 
         // The provide endpoint refuses non-active servers outright — a grant
         // that resolves while the server is filtered out of REMOTE_MCPS would
-        // be a silent no-op the agent can't detect.
+        // be a silent no-op the agent can't detect. Probe with the REAL open
+        // request: the already-settled gate answers side-effect-free for
+        // unknown toolUseIds, so only an open request reaches this check.
+        const snapshotResponse = await request.get(`/api/agents/${agent.slug}/pending-requests`)
+        expect(snapshotResponse.ok()).toBeTruthy()
+        const snapshot = await snapshotResponse.json() as {
+          requests: Array<{ id: string; kind: string; scope: { sessionId?: string } }>
+        }
+        const openRequest = snapshot.requests.find((r) => r.kind === 'remote_mcp')
+        expect(openRequest, 'the remote MCP request should be open in the registry').toBeTruthy()
+
         const provideResponse = await request.post(
-          `/api/agents/${agent.slug}/sessions/e2e-stale-check/provide-remote-mcp`,
-          { data: { toolUseId: 'e2e-stale-check', remoteMcpIds: [mcp.id] } },
+          `/api/agents/${agent.slug}/sessions/${openRequest!.scope.sessionId}/provide-remote-mcp`,
+          { data: { toolUseId: openRequest!.id, remoteMcpIds: [mcp.id] } },
         )
         expect(provideResponse.status()).toBe(409)
         const provideBody = await provideResponse.json() as { needsReauth?: boolean }

--- a/e2e/specs/pending-request-reconnect.spec.ts
+++ b/e2e/specs/pending-request-reconnect.spec.ts
@@ -5,10 +5,9 @@ import { SessionPage } from '../pages/session.page'
 
 /**
  * Regression coverage for the SSE late-join / reconnect recovery of pending input
- * requests. The agent's `*_request` events are one-shot SSE broadcasts; the server
- * (MessagePersister) stores them and the /stream route replays them on (re)connect,
- * and the renderer dedupes by toolUseId. See the "pending request missing on
- * reconnect" fix and SUP-213.
+ * requests. Request create/resolve broadcasts are one-shot; on (re)connect the
+ * client recovers by refetching the unified pending-requests snapshot (the
+ * `connected` handler invalidates it), and the renderer dedupes by toolUseId.
  *
  * These exercise the reconnect path directly (toggle the network so the EventSource
  * drops and re-establishes while the agent is still awaiting input), which the

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -3393,11 +3393,13 @@ describe('decision routes refuse to re-run side effects — the already-settled 
     kind: string,
     sessionId: string | undefined = 'sess-1',
     payload: Record<string, unknown> = {},
+    // null (not undefined — that would take the default) omits the agent.
+    agentSlug: string | null = 'test-agent',
   ) {
     userInputRequestManager.register({
       id,
       kind,
-      scope: { agentSlug: 'test-agent', ...(sessionId ? { sessionId } : {}) },
+      scope: { ...(agentSlug ? { agentSlug } : {}), ...(sessionId ? { sessionId } : {}) },
       blocking: true,
       autoApproved: false,
       payload,
@@ -3543,6 +3545,99 @@ describe('decision routes refuse to re-run side effects — the already-settled 
     const json = (await res.json()) as Record<string, unknown>
     expect(json.alreadySettled).toBeUndefined()
     expect(mockContainerFetch).toHaveBeenCalled()
+  })
+
+  it.each(GATE_CASES)(
+    "$label cannot decide a request parked for a DIFFERENT agent",
+    async ({ url, kind, body }) => {
+      // toolUseId is a caller-supplied pointer into one global, cross-agent
+      // registry. Without an agent-bound check, another agent's parked ask is
+      // decidable here — and these routes reach host side effects (run-script
+      // executes on the host, computer-use drives the machine).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.mocked(getSession).mockResolvedValue({ id: 'sess-1' } as any)
+      parkOpen(body.toolUseId as string, kind, 'sess-1', {}, 'victim-agent')
+      const res = await postJson(app, url, body)
+      expect(res.status).toBe(404)
+      expect(mockContainerFetch).not.toHaveBeenCalled()
+      expect(messagePersister.completeInputRequest).not.toHaveBeenCalled()
+      // Still open — a rejected probe must not settle what it could not decide.
+      expect(userInputRequestManager.getOpenRequest(body.toolUseId as string)).not.toBeNull()
+    },
+  )
+
+  it('the internal _auto session waives the session check ONLY, never the agent check', async () => {
+    parkOpen('tool-gate-auto-x', 'computer_use', 'sess-real', {}, 'victim-agent')
+    const res = await postJson(app, '/api/agents/test-agent/sessions/_auto/computer-use', {
+      toolUseId: 'tool-gate-auto-x',
+      decline: true,
+    })
+    expect(res.status).toBe(404)
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it('a request with no agent in scope is unattributable and decidable by nobody', async () => {
+    parkOpen('tool-gate-noagent', 'secret', 'sess-1', {}, null)
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/provide-secret', {
+      toolUseId: 'tool-gate-noagent',
+      secretName: 'K',
+      decline: true,
+    })
+    expect(res.status).toBe(404)
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it("does not disclose a settled outcome to another agent's route", async () => {
+    // Settling must not widen who may read the record: the same 404 an open
+    // cross-agent probe gets, not the outcome.
+    parkOpen('tool-gate-settled-agent', 'secret', 'sess-1', {}, 'victim-agent')
+    userInputRequestManager.resolve('tool-gate-settled-agent', 'answered')
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/provide-secret', {
+      toolUseId: 'tool-gate-settled-agent',
+      secretName: 'K',
+      decline: true,
+    })
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Request not found' })
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it('does not disclose a settled outcome through a route of another kind', async () => {
+    parkOpen('tool-gate-settled-kind', 'secret')
+    userInputRequestManager.resolve('tool-gate-settled-kind', 'answered')
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/answer-question', {
+      toolUseId: 'tool-gate-settled-kind',
+      answers: { Q: 'A' },
+    })
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Request not found' })
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it("does not disclose a settled outcome through another session's route", async () => {
+    parkOpen('tool-gate-settled-sess', 'secret', 'sess-2')
+    userInputRequestManager.resolve('tool-gate-settled-sess', 'declined')
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/provide-secret', {
+      toolUseId: 'tool-gate-settled-sess',
+      secretName: 'K',
+      decline: true,
+    })
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Request not found' })
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it('an id that never existed still gets the outcome-less settled shape', async () => {
+    // Unknown and rotated-off-the-trail ids are indistinguishable, and a stale
+    // card must still be able to dismiss itself.
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/provide-secret', {
+      toolUseId: 'tool-gate-never',
+      secretName: 'K',
+      decline: true,
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, alreadySettled: true })
+    expect(mockContainerFetch).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -127,6 +127,9 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     markSessionInterrupted: vi.fn(),
     cancelAwaitingInput: vi.fn(),
     completeInputRequest: vi.fn(),
+    completeCapabilityReview: vi.fn(),
+    clearPendingComputerUseRequest: vi.fn(),
+    grantSessionCapability: vi.fn(),
     getSettledInputRequests: vi.fn(() => new Map()),
     broadcastSessionEvent: vi.fn(),
   },
@@ -3241,74 +3244,102 @@ describe('decision routes settle their request immediately', () => {
     vi.clearAllMocks()
     app = createApp()
     mockIsAuthMode.mockReturnValue(false)
+    userInputRequestManager.reset()
     mockContainerFetch.mockResolvedValue(
       new Response(JSON.stringify({ success: true }), { status: 200 }),
     )
   })
 
+  afterEach(() => {
+    userInputRequestManager.reset()
+  })
+
+  function parkOpen(id: string, kind: string) {
+    userInputRequestManager.register({
+      id,
+      kind,
+      scope: { agentSlug: 'test-agent', sessionId: 'sess-1' },
+      blocking: true,
+      autoApproved: false,
+      payload: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+  }
+
   const CASES: Array<{
     label: string
     url: string
+    kind: string
     body: Record<string, unknown>
     outcome: 'answered' | 'declined'
   }> = [
     {
       label: 'secret decline',
       url: '/api/agents/test-agent/sessions/sess-1/provide-secret',
+      kind: 'secret',
       body: { toolUseId: 'tool-dec-1', secretName: 'K', decline: true },
       outcome: 'declined',
     },
     {
       label: 'question decline',
       url: '/api/agents/test-agent/sessions/sess-1/answer-question',
+      kind: 'question',
       body: { toolUseId: 'tool-dec-2', decline: true },
       outcome: 'declined',
     },
     {
       label: 'question answer',
       url: '/api/agents/test-agent/sessions/sess-1/answer-question',
+      kind: 'question',
       body: { toolUseId: 'tool-dec-3', answers: { 'Pick DB': 'sqlite' } },
       outcome: 'answered',
     },
     {
       label: 'browser input complete',
       url: '/api/agents/test-agent/sessions/sess-1/complete-browser-input',
+      kind: 'browser_input',
       body: { toolUseId: 'tool-dec-4' },
       outcome: 'answered',
     },
     {
       label: 'browser input decline',
       url: '/api/agents/test-agent/sessions/sess-1/complete-browser-input',
+      kind: 'browser_input',
       body: { toolUseId: 'tool-dec-5', decline: true },
       outcome: 'declined',
     },
     {
       label: 'script run deny',
       url: '/api/agents/test-agent/sessions/sess-1/run-script',
+      kind: 'script_run',
       body: { toolUseId: 'tool-dec-6', decline: true },
       outcome: 'declined',
     },
     {
       label: 'file decline',
       url: '/api/agents/test-agent/sessions/sess-1/provide-file',
+      kind: 'file',
       body: { toolUseId: 'tool-dec-7', decline: true },
       outcome: 'declined',
     },
     {
       label: 'connected account decline',
       url: '/api/agents/test-agent/sessions/sess-1/provide-connected-account',
+      kind: 'connected_account',
       body: { toolUseId: 'tool-dec-8', toolkit: 'github', decline: true },
       outcome: 'declined',
     },
     {
       label: 'remote MCP decline',
       url: '/api/agents/test-agent/sessions/sess-1/provide-remote-mcp',
+      kind: 'remote_mcp',
       body: { toolUseId: 'tool-dec-9', decline: true },
       outcome: 'declined',
     },
   ]
 
-  it.each(CASES)('$label settles as $outcome', async ({ url, body, outcome }) => {
+  it.each(CASES)('$label settles as $outcome', async ({ url, kind, body, outcome }) => {
+    parkOpen(body.toolUseId as string, kind)
     const res = await postJson(app, url, body)
     expect(res.status).toBe(200)
     expect(messagePersister.completeInputRequest).toHaveBeenCalledWith(
@@ -3319,6 +3350,7 @@ describe('decision routes settle their request immediately', () => {
   })
 
   it('a failed container reject does NOT settle the request', async () => {
+    parkOpen('tool-dec-10', 'secret')
     mockContainerFetch.mockResolvedValue(
       new Response(JSON.stringify({ error: 'no pending' }), { status: 404 }),
     )
@@ -3329,6 +3361,188 @@ describe('decision routes settle their request immediately', () => {
     })
     expect(res.status).toBe(500)
     expect(messagePersister.completeInputRequest).not.toHaveBeenCalled()
+  })
+})
+
+describe('decision routes refuse to re-run side effects — the already-settled gate', () => {
+  // A decision can arrive for a request that is no longer open: a second tab,
+  // a double-click racing the first response, or a stale card revived from an
+  // old snapshot. Acting again is not merely redundant — run-script would
+  // re-execute on the host, computer-use would re-drive the machine, and a
+  // browser-input decline would re-interrupt the session. A decision proceeds
+  // only while the registry holds the request OPEN with the kind the route
+  // handles; anything else gets a stable, side-effect-free answer.
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockIsAuthMode.mockReturnValue(false)
+    userInputRequestManager.reset()
+    mockContainerFetch.mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    )
+  })
+
+  afterEach(() => {
+    userInputRequestManager.reset()
+  })
+
+  function parkOpen(
+    id: string,
+    kind: string,
+    sessionId: string | undefined = 'sess-1',
+    payload: Record<string, unknown> = {},
+  ) {
+    userInputRequestManager.register({
+      id,
+      kind,
+      scope: { agentSlug: 'test-agent', ...(sessionId ? { sessionId } : {}) },
+      blocking: true,
+      autoApproved: false,
+      payload,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+  }
+
+  const GATE_CASES: Array<{
+    label: string
+    url: string
+    kind: string
+    body: Record<string, unknown>
+  }> = [
+    {
+      label: 'provide-secret',
+      url: '/api/agents/test-agent/sessions/sess-1/provide-secret',
+      kind: 'secret',
+      body: { toolUseId: 'tool-gate-1', secretName: 'K', decline: true },
+    },
+    {
+      label: 'answer-question',
+      url: '/api/agents/test-agent/sessions/sess-1/answer-question',
+      kind: 'question',
+      body: { toolUseId: 'tool-gate-2', answers: { Q: 'A' } },
+    },
+    {
+      label: 'provide-connected-account',
+      url: '/api/agents/test-agent/sessions/sess-1/provide-connected-account',
+      kind: 'connected_account',
+      body: { toolUseId: 'tool-gate-3', toolkit: 'github', decline: true },
+    },
+    {
+      label: 'capability-review',
+      url: '/api/agents/test-agent/sessions/sess-1/capability-review',
+      kind: 'capability_review',
+      body: { toolUseId: 'tool-gate-4', capability: 'subagents', decline: true },
+    },
+    {
+      label: 'complete-browser-input',
+      url: '/api/agents/test-agent/sessions/sess-1/complete-browser-input',
+      kind: 'browser_input',
+      body: { toolUseId: 'tool-gate-5', decline: true },
+    },
+    {
+      label: 'run-script',
+      url: '/api/agents/test-agent/sessions/sess-1/run-script',
+      kind: 'script_run',
+      body: { toolUseId: 'tool-gate-6', decline: true },
+    },
+    {
+      label: 'provide-remote-mcp',
+      url: '/api/agents/test-agent/sessions/sess-1/provide-remote-mcp',
+      kind: 'remote_mcp',
+      body: { toolUseId: 'tool-gate-7', decline: true },
+    },
+    {
+      label: 'provide-file',
+      url: '/api/agents/test-agent/sessions/sess-1/provide-file',
+      kind: 'file',
+      body: { toolUseId: 'tool-gate-8', decline: true },
+    },
+    {
+      label: 'computer-use',
+      url: '/api/agents/test-agent/sessions/sess-1/computer-use',
+      kind: 'computer_use',
+      body: { toolUseId: 'tool-gate-9', decline: true },
+    },
+  ]
+
+  it.each(GATE_CASES)(
+    '$label with no open request answers alreadySettled and touches nothing',
+    async ({ url, body }) => {
+      const res = await postJson(app, url, body)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toMatchObject({ success: true, alreadySettled: true })
+      expect(mockContainerFetch).not.toHaveBeenCalled()
+      expect(messagePersister.completeInputRequest).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each(GATE_CASES)('$label with an open request still proceeds', async ({ url, kind, body }) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(getSession).mockResolvedValue({ id: 'sess-1' } as any)
+    parkOpen(body.toolUseId as string, kind)
+    const res = await postJson(app, url, body)
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as Record<string, unknown>
+    expect(json.alreadySettled).toBeUndefined()
+    expect(mockContainerFetch).toHaveBeenCalled()
+  })
+
+  it('echoes the settled outcome when the resolution is still on record', async () => {
+    parkOpen('tool-gate-out', 'secret')
+    userInputRequestManager.resolve('tool-gate-out', 'declined')
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/provide-secret', {
+      toolUseId: 'tool-gate-out',
+      secretName: 'K',
+      decline: true,
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({
+      success: true,
+      alreadySettled: true,
+      outcome: 'declined',
+    })
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it('a toolUseId of a DIFFERENT kind cannot be settled through this route', async () => {
+    // A caller-supplied id must not settle someone else's parked wait — the
+    // same guard submitDecision grew for reviews in the registry migration.
+    parkOpen('tool-gate-kind', 'computer_use')
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/provide-secret', {
+      toolUseId: 'tool-gate-kind',
+      secretName: 'K',
+      decline: true,
+    })
+    expect(res.status).toBe(404)
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+    expect(messagePersister.completeInputRequest).not.toHaveBeenCalled()
+  })
+
+  it("a request parked in a DIFFERENT session is not decidable through this session's route", async () => {
+    parkOpen('tool-gate-sess', 'secret', 'sess-2')
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/provide-secret', {
+      toolUseId: 'tool-gate-sess',
+      secretName: 'K',
+      decline: true,
+    })
+    expect(res.status).toBe(404)
+    expect(mockContainerFetch).not.toHaveBeenCalled()
+  })
+
+  it('the internal _auto session bypasses the session-scope check', async () => {
+    // Auto-execute paths post to /sessions/_auto/... while the request is
+    // scoped to the real session that streamed it.
+    parkOpen('tool-gate-auto', 'computer_use', 'sess-real')
+    const res = await postJson(app, '/api/agents/test-agent/sessions/_auto/computer-use', {
+      toolUseId: 'tool-gate-auto',
+      decline: true,
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as Record<string, unknown>
+    expect(json.alreadySettled).toBeUndefined()
+    expect(mockContainerFetch).toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -34,6 +34,7 @@ import { guessMimeType } from '@shared/lib/utils/mime'
 import { parseByteRange } from '@shared/lib/utils/http-range'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import type { UserInputRequestKind } from '@shared/lib/user-input/request-schema'
 import {
   listSessions,
   listSessionsByIds,
@@ -2325,6 +2326,44 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
   }
 })
 
+/**
+ * The already-settled gate for request-decision routes. A decision proceeds
+ * only while the registry holds the request OPEN, with the kind this route
+ * handles, in the session the route addresses. Anything else gets a stable,
+ * side-effect-free answer — this is what makes decisions idempotent. Without
+ * it a duplicate POST (second tab, double-click, card revived from a stale
+ * snapshot) re-runs host side effects: run-script re-executes the script,
+ * computer-use re-drives the machine, a browser-input decline re-interrupts
+ * the session.
+ *
+ * Returns a Response to send instead of proceeding, or null to proceed.
+ */
+function gateRequestDecision(
+  c: Context,
+  toolUseId: string,
+  kind: UserInputRequestKind,
+): Response | null {
+  const open = userInputRequestManager.getOpenRequest(toolUseId)
+  if (!open) {
+    // Settled, or never existed — indistinguishable once the resolution trail
+    // rotates, so both get the stable already-settled shape. 200 (not an
+    // error): the caller's intent is satisfied or moot, and a stale card
+    // should dismiss itself exactly like a successful decision.
+    const outcome = userInputRequestManager.getRecentResolutionOutcome(toolUseId)
+    return c.json({ success: true, alreadySettled: true, ...(outcome ? { outcome } : {}) })
+  }
+  if (open.kind !== kind) {
+    // A caller-supplied id must not settle someone else's parked wait — the
+    // same guard submitDecision has for review kinds.
+    return c.json({ error: 'Request not found' }, 404)
+  }
+  const sessionId = c.req.param('sessionId')
+  if (sessionId !== '_auto' && open.scope.sessionId && open.scope.sessionId !== sessionId) {
+    return c.json({ error: 'Request not found' }, 404)
+  }
+  return null
+}
+
 // POST /api/agents/:id/sessions/:sessionId/provide-secret - Provide or decline a secret request
 agents.post('/:id/sessions/:sessionId/provide-secret', AgentUser(), async (c) => {
   try {
@@ -2335,6 +2374,9 @@ agents.post('/:id/sessions/:sessionId/provide-secret', AgentUser(), async (c) =>
     if (!toolUseId) {
       return c.json({ error: 'toolUseId is required' }, 400)
     }
+
+    const gated = gateRequestDecision(c, toolUseId, 'secret')
+    if (gated) return gated
 
     if (!secretName) {
       return c.json({ error: 'secretName is required' }, 400)
@@ -2445,6 +2487,9 @@ agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), a
     if (!toolUseId) {
       return c.json({ error: 'toolUseId is required' }, 400)
     }
+
+    const gated = gateRequestDecision(c, toolUseId, 'connected_account')
+    if (gated) return gated
 
     if (!toolkit) {
       return c.json({ error: 'toolkit is required' }, 400)
@@ -2605,6 +2650,9 @@ agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) =
       return c.json({ error: 'toolUseId is required' }, 400)
     }
 
+    const gated = gateRequestDecision(c, toolUseId, 'question')
+    if (gated) return gated
+
 
     const client = containerManager.getClient(agentSlug)
 
@@ -2686,6 +2734,9 @@ agents.post('/:id/sessions/:sessionId/capability-review', AgentUser(), async (c)
       return c.json({ error: 'capability must be subagents or workflows' }, 400)
     }
 
+    const gated = gateRequestDecision(c, toolUseId, 'capability_review')
+    if (gated) return gated
+
     const client = containerManager.getClient(agentSlug)
 
     if (decline) {
@@ -2757,6 +2808,9 @@ agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), asyn
     if (!toolUseId) {
       return c.json({ error: 'toolUseId is required' }, 400)
     }
+
+    const gated = gateRequestDecision(c, toolUseId, 'browser_input')
+    if (gated) return gated
 
     const client = containerManager.getClient(agentSlug)
 
@@ -2839,6 +2893,9 @@ agents.post('/:id/sessions/:sessionId/run-script', AgentUser(), async (c) => {
     if (!toolUseId) {
       return c.json({ error: 'toolUseId is required' }, 400)
     }
+
+    const gated = gateRequestDecision(c, toolUseId, 'script_run')
+    if (gated) return gated
 
     const client = containerManager.getClient(agentSlug)
 
@@ -2973,6 +3030,9 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
     if (!toolUseId) {
       return c.json({ error: 'toolUseId is required' }, 400)
     }
+
+    const gated = gateRequestDecision(c, toolUseId, 'computer_use')
+    if (gated) return gated
 
     // Validate session belongs to this agent (skip for _auto internal calls from auto-execute)
     if (sessionId !== '_auto') {
@@ -3650,6 +3710,9 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
     if (!body.decline && requestedMcpIds.length === 0) {
       return c.json({ error: 'remoteMcpId or remoteMcpIds is required when not declining' }, 400)
     }
+
+    const gated = gateRequestDecision(c, body.toolUseId, 'remote_mcp')
+    if (gated) return gated
 
     // In auth mode, only allow providing remote MCPs the caller owns before
     // mapping them to the agent. Otherwise a user could approve another user's
@@ -4921,6 +4984,9 @@ agents.post('/:id/sessions/:sessionId/provide-file', AgentUser(), async (c) => {
       return c.json({ error: 'toolUseId is required' }, 400)
     }
 
+    const gated = gateRequestDecision(c, toolUseId, 'file')
+    if (gated) return gated
+
 
     const client = containerManager.getClient(agentSlug)
 
@@ -5408,8 +5474,11 @@ setInterval(cleanupStaleUploads, 30 * 60 * 1000).unref()
 // session of the agent). This is the recovery source for the unified client
 // store: mount, reconnect, and invalidation refetch from here; live updates
 // arrive as user_request_created / user_request_resolved on the session and
-// global SSE streams. Legacy per-type events keep firing during the client
-// migration.
+// global SSE streams. The legacy per-type events still fire server-side for
+// the chat-integration connectors (their in-process consumer has not migrated)
+// and for the renderer's two narrow holdouts: the browser tray's
+// browser_input_request feed and the script/computer-use auto-approved
+// suppress-sets.
 agents.get('/:id/pending-requests', AgentRead(), (c) => {
   const agentSlug = getAgentId(c)
   const sessionId = c.req.query('sessionId') || undefined

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -34,7 +34,10 @@ import { guessMimeType } from '@shared/lib/utils/mime'
 import { parseByteRange } from '@shared/lib/utils/http-range'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
-import type { UserInputRequestKind } from '@shared/lib/user-input/request-schema'
+import type {
+  UserInputRequestKind,
+  UserInputRequestScope,
+} from '@shared/lib/user-input/request-schema'
 import {
   listSessions,
   listSessionsByIds,
@@ -2327,14 +2330,42 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
 })
 
 /**
+ * Whether a request — open or recently settled — belongs to the route the
+ * decision arrived on. A caller-supplied toolUseId is an unauthenticated
+ * pointer into a global, cross-agent registry, so every dimension of the
+ * request's identity has to be re-checked against the URL before the route
+ * acts on it (or reports on it): its kind, its agent, and its session.
+ *
+ * agentSlug is matched unconditionally and exactly — including for `_auto`,
+ * which is an internal auto-execute caller that names the real agent in its
+ * URL. A request whose scope carries no agent is unattributable and matches
+ * nothing; every registration path (stream handlers, computer-use, recovery)
+ * supplies one.
+ */
+function requestMatchesRoute(
+  request: { kind: UserInputRequestKind; scope: UserInputRequestScope },
+  kind: UserInputRequestKind,
+  agentSlug: string,
+  sessionId: string,
+): boolean {
+  if (request.kind !== kind) return false
+  if (!request.scope.agentSlug || request.scope.agentSlug !== agentSlug) return false
+  // Auto-execute paths post to /sessions/_auto/… while the request stays
+  // scoped to the real session that streamed it — the ONLY dimension `_auto`
+  // waives.
+  if (sessionId === '_auto') return true
+  return request.scope.sessionId === sessionId
+}
+
+/**
  * The already-settled gate for request-decision routes. A decision proceeds
  * only while the registry holds the request OPEN, with the kind this route
- * handles, in the session the route addresses. Anything else gets a stable,
- * side-effect-free answer — this is what makes decisions idempotent. Without
- * it a duplicate POST (second tab, double-click, card revived from a stale
- * snapshot) re-runs host side effects: run-script re-executes the script,
- * computer-use re-drives the machine, a browser-input decline re-interrupts
- * the session.
+ * handles, for the agent and session the route addresses. Anything else gets a
+ * stable, side-effect-free answer — this is what makes decisions idempotent.
+ * Without it a duplicate POST (second tab, double-click, card revived from a
+ * stale snapshot) re-runs host side effects: run-script re-executes the
+ * script, computer-use re-drives the machine, a browser-input decline
+ * re-interrupts the session.
  *
  * Returns a Response to send instead of proceeding, or null to proceed.
  */
@@ -2343,25 +2374,44 @@ function gateRequestDecision(
   toolUseId: string,
   kind: UserInputRequestKind,
 ): Response | null {
+  const agentSlug = getAgentId(c)
+  // Every gated route is mounted under /sessions/:sessionId, so the param is
+  // always present; '' is an unmatchable placeholder, not a wildcard.
+  const sessionId = c.req.param('sessionId') ?? ''
   const open = userInputRequestManager.getOpenRequest(toolUseId)
-  if (!open) {
-    // Settled, or never existed — indistinguishable once the resolution trail
-    // rotates, so both get the stable already-settled shape. 200 (not an
-    // error): the caller's intent is satisfied or moot, and a stale card
-    // should dismiss itself exactly like a successful decision.
-    const outcome = userInputRequestManager.getRecentResolutionOutcome(toolUseId)
-    return c.json({ success: true, alreadySettled: true, ...(outcome ? { outcome } : {}) })
+  if (open) {
+    if (!open.scope.agentSlug) {
+      // Fail closed, loudly: an unattributable request cannot be proven to
+      // belong to this agent, and a silent 404 on a card the user just clicked
+      // would be near-undiagnosable.
+      console.error(
+        `[agents] Refusing decision for request ${toolUseId} (kind=${kind}): scope carries no agentSlug`,
+      )
+    }
+    if (!requestMatchesRoute(open, kind, agentSlug, sessionId)) {
+      // A caller-supplied id must not settle someone else's parked wait — the
+      // same guard submitDecision has for review kinds.
+      return c.json({ error: 'Request not found' }, 404)
+    }
+    return null
   }
-  if (open.kind !== kind) {
-    // A caller-supplied id must not settle someone else's parked wait — the
-    // same guard submitDecision has for review kinds.
+  // Settled, or never existed. A settled record is still route-bound: report
+  // its outcome only to the route that could have decided it, so settling a
+  // request can never widen who may read it. A record that fails the match is
+  // as good as absent — same 404 an open mismatch gets.
+  const settled = userInputRequestManager.getRecentResolution(toolUseId)
+  if (settled && !requestMatchesRoute(settled, kind, agentSlug, sessionId)) {
     return c.json({ error: 'Request not found' }, 404)
   }
-  const sessionId = c.req.param('sessionId')
-  if (sessionId !== '_auto' && open.scope.sessionId && open.scope.sessionId !== sessionId) {
-    return c.json({ error: 'Request not found' }, 404)
-  }
-  return null
+  // 200 (not an error): the caller's intent is satisfied or moot, and a stale
+  // card should dismiss itself exactly like a successful decision. Unknown and
+  // rotated-off-the-trail ids are indistinguishable and share this shape,
+  // outcome-less.
+  return c.json({
+    success: true,
+    alreadySettled: true,
+    ...(settled ? { outcome: settled.outcome } : {}),
+  })
 }
 
 // POST /api/agents/:id/sessions/:sessionId/provide-secret - Provide or decline a secret request

--- a/src/api/routes/provide-connected-account.test.ts
+++ b/src/api/routes/provide-connected-account.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
 
 // ============================================================================
@@ -208,6 +208,7 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
 
 // Import the agents router after all mocks are set up
 import agents from './agents'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 
 function createApp() {
   const app = new Hono()
@@ -222,6 +223,33 @@ describe('provide-connected-account handler', () => {
     vi.clearAllMocks()
     app = createApp()
     mockInsertValues.mockResolvedValue(undefined)
+    // The route's already-settled gate only acts on requests the registry
+    // holds open — park every toolUseId this file decides on.
+    userInputRequestManager.reset()
+    for (const id of [
+      'tu-1',
+      'tu-active-only',
+      'tu-decline-1',
+      'tu-decline-2',
+      'tu-dup',
+      'tu-env-fail',
+      'tu-happy',
+      'tu-resolve-fail',
+    ]) {
+      userInputRequestManager.register({
+        id,
+        kind: 'connected_account',
+        scope: { agentSlug: 'test-agent', sessionId: 'sess-1' },
+        blocking: true,
+        autoApproved: false,
+        payload: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+    }
+  })
+
+  afterEach(() => {
+    userInputRequestManager.reset()
   })
 
   const ENDPOINT = '/api/agents/test-agent/sessions/sess-1/provide-connected-account'

--- a/src/api/routes/provide-remote-mcp.test.ts
+++ b/src/api/routes/provide-remote-mcp.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
 
 vi.mock('../middleware/auth', () => ({
@@ -348,6 +348,7 @@ vi.mock('../llm-polyfill', () => ({
 }))
 
 import agents from './agents'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 
 function createApp() {
   const app = new Hono()
@@ -363,6 +364,22 @@ describe('provide-remote-mcp handler', () => {
     app = createApp()
     mockInsertValues.mockResolvedValue(undefined)
     mockGetHostApiBaseUrl.mockResolvedValue('http://10.20.107.8:3000')
+    // The route's already-settled gate only acts on requests the registry
+    // holds open — park the toolUseId this file decides on.
+    userInputRequestManager.reset()
+    userInputRequestManager.register({
+      id: 'tu-1',
+      kind: 'remote_mcp',
+      scope: { agentSlug: 'test-agent', sessionId: 'sess-1' },
+      blocking: true,
+      autoApproved: false,
+      payload: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+  })
+
+  afterEach(() => {
+    userInputRequestManager.reset()
   })
 
   const ENDPOINT = '/api/agents/test-agent/sessions/sess-1/provide-remote-mcp'

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -339,6 +339,7 @@ vi.mock('hono/streaming', () => ({ streamSSE: vi.fn() }))
 // Import routers after all mocks are set up.
 import connectedAccountsRouter from './connected-accounts'
 import agents from './agents'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import platformAuthRoute from './platform-auth'
 
 // ---------------------------------------------------------------------------
@@ -636,6 +637,19 @@ describe('SUP-199: remote MCP assignment ownership (AUTH_MODE)', () => {
 
   it('rejects providing another user remote MCP id at runtime approval', async () => {
     selectQueue = [[]]
+    // The decision gate answers already-settled (side-effect-free) for
+    // requests the registry does not hold open — park the request so the
+    // route reaches the ownership check this test pins.
+    userInputRequestManager.reset()
+    userInputRequestManager.register({
+      id: 'tu-1',
+      kind: 'remote_mcp',
+      scope: { agentSlug: 'attacker-agent', sessionId: 'sess-1' },
+      blocking: true,
+      autoApproved: false,
+      payload: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
 
     const res = await appWithAgents().request('http://localhost/api/agents/attacker-agent/sessions/sess-1/provide-remote-mcp', {
       method: 'POST',
@@ -645,6 +659,7 @@ describe('SUP-199: remote MCP assignment ownership (AUTH_MODE)', () => {
 
     expectClientError(res.status)
     expect(mockDbInsertValues).not.toHaveBeenCalled()
+    userInputRequestManager.reset()
   })
 
   it('allows attaching a remote MCP the acting user owns', async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1265,9 +1265,15 @@ function startNotificationListener(): void {
       // doesn't sit in Notification Center inviting stale Approve/Deny
       // clicks (review S8). This mirrors the renderer-side query
       // invalidation and works for dismissal regardless of window state.
-      if (data.type === 'session_awaiting_input' && data.review?.type === 'proxy_review_resolved') {
-        const rid = data.review.reviewId
-        if (typeof rid === 'string') dismissReviewNotification(rid)
+      // Driven by the unified resolved event — every settle path (decision,
+      // timeout, sweep, policy sibling-resolve) emits it, so a dismissal
+      // cannot be missed by a settle path that forgot the legacy broadcast.
+      if (
+        data.type === 'user_request_resolved' &&
+        (data.kind === 'proxy_review' || data.kind === 'x_agent_review') &&
+        typeof data.requestId === 'string'
+      ) {
+        dismissReviewNotification(data.requestId)
       }
 
       if (data.type === 'os_notification') {

--- a/src/renderer/components/dashboards/pending-agent-reviews.test.tsx
+++ b/src/renderer/components/dashboards/pending-agent-reviews.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PendingAgentReviews } from './pending-agent-reviews'
+
+// The panel must render from the unified pending-requests snapshot — the
+// same store every other surface reads — not the legacy proxy-review poll.
+
+const mockUsePendingUserRequests = vi.fn()
+vi.mock('@renderer/hooks/use-pending-user-requests', () => ({
+  usePendingUserRequests: (agentSlug: string, sessionId?: string) =>
+    mockUsePendingUserRequests(agentSlug, sessionId),
+}))
+
+const mockUsePendingProxyReviews = vi.fn(() => ({ data: { reviews: [] }, refetch: vi.fn() }))
+vi.mock('@renderer/hooks/use-proxy-reviews', () => ({
+  usePendingProxyReviews: () => mockUsePendingProxyReviews(),
+}))
+
+vi.mock('@renderer/components/messages/proxy-review-request-item', () => ({
+  ProxyReviewRequestItem: ({ reviewId }: { reviewId: string }) => (
+    <div data-testid={`proxy-review-${reviewId}`} />
+  ),
+}))
+vi.mock('@renderer/components/messages/x-agent-review-request-item', () => ({
+  XAgentReviewRequestItem: ({ reviewId }: { reviewId: string }) => (
+    <div data-testid={`xagent-review-${reviewId}`} />
+  ),
+}))
+
+function envelope(overrides: Record<string, unknown>) {
+  return {
+    id: 'rev-1',
+    kind: 'proxy_review',
+    scope: { agentSlug: 'agent-a' },
+    blocking: true,
+    autoApproved: false,
+    payload: {
+      accountId: 'acc-1',
+      toolkit: 'github',
+      method: 'GET',
+      targetPath: '/user',
+      matchedScopes: [],
+      scopeDescriptions: {},
+      displayText: 'Allow reading your GitHub profile?',
+    },
+    ...overrides,
+  }
+}
+
+describe('PendingAgentReviews', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUsePendingUserRequests.mockReturnValue({ data: undefined, refetch: vi.fn() })
+  })
+
+  it('renders proxy and x-agent review cards from the unified snapshot', () => {
+    mockUsePendingUserRequests.mockReturnValue({
+      data: [
+        envelope({ id: 'rev-proxy-1' }),
+        envelope({
+          id: 'rev-xagent-1',
+          kind: 'x_agent_review',
+          payload: {
+            accountId: 'acc-1',
+            toolkit: 'x-agent',
+            method: 'POST',
+            targetPath: '/invoke',
+            xAgent: {
+              targetAgentSlug: 'agent-b',
+              targetAgentName: 'Agent B',
+              operation: 'invoke',
+            },
+          },
+        }),
+      ],
+      refetch: vi.fn(),
+    })
+
+    render(<PendingAgentReviews agentSlug="agent-a" />)
+
+    expect(screen.getByTestId('proxy-review-rev-proxy-1')).toBeTruthy()
+    expect(screen.getByTestId('xagent-review-rev-xagent-1')).toBeTruthy()
+    expect(mockUsePendingUserRequests).toHaveBeenCalledWith('agent-a', undefined)
+  })
+
+  it('ignores non-review kinds in the snapshot', () => {
+    mockUsePendingUserRequests.mockReturnValue({
+      data: [
+        envelope({ id: 'rev-proxy-2' }),
+        {
+          id: 'tool-secret-1',
+          kind: 'secret',
+          scope: { agentSlug: 'agent-a', sessionId: 'sess-1' },
+          blocking: true,
+          autoApproved: false,
+          payload: { secretName: 'API_KEY' },
+        },
+      ],
+      refetch: vi.fn(),
+    })
+
+    const { container } = render(<PendingAgentReviews agentSlug="agent-a" />)
+
+    expect(screen.getByTestId('proxy-review-rev-proxy-2')).toBeTruthy()
+    expect(container.querySelectorAll('[data-testid]')).toHaveLength(1)
+  })
+
+  it('renders nothing while the snapshot has never loaded', () => {
+    const { container } = render(<PendingAgentReviews agentSlug="agent-a" />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/renderer/components/dashboards/pending-agent-reviews.tsx
+++ b/src/renderer/components/dashboards/pending-agent-reviews.tsx
@@ -1,6 +1,9 @@
+import { useMemo } from 'react'
 import { ProxyReviewRequestItem } from '@renderer/components/messages/proxy-review-request-item'
 import { XAgentReviewRequestItem } from '@renderer/components/messages/x-agent-review-request-item'
-import { usePendingProxyReviews } from '@renderer/hooks/use-proxy-reviews'
+import { reviewFromEnvelope } from '@renderer/components/messages/use-pending-requests'
+import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-requests'
+import type { PendingReview } from '@renderer/hooks/use-proxy-reviews'
 
 interface PendingAgentReviewsProps {
   agentSlug: string
@@ -9,19 +12,24 @@ interface PendingAgentReviewsProps {
 }
 
 /**
- * Renders pending proxy review prompts for an agent.
- *
- * Real-time updates come from GlobalNotificationHandler which writes
- * directly into the ['proxy-reviews', agentSlug] query cache when
- * proxy_review_request / proxy_review_resolved events arrive via SSE.
- *
- * The 30s poll is a safety net only (e.g. if SSE reconnects and misses
- * an event). It is NOT the primary delivery mechanism.
+ * Renders pending proxy review prompts for an agent, from the unified
+ * pending-requests snapshot — the same store every other request surface
+ * reads. user_request_created / user_request_resolved SSE events invalidate
+ * the query (GlobalNotificationHandler); the hook's interval refetch is the
+ * safety net for a missed event.
  */
 export function PendingAgentReviews({ agentSlug, readOnly, onReviewResolved }: PendingAgentReviewsProps) {
-  const { data, refetch } = usePendingProxyReviews(agentSlug)
+  const { data, refetch } = usePendingUserRequests(agentSlug)
 
-  const reviews = data?.reviews ?? []
+  const reviews = useMemo(() => {
+    const out: PendingReview[] = []
+    for (const request of data ?? []) {
+      if (request.kind !== 'proxy_review' && request.kind !== 'x_agent_review') continue
+      const review = reviewFromEnvelope(request, request.payload as Record<string, unknown>)
+      if (review) out.push(review)
+    }
+    return out
+  }, [data])
 
   if (reviews.length === 0) return null
 

--- a/src/renderer/components/messages/use-pending-requests.test.tsx
+++ b/src/renderer/components/messages/use-pending-requests.test.tsx
@@ -28,29 +28,12 @@ const mockStreamState = {
   autoApprovedComputerUseIds: new Set<string>(),
 }
 
-const mockRemovers = {
-  removeSecretRequest: vi.fn(),
-  removeConnectedAccountRequest: vi.fn(),
-  removeRemoteMcpRequest: vi.fn(),
-  removeQuestionRequest: vi.fn(),
-  removeFileRequest: vi.fn(),
-  removeBrowserInputRequest: vi.fn(),
-  removeScriptRunRequest: vi.fn(),
-  removeComputerUseRequest: vi.fn(),
-  removeCapabilityReviewRequest: vi.fn(),
-}
+const mockRemovePendingRequestsByToolUseId = vi.fn()
 
 vi.mock('@renderer/hooks/use-message-stream', () => ({
   useMessageStream: () => mockStreamState,
-  removeSecretRequest: (...args: unknown[]) => mockRemovers.removeSecretRequest(...args),
-  removeConnectedAccountRequest: (...args: unknown[]) => mockRemovers.removeConnectedAccountRequest(...args),
-  removeRemoteMcpRequest: (...args: unknown[]) => mockRemovers.removeRemoteMcpRequest(...args),
-  removeQuestionRequest: (...args: unknown[]) => mockRemovers.removeQuestionRequest(...args),
-  removeFileRequest: (...args: unknown[]) => mockRemovers.removeFileRequest(...args),
-  removeBrowserInputRequest: (...args: unknown[]) => mockRemovers.removeBrowserInputRequest(...args),
-  removeScriptRunRequest: (...args: unknown[]) => mockRemovers.removeScriptRunRequest(...args),
-  removeComputerUseRequest: (...args: unknown[]) => mockRemovers.removeComputerUseRequest(...args),
-  removeCapabilityReviewRequest: (...args: unknown[]) => mockRemovers.removeCapabilityReviewRequest(...args),
+  removePendingRequestsByToolUseId: (...args: unknown[]) =>
+    mockRemovePendingRequestsByToolUseId(...args),
 }))
 
 // Mock the unified pending-request store — mutable per test.
@@ -958,79 +941,23 @@ describe('usePendingRequests', () => {
     expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['proxy-reviews'] })
   })
 
-  // ---- onComplete wiring: each kind's onComplete must call the matching remove* ----
+  // ---- onComplete wiring: every kind routes through the shared strip helper ----
 
-  it('secret onComplete calls removeSecretRequest with (sessionId, toolUseId)', () => {
+  it.each([
+    ['secret', 'tu-s', { secretName: 'A' }],
+    ['connected_account', 'tu-c', { toolkit: 'slack' }],
+    ['remote_mcp', 'tu-m', { url: 'https://x' }],
+    ['question', 'tu-q', { questions: [{ question: 'Q?', header: 'H', options: [], multiSelect: false }] }],
+    ['file', 'tu-f', { description: 'd' }],
+    ['browser_input', 'tu-b', { message: 'm', requirements: [] }],
+    ['script_run', 'tu-r', { script: 'echo', explanation: '', scriptType: 'shell' }],
+    ['computer_use', 'tu-cu', { method: 'click', params: {}, permissionLevel: 'high' }],
+  ] as const)('%s onComplete strips the settled id from the stream store', (kind, toolUseId, payload) => {
     mockStreamState.isActive = true
-    mockUnified.data = [unified('secret', 'tu-s', { secretName: 'A' })]
+    mockUnified.data = [unified(kind, toolUseId, payload as Record<string, unknown>)]
     const { result } = renderHook(() => usePendingRequests(defaultArgs))
-    ofKind(result.current.items, 'secret')[0].onComplete()
-    expect(mockRemovers.removeSecretRequest).toHaveBeenCalledTimes(1)
-    expect(mockRemovers.removeSecretRequest).toHaveBeenCalledWith('s-1', 'tu-s')
-  })
-
-  it('connected_account onComplete calls removeConnectedAccountRequest', () => {
-    mockStreamState.isActive = true
-    mockUnified.data = [unified('connected_account', 'tu-c', { toolkit: 'slack' })]
-    const { result } = renderHook(() => usePendingRequests(defaultArgs))
-    ofKind(result.current.items, 'connected_account')[0].onComplete()
-    expect(mockRemovers.removeConnectedAccountRequest).toHaveBeenCalledWith('s-1', 'tu-c')
-  })
-
-  it('remote_mcp onComplete calls removeRemoteMcpRequest', () => {
-    mockStreamState.isActive = true
-    mockUnified.data = [unified('remote_mcp', 'tu-m', { url: 'https://x' })]
-    const { result } = renderHook(() => usePendingRequests(defaultArgs))
-    ofKind(result.current.items, 'remote_mcp')[0].onComplete()
-    expect(mockRemovers.removeRemoteMcpRequest).toHaveBeenCalledWith('s-1', 'tu-m')
-  })
-
-  it('question onComplete calls removeQuestionRequest', () => {
-    mockStreamState.isActive = true
-    mockUnified.data = [
-      unified('question', 'tu-q', {
-        questions: [{ question: 'Q?', header: 'H', options: [], multiSelect: false }],
-      }),
-    ]
-    const { result } = renderHook(() => usePendingRequests(defaultArgs))
-    ofKind(result.current.items, 'question')[0].onComplete()
-    expect(mockRemovers.removeQuestionRequest).toHaveBeenCalledWith('s-1', 'tu-q')
-  })
-
-  it('file onComplete calls removeFileRequest', () => {
-    mockStreamState.isActive = true
-    mockUnified.data = [unified('file', 'tu-f', { description: 'd' })]
-    const { result } = renderHook(() => usePendingRequests(defaultArgs))
-    ofKind(result.current.items, 'file')[0].onComplete()
-    expect(mockRemovers.removeFileRequest).toHaveBeenCalledWith('s-1', 'tu-f')
-  })
-
-  it('browser_input onComplete calls removeBrowserInputRequest', () => {
-    mockStreamState.isActive = true
-    mockUnified.data = [unified('browser_input', 'tu-b', { message: 'm', requirements: [] })]
-    const { result } = renderHook(() => usePendingRequests(defaultArgs))
-    ofKind(result.current.items, 'browser_input')[0].onComplete()
-    expect(mockRemovers.removeBrowserInputRequest).toHaveBeenCalledWith('s-1', 'tu-b')
-  })
-
-  it('script_run onComplete calls removeScriptRunRequest', () => {
-    mockStreamState.isActive = true
-    mockUnified.data = [
-      unified('script_run', 'tu-r', { script: 'echo', explanation: '', scriptType: 'shell' }),
-    ]
-    const { result } = renderHook(() => usePendingRequests(defaultArgs))
-    ofKind(result.current.items, 'script_run')[0].onComplete()
-    expect(mockRemovers.removeScriptRunRequest).toHaveBeenCalledWith('s-1', 'tu-r')
-  })
-
-  it('computer_use onComplete calls removeComputerUseRequest', () => {
-    mockStreamState.isActive = true
-    mockUnified.data = [
-      unified('computer_use', 'tu-cu', { method: 'click', params: {}, permissionLevel: 'high' }),
-    ]
-    const { result } = renderHook(() => usePendingRequests(defaultArgs))
-    ofKind(result.current.items, 'computer_use')[0].onComplete()
-    expect(mockRemovers.removeComputerUseRequest).toHaveBeenCalledWith('s-1', 'tu-cu')
+    ofKind(result.current.items, kind)[0].onComplete()
+    expect(mockRemovePendingRequestsByToolUseId).toHaveBeenCalledWith('s-1', toolUseId)
   })
 
   // ---- Arrival-order sort across mixed types ----

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -1,17 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import {
-  useMessageStream,
-  removeSecretRequest,
-  removeConnectedAccountRequest,
-  removeRemoteMcpRequest,
-  removeQuestionRequest,
-  removeFileRequest,
-  removeBrowserInputRequest,
-  removeScriptRunRequest,
-  removeComputerUseRequest,
-  removeCapabilityReviewRequest,
-} from '@renderer/hooks/use-message-stream'
+import { useMessageStream, removePendingRequestsByToolUseId } from '@renderer/hooks/use-message-stream'
 import { useMessages } from '@renderer/hooks/use-messages'
 import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-requests'
 import { usePendingProxyReviews, type PendingReview } from '@renderer/hooks/use-proxy-reviews'
@@ -66,6 +55,28 @@ function createPendingRequestBuckets(): PendingRequestBuckets {
     browserInputRequests: [],
     scriptRunRequests: [],
     computerUseRequests: [],
+  }
+}
+
+// The single merge rule the per-kind memos used to duplicate eight times:
+// first occurrence of a toolUseId across the ordered sources wins, dismissed
+// and suppressed ids never surface.
+function mergeBucket<K extends keyof PendingRequestBuckets>(
+  target: PendingRequestBuckets,
+  kind: K,
+  sources: Array<PendingRequestBuckets[K]>,
+  dismissed: ReadonlySet<string>,
+  suppressed?: ReadonlySet<string>,
+): void {
+  const seen = new Set<string>()
+  const out = target[kind] as Array<PendingRequestBuckets[K][number]>
+  for (const source of sources) {
+    for (const req of source) {
+      if (suppressed?.has(req.toolUseId)) continue
+      if (seen.has(req.toolUseId) || dismissed.has(req.toolUseId)) continue
+      seen.add(req.toolUseId)
+      out.push(req)
+    }
   }
 }
 
@@ -192,8 +203,9 @@ function isXAgentOperation(value: unknown): value is 'list' | 'read' | 'invoke' 
 // Rebuild the legacy poll's PendingReview shape from a review envelope. The
 // payload carries the full ReviewDetails (plus the derived displayText), but
 // envelope payloads are lenient by design, so the card-critical fields are
-// re-validated here instead of trusted.
-function reviewFromEnvelope(
+// re-validated here instead of trusted. Exported for the dashboard's
+// pending-reviews panel, which reads the same snapshot.
+export function reviewFromEnvelope(
   request: PendingUserInputRequest,
   payload: Record<string, unknown>,
 ): PendingReview | null {
@@ -504,122 +516,36 @@ export function usePendingRequests({
     prevIsActive.current = isActive
   }, [isActive])
 
-  // TODO: currently request handling is super duplicative for different types
-  // (question, browser, permission, ...) — need to unify into a single helper.
-  // Tracked: SUP-163.
-  const pendingSecretRequests = useMemo(() => {
-    const seen = new Set<string>()
-    const merged: { toolUseId: string; secretName: string; reason?: string }[] = []
-    const messageBased = isActive ? messagesBasedPendingRequests.secretRequests : []
-    const streamingBased = isActive ? streamingBasedPendingRequests.secretRequests : []
-    for (const req of [...unified.buckets.secretRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
-        seen.add(req.toolUseId)
-        merged.push(req)
-      }
+  // One merge rule for every bucket kind: unified snapshot ∪ streaming
+  // fallback ∪ message-history fallback, first occurrence of a toolUseId
+  // wins, dismissed ids drop, and the auto-approved suppress-set (script_run
+  // and computer_use only) hides requests the server is already executing.
+  const merged = useMemo(() => {
+    const target = createPendingRequestBuckets()
+    for (const kind of Object.keys(target) as Array<keyof PendingRequestBuckets>) {
+      const suppressed =
+        kind === 'scriptRunRequests'
+          ? autoApprovedScriptRunIds
+          : kind === 'computerUseRequests'
+            ? autoApprovedComputerUseIds
+            : undefined
+      mergeBucket(
+        target,
+        kind,
+        // The fallbacks recover only ACTIVE turns — an idle session's
+        // unanswered tool calls are history, not open requests.
+        isActive
+          ? [unified.buckets[kind], streamingBasedPendingRequests[kind], messagesBasedPendingRequests[kind]]
+          : [unified.buckets[kind]],
+        dismissedRequestIds,
+        suppressed,
+      )
     }
-    return merged
-  }, [unified.buckets.secretRequests, streamingBasedPendingRequests.secretRequests, messagesBasedPendingRequests.secretRequests, isActive, dismissedRequestIds])
-
-  const pendingConnectedAccountRequests = useMemo(() => {
-    const seen = new Set<string>()
-    const merged: { toolUseId: string; toolkit: string; reason?: string }[] = []
-    const messageBased = isActive ? messagesBasedPendingRequests.connectedAccountRequests : []
-    const streamingBased = isActive ? streamingBasedPendingRequests.connectedAccountRequests : []
-    for (const req of [...unified.buckets.connectedAccountRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
-        seen.add(req.toolUseId)
-        merged.push(req)
-      }
-    }
-    return merged
-  }, [unified.buckets.connectedAccountRequests, streamingBasedPendingRequests.connectedAccountRequests, messagesBasedPendingRequests.connectedAccountRequests, isActive, dismissedRequestIds])
-
-  const pendingQuestionRequests = useMemo(() => {
-    const seen = new Set<string>()
-    const merged: { toolUseId: string; questions: Question[] }[] = []
-    const messageBased = isActive ? messagesBasedPendingRequests.questionRequests : []
-    const streamingBased = isActive ? streamingBasedPendingRequests.questionRequests : []
-    for (const req of [...unified.buckets.questionRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
-        seen.add(req.toolUseId)
-        merged.push(req)
-      }
-    }
-    return merged
-  }, [unified.buckets.questionRequests, streamingBasedPendingRequests.questionRequests, messagesBasedPendingRequests.questionRequests, isActive, dismissedRequestIds])
-
-  const pendingFileRequests = useMemo(() => {
-    const seen = new Set<string>()
-    const merged: { toolUseId: string; description: string; fileTypes?: string }[] = []
-    const messageBased = isActive ? messagesBasedPendingRequests.fileRequests : []
-    const streamingBased = isActive ? streamingBasedPendingRequests.fileRequests : []
-    for (const req of [...unified.buckets.fileRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
-        seen.add(req.toolUseId)
-        merged.push(req)
-      }
-    }
-    return merged
-  }, [unified.buckets.fileRequests, streamingBasedPendingRequests.fileRequests, messagesBasedPendingRequests.fileRequests, isActive, dismissedRequestIds])
-
-  const pendingRemoteMcpRequests = useMemo(() => {
-    const seen = new Set<string>()
-    const merged: { toolUseId: string; url: string; name?: string; reason?: string; authHint?: 'oauth' | 'bearer' }[] = []
-    const messageBased = isActive ? messagesBasedPendingRequests.remoteMcpRequests : []
-    const streamingBased = isActive ? streamingBasedPendingRequests.remoteMcpRequests : []
-    for (const req of [...unified.buckets.remoteMcpRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
-        seen.add(req.toolUseId)
-        merged.push(req)
-      }
-    }
-    return merged
-  }, [unified.buckets.remoteMcpRequests, streamingBasedPendingRequests.remoteMcpRequests, messagesBasedPendingRequests.remoteMcpRequests, isActive, dismissedRequestIds])
-
-  const pendingBrowserInputRequests = useMemo(() => {
-    const seen = new Set<string>()
-    const merged: { toolUseId: string; message: string; requirements: string[] }[] = []
-    const messageBased = isActive ? messagesBasedPendingRequests.browserInputRequests : []
-    const streamingBased = isActive ? streamingBasedPendingRequests.browserInputRequests : []
-    for (const req of [...unified.buckets.browserInputRequests, ...streamingBased, ...messageBased]) {
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
-        seen.add(req.toolUseId)
-        merged.push(req)
-      }
-    }
-    return merged
-  }, [unified.buckets.browserInputRequests, streamingBasedPendingRequests.browserInputRequests, messagesBasedPendingRequests.browserInputRequests, isActive, dismissedRequestIds])
-
-  const pendingScriptRunRequests = useMemo(() => {
-    const seen = new Set<string>()
-    const merged: { toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }[] = []
-    const messageBased = isActive ? messagesBasedPendingRequests.scriptRunRequests : []
-    const streamingBased = isActive ? streamingBasedPendingRequests.scriptRunRequests : []
-    for (const req of [...unified.buckets.scriptRunRequests, ...streamingBased, ...messageBased]) {
-      if (autoApprovedScriptRunIds.has(req.toolUseId)) continue
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
-        seen.add(req.toolUseId)
-        merged.push(req)
-      }
-    }
-    return merged
-  }, [unified.buckets.scriptRunRequests, streamingBasedPendingRequests.scriptRunRequests, messagesBasedPendingRequests.scriptRunRequests, isActive, autoApprovedScriptRunIds, dismissedRequestIds])
-
-  const pendingComputerUseRequests = useMemo(() => {
-    const seen = new Set<string>()
-    const merged: { toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }[] = []
-    const messageBased = isActive ? messagesBasedPendingRequests.computerUseRequests : []
-    const streamingBased = isActive ? streamingBasedPendingRequests.computerUseRequests : []
-    for (const req of [...unified.buckets.computerUseRequests, ...streamingBased, ...messageBased]) {
-      if (autoApprovedComputerUseIds.has(req.toolUseId)) continue
-      if (!seen.has(req.toolUseId) && !dismissedRequestIds.has(req.toolUseId)) {
-        seen.add(req.toolUseId)
-        merged.push(req)
-      }
-    }
-    return merged
-  }, [unified.buckets.computerUseRequests, streamingBasedPendingRequests.computerUseRequests, messagesBasedPendingRequests.computerUseRequests, isActive, autoApprovedComputerUseIds, dismissedRequestIds])
+    return target
+  }, [
+    unified.buckets, streamingBasedPendingRequests, messagesBasedPendingRequests,
+    isActive, autoApprovedScriptRunIds, autoApprovedComputerUseIds, dismissedRequestIds,
+  ])
 
   // Capability reviews come from the unified store (with the stream source as
   // the cold-start fallback) — no message-history or streaming recovery. A
@@ -640,14 +566,14 @@ export function usePendingRequests({
   const allPendingIds = useMemo(() => {
     const ids: string[] = []
     for (const arr of [
-      pendingSecretRequests,
-      pendingConnectedAccountRequests,
-      pendingRemoteMcpRequests,
-      pendingQuestionRequests,
-      pendingFileRequests,
-      pendingBrowserInputRequests,
-      pendingScriptRunRequests,
-      pendingComputerUseRequests,
+      merged.secretRequests,
+      merged.connectedAccountRequests,
+      merged.remoteMcpRequests,
+      merged.questionRequests,
+      merged.fileRequests,
+      merged.browserInputRequests,
+      merged.scriptRunRequests,
+      merged.computerUseRequests,
       pendingCapabilityReviewRequests,
     ]) {
       for (const req of arr) ids.push(req.toolUseId)
@@ -655,9 +581,9 @@ export function usePendingRequests({
     for (const review of pendingProxyReviews) ids.push(review.id)
     return ids
   }, [
-    pendingSecretRequests, pendingConnectedAccountRequests, pendingRemoteMcpRequests,
-    pendingQuestionRequests, pendingFileRequests, pendingBrowserInputRequests,
-    pendingScriptRunRequests, pendingComputerUseRequests, pendingCapabilityReviewRequests, pendingProxyReviews,
+    merged.secretRequests, merged.connectedAccountRequests, merged.remoteMcpRequests,
+    merged.questionRequests, merged.fileRequests, merged.browserInputRequests,
+    merged.scriptRunRequests, merged.computerUseRequests, pendingCapabilityReviewRequests, pendingProxyReviews,
   ])
 
   // Effect — not useMemo — because we mutate refs. useMemo may re-run for the
@@ -679,49 +605,11 @@ export function usePendingRequests({
     return arrivalOrder.current.get(id) ?? Infinity
   }, [])
 
-  const handleSecretRequestComplete = useCallback((toolUseId: string) => {
+  const handleRequestComplete = useCallback((toolUseId: string) => {
     dismissRequest(toolUseId)
-    removeSecretRequest(sessionId, toolUseId)
-  }, [sessionId, dismissRequest])
-
-  const handleConnectedAccountRequestComplete = useCallback((toolUseId: string) => {
-    dismissRequest(toolUseId)
-    removeConnectedAccountRequest(sessionId, toolUseId)
-  }, [sessionId, dismissRequest])
-
-  const handleQuestionRequestComplete = useCallback((toolUseId: string) => {
-    dismissRequest(toolUseId)
-    removeQuestionRequest(sessionId, toolUseId)
-  }, [sessionId, dismissRequest])
-
-  const handleRemoteMcpRequestComplete = useCallback((toolUseId: string) => {
-    dismissRequest(toolUseId)
-    removeRemoteMcpRequest(sessionId, toolUseId)
-  }, [sessionId, dismissRequest])
-
-  const handleFileRequestComplete = useCallback((toolUseId: string) => {
-    dismissRequest(toolUseId)
-    removeFileRequest(sessionId, toolUseId)
-  }, [sessionId, dismissRequest])
-
-  const handleScriptRunRequestComplete = useCallback((toolUseId: string) => {
-    dismissRequest(toolUseId)
-    removeScriptRunRequest(sessionId, toolUseId)
-  }, [sessionId, dismissRequest])
-
-  const handleComputerUseRequestComplete = useCallback((toolUseId: string) => {
-    dismissRequest(toolUseId)
-    removeComputerUseRequest(sessionId, toolUseId)
-  }, [sessionId, dismissRequest])
-
-  const handleBrowserInputRequestComplete = useCallback((toolUseId: string) => {
-    dismissRequest(toolUseId)
-    removeBrowserInputRequest(sessionId, toolUseId)
-  }, [sessionId, dismissRequest])
-
-  const handleCapabilityReviewRequestComplete = useCallback((toolUseId: string) => {
-    dismissRequest(toolUseId)
-    removeCapabilityReviewRequest(sessionId, toolUseId)
+    // The stream store still holds the browser tray's entries and the
+    // capability cold-start fallback — drop the settled id from those too.
+    removePendingRequestsByToolUseId(sessionId, toolUseId)
   }, [sessionId, dismissRequest])
 
   const handleProxyReviewComplete = useCallback(() => {
@@ -734,27 +622,27 @@ export function usePendingRequests({
 
   const items = useMemo<PendingRequestDescriptor[]>(() => {
     const all: PendingRequestDescriptor[] = []
-    for (const r of pendingSecretRequests) {
+    for (const r of merged.secretRequests) {
       all.push({
         kind: 'secret',
         key: r.toolUseId,
         toolUseId: r.toolUseId,
         secretName: r.secretName,
         reason: r.reason,
-        onComplete: () => handleSecretRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
-    for (const r of pendingConnectedAccountRequests) {
+    for (const r of merged.connectedAccountRequests) {
       all.push({
         kind: 'connected_account',
         key: r.toolUseId,
         toolUseId: r.toolUseId,
         toolkit: r.toolkit,
         reason: r.reason,
-        onComplete: () => handleConnectedAccountRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
-    for (const r of pendingRemoteMcpRequests) {
+    for (const r of merged.remoteMcpRequests) {
       all.push({
         kind: 'remote_mcp',
         key: r.toolUseId,
@@ -763,39 +651,39 @@ export function usePendingRequests({
         name: r.name,
         reason: r.reason,
         authHint: r.authHint,
-        onComplete: () => handleRemoteMcpRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
-    for (const r of pendingQuestionRequests) {
+    for (const r of merged.questionRequests) {
       all.push({
         kind: 'question',
         key: r.toolUseId,
         toolUseId: r.toolUseId,
         questions: r.questions,
-        onComplete: () => handleQuestionRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
-    for (const r of pendingFileRequests) {
+    for (const r of merged.fileRequests) {
       all.push({
         kind: 'file',
         key: r.toolUseId,
         toolUseId: r.toolUseId,
         description: r.description,
         fileTypes: r.fileTypes,
-        onComplete: () => handleFileRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
-    for (const r of pendingBrowserInputRequests) {
+    for (const r of merged.browserInputRequests) {
       all.push({
         kind: 'browser_input',
         key: r.toolUseId,
         toolUseId: r.toolUseId,
         message: r.message,
         requirements: r.requirements,
-        onComplete: () => handleBrowserInputRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
-    for (const r of pendingScriptRunRequests) {
+    for (const r of merged.scriptRunRequests) {
       all.push({
         kind: 'script_run',
         key: r.toolUseId,
@@ -803,10 +691,10 @@ export function usePendingRequests({
         script: r.script,
         explanation: r.explanation,
         scriptType: r.scriptType,
-        onComplete: () => handleScriptRunRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
-    for (const r of pendingComputerUseRequests) {
+    for (const r of merged.computerUseRequests) {
       all.push({
         kind: 'computer_use',
         key: r.toolUseId,
@@ -815,7 +703,7 @@ export function usePendingRequests({
         params: r.params,
         permissionLevel: r.permissionLevel,
         appName: r.appName,
-        onComplete: () => handleComputerUseRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
     for (const r of pendingCapabilityReviewRequests) {
@@ -826,7 +714,7 @@ export function usePendingRequests({
         capability: r.capability,
         toolName: r.toolName,
         input: r.input,
-        onComplete: () => handleCapabilityReviewRequestComplete(r.toolUseId),
+        onComplete: () => handleRequestComplete(r.toolUseId),
       })
     }
     for (const review of pendingProxyReviews) {
@@ -856,15 +744,10 @@ export function usePendingRequests({
     }
     return all.sort((a, b) => getArrivalOrder(a.key) - getArrivalOrder(b.key))
   }, [
-    pendingSecretRequests, pendingConnectedAccountRequests, pendingRemoteMcpRequests,
-    pendingQuestionRequests, pendingFileRequests, pendingBrowserInputRequests,
-    pendingScriptRunRequests, pendingComputerUseRequests, pendingCapabilityReviewRequests, pendingProxyReviews,
-    getArrivalOrder,
-    handleSecretRequestComplete, handleConnectedAccountRequestComplete,
-    handleRemoteMcpRequestComplete, handleQuestionRequestComplete,
-    handleFileRequestComplete, handleBrowserInputRequestComplete,
-    handleScriptRunRequestComplete, handleComputerUseRequestComplete,
-    handleCapabilityReviewRequestComplete, handleProxyReviewComplete,
+    merged.secretRequests, merged.connectedAccountRequests, merged.remoteMcpRequests,
+    merged.questionRequests, merged.fileRequests, merged.browserInputRequests,
+    merged.scriptRunRequests, merged.computerUseRequests, pendingCapabilityReviewRequests, pendingProxyReviews,
+    getArrivalOrder, handleRequestComplete, handleProxyReviewComplete,
   ])
 
   return { items, count: items.length }

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -216,7 +216,7 @@ describe('GlobalNotificationHandler — proxy review SSE pathway', () => {
     expect(proxyReviewCalls.length).toBe(1)
   })
 
-  it('user_request_created/resolved invalidate the unified store AND the legacy review poll', () => {
+  it('user_request_created/resolved invalidate the unified store', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
     render(
@@ -228,8 +228,8 @@ describe('GlobalNotificationHandler — proxy review SSE pathway', () => {
     const es = getLatestEventSource()
 
     // A dashboard-triggered review can exist with NO session anywhere — this
-    // global event is its only push signal, so it must nudge both the unified
-    // store and the dashboard panel's legacy poll (still unmigrated).
+    // global event is its only push signal. Every review surface (in-chat
+    // cards AND the dashboard panel) reads the unified store now.
     simulateSSEMessage(es, {
       type: 'user_request_created',
       request: {
@@ -251,7 +251,6 @@ describe('GlobalNotificationHandler — proxy review SSE pathway', () => {
 
     const keys = invalidateSpy.mock.calls.map((call) => (call[0] as { queryKey?: unknown[] }).queryKey?.[0])
     expect(keys.filter((k) => k === 'pending-user-requests')).toHaveLength(2)
-    expect(keys.filter((k) => k === 'proxy-reviews')).toHaveLength(2)
   })
 
   // SECURITY: focus-aware gate — when an actionable session_waiting fires

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -362,12 +362,6 @@ export function GlobalNotificationHandler() {
             // the cross-tab/cross-session sync for everything else; the
             // store's interval refetch is the safety net for a missed event.
             queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
-            // The dashboard's pending-reviews panel still reads the legacy
-            // poll (its store migration is a later phase). Nudging it here
-            // makes dashboard-triggered reviews — which may have NO session
-            // anywhere — appear/settle on creation, decision, timeout, and
-            // auto-deny instead of on the next 30s poll tick.
-            queryClient.invalidateQueries({ queryKey: ['proxy-reviews'] })
             break
 
           case 'agent_status_changed':

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -93,7 +93,7 @@ describe('useMessageStream', () => {
     expect(result.current.streamingMessage).toBeNull()
     expect(result.current.streamingToolUses).toEqual([])
     expect(result.current.error).toBeNull()
-    expect(result.current.pendingSecretRequests).toEqual([])
+    expect(result.current.pendingBrowserInputRequests).toEqual([])
   })
 
   it('creates EventSource for session', async () => {
@@ -340,34 +340,6 @@ describe('useMessageStream', () => {
     expect(result.current.apiErrorCode).toBe('authentication_failed')
   })
 
-  it('handles secret_request event', async () => {
-    const { useMessageStream } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'secret_request',
-        toolUseId: 'tu-1',
-        secretName: 'API_KEY',
-        reason: 'Need it',
-      })
-    })
-
-    expect(result.current.pendingSecretRequests).toHaveLength(1)
-    expect(result.current.pendingSecretRequests[0]).toEqual({
-      toolUseId: 'tu-1',
-      secretName: 'API_KEY',
-      reason: 'Need it',
-    })
-  })
-
   it('handles tool_use_start and tool_use_streaming events', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(
@@ -460,43 +432,6 @@ describe('useMessageStream', () => {
     expect(result.current.isActive).toBe(true)
     expect(result.current.isStreaming).toBe(false)
     expect(result.current.streamingMessage).toBeNull()
-  })
-
-  it('handles removeSecretRequest helper', async () => {
-    const { useMessageStream, removeSecretRequest } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'secret_request',
-        toolUseId: 'tu-1',
-        secretName: 'KEY1',
-      })
-    })
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'secret_request',
-        toolUseId: 'tu-2',
-        secretName: 'KEY2',
-      })
-    })
-
-    expect(result.current.pendingSecretRequests).toHaveLength(2)
-
-    act(() => {
-      removeSecretRequest('session-1', 'tu-1')
-    })
-
-    expect(result.current.pendingSecretRequests).toHaveLength(1)
-    expect(result.current.pendingSecretRequests[0].toolUseId).toBe('tu-2')
   })
 
   it('handles subagent streaming events', async () => {
@@ -628,116 +563,6 @@ describe('useMessageStream', () => {
   })
 
   // ---- Additional request event types ----
-
-  it('handles connected_account_request event', async () => {
-    const { useMessageStream } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'connected_account_request',
-        toolUseId: 'tu-ca-1',
-        toolkit: 'github',
-        reason: 'Need repo access',
-      })
-    })
-
-    expect(result.current.pendingConnectedAccountRequests).toHaveLength(1)
-    expect(result.current.pendingConnectedAccountRequests[0]).toEqual({
-      toolUseId: 'tu-ca-1',
-      toolkit: 'github',
-      reason: 'Need repo access',
-    })
-  })
-
-  it('handles user_question_request event', async () => {
-    const { useMessageStream } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'user_question_request',
-        toolUseId: 'tu-q-1',
-        questions: [{ question: 'Which DB?', header: 'DB', options: [{ label: 'PG', description: 'PostgreSQL' }], multiSelect: false }],
-      })
-    })
-
-    expect(result.current.pendingQuestionRequests).toHaveLength(1)
-    expect(result.current.pendingQuestionRequests[0].toolUseId).toBe('tu-q-1')
-    expect(result.current.pendingQuestionRequests[0].questions[0].question).toBe('Which DB?')
-  })
-
-  it('handles file_request event', async () => {
-    const { useMessageStream } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'file_request',
-        toolUseId: 'tu-f-1',
-        description: 'Upload your config',
-        fileTypes: '.json,.yaml',
-      })
-    })
-
-    expect(result.current.pendingFileRequests).toHaveLength(1)
-    expect(result.current.pendingFileRequests[0]).toEqual({
-      toolUseId: 'tu-f-1',
-      description: 'Upload your config',
-      fileTypes: '.json,.yaml',
-    })
-  })
-
-  it('handles remote_mcp_request event', async () => {
-    const { useMessageStream } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'remote_mcp_request',
-        toolUseId: 'tu-mcp-1',
-        url: 'https://mcp.example.com',
-        name: 'Example MCP',
-        reason: 'Need tools',
-      })
-    })
-
-    expect(result.current.pendingRemoteMcpRequests).toHaveLength(1)
-    expect(result.current.pendingRemoteMcpRequests[0]).toEqual({
-      toolUseId: 'tu-mcp-1',
-      url: 'https://mcp.example.com',
-      name: 'Example MCP',
-      reason: 'Need tools',
-    })
-  })
 
   // ---- Query invalidation ----
 
@@ -1331,118 +1156,6 @@ describe('useMessageStream', () => {
 
   // ---- Remove helpers ----
 
-  it('handles removeConnectedAccountRequest helper', async () => {
-    const { useMessageStream, removeConnectedAccountRequest } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'connected_account_request',
-        toolUseId: 'tu-ca-1',
-        toolkit: 'github',
-      })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'connected_account_request',
-        toolUseId: 'tu-ca-2',
-        toolkit: 'slack',
-      })
-    })
-    expect(result.current.pendingConnectedAccountRequests).toHaveLength(2)
-
-    act(() => {
-      removeConnectedAccountRequest('session-1', 'tu-ca-1')
-    })
-
-    expect(result.current.pendingConnectedAccountRequests).toHaveLength(1)
-    expect(result.current.pendingConnectedAccountRequests[0].toolkit).toBe('slack')
-  })
-
-  it('handles removeQuestionRequest helper', async () => {
-    const { useMessageStream, removeQuestionRequest } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'user_question_request',
-        toolUseId: 'tu-q-1',
-        questions: [{ question: 'Q1?', header: 'H', options: [], multiSelect: false }],
-      })
-    })
-    expect(result.current.pendingQuestionRequests).toHaveLength(1)
-
-    act(() => {
-      removeQuestionRequest('session-1', 'tu-q-1')
-    })
-
-    expect(result.current.pendingQuestionRequests).toHaveLength(0)
-  })
-
-  it('handles removeFileRequest helper', async () => {
-    const { useMessageStream, removeFileRequest } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'file_request',
-        toolUseId: 'tu-f-1',
-        description: 'Upload config',
-      })
-    })
-    expect(result.current.pendingFileRequests).toHaveLength(1)
-
-    act(() => {
-      removeFileRequest('session-1', 'tu-f-1')
-    })
-
-    expect(result.current.pendingFileRequests).toHaveLength(0)
-  })
-
-  it('handles removeRemoteMcpRequest helper', async () => {
-    const { useMessageStream, removeRemoteMcpRequest } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'remote_mcp_request',
-        toolUseId: 'tu-mcp-1',
-        url: 'https://mcp.example.com',
-      })
-    })
-    expect(result.current.pendingRemoteMcpRequests).toHaveLength(1)
-
-    act(() => {
-      removeRemoteMcpRequest('session-1', 'tu-mcp-1')
-    })
-
-    expect(result.current.pendingRemoteMcpRequests).toHaveLength(0)
-  })
-
   it('handles clearCompacting helper', async () => {
     const { useMessageStream, clearCompacting } = await getHookModule()
     const { result } = renderHook(
@@ -1489,7 +1202,7 @@ describe('useMessageStream', () => {
 
   // ---- State transition edge cases ----
 
-  it('session_idle clears all pending requests', async () => {
+  it('session_idle clears the surviving pending-request arrays', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(
       () => useMessageStream('session-1', 'agent-1'),
@@ -1500,39 +1213,25 @@ describe('useMessageStream', () => {
       MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
     })
 
-    // Accumulate pending requests of all types
+    // The two arrays that outlived the unified-store migration: the browser
+    // tray's feed and the capability-review cold-start fallback.
     act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'secret_request', toolUseId: 'tu-1', secretName: 'KEY' })
+      MockEventSource.instances[0].simulateMessage({ type: 'browser_input_request', toolUseId: 'tu-1', message: 'Log in', requirements: [] })
     })
     act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected_account_request', toolUseId: 'tu-2', toolkit: 'gh' })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'user_question_request', toolUseId: 'tu-3', questions: [] })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'file_request', toolUseId: 'tu-4', description: 'file' })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'remote_mcp_request', toolUseId: 'tu-5', url: 'http://x' })
+      MockEventSource.instances[0].simulateMessage({ type: 'capability_review_request', toolUseId: 'tu-2', capability: 'workflows', toolName: 'Workflow', input: {} })
     })
 
-    expect(result.current.pendingSecretRequests).toHaveLength(1)
-    expect(result.current.pendingConnectedAccountRequests).toHaveLength(1)
-    expect(result.current.pendingQuestionRequests).toHaveLength(1)
-    expect(result.current.pendingFileRequests).toHaveLength(1)
-    expect(result.current.pendingRemoteMcpRequests).toHaveLength(1)
+    expect(result.current.pendingBrowserInputRequests).toHaveLength(1)
+    expect(result.current.pendingCapabilityReviewRequests).toHaveLength(1)
 
-    // session_idle should clear all
+    // session_idle should clear both
     act(() => {
       MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
     })
 
-    expect(result.current.pendingSecretRequests).toHaveLength(0)
-    expect(result.current.pendingConnectedAccountRequests).toHaveLength(0)
-    expect(result.current.pendingQuestionRequests).toHaveLength(0)
-    expect(result.current.pendingFileRequests).toHaveLength(0)
-    expect(result.current.pendingRemoteMcpRequests).toHaveLength(0)
+    expect(result.current.pendingBrowserInputRequests).toHaveLength(0)
+    expect(result.current.pendingCapabilityReviewRequests).toHaveLength(0)
   })
 
   it('session_active clears previous error', async () => {
@@ -1811,179 +1510,6 @@ describe('useMessageStream', () => {
   })
 
   describe('script_run_request event', () => {
-    it('adds script run request to pending list', async () => {
-      const mod = await getHookModule()
-      const wrapper = createWrapper()
-
-      const { result } = renderHook(
-        () => mod.useMessageStream('session-1', 'agent-1'),
-        { wrapper }
-      )
-
-      // Wait for EventSource to be created
-      await vi.waitFor(() => {
-        expect(MockEventSource.instances.length).toBeGreaterThan(0)
-      })
-
-      const es = MockEventSource.instances[MockEventSource.instances.length - 1]
-
-      // Send connected event first
-      act(() => {
-        es.simulateMessage({ type: 'connected', isActive: true })
-      })
-
-      // Send script_run_request event
-      act(() => {
-        es.simulateMessage({
-          type: 'script_run_request',
-          toolUseId: 'tool-1',
-          script: 'sw_vers',
-          explanation: 'Check macOS version',
-          scriptType: 'shell',
-        })
-      })
-
-      await vi.waitFor(() => {
-        expect(result.current.pendingScriptRunRequests).toHaveLength(1)
-      })
-
-      expect(result.current.pendingScriptRunRequests[0]).toEqual({
-        toolUseId: 'tool-1',
-        script: 'sw_vers',
-        explanation: 'Check macOS version',
-        scriptType: 'shell',
-      })
-    })
-
-    it('deduplicates script run requests by toolUseId', async () => {
-      const mod = await getHookModule()
-      const wrapper = createWrapper()
-
-      const { result } = renderHook(
-        () => mod.useMessageStream('session-2', 'agent-1'),
-        { wrapper }
-      )
-
-      await vi.waitFor(() => {
-        expect(MockEventSource.instances.length).toBeGreaterThan(0)
-      })
-
-      const es = MockEventSource.instances[MockEventSource.instances.length - 1]
-
-      act(() => {
-        es.simulateMessage({ type: 'connected', isActive: true })
-      })
-
-      // Send same toolUseId twice
-      act(() => {
-        es.simulateMessage({
-          type: 'script_run_request',
-          toolUseId: 'tool-dup',
-          script: 'sw_vers',
-          explanation: 'Check version',
-          scriptType: 'shell',
-        })
-      })
-
-      act(() => {
-        es.simulateMessage({
-          type: 'script_run_request',
-          toolUseId: 'tool-dup',
-          script: 'sw_vers',
-          explanation: 'Check version',
-          scriptType: 'shell',
-        })
-      })
-
-      await vi.waitFor(() => {
-        expect(result.current.pendingScriptRunRequests).toHaveLength(1)
-      })
-    })
-
-    it('clears script run requests on session_idle', async () => {
-      const mod = await getHookModule()
-      const wrapper = createWrapper()
-
-      const { result } = renderHook(
-        () => mod.useMessageStream('session-3', 'agent-1'),
-        { wrapper }
-      )
-
-      await vi.waitFor(() => {
-        expect(MockEventSource.instances.length).toBeGreaterThan(0)
-      })
-
-      const es = MockEventSource.instances[MockEventSource.instances.length - 1]
-
-      act(() => {
-        es.simulateMessage({ type: 'connected', isActive: true })
-      })
-
-      act(() => {
-        es.simulateMessage({
-          type: 'script_run_request',
-          toolUseId: 'tool-clear',
-          script: 'test',
-          explanation: 'Test',
-          scriptType: 'shell',
-        })
-      })
-
-      await vi.waitFor(() => {
-        expect(result.current.pendingScriptRunRequests).toHaveLength(1)
-      })
-
-      act(() => {
-        es.simulateMessage({ type: 'session_idle' })
-      })
-
-      await vi.waitFor(() => {
-        expect(result.current.pendingScriptRunRequests).toHaveLength(0)
-      })
-    })
-
-    it('removeScriptRunRequest removes by toolUseId', async () => {
-      const mod = await getHookModule()
-      const wrapper = createWrapper()
-
-      const { result } = renderHook(
-        () => mod.useMessageStream('session-4', 'agent-1'),
-        { wrapper }
-      )
-
-      await vi.waitFor(() => {
-        expect(MockEventSource.instances.length).toBeGreaterThan(0)
-      })
-
-      const es = MockEventSource.instances[MockEventSource.instances.length - 1]
-
-      act(() => {
-        es.simulateMessage({ type: 'connected', isActive: true })
-      })
-
-      act(() => {
-        es.simulateMessage({
-          type: 'script_run_request',
-          toolUseId: 'tool-remove',
-          script: 'test',
-          explanation: 'Test',
-          scriptType: 'shell',
-        })
-      })
-
-      await vi.waitFor(() => {
-        expect(result.current.pendingScriptRunRequests).toHaveLength(1)
-      })
-
-      act(() => {
-        mod.removeScriptRunRequest('session-4', 'tool-remove')
-      })
-
-      await vi.waitFor(() => {
-        expect(result.current.pendingScriptRunRequests).toHaveLength(0)
-      })
-    })
-
     it('autoApproved:true populates suppress-set and skips pendingScriptRunRequests', async () => {
       const mod = await getHookModule()
       const wrapper = createWrapper()
@@ -2017,8 +1543,6 @@ describe('useMessageStream', () => {
         expect(result.current.autoApprovedScriptRunIds.has('tool-auto')).toBe(true)
       })
 
-      // Auto-approved requests must NOT appear in the pending prompt list.
-      expect(result.current.pendingScriptRunRequests).toHaveLength(0)
     })
 
     it('default autoApprovedScriptRunIds is empty for a fresh session', async () => {
@@ -2066,7 +1590,6 @@ describe('useMessageStream', () => {
         expect(result.current.autoApprovedComputerUseIds.has('tool-cu-auto')).toBe(true)
       })
 
-      expect(result.current.pendingComputerUseRequests).toHaveLength(0)
     })
 
     it('default autoApprovedComputerUseIds is empty for a fresh session', async () => {
@@ -2081,7 +1604,7 @@ describe('useMessageStream', () => {
       expect(result.current.autoApprovedComputerUseIds.size).toBe(0)
     })
 
-    it('mixes autoApproved and prompt requests independently', async () => {
+    it('only autoApproved requests enter the suppress-set; prompt-form events feed nothing', async () => {
       const mod = await getHookModule()
       const wrapper = createWrapper()
 
@@ -2099,7 +1622,8 @@ describe('useMessageStream', () => {
         es.simulateMessage({ type: 'connected', isActive: true })
       })
 
-      // First request: needs prompt.
+      // First request: needs prompt — the approval card comes from the
+      // unified store, so the legacy event must NOT suppress it.
       act(() => {
         es.simulateMessage({
           type: 'script_run_request',
@@ -2124,11 +1648,9 @@ describe('useMessageStream', () => {
       })
 
       await vi.waitFor(() => {
-        expect(result.current.pendingScriptRunRequests).toHaveLength(1)
         expect(result.current.autoApprovedScriptRunIds.has('tool-auto')).toBe(true)
       })
 
-      expect(result.current.pendingScriptRunRequests[0].toolUseId).toBe('tool-prompt')
       expect(result.current.autoApprovedScriptRunIds.has('tool-prompt')).toBe(false)
     })
   })

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -8,61 +8,10 @@ import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
 import type { WorkflowAgentNode } from '@shared/lib/workflows/workflow-schemas'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 
-interface SecretRequest {
-  toolUseId: string
-  secretName: string
-  reason?: string
-}
-
-interface ConnectedAccountRequest {
-  toolUseId: string
-  toolkit: string
-  reason?: string
-}
-
-interface QuestionRequest {
-  toolUseId: string
-  questions: Array<{
-    question: string
-    header: string
-    options: Array<{ label: string; description: string }>
-    multiSelect: boolean
-  }>
-}
-
-interface FileRequest {
-  toolUseId: string
-  description: string
-  fileTypes?: string
-}
-
-interface RemoteMcpRequest {
-  toolUseId: string
-  url: string
-  name?: string
-  reason?: string
-  authHint?: 'oauth' | 'bearer'
-}
-
 interface BrowserInputRequest {
   toolUseId: string
   message: string
   requirements: string[]
-}
-
-interface ScriptRunRequest {
-  toolUseId: string
-  script: string
-  explanation: string
-  scriptType: 'applescript' | 'shell' | 'powershell'
-}
-
-export interface ComputerUseRequest {
-  toolUseId: string
-  method: string
-  params: Record<string, unknown>
-  permissionLevel: string
-  appName?: string
 }
 
 // A subagent (Task/Agent) or workflow (Workflow) launch paused by a 'review'
@@ -114,14 +63,7 @@ interface StreamState {
   isStreaming: boolean // True while actively receiving tokens
   streamingMessage: string | null
   streamingToolUses: Array<{ id: string; name: string; partialInput: string; ready?: boolean }>
-  pendingSecretRequests: SecretRequest[]
-  pendingConnectedAccountRequests: ConnectedAccountRequest[]
-  pendingQuestionRequests: QuestionRequest[]
-  pendingFileRequests: FileRequest[]
-  pendingRemoteMcpRequests: RemoteMcpRequest[]
   pendingBrowserInputRequests: BrowserInputRequest[]
-  pendingScriptRunRequests: ScriptRunRequest[]
-  pendingComputerUseRequests: ComputerUseRequest[]
   pendingCapabilityReviewRequests: CapabilityReviewRequest[]
   error: string | null // Error message if session encountered an error
   /** SDK error code from the LLM provider (e.g., 'authentication_failed', 'rate_limit', 'server_error') */
@@ -163,14 +105,7 @@ const EMPTY_STREAM_STATE: StreamState = {
   isStreaming: false,
   streamingMessage: null,
   streamingToolUses: [],
-  pendingSecretRequests: [],
-  pendingConnectedAccountRequests: [],
-  pendingQuestionRequests: [],
-  pendingFileRequests: [],
-  pendingRemoteMcpRequests: [],
   pendingBrowserInputRequests: [],
-  pendingScriptRunRequests: [],
-  pendingComputerUseRequests: [],
   pendingCapabilityReviewRequests: [],
   error: null,
   apiErrorCode: null,
@@ -405,14 +340,7 @@ function getOrCreateEventSource(
           isStreaming: false,
           streamingMessage: null,
           streamingToolUses: [],
-          pendingSecretRequests: current?.pendingSecretRequests ?? [],
-          pendingConnectedAccountRequests: current?.pendingConnectedAccountRequests ?? [],
-          pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
-          pendingFileRequests: current?.pendingFileRequests ?? [],
-          pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
-          pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
-          pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
           pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: null,
           apiErrorCode: null,
@@ -468,14 +396,7 @@ function getOrCreateEventSource(
           isStreaming: current?.isStreaming ?? false,
           streamingMessage: current?.streamingMessage ?? null,
           streamingToolUses: current?.streamingToolUses ?? [],
-          pendingSecretRequests: current?.pendingSecretRequests ?? [],
-          pendingConnectedAccountRequests: current?.pendingConnectedAccountRequests ?? [],
-          pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
-          pendingFileRequests: current?.pendingFileRequests ?? [],
-          pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
-          pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
-          pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
           pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: null, // Clear any previous error when starting new request
           apiErrorCode: null,
@@ -515,14 +436,7 @@ function getOrCreateEventSource(
           isStreaming: false,
           streamingMessage: current?.streamingMessage ?? null,
           streamingToolUses: [],
-          pendingSecretRequests: [],
-          pendingConnectedAccountRequests: [],
-          pendingQuestionRequests: [],
-          pendingFileRequests: [],
-          pendingRemoteMcpRequests: [],
           pendingBrowserInputRequests: [],
-          pendingScriptRunRequests: [],
-          pendingComputerUseRequests: [],
           pendingCapabilityReviewRequests: [],
           error: null,
           // Preserve apiErrorCode — it was set from the assistant message's error field
@@ -569,14 +483,7 @@ function getOrCreateEventSource(
           isStreaming: false,
           streamingMessage: current?.streamingMessage ?? null,
           streamingToolUses: [],
-          pendingSecretRequests: [],
-          pendingConnectedAccountRequests: [],
-          pendingQuestionRequests: [],
-          pendingFileRequests: [],
-          pendingRemoteMcpRequests: [],
           pendingBrowserInputRequests: [],
-          pendingScriptRunRequests: [],
-          pendingComputerUseRequests: [],
           pendingCapabilityReviewRequests: [],
           error: data.error || 'An unknown error occurred',
           apiErrorCode: data.apiErrorCode || null,
@@ -741,14 +648,7 @@ function getOrCreateEventSource(
           isStreaming: true,
           streamingMessage: '',
           streamingToolUses: [],
-          pendingSecretRequests: current?.pendingSecretRequests ?? [],
-          pendingConnectedAccountRequests: current?.pendingConnectedAccountRequests ?? [],
-          pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
-          pendingFileRequests: current?.pendingFileRequests ?? [],
-          pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
-          pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
-          pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
           pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: null,
           apiErrorCode: null,
@@ -774,14 +674,7 @@ function getOrCreateEventSource(
           isStreaming: true,
           streamingMessage: (current?.streamingMessage || '') + data.text,
           streamingToolUses: current?.streamingToolUses ?? [],
-          pendingSecretRequests: current?.pendingSecretRequests ?? [],
-          pendingConnectedAccountRequests: current?.pendingConnectedAccountRequests ?? [],
-          pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
-          pendingFileRequests: current?.pendingFileRequests ?? [],
-          pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
-          pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
-          pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
           pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: data.apiErrorCode || current?.apiErrorCode || null,
@@ -823,14 +716,7 @@ function getOrCreateEventSource(
           isStreaming: true,
           streamingMessage: current?.streamingMessage ?? null,
           streamingToolUses: updatedTools,
-          pendingSecretRequests: current?.pendingSecretRequests ?? [],
-          pendingConnectedAccountRequests: current?.pendingConnectedAccountRequests ?? [],
-          pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
-          pendingFileRequests: current?.pendingFileRequests ?? [],
-          pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
-          pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
-          pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
           pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: current?.apiErrorCode ?? null,
@@ -872,14 +758,7 @@ function getOrCreateEventSource(
           isStreaming: false,
           streamingMessage: current?.streamingMessage ?? null,
           streamingToolUses: current?.streamingToolUses ?? [],
-          pendingSecretRequests: current?.pendingSecretRequests ?? [],
-          pendingConnectedAccountRequests: current?.pendingConnectedAccountRequests ?? [],
-          pendingQuestionRequests: current?.pendingQuestionRequests ?? [],
-          pendingFileRequests: current?.pendingFileRequests ?? [],
-          pendingRemoteMcpRequests: current?.pendingRemoteMcpRequests ?? [],
           pendingBrowserInputRequests: current?.pendingBrowserInputRequests ?? [],
-          pendingScriptRunRequests: current?.pendingScriptRunRequests ?? [],
-          pendingComputerUseRequests: current?.pendingComputerUseRequests ?? [],
           pendingCapabilityReviewRequests: current?.pendingCapabilityReviewRequests ?? [],
           error: current?.error ?? null,
           apiErrorCode: current?.apiErrorCode ?? null,
@@ -1012,52 +891,6 @@ function getOrCreateEventSource(
         // in-flight response can never overwrite a newer one.
         queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
       }
-      else if (data.type === 'secret_request') {
-        // Agent is requesting a secret from the user
-        const newRequest: SecretRequest = {
-          toolUseId: data.toolUseId,
-          secretName: data.secretName,
-          reason: data.reason,
-        }
-        if (current && !current.pendingSecretRequests.some(r => r.toolUseId === data.toolUseId)) {
-          streamStates.set(sessionId, {
-            ...current,
-            pendingSecretRequests: [...current.pendingSecretRequests, newRequest],
-          })
-          // Invalidate sessions so sidebar picks up awaiting-input state
-          // (redundant safety net for global SSE race condition)
-          queryClient.invalidateQueries({ queryKey: ['sessions'] })
-        }
-      }
-      else if (data.type === 'connected_account_request') {
-        // Agent is requesting access to a connected account
-        const newRequest: ConnectedAccountRequest = {
-          toolUseId: data.toolUseId,
-          toolkit: data.toolkit,
-          reason: data.reason,
-        }
-        if (current && !current.pendingConnectedAccountRequests.some(r => r.toolUseId === data.toolUseId)) {
-          streamStates.set(sessionId, {
-            ...current,
-            pendingConnectedAccountRequests: [...current.pendingConnectedAccountRequests, newRequest],
-          })
-          queryClient.invalidateQueries({ queryKey: ['sessions'] })
-        }
-      }
-      else if (data.type === 'user_question_request') {
-        // Agent is asking the user questions
-        const newRequest: QuestionRequest = {
-          toolUseId: data.toolUseId,
-          questions: data.questions,
-        }
-        if (current && !current.pendingQuestionRequests.some(r => r.toolUseId === data.toolUseId)) {
-          streamStates.set(sessionId, {
-            ...current,
-            pendingQuestionRequests: [...current.pendingQuestionRequests, newRequest],
-          })
-          queryClient.invalidateQueries({ queryKey: ['sessions'] })
-        }
-      }
       else if (data.type === 'capability_review_request') {
         // A subagent/workflow launch is paused awaiting the user's decision
         const newRequest: CapabilityReviewRequest = {
@@ -1086,38 +919,6 @@ function getOrCreateEventSource(
           })
         }
       }
-      else if (data.type === 'file_request') {
-        // Agent is requesting a file from the user
-        const newRequest: FileRequest = {
-          toolUseId: data.toolUseId,
-          description: data.description,
-          fileTypes: data.fileTypes,
-        }
-        if (current && !current.pendingFileRequests.some(r => r.toolUseId === data.toolUseId)) {
-          streamStates.set(sessionId, {
-            ...current,
-            pendingFileRequests: [...current.pendingFileRequests, newRequest],
-          })
-          queryClient.invalidateQueries({ queryKey: ['sessions'] })
-        }
-      }
-      else if (data.type === 'remote_mcp_request') {
-        // Agent is requesting access to a remote MCP server
-        const newRequest: RemoteMcpRequest = {
-          toolUseId: data.toolUseId,
-          url: data.url,
-          name: data.name,
-          reason: data.reason,
-          authHint: data.authHint,
-        }
-        if (current && !current.pendingRemoteMcpRequests.some(r => r.toolUseId === data.toolUseId)) {
-          streamStates.set(sessionId, {
-            ...current,
-            pendingRemoteMcpRequests: [...current.pendingRemoteMcpRequests, newRequest],
-          })
-          queryClient.invalidateQueries({ queryKey: ['sessions'] })
-        }
-      }
       else if (data.type === 'browser_input_request') {
         // Dedupe: the server may broadcast the same toolUseId from multiple detection points
         if (current && !current.pendingBrowserInputRequests.some(r => r.toolUseId === data.toolUseId)) {
@@ -1137,9 +938,10 @@ function getOrCreateEventSource(
         }
       }
       else if (data.type === 'script_run_request') {
-        // Agent is requesting script execution on the host. When `autoApproved` is
-        // true the server is already executing it; we just record the toolUseId so
-        // the messages-based fallback in MessageList knows to suppress its prompt.
+        // Approval cards come from the unified store; this legacy event
+        // matters only for its autoApproved form — the server is already
+        // executing, and the id set suppresses the streaming/message-history
+        // fallback prompt during the window before the result persists.
         if (data.autoApproved) {
           let approved = sessionAutoApprovedScriptRunIds.get(sessionId)
           if (!approved) {
@@ -1148,24 +950,11 @@ function getOrCreateEventSource(
           }
           approved.add(data.toolUseId)
           streamListeners.get(sessionId)?.forEach((l) => l())
-        } else if (current && !current.pendingScriptRunRequests.some(r => r.toolUseId === data.toolUseId)) {
-          const newRequest: ScriptRunRequest = {
-            toolUseId: data.toolUseId,
-            script: data.script,
-            explanation: data.explanation,
-            scriptType: data.scriptType,
-          }
-          streamStates.set(sessionId, {
-            ...current,
-            pendingScriptRunRequests: [...current.pendingScriptRunRequests, newRequest],
-          })
-          queryClient.invalidateQueries({ queryKey: ['sessions'] })
         }
       }
       else if (data.type === 'computer_use_request') {
-        // Agent is requesting computer use on the host. When autoApproved is
-        // true the backend is already executing it; record the id so fallback
-        // recovery does not surface a stale Allow/Deny card.
+        // Same as script_run above: only the autoApproved suppress-set is
+        // fed from the legacy event; approval cards read the unified store.
         if (data.autoApproved) {
           let approved = sessionAutoApprovedComputerUseIds.get(sessionId)
           if (!approved) {
@@ -1174,19 +963,6 @@ function getOrCreateEventSource(
           }
           approved.add(data.toolUseId)
           streamListeners.get(sessionId)?.forEach((l) => l())
-        } else if (current && !current.pendingComputerUseRequests.some(r => r.toolUseId === data.toolUseId)) {
-          const newRequest: ComputerUseRequest = {
-            toolUseId: data.toolUseId,
-            method: data.method,
-            params: data.params || {},
-            permissionLevel: data.permissionLevel,
-            appName: data.appName,
-          }
-          streamStates.set(sessionId, {
-            ...current,
-            pendingComputerUseRequests: [...current.pendingComputerUseRequests, newRequest],
-          })
-          queryClient.invalidateQueries({ queryKey: ['sessions'] })
         }
       }
       else if (data.type === 'compact_start') {
@@ -1496,110 +1272,21 @@ function releaseEventSource(sessionId: string): void {
 // Drop any pending user-input request matching a resolved tool call. Driven by
 // the server's `tool_result` broadcast, which fires for every tool — for ids
 // that never had a request card this is a no-op (no state write, no re-render).
-function removePendingRequestsByToolUseId(sessionId: string, toolUseId: string): void {
+export function removePendingRequestsByToolUseId(sessionId: string, toolUseId: string): void {
   const current = streamStates.get(sessionId)
   if (!current) return
   const strip = <T extends { toolUseId: string }>(list: T[]): T[] =>
     list.some((r) => r.toolUseId === toolUseId) ? list.filter((r) => r.toolUseId !== toolUseId) : list
   const next: StreamState = {
     ...current,
-    pendingSecretRequests: strip(current.pendingSecretRequests),
-    pendingConnectedAccountRequests: strip(current.pendingConnectedAccountRequests),
-    pendingQuestionRequests: strip(current.pendingQuestionRequests),
-    pendingFileRequests: strip(current.pendingFileRequests),
-    pendingRemoteMcpRequests: strip(current.pendingRemoteMcpRequests),
     pendingBrowserInputRequests: strip(current.pendingBrowserInputRequests),
-    pendingScriptRunRequests: strip(current.pendingScriptRunRequests),
-    pendingComputerUseRequests: strip(current.pendingComputerUseRequests),
     pendingCapabilityReviewRequests: strip(current.pendingCapabilityReviewRequests),
   }
   const changed =
-    next.pendingSecretRequests !== current.pendingSecretRequests ||
-    next.pendingConnectedAccountRequests !== current.pendingConnectedAccountRequests ||
-    next.pendingQuestionRequests !== current.pendingQuestionRequests ||
-    next.pendingFileRequests !== current.pendingFileRequests ||
-    next.pendingRemoteMcpRequests !== current.pendingRemoteMcpRequests ||
     next.pendingBrowserInputRequests !== current.pendingBrowserInputRequests ||
-    next.pendingScriptRunRequests !== current.pendingScriptRunRequests ||
-    next.pendingComputerUseRequests !== current.pendingComputerUseRequests ||
     next.pendingCapabilityReviewRequests !== current.pendingCapabilityReviewRequests
   if (changed) {
     streamStates.set(sessionId, next)
-    streamListeners.get(sessionId)?.forEach((listener) => listener())
-  }
-}
-
-// Helper function to remove a secret request from a session
-export function removeSecretRequest(sessionId: string, toolUseId: string): void {
-  const current = streamStates.get(sessionId)
-  if (current) {
-    streamStates.set(sessionId, {
-      ...current,
-      pendingSecretRequests: current.pendingSecretRequests.filter(
-        (r) => r.toolUseId !== toolUseId
-      ),
-    })
-    // Notify listeners
-    streamListeners.get(sessionId)?.forEach((listener) => listener())
-  }
-}
-
-// Helper function to remove a connected account request from a session
-export function removeConnectedAccountRequest(sessionId: string, toolUseId: string): void {
-  const current = streamStates.get(sessionId)
-  if (current) {
-    streamStates.set(sessionId, {
-      ...current,
-      pendingConnectedAccountRequests: current.pendingConnectedAccountRequests.filter(
-        (r) => r.toolUseId !== toolUseId
-      ),
-    })
-    // Notify listeners
-    streamListeners.get(sessionId)?.forEach((listener) => listener())
-  }
-}
-
-// Helper function to remove a file request from a session
-export function removeFileRequest(sessionId: string, toolUseId: string): void {
-  const current = streamStates.get(sessionId)
-  if (current) {
-    streamStates.set(sessionId, {
-      ...current,
-      pendingFileRequests: current.pendingFileRequests.filter(
-        (r) => r.toolUseId !== toolUseId
-      ),
-    })
-    // Notify listeners
-    streamListeners.get(sessionId)?.forEach((listener) => listener())
-  }
-}
-
-// Helper function to remove a question request from a session
-export function removeQuestionRequest(sessionId: string, toolUseId: string): void {
-  const current = streamStates.get(sessionId)
-  if (current) {
-    streamStates.set(sessionId, {
-      ...current,
-      pendingQuestionRequests: current.pendingQuestionRequests.filter(
-        (r) => r.toolUseId !== toolUseId
-      ),
-    })
-    // Notify listeners
-    streamListeners.get(sessionId)?.forEach((listener) => listener())
-  }
-}
-
-// Helper function to remove a remote MCP request from a session
-export function removeRemoteMcpRequest(sessionId: string, toolUseId: string): void {
-  const current = streamStates.get(sessionId)
-  if (current) {
-    streamStates.set(sessionId, {
-      ...current,
-      pendingRemoteMcpRequests: current.pendingRemoteMcpRequests.filter(
-        (r) => r.toolUseId !== toolUseId
-      ),
-    })
-    // Notify listeners
     streamListeners.get(sessionId)?.forEach((listener) => listener())
   }
 }
@@ -1611,34 +1298,6 @@ export function removeBrowserInputRequest(sessionId: string, toolUseId: string):
     streamStates.set(sessionId, {
       ...current,
       pendingBrowserInputRequests: current.pendingBrowserInputRequests.filter(
-        (r) => r.toolUseId !== toolUseId
-      ),
-    })
-    streamListeners.get(sessionId)?.forEach((listener) => listener())
-  }
-}
-
-// Helper function to remove a script run request from a session
-export function removeScriptRunRequest(sessionId: string, toolUseId: string): void {
-  const current = streamStates.get(sessionId)
-  if (current) {
-    streamStates.set(sessionId, {
-      ...current,
-      pendingScriptRunRequests: current.pendingScriptRunRequests.filter(
-        (r) => r.toolUseId !== toolUseId
-      ),
-    })
-    streamListeners.get(sessionId)?.forEach((listener) => listener())
-  }
-}
-
-// Helper function to remove a computer use request from a session
-export function removeComputerUseRequest(sessionId: string, toolUseId: string): void {
-  const current = streamStates.get(sessionId)
-  if (current) {
-    streamStates.set(sessionId, {
-      ...current,
-      pendingComputerUseRequests: current.pendingComputerUseRequests.filter(
         (r) => r.toolUseId !== toolUseId
       ),
     })

--- a/src/renderer/test/mock-stream.ts
+++ b/src/renderer/test/mock-stream.ts
@@ -3,22 +3,7 @@ export interface MockStreamState {
   isStreaming: boolean
   streamingMessage: string | null
   streamingToolUses: Array<{ id: string; name: string; partialInput: string; ready?: boolean }>
-  pendingSecretRequests: Array<{ toolUseId: string; secretName: string; reason?: string }>
-  pendingConnectedAccountRequests: Array<{ toolUseId: string; toolkit: string; reason?: string }>
-  pendingQuestionRequests: Array<{
-    toolUseId: string
-    questions: Array<{
-      question: string
-      header: string
-      options: Array<{ label: string; description: string }>
-      multiSelect: boolean
-    }>
-  }>
-  pendingFileRequests: Array<{ toolUseId: string; description: string; fileTypes?: string }>
-  pendingRemoteMcpRequests: Array<{ toolUseId: string; url: string; name?: string; reason?: string }>
   pendingBrowserInputRequests: Array<{ toolUseId: string; message: string; requirements: string[] }>
-  pendingScriptRunRequests: Array<{ toolUseId: string; script: string; explanation: string; scriptType: 'applescript' | 'shell' | 'powershell' }>
-  pendingComputerUseRequests: Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string }>
   autoApprovedScriptRunIds: ReadonlySet<string>
   autoApprovedComputerUseIds: ReadonlySet<string>
   error: string | null
@@ -35,14 +20,7 @@ export const DEFAULT_STREAM_STATE: MockStreamState = {
   isStreaming: false,
   streamingMessage: null,
   streamingToolUses: [],
-  pendingSecretRequests: [],
-  pendingConnectedAccountRequests: [],
-  pendingQuestionRequests: [],
-  pendingFileRequests: [],
-  pendingRemoteMcpRequests: [],
   pendingBrowserInputRequests: [],
-  pendingScriptRunRequests: [],
-  pendingComputerUseRequests: [],
   autoApprovedScriptRunIds: new Set(),
   autoApprovedComputerUseIds: new Set(),
   error: null,

--- a/src/shared/lib/chat-integrations/base-connector.test.ts
+++ b/src/shared/lib/chat-integrations/base-connector.test.ts
@@ -228,7 +228,7 @@ describe('MockChatClientConnector', () => {
   it('records sent cards', async () => {
     const mock = new MockChatClientConnector()
     const event = {
-      type: 'user_question_request' as const,
+      type: 'question_request' as const,
       toolUseId: 'tu-1',
       questions: [{ question: 'Pick one' }],
     }
@@ -236,8 +236,8 @@ describe('MockChatClientConnector', () => {
     await mock.sendUserRequestCard('chat-1', event as any)
 
     expect(mock.sentCards.length).toBe(1)
-    expect(mock.getLastSentCard()?.type).toBe('user_question_request')
-    expect(mock.getCardsOfType('user_question_request').length).toBe(1)
+    expect(mock.getLastSentCard()?.type).toBe('question_request')
+    expect(mock.getCardsOfType('question_request').length).toBe(1)
   })
 
   it('tracks connection state', async () => {

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1538,7 +1538,7 @@ class ChatIntegrationManager {
       : `🔐 *Permission Request*\n${displayText}`
 
     const card = {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: `review:${reviewId}:${agentSlug}`,
       questions: [{
         question: text,
@@ -1989,7 +1989,7 @@ export async function processSSEEvent(
       break
     }
 
-    case 'user_question_request':
+    case 'question_request':
     case 'secret_request':
     case 'file_request':
     case 'connected_account_request':

--- a/src/shared/lib/chat-integrations/finalize-streaming.test.ts
+++ b/src/shared/lib/chat-integrations/finalize-streaming.test.ts
@@ -272,7 +272,7 @@ describe('TelegramConnector.sendUserRequestCard (rich)', () => {
 
   it('sends a single question as rich with an inline keyboard', async () => {
     await connector.sendUserRequestCard('123', {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 't1',
       questions: [{ question: 'Pick one', header: 'Choice', options: [{ label: 'A' }, { label: 'B' }] }],
     } as any)
@@ -290,7 +290,7 @@ describe('TelegramConnector.sendUserRequestCard (rich)', () => {
 
   it('escapes interpolated values so they cannot break the markdown', async () => {
     await connector.sendUserRequestCard('123', {
-      type: 'user_question_request', toolUseId: 't3',
+      type: 'question_request', toolUseId: 't3',
       questions: [{ question: 'needs **admin** rights', options: [{ label: 'A' }] }],
     } as any)
     const md: string = mockSendRich.mock.calls[0][0].rich_message.markdown

--- a/src/shared/lib/chat-integrations/imessage-connector.test.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.test.ts
@@ -148,7 +148,7 @@ describe('IMessageConnector', () => {
 
     it('sends approval card text with reaction instructions', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'review:tool-1',
         questions: [{ question: 'Run command: rm -rf /' }],
       }
@@ -166,7 +166,7 @@ describe('IMessageConnector', () => {
 
     it('tracks the pending approval', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'review:tool-1',
         questions: [{ question: 'Allow this?' }],
       }
@@ -182,7 +182,7 @@ describe('IMessageConnector', () => {
 
     it('uses fallback text when no questions provided', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'review:tool-2',
       }
 
@@ -195,7 +195,7 @@ describe('IMessageConnector', () => {
 
     it('emits allow response on thumbs-up reaction', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'review:tool-1',
         questions: [{ question: 'Allow?' }],
       }
@@ -219,7 +219,7 @@ describe('IMessageConnector', () => {
 
     it('emits deny response on thumbs-down reaction', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'review:tool-1',
         questions: [{ question: 'Allow?' }],
       }
@@ -242,7 +242,7 @@ describe('IMessageConnector', () => {
 
     it('removes pending approval after it is resolved', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'review:tool-1',
         questions: [{ question: 'Allow?' }],
       }
@@ -272,7 +272,7 @@ describe('IMessageConnector', () => {
 
     it('formats question with numbered options', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-1',
         questions: [{
           question: 'Pick a color',
@@ -298,7 +298,7 @@ describe('IMessageConnector', () => {
 
     it('includes option descriptions when present', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-2',
         questions: [{
           question: 'Choose a plan',
@@ -318,7 +318,7 @@ describe('IMessageConnector', () => {
 
     it('includes header when present', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-3',
         questions: [{
           header: 'Configuration',
@@ -335,7 +335,7 @@ describe('IMessageConnector', () => {
 
     it('renders "(No question provided)" when questions array is empty', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-4',
         questions: [],
       }
@@ -348,7 +348,7 @@ describe('IMessageConnector', () => {
 
     it('tracks pending question', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-5',
         questions: [{
           question: 'Pick one',
@@ -365,7 +365,7 @@ describe('IMessageConnector', () => {
 
     it('resolves question by number', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-6',
         questions: [{
           question: 'Pick a color',
@@ -398,7 +398,7 @@ describe('IMessageConnector', () => {
 
     it('resolves question by exact label (case-insensitive)', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-7',
         questions: [{
           question: 'Pick a color',
@@ -426,7 +426,7 @@ describe('IMessageConnector', () => {
 
     it('resolves question with raw text when no match', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-8',
         questions: [{
           question: 'Pick a color',
@@ -454,7 +454,7 @@ describe('IMessageConnector', () => {
 
     it('does not emit a regular message when answering a question', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-9',
         questions: [{
           question: 'Pick one',
@@ -480,7 +480,7 @@ describe('IMessageConnector', () => {
 
     it('removes pending question after resolution', async () => {
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'q-10',
         questions: [{
           question: 'Pick one',
@@ -715,7 +715,7 @@ describe('IMessageConnector', () => {
       wireUp(connector)
 
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'review:tool-A',
         questions: [{ question: 'Allow A?' }],
       }
@@ -773,7 +773,7 @@ describe('IMessageConnector', () => {
       wireUp(connector)
 
       const event = {
-        type: 'user_question_request' as const,
+        type: 'question_request' as const,
         toolUseId: 'review:tool-C',
         questions: [{ question: 'Allow?' }],
       }

--- a/src/shared/lib/chat-integrations/imessage-connector.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.ts
@@ -348,7 +348,7 @@ export class IMessageConnector extends ChatClientConnector {
     }
 
     switch (event.type) {
-      case 'user_question_request': {
+      case 'question_request': {
         // Handle proxy review requests (approval cards)
         if (event.toolUseId.startsWith('review:')) {
           return this.sendApprovalCard(event, targetChatId)

--- a/src/shared/lib/chat-integrations/indicator-sleep.test.ts
+++ b/src/shared/lib/chat-integrations/indicator-sleep.test.ts
@@ -412,7 +412,7 @@ describe('settle handlers clear instantly but defer the sleep to the tick', () =
       vi.spyOn(messagePersister, 'getSessionActivity').mockReturnValue('awaiting')
 
       startIndicatorTick(managed, 'sess-q')
-      await processSSEEvent(managed, { type: 'user_question_request', toolUseId: 'tu-1', questions: [{ question: 'Which DB?' }] })
+      await processSSEEvent(managed, { type: 'question_request', toolUseId: 'tu-1', questions: [{ question: 'Which DB?' }] })
       expect(managed.sleepTimer).toBeFalsy()               // handler schedules nothing
       await vi.advanceTimersByTimeAsync(INDICATOR_TICK_MS)  // tick arms the sleep (awaiting = non-busy)
       await vi.advanceTimersByTimeAsync(INDICATOR_SLEEP_MS)

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.test.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.test.ts
@@ -33,7 +33,7 @@ describe('consumeOrCancelAwaitingInput', () => {
   it('resolves an open question with plain text and consumes the message (no cancel/dismiss)', async () => {
     const { rec, persister, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+      pending: [{ type: 'question_request', toolUseId: 't1' }],
       answerResult: true,
     })
     const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'my answer', hasFiles: false, persister, connector })
@@ -45,7 +45,7 @@ describe('consumeOrCancelAwaitingInput', () => {
   it('resolves with the raw answerText, not the group-prefixed messageText, when both are given', async () => {
     const { rec, persister, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+      pending: [{ type: 'question_request', toolUseId: 't1' }],
       answerResult: true,
     })
     // messageText carries the `\[Alice]: ` sender prefix (for the fresh-turn forward); the answer
@@ -65,7 +65,7 @@ describe('consumeOrCancelAwaitingInput', () => {
   it('cancels and dismisses when the open question declines the typed text', async () => {
     const { rec, persister, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+      pending: [{ type: 'question_request', toolUseId: 't1' }],
       answerResult: false,
     })
     const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'redirect me', hasFiles: false, persister, connector })
@@ -76,7 +76,7 @@ describe('consumeOrCancelAwaitingInput', () => {
   it('does not attempt to answer with a file/non-text message — cancels and dismisses', async () => {
     const { rec, persister, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+      pending: [{ type: 'question_request', toolUseId: 't1' }],
     })
     const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'caption', hasFiles: true, persister, connector })
     expect(consumed).toBe(false)
@@ -103,7 +103,7 @@ describe('consumeOrCancelAwaitingInput', () => {
   it('treats a whitespace-only message as non-text and does not answer', async () => {
     const { rec, persister, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'user_question_request', toolUseId: 't1' }],
+      pending: [{ type: 'question_request', toolUseId: 't1' }],
     })
     const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: '   ', hasFiles: false, persister, connector })
     expect(consumed).toBe(false)

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
@@ -48,7 +48,7 @@ export async function consumeOrCancelAwaitingInput(opts: {
   if (isPlainText && persister.isSessionAwaitingInput(sessionId)) {
     const pendingQuestion = persister
       .getPendingInputRequests(sessionId)
-      .find((r) => r.type === 'user_question_request')
+      .find((r) => r.type === 'question_request')
     if (pendingQuestion) {
       const answered = await connector.answerOpenQuestionWithText(chatId, pendingQuestion.toolUseId, answerText ?? messageText)
       if (answered) return true

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -852,7 +852,7 @@ export class SlackConnector extends ChatClientConnector {
     }
 
     switch (event.type) {
-      case 'user_question_request': {
+      case 'question_request': {
         let lastTs = ''
 
         // Track multi-question requests

--- a/src/shared/lib/chat-integrations/sse-error-resilience.test.ts
+++ b/src/shared/lib/chat-integrations/sse-error-resilience.test.ts
@@ -190,7 +190,7 @@ describe('tool_use_start error resilience', () => {
 
 describe('user request card error resilience', () => {
   const requestTypes = [
-    'user_question_request',
+    'question_request',
     'secret_request',
     'file_request',
     'connected_account_request',
@@ -218,7 +218,7 @@ describe('user request card error resilience', () => {
     mock.sendUserRequestCard = async () => { throw new Error('card send failed') }
 
     // Card fails
-    await processSSEEvent(managed, { type: 'user_question_request', toolUseId: 'tu-1' })
+    await processSSEEvent(managed, { type: 'question_request', toolUseId: 'tu-1' })
     // Streaming still works
     await processSSEEvent(managed, { type: 'stream_delta', text: 'After card failure' })
 
@@ -337,7 +337,7 @@ describe('pipeline isolation', () => {
     }
 
     // Process a card event (fails), then a streaming event (should succeed)
-    await processSSEEvent(managed, { type: 'user_question_request', toolUseId: 'tu-1' })
+    await processSSEEvent(managed, { type: 'question_request', toolUseId: 'tu-1' })
     await processSSEEvent(managed, { type: 'stream_delta', text: 'Still works' })
 
     expect(managed.streamingState.accumulatedText).toBe('Still works')

--- a/src/shared/lib/chat-integrations/sse-event-processing.test.ts
+++ b/src/shared/lib/chat-integrations/sse-event-processing.test.ts
@@ -298,16 +298,16 @@ describe('processSSEEvent', () => {
       expect(mock.sentMessages.length).toBe(0) // no tool summary
     })
 
-    it('forwards user_question_request to sendUserRequestCard', async () => {
+    it('forwards question_request to sendUserRequestCard', async () => {
       await processSSEEvent(managed, {
-        type: 'user_question_request',
+        type: 'question_request',
         toolUseId: 'tu-1',
         questions: [{ question: 'Which DB?' }],
       })
 
       const mock = getMock(managed)
       expect(mock.sentCards.length).toBe(1)
-      expect(mock.sentCards[0].event.type).toBe('user_question_request')
+      expect(mock.sentCards[0].event.type).toBe('question_request')
     })
 
     it('forwards secret_request to sendUserRequestCard', async () => {
@@ -1136,7 +1136,7 @@ describe('processSSEEvent: immediate clears', () => {
   })
 
   const cardTypes = [
-    'user_question_request',
+    'question_request',
     'secret_request',
     'file_request',
     'connected_account_request',

--- a/src/shared/lib/chat-integrations/telegram-connector.test.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.test.ts
@@ -321,7 +321,7 @@ describe('TelegramConnector — AskUserQuestion multi-select', () => {
 
   function multiSelectEvent(): any {
     return {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-multi',
       questions: [{
         question: 'Pick your stack',
@@ -341,7 +341,7 @@ describe('TelegramConnector — AskUserQuestion multi-select', () => {
 
   it('single-select question renders tap-to-resolve buttons with no Done (unchanged)', async () => {
     await (connector as any).sendUserRequestCard('123', {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-single',
       questions: [{ question: 'Which one?', options: [{ label: 'A' }, { label: 'B' }] }],
     })
@@ -418,7 +418,7 @@ describe('TelegramConnector — typed message answers an open question (Other)',
 
   function singleQuestionEvent(toolUseId = 'tu-q'): any {
     return {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId,
       questions: [{ question: 'Which database?', options: [{ label: 'Postgres' }, { label: 'MySQL' }] }],
     }
@@ -437,7 +437,7 @@ describe('TelegramConnector — typed message answers an open question (Other)',
     // No options -> no keyboard, but openQuestionCard is still set (cbIds:[]) so a typed message
     // is the only way to answer. This is the core "honest Other" path.
     await (connector as any).sendUserRequestCard('123', {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-open',
       questions: [{ question: 'What should I name the file?' }],
     })
@@ -462,7 +462,7 @@ describe('TelegramConnector — typed message answers an open question (Other)',
 
   it('multi-question sub-card tap rebuilds its confirmation from the stored sub-card question text', async () => {
     await (connector as any).sendUserRequestCard('123', {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-mq2',
       questions: [
         { question: 'Q1 pick', options: [{ label: 'A' }, { label: 'B' }] },
@@ -482,7 +482,7 @@ describe('TelegramConnector — typed message answers an open question (Other)',
     // Card A: single-question (lives in openQuestionCard). Card B: multi-question (pendingQuestions).
     await (connector as any).sendUserRequestCard('123', singleQuestionEvent('tu-a')) // sent[0], msg 1001
     await (connector as any).sendUserRequestCard('123', {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-b',
       questions: [
         { question: 'B1', options: [{ label: 'X' }] }, // sent[1], msg 1002
@@ -511,7 +511,7 @@ describe('TelegramConnector — typed message answers an open question (Other)',
 
   it('returns false for a multi-question card (v1 falls through to cancel)', async () => {
     await (connector as any).sendUserRequestCard('123', {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-mq',
       questions: [
         { question: 'Q1', options: [{ label: 'A' }] },
@@ -554,7 +554,7 @@ describe('TelegramConnector — typed message answers an open question (Other)',
 
   it('a stale sibling tap on the last sub-question of a multi-question card does not double-emit', async () => {
     await (connector as any).sendUserRequestCard('123', {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-mq',
       questions: [
         { question: 'Q1', options: [{ label: 'A' }, { label: 'B' }] },
@@ -583,14 +583,14 @@ describe('TelegramConnector — dismissOpenCards (cancel strips abandoned cards)
 
   function singleQuestionEvent(toolUseId = 'tu-q'): any {
     return {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId,
       questions: [{ question: 'Which database?', options: [{ label: 'Postgres' }, { label: 'MySQL' }] }],
     }
   }
   function multiSelectEvent(): any {
     return {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-multi',
       questions: [{ question: 'Pick your stack', multiSelect: true, options: [{ label: 'Redis' }, { label: 'S3' }] }],
     }
@@ -620,7 +620,7 @@ describe('TelegramConnector — dismissOpenCards (cancel strips abandoned cards)
 
   it('strips every sub-card of a multi-question card and invalidates their callbacks', async () => {
     await (connector as any).sendUserRequestCard('123', {
-      type: 'user_question_request',
+      type: 'question_request',
       toolUseId: 'tu-mq',
       questions: [
         { question: 'Q1', options: [{ label: 'A' }, { label: 'B' }] },

--- a/src/shared/lib/chat-integrations/telegram-connector.ts
+++ b/src/shared/lib/chat-integrations/telegram-connector.ts
@@ -510,7 +510,7 @@ export class TelegramConnector extends ChatClientConnector {
     }
 
     switch (event.type) {
-      case 'user_question_request': {
+      case 'question_request': {
         let lastMessageId = ''
 
         // Track multi-question requests so we wait for all answers

--- a/src/shared/lib/chat-integrations/utils.test.ts
+++ b/src/shared/lib/chat-integrations/utils.test.ts
@@ -135,8 +135,8 @@ describe('isUnsupportedInChat / describeUnsupportedRequest', () => {
     expect(describeUnsupportedRequest(event, desktopContext)).toContain('desktop')
   })
 
-  it('does not flag user_question_request as unsupported', () => {
-    const event: UserRequestEvent = { type: 'user_question_request', toolUseId: 't2', questions: [] }
+  it('does not flag question_request as unsupported', () => {
+    const event: UserRequestEvent = { type: 'question_request', toolUseId: 't2', questions: [] }
     expect(isUnsupportedInChat(event)).toBe(false)
   })
 

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -48,6 +48,7 @@ vi.mock('@shared/lib/notifications/notification-manager', () => ({
   notificationManager: {
     triggerSessionComplete: vi.fn(() => Promise.resolve()),
     triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+    triggerSessionApiReviewWaiting: vi.fn(() => Promise.resolve()),
   },
 }))
 
@@ -235,7 +236,7 @@ const STANDARD_KINDS: RequestKindCase[] = [
     input: {
       questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
     },
-    sseType: 'user_question_request',
+    sseType: 'question_request',
     waitingFor: 'question',
   },
   {
@@ -685,7 +686,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       input: {
         questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
       },
-      sseType: 'user_question_request',
+      sseType: 'question_request',
       surfacesToday: true,
     },
     {
@@ -934,7 +935,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
   describe('shadow registry equivalence', () => {
     const KIND_BY_SSE_TYPE: Record<string, string> = {
       secret_request: 'secret',
-      user_question_request: 'question',
+      question_request: 'question',
       connected_account_request: 'connected_account',
       file_request: 'file',
       remote_mcp_request: 'remote_mcp',
@@ -1686,6 +1687,99 @@ describe('pending user-input request lifecycle (characterization)', () => {
       userInputRequestManager.resolve('wire-snap-review', 'answered')
       sendToolResult('wire-snap-1')
       expect(userInputRequestManager.getSnapshotForScope(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // Notification dispatch is driven by registry transitions
+  // ==========================================================================
+
+  describe('notification dispatch (registry-transition-driven)', () => {
+    it('duplicate deliveries of the same request notify exactly ONCE', () => {
+      // The subagent stream and the complete-assistant message can both carry
+      // the same tool_use. The registry dedupes the ENTRY (first delivery
+      // wins), and the notification must ride that dedupe — per-handler
+      // triggering used to pop two OS notifications for one script approval.
+      const input = { script: 'sw_vers', explanation: 'Version check', scriptType: 'shell' }
+      const send = (via: 'stream' | 'complete') => {
+        if (via === 'complete') {
+          mockClient._sendMessage({
+            type: 'assistant',
+            parent_tool_use_id: 'parent-notif-1',
+            message: {
+              content: [
+                { type: 'tool_use', id: 'notif-dup-1', name: 'mcp__user-input__request_script_run', input },
+              ],
+            },
+          })
+          return
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const sendEvent = (event: any) =>
+          mockClient._sendMessage({ type: 'stream_event', parent_tool_use_id: 'parent-notif-1', event })
+        sendEvent({
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', id: 'notif-dup-1', name: 'mcp__user-input__request_script_run' },
+        })
+        sendEvent({
+          type: 'content_block_delta',
+          delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+        })
+        sendEvent({ type: 'content_block_stop' })
+      }
+
+      send('stream')
+      send('complete')
+
+      const triggerSpy = vi.mocked(notificationManager.triggerSessionWaitingInput)
+      const forThisRequest = triggerSpy.mock.calls.filter(
+        ([, , waitingFor]) => waitingFor === 'script_run',
+      )
+      expect(forThisRequest).toHaveLength(1)
+      expect(forThisRequest[0]).toEqual([SESSION_ID, AGENT_SLUG, 'script_run'])
+    })
+
+    it('a review registered directly with the registry notifies like any other review', () => {
+      // Since the registry became the pending-review store, registry-only
+      // entries are decidable and sweepable — they must be noticeable too.
+      userInputRequestManager.register({
+        id: 'notif-review-1',
+        kind: 'proxy_review',
+        scope: { agentSlug: AGENT_SLUG },
+        blocking: true,
+        autoApproved: false,
+        payload: { displayText: 'GET api.github.com /user' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      expect(notificationManager.triggerSessionApiReviewWaiting).toHaveBeenCalledExactlyOnceWith(
+        SESSION_ID,
+        AGENT_SLUG,
+        'notif-review-1',
+        'GET api.github.com /user',
+        undefined,
+        'api_request',
+      )
+    })
+
+    it('a recovered synthetic does not notify; its real upgrade notifies once', () => {
+      userInputRequestManager.register({
+        id: 'notif-rec-1',
+        kind: 'secret',
+        scope: { agentSlug: AGENT_SLUG, sessionId: SESSION_ID },
+        blocking: true,
+        autoApproved: false,
+        payload: { recovered: true },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      const triggerSpy = vi.mocked(notificationManager.triggerSessionWaitingInput)
+      expect(triggerSpy).not.toHaveBeenCalled()
+
+      simulateToolUse('mcp__user-input__request_secret', 'notif-rec-1', {
+        secretName: 'API_KEY',
+        reason: 'Recovered then streamed',
+      })
+      expect(triggerSpy.mock.calls.filter(([, , w]) => w === 'secret')).toHaveLength(1)
     })
   })
 })

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -973,7 +973,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         expect(
           userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
         ).not.toContain(toolId)
-        expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+        expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
           id: toolId,
           kind: KIND_BY_SSE_TYPE[kindCase.sseType],
           outcome: 'answered',
@@ -998,7 +998,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
       messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-cu-1')
       expect(userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'computer_use')).toEqual([])
-      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-cu-1',
         kind: 'computer_use',
         outcome: 'answered',
@@ -1070,7 +1070,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         ).toContain('shadow-out-1')
       })
       messagePersister.completeCapabilityReview(SESSION_ID, 'shadow-out-1', 'declined')
-      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-out-1',
         kind: 'capability_review',
         outcome: 'declined',
@@ -1079,7 +1079,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       // Computer use denied, then a second one consumed by an execution failure.
       simulateToolUse('mcp__computer-use__computer_click', 'shadow-out-2', { x: 1, y: 2 })
       messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-out-2', 'declined')
-      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-out-2',
         kind: 'computer_use',
         outcome: 'declined',
@@ -1087,7 +1087,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
       simulateToolUse('mcp__computer-use__computer_click', 'shadow-out-3', { x: 3, y: 4 })
       messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-out-3', 'invalidated')
-      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+      expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-out-3',
         kind: 'computer_use',
         outcome: 'invalidated',

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3979,6 +3979,42 @@ describe('MessagePersister', () => {
         vi.unstubAllGlobals()
       }
     })
+
+    it('registers the auto-approved request so the decision gate can let the auto-execute through', async () => {
+      // The /computer-use route only acts on requests the registry holds open.
+      // Auto-approved requests are executed via that same route (the _auto
+      // session), so they must be registered too — flagged autoApproved so no
+      // projection treats them as a user-facing wait, and kept out of the
+      // legacy replay so a reconnecting client never renders an approval card
+      // for a command that is already executing.
+      const originalE2eMock = process.env.E2E_MOCK
+      process.env.E2E_MOCK = 'true'
+      mockCheckPermission.mockReturnValue('granted')
+      vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)))
+
+      try {
+        simulateToolUse('mcp__computer-use__computer_apps', 'tool-cu-granted-reg', {
+          includeHidden: false,
+        })
+
+        await vi.waitFor(() => {
+          const open = userInputRequestManager.getOpenRequest('tool-cu-granted-reg')
+          expect(open).toMatchObject({
+            kind: 'computer_use',
+            blocking: true,
+            autoApproved: true,
+            scope: { agentSlug: AGENT_SLUG, sessionId: SESSION_ID },
+          })
+        })
+
+        expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
+        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      } finally {
+        if (originalE2eMock === undefined) delete process.env.E2E_MOCK
+        else process.env.E2E_MOCK = originalE2eMock
+        vi.unstubAllGlobals()
+      }
+    })
   })
 
   // ============================================================================

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -12,6 +12,7 @@ import { userInputRequestManager, type UserInputRequestTransition } from '@share
 import {
   isReplayableUserInputRequest,
   streamEventToPendingRequest,
+  type PendingUserInputRequest,
   type UserInputRequestOutcome,
 } from '@shared/lib/user-input/request-schema'
 import { classifyResult } from './result-classification'
@@ -274,13 +275,77 @@ class MessagePersister {
 
   constructor() {
     // Unified wire: every registry transition — no matter which of the many
-    // mutation paths drove it — broadcasts ONE typed event, alongside the
-    // legacy per-type events, to the global stream always and to the session
-    // stream when session-scoped. Emitting from the registry's single funnel
-    // (instead of per-callsite) is what makes a silent settle impossible on
-    // this wire. Legacy events keep firing during the client migration.
+    // mutation paths drove it — broadcasts ONE typed event, to the global
+    // stream always and to the session stream when session-scoped. Emitting
+    // from the registry's single funnel (instead of per-callsite) is what
+    // makes a silent settle impossible on this wire. The legacy per-type
+    // events still fire for the chat-integration connectors (in-process
+    // consumers of the same broadcast pipe) and the renderer's browser-tray /
+    // auto-approved-suppression holdouts — see the pending-requests route
+    // comment in agents.ts.
     userInputRequestManager.onTransition((transition) => {
       this.broadcastRequestTransition(transition)
+      // Notifications ride the same funnel: exactly one 'created' per request
+      // id — no matter how many delivery paths carried the tool_use — means
+      // exactly one OS notification. Per-handler triggering used to double-
+      // notify when the subagent stream and the complete-assistant message
+      // both delivered the same request.
+      if (transition.type === 'created') {
+        this.dispatchRequestNotification(transition.request)
+      }
+    })
+  }
+
+  /**
+   * One notification per registered request, driven by the registry 'created'
+   * transition. Replaces the per-handler trigger callsites (nine in this file
+   * plus ReviewManager's).
+   */
+  private dispatchRequestNotification(request: PendingUserInputRequest): void {
+    // Recovered synthetics were notified by the original process before it
+    // died; the recovery stub must not notify again. (Its later upgrade to a
+    // real registration re-emits 'created' — that matches the old behavior,
+    // where the re-streamed tool_use re-ran the handler.)
+    if (!isReplayableUserInputRequest(request)) return
+    // Auto-approved requests are already executing; non-blocking ones are
+    // automation-facing. Neither needs the user's attention.
+    if (!request.blocking || request.autoApproved) return
+    const agentSlug = request.scope.agentSlug
+    if (!agentSlug) return
+
+    if (request.kind === 'proxy_review' || request.kind === 'x_agent_review') {
+      // Reviews are agent-scoped — attribute the notification to the first
+      // active session, the same heuristic the awaiting projection applies.
+      // No active session (a dashboard-triggered review) → no notification;
+      // the dashboard panel is the surface for those.
+      const sessionId = request.scope.sessionId ?? this.getActiveSessionIdsForAgent(agentSlug)[0]
+      if (!sessionId) return
+      const payload = request.payload as { displayText?: unknown }
+      notificationManager
+        .triggerSessionApiReviewWaiting(
+          sessionId,
+          agentSlug,
+          request.id,
+          typeof payload.displayText === 'string' ? payload.displayText : 'API request review',
+          undefined,
+          request.kind === 'x_agent_review' ? 'agent_action' : 'api_request',
+        )
+        .catch((err) => {
+          console.error('[MessagePersister] Failed to trigger API review notification:', err)
+        })
+      return
+    }
+
+    const sessionId = request.scope.sessionId
+    if (!sessionId) return
+    const waitingFor =
+      request.kind === 'capability_review'
+        ? (request.payload as { capability?: unknown }).capability === 'workflows'
+          ? 'capability_review_workflows'
+          : 'capability_review_subagents'
+        : request.kind
+    notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, waitingFor).catch((err) => {
+      console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
     })
   }
 
@@ -592,7 +657,10 @@ class MessagePersister {
   getPendingComputerUseRequests(sessionId: string): Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> {
     return userInputRequestManager
       .getOpenRequestsForSession(sessionId)
-      .filter((r) => r.kind === 'computer_use')
+      // Auto-approved requests are registered only for the decision gate — a
+      // reconnecting client must never be replayed an approval card for a
+      // command that is already executing.
+      .filter((r) => r.kind === 'computer_use' && !r.autoApproved)
       .map((r) => {
         const payload = r.payload as {
           method?: string
@@ -1120,7 +1188,7 @@ class MessagePersister {
   // original one-shot event was missed. Keep in sync with the handlers'
   // broadcast types (INPUT_REQUEST_TYPES).
   private static readonly REQUEST_EVENT_TYPE_BY_TOOL_NAME: Record<string, string> = {
-    AskUserQuestion: 'user_question_request',
+    AskUserQuestion: 'question_request',
     'mcp__user-input__request_secret': 'secret_request',
     'mcp__user-input__request_connected_account': 'connected_account_request',
     'mcp__user-input__request_file': 'file_request',
@@ -1248,7 +1316,7 @@ class MessagePersister {
   private static readonly INPUT_REQUEST_TYPES = new Set([
     'secret_request',
     'connected_account_request',
-    'user_question_request',
+    'question_request',
     'file_request',
     'remote_mcp_request',
     'script_run_request',
@@ -2914,14 +2982,6 @@ class MessagePersister {
         agentSlug,
         ...(parentToolUseId ? { parentToolUseId } : {}),
       })
-
-      // Renderer's notification gate decides whether to show the OS popup
-      // based on focus / per-user viewing / `notifyWhenUnfocused` toggle.
-      if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'secret').catch((err) => {
-          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-        })
-      }
     } catch (error) {
       console.error('[MessagePersister] Error handling secret request:', error)
     }
@@ -2959,13 +3019,6 @@ class MessagePersister {
         agentSlug,
         ...(parentToolUseId ? { parentToolUseId } : {}),
       })
-
-      // Renderer-side gate handles suppression; see session_complete trigger.
-      if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'connected_account').catch((err) => {
-          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-        })
-      }
     } catch (error) {
       console.error('[MessagePersister] Error handling connected account request:', error)
     }
@@ -4151,19 +4204,12 @@ ${continuation}`
 
       // Broadcast the question request event to SSE clients
       this.broadcastToSSE(sessionId, {
-        type: 'user_question_request',
+        type: 'question_request',
         toolUseId,
         questions: input.questions,
         agentSlug,
         ...(parentToolUseId ? { parentToolUseId } : {}),
       })
-
-      // Renderer-side gate handles suppression; see session_complete trigger.
-      if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'question').catch((err) => {
-          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-        })
-      }
     } catch (error) {
       console.error('[MessagePersister] Error handling AskUserQuestion:', error)
     }
@@ -4237,16 +4283,6 @@ ${continuation}`
         agentSlug,
       })
       this.syncSessionAwaiting(sessionId)
-
-      if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(
-          sessionId,
-          agentSlug,
-          capability === 'workflows' ? 'capability_review_workflows' : 'capability_review_subagents'
-        ).catch((err) => {
-          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-        })
-      }
     } catch (error) {
       console.error('[MessagePersister] Error handling capability review:', error)
     }
@@ -4283,13 +4319,6 @@ ${continuation}`
         agentSlug,
         ...(parentToolUseId ? { parentToolUseId } : {}),
       })
-
-      // Renderer-side gate handles suppression; see session_complete trigger.
-      if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'file').catch((err) => {
-          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-        })
-      }
     } catch (error) {
       console.error('[MessagePersister] Error handling file request:', error)
     }
@@ -4328,13 +4357,6 @@ ${continuation}`
         agentSlug,
         ...(parentToolUseId ? { parentToolUseId } : {}),
       })
-
-      // Renderer-side gate handles suppression; see session_complete trigger.
-      if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'remote_mcp').catch((err) => {
-          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-        })
-      }
     } catch (error) {
       console.error('[MessagePersister] Error handling remote MCP request:', error)
     }
@@ -4379,13 +4401,6 @@ ${continuation}`
       // bypass that handler — without this the orange awaiting-input status
       // never flips and the agent shows "working" while parked on the user.
       this.syncSessionAwaiting(sessionId)
-
-      // Renderer-side gate handles suppression; see session_complete trigger.
-      if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'browser_input').catch((err) => {
-          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-        })
-      }
     } catch (error) {
       console.error('[MessagePersister] Error handling browser input request:', error)
     }
@@ -4469,12 +4484,6 @@ ${continuation}`
       // pill in the sidebar / tray) when the user actually has to respond.
       if (!autoApproved) {
         this.syncSessionAwaiting(sessionId)
-        // Renderer-side gate handles suppression; see session_complete trigger.
-        if (agentSlug) {
-          notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'script_run').catch((err) => {
-            console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-          })
-        }
       }
     } catch (error) {
       console.error('[MessagePersister] Error handling script run request:', error)
@@ -4533,9 +4542,23 @@ ${continuation}`
         const permissionResult = computerUsePermissionManager.checkPermission(agentSlug, permissionLevel, appName)
 
         if (permissionResult === 'granted') {
-          // Auto-execute: permission already granted. Broadcast with autoApproved
-          // so clients can suppress streaming/message-history fallback prompts
-          // during the window before the tool result is persisted.
+          // Auto-execute: permission already granted. Registered anyway —
+          // flagged autoApproved so no projection treats it as a user-facing
+          // wait — because the /computer-use route's already-settled gate only
+          // acts on requests the registry holds open, and auto-execution goes
+          // through that same route.
+          userInputRequestManager.register({
+            id: toolUseId,
+            kind: 'computer_use',
+            scope: { agentSlug, sessionId },
+            blocking: true,
+            autoApproved: true,
+            parentToolUseId,
+            payload: { method, params, permissionLevel, appName },
+          })
+          // Broadcast with autoApproved so clients can suppress streaming/
+          // message-history fallback prompts during the window before the
+          // tool result is persisted.
           this.broadcastToSSE(sessionId, {
             type: 'computer_use_request',
             toolUseId,
@@ -4575,13 +4598,6 @@ ${continuation}`
         agentSlug,
         autoApproved: false,
       })
-
-      // Renderer-side gate handles suppression; see session_complete trigger.
-      if (agentSlug) {
-        notificationManager.triggerSessionWaitingInput(sessionId, agentSlug, 'computer_use').catch((err) => {
-          console.error('[MessagePersister] Failed to trigger waiting input notification:', err)
-        })
-      }
     } catch (error) {
       console.error('[MessagePersister] Error handling computer use request:', error)
     }

--- a/src/shared/lib/proxy/review-manager.test.ts
+++ b/src/shared/lib/proxy/review-manager.test.ts
@@ -740,7 +740,7 @@ describe('ReviewManager shadow registry write-through (Phase 2)', () => {
     manager.submitDecision(reviewId, 'allow')
     await promise
     expect(userInputRequestManager.getAgentScopedRequests('shadow-agent')).toHaveLength(0)
-    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
       id: reviewId,
       kind: 'proxy_review',
       outcome: 'answered',
@@ -754,7 +754,7 @@ describe('ReviewManager shadow registry write-through (Phase 2)', () => {
 
     vi.advanceTimersByTime(5 * 60 * 1000)
     await expect(promise).rejects.toThrow('Review timeout')
-    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
       id: reviewId,
       kind: 'proxy_review',
       outcome: 'timeout',
@@ -769,7 +769,7 @@ describe('ReviewManager shadow registry write-through (Phase 2)', () => {
 
     controller.abort()
     await expect(promise).rejects.toThrow('Request aborted')
-    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
       id: reviewId,
       kind: 'proxy_review',
       outcome: 'cancelled',
@@ -860,7 +860,7 @@ describe('ReviewManager as registry adapter (Phase 5)', () => {
     registerRegistryOnlyReview('registry-review-2')
     expect(manager.submitDecision('registry-review-2', 'allow')).toBe(true)
     expect(userInputRequestManager.getAgentScopedRequests('adapter-agent')).toHaveLength(0)
-    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toEqual({
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
       id: 'registry-review-2',
       kind: 'proxy_review',
       outcome: 'answered',

--- a/src/shared/lib/proxy/review-manager.ts
+++ b/src/shared/lib/proxy/review-manager.ts
@@ -2,7 +2,6 @@ import crypto from 'crypto'
 import { broadcastReview } from './review-broadcast'
 import { getScopeLabel, type ScopeLabel } from './scope-metadata'
 import { messagePersister } from '@shared/lib/container/message-persister'
-import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
 
@@ -289,23 +288,9 @@ export class ReviewManager {
       // registry entry registered above is what flips them.
       messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
 
-      // Fire ONE OS notification per review, attributed to the first active
-      // session of this agent. The proxy call is agent-scoped (no sessionId
-      // in the request), so we pick an active session — same attribution
-      // heuristic the awaiting projection applies (an agent-scoped review
-      // blocks the agent's active sessions). Whether the OS popup actually
-      // shows is the renderer's call — it knows OS focus + per-user viewing
-      // + `notifyWhenUnfocused`. An open SSE connection ≠ actively looking
-      // at the screen.
-      const targetSessionId = messagePersister.getActiveSessionIdsForAgent(details.agentSlug)[0]
-      if (targetSessionId) {
-        const kind = details.xAgent ? 'agent_action' : 'api_request'
-        notificationManager
-          .triggerSessionApiReviewWaiting(targetSessionId, details.agentSlug, id, displayText, undefined, kind)
-          .catch((err) => {
-            console.error('[ReviewManager] Failed to trigger API review notification:', err)
-          })
-      }
+      // The OS notification fires from the registry 'created' transition
+      // (persister dispatchRequestNotification) — one per review, attributed
+      // to the agent's first active session there.
     })
   }
 

--- a/src/shared/lib/tool-definitions/types.ts
+++ b/src/shared/lib/tool-definitions/types.ts
@@ -45,7 +45,7 @@ export interface Question {
 
 export type UserRequestEvent =
   | {
-      type: 'user_question_request'
+      type: 'question_request'
       toolUseId: string
       questions: Question[]
       agentSlug?: string

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -109,9 +109,35 @@ describe('UserInputRequestManager', () => {
       const resolved = manager.resolve('tool-1', 'answered')
       expect(resolved?.kind).toBe('secret')
       expect(manager.stats.open).toBe(0)
+      // Kind AND scope survive on the trail: a settled request stays as
+      // route-bound as it was open, so the decision gate can validate it.
       expect(manager.stats.recentResolutions).toEqual([
-        { id: 'tool-1', kind: 'secret', outcome: 'answered' },
+        {
+          id: 'tool-1',
+          kind: 'secret',
+          scope: { agentSlug: 'agent-a', sessionId: 'session-1' },
+          outcome: 'answered',
+        },
       ])
+    })
+
+    it('getRecentResolution returns the settled record, newest first, then nothing', () => {
+      expect(manager.getRecentResolution('tool-1')).toBeUndefined()
+      manager.register(secretRequest())
+      manager.resolve('tool-1', 'declined')
+      expect(manager.getRecentResolution('tool-1')).toEqual({
+        id: 'tool-1',
+        kind: 'secret',
+        scope: { agentSlug: 'agent-a', sessionId: 'session-1' },
+        outcome: 'declined',
+      })
+      // Re-registration under a different scope wins the trail on settlement.
+      manager.register(secretRequest({ scope: { agentSlug: 'agent-b', sessionId: 'session-2' } }))
+      manager.resolve('tool-1', 'answered')
+      expect(manager.getRecentResolution('tool-1')).toMatchObject({
+        scope: { agentSlug: 'agent-b', sessionId: 'session-2' },
+        outcome: 'answered',
+      })
     })
 
     it('is idempotent: unknown ids are a no-op returning null', () => {

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -4,6 +4,7 @@ import {
   type PendingUserInputRequest,
   type PendingUserInputRequestInput,
   type UserInputRequestOutcome,
+  type UserInputRequestScope,
   type UserInputRequestStore,
 } from './request-schema'
 
@@ -33,17 +34,32 @@ export interface UserInputRequestTransition {
   outcome?: UserInputRequestOutcome
 }
 
+/**
+ * A settled request as the bounded resolution trail remembers it: enough
+ * identity (kind + scope) to re-run the same authorization checks an open
+ * request gets, plus how it settled.
+ */
+export interface SettledUserInputRequest {
+  id: string
+  kind: PendingUserInputRequest['kind']
+  scope: UserInputRequestScope
+  outcome: UserInputRequestOutcome
+}
+
 export class UserInputRequestManager {
   private requests = new Map<string, PendingUserInputRequest>()
 
   private transitionListeners = new Set<(transition: UserInputRequestTransition) => void>()
 
-  /** Bounded trail of recent settlements, for shadow-mode debugging and tests. */
-  private recentResolutions: Array<{
-    id: string
-    kind: PendingUserInputRequest['kind']
-    outcome: UserInputRequestOutcome
-  }> = []
+  /**
+   * Bounded trail of recent settlements, for shadow-mode debugging and tests.
+   * Carries kind AND scope, not just the outcome: the decision routes' gate
+   * validates a settled request exactly like an open one, so a settled id must
+   * stay as tightly bound to its route as it was while open — otherwise the
+   * moment a request settles, its outcome becomes readable through any agent's
+   * route of any kind.
+   */
+  private recentResolutions: SettledUserInputRequest[] = []
 
   private storeMismatchCount = 0
 
@@ -88,7 +104,7 @@ export class UserInputRequestManager {
     const request = this.requests.get(id)
     if (!request) return null
     this.requests.delete(id)
-    this.recentResolutions.push({ id, kind: request.kind, outcome })
+    this.recentResolutions.push({ id, kind: request.kind, scope: request.scope, outcome })
     if (this.recentResolutions.length > 100) this.recentResolutions.shift()
     this.emitTransition({ type: 'resolved', request, outcome })
     return request
@@ -170,13 +186,16 @@ export class UserInputRequestManager {
   }
 
   /**
-   * The outcome a request settled with, while it is still on the bounded
-   * resolution trail. Lets an already-settled decision answer with what
-   * actually happened instead of a bare "already settled".
+   * How a request settled, while it is still on the bounded resolution trail.
+   * Lets an already-settled decision answer with what actually happened
+   * instead of a bare "already settled" — but the caller must first check the
+   * returned kind and scope against the route it arrived on, exactly as it
+   * would for an open request. Once the trail rotates the record out, the id
+   * is indistinguishable from one that never existed.
    */
-  getRecentResolutionOutcome(id: string): UserInputRequestOutcome | undefined {
+  getRecentResolution(id: string): SettledUserInputRequest | undefined {
     for (let i = this.recentResolutions.length - 1; i >= 0; i--) {
-      if (this.recentResolutions[i].id === id) return this.recentResolutions[i].outcome
+      if (this.recentResolutions[i].id === id) return this.recentResolutions[i]
     }
     return undefined
   }
@@ -326,11 +345,7 @@ export class UserInputRequestManager {
   get stats(): {
     open: number
     storeMismatches: number
-    recentResolutions: Array<{
-      id: string
-      kind: PendingUserInputRequest['kind']
-      outcome: UserInputRequestOutcome
-    }>
+    recentResolutions: SettledUserInputRequest[]
   } {
     return {
       open: this.requests.size,

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -8,16 +8,17 @@ import {
 } from './request-schema'
 
 /**
- * Host-side registry of every pending user-input request, regardless of which
- * legacy store owns it (persister stream store, computer-use map, ReviewManager).
+ * Host-side registry of every pending user-input request — THE single pending
+ * store. Computer-use and review requests live only here; stream kinds keep a
+ * write-through mirror in the persister's per-session replay store
+ * (`pendingInputRequests`, verified by `verifyStoreParity`) because the
+ * legacy chat-integration events replay from it verbatim.
  *
- * Phase 3: the legacy stores stay authoritative for request CONTENTS (and
- * every mutation still writes through, with `verifyStoreParity` asserting the
- * mirror is exact), but the session "awaiting input" status is now DERIVED
- * from this registry via `isSessionAwaiting` — the persister's bit is just an
- * edge-detection cache of that projection. The imperative per-path mark/clear
- * calls (and their split-brains: parallel requests, direct-clear doors,
- * review blockers) are gone.
+ * Everything downstream derives from this registry: the session "awaiting
+ * input" status (`isSessionAwaiting` — the persister's bit is an
+ * edge-detection cache of that projection), the unified wire events, the
+ * snapshot endpoint, OS notifications, and the decision routes' already-
+ * settled gate.
  */
 /**
  * A registry transition: exactly one 'created' per accepted registration and
@@ -166,6 +167,18 @@ export class UserInputRequestManager {
   /** Look up a single open request by id. */
   getOpenRequest(id: string): PendingUserInputRequest | null {
     return this.requests.get(id) ?? null
+  }
+
+  /**
+   * The outcome a request settled with, while it is still on the bounded
+   * resolution trail. Lets an already-settled decision answer with what
+   * actually happened instead of a bare "already settled".
+   */
+  getRecentResolutionOutcome(id: string): UserInputRequestOutcome | undefined {
+    for (let i = this.recentResolutions.length - 1; i >= 0; i--) {
+      if (this.recentResolutions[i].id === id) return this.recentResolutions[i].outcome
+    }
+    return undefined
   }
 
   getOpenRequestsForSession(sessionId: string): PendingUserInputRequest[] {

--- a/src/shared/lib/user-input/request-schema.ts
+++ b/src/shared/lib/user-input/request-schema.ts
@@ -2,13 +2,10 @@ import { z } from 'zod'
 
 /**
  * Typed model for "the agent is blocked on a human" — one envelope for every
- * pending user-input request regardless of which store currently owns it.
- *
- * Phase 2 (shadow registry): this model mirrors the existing stores via
- * write-through and is compared against them; nothing reads it for behavior
- * yet. The envelope is strict (we construct it), the per-kind payloads are
- * deliberately lenient (`looseObject` + `.catch`) so a malformed tool input
- * can never make the shadow diverge from the store it mirrors.
+ * pending user-input request. The envelope is strict (we construct it), the
+ * per-kind payloads are deliberately lenient (`looseObject` + `.catch`) so a
+ * malformed tool input can never break the delivery path that carries it —
+ * the server keeps the wait alive even when the payload is unrenderable.
  */
 
 export const USER_INPUT_REQUEST_KINDS = [
@@ -156,10 +153,12 @@ export type PendingUserInputRequest = z.infer<typeof pendingUserInputRequestSche
 export type PendingUserInputRequestInput = z.input<typeof pendingUserInputRequestSchema>
 
 /**
- * Which legacy store a kind lives on today. The shadow registry uses this to
- * mirror store-scoped operations exactly (e.g. the turn-boundary clear wipes
- * only the stream store; a stray tool_result must never evict a computer-use
- * entry the store still holds).
+ * The lifecycle class of a kind. The names come from the pre-registry stores,
+ * but what they express is per-class clearing rules: the turn-boundary clear
+ * wipes only 'stream' entries, 'computer_use' entries survive idle for replay
+ * and are superseded on the next active turn, and 'review' entries are
+ * agent-scoped and outlive any one session. A stray tool_result must never
+ * evict an entry of another class.
  */
 export type UserInputRequestStore = 'stream' | 'computer_use' | 'review'
 
@@ -180,7 +179,7 @@ export function storeForKind(kind: UserInputRequestKind): UserInputRequestStore 
 
 /** Broadcast event type → request kind, for the persister's SSE-intercept feeder. */
 const STREAM_EVENT_TYPE_TO_KIND: Record<string, UserInputRequestKind> = {
-  user_question_request: 'question',
+  question_request: 'question',
   secret_request: 'secret',
   connected_account_request: 'connected_account',
   file_request: 'file',


### PR DESCRIPTION
Final phase of the user-input-request rearchitecture. The pending-request registry is now the single source of truth end to end (awaiting projection, wire, snapshot, notifications, and the decision gate all derive from it), and the last legacy scaffolding is removed.

## What's in it

**Already-settled gate on all 9 decision routes** (`gateRequestDecision`)
A decision proceeds only while the registry holds the request *open*, with the route's kind, in the route's session (`_auto` bypasses the session check). Otherwise it returns a stable, side-effect-free `200 {success, alreadySettled, outcome?}` (outcome from the bounded resolution trail), or `404` on a kind/session mismatch (no existence leak). This closes the **sequential** double-decision hole where a duplicate POST — stale second tab, page reload, retry-after-complete — used to silently re-run host side effects (re-execute a script, re-drive the machine, re-interrupt a session). Auto-approved computer-use now registers (`autoApproved: true`) so its `_auto` auto-execute path passes the gate.

**Notification collapse**
A single transition-driven `dispatchRequestNotification`, fired on the registry `created` event, replaces all 10 inline trigger callsites (9 persister handlers + ReviewManager). This structurally fixes the `script_run` / `computer_use` double-notify that came from duplicate subagent delivery paths (the registry `created` event is deduped), and registry-only review registrations now notify too.

**Renderer cleanup**
Seven dead per-type request arrays plus their SSE handlers and removers are deleted from `use-message-stream`; `removePendingRequestsByToolUseId` is now the single completion strip. `use-pending-requests` collapses 8 copy-pasted merge memos into one generic `mergeBucket` and 9 per-kind `onComplete` callbacks into one handler. The dashboard review panel now derives from the unified snapshot via `reviewFromEnvelope`.

**Wire rename + Electron main**
`user_question_request` → `question_request` across the wire and chat connectors. The Electron main OS-notification dismissal is ported to the unified `user_request_resolved` event.

## Validation

- Typecheck + lint clean, full unit suite green, mock E2E green.
- **Live real-container round** (real Docker container + real Claude): question lifecycle including full-reload snapshot recovery; the gate refusing a sequential re-run (`alreadySettled`, no re-execution); always-allow → auto-approve executing exactly once with no card; single-fire notifications.

## Known follow-up

[SUP-483](https://linear.app/datawizz/issue/SUP-483/decision-route-idempotency-gate-has-a-concurrent-toctou-race-double) tracks a **concurrent** double-approve TOCTOU race the gate does not yet close (two simultaneous approves both pass the check-then-act gate and the side effect runs twice). Not a regression — pre-Phase-6 there was no gate at all, so both sequential and concurrent double-decisions executed twice; this PR is a strict improvement that closes the common sequential case. Fix is a small atomic-claim change, tracked separately.

Chat/UI unification (Phase 7) and final legacy-emission removal (Phase 8) are documented as follow-up phases.

https://claude.ai/code/session_01DLw9AJ5VXVQPzBAz87nNAA