### PR TITLE
Fix sessions stuck on "Working" from a stale background-task level set

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1904,10 +1904,17 @@ async function handleWebSocketConnection(ws: WebSocket, sessionId: string) {
   // session_state_changed:'idle' as the idle authority from the first turn —
   // a 'result' alone must not end the session while queued messages keep the
   // runtime going.
+  // process_instance: identity of the CLI process backing the session right
+  // now. Background tasks are process-local and a fresh process emits no
+  // initial background_tasks_changed, so a client reconnecting after a restart
+  // it never observed (idle eviction + --resume, container restart — the live
+  // process_restarted broadcast fires before any subscriber exists) would
+  // otherwise keep bookkeeping for tasks that died with the old process.
   ws.send(JSON.stringify({
     type: 'system',
     subtype: 'capabilities',
     session_state_events: true,
+    process_instance: sessionManager.getProcessInstanceId(sessionId),
     timestamp: new Date(),
   }));
 

--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -707,6 +707,10 @@ describe('SessionManager idle eviction', () => {
     expect(received).toContainEqual(
       expect.objectContaining({ type: 'system', subtype: 'process_restarted' })
     )
+    // The live frame and the handshake must name the SAME process, or a client
+    // that sees both would read the second one as another restart.
+    const announced = received.find((m) => m.subtype === 'process_restarted')
+    expect(announced?.process_instance).toBe(manager.getProcessInstanceId(id))
   })
 
   it('records a fresh process instance id on a cold resume, before any subscriber exists', async () => {

--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -54,6 +54,9 @@ class MockClaudeProcess extends EventEmitter {
       throw err
     }
     this.running = true
+    // Faithful to ClaudeCodeProcess: initializeQuery() emits this from start(),
+    // i.e. before the caller can publish the session or attach a subscriber.
+    this.emit('query-start')
   }
 
   async sendMessage(content?: string): Promise<void> {
@@ -704,6 +707,37 @@ describe('SessionManager idle eviction', () => {
     expect(received).toContainEqual(
       expect.objectContaining({ type: 'system', subtype: 'process_restarted' })
     )
+  })
+
+  it('records a fresh process instance id on a cold resume, before any subscriber exists', async () => {
+    // Regression: process.start() emits query-start synchronously, BEFORE
+    // doResumeSession publishes the SessionData and long before the WebSocket
+    // subscriber attaches — so the live announcement reaches nobody. The host
+    // then reconnects still holding a bgTasksSnapshot from the dead process,
+    // the fresh CLI emits no initial snapshot, and the session is pinned
+    // "working" forever. The restart has to be readable at subscribe time, not
+    // only broadcast at restart time.
+    persistedSessions.set('cold-restart', {
+      sessionId: 'cold-restart',
+      claudeSessionId: 'cold-restart',
+      workingDirectory: workDir,
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+    })
+
+    await manager.getSession('cold-restart')
+
+    const afterResume = manager.getProcessInstanceId('cold-restart')
+    expect(afterResume).toBeTruthy()
+
+    // Same live process → the same id, so a plain reattach must not be
+    // mistaken for a restart (that would drop a genuinely running task).
+    expect(manager.getProcessInstanceId('cold-restart')).toBe(afterResume)
+
+    // A later replacement mints a new one.
+    const proc = spawnedProcesses[spawnedProcesses.length - 1]
+    proc.emit('query-start')
+    expect(manager.getProcessInstanceId('cold-restart')).not.toBe(afterResume)
   })
 
   it('a shouldQuery:false append does NOT promote an automated session', async () => {

--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -689,6 +689,23 @@ describe('SessionManager idle eviction', () => {
     expect(proc.stopCalls).toBe(1)
   })
 
+  it('announces process replacement to subscribers so the host can reset too', async () => {
+    // The host keeps its own copy of the background-task level set and has no
+    // other way to learn the CLI was replaced — `query-start` is an in-process
+    // event. Without this frame the host's snapshot keeps ids from the dead
+    // process forever and pins the session "working" at the end of every turn.
+    const { id, proc } = await createIdleSession()
+    const received: Array<Record<string, unknown>> = []
+    const unsubscribe = manager.subscribe(id, (msg) => received.push(msg as Record<string, unknown>))
+
+    proc.emit('query-start')
+    unsubscribe()
+
+    expect(received).toContainEqual(
+      expect.objectContaining({ type: 'system', subtype: 'process_restarted' })
+    )
+  })
+
   it('a shouldQuery:false append does NOT promote an automated session', async () => {
     const promoManager = new SessionManager(workDir, {
       prewarmEnabled: false,

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -321,6 +321,10 @@ export class SessionManager extends EventEmitter {
         stateEventsAuthority: true,
       }),
       eviction: null,
+      // Seeded, not derived from query-start: this path starts the process
+      // before SessionData exists (see the await process.start() above), so the
+      // first query-start predates the listener registered below. Every later
+      // replacement re-mints, which is all the host needs to spot a change.
       processInstanceId: uuidv4(),
     };
 

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -331,6 +331,7 @@ export class SessionManager extends EventEmitter {
     // initial snapshot — carried-over ids would pin the session forever.
     process.on('query-start', () => {
       sessionData.settlement.resetBackgroundTasks();
+      this.announceProcessRestart(sessionId);
     });
 
     process.on('stderr', (error: string) => {
@@ -618,6 +619,7 @@ export class SessionManager extends EventEmitter {
 
       process.on('query-start', () => {
         data.settlement.resetBackgroundTasks();
+        this.announceProcessRestart(sessionId);
       });
 
       process.on('stderr', (error: string) => {
@@ -796,6 +798,20 @@ export class SessionManager extends EventEmitter {
       } catch (error) {
         console.error(`Error in subscriber callback:`, error);
       }
+    });
+  }
+
+  // The host keeps its own copy of the background-task level set and has no
+  // other way to learn the CLI was replaced: `query-start` is in-process, and
+  // the SDK deliberately emits no background_tasks_changed at startup. Relay it
+  // so the host can reset the same bookkeeping resetBackgroundTasks() just did
+  // — otherwise ids from the dead process pin its session "working" forever.
+  private announceProcessRestart(sessionId: string): void {
+    this.broadcast(sessionId, {
+      type: 'system',
+      subtype: 'process_restarted',
+      session_id: sessionId,
+      timestamp: new Date().toISOString(),
     });
   }
 

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -25,6 +25,13 @@ interface SessionData {
   // completion-wake window) — the only state a subprocess may be stopped in.
   settlement: SessionSettlementTracker;
   eviction: Promise<void> | null;
+  // Identity of the CLI process currently backing this session, re-minted on
+  // every replacement. The host mirrors our background-task bookkeeping and
+  // needs to know when its copy belongs to a process that no longer exists;
+  // identity (not a counter) because the only question is "same process as the
+  // one my snapshot came from?", and it must survive SessionData being rebuilt
+  // on a cold resume.
+  processInstanceId: string;
 }
 
 const DEFAULT_INTERACTIVE_IDLE_EVICTION_MINUTES = 5;
@@ -314,6 +321,7 @@ export class SessionManager extends EventEmitter {
         stateEventsAuthority: true,
       }),
       eviction: null,
+      processInstanceId: uuidv4(),
     };
 
     // Set up event listeners
@@ -331,7 +339,7 @@ export class SessionManager extends EventEmitter {
     // initial snapshot — carried-over ids would pin the session forever.
     process.on('query-start', () => {
       sessionData.settlement.resetBackgroundTasks();
-      this.announceProcessRestart(sessionId);
+      this.noteProcessRestart(sessionData, sessionId);
     });
 
     process.on('stderr', (error: string) => {
@@ -606,6 +614,7 @@ export class SessionManager extends EventEmitter {
           stateEventsAuthority: true,
         }),
         eviction: null,
+        processInstanceId: uuidv4(),
       };
 
       // Set up event listeners (same as createSession)
@@ -617,9 +626,12 @@ export class SessionManager extends EventEmitter {
         data.settlement.noteOutboundMessage(info);
       });
 
+      // Fires from the process.start() below — before `data` is published into
+      // this.sessions, so the broadcast is a no-op here. The id it stamps on
+      // `data` is the durable part; the handshake replays it.
       process.on('query-start', () => {
         data.settlement.resetBackgroundTasks();
-        this.announceProcessRestart(sessionId);
+        this.noteProcessRestart(data, sessionId);
       });
 
       process.on('stderr', (error: string) => {
@@ -803,16 +815,33 @@ export class SessionManager extends EventEmitter {
 
   // The host keeps its own copy of the background-task level set and has no
   // other way to learn the CLI was replaced: `query-start` is in-process, and
-  // the SDK deliberately emits no background_tasks_changed at startup. Relay it
-  // so the host can reset the same bookkeeping resetBackgroundTasks() just did
-  // — otherwise ids from the dead process pin its session "working" forever.
-  private announceProcessRestart(sessionId: string): void {
+  // the SDK deliberately emits no background_tasks_changed at startup. Mint a
+  // new process identity and relay it so the host can reset the same
+  // bookkeeping resetBackgroundTasks() just did — otherwise ids from the dead
+  // process pin its session "working" forever.
+  //
+  // The broadcast alone is NOT sufficient: on a cold resume, process.start()
+  // emits query-start before doResumeSession publishes the SessionData and long
+  // before a subscriber attaches, so it reaches nobody. Recording the id on
+  // `data` is what makes the restart durable — the WebSocket handshake replays
+  // it (see getProcessInstanceId), which is the path that actually covers
+  // eviction + --resume and container restarts.
+  private noteProcessRestart(data: SessionData, sessionId: string): void {
+    data.processInstanceId = uuidv4();
     this.broadcast(sessionId, {
       type: 'system',
       subtype: 'process_restarted',
       session_id: sessionId,
+      process_instance: data.processInstanceId,
       timestamp: new Date().toISOString(),
     });
+  }
+
+  // Identity of the CLI process backing this session right now. Sent in the
+  // WebSocket handshake so a client that reconnects after a restart it never
+  // saw can tell its cached process-local state is stale.
+  getProcessInstanceId(sessionId: string): string | undefined {
+    return this.sessions.get(sessionId)?.processInstanceId;
   }
 
   private handleMessage(sessionId: string, message: SDKMessage): void {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -6170,6 +6170,57 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
     })
 
+    it('keeps process identity in sync across an interrupt-driven restart', () => {
+      // The interrupt path restarts the query (claude-code.ts "Restarting query
+      // after interrupt"), which mints a new process instance. But the host
+      // drops every non-result frame while isInterrupted is set, so that
+      // announcement was being swallowed — leaving the recorded identity one
+      // process behind the container. The NEXT reattach then reads a changed
+      // name and mistakes it for a restart, dropping background tasks that are
+      // genuinely running: a live indicator lost and auto-sleep un-gated
+      // mid-job, the exact failure the union gate exists to prevent.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-A',
+      })
+
+      return messagePersister.markSessionInterrupted(SESSION_ID).then(() => {
+        // The container restarts the CLI in response, while we're still flagged
+        // interrupted.
+        mockClient._sendMessage({
+          type: 'system', subtype: 'process_restarted', process_instance: 'proc-B',
+        })
+
+        // New turn on the new process, with real background work.
+        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        mockClient._sendMessage({
+          type: 'user',
+          tool_use_result: { backgroundTaskId: 'bg-live' },
+          message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+        })
+        mockClient._sendMessage({
+          type: 'system',
+          subtype: 'background_tasks_changed',
+          tasks: [{ task_id: 'bg-live', task_type: 'local_bash', description: 'yt-dlp' }],
+        })
+        mockClient._sendMessage({ type: 'result', subtype: 'success' })
+
+        sseEvents.length = 0
+        // A transport reattach. Same process as the one running bg-live, so
+        // nothing may be dropped.
+        mockClient._sendMessage({
+          type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-B',
+        })
+
+        expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
+        expect(messagePersister.getActiveBackgroundTasks(SESSION_ID).map(t => t.taskId)).toContain('bg-live')
+
+        mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+        expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(0)
+        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      })
+    })
+
     it('forwards command_lifecycle frames to SSE and drops malformed ones', () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
       sseEvents.length = 0

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -5974,6 +5974,132 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
     })
 
+    // ------------------------------------------------------------------
+    // The level set must drain from BOTH directions. `background_tasks_changed`
+    // is a level signal the SDK only re-emits on a membership CHANGE, and it
+    // emits nothing at all when a fresh CLI process starts. So any id that
+    // enters the snapshot and never leaves it pins the session in
+    // waiting-background forever: every later session_state_changed:'idle'
+    // takes the waiting branch instead of finalizing, and nothing — not a
+    // terminal per-task signal, not Stop, not a re-subscribe — ever clears it.
+    // These cover the three ways prod sessions got stuck that way.
+    // ------------------------------------------------------------------
+
+    it('terminal task signal drains the snapshot when the removal frame never arrives', () => {
+      // Mirror image of the self-heal test above: there the per-task terminal
+      // signal was lost and the snapshot rescued the session; here the snapshot's
+      // removal frame is the one that never comes. A background subagent settles
+      // via task_notification carrying its agentId as task_id — the incremental
+      // map clears, but the stale snapshot id keeps the union non-zero.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      // Background subagent launch: the ack registers it in the incremental map.
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { status: 'async_launched', isAsync: true, agentId: 'agent-bg-1' },
+        message: {
+          content: [{
+            type: 'tool_result',
+            tool_use_id: 'tool-agent-1',
+            content: 'Async agent launched successfully.',
+          }],
+        },
+      })
+      // The SDK announces the same task in its level set.
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 'agent-bg-1', task_type: 'local_agent', description: 'Verify policies' }],
+      })
+
+      // Turn ends while it runs → waiting, as designed.
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+
+      sseEvents.length = 0
+
+      // The subagent finishes. Its terminal signal arrives; the removal snapshot does not.
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'agent-bg-1',
+        tool_use_id: 'tool-agent-1',
+        status: 'completed',
+        summary: 'Agent finished',
+      })
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
+
+      // The wake turn's result + idle must now finalize the session.
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+      expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
+      expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    })
+
+    it('Stop drains the snapshot so later turns still settle', () => {
+      // The user hits Stop while a background task is live. The process is
+      // replaced, so no terminal signal or removal snapshot will EVER arrive for
+      // that id. If Stop clears only the incremental map, every subsequent turn
+      // in the session ends in waiting-background instead of idle — the session
+      // reads "Working…" at the end of every turn, permanently.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-download' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 'bg-download', task_type: 'local_bash', description: 'yt-dlp' }],
+      })
+
+      return messagePersister.markSessionInterrupted(SESSION_ID).then(() => {
+        expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
+
+        // A brand-new turn, with no background work at all.
+        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        sseEvents.length = 0
+        mockClient._sendMessage({ type: 'result', subtype: 'success' })
+        mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+        expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
+        expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
+        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      })
+    })
+
+    it('process_restarted drops the snapshot from the dead process', () => {
+      // The level set is per-process and a fresh CLI emits nothing at startup,
+      // so ids from the previous process can never be retired by the SDK. The
+      // container announces the replacement (idle eviction + --resume, crash,
+      // MCP-injection restart) and the host must reset to the empty set.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 'bg-doomed', task_type: 'local_bash', description: 'Sleep' }],
+      })
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+
+      // The CLI process is replaced; its background tasks died with it.
+      mockClient._sendMessage({ type: 'system', subtype: 'process_restarted' })
+
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      sseEvents.length = 0
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+      expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
+      expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    })
+
     it('forwards command_lifecycle frames to SSE and drops malformed ones', () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
       sseEvents.length = 0

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -6100,6 +6100,76 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
     })
 
