### PR TITLE
Chat integrations consume the unified request wire and the gated settle path (Phase 7)

### DIFF
--- a/.claude/skills/slack-chat-validation/SKILL.md
+++ b/.claude/skills/slack-chat-validation/SKILL.md
@@ -117,11 +117,27 @@ install is only ever read.**
 |---|---|
 | `inbound-turn` | An inbound Slack message creates a chat session bound to a real container session whose transcript holds the turn |
 | `question-card` | `AskUserQuestion` renders as Block Kit with one button per option and connector-registered `cb_<n>` action ids |
-| `question-freetext-answer` | A plain-text reply resolves the open single-question card as the free-form answer and the **same turn continues** — then the registry is empty |
+| `question-answered-in-app` | The card posted to Slack and the request the **app** answers are the same registry entry: answering through the app's decision route settles it and the continuation lands back in Slack |
+| `question-freetext-reply` | A plain-text reply to an open single-question card settles it and the agent responds — and the report says **which** path ran (answer-in-turn vs cancel → fresh turn) |
 | `question-cancelled-by-unrelated-message` | An unrelated message cancels the parked question instead of deadlocking behind it, and the fresh turn runs |
 | `question-multi-is-not-consumed-by-text` | A multi-question ask posts one card per question, and text does **not** answer it (an answer would be attributed to the wrong question) |
 | `file-delivery-notice` | `deliver_file` reaches the conversation as real uploaded bytes with the description as caption (text fallback accepted and reported) |
-| `unsupported-*` (6) | Per kind: the exact refusal wording, the **exact host-aware link tail**, no interactive card, and the request staying parked in the registry |
+| `unsupported-*` (7) | Per kind: the exact refusal wording, the **exact host-aware link tail**, no interactive card, and the request staying parked in the registry |
+
+`unsupported-capability-review` is the newest row and the one with the least
+margin: `workflows: 'review'` is the shipped default, so asking the agent to run
+a workflow parks a capability review — which chat was silent about entirely
+before the connectors moved onto the unified request wire. It needs the agent to
+actually reach for the `Workflow` tool, so it is the row most likely to need its
+retry.
+
+`question-freetext-reply` reports its path rather than asserting one, because
+the two are connector-dependent: the free-text **answer** path needs
+`answerOpenQuestionWithText`, which only the Telegram connector implements. On
+Slack the same message legitimately takes the **cancel** path. Both settle the
+request and both get a reply, so a check that only asserted "the agent
+answered" would stay green if the answer path broke outright — which is what
+the previous version of this check did.
 
 The `unsupported-*` checks are the regression test for the host-aware notice
 (PR #563). They rebuild the expected tail from the host shape and assert the
@@ -141,8 +157,16 @@ what stops a queued notice from linking a rotated-away session.
 - **Button taps are not automated.** Slack has no API to simulate clicking a
   Block Kit button; interactions only arrive from a real client over Socket
   Mode. The suite asserts the card is posted with the right buttons and
-  `action_id`s, and covers the answer path via the free-text branch. The
-  `action_id` → decision round trip needs a human tap in Slack.
+  `action_id`s, and covers a real decision via `question-answered-in-app` (the
+  app's decision route settles the same registry entry the Slack card came
+  from). The `action_id` → decision round trip still needs a human tap.
+- **The already-handled gate is not live-reachable on Slack.** A press on a card
+  whose request was settled elsewhere must be refused rather than buffered in
+  the container. Reaching it needs an interactive response, which on Slack means
+  a button tap — and the free-text branch does not produce one, because Slack
+  has no `answerOpenQuestionWithText`. That gate is covered instead by the
+  wire-contract suite in `chat-integration-e2e.test.ts`, which drives the real
+  persister and the real registry.
 - **`browser_input` is not asserted as parked** (`requiresParked: false`).
   `mcp__user-input__request_browser_input` is only in the web-browser
   subagent's tool list, so the main agent reaches it indirectly and the

--- a/e2e/live/slack-chat/lib/app.mjs
+++ b/e2e/live/slack-chat/lib/app.mjs
@@ -269,8 +269,29 @@ function makeApi(base) {
     if (!res.ok) return null
     return res.json()
   }
+  /**
+   * POST and report the failure body. Used to drive the app-side decision
+   * routes — the surface a chat user is NOT on — so a check can prove both
+   * surfaces settle the same request.
+   */
+  const post = async (pathname, body) => {
+    const res = await fetch(`${base}${pathname}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    const text = await res.text()
+    if (!res.ok) throw new Error(`POST ${pathname} → ${res.status}: ${text.slice(0, 300)}`)
+    try {
+      return JSON.parse(text)
+    } catch {
+      return {}
+    }
+  }
+
   return {
     json,
+    post,
     /** Sessions of an agent, newest first. */
     async sessions(agentSlug) {
       const body = await json(`/api/agents/${encodeURIComponent(agentSlug)}/sessions`)

--- a/e2e/live/slack-chat/lib/checks.mjs
+++ b/e2e/live/slack-chat/lib/checks.mjs
@@ -216,21 +216,87 @@ export const CHECKS = [
   },
 
   {
-    id: 'question-freetext-answer',
-    title: 'a plain-text reply answers the open question and the same turn continues',
+    id: 'question-freetext-reply',
+    title: 'a plain-text reply to an open question settles it and the agent responds',
     tags: ['question', 'answer'],
     async run(ctx) {
       // Depends on question-card leaving a single-question card open: that is
-      // the only shape the free-text path consumes.
+      // the only shape the free-text ANSWER path consumes.
       const open = await ctx.api.pendingRequests(ctx.agentSlug)
       if (!open.some((r) => r.kind === 'question')) {
         throw new Error('No open question to answer — question-card must run first')
       }
+      const sessionId = await currentSessionId(ctx)
+      const before = (await ctx.api.messages(ctx.agentSlug, sessionId)).length
+
       const tag = nonce()
       await ctx.conv.say(`Green ${tag}`)
-      await ctx.conv.awaitBot('the agent to use the free-text answer', contains(tag), 240_000)
+      await ctx.conv.awaitBot('the agent to respond to the typed reply', contains(tag), 240_000)
       await awaitRegistryEmpty(ctx)
-      return 'answered as the free-form option'
+
+      // Which of the two paths ran is worth reporting, because they are not
+      // interchangeable and the connectors differ:
+      //   answer  — the text resolves the open card as the free-form option and
+      //             the SAME turn continues (no new user message hits the
+      //             transcript). Needs `answerOpenQuestionWithText`, which only
+      //             the Telegram connector implements today.
+      //   cancel  — the parked ask is cancelled and the text starts a FRESH
+      //             turn, so it lands in the transcript as a user message.
+      // Both settle the request and both get a reply, so asserting only "the
+      // agent answered" cannot tell them apart — and a check that cannot tell
+      // them apart would stay green if the answer path broke entirely.
+      const after = await ctx.api.messages(ctx.agentSlug, sessionId)
+      const startedFreshTurn = after
+        .slice(before)
+        .some((m) => JSON.stringify(m).includes(`Green ${tag}`) && (m.role ?? m.type) === 'user')
+      return startedFreshTurn
+        ? 'cancelled → fresh turn (this connector has no free-text answer path)'
+        : 'answered in-turn as the free-form option'
+    },
+  },
+
+  {
+    id: 'question-answered-in-app',
+    title: 'answering the card in the app settles it for Slack and the same turn continues',
+    tags: ['question', 'answer', 'cross-surface'],
+    async run(ctx) {
+      // The one check that drives BOTH surfaces. Chat and the app used to read
+      // "what is the agent blocked on" from different stores; if they drift
+      // apart again, an answer given in the app leaves the Slack card live and
+      // the turn parked — which is exactly what this fails on.
+      const tag = nonce()
+      await ctx.conv.say(
+        'Use the AskUserQuestion tool to ask me exactly one question: "Pick a metal" with the ' +
+          `options "Iron" and "Tin". When I answer, reply with exactly: PICKED ${tag} <my answer>.`,
+      )
+      await ctx.conv.awaitBot('the metal question card', contains('Pick a metal'), 240_000)
+
+      const request = await awaitRegistryKind(ctx, 'question')
+      const sessionId = await currentSessionId(ctx)
+      if (request.scope?.sessionId !== sessionId) {
+        throw new Error(
+          `The app sees the question on session ${request.scope?.sessionId}, Slack is on ${sessionId} — ` +
+            `an answer in the app would settle a different session's card`,
+        )
+      }
+
+      // Answer with the question text the registry holds, not the text we asked
+      // the model for: the container keys answers by the question it actually
+      // sent, and the model is free to reword.
+      const question = request.payload?.questions?.[0]?.question ?? 'Pick a metal'
+      await ctx.api.post(
+        `/api/agents/${encodeURIComponent(ctx.agentSlug)}/sessions/${encodeURIComponent(sessionId)}/answer-question`,
+        { toolUseId: request.id, answers: { [question]: 'Iron' } },
+      )
+
+      // The continuation has to come back to SLACK: the app answered, but the
+      // turn belongs to the chat conversation.
+      await ctx.conv.awaitBot(`PICKED ${tag}`, contains(`PICKED ${tag}`), 240_000)
+      await awaitRegistryEmpty(ctx)
+      return `answered ${request.id} via the app route, continuation landed in Slack`
+    },
+    async cleanup(ctx) {
+      await clearPending(ctx)
     },
   },
 
