### PR TITLE
Live Slack chat-integration validation suite + skill

### DIFF
--- a/.claude/skills/slack-chat-validation/SKILL.md
+++ b/.claude/skills/slack-chat-validation/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: slack-chat-validation
+description: Run the live Slack chat-integration validation suite — a real Slack account messaging a real bot, driving a real app instance and a real container, asserting on what actually lands in Slack. Use before and after any change to src/shared/lib/chat-integrations/, to the user-input request path that feeds it, or to the "can't do this in chat" notice.
+---
+
+# Slack chat-integration validation
+
+## Why this exists
+
+Every other test around `src/shared/lib/chat-integrations/` is a **contract test**:
+it hands a connector an event object and asserts what the connector does with
+it. That pins the connector's behaviour and nothing else. If a refactor stops
+the host from *emitting* those events — or emits them for a different session,
+or stops registering the underlying request — every one of those tests stays
+green and the feature is dead.
+
+This suite closes that gap. Nothing on the path is mocked:
+
+```
+a real human Slack account
+  → real Slack (Socket Mode)
+    → a real app instance booted against an isolated data dir
+      → a real agent container running a real turn
+        → back to Slack
+          → assertions read the actual message, Block Kit payload included
+```
+
+Run it **before** starting a chat-integration change to record a green
+baseline, and **after** to prove nothing regressed.
+
+## Prerequisites
+
+Checked automatically by `preflight.mjs`; run that first when anything looks off.
+
+1. **A source install with exactly one Slack integration.** By default
+   `~/Library/Application Support/Superagent-dev`. Its bot and app tokens are
+   read from the integration row; they are never printed.
+2. **A second Slack identity that can post as somebody other than the bot.**
+   Resolved from `connected_accounts` in the source install, then in the
+   packaged install (`…/Superagent`). Two shapes work, and which one is found
+   decides the surface:
+   - **human (user) token** → the suite runs in a **DM with the bot**. Preferred:
+     it's how the feature is really used, and only a human identity can open a
+     `D…` channel.
+   - **another app's bot token** → the suite runs in a **shared public channel**.
+     Slack won't let one app post into another app's DM. The sender joins a
+     public channel the bot is already in if it isn't in one.
+
+   Composio-managed connections usually **do not** expose a raw token (Composio
+   returns a redacted one). That is expected: the harness falls back to
+   executing Slack calls through Composio's proxy, and a token Slack rejects
+   with `invalid_auth` is treated as "try the proxy", not "dead connection".
+   If no identity resolves at all, reconnect Slack in the app's
+   connected-accounts UI — the harness picks a human token up automatically on
+   the next run, no code change needed.
+3. **Docker running**, with the agent image named in the source install's
+   `settings.container.agentImage` (normally `superagent-container:latest`,
+   built by `npm run build:container`).
+4. **No other Superagent instance holding the same Slack app.** Slack
+   load-balances events across Socket Mode connections, so a second instance
+   makes the suite go nondeterministically quiet. Preflight flags a running
+   packaged/dev app whose data dir has an active Slack integration.
+5. **A free container publish range.** See the port hazard below.
+
+## Running it
+
+```bash
+node e2e/live/slack-chat/preflight.mjs        # ~10s, proves the environment
+node e2e/live/slack-chat/run.mjs              # full suite, web host (~5 min)
+node e2e/live/slack-chat/run.mjs --host=electron   # desktop host
+node e2e/live/slack-chat/run.mjs --no-public-url   # cloud host, no HOST_PUBLIC_URL
+```
+
+Useful flags:
+
+| Flag | Effect |
+|---|---|
+| `--only=<tag or ids>` | Run a subset: `--only=unsupported`, `--only=question`, `--only=inbound-turn,question-card` |
+| `--host=web\|electron` | Which host shape to boot (default `web`) |
+| `--no-public-url` | Boot the cloud host with `HOST_PUBLIC_URL` unset |
+| `--public-url=<url>` | Override the cloud base (default `https://validation.example.test`) |
+| `--boot-only` | Seed + boot + connect, then stop. Environment check without spending turns |
+| `--keep-app` | Leave the app running afterwards for manual poking |
+| `--no-retry` | Disable the one automatic retry per check |
+| `--with-computer-use` | Include the computer-use check — **drives the real machine** |
+| `--channel=#name` | Pin the channel when the surface is a channel |
+| `--container-base-port=N` | Move the container publish range (default 5300) |
+| `--source=<dir>` / `--sender-source=<dir>` | Point at other installs |
+
+Each run writes `report.json` and the full app log to a temp run dir, printed
+at the end.
+
+### A full pass before a chat-integration change
+
+```bash
+node e2e/live/slack-chat/run.mjs                   # 12/12
+node e2e/live/slack-chat/run.mjs --host=electron   # 12/12 — desktop links
+node e2e/live/slack-chat/run.mjs --no-public-url --only=unsupported   # link omitted
+```
+
+## What it isolates (and what it will never touch)
+
+`seed.mjs` builds `~/Downloads/slack-chat-validation` from the source install:
+`settings.json` verbatim, a fresh single-agent workspace, and a copy of the
+SQLite file pruned to **one** chat integration retargeted at the slug
+`slack-validation-agent`.
+
+That slug is the isolation boundary. The only container the suite ever creates,
+stops, or removes is `superagent-slack-validation-agent`. Scheduled tasks,
+webhook triggers, other integrations, and every other agent's rows are emptied
+in the copy, so the seeded install can't wake anything on its own. **The source
+install is only ever read.**
+
+## What each check protects
+
+| Check | Protects |
+|---|---|
+| `inbound-turn` | An inbound Slack message creates a chat session bound to a real container session whose transcript holds the turn |
+| `question-card` | `AskUserQuestion` renders as Block Kit with one button per option and connector-registered `cb_<n>` action ids |
+| `question-freetext-answer` | A plain-text reply resolves the open single-question card as the free-form answer and the **same turn continues** — then the registry is empty |
+| `question-cancelled-by-unrelated-message` | An unrelated message cancels the parked question instead of deadlocking behind it, and the fresh turn runs |
+| `question-multi-is-not-consumed-by-text` | A multi-question ask posts one card per question, and text does **not** answer it (an answer would be attributed to the wrong question) |
+| `file-delivery-notice` | `deliver_file` reaches the conversation as real uploaded bytes with the description as caption (text fallback accepted and reported) |
+| `unsupported-*` (6) | Per kind: the exact refusal wording, the **exact host-aware link tail**, no interactive card, and the request staying parked in the registry |
+
+The `unsupported-*` checks are the regression test for the host-aware notice
+(PR #563). They rebuild the expected tail from the host shape and assert the
+message **ends with it**, so all three rows of that matrix are distinguished:
+
+| Host | Expected tail |
+|---|---|
+| `--host=electron` | ` Open Gamut on your desktop to continue: superagent-dev://agent/<slug>/sessions/<id>` |
+| `--host=web` + `HOST_PUBLIC_URL` | ` Open Gamut to continue: <base>/agents/<slug>/sessions/<id>` |
+| `--host=web --no-public-url` | ` Open Gamut to continue.` (no link — never a broken URL) |
+
+The `<id>` is asserted to be the conversation's **actual** session, which is
+what stops a queued notice from linking a rotated-away session.
+
+## Known limits — read before trusting a green run
+
+- **Button taps are not automated.** Slack has no API to simulate clicking a
+  Block Kit button; interactions only arrive from a real client over Socket
+  Mode. The suite asserts the card is posted with the right buttons and
+  `action_id`s, and covers the answer path via the free-text branch. The
+  `action_id` → decision round trip needs a human tap in Slack.
+- **`browser_input` is not asserted as parked** (`requiresParked: false`).
+  `mcp__user-input__request_browser_input` is only in the web-browser
+  subagent's tool list, so the main agent reaches it indirectly and the
+  registration can settle with the subagent. The notice is still asserted.
+- **Computer use is opt-in** (`--with-computer-use`) because triggering it
+  drives the real machine.
+- **`proxy_review` cards are not covered.** They arrive through the global
+  notification path as a synthetic `question_request`, and triggering one needs
+  a proxied API call that requires review.
+- **One retry per check by default.** Each check drives a live model, and a
+  model that wanders off is not the product breaking. A real regression fails
+  both attempts. `--no-retry` disables it.
+
+## Environment hazards these runs actually hit
+
+- **Container publish range.** A packaged install's Lima runner forwards its
+  container ports on `127.0.0.1`, and a loopback-specific bind **shadows**
+  Docker's `0.0.0.0` publish. With the default base (4000) the validation app's
+  host→container calls silently land in the *other* install's container and
+  come back `401 Unauthorized` — which reads exactly like a broken build.
+  The harness pins `SUPERAGENT_BASE_PORT=5300` (away from 4000 and from
+  `dev:electron`'s 5000) and preflight checks the range is free.
+- **`better-sqlite3` ABI.** The web and Electron hosts need different builds, so
+  whichever ran last leaves the other broken. `startApp` rebuilds for the host
+  about to run.
+- **Electron outliving its wrapper.** `electron-vite dev` forks Electron;
+  killing the wrapper alone leaves the app holding the Socket Mode session and
+  writing into the seed dir (the next seed then fails with `ENOTEMPTY`). The
+  harness kills the process group and then pkills any Electron whose app path is
+  this repo, and the seed retries its clear.
+- **Electron ignores `PORT`.** Main binds its own API from 47891 upward, so the
+  harness reads the port back from the log line rather than assuming it.
+
+## Extending it
+
+Add an entry to `CHECKS` in `e2e/live/slack-chat/lib/checks.mjs`:
+
+```js
+{
+  id: 'stable-kebab-id',
+  title: 'reads as the behaviour being protected',
+  tags: ['group'],            // selectable via --only
+  async run(ctx) { /* ... */ return 'short detail for the report' },
+  async cleanup(ctx) { /* leave the session idle */ },
+}
+```
+
+`ctx` gives you `conv` (say / awaitBot / expectNoBot, watermarked), `api`
+(sessions, messages, `pendingRequests` — the Phase 6 registry snapshot),
+`agentSlug`, `integrationId`, and `hostShape`.
+
+Two rules worth keeping:
+
+1. **Predicates must be specific enough to fail.** An early version matched the
+   delivered file on its filename alone and passed on the `🔧 Write` tool-call
+   echo — a green check that tested nothing. If the agent echoes your marker for
+   an unrelated reason, the check is not doing its job.
+2. **Watch the registry from before the trigger**, not after the Slack message
+   lands (`watchRegistry`). A request can register and settle inside one poll
+   interval, and polling afterwards reports "never registered" for something
+   that did.
+
+## Files
+
+```
+e2e/live/slack-chat/
+  preflight.mjs       environment check, no side effects beyond joining a channel
+  run.mjs             the runner: seed → boot → checks → report
+  lib/data-dir.mjs    read-only access to an install's settings + SQLite
+  lib/slack.mjs       bot and sender identities, token vs Composio-proxy calling
+  lib/surface.mjs     DM vs shared channel, and how the sender gets in
+  lib/seed.mjs        the isolated data dir
+  lib/app.mjs         booting web/electron, port discovery, API helpers
+  lib/conversation.mjs watermarked send/await against the conversation
+  lib/checks.mjs      the assertions
+```

--- a/e2e/live/slack-chat/lib/app.mjs
+++ b/e2e/live/slack-chat/lib/app.mjs
@@ -1,0 +1,301 @@
+/**
+ * Booting the real app against the seeded data dir, and inspecting it.
+ *
+ * Two host shapes matter, because the "can't do this in chat" notice resolves
+ * its link differently on each (see resolveAppLinkContext):
+ *
+ *   web      — plain Node. `process.type` is undefined, so the notice takes the
+ *              cloud branch and links to HOST_PUBLIC_URL when one is set.
+ *   electron — `process.type === 'browser'`, so the notice takes the desktop
+ *              branch and links to the SUPERAGENT_PROTOCOL scheme
+ *              (superagent-dev:// in a dev build).
+ *
+ * Both run the same services: api/index.ts calls initializeServices() outside
+ * Electron, main/index.ts calls it inside — either way the chat integration
+ * manager comes up and connects to Slack for real.
+ */
+
+import { spawn, execFileSync } from 'node:child_process'
+import { createWriteStream, mkdirSync } from 'node:fs'
+import path from 'node:path'
+import net from 'node:net'
+
+/** A port nothing is listening on, so a run never lands on the user's dev server. */
+export async function freePort(preferred) {
+  const tryPort = (port) =>
+    new Promise((resolve) => {
+      const server = net.createServer()
+      server.once('error', () => resolve(false))
+      server.once('listening', () => server.close(() => resolve(true)))
+      server.listen(port, '127.0.0.1')
+    })
+  if (preferred && (await tryPort(preferred))) return preferred
+  for (let port = 3210; port < 3260; port++) if (await tryPort(port)) return port
+  throw new Error('no free port in 3210-3259')
+}
+
+/**
+ * Whether anything already owns loopback ports in the container publish range.
+ *
+ * This is checked explicitly because the failure it causes is silent: a
+ * loopback-specific listener (a packaged install's Lima port-forward) shadows
+ * Docker's 0.0.0.0 publish, so host→container calls reach the WRONG container
+ * and every one of them returns 401. Nothing in the app's logs points at the
+ * port.
+ */
+export async function containerPortRangeConflicts(basePort, span = 8) {
+  const conflicts = []
+  for (let port = basePort; port < basePort + span; port++) {
+    const busy = await new Promise((resolve) => {
+      const socket = net.createConnection({ port, host: '127.0.0.1' })
+      socket.setTimeout(400)
+      socket.once('connect', () => {
+        socket.destroy()
+        resolve(true)
+      })
+      socket.once('error', () => resolve(false))
+      socket.once('timeout', () => {
+        socket.destroy()
+        resolve(false)
+      })
+    })
+    if (busy) conflicts.push(port)
+  }
+  return conflicts
+}
+
+async function waitFor(label, probe, timeoutMs, intervalMs = 1000) {
+  const start = Date.now()
+  for (;;) {
+    let value
+    try {
+      value = await probe()
+    } catch {
+      value = false
+    }
+    if (value) return value
+    if (Date.now() - start > timeoutMs) throw new Error(`Timed out waiting for ${label} (${timeoutMs}ms)`)
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
+/**
+ * Start the app and wait until its API answers and the Slack integration
+ * reports connected.
+ *
+ * `hostPublicUrl` is passed through verbatim, including the empty string: the
+ * unset-cloud-host row of the notice matrix is a real case the suite checks,
+ * and it is expressed by NOT setting the variable.
+ */
+export async function startApp({
+  host = 'web',
+  dataDir,
+  port,
+  containerBasePort = 5300,
+  hostPublicUrl,
+  repoRoot,
+  logFile,
+  integrationId,
+  log = () => {},
+}) {
+  const env = {
+    ...process.env,
+    SUPERAGENT_DATA_DIR: dataDir,
+    PORT: String(port),
+    NODE_ENV: 'development',
+    // Container ports MUST NOT start at the 4000 default. A packaged install's
+    // Lima runner forwards its container ports on 127.0.0.1, and a
+    // loopback-specific bind shadows Docker's 0.0.0.0 bind — so a validation
+    // container published on 4001 is reachable from this process only if
+    // nothing else already owns loopback 4001. When something does, every
+    // host→container call silently lands in the OTHER install's container and
+    // comes back 401 (its host token differs). That failure looks exactly like
+    // a broken build, so the base port is pinned away from both the packaged
+    // default (4000) and dev:electron's (5000).
+    SUPERAGENT_BASE_PORT: String(containerBasePort),
+    // The suite's own agent is the only one; nothing here should phone home.
+    SUPERAGENT_TEST_UPDATES: '',
+  }
+  if (hostPublicUrl) env.HOST_PUBLIC_URL = hostPublicUrl
+  else delete env.HOST_PUBLIC_URL
+
+  // electron-vite directly, not `npm run dev:electron`: that script pins
+  // SUPERAGENT_BASE_PORT=5000 through cross-env, which would overwrite the
+  // range chosen above.
+  const command =
+    host === 'electron'
+      ? ['npx', ['electron-vite', 'dev']]
+      : ['npx', ['vite', '--port', String(port), '--strictPort']]
+
+  if (host === 'electron') {
+    // A packaged Gamut may be running; without this the dev build exits on the
+    // single-instance lock instead of booting.
+    env.SUPERAGENT_DISABLE_SINGLE_INSTANCE = '1'
+  }
+
+  mkdirSync(path.dirname(logFile), { recursive: true })
+  // better-sqlite3 is a native module and the two hosts need different ABIs, so
+  // whichever ran last leaves the other broken. Rebuilding for the host about
+  // to run is what `npm run dev` / `dev:electron` each do for themselves.
+  log(`rebuilding better-sqlite3 for ${host}…`)
+  await new Promise((resolve, reject) => {
+    const rebuild =
+      host === 'electron'
+        ? spawn('npx', ['electron-rebuild', '-f', '-w', 'better-sqlite3'], { cwd: repoRoot, stdio: 'ignore' })
+        : spawn('npm', ['rebuild', 'better-sqlite3'], { cwd: repoRoot, stdio: 'ignore' })
+    rebuild.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`rebuild exited ${code}`))))
+  })
+
+  const out = createWriteStream(logFile, { flags: 'a' })
+  // Own process group: electron-vite forks Electron, and SIGTERM to the
+  // wrapper alone would leave the app (and its Socket Mode session) running.
+  const child = spawn(command[0], command[1], {
+    cwd: repoRoot,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  })
+  child.stdout.pipe(out)
+  child.stderr.pipe(out)
+  log(`app (${host}) pid ${child.pid}, logs → ${logFile}`)
+
+  let exited = null
+  child.on('exit', (code, signal) => {
+    exited = `exited with code=${code} signal=${signal}`
+  })
+
+  // Electron ignores PORT: main binds its own API server from 47891 upward
+  // (bindServerWithRetry), so the port has to be read back rather than chosen.
+  let apiPort = port
+  if (host === 'electron') {
+    apiPort = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Electron never logged its API port')), 180_000)
+      let buffered = ''
+      const onData = (chunk) => {
+        buffered += chunk.toString()
+        const match = buffered.match(/API server running on http:\/\/localhost:(\d+)/)
+        if (!match) return
+        clearTimeout(timer)
+        child.stdout.off('data', onData)
+        resolve(Number(match[1]))
+      }
+      child.stdout.on('data', onData)
+    })
+    log(`electron API bound to ${apiPort}`)
+  }
+
+  const base = `http://127.0.0.1:${apiPort}`
+  const api = makeApi(base)
+
+  try {
+    await waitFor(
+      'the API to answer',
+      async () => {
+        if (exited) throw new Error(`app ${exited} — see ${logFile}`)
+        const res = await fetch(`${base}/api/agents`)
+        return res.ok
+      },
+      180_000,
+    )
+    log('API is up')
+
+    await waitFor(
+      'the Slack integration to report connected',
+      async () => {
+        if (exited) throw new Error(`app ${exited} — see ${logFile}`)
+        const status = await api.json(`/api/chat-integrations/${integrationId}/status`)
+        return status?.connected === true
+      },
+      120_000,
+    )
+    log('Slack integration is connected')
+  } catch (err) {
+    child.kill('SIGTERM')
+    throw err
+  }
+
+  return {
+    port: apiPort,
+    base,
+    api,
+    logFile,
+    async stop() {
+      if (exited) return
+      const signal = (sig) => {
+        try {
+          process.kill(-child.pid, sig)
+        } catch {
+          try {
+            child.kill(sig)
+          } catch {
+            /* already gone */
+          }
+        }
+      }
+      signal('SIGTERM')
+      await new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          signal('SIGKILL')
+          resolve()
+        }, 15_000)
+        child.on('exit', () => {
+          clearTimeout(timer)
+          resolve()
+        })
+      })
+      // Electron outlives its electron-vite wrapper often enough to matter: a
+      // survivor keeps the Socket Mode session (stealing the next run's events)
+      // and keeps writing into the seed dir (so the next seed's rm races it).
+      // Match on the repo path so only this harness's app is ever targeted.
+      if (host === 'electron') {
+        for (const sig of ['-TERM', '-KILL']) {
+          try {
+            execFileSync('pkill', [sig, '-f', `${repoRoot}/node_modules/electron/dist/Electron.app`], {
+              stdio: 'ignore',
+            })
+          } catch {
+            /* pkill exits non-zero when nothing matched — that is the good case */
+          }
+          await new Promise((r) => setTimeout(r, 2_000))
+        }
+      }
+    },
+  }
+}
+
+function makeApi(base) {
+  const json = async (pathname, init) => {
+    const res = await fetch(`${base}${pathname}`, init)
+    if (!res.ok) return null
+    return res.json()
+  }
+  return {
+    json,
+    /** Sessions of an agent, newest first. */
+    async sessions(agentSlug) {
+      const body = await json(`/api/agents/${encodeURIComponent(agentSlug)}/sessions`)
+      if (!body) return []
+      return Array.isArray(body) ? body : (body.sessions ?? [])
+    },
+    /** The registry snapshot Phase 6 exposes — the source of truth for open asks. */
+    async pendingRequests(agentSlug) {
+      const body = await json(`/api/agents/${encodeURIComponent(agentSlug)}/pending-requests`)
+      if (!body) return []
+      return Array.isArray(body) ? body : (body.requests ?? [])
+    },
+    async messages(agentSlug, sessionId) {
+      const body = await json(
+        `/api/agents/${encodeURIComponent(agentSlug)}/sessions/${encodeURIComponent(sessionId)}/messages`,
+      )
+      if (!body) return []
+      return Array.isArray(body) ? body : (body.messages ?? [])
+    },
+    async chatSessions(integrationId) {
+      const body = await json(`/api/chat-integrations/${encodeURIComponent(integrationId)}/sessions`)
+      if (!body) return []
+      return Array.isArray(body) ? body : (body.sessions ?? [])
+    },
+  }
+}
+
+export { waitFor }

