### PR TITLE
Register resumed subagent settlement fixture

### DIFF
--- a/agent-container/src/session-settlement.test.ts
+++ b/agent-container/src/session-settlement.test.ts
@@ -372,6 +372,7 @@ const FIXTURE_EXPECTATIONS: FixtureExpectation[] = [
   { name: 'sdk206-queued-message-interrupt-receipt', settledAtEnd: true },
   { name: 'sdk206-sequential-different-types', settledAtEnd: true },
   { name: 'sdk206-workflow-probe', settledAtEnd: true },
+  { name: 'sendmessage-resumed-subagent', settledAtEnd: true },
   { name: 'sequential-different-types', settledAtEnd: true },
   { name: 'single-subagent-progress', settledAtEnd: true },
 ];


### PR DESCRIPTION
## Summary

- register the `sendmessage-resumed-subagent` capture in the container settlement replay expectations
- mark the capture as settled because it ends with the final `session_state_changed: idle` event

## Root cause

PR #605 added a real resumed-subagent capture under the shared fixture directory, but the agent-container settlement suite requires every fixture on disk to have an explicit expected outcome. The fixture count increased from 19 to 20 while `FIXTURE_EXPECTATIONS` remained at 19, causing the inventory assertion to fail on both the PR and `main`.

## Impact

Restores the `container-tests` job and ensures the new resumed-subagent capture is included in settlement replay coverage.

## Validation

- `npm test -- src/session-settlement.test.ts` — 66 passed
- `npm test` — 776 passed, 8 skipped
- `npx tsc --noEmit`
- `git diff --check`
