### PR TITLE
perf: stream and bound workflow transcript reads

### DIFF
--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -705,6 +705,87 @@ describe('streamJsonlFile', () => {
     }
 
     expect(results).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  // Lines are split in the raw bytes, so chunk boundaries are the interesting
+  // failure surface: the stream reads 64KiB at a time and transcript rows are
+  // routinely wider than that.
+  const CHUNK_SIZE = 64 * 1024
+
+  it('reassembles rows wider than a read chunk', async () => {
+    const filePath = path.join(testDir, 'wide.jsonl')
+    const rows = [0, 1, 2].map((id) =>
+      JSON.stringify({ id, padding: 'x'.repeat(CHUNK_SIZE + 137) })
+    )
+    await fs.promises.writeFile(filePath, `${rows.join('\n')}\n`)
+
+    const results: { id: number; padding: string }[] = []
+    for await (const item of streamJsonlFile<{ id: number; padding: string }>(filePath)) {
+      results.push(item)
+    }
+
+    expect(results.map((r) => r.id)).toEqual([0, 1, 2])
+    expect(results.every((r) => r.padding.length === CHUNK_SIZE + 137)).toBe(true)
+  })
+
+  it('decodes a multi-byte character split across a chunk boundary', async () => {
+    const filePath = path.join(testDir, 'multibyte.jsonl')
+    // "€" is three bytes. Everything ahead of it is ASCII, so one measurement
+    // solves for the padding that lands its first byte at CHUNK_SIZE - 1.
+    const note = '€ mid-boundary'
+    const build = (width: number) => JSON.stringify({ padding: 'x'.repeat(width), note })
+    const row = build(CHUNK_SIZE - 1 - build(0).indexOf(note))
+    expect(Buffer.from(row, 'utf-8').indexOf(Buffer.from(note, 'utf-8'))).toBe(CHUNK_SIZE - 1)
+    await fs.promises.writeFile(filePath, `${row}\n`)
+
+    const results: { note: string }[] = []
+    for await (const item of streamJsonlFile<{ note: string }>(filePath)) {
+      results.push(item)
+    }
+
+    expect(results).toHaveLength(1)
+    expect(results[0].note).toBe(note)
+  })
+
+  it('skips blank lines and tolerates CRLF endings', async () => {
+    const filePath = path.join(testDir, 'crlf.jsonl')
+    await fs.promises.writeFile(filePath, '\r\n{"id": 1}\r\n   \r\n{"id": 2}\r\n')
+
+    const results: { id: number }[] = []
+    for await (const item of streamJsonlFile<{ id: number }>(filePath)) {
+      results.push(item)
+    }
+
+    expect(results).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('closes the file handle when the consumer stops early', async () => {
+    const filePath = path.join(testDir, 'early-break.jsonl')
+    await fs.promises.writeFile(filePath, '{"id": 1}\n{"id": 2}\n{"id": 3}\n')
+
+    let closed = false
+    const realOpen = fs.promises.open
+    const openSpy = vi.spyOn(fs.promises, 'open').mockImplementation(async (...args) => {
+      const handle = await (realOpen as typeof fs.promises.open)(
+        ...(args as Parameters<typeof fs.promises.open>)
+      )
+      const realClose = handle.close.bind(handle)
+      handle.close = async () => {
+        closed = true
+        return realClose()
+      }
+      return handle
+    })
+
+    try {
+      for await (const item of streamJsonlFile<{ id: number }>(filePath)) {
+        expect(item).toEqual({ id: 1 })
+        break // abandon the iterator mid-file
+      }
+      expect(closed).toBe(true)
+    } finally {
+      openSpy.mockRestore()
+    }
   })
 })
 

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -354,47 +354,72 @@ export async function readJsonlFile<T = unknown>(filePath: string): Promise<T[]>
   return parseJsonl<T>(content)
 }
 
