### PR TITLE
Wait for dashboards through serialized startup (SUP-485)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -5328,8 +5328,14 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
         const res = await fetch(basePath + '/artifacts');
         if (res.ok) {
           const artifacts = await res.json();
-          const d = Array.isArray(artifacts) && artifacts.find(a => a.slug === artifactSlug);
-          if (d && d.status === 'running') { setTitle(d.name); return; }
+          if (!Array.isArray(artifacts)) {
+            await new Promise(r => setTimeout(r, 1000));
+            continue;
+          }
+          const d = artifacts.find(a => a.slug === artifactSlug);
+          if (!d) { throw new Error('Dashboard not found.'); }
+          if (d.status === 'crashed') { throw new Error('Dashboard crashed.'); }
+          if (d.status === 'running') { setTitle(d.name); return; }
         }
         await new Promise(r => setTimeout(r, 1000));
       }

--- a/src/renderer/components/dashboards/dashboard-view-state.test.ts
+++ b/src/renderer/components/dashboards/dashboard-view-state.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DASHBOARD_WAIT_BOUND_MS,
+  resolveDashboardViewState,
+  type DashboardViewStateInput,
+} from './dashboard-view-state'
+
+function input(overrides: Partial<DashboardViewStateInput> = {}): DashboardViewStateInput {
+  return {
+    agentRunning: true,
+    artifactsLoaded: true,
+    dashboard: { status: 'stopped' },
+    canStart: true,
+    startFailed: false,
+    waitElapsedMs: 0,
+    iframeLoaded: false,
+    ...overrides,
+  }
+}
+
+describe('resolveDashboardViewState', () => {
+  describe('regression: transient startup must not look terminal', () => {
+    it('waits with a spinner while the artifacts list has not loaded', () => {
+      const state = resolveDashboardViewState(
+        input({ artifactsLoaded: false, dashboard: undefined }),
+      )
+
+      expect(state).toEqual({
+        kind: 'waiting',
+        message: 'Waiting for dashboard…',
+        showSpinner: true,
+        slow: false,
+        pollFast: true,
+      })
+    })
+
+    it('waits with a spinner while a healthy dashboard is still queued (stopped)', () => {
+      const state = resolveDashboardViewState(
+        input({ dashboard: { status: 'stopped' } }),
+      )
+
+      expect(state).toEqual({
+        kind: 'waiting',
+        message: 'Waiting for dashboard…',
+        showSpinner: true,
+        slow: false,
+        pollFast: true,
+      })
+    })
+  })
+
+  it('treats an absent dashboard as missing once the list has loaded', () => {
+    const state = resolveDashboardViewState(
+      input({ artifactsLoaded: true, dashboard: undefined }),
+    )
+
+    expect(state).toEqual({
+      kind: 'missing',
+      message: 'Dashboard not found.',
+    })
+  })
+
+  it('keeps waiting (no fast poll) until the iframe has painted after status is running', () => {
+    const beforePaint = resolveDashboardViewState(
+      input({ dashboard: { status: 'running' }, iframeLoaded: false }),
+    )
+    const afterPaint = resolveDashboardViewState(
+      input({ dashboard: { status: 'running' }, iframeLoaded: true }),
+    )
+
+    expect(beforePaint).toEqual({
+      kind: 'waiting',
+      message: 'Waiting for dashboard…',
+      showSpinner: true,
+      slow: false,
+      pollFast: false,
+    })
+    expect(afterPaint).toEqual({ kind: 'ready' })
+  })
+
+  it('treats starting the same as queued: one wait label', () => {
+    expect(resolveDashboardViewState(input({ dashboard: { status: 'starting' } }))).toEqual({
+      kind: 'waiting',
+      message: 'Waiting for dashboard…',
+      showSpinner: true,
+      slow: false,
+      pollFast: true,
+    })
+  })
+
+  it('surfaces crashed as terminal with no spinner', () => {
+    expect(resolveDashboardViewState(input({ dashboard: { status: 'crashed' } }))).toEqual({
+      kind: 'crashed',
+      message: 'Dashboard crashed.',
+    })
+  })
+
+  it.each([
+    {
+      condition: 'the list has not loaded',
+      overrides: { artifactsLoaded: false, dashboard: undefined },
+      pollFastBeforeBound: true,
+    },
+    {
+      condition: 'the dashboard is queued',
+      overrides: { dashboard: { status: 'stopped' as const } },
+      pollFastBeforeBound: true,
+    },
+    {
+      condition: 'the iframe has not loaded',
+      overrides: { dashboard: { status: 'running' as const }, iframeLoaded: false },
+      pollFastBeforeBound: false,
+    },
+  ])('acknowledges every slow wait after 120s when $condition', ({
+    overrides,
+    pollFastBeforeBound,
+  }) => {
+    expect(DASHBOARD_WAIT_BOUND_MS).toBe(120_000)
+    expect(
+      resolveDashboardViewState(input({ ...overrides, waitElapsedMs: 119_999 })),
+    ).toEqual({
+      kind: 'waiting',
+      message: 'Waiting for dashboard…',
+      showSpinner: true,
+      slow: false,
+      pollFast: pollFastBeforeBound,
+    })
+    expect(
+      resolveDashboardViewState(input({ ...overrides, waitElapsedMs: 120_000 })),
+    ).toEqual({
+      kind: 'waiting',
+      message: 'Dashboard is taking longer than expected to start.',
+      showSpinner: false,
+      slow: true,
+      pollFast: false,
+    })
+  })
+
+  describe('agent not running', () => {
+    it('shows starting with a spinner when auto-start can proceed', () => {
+      expect(
+        resolveDashboardViewState(input({ agentRunning: false, dashboard: undefined })),
+      ).toEqual({
+        kind: 'agent-starting',
+        message: 'Starting agent…',
+        showSpinner: true,
+      })
+    })
+
+    it('preserves the no-permission and start-failed terminals', () => {
+      expect(
+        resolveDashboardViewState(
+          input({ agentRunning: false, canStart: false, dashboard: undefined }),
+        ),
+      ).toEqual({
+        kind: 'agent-no-permission',
+        message: 'Agent is not running. Ask an admin to start it.',
+      })
+
+      expect(
+        resolveDashboardViewState(
+          input({
+            agentRunning: false,
+            startFailed: true,
+            dashboard: undefined,
+          }),
+        ),
+      ).toEqual({
+        kind: 'agent-start-failed',
+        message: 'Agent failed to start.',
+      })
+    })
+  })
+})

