### PR TITLE
Composer model picker: Set as Agent Default footer

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -402,7 +402,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                         onRecentFileAttach={(file) => composer.addFiles([{ file }])}
                         disabled={isDisabled}
                       />
-                      <ComposerOptions state={composerOptions} disabled={isDisabled} />
+                      <ComposerOptions state={composerOptions} disabled={isDisabled} agentSlug={agent.slug} agentHomeLink={false} />
                     </>
                   )}
                   topRightActions={(

--- a/src/renderer/components/messages/agent-default-footer.test.tsx
+++ b/src/renderer/components/messages/agent-default-footer.test.tsx
@@ -148,15 +148,11 @@ describe('AgentDefaultFooter', () => {
     expect(screen.queryByTestId('composer-agent-default-change')).not.toBeInTheDocument()
   })
 
-  it('pulses once when a pick first diverges from the default', () => {
+  it('swaps the status label for the promote action when the pick diverges', () => {
     const { rerender } = render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith()} />)
     expect(screen.getByTestId('composer-agent-default-current')).toBeInTheDocument()
     rerender(<AgentDefaultFooter agentSlug="my-agent" state={stateWith({ model: 'claude-sonnet-4-6' })} />)
-    expect(screen.getByTestId('composer-agent-default').className).toContain('animate-promote-pulse')
-  })
-
-  it('does not pulse when mounted into an already-diverged session', () => {
-    render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith({ model: 'claude-sonnet-4-6' })} />)
-    expect(screen.getByTestId('composer-agent-default').className).not.toContain('animate-promote-pulse')
+    expect(screen.getByTestId('composer-agent-default')).toBeInTheDocument()
+    expect(screen.queryByTestId('composer-agent-default-current')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/messages/agent-default-footer.test.tsx
+++ b/src/renderer/components/messages/agent-default-footer.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const useSettingsMock = vi.fn()
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useModelSettings: () => useSettingsMock(),
+}))
+
+const useAgentPreferencesMock = vi.fn()
+const mutateMock = vi.fn()
+vi.mock('@renderer/hooks/use-agent-preferences', () => ({
+  useAgentPreferences: () => useAgentPreferencesMock(),
+  useUpdateAgentPreferences: () => ({ mutate: mutateMock, isPending: false }),
+}))
+
+const canAdminAgentMock = vi.fn(() => true)
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({ canAdminAgent: canAdminAgentMock }),
+}))
+
+const navigateMock = vi.fn()
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+
+import { AgentDefaultFooter } from './agent-default-footer'
+import type { ComposerOptionsState } from './composer-options'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+
+const ALL = ['low', 'medium', 'high', 'xhigh', 'max']
+const STD = ['low', 'medium', 'high']
+const CATALOG = [
+  { id: 'claude-haiku-4-5', label: 'Haiku 4.5', family: 'haiku', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'sonnet', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
+  { id: 'claude-opus-4-7', label: 'Opus 4.7', family: 'opus', icon: 'anthropic', supportedEfforts: ALL },
+  { id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'opus', isLatest: true, icon: 'anthropic', supportedEfforts: ALL },
+]
+
+function stateWith(overrides: Partial<ComposerOptionsState> = {}): ComposerOptionsState {
+  return {
+    effort: 'medium' as EffortLevel,
+    setEffort: vi.fn(),
+    speed: 'normal' as SpeedLevel,
+    setSpeed: vi.fn(),
+    model: 'claude-opus-4-8',
+    setModel: vi.fn(),
+    catalog: CATALOG as ComposerOptionsState['catalog'],
+    webProvider: undefined,
+    toRuntimeOptions: () => ({}),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  canAdminAgentMock.mockReturnValue(true)
+  useSettingsMock.mockReturnValue({
+    data: { models: { agentModel: 'opus', agentEffort: 'medium' } },
+  })
+  useAgentPreferencesMock.mockReturnValue({ data: {}, isFetched: true })
+})
+
+describe('AgentDefaultFooter', () => {
+  it('renders nothing until agent preferences have answered', () => {
+    useAgentPreferencesMock.mockReturnValue({ data: undefined, isFetched: false })
+    render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith()} />)
+    expect(screen.queryByTestId('composer-agent-default')).not.toBeInTheDocument()
+  })
+
+  it('shows the status label when the pick already is the agent default (alias vs concrete latest)', () => {
+    // Default is the bare alias 'opus'; the composer holds the concrete latest id.
+    render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith({ model: 'claude-opus-4-8' })} />)
+    expect(screen.getByTestId('composer-agent-default-current')).toHaveTextContent('Current Agent Default')
+    expect(screen.queryByTestId('composer-agent-default')).not.toBeInTheDocument()
+  })
+
+  it('promotes a diverging pick, storing the family alias for a latest model', async () => {
+    const user = userEvent.setup()
+    render(
+      <AgentDefaultFooter
+        agentSlug="my-agent"
+        state={stateWith({ model: 'claude-sonnet-4-6', effort: 'high' as EffortLevel })}
+      />,
+    )
+    const promote = screen.getByTestId('composer-agent-default')
+    expect(promote).toBeEnabled()
+    await user.click(promote)
+    expect(mutateMock).toHaveBeenCalledWith(
+      { defaultModel: 'sonnet', defaultEffort: 'high', defaultSpeed: null },
+      expect.anything(),
+    )
+  })
+
+  it('stores the concrete id when the pick is a pinned older version', async () => {
+    const user = userEvent.setup()
+    render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith({ model: 'claude-opus-4-7' })} />)
+    await user.click(screen.getByTestId('composer-agent-default'))
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultModel: 'claude-opus-4-7' }),
+      expect.anything(),
+    )
+  })
+
+  it('enables the promote action on an effort-only divergence', () => {
+    render(
+      <AgentDefaultFooter agentSlug="my-agent" state={stateWith({ effort: 'xhigh' as EffortLevel })} />,
+    )
+    expect(screen.getByTestId('composer-agent-default')).toBeEnabled()
+  })
+
+  it('compares against the agent preference when one is set, not the app-wide default', () => {
+    useAgentPreferencesMock.mockReturnValue({
+      data: { defaultModel: 'sonnet', defaultEffort: 'high' },
+      isFetched: true,
+    })
+    render(
+      <AgentDefaultFooter
+        agentSlug="my-agent"
+        state={stateWith({ model: 'claude-sonnet-4-6', effort: 'high' as EffortLevel })}
+      />,
+    )
+    expect(screen.getByTestId('composer-agent-default-current')).toBeInTheDocument()
+    expect(screen.queryByTestId('composer-agent-default')).not.toBeInTheDocument()
+  })
+
+  it('shows members a read-only line naming the default instead of the button', () => {
+    canAdminAgentMock.mockReturnValue(false)
+    render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith()} />)
+    expect(screen.queryByTestId('composer-agent-default')).not.toBeInTheDocument()
+    expect(screen.getByTestId('composer-agent-default-readonly')).toHaveTextContent(
+      'Agent default: Opus · Medium',
+    )
+  })
+
+  it('links to the agent home page where the default-model card lives', async () => {
+    const user = userEvent.setup()
+    render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith()} />)
+    await user.click(screen.getByTestId('composer-agent-default-change'))
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/agents/$slug', params: { slug: 'my-agent' } })
+  })
+
+  it('hides the home link when the host is the agent home page itself', () => {
+    render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith()} agentHomeLink={false} />)
+    expect(screen.queryByTestId('composer-agent-default-change')).not.toBeInTheDocument()
+  })
+
+  it('pulses once when a pick first diverges from the default', () => {
+    const { rerender } = render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith()} />)
+    expect(screen.getByTestId('composer-agent-default-current')).toBeInTheDocument()
+    rerender(<AgentDefaultFooter agentSlug="my-agent" state={stateWith({ model: 'claude-sonnet-4-6' })} />)
+    expect(screen.getByTestId('composer-agent-default').className).toContain('animate-promote-pulse')
+  })
+
+  it('does not pulse when mounted into an already-diverged session', () => {
+    render(<AgentDefaultFooter agentSlug="my-agent" state={stateWith({ model: 'claude-sonnet-4-6' })} />)
+    expect(screen.getByTestId('composer-agent-default').className).not.toContain('animate-promote-pulse')
+  })
+})

