### PR TITLE
Fix skillset refresh on UID-mapped filesystems

### DIFF
--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -753,10 +753,11 @@ Instructions here`
       expect(onDiskSkill).toBe(localContent)
     })
 
-    it('gitPull resolves origin/HEAD via set-head and refreshes via fetch+reset FETCH_HEAD', async () => {
+    it('gitPull trusts only its cache path while refreshing via fetch+reset FETCH_HEAD', async () => {
       const skillContent = '# Test Skill\nOriginal content'
       const meta = buildMetadata({ originalContentHash: contentHash(skillContent) })
       const config = buildSkillsetConfig()
+      const repoDir = getSkillsetRepoDir(config.id)
       const index = buildIndex({
         skills: [{ name: 'Test Skill', path: meta.skillPath, description: 'desc', version: '1.0.0' }],
       })
@@ -791,6 +792,18 @@ Instructions here`
       // No brittle hardcoded master fallback and no full-history reset by name.
       expect(cmdline).not.toContain('git checkout master')
       expect(cmdline.some((c) => c.startsWith('git reset --hard origin/'))).toBe(false)
+
+      const repoCalls = mockExecFile.mock.calls.filter((call) => {
+        const [command, , options] = call as [string, string[], { cwd?: string }]
+        return command === 'git' && options?.cwd === repoDir
+      })
+      expect(repoCalls.length).toBeGreaterThan(0)
+      for (const call of repoCalls) {
+        const options = call[2] as { env: Record<string, string | undefined> }
+        const safeConfigIndex = Number(options.env.GIT_CONFIG_COUNT) - 1
+        expect(options.env[`GIT_CONFIG_KEY_${safeConfigIndex}`]).toBe('safe.directory')
+        expect(options.env[`GIT_CONFIG_VALUE_${safeConfigIndex}`]).toBe(repoDir)
+      }
     })
 
     it('coalesces concurrent refreshes for the same cache directory', async () => {

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -55,6 +55,17 @@ const GIT_ENV = {
   LANG: 'C',
 }
 
+function getRepoGitEnv(repoDir: string) {
+  const inheritedCount = Number.parseInt(process.env.GIT_CONFIG_COUNT ?? '0', 10)
+  const configIndex = Number.isInteger(inheritedCount) && inheritedCount >= 0 ? inheritedCount : 0
+  return {
+    ...GIT_ENV,
+    GIT_CONFIG_COUNT: String(configIndex + 1),
+    [`GIT_CONFIG_KEY_${configIndex}`]: 'safe.directory',
+    [`GIT_CONFIG_VALUE_${configIndex}`]: repoDir,
+  }
+}
+
 const activeSkillsetRefreshes = new Map<string, Promise<SkillsetIndex>>()
 
 // ============================================================================
@@ -506,7 +517,7 @@ async function resolveDefaultBranch(repoDir: string): Promise<DefaultBranchResol
     try {
       const { stdout } = await execFileAsync(
         'git', ['symbolic-ref', 'refs/remotes/origin/HEAD'],
-        { cwd: repoDir, timeout: 5000, env: GIT_ENV },
+        { cwd: repoDir, timeout: 5000, env: getRepoGitEnv(repoDir) },
       )
       const branch = stdout.trim().replace('refs/remotes/origin/', '')
       return branch || null
@@ -526,7 +537,7 @@ async function resolveDefaultBranch(repoDir: string): Promise<DefaultBranchResol
   let setHeadError: unknown = null
   try {
     await execFileAsync('git', ['remote', 'set-head', 'origin', '--auto'], {
-      cwd: repoDir, timeout: 10000, env: GIT_ENV,
+      cwd: repoDir, timeout: 10000, env: getRepoGitEnv(repoDir),
     })
   } catch (err) {
     setHeadError = err
@@ -573,7 +584,7 @@ async function gitPull(repoDir: string): Promise<GitPullResult> {
 
   try {
     await execFileAsync('git', ['checkout', defaultBranch], {
-      cwd: repoDir, timeout: 10000, env: GIT_ENV,
+      cwd: repoDir, timeout: 10000, env: getRepoGitEnv(repoDir),
     })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
@@ -593,10 +604,10 @@ async function gitPull(repoDir: string): Promise<GitPullResult> {
   // would break `reset --hard origin/<branch>` / `git pull`.
   try {
     await execFileAsync('git', ['fetch', '--depth', '1', 'origin', defaultBranch], {
-      cwd: repoDir, timeout: 30000, env: GIT_ENV,
+      cwd: repoDir, timeout: 30000, env: getRepoGitEnv(repoDir),
     })
     await execFileAsync('git', ['reset', '--hard', 'FETCH_HEAD'], {
-      cwd: repoDir, timeout: 10000, env: GIT_ENV,
+      cwd: repoDir, timeout: 10000, env: getRepoGitEnv(repoDir),
     })
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error)
@@ -813,7 +824,7 @@ async function refreshSkillsetCache(
       // corrupt-cache shape as an unresolvable origin/HEAD, so it recovers
       // through the same nuke-and-reclone.
       await execFileAsync('git', ['remote', 'set-url', 'origin', freshUrl], {
-        cwd: repoDir, timeout: 5000, env: GIT_ENV,
+        cwd: repoDir, timeout: 5000, env: getRepoGitEnv(repoDir),
       })
       pullResult = await gitPull(repoDir)
     } catch (error) {


### PR DESCRIPTION
## Summary
- fix skillset refresh failures when an app-managed cache is owned by a filesystem-mapped UID rather than the host process UID
- add `safe.directory` only to each Git child process and exact cache path; do not modify global Git configuration
- preserve inherited command-scope Git configuration and cover every in-repo refresh command with a regression assertion

## Bug and reproduction
On ECS, host-app runs as UID 0 while the S3 Files access point maps `/data` to UID/GID 1000. Refreshing an existing cache under `/data/skillset-cache` therefore fails before `git remote set-url` with:

```
fatal: detected dubious ownership in repository
```

A container reproduction against a UID-1000-owned repository exits 128 without the scoped config and 0 with it.

Fixes [SUP-454](https://linear.app/datawizz/issue/SUP-454/skillset-cache-refresh-fails-with-git-dubious-ownership-on-cloud-host).

## Test plan
- [x] `npx vitest run src/shared/lib/services/skillset-service.test.ts` (176 tests)
- [x] `npx eslint src/shared/lib/services/skillset-service.ts src/shared/lib/services/skillset-service.test.ts`
- [x] `git diff --check`
- [x] isolated Docker reproduction: ordinary Git exits 128; process-scoped `safe.directory` exits 0
- [ ] deploy to one cloud canary and confirm skillset refresh succeeds with no `dubious ownership` log