--- a/e2e/live/slack-chat/lib/checks.mjs
+++ b/e2e/live/slack-chat/lib/checks.mjs
@@ -1,0 +1,401 @@
+/**
+ * What the suite actually asserts.
+ *
+ * Each check is independent enough to read on its own, and they run in order
+ * because the cheap ones surface a broken environment before the slow ones
+ * spend a container turn on it. A check that leaves the session parked on a
+ * user-input request is responsible for clearing it (see `clearPending`) so the
+ * next check starts from an idle session.
+ *
+ * Adding a check: push an entry with a stable `id`, a `title` that reads as the
+ * behaviour being protected, and `tags` so it can be selected with --only.
+ */
+
+import { messageText, buttonActionIds, buttonLabels } from './conversation.mjs'
+
+/** Distinct per run so an assertion can never match an earlier run's message. */
+export function nonce() {
+  return Math.random().toString(36).slice(2, 8).toUpperCase()
+}
+
+const contains = (needle) => (_message, text) => text.includes(needle)
+
+/**
+ * The exact tail describeUnsupportedRequest() appends, rebuilt from the host
+ * shape the app was booted with. Asserting the whole tail (not just "some
+ * link") is what makes this a regression test for the host-aware notice: a
+ * desktop-shaped link leaking into a cloud host, or a session-less fallback
+ * where an identity was available, both fail here.
+ */
+export function expectedTail({ isDesktop, appLinkBase }, sessionId) {
+  const url = appLinkBase ? `${appLinkBase}/sessions/${encodeURIComponent(sessionId)}` : null
+  return ` Open Gamut${isDesktop ? ' on your desktop' : ''} to continue${url ? `: ${url}` : '.'}`
+}
+
+/** Wait until the agent's session has an open request of `kind` in the registry. */
+async function awaitRegistryKind(ctx, kind, timeoutMs = 60_000) {
+  const start = Date.now()
+  for (;;) {
+    const open = await ctx.api.pendingRequests(ctx.agentSlug)
+    const match = open.find((r) => r.kind === kind)
+    if (match) return match
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(
+        `No open ${kind} request in the registry after ${Math.round((Date.now() - start) / 1000)}s ` +
+          `(open: ${open.map((r) => r.kind).join(', ') || 'none'})`,
+      )
+    }
+    await new Promise((r) => setTimeout(r, 2_000))
+  }
+}
+
+/**
+ * Watch the registry for `kind` from *before* the trigger is sent.
+ *
+ * Polling only after the Slack notice lands is a race: a request can be
+ * registered and settled inside one poll interval (a subagent that dies, a
+ * tool that errors immediately), and the check would then report "never
+ * registered" for something that did register. Starting the watch first turns
+ * that into a reliable observation.
+ */
+function watchRegistry(ctx, kind, { intervalMs = 500 } = {}) {
+  let seen = null
+  let stopped = false
+  const loop = (async () => {
+    while (!stopped) {
+      try {
+        const open = await ctx.api.pendingRequests(ctx.agentSlug)
+        const match = open.find((r) => r.kind === kind)
+        if (match && !seen) seen = match
+      } catch {
+        /* the app is allowed to be briefly unreachable */
+      }
+      await new Promise((r) => setTimeout(r, intervalMs))
+    }
+  })()
+  return {
+    async stop() {
+      stopped = true
+      await loop
+      return seen
+    },
+  }
+}
+
+async function awaitRegistryEmpty(ctx, timeoutMs = 60_000) {
+  const start = Date.now()
+  for (;;) {
+    const open = await ctx.api.pendingRequests(ctx.agentSlug)
+    if (open.length === 0) return
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Registry still holds ${open.map((r) => `${r.kind}:${r.id}`).join(', ')}`)
+    }
+    await new Promise((r) => setTimeout(r, 2_000))
+  }
+}
+
+/**
+ * Clear a parked request the way a real user does: send an unrelated message.
+ * That is the production cancel path (consumeOrCancelAwaitingInput), so using
+ * it here means teardown is itself covered rather than being a back door.
+ */
+async function clearPending(ctx) {
+  const open = await ctx.api.pendingRequests(ctx.agentSlug)
+  if (open.length === 0) return
+  const tag = nonce()
+  await ctx.conv.say(`Never mind that. Reply with exactly: CLEARED ${tag}`)
+  await ctx.conv.awaitBot(`CLEARED ${tag}`, contains(`CLEARED ${tag}`), 180_000)
+  await awaitRegistryEmpty(ctx)
+}
+
+/** The chat session the integration is currently using for this conversation. */
+async function currentSessionId(ctx) {
+  const sessions = await ctx.api.chatSessions(ctx.integrationId)
+  const mine = sessions.filter(
+    (s) => (s.externalChatId ?? s.external_chat_id) === ctx.conv.channelId && !(s.archivedAt ?? s.archived_at),
+  )
+  if (mine.length === 0) throw new Error('No chat-integration session for this conversation yet')
+  return mine[0].sessionId ?? mine[0].session_id
+}
+
+/**
+ * One unsupported-in-chat kind: the notice's wording, its host-aware link, the
+ * absence of any interactive card, and the request staying parked in the
+ * registry (the notice tells the user to go elsewhere — it does not answer).
+ */
+function unsupportedCheck({ id, kind, prompt, phrase, requiresParked = true, tags = [] }) {
+  return {
+    id,
+    title: `${kind} is refused in chat with the host-aware notice${requiresParked ? ' and stays parked' : ''}`,
+    tags: ['unsupported', 'notice', ...tags],
+    async run(ctx) {
+      const watcher = watchRegistry(ctx, kind)
+      let notice
+      try {
+        await ctx.conv.say(prompt)
+        notice = await ctx.conv.awaitBot(`the ${kind} notice`, contains(phrase), 240_000)
+      } finally {
+        if (!notice) await watcher.stop()
+      }
+      const text = messageText(notice)
+      const sessionId = await currentSessionId(ctx)
+      const tail = expectedTail(ctx.hostShape, sessionId)
+
+      if (!text.endsWith(tail)) {
+        throw new Error(`Notice tail mismatch.\n  expected ending: ${tail}\n  actual notice:   ${text}`)
+      }
+      if (buttonActionIds(notice).length > 0) {
+        throw new Error(
+          `Unsupported-in-chat notice must not render an interactive card: ${buttonLabels(notice).join(', ')}`,
+        )
+      }
+
+      const request = await watcher.stop()
+      if (requiresParked && !request) {
+        throw new Error(
+          `The notice was sent but no ${kind} request was ever registered — the chat surface told ` +
+            `the user to finish this in the app, so something must be waiting for them there`,
+        )
+      }
+      if (request?.scope?.sessionId && request.scope.sessionId !== sessionId) {
+        throw new Error(
+          `Notice links session ${sessionId} but the request is scoped to ${request.scope.sessionId}`,
+        )
+      }
+      return `linked ${sessionId}${request ? '' : ' (request not parked — see title)'}`
+    },
+    async cleanup(ctx) {
+      await clearPending(ctx)
+    },
+  }
+}
+
+export const CHECKS = [
+  {
+    id: 'inbound-turn',
+    title: 'an inbound message creates a chat session and the agent replies',
+    tags: ['smoke'],
+    async run(ctx) {
+      const tag = nonce()
+      await ctx.conv.say(`Reply with exactly: HELLO ${tag}`)
+      await ctx.conv.awaitBot(`HELLO ${tag}`, contains(`HELLO ${tag}`), 300_000)
+      // The chat session is real on the host side too, not just a Slack echo:
+      // the conversation is bound to a container session whose transcript holds
+      // the turn. (Chat sessions stay out of the agent's session LIST until
+      // promoted, so absence there is expected, not a failure.)
+      const sessionId = await currentSessionId(ctx)
+      const messages = await ctx.api.messages(ctx.agentSlug, sessionId)
+      if (messages.length === 0) {
+        throw new Error(`Session ${sessionId} has no persisted messages`)
+      }
+      return `session ${sessionId}, ${messages.length} messages`
+    },
+  },
+
+  {
+    id: 'question-card',
+    title: 'AskUserQuestion renders a Block Kit card with one button per option',
+    tags: ['question', 'card'],
+    async run(ctx) {
+      await ctx.conv.say(
+        'Use the AskUserQuestion tool to ask me exactly one question: "Pick a color" ' +
+          'with the options "Red" and "Blue". Wait for my answer.',
+      )
+      const card = await ctx.conv.awaitBot('the question card', contains('Pick a color'), 240_000)
+      const labels = buttonLabels(card)
+      const actionIds = buttonActionIds(card)
+      if (labels.length !== 2 || !labels.includes('Red') || !labels.includes('Blue')) {
+        throw new Error(`Expected Red/Blue buttons, got: ${JSON.stringify(labels)}`)
+      }
+      if (!actionIds.every((a) => /^cb_\d+$/.test(a))) {
+        throw new Error(`Button action_ids must be the connector's registered callbacks: ${actionIds.join(', ')}`)
+      }
+      const request = await awaitRegistryKind(ctx, 'question')
+      return `${actionIds.length} buttons, request ${request.id}`
+    },
+  },
+
+  {
+    id: 'question-freetext-answer',
+    title: 'a plain-text reply answers the open question and the same turn continues',
+    tags: ['question', 'answer'],
+    async run(ctx) {
+      // Depends on question-card leaving a single-question card open: that is
+      // the only shape the free-text path consumes.
+      const open = await ctx.api.pendingRequests(ctx.agentSlug)
+      if (!open.some((r) => r.kind === 'question')) {
+        throw new Error('No open question to answer — question-card must run first')
+      }
+      const tag = nonce()
+      await ctx.conv.say(`Green ${tag}`)
+      await ctx.conv.awaitBot('the agent to use the free-text answer', contains(tag), 240_000)
+      await awaitRegistryEmpty(ctx)
+      return 'answered as the free-form option'
+    },
+  },
+
+  {
+    id: 'question-cancelled-by-unrelated-message',
+    title: 'an unrelated message cancels an open question instead of deadlocking',
+    tags: ['question', 'cancel'],
+    async run(ctx) {
+      await ctx.conv.say(
+        'Use the AskUserQuestion tool to ask me exactly one question: "Pick a fruit" ' +
+          'with the options "Apple" and "Pear". Wait for my answer.',
+      )
+      await ctx.conv.awaitBot('the second question card', contains('Pick a fruit'), 240_000)
+      await awaitRegistryKind(ctx, 'question')
+
+      const tag = nonce()
+      await ctx.conv.say(`Forget the fruit. What is 6 times 7? Reply with exactly: ANSWER ${tag} 42`)
+      await ctx.conv.awaitBot(`ANSWER ${tag} 42`, contains(`ANSWER ${tag} 42`), 240_000)
+      await awaitRegistryEmpty(ctx)
+      return 'cancelled and the fresh turn ran'
+    },
+  },
+
+  {
+    id: 'question-multi-is-not-consumed-by-text',
+    title: 'a multi-question card posts one message per question and text does not answer it',
+    tags: ['question', 'card'],
+    async run(ctx) {
+      await ctx.conv.say(
+        'Use the AskUserQuestion tool to ask me TWO questions in one call: "Pick a size" with ' +
+          'options "Small" and "Large", and "Pick a shape" with options "Circle" and "Square". ' +
+          'Wait for my answers.',
+      )
+      const first = await ctx.conv.awaitBot('the size question', contains('Pick a size'), 240_000)
+      const second = await ctx.conv.awaitBot('the shape question', contains('Pick a shape'), 120_000)
+      if (first.ts === second.ts) {
+        throw new Error('Both questions landed in one message — each must be its own card')
+      }
+      for (const [label, card] of [['size', first], ['shape', second]]) {
+        if (buttonActionIds(card).length !== 2) {
+          throw new Error(`The ${label} card has ${buttonActionIds(card).length} buttons, expected 2`)
+        }
+      }
+
+      // Free text only answers a SINGLE-question card; with more than one open
+      // the message has to fall through and cancel instead, or an answer would
+      // be silently attributed to the wrong question.
+      const tag = nonce()
+      await ctx.conv.say(`Actually stop. Reply with exactly: STOPPED ${tag}`)
+      await ctx.conv.awaitBot(`STOPPED ${tag}`, contains(`STOPPED ${tag}`), 240_000)
+      await awaitRegistryEmpty(ctx)
+      return 'two cards, text cancelled rather than answered'
+    },
+  },
+
+  {
+    id: 'file-delivery-notice',
+    title: 'deliver_file reaches the conversation as a delivery message',
+    tags: ['file-delivery'],
+    async run(ctx) {
+      const tag = nonce()
+      await ctx.conv.say(
+        `Create a file at /workspace/validation-${tag}.txt containing the text ${tag}, then use ` +
+          `the mcp__user-input__deliver_file tool to deliver it to me with the description ` +
+          `"validation artifact ${tag}".`,
+      )
+      // deliver_file uploads the real bytes and uses the description as the
+      // caption; it falls back to a text message only when the host can't read
+      // the file. Either shape counts as delivered, but the tool-call echo
+      // (`🔧 Write — validation-….txt`) does NOT — matching on the filename
+      // alone passes on that echo and tests nothing.
+      const delivered = await ctx.conv.awaitBot(
+        'the delivered file',
+        (message, text) =>
+          (message.files ?? []).some((f) => (f.name ?? '').includes(`validation-${tag}`)) ||
+          (text.includes('File ready') && text.includes(`validation-${tag}.txt`)),
+        300_000,
+      )
+      const uploaded = (delivered.files ?? [])[0]
+      const text = messageText(delivered)
+      if (!text.includes(`validation artifact ${tag}`)) {
+        throw new Error(`Delivery dropped the description: ${text.slice(0, 160)}`)
+      }
+      return uploaded
+        ? `uploaded ${uploaded.name} (${uploaded.size ?? '?'} bytes)`
+        : 'text fallback — the host could not read the file'
+    },
+    async cleanup(ctx) {
+      await clearPending(ctx)
+    },
+  },
+
+  unsupportedCheck({
+    id: 'unsupported-secret',
+    kind: 'secret',
+    prompt:
+      'Use the mcp__user-input__request_secret tool to ask me for a secret named ' +
+      'VALIDATION_TOKEN, with the reason "chat validation". Do not guess a value.',
+    phrase: "needs the secret VALIDATION_TOKEN, which isn't safe to provide in chat",
+  }),
+
+  unsupportedCheck({
+    id: 'unsupported-file',
+    kind: 'file',
+    prompt:
+      'Use the mcp__user-input__request_file tool to ask me to upload a file ' +
+      'described as "a logo image".',
+    // The parenthetical carries the agent's own wording, so only the fixed
+    // parts of the sentence are asserted here; the tail check below is exact.
+    phrase: 'wants you to upload a file',
+  }),
+
+  unsupportedCheck({
+    id: 'unsupported-connected-account',
+    kind: 'connected_account',
+    prompt:
+      'Use the mcp__user-input__request_connected_account tool to ask me to connect ' +
+      'the toolkit "github", with the reason "chat validation".',
+    phrase: "wants to connect your github account, which isn't supported in chat",
+  }),
+
+  unsupportedCheck({
+    id: 'unsupported-remote-mcp',
+    kind: 'remote_mcp',
+    prompt:
+      'Use the mcp__user-input__request_remote_mcp tool to ask me to connect a remote MCP ' +
+      'server named "Validation MCP" at https://example.com/mcp, reason "chat validation".',
+    phrase: 'wants to connect to a remote MCP server',
+  }),
+
+  unsupportedCheck({
+    id: 'unsupported-browser-input',
+    kind: 'browser_input',
+    prompt:
+      'Use the mcp__user-input__request_browser_input tool to ask me to sign in, with the ' +
+      'message "please sign in".',
+    phrase: "needs input in a browser session, which isn't supported in chat",
+    // request_browser_input is only in the web-browser subagent's tool list, so
+    // the main agent reaches it indirectly and the registration can settle with
+    // the subagent before a poll sees it. The notice is the assertion that
+    // matters here; the parked-request invariant is covered by the other kinds.
+    requiresParked: false,
+  }),
+
+  unsupportedCheck({
+    id: 'unsupported-script-run',
+    kind: 'script_run',
+    // The one notice whose wording is about approval rather than support —
+    // it is also the one with a host-side side effect behind it.
+    prompt:
+      'Use the mcp__user-input__request_script_run tool to run the shell script `sw_vers` ' +
+      'with the explanation "chat validation".',
+    phrase: 'wants to run a script, which needs your approval.',
+  }),
+]
+
+/** Checks that drive the user's real machine — opt-in only. */
+export const OPT_IN_CHECKS = [
+  unsupportedCheck({
+    id: 'unsupported-computer-use',
+    kind: 'computer_use',
+    tags: ['computer-use'],
+    prompt:
+      'Use a computer-use tool to take a screenshot of my screen. If computer use is ' +
+      'unavailable, say exactly: COMPUTER USE UNAVAILABLE.',
+    phrase: "wants to use your computer, which isn't supported in chat",
+  }),
+]

