### PR TITLE
Honor SUPERAGENT_DB_PATH for SQLite outside the data dir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,11 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Optional: Anthropic Base URL (for proxy or enterprise setups)
 # ANTHROPIC_BASE_URL=https://api.anthropic.com
 
-# Database path (optional, defaults to ./superagent.db)
-# DATABASE_PATH=./superagent.db
+# Optional: override SQLite file (default: $SUPERAGENT_DATA_DIR/superagent.db or ~/.superagent/superagent.db)
+# SUPERAGENT_DB_PATH=/path/to/superagent.db
+
+# Optional: override data directory (settings, agents, default DB location)
+# SUPERAGENT_DATA_DIR=~/.superagent
 
 # Container Status Sync
 # How often to sync container status with Docker/Podman (in seconds)

--- a/.env.local.example
+++ b/.env.local.example
@@ -5,8 +5,11 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Optional: Anthropic Base URL (for proxy or enterprise setups)
 # ANTHROPIC_BASE_URL=https://api.anthropic.com
 
-# Database path (optional, defaults to ./superagent.db)
-# DATABASE_PATH=./superagent.db
+# Optional: override SQLite file (default: $SUPERAGENT_DATA_DIR/superagent.db or ~/.superagent/superagent.db)
+# SUPERAGENT_DB_PATH=/path/to/superagent.db
+
+# Optional: override data directory (settings, agents, default DB location)
+# SUPERAGENT_DATA_DIR=~/.superagent
 
 # Container Status Sync
 # How often to sync container status with Docker/Podman (in seconds)

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,16 +2,21 @@ import type { Config } from 'drizzle-kit'
 import path from 'path'
 import os from 'os'
 
-// Get data directory (same logic as src/lib/config/data-dir.ts)
-const dataDir = process.env.SUPERAGENT_DATA_DIR
-  ? path.resolve(process.env.SUPERAGENT_DATA_DIR)
-  : path.join(os.homedir(), '.superagent')
+// Mirror getDatabasePath() in src/shared/lib/config/data-dir.ts
+const dbUrl = process.env.SUPERAGENT_DB_PATH
+  ? path.resolve(process.env.SUPERAGENT_DB_PATH)
+  : path.join(
+      process.env.SUPERAGENT_DATA_DIR
+        ? path.resolve(process.env.SUPERAGENT_DATA_DIR)
+        : path.join(os.homedir(), '.superagent'),
+      'superagent.db',
+    )
 
 export default {
   schema: './src/shared/lib/db/schema.ts',
   out: './src/shared/lib/db/migrations',
   dialect: 'sqlite',
   dbCredentials: {
-    url: path.join(dataDir, 'superagent.db'),
+    url: dbUrl,
   },
 } satisfies Config

--- a/src/shared/lib/config/data-dir.test.ts
+++ b/src/shared/lib/config/data-dir.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import os from 'os'
+import path from 'path'
+import { getDataDir, getDatabasePath } from './data-dir'
+
+describe('getDataDir / getDatabasePath', () => {
+  const prevDataDir = process.env.SUPERAGENT_DATA_DIR
+  const prevDbPath = process.env.SUPERAGENT_DB_PATH
+
+  afterEach(() => {
+    if (prevDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = prevDataDir
+    if (prevDbPath === undefined) delete process.env.SUPERAGENT_DB_PATH
+    else process.env.SUPERAGENT_DB_PATH = prevDbPath
+  })
+
+  it('defaults DB path to ~/.superagent/superagent.db', () => {
+    delete process.env.SUPERAGENT_DATA_DIR
+    delete process.env.SUPERAGENT_DB_PATH
+    expect(getDataDir()).toBe(path.join(os.homedir(), '.superagent'))
+    expect(getDatabasePath()).toBe(path.join(os.homedir(), '.superagent', 'superagent.db'))
+  })
+
+  it('places the DB under SUPERAGENT_DATA_DIR when set', () => {
+    process.env.SUPERAGENT_DATA_DIR = '/tmp/sa-data'
+    delete process.env.SUPERAGENT_DB_PATH
+    expect(getDataDir()).toBe(path.resolve('/tmp/sa-data'))
+    expect(getDatabasePath()).toBe(path.join(path.resolve('/tmp/sa-data'), 'superagent.db'))
+  })
+
+  it('lets SUPERAGENT_DB_PATH win over SUPERAGENT_DATA_DIR', () => {
+    process.env.SUPERAGENT_DATA_DIR = '/tmp/sa-data'
+    process.env.SUPERAGENT_DB_PATH = '/sqlite/superagent.db'
+    expect(getDataDir()).toBe(path.resolve('/tmp/sa-data'))
+    expect(getDatabasePath()).toBe(path.resolve('/sqlite/superagent.db'))
+  })
+
+  it('resolves a relative SUPERAGENT_DB_PATH', () => {
+    delete process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DB_PATH = 'relative/superagent.db'
+    expect(getDatabasePath()).toBe(path.resolve('relative/superagent.db'))
+  })
+})

--- a/src/shared/lib/config/data-dir.ts
+++ b/src/shared/lib/config/data-dir.ts
@@ -22,8 +22,13 @@ export function getDataDir(): string {
 
 /**
  * Get the path to the SQLite database file.
+ * SUPERAGENT_DB_PATH overrides the default ($SUPERAGENT_DATA_DIR/superagent.db).
  */
 export function getDatabasePath(): string {
+  const envDbPath = process.env.SUPERAGENT_DB_PATH
+  if (envDbPath) {
+    return path.resolve(envDbPath)
+  }
   return path.join(getDataDir(), 'superagent.db')
 }
 

--- a/src/shared/lib/db/db-path.test.ts
+++ b/src/shared/lib/db/db-path.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const mockPragma = vi.fn()
+const mockClose = vi.fn()
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(function MockDatabase(this: { pragma: typeof mockPragma; close: typeof mockClose }) {
+    this.pragma = mockPragma
+    this.close = mockClose
+  }),
+}))
+
+vi.mock('drizzle-orm/better-sqlite3', () => ({
+  drizzle: vi.fn(() => ({})),
+}))
+
+vi.mock('drizzle-orm/better-sqlite3/migrator', () => ({
+  migrate: vi.fn(),
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+}))
+
+describe('initDb parent directory', () => {
+  let tmpRoot: string
+  let prevDataDir: string | undefined
+  let prevDbPath: string | undefined
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-db-path-'))
+    prevDataDir = process.env.SUPERAGENT_DATA_DIR
+    prevDbPath = process.env.SUPERAGENT_DB_PATH
+    process.env.SUPERAGENT_DATA_DIR = path.join(tmpRoot, 'data')
+    process.env.SUPERAGENT_DB_PATH = path.join(tmpRoot, 'nested', 'sqlite', 'superagent.db')
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    if (prevDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = prevDataDir
+    if (prevDbPath === undefined) delete process.env.SUPERAGENT_DB_PATH
+    else process.env.SUPERAGENT_DB_PATH = prevDbPath
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+    vi.resetModules()
+  })
+
+  it('creates the SUPERAGENT_DB_PATH parent before opening SQLite', async () => {
+    const dbParent = path.join(tmpRoot, 'nested', 'sqlite')
+    expect(fs.existsSync(dbParent)).toBe(false)
+
+    const Database = (await import('better-sqlite3')).default
+    const { sqlite } = await import('./index')
+    // Touch the proxy to trigger initDb
+    void sqlite.close
+
+    expect(fs.existsSync(dbParent)).toBe(true)
+    expect(fs.existsSync(process.env.SUPERAGENT_DATA_DIR!)).toBe(true)
+    expect(Database).toHaveBeenCalledWith(process.env.SUPERAGENT_DB_PATH)
+  })
+})