+const NEWLINE_BYTE = 0x0a
+
 /**
  * Stream-read JSONL file line by line (for large files)
  * Yields parsed objects one at a time
+ *
+ * Lines are split in the raw bytes rather than through a string decoder: agent
+ * transcripts are dominated by very large tool-result rows, and materializing a
+ * whole file (or even a whole chunk-spanning row twice) costs several times the
+ * file size in peak memory. Only ASCII whitespace is trimmed at the byte level,
+ * and every such byte is < 0x80, so a multi-byte UTF-8 sequence is never split.
  */
 export async function* streamJsonlFile<T = unknown>(
   filePath: string
 ): AsyncIterable<T> {
   const fileHandle = await fs.promises.open(filePath, 'r')
-  const stream = fileHandle.createReadStream({ encoding: 'utf-8' })
+  try {
+    const stream = fileHandle.createReadStream()
+    // Chunks holding the trailing, not-yet-terminated line. Concatenated only
+    // once its newline arrives, so a row spanning many chunks is joined once.
+    let pending: Buffer[] = []
 
-  let buffer = ''
-
-  for await (const chunk of stream) {
-    buffer += chunk
-    const lines = buffer.split(/\r?\n/)
-
-    // Keep the last potentially incomplete line in buffer
-    buffer = lines.pop() || ''
-
-    for (const line of lines) {
-      const trimmed = line.trim()
-      if (!trimmed) continue
-
-      try {
-        yield JSON.parse(trimmed) as T
-      } catch {
-        // Skip malformed lines
+    for await (const chunk of stream) {
+      let start = 0
+      let idx = chunk.indexOf(NEWLINE_BYTE)
+      while (idx !== -1) {
+        let line: Buffer
+        if (pending.length > 0) {
+          pending.push(chunk.subarray(start, idx))
+          line = Buffer.concat(pending)
+          pending = []
+        } else {
+          line = chunk.subarray(start, idx)
+        }
+        const parsed = parseJsonlLine<T>(line)
+        if (parsed !== undefined) yield parsed
+        start = idx + 1
+        idx = chunk.indexOf(NEWLINE_BYTE, start)
       }
+      if (start < chunk.length) pending.push(chunk.subarray(start))
     }
-  }
 
-  // Process any remaining content in buffer
-  if (buffer.trim()) {
-    try {
-      yield JSON.parse(buffer.trim()) as T
-    } catch {
-      // Skip malformed line
+    // Process any remaining content (file not terminated by a newline)
+    if (pending.length > 0) {
+      const parsed = parseJsonlLine<T>(Buffer.concat(pending))
+      if (parsed !== undefined) yield parsed
     }
+  } finally {
+    // Runs on early `break` from the consumer's for-await too, which the
+    // previous trailing close() silently skipped — leaking the descriptor.
+    await fileHandle.close()
   }
+}
 
-  await fileHandle.close()
+/**
+ * Decode and parse one JSONL line. Returns undefined for blank and malformed
+ * lines (common while the SDK is mid-write), which callers skip.
+ */
+function parseJsonlLine<T>(line: Buffer): T | undefined {
+  const trimmed = line.toString('utf-8').trim()
+  if (!trimmed) return undefined
+  try {
+    return JSON.parse(trimmed) as T
+  } catch {
+    return undefined
+  }
 }
 
 // ============================================================================

--- a/src/shared/lib/workflows/workflow-tree.test.ts
+++ b/src/shared/lib/workflows/workflow-tree.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-template-curly-in-string -- these strings embed workflow-script SOURCE (literal `${expr}`), not interpolation */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import * as path from 'path'
 import * as os from 'os'
 import { promises as fs } from 'fs'
@@ -363,5 +363,61 @@ describe('buildWorkflowTree — synthetic edge cases', () => {
     })
     const tree = await buildWorkflowTree({ sessionsDir: root, sessionId: 's1', runId: 'wf_test' })
     expect(tree!.agents[0]).toMatchObject({ status: 'done', result: 'all good' })
+  })
+})
+
+describe('buildWorkflowTree — transcript reads stay bounded', () => {
+  /**
+   * Open one agent transcript per handle and never more than the cap at a time.
+   * Peak memory tracks the number of transcripts in flight, so a wide run
+   * (hundreds of agents, each tens of MB) is only safe while this holds.
+   */
+  it('never holds more than 10 agent transcripts open at once', async () => {
+    const AGENT_COUNT = 40
+    const agentIds = Array.from({ length: AGENT_COUNT }, (_, i) => `c${i}`)
+    const root = await scaffold({
+      script: "export const meta = { name: 'wide', description: 'd', phases: [] }\nawait agent('work', {})",
+      journal: agentIds.map((agentId, i) => ({ type: 'started', key: `v2:${i}`, agentId })),
+      agents: agentIds.map((agentId) => ({
+        agentId,
+        firstPrompt: 'work',
+        // Multi-chunk transcripts, so a read is still in flight when its
+        // siblings start — a cap that only holds for tiny files proves nothing.
+        extraLines: [{ type: 'assistant', agentId, message: { role: 'assistant', content: [{ type: 'text', text: 'x'.repeat(200_000) }] } }],
+      })),
+    })
+
+    let open = 0
+    let maxOpen = 0
+    const realOpen = fs.open
+    const openSpy = vi.spyOn(fs, 'open').mockImplementation(async (...args) => {
+      const handle = await (realOpen as typeof fs.open)(...(args as Parameters<typeof fs.open>))
+      open++
+      maxOpen = Math.max(maxOpen, open)
+      const realClose = handle.close.bind(handle)
+      // The read stream closes the handle too, so close() lands twice per
+      // handle — only the first one releases it.
+      let released = false
+      handle.close = async () => {
+        if (!released) {
+          released = true
+          open--
+        }
+        return realClose()
+      }
+      return handle
+    })
+
+    try {
+      const tree = await buildWorkflowTree({ sessionsDir: root, sessionId: 's1', runId: 'wf_test' })
+      expect(tree!.agents).toHaveLength(AGENT_COUNT)
+      // Sanity: the transcripts really were read concurrently, so the cap is
+      // what bounds this rather than the reads happening to serialize.
+      expect(maxOpen).toBeGreaterThan(1)
+      expect(maxOpen).toBeLessThanOrEqual(10)
+      expect(open).toBe(0) // every handle closed
+    } finally {
+      openSpy.mockRestore()
+    }
   })
 })