--- a/e2e/live/slack-chat/lib/conversation.mjs
+++ b/e2e/live/slack-chat/lib/conversation.mjs
@@ -1,0 +1,95 @@
+/**
+ * A conversation the suite drives, with a watermark.
+ *
+ * Every wait reads strictly forward from the last message the suite has already
+ * accounted for. Without that, a check can be satisfied by a *previous* check's
+ * output — the failure mode that makes a chat suite quietly stop testing
+ * anything — so `since` advances past everything a wait consumed.
+ */
+
+import { sendAsSender, messagesSince, currentWatermark, messageText, normalizeSlackText, buttonActionIds, buttonLabels } from './slack.mjs'
+
+export class Conversation {
+  constructor({ botToken, sender, channelId, botUserId, log = () => {} }) {
+    this.botToken = botToken
+    this.sender = sender
+    this.channelId = channelId
+    this.botUserId = botUserId
+    this.log = log
+    this.since = '0'
+  }
+
+  /** Start reading forward from now, discarding anything already in the channel. */
+  async resetWatermark() {
+    this.since = await currentWatermark(this.botToken, this.channelId)
+    return this.since
+  }
+
+  /** Post as the other identity — what a person typing in Slack produces. */
+  async say(text) {
+    const ts = await sendAsSender(this.sender, this.channelId, text)
+    this.log(`→ ${text.length > 120 ? `${text.slice(0, 117)}…` : text}`)
+    return ts
+  }
+
+  /** Everything posted since the watermark, oldest first (watermark unchanged). */
+  async peek() {
+    return messagesSince(this.botToken, this.channelId, this.since)
+  }
+
+  /**
+   * Wait for a message from the integration matching `predicate`.
+   *
+   * On success the watermark advances past that message, so the next wait
+   * cannot re-match it. On timeout the watermark is left alone and everything
+   * seen in the window is reported — a timeout here almost always means the
+   * agent said something *else*, and that text is the diagnosis.
+   */
+  async awaitBot(label, predicate, timeoutMs = 180_000, intervalMs = 2_000) {
+    const start = Date.now()
+    let seen = []
+    for (;;) {
+      const messages = await this.peek()
+      seen = messages
+      for (const message of messages) {
+        if (message.user !== this.botUserId) continue
+        if (predicate(message, messageText(message))) {
+          this.since = message.ts
+          return message
+        }
+      }
+      if (Date.now() - start > timeoutMs) {
+        const transcript = seen
+          .map((m) => `    [${m.user === this.botUserId ? 'bot' : 'them'}] ${messageText(m).replace(/\n/g, ' ⏎ ').slice(0, 200)}`)
+          .join('\n')
+        throw new Error(
+          `Timed out after ${Math.round((Date.now() - start) / 1000)}s waiting for ${label}.\n` +
+            `  messages in the window:\n${transcript || '    (none)'}`,
+        )
+      }
+      await new Promise((r) => setTimeout(r, intervalMs))
+    }
+  }
+
+  /** Assert the integration posts nothing matching `predicate` within a window. */
+  async expectNoBot(label, predicate, windowMs = 15_000) {
+    const start = Date.now()
+    while (Date.now() - start < windowMs) {
+      for (const message of await this.peek()) {
+        if (message.user !== this.botUserId) continue
+        if (predicate(message, messageText(message))) {
+          throw new Error(`Expected no ${label}, but got: ${messageText(message).slice(0, 200)}`)
+        }
+      }
+      await new Promise((r) => setTimeout(r, 2_000))
+    }
+  }
+
+  /** Advance past everything currently in the window without asserting on it. */
+  async drain() {
+    const messages = await this.peek()
+    if (messages.length > 0) this.since = messages[messages.length - 1].ts
+  }
+}
+
+export { messageText, normalizeSlackText, buttonActionIds, buttonLabels }