--- a/src/renderer/components/messages/agent-default-footer.tsx
+++ b/src/renderer/components/messages/agent-default-footer.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check, Pin, Settings } from 'lucide-react'
+import { useNavigate } from '@tanstack/react-router'
+import { toast } from 'sonner'
+import { cn } from '@shared/lib/utils'
+import { Separator } from '@renderer/components/ui/separator'
+import { useModelSettings } from '@renderer/hooks/use-settings'
+import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
+import { useUser } from '@renderer/context/user-context'
+import { findCatalogModel, type ComposerOptionsState } from './composer-options'
+import { familyDisplayName } from './model-family-list'
+import { EFFORT_LABELS } from './effort-slider'
+import { SPEED_LABELS } from './speed-section'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+
+interface AgentDefaultFooterProps {
+  agentSlug: string
+  state: ComposerOptionsState
+  /**
+   * Show the gear link to the agent home page, where the Agent Default Model
+   * card lives. Off for the agent-home composer itself — the card is already
+   * on screen there, and a link to the current page reads as a dead button.
+   */
+  agentHomeLink?: boolean
+}
+
+/**
+ * Footer for the composer model popover: the per-session counterpart of the
+ * settings picker's "Reset to Global Default" row, one level down the
+ * hierarchy. Where that row compares an agent default against the app-wide
+ * default, this one compares the session's pick against the agent default —
+ * "Set as Agent Default" promotes the current model/effort/speed into agent
+ * preferences so future sessions start there. Renders its own leading
+ * separator so a not-ready null return leaves no dangling rule.
+ *
+ * Only agent admins can write preferences (the PUT is AgentAdmin-gated), so
+ * members get a read-only line naming the default instead of a button that
+ * would 403.
+ */
+export function AgentDefaultFooter({ agentSlug, state, agentHomeLink = true }: AgentDefaultFooterProps) {
+  const { data: settings } = useModelSettings()
+  const { data: prefs, isFetched: prefsFetched } = useAgentPreferences(agentSlug)
+  const updatePreferences = useUpdateAgentPreferences(agentSlug)
+  const { canAdminAgent } = useUser()
+  const navigate = useNavigate()
+
+  // The effective default this composer's untouched state would adopt:
+  // agent preference → app-wide setting → built-in.
+  const defaultModel = prefs?.defaultModel ?? settings?.models?.agentModel
+  const defaultEffort = (prefs?.defaultEffort ?? settings?.models?.agentEffort ?? 'medium') as EffortLevel
+  const defaultSpeed = (prefs?.defaultSpeed ?? 'normal') as SpeedLevel
+
+  // Compare through catalog resolution: the composer stores concrete ids while
+  // defaults are usually bare family aliases, so a raw string compare would
+  // call the latest Opus an "override" of default 'opus'.
+  const resolvedCurrent = findCatalogModel(state.model, state.catalog)
+  const resolvedDefault = findCatalogModel(defaultModel, state.catalog)
+  const modelDiffers = (resolvedCurrent?.id ?? state.model) !== (resolvedDefault?.id ?? defaultModel)
+  const differs = modelDiffers || state.effort !== defaultEffort || state.speed !== defaultSpeed
+
+  // One brief highlight when a pick first diverges from the default — draws
+  // the eye to the promote action without an interrupting prompt. Ref-gated on
+  // the false→true edge so mounting into an already-diverged session (seeded
+  // metadata) stays quiet.
+  const [pulse, setPulse] = useState(false)
+  const prevDiffersRef = useRef(differs)
+  useEffect(() => {
+    const wasDiffering = prevDiffersRef.current
+    prevDiffersRef.current = differs
+    if (differs && !wasDiffering) {
+      setPulse(true)
+      const timer = setTimeout(() => setPulse(false), 1300)
+      return () => clearTimeout(timer)
+    }
+  }, [differs])
+
+  // Wait for both default sources — a footer computed off a half-loaded
+  // default would flash the wrong enabled state (and a spurious pulse).
+  if (!settings || !prefsFetched || !state.model) return null
+
+  const promote = () => {
+    updatePreferences.mutate(
+      {
+        // Store what the settings picker itself would: the family alias when
+        // the pick is that family's latest (rides upgrades), the concrete id
+        // only for a genuinely pinned older version.
+        defaultModel: resolvedCurrent?.isLatest ? resolvedCurrent.family : state.model,
+        defaultEffort: state.effort,
+        // 'normal' is the built-in default, not an override — store null so it
+        // never counts as a custom default (same rule as the home card).
+        defaultSpeed: state.speed === 'normal' ? null : state.speed,
+      },
+      { onError: () => toast.error("Couldn't update the agent default") },
+    )
+  }
+
+  if (!canAdminAgent(agentSlug)) {
+    // Members still learn the default exists and what it is.
+    const defaultIsAlias = defaultModel !== undefined && state.catalog.some((m) => m.family === defaultModel)
+    const defaultLabel = defaultIsAlias
+      ? familyDisplayName(defaultModel)
+      : resolvedDefault?.label ?? defaultModel
+    if (!defaultLabel) return null
+    const speedSuffix =
+      defaultSpeed !== 'normal' && SPEED_LABELS[defaultSpeed as SpeedLevel]
+        ? ` · ${SPEED_LABELS[defaultSpeed as SpeedLevel]}`
+        : ''
+    return (
+      <>
+        <Separator className="my-2 bg-border/50" />
+        <div className="truncate px-2 py-1 text-xs text-muted-foreground" data-testid="composer-agent-default-readonly">
+          Agent default: {defaultLabel} · {EFFORT_LABELS[defaultEffort]}{speedSuffix}
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Separator className="my-2 bg-border/50" />
+      <div className="flex items-center justify-between gap-2">
+        {/* The action is only offered when it would do something; a matching
+            pick states the status instead — which also serves as the
+            confirmation right after promoting. */}
+        {differs ? (
+          <button
+            type="button"
+            data-testid="composer-agent-default"
+            disabled={updatePreferences.isPending}
+            onClick={promote}
+            className={cn(
+              'flex min-w-0 items-center gap-1.5 rounded-sm px-2 py-1 text-left text-xs text-muted-foreground enabled:hover:bg-accent enabled:hover:text-foreground disabled:opacity-50',
+              pulse && 'animate-promote-pulse',
+            )}
+          >
+            <Pin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span className="truncate">Set as Agent Default</span>
+          </button>
+        ) : (
+          <div
+            data-testid="composer-agent-default-current"
+            className="flex min-w-0 items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground"
+          >
+            <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span className="truncate">Current Agent Default</span>
+          </div>
+        )}
+        {agentHomeLink && (
+          <button
+            type="button"
+            data-testid="composer-agent-default-change"
+            aria-label="Change agent default in Agent Home"
+            title="Change agent default in Agent Home"
+            onClick={() => void navigate({ to: '/agents/$slug', params: { slug: agentSlug } })}
+            className="shrink-0 rounded-sm p-1 text-muted-foreground/70 hover:text-foreground"
+          >
+            <Settings className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/renderer/components/messages/agent-default-footer.tsx
+++ b/src/renderer/components/messages/agent-default-footer.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
 import { Check, Pin, Settings } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
-import { cn } from '@shared/lib/utils'
 import { Separator } from '@renderer/components/ui/separator'
 import { useModelSettings } from '@renderer/hooks/use-settings'
 import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
@@ -58,24 +56,8 @@ export function AgentDefaultFooter({ agentSlug, state, agentHomeLink = true }: A
   const modelDiffers = (resolvedCurrent?.id ?? state.model) !== (resolvedDefault?.id ?? defaultModel)
   const differs = modelDiffers || state.effort !== defaultEffort || state.speed !== defaultSpeed
 
-  // One brief highlight when a pick first diverges from the default — draws
-  // the eye to the promote action without an interrupting prompt. Ref-gated on
-  // the false→true edge so mounting into an already-diverged session (seeded
-  // metadata) stays quiet.
-  const [pulse, setPulse] = useState(false)
-  const prevDiffersRef = useRef(differs)
-  useEffect(() => {
-    const wasDiffering = prevDiffersRef.current
-    prevDiffersRef.current = differs
-    if (differs && !wasDiffering) {
-      setPulse(true)
-      const timer = setTimeout(() => setPulse(false), 1300)
-      return () => clearTimeout(timer)
-    }
-  }, [differs])
-
   // Wait for both default sources — a footer computed off a half-loaded
-  // default would flash the wrong enabled state (and a spurious pulse).
+  // default would flash the wrong state.
   if (!settings || !prefsFetched || !state.model) return null
 
   const promote = () => {
@@ -128,10 +110,7 @@ export function AgentDefaultFooter({ agentSlug, state, agentHomeLink = true }: A
             data-testid="composer-agent-default"
             disabled={updatePreferences.isPending}
             onClick={promote}
-            className={cn(
-              'flex min-w-0 items-center gap-1.5 rounded-sm px-2 py-1 text-left text-xs text-muted-foreground enabled:hover:bg-accent enabled:hover:text-foreground disabled:opacity-50',
-              pulse && 'animate-promote-pulse',
-            )}
+            className="flex min-w-0 items-center gap-1.5 rounded-sm px-2 py-1 text-left text-xs text-muted-foreground enabled:hover:bg-accent enabled:hover:text-foreground disabled:opacity-50"
           >
             <Pin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
             <span className="truncate">Set as Agent Default</span>

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -9,15 +9,24 @@ import { type ComposerOptionsState } from './composer-options'
 import { ModelFamilyList, findCatalogModel } from './model-family-list'
 import { EFFORT_LABELS, EffortSection, useEffortClamp } from './effort-slider'
 import { SPEED_LABELS, SpeedSection, availableSpeeds, useSpeedClamp } from './speed-section'
+import { AgentDefaultFooter } from './agent-default-footer'
 
 interface ComposerOptionsPopoverProps {
   state: ComposerOptionsState
   disabled?: boolean
   /** Show the Effort section. Disable for model-only pickers (e.g. summarizer). */
   includeEffort?: boolean
+  /**
+   * Render the Agent Default footer ("Set as Agent Default" + link to the
+   * agent home card) for this agent. Requires router + user providers, so
+   * only main-app hosts pass it — quick-dispatch's slim window doesn't.
+   */
+  agentSlug?: string
+  /** Show the footer's gear link to Agent Home. Off for the agent-home composer itself. */
+  agentHomeLink?: boolean
 }
 
-function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: ComposerOptionsPopoverProps) {
+function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true, agentSlug, agentHomeLink }: ComposerOptionsPopoverProps) {
   const { effort, setEffort, speed, setSpeed, model, setModel, catalog, webProvider } = state
 
   // Trigger display fallback for the brief window before useComposerOptions
@@ -117,6 +126,8 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true }: C
             <SpeedSection speeds={visibleSpeeds} value={speed} onChange={setSpeed} />
           </>
         )}
+        {/* Renders its own separator (it returns null until defaults load). */}
+        {agentSlug && <AgentDefaultFooter agentSlug={agentSlug} state={state} agentHomeLink={agentHomeLink} />}
       </PopoverContent>
     </Popover>
   )

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -270,6 +270,10 @@ interface ComposerOptionsProps {
   disabled?: boolean
   /** Show the Effort section. Disable for model-only pickers (e.g. summarizer). */
   includeEffort?: boolean
+  /** Render the Agent Default footer for this agent (main-app hosts only). */
+  agentSlug?: string
+  /** Show the footer's gear link to Agent Home. Off for the agent-home composer itself. */
+  agentHomeLink?: boolean
 }
 
 /**
@@ -277,6 +281,14 @@ interface ComposerOptionsProps {
  * both the AgentHome and in-session composers. Stateless — owned by the
  * `useComposerOptions` hook above so the parent can read the values at submit.
  */
-export function ComposerOptions({ state, disabled, includeEffort }: ComposerOptionsProps) {
-  return <ComposerOptionsPopover state={state} disabled={disabled} includeEffort={includeEffort} />
+export function ComposerOptions({ state, disabled, includeEffort, agentSlug, agentHomeLink }: ComposerOptionsProps) {
+  return (
+    <ComposerOptionsPopover
+      state={state}
+      disabled={disabled}
+      includeEffort={includeEffort}
+      agentSlug={agentSlug}
+      agentHomeLink={agentHomeLink}
+    />
+  )
 }

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -304,7 +304,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
             />
             {/* Model/effort are locked while the agent works — changing them
                 mid-turn would interrupt the running query. */}
-            <ComposerOptions state={composerOptions} disabled={isDisabled || isActive} />
+            <ComposerOptions state={composerOptions} disabled={isDisabled || isActive} agentSlug={agentSlug} />
           </>
         )}
         rightActions={(

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -117,19 +117,10 @@ const config: Config = {
 					opacity: '1',
 				},
 			},
-			'promote-pulse': {
-				'0%, 100%': {
-					backgroundColor: 'transparent',
-				},
-				'50%': {
-					backgroundColor: 'hsl(var(--accent))',
-				},
-			},
 		},
 		animation: {
 			'cobalt-glow': 'cobalt-glow 4s ease-in-out infinite',
 			'dot-wave': 'dot-wave 2s ease-in-out infinite',
-			'promote-pulse': 'promote-pulse 0.65s ease-in-out 2',
 		}
 	}
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -117,10 +117,19 @@ const config: Config = {
 					opacity: '1',
 				},
 			},
