### PR TITLE
Keep chat history reachable during long agent activity (SUP-484)

### DIFF
--- a/e2e/specs/activity-card-history-floor.spec.ts
+++ b/e2e/specs/activity-card-history-floor.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+import { SessionPage } from '../pages/session.page'
+import {
+  createAgent,
+  gotoAgentHome,
+  uniqueName,
+  uniqueSuffix,
+  type TestAgent,
+} from '../helpers/agents'
+
+// The live activity card sits in the chat column's pinned bottom strip, beside
+// the composer. It renders one row per subagent launched during the turn and
+// never drops a finished one, so the card grows for the whole turn. The strip
+// is sized to its content and the message list takes what is left — so past
+// enough rows the history has nothing left to take.
+//
+// Reported by a dogfooder as "can't scroll into the chat history when the
+// action list gets long". Asserted on geometry, not classes: a component test
+// cannot see this at all, because jsdom has no layout engine and reports every
+// height as 0 whether or not the bug is present.
+test.describe('Activity card must not squeeze out the chat history', () => {
+  let sessionPage: SessionPage
+  let agent: TestAgent
+
+  // The history must stay usable while a turn runs — enough for a few lines of
+  // transcript, not a sliver.
+  const MIN_HISTORY_HEIGHT = 160
+
+  test.describe.configure({ timeout: 45000 })
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    sessionPage = new SessionPage(page)
+    agent = await createAgent(request, uniqueName(testInfo, 'Fanout Agent'))
+    await gotoAgentHome(page, agent)
+  })
+
+  test('a long action list leaves the history scrollable and the composer on screen', async ({ page }, testInfo) => {
+    await sessionPage.sendMessage(`subagent fanout ${uniqueSuffix(testInfo)}`)
+
+    const card = page.getByTestId('activity-indicator')
+    await expect(card).toBeVisible({ timeout: 15000 })
+    // Wait for the card to reach full height: every launched subagent has a row.
+    await expect(card.locator('li').filter({ hasText: 'general-purpose' })).toHaveCount(24, {
+      timeout: 15000,
+    })
+
+    const history = await page.locator('[data-testid="message-list"]').boundingBox()
+    const column = await page.locator('[data-testid="session-thread-main"]').boundingBox()
+    const cardBox = await card.boundingBox()
+    const viewport = page.viewportSize()
+    console.log(
+      `[repro] history ${history?.height}px of a ${column?.height}px column; ` +
+      `card ${cardBox?.height}px; viewport ${viewport?.height}px`
+    )
+
+    // THE BUG: the card takes the column and the history collapses to nothing.
+    expect(history!.height).toBeGreaterThanOrEqual(MIN_HISTORY_HEIGHT)
+
+    // Same collapse pushes the composer past the bottom edge of the window.
+    const composer = page.locator('[data-composer-footer]')
+    const composerBox = await composer.boundingBox()
+    expect(composerBox!.y + composerBox!.height).toBeLessThanOrEqual(viewport!.height)
+  })
+})