--- a/e2e/live/slack-chat/lib/data-dir.mjs
+++ b/e2e/live/slack-chat/lib/data-dir.mjs
@@ -1,0 +1,101 @@
+/**
+ * Reading a Superagent data directory from outside the app's module graph.
+ *
+ * The harness runs as plain Node (no vite aliases), so it cannot import
+ * `@shared/...`. Everything here is a deliberate, minimal re-read of on-disk
+ * state the app owns: settings.json and the SQLite file. Nothing is written
+ * back to a source data dir — see seed.mjs for the isolated copy the harness
+ * actually boots against.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+export const DEFAULT_SOURCE_DATA_DIR = path.join(
+  os.homedir(),
+  'Library',
+  'Application Support',
+  'Superagent-dev',
+)
+
+/**
+ * The packaged install. Kept as a second place to look for the human Slack
+ * connection: people connect their personal accounts in the app they actually
+ * use, which is usually not the dev build that owns the bot.
+ */
+export const PACKAGED_DATA_DIR = path.join(
+  os.homedir(),
+  'Library',
+  'Application Support',
+  'Superagent',
+)
+
+/** Run a query against a data dir's SQLite file, returning parsed JSON rows. */
+export function query(dataDir, sql) {
+  const dbPath = path.join(dataDir, 'superagent.db')
+  if (!existsSync(dbPath)) throw new Error(`No superagent.db in ${dataDir}`)
+  const out = execFileSync('sqlite3', ['-json', dbPath, sql], { encoding: 'utf8' }).trim()
+  if (!out) return []
+  try {
+    return JSON.parse(out)
+  } catch (err) {
+    throw new Error(`sqlite3 returned non-JSON for "${sql}": ${err.message}`)
+  }
+}
+
+/** Run a statement against a data dir's SQLite file (no result). */
+export function exec(dataDir, sql) {
+  execFileSync('sqlite3', [path.join(dataDir, 'superagent.db'), sql], { encoding: 'utf8' })
+}
+
+export function readSettings(dataDir) {
+  const file = path.join(dataDir, 'settings.json')
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch (err) {
+    throw new Error(`Could not read ${file}: ${err.message}`)
+  }
+}
+
+/**
+ * The Slack chat integration row plus its parsed config.
+ *
+ * The config holds the bot and app tokens. They are returned so the harness can
+ * open real Slack connections with them and MUST NOT be logged — every printer
+ * in this harness goes through redact().
+ */
+export function readSlackIntegration(dataDir) {
+  const rows = query(
+    dataDir,
+    "select id, agent_slug, provider, name, show_tool_calls, require_approval, status, config from chat_integrations where provider = 'slack';",
+  )
+  if (rows.length === 0) throw new Error(`No Slack chat integration in ${dataDir}`)
+  if (rows.length > 1) {
+    throw new Error(
+      `${rows.length} Slack integrations in ${dataDir} — the harness needs exactly one to be unambiguous`,
+    )
+  }
+  const row = rows[0]
+  try {
+    return { ...row, config: JSON.parse(row.config) }
+  } catch (err) {
+    throw new Error(`Slack integration ${row.id} has an unparseable config: ${err.message}`)
+  }
+}
+
+/** Every Slack connected account, newest first — candidates for the human sender. */
+export function readSlackConnectedAccounts(dataDir) {
+  return query(
+    dataDir,
+    "select id, provider_connection_id, provider_name, status, display_name from connected_accounts where toolkit_slug = 'slack' order by created_at desc;",
+  )
+}
+
+/** Redact a credential for logs: never print more than a recognisable stub. */
+export function redact(secret) {
+  if (!secret) return '<none>'
+  const s = String(secret)
+  return `${s.slice(0, 4)}…(${s.length} chars)`
+}

