### PR TITLE
fix: terminate MicroVMs on stop (no suspend) + dead-generation replace

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1202,11 +1202,14 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         )
       }
 
-      // Handle network errors with user-friendly messages
+      // Handle network errors with user-friendly messages.
+      // Keep the original as cause so callers can distinguish refused (never
+      // delivered) from reset/timeout (prompt may already be running).
       if (this.isConnectionError(err)) {
         this.handleConnectionError()
         throw new Error(
-          'Failed to start session - unable to connect to the agent. Please check that the agent is running and try again.'
+          'Failed to start session - unable to connect to the agent. Please check that the agent is running and try again.',
+          { cause: err },
         )
       }
 

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -108,6 +108,9 @@ class ContainerManager {
             })
           })
         },
+        // MicroVM dead-generation replace (and similar) must restart through the
+        // manager so starts share startingAgents and rebuild env from the DB.
+        restartAgent: () => this.restartAgent(agentId),
       }
 
       client = createContainerClient(config)
@@ -115,6 +118,28 @@ class ContainerManager {
     }
 
     return client
+  }
+
+  // Single-flight restart used by runtime clients that tear down a dead generation.
+  private async restartAgent(agentId: string): Promise<void> {
+    if (this.stoppingAgents.has(agentId)) {
+      throw new Error(`Cannot restart agent ${agentId} while it is stopping`)
+    }
+    const inflight = this.startingAgents.get(agentId)
+    if (inflight) {
+      await inflight
+      return
+    }
+
+    this.markAsStopped(agentId)
+    const client = this.getClient(agentId)
+    const startPromise = this.doStartContainer(agentId, client)
+    this.startingAgents.set(agentId, startPromise)
+    try {
+      await startPromise
+    } finally {
+      this.startingAgents.delete(agentId)
+    }
   }
 
   /**

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -132,6 +132,14 @@ class ContainerManager {
     }
 
     this.markAsStopped(agentId)
+    // Dead generation had live sessions; clear isActive before the new start
+    // (same as stopContainer — replace does not go through stopContainer).
+    messagePersister.markAllSessionsInactiveForAgent(agentId)
+    messagePersister.broadcastGlobal({
+      type: 'agent_status_changed',
+      agentSlug: agentId,
+      status: 'stopped',
+    })
     const client = this.getClient(agentId)
     const startPromise = this.doStartContainer(agentId, client)
     this.startingAgents.set(agentId, startPromise)

--- a/src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.e2e.test.ts
@@ -21,7 +21,7 @@ import { LambdaMicroVmRuntimeClient } from './lambda-microvm-runtime'
 const enabled = process.env.RUN_MICROVM_E2E === '1'
 
 describe.skipIf(!enabled)('LambdaMicroVmRuntimeClient e2e (real AWS)', () => {
-  it('runs a real MicroVM, serves /health through the proxy, then suspends', async () => {
+  it('runs a real MicroVM, serves /health through the proxy, then terminates', async () => {
     const client = new LambdaMicroVmRuntimeClient({ agentId: `e2e-${Date.now()}` })
     try {
       await client.start()
@@ -63,26 +63,23 @@ describe.skipIf(!enabled)('LambdaMicroVmRuntimeClient e2e (real AWS)', () => {
     expect(max).toBeLessThan(30_000)
   }, 600_000)
 
-  // Stop means suspend; the next plain request resumes the same VM warmly.
-  it('auto-sleep suspends, then a plain request transparently auto-resumes (warm)', async () => {
-    const client = new LambdaMicroVmRuntimeClient({ agentId: `e2e-resume-${Date.now()}` })
+  // Stop means terminate; the next start is a cold boot (no warm resume).
+  it('stop terminates; a later start is a cold boot', async () => {
+    const client = new LambdaMicroVmRuntimeClient({ agentId: `e2e-terminate-${Date.now()}` })
     try {
       await client.start()
       expect((await client.getInfoFromRuntime()).status).toBe('running')
 
-      await client.stop() // plain stop -> suspend (default)
-      // Let the suspend settle (SuspendMicrovm completes in ~1s); the client maps
-      // SUSPENDED/SUSPENDING to 'running' since the VM auto-resumes on demand.
-      await new Promise((r) => setTimeout(r, 10_000))
-      expect((await client.getInfoFromRuntime()).status).toBe('running')
+      await client.stop()
+      expect((await client.getInfoFromRuntime()).status).toBe('stopped')
 
-      // No waitForHealthy kick: a normal request resumes + succeeds via the proxy.
       const t0 = Date.now()
+      await client.start()
+      const coldMs = Date.now() - t0
       const res = await client.fetch('/health')
-      const resumeMs = Date.now() - t0
       expect(res.ok).toBe(true)
-      console.log(`[E2E-RESUME] suspend -> /health ok (transparent auto-resume): ${resumeMs}ms`)
-      expect(resumeMs).toBeLessThan(15_000)
+      console.log(`[E2E-TERMINATE] stop -> cold start -> /health ok: ${coldMs}ms`)
+      expect(coldMs).toBeLessThan(60_000)
     } finally {
       await client.stop()
     }

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -542,7 +542,7 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     superCreate.mockRestore()
   })
 
-  it('createSession replaces after a create failure when the generation is TERMINATED', async () => {
+  it('createSession replaces after an unreachable create failure when the generation is TERMINATED', async () => {
     const { BaseContainerClient } = await import('./base-container-client')
     const client = newClient()
     await client.start()
@@ -593,6 +593,27 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     superCreate.mockRestore()
   })
 
+  it('createSession does not replace on timeout even if the generation later looks dead', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate.mockImplementationOnce(async () => {
+      responses.getState = 'TERMINATED'
+      throw new Error(
+        'Failed to start session - request timed out. This may be due to network issues or the AI service being slow. Please try again.',
+      )
+    })
+
+    await expect(client.createSession({ initialMessage: 'hi' })).rejects.toThrow(/timed out/)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+    expect(superCreate).toHaveBeenCalledTimes(1)
+    superCreate.mockRestore()
+  })
+
   it('concurrent createSession on a dead generation only RunMicrovm once', async () => {
     const { BaseContainerClient } = await import('./base-container-client')
     const client = newClient()
@@ -624,6 +645,141 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     ])
     expect(runCount).toBe(1)
     expect(superCreate).toHaveBeenCalledTimes(2)
+    superCreate.mockRestore()
+  })
+
+  it('stale dead-generation observation does not terminate a newer healthy generation', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    let releaseGet: (() => void) | undefined
+    const getGate = new Promise<void>((resolve) => {
+      releaseGet = resolve
+    })
+    let observeGetStarted!: () => void
+    const observeGetStartedP = new Promise<void>((resolve) => {
+      observeGetStarted = resolve
+    })
+
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    const terminateIds: string[] = []
+    let runCount = 0
+    let gated = false
+    sendMock.mockImplementation(async (cmd: { type: string; input?: { microvmIdentifier?: string } }) => {
+      if (cmd.type === 'Get') {
+        // Gate only the first Get (observeDeadGeneration on mvm-1).
+        if (!gated) {
+          gated = true
+          observeGetStarted()
+          await getGate
+          return { state: 'TERMINATING' }
+        }
+        return { state: responses.getState ?? 'RUNNING' }
+      }
+      if (cmd.type === 'Run') {
+        runCount++
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-fresh-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Terminate') {
+        terminateIds.push(String(cmd.input?.microvmIdentifier ?? ''))
+        return {}
+      }
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockResolvedValue({ id: 'sess-cas' } as never)
+
+    const createPromise = client.createSession({ initialMessage: 'hi' })
+    await observeGetStartedP
+    // Swap in a healthy generation while observe is still awaiting GetMicrovm.
+    client.stopSync()
+    responses.getState = 'RUNNING'
+    await client.start()
+    releaseGet?.()
+    await createPromise
+
+    expect(terminateIds).not.toContain('mvm-fresh-1')
+    expect(runCount).toBe(1)
+    superCreate.mockRestore()
+  })
+
+  it('restartAgent single-flight prevents duplicate RunMicrovm when replace races start', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    let inflight: Promise<void> | null = null
+    let client!: LambdaMicroVmRuntimeClient
+    const restartAgent = async () => {
+      if (inflight) return inflight
+      inflight = client.start().finally(() => {
+        inflight = null
+      })
+      return inflight
+    }
+    client = new LambdaMicroVmRuntimeClient({
+      agentId: 'agent-xyz',
+      envVars: { FOO: 'bar' },
+      restartAgent,
+    })
+    await client.start()
+    sendMock.mockClear()
+
+    let runCount = 0
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Run') {
+        runCount++
+        await new Promise((r) => setTimeout(r, 40))
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-race-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+      if (cmd.type === 'Terminate') return {}
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+    responses.getState = 'TERMINATING'
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockResolvedValue({ id: 'sess-race' } as never)
+
+    // createSession replaces then restartAgent; a concurrent ensureRunning-style
+    // restart shares the same single-flight lock (prod: ContainerManager.startingAgents).
+    await Promise.all([
+      client.createSession({ initialMessage: 'a' }),
+      (async () => {
+        await new Promise((r) => setTimeout(r, 5))
+        await restartAgent()
+      })(),
+    ])
+    expect(runCount).toBe(1)
+    superCreate.mockRestore()
+  })
+
+  it('observeDeadGeneration returning false on throttling does not replace', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Get') throw new Error('ThrottlingException')
+      if (cmd.type === 'Run') return { microvmId: 'mvm-should-not', endpoint: 'ep.lambda-microvm.aws' }
+      if (cmd.type === 'Terminate') return {}
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockResolvedValue({ id: 'sess-throttle' } as never)
+
+    await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-throttle' })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
     superCreate.mockRestore()
   })
 })

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -74,7 +74,7 @@ const FULL_ENV = { ...REQUIRED_ENV, HOST_PUBLIC_URL: 'https://host.example' }
 const TOUCHED = [
   ...Object.keys(FULL_ENV),
   'AWS_REGION', 'AWS_DEFAULT_REGION', 'MICROVM_AGENT_IMAGE_VERSION', 'MICROVM_INGRESS_CONNECTOR_ARN',
-  'MICROVM_AGENT_PORT', 'MICROVM_MAX_DURATION_SECONDS', 'MICROVM_SUSPENDED_SECONDS', 'MICROVM_LOG_GROUP',
+  'MICROVM_AGENT_PORT', 'MICROVM_MAX_DURATION_SECONDS', 'MICROVM_LOG_GROUP',
   'MICROVM_FS_ID', 'MICROVM_ACCESS_POINT', 'MICROVM_MOUNT_TARGET_IP', 'ECS_CONTAINER_METADATA_URI_V4', 'PORT',
   'MICROVM_PROXY_URL', 'MICROVM_PROXY_TOKEN',
 ]
@@ -121,10 +121,8 @@ describe('microvm runtime config', () => {
     expect(config.region).toBe('us-east-2')
     expect(config.imageArn).toBe('arn:img')
     expect(config.agentPort).toBe(3000)
-    // Lifetime + suspend default to the AWS 8h cap: a suspended VM survives
-    // "until killed" and only the ceiling force-terminates an untouched one.
+    // Lifetime defaults to the AWS 8h cap.
     expect(config.maxDurationSeconds).toBe(28_800)
-    expect(config.suspendedSeconds).toBe(28_800)
   })
 
   it('defaults the ingress connector to the AWS well-known ALL_INGRESS for the region', () => {
@@ -149,12 +147,10 @@ describe('microvm runtime config', () => {
   it('coerces numeric overrides from strings', () => {
     Object.assign(process.env, REQUIRED_ENV, {
       MICROVM_AGENT_PORT: '8080',
-      MICROVM_SUSPENDED_SECONDS: '120',
       MICROVM_MAX_DURATION_SECONDS: '600',
     })
     const config = getMicrovmRuntimeConfig()
     expect(config.agentPort).toBe(8080)
-    expect(config.suspendedSeconds).toBe(120)
     expect(config.maxDurationSeconds).toBe(600)
   })
 
@@ -258,10 +254,10 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(input.imageIdentifier).toBe('arn:img')
     expect(input.executionRoleArn).toBe('arn:exec')
     expect(input.egressNetworkConnectors).toEqual(['arn:egress'])
-    expect(input.idlePolicy.autoResumeEnabled).toBe(true)
-    // idle tracks the app auto-sleep setting (30m); suspend/lifetime hit the 8h cap.
-    expect(input.idlePolicy.maxIdleDurationSeconds).toBe(1_800)
-    expect(input.idlePolicy.suspendedDurationSeconds).toBe(28_800)
+    expect(input.idlePolicy.autoResumeEnabled).toBe(false)
+    // AWS idle capped at lifetime — host auto-sleep terminates; no suspend path.
+    expect(input.idlePolicy.maxIdleDurationSeconds).toBe(28_800)
+    expect(input.idlePolicy.suspendedDurationSeconds).toBe(1)
     expect(input.maximumDurationInSeconds).toBe(28_800)
     expect(typeof input.clientToken).toBe('string')
     expect(input.clientToken.length).toBeGreaterThan(0)
@@ -408,11 +404,13 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(await newClient().getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
   })
 
-  it('getInfoFromRuntime treats SUSPENDED as running (auto-resume on request)', async () => {
+  it('getInfoFromRuntime treats SUSPENDED as stopped and terminates the leftover VM', async () => {
     const client = newClient()
     await client.start()
     responses.getState = 'SUSPENDED'
-    expect((await client.getInfoFromRuntime()).status).toBe('running')
+    sendMock.mockClear()
+    expect(await client.getInfoFromRuntime()).toEqual({ status: 'stopped', port: null })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(true)
   })
 
   it('getInfoFromRuntime reports stopped when the VM is TERMINATED and cleans up local state', async () => {
@@ -466,16 +464,16 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     stopSpy.mockRestore()
   })
 
-  it('background auto-sleep (escalateToForceStop:false) is a no-op — idlePolicy owns idle', async () => {
+  it('background auto-sleep (escalateToForceStop:false) terminates like other runners', async () => {
     const client = newClient()
     await client.start()
     sendMock.mockClear()
     await client.stop({ escalateToForceStop: false })
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(false)
-    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(true)
   })
 
-  it('a plain stop() suspends (preserves state for warm resume), not terminate', async () => {
+  it('a plain stop() terminates (no suspend / warm resume)', async () => {
     const client = newClient()
     await client.start()
     sendMock.mockClear()
@@ -483,24 +481,27 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     const result = await client.stop()
 
     expect(result).toEqual({ forceStopUsed: false, stopped: true })
-    const suspendCall = sendMock.mock.calls.find((c) => c[0].type === 'Suspend')
-    expect(suspendCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
-    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+    const terminateCall = sendMock.mock.calls.find((c) => c[0].type === 'Terminate')
+    expect(terminateCall![0].input).toEqual({ microvmIdentifier: 'mvm-1' })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(false)
 
-    // State is preserved: a subsequent start() short-circuits (no new RunMicrovm).
+    // State is cleared: a subsequent start() runs a fresh MicroVM.
     sendMock.mockClear()
-    responses.getState = 'SUSPENDED'
+    responses.getState = 'RUNNING'
     await client.start()
-    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(true)
   })
 
-  it('a plain stop() is a no-op suspend when already SUSPENDED', async () => {
+  it('a plain stop() is a no-op terminate when already gone', async () => {
     const client = newClient()
     await client.start()
-    responses.getState = 'SUSPENDED'
+    responses.getState = 'TERMINATED'
+    // Drop local state as if getInfo already cleaned up.
+    await client.getInfoFromRuntime()
     sendMock.mockClear()
     await client.stop()
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Suspend')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
   })
 
   it('start is a no-op when the agent is already running', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -510,6 +510,122 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     await client.start()
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
   })
+
+  it('createSession replaces a TERMINATING generation then creates once', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start({ envVars: { FOO: 'bar' } })
+    sendMock.mockClear()
+
+    let runCount = 0
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Run') {
+        runCount++
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-new-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+      if (cmd.type === 'Terminate') return {}
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+    responses.getState = 'TERMINATING'
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockResolvedValue({ id: 'sess-1' } as never)
+
+    await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-1' })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(true)
+    expect(runCount).toBe(1)
+    expect(superCreate).toHaveBeenCalledTimes(1)
+    superCreate.mockRestore()
+  })
+
+  it('createSession replaces after a create failure when the generation is TERMINATED', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    let runCount = 0
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Run') {
+        runCount++
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-retry-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+      if (cmd.type === 'Terminate') return {}
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate
+      .mockImplementationOnce(async () => {
+        responses.getState = 'TERMINATED'
+        throw new Error('Failed to start session - unable to connect to the agent')
+      })
+      .mockResolvedValueOnce({ id: 'sess-2' } as never)
+
+    await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-2' })
+    expect(runCount).toBe(1)
+    expect(superCreate).toHaveBeenCalledTimes(2)
+    superCreate.mockRestore()
+  })
+
+  it('createSession does not replace on a generic create failure while the VM is RUNNING', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+    responses.getState = 'RUNNING'
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockRejectedValue(new Error('Failed to create session: boom'))
+
+    await expect(client.createSession({ initialMessage: 'hi' })).rejects.toThrow(/boom/)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+    expect(superCreate).toHaveBeenCalledTimes(1)
+    superCreate.mockRestore()
+  })
+
+  it('concurrent createSession on a dead generation only RunMicrovm once', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    let runCount = 0
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Run') {
+        runCount++
+        await new Promise((r) => setTimeout(r, 20))
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-once-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+      if (cmd.type === 'Terminate') return {}
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+    responses.getState = 'TERMINATING'
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockResolvedValue({ id: 'sess-x' } as never)
+
+    await Promise.all([
+      client.createSession({ initialMessage: 'a' }),
+      client.createSession({ initialMessage: 'b' }),
+    ])
+    expect(runCount).toBe(1)
+    expect(superCreate).toHaveBeenCalledTimes(2)
+    superCreate.mockRestore()
+  })
 })
 
 describe('LocalAuthForwardProxy', () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -543,7 +543,7 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     superCreate.mockRestore()
   })
 
-  it('createSession replaces after an unreachable create failure when the generation is TERMINATED', async () => {
+  it('createSession replaces after connect-refused when the generation is TERMINATED', async () => {
     const { BaseContainerClient } = await import('./base-container-client')
     const client = newClient()
     await client.start()
@@ -566,13 +566,44 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     superCreate
       .mockImplementationOnce(async () => {
         responses.getState = 'TERMINATED'
-        throw new Error('Failed to start session - unable to connect to the agent')
+        throw new Error('Failed to start session - unable to connect to the agent', {
+          cause: new Error('connect ECONNREFUSED 127.0.0.1:4000'),
+        })
       })
       .mockResolvedValueOnce({ id: 'sess-2' } as never)
 
     await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-2' })
     expect(runCount).toBe(1)
     expect(superCreate).toHaveBeenCalledTimes(2)
+    superCreate.mockRestore()
+  })
+
+  it('createSession does not replace on reset/timeout-shaped unable-to-connect (ambiguous delivery)', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+    responses.getState = 'RUNNING'
+
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    for (const cause of [
+      new Error('read ECONNRESET'),
+      new Error('connect ETIMEDOUT 10.0.0.1:3000'),
+      new Error('fetch failed'),
+    ]) {
+      // Keep generation RUNNING so ensureAlive does not replace; only the
+      // post-create classifier under test can decide to retry.
+      responses.getState = 'RUNNING'
+      superCreate.mockReset()
+      superCreate.mockRejectedValueOnce(
+        new Error('Failed to start session - unable to connect to the agent', { cause }),
+      )
+      await expect(client.createSession({ initialMessage: 'hi' })).rejects.toThrow(/unable to connect/)
+      expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+      expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+      expect(superCreate).toHaveBeenCalledTimes(1)
+      sendMock.mockClear()
+    }
     superCreate.mockRestore()
   })
 
@@ -646,6 +677,67 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     ])
     expect(runCount).toBe(1)
     expect(superCreate).toHaveBeenCalledTimes(2)
+    superCreate.mockRestore()
+  })
+
+  it('replace Terminate await does not wipe a newer generation installed mid-flight', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    let releaseTerminate: (() => void) | undefined
+    const terminateGate = new Promise<void>((resolve) => {
+      releaseTerminate = resolve
+    })
+    let terminateStarted!: () => void
+    const terminateStartedP = new Promise<void>((resolve) => {
+      terminateStarted = resolve
+    })
+
+    const client = newClient()
+    await client.start()
+    const oldId = 'mvm-1'
+    sendMock.mockClear()
+
+    const terminateIds: string[] = []
+    let runCount = 0
+    sendMock.mockImplementation(async (cmd: { type: string; input?: { microvmIdentifier?: string } }) => {
+      if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+      if (cmd.type === 'Run') {
+        runCount++
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-cas-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Terminate') {
+        const id = String(cmd.input?.microvmIdentifier ?? '')
+        terminateIds.push(id)
+        if (id === oldId) {
+          terminateStarted()
+          await terminateGate
+        }
+        return {}
+      }
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+    responses.getState = 'TERMINATING'
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockResolvedValue({ id: 'sess-cas-teardown' } as never)
+
+    const createPromise = client.createSession({ initialMessage: 'hi' })
+    await terminateStartedP
+    // Install a healthy generation while Terminate(old) is still awaiting.
+    client.stopSync()
+    responses.getState = 'RUNNING'
+    await client.start()
+    const freshId = `mvm-cas-${runCount}`
+    releaseTerminate?.()
+    await createPromise
+
+    expect(terminateIds).toContain(oldId)
+    expect(terminateIds).not.toContain(freshId)
+    const info = await client.getInfoFromRuntime()
+    expect(info.status).toBe('running')
+    expect(runCount).toBe(1)
     superCreate.mockRestore()
   })
 

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -539,6 +539,43 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     superCreate.mockRestore()
   })
 
+  // getPortOrThrow → getInfoFromRuntime CAS-drops TERMINATING before the catch;
+  // without the installedId snapshot, observeDeadGeneration sees nothing and we
+  // never replace — the primary scenario this PR exists to fix.
+  it('createSession replaces when getPortOrThrow wiped a TERMINATING generation', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    let runCount = 0
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Run') {
+        runCount++
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-wipe-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+      if (cmd.type === 'Terminate') return {}
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+
+    responses.getState = 'TERMINATING'
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate.mockImplementation(async function (this: LambdaMicroVmRuntimeClient) {
+      const info = await this.getInfoFromRuntime()
+      if (info.status !== 'running' || !info.port) throw new Error('Container is not running')
+      return { id: 'sess-real' } as never
+    })
+
+    await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-real' })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(true)
+    expect(runCount).toBe(1)
+    expect(superCreate).toHaveBeenCalledTimes(2)
+    superCreate.mockRestore()
+  })
+
   it('createSession replaces after connect-refused when the generation is TERMINATED', async () => {
     const { BaseContainerClient } = await import('./base-container-client')
     const client = newClient()

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -23,14 +23,12 @@ vi.mock('tls', () => ({
 vi.mock('@aws-sdk/client-lambda-microvms', () => {
   class RunMicrovmCommand { type = 'Run'; constructor(public input: unknown) {} }
   class GetMicrovmCommand { type = 'Get'; constructor(public input: unknown) {} }
-  class SuspendMicrovmCommand { type = 'Suspend'; constructor(public input: unknown) {} }
   class TerminateMicrovmCommand { type = 'Terminate'; constructor(public input: unknown) {} }
   class CreateMicrovmAuthTokenCommand { type = 'Token'; constructor(public input: unknown) {} }
   return {
     LambdaMicrovmsClient: class { send = (cmd: { type: string }) => sendMock(cmd) },
     RunMicrovmCommand,
     GetMicrovmCommand,
-    SuspendMicrovmCommand,
     TerminateMicrovmCommand,
     CreateMicrovmAuthTokenCommand,
   }
@@ -59,7 +57,6 @@ import {
   resolveMicrovmRuntimeConfigOrNull,
   isMicrovmRuntimeConfigured,
   getMicrovmRuntimeConfig,
-  resolveIdleSeconds,
 } from './lambda-microvm-runtime'
 import { readBootstrapEnv, resetBootstrapEnvStoreForTests } from './agent-bootstrap-env-store'
 
@@ -164,29 +161,6 @@ describe('microvm runtime config', () => {
   })
 })
 
-describe('resolveIdleSeconds', () => {
-  beforeEach(() => {
-    Object.assign(process.env, REQUIRED_ENV)
-  })
-
-  it('derives the idle window from the app auto-sleep setting (single source of truth)', () => {
-    autoSleepTimeoutMinutes.mockReturnValue(30)
-    expect(resolveIdleSeconds(getMicrovmRuntimeConfig())).toBe(1_800)
-  })
-
-  it('never idle-suspends (falls back to the lifetime cap) when auto-sleep is disabled', () => {
-    autoSleepTimeoutMinutes.mockReturnValue(0)
-    const config = getMicrovmRuntimeConfig()
-    expect(resolveIdleSeconds(config)).toBe(config.maxDurationSeconds)
-  })
-
-  it('clamps an app setting longer than the lifetime cap to maxDurationSeconds', () => {
-    autoSleepTimeoutMinutes.mockReturnValue(600) // 10h > 8h cap
-    const config = getMicrovmRuntimeConfig()
-    expect(resolveIdleSeconds(config)).toBe(config.maxDurationSeconds)
-  })
-})
-
 describe('LambdaMicroVmRuntimeClient eligibility', () => {
   it('isEligible only when runtime env is configured', () => {
     Object.assign(process.env, FULL_ENV)
@@ -240,10 +214,29 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     resetMicrovmRuntimeForTests()
   })
 
-  function newClient() {
+  function newClient(opts?: { withRestartAgent?: boolean }) {
     // envVars is the public seam: whatever the agent is configured with must
     // arrive inside runHookPayload.env, regardless of how the env is built.
-    return new LambdaMicroVmRuntimeClient({ agentId: 'agent-xyz', envVars: { FOO: 'bar' } })
+    // Replace requires restartAgent (prod: ContainerManager); unit tests stub it.
+    let client!: LambdaMicroVmRuntimeClient
+    client = new LambdaMicroVmRuntimeClient({
+      agentId: 'agent-xyz',
+      envVars: { FOO: 'bar' },
+      ...(opts?.withRestartAgent === false
+        ? {}
+        : {
+            restartAgent: async () => {
+              await client.start()
+            },
+          }),
+    })
+    return client
+  }
+
+  function refusedConnectError() {
+    return new Error('Failed to start session - unable to connect to the agent', {
+      cause: new Error('connect ECONNREFUSED 127.0.0.1:4000'),
+    })
   }
 
   it('start runs a MicroVM with image/role/connectors and becomes healthy', async () => {
@@ -512,7 +505,7 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
   })
 
-  it('createSession replaces a TERMINATING generation then creates once', async () => {
+  it('createSession replaces after connect-refused when the generation is TERMINATING', async () => {
     const { BaseContainerClient } = await import('./base-container-client')
     const client = newClient()
     await client.start({ envVars: { FOO: 'bar' } })
@@ -530,16 +523,19 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
       if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
       return {}
     })
-    responses.getState = 'TERMINATING'
 
-    const superCreate = vi
-      .spyOn(BaseContainerClient.prototype, 'createSession')
-      .mockResolvedValue({ id: 'sess-1' } as never)
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate
+      .mockImplementationOnce(async () => {
+        responses.getState = 'TERMINATING'
+        throw refusedConnectError()
+      })
+      .mockResolvedValueOnce({ id: 'sess-1' } as never)
 
     await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-1' })
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(true)
     expect(runCount).toBe(1)
-    expect(superCreate).toHaveBeenCalledTimes(1)
+    expect(superCreate).toHaveBeenCalledTimes(2)
     superCreate.mockRestore()
   })
 
@@ -566,15 +562,48 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     superCreate
       .mockImplementationOnce(async () => {
         responses.getState = 'TERMINATED'
-        throw new Error('Failed to start session - unable to connect to the agent', {
-          cause: new Error('connect ECONNREFUSED 127.0.0.1:4000'),
-        })
+        throw refusedConnectError()
       })
       .mockResolvedValueOnce({ id: 'sess-2' } as never)
 
     await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-2' })
     expect(runCount).toBe(1)
     expect(superCreate).toHaveBeenCalledTimes(2)
+    superCreate.mockRestore()
+  })
+
+  it('createSession does not resurrect when connect-refused but generation is still RUNNING', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+    responses.getState = 'RUNNING'
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockRejectedValue(refusedConnectError())
+
+    await expect(client.createSession({ initialMessage: 'hi' })).rejects.toThrow(/unable to connect/)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+    expect(superCreate).toHaveBeenCalledTimes(1)
+    superCreate.mockRestore()
+  })
+
+  it('replace without restartAgent throws instead of booting an env-less VM', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient({ withRestartAgent: false })
+    await client.start()
+    sendMock.mockClear()
+
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate.mockImplementationOnce(async () => {
+      responses.getState = 'TERMINATED'
+      throw refusedConnectError()
+    })
+
+    await expect(client.createSession({ initialMessage: 'hi' })).rejects.toThrow(/restartAgent is required/)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
     superCreate.mockRestore()
   })
 
@@ -591,8 +620,7 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
       new Error('connect ETIMEDOUT 10.0.0.1:3000'),
       new Error('fetch failed'),
     ]) {
-      // Keep generation RUNNING so ensureAlive does not replace; only the
-      // post-create classifier under test can decide to retry.
+      // Keep generation RUNNING so observeDeadGeneration returns null.
       responses.getState = 'RUNNING'
       superCreate.mockReset()
       superCreate.mockRejectedValueOnce(
@@ -665,18 +693,23 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
       if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
       return {}
     })
-    responses.getState = 'TERMINATING'
 
-    const superCreate = vi
-      .spyOn(BaseContainerClient.prototype, 'createSession')
-      .mockResolvedValue({ id: 'sess-x' } as never)
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate.mockImplementation(async () => {
+      if (responses.getState === 'TERMINATING' || responses.getState === 'TERMINATED') {
+        throw refusedConnectError()
+      }
+      return { id: 'sess-x' } as never
+    })
+    responses.getState = 'TERMINATING'
 
     await Promise.all([
       client.createSession({ initialMessage: 'a' }),
       client.createSession({ initialMessage: 'b' }),
     ])
     expect(runCount).toBe(1)
-    expect(superCreate).toHaveBeenCalledTimes(2)
+    // Two refused attempts + two successful retries after shared replace.
+    expect(superCreate).toHaveBeenCalledTimes(4)
     superCreate.mockRestore()
   })
 
@@ -717,10 +750,13 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
       if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
       return {}
     })
-    responses.getState = 'TERMINATING'
 
-    const superCreate = vi
-      .spyOn(BaseContainerClient.prototype, 'createSession')
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate
+      .mockImplementationOnce(async () => {
+        responses.getState = 'TERMINATING'
+        throw refusedConnectError()
+      })
       .mockResolvedValue({ id: 'sess-cas-teardown' } as never)
 
     const createPromise = client.createSession({ initialMessage: 'hi' })
@@ -739,6 +775,58 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(info.status).toBe('running')
     expect(runCount).toBe(1)
     superCreate.mockRestore()
+  })
+
+  it('stop() teardown must not wipe a generation installed during TerminateMicrovm', async () => {
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    let releaseTerminate!: () => void
+    const gate = new Promise<void>((r) => {
+      releaseTerminate = r
+    })
+    let terminateStarted!: () => void
+    const terminateStartedP = new Promise<void>((r) => {
+      terminateStarted = r
+    })
+
+    const terminateIds: string[] = []
+    let gatedOnce = false
+    let runCount = 0
+    sendMock.mockImplementation(async (cmd: { type: string; input?: { microvmIdentifier?: string } }) => {
+      if (cmd.type === 'Run') {
+        runCount++
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-probe-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+      if (cmd.type === 'Terminate') {
+        terminateIds.push(String(cmd.input?.microvmIdentifier ?? ''))
+        if (!gatedOnce) {
+          gatedOnce = true
+          terminateStarted()
+          await gate
+        }
+        return {}
+      }
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+
+    const stopPromise = client.stop()
+    await terminateStartedP
+    responses.getState = 'TERMINATING'
+    await client.getInfoFromRuntime()
+    responses.getState = 'RUNNING'
+    await client.start()
+    releaseTerminate()
+    await stopPromise
+
+    responses.getState = 'RUNNING'
+    expect((await client.getInfoFromRuntime()).status).toBe('running')
+    expect(terminateIds).toContain('mvm-1')
+    expect(terminateIds).not.toContain('mvm-probe-1')
   })
 
   it('stale dead-generation observation does not terminate a newer healthy generation', async () => {
@@ -783,8 +871,9 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
       return {}
     })
 
-    const superCreate = vi
-      .spyOn(BaseContainerClient.prototype, 'createSession')
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate
+      .mockRejectedValueOnce(refusedConnectError())
       .mockResolvedValue({ id: 'sess-cas' } as never)
 
     const createPromise = client.createSession({ initialMessage: 'hi' })
@@ -833,10 +922,13 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
       if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
       return {}
     })
-    responses.getState = 'TERMINATING'
 
-    const superCreate = vi
-      .spyOn(BaseContainerClient.prototype, 'createSession')
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate
+      .mockImplementationOnce(async () => {
+        responses.getState = 'TERMINATING'
+        throw refusedConnectError()
+      })
       .mockResolvedValue({ id: 'sess-race' } as never)
 
     // createSession replaces then restartAgent; a concurrent ensureRunning-style
@@ -852,7 +944,7 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     superCreate.mockRestore()
   })
 
-  it('observeDeadGeneration returning false on throttling does not replace', async () => {
+  it('throttled GetMicrovm after connect-refused does not replace', async () => {
     const { BaseContainerClient } = await import('./base-container-client')
     const client = newClient()
     await client.start()
@@ -868,9 +960,9 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
 
     const superCreate = vi
       .spyOn(BaseContainerClient.prototype, 'createSession')
-      .mockResolvedValue({ id: 'sess-throttle' } as never)
+      .mockRejectedValue(refusedConnectError())
 
-    await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-throttle' })
+    await expect(client.createSession({ initialMessage: 'hi' })).rejects.toThrow(/unable to connect/)
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Run')).toBe(false)
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
     superCreate.mockRestore()

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -754,12 +754,18 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   // replace once then retry. No pre-create GetMicrovm — ensureRunning's health
   // probe covers the common path; dead gens are rare after terminate-on-stop.
   async createSession(options: CreateSessionOptions): Promise<ContainerSession> {
+    // Snapshot before super.createSession: getPortOrThrow → getInfoFromRuntime
+    // CAS-drops a terminal generation, so observeDeadGeneration would see nothing.
+    const installedId = agentStates.get(this.config.agentId)?.microvmId ?? null
     try {
       return await super.createSession(options)
     } catch (error) {
       if (!isUnreachableCreateSessionError(error)) throw error
-      const deadId = await this.observeDeadGeneration()
-      // Alive, unknown, or no local state — do not resurrect a stopped agent.
+      let deadId = await this.observeDeadGeneration()
+      if (deadId === null && installedId !== null && !agentStates.has(this.config.agentId)) {
+        deadId = installedId
+      }
+      // Alive, unknown, or never had a generation — do not resurrect a stopped agent.
       if (deadId === null) throw error
       await this.replaceGeneration('post_create_unreachable', deadId)
       return await super.createSession(options)

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -636,16 +636,24 @@ async function createMicrovmAuthToken(
 
 const TERMINAL_MICROVM_STATES = new Set(['TERMINATED', 'TERMINATING'])
 
-// Only retry createSession when the request clearly never reached the container.
-// Abort/timeout and mid-response resets are ambiguous (prompt may already be running).
+// True only when the create never left the host TCP stack (connect refused).
+// BaseContainerClient maps ECONNRESET/ETIMEDOUT/fetch failed to the same
+// "unable to connect" string — those are ambiguous (prompt may already run).
+function causeChainIncludes(error: Error, needle: string): boolean {
+  let cur: unknown = error
+  for (let i = 0; i < 5 && cur instanceof Error; i++) {
+    if (cur.message.includes(needle)) return true
+    cur = cur.cause
+  }
+  return false
+}
+
 function isUnreachableCreateSessionError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
   const msg = error.message
-  return (
-    msg.includes('unable to connect to the agent') ||
-    msg.includes('Container is not running') ||
-    msg.includes('ECONNREFUSED')
-  )
+  if (msg.includes('Container is not running')) return true
+  if (msg.includes('ECONNREFUSED') || causeChainIncludes(error, 'ECONNREFUSED')) return true
+  return false
 }
 
 export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
@@ -888,7 +896,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
     const current = agentStates.get(this.config.agentId)
     if (observedId && current?.microvmId === observedId) {
-      await this.teardown()
+      // Terminate then CAS-cleanup — never teardown(): awaiting Terminate can
+      // race a newer generation into agentStates, and teardown always wipes local.
+      await this.terminateObserved(observedId)
+      this.cleanupLocalIf(observedId)
     } else if (observedId && !current) {
       // Local state already dropped (e.g. getInfo CAS); still terminate the observed id.
       await this.terminateObserved(observedId)

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -8,7 +8,6 @@ import {
   LambdaMicrovmsClient,
   RunMicrovmCommand,
   GetMicrovmCommand,
-  SuspendMicrovmCommand,
   TerminateMicrovmCommand,
   CreateMicrovmAuthTokenCommand,
 } from '@aws-sdk/client-lambda-microvms'
@@ -37,14 +36,13 @@ import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
 // start()). This guard backstops an unexpectedly large payload.
 const RUN_HOOK_PAYLOAD_MAX_BYTES = 4_096
 const AUTH_TOKEN_EXPIRATION_MINUTES = 60
-// Max wait to kick a (possibly suspended) VM back to a serveable agent before a real
-// request. Covers auto-resume (~2-10s) with headroom; returns as soon as /health is ok.
+// Max wait for a freshly started VM to serve /health before a real request.
 const RESUME_KICK_TIMEOUT_MS = 60_000
-// Gap between proxy retries while a suspended VM wakes (it 502s for ~2-3s).
+// Gap between proxy retries while a new VM's ingress is still coming up.
 const RESUME_RETRY_DELAY_MS = 400
 // Idle timeout on a single upstream exchange (HTTP request, or the WS connect
 // handshake). Guards against a silently hung socket that never errors or 502s,
-// which would otherwise wedge the resume-retry loop forever. Disabled once a WS
+// which would otherwise wedge the bring-up retry loop forever. Disabled once a WS
 // handshake completes (a live stream is idle by design).
 const UPSTREAM_IDLE_TIMEOUT_MS = 30_000
 const ECS_METADATA_TIMEOUT_MS = 2_000
@@ -100,13 +98,9 @@ const microvmRuntimeSchema = z.object({
   egressConnectorArn: z.string().min(1),
   ingressConnectorArn: z.string().min(1).optional(),
   agentPort: z.coerce.number().int().positive().default(CONTAINER_INTERNAL_PORT),
-  // Total VM lifetime cap (AWS hard max 28_800 = 8h). Default to the max so a
-  // suspended VM survives "until killed" — the next request auto-resumes it and
-  // only the 8h ceiling force-terminates an untouched VM.
+  // Total VM lifetime cap (AWS hard max 28_800 = 8h). Default to the max so an
+  // untouched RUNNING VM is only force-terminated by the lifetime ceiling.
   maxDurationSeconds: z.coerce.number().int().positive().max(28_800).default(28_800),
-  // How long a suspended VM is kept before AWS terminates it. Maxed so suspend
-  // lasts "until killed" within the 8h lifetime cap.
-  suspendedSeconds: z.coerce.number().int().positive().max(28_800).default(28_800),
   logGroup: z.string().min(1).optional(),
   // Per-org S3 Files workspace mount, passed to the image's run hook so the
   // supervisor mounts /workspace. All three required together or none (no mount).
@@ -132,7 +126,6 @@ function computeConfigOrNull(): MicrovmRuntimeConfig | null {
     ingressConnectorArn: process.env.MICROVM_INGRESS_CONNECTOR_ARN,
     agentPort: process.env.MICROVM_AGENT_PORT,
     maxDurationSeconds: process.env.MICROVM_MAX_DURATION_SECONDS,
-    suspendedSeconds: process.env.MICROVM_SUSPENDED_SECONDS,
     logGroup: process.env.MICROVM_LOG_GROUP,
     fsId: process.env.MICROVM_FS_ID,
     accessPoint: process.env.MICROVM_ACCESS_POINT,
@@ -206,7 +199,8 @@ async function resolveHostApiBaseUrlForMicrovm(): Promise<string> {
   return `http://${privateIp}:${port}`
 }
 
-// Idle→suspend window: app settings are the single source of truth.
+// Kept for tests/callers that mirror auto-sleep into seconds. Idle stop is
+// host-owned (terminate); AWS idlePolicy no longer suspends on this window.
 export function resolveIdleSeconds(config: MicrovmRuntimeConfig): number {
   const minutes = getSettings().app?.autoSleepTimeoutMinutes ?? 30
   if (minutes <= 0) return config.maxDurationSeconds
@@ -320,9 +314,9 @@ export class LocalAuthForwardProxy {
     })
   }
 
-  // Wake a (possibly suspended) VM and confirm it serves before we start an
-  // unreplayable WS pipe. Reuses the HTTP forward+retry over /health so a 502
-  // (resuming) or connection refusal (still waking) is retried within the budget.
+  // Confirm the MicroVM agent serves before we start an unreplayable WS pipe.
+  // Reuses the HTTP forward+retry over /health so a 502 or connection refusal
+  // during cold bring-up is retried within the budget.
   private async waitForUpstreamReady(): Promise<boolean> {
     const deadline = Date.now() + RESUME_KICK_TIMEOUT_MS
     for (;;) {
@@ -471,8 +465,8 @@ export class LocalAuthForwardProxy {
 
 // MicroVM ids are AWS-generated (no deterministic name, no tag-filtered lookup),
 // so the agentId→microvm mapping + its loopback proxy live in process memory.
-// Lost on host-app restart: the orphaned VM is reclaimed by its idlePolicy
-// (idle→suspend→suspended-timeout→terminate) and the next start() re-runs.
+// Lost on host-app restart: the orphaned VM is reclaimed by the lifetime cap
+// (or host auto-sleep terminate on the previous generation) and the next start() re-runs.
 interface AgentMicrovmState {
   microvmId: string
   endpoint: string
@@ -550,10 +544,12 @@ async function runMicrovm(
   config: MicrovmRuntimeConfig,
   opts: { runHookPayload: string; clientToken: string; logStream: string },
 ): Promise<{ microvmId: string; endpoint: string }> {
+  // No suspend: match other runners (stop = terminate). Cap AWS idle at the
+  // lifetime so the control plane never auto-suspends; host auto-sleep terminates.
   const idlePolicy = {
-    maxIdleDurationSeconds: resolveIdleSeconds(config),
-    suspendedDurationSeconds: config.suspendedSeconds,
-    autoResumeEnabled: true,
+    maxIdleDurationSeconds: config.maxDurationSeconds,
+    suspendedDurationSeconds: 1,
+    autoResumeEnabled: false,
   }
   const logging = config.logGroup
     ? { cloudWatch: { logGroup: config.logGroup, logStream: opts.logStream } }
@@ -600,15 +596,6 @@ async function getMicrovm(region: string, microvmId: string): Promise<MicrovmDet
     new GetMicrovmCommand({ microvmIdentifier: microvmId }),
   )) as GetMicrovmCommandOutput
   return { state: res.state, endpoint: res.endpoint }
-}
-
-async function suspendMicrovm(region: string, microvmId: string): Promise<void> {
-  const svc = microvmService()
-  if (svc) {
-    await serviceFetch(svc, 'POST', `/microvm/${encodeURIComponent(microvmId)}/suspend`)
-    return
-  }
-  await getMicrovmClient(region).send(new SuspendMicrovmCommand({ microvmIdentifier: microvmId }))
 }
 
 async function terminateMicrovm(region: string, microvmId: string): Promise<void> {
@@ -762,8 +749,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     }
   }
 
-  // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
-  // When the generation is already TERMINATING/TERMINATED (resume-vs-kill race),
+  // When the generation is already TERMINATING/TERMINATED (lifetime-cap / race),
   // replace once then retry createSession — callers must not branch on provider type.
   async createSession(options: CreateSessionOptions): Promise<ContainerSession> {
     await this.ensureAliveGeneration()
@@ -779,19 +765,16 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     }
   }
 
-  async stop(options?: StopOptions): Promise<StopResult> {
+  async stop(_options?: StopOptions): Promise<StopResult> {
     this.terminateWebSocketConnections()
-    // Auto-sleep is handled by AWS idlePolicy; the host-app sweep is a no-op.
-    if (options?.escalateToForceStop === false) {
-      return { forceStopUsed: false, stopped: true }
-    }
-    await this.suspend()
+    // Same as other runners: stop means gone. Auto-sleep and explicit stop both terminate.
+    await this.teardown()
     return { forceStopUsed: false, stopped: true }
   }
 
   stopSync(): void {
     // Terminate uses the async AWS API; sync shutdown only tears down WS + proxy.
-    // The VM itself is reclaimed by its idlePolicy.
+    // The VM is reclaimed by the next async stop/teardown or the lifetime cap.
     this.terminateWebSocketConnections()
     this.cleanupLocal()
   }
@@ -803,15 +786,23 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const config = getMicrovmRuntimeConfig()
     try {
       const mvm = await getMicrovm(config.region, observedId)
-      // SUSPENDED is "running on demand": idlePolicy.autoResumeEnabled wakes it
-      // on the next request through the proxy.
-      if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+      if (mvm.state === 'RUNNING') {
         const current = agentStates.get(this.config.agentId)
         // Generation swapped during GetMicrovm — report whatever is installed now.
         if (current && current.microvmId !== observedId) {
           return { status: 'running', port: current.proxyPort }
         }
         return { status: 'running', port: state.proxyPort }
+      }
+      // Pre-policy SUSPENDED leftovers: terminate that generation (CAS) and drop local state.
+      if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+        if (agentStates.get(this.config.agentId)?.microvmId === observedId) {
+          await this.terminateObserved(observedId)
+          this.cleanupLocalIf(observedId)
+        }
+        const current = agentStates.get(this.config.agentId)
+        if (current) return { status: 'running', port: current.proxyPort }
+        return { status: 'stopped', port: null }
       }
       // Terminal: drop only the generation we observed (CAS) so a concurrent
       // replace/start isn't wiped by a stale answer.
@@ -945,28 +936,6 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       await new Promise((resolve) => setTimeout(resolve, 2_000))
     }
     throw new Error(`Timed out waiting for MicroVM ${microvmId} to become RUNNING`)
-  }
-
-  // Keep local proxy state so the next request auto-resumes the same VM.
-  private async suspend(): Promise<void> {
-    const state = agentStates.get(this.config.agentId)
-    if (!state) return
-    const config = getMicrovmRuntimeConfig()
-    try {
-      const mvm = await getMicrovm(config.region, state.microvmId)
-      if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') return
-      if (TERMINAL_MICROVM_STATES.has(mvm.state ?? '')) {
-        this.cleanupLocalIf(state.microvmId)
-        return
-      }
-      await suspendMicrovm(config.region, state.microvmId)
-    } catch (error) {
-      if (isNotFound(error)) {
-        this.cleanupLocalIf(state.microvmId)
-        return
-      }
-      captureException(error, { tags: { area: 'container', op: 'microvm.suspend' }, extra: { microvmId: state.microvmId } })
-    }
   }
 
   private async teardown(): Promise<void> {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -18,7 +18,16 @@ import type {
   RunMicrovmCommandOutput,
 } from '@aws-sdk/client-lambda-microvms'
 import { BaseContainerClient, CONTAINER_INTERNAL_PORT } from './base-container-client'
-import type { ContainerConfig, ContainerInfo, ContainerStats, StartOptions, StopOptions, StopResult } from './types'
+import type {
+  ContainerConfig,
+  ContainerInfo,
+  ContainerSession,
+  ContainerStats,
+  CreateSessionOptions,
+  StartOptions,
+  StopOptions,
+  StopResult,
+} from './types'
 import { getSettings } from '@shared/lib/config/settings'
 import { captureException } from '@shared/lib/error-reporting'
 import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
@@ -638,12 +647,18 @@ async function createMicrovmAuthToken(
   return out.authToken
 }
 
+const TERMINAL_MICROVM_STATES = new Set(['TERMINATED', 'TERMINATING'])
+
 export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   static readonly runnerName = 'lambda-microvm'
   // Image is built once via create-microvm-image and run by AWS; nothing local.
   static readonly requiresLocalImage = false
   // Image comes solely from MICROVM_AGENT_IMAGE_ARN/_VERSION; settings.container.agentImage is ignored.
   static readonly supportsCustomAgentImage = false
+
+  private lastStartOptions?: StartOptions
+  private hasStarted = false
+  private replaceInFlight: Promise<void> | null = null
 
   constructor(config: ContainerConfig) {
     super(config)
@@ -735,9 +750,23 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       await this.teardown()
       throw error
     }
+    this.lastStartOptions = options
+    this.hasStarted = true
   }
 
   // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
+  // When the generation is already TERMINATING/TERMINATED (resume-vs-kill race),
+  // replace once then retry createSession — callers must not branch on provider type.
+  async createSession(options: CreateSessionOptions): Promise<ContainerSession> {
+    await this.ensureAliveGeneration()
+    try {
+      return await super.createSession(options)
+    } catch (error) {
+      if (!(await this.isDeadGeneration())) throw error
+      await this.replaceGeneration('post_create_dead')
+      return await super.createSession(options)
+    }
+  }
 
   async stop(options?: StopOptions): Promise<StopResult> {
     this.terminateWebSocketConnections()
@@ -801,12 +830,64 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     return createMicrovmAuthToken(config.region, microvmId, [config.agentPort], AUTH_TOKEN_EXPIRATION_MINUTES)
   }
 
+  private async ensureAliveGeneration(): Promise<void> {
+    if (await this.isDeadGeneration()) {
+      await this.replaceGeneration('pre_create_dead')
+    }
+  }
+
+  private async isDeadGeneration(): Promise<boolean> {
+    const state = agentStates.get(this.config.agentId)
+    if (!state) return this.hasStarted
+    const config = getMicrovmRuntimeConfig()
+    try {
+      const mvm = await getMicrovm(config.region, state.microvmId)
+      return TERMINAL_MICROVM_STATES.has(mvm.state ?? '')
+    } catch (error) {
+      if (isNotFound(error)) return true
+      return false
+    }
+  }
+
+  private async replaceGeneration(reason: string): Promise<void> {
+    if (this.replaceInFlight) return this.replaceInFlight
+    this.replaceInFlight = this.replaceGenerationInner(reason).finally(() => {
+      this.replaceInFlight = null
+    })
+    return this.replaceInFlight
+  }
+
+  private async replaceGenerationInner(reason: string): Promise<void> {
+    const failedId = agentStates.get(this.config.agentId)?.microvmId
+
+    console.warn(
+      `[LambdaMicroVmRuntimeClient] Replacing dead MicroVM generation agent=${this.config.agentId} reason=${reason} old=${failedId ?? 'none'}`,
+    )
+    captureException(new Error(`MicroVM generation replaced: ${reason}`), {
+      tags: { area: 'container', op: 'microvm.replace' },
+      extra: { agentId: this.config.agentId, oldMicrovmId: failedId, reason },
+      level: 'warning',
+    })
+
+    if (failedId && agentStates.get(this.config.agentId)?.microvmId === failedId) {
+      await this.teardown()
+    } else {
+      this.cleanupLocal()
+    }
+    // Peer single-flight waiter: another replace may have already started a fresh VM.
+    if (agentStates.has(this.config.agentId)) return
+    if (!this.hasStarted) {
+      throw new Error('Cannot replace MicroVM generation before the first start')
+    }
+    await this.start(this.lastStartOptions)
+  }
+
   private async waitForRunning(region: string, microvmId: string, timeoutMs: number): Promise<void> {
     const startedAt = Date.now()
     while (Date.now() - startedAt < timeoutMs) {
       const mvm = await getMicrovm(region, microvmId)
       if (mvm.state === 'RUNNING') return
-      if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
+      if (TERMINAL_MICROVM_STATES.has(mvm.state ?? '')) {
         throw new Error(`MicroVM ${microvmId} entered ${mvm.state} before becoming ready`)
       }
       await new Promise((resolve) => setTimeout(resolve, 2_000))
@@ -822,7 +903,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     try {
       const mvm = await getMicrovm(config.region, state.microvmId)
       if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') return
-      if (mvm.state === 'TERMINATED' || mvm.state === 'TERMINATING') {
+      if (TERMINAL_MICROVM_STATES.has(mvm.state ?? '')) {
         this.cleanupLocal()
         return
       }

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -29,7 +29,7 @@ import type {
   StopResult,
 } from './types'
 import { getSettings } from '@shared/lib/config/settings'
-import { captureException } from '@shared/lib/error-reporting'
+import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
 
 // RunMicrovm caps runHookPayload at 4096 bytes. We only put a small bootstrap
@@ -649,6 +649,18 @@ async function createMicrovmAuthToken(
 
 const TERMINAL_MICROVM_STATES = new Set(['TERMINATED', 'TERMINATING'])
 
+// Only retry createSession when the request clearly never reached the container.
+// Abort/timeout and mid-response resets are ambiguous (prompt may already be running).
+function isUnreachableCreateSessionError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const msg = error.message
+  return (
+    msg.includes('unable to connect to the agent') ||
+    msg.includes('Container is not running') ||
+    msg.includes('ECONNREFUSED')
+  )
+}
+
 export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   static readonly runnerName = 'lambda-microvm'
   // Image is built once via create-microvm-image and run by AWS; nothing local.
@@ -656,8 +668,6 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   // Image comes solely from MICROVM_AGENT_IMAGE_ARN/_VERSION; settings.container.agentImage is ignored.
   static readonly supportsCustomAgentImage = false
 
-  private lastStartOptions?: StartOptions
-  private hasStarted = false
   private replaceInFlight: Promise<void> | null = null
 
   constructor(config: ContainerConfig) {
@@ -750,8 +760,6 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       await this.teardown()
       throw error
     }
-    this.lastStartOptions = options
-    this.hasStarted = true
   }
 
   // Proxy-level retry handles the suspend→resume 502 window for all HTTP calls.
@@ -762,8 +770,11 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     try {
       return await super.createSession(options)
     } catch (error) {
-      if (!(await this.isDeadGeneration())) throw error
-      await this.replaceGeneration('post_create_dead')
+      if (!isUnreachableCreateSessionError(error)) throw error
+      const deadId = await this.observeDeadGeneration()
+      // Live generation still installed — connection blip, not a dead MicroVM.
+      if (deadId === null && agentStates.has(this.config.agentId)) throw error
+      await this.replaceGeneration('post_create_unreachable', deadId)
       return await super.createSession(options)
     }
   }
@@ -788,25 +799,36 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   async getInfoFromRuntime(): Promise<ContainerInfo> {
     const state = agentStates.get(this.config.agentId)
     if (!state) return { status: 'stopped', port: null }
+    const observedId = state.microvmId
     const config = getMicrovmRuntimeConfig()
     try {
-      const mvm = await getMicrovm(config.region, state.microvmId)
+      const mvm = await getMicrovm(config.region, observedId)
       // SUSPENDED is "running on demand": idlePolicy.autoResumeEnabled wakes it
       // on the next request through the proxy.
       if (mvm.state === 'RUNNING' || mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
+        const current = agentStates.get(this.config.agentId)
+        // Generation swapped during GetMicrovm — report whatever is installed now.
+        if (current && current.microvmId !== observedId) {
+          return { status: 'running', port: current.proxyPort }
+        }
         return { status: 'running', port: state.proxyPort }
       }
-      // Terminal: VM is gone — drop state + proxy (mirror NotFound) so it isn't leaked.
-      this.cleanupLocal()
+      // Terminal: drop only the generation we observed (CAS) so a concurrent
+      // replace/start isn't wiped by a stale answer.
+      this.cleanupLocalIf(observedId)
+      const current = agentStates.get(this.config.agentId)
+      if (current) return { status: 'running', port: current.proxyPort }
       return { status: 'stopped', port: null }
     } catch (error) {
       if (isNotFound(error)) {
-        this.cleanupLocal()
+        this.cleanupLocalIf(observedId)
+        const current = agentStates.get(this.config.agentId)
+        if (current) return { status: 'running', port: current.proxyPort }
         return { status: 'stopped', port: null }
       }
       // Transient (throttling/network): keep last known state so we don't orphan a live
       // VM; container-manager's TTL /health re-probe backstops a genuinely dead one.
-      captureException(error, { tags: { area: 'container', op: 'microvm.getInfo' }, extra: { microvmId: state.microvmId } })
+      captureException(error, { tags: { area: 'container', op: 'microvm.getInfo' }, extra: { microvmId: observedId } })
       return { status: 'running', port: state.proxyPort }
     }
   }
@@ -831,55 +853,85 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   }
 
   private async ensureAliveGeneration(): Promise<void> {
-    if (await this.isDeadGeneration()) {
-      await this.replaceGeneration('pre_create_dead')
+    const deadId = await this.observeDeadGeneration()
+    if (deadId !== null) {
+      await this.replaceGeneration('pre_create_dead', deadId)
     }
   }
 
-  private async isDeadGeneration(): Promise<boolean> {
+  // Returns the observed microvmId when that generation is terminal/missing; null if alive or unknown.
+  private async observeDeadGeneration(): Promise<string | null> {
     const state = agentStates.get(this.config.agentId)
-    if (!state) return this.hasStarted
+    if (!state) return null
+    const observedId = state.microvmId
     const config = getMicrovmRuntimeConfig()
     try {
-      const mvm = await getMicrovm(config.region, state.microvmId)
-      return TERMINAL_MICROVM_STATES.has(mvm.state ?? '')
+      const mvm = await getMicrovm(config.region, observedId)
+      return TERMINAL_MICROVM_STATES.has(mvm.state ?? '') ? observedId : null
     } catch (error) {
-      if (isNotFound(error)) return true
-      return false
+      if (isNotFound(error)) return observedId
+      return null
     }
   }
 
-  private async replaceGeneration(reason: string): Promise<void> {
+  private async replaceGeneration(reason: string, observedId: string | null): Promise<void> {
     if (this.replaceInFlight) return this.replaceInFlight
-    this.replaceInFlight = this.replaceGenerationInner(reason).finally(() => {
+    this.replaceInFlight = this.replaceGenerationInner(reason, observedId).finally(() => {
       this.replaceInFlight = null
     })
     return this.replaceInFlight
   }
 
-  private async replaceGenerationInner(reason: string): Promise<void> {
-    const failedId = agentStates.get(this.config.agentId)?.microvmId
-
+  private async replaceGenerationInner(reason: string, observedId: string | null): Promise<void> {
     console.warn(
-      `[LambdaMicroVmRuntimeClient] Replacing dead MicroVM generation agent=${this.config.agentId} reason=${reason} old=${failedId ?? 'none'}`,
+      `[LambdaMicroVmRuntimeClient] Replacing dead MicroVM generation agent=${this.config.agentId} reason=${reason} old=${observedId ?? 'none'}`,
     )
-    captureException(new Error(`MicroVM generation replaced: ${reason}`), {
-      tags: { area: 'container', op: 'microvm.replace' },
-      extra: { agentId: this.config.agentId, oldMicrovmId: failedId, reason },
+    addErrorBreadcrumb({
+      category: 'container',
+      message: `MicroVM generation replaced: ${reason}`,
+      data: { agentId: this.config.agentId, oldMicrovmId: observedId, reason },
       level: 'warning',
     })
 
-    if (failedId && agentStates.get(this.config.agentId)?.microvmId === failedId) {
+    this.terminateWebSocketConnections()
+
+    const current = agentStates.get(this.config.agentId)
+    if (observedId && current?.microvmId === observedId) {
       await this.teardown()
-    } else {
+    } else if (observedId && !current) {
+      // Local state already dropped (e.g. getInfo CAS); still terminate the observed id.
+      await this.terminateObserved(observedId)
+    } else if (!observedId) {
       this.cleanupLocal()
     }
-    // Peer single-flight waiter: another replace may have already started a fresh VM.
+    // CAS miss (current is a different generation): leave it installed.
+
     if (agentStates.has(this.config.agentId)) return
-    if (!this.hasStarted) {
-      throw new Error('Cannot replace MicroVM generation before the first start')
+
+    try {
+      if (this.config.restartAgent) {
+        await this.config.restartAgent()
+      } else {
+        await this.start()
+      }
+    } catch (error) {
+      captureException(error, {
+        tags: { area: 'container', op: 'microvm.replace' },
+        extra: { agentId: this.config.agentId, oldMicrovmId: observedId, reason },
+      })
+      throw error
     }
-    await this.start(this.lastStartOptions)
+  }
+
+  private async terminateObserved(microvmId: string): Promise<void> {
+    const config = getMicrovmRuntimeConfig()
+    try {
+      await terminateMicrovm(config.region, microvmId)
+    } catch (error) {
+      if (!isNotFound(error)) {
+        captureException(error, { tags: { area: 'container', op: 'microvm.terminate' }, extra: { microvmId } })
+      }
+    }
   }
 
   private async waitForRunning(region: string, microvmId: string, timeoutMs: number): Promise<void> {
@@ -904,13 +956,13 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       const mvm = await getMicrovm(config.region, state.microvmId)
       if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') return
       if (TERMINAL_MICROVM_STATES.has(mvm.state ?? '')) {
-        this.cleanupLocal()
+        this.cleanupLocalIf(state.microvmId)
         return
       }
       await suspendMicrovm(config.region, state.microvmId)
     } catch (error) {
       if (isNotFound(error)) {
-        this.cleanupLocal()
+        this.cleanupLocalIf(state.microvmId)
         return
       }
       captureException(error, { tags: { area: 'container', op: 'microvm.suspend' }, extra: { microvmId: state.microvmId } })
@@ -937,6 +989,13 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     state?.proxy.stop()
     agentStates.delete(this.config.agentId)
     clearBootstrapEnv(this.config.agentId)
+  }
+
+  // Compare-and-swap cleanup: only drop state if it still points at observedId.
+  private cleanupLocalIf(observedId: string): void {
+    if (agentStates.get(this.config.agentId)?.microvmId === observedId) {
+      this.cleanupLocal()
+    }
   }
 }
 

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -27,7 +27,6 @@ import type {
   StopOptions,
   StopResult,
 } from './types'
-import { getSettings } from '@shared/lib/config/settings'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
 
@@ -197,14 +196,6 @@ async function resolveHostApiBaseUrlForMicrovm(): Promise<string> {
 
   const port = hostAppPortSchema.parse(process.env.PORT)
   return `http://${privateIp}:${port}`
-}
-
-// Kept for tests/callers that mirror auto-sleep into seconds. Idle stop is
-// host-owned (terminate); AWS idlePolicy no longer suspends on this window.
-export function resolveIdleSeconds(config: MicrovmRuntimeConfig): number {
-  const minutes = getSettings().app?.autoSleepTimeoutMinutes ?? 30
-  if (minutes <= 0) return config.maxDurationSeconds
-  return Math.min(minutes * 60, config.maxDurationSeconds)
 }
 
 // ---------------------------------------------------------------------------
@@ -546,6 +537,8 @@ async function runMicrovm(
 ): Promise<{ microvmId: string; endpoint: string }> {
   // No suspend: match other runners (stop = terminate). Cap AWS idle at the
   // lifetime so the control plane never auto-suspends; host auto-sleep terminates.
+  // suspendedDurationSeconds is required by the API; 1 is the floor placeholder
+  // (autoResumeEnabled is false so it is never used). Staging canary accepted it.
   const idlePolicy = {
     maxIdleDurationSeconds: config.maxDurationSeconds,
     suspendedDurationSeconds: 1,
@@ -757,17 +750,17 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     }
   }
 
-  // When the generation is already TERMINATING/TERMINATED (lifetime-cap / race),
-  // replace once then retry createSession — callers must not branch on provider type.
+  // On connect-refused against a dead generation (lifetime-cap / stop race),
+  // replace once then retry. No pre-create GetMicrovm — ensureRunning's health
+  // probe covers the common path; dead gens are rare after terminate-on-stop.
   async createSession(options: CreateSessionOptions): Promise<ContainerSession> {
-    await this.ensureAliveGeneration()
     try {
       return await super.createSession(options)
     } catch (error) {
       if (!isUnreachableCreateSessionError(error)) throw error
       const deadId = await this.observeDeadGeneration()
-      // Live generation still installed — connection blip, not a dead MicroVM.
-      if (deadId === null && agentStates.has(this.config.agentId)) throw error
+      // Alive, unknown, or no local state — do not resurrect a stopped agent.
+      if (deadId === null) throw error
       await this.replaceGeneration('post_create_unreachable', deadId)
       return await super.createSession(options)
     }
@@ -802,7 +795,7 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
         }
         return { status: 'running', port: state.proxyPort }
       }
-      // Pre-policy SUSPENDED leftovers: terminate that generation (CAS) and drop local state.
+      // One-time migration for pre-terminate-on-stop SUSPENDED leftovers (CAS).
       if (mvm.state === 'SUSPENDED' || mvm.state === 'SUSPENDING') {
         if (agentStates.get(this.config.agentId)?.microvmId === observedId) {
           await this.terminateObserved(observedId)
@@ -851,13 +844,6 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     return createMicrovmAuthToken(config.region, microvmId, [config.agentPort], AUTH_TOKEN_EXPIRATION_MINUTES)
   }
 
-  private async ensureAliveGeneration(): Promise<void> {
-    const deadId = await this.observeDeadGeneration()
-    if (deadId !== null) {
-      await this.replaceGeneration('pre_create_dead', deadId)
-    }
-  }
-
   // Returns the observed microvmId when that generation is terminal/missing; null if alive or unknown.
   private async observeDeadGeneration(): Promise<string | null> {
     const state = agentStates.get(this.config.agentId)
@@ -894,28 +880,29 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
     this.terminateWebSocketConnections()
 
+    if (!observedId) {
+      throw new Error(`Cannot replace MicroVM generation for ${this.config.agentId}: no observed id`)
+    }
+
     const current = agentStates.get(this.config.agentId)
-    if (observedId && current?.microvmId === observedId) {
-      // Terminate then CAS-cleanup — never teardown(): awaiting Terminate can
-      // race a newer generation into agentStates, and teardown always wipes local.
+    if (current?.microvmId === observedId) {
       await this.terminateObserved(observedId)
       this.cleanupLocalIf(observedId)
-    } else if (observedId && !current) {
+    } else if (!current) {
       // Local state already dropped (e.g. getInfo CAS); still terminate the observed id.
       await this.terminateObserved(observedId)
-    } else if (!observedId) {
-      this.cleanupLocal()
     }
     // CAS miss (current is a different generation): leave it installed.
 
     if (agentStates.has(this.config.agentId)) return
 
+    if (!this.config.restartAgent) {
+      throw new Error(
+        `Cannot replace MicroVM generation for ${this.config.agentId}: restartAgent is required`,
+      )
+    }
     try {
-      if (this.config.restartAgent) {
-        await this.config.restartAgent()
-      } else {
-        await this.start()
-      }
+      await this.config.restartAgent()
     } catch (error) {
       captureException(error, {
         tags: { area: 'container', op: 'microvm.replace' },
@@ -951,17 +938,22 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
   private async teardown(): Promise<void> {
     const state = agentStates.get(this.config.agentId)
-    if (state) {
-      const config = getMicrovmRuntimeConfig()
-      try {
-        await terminateMicrovm(config.region, state.microvmId)
-      } catch (error) {
-        if (!isNotFound(error)) {
-          captureException(error, { tags: { area: 'container', op: 'microvm.terminate' }, extra: { microvmId: state.microvmId } })
-        }
+    if (!state) {
+      this.cleanupLocal()
+      return
+    }
+    const observedId = state.microvmId
+    const config = getMicrovmRuntimeConfig()
+    try {
+      await terminateMicrovm(config.region, observedId)
+    } catch (error) {
+      if (!isNotFound(error)) {
+        captureException(error, { tags: { area: 'container', op: 'microvm.terminate' }, extra: { microvmId: observedId } })
       }
     }
-    this.cleanupLocal()
+    // CAS: a newer generation may have been installed while Terminate was in
+    // flight — wiping it here would leak that live VM.
+    this.cleanupLocalIf(observedId)
   }
 
   private cleanupLocal(): void {

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -24,6 +24,8 @@ export interface ContainerConfig {
   envVars?: Record<string, string>
   /** Called when a connection error is detected (ECONNREFUSED, etc.) */
   onConnectionError?: () => void
