### PR TITLE
Restyle the Computer Use settings tab

### DIFF
--- a/e2e/specs/computer-use.spec.ts
+++ b/e2e/specs/computer-use.spec.ts
@@ -29,8 +29,8 @@ test.describe('Computer Use requests', () => {
 
     // Verify content is shown
     const request = sessionPage.getComputerUseRequests().first()
-    await expect(request).toContainText('Allow the agent to list apps & windows?')
-    await expect(request).toContainText('List Apps & Windows')
+    await expect(request).toContainText('Allow the agent to list apps & windows (read-only)?')
+    await expect(request).toContainText('List Apps & Windows (read-only)')
 
     // Approve once
     await sessionPage.approveComputerUseOnce()

--- a/src/renderer/components/messages/computer-use-request-item.test.tsx
+++ b/src/renderer/components/messages/computer-use-request-item.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders as render } from '@renderer/test/test-utils'
+import { ComputerUseRequestItem } from './computer-use-request-item'
+
+const baseProps = {
+  toolUseId: 'tool-use-1',
+  method: 'apps',
+  params: {},
+  sessionId: 'session-1',
+  agentSlug: 'agent-1',
+  onComplete: vi.fn(),
+}
+
+describe('ComputerUseRequestItem permission labels', () => {
+  it('explains read-only access in both the prompt and permission badge', () => {
+    render(
+      <ComputerUseRequestItem
+        {...baseProps}
+        permissionLevel="list_apps_windows"
+      />
+    )
+
+    expect(screen.getByText('Allow the agent to list apps & windows (read-only)?')).toBeInTheDocument()
+    expect(screen.getByText('List Apps & Windows (read-only)')).toBeInTheDocument()
+  })
+
+  it('uses the self-explanatory shell permission wording', () => {
+    render(
+      <ComputerUseRequestItem
+        {...baseProps}
+        method="run"
+        permissionLevel="use_host_shell"
+      />
+    )
+
+    expect(screen.getByText('Allow the agent to run shell commands & scripts?')).toBeInTheDocument()
+    expect(screen.getByText('Run Shell Commands & Scripts')).toBeInTheDocument()
+    expect(screen.queryByText('Host Shell')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/messages/computer-use-request-item.tsx
+++ b/src/renderer/components/messages/computer-use-request-item.tsx
@@ -12,6 +12,7 @@ import {
 } from '@renderer/components/ui/dialog'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { cn } from '@shared/lib/utils/cn'
+import { PERMISSION_LEVEL_LABELS } from '@shared/lib/computer-use/types'
 import { DeclineButton } from './decline-button'
 import { RequestItemShell } from './request-item-shell'
 import { RequestItemActions } from './request-item-actions'
@@ -30,11 +31,7 @@ interface ComputerUseRequestItemProps {
 
 type RequestStatus = 'pending' | 'submitting' | 'executed' | 'denied'
 
-const PERMISSION_LABELS: Record<string, string> = {
-  list_apps_windows: 'List Apps & Windows',
-  use_application: 'Use Application',
-  use_host_shell: 'Host Shell',
-}
+const PERMISSION_LABELS: Record<string, string> = PERMISSION_LEVEL_LABELS
 
 function formatParams(params: Record<string, unknown>): string {
   const parts: string[] = []

--- a/src/renderer/components/settings/computer-use-tab.test.tsx
+++ b/src/renderer/components/settings/computer-use-tab.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ComputerUseTab } from './computer-use-tab'
+
+const useSettingsMock = vi.fn()
+const useAgentsMock = vi.fn()
+const mutateMock = vi.fn()
+const getPlatformMock = vi.fn()
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => useSettingsMock(),
+  useUpdateSettings: () => ({ mutate: mutateMock }),
+}))
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useAgents: () => useAgentsMock(),
+}))
+
+vi.mock('@renderer/lib/env', () => ({
+  getPlatform: () => getPlatformMock(),
+}))
+
+const grants = {
+  'designer-agent': {
+    grants: [
+      {
+        level: 'list_apps_windows' as const,
+        grantType: 'always' as const,
+      },
+      {
+        level: 'use_application' as const,
+        appName: 'Figma',
+        grantType: 'always' as const,
+      },
+    ],
+  },
+}
+
+function setSettings(agentPermissions: typeof grants | Record<string, never> = {}) {
+  useSettingsMock.mockReturnValue({
+    data: {
+      computerUse: { agentPermissions },
+    },
+  })
+}
+
+describe('ComputerUseTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPlatformMock.mockReturnValue('darwin')
+    useAgentsMock.mockReturnValue({
+      data: [{ slug: 'designer-agent', name: 'Design Agent' }],
+    })
+    setSettings()
+  })
+
+  it('shows the compact caution and card-based empty state without the old legend', () => {
+    render(<ComputerUseTab />)
+
+    expect(screen.getByText('Persistent Permissions')).toBeInTheDocument()
+    expect(
+      screen.getByText('Agents you grant `always allow` computer use permissions will appear here.')
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Review each request carefully/)).toBeInTheDocument()
+    expect(screen.queryByText('Permission Levels')).not.toBeInTheDocument()
+    expect(screen.queryByText('Security Warning')).not.toBeInTheDocument()
+  })
+
+  it('renders shared permission wording and contextual revoke names', () => {
+    setSettings(grants)
+    render(<ComputerUseTab />)
+
+    expect(screen.getByText('Design Agent')).toBeInTheDocument()
+    expect(screen.getByText('List Apps & Windows (read-only)')).toBeInTheDocument()
+    expect(screen.getByText('Use Application — Figma')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: 'Revoke List Apps & Windows (read-only) permission for Design Agent',
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: 'Revoke all computer use permissions for Design Agent',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('removes only the selected grant', async () => {
+    const user = userEvent.setup()
+    setSettings(grants)
+    render(<ComputerUseTab />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Revoke Use Application — Figma permission for Design Agent',
+      })
+    )
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      computerUse: {
+        agentPermissions: {
+          'designer-agent': {
+            grants: [grants['designer-agent'].grants[0]],
+          },
+        },
+      },
+    })
+  })
+
+  it('removes the agent when all permissions are revoked', async () => {
+    const user = userEvent.setup()
+    setSettings(grants)
+    render(<ComputerUseTab />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Revoke all computer use permissions for Design Agent',
+      })
+    )
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      computerUse: { agentPermissions: {} },
+    })
+  })
+
+  it('keeps the unsupported-platform notice', () => {
+    getPlatformMock.mockReturnValue('linux')
+    render(<ComputerUseTab />)
+
+    expect(screen.getByText('Not Available')).toBeInTheDocument()
+    expect(screen.queryByText('Persistent Permissions')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/settings/computer-use-tab.tsx
+++ b/src/renderer/components/settings/computer-use-tab.tsx
@@ -3,14 +3,11 @@ import { useAgents } from '@renderer/hooks/use-agents'
 import { getPlatform } from '@renderer/lib/env'
 import { Alert, AlertDescription, AlertTitle } from '@renderer/components/ui/alert'
 import { Button } from '@renderer/components/ui/button'
-import { Monitor, AlertTriangle, Trash2 } from 'lucide-react'
-import type { ComputerUseSettings } from '@shared/lib/computer-use/types'
+import { TriangleAlert } from 'lucide-react'
+import { PERMISSION_LEVEL_LABELS, type ComputerUseSettings } from '@shared/lib/computer-use/types'
 
-const PERMISSION_LABELS: Record<string, string> = {
-  list_apps_windows: 'List Apps & Windows',
-  use_application: 'Use Application',
-  use_host_shell: 'Host Shell',
-}
+const CARD_CLASS = 'rounded-xl border bg-background divide-y divide-border/50 overflow-hidden'
+const SECTION_HEADING = 'text-xs font-medium text-muted-foreground px-1'
 
 export function ComputerUseTab() {
   const { data: settings } = useSettings()
@@ -22,7 +19,7 @@ export function ComputerUseTab() {
   if (!supported) {
     return (
       <Alert>
-        <AlertTriangle className="h-4 w-4" />
+        <TriangleAlert className="h-4 w-4" />
         <AlertTitle>Not Available</AlertTitle>
         <AlertDescription>
           Computer Use is only available on macOS and Windows in the Electron desktop app.
@@ -37,6 +34,7 @@ export function ComputerUseTab() {
 
   // Map slug → display name
   const agentNameMap = new Map(agents?.map((a) => [a.slug, a.name]) ?? [])
+  const displayName = (agentSlug: string) => agentNameMap.get(agentSlug) ?? agentSlug
 
   const handleRevokeAll = (agentSlug: string) => {
     const newPerms = { ...agentPermissions }
@@ -62,74 +60,53 @@ export function ComputerUseTab() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h3 className="text-lg font-medium flex items-center gap-2">
-          <Monitor className="h-5 w-5" />
-          Computer Use
-        </h3>
-        <p className="text-sm text-muted-foreground mt-1">
-          Agents can control applications on your computer. Permissions are granted per-agent when requested.
+      <div className="flex gap-2 rounded-md bg-yellow-500/10 px-2.5 py-2 text-[11px] text-yellow-700 dark:text-yellow-500/90 leading-relaxed">
+        <TriangleAlert className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <p>
+          Agents interact with applications on your machine using your user permissions.
+          Review each request carefully and only grant persistent access to trusted agents.
         </p>
       </div>
 
-      <Alert variant="destructive">
-        <AlertTriangle className="h-4 w-4" />
-        <AlertTitle>Security Warning</AlertTitle>
-        <AlertDescription>
-          Computer Use allows agents to interact with applications on your machine using your user permissions.
-          Review each request carefully. Only grant persistent permissions to trusted agents.
-        </AlertDescription>
-      </Alert>
-
-      <div>
-        <h4 className="text-sm font-medium mb-3">Permission Levels</h4>
-        <ul className="text-sm text-muted-foreground space-y-1.5">
-          <li><strong>List Apps & Windows</strong> — Read-only: list running applications and open windows.</li>
-          <li><strong>Use Application</strong> — Interact with a specific app: click, type, screenshot, etc.</li>
-          <li><strong>Host Shell</strong> — Run shell commands and scripts on the host machine.</li>
-        </ul>
-      </div>
-
-      <div>
-        <h4 className="text-sm font-medium mb-3">Persistent Permissions (&quot;Always Allow&quot;)</h4>
+      <div className="space-y-2">
+        <h3 className={SECTION_HEADING}>Persistent Permissions</h3>
         {!hasGrants ? (
-          <p className="text-sm text-muted-foreground">
-            No persistent permissions granted. Permissions will be granted per-request when agents need computer access.
-          </p>
+          <div className={CARD_CLASS}>
+            <p className="py-3 px-4 text-[11px] text-muted-foreground leading-relaxed">
+              Agents you grant `always allow` computer use permissions will appear here.
+            </p>
+          </div>
         ) : (
           <div className="space-y-3">
             {Object.entries(agentPermissions).map(([agentSlug, agentPerms]) => (
-              <div key={agentSlug} className="border rounded-md p-3">
-                <div className="flex items-center justify-between mb-2">
-                  <span className="font-medium text-sm">{agentNameMap.get(agentSlug) || agentSlug}</span>
+              <div key={agentSlug} className={CARD_CLASS}>
+                <div className="group flex items-center justify-between py-2 pl-4 pr-2">
+                  <span className="text-xs font-medium truncate">{displayName(agentSlug)}</span>
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => handleRevokeAll(agentSlug)}
-                    className="text-destructive hover:text-destructive"
+                    className="h-7 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
                   >
-                    <Trash2 className="h-3.5 w-3.5 mr-1" />
                     Revoke All
                   </Button>
                 </div>
-                <div className="space-y-1">
-                  {agentPerms.grants.map((grant, i) => (
-                    <div key={i} className="flex items-center justify-between text-sm text-muted-foreground">
-                      <span>
-                        {PERMISSION_LABELS[grant.level] || grant.level}
-                        {grant.appName ? ` — ${grant.appName}` : ''}
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleRevokeGrant(agentSlug, i)}
-                        className="h-6 px-2 text-muted-foreground hover:text-destructive"
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </Button>
-                    </div>
-                  ))}
-                </div>
+                {agentPerms.grants.map((grant, i) => (
+                  <div key={i} className="group flex items-center justify-between py-2 pl-4 pr-2">
+                    <span className="text-[11px] text-muted-foreground truncate">
+                      {PERMISSION_LEVEL_LABELS[grant.level] || grant.level}
+                      {grant.appName ? ` — ${grant.appName}` : ''}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleRevokeGrant(agentSlug, i)}
+                      className="h-6 px-2 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                    >
+                      Revoke
+                    </Button>
+                  </div>
+                ))}
               </div>
             ))}
           </div>

--- a/src/renderer/components/settings/computer-use-tab.tsx
+++ b/src/renderer/components/settings/computer-use-tab.tsx
@@ -86,6 +86,7 @@ export function ComputerUseTab() {
                     variant="ghost"
                     size="sm"
                     onClick={() => handleRevokeAll(agentSlug)}
+                    aria-label={`Revoke all computer use permissions for ${displayName(agentSlug)}`}
                     className="h-7 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
                   >
                     Revoke All
@@ -101,6 +102,11 @@ export function ComputerUseTab() {
                       variant="ghost"
                       size="sm"
                       onClick={() => handleRevokeGrant(agentSlug, i)}
+                      aria-label={`Revoke ${
+                        grant.appName
+                          ? `${PERMISSION_LEVEL_LABELS[grant.level]} — ${grant.appName}`
+                          : PERMISSION_LEVEL_LABELS[grant.level]
+                      } permission for ${displayName(agentSlug)}`}
                       className="h-6 px-2 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
                     >
                       Revoke

--- a/src/shared/lib/computer-use/types.ts
+++ b/src/shared/lib/computer-use/types.ts
@@ -12,6 +12,14 @@ export type ComputerUsePermissionLevel =
   | 'use_application'
   | 'use_host_shell'
 
+/** User-facing names for the permission levels, shared by the settings tab and
+    the in-chat approval card. Written to be self-explanatory without a legend. */
+export const PERMISSION_LEVEL_LABELS: Record<ComputerUsePermissionLevel, string> = {
+  list_apps_windows: 'List Apps & Windows (read-only)',
+  use_application: 'Use Application',
+  use_host_shell: 'Run Shell Commands & Scripts',
+}
+
 export type PermissionGrantType = 'once' | 'timed' | 'always'
 
 export interface PermissionGrant {


### PR DESCRIPTION
## Summary
- Restyles the Computer Use settings tab to match the card language of the other reworked tabs (Browser Use, Web Search, Subagents). No behavior changes — same settings reads and revoke mutations.
- **Persistent Permissions leads the page**: one rounded card per agent with divided grant rows; Revoke / Revoke All are text-only buttons revealed on row hover (and on keyboard focus). The empty state renders in a card: ``Agents you grant `always allow` computer use permissions will appear here.``
- **The Permission Levels legend is gone.** The level labels now explain themselves — `List Apps & Windows (read-only)`, `Use Application`, `Run Shell Commands & Scripts` (formerly "Host Shell") — and live in a shared `PERMISSION_LEVEL_LABELS` constant in `src/shared/lib/computer-use/types.ts`, used by both the settings tab and the in-chat approval card so wording can't drift. The approval prompt now reads "Allow the agent to run shell commands & scripts?".
- The redundant in-tab header is dropped (the page title already names the tab) and the destructive Alert is replaced with the compact yellow caution-note pattern from the General tab.
- Revoke actions keep the hover-only visual treatment while exposing contextual accessible names to assistive technology.

## Test plan
- `npm run typecheck`
- ESLint on all changed files
- 755 related renderer unit tests pass across 51 files, including new direct coverage for the settings tab and in-chat approval labels
- `npm run test:e2e -- e2e/specs/computer-use.spec.ts` — 3 tests pass with exact assertions for the new read-only wording
- Manually verified in the Electron dev app: empty state, populated cards (via temporary mock data, removed before commit), hover reveal, and revoke safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)