--- a/e2e/live/slack-chat/lib/seed.mjs
+++ b/e2e/live/slack-chat/lib/seed.mjs
@@ -1,0 +1,160 @@
+/**
+ * Build the isolated data dir the suite boots against.
+ *
+ * The source install is never written to. What the seed produces is a data dir
+ * that holds exactly one agent and exactly one chat integration — the Slack
+ * one, retargeted at the seeded agent — so that:
+ *
+ *   - the container name is derived from a slug the source install does not
+ *     use, and a run cannot collide with (or tear down) the agent the user is
+ *     working in,
+ *   - no scheduled task, trigger, or second integration wakes anything the
+ *     suite did not ask for,
+ *   - each run starts from an empty conversation history, so "the agent
+ *     replied" is never satisfied by a previous run's transcript.
+ *
+ * The Slack tokens are carried over verbatim — there is only one Slack app, and
+ * the whole point is to drive it for real.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, rmSync, copyFileSync, writeFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+import { readSlackIntegration, exec, query } from './data-dir.mjs'
+
+export const DEFAULT_TARGET_DIR = path.join(os.homedir(), 'Downloads', 'slack-chat-validation')
+
+/**
+ * A slug no real install uses, so `superagent-<slug>` can never be the
+ * container of an agent someone is working in.
+ */
+export const VALIDATION_AGENT_SLUG = 'slack-validation-agent'
+
+const AGENT_CLAUDE_MD = `---
+name: Slack Validation Agent
+createdAt: "2026-01-01T00:00:00.000Z"
+description: Drives the Slack chat-integration validation suite
+---
+
+# Agent Instructions
+
+You are the target of an automated validation suite for the Slack chat
+integration. Follow instructions literally and completely.
+
+## Rules
+
+- When asked to call a specific tool, call exactly that tool, once, with the
+  arguments described — do not substitute a different tool and do not ask for
+  confirmation first.
+- If a named tool is not already loaded, use ToolSearch to load it by name and
+  then call it. Never give up on a named tool because it was not in the initial
+  list, and never report success without having called it.
+- When asked to reply with an exact marker (e.g. \`DONE: <something>\`), reply
+  with that marker on its own line and nothing else around it.
+- Never invent a value for something you were asked to request from the user.
+  Requesting it through the proper tool IS the task.
+- Keep replies short. Do not summarise these instructions back.
+`
+
+/**
+ * Tables whose rows would make the seeded install do something on its own, or
+ * would carry another install's history into a run. Emptied rather than
+ * dropped so the schema (and drizzle's migration bookkeeping) stays intact.
+ */
+const TABLES_TO_EMPTY = [
+  'chat_integration_sessions',
+  'chat_integration_access',
+  'scheduled_tasks',
+  'webhook_triggers',
+  'notifications',
+  'agent_acl',
+  'agent_connected_accounts',
+  'agent_remote_mcps',
+  'remote_mcp_servers',
+  'x_agent_policies',
+  'api_scope_policies',
+  'mcp_tool_policies',
+  'proxy_audit_log',
+  'mcp_audit_log',
+  'audit_log',
+  'message_author',
+  'proxy_tokens',
+  'token_exchange_jti',
+  'session',
+]
+
+export function seed({ source, target = DEFAULT_TARGET_DIR, log = () => {} } = {}) {
+  const integration = readSlackIntegration(source)
+
+  // A previous host that is still shutting down can write into the dir mid-rm
+  // (Electron drops a crash marker on exit), which surfaces as ENOTEMPTY.
+  // Retry rather than fail the run on a teardown race.
+  for (let attempt = 1; ; attempt++) {
+    try {
+      rmSync(target, { recursive: true, force: true })
+      break
+    } catch (err) {
+      if (attempt >= 5) {
+        throw new Error(
+          `Could not clear ${target} (${err.message}). Something is still writing to it — ` +
+            `check for a surviving Electron or vite process from an earlier run.`,
+        )
+      }
+      execFileSync('sleep', ['2'])
+    }
+  }
+  mkdirSync(path.join(target, 'agents', VALIDATION_AGENT_SLUG, 'workspace'), { recursive: true })
+  log(`seeded data dir: ${target}`)
+
+  // settings.json verbatim: the LLM key, container runner, and account
+  // providers all have to match the install the integration came from.
+  copyFileSync(path.join(source, 'settings.json'), path.join(target, 'settings.json'))
+  for (const optional of ['tenant-id', 'host-container-tokens.json']) {
+    const from = path.join(source, optional)
+    if (existsSync(from)) copyFileSync(from, path.join(target, optional))
+  }
+
+  writeFileSync(
+    path.join(target, 'agents', VALIDATION_AGENT_SLUG, 'workspace', 'CLAUDE.md'),
+    AGENT_CLAUDE_MD,
+  )
+
+  copyFileSync(path.join(source, 'superagent.db'), path.join(target, 'superagent.db'))
+  // WAL/SHM siblings would otherwise replay the source's uncommitted tail over
+  // the copy. Checkpointing the copy on first open is enough — we simply don't
+  // carry them across.
+  for (const sidecar of ['superagent.db-wal', 'superagent.db-shm']) {
+    rmSync(path.join(target, sidecar), { force: true })
+  }
+
+  const statements = [
+    ...TABLES_TO_EMPTY.map((t) => `delete from ${t};`),
+    `delete from chat_integrations where id <> '${integration.id}';`,
+    `update chat_integrations set agent_slug = '${VALIDATION_AGENT_SLUG}', status = 'active' where id = '${integration.id}';`,
+  ]
+  exec(target, statements.join('\n'))
+
+  const kept = query(target, 'select id, agent_slug, provider, status, show_tool_calls, require_approval from chat_integrations;')
+  log(
+    `integration ${kept[0].id} retargeted to ${kept[0].agent_slug} ` +
+      `(showToolCalls=${kept[0].show_tool_calls}, requireApproval=${kept[0].require_approval})`,
+  )
+
+  return { target, integrationId: integration.id, agentSlug: VALIDATION_AGENT_SLUG, config: integration.config }
+}
+
+/** Container left over from an earlier run — removed so each run boots clean. */
+export function removeValidationContainer(log = () => {}) {
+  const name = `superagent-${VALIDATION_AGENT_SLUG}`
+  try {
+    const out = execFileSync('docker', ['ps', '-aq', '--filter', `name=^${name}$`], { encoding: 'utf8' }).trim()
+    if (!out) return
+    execFileSync('docker', ['rm', '-f', name], { encoding: 'utf8' })
+    log(`removed stale container ${name}`)
+  } catch (err) {
+    log(`could not remove ${name}: ${err.message}`)
+  }
+}
+

