### PR TITLE
Animate truncated session names on hover

### DIFF
--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -70,6 +70,7 @@ import { useUpdateStatus } from '@renderer/context/update-status-context'
 import { useUnreadNotificationCount } from '@renderer/hooks/use-notifications'
 import { usePlatformUnreadCount } from '@renderer/hooks/use-platform-notifications'
 import { useIsOnline } from '@renderer/context/connectivity-context'
+import { HoverScrollText } from '@renderer/components/ui/hover-scroll-text'
 import {
   DndContext,
   closestCenter,
@@ -163,7 +164,13 @@ function SessionSubItem({
             className="flex items-center gap-2 w-full"
             data-testid={`session-item-${session.id}`}
           >
-            <span className="flex-1 min-w-0 truncate text-left">{session.name}</span>
+            <HoverScrollText
+              className="flex-1 text-left"
+              data-testid={`session-name-${session.id}`}
+              hoverTarget="parent"
+            >
+              {session.name}
+            </HoverScrollText>
             {hint !== null ? (
               <CmdHintBadge hint={hint} />
             ) : (

--- a/src/renderer/components/ui/hover-scroll-text.test.tsx
+++ b/src/renderer/components/ui/hover-scroll-text.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  HOVER_SCROLL_DELAY_MS,
+  HoverScrollText,
+} from './hover-scroll-text'
+
+function setTextWidths(viewport: HTMLElement, content: HTMLElement, viewportWidth: number, contentWidth: number) {
+  Object.defineProperty(viewport, 'clientWidth', {
+    configurable: true,
+    value: viewportWidth,
+  })
+  Object.defineProperty(content, 'scrollWidth', {
+    configurable: true,
+    value: contentWidth,
+  })
+}
+
+describe('HoverScrollText', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('waits before scrolling clipped text and resets as soon as hover ends', () => {
+    render(<HoverScrollText data-testid="label">A long session name</HoverScrollText>)
+    const viewport = screen.getByTestId('label')
+    const content = viewport.firstElementChild as HTMLElement
+    setTextWidths(viewport, content, 100, 145)
+
+    fireEvent.mouseEnter(viewport)
+    expect(viewport).toHaveAttribute('data-overflowing', 'true')
+    expect(viewport).toHaveAttribute('data-scrolling', 'false')
+
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS - 1))
+    expect(viewport).toHaveAttribute('data-scrolling', 'false')
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(viewport).toHaveAttribute('data-scrolling', 'true')
+    expect(viewport).toHaveStyle({
+      '--hover-scroll-distance': '45px',
+      '--hover-scroll-duration': '1406ms',
+    })
+
+    fireEvent.mouseLeave(viewport)
+    expect(viewport).toHaveAttribute('data-scrolling', 'false')
+  })
+
+  it('does not animate text that fits', () => {
+    render(<HoverScrollText data-testid="label">Short name</HoverScrollText>)
+    const viewport = screen.getByTestId('label')
+    const content = viewport.firstElementChild as HTMLElement
+    setTextWidths(viewport, content, 120, 80)
+
+    fireEvent.mouseEnter(viewport)
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS))
+
+    expect(viewport).toHaveAttribute('data-overflowing', 'false')
+    expect(viewport).toHaveAttribute('data-scrolling', 'false')
+  })
+
+  it('can use the entire parent row as its hover target', () => {
+    render(
+      <span data-testid="row">
+        <HoverScrollText data-testid="label" hoverTarget="parent">
+          A long session name
+        </HoverScrollText>
+        <span data-testid="status">Status</span>
+      </span>
+    )
+    const row = screen.getByTestId('row')
+    const viewport = screen.getByTestId('label')
+    const content = viewport.firstElementChild as HTMLElement
+    setTextWidths(viewport, content, 100, 145)
+
+    fireEvent.mouseEnter(row)
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS))
+    expect(viewport).toHaveAttribute('data-scrolling', 'true')
+
+    // Moving from the text into another part of the row must not reset it.
+    fireEvent.mouseLeave(viewport)
+    expect(viewport).toHaveAttribute('data-scrolling', 'true')
+
+    fireEvent.mouseLeave(row)
+    expect(viewport).toHaveAttribute('data-scrolling', 'false')
+  })
+
+  it('keeps clipped text still when reduced motion is requested', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    render(<HoverScrollText data-testid="label">A long session name</HoverScrollText>)
+    const viewport = screen.getByTestId('label')
+    const content = viewport.firstElementChild as HTMLElement
+    setTextWidths(viewport, content, 100, 145)
+
+    fireEvent.mouseEnter(viewport)
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS))
+
+    expect(viewport).toHaveAttribute('data-overflowing', 'true')
+    expect(viewport).toHaveAttribute('data-scrolling', 'false')
+  })
+})

