### PR TITLE
Restore spacing above session composer

### DIFF
--- a/src/renderer/components/messages/stale-session-notice.test.tsx
+++ b/src/renderer/components/messages/stale-session-notice.test.tsx
@@ -14,6 +14,7 @@ describe('StaleSessionNotice', () => {
     )
 
     expect(screen.getByText('Start a new conversation?')).toBeInTheDocument()
+    expect(screen.getByTestId('stale-toast')).toHaveClass('mb-2')
     await user.click(screen.getByTestId('stale-toast-ignore'))
     await user.click(screen.getByTestId('stale-new-chat'))
     expect(onIgnore).toHaveBeenCalledOnce()

--- a/src/renderer/components/messages/stale-session-notice.tsx
+++ b/src/renderer/components/messages/stale-session-notice.tsx
@@ -31,7 +31,7 @@ export function StaleSessionNotice({
   }, [learnMoreOpen, onLearnMoreOpenChange])
 
   return (
-    <div data-testid="stale-toast" className="mx-auto -mb-1 w-full max-w-[740px] px-4">
+    <div data-testid="stale-toast" className="mx-auto mb-2 w-full max-w-[740px] px-4">
       <div className="flex items-center justify-between gap-4 rounded-2xl border bg-muted/50 p-4">
         <div className="flex min-w-0 max-w-[60%] flex-col gap-1.5">
           <p className="text-sm font-medium">Start a new conversation?</p>


### PR DESCRIPTION
## Summary

- restore an 8px gap between the stale-conversation alert and the message composer
- keep the spacing owned by the alert so the composer remains flush with the transcript when no alert is present
- add a focused regression assertion for the alert margin

## Root cause

The composer's 12px top padding was recently removed, but the alert retained its `-mb-1` negative bottom margin. The old combination produced an 8px gap; without the composer padding, the alert and composer overlapped slightly.

## User impact

The stale-conversation alert no longer touches the composer, while sessions without the alert keep the intended flush composer layout.

## Validation

- `npm run test:run -- src/renderer/components/messages/stale-session-notice.test.tsx src/renderer/components/messages/message-input.test.tsx src/renderer/components/layout/session-chat-column.test.tsx` (64 tests passed)
- `npx eslint src/renderer/components/messages/stale-session-notice.tsx src/renderer/components/messages/stale-session-notice.test.tsx`
- `npm run typecheck`
- `git diff --check`
