### PR TITLE
perf: byte-scan session transcripts when computing usage

### DIFF
--- a/src/shared/lib/services/usage-service.test.ts
+++ b/src/shared/lib/services/usage-service.test.ts
@@ -541,6 +541,131 @@ describe('usage-service', () => {
     })
   })
 
+  describe('loadDailyUsageData — line splitting', () => {
+    // Transcripts are scanned as raw bytes and only usage-bearing lines are
+    // decoded, so line boundaries have to survive stream chunking without a
+    // string decoder in front of them. The stream reads 64KiB at a time.
+    const CHUNK_SIZE = 64 * 1024
+
+    function usageRow(overrides: { id: string; padding?: string; note?: string }) {
+      return JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-01-01T12:00:00.000Z',
+        padding: overrides.padding,
+        note: overrides.note,
+        message: {
+          id: overrides.id,
+          model: 'claude-sonnet-4-6',
+          usage: { input_tokens: 100, output_tokens: 10 },
+        },
+      })
+    }
+
+    it('reassembles rows that span stream chunk boundaries', async () => {
+      const dir = mkdtempSync(path.join(tmpdir(), 'usage-chunk-spanning-'))
+      const transcript = path.join(dir, 'session.jsonl')
+      // Each row is wider than a chunk, so every row is reassembled from
+      // several chunks and no boundary lands on a newline.
+      const rows = ['a', 'b', 'c'].map((id) =>
+        usageRow({ id, padding: 'x'.repeat(CHUNK_SIZE + 137) }),
+      )
+      writeFileSync(transcript, `${rows.join('\n')}\n`)
+
+      try {
+        await expect(loadSessionUsageTotals({ sessionPath: transcript })).resolves.toEqual({
+          totalCost: 0.00135,
+          totalTokens: 330,
+          priceMissing: false,
+          usageIncomplete: false,
+        })
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('decodes multi-byte characters split across a chunk boundary', async () => {
+      const dir = mkdtempSync(path.join(tmpdir(), 'usage-multibyte-'))
+      const transcript = path.join(dir, 'session.jsonl')
+      // "€" is three bytes; pad so its bytes straddle the 64KiB read boundary.
+      const note = '€ mid-boundary'
+      const buildRow = (paddingWidth: number) =>
+        usageRow({ id: 'multibyte', padding: 'x'.repeat(paddingWidth), note })
+      // Everything ahead of the note is ASCII, so one measurement is enough to
+      // solve for the padding that puts the first "€" byte at CHUNK_SIZE - 1.
+      const probe = buildRow(0)
+      const row = buildRow(CHUNK_SIZE - 1 - probe.indexOf(note))
+      expect(Buffer.from(row, 'utf-8').indexOf(Buffer.from(note, 'utf-8'))).toBe(CHUNK_SIZE - 1)
+      writeFileSync(transcript, `${row}\n`)
+
+      try {
+        await expect(loadSessionUsageTotals({ sessionPath: transcript })).resolves.toEqual({
+          totalCost: 0.00045,
+          totalTokens: 110,
+          priceMissing: false,
+          usageIncomplete: false,
+        })
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('counts a final row written without a trailing newline', async () => {
+      const dir = mkdtempSync(path.join(tmpdir(), 'usage-no-trailing-newline-'))
+      const transcript = path.join(dir, 'session.jsonl')
+      writeFileSync(transcript, usageRow({ id: 'last' }))
+
+      try {
+        await expect(loadSessionUsageTotals({ sessionPath: transcript })).resolves.toEqual({
+          totalCost: 0.00045,
+          totalTokens: 110,
+          priceMissing: false,
+          usageIncomplete: false,
+        })
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('skips blank and CRLF-terminated separator lines without flagging the load', async () => {
+      const dir = mkdtempSync(path.join(tmpdir(), 'usage-blank-lines-'))
+      const transcript = path.join(dir, 'session.jsonl')
+      writeFileSync(transcript, `\n   \n${usageRow({ id: 'crlf' })}\r\n\r\n`)
+
+      try {
+        await expect(loadSessionUsageTotals({ sessionPath: transcript })).resolves.toEqual({
+          totalCost: 0.00045,
+          totalTokens: 110,
+          priceMissing: false,
+          usageIncomplete: false,
+        })
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('ignores rows whose only "_tokens" match sits outside message.usage', async () => {
+      const dir = mkdtempSync(path.join(tmpdir(), 'usage-marker-decoy-'))
+      const transcript = path.join(dir, 'session.jsonl')
+      const decoy = JSON.stringify({
+        type: 'user',
+        timestamp: '2026-01-01T12:00:00.000Z',
+        message: { content: 'reported "input_tokens" in the logs' },
+      })
+      writeFileSync(transcript, `${decoy}\n${usageRow({ id: 'real' })}\n`)
+
+      try {
+        await expect(loadSessionUsageTotals({ sessionPath: transcript })).resolves.toEqual({
+          totalCost: 0.00045,
+          totalTokens: 110,
+          priceMissing: false,
+          usageIncomplete: false,
+        })
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  })
+
   describe('loadDailyUsageData — costUSD field', () => {
     it('uses costUSD from entries when available', async () => {
       const claudePath = getClaudePath('bedrock-agent')

--- a/src/shared/lib/services/usage-service.ts
+++ b/src/shared/lib/services/usage-service.ts
@@ -348,6 +348,17 @@ function isMissingPathError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT'
 }
 
+const NEWLINE_BYTE = 0x0a
+const OPEN_BRACE_BYTE = 0x7b
+const CLOSE_BRACE_BYTE = 0x7d
+// Every `"…_tokens"` key processLine screens for ends in this sequence, so a
+// line without it can be skipped without decoding.
+const USAGE_MARKER = Buffer.from('_tokens"')
+
+function isAsciiWhitespaceByte(byte: number): boolean {
+  return byte === 0x20 || (byte >= 0x09 && byte <= 0x0d)
+}
+
 /**
  * Lightweight replacement for ccusage's loadDailyUsageData.
  * - Pre-filters files by mtime when `since` is set
@@ -508,22 +519,35 @@ export async function loadDailyUsageData(
         let fh: fs.promises.FileHandle | null = null
         try {
           fh = await fs.promises.open(file, 'r')
-          const stream = fh.createReadStream({ encoding: 'utf-8' })
-          let buffer = ''
+          const stream = fh.createReadStream()
+          // Split on newlines in the raw bytes and decode only the lines that
+          // could carry usage. Transcripts are dominated by large tool-result
+          // rows; decoding every byte to a JS string costs multiples of the
+          // actual work and is the bulk of the wall-clock on big sessions.
+          let pending: Buffer[] = []
 
           for await (const chunk of stream) {
-            buffer += chunk
-            const lines = buffer.split('\n')
-            // Keep last (potentially incomplete) line in buffer
-            buffer = lines.pop() || ''
-
-            for (const line of lines) {
-              processLine(line, countedByKey, unkeyedUsages, sinceDate)
+            let start = 0
+            let idx = chunk.indexOf(NEWLINE_BYTE)
+            while (idx !== -1) {
+              let line: Buffer
+              if (pending.length > 0) {
+                pending.push(chunk.subarray(start, idx))
+                line = Buffer.concat(pending)
+                pending = []
+              } else {
+                line = chunk.subarray(start, idx)
+              }
+              processLineBytes(line, countedByKey, unkeyedUsages, sinceDate)
+              start = idx + 1
+              idx = chunk.indexOf(NEWLINE_BYTE, start)
             }
+            // Keep the trailing (potentially incomplete) line for the next chunk
+            if (start < chunk.length) pending.push(chunk.subarray(start))
           }
           // Process any remaining content
-          if (buffer.trim()) {
-            processLine(buffer, countedByKey, unkeyedUsages, sinceDate)
+          if (pending.length > 0) {
+            processLineBytes(Buffer.concat(pending), countedByKey, unkeyedUsages, sinceDate)
           }
         } catch {
           // Skip unreadable files
@@ -534,6 +558,38 @@ export async function loadDailyUsageData(
       })
     )
   )
+
+  /**
+   * Byte-level gate in front of {@link processLine}: a line is decoded only
+   * when it survives the same emptiness/shape/token checks the string path
+   * applies, so behaviour is unchanged and non-usage rows are never decoded.
+   */
+  function processLineBytes(
+    line: Buffer,
+    countedEntries: Map<string, CountedUsage>,
+    unkeyedEntries: CountedUsage[],
+    sinceDateFilter: Date | null,
+  ) {
+    // Only ASCII whitespace is trimmed here; every such byte is < 0x80, so this
+    // can never slice a multi-byte UTF-8 sequence.
+    let start = 0
+    let end = line.length
+    while (start < end && isAsciiWhitespaceByte(line[start])) start++
+    while (end > start && isAsciiWhitespaceByte(line[end - 1])) end--
+    if (start === end) return
+
+    // Malformed rows are rare and must go through the string path so the
+    // incomplete-load reporting stays identical.
+    if (line[start] !== OPEN_BRACE_BYTE || line[end - 1] !== CLOSE_BRACE_BYTE) {
+      processLine(line.toString('utf-8'), countedEntries, unkeyedEntries, sinceDateFilter)
+      return
+    }
+
+    // Superset of the four `"…_tokens"` keys processLine looks for.
+    if (!line.includes(USAGE_MARKER, start)) return
+
+    processLine(line.toString('utf-8'), countedEntries, unkeyedEntries, sinceDateFilter)
+  }
 
   function processLine(
     line: string,


### PR DESCRIPTION
## Problem

Right-clicking a large session to view its cost took ~5 seconds.

`loadDailyUsageData` reads the session's primary transcript plus every nested subagent/workflow transcript. On a real session in my prod install that is **151 files / 936 MB**. It opened each one with `createReadStream({ encoding: 'utf-8' })`, so every byte was decoded into JS strings (~1.9 GB of UTF-16) and `.split('\n')`-ed *before* the cheap `"…_tokens"` substring prefilter got a chance to reject the line.

Measured on that session:

| | |
|---|---|
| total bytes read | 935.7 MB |
| bytes on usage-bearing lines | **24.7 MB** (2.6%) |
| newline scan + decode + `JSON.parse` of that 2.6% | ~140 ms |
| everything else | ~4.5 s of wasted decode |

## Fix

Split lines on raw `Buffer`s and decode a line only once it passes byte-level checks: non-empty, `{`…`}` shape, and a `_tokens"` byte search — a strict superset of the four keys `processLine` screens for. Malformed rows still fall through to the string path, so the "usage may be incomplete" reporting is unchanged.

Only ASCII whitespace is trimmed at the byte level; every such byte is `< 0x80`, so it can never slice a multi-byte UTF-8 sequence.

## Result

Same output both ways, on the real session:

```
old: 5187 / 5290 / 5402 ms   {"totalCost":650.685192,"totalTokens":297119259,…}
new:  388 /  330 /  347 ms   {"totalCost":650.685192,"totalTokens":297119259,…}
peak RSS: 467 MB -> 376 MB
```

`/api/usage` (the dashboard chart) shares this loader and gets the same speedup.

## Tests

New `loadDailyUsageData — line splitting` block: rows spanning stream chunks, a multi-byte `€` straddling the 64 KiB read boundary (the test asserts the byte offset so it can't silently stop straddling), a final row with no trailing newline, CRLF/blank separator lines, and a decoy `"input_tokens"` inside message text.

Mutation-checked: breaking cross-chunk reassembly fails 3 of the new tests and **zero** of the 94 pre-existing ones — this path had no coverage before.

`npx tsc --noEmit` and eslint clean; 97 usage-service + 41 route/renderer tests pass.

## Not included

A per-file `(size, mtimeMs)` result cache would make repeat opens near-instant, since subagent transcripts are frozen once written and only the primary `<id>.jsonl` grows. Left out deliberately — it costs memory and invalidation risk, and 0.35 s seemed like enough. Easy follow-up if we want it.

https://claude.ai/code/session_01SgyFgE4NbFbX1Wp68H13Dy