### PR TITLE
Cap the activity card's action list and scroll it in place

### DIFF
--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -156,7 +156,9 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
 
   return (
     <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
-      <div className="rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
+      {/* Capped and scrolled in place: a long action list must not grow the
+          card until it pushes the chat history off screen. */}
+      <div className="max-h-[30vh] overflow-y-auto rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
         {/* Header with pulsing indicator */}
         <div className="flex items-center gap-2">
           <span className="relative flex h-3 w-3">


### PR DESCRIPTION
https://linear.app/datawizz/issue/SUP-484/keep-chat-history-reachable-during-long-agent-activity

## What

The activity card is capped at `30vh` and scrolls.
Two classes on the card the component already renders.

## Why

A long subagent fanout grew the card without bound.
The card pushed the chat history off screen, so you could not scroll back into the conversation.

## Not covered

A pending request card on screen at the same time still takes the transcript.
The capped card, the request card, and the composer together fill the column.
Bounding that needs a floor on the transcript row, which is a separate change.

The status header scrolls with the list rather than staying pinned.
Pinning it costs a sticky header with its own background, which this change deliberately leaves out.

## Verification

Ran a 24-subagent fanout against a mock container at 1280x720.
Before: transcript 0px.
After: transcript 288px, card 214px holding 528px of content, and the footer does not scroll as a unit.