+    it('a capabilities handshake naming a new process instance drops the stale snapshot', () => {
+      // The cold-resume path: the CLI is replaced while nothing is attached
+      // (idle eviction + --resume, container restart), so the live
+      // process_restarted broadcast reaches nobody — it fires before the
+      // session is published and before the socket subscribes. The host state
+      // survives that reconnect, so the handshake has to carry the process
+      // identity and the host has to notice it changed.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-1',
+      })
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 'bg-orphan', task_type: 'local_bash', description: 'Sleep' }],
+      })
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+
+      // Reconnect after the process was replaced behind our back.
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-2',
+      })
+
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      sseEvents.length = 0
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+      expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
+      expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    })
+
+    it('a reattach to the SAME process instance keeps running tasks tracked', () => {
+      // The other direction, and the reason this keys on identity rather than
+      // "saw a handshake": an SSE/WebSocket reattach mid-job is the same live
+      // CLI with the same tasks still running. Resetting there would drop the
+      // indicator and un-gate auto-sleep on real work.
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-1',
+      })
+      mockClient._sendMessage({
+        type: 'user',
+        tool_use_result: { backgroundTaskId: 'bg-live' },
+        message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+      })
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 'bg-live', task_type: 'local_bash', description: 'yt-dlp' }],
+      })
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+
+      sseEvents.length = 0
+      // Transport reattach: same process, same handshake identity.
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-1',
+      })
+
+      expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
+      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID).map(t => t.taskId)).toContain('bg-live')
+
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(0)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+    })
+
     it('forwards command_lifecycle frames to SSE and drops malformed ones', () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
       sseEvents.length = 0

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1401,8 +1401,17 @@ class MessagePersister {
     if (!state) return
 
     // Skip processing if session was interrupted (prevents race conditions)
-    // Allow 'result' through as it indicates the container actually stopped
-    if (state.isInterrupted && message.content?.type !== 'result') {
+    // Allow 'result' through as it indicates the container actually stopped.
+    // `process_restarted` is allowed for the same reason: the interrupt path itself
+    // restarts the query, so this is a fact about which runtime we are now
+    // talking to, not turn content. Swallowing it leaves the recorded process
+    // identity a generation behind, and the next reattach then reads a changed
+    // name as a restart and drops background tasks that are actually running.
+    if (
+      state.isInterrupted &&
+      message.content?.type !== 'result' &&
+      message.content?.subtype !== 'process_restarted'
+    ) {
       return
     }
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -963,6 +963,11 @@ class MessagePersister {
       state.currentToolInput = ''
       state.activeSubagents.clear()
       state.activeBackgroundTasks.clear()
+      // Stop replaces the CLI process, so its background tasks are gone and no
+      // terminal signal or removal snapshot will ever arrive for them. Dropping
+      // only the incremental map would leave the level set stale for the life of
+      // the session — every later turn would end waiting-background, never idle.
+      state.bgTasksSnapshot = null
       this.stopAllWorkflowTailers(sessionId)
     }
 
@@ -1401,9 +1406,14 @@ class MessagePersister {
     // carrying this task's id + status. The busy path (task settles while a foreground
     // tool is in flight) is handled separately via `task_updated` in the system switch
     // below — that path does NOT emit a matching `task_notification`.
-    if (content.type === 'system' && state.activeBackgroundTasks.size > 0) {
+    // Runs whether or not the id is in the incremental map: the snapshot can
+    // carry ids the map never had (a subagent's own nested background agents
+    // notify onto the lead session), and those must retire here or they pin
+    // the union forever. clearBackgroundTask no-ops the broadcast side for
+    // anything untracked.
+    if (content.type === 'system') {
       const taskId = content.task_id as string | undefined
-      if (taskId && content.status && state.activeBackgroundTasks.has(taskId)) {
+      if (taskId && content.status) {
         this.clearBackgroundTask(sessionId, state, taskId)
       }
     }
@@ -1735,7 +1745,9 @@ class MessagePersister {
           const taskId = content.task_id as string | undefined
           const status = (content.patch as { status?: string } | undefined)?.status
           const isTerminal = status === 'completed' || status === 'failed' || status === 'killed'
-          if (taskId && isTerminal && state.activeBackgroundTasks.has(taskId)) {
+          // Unconditional on map membership, same reason as the task_notification
+          // path above: the id may only exist in the snapshot.
+          if (taskId && isTerminal) {
             this.clearBackgroundTask(sessionId, state, taskId)
           }
           // A background *subagent* (task_type 'local_agent') settles via a
@@ -1774,6 +1786,19 @@ class MessagePersister {
             const summary = typeof content.summary === 'string' ? content.summary : undefined
             this.broadcastSubagentCompleted(sessionId, state, toolUseId!, summary)
           }
+        } else if (content.subtype === 'process_restarted') {
+          // Container-synthesized: the session's CLI process was replaced (idle
+          // eviction + --resume, crash, MCP-injection restart). Background tasks
+          // are process-local and a fresh process emits NO initial
+          // background_tasks_changed, so every id we still hold is unretirable —
+          // no terminal signal or removal snapshot is ever coming. Reset to
+          // "nothing known", matching SessionSettlementTracker.resetBackgroundTasks.
+          // NOT the same as a transport reattach, which must keep the level set:
+          // that's the same live process still running the same tasks.
+          for (const taskId of [...state.activeBackgroundTasks.keys()]) {
+            this.clearBackgroundTask(sessionId, state, taskId)
+          }
+          state.bgTasksSnapshot = null
         } else if (content.subtype === 'capabilities') {
           // The container announces its stream contract when the WebSocket
           // connects, before relaying any SDK message. `session_state_events`
@@ -2168,6 +2193,9 @@ class MessagePersister {
     state.currentToolInput = ''
     state.activeSubagents.clear()
     state.activeBackgroundTasks.clear()
+    // The runtime is gone; its background tasks went with it (same reasoning as
+    // markSessionInterrupted).
+    state.bgTasksSnapshot = null
     this.stopAllWorkflowTailers(sessionId)
     if (diedMidTurn) {
       // Mirror the result-error path: settle isActive BEFORE broadcasting so
@@ -2336,6 +2364,10 @@ class MessagePersister {
   // briefly know a task the other doesn't. Counting the union means a missed
   // registration can't cause a premature idle and a missed terminal signal
   // can't pin the session forever (the snapshot self-heal below clears it).
+  // Both directions must drain, or the union stops being a safety net and
+  // becomes a permanent pin: the SDK re-emits the level only on a membership
+  // CHANGE and emits nothing at all for a fresh process, so an id that enters
+  // bgTasksSnapshot and never leaves it can never be retired by the SDK.
   private openBackgroundWorkCount(state: StreamingState): number {
     if (!state.bgTasksSnapshot) return state.activeBackgroundTasks.size
     const union = new Set(state.activeBackgroundTasks.keys())
@@ -2344,6 +2376,11 @@ class MessagePersister {
   }
 
   private clearBackgroundTask(sessionId: string, state: StreamingState, taskId: string): boolean {
+    // Retire the id from the level set too. A terminal per-task signal normally
+    // trails the snapshot that already dropped the task and this is a no-op; if
+    // that removal frame never arrives, the freshest information has to win or
+    // the union pins the session. Mirrors SessionSettlementTracker.removeTask.
+    state.bgTasksSnapshot?.delete(taskId)
     const info = state.activeBackgroundTasks.get(taskId)
     if (!info) return false
     state.activeBackgroundTasks.delete(taskId)

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -164,6 +164,10 @@ interface StreamingState {
   // arrives with the following task_started/tool-result) — liveness gates use
   // the UNION of both.
   bgTasksSnapshot: Set<string> | null
+  // Identity of the CLI process the background-task bookkeeping above belongs
+  // to, from the container's handshake. Those tasks are process-local, so when
+  // this changes every id we hold is unretirable and must be dropped.
+  processInstanceId: string | null
   pendingDeliverFiles: Map<string, { filePath: string; description?: string }> // deliver_file tool calls awaiting their tool_result, keyed by tool_use ID
   // True when the runtime publishes session_state_changed events — then IT is
   // the idle authority: a 'result' alone does not end the session (queued
@@ -452,6 +456,9 @@ class MessagePersister {
       lastApiErrorCode: null,
       activeBackgroundTasks: priorBackgroundTasks,
       bgTasksSnapshot: prior?.bgTasksSnapshot ?? null,
+      // Carried with the snapshot it describes — the incoming handshake is what
+      // decides whether both are still valid.
+      processInstanceId: prior?.processInstanceId ?? null,
       pendingDeliverFiles: new Map(),
       stateEventsAuthority: prior?.stateEventsAuthority ?? false,
       lastResultSubtype: null,
@@ -1033,6 +1040,7 @@ class MessagePersister {
         lastApiErrorCode: null,
         activeBackgroundTasks: new Map(),
         bgTasksSnapshot: null,
+        processInstanceId: null,
         pendingDeliverFiles: new Map(),
         stateEventsAuthority: false,
         lastResultSubtype: null,
@@ -1787,18 +1795,12 @@ class MessagePersister {
             this.broadcastSubagentCompleted(sessionId, state, toolUseId!, summary)
           }
         } else if (content.subtype === 'process_restarted') {
-          // Container-synthesized: the session's CLI process was replaced (idle
-          // eviction + --resume, crash, MCP-injection restart). Background tasks
-          // are process-local and a fresh process emits NO initial
-          // background_tasks_changed, so every id we still hold is unretirable —
-          // no terminal signal or removal snapshot is ever coming. Reset to
-          // "nothing known", matching SessionSettlementTracker.resetBackgroundTasks.
-          // NOT the same as a transport reattach, which must keep the level set:
-          // that's the same live process still running the same tasks.
-          for (const taskId of [...state.activeBackgroundTasks.keys()]) {
-            this.clearBackgroundTask(sessionId, state, taskId)
-          }
-          state.bgTasksSnapshot = null
+          // Container-synthesized, live: the session's CLI process was replaced
+          // while we were attached (MCP-injection restart, crash, an
+          // interrupt-driven respawn). The handshake below covers the restarts
+          // that happen with nobody attached; this one settles the indicator
+          // immediately instead of at the next reconnect.
+          this.handleProcessRestarted(sessionId, state, content.process_instance)
         } else if (content.subtype === 'capabilities') {
           // The container announces its stream contract when the WebSocket
           // connects, before relaying any SDK message. `session_state_events`
@@ -1810,6 +1812,11 @@ class MessagePersister {
           if (content.session_state_events === true) {
             state.stateEventsAuthority = true
           }
+          // The handshake also names the CLI process we're now attached to.
+          // This is the path that catches a replacement we never saw: on a cold
+          // resume the container's live announcement fires before the session is
+          // published and before this socket subscribes, so it reaches nobody.
+          this.adoptHandshakeProcessInstance(sessionId, state, content.process_instance)
         } else if (content.subtype === 'session_state_changed') {
           // The runtime's own session state — `idle` is the SDK's authoritative
           // "fully settled" signal: it fires only after heldBackResult flushes
@@ -2373,6 +2380,39 @@ class MessagePersister {
     const union = new Set(state.activeBackgroundTasks.keys())
     for (const id of state.bgTasksSnapshot) union.add(id)
     return union.size
+  }
+
+  // The live `process_restarted` frame: the container is telling us outright
+  // that the CLI was replaced, so reset regardless of whether we had recorded
+  // the outgoing process's identity.
+  private handleProcessRestarted(sessionId: string, state: StreamingState, instance: unknown): void {
+    this.dropProcessLocalBackgroundState(sessionId, state)
+    if (typeof instance === 'string' && instance !== '') state.processInstanceId = instance
+  }
+
+  // The handshake's process identity. A first sighting is NOT a restart — it's
+  // just the first time we've been told — so reset only when the name actually
+  // changes. That distinction is the point of keying on identity: a plain
+  // transport reattach re-announces the SAME process with the same tasks still
+  // running, and resetting there would drop a live indicator and un-gate
+  // auto-sleep mid-job. A container too old to send the field is a no-op.
+  private adoptHandshakeProcessInstance(sessionId: string, state: StreamingState, instance: unknown): void {
+    if (typeof instance !== 'string' || instance === '') return
+    if (state.processInstanceId === instance) return
+    const isReplacement = state.processInstanceId !== null
+    state.processInstanceId = instance
+    if (isReplacement) this.dropProcessLocalBackgroundState(sessionId, state)
+  }
+
+  // Background tasks die with their CLI process, and a fresh process emits NO
+  // initial background_tasks_changed — so once the process is gone, nothing will
+  // ever retire the ids we hold and they would pin the session "working" for the
+  // rest of its life. Mirrors SessionSettlementTracker.resetBackgroundTasks.
+  private dropProcessLocalBackgroundState(sessionId: string, state: StreamingState): void {
+    for (const taskId of [...state.activeBackgroundTasks.keys()]) {
+      this.clearBackgroundTask(sessionId, state, taskId)
+    }
+    state.bgTasksSnapshot = null
   }
 
   private clearBackgroundTask(sessionId: string, state: StreamingState, taskId: string): boolean {

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -2727,9 +2727,18 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     // before any relayed message so the persister treats state events as the
     // idle authority from the first turn (the mock emits them — see
     // emitSessionState).
+    // process_instance is STABLE per session here: the mock never replaces a
+    // CLI process, so every reattach must name the same one. A fresh id per
+    // subscribe would make each reconnect look like a restart and drop
+    // background tasks that are still running.
     callback({
       type: 'system',
-      content: { type: 'system', subtype: 'capabilities', session_state_events: true },
+      content: {
+        type: 'system',
+        subtype: 'capabilities',
+        session_state_events: true,
+        process_instance: `mock-process-${sessionId}`,
+      },
       timestamp: new Date(),
       sessionId,
     })


### PR DESCRIPTION
## Symptom

A prod agent on 0.4.17-rc.2 (TV Downloader) ended **every** turn stuck on "Working…" with no background work outstanding, and Stop didn't clear it. Its container background tasks:

```
17:53:32  b0l9w1jgp  start (auto-backgrounded after a 120s foreground timeout)
17:55:32  b0l9w1jgp  killed
18:56:21  bhwi35mjn  start
19:28:23  bhwi35mjn  completed     ← last background task of the session
```

Three further turns ran after that with zero live background work (19:55, 19:56, 20:22), each ending pinned. At 19:55:18 the transcript shows `[SYSTEM] This session is resuming now — the user chose to wake it early`: a scheduled sleep and **cold resume**, which replaces the CLI process.

> **Correction (was in the first draft of this PR):** a second agent (SEO) was originally cited here as the headline evidence. Re-examination showed that session was *not* wedged — a nested background subagent (`a1652462544859ca5`, "Research MCP registry downstream consumers", spawned by another subagent and outliving it) was genuinely running and completed at 21:14. Its `isActive: true` with an empty `activeBackgroundTasks` is exactly what a live snapshot-only task looks like, and the union gate was behaving correctly. That incident is a separate observability bug — a nested background subagent pins the session while being invisible in the UI — and is **not** what this PR fixes.

## Cause

`openBackgroundWorkCount()` gates every settle path on the union of two sets: the incremental `activeBackgroundTasks` map, and `bgTasksSnapshot` — the SDK's `background_tasks_changed` level signal. The union is deliberate: either side alone can miss a transition.

But only the map was ever pruned. `bgTasksSnapshot` was assigned from SDK frames and read, never retired — not by a terminal per-task signal, not by Stop, not by a re-subscribe. And the SDK only re-emits the level on a membership *change*, with nothing at all at process startup:

> The level is per-process: nothing is emitted at startup, so consumers must reset to the empty set whenever the session's CLI process (re)starts.
> — `SDKBackgroundTasksChangedMessage`, agent-sdk 0.3.219

So any id that entered the snapshot and never left it was unretirable. Every later `session_state_changed: 'idle'` took the `session_waiting_background` branch, `finalizeIdle` never ran, and the session read "Working…" forever.

`SessionSettlementTracker` in agent-container already had both directions — `removeTask()` deletes from `snapshotTaskIds`, and `resetBackgroundTasks()` is wired to `query-start` with a comment that carried-over ids "would pin the session unevictable forever". That landed in #440, one day after the host got the union in #438, and was never ported across.

## Changes

- `clearBackgroundTask()` retires the id from `bgTasksSnapshot` too, and the two terminal call sites (`task_notification`, `task_updated`) no longer gate on map membership — the snapshot carries ids the map never had, since a subagent's own nested background agents notify onto the lead session.
- `markSessionInterrupted` / `markSessionInactive` reset the snapshot alongside the map clear they already did.
- New `process_restarted` frame: the container broadcasts it on `query-start` (idle eviction + `--resume`, crash, MCP-injection restart), the host retires tracked tasks and resets the level set. `query-start` is in-process, so the host previously had no way to learn the CLI was replaced.
- Transport reattach still carries the snapshot forward — that's the same live process with the same tasks running, and dropping it would under-report real work.

## Tests

Written first, all four red, each mirroring one observed failure:

| Test | Mirrors |
|---|---|
| `terminal task signal drains the snapshot when the removal frame never arrives` | SEO agent — mirror image of the existing self-heal test, which covers the other direction |
| `Stop drains the snapshot so later turns still settle` | TV Downloader — every turn after the interrupt |
| `process_restarted drops the snapshot from the dead process` | CLI process replacement |
| `announces process replacement to subscribers so the host can reset too` | container must emit the frame at all |

## Validation

- root suite: 8060 passed, 45 skipped, 0 failed
- container suite: 774 passed, 8 skipped, 0 failed
- `tsc --noEmit` clean on both projects; eslint clean on all four changed files
- The SDK-capture replay fixtures (`sdk206-fixtures-replay`, `subagent-task-events-replay`, `background-bash-busy-completion`) still pass — the check that mattered for relaxing the two call-site guards

## Notes

- The host-side changes take effect on app restart; the `process_restarted` path needs a container image rebuild.
- Dead-subagent cards lingering after a process restart remain the separate follow-up tracked from the earlier stuck-session incident — out of scope here.

https://claude.ai/code/session_01BRHQshiwhUSM64WNmuswhr