--- a/e2e/live/slack-chat/lib/slack.mjs
+++ b/e2e/live/slack-chat/lib/slack.mjs
@@ -1,0 +1,325 @@
+/**
+ * The two Slack identities the harness needs.
+ *
+ *   BOT    — the chat integration itself. Its token comes straight from the
+ *            integration config; used to read what the app posted
+ *            (conversations.history), Block Kit payloads included.
+ *   SENDER — a second identity in the same workspace that posts the messages a
+ *            person would, so inbound traffic takes the real
+ *            message → Socket Mode → connector path.
+ *
+ * A sender is reached one of two ways, and the difference matters:
+ *
+ *   raw token — the connected account exposes a usable Slack token.
+ *   proxy     — Composio refuses to hand out the raw token (it returns a
+ *               redacted one) and executes the call server-side instead. This
+ *               is the normal case for Composio-managed OAuth connections, so
+ *               the harness treats a token that Slack rejects as a signal to
+ *               fall back rather than as a dead connection.
+ *
+ * No token is ever logged.
+ */
+
+import { readSettings, readSlackConnectedAccounts } from './data-dir.mjs'
+
+const COMPOSIO_HOST = 'https://backend.composio.dev'
+const NANGO_HOST = 'https://api.nango.dev'
+const PLATFORM_PROXY_HOST =
+  process.env.PLATFORM_PROXY_URL?.replace(/\/+$/, '').replace(/\/v1$/, '') ??
+  'https://platformproxy.gamutagents.com'
+
+async function slackWithToken(token, method, params = {}) {
+  const res = await fetch(`https://slack.com/api/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(params),
+  })
+  return res.json()
+}
+
+/** How composioFetch picks its route: a local key, else the platform proxy. */
+function composioRoute(settings, endpoint, apiVersion = 'v3') {
+  const key = settings.apiKeys?.composioApiKey
+  if (key) return [`${COMPOSIO_HOST}/api/${apiVersion}${endpoint}`, { 'x-api-key': key }]
+  const platformToken = settings.platformAuth?.token
+  if (!platformToken) throw new Error('neither composioApiKey nor a platform auth token is present')
+  return [`${PLATFORM_PROXY_HOST}/v1/composio${endpoint}`, { Authorization: `Bearer ${platformToken}` }]
+}
+
+/** Execute a Slack call through Composio, which attaches the auth server-side. */
+async function slackViaComposio(settings, connectedAccountId, method, params = {}) {
+  const [url, headers] = composioRoute(settings, '/tools/execute/proxy', 'v3.1')
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      endpoint: `https://slack.com/api/${method}`,
+      method: 'POST',
+      connected_account_id: connectedAccountId,
+      body: params,
+    }),
+  })
+  if (!res.ok) throw new Error(`composio proxy ${res.status} for ${method}`)
+  const parsed = await res.json()
+  return parsed.data ?? parsed
+}
+
+async function composioRawToken(settings, connectedAccountId) {
+  const [url, headers] = composioRoute(settings, `/connected_accounts/${encodeURIComponent(connectedAccountId)}`)
+  const res = await fetch(url, { headers })
+  if (!res.ok) throw new Error(`composio ${res.status}`)
+  const json = await res.json()
+  const val = json.state?.val ?? {}
+  return val.access_token ?? val.oauth_token ?? val.api_key ?? val.generic_api_key ?? null
+}
+
+async function nangoRawToken(settings, connectionId) {
+  const key = settings.apiKeys?.nangoSecretKey
+  if (!key) throw new Error('nangoSecretKey missing from settings')
+  const url =
+    `${NANGO_HOST}/connections/${encodeURIComponent(connectionId)}` +
+    `?provider_config_key=slack&force_refresh=true`
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${key}` } })
+  if (!res.ok) throw new Error(`nango ${res.status}`)
+  const creds = (await res.json()).credentials ?? {}
+  return creds.access_token ?? creds.oauth_token ?? creds.api_key ?? null
+}
+
+/** Every way one connected account might be able to speak Slack, in order. */
+async function candidateCallers(settings, account) {
+  const callers = []
+  try {
+    const token =
+      account.provider_name === 'nango'
+        ? await nangoRawToken(settings, account.provider_connection_id)
+        : await composioRawToken(settings, account.provider_connection_id)
+    if (token) {
+      callers.push({
+        via: 'token',
+        call: (method, params) => slackWithToken(token, method, params),
+      })
+    }
+  } catch (err) {
+    callers.push({ via: 'token', error: err.message })
+  }
+  if (account.provider_name !== 'nango') {
+    callers.push({
+      via: 'composio-proxy',
+      call: (method, params) =>
+        slackViaComposio(settings, account.provider_connection_id, method, params),
+    })
+  }
+  return callers
+}
+
+/**
+ * Find a connected account that can post into the bot's workspace as somebody
+ * other than the integration itself.
+ *
+ * A human (user) identity is preferred: it is the only shape that can open a DM
+ * with the bot, which is how the feature is actually used. A second app's bot
+ * identity is the accepted fallback — Slack delivers its posts as ordinary
+ * `message` events with no subtype, so the connector's inbound path treats them
+ * exactly like a person's, but they can only reach a shared channel.
+ */
+export async function resolveSender(sourceDataDir, botAuth, log = () => {}, { requireHuman = false } = {}) {
+  const settings = readSettings(sourceDataDir)
+  const accounts = readSlackConnectedAccounts(sourceDataDir).filter((a) => a.status === 'active')
+  const rejected = []
+  const appFallbacks = []
+
+  for (const account of accounts) {
+    for (const caller of await candidateCallers(settings, account)) {
+      const label = `${account.provider_name}:${account.provider_connection_id} (${caller.via})`
+      if (caller.error) {
+        rejected.push(`${label} — ${caller.error}`)
+        continue
+      }
+      let auth
+      try {
+        auth = await caller.call('auth.test')
+      } catch (err) {
+        rejected.push(`${label} — ${err.message}`)
+        continue
+      }
+      if (!auth?.ok) {
+        rejected.push(`${label} — auth.test failed (${auth?.error ?? 'no response'})`)
+        continue
+      }
+      if (auth.team_id !== botAuth.team_id) {
+        rejected.push(`${label} — workspace ${auth.team ?? auth.team_id}, not the bot's`)
+        continue
+      }
+      if (auth.user_id === botAuth.user_id) {
+        rejected.push(`${label} — this is the integration's own identity`)
+        continue
+      }
+      const sender = { auth, call: caller.call, accountId: account.id, label, via: caller.via }
+      if (auth.bot_id) {
+        appFallbacks.push({ ...sender, kind: 'app' })
+        continue
+      }
+      log(`sender: human ${auth.user} (${auth.user_id}) in ${auth.team} via ${label}`)
+      return { ...sender, kind: 'human', rejected }
+    }
+  }
+
+  if (requireHuman) {
+    const detail = rejected.length ? `\n  ${rejected.join('\n  ')}` : ''
+    throw new Error(`No human Slack identity in this install.${detail}`)
+  }
+
+  if (appFallbacks.length > 0) {
+    const pick = appFallbacks[0]
+    log(
+      `sender: app ${pick.auth.user} (${pick.auth.user_id}) in ${pick.auth.team} via ${pick.label} ` +
+        `— no human identity available, so the surface will be a shared channel`,
+    )
+    return { ...pick, rejected }
+  }
+
+  const detail = rejected.length ? `\n  ${rejected.join('\n  ')}` : ''
+  throw new Error(
+    `No Slack connected account can post into the bot's workspace as another identity.${detail}`,
+  )
+}
+
+/**
+ * Try each data dir in turn for a usable sender.
+ *
+ * The integration's install and the install holding the personal Slack
+ * connection are routinely different (the packaged app is where people
+ * actually connect their accounts), so "no sender here" is a reason to look in
+ * the next install, not to stop. Every dir is read-only.
+ */
+export async function resolveSenderAcross(dirs, botAuth, log = () => {}) {
+  const candidates = dirs.filter(Boolean)
+  const tried = []
+  // A human anywhere beats an app identity everywhere: only a human can open
+  // the DM, which is the surface the feature is actually used on.
+  for (const requireHuman of [true, false]) {
+    for (const dir of candidates) {
+      try {
+        const sender = await resolveSender(dir, botAuth, log, { requireHuman })
+        return { ...sender, sourceDir: dir }
+      } catch (err) {
+        if (!requireHuman) tried.push(`${dir}:\n    ${err.message.split('\n').join('\n    ')}`)
+      }
+    }
+  }
+  throw new Error(`No usable Slack sender in any candidate install.\n  ${tried.join('\n  ')}`)
+}
+
+/** Bot identity, and a hard failure if the integration's token is dead. */
+export async function resolveBot(botToken) {
+  const auth = await slackWithToken(botToken, 'auth.test')
+  if (!auth.ok) throw new Error(`Slack bot token rejected: ${auth.error}`)
+  return auth
+}
+
+/**
+ * The DM channel between the sender and the bot, opened from the SENDER side so
+ * the id is the same one a real person's messages arrive on.
+ */
+export async function openDirectMessage(sender, botUserId) {
+  const res = await sender.call('conversations.open', { users: botUserId })
+  if (!res.ok) throw new Error(`conversations.open failed: ${res.error}`)
+  return res.channel.id
+}
+
+/** Post as the sender. Returns the message ts. */
+export async function sendAsSender(sender, channel, text) {
+  const res = await sender.call('chat.postMessage', { channel, text })
+  if (!res.ok) throw new Error(`sender chat.postMessage failed: ${res.error}`)
+  return res.ts
+}
+
+/**
+ * Messages in the channel strictly after `sinceTs`, oldest first, read with the
+ * BOT token so we see exactly what the integration published.
+ */
+export async function messagesSince(botToken, channel, sinceTs, limit = 200) {
+  const res = await slackWithToken(botToken, 'conversations.history', {
+    channel,
+    oldest: sinceTs,
+    inclusive: false,
+    limit,
+  })
+  if (!res.ok) throw new Error(`conversations.history failed: ${res.error}`)
+  return (res.messages ?? []).slice().reverse()
+}
+
+/** Latest ts in the channel — the watermark a step reads forward from. */
+export async function currentWatermark(botToken, channel) {
+  const res = await slackWithToken(botToken, 'conversations.history', { channel, limit: 1 })
+  if (!res.ok) throw new Error(`conversations.history failed: ${res.error}`)
+  return res.messages?.[0]?.ts ?? '0'
+}
+
+/** Channel ids an identity is a member of. `who` is a bot token or a sender. */
+export async function memberChannels(who) {
+  const params = { types: 'public_channel,private_channel', limit: 200, exclude_archived: true }
+  const res = typeof who === 'string'
+    ? await slackWithToken(who, 'users.conversations', params)
+    : await who.call('users.conversations', params)
+  if (!res.ok) throw new Error(`users.conversations failed: ${res.error}`)
+  return (res.channels ?? []).map((c) => ({ id: c.id, name: c.name, isPrivate: !!c.is_private }))
+}
+
+export async function joinChannel(sender, channelId) {
+  return sender.call('conversations.join', { channel: channelId })
+}
+
+/** Every button action_id in a message's Block Kit payload. */
+export function buttonActionIds(message) {
+  const ids = []
+  for (const block of message.blocks ?? []) {
+    if (block.type !== 'actions') continue
+    for (const el of block.elements ?? []) {
+      if (el.type === 'button' && el.action_id) ids.push(el.action_id)
+    }
+  }
+  return ids
+}
+
+/** Button labels in a message, in render order. */
+export function buttonLabels(message) {
+  const labels = []
+  for (const block of message.blocks ?? []) {
+    if (block.type !== 'actions') continue
+    for (const el of block.elements ?? []) {
+      if (el.type === 'button') labels.push(el.text?.text ?? '')
+    }
+  }
+  return labels
+}
+
+/**
+ * Undo Slack's on-the-wire encoding so an assertion can compare against the
+ * text the app actually posted.
+ *
+ * Slack auto-links bare URLs and hands them back wrapped in angle brackets
+ * (`<https://…>`, or `<url|label>` when a label is present), and escapes
+ * &, < and >. None of that is in what the connector sent, so comparing raw
+ * would fail on every notice that ends in a link — which is all of them.
+ */
+export function normalizeSlackText(text) {
+  return text
+    .replace(/<((?:https?|[a-z][a-z0-9+.-]*):\/\/[^|>]+)(?:\|[^>]*)?>/gi, '$1')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+}
+
+/** All human-readable text in a message: top-level text plus every block. */
+export function messageText(message) {
+  const parts = [message.text ?? '']
+  for (const block of message.blocks ?? []) {
+    if (block.text?.text) parts.push(block.text.text)
+    for (const field of block.fields ?? []) if (field.text) parts.push(field.text)
+  }
+  return normalizeSlackText(parts.join('\n'))
+}