@@ -373,6 +439,21 @@ export const CHECKS = [
     // the subagent before a poll sees it. The notice is the assertion that
     // matters here; the parked-request invariant is covered by the other kinds.
     requiresParked: false,
+  }),
+
+  unsupportedCheck({
+    id: 'unsupported-capability-review',
+    kind: 'capability_review',
+    // Before the chat integrations moved onto the unified wire this kind had no
+    // case in processSSEEvent at all: the workflow parked on an approval the
+    // chat user was never told about, and the conversation just went quiet.
+    // `workflows: 'review'` is the shipped default, so no settings tampering is
+    // needed to reach it.
+    prompt:
+      'Use the Workflow tool to run a one-agent workflow that just echoes the word ping. ' +
+      'If the tool is unavailable, say exactly: WORKFLOW TOOL UNAVAILABLE.',
+    phrase: 'wants to run a workflow, which needs your approval.',
+    tags: ['capability'],
   }),
 
   unsupportedCheck({

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -5525,10 +5525,9 @@ setInterval(cleanupStaleUploads, 30 * 60 * 1000).unref()
 // store: mount, reconnect, and invalidation refetch from here; live updates
 // arrive as user_request_created / user_request_resolved on the session and
 // global SSE streams. The legacy per-type events still fire server-side for
-// the chat-integration connectors (their in-process consumer has not migrated)
-// and for the renderer's two narrow holdouts: the browser tray's
-// browser_input_request feed and the script/computer-use auto-approved
-// suppress-sets.
+// the renderer's two narrow holdouts: the browser tray's browser_input_request
+// feed and the script/computer-use auto-approved suppress-sets. (The chat
+// integrations moved onto this wire in Phase 7 and ignore the legacy events.)
 agents.get('/:id/pending-requests', AgentRead(), (c) => {
   const agentSlug = getAgentId(c)
   const sessionId = c.req.query('sessionId') || undefined

--- a/src/shared/lib/chat-integrations/chat-integration-access-gate.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-access-gate.test.ts
@@ -352,7 +352,9 @@ describe('chat-integration callback access gate', () => {
     await callback('c1')
 
     expect(reviewManager.submitDecision).toHaveBeenCalledTimes(1)
-    expect(reviewManager.submitDecision).toHaveBeenCalledWith('test-review', 'allow')
+    // Bound to the integration's agent: a caller-supplied review id must not be
+    // decidable through another agent's chat.
+    expect(reviewManager.submitDecision).toHaveBeenCalledWith('test-review', 'allow', 'test-agent')
   })
 
   it('revoked chat → silently dropped before review/resolve', async () => {

--- a/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
@@ -64,7 +64,12 @@ vi.mock('@shared/lib/services/session-service', () => ({
   finalizeAutomationStatus: vi.fn(() => Promise.resolve('not-automation')),
 }))
 
-// Mock settings
+// Mock settings. The capability + script-type reads belong to the persister's
+// request path, which the wire-contract suite below drives for real.
+const mockAgentCapabilities: Record<'subagents' | 'workflows', 'allow' | 'review' | 'block'> = {
+  subagents: 'allow',
+  workflows: 'allow',
+}
 vi.mock('@shared/lib/config/settings', () => ({
   getEffectiveModels: () => ({
     agentModel: 'claude-sonnet-4-5',
@@ -72,6 +77,13 @@ vi.mock('@shared/lib/config/settings', () => ({
     summarizerModel: 'claude-haiku-4-5',
   }),
   getSettings: () => ({}),
+  getAgentCapabilitySettings: () => ({ ...mockAgentCapabilities }),
+  getModelCatalogSettings: () => ({}),
+  VALID_SCRIPT_TYPES: {
+    darwin: ['applescript', 'shell'],
+    linux: ['shell'],
+    win32: ['powershell'],
+  },
 }))
 
 // Mock secrets service
@@ -97,7 +109,8 @@ import { createChatIntegration, getChatIntegration } from '@shared/lib/services/
 import { listChatIntegrationSessions } from '@shared/lib/services/chat-integration-session-service'
 import { approveChatAccess, revokeChatAccess } from '@shared/lib/services/chat-integration-access-service'
 import { containerManager } from '@shared/lib/container/container-manager'
-import { MockContainerClient } from '@shared/lib/container/mock-container-client'
+import { MockContainerClient, UserInputRequestScenario } from '@shared/lib/container/mock-container-client'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -492,6 +505,178 @@ describe('Chat integration E2E', () => {
       mockConnector = new MockChatClientConnector()
       await chatIntegrationManager.resumeIntegration(integrationId)
       expect(chatIntegrationManager.isIntegrationConnected(integrationId)).toBe(true)
+    })
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  // Unified wire contract.
+  //
+  // Every other chat test around user-input requests hands processSSEEvent a
+  // hand-built event and asserts what the connector does with it — which stays
+  // green even if the host stops emitting the event entirely. These rows drive
+  // a REAL tool_use through the REAL MessagePersister and assert on the card
+  // that comes out the far end of the chat manager. If the registry stops
+  // registering a kind, stops broadcasting it, or maps it to the wrong card,
+  // exactly one row goes red and it names the kind.
+  // ────────────────────────────────────────────────────────────────────
+
+  describe('unified wire contract (persister → registry → chat card)', () => {
+    interface WireRow {
+      kind: string
+      trigger: string
+      cardType: string
+      expect?: Record<string, unknown>
+      /** Capability kinds only surface when the capability is set to review. */
+      capability?: 'subagents' | 'workflows'
+    }
+
+    const WIRE_ROWS: WireRow[] = [
+      { kind: 'secret', trigger: 'ask secret', cardType: 'secret_request', expect: { secretName: 'OPENAI_API_KEY' } },
+      { kind: 'question', trigger: 'ask question', cardType: 'question_request' },
+      { kind: 'connected_account', trigger: 'ask account', cardType: 'connected_account_request' },
+      { kind: 'remote_mcp', trigger: 'request mcp', cardType: 'remote_mcp_request' },
+      { kind: 'script_run', trigger: 'ask script', cardType: 'script_run_request', expect: { scriptType: process.platform === 'win32' ? 'powershell' : 'shell' } },
+      { kind: 'file', trigger: 'need a file', cardType: 'file_request', expect: { description: 'A CSV of last quarter' } },
+      { kind: 'browser_input', trigger: 'need browser help', cardType: 'browser_input_request', expect: { message: 'Please sign in' } },
+      { kind: 'capability_review', trigger: 'launch subagent', cardType: 'capability_review_request', capability: 'subagents' },
+    ]
+
+    let originalE2eMock: string | undefined
+
+    beforeEach(() => {
+      // Computer-use interception is platform-gated with this escape hatch, and
+      // the capability rows need the gate armed too.
+      originalE2eMock = process.env.E2E_MOCK
+      process.env.E2E_MOCK = 'true'
+      mockAgentCapabilities.subagents = 'allow'
+      mockAgentCapabilities.workflows = 'allow'
+      userInputRequestManager.reset()
+
+      // start() arms this in production; this harness drives addIntegration
+      // directly, and without it the review card has no wire to arrive on.
+      ;(chatIntegrationManager as unknown as { subscribeGlobalNotifications(): void })
+        .subscribeGlobalNotifications()
+
+      // Two kinds the shared scenario table has no trigger for.
+      MockContainerClient.registerScenario('need a file', new UserInputRequestScenario([
+        { name: 'mcp__user-input__request_file', input: { description: 'A CSV of last quarter' } },
+      ]))
+      MockContainerClient.registerScenario('need browser help', new UserInputRequestScenario([
+        { name: 'mcp__user-input__request_browser_input', input: { message: 'Please sign in', requirements: ['credentials'] } },
+      ]))
+    })
+
+    afterEach(() => {
+      if (originalE2eMock === undefined) delete process.env.E2E_MOCK
+      else process.env.E2E_MOCK = originalE2eMock
+    })
+
+    /** Drive one turn and return the first card the connector was handed. */
+    async function cardFor(trigger: string) {
+      const integrationId = createTestIntegration()
+      await chatIntegrationManager.addIntegration(integrationId)
+      mockConnector.simulateIncomingMessage(trigger, 'chat-1', 'user-1')
+      await waitForCondition(() => mockConnector.sentCards.length > 0, 8000)
+      return mockConnector.sentCards[0]
+    }
+
+    it.each(WIRE_ROWS)('a real $kind tool_use reaches chat as $cardType', async (row) => {
+      if (row.capability) mockAgentCapabilities[row.capability] = 'review'
+
+      const sent = await cardFor(row.trigger)
+
+      expect(sent.event.type).toBe(row.cardType)
+      expect(sent.chatId).toBe('chat-1')
+      // The card must carry the session it came from: the "finish this in the
+      // app" notice links it, and a card linking a rotated-away session sends
+      // the user to the wrong place.
+      expect(sent.sessionId).toBeTruthy()
+      // …and it must be the id the registry holds, not a chat-side invention.
+      const open = userInputRequestManager.getOpenRequest(
+        (sent.event as { toolUseId: string }).toolUseId,
+      )
+      expect(open?.kind).toBe(row.kind)
+      expect(open?.scope.sessionId).toBe(sent.sessionId)
+      if (row.expect) expect(sent.event).toMatchObject(row.expect)
+    })
+
+    it('a parked proxy review reaches chat as the Allow/Deny card off the global wire', async () => {
+      // Reviews are agent-scoped, so they never touch a session SSE stream —
+      // this is the only path that carries them, and it is a different one from
+      // every row above.
+      const sent = await cardFor('proxy review please')
+
+      expect(sent.event.type).toBe('question_request')
+      const toolUseId = (sent.event as { toolUseId: string }).toolUseId
+      expect(toolUseId).toMatch(/^review:[^:]+:test-agent$/)
+      const labels = ((sent.event as { questions: Array<{ options?: Array<{ label: string }> }> }).questions[0].options ?? [])
+        .map((o) => o.label)
+      expect(labels).toEqual(['✅ Allow', '❌ Deny'])
+      // The id in the card is the registry's review id, so the decision routes
+      // back to the entry that is actually parked.
+      const reviewId = toolUseId.split(':')[1]
+      expect(userInputRequestManager.getOpenRequest(reviewId)?.kind).toBe('proxy_review')
+    })
+
+    it('a press on a card settled elsewhere is refused instead of buffered in the container', async () => {
+      const sent = await cardFor('ask secret')
+      const toolUseId = (sent.event as { toolUseId: string }).toolUseId
+
+      // Settled in the app while the chat card still shows live buttons.
+      expect(userInputRequestManager.resolve(toolUseId, 'answered')).not.toBeNull()
+
+      const fetchSpy = vi.spyOn(mockContainerClient, 'fetch')
+      mockConnector.sentMessages = []
+      mockConnector.simulateInteractiveResponse(toolUseId, 'hunter2', 'chat-1')
+      await waitForCondition(() => mockConnector.sentMessages.length > 0, 3000)
+
+      expect(mockConnector.sentMessages[0].message.text).toContain('already handled')
+      // The container must never see it: a resolve for an id nothing is waiting
+      // on buffers an earlyResult that no tool will ever collect.
+      expect(fetchSpy.mock.calls.filter(([p]) => String(p).includes('/resolve'))).toHaveLength(0)
+      fetchSpy.mockRestore()
+    })
+
+    it('a press on another agent\'s open request is refused the same way', async () => {
+      const sent = await cardFor('ask secret')
+      const toolUseId = (sent.event as { toolUseId: string }).toolUseId
+
+      // Same id, re-parked under a different agent — the shape a forged or
+      // crossed-wires payload takes. Still open, still not this chat's to decide.
+      userInputRequestManager.resolve(toolUseId, 'cancelled')
+      userInputRequestManager.register({
+        id: toolUseId,
+        kind: 'secret',
+        scope: { agentSlug: 'other-agent', sessionId: 'other-session' },
+        blocking: true,
+        autoApproved: false,
+        payload: { secretName: 'OPENAI_API_KEY' },
+      })
+
+      const fetchSpy = vi.spyOn(mockContainerClient, 'fetch')
+      mockConnector.sentMessages = []
+      mockConnector.simulateInteractiveResponse(toolUseId, 'hunter2', 'chat-1')
+      await waitForCondition(() => mockConnector.sentMessages.length > 0, 3000)
+
+      expect(mockConnector.sentMessages[0].message.text).toContain('already handled')
+      expect(fetchSpy.mock.calls.filter(([p]) => String(p).includes('/resolve'))).toHaveLength(0)
+      expect(userInputRequestManager.getOpenRequest(toolUseId)).not.toBeNull()
+      fetchSpy.mockRestore()
+    })
+
+    it('a press on a genuinely open request still resolves the container', async () => {
+      // The negative tests above are only meaningful if the positive path works.
+      const sent = await cardFor('ask secret')
+      const toolUseId = (sent.event as { toolUseId: string }).toolUseId
+
+      const fetchSpy = vi.spyOn(mockContainerClient, 'fetch')
+      mockConnector.simulateInteractiveResponse(toolUseId, 'hunter2', 'chat-1')
+
+      await waitForCondition(
+        () => fetchSpy.mock.calls.some(([p]) => String(p).includes('/resolve')),
+        3000,
+      )
+      fetchSpy.mockRestore()
     })
   })
 

--- a/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-e2e.test.ts
@@ -552,6 +552,12 @@ describe('Chat integration E2E', () => {
       mockAgentCapabilities.workflows = 'allow'
       userInputRequestManager.reset()
 
+      // mockResolvedValue sets the DEFAULT but does not drain queued
+      // *Once implementations — an unconsumed one from a timed-out test
+      // would fire in the next one.
+      vi.mocked(containerManager.ensureRunning).mockReset()
+      vi.mocked(containerManager.ensureRunning).mockResolvedValue(mockContainerClient)
+
       // start() arms this in production; this harness drives addIntegration
       // directly, and without it the review card has no wire to arrive on.
       ;(chatIntegrationManager as unknown as { subscribeGlobalNotifications(): void })
@@ -661,6 +667,71 @@ describe('Chat integration E2E', () => {
       expect(mockConnector.sentMessages[0].message.text).toContain('already handled')
       expect(fetchSpy.mock.calls.filter(([p]) => String(p).includes('/resolve'))).toHaveLength(0)
       expect(userInputRequestManager.getOpenRequest(toolUseId)).not.toBeNull()
+      fetchSpy.mockRestore()
+    })
+
+    it('a settle that lands while ensureRunning is pending stops the container call', async () => {
+      // The check-then-act window. Reading "is it open?" and then awaiting the
+      // container lookup leaves a gap in which another surface can settle the
+      // request; resolving after that buffers an earlyResult in a container
+      // with nothing parked, and the chat user is told nothing.
+      const sent = await cardFor('ask secret')
+      const toolUseId = (sent.event as { toolUseId: string }).toolUseId
+
+      let releaseContainer = () => {}
+      const gate = new Promise<void>((resolve) => {
+        releaseContainer = resolve
+      })
+      vi.mocked(containerManager.ensureRunning).mockImplementationOnce(async () => {
+        await gate
+        return mockContainerClient
+      })
+
+      const fetchSpy = vi.spyOn(mockContainerClient, 'fetch')
+      mockConnector.sentMessages = []
+      mockConnector.simulateInteractiveResponse(toolUseId, 'hunter2', 'chat-1')
+
+      // Settle in the app while the press is parked on the container lookup.
+      await waitForCondition(() => vi.mocked(containerManager.ensureRunning).mock.calls.length > 0, 3000)
+      expect(userInputRequestManager.resolve(toolUseId, 'answered')).not.toBeNull()
+      releaseContainer()
+
+      // Wait on something BOTH outcomes produce, so the assertion below is what
+      // fails when the gate regresses — not the wait. Gated: an already-handled
+      // reply. Racy: a resolve posted to a container with nothing parked.
+      const resolveCalls = () => fetchSpy.mock.calls.filter(([p]) => String(p).includes('/resolve'))
+      await waitForCondition(
+        () => mockConnector.sentMessages.length > 0 || resolveCalls().length > 0,
+        3000,
+      )
+      expect(resolveCalls()).toHaveLength(0)
+      expect(mockConnector.sentMessages[0]?.message.text).toContain('already handled')
+      fetchSpy.mockRestore()
+    })
+
+    it('a failed decision releases the claim so the request stays decidable', async () => {
+      // A leaked claim is worse than the race: the card would stay up forever
+      // with every press refused.
+      const sent = await cardFor('ask secret')
+      const toolUseId = (sent.event as { toolUseId: string }).toolUseId
+
+      vi.mocked(containerManager.ensureRunning).mockRejectedValueOnce(new Error('container down'))
+      mockConnector.sentMessages = []
+      mockConnector.simulateInteractiveResponse(toolUseId, 'hunter2', 'chat-1')
+      await waitForCondition(
+        () => vi.mocked(containerManager.ensureRunning).mock.calls.length > 0,
+        3000,
+      )
+
+      await waitForCondition(() => userInputRequestManager.stats.claimed === 0, 3000)
+      // Still open, and the next press gets through.
+      expect(userInputRequestManager.getOpenRequest(toolUseId)).not.toBeNull()
+      const fetchSpy = vi.spyOn(mockContainerClient, 'fetch')
+      mockConnector.simulateInteractiveResponse(toolUseId, 'hunter2', 'chat-1')
+      await waitForCondition(
+        () => fetchSpy.mock.calls.some(([p]) => String(p).includes('/resolve')),
+        3000,
+      )
       fetchSpy.mockRestore()
     })
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -11,12 +11,14 @@
  */
 
 import type { ChatClientConnector, ChatConnectorClass, IncomingMessage } from './base-connector'
-import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
 import type { SessionActivity } from '@shared/lib/types/agent'
 import { getToolDefinition } from '@shared/lib/tool-definitions/registry'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
 import { parseChatIntegrationConfig, type ChatProvider } from './config-schema'
-import { formatProviderName, formatSessionTimestamp, resolveAppLinkContext } from './utils'
+import { formatSessionTimestamp, resolveAppLinkContext } from './utils'
+import { requestCardFromRegistry, reviewCardFromRegistry } from './request-card'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
 import { consumeOrCancelAwaitingInput } from './resolve-awaiting-input'
 import {
   listStartupChatIntegrations,
@@ -214,13 +216,7 @@ class ChatIntegrationManager {
       })
     }, HEALTH_CHECK_INTERVAL_MS)
 
-    // Subscribe to global notifications for proxy review requests (tool approvals)
-    this.globalNotificationUnsubscribe = messagePersister.addGlobalNotificationClient((event: unknown) => {
-      this.handleGlobalNotification(event).catch((err) => {
-        console.error('[ChatIntegrationManager] Error handling global notification:', err)
-        reportError(err, 'global-notification')
-      })
-    })
+    this.subscribeGlobalNotifications()
 
     // Positive start signal: startup.ts only logs start() FAILURES, so without
     // this a dead manager is indistinguishable from a healthy idle one.
@@ -1043,6 +1039,7 @@ class ChatIntegrationManager {
         answerText: message.text ?? '',
         hasFiles: !!(message.files && message.files.length > 0),
         persister: messagePersister,
+        registry: userInputRequestManager,
         connector: conn.connector,
       })
       if (consumed) return
@@ -1518,36 +1515,43 @@ class ChatIntegrationManager {
 
   // ── Global notification handling (proxy review requests) ─────────
 
+  /**
+   * Reviews are agent-scoped, so they reach no session SSE stream — this
+   * subscription is the ONLY way an Allow/Deny card ever gets to chat.
+   * Idempotent so a harness that drives integrations without start() can arm
+   * it without risking a double-send.
+   */
+  private subscribeGlobalNotifications(): void {
+    if (this.globalNotificationUnsubscribe) return
+    this.globalNotificationUnsubscribe = messagePersister.addGlobalNotificationClient((event: unknown) => {
+      this.handleGlobalNotification(event).catch((err) => {
+        console.error('[ChatIntegrationManager] Error handling global notification:', err)
+        reportError(err, 'global-notification')
+      })
+    })
+  }
+
   private async handleGlobalNotification(event: unknown): Promise<void> {
     const data = event as Record<string, unknown>
-    if (data.type !== 'session_awaiting_input') return
+    // Reviews are agent-scoped, so they never reach a session SSE stream —
+    // the global registry event is the only place chat can see them. Same
+    // wire the session cards come from, filtered to the review kinds.
+    if (data.type !== 'user_request_created') return
+    const request = data.request as PendingUserInputRequest | undefined
+    if (!request) return
 
-    const review = data.review as Record<string, unknown> | undefined
-    if (!review || review.type !== 'proxy_review_request') return
+    // Non-review kinds return null here and are left to the session stream —
+    // they arrive on BOTH wires, so rendering them here too would double-send.
+    const card = reviewCardFromRegistry(request)
+    const agentSlug = request.scope.agentSlug
+    if (!card || !agentSlug) return
 
-    const agentSlug = data.agentSlug as string
-    const sessionId = data.sessionId as string
-    if (!agentSlug) return
-
-    const reviewId = review.reviewId as string
-    const displayText = review.displayText as string || 'Allow this action?'
-    const toolkit = review.toolkit as string || ''
-
-    const text = toolkit
-      ? `🔐 *${formatProviderName(toolkit)} — Permission Request*\n${displayText}`
-      : `🔐 *Permission Request*\n${displayText}`
-
-    const card = {
-      type: 'question_request',
-      toolUseId: `review:${reviewId}:${agentSlug}`,
-      questions: [{
-        question: text,
-        options: [
-          { label: '✅ Allow', value: 'allow' },
-          { label: '❌ Deny', value: 'deny' },
-        ],
-      }],
-    } as any
+    // A proxied call carries no session of its own, so the scope has none to
+    // route by; the agent's active session is the same fallback the review
+    // notification uses, and it is what gives the card's link a live session
+    // to open rather than the agent home.
+    const sessionId =
+      request.scope.sessionId ?? messagePersister.getActiveSessionIdsForAgent(agentSlug)[0]
 
     // If we know the sessionId, send only to the chat session that owns it
     if (sessionId) {
@@ -1608,6 +1612,9 @@ class ChatIntegrationManager {
   ): Promise<void> {
     if (!isChatAllowed(integrationId, chatId ?? '')) return // revoked/stale keyboard, or missing identity → fail closed
 
+    const integration = getChatIntegration(integrationId)
+    if (!integration) return
+
     // Handle proxy review decisions (tool approval requests)
     if (toolUseId.startsWith('review:')) {
       const parts = toolUseId.split(':')
@@ -1618,7 +1625,11 @@ class ChatIntegrationManager {
 
       try {
         const { reviewManager } = await import('@shared/lib/proxy/review-manager')
-        reviewManager.submitDecision(reviewId, decision as 'allow' | 'deny')
+        // Bound to this integration's agent: the id rides in from a chat
+        // client, and submitDecision returns false for a review that is
+        // settled, of another kind, or another agent's.
+        const settled = reviewManager.submitDecision(reviewId, decision as 'allow' | 'deny', integration.agentSlug)
+        if (!settled) await this.replyAlreadyHandled(integrationId, chatId)
       } catch (err) {
         console.error(`[ChatIntegrationManager] Failed to submit review decision:`, err)
         reportError(err, 'review-decision', { integrationId, reviewId, decision })
@@ -1626,8 +1637,19 @@ class ChatIntegrationManager {
       return
     }
 
-    const integration = getChatIntegration(integrationId)
-    if (!integration) return
+    // The same gate for container inputs. A card whose request was settled
+    // elsewhere — answered in the app, cancelled by the next turn, invalidated
+    // with a dead subagent — keeps live-looking buttons in chat; without this
+    // the press buffers an earlyResult in the container that nothing will ever
+    // consume, and the user walks away believing they answered. Not-open and
+    // not-this-agent's collapse to the same reply on purpose: both mean the
+    // button did nothing, and distinguishing them would confirm to one chat
+    // that another agent holds that id.
+    const open = userInputRequestManager.getOpenRequest(toolUseId)
+    if (!open || open.scope.agentSlug !== integration.agentSlug) {
+      await this.replyAlreadyHandled(integrationId, chatId)
+      return
+    }
 
     try {
       const { containerManager } = await import('@shared/lib/container/container-manager')
@@ -1677,6 +1699,25 @@ class ChatIntegrationManager {
     } catch (err) {
       console.error(`[ChatIntegrationManager] Failed to handle interactive response:`, err)
       reportError(err, 'interactive-response-resolve', { integrationId, toolUseId })
+    }
+  }
+
+  /**
+   * Tell the chat that the button it just pressed is dead. Best-effort and
+   * deliberately vague about why: silence is the failure mode this replaces —
+   * a user who pressed Allow and got nothing back has no way to know whether
+   * the agent is thinking or the press was swallowed.
+   */
+  private async replyAlreadyHandled(integrationId: string, chatId?: string): Promise<void> {
+    if (!chatId) return
+    const connector = this.connections.get(integrationId)?.connector
+    if (!connector) return
+    try {
+      await connector.sendMessage(chatId, {
+        text: 'That request was already handled — this card is no longer waiting on you.',
+      })
+    } catch (err) {
+      console.error('[ChatIntegrationManager] Failed to send already-handled notice:', err)
     }
   }
 
@@ -1989,26 +2030,36 @@ export async function processSSEEvent(
       break
     }
 
-    case 'question_request':
-    case 'secret_request':
-    case 'file_request':
-    case 'connected_account_request':
-    case 'remote_mcp_request':
-    case 'browser_input_request':
-    case 'script_run_request':
-    case 'computer_use_request': {
+    case 'user_request_created': {
+      // The one wire chat renders cards from. The legacy per-type events still
+      // fire alongside this one (they die in Phase 8) and are deliberately NOT
+      // handled here — handling both would double-send every card.
+      const request = (data as { request?: PendingUserInputRequest }).request
+      if (!request) break
+      const card = requestCardFromRegistry(request)
+      // null = chat stays quiet: a review (agent-scoped, rendered off the
+      // global channel) or an auto-approved ask nobody has to decide.
+      if (!card) break
+
       // The agent is now waiting on the user → 'awaiting' (non-busy). Settle the
       // indicator the moment the card is shown (the persister flips isAwaitingInput,
       // so the tick would clear within a tick anyway — this just makes it instant). The
-      // tick then sleeps after the lull and re-checks activity at fire time, so an
-      // auto-approved script run (card shown but the session stays 'working') keeps its tick.
+      // tick then sleeps after the lull and re-checks activity at fire time.
       clearIndicator(managed)
       try {
-        await managed.connector.sendUserRequestCard(managed.chatId, data as UserRequestEvent, sessionId)
+        await managed.connector.sendUserRequestCard(managed.chatId, card, sessionId)
       } catch (err) {
-        console.error(`[ChatIntegrationManager] Failed to send user request card (${eventType}):`, err)
-        reportError(err, 'send-user-request-card', { integrationId: managed.integration.id, provider: managed.integration.provider, eventType })
+        console.error(`[ChatIntegrationManager] Failed to send user request card (${request.kind}):`, err)
+        reportError(err, 'send-user-request-card', { integrationId: managed.integration.id, provider: managed.integration.provider, eventType: card.type })
       }
+      break
+    }
+
+    case 'user_request_resolved': {
+      // Settled — by a decision here, in the app, or by a sweep. Nothing to
+      // render: the gate in handleInteractiveResponse is what stops a press on
+      // the now-dead card, because no connector can dismiss a single card yet
+      // (dismissOpenCards is all-or-nothing, and Slack does not implement it).
       break
     }
 

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1645,8 +1645,16 @@ class ChatIntegrationManager {
     // not-this-agent's collapse to the same reply on purpose: both mean the
     // button did nothing, and distinguishing them would confirm to one chat
     // that another agent holds that id.
-    const open = userInputRequestManager.getOpenRequest(toolUseId)
+    //
+    // CLAIM it rather than merely reading it: everything below yields (the
+    // dynamic import, ensureRunning, the resolve call), so a plain "is it
+    // open?" read is check-then-act — a second press observes the same open
+    // request and both proceed. claimRequest is a synchronous check-and-mark,
+    // so exactly one presser wins.
+    const open = userInputRequestManager.claimRequest(toolUseId)
     if (!open || open.scope.agentSlug !== integration.agentSlug) {
+      // Wrong agent: release immediately, we never had the right to hold it.
+      if (open) userInputRequestManager.releaseClaim(toolUseId)
       await this.replyAlreadyHandled(integrationId, chatId)
       return
     }
@@ -1654,6 +1662,18 @@ class ChatIntegrationManager {
     try {
       const { containerManager } = await import('@shared/lib/container/container-manager')
       const client = await containerManager.ensureRunning(integration.agentSlug)
+
+      // Re-check with NO await between here and the container call. The claim
+      // only excludes another chat press; a decision on another surface settles
+      // the registry directly, and if that landed while ensureRunning was in
+      // flight the container has nothing parked — resolving now would buffer an
+      // earlyResult nothing will ever collect, which is the phantom this gate
+      // exists to prevent. What remains after this is the container round trip
+      // itself, which only the container can arbitrate.
+      if (!userInputRequestManager.getOpenRequest(toolUseId)) {
+        await this.replyAlreadyHandled(integrationId, chatId)
+        return
+      }
 
       const responseObj = response as Record<string, unknown>
       if (responseObj && typeof responseObj === 'object' && 'question' in responseObj && 'answer' in responseObj) {
@@ -1699,6 +1719,13 @@ class ChatIntegrationManager {
     } catch (err) {
       console.error(`[ChatIntegrationManager] Failed to handle interactive response:`, err)
       reportError(err, 'interactive-response-resolve', { integrationId, toolUseId })
+    } finally {
+      // Unconditional: on the success path the claim is already gone (resolve
+      // drops it with the entry), so this only matters for the paths that bail
+      // — a container that never came up, a failed resolve, a settle that beat
+      // us. A leaked claim would make the request undecidable forever, which is
+      // worse than the race it guards.
+      userInputRequestManager.releaseClaim(toolUseId)
     }
   }
 

--- a/src/shared/lib/chat-integrations/mock-connector.ts
+++ b/src/shared/lib/chat-integrations/mock-connector.ts
@@ -42,9 +42,14 @@ export class MockChatClientConnector extends ChatClientConnector {
     })
   }
 
-  /** Simulate an interactive response (button click / callback query). */
-  simulateInteractiveResponse(toolUseId: string, response: unknown): void {
-    this.emitInteractiveResponse(toolUseId, response)
+  /**
+   * Simulate an interactive response (button click / callback query). `chatId`
+   * is what the manager's access gate and its already-handled reply need — a
+   * press with no chat identity fails closed, which is the real behaviour but
+   * makes for a test that can never reach the logic under it.
+   */
+  simulateInteractiveResponse(toolUseId: string, response: unknown, chatId?: string): void {
+    this.emitInteractiveResponse(toolUseId, response, chatId)
   }
 
   /** Simulate a connection error. */

--- a/src/shared/lib/chat-integrations/request-card.test.ts
+++ b/src/shared/lib/chat-integrations/request-card.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { requestCardFromRegistry, reviewCardFromRegistry } from './request-card'
+import {
+  pendingUserInputRequestSchema,
+  USER_INPUT_REQUEST_KINDS,
+  type PendingUserInputRequest,
+} from '@shared/lib/user-input/request-schema'
+import { isUnsupportedInChat, describeUnsupportedRequest } from './utils'
+
+/** A real registry envelope — parsed, so a card can only come from a valid one. */
+function request(
+  kind: string,
+  payload: Record<string, unknown> = {},
+  // null omits the field (undefined would take the default).
+  over: { id?: string; autoApproved?: boolean; agentSlug?: string | null; sessionId?: string | null } = {},
+): PendingUserInputRequest {
+  return pendingUserInputRequestSchema.parse({
+    id: over.id ?? 'req-1',
+    kind,
+    scope: {
+      ...(over.agentSlug === null ? {} : { agentSlug: over.agentSlug ?? 'agent-a' }),
+      ...(over.sessionId === null ? {} : { sessionId: over.sessionId ?? 'session-1' }),
+    },
+    blocking: true,
+    autoApproved: over.autoApproved ?? false,
+    payload,
+  })
+}
+
+describe('requestCardFromRegistry', () => {
+  it('carries the payload through under the card type the connectors switch on', () => {
+    const card = requestCardFromRegistry(
+      request('secret', { secretName: 'API_KEY', reason: 'Need it' }, { id: 'tu-9' }),
+    )
+    expect(card).toEqual({
+      type: 'secret_request',
+      toolUseId: 'tu-9',
+      secretName: 'API_KEY',
+      reason: 'Need it',
+      agentSlug: 'agent-a',
+    })
+  })
+
+  it('never lets a payload field overwrite the identity fields', () => {
+    // The payload is whatever the model put in the tool input; it must not be
+    // able to redirect the card to another type or another request's id.
+    const card = requestCardFromRegistry(
+      request('secret', { type: 'question_request', toolUseId: 'someone-else', secretName: 'K' }),
+    )
+    expect(card).toMatchObject({ type: 'secret_request', toolUseId: 'req-1' })
+  })
+
+  it('stays quiet for an auto-approved ask', () => {
+    // Nothing is waiting on the user, so "go approve this in the app" would be
+    // a lie — the host is already running it.
+    expect(requestCardFromRegistry(request('script_run', { script: 'ls' }, { autoApproved: true }))).toBeNull()
+  })
+
+  it('stays quiet for reviews — those render off the global channel', () => {
+    expect(requestCardFromRegistry(request('proxy_review', {}, { sessionId: null }))).toBeNull()
+    expect(requestCardFromRegistry(request('x_agent_review', {}, { sessionId: null }))).toBeNull()
+  })
+
+  it('maps every request kind to a decision — no kind can go silent by omission', () => {
+    // The regression this guards: before the unified wire, a new kind fell
+    // through processSSEEvent's else-if chain and chat users waited on a card
+    // that was never coming. Every kind must either render or be one of the
+    // two documented quiet cases.
+    const quiet = new Set(['proxy_review', 'x_agent_review'])
+    for (const kind of USER_INPUT_REQUEST_KINDS) {
+      const card = requestCardFromRegistry(request(kind, {}, { sessionId: quiet.has(kind) ? null : 'session-1' }))
+      if (quiet.has(kind)) {
+        expect(card, kind).toBeNull()
+      } else {
+        expect(card, kind).not.toBeNull()
+      }
+    }
+  })
+
+  it('gives every rendered kind either an interactive card or a notice a connector can write', () => {
+    // A card type with no notice arm and no interactive rendering would post
+    // the generic fallback wording, which reads like a bug to the user.
+    for (const kind of USER_INPUT_REQUEST_KINDS) {
+      const card = requestCardFromRegistry(request(kind, {}, { sessionId: 'session-1' }))
+      if (!card) continue
+      if (card.type === 'question_request') continue // rendered interactively
+      expect(isUnsupportedInChat(card), kind).toBe(true)
+      expect(describeUnsupportedRequest(card), kind).not.toContain('request that isn\'t supported in chat')
+    }
+  })
+})
+
+describe('reviewCardFromRegistry', () => {
+  it('builds the Allow/Deny card with the id the decision router splits on', () => {
+    const card = reviewCardFromRegistry(
+      request('proxy_review', { toolkit: 'slack', displayText: 'Post to #general?' }, { id: 'rev-7', sessionId: null }),
+    )
+    expect(card).toEqual({
+      type: 'question_request',
+      toolUseId: 'review:rev-7:agent-a',
+      questions: [
+        {
+          question: '🔐 *Slack — Permission Request*\nPost to #general?',
+          options: [{ label: '✅ Allow' }, { label: '❌ Deny' }],
+        },
+      ],
+      agentSlug: 'agent-a',
+    })
+  })
+
+  it('renders an x-agent review the same way', () => {
+    const card = reviewCardFromRegistry(
+      request('x_agent_review', { displayText: 'Ask Helper Bot to list files?' }, { id: 'rev-8', sessionId: null }),
+    )
+    expect(card?.toolUseId).toBe('review:rev-8:agent-a')
+    expect((card as { questions: Array<{ question: string }> }).questions[0].question).toBe(
+      '🔐 *Permission Request*\nAsk Helper Bot to list files?',
+    )
+  })
+
+  it('returns null for a non-review kind', () => {
+    expect(reviewCardFromRegistry(request('secret', { secretName: 'K' }))).toBeNull()
+  })
+
+  it('returns null for a review with no agent — the id it would build is unroutable', () => {
+    expect(reviewCardFromRegistry(request('proxy_review', {}, { agentSlug: null, sessionId: null }))).toBeNull()
+  })
+})

--- a/src/shared/lib/chat-integrations/request-card.ts
+++ b/src/shared/lib/chat-integrations/request-card.ts
@@ -1,0 +1,101 @@
+/**
+ * Registry envelope → the card shape connectors render.
+ *
+ * Chat used to consume the eight legacy per-type SSE events directly, which
+ * made it a second reader of "what is the agent blocked on" — one that missed
+ * recovered registrations, had no resolved signal, and silently dropped any
+ * kind nobody remembered to wire up. Everything chat renders now derives from
+ * the one registry event (`user_request_created`) through this module; the
+ * per-connector `sendUserRequestCard` switches are unchanged and still see the
+ * card shapes they always did.
+ */
+
+import type { UserRequestEvent } from '@shared/lib/tool-definitions/types'
+import type {
+  PendingUserInputRequest,
+  UserInputRequestKind,
+} from '@shared/lib/user-input/request-schema'
+import { formatProviderName } from './utils'
+
+/**
+ * Kind → the card `type` a connector switches on.
+ *
+ * Total on purpose: a twelfth request kind is a compile error here until
+ * someone decides what chat does with it. Connectors render an unknown type as
+ * the "finish this in the app" notice via their switch default, so the only
+ * way a kind can go silent in chat is an explicit `null` in this table.
+ *
+ * The two review kinds are null: they are agent-scoped, arrive on the global
+ * notification channel rather than any session stream, and render as the
+ * synthetic Allow/Deny card `reviewCardFromRegistry` builds.
+ */
+const KIND_TO_CARD_TYPE: Record<UserInputRequestKind, UserRequestEvent['type'] | null> = {
+  question: 'question_request',
+  secret: 'secret_request',
+  connected_account: 'connected_account_request',
+  file: 'file_request',
+  remote_mcp: 'remote_mcp_request',
+  browser_input: 'browser_input_request',
+  script_run: 'script_run_request',
+  capability_review: 'capability_review_request',
+  computer_use: 'computer_use_request',
+  proxy_review: null,
+  x_agent_review: null,
+}
+
+/**
+ * The card for a session-scoped request, or null when chat should stay quiet.
+ *
+ * Auto-approved asks are the quiet case: they are visible-but-not-blocking (the
+ * host is already executing them, `isRealWait` reads false), and chat's only
+ * rendering for those kinds is "go finish this in the app" — which would send
+ * the user to a screen with nothing on it.
+ */
+export function requestCardFromRegistry(request: PendingUserInputRequest): UserRequestEvent | null {
+  const type = KIND_TO_CARD_TYPE[request.kind]
+  if (!type) return null
+  if (request.autoApproved) return null
+  return {
+    // Payload first: `type` and `toolUseId` are ours to set, and a malformed
+    // tool input must not be able to redirect the card it renders as.
+    ...(request.payload as Record<string, unknown>),
+    type,
+    toolUseId: request.id,
+    ...(request.scope.agentSlug ? { agentSlug: request.scope.agentSlug } : {}),
+  } as UserRequestEvent
+}
+
+/**
+ * The synthetic Allow/Deny question card for an agent-scoped review.
+ *
+ * `toolUseId` keeps the `review:<id>:<agent>` convention byte-for-byte: it is
+ * what `handleInteractiveResponse` splits on to route the press back to
+ * ReviewManager rather than to a container input.
+ */
+export function reviewCardFromRegistry(request: PendingUserInputRequest): UserRequestEvent | null {
+  if (request.kind !== 'proxy_review' && request.kind !== 'x_agent_review') return null
+  const agentSlug = request.scope.agentSlug
+  if (!agentSlug) return null
+
+  const payload = request.payload as { displayText?: unknown; toolkit?: unknown }
+  const displayText =
+    typeof payload.displayText === 'string' && payload.displayText
+      ? payload.displayText
+      : 'Allow this action?'
+  const toolkit = typeof payload.toolkit === 'string' ? payload.toolkit : ''
+  const text = toolkit
+    ? `🔐 *${formatProviderName(toolkit)} — Permission Request*\n${displayText}`
+    : `🔐 *Permission Request*\n${displayText}`
+
+  return {
+    type: 'question_request',
+    toolUseId: `review:${request.id}:${agentSlug}`,
+    questions: [
+      {
+        question: text,
+        options: [{ label: '✅ Allow' }, { label: '❌ Deny' }],
+      },
+    ],
+    agentSlug,
+  }
+}

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.test.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.test.ts
@@ -3,7 +3,8 @@ import { consumeOrCancelAwaitingInput } from './resolve-awaiting-input'
 
 interface Recorder {
   awaiting: boolean
-  pending: Array<{ type: string; toolUseId: string }>
+  /** Registry envelopes, narrowed to the fields the decision reads. */
+  pending: Array<{ id: string; kind: string; payload: unknown }>
   answerResult: boolean
   calls: string[]
   answerArgs?: { chatId: string; toolUseId: string; text: string }
@@ -13,8 +14,10 @@ function makeDeps(over: Partial<Recorder> = {}) {
   const rec: Recorder = { awaiting: false, pending: [], answerResult: false, calls: [], ...over }
   const persister = {
     isSessionAwaitingInput: () => rec.awaiting,
-    getPendingInputRequests: () => rec.pending,
     cancelAwaitingInput: async () => { rec.calls.push('cancel') },
+  }
+  const registry = {
+    getOpenRequestsForSession: () => rec.pending,
   }
   const connector = {
     answerOpenQuestionWithText: async (chatId: string, toolUseId: string, text: string) => {
@@ -24,28 +27,28 @@ function makeDeps(over: Partial<Recorder> = {}) {
     },
     dismissOpenCards: async () => { rec.calls.push('dismiss') },
   }
-  return { rec, persister, connector }
+  return { rec, persister, registry, connector }
 }
 
 const base = { sessionId: 's1', agentSlug: 'agent', chatId: 'c1' }
 
 describe('consumeOrCancelAwaitingInput', () => {
   it('resolves an open question with plain text and consumes the message (no cancel/dismiss)', async () => {
-    const { rec, persister, connector } = makeDeps({
+    const { rec, persister, registry, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'question_request', toolUseId: 't1' }],
+      pending: [{ id: 't1', kind: 'question', payload: {} }],
       answerResult: true,
     })
-    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'my answer', hasFiles: false, persister, connector })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'my answer', hasFiles: false, persister, registry, connector })
     expect(consumed).toBe(true)
     expect(rec.calls).toEqual(['answer'])
     expect(rec.answerArgs).toEqual({ chatId: 'c1', toolUseId: 't1', text: 'my answer' })
   })
 
   it('resolves with the raw answerText, not the group-prefixed messageText, when both are given', async () => {
-    const { rec, persister, connector } = makeDeps({
+    const { rec, persister, registry, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'question_request', toolUseId: 't1' }],
+      pending: [{ id: 't1', kind: 'question', payload: {} }],
       answerResult: true,
     })
     // messageText carries the `\[Alice]: ` sender prefix (for the fresh-turn forward); the answer
@@ -56,6 +59,7 @@ describe('consumeOrCancelAwaitingInput', () => {
       answerText: 'option nobody listed',
       hasFiles: false,
       persister,
+      registry,
       connector,
     })
     expect(consumed).toBe(true)
@@ -63,49 +67,64 @@ describe('consumeOrCancelAwaitingInput', () => {
   })
 
   it('cancels and dismisses when the open question declines the typed text', async () => {
-    const { rec, persister, connector } = makeDeps({
+    const { rec, persister, registry, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'question_request', toolUseId: 't1' }],
+      pending: [{ id: 't1', kind: 'question', payload: {} }],
       answerResult: false,
     })
-    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'redirect me', hasFiles: false, persister, connector })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'redirect me', hasFiles: false, persister, registry, connector })
     expect(consumed).toBe(false)
     expect(rec.calls).toEqual(['answer', 'cancel', 'dismiss'])
   })
 
   it('does not attempt to answer with a file/non-text message — cancels and dismisses', async () => {
-    const { rec, persister, connector } = makeDeps({
+    const { rec, persister, registry, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'question_request', toolUseId: 't1' }],
+      pending: [{ id: 't1', kind: 'question', payload: {} }],
     })
-    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'caption', hasFiles: true, persister, connector })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'caption', hasFiles: true, persister, registry, connector })
     expect(consumed).toBe(false)
     expect(rec.calls).toEqual(['cancel', 'dismiss'])
   })
 
   it('cancels and dismisses when awaiting a non-question request (e.g. secret)', async () => {
-    const { rec, persister, connector } = makeDeps({
+    const { rec, persister, registry, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'secret_request', toolUseId: 't9' }],
+      pending: [{ id: 't9', kind: 'secret', payload: {} }],
     })
-    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'hello', hasFiles: false, persister, connector })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'hello', hasFiles: false, persister, registry, connector })
     expect(consumed).toBe(false)
     expect(rec.calls).toEqual(['cancel', 'dismiss'])
   })
 
   it('cancels and dismisses (both no-ops downstream) when not awaiting input', async () => {
-    const { rec, persister, connector } = makeDeps({ awaiting: false })
-    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'hi', hasFiles: false, persister, connector })
+    const { rec, persister, registry, connector } = makeDeps({ awaiting: false })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'hi', hasFiles: false, persister, registry, connector })
+    expect(consumed).toBe(false)
+    expect(rec.calls).toEqual(['cancel', 'dismiss'])
+  })
+
+  it('does not answer a recovered question stub — no card was ever posted for it', async () => {
+    const { rec, persister, registry, connector } = makeDeps({
+      awaiting: true,
+      // Transcript recovery synthesizes a payload-less stub after a host
+      // restart. It is a real wait, but it is filtered off the wire, so this
+      // chat never saw a question to answer — resolving it against typed text
+      // would answer a card the user cannot see.
+      pending: [{ id: 't-recovered', kind: 'question', payload: { recovered: true } }],
+      answerResult: true,
+    })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: 'blue', hasFiles: false, persister, registry, connector })
     expect(consumed).toBe(false)
     expect(rec.calls).toEqual(['cancel', 'dismiss'])
   })
 
   it('treats a whitespace-only message as non-text and does not answer', async () => {
-    const { rec, persister, connector } = makeDeps({
+    const { rec, persister, registry, connector } = makeDeps({
       awaiting: true,
-      pending: [{ type: 'question_request', toolUseId: 't1' }],
+      pending: [{ id: 't1', kind: 'question', payload: {} }],
     })
-    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: '   ', hasFiles: false, persister, connector })
+    const consumed = await consumeOrCancelAwaitingInput({ ...base, messageText: '   ', hasFiles: false, persister, registry, connector })
     expect(consumed).toBe(false)
     expect(rec.calls).toEqual(['cancel', 'dismiss'])
   })

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
@@ -14,8 +14,22 @@
 
 interface AwaitingInputPersister {
   isSessionAwaitingInput(sessionId: string): boolean
-  getPendingInputRequests(sessionId: string): Array<{ type: string; toolUseId: string }>
   cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void>
+}
+
+/**
+ * The registry, narrowed to what this decision needs. Reading the open request
+ * from here rather than the persister's replay mirror is what keeps chat and
+ * the app answering the same question from the same source — the mirror is a
+ * legacy store scheduled for deletion, and it holds entries the registry has
+ * already settled.
+ */
+interface OpenRequestRegistry {
+  getOpenRequestsForSession(sessionId: string): Array<{
+    id: string
+    kind: string
+    payload: unknown
+  }>
 }
 
 interface DismissibleConnector {
@@ -35,9 +49,10 @@ export async function consumeOrCancelAwaitingInput(opts: {
   answerText?: string
   hasFiles: boolean
   persister: AwaitingInputPersister
+  registry: OpenRequestRegistry
   connector: DismissibleConnector
 }): Promise<boolean> {
-  const { sessionId, agentSlug, chatId, messageText, answerText, hasFiles, persister, connector } = opts
+  const { sessionId, agentSlug, chatId, messageText, answerText, hasFiles, persister, registry, connector } = opts
 
   // A plain-text message during an open single-question card is the free-form "Other" answer:
   // resolve that question so the same turn continues. isSessionAwaitingInput is the source of
@@ -46,11 +61,14 @@ export async function consumeOrCancelAwaitingInput(opts: {
   // awaiting type falls through to cancel.
   const isPlainText = !!messageText.trim() && !hasFiles
   if (isPlainText && persister.isSessionAwaitingInput(sessionId)) {
-    const pendingQuestion = persister
-      .getPendingInputRequests(sessionId)
-      .find((r) => r.type === 'question_request')
+    // Recovered stubs are excluded the same way they are excluded from the
+    // wire: they carry no renderable payload, so no card was ever posted and
+    // there is nothing in this chat for the text to answer.
+    const pendingQuestion = registry
+      .getOpenRequestsForSession(sessionId)
+      .find((r) => r.kind === 'question' && (r.payload as { recovered?: unknown }).recovered !== true)
     if (pendingQuestion) {
-      const answered = await connector.answerOpenQuestionWithText(chatId, pendingQuestion.toolUseId, answerText ?? messageText)
+      const answered = await connector.answerOpenQuestionWithText(chatId, pendingQuestion.id, answerText ?? messageText)
       if (answered) return true
     }
   }

--- a/src/shared/lib/chat-integrations/sse-error-resilience.test.ts
+++ b/src/shared/lib/chat-integrations/sse-error-resilience.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { processSSEEvent, finalizeStreaming, resolvePendingToolMessages, type ManagedConnector } from './chat-integration-manager'
 import { MockChatClientConnector } from './mock-connector'
+import { createdEvent } from './user-request-fixtures'
 import type { ChatIntegration } from '@shared/lib/db/schema'
 
 // Suppress console.error noise from intentional throws
@@ -189,25 +190,33 @@ describe('tool_use_start error resilience', () => {
 // ── user request card: sendUserRequestCard throws ───────────────────────
 
 describe('user request card error resilience', () => {
-  const requestTypes = [
-    'question_request',
-    'secret_request',
-    'file_request',
-    'connected_account_request',
-    'remote_mcp_request',
-    'browser_input_request',
-    'script_run_request',
-    'computer_use_request',
+  const requestKinds = [
+    'question',
+    'secret',
+    'file',
+    'connected_account',
+    'remote_mcp',
+    'browser_input',
+    'script_run',
+    'capability_review',
+    'computer_use',
   ]
 
-  for (const eventType of requestTypes) {
-    it(`does not throw when sendUserRequestCard fails for ${eventType}`, async () => {
+  for (const kind of requestKinds) {
+    it(`does not throw when sendUserRequestCard fails for ${kind}`, async () => {
       const managed = createManagedConnector()
       const mock = getMock(managed)
-      mock.sendUserRequestCard = async () => { throw new Error('card send failed') }
+      let attempted = false
+      mock.sendUserRequestCard = async () => {
+        attempted = true
+        throw new Error('card send failed')
+      }
 
       // Should not throw
-      await processSSEEvent(managed, { type: eventType, toolUseId: 'tu-1' })
+      await processSSEEvent(managed, createdEvent(kind))
+      // …and the throw must have come from a real attempt: an event the
+      // manager silently ignores would pass this test having proven nothing.
+      expect(attempted).toBe(true)
     })
   }
 
@@ -218,7 +227,7 @@ describe('user request card error resilience', () => {
     mock.sendUserRequestCard = async () => { throw new Error('card send failed') }
 
     // Card fails
-    await processSSEEvent(managed, { type: 'question_request', toolUseId: 'tu-1' })
+    await processSSEEvent(managed, createdEvent('question'))
     // Streaming still works
     await processSSEEvent(managed, { type: 'stream_delta', text: 'After card failure' })
 
@@ -337,7 +346,7 @@ describe('pipeline isolation', () => {
     }
 
     // Process a card event (fails), then a streaming event (should succeed)
-    await processSSEEvent(managed, { type: 'question_request', toolUseId: 'tu-1' })
+    await processSSEEvent(managed, createdEvent('question'))
     await processSSEEvent(managed, { type: 'stream_delta', text: 'Still works' })
 
     expect(managed.streamingState.accumulatedText).toBe('Still works')

--- a/src/shared/lib/chat-integrations/sse-event-processing.test.ts
+++ b/src/shared/lib/chat-integrations/sse-event-processing.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { processSSEEvent, finalizeStreaming, resolvePendingToolMessages, type ManagedConnector } from './chat-integration-manager'
 import { MockChatClientConnector } from './mock-connector'
+import { createdEvent } from './user-request-fixtures'
 import type { ChatIntegration } from '@shared/lib/db/schema'
 
 // ── Test helpers ────────────────────────────────────────────────────────
@@ -298,37 +299,59 @@ describe('processSSEEvent', () => {
       expect(mock.sentMessages.length).toBe(0) // no tool summary
     })
 
-    it('forwards question_request to sendUserRequestCard', async () => {
-      await processSSEEvent(managed, {
+    it('forwards a question request to sendUserRequestCard', async () => {
+      await processSSEEvent(managed, createdEvent('question', { questions: [{ question: 'Which DB?' }] }))
+
+      const mock = getMock(managed)
+      expect(mock.sentCards.length).toBe(1)
+      expect(mock.sentCards[0].event).toMatchObject({
         type: 'question_request',
         toolUseId: 'tu-1',
         questions: [{ question: 'Which DB?' }],
       })
+    })
+
+    it('forwards a secret request to sendUserRequestCard', async () => {
+      await processSSEEvent(managed, createdEvent('secret', { secretName: 'API_KEY' }, { id: 'tu-2' }))
 
       const mock = getMock(managed)
       expect(mock.sentCards.length).toBe(1)
-      expect(mock.sentCards[0].event.type).toBe('question_request')
-    })
-
-    it('forwards secret_request to sendUserRequestCard', async () => {
-      await processSSEEvent(managed, {
+      expect(mock.sentCards[0].event).toMatchObject({
         type: 'secret_request',
         toolUseId: 'tu-2',
         secretName: 'API_KEY',
       })
+    })
 
-      const mock = getMock(managed)
-      expect(mock.sentCards.length).toBe(1)
-      expect(mock.sentCards[0].event.type).toBe('secret_request')
+    it('ignores the legacy per-type event — handling both wires would double-send every card', async () => {
+      // Both wires fire until Phase 8 removes the legacy emission.
+      await processSSEEvent(managed, { type: 'secret_request', toolUseId: 'tu-2', secretName: 'API_KEY' })
+      expect(getMock(managed).sentCards.length).toBe(0)
+    })
+
+    it('stays quiet for an auto-approved ask — nothing is waiting on the user', async () => {
+      // The host is already executing it (`isRealWait` is false). Chat's only
+      // rendering for script_run is "go approve this in the app", which would
+      // send the user to a screen with nothing on it.
+      await processSSEEvent(
+        managed,
+        createdEvent('script_run', { script: 'sw_vers', explanation: 'check', scriptType: 'shell' }, { autoApproved: true }),
+      )
+      expect(getMock(managed).sentCards.length).toBe(0)
+    })
+
+    it('stays quiet for a review — those are agent-scoped and render off the global channel', async () => {
+      await processSSEEvent(managed, createdEvent('proxy_review', { toolkit: 'github', displayText: 'Allow?' }))
+      expect(getMock(managed).sentCards.length).toBe(0)
     })
 
     it('threads the originating sessionId into sendUserRequestCard', async () => {
-      await processSSEEvent(managed, { type: 'secret_request', secretName: 'K' }, false, 'sess-42')
+      await processSSEEvent(managed, createdEvent('secret', { secretName: 'K' }), false, 'sess-42')
       expect(getMock(managed).sentCards[0]?.sessionId).toBe('sess-42')
     })
 
     it('sends no sessionId when the caller has none', async () => {
-      await processSSEEvent(managed, { type: 'secret_request', secretName: 'K' }, false)
+      await processSSEEvent(managed, createdEvent('secret', { secretName: 'K' }), false)
       expect(getMock(managed).sentCards[0]?.sessionId).toBeUndefined()
     })
   })
@@ -597,22 +620,28 @@ describe('all user request event types', () => {
     managed = createManagedConnector()
   })
 
-  const userRequestEvents = [
-    { type: 'file_request', toolUseId: 'tu-1', description: 'Upload a CSV' },
-    { type: 'connected_account_request', toolUseId: 'tu-2', provider: 'github' },
-    { type: 'remote_mcp_request', toolUseId: 'tu-3', serverName: 'my-mcp' },
-    { type: 'browser_input_request', toolUseId: 'tu-4', url: 'https://example.com' },
-    { type: 'script_run_request', toolUseId: 'tu-5', script: 'npm test' },
-    { type: 'computer_use_request', toolUseId: 'tu-6', action: 'screenshot' },
+  // Every kind chat renders, and the card type each must arrive as. A kind
+  // missing from this table is one nobody would notice going silent.
+  const userRequestKinds = [
+    { kind: 'question', cardType: 'question_request', payload: { questions: [{ question: 'Which DB?' }] } },
+    { kind: 'secret', cardType: 'secret_request', payload: { secretName: 'API_KEY' } },
+    { kind: 'file', cardType: 'file_request', payload: { description: 'Upload a CSV' } },
+    { kind: 'connected_account', cardType: 'connected_account_request', payload: { toolkit: 'github' } },
+    { kind: 'remote_mcp', cardType: 'remote_mcp_request', payload: { url: 'https://example.com/mcp', name: 'my-mcp' } },
+    { kind: 'browser_input', cardType: 'browser_input_request', payload: { message: 'Sign in' } },
+    { kind: 'script_run', cardType: 'script_run_request', payload: { script: 'npm test', explanation: 'x', scriptType: 'shell' } },
+    { kind: 'capability_review', cardType: 'capability_review_request', payload: { capability: 'subagents', toolName: 'Task' } },
+    { kind: 'computer_use', cardType: 'computer_use_request', payload: { method: 'screenshot', permissionLevel: 'use_application' } },
   ]
 
-  for (const event of userRequestEvents) {
-    it(`forwards ${event.type} to sendUserRequestCard`, async () => {
-      await processSSEEvent(managed, event)
+  for (const { kind, cardType, payload } of userRequestKinds) {
+    it(`forwards a ${kind} request as ${cardType}`, async () => {
+      await processSSEEvent(managed, createdEvent(kind, payload))
 
       const mock = getMock(managed)
       expect(mock.sentCards.length).toBe(1)
-      expect(mock.sentCards[0].event.type).toBe(event.type)
+      expect(mock.sentCards[0].event.type).toBe(cardType)
+      expect(mock.sentCards[0].event.toolUseId).toBe('tu-1')
     })
   }
 
@@ -1135,25 +1164,35 @@ describe('processSSEEvent: immediate clears', () => {
     managed = createManagedConnector()
   })
 
-  const cardTypes = [
-    'question_request',
-    'secret_request',
-    'file_request',
-    'connected_account_request',
-    'remote_mcp_request',
-    'browser_input_request',
-    'script_run_request',
-    'computer_use_request',
+  const cardKinds = [
+    'question',
+    'secret',
+    'file',
+    'connected_account',
+    'remote_mcp',
+    'browser_input',
+    'script_run',
+    'capability_review',
+    'computer_use',
   ]
 
-  for (const type of cardTypes) {
-    it(`clears the indicator the moment a ${type} card is shown`, async () => {
+  for (const kind of cardKinds) {
+    it(`clears the indicator the moment a ${kind} card is shown`, async () => {
       managed.indicatorShown = true
-      await processSSEEvent(managed, { type, requestId: 'r1' })
+      await processSSEEvent(managed, createdEvent(kind))
       expect(getMock(managed).stoppedWorking).toContain('chat-123')
       expect(managed.indicatorShown).toBe(false)
     })
   }
+
+  it('does NOT clear the indicator for a card it stays quiet about', async () => {
+    // An auto-approved run keeps the session 'working': settling the indicator
+    // there would paint the agent as idle mid-turn.
+    managed.indicatorShown = true
+    await processSSEEvent(managed, createdEvent('script_run', {}, { autoApproved: true }))
+    expect(getMock(managed).stoppedWorking).not.toContain('chat-123')
+    expect(managed.indicatorShown).toBe(true)
+  })
 
   it('clears on the first reply stream_delta (the stream owns the surface)', async () => {
     managed.indicatorShown = true

--- a/src/shared/lib/chat-integrations/user-request-fixtures.ts
+++ b/src/shared/lib/chat-integrations/user-request-fixtures.ts
@@ -1,0 +1,31 @@
+/**
+ * Test fixtures for the unified user-request wire.
+ *
+ * Built through the registry schema rather than by hand: a card a test accepts
+ * has to come from an envelope the registry could really have produced. (That
+ * the persister EMITS these at all is proven separately, by the wire-contract
+ * suite in chat-integration-e2e.test.ts, which drives a real tool_use through
+ * the real MessagePersister.)
+ */
+
+import { pendingUserInputRequestSchema } from '@shared/lib/user-input/request-schema'
+
+/** The exact event the persister puts on the wire when a request opens. */
+export function createdEvent(
+  kind: string,
+  payload: Record<string, unknown> = {},
+  over: { id?: string; autoApproved?: boolean; sessionId?: string; agentSlug?: string } = {},
+) {
+  const request = pendingUserInputRequestSchema.parse({
+    id: over.id ?? 'tu-1',
+    kind,
+    scope: {
+      agentSlug: over.agentSlug ?? 'test-agent',
+      sessionId: over.sessionId ?? 'sess-1',
+    },
+    blocking: true,
+    autoApproved: over.autoApproved ?? false,
+    payload,
+  })
+  return { type: 'user_request_created', agentSlug: request.scope.agentSlug, request }
+}

--- a/src/shared/lib/chat-integrations/utils.ts
+++ b/src/shared/lib/chat-integrations/utils.ts
@@ -84,6 +84,7 @@ const UNSUPPORTED_IN_CHAT: ReadonlySet<UserRequestEvent['type']> = new Set([
   'browser_input_request',
   'script_run_request',
   'computer_use_request',
+  'capability_review_request',
   'secret_request',
   'file_request',
 ])
@@ -174,6 +175,8 @@ export function describeUnsupportedRequest(event: UserRequestEvent, appLink?: Ap
       return `The agent needs input in a browser session, which isn't supported in chat.${tail}`
     case 'script_run_request':
       return `The agent wants to run a script, which needs your approval.${tail}`
+    case 'capability_review_request':
+      return `The agent wants to ${event.capability === 'workflows' ? 'run a workflow' : 'launch a subagent'}, which needs your approval.${tail}`
     case 'computer_use_request':
       return `The agent wants to use your computer, which isn't supported in chat.${tail}`
     case 'secret_request':

--- a/src/shared/lib/tool-definitions/types.ts
+++ b/src/shared/lib/tool-definitions/types.ts
@@ -113,6 +113,14 @@ export type UserRequestEvent =
       autoApproved?: boolean
     }
   | {
+      type: 'capability_review_request'
+      toolUseId: string
+      capability: string
+      toolName?: string
+      input?: unknown
+      agentSlug?: string
+    }
+  | {
       type: 'tool_status'
       toolUseId: string
       toolName: string

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -362,6 +362,80 @@ describe('UserInputRequestManager', () => {
     })
   })
 
+  describe('claimRequest / releaseClaim', () => {
+    it('hands the request to the FIRST caller and null to every other', () => {
+      manager.register(secretRequest())
+
+      const first = manager.claimRequest('tool-1')
+      const second = manager.claimRequest('tool-1')
+
+      expect(first?.id).toBe('tool-1')
+      // The whole point: two deciders that both read an open request would both
+      // act on it. Exactly one may win.
+      expect(second).toBeNull()
+      expect(manager.stats.claimed).toBe(1)
+    })
+
+    it('returns null for an id that is not open', () => {
+      expect(manager.claimRequest('never-existed')).toBeNull()
+      manager.register(secretRequest())
+      manager.resolve('tool-1', 'answered')
+      expect(manager.claimRequest('tool-1')).toBeNull()
+    })
+
+    it('a claim does not hide the request from any reader', () => {
+      // A claim is an in-flight decision, not a settlement — if the claimer
+      // dies the human is still waiting, so the card, the snapshot and the
+      // awaiting light must all still show it.
+      manager.register(secretRequest())
+      manager.claimRequest('tool-1')
+
+      expect(manager.getOpenRequest('tool-1')).not.toBeNull()
+      expect(manager.isSessionAwaiting('session-1', 'agent-a')).toBe(true)
+      expect(manager.getSnapshotForScope('agent-a', 'session-1')).toHaveLength(1)
+      expect(manager.stats.open).toBe(1)
+    })
+
+    it('releaseClaim makes it claimable again — a bailed decision must not strand it', () => {
+      manager.register(secretRequest())
+      manager.claimRequest('tool-1')
+
+      manager.releaseClaim('tool-1')
+
+      expect(manager.claimRequest('tool-1')?.id).toBe('tool-1')
+    })
+
+    it('releaseClaim on an unknown or already-settled id is a no-op', () => {
+      manager.register(secretRequest())
+      manager.claimRequest('tool-1')
+      manager.resolve('tool-1', 'answered')
+
+      expect(() => manager.releaseClaim('tool-1')).not.toThrow()
+      expect(() => manager.releaseClaim('never-existed')).not.toThrow()
+      expect(manager.stats.claimed).toBe(0)
+    })
+
+    it('resolve drops the claim, so a re-registered id does not inherit it', () => {
+      // Callers release in a finally, but the success path settles instead —
+      // if resolve leaked the claim, the next request to reuse the toolUseId
+      // would be born undecidable.
+      manager.register(secretRequest())
+      manager.claimRequest('tool-1')
+      manager.resolve('tool-1', 'answered')
+      expect(manager.stats.claimed).toBe(0)
+
+      manager.register(secretRequest())
+      expect(manager.claimRequest('tool-1')?.id).toBe('tool-1')
+    })
+
+    it('reset clears claims', () => {
+      manager.register(secretRequest())
+      manager.claimRequest('tool-1')
+      manager.reset()
+      expect(manager.stats.claimed).toBe(0)
+    })
+  })
+
   describe('shadow diagnostics', () => {
     it('verifyStoreParity passes silently when both stores match', () => {
       manager.register(secretRequest({ id: 'stream-1' }))
@@ -426,6 +500,7 @@ describe('UserInputRequestManager', () => {
       manager.reset()
       expect(manager.stats).toEqual({
         open: 0,
+        claimed: 0,
         storeMismatches: 0,
         recentResolutions: [],
       })

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -62,6 +62,16 @@ export class UserInputRequestManager {
    */
   private recentResolutions: SettledUserInputRequest[] = []
 
+  /**
+   * Ids reserved by an in-flight decision.
+   *
+   * A claim is NOT a settlement: the request stays open to every reader — the
+   * awaiting projection, the snapshot, the wire — because if the claimer fails
+   * before settling, a human is still waiting on it. All a claim does is make
+   * the DECISION path single-entry.
+   */
+  private claimed = new Set<string>()
+
   private storeMismatchCount = 0
 
   /**
@@ -105,6 +115,10 @@ export class UserInputRequestManager {
     const request = this.requests.get(id)
     if (!request) return null
     this.requests.delete(id)
+    // The claim dies with the entry: a settled id must never leave a
+    // reservation behind that a re-registration under the same toolUseId
+    // would inherit.
+    this.claimed.delete(id)
     this.recentResolutions.push({ id, kind: request.kind, scope: request.scope, outcome })
     if (this.recentResolutions.length > 100) this.recentResolutions.shift()
     this.emitTransition({ type: 'resolved', request, outcome })
@@ -184,6 +198,31 @@ export class UserInputRequestManager {
   /** Look up a single open request by id. */
   getOpenRequest(id: string): PendingUserInputRequest | null {
     return this.requests.get(id) ?? null
+  }
+
+  /**
+   * Reserve an open request for settlement, returning it to the FIRST caller
+   * only. A plain `getOpenRequest` before a decision is check-then-act: the
+   * decision path awaits (container lookup, the resolve call itself) between
+   * observing the request and settling it, so a second decider observes the
+   * same open request and both act. This is a synchronous check-and-mark with
+   * no await inside, which on node's single thread makes it atomic — the
+   * loser gets null and can report the decision as already handled.
+   *
+   * The caller MUST `releaseClaim` on every path that does NOT settle the
+   * request, or it stays open and permanently undecidable. `resolve` drops the
+   * claim with the entry, so the success path needs no explicit release.
+   */
+  claimRequest(id: string): PendingUserInputRequest | null {
+    const request = this.requests.get(id)
+    if (!request || this.claimed.has(id)) return null
+    this.claimed.add(id)
+    return request
+  }
+
+  /** Drop a claim. No-op for an id that already settled. */
+  releaseClaim(id: string): void {
+    this.claimed.delete(id)
   }
 
   /**
@@ -345,11 +384,14 @@ export class UserInputRequestManager {
 
   get stats(): {
     open: number
+    /** In-flight decision reservations. A non-zero idle value is a leaked claim. */
+    claimed: number
     storeMismatches: number
     recentResolutions: SettledUserInputRequest[]
   } {
     return {
       open: this.requests.size,
+      claimed: this.claimed.size,
       storeMismatches: this.storeMismatchCount,
       recentResolutions: [...this.recentResolutions],
     }
@@ -358,6 +400,7 @@ export class UserInputRequestManager {
   /** Test hook: wipe all state including diagnostics. */
   reset(): void {
     this.requests.clear()
+    this.claimed.clear()
     this.recentResolutions = []
     this.storeMismatchCount = 0
   }

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -13,7 +13,8 @@ import {
  * store. Computer-use and review requests live only here; stream kinds keep a
  * write-through mirror in the persister's per-session replay store
  * (`pendingInputRequests`, verified by `verifyStoreParity`) because the
- * legacy chat-integration events replay from it verbatim.
+ * /stream route replays the legacy per-type events from it verbatim for the
+ * renderer's remaining holdouts. Phase 8 collapses that mirror.
  *
  * Everything downstream derives from this registry: the session "awaiting
  * input" status (`isSessionAwaiting` — the persister's bit is an


### PR DESCRIPTION
## Why

Phases 0–6 moved the renderer, notifications, Electron main, and the decision routes onto the registry. Chat integrations were the last consumer still reading the legacy per-type events off the in-process broadcast pipe and settling container inputs directly — two readers of "what is the agent blocked on", reading two different sources. Four mismatches were open today:

1. Recovered registrations emit no legacy event, so they were invisible to chat.
2. Chat had no resolved signal — a card settled elsewhere kept live-looking buttons, and pressing one buffered a phantom `earlyResult` in the container while the user believed they had answered.
3. Chat decisions bypassed the Phase-6 already-settled gate entirely.
4. A new request kind needed manual chat wiring or silently fell through `processSSEEvent` — the "kind #12 = one descriptor" promise didn't hold for chat.

## What

**One wire.** `processSSEEvent`'s eight per-type cases collapse to a single `user_request_created` case. The legacy events still fire (they die in Phase 8) and are deliberately *ignored* — handling both would double-send every card. The envelope→card mapping lives in a new `chat-integrations/request-card.ts`; connector `sendUserRequestCard` switches are untouched.

**Kind coverage is now structural.** `KIND_TO_CARD_TYPE` is a total `Record<UserInputRequestKind, …>`, so a twelfth kind is a compile error until someone decides what chat does with it. That's mismatch #4, fixed by the type system rather than by remembering.

**Reviews off the same wire.** `handleGlobalNotification` triggers on `user_request_created` filtered to `proxy_review`/`x_agent_review`, keeping the `review:<id>:<agent>` synthetic-card id byte-identical so decision routing is unchanged. This fixed their routing as a side effect: the old handler read a top-level `data.sessionId` that `broadcastReview` **never sets**, so it always fell through to the agent-wide fan-out and sent a session-less (agent-home) link. It now uses the agent's active session, matching what the review notification does.

**Chat decisions are gated.** `handleInteractiveResponse` checks `userInputRequestManager.getOpenRequest` *and* an agent match before touching the container, and passes `integration.agentSlug` to `reviewManager.submitDecision` (whose third parameter already existed for exactly this). A refused press gets an explicit "already handled" reply — silence was the failure mode being replaced.

**Text answers come from the registry.** `consumeOrCancelAwaitingInput` takes a `registry` dependency and reads open `question` entries from it, filtering recovered stubs (no card was ever posted for those, so typed text must not answer one). That removes the last chat dependency on the persister's replay mirror ahead of Phase 8.

### Two behaviour changes, both intended

| Change | Why |
|---|---|
| `capability_review` now surfaces in chat | Before, a workflow parked on an approval the chat user was never told about and the conversation just went quiet. Added to the `UserRequestEvent` union, `UNSUPPORTED_IN_CHAT`, and `describeUnsupportedRequest`. |
| Auto-approved asks send **nothing** | The registry already classes them as not-a-real-wait (`isRealWait` is false); "The agent wants to run a script, which needs your approval" pointed the user at a screen with nothing on it. |

### Deliberately not done

Card *dismissal* on `user_request_resolved`. No connector can dismiss a single card — `dismissOpenCards` is all-or-nothing, and Slack implements neither it nor `answerOpenQuestionWithText`. That needs connector work this phase promised not to touch; the interactive gate covers the correctness half.

## The test blind spot, closed

Every chat test around user-input requests handed `processSSEEvent` a hand-built legacy event and asserted what the connector did with it. That pins connector behaviour and nothing else: if the host stopped *emitting* those events, every one of them stayed green and the feature was dead.

New `unified wire contract` suite in `chat-integration-e2e.test.ts` drives a **real tool_use through the real `MessagePersister`** and asserts on the card that comes out of the chat manager — one row per kind, plus the review path off the global channel and three decision-gate rows. The `processSSEEvent`/resilience tests now build their events through the registry schema (shared `user-request-fixtures.ts`), and one asserts the legacy event is **ignored**; that pair is what pins the card came from the unified wire.

**Red-proof:** reverting the manager to pre-Phase-7 behaviour fails **36 tests**.

One harness change was needed: `subscribeGlobalNotifications()` extracted from `start()` (idempotent), because the e2e harness drives `addIntegration` directly and reviews therefore had no wire to arrive on.

## Validated

- `tsc --noEmit` clean; ESLint 0 errors (warnings all pre-existing)
- Full unit suite **8,089 passed** (455 files)
- Request-path mock E2E **53 passed** (`user-input-requests`, `awaiting-input-status`, `concurrent-tabs-request-sync`, `mixed-pending-requests`, `pending-request-reconnect`, `computer-use`, `proxy-review`, `capability-review`)
- Live Slack suite (real account → real Slack → real app instance → real container): **14/14 web host**, **12/12 electron host**

The live suite gained two checks:

- `question-answered-in-app` — the card Slack posted and the request the **app** answers are the same registry entry; answering through the app's decision route settles it and the continuation lands back in Slack. This is the cross-surface proof, and it's the check that fails if the two readers ever drift apart again.
- `unsupported-capability-review` — the newly-surfaced kind. `workflows: 'review'` is the shipped default, so it needs no settings tampering to reach.

## Two things found while validating

1. **The live `question-freetext-answer` check was passing via the cancel path.** Its title claimed "the same turn continues", but Slack implements neither `answerOpenQuestionWithText` nor `dismissOpenCards`, so free text there *always* cancels and starts a fresh turn. Both paths settle the request and both get a reply, so a check asserting only "the agent answered" couldn't tell them apart. Renamed `question-freetext-reply`; it now discriminates via the transcript and reports which path ran (measured on Slack: `cancelled → fresh turn`). Slack's missing free-text answer path is a real gap, not a Phase 7 regression — flagged, not built.
2. **The already-handled gate is not live-reachable on Slack.** It needs an interactive response, which means a human button tap; the free-text branch produces none. Covered by the wire-contract suite instead, and written into the skill's known-limits.

## Next

Phase 8 (final legacy removal) is unchanged and unblocked by this: consumers first (browser tray, auto-approved suppress-sets, cold-start fallbacks), then re-home registration out of the broadcast intercept, then delete the nine legacy broadcasts and collapse the persister's mirror store.

https://claude.ai/code/session_01DLw9AJ5VXVQPzBAz87nNAA