--- a/src/shared/lib/db/index.ts
+++ b/src/shared/lib/db/index.ts
@@ -20,8 +20,7 @@ function getMigrationsFolder(): string {
 }
 
 // Lazy initialization: defer DB creation until first access so that
-// SUPERAGENT_DATA_DIR (set by the Electron main process at startup)
-// is available when the path is resolved.
+// SUPERAGENT_DATA_DIR / SUPERAGENT_DB_PATH (set at startup) are available.
 let _sqlite: InstanceType<typeof Database> | null = null
 let _db: BetterSQLite3Database<typeof schema> | null = null
 
@@ -31,10 +30,9 @@ function initDb() {
   const dbPath = getDatabasePath()
   const dataDir = getDataDir()
 
-  // Ensure data directory exists
-  if (!fs.existsSync(dataDir)) {
-    fs.mkdirSync(dataDir, { recursive: true })
-  }
+  // Data dir (settings/agents) and DB parent may differ when SUPERAGENT_DB_PATH is set.
+  fs.mkdirSync(dataDir, { recursive: true })
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true })
 
   try {
     _sqlite = new Database(dbPath)

--- a/src/shared/lib/db/index.ts
+++ b/src/shared/lib/db/index.ts
@@ -31,8 +31,13 @@ function initDb() {
   const dataDir = getDataDir()
 
   // Data dir (settings/agents) and DB parent may differ when SUPERAGENT_DB_PATH is set.
-  fs.mkdirSync(dataDir, { recursive: true })
-  fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true })
+  }
+  const dbParent = path.dirname(dbPath)
+  if (!fs.existsSync(dbParent)) {
+    fs.mkdirSync(dbParent, { recursive: true })
+  }
 
   try {
     _sqlite = new Database(dbPath)


### PR DESCRIPTION
## Summary
- `getDatabasePath()` honors `SUPERAGENT_DB_PATH` when set; desktop/self-host default (`$SUPERAGENT_DATA_DIR/superagent.db` or `~/.superagent/superagent.db`) unchanged.
- `initDb()` mkdir’s the DB parent so a path like `/sqlite/superagent.db` cannot `SQLITE_CANTOPEN` on first open.
- Align `drizzle.config.ts` and replace dead `DATABASE_PATH` docs with `SUPERAGENT_DB_PATH` / `SUPERAGENT_DATA_DIR`.

Needed so cloud can keep settings/agents on the S3 Files mount while the live DB sits on Fargate ephemeral disk (Litestream track in gamut-infra).

## Test plan
- [x] `vitest` `data-dir.test.ts` + `db-path.test.ts`
- [ ] Desktop: unset env → DB still under userData / `~/.superagent`
- [ ] Set `SUPERAGENT_DB_PATH` to a nested path → parent created, DB opens

Made with [Cursor](https://cursor.com)