--- a/e2e/specs/activity-card-history-floor.spec.ts
+++ b/e2e/specs/activity-card-history-floor.spec.ts
@@ -35,6 +35,20 @@ test.describe('Activity card must not squeeze out the chat history', () => {
     return rows
   }
 
+  // Which element owns the overflow, not just how tall things are: the card's own
+  // list absorbs a long action list, so the footer never scrolls as a single unit.
+  async function scrollOwnership(page: Page) {
+    return page.evaluate(() => {
+      const overflows = (el: Element | null | undefined) =>
+        el ? el.scrollHeight > el.clientHeight + 1 : null
+      const card = document.querySelector('[data-testid="activity-indicator"]')
+      return {
+        cardList: overflows(card?.querySelector('.overflow-y-auto')),
+        footer: overflows(document.querySelector('[data-composer-footer]')),
+      }
+    })
+  }
+
   test('a long action list leaves the history scrollable and the composer on screen', async ({ page }, testInfo) => {
     const rows = await launchFanout(page, testInfo)
     for (let i = 0; i < 4; i++) {
@@ -49,17 +63,24 @@ test.describe('Activity card must not squeeze out the chat history', () => {
     const composer = page.locator('[data-composer-footer]')
     const composerBox = await composer.boundingBox()
     expect(composerBox!.y + composerBox!.height).toBeLessThanOrEqual(viewport!.height)
+
+    expect(await scrollOwnership(page)).toEqual({ cardList: true, footer: false })
   })
 
-  test('a request card shares the bounded footer without squeezing out history', async ({ page }, testInfo) => {
+  test('a pending request stays whole on screen and the card gives way instead', async ({ page }, testInfo) => {
     await launchFanout(page, testInfo, 'subagent fanout with question')
     const request = sessionPage.getQuestionRequests().first()
     await expect(request).toBeVisible({ timeout: 15000 })
 
     const history = await page.locator('[data-testid="message-list"]').boundingBox()
-    const footer = await page.locator('[data-composer-footer]').boundingBox()
+    const viewport = page.viewportSize()
     const requestBox = await request.boundingBox()
     expect(history!.height).toBeGreaterThanOrEqual(MIN_HISTORY_HEIGHT)
-    expect(requestBox!.y).toBeLessThan(footer!.y + footer!.height)
+
+    // The card the user has to act on is never the thing that gets scrolled away.
+    expect(requestBox!.y).toBeGreaterThanOrEqual(0)
+    expect(requestBox!.y + requestBox!.height).toBeLessThanOrEqual(viewport!.height)
+
+    expect(await scrollOwnership(page)).toEqual({ cardList: true, footer: false })
   })
 })

--- a/e2e/specs/activity-card-history-floor.spec.ts
+++ b/e2e/specs/activity-card-history-floor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page, type TestInfo } from '@playwright/test'
 import { SessionPage } from '../pages/session.page'
 import {
   createAgent,
@@ -8,22 +8,12 @@ import {
   type TestAgent,
 } from '../helpers/agents'
 
-// The live activity card sits in the chat column's pinned bottom strip, beside
-// the composer. It renders one row per subagent launched during the turn and
-// never drops a finished one, so the card grows for the whole turn. The strip
-// is sized to its content and the message list takes what is left — so past
-// enough rows the history has nothing left to take.
-//
-// Reported by a dogfooder as "can't scroll into the chat history when the
-// action list gets long". Asserted on geometry, not classes: a component test
-// cannot see this at all, because jsdom has no layout engine and reports every
-// height as 0 whether or not the bug is present.
+// Layout needs a real browser; jsdom reports zero heights for both broken and fixed states.
 test.describe('Activity card must not squeeze out the chat history', () => {
   let sessionPage: SessionPage
   let agent: TestAgent
 
-  // The history must stay usable while a turn runs — enough for a few lines of
-  // transcript, not a sliver.
+  // Preserve enough space for usable transcript context, not only a visible sliver.
   const MIN_HISTORY_HEIGHT = 160
 
   test.describe.configure({ timeout: 45000 })
@@ -34,31 +24,42 @@ test.describe('Activity card must not squeeze out the chat history', () => {
     await gotoAgentHome(page, agent)
   })
 
-  test('a long action list leaves the history scrollable and the composer on screen', async ({ page }, testInfo) => {
-    await sessionPage.sendMessage(`subagent fanout ${uniqueSuffix(testInfo)}`)
-
+  async function launchFanout(page: Page, testInfo: TestInfo, trigger = 'subagent fanout') {
+    await sessionPage.sendMessage(`${trigger} ${uniqueSuffix(testInfo)}`)
     const card = page.getByTestId('activity-indicator')
     await expect(card).toBeVisible({ timeout: 15000 })
-    // Wait for the card to reach full height: every launched subagent has a row.
-    await expect(card.locator('li').filter({ hasText: 'general-purpose' })).toHaveCount(24, {
+    const rows = card.locator('li').filter({ hasText: 'general-purpose' })
+    await expect(rows).toHaveCount(24, {
       timeout: 15000,
     })
+    return rows
+  }
+
+  test('a long action list leaves the history scrollable and the composer on screen', async ({ page }, testInfo) => {
+    const rows = await launchFanout(page, testInfo)
+    for (let i = 0; i < 4; i++) {
+      await expect(rows.nth(i)).not.toContainText('✓')
+    }
+    await expect(rows.nth(4)).toContainText('✓')
 
     const history = await page.locator('[data-testid="message-list"]').boundingBox()
-    const column = await page.locator('[data-testid="session-thread-main"]').boundingBox()
-    const cardBox = await card.boundingBox()
     const viewport = page.viewportSize()
-    console.log(
-      `[repro] history ${history?.height}px of a ${column?.height}px column; ` +
-      `card ${cardBox?.height}px; viewport ${viewport?.height}px`
-    )
-
-    // THE BUG: the card takes the column and the history collapses to nothing.
     expect(history!.height).toBeGreaterThanOrEqual(MIN_HISTORY_HEIGHT)
 
-    // Same collapse pushes the composer past the bottom edge of the window.
     const composer = page.locator('[data-composer-footer]')
     const composerBox = await composer.boundingBox()
     expect(composerBox!.y + composerBox!.height).toBeLessThanOrEqual(viewport!.height)
+  })
+
+  test('a request card shares the bounded footer without squeezing out history', async ({ page }, testInfo) => {
+    await launchFanout(page, testInfo, 'subagent fanout with question')
+    const request = sessionPage.getQuestionRequests().first()
+    await expect(request).toBeVisible({ timeout: 15000 })
+
+    const history = await page.locator('[data-testid="message-list"]').boundingBox()
+    const footer = await page.locator('[data-composer-footer]').boundingBox()
+    const requestBox = await request.boundingBox()
+    expect(history!.height).toBeGreaterThanOrEqual(MIN_HISTORY_HEIGHT)
+    expect(requestBox!.y).toBeLessThan(footer!.y + footer!.height)
   })
 })

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -94,7 +94,7 @@ export function SessionChatColumn({
       onPendingMessageAppeared={onPendingMessageAppeared}
       suppressScrollToBottom={staleSession.learnMoreOpen}
       footerClassName="bg-background max-w-[740px] mx-auto w-full"
-      growableFooter={
+      footer={
         pendingRequestCount > 0 ? (
           <div className="px-4 pb-4" data-testid="pending-request-slot">
             <PendingRequestStack>
@@ -112,10 +112,7 @@ export function SessionChatColumn({
               ))}
             </PendingRequestStack>
           </div>
-        ) : null
-      }
-      footer={
-        pendingRequestCount > 0 ? null : (
+        ) : (
           <>
             {pendingWakeAt && pendingWakeTaskId && !isActive && (
               <PendingWakeBanner

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -94,7 +94,7 @@ export function SessionChatColumn({
       onPendingMessageAppeared={onPendingMessageAppeared}
       suppressScrollToBottom={staleSession.learnMoreOpen}
       footerClassName="bg-background max-w-[740px] mx-auto w-full"
-      footer={
+      growableFooter={
         pendingRequestCount > 0 ? (
           <div className="px-4 pb-4" data-testid="pending-request-slot">
             <PendingRequestStack>
@@ -112,7 +112,10 @@ export function SessionChatColumn({
               ))}
             </PendingRequestStack>
           </div>
-        ) : (
+        ) : null
+      }
+      footer={
+        pendingRequestCount > 0 ? null : (
           <>
             {pendingWakeAt && pendingWakeTaskId && !isActive && (
               <PendingWakeBanner

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -102,7 +102,10 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         }
       }
     }
-    return items
+    // Running first, then newest-finished - mirrors the todo list in this card.
+    const running = items.filter((i) => i.status === 'running')
+    const completed = items.filter((i) => i.status === 'completed').reverse()
+    return [...running, ...completed]
   }, [messages, activeSubagents, completedSubagents])
 
   // Derive the todo/task list from TaskCreate/TaskUpdate (newer SDK) or fall back

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -102,7 +102,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         }
       }
     }
-    // Running first, then newest-finished - mirrors the todo list in this card.
+    // Keep live work above completed history.
     const running = items.filter((i) => i.status === 'running')
     const completed = items.filter((i) => i.status === 'completed').reverse()
     return [...running, ...completed]

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -158,10 +158,10 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
           : (activeItem?.activeForm || 'Working...')
 
   return (
-    <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
-      <div className="rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
-        {/* Header with pulsing indicator */}
-        <div className="flex items-center gap-2">
+    <div className="mx-auto mb-2 flex w-full min-h-0 max-w-[740px] flex-col px-4">
+      <div className="flex min-h-0 flex-col rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
+        {/* Header with pulsing indicator — stays put while the list below scrolls */}
+        <div className="flex shrink-0 items-center gap-2">
           <span className="relative flex h-3 w-3">
             <span className={cn(
               "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
@@ -202,121 +202,125 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         {/* Streamed reasoning renders as a thinking card in the transcript
             (see ThinkingBlockItem) — only the "Thinking..." status shows here. */}
 
-        {/* Active subagents */}
-        {subagentItems.length > 0 && (
-          <ul className="mt-2 space-y-1 text-sm pl-5">
-            {subagentItems.map((item) => (
-              <li key={item.id} className="flex flex-col gap-0.5">
-                <div className="flex items-center gap-2">
-                  {item.status === 'running' ? (
-                    <span className="relative flex h-2 w-2 shrink-0">
-                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
-                      <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
+        {/* The card's own ceiling. The column floors the transcript separately,
+            because a sibling card can shrink this one past its cap. */}
+        <div className="min-h-0 max-h-[30vh] overflow-y-auto">
+          {/* Active subagents */}
+          {subagentItems.length > 0 && (
+            <ul className="mt-2 space-y-1 text-sm pl-5">
+              {subagentItems.map((item) => (
+                <li key={item.id} className="flex flex-col gap-0.5">
+                  <div className="flex items-center gap-2">
+                    {item.status === 'running' ? (
+                      <span className="relative flex h-2 w-2 shrink-0">
+                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+                        <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
+                      </span>
+                    ) : (
+                      <span className="text-xs text-green-500 shrink-0">✓</span>
+                    )}
+                    <span className={cn(
+                      'font-mono text-xs',
+                      item.status === 'completed' && 'text-muted-foreground'
+                    )}>
+                      {item.name}
                     </span>
-                  ) : (
-                    <span className="text-xs text-green-500 shrink-0">✓</span>
-                  )}
-                  <span className={cn(
-                    'font-mono text-xs',
-                    item.status === 'completed' && 'text-muted-foreground'
-                  )}>
-                    {item.name}
-                  </span>
-                  {item.description && (
-                    <span className="text-xs text-muted-foreground truncate">
-                      {item.description}
+                    {item.description && (
+                      <span className="text-xs text-muted-foreground truncate">
+                        {item.description}
+                      </span>
+                    )}
+                  </div>
+                  {item.progressSummary && item.status === 'running' && (
+                    <span className="text-xs text-muted-foreground ml-4 italic">
+                      {item.progressSummary}
                     </span>
                   )}
-                </div>
-                {item.progressSummary && item.status === 'running' && (
-                  <span className="text-xs text-muted-foreground ml-4 italic">
-                    {item.progressSummary}
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
-        )}
-
-        {/* Active background processes. Background subagents are excluded: they
-            already render as named subagent rows above, and counting them here
-            would show the same work twice. */}
-        {backgroundTasks.some((t) => !t.isSubagent) && (
-          <BackgroundTasksSection tasks={backgroundTasks.filter((t) => !t.isSubagent)} />
-        )}
-
-        {/* Todo list if available and at least one item is not completed */}
-        {todos && todos.length > 0 && todos.some((t) => t.status !== 'completed') && (() => {
-          const MAX_VISIBLE = 5
-          const needsTruncation = todos.length > MAX_VISIBLE && !showAllTodos
-
-          const notDone = todos.filter(t => t.status !== 'completed')
-          const doneReversed = todos.filter(t => t.status === 'completed').reverse()
-
-          let visibleTodos: Todo[]
-          let hiddenTodos: Todo[]
-
-          if (!needsTruncation) {
-            visibleTodos = [...notDone, ...doneReversed]
-            hiddenTodos = []
-          } else {
-            const visibleNotDone = notDone.slice(0, MAX_VISIBLE)
-            const remainingSlots = MAX_VISIBLE - visibleNotDone.length
-            const visibleDone = doneReversed.slice(0, remainingSlots)
-            visibleTodos = [...visibleNotDone, ...visibleDone]
-            const visibleSet = new Set(visibleTodos)
-            hiddenTodos = todos.filter(t => !visibleSet.has(t))
-          }
-
-          const hiddenPending = hiddenTodos.filter(t => t.status !== 'completed').length
-          const hiddenDone = hiddenTodos.filter(t => t.status === 'completed').length
-
-          return (
-            <ul className="mt-2 space-y-1 text-sm">
-              {hiddenTodos.length > 0 && (
-                <li>
-                  <button
-                    onClick={() => setShowAllTodos(true)}
-                    className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                  >
-                    {hiddenTodos.length} more{': '}
-                    {[
-                      hiddenPending > 0 && `${hiddenPending} pending`,
-                      hiddenDone > 0 && `${hiddenDone} done`,
-                    ].filter(Boolean).join(', ')}
-                  </button>
-                </li>
-              )}
-              {showAllTodos && todos.length > MAX_VISIBLE && (
-                <li>
-                  <button
-                    onClick={() => setShowAllTodos(false)}
-                    className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                  >
-                    Show fewer
-                  </button>
-                </li>
-              )}
-              {visibleTodos.map((todo, index) => (
-                <li
-                  key={index}
-                  className={cn(
-                    'flex items-center gap-2',
-                    todo.status === 'completed' && 'text-muted-foreground line-through',
-                    todo.status === 'in_progress' && 'font-medium'
-                  )}
-                >
-                  <span className="text-xs">
-                    {todo.status === 'completed' && '✓'}
-                    {todo.status === 'in_progress' && '→'}
-                    {todo.status === 'pending' && '○'}
-                  </span>
-                  {todo.content}
                 </li>
               ))}
             </ul>
-          )
-        })()}
+          )}
+
+          {/* Active background processes. Background subagents are excluded: they
+              already render as named subagent rows above, and counting them here
+              would show the same work twice. */}
+          {backgroundTasks.some((t) => !t.isSubagent) && (
+            <BackgroundTasksSection tasks={backgroundTasks.filter((t) => !t.isSubagent)} />
+          )}
+
+          {/* Todo list if available and at least one item is not completed */}
+          {todos && todos.length > 0 && todos.some((t) => t.status !== 'completed') && (() => {
+            const MAX_VISIBLE = 5
+            const needsTruncation = todos.length > MAX_VISIBLE && !showAllTodos
+
+            const notDone = todos.filter(t => t.status !== 'completed')
+            const doneReversed = todos.filter(t => t.status === 'completed').reverse()
+
+            let visibleTodos: Todo[]
+            let hiddenTodos: Todo[]
+
+            if (!needsTruncation) {
+              visibleTodos = [...notDone, ...doneReversed]
+              hiddenTodos = []
+            } else {
+              const visibleNotDone = notDone.slice(0, MAX_VISIBLE)
+              const remainingSlots = MAX_VISIBLE - visibleNotDone.length
+              const visibleDone = doneReversed.slice(0, remainingSlots)
+              visibleTodos = [...visibleNotDone, ...visibleDone]
+              const visibleSet = new Set(visibleTodos)
+              hiddenTodos = todos.filter(t => !visibleSet.has(t))
+            }
+
+            const hiddenPending = hiddenTodos.filter(t => t.status !== 'completed').length
+            const hiddenDone = hiddenTodos.filter(t => t.status === 'completed').length
+
+            return (
+              <ul className="mt-2 space-y-1 text-sm">
+                {hiddenTodos.length > 0 && (
+                  <li>
+                    <button
+                      onClick={() => setShowAllTodos(true)}
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                    >
+                      {hiddenTodos.length} more{': '}
+                      {[
+                        hiddenPending > 0 && `${hiddenPending} pending`,
+                        hiddenDone > 0 && `${hiddenDone} done`,
+                      ].filter(Boolean).join(', ')}
+                    </button>
+                  </li>
+                )}
+                {showAllTodos && todos.length > MAX_VISIBLE && (
+                  <li>
+                    <button
+                      onClick={() => setShowAllTodos(false)}
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                    >
+                      Show fewer
+                    </button>
+                  </li>
+                )}
+                {visibleTodos.map((todo, index) => (
+                  <li
+                    key={index}
+                    className={cn(
+                      'flex items-center gap-2',
+                      todo.status === 'completed' && 'text-muted-foreground line-through',
+                      todo.status === 'in_progress' && 'font-medium'
+                    )}
+                  >
+                    <span className="text-xs">
+                      {todo.status === 'completed' && '✓'}
+                      {todo.status === 'in_progress' && '→'}
+                      {todo.status === 'pending' && '○'}
+                    </span>
+                    {todo.content}
+                  </li>
+                ))}
+              </ul>
+            )
+          })()}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -64,7 +64,10 @@ export function SessionThread({
           suppressScrollToBottom={suppressScrollToBottom}
         />
         <div className={`${footerClassName} pb-[env(safe-area-inset-bottom)]`} data-composer-footer>
-          <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />
+          {/* vh: % max-height won't resolve against an auto grid row */}
+          <div className="max-h-[40vh] min-h-0 overflow-y-auto">
+            <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />
+          </div>
           {footer}
         </div>
       </div>

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -9,6 +9,8 @@ interface SessionThreadProps {
   agentSlug: string
   /** Footer pinned below the scrollable message list (input bar, read-only notice, etc.) */
   footer: ReactNode
+  /** Additional content in the capped growable footer region. */
+  growableFooter?: ReactNode
   /** Classes for the footer wrapper — callers set their own max-width/background. */
   footerClassName?: string
   /** Whether the browser tray tab is available (interactive session view only). */
@@ -35,6 +37,7 @@ export function SessionThread({
   sessionId,
   agentSlug,
   footer,
+  growableFooter,
   footerClassName = 'bg-background',
   browserActive = false,
   readOnly,
@@ -65,7 +68,8 @@ export function SessionThread({
         />
         <div className={`${footerClassName} pb-[env(safe-area-inset-bottom)]`} data-composer-footer>
           {/* vh: % max-height won't resolve against an auto grid row */}
-          <div className="max-h-[40vh] min-h-0 overflow-y-auto">
+          <div className="max-h-[40vh] overflow-y-auto">
+            {growableFooter}
             <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />
           </div>
           {footer}

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -9,8 +9,6 @@ interface SessionThreadProps {
   agentSlug: string
   /** Footer pinned below the scrollable message list (input bar, read-only notice, etc.) */
   footer: ReactNode
-  /** Additional content in the capped growable footer region. */
-  growableFooter?: ReactNode
   /** Classes for the footer wrapper — callers set their own max-width/background. */
   footerClassName?: string
   /** Whether the browser tray tab is available (interactive session view only). */
@@ -37,7 +35,6 @@ export function SessionThread({
   sessionId,
   agentSlug,
   footer,
-  growableFooter,
   footerClassName = 'bg-background',
   browserActive = false,
   readOnly,
@@ -51,9 +48,11 @@ export function SessionThread({
       className="file-preview-container relative flex flex-1 min-h-0 min-w-0"
       data-testid="file-preview-container"
     >
-      {/* Chat column — grid pins the footer at the bottom */}
+      {/* Chat column — grid pins the footer at the bottom. The transcript's floor
+          is a row minimum, so no amount of footer content can take the history;
+          the footer row is capped by what's left and gives way from the inside. */}
       <div
-        className="flex-1 min-w-0 grid grid-rows-[1fr_auto] min-h-0"
+        className="flex-1 min-w-0 grid grid-rows-[minmax(160px,1fr)_minmax(0,auto)] min-h-0"
         data-testid="session-thread-main"
       >
         <MessageList
@@ -66,13 +65,13 @@ export function SessionThread({
           onPendingMessageAppeared={onPendingMessageAppeared}
           suppressScrollToBottom={suppressScrollToBottom}
         />
-        <div className={`${footerClassName} pb-[env(safe-area-inset-bottom)]`} data-composer-footer>
-          {/* vh: % max-height won't resolve against an auto grid row */}
-          <div className="max-h-[40vh] overflow-y-auto">
-            {growableFooter}
-            <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />
-          </div>
-          {footer}
+        <div
+          className={`${footerClassName} pb-[env(safe-area-inset-bottom)] flex min-h-0 flex-col`}
+          data-composer-footer
+        >
+          {/* The activity card is the only part that gives way; it scrolls inside itself. */}
+          <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />
+          <div className="shrink-0">{footer}</div>
         </div>
       </div>
       {/* Side tray (browser, file preview) */}

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -667,6 +667,19 @@ export interface UserInputTool {
   input: UserInputToolInput
 }
 
+const DATABASE_QUESTION_INPUT = {
+  questions: [{
+    question: 'Which database should we use?',
+    header: 'Database',
+    options: [
+      { label: 'PostgreSQL', description: 'Reliable relational database' },
+      { label: 'MongoDB', description: 'Flexible document store' },
+      { label: 'SQLite', description: 'Lightweight embedded database' },
+    ],
+    multiSelect: false,
+  }],
+}
+
 export class UserInputRequestScenario implements MockScenario {
   constructor(
     private tools: UserInputTool[],
@@ -866,20 +879,20 @@ export class SubagentBrowserInputScenario implements MockScenario {
   }
 }
 
-/**
- * Many subagents across one turn. The activity card renders one row per
- * subagent and never drops a finished one (subagent_completed upserts), so the
- * card grows for the whole turn — a run of sequential waves reaches the same
- * height as one wide fan-out. Most rows arrive already finished, matching the
- * reported screenshot (20 ✓, 4 running). The turn is held open so the card
- * stays on screen while the test measures the layout it squeezes.
- */
+const FANOUT_SUBAGENT_COUNT = 24
+const FANOUT_RUNNING_COUNT = 4
+
 export class SubagentFanoutScenario implements MockScenario {
-  constructor(private count = 24, private runningTail = 4) {}
+  constructor(private includeQuestion = false) {}
 
   execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
-    const toolIds = Array.from({ length: this.count }, (_, i) => `agent_fanout_${i}`)
+    const toolIds = Array.from({ length: FANOUT_SUBAGENT_COUNT }, (_, i) => `agent_fanout_${i}`)
     const describe = (i: number) => `Verify chunk ${i}`
+    const questionToolId = 'fanout_question'
+
+    if (this.includeQuestion) {
+      client.registerPendingInputs(sessionId, 1)
+    }
 
     client.writeJsonlEntry(sessionId, {
       type: 'user',
@@ -895,21 +908,27 @@ export class SubagentFanoutScenario implements MockScenario {
     }, 10)
 
     setTimeout(() => {
-      // One assistant turn that launched every subagent.
+      const assistantContent = [
+        ...toolIds.map((id, i) => ({
+          type: 'tool_use',
+          id,
+          name: 'Task',
+          input: { subagent_type: 'general-purpose', description: describe(i) },
+        })),
+        ...(this.includeQuestion ? [{
+          type: 'tool_use',
+          id: questionToolId,
+          name: 'AskUserQuestion',
+          input: DATABASE_QUESTION_INPUT,
+        }] : []),
+      ]
       client.writeJsonlEntry(sessionId, {
         type: 'assistant',
-        message: {
-          content: toolIds.map((id, i) => ({
-            type: 'tool_use',
-            id,
-            name: 'Task',
-            input: { subagent_type: 'general-purpose', description: describe(i) },
-          })),
-        },
+        message: { content: assistantContent },
         timestamp: new Date().toISOString(),
       })
 
-      // task_started is what puts a row in the card (persister → subagent_started).
+      // The card needs task_started events matched to persisted Task calls.
       toolIds.forEach((id, i) => {
         client.emitStreamMessage(sessionId, {
           type: 'system',
@@ -924,24 +943,48 @@ export class SubagentFanoutScenario implements MockScenario {
         })
       })
 
-      // Finished subagents keep their row as a ✓ for the rest of the turn.
+      if (this.includeQuestion) {
+        client.emitStreamMessage(sessionId, {
+          type: 'stream_event',
+          content: {
+            type: 'stream_event',
+            event: {
+              type: 'content_block_start',
+              content_block: { type: 'tool_use', id: questionToolId, name: 'AskUserQuestion' },
+            },
+          },
+        })
+        client.emitStreamMessage(sessionId, {
+          type: 'stream_event',
+          content: {
+            type: 'stream_event',
+            event: {
+              type: 'content_block_delta',
+              delta: { type: 'input_json_delta', partial_json: JSON.stringify(DATABASE_QUESTION_INPUT) },
+            },
+          },
+        })
+        client.emitStreamMessage(sessionId, {
+          type: 'stream_event',
+          content: { type: 'stream_event', event: { type: 'content_block_stop' } },
+        })
+      }
+
       const results = toolIds
-        .slice(0, Math.max(0, this.count - this.runningTail))
+        .slice(0, FANOUT_SUBAGENT_COUNT - FANOUT_RUNNING_COUNT)
         .map((id) => ({ type: 'tool_result', tool_use_id: id, content: 'done' }))
       client.writeJsonlEntry(sessionId, {
         type: 'user',
         message: { content: results },
         timestamp: new Date().toISOString(),
       })
-      // A 'user' stream message is what makes the client refetch persisted
-      // messages; without it the card has SSE rows but no tool calls to match.
+      // JSONL writes do not broadcast, so force a persisted-message refetch.
       client.emitStreamMessage(sessionId, {
         type: 'user',
         content: { type: 'user', message: { content: results } },
       })
     }, 60)
-
-    // No 'result': the turn stays open, like a run still fanning out.
+    // No result event: keep the activity card open for geometry checks.
   }
 }
 
@@ -1593,18 +1636,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     ['ask question', new UserInputRequestScenario([
       {
         name: 'AskUserQuestion',
-        input: {
-          questions: [{
-            question: 'Which database should we use?',
-            header: 'Database',
-            options: [
-              { label: 'PostgreSQL', description: 'Reliable relational database' },
-              { label: 'MongoDB', description: 'Flexible document store' },
-              { label: 'SQLite', description: 'Lightweight embedded database' },
-            ],
-            multiSelect: false,
-          }],
-        },
+        input: DATABASE_QUESTION_INPUT,
       },
     ])],
     // Note: scenarios are matched by substring in insertion order, so
@@ -1780,6 +1812,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       },
     ])],
     ['subagent browser input', new SubagentBrowserInputScenario()],
+    ['subagent fanout with question', new SubagentFanoutScenario(true)],
     ['subagent fanout', new SubagentFanoutScenario()],
     ['dead subagent input', new DeadSubagentInputScenario()],
     // Proxy review scenario for E2E tests

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -867,6 +867,85 @@ export class SubagentBrowserInputScenario implements MockScenario {
 }
 
 /**
+ * Many subagents across one turn. The activity card renders one row per
+ * subagent and never drops a finished one (subagent_completed upserts), so the
+ * card grows for the whole turn — a run of sequential waves reaches the same
+ * height as one wide fan-out. Most rows arrive already finished, matching the
+ * reported screenshot (20 ✓, 4 running). The turn is held open so the card
+ * stays on screen while the test measures the layout it squeezes.
+ */
+export class SubagentFanoutScenario implements MockScenario {
+  constructor(private count = 24, private runningTail = 4) {}
+
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    const toolIds = Array.from({ length: this.count }, (_, i) => `agent_fanout_${i}`)
+    const describe = (i: number) => `Verify chunk ${i}`
+
+    client.writeJsonlEntry(sessionId, {
+      type: 'user',
+      message: { content: userMessage },
+      timestamp: new Date().toISOString(),
+    })
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'message_start' } },
+      })
+    }, 10)
+
+    setTimeout(() => {
+      // One assistant turn that launched every subagent.
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: {
+          content: toolIds.map((id, i) => ({
+            type: 'tool_use',
+            id,
+            name: 'Task',
+            input: { subagent_type: 'general-purpose', description: describe(i) },
+          })),
+        },
+        timestamp: new Date().toISOString(),
+      })
+
+      // task_started is what puts a row in the card (persister → subagent_started).
+      toolIds.forEach((id, i) => {
+        client.emitStreamMessage(sessionId, {
+          type: 'system',
+          content: {
+            type: 'system',
+            subtype: 'task_started',
+            tool_use_id: id,
+            task_id: `task_fanout_${i}`,
+            subagent_type: 'general-purpose',
+            description: describe(i),
+          },
+        })
+      })
+
+      // Finished subagents keep their row as a ✓ for the rest of the turn.
+      const results = toolIds
+        .slice(0, Math.max(0, this.count - this.runningTail))
+        .map((id) => ({ type: 'tool_result', tool_use_id: id, content: 'done' }))
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        message: { content: results },
+        timestamp: new Date().toISOString(),
+      })
+      // A 'user' stream message is what makes the client refetch persisted
+      // messages; without it the card has SSE rows but no tool calls to match.
+      client.emitStreamMessage(sessionId, {
+        type: 'user',
+        content: { type: 'user', message: { content: results } },
+      })
+    }, 60)
+
+    // No 'result': the turn stays open, like a run still fanning out.
+  }
+}
+
+/**
  * A background subagent parks on request_browser_input and then DIES — its
  * sidechain 'result' arrives with no tool_result for the parked ask — while
  * the main turn keeps running. The host must invalidate the orphaned request
@@ -1701,6 +1780,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       },
     ])],
     ['subagent browser input', new SubagentBrowserInputScenario()],
+    ['subagent fanout', new SubagentFanoutScenario()],
     ['dead subagent input', new DeadSubagentInputScenario()],
     // Proxy review scenario for E2E tests
     // Cross-store mix: container input asks + a parked ReviewManager review


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-484/keep-chat-history-reachable-during-long-agent-activity

## What

The activity card now caps and scrolls inside itself, under a pinned status header, and the chat column guarantees the transcript a minimum height.

## Why

You can't scroll back into the conversation once the action list gets long.

The chat column is a two-row grid - transcript on top, pinned footer below. The footer row is `auto`, so it takes the height it wants first and the transcript gets the remainder. The footer holds the activity card, and that card had no cap: one row per subagent, and `subagent_completed` upserts rather than removes, so its height only ever grows within a turn. Once the card is as tall as the column, the remainder is zero.

Measured at 1280x720, 24 subagents with 4 still running:

| | main | this PR |
| --- | --- | --- |
| Chat history, long action list | 0px | 242px |
| Chat history, plus a pending question | 0px | 160px |
| Activity card | 530px | 262px (112px next to a question card) |
| Request card below the bottom of the window | 64px | none |

At 0px the transcript isn't merely hard to reach - there's no region left to scroll.

## How it works

Two bounds, because one doesn't hold:

- The card caps its own list at 30vh and scrolls it. The status row, timer and computer-use chip are pinned above the scroll area, so the label stays put while the rows move. Running subagents sort above completed ones, otherwise the capped card shows the oldest ✓ rows and pushes live work below the fold.
- The column floors the transcript with a grid row minimum. A per-card cap can't bound a sum: a card capped at 30vh plus a 376px request card is 710px of footer in a 656px column, which puts the transcript straight back to 0px. With the floor, the card is the thing that gives way - it shrinks to 112px and scrolls, and the request card stays whole and on screen.

The composer and the request card sit outside the scroll area, so nothing scrolls as a unit and the card the user has to act on is never scrolled away.

## How it was verified

`e2e/specs/activity-card-history-floor.spec.ts` drives a 24-subagent fan-out in a real browser and asserts both the heights and which element owns the overflow - the card's list scrolls, the footer does not. Two cases: activity card alone, and activity card plus a pending question. Layout needs a real browser here; jsdom reports zero heights for the broken and fixed states alike.

Also checked by hand at 1280x720 and 1280x600. At 600px the card degrades to just its status row rather than colliding with the question card.

## Repro

1. `E2E_MOCK=true npm run dev:web`
2. New agent, send `subagent fanout` - 24 subagents, 4 left running
3. Try to scroll up into the conversation
4. `subagent fanout with question` for the combined case

## Notes for the reviewer

- `agent-activity-indicator.tsx` reads as a large diff but it's about 12 real lines. The rest is the existing block being re-indented into the new scroll container - `?w=1` shows it.
- Flagged, not fixed: `subagent_completed` upserts instead of removing (`use-message-stream.ts`), so finished subagents keep their rows for the rest of the turn. That's what makes the card grow monotonically. Changing it is a product decision about what the card reports, and it wouldn't help a wide concurrent fan-out anyway.