+  /** Manager-owned restart: single-flight doStartContainer (fresh env + status cache). */
+  restartAgent?: () => Promise<void>
 }
 
 export interface SlashCommandInfo {


### PR DESCRIPTION
## Summary
- **Stop / auto-sleep terminate** instead of suspend — MicroVM matches other runners (no warm resume). ~3s resume win was not worth suspend complexity / quota cost.
- AWS idlePolicy: `maxIdle` = lifetime, `autoResumeEnabled: false` (host owns idle via terminate).
- Keep **dead-generation replace** on `createSession` for TERMINATING/TERMINATED races (lifetime cap / concurrent teardown) — still useful without suspend.

Supersedes the suspend path that [#576](https://github.com/SkillfulAgents/SuperAgent/pull/576) targeted (closed). Staging canary verified on `yitian-superagent`.

## Bug / repro (original #613)
1. Agent MicroVM idle → eventually TERMINATING / gone while host still holds the old generation.
2. User creates a session → resume/connection failure → UI "Failed to create session".

## What changed
- `stop()` / auto-sleep → `teardown()` (terminate); drop `SuspendMicrovm` / `MICROVM_SUSPENDED_SECONDS`.
- `getInfoFromRuntime`: RUNNING only is running; SUSPENDED leftovers terminated (CAS-safe with #613 cleanup).
- `createSession`: ensure live generation; on unreachable post-create, replace once and retry.

## Test plan
- [x] `npx vitest run src/shared/lib/container/lambda-microvm-runtime.test.ts` (55)
- [x] Staging: `yitian-superagent` on `microvm-no-suspend-*` image — stop terminates (no suspend)
- [ ] Staging: force TERMINATING wake still replaces + creates session once