### PR TITLE
Surface background work a subagent started itself

### DIFF
--- a/agent-container/src/session-settlement.ts
+++ b/agent-container/src/session-settlement.ts
@@ -16,7 +16,13 @@ import { z } from 'zod';
 // snapshot LEADS its per-task signal — the frame announcing an addition
 // arrives just before task_started, the frame announcing a removal just
 // before the terminal task_notification/task_updated. The snapshot covers
-// only the lead session's own tasks (a subagent's inner tasks never appear).
+// every background task in the session's CLI process, INCLUDING ones a
+// subagent started itself — captured on 0.3.219: a background agent spawned by
+// another subagent appears in the lead session's level frame (with its own
+// task_type + description) and its task_started/terminal signals arrive
+// unparented, keyed by a tool_use_id the lead never issued. An earlier note
+// here claimed inner tasks never appear; that was wrong, and the host relied
+// on it.
 
 const backgroundTaskSchema = z.object({
   task_id: z.string(),

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -25,6 +25,7 @@ const mockStreamState = {
   completedSubagents: null as Set<string> | null,
   slashCommands: [],
   backgroundTasks: [] as Array<{ taskId: string; startedAt: number; isWorkflow?: boolean; isSubagent?: boolean }>,
+  backgroundWaitTasks: [] as Array<{ taskId: string; taskType?: string; description?: string }>,
 }
 
 vi.mock('@renderer/hooks/use-message-stream', () => ({
@@ -112,6 +113,31 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByText('Error')).toBeInTheDocument()
     expect(screen.getByText('The agent process was terminated unexpectedly.')).toBeInTheDocument()
     expect(screen.getByText('Send another message to retry.')).toBeInTheDocument()
+  })
+
+  it('names background work that has no tool call in this transcript', () => {
+    // A background subagent spawned by ANOTHER subagent: its parentToolId comes
+    // from the parent subagent's stream, so the subagent-row join (activeSubagents
+    // x Agent tool calls in these messages) can never match it. Without this the
+    // session reads "Working..." with nothing explaining why — the SEO incident.
+    mockStreamState.isActive = true
+    mockStreamState.backgroundWaitTasks = [
+      { taskId: 'nested-1', taskType: 'local_agent', description: 'Research MCP registry downstream consumers' },
+    ]
+    render(<AgentActivityIndicator sessionId="s1" agentSlug="a1" />)
+    expect(screen.getByText('Research MCP registry downstream consumers')).toBeInTheDocument()
+  })
+
+  it('does not repeat work already shown as a subagent row', () => {
+    // A lead-launched background agent DOES join to a tool call and renders as a
+    // named row; listing it again here would show the same work twice.
+    mockStreamState.isActive = true
+    mockStreamState.activeSubagents = [{ parentToolId: 'toolu-1', agentId: 'lead-1' }]
+    mockStreamState.backgroundWaitTasks = [
+      { taskId: 'lead-1', taskType: 'local_agent', description: 'Reply alpha' },
+    ]
+    render(<AgentActivityIndicator sessionId="s1" agentSlug="a1" />)
+    expect(screen.queryByText('Reply alpha')).not.toBeInTheDocument()
   })
 
   it('shows "Working..." status when active with no todo', () => {

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -22,7 +22,7 @@ interface AgentActivityIndicatorProps {
 export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIndicatorProps) {
   const {
     isActive, error, apiErrorCode, activeStartTime, isCompacting, activeSubagents, completedSubagents,
-    apiRetry, computerUseApp, computerUseAppIcon, backgroundTasks,
+    apiRetry, computerUseApp, computerUseAppIcon, backgroundTasks, backgroundWaitTasks,
     isThinking,
   } = useMessageStream(sessionId, agentSlug)
   const { data: pendingUserRequests } = usePendingUserRequests(agentSlug, sessionId)
@@ -72,6 +72,16 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
   }, [activeStartTime, messages])
 
   const elapsed = useElapsedTimer(isActive ? timerStartTime : null)
+
+  // Level-set entries whose work is already represented by a subagent row (keyed
+  // by agentId === task_id) or the background-process row are dropped, leaving
+  // only work nothing else can show.
+  const unroutedWaitTasks = useMemo(() => {
+    if (!backgroundWaitTasks || backgroundWaitTasks.length === 0) return []
+    const shownAsSubagent = new Set(activeSubagents.map((s) => s.agentId).filter(Boolean))
+    const shownAsProcess = new Set(backgroundTasks.map((t) => t.taskId))
+    return backgroundWaitTasks.filter((t) => !shownAsSubagent.has(t.taskId) && !shownAsProcess.has(t.taskId))
+  }, [backgroundWaitTasks, activeSubagents, backgroundTasks])
 
   // Collect subagent display info by matching activeSubagents (SSE-tracked) with tool calls in messages
   const subagentItems = useMemo(() => {
@@ -230,6 +240,29 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
                     {item.progressSummary}
                   </span>
                 )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {/* Background work with no tool call in THIS transcript to hang a
+            subagent row off — i.e. a background agent a subagent started itself.
+            The subagent-row join above can structurally never match those (their
+            parentToolId belongs to the parent subagent's stream), so without this
+            the session sits on "Working..." naming nothing. Anything already
+            covered by a row above is filtered out so the same work isn't listed
+            twice. */}
+        {unroutedWaitTasks.length > 0 && (
+          <ul className="mt-2 space-y-1 text-sm pl-5">
+            {unroutedWaitTasks.map((task) => (
+              <li key={task.taskId} className="flex items-center gap-2">
+                <span className="relative flex h-2 w-2 shrink-0">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+                </span>
+                <span className="text-xs text-muted-foreground truncate">
+                  {task.description || task.taskId}
+                </span>
               </li>
             ))}
           </ul>

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -2305,6 +2305,42 @@ describe('useMessageStream', () => {
     expect(result.current.backgroundTasks).toEqual([{ taskId: 'bg-1', startedAt: 1000 }])
   })
 
+  it('keeps the named background work the session is waiting on', async () => {
+    // A background subagent spawned by another subagent can never render as a
+    // subagent row: those are built by joining activeSubagents against Agent
+    // tool calls in THIS session's transcript, and a nested task's parentToolId
+    // belongs to a subagent's stream. The waiting event carries the names, so
+    // the indicator has something to show instead of a bare "Working".
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    expect(result.current.backgroundWaitTasks).toEqual([])
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'session_waiting_background',
+        backgroundTaskCount: 1,
+        tasks: [{ taskId: 'nested-1', taskType: 'local_agent', description: 'nested probe' }],
+      })
+    })
+
+    expect(result.current.backgroundWaitTasks).toEqual([
+      { taskId: 'nested-1', taskType: 'local_agent', description: 'nested probe' },
+    ])
+
+    // Settling clears it — a stale name outliving the work reads as still-running.
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_idle', isActive: false })
+    })
+    expect(result.current.backgroundWaitTasks).toEqual([])
+  })
+
   it('sets isWaitingBackground on session_waiting_background event', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -81,6 +81,10 @@ interface StreamState {
   apiRetry: ApiRetryInfo | null // Non-null while API is retrying a transient error
   backgroundTasks: Array<{ taskId: string; startedAt: number; isWorkflow?: boolean; isSubagent?: boolean }> // Active background Bash commands, dynamic workflows + background subagents
   isWaitingBackground: boolean // True when agent turn ended but background tasks are still running
+  // What that background work IS, from the host's level-set metadata. Subagent
+  // rows can't cover it: they join activeSubagents against Agent tool calls in
+  // THIS transcript, and a subagent's own background agent has no such call.
+  backgroundWaitTasks: Array<{ taskId: string; taskType?: string; description?: string }>
   // Uuids of queued user messages the runtime reported dead (command_lifecycle
   // state discarded/cancelled — e.g. killed by an interrupt). MessageList
   // rescues matching ghosts' text to the composer immediately instead of
@@ -122,6 +126,7 @@ const EMPTY_STREAM_STATE: StreamState = {
   apiRetry: null,
   backgroundTasks: [],
   isWaitingBackground: false,
+  backgroundWaitTasks: [],
   discardedCommandUuids: [],
 }
 
@@ -357,6 +362,7 @@ function getOrCreateEventSource(
           apiRetry: current?.apiRetry ?? null,
           backgroundTasks: Array.isArray(data.backgroundTasks) ? data.backgroundTasks : (current?.backgroundTasks ?? []),
           isWaitingBackground: Array.isArray(data.backgroundTasks) && data.backgroundTasks.length > 0,
+          backgroundWaitTasks: current?.backgroundWaitTasks ?? [],
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
         // Reconcile against the persisted transcript on every (re)connect. A client
@@ -413,6 +419,7 @@ function getOrCreateEventSource(
           apiRetry: null,
           backgroundTasks: current?.backgroundTasks ?? [],
           isWaitingBackground: false,
+          backgroundWaitTasks: [],
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
@@ -458,6 +465,7 @@ function getOrCreateEventSource(
           apiRetry: current?.apiRetry ?? null,
           backgroundTasks: [],
           isWaitingBackground: false,
+          backgroundWaitTasks: [],
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
         queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
@@ -471,7 +479,11 @@ function getOrCreateEventSource(
       // Agent turn ended but background tasks are still running — allow sending messages
       else if (data.type === 'session_waiting_background') {
         if (current) {
-          streamStates.set(sessionId, { ...current, isWaitingBackground: true })
+          streamStates.set(sessionId, {
+            ...current,
+            isWaitingBackground: true,
+            backgroundWaitTasks: Array.isArray(data.tasks) ? data.tasks : [],
+          })
         }
       }
       else if (data.type === 'session_error') {
@@ -500,6 +512,7 @@ function getOrCreateEventSource(
           apiRetry: current?.apiRetry ?? null,
           backgroundTasks: [],
           isWaitingBackground: false,
+          backgroundWaitTasks: [],
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
         queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
@@ -557,6 +570,7 @@ function getOrCreateEventSource(
             // otherwise only reset by session_idle/session_active — so if the final
             // task clears without a follow-up idle, the composer would stay pinned.
             isWaitingBackground: current.isWaitingBackground && backgroundTasks.length > 0,
+            backgroundWaitTasks: (current.backgroundWaitTasks ?? []).filter(t => t.taskId !== data.taskId),
           })
         }
       }
@@ -665,6 +679,7 @@ function getOrCreateEventSource(
           apiRetry: null, // Clear retry state — API call succeeded
           backgroundTasks: current?.backgroundTasks ?? [],
           isWaitingBackground: false,
+          backgroundWaitTasks: [],
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
       }
@@ -691,6 +706,7 @@ function getOrCreateEventSource(
           apiRetry: current?.apiRetry ?? null,
           backgroundTasks: current?.backgroundTasks ?? [],
           isWaitingBackground: current?.isWaitingBackground ?? false,
+          backgroundWaitTasks: current?.backgroundWaitTasks ?? [],
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
       }
@@ -733,6 +749,7 @@ function getOrCreateEventSource(
           apiRetry: current?.apiRetry ?? null,
           backgroundTasks: current?.backgroundTasks ?? [],
           isWaitingBackground: current?.isWaitingBackground ?? false,
+          backgroundWaitTasks: current?.backgroundWaitTasks ?? [],
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
       }
@@ -775,6 +792,7 @@ function getOrCreateEventSource(
           apiRetry: current?.apiRetry ?? null,
           backgroundTasks: current?.backgroundTasks ?? [],
           isWaitingBackground: current?.isWaitingBackground ?? false,
+          backgroundWaitTasks: current?.backgroundWaitTasks ?? [],
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
       }

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -5675,6 +5675,88 @@ describe('MessagePersister', () => {
   // Background Bash task tracking
   // ============================================================================
 
+  // A background subagent spawned by ANOTHER subagent surfaces on the lead
+  // session's stream — its `background_tasks_changed` entry, `task_started` and
+  // terminal signals all arrive unparented (`parent_tool_use_id: null`), keyed
+  // by a `tool_use_id` the lead never issued. Captured live on SDK 0.3.219;
+  // see the frame ordering asserted below (snapshot leads task_started by ~1ms).
+  //
+  // The lead therefore never sees the `async_launched` tool_result that is the
+  // only thing marking a subagent `isBackground`, which is what these cover.
+  describe('nested background subagents', () => {
+    const NESTED = { task_id: 'nested-1', task_type: 'local_agent', description: 'nested probe' }
+    const NESTED_TOOL_USE = 'toolu_nested_unknown_to_lead'
+
+    function launchNested() {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      // The snapshot leads task_started, so the level set already knows this id.
+      mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [NESTED] })
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'task_started',
+        task_id: NESTED.task_id,
+        tool_use_id: NESTED_TOOL_USE,
+        task_type: NESTED.task_type,
+        description: NESTED.description,
+      })
+    }
+
+    it('completes the card when the nested agent finishes', () => {
+      // Without an async_launched ack the subagent stays isBackground:false, so
+      // neither terminal branch fires broadcastSubagentCompleted and the card
+      // started here leaks for the rest of the session.
+      launchNested()
+      expect(sseEvents.filter(e => e.type === 'subagent_started').map(e => e.taskId)).toContain(NESTED.task_id)
+
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+
+      sseEvents.length = 0
+      mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [] })
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: NESTED.task_id,
+        tool_use_id: NESTED_TOOL_USE,
+        status: 'completed',
+        summary: 'Agent "nested probe" finished',
+      })
+
+      const completed = sseEvents.filter(e => e.type === 'subagent_completed')
+      expect(completed.map(e => e.parentToolId)).toContain(NESTED_TOOL_USE)
+    })
+
+    it('names the work the session is waiting on', () => {
+      // The session correctly stays "Working" while a nested agent runs, but the
+      // snapshot's description is dropped on the floor (only ids are kept), so
+      // the UI can say "Working" and nothing more. The wire already carries it.
+      launchNested()
+      sseEvents.length = 0
+
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+
+      const waiting = sseEvents.filter(e => e.type === 'session_waiting_background')
+      expect(waiting).toHaveLength(1)
+      expect(waiting[0].backgroundTaskCount).toBe(1)
+      expect(waiting[0].tasks).toEqual([
+        { taskId: NESTED.task_id, taskType: NESTED.task_type, description: NESTED.description },
+      ])
+    })
+
+    it('drops the metadata when the snapshot drains', () => {
+      launchNested()
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [] })
+      sseEvents.length = 0
+
+      // Settled: nothing to report, and no stale description carried forward.
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
+      expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
+    })
+  })
+
   describe('background Bash task tracking', () => {
     it('detects backgroundTaskId from tool_use_result and broadcasts start event', () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -164,6 +164,10 @@ interface StreamingState {
   // arrives with the following task_started/tool-result) — liveness gates use
   // the UNION of both.
   bgTasksSnapshot: Set<string> | null
+  // What each snapshot id actually is, so a session waiting on background
+  // work can say what it is waiting ON. The SDK sends task_type + description
+  // with every level frame; without keeping them the UI has an id at best.
+  bgTasksMeta: Map<string, { taskType?: string; description?: string }>
   // Identity of the CLI process the background-task bookkeeping above belongs
   // to, from the container's handshake. Those tasks are process-local, so when
   // this changes every id we hold is unretirable and must be dropped.
@@ -456,6 +460,7 @@ class MessagePersister {
       lastApiErrorCode: null,
       activeBackgroundTasks: priorBackgroundTasks,
       bgTasksSnapshot: prior?.bgTasksSnapshot ?? null,
+      bgTasksMeta: prior?.bgTasksMeta ?? new Map(),
       // Carried with the snapshot it describes — the incoming handshake is what
       // decides whether both are still valid.
       processInstanceId: prior?.processInstanceId ?? null,
@@ -1040,6 +1045,7 @@ class MessagePersister {
         lastApiErrorCode: null,
         activeBackgroundTasks: new Map(),
         bgTasksSnapshot: null,
+        bgTasksMeta: new Map(),
         processInstanceId: null,
         pendingDeliverFiles: new Map(),
         stateEventsAuthority: false,
@@ -1690,12 +1696,21 @@ class MessagePersister {
             if (existing) {
               if (agentId) existing.agentId = agentId
             } else {
+              // The snapshot LEADS task_started (captured on 0.3.219: level frame
+              // ~1ms ahead), so if this id is in the level set it IS background
+              // work. That is the only signal available for a NESTED background
+              // subagent — one spawned by another subagent — because the
+              // `async_launched` tool_result that normally sets this flag belongs
+              // to the parent subagent's stream and never reaches the lead. Left
+              // false, neither terminal branch completes the card and it leaks
+              // for the rest of the session.
+              const isBackground = agentId ? state.bgTasksSnapshot?.has(agentId) === true : false
               state.activeSubagents.set(toolUseId, {
                 agentId: agentId ?? null,
                 currentText: '',
                 currentToolUse: null,
                 currentToolInput: '',
-                isBackground: false,
+                isBackground,
               })
             }
             this.broadcastToSSE(sessionId, {
@@ -1860,6 +1875,7 @@ class MessagePersister {
                 this.broadcastToSSE(sessionId, {
                   type: 'session_waiting_background',
                   backgroundTaskCount: openBackgroundWork,
+                  tasks: this.describeOpenBackgroundWork(state),
                 })
               } else {
                 this.finalizeIdle(sessionId, state)
@@ -1898,6 +1914,10 @@ class MessagePersister {
           const snapshot = parseBackgroundTasksChanged(content)
           if (snapshot) {
             state.bgTasksSnapshot = snapshot.taskIds
+            // REPLACE semantics, same as the id set it describes.
+            state.bgTasksMeta = new Map(
+              snapshot.tasks.map((t) => [t.task_id, { taskType: t.task_type, description: t.description }])
+            )
             // Self-heal: a tracked task the SDK no longer lists has finished.
             // Its per-task terminal signal normally follows within a frame and
             // then no-ops (clearBackgroundTask is idempotent) — but if that
@@ -2066,6 +2086,7 @@ class MessagePersister {
             this.broadcastToSSE(sessionId, {
               type: 'session_waiting_background',
               backgroundTaskCount: openBackgroundWork,
+              tasks: this.describeOpenBackgroundWork(state),
             })
           }
         }
@@ -2422,6 +2443,21 @@ class MessagePersister {
       this.clearBackgroundTask(sessionId, state, taskId)
     }
     state.bgTasksSnapshot = null
+    state.bgTasksMeta.clear()
+  }
+
+  // What the session is waiting ON, for the waiting-background indicator. Ids
+  // the level set never described (a lead-launched bash registered only from its
+  // tool_result) still appear, so the count and this list can never disagree.
+  private describeOpenBackgroundWork(
+    state: StreamingState
+  ): Array<{ taskId: string; taskType?: string; description?: string }> {
+    const ids = new Set(state.activeBackgroundTasks.keys())
+    for (const id of state.bgTasksSnapshot ?? []) ids.add(id)
+    return [...ids].map((taskId) => {
+      const meta = state.bgTasksMeta.get(taskId)
+      return { taskId, ...(meta?.taskType && { taskType: meta.taskType }), ...(meta?.description && { description: meta.description }) }
+    })
   }
 
   private clearBackgroundTask(sessionId: string, state: StreamingState, taskId: string): boolean {
@@ -2430,6 +2466,7 @@ class MessagePersister {
     // that removal frame never arrives, the freshest information has to win or
     // the union pins the session. Mirrors SessionSettlementTracker.removeTask.
     state.bgTasksSnapshot?.delete(taskId)
+    state.bgTasksMeta.delete(taskId)
     const info = state.activeBackgroundTasks.get(taskId)
     if (!info) return false
     state.activeBackgroundTasks.delete(taskId)


### PR DESCRIPTION
Follow-up to #598. That PR fixed sessions pinned on "Working" with *nothing* running. This one fixes the opposite complaint from the same investigation: a session correctly working, with no way to tell what on.

## The capture

`session-settlement.ts` asserted that "a subagent's inner tasks never appear" in `background_tasks_changed`. I ran a live probe on SDK 0.3.219 (lead → subagent → background subagent → `sleep 100`) with `SUPERAGENT_CAPTURE_DIR` recording every inbound frame. That claim is **false**:

```
t= 16908  background_tasks_changed [{task_id: a5f6…, task_type: local_agent,
                                     description: "nested probe"}]
t= 16909  task_started  id=a5f6…  tool_use_id=toolu_01CpL9…
t= 19356  result success
t= 19365  session_state_changed idle          ← lead's turn ends, nested still running
t=119368  task_notification bnk5qlzz4 completed
t=120580  background_tasks_changed []
t=120590  task_updated/task_notification a5f6… completed
t=123081  session_state_changed idle
```

The nested task is in the lead's level set, the level frame leads `task_started` by ~1ms, and both arrive unparented (`parent_tool_use_id: null`) keyed by a `tool_use_id` the lead never issued.

Two defects follow, and the SSE output confirms both:

```
t= 16909  subagent_started   parentToolId=toolu_01CpL9…  description="nested probe"
t= 19364  session_waiting_background {backgroundTaskCount: 1}
          … 100 seconds …
t=123081  session_idle
```

A card opens, `session_waiting_background` says only "1", and **no `subagent_completed` ever fires**.

## Defect 1 — the nested card never completes

Both terminal branches are gated on `sub.isBackground`, which is set *only* by the `async_launched` tool_result. That result belongs to the parent subagent's stream, so the lead never sees it and the flag stays false. The card leaks for the rest of the session.

`task_started` now takes the level set as the authority: if the snapshot already lists the id, it is background work. The snapshot leads `task_started`, so it is always populated in time.

## Defect 2 — the work has no name

Subagent rows are built by joining `activeSubagents` against Agent/Task tool calls in *this* transcript (`agent-activity-indicator.tsx:84`). A nested task's `parentToolId` has no such call, so it can never render as a row — structurally, not by omission.

The level frame carries `task_type` and `description`, and the host was discarding them (`state.bgTasksSnapshot = snapshot.taskIds`). Now retained, sent on `session_waiting_background`, and rendered by the activity indicator for anything no other row already covers.

## Also

Corrects the `session-settlement.ts` comment. It was wrong, and the host had relied on it — it is what made me initially misdiagnose one of the two reported incidents.

## Tests (written first, all red before the fix)

| Test | Covers |
|---|---|
| `completes the card when the nested agent finishes` | defect 1 |
| `names the work the session is waiting on` | defect 2, host |
| `drops the metadata when the snapshot drains` | no stale name outliving the work |
| `keeps the named background work the session is waiting on` | hook state + clearing |
| `names background work that has no tool call in this transcript` | renderer |
| `does not repeat work already shown as a subagent row` | no double-listing |

## Live verification

Same probe, after the fix:

```
session_waiting_background {backgroundTaskCount: 1,
  tasks: [{taskId: aa6794e499240ff09, taskType: local_agent, description: "nested probe"}]}
subagent_completed {agentId: aa6794e499240ff09}   t=118274
session_idle                                       t=120361
```

## Validation

- root suite: 8119 passed, 0 failed
- container suite: 775 passed, 0 failed
- `tsc --noEmit` clean on both projects; eslint clean on all changed files

https://claude.ai/code/session_01BRHQshiwhUSM64WNmuswhr