--- a/src/renderer/components/dashboards/dashboard-view-state.ts
+++ b/src/renderer/components/dashboards/dashboard-view-state.ts
@@ -1,0 +1,96 @@
+import type { ArtifactInfo } from '@renderer/hooks/use-artifacts'
+
+export const DASHBOARD_WAIT_BOUND_MS = 120_000
+
+export type DashboardViewState =
+  | { kind: 'agent-start-failed'; message: string }
+  | { kind: 'agent-no-permission'; message: string }
+  | { kind: 'agent-starting'; message: string; showSpinner: true }
+  | {
+      kind: 'waiting'
+      message: string
+      showSpinner: boolean
+      slow: boolean
+      pollFast: boolean
+    }
+  | { kind: 'crashed'; message: string }
+  | { kind: 'missing'; message: string }
+  | { kind: 'ready' }
+
+export type DashboardViewStateInput = {
+  agentRunning: boolean
+  artifactsLoaded: boolean
+  dashboard: Pick<ArtifactInfo, 'status'> | undefined
+  canStart: boolean
+  startFailed: boolean
+  waitElapsedMs: number
+  iframeLoaded: boolean
+}
+
+function waiting(slow: boolean, pollFast: boolean): Extract<DashboardViewState, { kind: 'waiting' }> {
+  return {
+    kind: 'waiting',
+    message: slow
+      ? 'Dashboard is taking longer than expected to start.'
+      : 'Waiting for dashboard…',
+    showSpinner: !slow,
+    slow,
+    pollFast,
+  }
+}
+
+export function resolveDashboardViewState(input: DashboardViewStateInput): DashboardViewState {
+  const {
+    agentRunning,
+    artifactsLoaded,
+    dashboard,
+    canStart,
+    startFailed,
+    waitElapsedMs,
+    iframeLoaded,
+  } = input
+
+  if (!agentRunning) {
+    if (startFailed) {
+      return {
+        kind: 'agent-start-failed',
+        message: 'Agent failed to start.',
+      }
+    }
+    if (!canStart) {
+      return {
+        kind: 'agent-no-permission',
+        message: 'Agent is not running. Ask an admin to start it.',
+      }
+    }
+    return {
+      kind: 'agent-starting',
+      message: 'Starting agent…',
+      showSpinner: true,
+    }
+  }
+
+  const slow = waitElapsedMs >= DASHBOARD_WAIT_BOUND_MS
+
+  if (!artifactsLoaded) {
+    return waiting(slow, !slow)
+  }
+
+  if (!dashboard) {
+    return { kind: 'missing', message: 'Dashboard not found.' }
+  }
+
+  if (dashboard.status === 'crashed') {
+    return { kind: 'crashed', message: 'Dashboard crashed.' }
+  }
+
+  if (dashboard.status === 'running') {
+    if (!iframeLoaded) {
+      return waiting(slow, false)
+    }
+    return { kind: 'ready' }
+  }
+
+  // `starting` and queued `stopped` are both transient from outside.
+  return waiting(slow, !slow)
+}