--- a/e2e/live/slack-chat/lib/surface.mjs
+++ b/e2e/live/slack-chat/lib/surface.mjs
@@ -1,0 +1,75 @@
+/**
+ * Choosing the Slack conversation the suite runs in.
+ *
+ * The surface follows from what the sender is:
+ *
+ *   human identity → a DM with the bot. Closest to how the feature is really
+ *                    used, and the only shape that can open a D… channel.
+ *   app identity   → a shared channel. Slack will not let one app post into
+ *                    another app's DM, so a channel is the only reachable
+ *                    surface.
+ *
+ * Either way the integration sees an inbound `message` event on a chat id and
+ * takes the identical connector path; the channel case additionally exercises
+ * channel routing (which, with onlyMentioned off, processes every message).
+ */
+
+import { openDirectMessage, memberChannels, joinChannel } from './slack.mjs'
+
+export async function resolveSurface({ sender, botToken, botAuth, preferred, log = () => {} }) {
+  if (sender.kind === 'human') {
+    const id = await openDirectMessage(sender, botAuth.user_id)
+    return { kind: 'dm', channelId: id, label: `DM with ${botAuth.user}` }
+  }
+
+  const [botChannels, senderChannels] = await Promise.all([
+    memberChannels(botToken),
+    memberChannels(sender),
+  ])
+  const senderIds = new Set(senderChannels.map((c) => c.id))
+  const wanted = preferred?.replace(/^#/, '')
+  let shared = botChannels.filter((c) => senderIds.has(c.id))
+
+  // The sender app is typically installed but in no channels. It can add itself
+  // to a PUBLIC channel the integration bot already sits in (conversations.join
+  // needs channels:join and works only for public channels); private ones need
+  // a human invite, which the error below spells out.
+  if (shared.length === 0) {
+    const target =
+      (wanted && botChannels.find((c) => c.id === wanted || c.name === wanted)) ??
+      botChannels.find((c) => !c.isPrivate)
+    if (target && !target.isPrivate) {
+      const joined = await joinChannel(sender, target.id)
+      if (joined.ok) {
+        log(`sender joined #${target.name} (it was in no channel the bot is in)`)
+        shared = [target]
+      }
+    }
+  }
+
+  if (shared.length === 0) {
+    throw new Error(
+      `The integration bot (${botAuth.user}) and the sender (${sender.auth.user}) share no channel, ` +
+        `and the sender could not join one on its own. Invite ${sender.auth.user} to a channel ` +
+        `${botAuth.user} is in — a channel dedicated to validation is best, since every message ` +
+        `in it wakes the agent.\n` +
+        `  bot is in:    ${botChannels.map((c) => `#${c.name}`).join(', ') || '(none)'}\n` +
+        `  sender is in: ${senderChannels.map((c) => `#${c.name}`).join(', ') || '(none)'}`,
+    )
+  }
+
+  const pick = (wanted && shared.find((c) => c.id === wanted || c.name === wanted)) ?? shared[0]
+  if (wanted && pick.id !== wanted && pick.name !== wanted) {
+    throw new Error(
+      `Requested channel "${preferred}" is not shared by both identities. Shared: ${shared
+        .map((c) => `#${c.name}`)
+        .join(', ')}`,
+    )
+  }
+  return {
+    kind: 'channel',
+    channelId: pick.id,
+    label: `#${pick.name}`,
+    shared: shared.map((c) => `#${c.name}`),
+  }
+}

--- a/e2e/live/slack-chat/preflight.mjs
+++ b/e2e/live/slack-chat/preflight.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Preflight for the Slack chat-integration validation harness.
+ *
+ * Proves the environment can run the suite before anything is seeded or
+ * booted — the slow, stateful parts should never fail for a reason a five
+ * second check could have surfaced:
+ *
+ *   1. the source data dir exists and holds exactly one Slack integration,
+ *   2. its bot token still authenticates,
+ *   3. some connected account authenticates as a HUMAN in the same workspace,
+ *   4. the DM between them opens,
+ *   5. docker and the agent image the seed will boot against are present,
+ *   6. nothing else is already holding this Slack app's Socket Mode session.
+ *
+ * Run:  node e2e/live/slack-chat/preflight.mjs [--source=<data dir>]
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+import { DEFAULT_SOURCE_DATA_DIR, PACKAGED_DATA_DIR, readSettings, readSlackIntegration } from './lib/data-dir.mjs'
+import { resolveBot, resolveSenderAcross, currentWatermark } from './lib/slack.mjs'
+import { resolveSurface } from './lib/surface.mjs'
+import { containerPortRangeConflicts } from './lib/app.mjs'
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const [k, ...v] = a.replace(/^--/, '').split('=')
+    return [k, v.join('=') || true]
+  }),
+)
+
+const SOURCE = args.source || process.env.SLACK_VALIDATION_SOURCE_DIR || DEFAULT_SOURCE_DATA_DIR
+
+const results = []
+const check = (name, ok, detail = '') => {
+  results.push({ name, ok, detail })
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+  return ok
+}
+
+export async function preflight({ source = SOURCE, log = console.log } = {}) {
+  if (!existsSync(source)) throw new Error(`Source data dir not found: ${source}`)
+  log(`source data dir: ${source}`)
+
+  const integration = readSlackIntegration(source)
+  check('exactly one Slack integration in the source data dir', true, `agent=${integration.agent_slug} showToolCalls=${integration.show_tool_calls}`)
+
+  const settings = readSettings(source)
+  check(
+    'settings carry an LLM key the seeded app can run turns with',
+    Boolean(settings.apiKeys?.anthropicApiKey) || settings.llmProvider === 'platform',
+    settings.apiKeys?.anthropicApiKey ? 'anthropicApiKey present' : `llmProvider=${settings.llmProvider}`,
+  )
+
+  const botAuth = await resolveBot(integration.config.botToken)
+  check('bot token authenticates', true, `${botAuth.user} (${botAuth.user_id}) in ${botAuth.team}`)
+
+  // The sender's credentials may live in a different install than the
+  // integration's (e.g. the packaged app holds the personal Slack connection
+  // while the dev install holds the bot). Both are read-only here.
+  const senderDirs = args['sender-source'] || process.env.SLACK_VALIDATION_SENDER_DIR
+    ? [args['sender-source'] || process.env.SLACK_VALIDATION_SENDER_DIR]
+    : [source, PACKAGED_DATA_DIR]
+  const sender = await resolveSenderAcross(senderDirs, botAuth, (m) => log(`  ${m}`))
+  if (sender.sourceDir !== source) log(`  sender credentials came from ${sender.sourceDir}`)
+  check(
+    'a connected account can post as a second identity in the same workspace',
+    true,
+    `${sender.kind} ${sender.auth.user} via ${sender.label}`,
+  )
+
+  const surface = await resolveSurface({
+    sender,
+    botToken: integration.config.botToken,
+    botAuth,
+    preferred: args.channel || process.env.SLACK_VALIDATION_CHANNEL,
+    log: (m) => log(`  ${m}`),
+  })
+  const watermark = await currentWatermark(integration.config.botToken, surface.channelId)
+  check(
+    'the conversation to drive is reachable',
+    true,
+    `${surface.label} (${surface.channelId}, watermark ${watermark})`,
+  )
+
+  let dockerOk = false
+  let images = ''
+  try {
+    images = execFileSync('docker', ['images', '--format', '{{.Repository}}:{{.Tag}}'], { encoding: 'utf8' })
+    dockerOk = true
+  } catch {
+    /* reported below */
+  }
+  check('docker is reachable', dockerOk)
+  const wantImage = settings.container?.agentImage ?? 'superagent-container:latest'
+  check(`agent image ${wantImage} exists locally`, images.split('\n').includes(wantImage))
+
+  const basePort = Number(args['container-base-port'] ?? 5300)
+  const conflicts = await containerPortRangeConflicts(basePort)
+  check(
+    `container publish range ${basePort}-${basePort + 7} is free`,
+    conflicts.length === 0,
+    conflicts.length
+      ? `busy: ${conflicts.join(', ')} — a loopback listener there silently steals host→container traffic`
+      : '',
+  )
+
+  // One Socket Mode session per app token wins the events; a second one makes
+  // Slack load-balance and the suite goes nondeterministically quiet.
+  const competing = detectCompetingHosts(source)
+  check(
+    'no other Superagent instance is holding this Slack app',
+    competing.length === 0,
+    competing.length ? competing.join('; ') : 'no running app with an active Slack integration',
+  )
+
+  return { source, integration, settings, botAuth, sender, surface, watermark, ok: results.every((r) => r.ok) }
+}
+
+/**
+ * Any *running* Superagent process whose data dir holds an ACTIVE Slack
+ * integration would compete for the same Socket Mode session. Paused rows are
+ * harmless; so is a data dir nobody is running.
+ */
+function detectCompetingHosts(source) {
+  const found = []
+  let ps = ''
+  try {
+    ps = execFileSync('ps', ['ax', '-o', 'command'], { encoding: 'utf8' })
+  } catch {
+    return found
+  }
+  const running = {
+    packaged: /\/(Gamut|Superagent)\.app\/Contents\/MacOS\//.test(ps),
+    electronDev: /electron-vite dev/.test(ps),
+  }
+  const candidates = [
+    ['packaged app', path.join(process.env.HOME, 'Library', 'Application Support', 'Superagent'), running.packaged],
+    ['electron dev', DEFAULT_SOURCE_DATA_DIR, running.electronDev],
+  ]
+  for (const [label, dir, isRunning] of candidates) {
+    if (!isRunning || dir === source) continue
+    if (!existsSync(path.join(dir, 'superagent.db'))) continue
+    try {
+      const rows = execFileSync(
+        'sqlite3',
+        [path.join(dir, 'superagent.db'), "select count(*) from chat_integrations where provider='slack' and status='active';"],
+        { encoding: 'utf8' },
+      ).trim()
+      if (Number(rows) > 0) found.push(`${label} is running with an active Slack integration (${dir})`)
+    } catch {
+      /* unreadable db — not evidence of a conflict */
+    }
+  }
+  return found
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  preflight()
+    .then((r) => {
+      console.log(r.ok ? '\npreflight PASSED' : '\npreflight FAILED')
+      process.exit(r.ok ? 0 : 1)
+    })
+    .catch((err) => {
+      console.error(`\npreflight ERROR: ${err.message}`)
+      process.exit(1)
+    })
+}

