### PR TITLE
perf: summarize session transcripts instead of parsing them whole

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -258,6 +258,7 @@ vi.mock('@shared/lib/services/session-service', () => ({
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),
+  sessionIsKnown: vi.fn().mockResolvedValue(true),
   isSessionRegistered: vi.fn().mockResolvedValue(false),
   updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(),
@@ -460,7 +461,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, isSessionRegistered, deleteSession, getSession, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -5227,5 +5228,63 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
     const res = await getReq(app, `${NOTABLE_URL}&limit=zero`)
     const body = await res.json()
     expect(body).toHaveLength(25)
+  })
+})
+
+describe('session existence guards read metadata, not the transcript', () => {
+  let app: ReturnType<typeof createApp>
+
+  const SESSION_INFO = {
+    id: 'sess-1',
+    agentSlug: 'test-agent',
+    name: 'Renamed',
+    createdAt: new Date('2026-03-01T10:00:00.000Z'),
+    lastActivityAt: new Date('2026-03-01T10:05:00.000Z'),
+    messageCount: 7,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    vi.mocked(sessionIsKnown).mockResolvedValue(true)
+    vi.mocked(getSession).mockResolvedValue(SESSION_INFO)
+  })
+
+  it('renames a session with a single transcript read', async () => {
+    const res = await patchJson(app, '/api/agents/test-agent/sessions/sess-1', { name: 'Renamed' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ id: 'sess-1', name: 'Renamed', messageCount: 7 })
+    expect(updateSessionName).toHaveBeenCalledWith('test-agent', 'sess-1', 'Renamed')
+    // Was two full passes over the transcript — one on each side of the rename.
+    expect(getSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('404s a rename for an unknown session without writing metadata', async () => {
+    vi.mocked(sessionIsKnown).mockResolvedValue(false)
+
+    const res = await patchJson(app, '/api/agents/test-agent/sessions/ghost', { name: 'Nope' })
+
+    expect(res.status).toBe(404)
+    // The guard has to run BEFORE the rename: updateSessionName would otherwise
+    // register metadata for a session that does not exist.
+    expect(updateSessionName).not.toHaveBeenCalled()
+    expect(getSession).not.toHaveBeenCalled()
+  })
+
+  it('guards computer-use revoke without reading the transcript', async () => {
+    const res = await postJson(app, '/api/agents/test-agent/sessions/sess-1/computer-use/revoke', {})
+
+    expect(res.status).not.toBe(404)
+    expect(sessionIsKnown).toHaveBeenCalledWith('test-agent', 'sess-1')
+    expect(getSession).not.toHaveBeenCalled()
+  })
+
+  it('404s computer-use revoke for an unknown session', async () => {
+    vi.mocked(sessionIsKnown).mockResolvedValue(false)
+
+    const res = await postJson(app, '/api/agents/test-agent/sessions/ghost/computer-use/revoke', {})
+
+    expect(res.status).toBe(404)
   })
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -49,6 +49,7 @@ import {
   getSession,
   getSessionMetadata,
   sessionExists,
+  sessionIsKnown,
   isSessionRegistered,
   updateSessionMetadata,
   deleteSession,
@@ -2102,9 +2103,9 @@ agents.patch('/:id/sessions/:sessionId', AgentUser(), async (c) => {
     const { name } = body
 
 
-    const session = await getSession(agentSlug, sessionId)
-
-    if (!session) {
+    // Guard before renaming so an unknown session never gets metadata written
+    // for it — the rename below would otherwise register one.
+    if (!(await sessionIsKnown(agentSlug, sessionId))) {
       return c.json({ error: 'Session not found' }, 404)
     }
 
@@ -2112,15 +2113,22 @@ agents.patch('/:id/sessions/:sessionId', AgentUser(), async (c) => {
       await updateSessionName(agentSlug, sessionId, name.trim())
     }
 
+    // Read the transcript once, after the rename, rather than on both sides of
+    // it: renaming touches metadata only, so the pre-rename read differed from
+    // this one by exactly the name.
     const updated = await getSession(agentSlug, sessionId)
 
+    if (!updated) {
+      return c.json({ error: 'Session not found' }, 404)
+    }
+
     return c.json({
-      id: updated?.id || sessionId,
-      agentSlug: updated?.agentSlug || agentSlug,
-      name: updated?.name || name?.trim() || session.name,
-      createdAt: updated?.createdAt || session.createdAt,
-      lastActivityAt: updated?.lastActivityAt || session.lastActivityAt,
-      messageCount: updated?.messageCount || session.messageCount,
+      id: updated.id,
+      agentSlug: updated.agentSlug,
+      name: updated.name,
+      createdAt: updated.createdAt,
+      lastActivityAt: updated.lastActivityAt,
+      messageCount: updated.messageCount,
     })
   } catch (error) {
     console.error('Failed to update session:', error)
@@ -3063,8 +3071,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
 
     // Validate session belongs to this agent (skip for _auto internal calls from auto-execute)
     if (sessionId !== '_auto') {
-      const session = await getSession(agentSlug, sessionId)
-      if (!session) {
+      if (!(await sessionIsKnown(agentSlug, sessionId))) {
         return c.json({ error: 'Session not found' }, 404)
       }
     }
@@ -3221,8 +3228,7 @@ agents.post('/:id/sessions/:sessionId/computer-use/revoke', AgentUser(), async (
     const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
-    const session = await getSession(agentSlug, sessionId)
-    if (!session) {
+    if (!(await sessionIsKnown(agentSlug, sessionId))) {
       return c.json({ error: 'Session not found' }, 404)
     }
 

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -19,6 +19,7 @@ import {
   readSessionMetadata,
   updateSessionName,
   sessionExists,
+  sessionIsKnown,
   registerSession,
   isSessionRegistered,
   updateSessionMetadata,
@@ -489,6 +490,137 @@ describe('session-service', () => {
       const session = await getSession('test-agent', 'half-written')
       expect(session).toBeNull()
     })
+
+    // The transcript is summarized in a single streaming pass rather than parsed
+    // into an array, so the shapes real transcripts take — rows far wider than a
+    // read chunk, tool-result user rows ahead of any prose, queued commands —
+    // are what the summary has to keep getting right.
+    it('summarizes a transcript whose rows are wider than a read chunk', async () => {
+      const CHUNK_SIZE = 64 * 1024
+      await createSessionFile('test-agent', 'wide-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-02-01T10:00:00.000Z',
+          message: { role: 'user', content: 'Summarize the attached log' },
+        },
+        {
+          type: 'assistant',
+          uuid: 'a1',
+          timestamp: '2026-02-01T10:00:05.000Z',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'x'.repeat(CHUNK_SIZE * 3) }] },
+        },
+        {
+          type: 'user',
+          uuid: 'u2',
+          timestamp: '2026-02-01T10:00:09.000Z',
+          message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'y'.repeat(CHUNK_SIZE * 2) }] },
+        },
+      ])
+
+      const session = await getSession('test-agent', 'wide-session')
+
+      expect(session?.messageCount).toBe(3)
+      expect(session?.createdAt.toISOString()).toBe('2026-02-01T10:00:00.000Z')
+      expect(session?.lastActivityAt.toISOString()).toBe('2026-02-01T10:00:09.000Z')
+      expect(session?.name).toBe('Summarize the attached log')
+    })
+
+    it('names the session from the first user row with string content, not a tool result', async () => {
+      await createSessionFile('test-agent', 'tool-first', [
+        // A resumed session can open on a tool_result user row; its content is an
+        // array, so it must not be mistaken for the prompt.
+        {
+          type: 'user',
+          uuid: 'u0',
+          timestamp: '2026-02-02T10:00:00.000Z',
+          message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't0', content: 'ok' }] },
+        },
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-02-02T10:00:01.000Z',
+          message: { role: 'user', content: 'The actual prompt' },
+        },
+        // A later turn must not overwrite the name.
+        {
+          type: 'user',
+          uuid: 'u2',
+          timestamp: '2026-02-02T10:00:02.000Z',
+          message: { role: 'user', content: 'A follow-up question' },
+        },
+      ])
+
+      const session = await getSession('test-agent', 'tool-first')
+
+      expect(session?.name).toBe('The actual prompt')
+      expect(session?.messageCount).toBe(3)
+      // Timestamps still span every message, including the tool_result row.
+      expect(session?.createdAt.toISOString()).toBe('2026-02-02T10:00:00.000Z')
+      expect(session?.lastActivityAt.toISOString()).toBe('2026-02-02T10:00:02.000Z')
+    })
+
+    it('truncates a long derived name to 50 chars with an ellipsis', async () => {
+      await createSessionFile('test-agent', 'long-name', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-02-03T10:00:00.000Z',
+          message: { role: 'user', content: 'a'.repeat(80) },
+        },
+      ])
+
+      const session = await getSession('test-agent', 'long-name')
+      expect(session?.name).toBe(`${'a'.repeat(50)}...`)
+    })
+
+    it('counts a mid-turn queued_command attachment as a user message', async () => {
+      await createSessionFile('test-agent', 'queued-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-02-04T10:00:00.000Z',
+          message: { role: 'user', content: 'first' },
+        },
+        {
+          type: 'attachment',
+          uuid: 'att1',
+          timestamp: '2026-02-04T10:00:30.000Z',
+          attachment: {
+            type: 'queued_command',
+            commandMode: 'prompt',
+            prompt: 'steer left',
+            source_uuid: 'q1',
+          },
+        },
+        // Not user-typed — must not count.
+        {
+          type: 'attachment',
+          uuid: 'att2',
+          timestamp: '2026-02-04T10:01:00.000Z',
+          attachment: { type: 'queued_command', commandMode: 'prompt', prompt: 'meta', isMeta: true },
+        },
+      ])
+
+      const session = await getSession('test-agent', 'queued-session')
+
+      expect(session?.messageCount).toBe(2)
+      // The queued command is the last activity, so it moves the timestamp.
+      expect(session?.lastActivityAt.toISOString()).toBe('2026-02-04T10:00:30.000Z')
+    })
+
+    it('skips a half-written trailing row rather than failing the whole session', async () => {
+      const sessionsDir = await createSessionsDir('test-agent')
+      await fs.promises.writeFile(
+        path.join(sessionsDir, 'torn.jsonl'),
+        `${JSON.stringify({ type: 'user', uuid: 'u1', timestamp: '2026-02-05T10:00:00.000Z', message: { role: 'user', content: 'hello' } })}\n{"type":"assistant","timestamp":"2026-02-05T10`
+      )
+
+      const session = await getSession('test-agent', 'torn')
+
+      expect(session?.messageCount).toBe(1)
+      expect(session?.name).toBe('hello')
+    })
   })
 
   describe('getSessionMessages', () => {
@@ -751,6 +883,56 @@ describe('session-service', () => {
 
       const exists = await sessionExists('test-agent', 'test-session')
       expect(exists).toBe(true)
+    })
+  })
+
+  describe('sessionIsKnown', () => {
+    // Existence guards use this instead of getSession, so it has to agree with
+    // getSession on every case — otherwise a route 404s a session the rest of
+    // the app considers real (or the reverse).
+    it('agrees with getSession on a written transcript', async () => {
+      await createSessionFile('test-agent', 'test-session', SAMPLE_JSONL_ENTRIES)
+
+      expect(await sessionIsKnown('test-agent', 'test-session')).toBe(true)
+      expect(await getSession('test-agent', 'test-session')).not.toBeNull()
+    })
+
+    it('agrees with getSession on a registered session with no transcript yet', async () => {
+      await createSessionsDir('test-agent')
+      await createSessionMetadata('test-agent', {
+        'settling-session': { name: 'Brand New', createdAt: '2026-06-18T12:00:00.000Z' },
+      })
+
+      expect(await sessionIsKnown('test-agent', 'settling-session')).toBe(true)
+      expect(await getSession('test-agent', 'settling-session')).not.toBeNull()
+    })
+
+    it('agrees with getSession on a metadata entry with no createdAt', async () => {
+      await createSessionsDir('test-agent')
+      await createSessionMetadata('test-agent', { 'half-written': { name: 'No CreatedAt' } })
+
+      expect(await sessionIsKnown('test-agent', 'half-written')).toBe(false)
+      expect(await getSession('test-agent', 'half-written')).toBeNull()
+    })
+
+    it('agrees with getSession on an unknown session', async () => {
+      await createSessionsDir('test-agent')
+
+      expect(await sessionIsKnown('test-agent', 'nonexistent')).toBe(false)
+      expect(await getSession('test-agent', 'nonexistent')).toBeNull()
+    })
+
+    it('never reads the transcript', async () => {
+      // The whole point: a 404 guard must not pay for a 100MB transcript pass.
+      await createSessionFile('test-agent', 'test-session', SAMPLE_JSONL_ENTRIES)
+      const openSpy = vi.spyOn(fs.promises, 'open')
+
+      try {
+        expect(await sessionIsKnown('test-agent', 'test-session')).toBe(true)
+        expect(openSpy).not.toHaveBeenCalled()
+      } finally {
+        openSpy.mockRestore()
+      }
     })
   })
 

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -22,6 +22,7 @@ import {
   withFileLock,
   CorruptFileError,
   readJsonlFile,
+  streamJsonlFile,
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
@@ -248,40 +249,79 @@ function normalizeQueuedCommandEntry(entry: JsonlEntry): JsonlEntry {
 }
 
 /**
- * Parse session info from JSONL entries
+ * The four things a SessionInfo needs from a transcript. Accumulated in one
+ * streaming pass so a session's size never has to be held in memory: transcripts
+ * routinely reach 100MB+ and this summary is a handful of scalars.
+ */
+interface TranscriptSummary {
+  messageCount: number
+  firstTimestamp: string | undefined
+  lastTimestamp: string | undefined
+  /** Content of the first user message whose content is a plain string. */
+  firstUserText: string | undefined
+}
+
+const EMPTY_TRANSCRIPT_SUMMARY: TranscriptSummary = {
+  messageCount: 0,
+  firstTimestamp: undefined,
+  lastTimestamp: undefined,
+  firstUserText: undefined,
+}
+
+/**
+ * Stream a session transcript and accumulate only what SessionInfo reports.
+ * Nothing per-entry is retained, so cost is one pass and constant memory.
+ */
+async function summarizeSessionTranscript(jsonlPath: string): Promise<TranscriptSummary> {
+  const summary: TranscriptSummary = { ...EMPTY_TRANSCRIPT_SUMMARY }
+
+  for await (const raw of streamJsonlFile<JsonlEntry>(jsonlPath)) {
+    // Normalize queued_command attachments so mid-turn messages count toward
+    // naming, messageCount, and activity timestamps like any other user message.
+    const entry = normalizeQueuedCommandEntry(raw)
+    if (!isMessageEntry(entry)) continue
+
+    summary.messageCount++
+    if (summary.messageCount === 1) summary.firstTimestamp = entry.timestamp
+    summary.lastTimestamp = entry.timestamp
+    if (
+      summary.firstUserText === undefined &&
+      entry.type === 'user' &&
+      typeof entry.message.content === 'string'
+    ) {
+      summary.firstUserText = entry.message.content
+    }
+  }
+
+  return summary
+}
+
+/**
+ * Project a transcript summary into the session's SessionInfo.
  */
 function parseSessionInfo(
   sessionId: string,
   agentSlug: string,
-  entries: JsonlEntry[],
+  summary: TranscriptSummary,
   metadata?: SessionMetadata
 ): SessionInfo {
-  // Normalize queued_command attachments so mid-turn messages count toward
-  // naming, messageCount, and activity timestamps like any other user message.
-  const messages = entries.map(normalizeQueuedCommandEntry).filter(isMessageEntry)
-
   // Get timestamps
   let createdAt = new Date()
   let lastActivityAt = new Date()
 
-  if (messages.length > 0) {
-    createdAt = new Date(messages[0].timestamp)
-    lastActivityAt = new Date(messages[messages.length - 1].timestamp)
+  if (summary.messageCount > 0) {
+    createdAt = new Date(summary.firstTimestamp as string)
+    lastActivityAt = new Date(summary.lastTimestamp as string)
   }
 
   // Generate name from first user message if no custom name
   let name = metadata?.name || 'New Session'
-  if (!metadata?.name && messages.length > 0) {
-    const firstUserMessage = messages.find(
-      (m) => m.type === 'user' && typeof m.message.content === 'string'
-    )
-    if (firstUserMessage && typeof firstUserMessage.message.content === 'string') {
-      // Use first 50 chars of first message as name
-      const content = firstUserMessage.message.content
-      name = content.substring(0, 50).trim()
-      if (content.length > 50) {
-        name += '...'
-      }
+  if (!metadata?.name && summary.firstUserText !== undefined) {
+    // Use first 50 chars of first message as name
+    const content = summary.firstUserText
+    name = content.substring(0, 50).trim()
+    if (content.length > 50) {
+      name += '...'
     }
   }
 
@@ -291,7 +331,7 @@ function parseSessionInfo(
     name,
     createdAt,
     lastActivityAt,
-    messageCount: messages.length,
+    messageCount: summary.messageCount,
   }
 }
 
@@ -519,8 +559,8 @@ export async function getSession(
   const metadata = await getSessionMetadata(agentSlug, sessionId)
 
   if (await fileExists(jsonlPath)) {
-    const entries = await readJsonlFile<JsonlEntry>(jsonlPath)
-    return parseSessionInfo(sessionId, agentSlug, entries, metadata || undefined)
+    const summary = await summarizeSessionTranscript(jsonlPath)
+    return parseSessionInfo(sessionId, agentSlug, summary, metadata || undefined)
   }
 
   // No transcript yet, but the session is registered → it was just created and
@@ -700,6 +740,22 @@ export async function sessionExists(
 ): Promise<boolean> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   return fileExists(jsonlPath)
+}
+
+/**
+ * Whether a session exists at all — a written transcript, or a registration for
+ * one whose agent hasn't streamed its first message yet. This is exactly the
+ * rule getSession returns non-null on, but it costs a stat and a metadata read
+ * instead of a full transcript pass. Use it for 404 guards that don't go on to
+ * read any SessionInfo field.
+ */
+export async function sessionIsKnown(
+  agentSlug: string,
+  sessionId: string
+): Promise<boolean> {
+  if (await sessionExists(agentSlug, sessionId)) return true
+  const metadata = await getSessionMetadata(agentSlug, sessionId)
+  return Boolean(metadata?.createdAt)
 }
 
 // ============================================================================


### PR DESCRIPTION
Rebased onto `main` now that #610 has merged — this is a plain single-commit PR against `main`, no longer stacked.

## Problem

`getSession` reads the whole transcript into a single string, `JSON.parse`s every entry into an array, then maps + filters it — to report four scalars: first timestamp, last timestamp, message count, and the first 50 chars of the first user message.

Cost breakdown on a 107 MB session: `readFile` 82 ms, `split(/\r?\n/)` **152 ms**, parse 88 ms.

Worse, several callers don't want a `SessionInfo` at all — they use it as a 404 guard:
- `computer-use/decide` and `computer-use/revoke` — a full transcript pass to answer "does this session exist"
- the rename route called it **twice**, once on each side of a metadata-only write

## Fix

- `summarizeSessionTranscript()` streams the transcript (via the raw-`Buffer` `streamJsonlFile` that landed in #610) and accumulates only those four values. Nothing per-entry is retained, so memory is constant in the transcript's size. `parseSessionInfo` now projects that summary.
- `sessionIsKnown()` — a stat plus a metadata read, matching `getSession`'s non-null rule exactly (written transcript, **or** a registration with `createdAt`). Used for the two computer-use guards.
- The rename route guards with `sessionIsKnown` *before* the write (so an unknown session never gets metadata registered for it), then reads once afterwards.

## Result

Five runs each, isolated per process — a first pass had me comparing them in one loop, where RSS carry-over made the smaller sessions look like regressions:

```
                        OLD                      NEW
9b6a0e0c (107MB)   365-408 ms            →   154-177 ms
cc42cf89  (46MB)    93-111 ms            →    72- 93 ms
c126e742  (28MB)    61- 65 ms            →    40- 52 ms

peak RSS on the 107MB session:  324 MB   →   202 MB
```

`SessionInfo` compared field-for-field across five real sessions on this machine: **identical**.

The 404 guards go from a full pass to a stat — on the 107 MB session that's ~390 ms → sub-millisecond.

## Not done

I tried a byte-level prefilter (classify rows by searching for `"user"`/`"assistant"` without decoding) expecting a further 2-3×. **Measured, it's slower** — 196 ms vs 171 ms — because tool results are `user` entries, so ~78% of rows are candidates anyway and the extra `Buffer.includes` scans over 107 MB cost more than they save. A variant that byte-matches `"type":"user"` exactly and parses only three rows does hit ~65 ms, but it silently reports zero messages if a future CLI ever writes the JSON with different spacing, and I didn't think ~90 ms was worth that failure mode.

`getSessionMessagesWithCompact` (the messages route) has the same whole-file-as-one-string shape but genuinely needs every entry, so the parse is inherent. Left alone.

## Tests

**`session-service.test.ts`** — `getSession` gains: rows wider than a read chunk, naming from the first *string-content* user row when a `tool_result` row comes first (and a later turn not overwriting it), 50-char truncation, `queued_command` normalization including the `isMeta` exclusion, and a half-written trailing row. New `sessionIsKnown` describe asserts it agrees with `getSession` on all four existence cases and never opens the transcript.

**`agents.test.ts`** — rename does exactly one `getSession`; rename 404s without calling `updateSessionName`; computer-use revoke guards via `sessionIsKnown` without touching `getSession`.

Mutation-checked, each independently: file-only `sessionIsKnown`, last-user-text instead of first, first-timestamp taken from the last row, dropped `queued_command` normalization, and the rename guard moved after the write — all five turn tests red. (The last-user-text one initially survived, so I added a second prose turn to that fixture to pin it.)

Re-verified after the rebase against merged `main`: full unit suite green (8168 passed), `tsc --noEmit` and eslint clean.

https://claude.ai/code/session_01SgyFgE4NbFbX1Wp68H13Dy