--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DashboardView } from './dashboard-view'
 
 const mocks = vi.hoisted(() => ({
   agentStatus: 'running',
+  dashboardStatus: 'crashed',
   start: {
     mutate: vi.fn(),
     mutateAsync: vi.fn(),
@@ -36,7 +37,7 @@ vi.mock('@renderer/hooks/use-artifacts', () => ({
       slug: 'dashboard',
       name: 'Dashboard',
       description: '',
-      status: 'crashed',
+      status: mocks.dashboardStatus,
       port: 0,
     }],
   }),
@@ -78,6 +79,7 @@ describe('DashboardView restart', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.agentStatus = 'running'
+    mocks.dashboardStatus = 'crashed'
     mocks.start.mutateAsync.mockResolvedValue({})
   })
 
@@ -104,5 +106,27 @@ describe('DashboardView restart', () => {
     await act(async () => finishStop())
 
     expect(mocks.start.mutateAsync).toHaveBeenCalledOnce()
+  })
+
+  it('waits for the new document when the frame remounts after the agent left running', () => {
+    mocks.dashboardStatus = 'running'
+    const frame = () => document.querySelector('iframe')
+    const waiting = () => screen.queryByText('Waiting for dashboard…')
+
+    const view = render(
+      <DashboardView agentSlug="agent" dashboardSlug="dashboard" />,
+    )
+    fireEvent.load(frame()!)
+    expect(waiting()).toBeNull()
+
+    // The agent leaves running through a control outside this view.
+    mocks.agentStatus = 'stopped'
+    view.rerender(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    expect(frame()).toBeNull()
+
+    mocks.agentStatus = 'running'
+    view.rerender(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+
+    expect(waiting()).not.toBeNull()
   })
 })

--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DashboardView } from './dashboard-view'
+
+const mocks = vi.hoisted(() => ({
+  agentStatus: 'running',
+  start: {
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  },
+  stop: {
+    mutateAsync: vi.fn(),
+    isPending: false,
+  },
+}))
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useAgent: () => ({
+    data: {
+      slug: 'agent',
+      status: mocks.agentStatus,
+    },
+  }),
+  useStartAgent: () => mocks.start,
+  useStopAgent: () => mocks.stop,
+}))
+
+vi.mock('@renderer/hooks/use-artifacts', () => ({
+  useArtifacts: () => ({
+    data: [{
+      slug: 'dashboard',
+      name: 'Dashboard',
+      description: '',
+      status: 'crashed',
+      port: 0,
+    }],
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-keep-alive', () => ({
+  useKeepAlive: vi.fn(),
+}))
+
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({
+    canUseAgent: () => true,
+  }),
+}))
+
+vi.mock('@renderer/components/dashboards/add-to-dock-dialog', () => ({
+  AddToDockDialog: () => null,
+}))
+
+vi.mock('@renderer/components/dashboards/pending-agent-reviews', () => ({
+  PendingAgentReviews: () => null,
+}))
+
+vi.mock('@renderer/lib/env', () => ({
+  getApiBaseUrl: () => '',
+  getPlatform: () => 'web',
+  isElectron: () => false,
+}))
+
+vi.mock('@renderer/lib/dashboard-utils', () => ({
+  openDashboardExternal: vi.fn(),
+}))
+
+vi.mock('@renderer/lib/perf', () => ({
+  useRenderTracker: vi.fn(),
+}))
+
+describe('DashboardView restart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.agentStatus = 'running'
+    mocks.start.mutateAsync.mockResolvedValue({})
+  })
+
+  it('does not auto-start a second time while a deliberate stop is pending', async () => {
+    let finishStop: () => void = () => {}
+    mocks.stop.mutateAsync.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        finishStop = resolve
+      }),
+    )
+
+    const view = render(
+      <DashboardView agentSlug="agent" dashboardSlug="dashboard" />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Restart agent' }))
+
+    expect(mocks.stop.mutateAsync).toHaveBeenCalledOnce()
+
+    mocks.agentStatus = 'stopped'
+    view.rerender(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+
+    expect(mocks.start.mutate).not.toHaveBeenCalled()
+
+    await act(async () => finishStop())
+
+    expect(mocks.start.mutateAsync).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -31,6 +31,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const [restartError, setRestartError] = useState<string | null>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const waitStartedAtRef = useRef<number | null>(null)
+  const autoStartedRef = useRef<string | null>(null)
   const { data: agent } = useAgent(agentSlug)
   const { data: artifacts } = useArtifacts(agentSlug, { pollFast })
   const startAgent = useStartAgent()
@@ -106,6 +107,8 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   }, [startAgent, agentSlug])
 
   const handleRestartAgent = useCallback(async () => {
+    // The deliberate stop must not re-trigger this view's auto-start effect.
+    autoStartedRef.current = agentSlug
     setRestarting(true)
     setRestartError(null)
     setIframeLoaded(false)
@@ -123,7 +126,6 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     }
   }, [isAgentRunning, stopAgent, startAgent, agentSlug])
 