--- a/e2e/live/slack-chat/run.mjs
+++ b/e2e/live/slack-chat/run.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * Live end-to-end validation of the Slack chat integration.
+ *
+ * Nothing on the path is mocked. A real second Slack identity posts into a real
+ * conversation, a real app instance (booted against an isolated data dir)
+ * receives it over Socket Mode, a real container runs the turn, and the
+ * assertions read what actually landed back in Slack — Block Kit payloads
+ * included.
+ *
+ * The suite exists because the chat integration's own tests are contract tests:
+ * they pin the shape of events the connectors are handed, not the fact that the
+ * host still hands them those events. A refactor can keep every contract test
+ * green and still stop delivering cards.
+ *
+ * Run:
+ *   node e2e/live/slack-chat/run.mjs                      # web host, linked notices
+ *   node e2e/live/slack-chat/run.mjs --host=electron      # desktop host (superagent-dev:// links)
+ *   node e2e/live/slack-chat/run.mjs --no-public-url      # cloud host with no HOST_PUBLIC_URL
+ *   node e2e/live/slack-chat/run.mjs --only=unsupported   # a tag or comma-separated ids
+ *   node e2e/live/slack-chat/run.mjs --keep-app           # leave the app running for poking
+ *
+ * See .claude/skills/slack-chat-validation/SKILL.md for prerequisites and for
+ * what each check protects.
+ */
+
+import path from 'node:path'
+import os from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { writeFileSync, mkdirSync } from 'node:fs'
+
+import { DEFAULT_SOURCE_DATA_DIR, PACKAGED_DATA_DIR, readSlackIntegration } from './lib/data-dir.mjs'
+import { resolveBot, resolveSenderAcross } from './lib/slack.mjs'
+import { resolveSurface } from './lib/surface.mjs'
+import { seed, removeValidationContainer, DEFAULT_TARGET_DIR, VALIDATION_AGENT_SLUG } from './lib/seed.mjs'
+import { startApp, freePort, containerPortRangeConflicts } from './lib/app.mjs'
+import { Conversation } from './lib/conversation.mjs'
+import { CHECKS, OPT_IN_CHECKS } from './lib/checks.mjs'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const [k, ...v] = a.replace(/^--/, '').split('=')
+    return [k, v.length ? v.join('=') : true]
+  }),
+)
+
+const HOST = args.host === 'electron' ? 'electron' : 'web'
+const SOURCE = args.source || process.env.SLACK_VALIDATION_SOURCE_DIR || DEFAULT_SOURCE_DATA_DIR
+const SENDER_OVERRIDE = args['sender-source'] || process.env.SLACK_VALIDATION_SENDER_DIR
+const TARGET = args.target || DEFAULT_TARGET_DIR
+const RUN_DIR = path.join(os.tmpdir(), `slack-chat-validation-${Date.now()}`)
+
+// The cloud host links to HOST_PUBLIC_URL. --no-public-url exercises the row of
+// the notice matrix where it is unset and the link must be omitted entirely
+// rather than degrading to a broken URL.
+const PUBLIC_URL = args['no-public-url'] ? '' : args['public-url'] || 'https://validation.example.test'
+
+const log = (msg) => console.log(`[slack-validation] ${msg}`)
+
+function selected() {
+  const all = [...CHECKS, ...(args['with-computer-use'] ? OPT_IN_CHECKS : [])]
+  if (!args.only) return all
+  const wanted = String(args.only).split(',').map((s) => s.trim()).filter(Boolean)
+  const picked = all.filter((c) => wanted.includes(c.id) || c.tags?.some((t) => wanted.includes(t)))
+  if (picked.length === 0) throw new Error(`--only=${args.only} matched no checks`)
+  return picked
+}
+
+async function main() {
+  mkdirSync(RUN_DIR, { recursive: true })
+  const checks = selected()
+  log(`${checks.length} checks, host=${HOST}, run dir ${RUN_DIR}`)
+
+  // ── Slack identities and the conversation ──────────────────────────
+  const sourceIntegration = readSlackIntegration(SOURCE)
+  const botAuth = await resolveBot(sourceIntegration.config.botToken)
+  log(`integration bot: ${botAuth.user} (${botAuth.user_id}) in ${botAuth.team}`)
+  const sender = await resolveSenderAcross(
+    SENDER_OVERRIDE ? [SENDER_OVERRIDE] : [SOURCE, PACKAGED_DATA_DIR],
+    botAuth,
+    log,
+  )
+  const surface = await resolveSurface({
+    sender,
+    botToken: sourceIntegration.config.botToken,
+    botAuth,
+    preferred: args.channel || process.env.SLACK_VALIDATION_CHANNEL,
+    log,
+  })
+  log(`conversation: ${surface.label} (${surface.channelId})`)
+
+  // ── Isolated install ───────────────────────────────────────────────
+  const seeded = seed({ source: SOURCE, target: TARGET, log })
+  removeValidationContainer(log)
+
+  // ── The app under test ─────────────────────────────────────────────
+  const containerBasePort = Number(args['container-base-port'] ?? 5300)
+  const conflicts = await containerPortRangeConflicts(containerBasePort)
+  if (conflicts.length > 0) {
+    throw new Error(
+      `Container publish range ${containerBasePort}+ is not free (busy: ${conflicts.join(', ')}). ` +
+        `A loopback listener there — typically a packaged install's Lima port-forward — shadows ` +
+        `Docker's publish, so every host→container call lands in the other install's container and ` +
+        `returns 401. Pass --container-base-port=<free base>.`,
+    )
+  }
+  const port = await freePort(Number(args.port) || undefined)
+  const app = await startApp({
+    host: HOST,
+    dataDir: seeded.target,
+    port,
+    containerBasePort,
+    hostPublicUrl: PUBLIC_URL,
+    repoRoot: REPO_ROOT,
+    logFile: path.join(RUN_DIR, `app-${HOST}.log`),
+    integrationId: seeded.integrationId,
+    log,
+  })
+
+  const hostShape =
+    HOST === 'electron'
+      ? { isDesktop: true, appLinkBase: `superagent-dev://agent/${encodeURIComponent(VALIDATION_AGENT_SLUG)}` }
+      : {
+          isDesktop: false,
+          appLinkBase: PUBLIC_URL
+            ? `${PUBLIC_URL.replace(/\/+$/, '')}/agents/${encodeURIComponent(VALIDATION_AGENT_SLUG)}`
+            : null,
+        }
+  log(`expected app link base: ${hostShape.appLinkBase ?? '(none — link omitted)'}`)
+
+  const conv = new Conversation({
+    botToken: sourceIntegration.config.botToken,
+    sender,
+    channelId: surface.channelId,
+    botUserId: botAuth.user_id,
+    log: (m) => log(m),
+  })
+  await conv.resetWatermark()
+
+  if (args['boot-only']) {
+    // Everything except spending container turns: proves the seed, the host
+    // boot, the Socket Mode connection, and both Slack identities line up.
+    log(`boot-only: app on ${app.base}, data dir ${seeded.target}`)
+    await app.stop()
+    return true
+  }
+
+  const ctx = {
+    conv,
+    api: app.api,
+    agentSlug: seeded.agentSlug,
+    integrationId: seeded.integrationId,
+    hostShape,
+    host: HOST,
+  }
+
+  // ── Warm up ────────────────────────────────────────────────────────
+  // The first turn pays for the container's cold start, which can exceed a
+  // check's own timeout. When inbound-turn is in the selection it absorbs that
+  // itself; otherwise a --only run would charge the cold start to whichever
+  // check happened to go first and fail it for the wrong reason.
+  if (!checks.some((c) => c.id === 'inbound-turn')) {
+    const tag = Math.random().toString(36).slice(2, 8).toUpperCase()
+    log('warming up the container with one throwaway turn…')
+    await conv.say(`Reply with exactly: WARM ${tag}`)
+    await conv.awaitBot(`WARM ${tag}`, (_m, text) => text.includes(`WARM ${tag}`), 480_000)
+    log('warm')
+  }
+
+  // ── Run ────────────────────────────────────────────────────────────
+  const results = []
+  // One retry by default. Every check drives a live model, and a model that
+  // wanders off (searching for a tool instead of calling it, answering in prose)
+  // is not the product being broken. A real regression fails both attempts, so
+  // retrying costs a turn and buys a suite that is worth believing.
+  const runCleanup = async (check) => {
+    if (!check.cleanup) return
+    try {
+      await check.cleanup(ctx)
+    } catch (err) {
+      console.log(`  (cleanup for ${check.id} failed: ${err.message})`)
+    }
+  }
+
+  for (const check of checks) {
+    const started = Date.now()
+    const attempts = args['no-retry'] ? 1 : (check.retries ?? 1) + 1
+    process.stdout.write(`\n▸ ${check.id} — ${check.title}\n`)
+    let lastError
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        const detail = await check.run(ctx)
+        const suffix = attempt > 1 ? ` (attempt ${attempt})` : ''
+        results.push({ id: check.id, ok: true, detail: (detail ?? '') + suffix, ms: Date.now() - started })
+        console.log(`  PASS (${Math.round((Date.now() - started) / 1000)}s)${detail ? ` — ${detail}` : ''}${suffix}`)
+        lastError = null
+        break
+      } catch (err) {
+        lastError = err
+        if (attempt < attempts) {
+          console.log(`  attempt ${attempt} failed, retrying — ${err.message.split('\n')[0]}`)
+          await runCleanup(check)
+          await conv.drain()
+        }
+      }
+    }
+    if (lastError) {
+      results.push({ id: check.id, ok: false, detail: lastError.message, ms: Date.now() - started })
+      console.log(`  FAIL (${Math.round((Date.now() - started) / 1000)}s) — ${lastError.message}`)
+    }
+    await runCleanup(check)
+  }
+
+  // ── Report ─────────────────────────────────────────────────────────
+  const passed = results.filter((r) => r.ok).length
+  console.log(`\n${'═'.repeat(70)}`)
+  for (const r of results) console.log(`${r.ok ? 'PASS' : 'FAIL'}  ${r.id}${r.detail ? ` — ${r.detail}` : ''}`)
+  console.log(`${'═'.repeat(70)}\n${passed}/${results.length} passed — host=${HOST}, ${surface.label}`)
+
+  const reportPath = path.join(RUN_DIR, 'report.json')
+  writeFileSync(
+    reportPath,
+    JSON.stringify({ host: HOST, surface: surface.label, hostShape, results }, null, 2),
+  )
+  console.log(`report: ${reportPath}\napp log: ${app.logFile}`)
+
+  if (args['keep-app']) {
+    console.log(`\napp left running on ${app.base} (data dir ${seeded.target}) — ctrl-c to stop`)
+    await new Promise(() => {})
+  }
+  await app.stop()
+  return passed === results.length
+}
+
+main()
+  .then((ok) => process.exit(ok ? 0 : 1))
+  .catch((err) => {
+    console.error(`\n[slack-validation] ERROR: ${err.stack || err.message}`)
+    process.exit(1)
+  })


### PR DESCRIPTION
## Why

Everything currently testing `src/shared/lib/chat-integrations/` is a **contract test**: it hands a connector an event object and asserts what the connector does with it. That pins connector behaviour and nothing else. If a refactor stops the host from *emitting* those events — or emits them for a different session, or stops registering the underlying request — every one of those tests stays green and the feature is dead.

Phase 7 of the user-input rearchitecture is exactly that kind of refactor, so this lands first as the baseline to refactor against.

## What

Nothing on the path is mocked:

```
a real human Slack account
  → real Slack (Socket Mode)
    → a real app instance booted against an isolated data dir
      → a real agent container running a real turn
        → back to Slack
          → assertions read the actual message, Block Kit payload included
```

12 checks:

| Check | Protects |
|---|---|
| `inbound-turn` | An inbound message creates a chat session bound to a real container session whose transcript holds the turn |
| `question-card` | `AskUserQuestion` renders as Block Kit with one button per option and `cb_<n>` action ids |
| `question-freetext-answer` | A plain-text reply resolves the open single-question card and the **same turn continues**; registry then empty |
| `question-cancelled-by-unrelated-message` | An unrelated message cancels the parked question instead of deadlocking |
| `question-multi-is-not-consumed-by-text` | Multi-question asks post one card each, and text does **not** answer them |
| `file-delivery-notice` | `deliver_file` reaches the conversation as real uploaded bytes with the description as caption |
| `unsupported-*` (6) | Per kind: exact refusal wording, exact host-aware link tail, no interactive card, request stays parked |

The `unsupported-*` checks are the regression test for the host-aware notice (#563). They rebuild the expected tail from the host shape and assert the message **ends with it**, so all three rows of that matrix are distinguished:

| Host | Expected tail |
|---|---|
| `--host=electron` | ` Open Gamut on your desktop to continue: superagent-dev://agent/<slug>/sessions/<id>` |
| `--host=web` + `HOST_PUBLIC_URL` | ` Open Gamut to continue: <base>/agents/<slug>/sessions/<id>` |
| `--host=web --no-public-url` | ` Open Gamut to continue.` (no link) |

`<id>` is asserted to be the conversation's actual session, which is what stops a queued notice from linking a rotated-away session.

## Isolation

`seed.mjs` builds `~/Downloads/slack-chat-validation` from the source install: settings verbatim, a fresh single-agent workspace, and a SQLite copy pruned to one integration retargeted at the slug `slack-validation-agent`. That slug is the boundary — the only container a run creates, stops, or removes is `superagent-slack-validation-agent`. Scheduled tasks, triggers, other integrations and agents are emptied in the copy. **The source install is only ever read.** No credential is ever logged.

## Two silent environment hazards, handled

- **Container publish range.** A packaged install's Lima runner forwards container ports on `127.0.0.1`, and a loopback-specific bind *shadows* Docker's `0.0.0.0` publish. At the default base (4000) the validation app's host→container calls land in the **other install's** container and return `401 Unauthorized` — indistinguishable from a broken build. Pinned to `SUPERAGENT_BASE_PORT=5300`, with a preflight check that the range is free.
- **`better-sqlite3` ABI.** Web and Electron need different builds; whichever ran last leaves the other broken. `startApp` rebuilds for the host about to run.

Also handled: Electron ignores `PORT` (the harness reads the bound port back from the log) and Electron outlives its `electron-vite` wrapper (process-group kill plus a repo-scoped pkill, and the seed retries its clear).

## Known limits (documented in the skill, not hidden)

- **Button taps are not automated** — Slack has no API to simulate a Block Kit click. The suite asserts the card's buttons and `action_id`s and covers the answer path via free text; the tap round trip needs a human.
- `browser_input` is not asserted as parked (it's only in the web-browser subagent's tool list, so the registration can settle with the subagent).
- Computer use is opt-in (`--with-computer-use`) — it drives the real machine.
- `proxy_review` cards are not covered.
- One retry per check by default: each check drives a live model, and a wandering model isn't the product breaking. A real regression fails both attempts.

## Verified

- `node e2e/live/slack-chat/run.mjs` → **12/12**, web host
- `node e2e/live/slack-chat/run.mjs --host=electron` → **12/12**, desktop links
- `--no-public-url` row verified separately (link correctly omitted)
- ESLint clean on the new files

One bug in the suite itself was found and fixed while building it: the file-delivery check originally matched on the filename alone and passed on the `🔧 Write` tool-call echo — a green check that tested nothing. That lesson is written into the skill's "extending it" section.

https://claude.ai/code/session_01NRdLzSWQJmp28qDyhc3r2p