+			'promote-pulse': {
+				'0%, 100%': {
+					backgroundColor: 'transparent',
+				},
+				'50%': {
+					backgroundColor: 'hsl(var(--accent))',
+				},
+			},
 		},
 		animation: {
 			'cobalt-glow': 'cobalt-glow 4s ease-in-out infinite',
 			'dot-wave': 'dot-wave 2s ease-in-out infinite',
+			'promote-pulse': 'promote-pulse 0.65s ease-in-out 2',
 		}
 	}
   },


### PR DESCRIPTION
## What

Adds an Agent Default footer to the composer's model picker popover (in-session and agent-home composers) — the per-session counterpart of the settings picker's "Reset to Global Default" row, one level down the hierarchy. Users changing a model per-session now learn that an agent default exists, see whether they're on it, and can promote their pick to it in one click.

## Behavior

- **Pick diverges from the agent default** → a "Set as Agent Default" action (pin icon). Clicking writes model + effort + speed to agent preferences via the existing `PUT /api/agents/:id/preferences`:
  - family alias when the pick is that family's latest (default rides upgrades, matching what the settings picker itself stores), concrete id for a pinned older version
  - speed `normal` stored as `null`, same rule as the home card
- **Pick matches the default** → a "✓ Current Agent Default" status line, which also serves as confirmation right after promoting.
- **Gear link** ("Change agent default in Agent Home") navigates to the agent home page where the default-model card lives; hidden on the agent-home composer itself, where the card is already on screen.
- **Members without agent admin** (the PUT is `AgentAdmin()`-gated) get a read-only "Agent default: … · …" line instead of a button that would 403.
- Divergence is computed through catalog resolution, so a concrete latest id vs. a bare family alias compares as equal.
- Quick-dispatch is deliberately left out — its slim window mounts no router or user providers.

## Tests

- 10 new unit tests in `agent-default-footer.test.tsx`: alias-vs-concrete equality, promote payloads (alias vs pinned), effort-only divergence, agent-preference precedence, member read-only line, navigation, home-link suppression, and the status↔action swap.
- `npm run typecheck` clean; lint 0 errors; full messages/settings/agent-home suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)