--- a/src/shared/lib/workflows/workflow-tree.ts
+++ b/src/shared/lib/workflows/workflow-tree.ts
@@ -1,6 +1,8 @@
 import * as path from 'path'
 import { promises as fs } from 'fs'
+import pLimit from 'p-limit'
 import { isPathWithinDir } from '../utils/path-safety'
+import { streamJsonlFile } from '../utils/file-storage'
 import { parseWorkflowScript } from './workflow-script-parser'
 import {
   JournalLineSchema,
@@ -14,6 +16,13 @@ import {
 // The join produces the structural fields; per-agent transcript stats (prompt,
 // toolCount, tokens, durationMs) are layered on afterwards from readAgentStats.
 type JoinedAgent = Omit<WorkflowAgentNode, 'prompt' | 'toolCount' | 'tokens' | 'durationMs'>
+
+/**
+ * How many agent transcripts readAgentStats has open concurrently. Peak memory
+ * is roughly this times the largest transcript, so it bounds the drawer's cost
+ * on a run with hundreds of agents instead of scaling with the run.
+ */
+const AGENT_STATS_CONCURRENCY = 10
 
 /**
  * Reconstruct a workflow's per-agent tree from its on-disk artifacts and join each
@@ -77,10 +86,15 @@ export async function buildWorkflowTree(opts: {
   const invocation = await findWorkflowInvocation(sessionsDir, sessionId, runId)
   const script = await loadScript(sessionsDir, sessionId, runId, invocation.scriptHostPath)
   const stats = new Map<string, AgentStats>()
+  // A wide run has hundreds of agent transcripts and they are individually
+  // large; reading them all at once puts the whole run dir in memory at peak.
+  const statsLimit = pLimit(AGENT_STATS_CONCURRENCY)
   await Promise.all(
-    startedOrder.map(async (agentId) => {
-      stats.set(agentId, await readAgentStats(path.join(runDir, `agent-${agentId}.jsonl`)))
-    })
+    startedOrder.map((agentId) =>
+      statsLimit(async () => {
+        stats.set(agentId, await readAgentStats(path.join(runDir, `agent-${agentId}.jsonl`)))
+      })
+    )
   )
 
   const firstPrompts = new Map([...stats].map(([id, s]) => [id, s.firstPrompt]))
@@ -262,42 +276,37 @@ async function findWorkflowInvocation(
   runId: string
 ): Promise<WorkflowInvocation> {
   const none: WorkflowInvocation = { scriptHostPath: null, args: undefined }
-  let raw: string
-  try {
-    raw = await fs.readFile(path.join(sessionsDir, `${sessionId}.jsonl`), 'utf8')
-  } catch {
-    return none
-  }
   // sessionsDir = <workspace>/.claude/projects/-workspace
   const workspaceDir = path.resolve(sessionsDir, '..', '..', '..')
 
   const inputsByToolUseId = new Map<string, Record<string, unknown>>()
   let resultText: string | null = null
   let resultToolUseId: string | null = null
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    let entry: { message?: { content?: unknown } }
-    try {
-      entry = JSON.parse(trimmed)
-    } catch {
-      continue
-    }
-    const content = entry.message?.content
-    if (!Array.isArray(content)) continue
-    for (const block of content as Array<Record<string, unknown>>) {
-      if (block?.type === 'tool_use' && block.name === 'Workflow' && typeof block.id === 'string') {
-        const input = block.input
-        inputsByToolUseId.set(block.id, input !== null && typeof input === 'object' ? (input as Record<string, unknown>) : {})
-      }
-      if (resultText === null && block?.type === 'tool_result') {
-        const text = messageText(block.content)
-        if (text.includes(runId)) {
-          resultText = text
-          resultToolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : null
+  try {
+    // The parent transcript is the largest file this module touches; stream it
+    // rather than holding it whole to pull one tool_use/tool_result pair out.
+    const lines = streamJsonlFile<{ message?: { content?: unknown } }>(
+      path.join(sessionsDir, `${sessionId}.jsonl`)
+    )
+    for await (const entry of lines) {
+      const content = entry.message?.content
+      if (!Array.isArray(content)) continue
+      for (const block of content as Array<Record<string, unknown>>) {
+        if (block?.type === 'tool_use' && block.name === 'Workflow' && typeof block.id === 'string') {
+          const input = block.input
+          inputsByToolUseId.set(block.id, input !== null && typeof input === 'object' ? (input as Record<string, unknown>) : {})
+        }
+        if (resultText === null && block?.type === 'tool_result') {
+          const text = messageText(block.content)
+          if (text.includes(runId)) {
+            resultText = text
+            resultToolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : null
+          }
         }
       }
     }
+  } catch {
+    return none
   }
   if (resultText === null) return none
 
@@ -351,58 +360,51 @@ async function readAgentStats(filePath: string): Promise<AgentStats> {
     lastTs: null,
     trailingError: null,
   }
-  let raw: string
-  try {
-    raw = await fs.readFile(filePath, 'utf8')
-  } catch {
-    return empty
-  }
   let firstPrompt = ''
   let toolCount = 0
   let tokens = 0
   let firstTs: number | null = null
   let lastTs: number | null = null
   let trailingError: string | null = null
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    let entry: {
+  try {
+    // Streamed, not read whole: a single agent transcript can be tens of MB and
+    // a wide run holds AGENT_STATS_CONCURRENCY of them open at once.
+    const lines = streamJsonlFile<{
       type?: string
       timestamp?: string
       error?: unknown
       errorDetails?: unknown
       message?: { content?: unknown; usage?: { output_tokens?: number } }
-    }
-    try {
-      entry = JSON.parse(trimmed)
-    } catch {
-      continue
-    }
-    // Track the error marker of the LAST entry only: a mid-transcript error the
-    // agent recovered from must not read as failure, so any later entry clears it.
-    trailingError =
-      typeof entry.error === 'string'
-        ? typeof entry.errorDetails === 'string'
-          ? entry.errorDetails
-          : entry.error
-        : null
-    if (typeof entry.timestamp === 'string') {
-      const t = Date.parse(entry.timestamp)
-      if (!Number.isNaN(t)) {
-        if (firstTs == null) firstTs = t
-        lastTs = t
+    }>(filePath)
+    for await (const entry of lines) {
+      // Track the error marker of the LAST entry only: a mid-transcript error the
+      // agent recovered from must not read as failure, so any later entry clears it.
+      trailingError =
+        typeof entry.error === 'string'
+          ? typeof entry.errorDetails === 'string'
+            ? entry.errorDetails
+            : entry.error
+          : null
+      if (typeof entry.timestamp === 'string') {
+        const t = Date.parse(entry.timestamp)
+        if (!Number.isNaN(t)) {
+          if (firstTs == null) firstTs = t
+          lastTs = t
+        }
+      }
+      if (entry.type === 'user' && !firstPrompt) {
+        firstPrompt = messageText(entry.message?.content)
+      }
+      if (entry.type === 'assistant') {
+        const content = entry.message?.content
+        if (Array.isArray(content)) {
+          toolCount += content.filter((b) => (b as { type?: string })?.type === 'tool_use').length
+        }
+        tokens += entry.message?.usage?.output_tokens ?? 0
       }
     }
-    if (entry.type === 'user' && !firstPrompt) {
-      firstPrompt = messageText(entry.message?.content)
-    }
-    if (entry.type === 'assistant') {
-      const content = entry.message?.content
-      if (Array.isArray(content)) {
-        toolCount += content.filter((b) => (b as { type?: string })?.type === 'tool_use').length
-      }
-      tokens += entry.message?.usage?.output_tokens ?? 0
-    }
+  } catch {
+    return empty
   }
   return { firstPrompt, toolCount, tokens, firstTs, lastTs, trailingError }
 }


### PR DESCRIPTION
## Problem

`buildWorkflowTree` (the workflow drawer) reads every `agent-*.jsonl` in a run dir through an **unbounded** `Promise.all`, each one via `fs.readFile(…, 'utf8')` — the whole file as a single string. `readAgentStats` then splits and parses it.

Peak memory is therefore `run size × ~2` (UTF-16), all resident at once, in the **main process**, and it scales linearly with the run with no cap.

On a real run in my install (`wf_a3b27b5a-117`, 126 transcripts / 287 MB):

```
buildWorkflowTree:  870 ms,  peak RSS 890 MB
```

`findWorkflowInvocation` has the same shape — it slurps the entire parent session transcript (107 MB on my largest session) to pull out a single `Workflow` tool_use/tool_result pair.

## Fix

- `streamJsonlFile` (already in `file-storage.ts`, previously unused in prod) now splits lines in the **raw bytes** and decodes one line at a time, instead of putting a string decoder in front of the whole file. Only ASCII whitespace is trimmed at the byte level, and every such byte is `< 0x80`, so a multi-byte UTF-8 sequence is never split.
- `readAgentStats` and `findWorkflowInvocation` consume it instead of `readFile`.
- The agent-transcript fan-out is capped at 10 concurrent reads (`AGENT_STATS_CONCURRENCY`), so peak memory is bounded by the cap rather than by the run.

Also fixes a latent handle leak in `streamJsonlFile`: `close()` was a trailing statement, so an early `break` from the consumer's `for await` (or a stream error) skipped it. It's now in a `finally`.

## Result

Measured across **all six** real workflow runs on this machine, old vs new, comparing the full serialized tree:

```
             OLD                     NEW
wf_a3b27b5a  870ms  peak 890MB   →   382ms  peak 219MB     (126 transcripts, 287MB)
wf_27a3371b   32ms                    30ms                 (144 transcripts)
wf_b10b5cb5   15ms                    18ms                 (122 transcripts)
wf_75967893   20ms                    14ms
wf_ca1d178b    1ms                     2ms
wf_851b42bc    1ms                     2ms

diff old-trees.json new-trees.json  →  IDENTICAL
```

## Tests

**`file-storage.test.ts`** — `streamJsonlFile` gains: rows wider than a read chunk, a multi-byte `€` straddling the 64 KiB boundary (the test asserts the byte offset, so it can't silently stop straddling), CRLF/blank lines, and handle-closed-on-early-`break`.

**`workflow-tree.test.ts`** — a 40-agent synthetic run with multi-chunk transcripts asserts that no more than 10 handles are ever open at once, that reads really did overlap (`maxOpen > 1`, so the cap is what bounds it rather than accidental serialization), and that every handle is released.

Mutation-checked, each independently:
- removing the `pLimit` cap → the concurrency test fails
- dropping cross-chunk reassembly → 5 `streamJsonlFile` tests fail
- the early-`break` test fails against the pre-existing `streamJsonlFile` on `main`

Full unit suite green (8149 passed), `tsc --noEmit` and eslint clean.

https://claude.ai/code/session_01SgyFgE4NbFbX1Wp68H13Dy