-  const autoStartedRef = useRef<string | null>(null)
   useEffect(() => {
     if (autoStartedRef.current === agentSlug) return
     if (!agent || isAgentRunning || isAgentStarting || !canStart) return

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { Button } from '@renderer/components/ui/button'
 import { Play, RefreshCw, SquareMousePointer, ExternalLink, Dock, Loader2 } from 'lucide-react'
-import { useAgent, useStartAgent } from '@renderer/hooks/use-agents'
+import { useAgent, useStartAgent, useStopAgent } from '@renderer/hooks/use-agents'
 import { useKeepAlive } from '@renderer/hooks/use-keep-alive'
 import { useArtifacts } from '@renderer/hooks/use-artifacts'
 import { useUser } from '@renderer/context/user-context'
@@ -10,6 +10,11 @@ import { buildDashboardArtifactPath } from '@shared/lib/dashboard-url'
 import { AddToDockDialog } from './add-to-dock-dialog'
 import { PendingAgentReviews } from './pending-agent-reviews'
 import { useRenderTracker } from '@renderer/lib/perf'
+import {
+  DASHBOARD_WAIT_BOUND_MS,
+  resolveDashboardViewState,
+  type DashboardViewState,
+} from './dashboard-view-state'
 
 interface DashboardViewProps {
   agentSlug: string
@@ -19,23 +24,74 @@ interface DashboardViewProps {
 export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) {
   useRenderTracker('DashboardView')
   const [dockDialogOpen, setDockDialogOpen] = useState(false)
+  const [iframeLoaded, setIframeLoaded] = useState(false)
+  const [pollFast, setPollFast] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
+  const [restarting, setRestarting] = useState(false)
+  const [restartError, setRestartError] = useState<string | null>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const waitStartedAtRef = useRef<number | null>(null)
   const { data: agent } = useAgent(agentSlug)
-  const { data: artifacts } = useArtifacts(agentSlug)
+  const { data: artifacts } = useArtifacts(agentSlug, { pollFast })
   const startAgent = useStartAgent()
+  const stopAgent = useStopAgent()
   const { canUseAgent } = useUser()
   const canStart = canUseAgent(agentSlug)
   useKeepAlive(agentSlug)
 
   const dashboard = artifacts?.find((a) => a.slug === dashboardSlug)
+  const artifactsLoaded = artifacts !== undefined
   const isAgentRunning = agent?.status === 'running'
   const isAgentStarting = startAgent.isPending
-  const isDashboardRunning = dashboard?.status === 'running'
+
+  const trackingWait = isAgentRunning && (
+    !artifactsLoaded
+    || (dashboard != null && (dashboard.status === 'starting' || dashboard.status === 'stopped'))
+    || (dashboard?.status === 'running' && !iframeLoaded)
+  )
+
+  const waitElapsedMs = waitStartedAtRef.current === null
+    ? 0
+    : now - waitStartedAtRef.current
+  const waitIsSlow = trackingWait && waitElapsedMs >= DASHBOARD_WAIT_BOUND_MS
+
+  useEffect(() => {
+    if (!trackingWait) {
+      waitStartedAtRef.current = null
+      return
+    }
+    if (waitStartedAtRef.current === null) {
+      waitStartedAtRef.current = Date.now()
+    }
+    if (waitIsSlow) return
+    const id = window.setInterval(() => setNow(Date.now()), 1_000)
+    return () => window.clearInterval(id)
+  }, [trackingWait, waitIsSlow])
+
+  const viewState = resolveDashboardViewState({
+    agentRunning: isAgentRunning,
+    artifactsLoaded,
+    dashboard,
+    canStart,
+    startFailed: startAgent.isError,
+    waitElapsedMs,
+    iframeLoaded,
+  })
+
+  const nextPollFast = viewState.kind === 'waiting' && viewState.pollFast
+  useEffect(() => {
+    setPollFast((prev) => (prev === nextPollFast ? prev : nextPollFast))
+  }, [nextPollFast])
 
   const baseUrl = getApiBaseUrl()
   const iframeSrc = `${baseUrl}${buildDashboardArtifactPath(agentSlug, dashboardSlug)}`
 
+  useEffect(() => {
+    setIframeLoaded(false)
+  }, [iframeSrc])
+
   const handleRefresh = useCallback(() => {
+    setIframeLoaded(false)
     if (iframeRef.current) {
       iframeRef.current.src = iframeSrc
     }
@@ -49,6 +105,24 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     startAgent.mutate(agentSlug)
   }, [startAgent, agentSlug])
 
+  const handleRestartAgent = useCallback(async () => {
+    setRestarting(true)
+    setRestartError(null)
+    setIframeLoaded(false)
+    waitStartedAtRef.current = Date.now()
+    try {
+      if (isAgentRunning) {
+        await stopAgent.mutateAsync(agentSlug)
+      }
+      await startAgent.mutateAsync(agentSlug)
+    } catch (error) {
+      console.error('Failed to restart agent:', error)
+      setRestartError(error instanceof Error ? error.message : 'Failed to restart agent')
+    } finally {
+      setRestarting(false)
+    }
+  }, [isAgentRunning, stopAgent, startAgent, agentSlug])
+
   const autoStartedRef = useRef<string | null>(null)
   useEffect(() => {
     if (autoStartedRef.current === agentSlug) return
@@ -58,38 +132,24 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     startAgent.mutate(agentSlug)
   }, [agent, agentSlug, isAgentRunning, isAgentStarting, canStart, startAgent])
 
-  if (!isAgentRunning || !isDashboardRunning) {
-    const showSpinner = !isAgentRunning
-      ? !startAgent.isError && canStart
-      : dashboard?.status === 'starting'
-    const message = !isAgentRunning
-      ? startAgent.isError
-        ? 'Agent failed to start.'
-        : !canStart
-          ? 'Agent is not running. Ask an admin to start it.'
-          : 'Starting up...'
-      : dashboard?.status === 'starting'
-        ? 'Dashboard is starting up...'
-        : 'Dashboard is not running. It will start automatically when the agent starts.'
+  const showFrame = isAgentRunning && dashboard?.status === 'running'
+  const showOverlay = viewState.kind !== 'ready'
+  const actionPending = restarting || stopAgent.isPending || startAgent.isPending
+
+  if (!showFrame) {
     return (
       <div className="flex-1 overflow-y-auto flex flex-col items-center text-muted-foreground p-8">
         <div className="m-auto flex flex-col items-center gap-4 w-full max-w-2xl">
-          <div className="flex items-center gap-2">
-            {showSpinner && <Loader2 className="h-4 w-4 animate-spin" />}
-            <p className="text-base">{message}</p>
-          </div>
-          {!isAgentRunning && canStart && startAgent.isError && (
-            <Button
-              onClick={handleStartAgent}
-              disabled={startAgent.isPending}
-            >
-              <Play className="mr-2 h-4 w-4" />
-              Retry
-            </Button>
-          )}
-          {startAgent.isError && (
-            <p className="text-sm text-destructive">{startAgent.error.message}</p>
-          )}
+          <DashboardStatusBody
+            viewState={viewState}
+            startErrorMessage={startAgent.error?.message}
+            restartErrorMessage={restartError ?? undefined}
+            onRetry={handleStartAgent}
+            onRestart={handleRestartAgent}
+            retryPending={startAgent.isPending}
+            restartPending={actionPending}
+            canStart={canStart}
+          />
           <div className="w-full">
             <PendingAgentReviews agentSlug={agentSlug} />
           </div>
@@ -131,14 +191,86 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
         dashboardSlug={dashboardSlug}
         dashboardName={dashboard?.name || dashboardSlug}
       />
-      <iframe
-        ref={iframeRef}
-        src={iframeSrc}
-        className="flex-1 w-full border-0"
-        title={dashboard?.name || dashboardSlug}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
-        allow="microphone; camera"
-      />
+      <div className="flex-1 min-h-0 relative">
+        {showOverlay && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-background text-muted-foreground p-8">
+            <DashboardStatusBody
+              viewState={viewState}
+              startErrorMessage={startAgent.error?.message}
+              restartErrorMessage={restartError ?? undefined}
+              onRetry={handleStartAgent}
+              onRestart={handleRestartAgent}
+              retryPending={startAgent.isPending}
+              restartPending={actionPending}
+              canStart={canStart}
+            />
+          </div>
+        )}
+        <iframe
+          ref={iframeRef}
+          src={iframeSrc}
+          className="h-full w-full border-0"
+          title={dashboard?.name || dashboardSlug}
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
+          allow="microphone; camera"
+          onLoad={() => setIframeLoaded(true)}
+        />
+      </div>
+    </div>
+  )
+}
+
+function DashboardStatusBody({
+  viewState,
+  startErrorMessage,
+  restartErrorMessage,
+  onRetry,
+  onRestart,
+  retryPending,
+  restartPending,
+  canStart,
+}: {
+  viewState: DashboardViewState
+  startErrorMessage?: string
+  restartErrorMessage?: string
+  onRetry: () => void
+  onRestart: () => void
+  retryPending: boolean
+  restartPending: boolean
+  canStart: boolean
+}) {
+  if (viewState.kind === 'ready') return null
+
+  const showSpinner = 'showSpinner' in viewState && viewState.showSpinner
+  const showRetry = viewState.kind === 'agent-start-failed' && canStart
+  const showRestart =
+    (viewState.kind === 'crashed' || (viewState.kind === 'waiting' && viewState.slow))
+    && canStart
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex items-center gap-2">
+        {showSpinner && <Loader2 className="h-4 w-4 animate-spin" />}
+        <p className="text-base">{viewState.message}</p>
+      </div>
+      {showRetry && (
+        <Button onClick={onRetry} disabled={retryPending}>
+          <Play className="mr-2 h-4 w-4" />
+          Retry
+        </Button>
+      )}
+      {showRestart && (
+        <Button onClick={onRestart} disabled={restartPending}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Restart agent
+        </Button>
+      )}
+      {viewState.kind === 'agent-start-failed' && startErrorMessage && (
+        <p className="text-sm text-destructive">{startErrorMessage}</p>
+      )}
+      {showRestart && restartErrorMessage && (
+        <p className="text-sm text-destructive">{restartErrorMessage}</p>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -138,6 +138,12 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const showOverlay = viewState.kind !== 'ready'
   const actionPending = restarting || stopAgent.isPending || startAgent.isPending
 
+  // The iframe unmounts whenever the frame is hidden, so its load state must not
+  // outlive it and mark the next mount ready before that document loads.
+  useEffect(() => {
+    if (!showFrame) setIframeLoaded(false)
+  }, [showFrame])
+
   if (!showFrame) {
     return (
       <div className="flex-1 overflow-y-auto flex flex-col items-center text-muted-foreground p-8">

--- a/src/renderer/hooks/use-artifacts.test.ts
+++ b/src/renderer/hooks/use-artifacts.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { artifactsRefetchIntervalMs, type ArtifactInfo } from './use-artifacts'
+
+function artifact(status: ArtifactInfo['status'], slug = 'dash'): ArtifactInfo {
+  return { slug, name: slug, description: '', status, port: 1 }
+}
+
+describe('artifactsRefetchIntervalMs', () => {
+  it('escalates only when pollFast is requested or some dashboard is starting', () => {
+    expect(artifactsRefetchIntervalMs(undefined, false)).toBe(60_000)
+    expect(artifactsRefetchIntervalMs([artifact('stopped')], false)).toBe(60_000)
+    expect(artifactsRefetchIntervalMs([artifact('starting')], false)).toBe(1_000)
+    expect(artifactsRefetchIntervalMs([artifact('stopped')], true)).toBe(1_000)
+    expect(artifactsRefetchIntervalMs(undefined, true)).toBe(1_000)
+  })
+})

--- a/src/renderer/hooks/use-artifacts.ts
+++ b/src/renderer/hooks/use-artifacts.ts
@@ -9,7 +9,21 @@ export interface ArtifactInfo {
   port: number
 }
 
-export function useArtifacts(agentSlug: string | null) {
+/** Default cadence, or 1s when the viewed dashboard is actively waiting. */
+export function artifactsRefetchIntervalMs(
+  data: ArtifactInfo[] | undefined,
+  pollFast: boolean,
+): number {
+  if (pollFast) return 1_000
+  const hasStarting = data?.some((a) => a.status === 'starting')
+  return hasStarting ? 1_000 : 60_000
+}
+
+export function useArtifacts(
+  agentSlug: string | null,
+  options?: { pollFast?: boolean },
+) {
+  const pollFast = options?.pollFast ?? false
   return useQuery<ArtifactInfo[]>({
     queryKey: ['artifacts', agentSlug],
     queryFn: async () => {
@@ -19,10 +33,6 @@ export function useArtifacts(agentSlug: string | null) {
     },
     enabled: !!agentSlug,
     staleTime: 60_000,
-    refetchInterval: (query) => {
-      const data = query.state.data
-      const hasStarting = data?.some((a) => a.status === 'starting')
-      return hasStarting ? 1_000 : 60_000
-    },
+    refetchInterval: (query) => artifactsRefetchIntervalMs(query.state.data, pollFast),
   })
 }

--- a/src/renderer/router/route-components.tsx
+++ b/src/renderer/router/route-components.tsx
@@ -99,7 +99,7 @@ export function DashboardRoute() {
   const slug = useAgentSlug()
   const { dashSlug } = useParams({ strict: false }) as { dashSlug?: string }
   if (!slug || !dashSlug) return null
-  return <DashboardView agentSlug={slug} dashboardSlug={dashSlug} />
+  return <DashboardView key={`${slug}/${dashSlug}`} agentSlug={slug} dashboardSlug={dashSlug} />
 }
 
 // integrationId is a path param and the optional active sub-session travels in


### PR DESCRIPTION
https://linear.app/datawizz/issue/SUP-485/dashboard-view-treats-a-transient-startup-state-as-terminal

## Problem
Dashboards start serially inside the agent container.
While a dashboard is waiting behind its siblings, it reports `stopped`.
The renderer treated that transient state, and an unloaded artifact list, as a terminal failure.

## State behavior
| Input | User-facing result |
| --- | --- |
| Agent stopped and start allowed | Starting agent with spinner |
| Agent stopped and start forbidden | Ask an admin to start it |
| Agent start failed | Failure with retry |
| Artifact list not loaded | Waiting with spinner and 1-second polling |
| Loaded list does not contain dashboard | Dashboard not found |
| Dashboard stopped and queued | Waiting with spinner and 1-second polling |
| Dashboard starting | Waiting with spinner and 1-second polling |
| Dashboard crashed | Crashed state with restart action |
| Dashboard running, iframe loading | Waiting with spinner |
| Dashboard running, iframe loaded | Dashboard displayed |
| Any wait reaches 120 seconds | Slow-start message with restart action |

## Implementation
- Centralize the presentation policy in a pure `resolveDashboardViewState` function.
- Keep cached artifact data usable through background refetch failures.
- Poll artifacts quickly only while startup progress is expected.
- Keep the loading overlay visible until the iframe document loads.
- Reset dashboard-local state when navigating between dashboards.
- Stop pop-out polling immediately when a dashboard is missing or crashed.
- Prevent a deliberate restart from racing the view's automatic start.

The restart action reuses the existing agent stop and start APIs.
It restarts the entire agent container and therefore all dashboards for that agent.
No new backend restart route or container behavior was added.

## Reviewer guide
- State policy and boundary: `dashboard-view-state.ts`
- Renderer wiring and restart flow: `dashboard-view.tsx`
- Polling cadence: `use-artifacts.ts`
- Pop-out terminal handling: `agents.ts`
- Regression coverage: the three new co-located test files

## Scope
- No changes to dashboard launch order
- No new artifact statuses or API shapes
- No database or dependency changes

## Test plan
- [x] Dashboard state, polling, and restart-race unit tests
- [x] Typecheck
- [x] Lint
- [x] Headed visual state carousel
- [x] Real two-dashboard cold boot through Apple container
- [x] Real restart button stop/start recovery
- [x] GitHub CI: 10 passed, 0 failed