--- a/src/renderer/components/ui/hover-scroll-text.tsx
+++ b/src/renderer/components/ui/hover-scroll-text.tsx
@@ -1,0 +1,157 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+} from 'react'
+import { cn } from '@shared/lib/utils/cn'
+
+// A tiny dwell avoids triggering while the pointer merely crosses a row, while
+// still making the interaction feel effectively immediate.
+export const HOVER_SCROLL_DELAY_MS = 120
+export const HOVER_SCROLL_SPEED_PX_PER_SECOND = 32
+
+type HoverScrollStyle = CSSProperties & {
+  '--hover-scroll-distance': string
+  '--hover-scroll-duration': string
+}
+
+type HoverScrollTextProps = HTMLAttributes<HTMLSpanElement> & {
+  hoverTarget?: 'self' | 'parent'
+}
+
+export function HoverScrollText({
+  children,
+  className,
+  hoverTarget = 'self',
+  onMouseEnter,
+  onMouseLeave,
+  style: styleProp,
+  ...props
+}: HoverScrollTextProps) {
+  const viewportRef = useRef<HTMLSpanElement>(null)
+  const contentRef = useRef<HTMLSpanElement>(null)
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isHoveredRef = useRef(false)
+  const [scrollDistance, setScrollDistance] = useState(0)
+  const [isScrolling, setIsScrolling] = useState(false)
+  const [motionAllowed, setMotionAllowed] = useState(() =>
+    typeof window === 'undefined'
+      ? true
+      : !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+
+  const clearHoverTimer = useCallback(() => {
+    if (hoverTimerRef.current !== null) {
+      clearTimeout(hoverTimerRef.current)
+      hoverTimerRef.current = null
+    }
+  }, [])
+
+  const measureOverflow = useCallback(() => {
+    const viewport = viewportRef.current
+    const content = contentRef.current
+    if (!viewport || !content) return 0
+
+    const distance = Math.max(0, Math.ceil(content.scrollWidth - viewport.clientWidth))
+    setScrollDistance(distance)
+    if (distance === 0) {
+      clearHoverTimer()
+      setIsScrolling(false)
+    }
+    return distance
+  }, [clearHoverTimer])
+
+  const stopScrolling = useCallback(() => {
+    isHoveredRef.current = false
+    clearHoverTimer()
+    setIsScrolling(false)
+  }, [clearHoverTimer])
+
+  const startScrolling = useCallback(() => {
+    isHoveredRef.current = true
+    clearHoverTimer()
+
+    const distance = measureOverflow()
+    if (!motionAllowed || distance === 0) return
+
+    hoverTimerRef.current = setTimeout(() => {
+      hoverTimerRef.current = null
+      if (isHoveredRef.current && measureOverflow() > 0) {
+        setIsScrolling(true)
+      }
+    }, HOVER_SCROLL_DELAY_MS)
+  }, [clearHoverTimer, measureOverflow, motionAllowed])
+
+  useLayoutEffect(() => {
+    stopScrolling()
+    measureOverflow()
+  }, [children, measureOverflow, stopScrolling])
+
+  useEffect(() => {
+    const viewport = viewportRef.current
+    if (!viewport || typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(measureOverflow)
+    observer.observe(viewport)
+    return () => observer.disconnect()
+  }, [measureOverflow])
+
+  useEffect(() => {
+    const viewport = viewportRef.current
+    const target = hoverTarget === 'parent' ? viewport?.parentElement : viewport
+    if (!target) return
+
+    target.addEventListener('mouseenter', startScrolling)
+    target.addEventListener('mouseleave', stopScrolling)
+    return () => {
+      target.removeEventListener('mouseenter', startScrolling)
+      target.removeEventListener('mouseleave', stopScrolling)
+    }
+  }, [hoverTarget, startScrolling, stopScrolling])
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const handleMotionPreference = () => {
+      const isAllowed = !mediaQuery.matches
+      setMotionAllowed(isAllowed)
+      if (!isAllowed) stopScrolling()
+    }
+
+    handleMotionPreference()
+    mediaQuery.addEventListener('change', handleMotionPreference)
+    return () => mediaQuery.removeEventListener('change', handleMotionPreference)
+  }, [stopScrolling])
+
+  useEffect(() => () => clearHoverTimer(), [clearHoverTimer])
+
+  const durationMs = Math.max(
+    250,
+    Math.round((scrollDistance / HOVER_SCROLL_SPEED_PX_PER_SECOND) * 1_000)
+  )
+  const style: HoverScrollStyle = {
+    ...styleProp,
+    '--hover-scroll-distance': `${scrollDistance}px`,
+    '--hover-scroll-duration': `${durationMs}ms`,
+  }
+
+  return (
+    <span
+      ref={viewportRef}
+      className={cn('hover-scroll-text block min-w-0 overflow-hidden', className)}
+      data-overflowing={scrollDistance > 0}
+      data-scrolling={isScrolling}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={style}
+      {...props}
+    >
+      <span ref={contentRef} className="hover-scroll-text-content block truncate">
+        {children}
+      </span>
+    </span>
+  )
+}

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -682,6 +682,33 @@ html[data-keyboard-open] [data-composer-footer] {
 }
 
 /*
+  Long sidebar labels stay ellipsized until the user has briefly dwelled on
+  them, then ease into one pass that reveals the hidden end. Removing
+  data-scrolling on mouse leave removes the animation and restores the start
+  immediately, matching native sidebar marquee behavior.
+*/
+@keyframes hover-scroll-text {
+  from { transform: translateX(0); }
+  to { transform: translateX(calc(-1 * var(--hover-scroll-distance))); }
+}
+
+.hover-scroll-text[data-scrolling="true"] .hover-scroll-text-content {
+  width: max-content;
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: nowrap;
+  animation: hover-scroll-text var(--hover-scroll-duration) cubic-bezier(0.42, 0, 0.58, 1) forwards;
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hover-scroll-text[data-scrolling="true"] .hover-scroll-text-content {
+    animation: none;
+  }
+}
+
+/*
   Installed-PWA full height (iOS). `h-screen`/`min-h-svh` resolve to the DYNAMIC viewport
   (100dvh/100svh) so mobile-BROWSER layouts track the URL bar — keep that. But in an
   installed PWA there's no URL bar, and iOS reports dvh/svh EXCLUDING the top safe area


### PR DESCRIPTION
## Summary

- add a reusable overflow-aware hover-scroll text component
- animate truncated sidebar session names after a near-immediate 120 ms dwell
- use a slower symmetric ease-in-out pass and hold the revealed end until mouse-out
- trigger the animation from the entire session row, including padding and status areas
- preserve the existing ellipsis for text that fits and for reduced-motion users

## Why

Long session names are currently ellipsized with no way to reveal the hidden portion in place. The initial implementation also scoped hover detection to the text viewport, so hovering the highlighted row's padding or status area did not start the animation.

This change makes long names readable without changing the sidebar layout and aligns the trigger with the full interactive row users perceive as hovered.

## Validation

- `npm test -- --run src/renderer/components/ui/hover-scroll-text.test.tsx src/renderer/components/layout/app-sidebar.test.tsx` (32 tests passed)
- `npm run typecheck`
- ESLint on the changed TypeScript files
- `npm run build:web`
- live local layout verification with overflow and full-row hover states
