### PR TITLE
Fix homepage grid interaction, accessibility, and request fan-out

### DIFF
--- a/e2e/specs/home-cards.spec.ts
+++ b/e2e/specs/home-cards.spec.ts
@@ -37,6 +37,34 @@ test.describe('home card arrangement', () => {
     await expect(widget).toBeVisible({ timeout: 15_000 })
     await widget.scrollIntoViewIfNeeded()
     await expect(widget.locator('button button')).toHaveCount(0)
+    await expect(widget.getByRole('link', { name: `Open ${agent.name}` })).toHaveAttribute(
+      'draggable',
+      'false'
+    )
+
+    // Outside Arrange mode, desktop still supports direct pointer reordering.
+    // The full-card anchor must not hand the gesture to native HTML link drag.
+    const beforeDirectDrag = await widget.boundingBox()
+    expect(beforeDirectDrag).not.toBeNull()
+    const directSaved = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/user-settings') &&
+        response.request().method() === 'PUT' &&
+        response.request().postData()?.includes('homeGridLayout') === true &&
+        response.ok()
+    )
+    await page.mouse.move(
+      beforeDirectDrag!.x + beforeDirectDrag!.width / 2,
+      beforeDirectDrag!.y + beforeDirectDrag!.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      beforeDirectDrag!.x + beforeDirectDrag!.width / 2,
+      beforeDirectDrag!.y + beforeDirectDrag!.height / 2 + 180,
+      { steps: 8 }
+    )
+    await page.mouse.up()
+    await directSaved
 
     await page.getByRole('button', { name: 'Agent layout options' }).click()
     await page.getByTestId('home-arrange-action').click()

--- a/e2e/specs/home-cards.spec.ts
+++ b/e2e/specs/home-cards.spec.ts
@@ -49,6 +49,14 @@ test.describe('home card arrangement', () => {
     await expect(dashboardLink).toHaveAttribute('draggable', 'false')
     await expect(dashboardLink).toHaveAttribute('data-widget-drag-surface')
 
+    // The card keeps a single visible/menu affordance model. Keyboard users
+    // can invoke the same context menu from the focused link with Shift+F10.
+    await expect(widget.getByRole('button', { name: `Options for ${agent.name}` })).toHaveCount(0)
+    await widget.getByRole('link', { name: `Open ${agent.name}` }).focus()
+    await page.keyboard.press('Shift+F10')
+    await expect(page.getByRole('menuitemcheckbox', { name: 'Expanded' })).toBeVisible()
+    await page.keyboard.press('Escape')
+
     // Outside Arrange mode, desktop still supports direct pointer reordering.
     // The full-card anchor must not hand the gesture to native HTML link drag.
     await dashboardWidget.scrollIntoViewIfNeeded()
@@ -108,14 +116,10 @@ test.describe('home card arrangement', () => {
     await widget.click({ button: 'right', position: { x: 30, y: 30 } })
     const showApp = page.getByRole('menuitemcheckbox', { name: 'Show app' })
     await expect(showApp).toBeVisible()
-    const visibilitySaved = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/user-settings') &&
-        response.request().method() === 'PUT' &&
-        response.ok()
-    )
     await showApp.click({ force: true })
-    await visibilitySaved
+    // Arrange is transactional: this hides the tile locally, but must not PUT
+    // until Done commits both the layout and visibility changes.
+    await expect(dashboardWidget).not.toBeVisible()
     await page.keyboard.press('Escape')
     await expect(page.getByTestId('agent-settings-item')).not.toBeVisible()
 
@@ -128,14 +132,22 @@ test.describe('home card arrangement', () => {
     })
     await page.mouse.up()
 
-    const saved = page.waitForResponse(
+    const layoutSaved = page.waitForResponse(
       (response) =>
         response.url().includes('/api/user-settings') &&
         response.request().method() === 'PUT' &&
+        response.request().postData()?.includes('homeGridLayout') === true &&
+        response.ok()
+    )
+    const visibilitySaved = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/user-settings') &&
+        response.request().method() === 'PUT' &&
+        response.request().postData()?.includes('hiddenAppCards') === true &&
         response.ok()
     )
     await page.getByRole('button', { name: 'Done' }).click()
-    await saved
+    await Promise.all([layoutSaved, visibilitySaved])
 
     const settings = (await (await request.get('/api/user-settings')).json()) as {
       homeGridLayout?: Record<string, { x: number; y: number; w: number; h: number }>

--- a/e2e/specs/home-cards.spec.ts
+++ b/e2e/specs/home-cards.spec.ts
@@ -34,17 +34,25 @@ test.describe('home card arrangement', () => {
 
     await page.goto('/')
     const widget = page.locator(`[data-widget-id="${agent.slug}"]`)
+    const dashboardWidget = page.locator(
+      `[data-widget-id="dash::${agent.slug}::arrange-dashboard"]`
+    )
     await expect(widget).toBeVisible({ timeout: 15_000 })
+    await expect(dashboardWidget).toBeVisible({ timeout: 15_000 })
     await widget.scrollIntoViewIfNeeded()
     await expect(widget.locator('button button')).toHaveCount(0)
     await expect(widget.getByRole('link', { name: `Open ${agent.name}` })).toHaveAttribute(
       'draggable',
       'false'
     )
+    const dashboardLink = dashboardWidget.getByRole('link', { name: 'Open app' })
+    await expect(dashboardLink).toHaveAttribute('draggable', 'false')
+    await expect(dashboardLink).toHaveAttribute('data-widget-drag-surface')
 
     // Outside Arrange mode, desktop still supports direct pointer reordering.
     // The full-card anchor must not hand the gesture to native HTML link drag.
-    const beforeDirectDrag = await widget.boundingBox()
+    await dashboardWidget.scrollIntoViewIfNeeded()
+    const beforeDirectDrag = await dashboardWidget.boundingBox()
     expect(beforeDirectDrag).not.toBeNull()
     const directSaved = page.waitForResponse(
       (response) =>
@@ -70,6 +78,23 @@ test.describe('home card arrangement', () => {
     await page.getByTestId('home-arrange-action').click()
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
+
+    // Dashboard anchors also remain grid drag surfaces in desktop Arrange.
+    await dashboardWidget.scrollIntoViewIfNeeded()
+    const beforeDashboardArrangeDrag = await dashboardWidget.boundingBox()
+    expect(beforeDashboardArrangeDrag).not.toBeNull()
+    await page.mouse.move(
+      beforeDashboardArrangeDrag!.x + beforeDashboardArrangeDrag!.width / 2,
+      beforeDashboardArrangeDrag!.y + beforeDashboardArrangeDrag!.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      beforeDashboardArrangeDrag!.x + beforeDashboardArrangeDrag!.width / 2,
+      beforeDashboardArrangeDrag!.y + beforeDashboardArrangeDrag!.height / 2 + 180,
+      { steps: 8 }
+    )
+    await expect(dashboardWidget).toHaveClass(/scale-\[1\.02\]/)
+    await page.mouse.up()
 
     // Arrange owns pointer dragging, but desktop right-click still bubbles
     // through its overlay to the unified agent context menu.

--- a/e2e/specs/home-cards.spec.ts
+++ b/e2e/specs/home-cards.spec.ts
@@ -26,9 +26,9 @@ test.describe('home card arrangement', () => {
       .poll(async () => {
         const agents = (await (await request.get('/api/agents')).json()) as Array<{
           slug: string
-          dashboardCount?: number
+          dashboards?: Array<{ slug: string }>
         }>
-        return agents.find((candidate) => candidate.slug === agent.slug)?.dashboardCount
+        return agents.find((candidate) => candidate.slug === agent.slug)?.dashboards?.length
       })
       .toBe(1)
 

--- a/e2e/specs/home-cards.spec.ts
+++ b/e2e/specs/home-cards.spec.ts
@@ -15,7 +15,7 @@ function seedDashboard(agentSlug: string) {
 }
 
 test.describe('home card arrangement', () => {
-  test('desktop Arrange keeps the context menu and persists drag/size through reload', async ({
+  test('desktop Arrange persists independently from the mobile layout', async ({
     page,
     request,
   }, testInfo) => {
@@ -97,5 +97,46 @@ test.describe('home card arrangement', () => {
       homeGridLayout?: Record<string, { x: number; y: number; w: number; h: number }>
     }
     expect(afterReload.homeGridLayout?.[agent.slug]).toEqual(settings.homeGridLayout?.[agent.slug])
+
+    const desktopRect = settings.homeGridLayout?.[agent.slug]
+    expect(desktopRect).toBeDefined()
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.reload()
+    const mobileWidget = page.locator(`[data-widget-id="${agent.slug}"]`)
+    await expect(mobileWidget).toBeVisible({ timeout: 15_000 })
+    await mobileWidget.scrollIntoViewIfNeeded()
+    await page.getByRole('button', { name: 'Agent layout options' }).click()
+    await page.getByTestId('home-arrange-action').click()
+
+    const beforeMobile = await mobileWidget.boundingBox()
+    expect(beforeMobile).not.toBeNull()
+    await page.mouse.move(
+      beforeMobile!.x + beforeMobile!.width / 2,
+      beforeMobile!.y + beforeMobile!.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      beforeMobile!.x + beforeMobile!.width / 2,
+      beforeMobile!.y + beforeMobile!.height / 2 + 180,
+      { steps: 8 }
+    )
+    await page.mouse.up()
+
+    const mobileSaved = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/user-settings') &&
+        response.request().method() === 'PUT' &&
+        response.request().postData()?.includes('homeGridMobileLayout') === true &&
+        response.ok()
+    )
+    await page.getByRole('button', { name: 'Done' }).click()
+    await mobileSaved
+
+    const afterMobileArrange = (await (await request.get('/api/user-settings')).json()) as {
+      homeGridLayout?: Record<string, { x: number; y: number; w: number; h: number }>
+      homeGridMobileLayout?: Record<string, { x: number; y: number; w: number; h: number }>
+    }
+    expect(afterMobileArrange.homeGridMobileLayout?.[agent.slug]).toBeDefined()
+    expect(afterMobileArrange.homeGridLayout?.[agent.slug]).toEqual(desktopRect)
   })
 })

--- a/e2e/specs/home-cards.spec.ts
+++ b/e2e/specs/home-cards.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { createAgent, uniqueName } from '../helpers/agents'
+
+function seedDashboard(agentSlug: string) {
+  const dataDir = process.env.SUPERAGENT_DATA_DIR
+  if (!dataDir) throw new Error('SUPERAGENT_DATA_DIR is required for dashboard seeding')
+  const dashboardDir = path.join(dataDir, 'agents', agentSlug, 'workspace', 'artifacts', 'arrange-dashboard')
+  fs.mkdirSync(dashboardDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(dashboardDir, 'package.json'),
+    JSON.stringify({ name: 'Arrange Dashboard', version: '1.0.0' })
+  )
+}
+
+test.describe('home card arrangement', () => {
+  test('desktop Arrange keeps the context menu and persists drag/size through reload', async ({
+    page,
+    request,
+  }, testInfo) => {
+    test.setTimeout(60_000)
+    const agent = await createAgent(request, uniqueName(testInfo, 'Home Arrange'))
+    seedDashboard(agent.slug)
+    await expect
+      .poll(async () => {
+        const agents = (await (await request.get('/api/agents')).json()) as Array<{
+          slug: string
+          dashboardCount?: number
+        }>
+        return agents.find((candidate) => candidate.slug === agent.slug)?.dashboardCount
+      })
+      .toBe(1)
+
+    await page.goto('/')
+    const widget = page.locator(`[data-widget-id="${agent.slug}"]`)
+    await expect(widget).toBeVisible({ timeout: 15_000 })
+    await widget.scrollIntoViewIfNeeded()
+    await expect(widget.locator('button button')).toHaveCount(0)
+
+    await page.getByRole('button', { name: 'Agent layout options' }).click()
+    await page.getByTestId('home-arrange-action').click()
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
+
+    // Arrange owns pointer dragging, but desktop right-click still bubbles
+    // through its overlay to the unified agent context menu.
+    await widget.click({ button: 'right', position: { x: 30, y: 30 } })
+    await expect(page.getByTestId('agent-settings-item')).toBeVisible()
+    const expanded = page.getByRole('menuitemcheckbox', { name: 'Expanded' })
+    await expect(expanded).toBeVisible()
+    await expanded.click()
+    // Changing the card size remounts its context-menu trigger, so reopen the
+    // unified menu on the newly rendered card before toggling the app row.
+    await widget.click({ button: 'right', position: { x: 30, y: 30 } })
+    const showApp = page.getByRole('menuitemcheckbox', { name: 'Show app' })
+    await expect(showApp).toBeVisible()
+    const visibilitySaved = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/user-settings') &&
+        response.request().method() === 'PUT' &&
+        response.ok()
+    )
+    await showApp.click({ force: true })
+    await visibilitySaved
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('agent-settings-item')).not.toBeVisible()
+
+    const before = await widget.boundingBox()
+    expect(before).not.toBeNull()
+    await page.mouse.move(before!.x + before!.width / 2, before!.y + before!.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(before!.x + before!.width / 2, before!.y + before!.height / 2 + 280, {
+      steps: 8,
+    })
+    await page.mouse.up()
+
+    const saved = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/user-settings') &&
+        response.request().method() === 'PUT' &&
+        response.ok()
+    )
+    await page.getByRole('button', { name: 'Done' }).click()
+    await saved
+
+    const settings = (await (await request.get('/api/user-settings')).json()) as {
+      homeGridLayout?: Record<string, { x: number; y: number; w: number; h: number }>
+      hiddenAppCards?: string[]
+    }
+    expect(settings.homeGridLayout?.[agent.slug]).toMatchObject({ w: 1, h: 1 })
+    expect(settings.hiddenAppCards).toContain(agent.slug)
+
+    await page.reload()
+    await expect(page.locator(`[data-widget-id="${agent.slug}"]`)).toBeVisible({ timeout: 15_000 })
+    const afterReload = (await (await request.get('/api/user-settings')).json()) as {
+      homeGridLayout?: Record<string, { x: number; y: number; w: number; h: number }>
+    }
+    expect(afterReload.homeGridLayout?.[agent.slug]).toEqual(settings.homeGridLayout?.[agent.slug])
+  })
+})

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,6 +22,7 @@ import remoteMcps from './routes/remote-mcps'
 import commonMcpServers from './routes/common-mcp-servers'
 import userSettingsRouter from './routes/user-settings'
 import homeGraph from './routes/home-graph'
+import homeCardHealth from './routes/home-card-health'
 import policies from './routes/policies'
 import runtimeStatusRouter from './routes/runtime-status'
 import firewallRouter from './routes/firewall'
@@ -218,6 +219,7 @@ app.route('/api/remote-mcps', remoteMcps)
 app.route('/api/common-mcp-servers', commonMcpServers)
 app.route('/api/user-settings', userSettingsRouter)
 app.route('/api/home-graph', homeGraph)
+app.route('/api/home-card-health', homeCardHealth)
 app.route('/api/policies', policies)
 app.route('/api/runtime-status', runtimeStatusRouter)
 app.route('/api/firewall', firewallRouter)

--- a/src/api/routes/activity-query.ts
+++ b/src/api/routes/activity-query.ts
@@ -1,0 +1,21 @@
+import {
+  DEFAULT_ACTIVITY_DAYS,
+  MAX_ACTIVITY_DAYS,
+  MIN_ACTIVITY_DAYS,
+} from '@shared/lib/types/activity'
+
+export function parseActivityDays(raw: string | undefined): number {
+  if (!raw) return DEFAULT_ACTIVITY_DAYS
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return DEFAULT_ACTIVITY_DAYS
+  return Math.min(MAX_ACTIVITY_DAYS, Math.max(MIN_ACTIVITY_DAYS, parsed))
+}
+
+// Viewer's Date.prototype.getTimezoneOffset(): real-world values span
+// UTC+14 (-840) to UTC-12 (+720); anything outside is a bogus client.
+export function parseActivityTzOffset(raw: string | undefined): number {
+  if (!raw) return 0
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return 0
+  return Math.min(840, Math.max(-840, parsed))
+}

--- a/src/api/routes/activity.ts
+++ b/src/api/routes/activity.ts
@@ -1,15 +1,11 @@
 import { Hono } from 'hono'
 import { getViewerUserId } from '@shared/lib/auth/ownership'
 import {
-  DEFAULT_ACTIVITY_DAYS,
-  MAX_ACTIVITY_DAYS,
-  MIN_ACTIVITY_DAYS,
-} from '@shared/lib/types/activity'
-import {
   getAgentActivityStats,
   getConnectionActivityStats,
 } from '@shared/lib/services/activity-stats-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
+import { parseActivityDays, parseActivityTzOffset } from './activity-query'
 import {
   AgentRead,
   Authenticated,
@@ -21,22 +17,6 @@ const activityRouter = new Hono()
 
 activityRouter.use('*', Authenticated())
 
-function parseDays(raw: string | undefined): number {
-  if (!raw) return DEFAULT_ACTIVITY_DAYS
-  const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed)) return DEFAULT_ACTIVITY_DAYS
-  return Math.min(MAX_ACTIVITY_DAYS, Math.max(MIN_ACTIVITY_DAYS, parsed))
-}
-
-// Viewer's Date.prototype.getTimezoneOffset(): real-world values span
-// UTC+14 (-840) to UTC-12 (+720); anything outside is a bogus client.
-function parseTzOffset(raw: string | undefined): number {
-  if (!raw) return 0
-  const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed)) return 0
-  return Math.min(840, Math.max(-840, parsed))
-}
-
 // Execution liveness, not subscription: subscriptions outlive idle, Stop, and
 // some connection-loss paths, but isSessionActive is true only while a turn is
 // actually processing — a persisted 'running' with an inactive session is a
@@ -45,8 +25,8 @@ const isSessionLive = (sessionId: string) => messagePersister.isSessionActive(se
 
 activityRouter.get('/agents/:id', ResolveAgent(), AgentRead(), async (c) => {
   try {
-    const days = parseDays(c.req.query('days'))
-    const tzOffsetMinutes = parseTzOffset(c.req.query('tz'))
+    const days = parseActivityDays(c.req.query('days'))
+    const tzOffsetMinutes = parseActivityTzOffset(c.req.query('tz'))
     const ownerId = getViewerUserId(c) ?? undefined
     return c.json(await getAgentActivityStats(getAgentId(c), {
       days,
@@ -62,8 +42,8 @@ activityRouter.get('/agents/:id', ResolveAgent(), AgentRead(), async (c) => {
 
 activityRouter.get('/connections', async (c) => {
   try {
-    const days = parseDays(c.req.query('days'))
-    const tzOffsetMinutes = parseTzOffset(c.req.query('tz'))
+    const days = parseActivityDays(c.req.query('days'))
+    const tzOffsetMinutes = parseActivityTzOffset(c.req.query('tz'))
     const ownerId = getViewerUserId(c) ?? undefined
     return c.json(await getConnectionActivityStats({ days, tzOffsetMinutes, ownerId }))
   } catch (error) {

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -295,7 +295,6 @@ vi.mock('@shared/lib/services/audit-log-service', () => ({
 vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   listScheduledTasks: vi.fn(),
   listPendingScheduledTasks: vi.fn(),
-  listPendingScheduledTasksByAgents: vi.fn(() => Promise.resolve(new Map())),
   listCancelledScheduledTasks: vi.fn(),
   listPendingWakesByAgent: vi.fn(() => Promise.resolve([])),
   getPendingWakeForSession: vi.fn(() => Promise.resolve(null)),
@@ -328,7 +327,6 @@ vi.mock('@shared/lib/services/artifact-service', () => ({
 
 vi.mock('@shared/lib/services/chat-integration-service', () => ({
   listChatIntegrations: vi.fn(() => []),
-  listChatIntegrationsByAgents: vi.fn(() => new Map()),
 }))
 
 vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
@@ -498,7 +496,7 @@ import {
 } from '@shared/lib/services/skillset-service'
 import { getAgent, listAgentsWithStatus } from '@shared/lib/services/agent-service'
 import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
-import { listPendingScheduledTasks, listPendingScheduledTasksByAgents } from '@shared/lib/services/scheduled-task-service'
+import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
 import { messagePersister } from '@shared/lib/container/message-persister'
@@ -4099,7 +4097,7 @@ describe('GET /api/agents (enriched summary)', () => {
     vi.clearAllMocks()
     app = createApp()
     mockIsAuthMode.mockReturnValue(false)
-    // Default: no sessions, no tasks, no artifacts
+    // Default: no sessions or artifacts
     vi.mocked(getSessionSummary).mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null })
     vi.mocked(listSessions).mockResolvedValue([])
     vi.mocked(listPendingScheduledTasks).mockResolvedValue([])
@@ -4123,10 +4121,10 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(body[0].hasActiveSessions).toBe(false)
     expect(body[0].hasSessionsAwaitingInput).toBe(false)
     expect(body[0].lastActivityAt).toBe('2026-01-01T12:00:00.000Z')
-    expect(body[0].scheduledTaskCount).toBe(0)
-    expect(body[0].nextScheduledTaskAt).toBeNull()
-    expect(body[0].dashboardCount).toBe(0)
-    expect(body[0].dashboardNames).toEqual([])
+    expect(body[0].dashboards).toEqual([])
+    expect(body[0]).not.toHaveProperty('scheduledTaskCount')
+    expect(body[0]).not.toHaveProperty('chatIntegrationCount')
+    expect(body[0]).not.toHaveProperty('autoDeleteInactiveDays')
   })
 
   it('detects active sessions via messagePersister', async () => {
@@ -4270,57 +4268,7 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(body[0].lastActivityAt).toBe('2026-01-01T15:00:00.000Z')
   })
 
-  it('returns scheduled task count and nearest next execution', async () => {
-    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    const tasks = [
-      {
-        id: 'task-1',
-        agentSlug: 'agent-1',
-        scheduleType: 'cron',
-        scheduleExpression: '0 9 * * *',
-        prompt: 'do stuff',
-        name: 'Morning task',
-        status: 'pending',
-        nextExecutionAt: new Date('2026-01-02T09:00:00Z'),
-        lastExecutedAt: null,
-        isRecurring: true,
-        executionCount: 0,
-        lastSessionId: null,
-        createdBySessionId: null,
-        timezone: null,
-        createdAt: new Date('2026-01-01'),
-        cancelledAt: null,
-      },
-      {
-        id: 'task-2',
-        agentSlug: 'agent-1',
-        scheduleType: 'cron',
-        scheduleExpression: '0 */2 * * *',
-        prompt: 'check stuff',
-        name: 'Frequent check',
-        status: 'pending',
-        nextExecutionAt: new Date('2026-01-01T14:00:00Z'),
-        lastExecutedAt: null,
-        isRecurring: true,
-        executionCount: 0,
-        lastSessionId: null,
-        createdBySessionId: null,
-        timezone: null,
-        createdAt: new Date('2026-01-01'),
-        cancelledAt: null,
-      },
-    ]
-    vi.mocked(listPendingScheduledTasksByAgents).mockResolvedValue(new Map([['agent-1', tasks]]) as any)
-
-    const res = await getReq(app, '/api/agents')
-    const body = await res.json()
-
-    expect(body[0].scheduledTaskCount).toBe(2)
-    // Should pick the earlier of the two next execution times
-    expect(body[0].nextScheduledTaskAt).toBe('2026-01-01T14:00:00.000Z')
-  })
-
-  it('returns dashboard count and names from artifacts', async () => {
+  it('returns dashboard summaries from artifacts', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
     vi.mocked(listArtifactsFromFilesystem).mockResolvedValue([
       { slug: 'dash-1', name: 'Sales Dashboard', description: '', status: 'running', port: 5000 },
@@ -4330,8 +4278,10 @@ describe('GET /api/agents (enriched summary)', () => {
     const res = await getReq(app, '/api/agents')
     const body = await res.json()
 
-    expect(body[0].dashboardCount).toBe(2)
-    expect(body[0].dashboardNames).toEqual(['Sales Dashboard', 'Metrics'])
+    expect(body[0].dashboards).toEqual([
+      { slug: 'dash-1', name: 'Sales Dashboard' },
+      { slug: 'dash-2', name: 'Metrics' },
+    ])
   })
 
   it('uses artifact slug as fallback name when name is empty', async () => {
@@ -4343,7 +4293,7 @@ describe('GET /api/agents (enriched summary)', () => {
     const res = await getReq(app, '/api/agents')
     const body = await res.json()
 
-    expect(body[0].dashboardNames).toEqual(['unnamed-dash'])
+    expect(body[0].dashboards).toEqual([{ slug: 'unnamed-dash', name: 'unnamed-dash' }])
   })
 
   it('enriches agents in auth mode', async () => {
@@ -4362,8 +4312,7 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(body).toHaveLength(1)
     // Summary fields should be present even in auth mode
     expect(body[0]).toHaveProperty('hasActiveSessions')
-    expect(body[0]).toHaveProperty('scheduledTaskCount')
-    expect(body[0]).toHaveProperty('dashboardCount')
+    expect(body[0]).toHaveProperty('dashboards')
   })
 
   it('sorts the auth-mode list newest-first', async () => {
@@ -4416,8 +4365,8 @@ describe('GET /api/agents (enriched summary)', () => {
 
     expect(body).toHaveLength(2)
     // Both agents should have summary fields
-    expect(body[0]).toHaveProperty('dashboardCount', 0)
-    expect(body[1]).toHaveProperty('dashboardCount', 0)
+    expect(body[0]).toHaveProperty('dashboards')
+    expect(body[1]).toHaveProperty('dashboards')
     // getSessionSummary called once per agent
     expect(getSessionSummary).toHaveBeenCalledTimes(2)
     expect(getSessionSummary).toHaveBeenCalledWith('agent-1')

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -27,7 +27,7 @@ import {
 import { parseRuntimeOptions } from '@shared/lib/container/runtime-options'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 import { listWebhookTriggers, listActiveWebhookTriggers, listCancelledWebhookTriggers } from '@shared/lib/services/webhook-trigger-service'
-import { listChatIntegrations, listChatIntegrationsByAgents } from '@shared/lib/services/chat-integration-service'
+import { listChatIntegrations } from '@shared/lib/services/chat-integration-service'
 import { chatIntegrationManager } from '@shared/lib/chat-integrations/chat-integration-manager'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { guessMimeType } from '@shared/lib/utils/mime'
@@ -81,7 +81,6 @@ import { keyToEnvVar } from '@shared/lib/utils/secrets'
 import {
   listScheduledTasks,
   listPendingScheduledTasks,
-  listPendingScheduledTasksByAgents,
   listCancelledScheduledTasks,
   cancelPendingWakeForSession,
   getPendingWakeForSession,
@@ -384,34 +383,25 @@ function toSkillsetRef(config: Pick<SkillsetConfig, 'id' | 'url' | 'name' | 'pro
 
 /**
  * Enrich an array of ApiAgent objects with summary fields:
- * active/awaiting sessions, last activity, scheduled tasks, dashboards.
- * Batch DB queries upfront, then parallelize per-agent FS operations.
+ * active/awaiting sessions, last activity, and dashboards.
+ * Batch notification lookup upfront, then parallelize per-agent FS operations.
  */
 async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> {
   const slugs = agents.map(a => a.slug)
 
-  // Batch DB queries: 2 queries instead of 2*N individual queries
-  const [unreadByAgent, tasksByAgent, chatIntegrationsByAgent] = await Promise.all([
-    getUnreadNotificationsByAgents(slugs),
-    listPendingScheduledTasksByAgents(slugs),
-    Promise.resolve(listChatIntegrationsByAgents(slugs)),
-  ])
+  const unreadByAgent = await getUnreadNotificationsByAgents(slugs)
 
   const limit = pLimit(5)
   return Promise.all(
     agents.map((agent) => limit(async () => {
       // Only FS operations remain per-agent (parallelized)
-      const [sessionSummary, artifacts, agentPrefs, sessionMetadata] = await Promise.all([
+      const [sessionSummary, artifacts, sessionMetadata] = await Promise.all([
         getSessionSummary(agent.slug),
         listArtifactsFromFilesystem(agent.slug),
-        readAgentPreferences(agent.slug),
         readSessionMetadata(agent.slug),
       ])
 
       const unreadSessionIds = unreadByAgent.get(agent.slug) ?? new Set<string>()
-      // Session wakes are excluded from the agent-level automation summary —
-      // they belong to a session, not the agent's schedule.
-      const pendingTasks = (tasksByAgent.get(agent.slug) ?? []).filter((t) => !t.resumeSessionId)
 
       // Compute session flags from in-memory state (no I/O needed).
       // `unreadByAgent` is already filtered to user-actionable notification types
@@ -452,18 +442,6 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
         hasSessionsAwaitingInput = true
       }
 
-      // Compute scheduled task summary
-      const scheduledTaskCount = pendingTasks.length
-      let nextScheduledTaskAt: Date | null = null
-      for (const task of pendingTasks) {
-        if (task.nextExecutionAt) {
-          const ts = new Date(task.nextExecutionAt)
-          if (!nextScheduledTaskAt || ts < nextScheduledTaskAt) {
-            nextScheduledTaskAt = ts
-          }
-        }
-      }
-
       return {
         ...agent,
         hasActiveSessions,
@@ -471,18 +449,11 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
         hasUnreadNotifications,
         sessionCount: sessionSummary.sessionCount,
         lastActivityAt: sessionSummary.lastActivityAt,
-        scheduledTaskCount,
-        nextScheduledTaskAt,
-        chatIntegrationCount: (chatIntegrationsByAgent.get(agent.slug) ?? []).length,
-        dashboardCount: artifacts.length,
-        dashboardNames: artifacts.map((a) => a.name || a.slug),
-        dashboardSlugs: artifacts.map((a) => a.slug),
         dashboards: artifacts.map((a) => ({
           slug: a.slug,
           name: a.name || a.slug,
           ...(a.hasScreenshot ? { hasScreenshot: true } : {}),
         })),
-        autoDeleteInactiveDays: agentPrefs.autoDeleteInactiveDays,
       }
     }))
   )
@@ -956,7 +927,7 @@ Respond with ONLY the session name, nothing else. No quotes, no explanation.`,
 }
 
 // GET /api/agents - List agents with status (filtered by ACL in auth mode)
-// Response includes pre-aggregated summary: active sessions, scheduled tasks, dashboards.
+// Response includes pre-aggregated summary: session activity and dashboards.
 agents.get('/', async (c) => {
   try {
     // In auth mode, only return agents the user has explicit ACL entries for.

--- a/src/api/routes/home-agent-scope.ts
+++ b/src/api/routes/home-agent-scope.ts
@@ -1,0 +1,27 @@
+import type { Context } from 'hono'
+import { eq } from 'drizzle-orm'
+import { getViewerUserId } from '@shared/lib/auth/ownership'
+import { db } from '@shared/lib/db'
+import { agentAcl } from '@shared/lib/db/schema'
+import { listAgentSlugs } from '@shared/lib/services/agent-service'
+
+export interface HomeAgentScope {
+  agentSlugs: string[]
+  userId: string | null
+}
+
+/** Match GET /api/agents visibility for home-page aggregate endpoints. */
+export async function getHomeAgentScope(c: Context): Promise<HomeAgentScope> {
+  const userId = getViewerUserId(c)
+  if (userId === null) {
+    // Slugs only — listAgents() would parse every agent's CLAUDE.md just to
+    // throw the result away.
+    return { agentSlugs: await listAgentSlugs(), userId }
+  }
+
+  const rows = await db
+    .select({ agentSlug: agentAcl.agentSlug })
+    .from(agentAcl)
+    .where(eq(agentAcl.userId, userId))
+  return { agentSlugs: rows.map((row) => row.agentSlug), userId }
+}

--- a/src/api/routes/home-card-health.test.ts
+++ b/src/api/routes/home-card-health.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+
+const mockBuildHomeCardHealth = vi.fn()
+const mockGetHomeAgentScope = vi.fn()
+const mockIsSessionActive = vi.fn()
+
+vi.mock('@shared/lib/services/home-card-health-service', () => ({
+  buildHomeCardHealth: (...args: unknown[]) => mockBuildHomeCardHealth(...args),
+}))
+
+vi.mock('./home-agent-scope', () => ({
+  getHomeAgentScope: (...args: unknown[]) => mockGetHomeAgentScope(...args),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    isSessionActive: (...args: unknown[]) => mockIsSessionActive(...args),
+  },
+}))
+
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+import homeCardHealth from './home-card-health'
+
+function createApp() {
+  const app = new Hono()
+  app.route('/api/home-card-health', homeCardHealth)
+  return app
+}
+
+describe('home card health API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetHomeAgentScope.mockResolvedValue({
+      agentSlugs: ['agent-a', 'agent-b'],
+      userId: 'user-123',
+    })
+    mockBuildHomeCardHealth.mockResolvedValue({
+      days: 14,
+      generatedAt: '2026-07-30T12:00:00.000Z',
+      crons: [],
+      webhooks: [],
+      cronByTaskId: {},
+      webhookByTriggerId: {},
+    })
+  })
+
+  it('passes the visible agent scope and normalized activity window to one batch build', async () => {
+    const response = await createApp().request(
+      'http://localhost/api/home-card-health?days=999&tz=-540',
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockBuildHomeCardHealth).toHaveBeenCalledWith({
+      agentSlugs: ['agent-a', 'agent-b'],
+      days: 30,
+      tzOffsetMinutes: -540,
+      isSessionLive: expect.any(Function),
+    })
+
+    const { isSessionLive } = mockBuildHomeCardHealth.mock.calls[0][0] as {
+      isSessionLive: (sessionId: string) => boolean
+    }
+    mockIsSessionActive.mockReturnValue(true)
+    expect(isSessionLive('session-1')).toBe(true)
+    expect(mockIsSessionActive).toHaveBeenCalledWith('session-1')
+  })
+
+  it('returns a sanitized error when the batch build fails', async () => {
+    mockBuildHomeCardHealth.mockRejectedValue(new Error('private filesystem path'))
+    const response = await createApp().request('http://localhost/api/home-card-health')
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: 'Failed to build home card health' })
+  })
+})

--- a/src/api/routes/home-card-health.ts
+++ b/src/api/routes/home-card-health.ts
@@ -1,0 +1,29 @@
+import { Hono } from 'hono'
+import { Authenticated } from '../middleware/auth'
+import { messagePersister } from '@shared/lib/container/message-persister'
+import { buildHomeCardHealth } from '@shared/lib/services/home-card-health-service'
+import { parseActivityDays, parseActivityTzOffset } from './activity-query'
+import { getHomeAgentScope } from './home-agent-scope'
+
+const homeCardHealth = new Hono()
+
+homeCardHealth.use('*', Authenticated())
+
+// GET /api/home-card-health - compact automation descriptors and chart series
+// for Card view. Graph topology is deliberately owned by /api/home-graph.
+homeCardHealth.get('/', async (c) => {
+  try {
+    const { agentSlugs } = await getHomeAgentScope(c)
+    return c.json(await buildHomeCardHealth({
+      agentSlugs,
+      days: parseActivityDays(c.req.query('days')),
+      tzOffsetMinutes: parseActivityTzOffset(c.req.query('tz')),
+      isSessionLive: (sessionId) => messagePersister.isSessionActive(sessionId),
+    }))
+  } catch (error) {
+    console.error('Failed to build home card health:', error)
+    return c.json({ error: 'Failed to build home card health' }, 500)
+  }
+})
+
+export default homeCardHealth

--- a/src/api/routes/home-graph.ts
+++ b/src/api/routes/home-graph.ts
@@ -1,13 +1,8 @@
 import { Hono } from 'hono'
-import { eq } from 'drizzle-orm'
-import { db } from '@shared/lib/db'
-import { agentAcl } from '@shared/lib/db/schema'
 import { Authenticated } from '../middleware/auth'
-import { isAuthMode } from '@shared/lib/auth/mode'
-import { getCurrentUserId } from '@shared/lib/auth/config'
-import { listAgentSlugs } from '@shared/lib/services/agent-service'
 import { buildHomeGraph } from '@shared/lib/services/home-graph-service'
 import { chatIntegrationManager } from '@shared/lib/chat-integrations/chat-integration-manager'
+import { getHomeAgentScope } from './home-agent-scope'
 
 const homeGraph = new Hono()
 
@@ -19,22 +14,7 @@ homeGraph.use('*', Authenticated())
 // home-graph-schema.ts for the wire shape.
 homeGraph.get('/', async (c) => {
   try {
-    // Same visibility rule as GET /api/agents: in auth mode only agents the
-    // user has explicit ACL entries for (admins get no implicit listing).
-    let agentSlugs: string[]
-    let userId: string | null = null
-    if (isAuthMode()) {
-      userId = getCurrentUserId(c)
-      const rows = await db
-        .select({ agentSlug: agentAcl.agentSlug })
-        .from(agentAcl)
-        .where(eq(agentAcl.userId, userId))
-      agentSlugs = rows.map((r) => r.agentSlug)
-    } else {
-      // Slugs only — listAgents() would parse every agent's CLAUDE.md just
-      // to throw the result away.
-      agentSlugs = await listAgentSlugs()
-    }
+    const { agentSlugs, userId } = await getHomeAgentScope(c)
 
     const graph = await buildHomeGraph({
       agentSlugs,

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -24,17 +24,26 @@ import { useUser } from '@renderer/context/user-context'
 import { AgentSettingsDialog } from './agent-settings-dialog'
 import { apiFetch } from '@renderer/lib/api'
 import { isElectron } from '@renderer/lib/env'
-import { Settings, FolderOpen, Copy, Trash2, LogOut } from 'lucide-react'
+import { Settings, FolderOpen, Copy, Trash2, LogOut, Move } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 
 interface AgentContextMenuProps {
   agent: ApiAgent
   children: React.ReactNode
+  /** Homepage-only controls that should share the agent's single menu surface. */
+  additionalOptions?: React.ReactNode
+  /** Enables the homepage grid's explicit arrange mode from any agent card. */
+  onArrange?: () => void
+  /** Let an explicit mobile arrange gesture own touch holds. */
+  disableTouchLongPress?: boolean
 }
 
 export function AgentContextMenu({
   agent,
   children,
+  additionalOptions,
+  onArrange,
+  disableTouchLongPress,
 }: AgentContextMenuProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showLeaveDialog, setShowLeaveDialog] = useState(false)
@@ -111,10 +120,23 @@ export function AgentContextMenu({
   return (
     <>
       <ContextMenu>
-        <ContextMenuTrigger asChild>
+        <ContextMenuTrigger asChild disableTouchLongPress={disableTouchLongPress}>
           {children}
         </ContextMenuTrigger>
         <ContextMenuContent>
+          {onArrange && (
+            <ContextMenuItem
+              onClick={() => {
+                onArrange()
+              }}
+              data-testid="arrange-agent-cards-item"
+            >
+              <Move className="h-4 w-4 mr-2" />
+              Arrange
+            </ContextMenuItem>
+          )}
+          {additionalOptions}
+          {(onArrange || additionalOptions) && <ContextMenuSeparator />}
           <ContextMenuItem
             onClick={() => setShowSettingsDialog(true)}
             data-testid="agent-settings-item"

--- a/src/renderer/components/agents/halftone.test.tsx
+++ b/src/renderer/components/agents/halftone.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { act } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@renderer/test/test-utils'
+import { Halftone } from './halftone'
+
+describe('Halftone animation lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('pauses its animation while the card is offscreen and resumes on re-entry', () => {
+    let intersectionCallback: IntersectionObserverCallback | undefined
+    const disconnectObserver = vi.fn()
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+        observe() {}
+        unobserve() {}
+        disconnect = disconnectObserver
+        takeRecords() {
+          return []
+        }
+        root = null
+        rootMargin = '0px'
+        thresholds = [0]
+      }
+    )
+
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(240)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(120)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      setTransform: vi.fn(),
+    } as unknown as CanvasRenderingContext2D)
+
+    let nextRaf = 1
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => nextRaf++)
+    const cancelAnimationFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+
+    const { unmount } = renderWithProviders(<Halftone motif="flow_3d" />)
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
+    expect(intersectionCallback).toBeTypeOf('function')
+
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: false } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1)
+
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(2)
+
+    unmount()
+    expect(disconnectObserver).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/agents/halftone.test.tsx
+++ b/src/renderer/components/agents/halftone.test.tsx
@@ -66,4 +66,44 @@ describe('Halftone animation lifecycle', () => {
     unmount()
     expect(disconnectObserver).toHaveBeenCalled()
   })
+
+  it('recovers when its first measurement is zero-sized', () => {
+    let resizeCallback: ResizeObserverCallback | undefined
+    const observe = vi.fn()
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback
+        }
+        observe = observe
+        unobserve() {}
+        disconnect() {}
+      }
+    )
+
+    let width = 0
+    let height = 0
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => width)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(() => height)
+    const setTransform = vi.fn()
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      setTransform,
+    } as unknown as CanvasRenderingContext2D)
+    const requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+
+    renderWithProviders(<Halftone motif="flow_3d" />)
+    expect(observe).toHaveBeenCalledTimes(1)
+    expect(setTransform).not.toHaveBeenCalled()
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+
+    width = 240
+    height = 120
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(setTransform).toHaveBeenCalled()
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/components/agents/halftone.tsx
+++ b/src/renderer/components/agents/halftone.tsx
@@ -163,6 +163,8 @@ export function Halftone({
 
     let raf = 0
     let stopped = false
+    let ready = false
+    let lastDrawTime = 0
     let t = seed % 1000 // phase offset so cards animate out of sync
     let W = 0, H = 0, COLS = 0, ROWS = 0, offsetX = 0, offsetY = 0, cx = 0, cy = 0
     let infl = new Float32Array(0) // per-cell eased cursor boost (0..1)
@@ -176,7 +178,10 @@ export function Halftone({
     function setup(): boolean {
       W = wrap!.clientWidth
       H = wrap!.clientHeight
-      if (W === 0 || H === 0) return false
+      if (W <= 0 || H <= 0) {
+        ready = false
+        return false
+      }
       const dpr = window.devicePixelRatio || 1
       canvas!.width = Math.round(W * dpr)
       canvas!.height = Math.round(H * dpr)
@@ -188,6 +193,8 @@ export function Halftone({
       cx = (COLS - 1) / 2
       cy = (ROWS - 1) / 2
       infl = new Float32Array(COLS * ROWS)
+      ready = true
+      lastDrawTime = 0
       return true
     }
 
@@ -243,7 +250,7 @@ export function Halftone({
           const cur = infl[idx]
           const h = (infl[idx] = cur + (target - cur) * (target > cur ? CURSOR_ATTACK : CURSOR_RELEASE))
           if (h > 0.003) r += h * CURSOR_R
-          const v = vignetteAt((i - cx) / cx, (j - cy) / cy)
+          const v = vignetteAt(cx === 0 ? 0 : (i - cx) / cx, cy === 0 ? 0 : (j - cy) / cy)
           if (v <= 0) continue
           // Cursor darkening is added on top of the state-dimmed alpha, so dots
           // read clearly darker near the pointer even in faint states.
@@ -274,18 +281,26 @@ export function Halftone({
       }
     }
 
-    function frame() {
+    const frameInterval = 1000 / 30
+    function frame(now: number) {
       raf = 0
-      if (stopped || !intersecting || document.hidden) return
-      draw()
-      t += speed
+      if (stopped || !ready || !intersecting || document.hidden) return
+      const elapsed = lastDrawTime === 0 ? frameInterval : now - lastDrawTime
+      if (elapsed >= frameInterval) {
+        draw()
+        // Preserve the original 60fps phase velocity while drawing half as
+        // often, substantially reducing per-card field math and Canvas2D paths.
+        t += speed * (elapsed / (1000 / 60))
+        lastDrawTime = now
+      }
       raf = requestAnimationFrame(frame)
     }
 
     const syncAnimation = () => {
-      const active = !reduce && intersecting && !document.hidden && !stopped
+      const active = ready && !reduce && intersecting && !document.hidden && !stopped
       setPointerListening(active)
       if (active && raf === 0) {
+        lastDrawTime = 0
         raf = requestAnimationFrame(frame)
       } else if (!active && raf !== 0) {
         cancelAnimationFrame(raf)
@@ -293,14 +308,17 @@ export function Halftone({
       }
     }
 
-    if (!setup()) return
-    if (reduce) draw()
-    else syncAnimation()
-
     const ro = new ResizeObserver(() => {
-      if (setup() && reduce) draw()
+      const measured = setup()
+      if (measured && reduce) draw()
+      syncAnimation()
     })
     ro.observe(wrap)
+
+    if (setup()) {
+      if (reduce) draw()
+      else syncAnimation()
+    }
 
     const io =
       typeof IntersectionObserver === 'undefined'
@@ -308,7 +326,7 @@ export function Halftone({
         : new IntersectionObserver(([entry]) => {
             intersecting = entry?.isIntersecting ?? true
             if (reduce) {
-              if (intersecting) draw()
+              if (intersecting && ready) draw()
             } else {
               syncAnimation()
             }
@@ -317,7 +335,7 @@ export function Halftone({
 
     const onVisibilityChange = () => {
       if (reduce) {
-        if (!document.hidden && intersecting) draw()
+        if (!document.hidden && intersecting && ready) draw()
       } else {
         syncAnimation()
       }

--- a/src/renderer/components/agents/halftone.tsx
+++ b/src/renderer/components/agents/halftone.tsx
@@ -260,28 +260,77 @@ export function Halftone({
       }
     }
 
+    let intersecting = true
+    let pointerListening = false
+
+    const setPointerListening = (next: boolean) => {
+      if (next === pointerListening) return
+      pointerListening = next
+      if (next) {
+        window.addEventListener('pointermove', onPointerMove, { passive: true })
+      } else {
+        window.removeEventListener('pointermove', onPointerMove)
+        pointerSeen = false
+      }
+    }
+
     function frame() {
-      if (stopped) return
+      raf = 0
+      if (stopped || !intersecting || document.hidden) return
       draw()
       t += speed
       raf = requestAnimationFrame(frame)
     }
 
+    const syncAnimation = () => {
+      const active = !reduce && intersecting && !document.hidden && !stopped
+      setPointerListening(active)
+      if (active && raf === 0) {
+        raf = requestAnimationFrame(frame)
+      } else if (!active && raf !== 0) {
+        cancelAnimationFrame(raf)
+        raf = 0
+      }
+    }
+
     if (!setup()) return
     if (reduce) draw()
-    else frame()
+    else syncAnimation()
 
     const ro = new ResizeObserver(() => {
       if (setup() && reduce) draw()
     })
     ro.observe(wrap)
-    if (!reduce) window.addEventListener('pointermove', onPointerMove, { passive: true })
+
+    const io =
+      typeof IntersectionObserver === 'undefined'
+        ? null
+        : new IntersectionObserver(([entry]) => {
+            intersecting = entry?.isIntersecting ?? true
+            if (reduce) {
+              if (intersecting) draw()
+            } else {
+              syncAnimation()
+            }
+          })
+    io?.observe(wrap)
+
+    const onVisibilityChange = () => {
+      if (reduce) {
+        if (!document.hidden && intersecting) draw()
+      } else {
+        syncAnimation()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
 
     return () => {
       stopped = true
       cancelAnimationFrame(raf)
       ro.disconnect()
-      window.removeEventListener('pointermove', onPointerMove)
+      io?.disconnect()
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      setPointerListening(false)
     }
   }, [motif, state, speedProp, color, spacing, maxRadius, vignette, contrast, speedScale, dim, seed])
 

--- a/src/renderer/components/home/dashboard-card.tsx
+++ b/src/renderer/components/home/dashboard-card.tsx
@@ -45,6 +45,8 @@ export function DashboardCard({
     return (
       <AppLink
         {...linkProps}
+        draggable={false}
+        data-widget-drag-surface=""
         className="group relative block h-full w-full overflow-hidden rounded-lg border bg-card text-left shadow-sm transition-[box-shadow,border-color] duration-150 hover:border-accent-foreground/20 group-hover/widget:shadow-md"
       >
         <CardContent screenshotUrl={screenshotUrl} objectClass={align === 'top-left' ? 'object-left-top' : 'object-top'} />

--- a/src/renderer/components/home/graph/graph-nodes.tsx
+++ b/src/renderer/components/home/graph/graph-nodes.tsx
@@ -20,7 +20,6 @@ import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-ind
 import { useNotableSessions } from '@renderer/hooks/use-sessions'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { useAgentActivityStats } from '@renderer/hooks/use-activity-stats'
-import { useUsageData } from '@renderer/hooks/use-usage'
 import { useUser } from '@renderer/context/user-context'
 import {
   ActivitySparkChart,
@@ -241,13 +240,6 @@ const agentBorder: Record<AgentActivityStatus, string> = {
   sleeping: 'border-border/60 dark:border-white/10',
 }
 
-// Same abbreviation the home-page card details row uses.
-function formatTokenCount(tokens: number): string {
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`
-  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(0)}k`
-  return String(tokens)
-}
-
 export function AgentGraphNode({ data, selected }: NodeProps<Node<AgentNodeData, 'agent'>>) {
   const { agent } = data
   // Ports draw new connections AND act as drop targets; both link routes
@@ -275,16 +267,6 @@ export function AgentGraphNode({ data, selected }: NodeProps<Node<AgentNodeData,
   const lastWorked = agent.lastActivityAt
     ? formatDistanceToNow(new Date(agent.lastActivityAt), { addSuffix: true })
     : null
-  // 7-day token total, matching the home-page card. One global usage query —
-  // react-query dedupes the fetch across every agent node.
-  const { data: usageData } = useUsageData(7)
-  const tokens7d = useMemo(() => {
-    let sum = 0
-    for (const day of usageData?.daily ?? []) {
-      sum += day.byAgent.find((a) => a.agentSlug === agent.slug)?.totalTokens ?? 0
-    }
-    return sum
-  }, [usageData, agent.slug])
   return (
     <div
       role="button"
@@ -317,7 +299,7 @@ export function AgentGraphNode({ data, selected }: NodeProps<Node<AgentNodeData,
           className="mt-0.5 shrink-0"
         />
       </div>
-      {/* Details row pinned to the card bottom: last worked + 7-day tokens */}
+      {/* Details row pinned to the card bottom. */}
       <div className="mt-auto flex w-full items-center justify-between gap-2 text-2xs text-muted-foreground">
         {lastWorked && (
           <span className="flex min-w-0 items-center gap-1">
@@ -325,7 +307,6 @@ export function AgentGraphNode({ data, selected }: NodeProps<Node<AgentNodeData,
             <span className="truncate">{lastWorked}</span>
           </span>
         )}
-        {tokens7d > 0 && <span className="ml-auto shrink-0">{formatTokenCount(tokens7d)} tok/7d</span>}
       </div>
       <CenterHandles />
     </div>

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -212,10 +212,6 @@ function makeAgent(overrides = {}) {
     hasActiveSessions: false,
     hasSessionsAwaitingInput: false,
     lastActivityAt: null as Date | null,
-    scheduledTaskCount: 0,
-    nextScheduledTaskAt: null as Date | null,
-    dashboardCount: 0,
-    dashboardNames: [] as string[],
     dashboards: [] as Array<{ slug: string; name: string; hasScreenshot?: boolean }>,
     ...overrides,
   }
@@ -262,20 +258,9 @@ describe('HomePage AgentCard', () => {
     expect(screen.queryByText(/ago/)).not.toBeInTheDocument()
   })
 
-  it('does not render scheduled task details (removed from the compact card)', () => {
-    mockAgentsData.mockReturnValue({
-      data: [makeAgent({ scheduledTaskCount: 3, nextScheduledTaskAt: new Date('2026-03-27T12:00:00Z') })],
-      isLoading: false,
-    })
-    renderWithProviders(<HomePage />)
-    expect(screen.queryByText('3 tasks')).not.toBeInTheDocument()
-  })
-
   it('renders a dashboard card per dashboard alongside the agent card', () => {
     mockAgentsData.mockReturnValue({
       data: [makeAgent({
-        dashboardCount: 2,
-        dashboardNames: ['Sales', 'Metrics'],
         dashboards: [
           { slug: 'sales', name: 'Sales' },
           { slug: 'metrics', name: 'Metrics', hasScreenshot: true },
@@ -295,7 +280,6 @@ describe('HomePage AgentCard', () => {
   it('renders a screenshot img when hasScreenshot is true', () => {
     mockAgentsData.mockReturnValue({
       data: [makeAgent({
-        dashboardCount: 1,
         dashboards: [{ slug: 'sales', name: 'Sales', hasScreenshot: true }],
       })],
       isLoading: false,
@@ -308,7 +292,6 @@ describe('HomePage AgentCard', () => {
   it('shows a placeholder icon when a dashboard has no screenshot', () => {
     mockAgentsData.mockReturnValue({
       data: [makeAgent({
-        dashboardCount: 1,
         dashboards: [{ slug: 'sales', name: 'Sales' }],
       })],
       isLoading: false,
@@ -318,9 +301,9 @@ describe('HomePage AgentCard', () => {
     expect(img).toBeNull()
   })
 
-  it('renders no dashboard cards when count is 0', () => {
+  it('renders no dashboard cards when the dashboard list is empty', () => {
     mockAgentsData.mockReturnValue({
-      data: [makeAgent({ dashboardCount: 0, dashboards: [] })],
+      data: [makeAgent({ dashboards: [] })],
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
@@ -337,14 +320,10 @@ describe('HomePage AgentCard', () => {
     expect(screen.getByText('No agents yet')).toBeInTheDocument()
   })
 
-  it('renders all summary fields together', () => {
+  it('renders last activity with dashboard summaries', () => {
     mockAgentsData.mockReturnValue({
       data: [makeAgent({
         lastActivityAt: new Date('2026-03-26T11:00:00Z'),
-        scheduledTaskCount: 2,
-        nextScheduledTaskAt: new Date('2026-03-26T13:00:00Z'),
-        dashboardCount: 1,
-        dashboardNames: ['Overview'],
         dashboards: [{ slug: 'overview', name: 'Overview' }],
       })],
       isLoading: false,
@@ -434,7 +413,6 @@ describe('HomePage AgentCard', () => {
     mockAgentsData.mockReturnValue({
       data: [
         makeAgent({
-          dashboardCount: 1,
           dashboards: [{ slug: 'sales', name: 'Sales' }],
         }),
       ],
@@ -460,7 +438,7 @@ describe('HomePage AgentCard', () => {
       },
     })
     mockAgentsData.mockReturnValue({
-      data: [makeAgent({ dashboardCount: 0, dashboards: [] })],
+      data: [makeAgent({ dashboards: [] })],
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
@@ -499,7 +477,6 @@ describe('HomePage AgentCard', () => {
     mockAgentsData.mockReturnValue({
       data: [
         makeAgent({
-          dashboardCount: 1,
           dashboards: [{ slug: 'sales', name: 'Sales' }],
         }),
       ],

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
 import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/test/test-utils'
 
@@ -17,7 +17,7 @@ const {
   mockToastError,
   mockUseIsMobile,
 } = vi.hoisted(() => ({
-  mockUseNotableSessions: vi.fn(() => ({ data: [] })),
+  mockUseNotableSessions: vi.fn<() => { data: Array<Record<string, unknown>> }>(() => ({ data: [] })),
   mockUseAgentActivityStats: vi.fn(() => ({ data: undefined, isPending: true })),
   mockUserSettingsData: vi.fn<() => Record<string, unknown> | null>(() => null),
   mockUpdateSettingsMutate: vi.fn(),
@@ -106,12 +106,17 @@ vi.mock('@renderer/components/agents/agent-context-menu', () => ({
     children,
     additionalOptions,
     onArrange,
+    disableTouchLongPress,
   }: {
     children: React.ReactNode
     additionalOptions?: React.ReactNode
     onArrange?: () => void
+    disableTouchLongPress?: boolean
   }) => (
-    <div>
+    <div
+      data-testid="agent-context-trigger"
+      data-touch-long-press-disabled={disableTouchLongPress || undefined}
+    >
       {children}
       {additionalOptions}
       {onArrange && (
@@ -184,6 +189,16 @@ vi.mock('@renderer/lib/env', () => ({
 
 // Import after mocks
 import { HomePage } from './home-page'
+
+beforeEach(() => {
+  // Halftone intentionally owns its canvas mock in its focused test file.
+  // Homepage tests only need the no-context bail path.
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function makeAgent(overrides = {}) {
   return {
@@ -340,9 +355,34 @@ describe('HomePage AgentCard', () => {
       isLoading: false,
     })
     renderWithProviders(<HomePage />)
-    // status='running' + hasSessionsAwaitingInput → getAgentActivityStatus aggregates
-    // to 'awaiting_input', surfaced as the dot-matrix indicator's aria-label.
-    expect(screen.getByRole('img', { name: 'awaiting_input' })).toBeInTheDocument()
+    // The status chip is the single accessible announcement; the decorative
+    // dot matrix must not expose its internal enum.
+    expect(screen.getByText('Needs input')).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: 'awaiting_input' })).not.toBeInTheDocument()
+  })
+
+  it('uses a real link for card navigation and keeps notification actions reachable', () => {
+    mockUseNotableSessions.mockReturnValue({
+      data: [
+        {
+          id: 'session-1',
+          name: 'Test Agent Review',
+          hasUnreadNotifications: true,
+          lastActivityAt: new Date('2026-03-26T11:55:00Z'),
+        },
+      ],
+    })
+    mockAgentsData.mockReturnValue({
+      data: [makeAgent({ hasUnreadNotifications: true })],
+      isLoading: false,
+    })
+    renderWithProviders(<HomePage />)
+
+    const cardLink = screen.getByRole('link', { name: 'Open Test Agent' })
+    expect(cardLink.tagName).toBe('A')
+    expect(cardLink).toHaveAttribute('data-widget-drag-surface')
+    expect(screen.getByRole('button', { name: 'Mark as read' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Open session' })).toBeVisible()
   })
 
   it('uses the notable-session fast path for cards with live or unread work', () => {
@@ -405,6 +445,50 @@ describe('HomePage AgentCard', () => {
     expect(layoutCall?.[0].homeGridLayout['dash::test-agent::sales']).toEqual(dashboardRect)
   })
 
+  it('preserves missing dashboard geometry while its owning agent still exists', () => {
+    const dashboardRect = { x: 2, y: 3, w: 1, h: 1 }
+    mockUserSettingsData.mockReturnValue({
+      hiddenAppCards: [],
+      homeGridLayout: {
+        'test-agent': { x: 0, y: 0, w: 2, h: 1 },
+        'dash::test-agent::sales': dashboardRect,
+      },
+    })
+    mockAgentsData.mockReturnValue({
+      data: [makeAgent({ dashboardCount: 0, dashboards: [] })],
+      isLoading: false,
+    })
+    renderWithProviders(<HomePage />)
+
+    screen.getByRole('switch', { name: 'Expanded' }).click()
+
+    const layoutCall = mockUpdateSettingsMutate.mock.calls.find(
+      ([data]) => data && typeof data === 'object' && 'homeGridLayout' in data
+    )
+    expect(layoutCall?.[0].homeGridLayout['dash::test-agent::sales']).toEqual(dashboardRect)
+  })
+
+  it('rolls back an optimistic layout change when persistence fails', () => {
+    mockUserSettingsData.mockReturnValue({
+      homeGridLayout: {
+        'test-agent': { x: 0, y: 0, w: 2, h: 1 },
+      },
+    })
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    mockUpdateSettingsMutate.mockImplementationOnce((_data, options) => {
+      options?.onError?.(new Error('offline'))
+      options?.onSettled?.()
+    })
+    renderWithProviders(<HomePage />)
+
+    screen.getByRole('switch', { name: 'Expanded' }).click()
+
+    expect(screen.getByRole('switch', { name: 'Expanded' })).toHaveAttribute('aria-checked', 'true')
+    expect(mockToastError).toHaveBeenCalledWith('Failed to save the home layout', {
+      description: 'offline',
+    })
+  })
+
   it('rolls back an optimistic app-card toggle when persistence fails', () => {
     mockUserSettingsData.mockReturnValue({ hiddenAppCards: [] })
     mockAgentsData.mockReturnValue({
@@ -441,6 +525,7 @@ describe('HomePage AgentCard', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
     expect(document.querySelector('[data-widget-id="test-agent"]')).toHaveAttribute('data-arranging', 'true')
+    expect(screen.getByTestId('agent-context-trigger')).not.toHaveAttribute('data-touch-long-press-disabled')
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(screen.getByRole('button', { name: 'New Agent' })).toBeInTheDocument()
@@ -489,6 +574,7 @@ describe('HomePage AgentCard', () => {
 
     fireEvent.click(screen.getByTestId('home-arrange-action'))
     expect(document.querySelector('[data-widget-id="test-agent"]')).toHaveClass('touch-none')
+    expect(screen.getByTestId('agent-context-trigger')).toHaveAttribute('data-touch-long-press-disabled', 'true')
   })
 })
 

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -286,6 +286,10 @@ describe('HomePage AgentCard', () => {
     renderWithProviders(<HomePage />)
     // Each dashboard tile is an "Open app" screenshot card; agent cards aren't.
     expect(screen.getAllByText('Open app').length).toBeGreaterThanOrEqual(2)
+    for (const link of screen.getAllByRole('link', { name: 'Open app' })) {
+      expect(link).toHaveAttribute('draggable', 'false')
+      expect(link).toHaveAttribute('data-widget-drag-surface')
+    }
   })
 
   it('renders a screenshot img when hasScreenshot is true', () => {

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/test/test-utils'
 
 // ============================================================================
@@ -11,14 +11,16 @@ import { renderWithProviders } from '@renderer/test/test-utils'
 
 const {
   mockUseNotableSessions,
-  mockUseAgentActivityStats,
+  mockApiFetch,
+  mockHomeCardHealthData,
   mockUserSettingsData,
   mockUpdateSettingsMutate,
   mockToastError,
   mockUseIsMobile,
 } = vi.hoisted(() => ({
   mockUseNotableSessions: vi.fn<() => { data: Array<Record<string, unknown>> }>(() => ({ data: [] })),
-  mockUseAgentActivityStats: vi.fn(() => ({ data: undefined, isPending: true })),
+  mockApiFetch: vi.fn(),
+  mockHomeCardHealthData: vi.fn<() => Record<string, unknown>>(),
   mockUserSettingsData: vi.fn<() => Record<string, unknown> | null>(() => null),
   mockUpdateSettingsMutate: vi.fn(),
   mockToastError: vi.fn(),
@@ -62,27 +64,8 @@ vi.mock('@renderer/hooks/use-sessions', () => ({
   useNotableSessions: mockUseNotableSessions,
 }))
 
-vi.mock('@renderer/hooks/use-activity-stats', () => ({
-  useAgentActivityStats: mockUseAgentActivityStats,
-}))
-
-// The home page fetches the /api/home-graph topology snapshot for the cards'
-// health carousels; return an empty topology so no carousel renders.
 vi.mock('@renderer/lib/api', () => ({
-  apiFetch: vi.fn(async () => ({
-    ok: true,
-    json: async () => ({
-      accountLinks: [],
-      mcpLinks: [],
-      chats: [],
-      webhooks: [],
-      crons: [],
-      permissions: [],
-      invocations: [],
-      accountUsage: {},
-      mcpUsage: {},
-    }),
-  })),
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }))
 
 const mockAgentsData = vi.fn()
@@ -222,6 +205,18 @@ describe('HomePage AgentCard', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-26T12:00:00Z'))
     vi.clearAllMocks()
+    mockHomeCardHealthData.mockReturnValue({
+      days: 14,
+      generatedAt: '2026-03-26T12:00:00.000Z',
+      crons: [],
+      webhooks: [],
+      cronByTaskId: {},
+      webhookByTriggerId: {},
+    })
+    mockApiFetch.mockImplementation(async () => ({
+      ok: true,
+      json: async () => mockHomeCardHealthData(),
+    }))
     mockUserSettingsData.mockReturnValue(null)
     mockUseIsMobile.mockReturnValue(false)
   })
@@ -382,11 +377,46 @@ describe('HomePage AgentCard', () => {
     })
   })
 
-  it('does not request activity statistics for agents without health slides', () => {
+  it('uses one card-health batch without fetching graph topology or per-agent activity', async () => {
+    vi.useRealTimers()
     mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
     renderWithProviders(<HomePage />)
 
-    expect(mockUseAgentActivityStats).toHaveBeenCalledWith(null, 14, { live: false })
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
+    const urls = mockApiFetch.mock.calls.map(([url]) => url)
+    expect(urls).toEqual([
+      `/api/home-card-health?days=14&tz=${new Date().getTimezoneOffset()}`,
+    ])
+    expect(urls).not.toContain('/api/home-graph')
+    expect(urls.some((url) => String(url).startsWith('/api/activity/agents/'))).toBe(false)
+  })
+
+  it('renders cron activity from the shared card-health payload', async () => {
+    vi.useRealTimers()
+    mockHomeCardHealthData.mockReturnValue({
+      days: 14,
+      generatedAt: '2026-03-26T12:00:00.000Z',
+      crons: [{
+        id: 'cron-a',
+        agentSlug: 'test-agent',
+        name: 'Daily report',
+        scheduleExpression: '0 9 * * *',
+      }],
+      webhooks: [],
+      cronByTaskId: {
+        'cron-a': [{
+          scheduledAt: '2026-03-26T09:00:00.000Z',
+          status: 'succeeded',
+        }],
+      },
+      webhookByTriggerId: {},
+    })
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    renderWithProviders(<HomePage />)
+
+    expect(await screen.findByRole('img', {
+      name: 'Daily report: 1 planned run, 1 ran, 0 skipped, and 0 failed.',
+    })).toBeInTheDocument()
   })
 
   it('moves card options into the context menu and avoids nested native buttons', () => {

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -380,6 +380,7 @@ describe('HomePage AgentCard', () => {
 
     const cardLink = screen.getByRole('link', { name: 'Open Test Agent' })
     expect(cardLink.tagName).toBe('A')
+    expect(cardLink).toHaveAttribute('draggable', 'false')
     expect(cardLink).toHaveAttribute('data-widget-drag-surface')
     expect(screen.getByRole('button', { name: 'Mark as read' })).toBeVisible()
     expect(screen.getByRole('button', { name: 'Open session' })).toBeVisible()

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/test/test-utils'
+import { createPortal } from 'react-dom'
 
 // ============================================================================
 // AgentCard component tests (rendered via HomePage)
@@ -101,7 +102,7 @@ vi.mock('@renderer/components/agents/agent-context-menu', () => ({
       data-touch-long-press-disabled={disableTouchLongPress || undefined}
     >
       {children}
-      {additionalOptions}
+      {additionalOptions && createPortal(additionalOptions, document.body)}
       {onArrange && (
         <button type="button" data-testid="agent-menu-arrange" onClick={onArrange}>
           Arrange
@@ -419,13 +420,20 @@ describe('HomePage AgentCard', () => {
     })).toBeInTheDocument()
   })
 
-  it('moves card options into the context menu and avoids nested native buttons', () => {
+  it('opens the unified card menu from the focused link without a visible kebab', () => {
     mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
     renderWithProviders(<HomePage />)
 
-    expect(screen.queryByRole('button', { name: 'Card options' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Options for Test Agent' })).not.toBeInTheDocument()
     expect(screen.getByRole('switch', { name: 'Expanded' })).toBeInTheDocument()
     expect(document.querySelector('button button')).toBeNull()
+    const contextMenuEvent = vi.fn()
+    screen.getByTestId('agent-context-trigger').addEventListener('contextmenu', contextMenuEvent)
+    fireEvent.keyDown(screen.getByRole('link', { name: 'Open Test Agent' }), {
+      key: 'F10',
+      shiftKey: true,
+    })
+    expect(contextMenuEvent).toHaveBeenCalledTimes(1)
     const widget = document.querySelector('[data-widget-id="test-agent"]')
     expect(widget).toHaveClass('touch-pan-y')
     expect(widget).not.toHaveClass('touch-none')
@@ -570,6 +578,46 @@ describe('HomePage AgentCard', () => {
       expect.objectContaining({ homeGridLayout: expect.any(Object) }),
       expect.any(Object),
     )
+  })
+
+  it('stages app-card visibility until Done and restores it on Cancel', () => {
+    mockUserSettingsData.mockReturnValue({ hiddenAppCards: [] })
+    mockAgentsData.mockReturnValue({
+      data: [makeAgent({ dashboards: [{ slug: 'sales', name: 'Sales' }] })],
+      isLoading: false,
+    })
+    renderWithProviders(<HomePage />)
+
+    fireEvent.click(screen.getByTestId('home-arrange-action'))
+    fireEvent.click(screen.getByRole('switch', { name: 'Show app' }))
+    expect(screen.queryByText('Open app')).not.toBeInTheDocument()
+    expect(mockUpdateSettingsMutate).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getByText('Open app')).toBeInTheDocument()
+    expect(mockUpdateSettingsMutate).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByTestId('home-arrange-action'))
+    fireEvent.click(screen.getByRole('switch', { name: 'Show app' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(mockUpdateSettingsMutate).toHaveBeenCalledWith(
+      { hiddenAppCards: ['test-agent'] },
+      expect.any(Object)
+    )
+  })
+
+  it('cancels Arrange when the mobile breakpoint changes', () => {
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    const { rerender } = renderWithProviders(<HomePage />)
+    fireEvent.click(screen.getByTestId('home-arrange-action'))
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+
+    mockUseIsMobile.mockReturnValue(true)
+    rerender(<HomePage />)
+
+    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New Agent' })).toBeInTheDocument()
+    expect(mockUpdateSettingsMutate).not.toHaveBeenCalled()
   })
 
   it('disables mobile dragging until explicit arrange mode', () => {

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@renderer/test/test-utils'
 
 // ============================================================================
@@ -15,12 +15,14 @@ const {
   mockUserSettingsData,
   mockUpdateSettingsMutate,
   mockToastError,
+  mockUseIsMobile,
 } = vi.hoisted(() => ({
   mockUseNotableSessions: vi.fn(() => ({ data: [] })),
   mockUseAgentActivityStats: vi.fn(() => ({ data: undefined, isPending: true })),
   mockUserSettingsData: vi.fn<() => Record<string, unknown> | null>(() => null),
   mockUpdateSettingsMutate: vi.fn(),
   mockToastError: vi.fn(),
+  mockUseIsMobile: vi.fn(() => false),
 }))
 
 vi.mock('@shared/lib/utils/cn', () => ({
@@ -100,7 +102,25 @@ vi.mock('@renderer/lib/agent-ordering', () => ({
 }))
 
 vi.mock('@renderer/components/agents/agent-context-menu', () => ({
-  AgentContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AgentContextMenu: ({
+    children,
+    additionalOptions,
+    onArrange,
+  }: {
+    children: React.ReactNode
+    additionalOptions?: React.ReactNode
+    onArrange?: () => void
+  }) => (
+    <div>
+      {children}
+      {additionalOptions}
+      {onArrange && (
+        <button type="button" data-testid="agent-menu-arrange" onClick={onArrange}>
+          Arrange
+        </button>
+      )}
+    </div>
+  ),
 }))
 
 
@@ -123,8 +143,33 @@ vi.mock('@renderer/components/ui/popover', () => ({
   PopoverContent: ({ children }: { children: React.ReactNode }) => <div data-testid="popover-content">{children}</div>,
 }))
 
+vi.mock('@renderer/components/ui/context-menu', () => ({
+  ContextMenuSwitchItem: ({
+    children,
+    checked,
+    onCheckedChange,
+  }: {
+    children: React.ReactNode
+    checked: boolean
+    onCheckedChange: (checked: boolean) => void
+  }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      {children}
+    </button>
+  ),
+}))
+
 vi.mock('@renderer/hooks/use-fullscreen', () => ({
   useFullScreen: () => false,
+}))
+
+vi.mock('@renderer/hooks/use-mobile', () => ({
+  useIsMobile: mockUseIsMobile,
 }))
 
 vi.mock('sonner', () => ({
@@ -167,6 +212,7 @@ describe('HomePage AgentCard', () => {
     vi.setSystemTime(new Date('2026-03-26T12:00:00Z'))
     vi.clearAllMocks()
     mockUserSettingsData.mockReturnValue(null)
+    mockUseIsMobile.mockReturnValue(false)
   })
 
   afterAll(() => {
@@ -319,11 +365,12 @@ describe('HomePage AgentCard', () => {
     expect(mockUseAgentActivityStats).toHaveBeenCalledWith(null, 14, { live: false })
   })
 
-  it('keeps card options reachable and avoids nested native buttons', () => {
+  it('moves card options into the context menu and avoids nested native buttons', () => {
     mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
     renderWithProviders(<HomePage />)
 
-    expect(screen.getByRole('button', { name: 'Card options' })).not.toHaveClass('hidden')
+    expect(screen.queryByRole('button', { name: 'Card options' })).not.toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Expanded' })).toBeInTheDocument()
     expect(document.querySelector('button button')).toBeNull()
     const widget = document.querySelector('[data-widget-id="test-agent"]')
     expect(widget).toHaveClass('touch-pan-y')
@@ -381,6 +428,67 @@ describe('HomePage AgentCard', () => {
     expect(mockToastError).toHaveBeenCalledWith('Failed to update app-card visibility', {
       description: 'offline',
     })
+  })
+
+  it('replaces New Agent with Cancel and Done while arranging', () => {
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    renderWithProviders(<HomePage />)
+
+    expect(screen.getByRole('button', { name: 'New Agent' })).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('home-arrange-action'))
+
+    expect(screen.queryByRole('button', { name: 'New Agent' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+    expect(document.querySelector('[data-widget-id="test-agent"]')).toHaveAttribute('data-arranging', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getByRole('button', { name: 'New Agent' })).toBeInTheDocument()
+  })
+
+  it('can enter arrange mode from an agent context menu', () => {
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    renderWithProviders(<HomePage />)
+
+    fireEvent.click(screen.getByTestId('agent-menu-arrange'))
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(document.querySelector('[data-widget-id="test-agent"]')).toHaveAttribute('data-arranging', 'true')
+  })
+
+  it('stages arrange-mode drags until Done persists them', () => {
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    renderWithProviders(<HomePage />)
+    fireEvent.click(screen.getByTestId('home-arrange-action'))
+
+    const widget = document.querySelector('[data-widget-id="test-agent"]')
+    expect(widget).not.toBeNull()
+    fireEvent.pointerDown(widget!, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.pointerMove(window, { clientX: 40, clientY: 80 })
+    fireEvent.pointerUp(window)
+
+    expect(mockUpdateSettingsMutate).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(mockUpdateSettingsMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ homeGridLayout: expect.any(Object) }),
+      expect.any(Object),
+    )
+  })
+
+  it('disables mobile dragging until explicit arrange mode', () => {
+    mockUseIsMobile.mockReturnValue(true)
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    renderWithProviders(<HomePage />)
+
+    const widget = document.querySelector('[data-widget-id="test-agent"]')
+    fireEvent.pointerDown(widget!, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.pointerMove(window, { clientX: 40, clientY: 80 })
+    fireEvent.pointerUp(window)
+    expect(mockUpdateSettingsMutate).not.toHaveBeenCalled()
+    expect(widget).toHaveClass('touch-pan-y')
+
+    fireEvent.click(screen.getByTestId('home-arrange-action'))
+    expect(document.querySelector('[data-widget-id="test-agent"]')).toHaveClass('touch-none')
   })
 })
 

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -576,6 +576,36 @@ describe('HomePage AgentCard', () => {
     expect(document.querySelector('[data-widget-id="test-agent"]')).toHaveClass('touch-none')
     expect(screen.getByTestId('agent-context-trigger')).toHaveAttribute('data-touch-long-press-disabled', 'true')
   })
+
+  it('forks mobile changes without overwriting the saved desktop layout', () => {
+    const desktopRect = { x: 4, y: 2, w: 2, h: 1 }
+    const settings = {
+      homeGridLayout: {
+        'test-agent': desktopRect,
+      },
+    }
+    mockUseIsMobile.mockReturnValue(true)
+    mockUserSettingsData.mockReturnValue(settings)
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    renderWithProviders(<HomePage />)
+
+    // With no mobile map yet, the phone inherits the desktop card size.
+    const expanded = screen.getByRole('switch', { name: 'Expanded' })
+    expect(expanded).toHaveAttribute('aria-checked', 'true')
+    expanded.click()
+
+    expect(mockUpdateSettingsMutate).toHaveBeenCalledWith(
+      {
+        homeGridMobileLayout: {
+          'test-agent': expect.objectContaining({ w: 1, h: 1 }),
+        },
+      },
+      expect.any(Object)
+    )
+    const payload = mockUpdateSettingsMutate.mock.calls[0][0]
+    expect(payload).not.toHaveProperty('homeGridLayout')
+    expect(settings.homeGridLayout['test-agent']).toEqual(desktopRect)
+  })
 })
 
 describe('HomePage view toggle', () => {

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -9,6 +9,20 @@ import { renderWithProviders } from '@renderer/test/test-utils'
 
 // Mock all dependencies for HomePage rendering
 
+const {
+  mockUseNotableSessions,
+  mockUseAgentActivityStats,
+  mockUserSettingsData,
+  mockUpdateSettingsMutate,
+  mockToastError,
+} = vi.hoisted(() => ({
+  mockUseNotableSessions: vi.fn(() => ({ data: [] })),
+  mockUseAgentActivityStats: vi.fn(() => ({ data: undefined, isPending: true })),
+  mockUserSettingsData: vi.fn<() => Record<string, unknown> | null>(() => null),
+  mockUpdateSettingsMutate: vi.fn(),
+  mockToastError: vi.fn(),
+}))
+
 vi.mock('@shared/lib/utils/cn', () => ({
   cn: (...args: unknown[]) => {
     const classes: string[] = []
@@ -43,11 +57,11 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 })
 
 vi.mock('@renderer/hooks/use-sessions', () => ({
-  useSessions: () => ({ data: [] }),
+  useNotableSessions: mockUseNotableSessions,
 }))
 
 vi.mock('@renderer/hooks/use-activity-stats', () => ({
-  useAgentActivityStats: () => ({ data: undefined, isPending: true }),
+  useAgentActivityStats: mockUseAgentActivityStats,
 }))
 
 // The home page fetches the /api/home-graph topology snapshot for the cards'
@@ -77,8 +91,8 @@ vi.mock('@renderer/hooks/use-agents', () => ({
 }))
 
 vi.mock('@renderer/hooks/use-user-settings', () => ({
-  useUserSettings: () => ({ data: null }),
-  useUpdateUserSettings: () => ({ mutate: vi.fn(), isPending: false }),
+  useUserSettings: () => ({ data: mockUserSettingsData() }),
+  useUpdateUserSettings: () => ({ mutate: mockUpdateSettingsMutate, isPending: false }),
 }))
 
 vi.mock('@renderer/lib/agent-ordering', () => ({
@@ -111,6 +125,10 @@ vi.mock('@renderer/components/ui/popover', () => ({
 
 vi.mock('@renderer/hooks/use-fullscreen', () => ({
   useFullScreen: () => false,
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mockToastError },
 }))
 
 vi.mock('@renderer/lib/env', () => ({
@@ -148,6 +166,7 @@ describe('HomePage AgentCard', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-26T12:00:00Z'))
     vi.clearAllMocks()
+    mockUserSettingsData.mockReturnValue(null)
   })
 
   afterAll(() => {
@@ -278,6 +297,90 @@ describe('HomePage AgentCard', () => {
     // status='running' + hasSessionsAwaitingInput → getAgentActivityStatus aggregates
     // to 'awaiting_input', surfaced as the dot-matrix indicator's aria-label.
     expect(screen.getByRole('img', { name: 'awaiting_input' })).toBeInTheDocument()
+  })
+
+  it('uses the notable-session fast path for cards with live or unread work', () => {
+    mockAgentsData.mockReturnValue({
+      data: [makeAgent({ hasUnreadNotifications: true })],
+      isLoading: false,
+    })
+    renderWithProviders(<HomePage />)
+
+    expect(mockUseNotableSessions).toHaveBeenCalledWith('test-agent', {
+      limit: 100,
+      staleTime: 30_000,
+    })
+  })
+
+  it('does not request activity statistics for agents without health slides', () => {
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    renderWithProviders(<HomePage />)
+
+    expect(mockUseAgentActivityStats).toHaveBeenCalledWith(null, 14, { live: false })
+  })
+
+  it('keeps card options reachable and avoids nested native buttons', () => {
+    mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
+    renderWithProviders(<HomePage />)
+
+    expect(screen.getByRole('button', { name: 'Card options' })).not.toHaveClass('hidden')
+    expect(document.querySelector('button button')).toBeNull()
+    const widget = document.querySelector('[data-widget-id="test-agent"]')
+    expect(widget).toHaveClass('touch-pan-y')
+    expect(widget).not.toHaveClass('touch-none')
+  })
+
+  it('preserves hidden dashboard geometry when another card is resized', () => {
+    const dashboardRect = { x: 2, y: 3, w: 1, h: 1 }
+    mockUserSettingsData.mockReturnValue({
+      hiddenAppCards: ['test-agent'],
+      homeGridLayout: {
+        'test-agent': { x: 0, y: 0, w: 2, h: 1 },
+        'dash::test-agent::sales': dashboardRect,
+      },
+    })
+    mockAgentsData.mockReturnValue({
+      data: [
+        makeAgent({
+          dashboardCount: 1,
+          dashboards: [{ slug: 'sales', name: 'Sales' }],
+        }),
+      ],
+      isLoading: false,
+    })
+    renderWithProviders(<HomePage />)
+
+    screen.getByRole('switch', { name: 'Expanded' }).click()
+
+    const layoutCall = mockUpdateSettingsMutate.mock.calls.find(
+      ([data]) => data && typeof data === 'object' && 'homeGridLayout' in data
+    )
+    expect(layoutCall?.[0].homeGridLayout['dash::test-agent::sales']).toEqual(dashboardRect)
+  })
+
+  it('rolls back an optimistic app-card toggle when persistence fails', () => {
+    mockUserSettingsData.mockReturnValue({ hiddenAppCards: [] })
+    mockAgentsData.mockReturnValue({
+      data: [
+        makeAgent({
+          dashboardCount: 1,
+          dashboards: [{ slug: 'sales', name: 'Sales' }],
+        }),
+      ],
+      isLoading: false,
+    })
+    mockUpdateSettingsMutate.mockImplementationOnce((_data, options) => {
+      options?.onError?.(new Error('offline'))
+      options?.onSettled?.()
+    })
+    renderWithProviders(<HomePage />)
+
+    screen.getByRole('switch', { name: 'Show app' }).click()
+
+    expect(screen.getByText('Open app')).toBeInTheDocument()
+    expect(mockToastError).toHaveBeenCalledWith('Failed to update app-card visibility', {
+      description: 'offline',
+    })
   })
 })
 

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -1,7 +1,7 @@
 
 import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useNavigate, useSearch as useRouteSearch } from '@tanstack/react-router'
-import { WidgetBoard, WidgetSizePopover, WidgetToggleRow, type GridRect, type WidgetItem, type WidgetSizeKey } from './widget-grid'
+import { WidgetBoard, WidgetSizePopover, type GridRect, type WidgetItem, type WidgetSizeKey } from './widget-grid'
 import { useAgents, useStartAgent, useStopAgent } from '@renderer/hooks/use-agents'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import { useMarkSessionNotificationsRead } from '@renderer/hooks/use-notifications'
@@ -30,12 +30,15 @@ import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu
 import { useCreateUntitledAgent } from '@renderer/hooks/use-create-untitled-agent'
 import { SidebarTrigger } from '@renderer/components/ui/sidebar'
 import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { ContextMenuSwitchItem } from '@renderer/components/ui/context-menu'
 import { useSidebar } from '@renderer/components/ui/sidebar'
 import { useFullScreen } from '@renderer/hooks/use-fullscreen'
+import { useIsMobile } from '@renderer/hooks/use-mobile'
 import { DashboardCard } from './dashboard-card'
 import { PwaInstallBanner } from './pwa-install-banner'
 import { isElectron, getPlatform } from '@renderer/lib/env'
-import { Plus, Bot, Loader2, Search, Power, Square, Check, ArrowRight, LayoutGrid, Waypoints } from 'lucide-react'
+import { Plus, Bot, Loader2, Search, Power, Square, Check, ArrowRight, LayoutGrid, Waypoints, MoreVertical, Move } from 'lucide-react'
 import { useSearch } from '@renderer/context/search-context'
 import { cn } from '@shared/lib/utils/cn'
 import type { ApiAgent } from '@shared/lib/types/api'
@@ -543,13 +546,17 @@ function TickerTitleMeta({
 function AgentCard({
   agent,
   size = 'W',
-  sizeControl,
+  additionalOptions,
+  onArrange,
+  disableTouchLongPress,
   crons = [],
   webhooks = [],
 }: {
   agent: ApiAgent
   size?: WidgetSizeKey
-  sizeControl?: ReactNode
+  additionalOptions?: ReactNode
+  onArrange?: () => void
+  disableTouchLongPress?: boolean
   crons?: HomeGraphCron[]
   webhooks?: HomeGraphWebhook[]
 }) {
@@ -591,7 +598,12 @@ function AgentCard({
   )
 
   return (
-    <AgentContextMenu agent={agent}>
+    <AgentContextMenu
+      agent={agent}
+      additionalOptions={additionalOptions}
+      onArrange={onArrange}
+      disableTouchLongPress={disableTouchLongPress}
+    >
       <div
         className="relative flex h-full w-full flex-col gap-3 overflow-hidden rounded-lg border bg-card p-4 text-left shadow-sm transition-[box-shadow,transform,border-color] duration-150 hover:border-accent-foreground/20 group-hover/widget:-translate-y-0.5 group-hover/widget:shadow-md"
       >
@@ -607,12 +619,10 @@ function AgentCard({
           className="absolute inset-0 z-20 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
         />
 
-        {/* Control row: status chip + size kebab share one flex row, so
-            items-center vertically centers the kebab against the chip in one
-            right-anchored row. */}
+        {/* The card now has one menu surface: its context menu. Keep only the
+            status/power chip visible on the card itself. */}
         <div className="absolute top-2 right-4 z-30 flex items-center gap-1.5">
           <AgentCardPowerButton agent={agent} />
-          {sizeControl}
         </div>
 
         {isSmall ? (
@@ -678,6 +688,45 @@ function dashboardAgentSlugFromKey(id: string): string | null {
   return separator === -1 ? null : rest.slice(0, separator)
 }
 
+function HomeArrangeMenu({
+  onArrange,
+  disabled,
+}: {
+  onArrange: () => void
+  disabled: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Agent layout options"
+          title="Agent layout options"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <MoreVertical className="h-4 w-4" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-40 p-1">
+        <button
+          type="button"
+          data-testid="home-arrange-action"
+          disabled={disabled}
+          onClick={() => {
+            setOpen(false)
+            onArrange()
+          }}
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+        >
+          <Move className="h-4 w-4" />
+          Arrange
+        </button>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 export function HomePage() {
   useRenderTracker('HomePage')
   const { data: agents, isLoading: agentsLoading } = useAgents()
@@ -695,6 +744,11 @@ export function HomePage() {
   const [localLayout, setLocalLayout] = useState<Record<string, GridRect> | null>(null)
   const layoutMutationVersion = useRef(0)
   const savedLayout = localLayout ?? userSettings?.homeGridLayout
+  // Arrange mode stages its layout locally. Done persists the staged map once;
+  // Cancel drops it and restores the last saved geometry.
+  const [isArranging, setIsArranging] = useState(false)
+  const [arrangeLayout, setArrangeLayout] = useState<Record<string, GridRect> | null>(null)
+  const displayedLayout = arrangeLayout ?? savedLayout
 
   // Agents whose associated app/dashboard card is toggled off. localHidden is a
   // session override that wins over the server value, so the toggle takes effect
@@ -711,18 +765,18 @@ export function HomePage() {
     const dashes = new Map<string, { agentSlug: string; dashboard: { slug: string; name: string } }>()
     const withApp = new Set<string>()
     for (const agent of orderedAgents) {
-      items.push({ id: agent.slug, rect: savedLayout?.[agent.slug], defaultSize: 'W' })
+      items.push({ id: agent.slug, rect: displayedLayout?.[agent.slug], defaultSize: 'W' })
       const dashboards = Array.isArray(agent.dashboards) ? agent.dashboards : []
       if (dashboards.length > 0) withApp.add(agent.slug)
       if (hiddenApps.has(agent.slug)) continue // app card toggled off — skip its dashboard tiles
       for (const d of dashboards) {
         const id = dashKey(agent.slug, d.slug)
-        items.push({ id, rect: savedLayout?.[id], defaultSize: 'S' })
+        items.push({ id, rect: displayedLayout?.[id], defaultSize: 'S' })
         dashes.set(id, { agentSlug: agent.slug, dashboard: d })
       }
     }
     return { widgetItems: items, dashboardsById: dashes, agentsWithApp: withApp }
-  }, [orderedAgents, savedLayout, hiddenApps])
+  }, [orderedAgents, displayedLayout, hiddenApps])
 
   const agentBySlug = useMemo(() => new Map(orderedAgents.map((a) => [a.slug, a])), [orderedAgents])
 
@@ -801,6 +855,7 @@ export function HomePage() {
   }
 
   const { createUntitledAgent, isPending: isCreatingAgent } = useCreateUntitledAgent()
+  const isMobile = useIsMobile()
   const { state: sidebarState } = useSidebar()
   const isFullScreen = useFullScreen()
   const needsTrafficLightPadding = isElectron() && getPlatform() === 'darwin' && sidebarState === 'collapsed' && !isFullScreen
@@ -815,6 +870,10 @@ export function HomePage() {
   const view: 'cards' | 'graph' = routeSearch.view === 'graph' ? 'graph' : 'cards'
   const setView = (next: 'cards' | 'graph') => {
     if (next === view) return
+    if (next === 'graph') {
+      setArrangeLayout(null)
+      setIsArranging(false)
+    }
     void navigate({
       to: '/',
       search: (prev: Record<string, unknown>) => ({
@@ -822,6 +881,28 @@ export function HomePage() {
         view: next === 'graph' ? ('graph' as const) : undefined,
       }),
     })
+  }
+  const beginArrange = () => {
+    if (!hasAgents) return
+    setArrangeLayout(null)
+    setIsArranging(true)
+  }
+  const cancelArrange = () => {
+    setArrangeLayout(null)
+    setIsArranging(false)
+  }
+  const finishArrange = () => {
+    const nextLayout = arrangeLayout
+    setArrangeLayout(null)
+    setIsArranging(false)
+    if (nextLayout) commitLayout(nextLayout)
+  }
+  const handleBoardCommit = (layout: Record<string, GridRect>) => {
+    if (isArranging) {
+      setArrangeLayout(layout)
+      return
+    }
+    commitLayout(layout)
   }
 
   return (
@@ -909,16 +990,30 @@ export function HomePage() {
           {/* Agents Section */}
           <section>
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-medium">Your Agents</h2>
-              <Button
-                size="sm"
-                onClick={() => { void createUntitledAgent() }}
-                className="app-no-drag"
-                disabled={isCreatingAgent}
-              >
-                <Plus className="h-4 w-4 mr-1" />
-                New Agent
-              </Button>
+              <div className="flex items-center gap-1">
+                <h2 className="text-lg font-medium">Your Agents</h2>
+                {!isArranging && <HomeArrangeMenu onArrange={beginArrange} disabled={!hasAgents} />}
+              </div>
+              {isArranging ? (
+                <div className="flex items-center gap-2">
+                  <Button size="sm" variant="outline" onClick={cancelArrange}>
+                    Cancel
+                  </Button>
+                  <Button size="sm" onClick={finishArrange}>
+                    Done
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  size="sm"
+                  onClick={() => { void createUntitledAgent() }}
+                  className="app-no-drag"
+                  disabled={isCreatingAgent}
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  New Agent
+                </Button>
+              )}
             </div>
 
             {agentsLoading ? (
@@ -928,7 +1023,10 @@ export function HomePage() {
             ) : hasAgents ? (
               <WidgetBoard
                 items={widgetItems}
-                onCommit={commitLayout}
+                onCommit={handleBoardCommit}
+                arranging={isArranging}
+                dragEnabled={!isMobile || isArranging}
+                disableContextMenu={isMobile && isArranging}
                 renderItem={(id, size, onResize) => {
                   const dash = dashboardsById.get(id)
                   if (dash) {
@@ -943,29 +1041,34 @@ export function HomePage() {
                   }
                   const agent = agentBySlug.get(id)
                   if (!agent) return null
-                  const sizeControl = (
-                    <WidgetSizePopover
-                      size={size}
-                      onPick={onResize}
-                      extra={(close) =>
-                        agentsWithApp.has(agent.slug) ? (
-                          <WidgetToggleRow
-                            label="Show app"
-                            checked={!hiddenApps.has(agent.slug)}
-                            onToggle={() => {
-                              close()
-                              toggleAppCard(agent.slug)
-                            }}
-                          />
-                        ) : null
-                      }
-                    />
-                  )
                   return (
                     <AgentCard
                       agent={agent}
                       size={size}
-                      sizeControl={sizeControl}
+                      onArrange={beginArrange}
+                      disableTouchLongPress={isMobile && isArranging}
+                      additionalOptions={
+                        <>
+                          <ContextMenuSwitchItem
+                            checked={size === 'W'}
+                            onCheckedChange={() => {
+                              onResize(size === 'W' ? 'S' : 'W')
+                            }}
+                          >
+                            Expanded
+                          </ContextMenuSwitchItem>
+                          {agentsWithApp.has(agent.slug) && (
+                            <ContextMenuSwitchItem
+                              checked={!hiddenApps.has(agent.slug)}
+                              onCheckedChange={() => {
+                                toggleAppCard(agent.slug)
+                              }}
+                            >
+                              Show app
+                            </ContextMenuSwitchItem>
+                          )}
+                        </>
+                      }
                       crons={cronsByAgent.get(agent.slug)}
                       webhooks={webhooksByAgent.get(agent.slug)}
                     />

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -30,6 +30,7 @@ import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu
 import { useCreateUntitledAgent } from '@renderer/hooks/use-create-untitled-agent'
 import { SidebarTrigger } from '@renderer/components/ui/sidebar'
 import { Button } from '@renderer/components/ui/button'
+import { AppLink } from '@renderer/components/ui/app-link'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { ContextMenuSwitchItem } from '@renderer/components/ui/context-menu'
 import { useSidebar } from '@renderer/components/ui/sidebar'
@@ -70,6 +71,23 @@ function hashSlug(s: string): number {
   return h
 }
 
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
+  )
+
+  useEffect(() => {
+    const media = window.matchMedia?.('(prefers-reduced-motion: reduce)')
+    if (!media) return
+    const update = () => setReduced(media.matches)
+    update()
+    media.addEventListener?.('change', update)
+    return () => media.removeEventListener?.('change', update)
+  }, [])
+
+  return reduced
+}
+
 // State label for the top-right status/control chip.
 const AGENT_STATE_TAG: Record<'sleeping' | 'idle' | 'working' | 'awaiting', string> = {
   sleeping: 'Sleeping',
@@ -108,23 +126,17 @@ function AgentCardPowerButton({ agent }: { agent: ApiAgent }) {
     // with it natively.
     <div className="flex items-center gap-1.5 rounded-md border border-border/50 bg-white/10 py-0.5 pl-1.5 pr-1 text-xs backdrop-blur-sm">
       <span className="leading-none text-muted-foreground">{label}</span>
-      <span
-        role="button"
-        tabIndex={0}
+      <button
+        type="button"
+        disabled={isPending}
         aria-label={isRunning ? 'Stop agent' : 'Wake up agent'}
         title={isRunning ? 'Stop agent' : 'Wake up agent'}
         onClick={activate}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            activate(e)
-          }
-        }}
         className={cn(
           'flex h-5 w-5 shrink-0 items-center justify-center rounded border bg-background text-foreground shadow-sm',
           'cursor-pointer transition-colors hover:bg-muted',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
-          isPending && 'pointer-events-none opacity-60'
+          'disabled:cursor-wait disabled:opacity-60'
         )}
       >
         {isPending ? (
@@ -134,7 +146,7 @@ function AgentCardPowerButton({ agent }: { agent: ApiAgent }) {
         ) : (
           <Power className="h-2.5 w-2.5" />
         )}
-      </span>
+      </button>
     </div>
   )
 }
@@ -169,8 +181,7 @@ function AgentCardMatrix({
   const stateTweak = activityStatus === 'awaiting_input' ? undefined : HALFTONE_STATE[activityStatus]
   return (
     <div
-      role="img"
-      aria-label={activityStatus}
+      aria-hidden="true"
       className={cn('w-full overflow-hidden', className ?? 'aspect-[32/9]', HALFTONE_INK[activityStatus])}
     >
       <Halftone
@@ -257,25 +268,6 @@ function SessionStateDot({ state }: { state: SessionState }) {
   return <span className="flex h-3 w-3 shrink-0 items-center justify-center">{dot}</span>
 }
 
-/** Keyboard-activatable span — cards are <button>s, so inner controls can't be native buttons. */
-function rowButtonProps(onActivate: (e: React.SyntheticEvent) => void) {
-  return {
-    role: 'button' as const,
-    tabIndex: 0,
-    onClick: (e: React.MouseEvent) => {
-      e.stopPropagation()
-      onActivate(e)
-    },
-    onKeyDown: (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault()
-        e.stopPropagation()
-        onActivate(e)
-      }
-    },
-  }
-}
-
 /**
  * Notifications section: a frosted panel (matching the title pill / health
  * chips) of hairline-divided rows — state dot, name, and a right-aligned
@@ -319,37 +311,50 @@ function AgentCardSessions({
               key={s.id}
               className="group/row flex h-6 w-full items-center gap-2.5 text-xs"
             >
-              <span {...rowButtonProps(() => open(s.id))} className="flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 text-left">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  open(s.id)
+                }}
+                className="flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
                 <SessionStateDot state={st} />
                 <span className="truncate text-foreground">
                   <span className="text-muted-foreground">{SESSION_STATE_PREFIX[st]}: </span>
                   {stripAgentPrefix(s.name, agentName)}
                 </span>
-              </span>
+              </button>
               {st === 'unread' || st === 'awaiting' ? (
                 <>
-                  {/* The timestamp swaps for actions on hover: unread gets
-                      clear + open; needs-input has nothing to clear, just open. */}
-                  <span className="shrink-0 text-muted-foreground tabular-nums group-hover/row:hidden">{right}</span>
-                  <span className="hidden shrink-0 items-center gap-0.5 group-hover/row:flex">
+                  <span className="shrink-0 text-muted-foreground tabular-nums">{right}</span>
+                  <span className="flex shrink-0 items-center gap-0.5 opacity-60 transition-opacity group-hover/row:opacity-100 group-focus-within/row:opacity-100">
                     {st === 'unread' && (
-                      <span
-                        {...rowButtonProps(() => markRead.mutate(s.id))}
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          markRead.mutate(s.id)
+                        }}
                         aria-label="Mark as read"
                         title="Mark as read"
-                        className="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                        className="inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         <Check className="h-3.5 w-3.5" />
-                      </span>
+                      </button>
                     )}
-                    <span
-                      {...rowButtonProps(() => open(s.id))}
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        open(s.id)
+                      }}
                       aria-label="Open session"
                       title="Open session"
-                      className="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      className="inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <ArrowRight className="h-3.5 w-3.5" />
-                    </span>
+                    </button>
                   </span>
                 </>
               ) : (
@@ -359,17 +364,19 @@ function AgentCardSessions({
           )
         })}
         {moreCount > 0 && (
-          <span
-            {...rowButtonProps(() => {
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
               void navigate({ to: '/agents/$slug', params: { slug: agentDisplaySlug } })
-            })}
+            }}
             className="group/row flex h-6 w-full cursor-pointer items-center justify-end gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
             <span>{moreCount} more</span>
-            <span className="hidden h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground group-hover/row:inline-flex">
+            <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground opacity-60 transition-all group-hover/row:opacity-100">
               <ArrowRight className="h-3.5 w-3.5" />
             </span>
-          </span>
+          </button>
         )}
       </div>
     </div>
@@ -412,7 +419,10 @@ function AgentHealthCarousel({
     { live: false }
   )
   const [index, setIndex] = useState(0)
-  const [paused, setPaused] = useState(false)
+  const [hovered, setHovered] = useState(false)
+  const [focusWithin, setFocusWithin] = useState(false)
+  const reduceMotion = usePrefersReducedMotion()
+  const paused = hovered || focusWithin || reduceMotion
 
   useEffect(() => {
     if (paused || count < 2) return
@@ -448,8 +458,12 @@ function AgentHealthCarousel({
       metric = `${total}/${DEFAULT_ACTIVITY_DAYS}d`
     }
     return (
-      <span
-        {...rowButtonProps(() => openSlide(s))}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          openSlide(s)
+        }}
         className="flex w-full cursor-pointer items-center gap-2 text-xs"
       >
         <span className="min-w-0 flex-1 truncate">
@@ -458,15 +472,19 @@ function AgentHealthCarousel({
         </span>
         <span className="shrink-0">{chart}</span>
         <span className="shrink-0 tabular-nums text-muted-foreground">{metric}</span>
-      </span>
+      </button>
     )
   }
 
   return (
     <div
       className="pointer-events-auto mt-auto flex shrink-0 items-center gap-1.5"
-      onMouseEnter={() => setPaused(true)}
-      onMouseLeave={() => setPaused(false)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onFocusCapture={() => setFocusWithin(true)}
+      onBlurCapture={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setFocusWithin(false)
+      }}
     >
       {/* The frosted panel (title's bg-white/10 + backdrop-blur) lives on the
           container so the halftone reads softly through it and never flashes.
@@ -475,24 +493,33 @@ function AgentHealthCarousel({
       <div className="relative min-w-0 flex-1 overflow-hidden rounded-md border border-border/50 bg-white/10 backdrop-blur-sm">
         <div
           key={active.id}
-          className="px-2 py-1.5 animate-in slide-in-from-bottom-full duration-300"
+          className={cn('px-2 py-1.5', !reduceMotion && 'animate-in slide-in-from-bottom-full duration-300')}
         >
           {renderSlide(active)}
         </div>
       </div>
       {/* Vertical position dots, outside the chip to the right */}
       {count > 1 && (
-        <span className="flex shrink-0 flex-col items-center gap-1">
+        <span className="flex shrink-0 items-center">
           {slides.map((s, i) => (
-            <span
+            <button
+              type="button"
               key={s.id}
-              {...rowButtonProps(() => setIndex(i))}
+              onClick={(e) => {
+                e.stopPropagation()
+                setIndex(i)
+              }}
               aria-label={`Show health row ${i + 1} of ${count}`}
-              className={cn(
-                'h-[3px] w-[3px] cursor-pointer rounded-full transition-colors',
-                i === index % count ? 'bg-foreground/70' : 'bg-muted-foreground/30 hover:bg-muted-foreground/60'
-              )}
-            />
+              aria-pressed={i === index % count}
+              className="group inline-flex h-6 w-6 items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span
+                className={cn(
+                  'h-[3px] w-[3px] rounded-full transition-colors',
+                  i === index % count ? 'bg-foreground/70' : 'bg-muted-foreground/30 group-hover:bg-muted-foreground/60'
+                )}
+              />
+            </button>
           ))}
         </span>
       )}
@@ -525,11 +552,7 @@ function TickerTitleMeta({
   )
   return (
     <div className="relative h-4 overflow-hidden text-xs">
-      <style>{'@keyframes title-ticker{from{transform:translateX(0)}to{transform:translateX(-50%)}}'}</style>
-      <div
-        className="flex w-max items-center whitespace-nowrap"
-        style={{ animation: 'title-ticker 14s linear infinite' }}
-      >
+      <div className="home-title-ticker flex w-max items-center whitespace-nowrap group-hover/widget:[animation-play-state:paused] group-focus-within/widget:[animation-play-state:paused]">
         {run}
         {run}
       </div>
@@ -561,7 +584,6 @@ function AgentCard({
   webhooks?: HomeGraphWebhook[]
 }) {
   useRenderTracker('AgentCard')
-  const navigate = useNavigate()
   const lastWorked = agent.lastActivityAt ? formatDistanceToNow(new Date(agent.lastActivityAt), { addSuffix: true }) : null
 
   const isSmall = size === 'S'
@@ -610,12 +632,11 @@ function AgentCard({
         {/* Keep navigation as a sibling of the card controls so the DOM never
             nests buttons inside a button. Interactive rows sit above this
             transparent hit target and handle their own actions. */}
-        <button
-          type="button"
+        <AppLink
+          to="/agents/$slug"
+          params={{ slug: agent.displaySlug }}
+          data-widget-drag-surface=""
           aria-label={`Open ${agent.name}`}
-          onClick={() => {
-            void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
-          }}
           className="absolute inset-0 z-20 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
         />
 
@@ -812,12 +833,14 @@ export function HomePage() {
 
   const commitLayout = (layout: Record<string, GridRect>) => {
     // WidgetBoard only knows about currently rendered items. Preserve saved
-    // geometry for intentionally hidden dashboard cards so a later drag does
-    // not reset their position/size when they are shown again.
+    // geometry for any missing item whose owning agent still exists. This
+    // covers intentionally hidden cards and transiently incomplete dashboard
+    // inventories without retaining entries for agents that were deleted.
     const nextLayout = { ...layout }
     for (const [id, rect] of Object.entries(savedLayout ?? {})) {
-      const agentSlug = dashboardAgentSlugFromKey(id)
-      if (agentSlug && hiddenApps.has(agentSlug)) nextLayout[id] = rect
+      if (id in nextLayout) continue
+      const ownerSlug = dashboardAgentSlugFromKey(id) ?? id
+      if (agentBySlug.has(ownerSlug)) nextLayout[id] = rect
     }
 
     const version = ++layoutMutationVersion.current

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -1,5 +1,5 @@
 
-import { lazy, Suspense, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useNavigate, useSearch as useRouteSearch } from '@tanstack/react-router'
 import { WidgetBoard, WidgetSizePopover, WidgetToggleRow, type GridRect, type WidgetItem, type WidgetSizeKey } from './widget-grid'
 import { useAgents, useStartAgent, useStopAgent } from '@renderer/hooks/use-agents'
@@ -7,7 +7,7 @@ import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user
 import { useMarkSessionNotificationsRead } from '@renderer/hooks/use-notifications'
 import { useAgentActivityStats } from '@renderer/hooks/use-activity-stats'
 import { applyAgentOrder } from '@renderer/lib/agent-ordering'
-import { useSessions } from '@renderer/hooks/use-sessions'
+import { useNotableSessions } from '@renderer/hooks/use-sessions'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@renderer/lib/api'
 import { Halftone } from '@renderer/components/agents/halftone'
@@ -41,6 +41,7 @@ import { cn } from '@shared/lib/utils/cn'
 import type { ApiAgent } from '@shared/lib/types/api'
 import { formatDistanceToNow } from 'date-fns'
 import { useRenderTracker } from '@renderer/lib/perf'
+import { toast } from 'sonner'
 
 // Code-split: the graph pulls in @xyflow/react + d3-force, which nobody
 // should pay for on a cards-only page load.
@@ -305,7 +306,7 @@ function AgentCardSessions({
   const moreCount = notable.length - visible.length
 
   return (
-    <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-md border border-border/50 bg-white/10 backdrop-blur-sm">
+    <div className="pointer-events-auto flex max-h-full min-h-0 flex-col overflow-hidden rounded-md border border-border/50 bg-white/10 backdrop-blur-sm">
       <div className="min-h-0 overflow-y-auto px-2 py-1">
         {visible.map((s) => {
           const st = sessionState(s)
@@ -392,12 +393,6 @@ function AgentHealthCarousel({
   webhooks: HomeGraphWebhook[]
 }) {
   const navigate = useNavigate()
-  // live:false — many cards mount at once; same reasoning as the graph's
-  // hover cards (no poll, refetch only when stale).
-  const { data: stats, isPending: statsPending } = useAgentActivityStats(agent.slug, DEFAULT_ACTIVITY_DAYS, {
-    live: false,
-  })
-
   const slides = useMemo<HealthSlide[]>(
     () => [
       ...crons.map((c) => ({ kind: 'cron' as const, id: c.id, name: c.name ?? c.scheduleExpression })),
@@ -406,6 +401,13 @@ function AgentHealthCarousel({
     [crons, webhooks]
   )
   const count = slides.length
+  // Avoid one activity request per agent when there are no charts to render.
+  // live:false also prevents decorative cards from polling independently.
+  const { data: stats, isPending: statsPending } = useAgentActivityStats(
+    count > 0 ? agent.slug : null,
+    DEFAULT_ACTIVITY_DAYS,
+    { live: false }
+  )
   const [index, setIndex] = useState(0)
   const [paused, setPaused] = useState(false)
 
@@ -459,7 +461,7 @@ function AgentHealthCarousel({
 
   return (
     <div
-      className="mt-auto flex shrink-0 items-center gap-1.5"
+      className="pointer-events-auto mt-auto flex shrink-0 items-center gap-1.5"
       onMouseEnter={() => setPaused(true)}
       onMouseLeave={() => setPaused(false)}
     >
@@ -560,7 +562,10 @@ function AgentCard({
   // Fetch sessions whenever there are notable ones — the Wide card lists them,
   // the Small card rotates a count into the title.
   const hasNotable = agent.hasActiveSessions || agent.hasSessionsAwaitingInput || agent.hasUnreadNotifications
-  const { data: sessions } = useSessions(hasNotable ? agent.slug : null, { staleTime: 30_000 })
+  const { data: sessions } = useNotableSessions(hasNotable ? agent.slug : null, {
+    limit: 100,
+    staleTime: 30_000,
+  })
 
   // Notification summary for the Small card's rotating title meta. Orange
   // (needs input) always wins over blue (unread).
@@ -575,7 +580,7 @@ function AgentCard({
       : null
 
   const titleOverlay = (
-    <div className="absolute bottom-2 left-4 max-w-[calc(100%-2rem)] rounded-md bg-white/10 px-2.5 py-1 backdrop-blur-sm">
+    <div className="pointer-events-none absolute bottom-2 left-4 z-10 max-w-[calc(100%-2rem)] rounded-md bg-white/10 px-2.5 py-1 backdrop-blur-sm">
       <div className="truncate text-sm font-normal text-foreground">{agent.name}</div>
       {isSmall && notifState ? (
         <TickerTitleMeta lastWorked={lastWorked} notifCount={notifSessions.length} notifState={notifState} />
@@ -587,15 +592,24 @@ function AgentCard({
 
   return (
     <AgentContextMenu agent={agent}>
-      <button
-        onClick={() => {
-          void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
-        }}
+      <div
         className="relative flex h-full w-full flex-col gap-3 overflow-hidden rounded-lg border bg-card p-4 text-left shadow-sm transition-[box-shadow,transform,border-color] duration-150 hover:border-accent-foreground/20 group-hover/widget:-translate-y-0.5 group-hover/widget:shadow-md"
       >
+        {/* Keep navigation as a sibling of the card controls so the DOM never
+            nests buttons inside a button. Interactive rows sit above this
+            transparent hit target and handle their own actions. */}
+        <button
+          type="button"
+          aria-label={`Open ${agent.name}`}
+          onClick={() => {
+            void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
+          }}
+          className="absolute inset-0 z-20 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        />
+
         {/* Control row: status chip + size kebab share one flex row, so
-            items-center vertically centers the kebab against the chip, and the
-            kebab simply appears to its right on hover (right-anchored row). */}
+            items-center vertically centers the kebab against the chip in one
+            right-anchored row. */}
         <div className="absolute top-2 right-4 z-30 flex items-center gap-1.5">
           <AgentCardPowerButton agent={agent} />
           {sizeControl}
@@ -630,7 +644,7 @@ function AgentCard({
                 className="h-full"
               />
             </div>
-            <div className="relative z-10 flex min-h-0 flex-1 flex-col gap-1.5 pb-11">
+            <div className="pointer-events-none relative z-30 flex min-h-0 flex-1 flex-col gap-1.5 pb-11">
               {/* Notifications sit directly above the cron/webhook carousel
                   (bottom-aligned); any slack opens up above them. Scrolls when
                   the list overflows. */}
@@ -649,13 +663,20 @@ function AgentCard({
             {titleOverlay}
           </>
         )}
-      </button>
+      </div>
     </AgentContextMenu>
   )
 }
 
 /** Widget-grid key for a dashboard tile. Agents use their bare slug. */
 const dashKey = (agentSlug: string, dashSlug: string) => `dash::${agentSlug}::${dashSlug}`
+
+function dashboardAgentSlugFromKey(id: string): string | null {
+  if (!id.startsWith('dash::')) return null
+  const rest = id.slice('dash::'.length)
+  const separator = rest.indexOf('::')
+  return separator === -1 ? null : rest.slice(0, separator)
+}
 
 export function HomePage() {
   useRenderTracker('HomePage')
@@ -672,12 +693,14 @@ export function HomePage() {
 
   // Optimistic local layout while the homeGridLayout mutation is in flight.
   const [localLayout, setLocalLayout] = useState<Record<string, GridRect> | null>(null)
+  const layoutMutationVersion = useRef(0)
   const savedLayout = localLayout ?? userSettings?.homeGridLayout
 
   // Agents whose associated app/dashboard card is toggled off. localHidden is a
   // session override that wins over the server value, so the toggle takes effect
   // immediately and isn't clobbered by the post-save refetch.
   const [localHidden, setLocalHidden] = useState<Set<string> | null>(null)
+  const hiddenMutationVersion = useRef(0)
   const hiddenApps = useMemo(
     () => localHidden ?? new Set(userSettings?.hiddenAppCards ?? []),
     [localHidden, userSettings?.hiddenAppCards]
@@ -734,16 +757,47 @@ export function HomePage() {
   }, [topology])
 
   const commitLayout = (layout: Record<string, GridRect>) => {
-    setLocalLayout(layout)
-    updateSettings.mutate({ homeGridLayout: layout }, { onSettled: () => setLocalLayout(null) })
+    // WidgetBoard only knows about currently rendered items. Preserve saved
+    // geometry for intentionally hidden dashboard cards so a later drag does
+    // not reset their position/size when they are shown again.
+    const nextLayout = { ...layout }
+    for (const [id, rect] of Object.entries(savedLayout ?? {})) {
+      const agentSlug = dashboardAgentSlugFromKey(id)
+      if (agentSlug && hiddenApps.has(agentSlug)) nextLayout[id] = rect
+    }
+
+    const version = ++layoutMutationVersion.current
+    setLocalLayout(nextLayout)
+    updateSettings.mutate(
+      { homeGridLayout: nextLayout },
+      {
+        onError: (error) => {
+          toast.error('Failed to save the home layout', { description: error.message })
+        },
+        onSettled: () => {
+          if (version === layoutMutationVersion.current) setLocalLayout(null)
+        },
+      }
+    )
   }
 
   const toggleAppCard = (agentSlug: string) => {
     const next = new Set(hiddenApps)
     if (next.has(agentSlug)) next.delete(agentSlug)
     else next.add(agentSlug)
+    const version = ++hiddenMutationVersion.current
     setLocalHidden(next)
-    updateSettings.mutate({ hiddenAppCards: [...next] })
+    updateSettings.mutate(
+      { hiddenAppCards: [...next] },
+      {
+        onError: (error) => {
+          toast.error('Failed to update app-card visibility', { description: error.message })
+        },
+        onSettled: () => {
+          if (version === hiddenMutationVersion.current) setLocalHidden(null)
+        },
+      }
+    )
   }
 
   const { createUntitledAgent, isPending: isCreatingAgent } = useCreateUntitledAgent()

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -753,22 +753,32 @@ export function HomePage() {
   const { data: agents, isLoading: agentsLoading } = useAgents()
   const { data: userSettings } = useUserSettings()
   const updateSettings = useUpdateUserSettings()
+  const isMobile = useIsMobile()
+  const layoutTarget = isMobile ? 'mobile' : 'desktop'
 
   // agentOrder (sidebar drag order) drives the initial flow-pack order of
-  // uncustomized boards; once the user drags/resizes here, homeGridLayout wins.
+  // uncustomized boards; once the user drags/resizes here, the layout for the
+  // current breakpoint wins.
   const orderedAgents = useMemo(
     () => applyAgentOrder(agents ?? [], userSettings?.agentOrder),
     [agents, userSettings?.agentOrder]
   )
 
-  // Optimistic local layout while the homeGridLayout mutation is in flight.
-  const [localLayout, setLocalLayout] = useState<Record<string, GridRect> | null>(null)
-  const layoutMutationVersion = useRef(0)
-  const savedLayout = localLayout ?? userSettings?.homeGridLayout
+  // Desktop and phone layouts are intentionally independent. A phone without a
+  // customized layout starts from the desktop map and is responsively re-packed
+  // by WidgetBoard, but its first save forks into homeGridMobileLayout.
+  const [localDesktopLayout, setLocalDesktopLayout] = useState<Record<string, GridRect> | null>(null)
+  const [localMobileLayout, setLocalMobileLayout] = useState<Record<string, GridRect> | null>(null)
+  const layoutMutationVersion = useRef({ desktop: 0, mobile: 0 })
+  const savedDesktopLayout = localDesktopLayout ?? userSettings?.homeGridLayout
+  const savedMobileLayout =
+    localMobileLayout ?? userSettings?.homeGridMobileLayout ?? savedDesktopLayout
+  const savedLayout = isMobile ? savedMobileLayout : savedDesktopLayout
   // Arrange mode stages its layout locally. Done persists the staged map once;
   // Cancel drops it and restores the last saved geometry.
   const [isArranging, setIsArranging] = useState(false)
   const [arrangeLayout, setArrangeLayout] = useState<Record<string, GridRect> | null>(null)
+  const [arrangeTarget, setArrangeTarget] = useState<'desktop' | 'mobile' | null>(null)
   const displayedLayout = arrangeLayout ?? savedLayout
 
   // Agents whose associated app/dashboard card is toggled off. localHidden is a
@@ -831,28 +841,35 @@ export function HomePage() {
     return { cronsByAgent: cronsMap, webhooksByAgent: webhooksMap }
   }, [topology])
 
-  const commitLayout = (layout: Record<string, GridRect>) => {
+  const commitLayout = (
+    layout: Record<string, GridRect>,
+    target: 'desktop' | 'mobile' = layoutTarget
+  ) => {
     // WidgetBoard only knows about currently rendered items. Preserve saved
     // geometry for any missing item whose owning agent still exists. This
     // covers intentionally hidden cards and transiently incomplete dashboard
     // inventories without retaining entries for agents that were deleted.
     const nextLayout = { ...layout }
-    for (const [id, rect] of Object.entries(savedLayout ?? {})) {
+    const targetSavedLayout = target === 'mobile' ? savedMobileLayout : savedDesktopLayout
+    for (const [id, rect] of Object.entries(targetSavedLayout ?? {})) {
       if (id in nextLayout) continue
       const ownerSlug = dashboardAgentSlugFromKey(id) ?? id
       if (agentBySlug.has(ownerSlug)) nextLayout[id] = rect
     }
 
-    const version = ++layoutMutationVersion.current
+    const version = ++layoutMutationVersion.current[target]
+    const setLocalLayout = target === 'mobile' ? setLocalMobileLayout : setLocalDesktopLayout
     setLocalLayout(nextLayout)
     updateSettings.mutate(
-      { homeGridLayout: nextLayout },
+      target === 'mobile'
+        ? { homeGridMobileLayout: nextLayout }
+        : { homeGridLayout: nextLayout },
       {
         onError: (error) => {
           toast.error('Failed to save the home layout', { description: error.message })
         },
         onSettled: () => {
-          if (version === layoutMutationVersion.current) setLocalLayout(null)
+          if (version === layoutMutationVersion.current[target]) setLocalLayout(null)
         },
       }
     )
@@ -878,7 +895,6 @@ export function HomePage() {
   }
 
   const { createUntitledAgent, isPending: isCreatingAgent } = useCreateUntitledAgent()
-  const isMobile = useIsMobile()
   const { state: sidebarState } = useSidebar()
   const isFullScreen = useFullScreen()
   const needsTrafficLightPadding = isElectron() && getPlatform() === 'darwin' && sidebarState === 'collapsed' && !isFullScreen
@@ -895,6 +911,7 @@ export function HomePage() {
     if (next === view) return
     if (next === 'graph') {
       setArrangeLayout(null)
+      setArrangeTarget(null)
       setIsArranging(false)
     }
     void navigate({
@@ -908,24 +925,28 @@ export function HomePage() {
   const beginArrange = () => {
     if (!hasAgents) return
     setArrangeLayout(null)
+    setArrangeTarget(layoutTarget)
     setIsArranging(true)
   }
   const cancelArrange = () => {
     setArrangeLayout(null)
+    setArrangeTarget(null)
     setIsArranging(false)
   }
   const finishArrange = () => {
     const nextLayout = arrangeLayout
+    const target = arrangeTarget ?? layoutTarget
     setArrangeLayout(null)
+    setArrangeTarget(null)
     setIsArranging(false)
-    if (nextLayout) commitLayout(nextLayout)
+    if (nextLayout) commitLayout(nextLayout, target)
   }
   const handleBoardCommit = (layout: Record<string, GridRect>) => {
     if (isArranging) {
       setArrangeLayout(layout)
       return
     }
-    commitLayout(layout)
+    commitLayout(layout, layoutTarget)
   }
 
   return (

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -629,12 +629,26 @@ function AgentCard({
           draggable={false}
           data-widget-drag-surface=""
           aria-label={`Open ${agent.name}`}
+          onKeyDown={(event) => {
+            if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) return
+            event.preventDefault()
+            const rect = event.currentTarget.getBoundingClientRect()
+            event.currentTarget.dispatchEvent(
+              new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+                clientX: rect.right,
+                clientY: rect.top,
+              })
+            )
+          }}
           className="absolute inset-0 z-20 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
         />
 
-        {/* The card now has one menu surface: its context menu. Keep only the
-            status/power chip visible on the card itself. */}
-        <div className="absolute top-2 right-4 z-30 flex items-center gap-1.5">
+        {/* The card has one visible control row and one menu surface: its
+            right-click/long-press context menu. The focused card link also
+            opens that menu with the standard Shift+F10 keyboard gesture. */}
+        <div className="absolute top-2 right-4 z-30">
           <AgentCardPowerButton agent={agent} />
         </div>
 
@@ -787,6 +801,8 @@ export function HomePage() {
     () => localHidden ?? new Set(userSettings?.hiddenAppCards ?? []),
     [localHidden, userSettings?.hiddenAppCards]
   )
+  const [arrangeHiddenApps, setArrangeHiddenApps] = useState<Set<string> | null>(null)
+  const displayedHiddenApps = arrangeHiddenApps ?? hiddenApps
 
   const { widgetItems, dashboardsById, agentsWithApp } = useMemo(() => {
     const items: WidgetItem[] = []
@@ -796,7 +812,7 @@ export function HomePage() {
       items.push({ id: agent.slug, rect: displayedLayout?.[agent.slug], defaultSize: 'W' })
       const dashboards = Array.isArray(agent.dashboards) ? agent.dashboards : []
       if (dashboards.length > 0) withApp.add(agent.slug)
-      if (hiddenApps.has(agent.slug)) continue // app card toggled off — skip its dashboard tiles
+      if (displayedHiddenApps.has(agent.slug)) continue // app card toggled off — skip its dashboard tiles
       for (const d of dashboards) {
         const id = dashKey(agent.slug, d.slug)
         items.push({ id, rect: displayedLayout?.[id], defaultSize: 'S' })
@@ -804,7 +820,7 @@ export function HomePage() {
       }
     }
     return { widgetItems: items, dashboardsById: dashes, agentsWithApp: withApp }
-  }, [orderedAgents, displayedLayout, hiddenApps])
+  }, [orderedAgents, displayedLayout, displayedHiddenApps])
 
   const agentBySlug = useMemo(() => new Map(orderedAgents.map((a) => [a.slug, a])), [orderedAgents])
 
@@ -861,10 +877,7 @@ export function HomePage() {
     )
   }
 
-  const toggleAppCard = (agentSlug: string) => {
-    const next = new Set(hiddenApps)
-    if (next.has(agentSlug)) next.delete(agentSlug)
-    else next.add(agentSlug)
+  const commitHiddenApps = (next: Set<string>) => {
     const version = ++hiddenMutationVersion.current
     setLocalHidden(next)
     updateSettings.mutate(
@@ -878,6 +891,17 @@ export function HomePage() {
         },
       }
     )
+  }
+
+  const toggleAppCard = (agentSlug: string) => {
+    const next = new Set(displayedHiddenApps)
+    if (next.has(agentSlug)) next.delete(agentSlug)
+    else next.add(agentSlug)
+    if (isArranging) {
+      setArrangeHiddenApps(next)
+      return
+    }
+    commitHiddenApps(next)
   }
 
   const { createUntitledAgent, isPending: isCreatingAgent } = useCreateUntitledAgent()
@@ -906,21 +930,32 @@ export function HomePage() {
   const beginArrange = () => {
     if (!hasAgents) return
     setArrangeLayout(null)
+    setArrangeHiddenApps(new Set(hiddenApps))
     setArrangeTarget(layoutTarget)
     setIsArranging(true)
   }
   const cancelArrange = () => {
     setArrangeLayout(null)
+    setArrangeHiddenApps(null)
     setArrangeTarget(null)
     setIsArranging(false)
   }
   const finishArrange = () => {
     const nextLayout = arrangeLayout
+    const nextHiddenApps = arrangeHiddenApps
     const target = arrangeTarget ?? layoutTarget
     setArrangeLayout(null)
+    setArrangeHiddenApps(null)
     setArrangeTarget(null)
     setIsArranging(false)
     if (nextLayout) commitLayout(nextLayout, target)
+    if (
+      nextHiddenApps &&
+      (nextHiddenApps.size !== hiddenApps.size ||
+        [...nextHiddenApps].some((agentSlug) => !hiddenApps.has(agentSlug)))
+    ) {
+      commitHiddenApps(nextHiddenApps)
+    }
   }
   const handleBoardCommit = (layout: Record<string, GridRect>) => {
     if (isArranging) {
@@ -929,6 +964,17 @@ export function HomePage() {
     }
     commitLayout(layout, layoutTarget)
   }
+
+  // A live breakpoint change repacks the board into a different coordinate
+  // system. End the transaction instead of allowing mobile geometry to be
+  // committed to the desktop setting (or vice versa).
+  useEffect(() => {
+    if (!isArranging || arrangeTarget === null || arrangeTarget === layoutTarget) return
+    setArrangeLayout(null)
+    setArrangeHiddenApps(null)
+    setArrangeTarget(null)
+    setIsArranging(false)
+  }, [arrangeTarget, isArranging, layoutTarget])
 
   return (
     <div className="h-full flex flex-col">
@@ -1084,7 +1130,7 @@ export function HomePage() {
                           </ContextMenuSwitchItem>
                           {agentsWithApp.has(agent.slug) && (
                             <ContextMenuSwitchItem
-                              checked={!hiddenApps.has(agent.slug)}
+                              checked={!displayedHiddenApps.has(agent.slug)}
                               onCheckedChange={() => {
                                 toggleAppCard(agent.slug)
                               }}

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -5,25 +5,21 @@ import { WidgetBoard, WidgetSizePopover, type GridRect, type WidgetItem, type Wi
 import { useAgents, useStartAgent, useStopAgent } from '@renderer/hooks/use-agents'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import { useMarkSessionNotificationsRead } from '@renderer/hooks/use-notifications'
-import { useAgentActivityStats } from '@renderer/hooks/use-activity-stats'
+import { useHomeCardHealth } from '@renderer/hooks/use-home-card-health'
 import { applyAgentOrder } from '@renderer/lib/agent-ordering'
 import { useNotableSessions } from '@renderer/hooks/use-sessions'
-import { useQuery } from '@tanstack/react-query'
-import { apiFetch } from '@renderer/lib/api'
 import { Halftone } from '@renderer/components/agents/halftone'
 import {
   ActivitySparkChart,
-  ActivitySparkChartSkeleton,
   CronSparkChart,
   summarizeDailyActivity,
 } from '@renderer/components/activity/activity-spark-chart'
 import { DEFAULT_ACTIVITY_DAYS } from '@shared/lib/types/activity'
 import {
-  homeGraphSchema,
-  type HomeGraphCron,
-  type HomeGraphData,
-  type HomeGraphWebhook,
-} from '@shared/lib/types/home-graph-schema'
+  type HomeCardCron,
+  type HomeCardHealthData,
+  type HomeCardWebhook,
+} from '@shared/lib/types/home-card-health-schema'
 import { getAgentActivityStatus } from '@shared/lib/types/agent-activity-status'
 import { WorkingDots, AwaitingDot, UnreadDot } from '@renderer/components/agents/status-indicators'
 import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
@@ -397,10 +393,12 @@ function AgentHealthCarousel({
   agent,
   crons,
   webhooks,
+  health,
 }: {
   agent: ApiAgent
-  crons: HomeGraphCron[]
-  webhooks: HomeGraphWebhook[]
+  crons: HomeCardCron[]
+  webhooks: HomeCardWebhook[]
+  health?: HomeCardHealthData
 }) {
   const navigate = useNavigate()
   const slides = useMemo<HealthSlide[]>(
@@ -411,13 +409,6 @@ function AgentHealthCarousel({
     [crons, webhooks]
   )
   const count = slides.length
-  // Avoid one activity request per agent when there are no charts to render.
-  // live:false also prevents decorative cards from polling independently.
-  const { data: stats, isPending: statsPending } = useAgentActivityStats(
-    count > 0 ? agent.slug : null,
-    DEFAULT_ACTIVITY_DAYS,
-    { live: false }
-  )
   const [index, setIndex] = useState(0)
   const [hovered, setHovered] = useState(false)
   const [focusWithin, setFocusWithin] = useState(false)
@@ -444,18 +435,16 @@ function AgentHealthCarousel({
   const renderSlide = (s: HealthSlide) => {
     let chart: ReactNode
     let metric = ''
-    if (statsPending) {
-      chart = <ActivitySparkChartSkeleton className="h-5 w-24" />
-    } else if (s.kind === 'cron') {
-      const activity = stats?.cronByTaskId[s.id] ?? []
+    if (s.kind === 'cron') {
+      const activity = health?.cronByTaskId[s.id] ?? []
       const succeeded = activity.filter((p) => p.status === 'succeeded').length
       chart = <CronSparkChart label={s.name} data={activity} className="h-5 w-24" />
       metric = `${succeeded}/${activity.length}`
     } else {
-      const activity = stats?.webhookByTriggerId[s.id] ?? []
+      const activity = health?.webhookByTriggerId[s.id] ?? []
       const { total } = summarizeDailyActivity(activity)
       chart = <ActivitySparkChart label={s.name} data={activity} className="h-5 w-24" />
-      metric = `${total}/${DEFAULT_ACTIVITY_DAYS}d`
+      metric = `${total}/${health?.days ?? DEFAULT_ACTIVITY_DAYS}d`
     }
     return (
       <button
@@ -574,14 +563,16 @@ function AgentCard({
   disableTouchLongPress,
   crons = [],
   webhooks = [],
+  health,
 }: {
   agent: ApiAgent
   size?: WidgetSizeKey
   additionalOptions?: ReactNode
   onArrange?: () => void
   disableTouchLongPress?: boolean
-  crons?: HomeGraphCron[]
-  webhooks?: HomeGraphWebhook[]
+  crons?: HomeCardCron[]
+  webhooks?: HomeCardWebhook[]
+  health?: HomeCardHealthData
 }) {
   useRenderTracker('AgentCard')
   const lastWorked = agent.lastActivityAt ? formatDistanceToNow(new Date(agent.lastActivityAt), { addSuffix: true }) : null
@@ -690,7 +681,7 @@ function AgentCard({
               </div>
               {/* Rotating cron/webhook health carousel (renders nothing when
                   the agent has no triggers). */}
-              <AgentHealthCarousel agent={agent} crons={crons} webhooks={webhooks} />
+              <AgentHealthCarousel agent={agent} crons={crons} webhooks={webhooks} health={health} />
             </div>
             {titleOverlay}
           </>
@@ -756,6 +747,11 @@ export function HomePage() {
   const updateSettings = useUpdateUserSettings()
   const isMobile = useIsMobile()
   const layoutTarget = isMobile ? 'mobile' : 'desktop'
+  // Cards vs. graph view — URL-driven (`/?view=graph`) so back/forward
+  // navigation and reloads restore the selection; absent = cards.
+  const navigate = useNavigate()
+  const routeSearch = useRouteSearch({ strict: false }) as { view?: string }
+  const view: 'cards' | 'graph' = routeSearch.view === 'graph' ? 'graph' : 'cards'
 
   // agentOrder (sidebar drag order) drives the initial flow-pack order of
   // uncustomized boards; once the user drags/resizes here, the layout for the
@@ -812,35 +808,24 @@ export function HomePage() {
 
   const agentBySlug = useMemo(() => new Map(orderedAgents.map((a) => [a.slug, a])), [orderedAgents])
 
-  // Shared topology snapshot for the cards' health carousels (cron/webhook
-  // names per agent in one request). Same query key as the graph view, so
-  // cards⇄graph flips reuse the cache; parsed at the boundary like the graph.
-  const { data: topology } = useQuery<HomeGraphData>({
-    queryKey: ['home-graph'],
-    queryFn: async () => {
-      const res = await apiFetch('/api/home-graph')
-      if (!res.ok) throw new Error('Failed to fetch home graph')
-      return homeGraphSchema.parse(await res.json())
-    },
-    staleTime: 60_000,
-  })
+  // Card view owns a compact automation+activity projection. The full graph
+  // topology is fetched only by the lazily mounted AgentGraph.
+  const { data: cardHealth } = useHomeCardHealth(view === 'cards' && orderedAgents.length > 0)
   const { cronsByAgent, webhooksByAgent } = useMemo(() => {
-    const cronsMap = new Map<string, HomeGraphCron[]>()
-    const webhooksMap = new Map<string, HomeGraphWebhook[]>()
-    for (const cron of topology?.crons ?? []) {
-      if (cron.status === 'cancelled') continue
+    const cronsMap = new Map<string, HomeCardCron[]>()
+    const webhooksMap = new Map<string, HomeCardWebhook[]>()
+    for (const cron of cardHealth?.crons ?? []) {
       const list = cronsMap.get(cron.agentSlug) ?? []
       list.push(cron)
       cronsMap.set(cron.agentSlug, list)
     }
-    for (const webhook of topology?.webhooks ?? []) {
-      if (webhook.status === 'cancelled') continue
+    for (const webhook of cardHealth?.webhooks ?? []) {
       const list = webhooksMap.get(webhook.agentSlug) ?? []
       list.push(webhook)
       webhooksMap.set(webhook.agentSlug, list)
     }
     return { cronsByAgent: cronsMap, webhooksByAgent: webhooksMap }
-  }, [topology])
+  }, [cardHealth])
 
   const commitLayout = (
     layout: Record<string, GridRect>,
@@ -903,11 +888,6 @@ export function HomePage() {
   const hasAgents = orderedAgents.length > 0
   const { openSearch } = useSearch()
   const isMac = getPlatform() === 'darwin'
-  // Cards vs. graph view — URL-driven (`/?view=graph`) so back/forward
-  // navigation and reloads restore the selection; absent = cards.
-  const navigate = useNavigate()
-  const routeSearch = useRouteSearch({ strict: false }) as { view?: string }
-  const view: 'cards' | 'graph' = routeSearch.view === 'graph' ? 'graph' : 'cards'
   const setView = (next: 'cards' | 'graph') => {
     if (next === view) return
     if (next === 'graph') {
@@ -1116,6 +1096,7 @@ export function HomePage() {
                       }
                       crons={cronsByAgent.get(agent.slug)}
                       webhooks={webhooksByAgent.get(agent.slug)}
+                      health={cardHealth}
                     />
                   )
                 }}

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -635,6 +635,7 @@ function AgentCard({
         <AppLink
           to="/agents/$slug"
           params={{ slug: agent.displaySlug }}
+          draggable={false}
           data-widget-drag-surface=""
           aria-label={`Open ${agent.name}`}
           className="absolute inset-0 z-20 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"

--- a/src/renderer/components/home/widget-grid.test.tsx
+++ b/src/renderer/components/home/widget-grid.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@renderer/test/test-utils'
+import { WidgetBoard } from './widget-grid'
+
+describe('WidgetBoard pointer behavior', () => {
+  it('keeps vertical touch panning enabled', () => {
+    renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'alpha', defaultSize: 'S' }]}
+        renderItem={() => <span>Alpha</span>}
+        onCommit={vi.fn()}
+      />
+    )
+
+    const widget = screen.getByText('Alpha').closest('[data-widget-id]')
+    expect(widget).toHaveClass('touch-pan-y')
+    expect(widget).not.toHaveClass('touch-none')
+  })
+
+  it('cancels a tentative drag without committing when the browser claims the gesture', () => {
+    const onCommit = vi.fn()
+    renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'alpha', defaultSize: 'S' }]}
+        renderItem={() => <span>Alpha</span>}
+        onCommit={onCommit}
+      />
+    )
+
+    const widget = screen.getByText('Alpha').closest('[data-widget-id]')
+    expect(widget).not.toBeNull()
+
+    fireEvent.pointerDown(widget!, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.pointerMove(window, { clientX: 30, clientY: 30 })
+    fireEvent.pointerCancel(window)
+
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/home/widget-grid.test.tsx
+++ b/src/renderer/components/home/widget-grid.test.tsx
@@ -38,4 +38,44 @@ describe('WidgetBoard pointer behavior', () => {
 
     expect(onCommit).not.toHaveBeenCalled()
   })
+
+  it('does not arm a drag when drag gestures are disabled', () => {
+    const onCommit = vi.fn()
+    renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'alpha', defaultSize: 'S' }]}
+        renderItem={() => <span>Alpha</span>}
+        onCommit={onCommit}
+        dragEnabled={false}
+      />
+    )
+
+    const widget = screen.getByText('Alpha').closest('[data-widget-id]')
+    fireEvent.pointerDown(widget!, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.pointerMove(window, { clientX: 40, clientY: 80 })
+    fireEvent.pointerUp(window)
+
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('uses the whole card as a touch-safe, subtly animated arrange handle', () => {
+    renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'alpha', defaultSize: 'S' }]}
+        renderItem={() => <button type="button">Alpha action</button>}
+        onCommit={vi.fn()}
+        arranging
+        disableContextMenu
+      />
+    )
+
+    const widget = screen.getByRole('button', { name: 'Alpha action' }).closest('[data-widget-id]')
+    expect(widget).toHaveClass('touch-none')
+    expect(widget).not.toHaveClass('touch-pan-y')
+    expect(widget?.firstElementChild).toHaveClass('home-card-jiggle')
+
+    const contextMenu = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+    widget?.dispatchEvent(contextMenu)
+    expect(contextMenu.defaultPrevented).toBe(true)
+  })
 })

--- a/src/renderer/components/home/widget-grid.test.tsx
+++ b/src/renderer/components/home/widget-grid.test.tsx
@@ -78,6 +78,28 @@ describe('WidgetBoard pointer behavior', () => {
     })
   })
 
+  it('allows a marked full-card link to initiate direct desktop dragging', () => {
+    const onCommit = vi.fn()
+    renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'dashboard', defaultSize: 'S' }]}
+        renderItem={() => (
+          <a href="/dashboard" draggable={false} data-widget-drag-surface="">
+            Open app
+          </a>
+        )}
+        onCommit={onCommit}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'Open app' })
+    fireEvent.pointerDown(link, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.pointerMove(window, { clientX: 250, clientY: 250 })
+    fireEvent.pointerUp(window)
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+  })
+
   it('does not arm direct dragging from an interactive control', () => {
     const onCommit = vi.fn()
     renderWithProviders(

--- a/src/renderer/components/home/widget-grid.test.tsx
+++ b/src/renderer/components/home/widget-grid.test.tsx
@@ -2,7 +2,25 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@renderer/test/test-utils'
-import { WidgetBoard } from './widget-grid'
+import { WidgetBoard, repackLayout } from './widget-grid'
+
+describe('responsive layout packing', () => {
+  it('repacks an overflowing desktop row across narrower columns', () => {
+    const packed = repackLayout(
+      Array.from({ length: 6 }, (_, x) => ({ id: String(x), x, y: 0, w: 1, h: 1 })),
+      2
+    )
+
+    expect(packed.map(({ x, y }) => ({ x, y }))).toEqual([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 0, y: 2 },
+      { x: 1, y: 2 },
+    ])
+  })
+})
 
 describe('WidgetBoard pointer behavior', () => {
   it('keeps vertical touch panning enabled', () => {
@@ -35,6 +53,64 @@ describe('WidgetBoard pointer behavior', () => {
     fireEvent.pointerDown(widget!, { button: 0, clientX: 10, clientY: 10 })
     fireEvent.pointerMove(window, { clientX: 30, clientY: 30 })
     fireEvent.pointerCancel(window)
+
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('commits a completed drag', () => {
+    const onCommit = vi.fn()
+    renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'alpha', defaultSize: 'S' }]}
+        renderItem={() => <span>Alpha</span>}
+        onCommit={onCommit}
+      />
+    )
+
+    const widget = screen.getByText('Alpha').closest('[data-widget-id]')
+    fireEvent.pointerDown(widget!, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.pointerMove(window, { clientX: 250, clientY: 250 })
+    fireEvent.pointerUp(window)
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit).toHaveBeenCalledWith({
+      alpha: expect.objectContaining({ x: expect.any(Number), y: expect.any(Number), w: 1, h: 1 }),
+    })
+  })
+
+  it('does not arm direct dragging from an interactive control', () => {
+    const onCommit = vi.fn()
+    renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'alpha', defaultSize: 'S' }]}
+        renderItem={() => <button type="button">Stop agent</button>}
+        onCommit={onCommit}
+      />
+    )
+
+    const control = screen.getByRole('button', { name: 'Stop agent' })
+    fireEvent.pointerDown(control, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.pointerMove(window, { clientX: 250, clientY: 250 })
+    fireEvent.pointerUp(window)
+
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('removes active window listeners without committing when unmounted mid-drag', () => {
+    const onCommit = vi.fn()
+    const { unmount } = renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'alpha', defaultSize: 'S' }]}
+        renderItem={() => <span>Alpha</span>}
+        onCommit={onCommit}
+      />
+    )
+
+    const widget = screen.getByText('Alpha').closest('[data-widget-id]')
+    fireEvent.pointerDown(widget!, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.pointerMove(window, { clientX: 250, clientY: 250 })
+    unmount()
+    fireEvent.pointerUp(window)
 
     expect(onCommit).not.toHaveBeenCalled()
   })
@@ -77,5 +153,22 @@ describe('WidgetBoard pointer behavior', () => {
     const contextMenu = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
     widget?.dispatchEvent(contextMenu)
     expect(contextMenu.defaultPrevented).toBe(true)
+  })
+
+  it('keeps desktop context menus enabled while arranging', () => {
+    renderWithProviders(
+      <WidgetBoard
+        items={[{ id: 'alpha', defaultSize: 'S' }]}
+        renderItem={() => <button type="button">Alpha action</button>}
+        onCommit={vi.fn()}
+        arranging
+        disableContextMenu={false}
+      />
+    )
+
+    const widget = screen.getByRole('button', { name: 'Alpha action' }).closest('[data-widget-id]')
+    const contextMenu = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+    widget?.dispatchEvent(contextMenu)
+    expect(contextMenu.defaultPrevented).toBe(false)
   })
 })

--- a/src/renderer/components/home/widget-grid.tsx
+++ b/src/renderer/components/home/widget-grid.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { MoreVertical } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { cn } from '@shared/lib/utils/cn'
@@ -40,7 +40,7 @@ export function widgetSizeKey(w: number, h: number): WidgetSizeKey {
 const GAP = 16 // px between cells
 const TARGET_CELL = 232 // desired cell+gap size — drives the column count
 
-interface Placed extends GridRect {
+export interface Placed extends GridRect {
   id: string
 }
 
@@ -89,6 +89,20 @@ export function placeOne(items: GridRect[], cols: number, w: number, h: number):
     for (let x = 0; x <= cols - w; x++) if (fits(x, y)) return { x, y }
   }
   return { x: 0, y: 0 }
+}
+
+/** Repack a saved layout row-major when its coordinates no longer fit a
+ * narrower responsive column count. The saved desktop geometry is not mutated,
+ * so expanding the viewport restores it until the user explicitly commits. */
+export function repackLayout(items: Placed[], cols: number): Placed[] {
+  const packed: Placed[] = []
+  const ordered = [...items].sort((a, b) => (a.y === b.y ? a.x - b.x : a.y - b.y))
+  for (const item of ordered) {
+    const w = Math.min(item.w, cols)
+    const spot = placeOne(packed, cols, w, item.h)
+    packed.push({ ...item, ...spot, w })
+  }
+  return packed
 }
 
 export interface WidgetItem {
@@ -142,6 +156,7 @@ export function WidgetBoard({
     if (!el) return
     const measure = () => {
       const wpx = el.clientWidth
+      if (wpx <= 0) return
       const c = Math.max(2, Math.min(6, Math.round((wpx + GAP) / TARGET_CELL)))
       setCols(c)
       setCellW((wpx - (c - 1) * GAP) / c)
@@ -156,15 +171,18 @@ export function WidgetBoard({
   // flow-packed placement for items without one. Recomputes on resize, so
   // uncustomized boards stay responsively packed.
   const placed = useMemo<Placed[]>(() => {
-    const out: Placed[] = []
+    const saved: Placed[] = []
     for (const it of items) {
       if (!it.rect) continue
       const w = Math.min(it.rect.w, cols)
       // Clamp to 1-tall: layouts saved before the Tall/Large sizes were removed
       // may still carry h:2 rects.
-      out.push({ id: it.id, w, h: Math.min(it.rect.h, 1), x: Math.min(it.rect.x, cols - w), y: it.rect.y })
+      saved.push({ id: it.id, w, h: Math.min(it.rect.h, 1), x: it.rect.x, y: it.rect.y })
     }
-    let resolved = resolveLayout(out, null)
+    const needsResponsiveRepack = saved.some((it) => it.x < 0 || it.x + it.w > cols)
+    let resolved = needsResponsiveRepack
+      ? repackLayout(saved, cols)
+      : resolveLayout(saved.map((it) => ({ ...it, x: Math.min(it.x, cols - it.w) })), null)
     for (const it of items) {
       if (it.rect) continue
       const def = WIDGET_SIZES.find((s) => s.key === it.defaultSize) ?? WIDGET_SIZES[WIDGET_SIZES.length - 1]
@@ -191,6 +209,17 @@ export function WidgetBoard({
   // Suppresses the click that follows a drag release, so dragging a card
   // doesn't also open the agent.
   const didDragRef = useRef(false)
+  const activeDragCleanupRef = useRef<(() => void) | null>(null)
+
+  useEffect(
+    () => () => {
+      activeDragCleanupRef.current?.()
+      activeDragCleanupRef.current = null
+      dragRef.current = null
+      didDragRef.current = false
+    },
+    []
+  )
 
   const commitFromPlaced = (grids: Placed[]) => {
     const layout: Record<string, GridRect> = {}
@@ -201,13 +230,15 @@ export function WidgetBoard({
   function onPointerDown(e: React.PointerEvent, item: Placed) {
     if (!dragEnabled) return
     if (e.button !== 0) return
-    // Drag can start anywhere on the card — our cards are themselves <button>s,
-    // so we can't exclude interactive elements generically. Inner controls keep
-    // working because a drag only arms after 5px of movement (a plain click
-    // never moves) and only an actual drag swallows the following click.
-    // data-widget-no-drag opts out the pencil/popover explicitly.
+    // Native controls opt out of direct desktop dragging so a small pointer slip
+    // cannot swallow their click. The full-card AppLink is the intentional drag
+    // surface and opts back in with data-widget-drag-surface. In Arrange mode
+    // the board always owns the gesture (with an extra touch shield on mobile).
     const target = e.target as HTMLElement
-    if (!arranging && target.closest('[data-widget-no-drag]')) return
+    const interactive = target.closest<HTMLElement>(
+      'button, a, input, select, textarea, [role="button"], [data-widget-no-drag]'
+    )
+    if (!arranging && interactive && !interactive.hasAttribute('data-widget-drag-surface')) return
     const board = wrapRef.current
     if (!board) return
     const boardRect = board.getBoundingClientRect()
@@ -237,6 +268,7 @@ export function WidgetBoard({
       window.removeEventListener('pointermove', move)
       window.removeEventListener('pointerup', up)
       window.removeEventListener('pointercancel', cancel)
+      if (activeDragCleanupRef.current === cleanup) activeDragCleanupRef.current = null
     }
     const up = () => {
       cleanup()
@@ -253,6 +285,8 @@ export function WidgetBoard({
       setDrag(null)
       didDragRef.current = false
     }
+    activeDragCleanupRef.current?.()
+    activeDragCleanupRef.current = cleanup
     window.addEventListener('pointermove', move)
     window.addEventListener('pointerup', up)
     window.addEventListener('pointercancel', cancel)
@@ -334,7 +368,12 @@ export function WidgetBoard({
               if (disableContextMenu) e.preventDefault()
             }}
             onClickCapture={(e) => {
-              if (didDragRef.current) {
+              // Radix context-menu content is portaled outside this widget's
+              // DOM but still bubbles through its React tree. Only shield
+              // clicks that physically originated on the card; otherwise
+              // Arrange mode would cancel its own menu items.
+              const originatedOnCard = e.currentTarget.contains(e.target as Node)
+              if (originatedOnCard && (arranging || didDragRef.current)) {
                 e.preventDefault()
                 e.stopPropagation()
               }
@@ -346,10 +385,13 @@ export function WidgetBoard({
             >
               {renderItem(item.id, widgetSizeKey(item.w, item.h), (s) => setSize(item, s))}
             </div>
-            {/* Arrange mode turns the full card surface into the drag handle.
-                Besides preventing accidental navigation/actions, this keeps a
-                touch hold from reaching Radix's context-menu long press. */}
-            {arranging && <div className="absolute inset-0 z-[60] cursor-grab active:cursor-grabbing" />}
+            {/* Mobile Arrange gets a full-card overlay so a touch hold cannot
+                reach Radix's long-press menu. Desktop uses the board's bubbling
+                pointer handler instead, leaving the real card under right-click
+                so its unified context menu remains available. */}
+            {arranging && disableContextMenu && (
+              <div className="absolute inset-0 z-[60] cursor-grab active:cursor-grabbing" />
+            )}
           </div>
         )
       })}

--- a/src/renderer/components/home/widget-grid.tsx
+++ b/src/renderer/components/home/widget-grid.tsx
@@ -9,8 +9,8 @@ import { cn } from '@shared/lib/utils/cn'
  * Cards live on a board of square cells (responsive 2–6 columns). Each card
  * occupies a rect {x, y, w, h} in cell units and comes in two footprints:
  * Small 1×1 and Wide 2×1. Cards are dragged anywhere on the
- * board with a snapped drop-ghost and live reflow of the other cards; a hover
- * pencil opens a popover with the size picker. The parent owns persistence —
+ * board with a snapped drop-ghost and live reflow of the other cards; a card
+ * options control opens a popover with the size picker. The parent owns persistence —
  * the board calls onCommit with the full layout map after a drag or resize.
  *
  * Ported from the Claude Design handoff (Agent Homepage prototype): the
@@ -218,9 +218,13 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
       const preview = resolveLayout(moved, item.id)
       setDrag({ id: item.id, left, top, w: item.w, h: item.h, target: { x: tx, y: ty }, preview })
     }
-    const up = () => {
+    const cleanup = () => {
       window.removeEventListener('pointermove', move)
       window.removeEventListener('pointerup', up)
+      window.removeEventListener('pointercancel', cancel)
+    }
+    const up = () => {
+      cleanup()
       const d = dragRef.current
       if (d?.preview) commitFromPlaced(d.preview)
       setDrag(null)
@@ -229,8 +233,14 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
         didDragRef.current = false
       }, 0)
     }
+    const cancel = () => {
+      cleanup()
+      setDrag(null)
+      didDragRef.current = false
+    }
     window.addEventListener('pointermove', move)
     window.addEventListener('pointerup', up)
+    window.addEventListener('pointercancel', cancel)
   }
 
   function setSize(item: Placed, size: WidgetSizeKey) {
@@ -285,7 +295,10 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
             key={item.id}
             data-widget-id={item.id}
             className={cn(
-              'group/widget absolute touch-none',
+              // Keep vertical touch panning available. If the browser claims a
+              // gesture for scrolling it sends pointercancel, which tears down
+              // the tentative drag above without committing it.
+              'group/widget absolute touch-pan-y',
               // Tiles glide to new positions (reflow, drop-settle) but snap
               // their size in one frame — tweening width/height fights the
               // card's contents (instant inner-layout swap + the halftone
@@ -368,6 +381,7 @@ export function WidgetSizePopover({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
+          type="button"
           data-widget-no-drag
           aria-label="Card options"
           title="Card options"
@@ -376,9 +390,11 @@ export function WidgetSizePopover({
           className={cn(
             // Same size as the status chip's stop button (h-5 w-5). The caller
             // places it in an items-center row so it centers against the chip.
-            // Hidden until the card is hovered.
-            'hidden h-5 w-5 items-center justify-center rounded border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground group-hover/widget:flex',
-            open && 'flex bg-muted text-foreground'
+            // Keep the control in the focus order and available on coarse
+            // pointers; reducing opacity preserves the quiet default treatment
+            // without making it hover-only.
+            'flex h-5 w-5 items-center justify-center rounded border bg-background text-muted-foreground opacity-60 shadow-sm transition-[color,background-color,opacity] hover:bg-muted hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
+            open && 'bg-muted text-foreground opacity-100'
           )}
         >
           <MoreVertical className="h-3.5 w-3.5" />

--- a/src/renderer/components/home/widget-grid.tsx
+++ b/src/renderer/components/home/widget-grid.tsx
@@ -92,8 +92,9 @@ export function placeOne(items: GridRect[], cols: number, w: number, h: number):
 }
 
 /** Repack a saved layout row-major when its coordinates no longer fit a
- * narrower responsive column count. The saved desktop geometry is not mutated,
- * so expanding the viewport restores it until the user explicitly commits. */
+ * narrower responsive column count. Rendering the responsive projection does
+ * not mutate the saved geometry; a later drag or resize may persist it through
+ * the board's normal `onCommit` contract. */
 export function repackLayout(items: Placed[], cols: number): Placed[] {
   const packed: Placed[] = []
   const ordered = [...items].sort((a, b) => (a.y === b.y ? a.x - b.x : a.y - b.y))

--- a/src/renderer/components/home/widget-grid.tsx
+++ b/src/renderer/components/home/widget-grid.tsx
@@ -106,6 +106,13 @@ interface WidgetBoardProps {
   renderItem: (id: string, size: WidgetSizeKey, onResize: (size: WidgetSizeKey) => void) => ReactNode
   /** Called with the full layout map after any user drag or resize. */
   onCommit: (layout: Record<string, GridRect>) => void
+  /** Whether pointer gestures may reorder cards. Mobile disables this outside
+   *  explicit arrange mode; desktop leaves it enabled. */
+  dragEnabled?: boolean
+  /** Applies the edit-mode treatment and makes the whole card a drag target. */
+  arranging?: boolean
+  /** Suppress native/synthetic context menus while touch arrange mode is active. */
+  disableContextMenu?: boolean
 }
 
 interface DragState {
@@ -118,7 +125,14 @@ interface DragState {
   preview: Placed[]
 }
 
-export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
+export function WidgetBoard({
+  items,
+  renderItem,
+  onCommit,
+  dragEnabled = true,
+  arranging = false,
+  disableContextMenu = false,
+}: WidgetBoardProps) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const [cols, setCols] = useState(4)
   const [cellW, setCellW] = useState(216)
@@ -185,6 +199,7 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
   }
 
   function onPointerDown(e: React.PointerEvent, item: Placed) {
+    if (!dragEnabled) return
     if (e.button !== 0) return
     // Drag can start anywhere on the card — our cards are themselves <button>s,
     // so we can't exclude interactive elements generically. Inner controls keep
@@ -192,7 +207,7 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
     // never moves) and only an actual drag swallows the following click.
     // data-widget-no-drag opts out the pencil/popover explicitly.
     const target = e.target as HTMLElement
-    if (target.closest('[data-widget-no-drag]')) return
+    if (!arranging && target.closest('[data-widget-no-drag]')) return
     const board = wrapRef.current
     if (!board) return
     const boardRect = board.getBoundingClientRect()
@@ -283,7 +298,7 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
         />
       )}
 
-      {placed.map((item) => {
+      {placed.map((item, index) => {
         const isDragging = drag?.id === item.id
         const g = previewMap.get(item.id) ?? item
         const p = pos(g)
@@ -294,11 +309,16 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
           <div
             key={item.id}
             data-widget-id={item.id}
+            data-arranging={arranging || undefined}
             className={cn(
               // Keep vertical touch panning available. If the browser claims a
               // gesture for scrolling it sends pointercancel, which tears down
-              // the tentative drag above without committing it.
-              'group/widget absolute touch-pan-y',
+              // the tentative drag above without committing it. Explicit
+              // arrange mode owns the gesture instead, so touch scrolling is
+              // disabled until the card is dropped.
+              'group/widget absolute',
+              arranging ? 'touch-none' : 'touch-pan-y',
+              dragEnabled && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
               // Tiles glide to new positions (reflow, drop-settle) but snap
               // their size in one frame — tweening width/height fights the
               // card's contents (instant inner-layout swap + the halftone
@@ -310,6 +330,9 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
             )}
             style={style}
             onPointerDown={(e) => onPointerDown(e, item)}
+            onContextMenu={(e) => {
+              if (disableContextMenu) e.preventDefault()
+            }}
             onClickCapture={(e) => {
               if (didDragRef.current) {
                 e.preventDefault()
@@ -317,9 +340,16 @@ export function WidgetBoard({ items, renderItem, onCommit }: WidgetBoardProps) {
               }
             }}
           >
-            <div className="h-full w-full">
+            <div
+              className={cn('h-full w-full', arranging && !isDragging && 'home-card-jiggle')}
+              style={arranging ? { animationDelay: `${-(index % 5) * 37}ms` } : undefined}
+            >
               {renderItem(item.id, widgetSizeKey(item.w, item.h), (s) => setSize(item, s))}
             </div>
+            {/* Arrange mode turns the full card surface into the drag handle.
+                Besides preventing accidental navigation/actions, this keeps a
+                touch hold from reaching Radix's context-menu long press. */}
+            {arranging && <div className="absolute inset-0 z-[60] cursor-grab active:cursor-grabbing" />}
           </div>
         )
       })}

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -291,8 +291,7 @@ function makeAgent(overrides: Record<string, any> = {}) {
     hasSessionsAwaitingInput: false,
     hasUnreadNotifications: false,
     sessionCount: 1,
-    chatIntegrationCount: 0,
-    dashboardCount: 0,
+    dashboards: [],
     ...overrides,
   }
 }
@@ -515,11 +514,9 @@ describe('AppSidebar — agent rows', () => {
     expect(dots.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('agent with only chat integrations does not render an expand chevron', () => {
-    // After removing chatIntegrationCount from the expand predicate, an agent
-    // whose only expandable children were chat integrations must NOT show a chevron.
+  it('agent with no sessions or dashboards does not render an expand chevron', () => {
     mockUseAgents.mockReturnValue({
-      data: [makeAgent({ sessionCount: 0, dashboardCount: 0, chatIntegrationCount: 1 })],
+      data: [makeAgent({ sessionCount: 0, dashboards: [] })],
       isLoading: false,
       error: null,
     })

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -397,7 +397,7 @@ export const AgentMenuItem = React.forwardRef<
   // would just be visual noise.
   const hasInitialContent =
     (agent.sessionCount ?? 0) > 0 ||
-    (agent.dashboardCount ?? 0) > 0
+    (agent.dashboards?.length ?? 0) > 0
   const [isOpen, setIsOpen] = useState(isSelected && hasInitialContent)
 
   // Once the user navigates into a sub-item (session / task / webhook / chat /
@@ -433,7 +433,7 @@ export const AgentMenuItem = React.forwardRef<
   const hasExpandableContent =
     isOpen ||
     (agent.sessionCount ?? 0) > 0 ||
-    (agent.dashboardCount ?? 0) > 0
+    (agent.dashboards?.length ?? 0) > 0
 
   // Show skeleton after 100ms if sessions haven't loaded yet
   useEffect(() => {

--- a/src/renderer/components/search/filter.test.ts
+++ b/src/renderer/components/search/filter.test.ts
@@ -108,22 +108,6 @@ describe('filterAgentsAndSessions', () => {
     expect(groups[0].dashboards.map((d) => d.slug)).toEqual(['revops'])
   })
 
-  it('falls back to dashboard summary names and slugs', () => {
-    const legacyAgent: ApiAgent = {
-      ...agent('legacy', 'Legacy Bot', new Date('2025-01-01')),
-      dashboards: undefined,
-      dashboardNames: ['Legacy Dashboard'],
-      dashboardSlugs: ['legacy-dashboard'],
-    }
-
-    const groups = filterAgentsAndSessions([legacyAgent], {}, 'legacy dashboard')
-
-    expect(groups).toHaveLength(1)
-    expect(groups[0].dashboards).toEqual([
-      { slug: 'legacy-dashboard', name: 'Legacy Dashboard' },
-    ])
-  })
-
   it('hides agents with no name match and no session match', () => {
     const groups = filterAgentsAndSessions([alpha, beta], sessions, 'zzz')
     expect(groups).toHaveLength(0)

--- a/src/renderer/components/search/filter.ts
+++ b/src/renderer/components/search/filter.ts
@@ -14,14 +14,7 @@ export type FlatItem =
   | { kind: 'session'; agent: ApiAgent; session: ApiSession }
 
 function getAgentDashboards(agent: ApiAgent): ApiAgentDashboard[] {
-  if (Array.isArray(agent.dashboards)) return agent.dashboards
-
-  const slugs = agent.dashboardSlugs ?? []
-  const names = agent.dashboardNames ?? []
-  return slugs.map((slug, index) => ({
-    slug,
-    name: names[index] || slug,
-  }))
+  return Array.isArray(agent.dashboards) ? agent.dashboards : []
 }
 
 /**

--- a/src/renderer/components/ui/app-link.tsx
+++ b/src/renderer/components/ui/app-link.tsx
@@ -13,6 +13,7 @@ type AppLinkProps = LinkProps & {
   onClick?: MouseEventHandler<HTMLAnchorElement>
   onDoubleClick?: MouseEventHandler<HTMLAnchorElement>
   title?: string
+  draggable?: boolean
   'aria-label'?: string
   'data-testid'?: string
   /** Marks a full-card navigation link that may also initiate board dragging. */

--- a/src/renderer/components/ui/app-link.tsx
+++ b/src/renderer/components/ui/app-link.tsx
@@ -1,5 +1,10 @@
 import { Link, type LinkProps } from '@tanstack/react-router'
-import { forwardRef, type MouseEventHandler, type ReactNode } from 'react'
+import {
+  forwardRef,
+  type KeyboardEventHandler,
+  type MouseEventHandler,
+  type ReactNode,
+} from 'react'
 import { cn } from '@shared/lib/utils/cn'
 import { router } from '@renderer/router'
 
@@ -12,6 +17,7 @@ type AppLinkProps = LinkProps & {
   children?: ReactNode
   onClick?: MouseEventHandler<HTMLAnchorElement>
   onDoubleClick?: MouseEventHandler<HTMLAnchorElement>
+  onKeyDown?: KeyboardEventHandler<HTMLAnchorElement>
   title?: string
   draggable?: boolean
   'aria-label'?: string

--- a/src/renderer/components/ui/app-link.tsx
+++ b/src/renderer/components/ui/app-link.tsx
@@ -15,6 +15,8 @@ type AppLinkProps = LinkProps & {
   title?: string
   'aria-label'?: string
   'data-testid'?: string
+  /** Marks a full-card navigation link that may also initiate board dragging. */
+  'data-widget-drag-surface'?: string
 }
 
 /**

--- a/src/renderer/components/ui/context-menu.test.tsx
+++ b/src/renderer/components/ui/context-menu.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { createEvent, fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@renderer/test/test-utils'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuSwitchItem,
+  ContextMenuTrigger,
+} from './context-menu'
+
+describe('ContextMenu touch and switch options', () => {
+  it('suppresses touch long-press when an explicit gesture mode owns the hold', () => {
+    renderWithProviders(
+      <ContextMenu>
+        <ContextMenuTrigger disableTouchLongPress>
+          <div>Agent card</div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuSwitchItem checked>Expanded</ContextMenuSwitchItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    )
+
+    const trigger = screen.getByText('Agent card')
+    const pointerDown = createEvent.pointerDown(trigger, {
+      pointerType: 'touch',
+      clientX: 10,
+      clientY: 10,
+    })
+    fireEvent(trigger, pointerDown)
+
+    expect(pointerDown.defaultPrevented).toBe(true)
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'Expanded' })).not.toBeInTheDocument()
+  })
+
+  it('renders an accessible switch row and reports its next value', () => {
+    const onCheckedChange = vi.fn()
+    renderWithProviders(
+      <ContextMenu>
+        <ContextMenuTrigger>
+          <div>Agent card</div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuSwitchItem checked onCheckedChange={onCheckedChange}>
+            Expanded
+          </ContextMenuSwitchItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByText('Agent card'))
+    const option = screen.getByRole('menuitemcheckbox', { name: 'Expanded' })
+    expect(option).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.click(option)
+    expect(onCheckedChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/renderer/components/ui/context-menu.tsx
+++ b/src/renderer/components/ui/context-menu.tsx
@@ -247,7 +247,7 @@ const ContextMenuSwitchItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center justify-between gap-3 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}

--- a/src/renderer/components/ui/context-menu.tsx
+++ b/src/renderer/components/ui/context-menu.tsx
@@ -23,8 +23,11 @@ const ContextMenu = ContextMenuPrimitive.Root
 // trigger it).
 const ContextMenuTrigger = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Trigger>
->(({ className, style, onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onClick, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Trigger> & {
+    /** Prevent the touch/pen long-press menu without affecting mouse right-click. */
+    disableTouchLongPress?: boolean
+  }
+>(({ className, style, onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onClick, disableTouchLongPress, ...props }, ref) => {
   const pressStart = React.useRef<{ x: number; y: number } | null>(null)
   const longPressTimer = React.useRef<number>()
 
@@ -41,6 +44,16 @@ const ContextMenuTrigger = React.forwardRef<
 
   const handlePointerDown = (e: React.PointerEvent<HTMLElement>) => {
     if (e.pointerType === 'touch' || e.pointerType === 'pen') {
+      if (disableTouchLongPress) {
+        pressStart.current = null
+        setPressing(e.currentTarget, false)
+        clearLongPress()
+        // Radix composes this handler before its built-in long-press handler
+        // and respects defaultPrevented, leaving the gesture to the grid.
+        e.preventDefault()
+        onPointerDown?.(e)
+        return
+      }
       pressStart.current = { x: e.clientX, y: e.clientY }
       setPressing(e.currentTarget, true)
       // Open the menu sooner than Radix's built-in ~700ms long-press: after a
@@ -227,6 +240,38 @@ const ContextMenuCheckboxItem = React.forwardRef<
 ContextMenuCheckboxItem.displayName =
   ContextMenuPrimitive.CheckboxItem.displayName
 
+const ContextMenuSwitchItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span>{children}</span>
+    <span
+      aria-hidden="true"
+      className={cn(
+        "relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors",
+        checked ? "bg-primary" : "bg-input"
+      )}
+    >
+      <span
+        className={cn(
+          "block h-3 w-3 rounded-full bg-background shadow transition-transform",
+          checked ? "translate-x-3.5" : "translate-x-0.5"
+        )}
+      />
+    </span>
+  </ContextMenuPrimitive.CheckboxItem>
+))
+ContextMenuSwitchItem.displayName = "ContextMenuSwitchItem"
+
 const ContextMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
@@ -301,6 +346,7 @@ export {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuCheckboxItem,
+  ContextMenuSwitchItem,
   ContextMenuRadioItem,
   ContextMenuLabel,
   ContextMenuSeparator,

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -350,8 +350,25 @@ html[data-keyboard-open] [data-composer-footer] {
   animation: home-card-jiggle 160ms ease-in-out infinite alternate;
 }
 
+@keyframes home-title-ticker {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.home-title-ticker {
+  animation: home-title-ticker 14s linear infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .home-card-jiggle {
+    animation: none;
+  }
+
+  .home-title-ticker {
     animation: none;
   }
 }

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -336,6 +336,26 @@ html[data-keyboard-open] [data-composer-footer] {
   -webkit-app-region: no-drag;
 }
 
+@keyframes home-card-jiggle {
+  from {
+    transform: rotate(-0.35deg) translateY(0);
+  }
+  to {
+    transform: rotate(0.35deg) translateY(-0.4px);
+  }
+}
+
+.home-card-jiggle {
+  transform-origin: 50% 55%;
+  animation: home-card-jiggle 160ms ease-in-out infinite alternate;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-card-jiggle {
+    animation: none;
+  }
+}
+
 /* Windows: pad right side of main content headers to avoid overlapping with the custom
    window controls (144px wide at right-2, so 152px total reserved). */
 .electron-vibrancy-win main > div > header,

--- a/src/renderer/hooks/use-home-card-health.test.tsx
+++ b/src/renderer/hooks/use-home-card-health.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useHomeCardHealth } from './use-home-card-health'
+
+const mockApiFetch = vi.fn()
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}))
+
+const TZ = new Date().getTimezoneOffset()
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })}>
+      {children}
+    </QueryClientProvider>
+  )
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response
+}
+
+describe('home card health hook', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('fetches and validates the single card-health batch', async () => {
+    const payload = {
+      days: 14,
+      generatedAt: '2026-07-30T12:00:00.000Z',
+      crons: [],
+      webhooks: [],
+      cronByTaskId: {},
+      webhookByTriggerId: {},
+    }
+    mockApiFetch.mockResolvedValue(jsonResponse(payload))
+
+    const { result } = renderHook(() => useHomeCardHealth(true), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockApiFetch).toHaveBeenCalledTimes(1)
+    expect(mockApiFetch).toHaveBeenCalledWith(`/api/home-card-health?days=14&tz=${TZ}`)
+    expect(result.current.data).toEqual(payload)
+  })
+
+  it('does not fetch while Card view is inactive', () => {
+    const { result } = renderHook(() => useHomeCardHealth(false), { wrapper })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects graph-shaped or malformed data at the card boundary', async () => {
+    mockApiFetch.mockResolvedValue(jsonResponse({
+      accountLinks: [],
+      invocations: [],
+    }))
+
+    const { result } = renderHook(() => useHomeCardHealth(true), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.data).toBeUndefined()
+  })
+})

--- a/src/renderer/hooks/use-home-card-health.ts
+++ b/src/renderer/hooks/use-home-card-health.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@renderer/lib/api'
+import { DEFAULT_ACTIVITY_DAYS } from '@shared/lib/types/activity'
+import {
+  homeCardHealthSchema,
+  type HomeCardHealthData,
+} from '@shared/lib/types/home-card-health-schema'
+
+export function useHomeCardHealth(
+  enabled: boolean,
+  days = DEFAULT_ACTIVITY_DAYS,
+) {
+  const tzOffsetMinutes = new Date().getTimezoneOffset()
+  return useQuery<HomeCardHealthData>({
+    queryKey: ['home-card-health', days, tzOffsetMinutes],
+    queryFn: async () => {
+      const response = await apiFetch(`/api/home-card-health?days=${days}&tz=${tzOffsetMinutes}`)
+      if (!response.ok) throw new Error('Failed to fetch home card health')
+      return homeCardHealthSchema.parse(await response.json())
+    },
+    enabled,
+    staleTime: 60_000,
+    // A single batch replaces the former per-card requests, so refresh once
+    // whenever the cards page mounts instead of polling every carousel.
+    refetchOnMount: 'always',
+  })
+}

--- a/src/renderer/hooks/use-user-settings.ts
+++ b/src/renderer/hooks/use-user-settings.ts
@@ -19,6 +19,10 @@ export function useUpdateUserSettings() {
   const queryClient = useQueryClient()
 
   return useMutation<UserSettingsData, Error, Partial<UserSettingsData>>({
+    // Settings writes are partial read/merge/write operations on one document.
+    // Serialize every instance of this mutation so rapid layout/visibility
+    // changes cannot complete out of order and restore an older snapshot.
+    scope: { id: 'user-settings' },
     meta: { skipGlobalErrorToast: true },
     mutationFn: async (data) => {
       const res = await apiFetch('/api/user-settings', {

--- a/src/renderer/test/setup.ts
+++ b/src/renderer/test/setup.ts
@@ -29,13 +29,6 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
   }
 }
 
-// jsdom doesn't implement canvas; the Halftone banner calls getContext('2d').
-// Stub it to null so the component takes its no-context bail path quietly
-// (instead of jsdom logging "Not implemented" for every card it renders).
-if (typeof HTMLCanvasElement !== 'undefined') {
-  HTMLCanvasElement.prototype.getContext = () => null
-}
-
 const signIn = {
   email: vi.fn(),
   oauth2: vi.fn(),

--- a/src/shared/lib/services/activity-stats-service.ts
+++ b/src/shared/lib/services/activity-stats-service.ts
@@ -15,6 +15,7 @@ import type { SessionMetadataMap } from '@shared/lib/types/agent'
 import type {
   AgentActivityStats,
   ConnectionActivityStats,
+  CronActivityPoint,
   DailyActivityPoint,
 } from '@shared/lib/types/activity'
 import { DEFAULT_CRON_ACTIVITY_SLOTS } from '@shared/lib/types/activity'
@@ -48,6 +49,25 @@ export interface ActivityStatsOptions {
 }
 
 export type ConnectionStatsOptions = ActivityStatsOptions
+
+interface AutomationTaskInput {
+  id: string
+  scheduleType: 'at' | 'cron'
+  scheduleExpression: string
+  timezone?: string | null
+  createdAt: Date
+  pausedAt?: Date | null
+  cancelledAt?: Date | null
+}
+
+interface AutomationTriggerInput {
+  id: string
+}
+
+export interface AutomationActivityStats {
+  cronByTaskId: Record<string, CronActivityPoint[]>
+  webhookByTriggerId: Record<string, DailyActivityPoint[]>
+}
 
 function dailyEventsById(
   ids: string[],
@@ -100,6 +120,58 @@ function webhookEvents(
   }
 
   return events
+}
+
+/**
+ * Build only the automation series from one already-loaded metadata map.
+ * The homepage batch endpoint reuses this path so card and agent-detail
+ * charts cannot drift while avoiding connection/audit queries entirely.
+ */
+export function buildAutomationActivityStats(
+  tasks: AutomationTaskInput[],
+  triggers: AutomationTriggerInput[],
+  metadata: SessionMetadataMap,
+  options: ActivityStatsOptions,
+): AutomationActivityStats {
+  const now = options.now ?? new Date()
+  const tzOffsetMinutes = options.tzOffsetMinutes ?? 0
+
+  // One pass over the metadata map, grouped by task; a persisted 'running'
+  // with no live session is downgraded to failed (see isSessionLive).
+  const sessionsByTaskId = new Map<string, Array<{
+    scheduledExecutionAt?: string
+    automationStatus?: 'running' | 'succeeded' | 'failed'
+  }>>()
+  for (const [sessionId, meta] of Object.entries(metadata)) {
+    if (!meta.scheduledTaskId) continue
+    let status = normalizeAutomationStatus(meta.automationStatus)
+    if (status === 'running' && options.isSessionLive && !options.isSessionLive(sessionId)) {
+      status = 'failed'
+    }
+    const sessions = sessionsByTaskId.get(meta.scheduledTaskId) ?? []
+    sessions.push({ scheduledExecutionAt: meta.scheduledExecutionAt, automationStatus: status })
+    sessionsByTaskId.set(meta.scheduledTaskId, sessions)
+  }
+
+  const cronByTaskId = Object.fromEntries(
+    tasks
+      .filter((task) => task.scheduleType === 'cron')
+      .map((task) => [task.id, buildCronActivitySeries({
+        task,
+        sessions: sessionsByTaskId.get(task.id) ?? [],
+        now,
+        slots: options.cronSlots ?? DEFAULT_CRON_ACTIVITY_SLOTS,
+      })]),
+  )
+
+  const webhookIds = triggers.map((trigger) => trigger.id)
+  const webhookByTriggerId = dailyEventsById(
+    webhookIds,
+    webhookEvents(metadata, { ...options, tzOffsetMinutes }),
+    { ...options, now, tzOffsetMinutes },
+  )
+
+  return { cronByTaskId, webhookByTriggerId }
 }
 
 // Audit tables grow with every proxied call and have no time-based retention,
@@ -226,38 +298,10 @@ export async function getAgentActivityStats(
     ), tzOffsetMinutes),
   ])
 
-  // One pass over the metadata map, grouped by task; a persisted 'running'
-  // with no live session is downgraded to failed (see isSessionLive).
-  const sessionsByTaskId = new Map<string, Array<{
-    scheduledExecutionAt?: string
-    automationStatus?: 'running' | 'succeeded' | 'failed'
-  }>>()
-  for (const [sessionId, meta] of Object.entries(metadata)) {
-    if (!meta.scheduledTaskId) continue
-    let status = normalizeAutomationStatus(meta.automationStatus)
-    if (status === 'running' && options.isSessionLive && !options.isSessionLive(sessionId)) {
-      status = 'failed'
-    }
-    const sessions = sessionsByTaskId.get(meta.scheduledTaskId) ?? []
-    sessions.push({ scheduledExecutionAt: meta.scheduledExecutionAt, automationStatus: status })
-    sessionsByTaskId.set(meta.scheduledTaskId, sessions)
-  }
-
-  const cronByTaskId = Object.fromEntries(
-    tasks
-      .filter((task) => task.scheduleType === 'cron')
-      .map((task) => [task.id, buildCronActivitySeries({
-        task,
-        sessions: sessionsByTaskId.get(task.id) ?? [],
-        now,
-        slots: options.cronSlots ?? DEFAULT_CRON_ACTIVITY_SLOTS,
-      })]),
-  )
-
-  const webhookIds = triggers.map((trigger) => trigger.id)
-  const webhookByTriggerId = dailyEventsById(
-    webhookIds,
-    webhookEvents(metadata, { ...options, tzOffsetMinutes }),
+  const { cronByTaskId, webhookByTriggerId } = buildAutomationActivityStats(
+    tasks,
+    triggers,
+    metadata,
     { ...options, now, tzOffsetMinutes },
   )
 

--- a/src/shared/lib/services/home-card-health-service.test.ts
+++ b/src/shared/lib/services/home-card-health-service.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../db/schema'
+
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+const mockReadSessionMetadata = vi.fn()
+
+vi.mock('../db', () => ({
+  get db() {
+    return testDb
+  },
+}))
+
+vi.mock('./session-service', () => ({
+  readSessionMetadata: (...args: unknown[]) => mockReadSessionMetadata(...args),
+}))
+
+import { buildHomeCardHealth } from './home-card-health-service'
+
+const NOW = new Date('2026-07-30T12:00:00.000Z')
+
+describe('home-card-health-service', () => {
+  beforeEach(() => {
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+    migrate(testDb, {
+      migrationsFolder: path.join(process.cwd(), 'src/shared/lib/db/migrations'),
+    })
+    mockReadSessionMetadata.mockReset()
+    mockReadSessionMetadata.mockImplementation(async (agentSlug: string) => (
+      agentSlug === 'agent-a'
+        ? {
+            'cron-success': {
+              scheduledTaskId: 'cron-a',
+              scheduledExecutionAt: '2026-07-29T09:00:00.000Z',
+              automationStatus: 'succeeded',
+              createdAt: '2026-07-29T09:00:00.000Z',
+            },
+            'webhook-success': {
+              isWebhookExecution: true,
+              webhookTriggerId: 'webhook-a',
+              webhookInvocationCount: 3,
+              automationStatus: 'succeeded',
+              createdAt: '2026-07-30T10:00:00.000Z',
+            },
+          }
+        : {}
+    ))
+  })
+
+  afterEach(() => {
+    testSqlite.close()
+  })
+
+  it('returns card automation descriptors and chart series without unrelated scheduled rows', async () => {
+    await testDb.insert(schema.scheduledTasks).values([
+      {
+        id: 'cron-a',
+        agentSlug: 'agent-a',
+        scheduleType: 'cron',
+        scheduleExpression: '0 9 * * *',
+        prompt: 'report',
+        name: 'Daily report',
+        status: 'pending',
+        nextExecutionAt: new Date('2099-01-01T09:00:00.000Z'),
+        isRecurring: true,
+        executionCount: 1,
+        timezone: 'UTC',
+        createdAt: new Date('2026-07-28T00:00:00.000Z'),
+      },
+      {
+        id: 'one-time-a',
+        agentSlug: 'agent-a',
+        scheduleType: 'at',
+        scheduleExpression: '2099-01-01T09:00:00.000Z',
+        prompt: 'one time',
+        name: 'One-time reminder',
+        status: 'pending',
+        nextExecutionAt: new Date('2099-01-01T09:00:00.000Z'),
+        isRecurring: false,
+        executionCount: 0,
+        createdAt: NOW,
+      },
+      {
+        id: 'cron-hidden',
+        agentSlug: 'hidden-agent',
+        scheduleType: 'cron',
+        scheduleExpression: '0 9 * * *',
+        prompt: 'hidden',
+        status: 'pending',
+        nextExecutionAt: new Date('2099-01-01T09:00:00.000Z'),
+        isRecurring: true,
+        executionCount: 0,
+        createdAt: NOW,
+      },
+    ])
+    await testDb.insert(schema.webhookTriggers).values([
+      {
+        id: 'webhook-a',
+        agentSlug: 'agent-a',
+        kind: 'custom',
+        triggerType: 'CUSTOM_WEBHOOK',
+        prompt: 'handle',
+        name: 'Feedback',
+        status: 'active',
+        fireCount: 3,
+        createdAt: NOW,
+      },
+      {
+        id: 'webhook-cancelled',
+        agentSlug: 'agent-a',
+        kind: 'custom',
+        triggerType: 'CUSTOM_WEBHOOK',
+        prompt: 'old',
+        status: 'cancelled',
+        fireCount: 1,
+        createdAt: NOW,
+      },
+    ])
+
+    const result = await buildHomeCardHealth({
+      agentSlugs: ['agent-a', 'agent-without-charts'],
+      days: 7,
+      now: NOW,
+      tzOffsetMinutes: 0,
+    })
+
+    expect(result.crons).toEqual([
+      expect.objectContaining({
+        id: 'cron-a',
+        agentSlug: 'agent-a',
+        name: 'Daily report',
+      }),
+    ])
+    expect(result.webhooks).toEqual([
+      expect.objectContaining({
+        id: 'webhook-a',
+        agentSlug: 'agent-a',
+        name: 'Feedback',
+      }),
+    ])
+    expect(result.cronByTaskId['cron-a']).toEqual([
+      { scheduledAt: '2026-07-28T09:00:00.000Z', status: 'skipped' },
+      { scheduledAt: '2026-07-29T09:00:00.000Z', status: 'succeeded' },
+      { scheduledAt: '2026-07-30T09:00:00.000Z', status: 'skipped' },
+    ])
+    expect(result.webhookByTriggerId['webhook-a'][6]).toEqual({
+      date: '2026-07-30',
+      succeeded: 3,
+      failed: 0,
+    })
+    expect(mockReadSessionMetadata).toHaveBeenCalledTimes(1)
+    expect(mockReadSessionMetadata).toHaveBeenCalledWith('agent-a')
+    expect(result).not.toHaveProperty('accountLinks')
+    expect(result).not.toHaveProperty('connectionById')
+  })
+
+  it('short-circuits an empty visible-agent scope', async () => {
+    const result = await buildHomeCardHealth({
+      agentSlugs: [],
+      days: 14,
+      now: NOW,
+    })
+
+    expect(result).toEqual({
+      days: 14,
+      generatedAt: NOW.toISOString(),
+      crons: [],
+      webhooks: [],
+      cronByTaskId: {},
+      webhookByTriggerId: {},
+    })
+    expect(mockReadSessionMetadata).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/services/home-card-health-service.ts
+++ b/src/shared/lib/services/home-card-health-service.ts
@@ -1,0 +1,143 @@
+/**
+ * Home Card Health Service — the compact, card-only projection behind
+ * GET /api/home-card-health.
+ *
+ * Unlike the graph snapshot, this path performs no topology, permissions,
+ * chat/session-count, connection-usage, or invocation aggregation. It uses
+ * two batched SQL queries and reads session metadata only for agents that
+ * actually have a cron or webhook chart to render.
+ */
+
+import pLimit from 'p-limit'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { scheduledTasks, webhookTriggers } from '@shared/lib/db/schema'
+import type { HomeCardHealthData } from '@shared/lib/types/home-card-health-schema'
+import type { ActivityStatsOptions } from './activity-stats-service'
+import { buildAutomationActivityStats } from './activity-stats-service'
+import { readSessionMetadata } from './session-service'
+
+export interface HomeCardHealthScope extends ActivityStatsOptions {
+  /** Agents the caller may see (ACL-resolved in auth mode, all otherwise). */
+  agentSlugs: string[]
+}
+
+type CardCronRow = Awaited<ReturnType<typeof listCardCrons>>[number]
+type CardWebhookRow = Awaited<ReturnType<typeof listCardWebhooks>>[number]
+
+async function listCardCrons(agentSlugs: string[]) {
+  return db
+    .select({
+      id: scheduledTasks.id,
+      agentSlug: scheduledTasks.agentSlug,
+      name: scheduledTasks.name,
+      scheduleType: scheduledTasks.scheduleType,
+      scheduleExpression: scheduledTasks.scheduleExpression,
+      timezone: scheduledTasks.timezone,
+      createdAt: scheduledTasks.createdAt,
+      pausedAt: scheduledTasks.pausedAt,
+      cancelledAt: scheduledTasks.cancelledAt,
+    })
+    .from(scheduledTasks)
+    .where(and(
+      inArray(scheduledTasks.agentSlug, agentSlugs),
+      inArray(scheduledTasks.status, ['pending', 'paused']),
+      eq(scheduledTasks.scheduleType, 'cron'),
+      // Session wake timers are `at` tasks today, but keep the explicit guard
+      // so they cannot accidentally become homepage charts if that changes.
+      isNull(scheduledTasks.resumeSessionId),
+    ))
+}
+
+async function listCardWebhooks(agentSlugs: string[]) {
+  return db
+    .select({
+      id: webhookTriggers.id,
+      agentSlug: webhookTriggers.agentSlug,
+      triggerType: webhookTriggers.triggerType,
+      name: webhookTriggers.name,
+    })
+    .from(webhookTriggers)
+    .where(and(
+      inArray(webhookTriggers.agentSlug, agentSlugs),
+      inArray(webhookTriggers.status, ['active', 'paused']),
+    ))
+}
+
+function groupByAgent<T extends { agentSlug: string }>(rows: T[]): Map<string, T[]> {
+  const grouped = new Map<string, T[]>()
+  for (const row of rows) {
+    const current = grouped.get(row.agentSlug)
+    if (current) current.push(row)
+    else grouped.set(row.agentSlug, [row])
+  }
+  return grouped
+}
+
+export async function buildHomeCardHealth(
+  scope: HomeCardHealthScope,
+): Promise<HomeCardHealthData> {
+  const now = scope.now ?? new Date()
+  if (scope.agentSlugs.length === 0) {
+    return {
+      days: scope.days,
+      generatedAt: now.toISOString(),
+      crons: [],
+      webhooks: [],
+      cronByTaskId: {},
+      webhookByTriggerId: {},
+    }
+  }
+
+  const [cronRows, webhookRows] = await Promise.all([
+    listCardCrons(scope.agentSlugs),
+    listCardWebhooks(scope.agentSlugs),
+  ])
+  const cronsByAgent = groupByAgent<CardCronRow>(cronRows)
+  const webhooksByAgent = groupByAgent<CardWebhookRow>(webhookRows)
+  const agentsWithCharts = new Set([
+    ...cronsByAgent.keys(),
+    ...webhooksByAgent.keys(),
+  ])
+
+  const cronByTaskId: HomeCardHealthData['cronByTaskId'] = {}
+  const webhookByTriggerId: HomeCardHealthData['webhookByTriggerId'] = {}
+  const limit = pLimit(10)
+  await Promise.all(
+    [...agentsWithCharts].map((agentSlug) =>
+      limit(async () => {
+        const activity = buildAutomationActivityStats(
+          cronsByAgent.get(agentSlug) ?? [],
+          webhooksByAgent.get(agentSlug) ?? [],
+          await readSessionMetadata(agentSlug),
+          { ...scope, now },
+        )
+        Object.assign(cronByTaskId, activity.cronByTaskId)
+        Object.assign(webhookByTriggerId, activity.webhookByTriggerId)
+      }),
+    ),
+  )
+
+  return {
+    days: scope.days,
+    generatedAt: now.toISOString(),
+    crons: cronRows
+      .map((row) => ({
+        id: row.id,
+        agentSlug: row.agentSlug,
+        name: row.name,
+        scheduleExpression: row.scheduleExpression,
+      }))
+      .sort((a, b) => a.agentSlug.localeCompare(b.agentSlug) || a.id.localeCompare(b.id)),
+    webhooks: webhookRows
+      .map((row) => ({
+        id: row.id,
+        agentSlug: row.agentSlug,
+        triggerType: row.triggerType,
+        name: row.name,
+      }))
+      .sort((a, b) => a.agentSlug.localeCompare(b.agentSlug) || a.id.localeCompare(b.id)),
+    cronByTaskId,
+    webhookByTriggerId,
+  }
+}

--- a/src/shared/lib/services/user-settings-schema.test.ts
+++ b/src/shared/lib/services/user-settings-schema.test.ts
@@ -39,3 +39,29 @@ describe('userSettingsSchema agentOrder', () => {
     expect(result.agentOrder).toEqual(['c', 'a'])
   })
 })
+
+describe('userSettingsSchema home grid layouts', () => {
+  it('keeps desktop and mobile geometry as independent optional maps', () => {
+    const result = userSettingsSchema.parse({
+      homeGridLayout: {
+        agent: { x: 4, y: 0, w: 2, h: 1 },
+      },
+      homeGridMobileLayout: {
+        agent: { x: 1, y: 3, w: 1, h: 1 },
+      },
+    })
+
+    expect(result.homeGridLayout?.agent).toEqual({ x: 4, y: 0, w: 2, h: 1 })
+    expect(result.homeGridMobileLayout?.agent).toEqual({ x: 1, y: 3, w: 1, h: 1 })
+  })
+
+  it('leaves the mobile layout absent for migration-safe desktop fallback', () => {
+    const result = userSettingsSchema.parse({
+      homeGridLayout: {
+        agent: { x: 0, y: 0, w: 2, h: 1 },
+      },
+    })
+
+    expect(result.homeGridMobileLayout).toBeUndefined()
+  })
+})

--- a/src/shared/lib/services/user-settings-service.ts
+++ b/src/shared/lib/services/user-settings-service.ts
@@ -15,6 +15,16 @@ const notificationSettingsSchema = z.object({
   notifyWhenUnfocused: z.boolean().default(false),
 })
 
+const homeGridLayoutSchema = z.record(
+  z.string(),
+  z.object({
+    x: z.number().int().min(0),
+    y: z.number().int().min(0),
+    w: z.number().int().min(1).max(2),
+    h: z.number().int().min(1).max(2),
+  })
+)
+
 export const userSettingsSchema = z.object({
   theme: z.enum(['system', 'light', 'dark']).default('system'),
   notifications: notificationSettingsSchema.default({
@@ -55,15 +65,11 @@ export const userSettingsSchema = z.object({
   // Home page widget grid: per-card position + footprint in grid cells,
   // keyed by card id (agent slug or dashboard key). Absent = never customized
   // (the board auto-packs responsively until the user drags/resizes).
-  homeGridLayout: z.record(
-    z.string(),
-    z.object({
-      x: z.number().int().min(0),
-      y: z.number().int().min(0),
-      w: z.number().int().min(1).max(2),
-      h: z.number().int().min(1).max(2),
-    })
-  ).optional(),
+  homeGridLayout: homeGridLayoutSchema.optional(),
+  // Phone layout is persisted independently so arranging a responsive two-
+  // column board never overwrites desktop geometry. Until customized, mobile
+  // falls back to homeGridLayout and lets WidgetBoard re-pack it responsively.
+  homeGridMobileLayout: homeGridLayoutSchema.optional(),
   // Agent slugs whose associated app/dashboard card is hidden from the home grid
   // (toggled from the agent card). Absent/empty = all app cards shown.
   hiddenAppCards: z.array(z.string()).optional(),

--- a/src/shared/lib/types/activity-schema.ts
+++ b/src/shared/lib/types/activity-schema.ts
@@ -11,13 +11,13 @@ import type {
 // deliberately-lenient persisted-file schemas, these are strict: client and
 // server ship in the same build, so a mismatch here is drift worth surfacing.
 
-const dailyActivityPointSchema = z.object({
+export const dailyActivityPointSchema = z.object({
   date: z.string(),
   succeeded: z.number(),
   failed: z.number(),
 }) satisfies z.ZodType<DailyActivityPoint>
 
-const cronActivityPointSchema = z.object({
+export const cronActivityPointSchema = z.object({
   scheduledAt: z.string(),
   status: z.enum(['succeeded', 'running', 'skipped', 'failed']),
 }) satisfies z.ZodType<CronActivityPoint>

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -34,14 +34,7 @@ export interface ApiAgent {
   hasUnreadNotifications?: boolean
   sessionCount?: number
   lastActivityAt?: Date | null
-  scheduledTaskCount?: number
-  nextScheduledTaskAt?: Date | null
-  chatIntegrationCount?: number
-  dashboardCount?: number
-  dashboardNames?: string[]
-  dashboardSlugs?: string[]
   dashboards?: ApiAgentDashboard[]
-  autoDeleteInactiveDays?: number
 }
 
 export interface ApiAgentDashboard {

--- a/src/shared/lib/types/home-card-health-schema.ts
+++ b/src/shared/lib/types/home-card-health-schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+import {
+  cronActivityPointSchema,
+  dailyActivityPointSchema,
+} from './activity-schema'
+
+/**
+ * Compact wire shape for the home card health carousel. The automation
+ * descriptors contain only fields the cards render; graph status, counts,
+ * topology, connection usage, and chat data stay out of this response.
+ */
+export const homeCardCronSchema = z.object({
+  id: z.string(),
+  agentSlug: z.string(),
+  name: z.string().nullable(),
+  scheduleExpression: z.string(),
+})
+
+export const homeCardWebhookSchema = z.object({
+  id: z.string(),
+  agentSlug: z.string(),
+  triggerType: z.string(),
+  name: z.string().nullable(),
+})
+
+export const homeCardHealthSchema = z.object({
+  days: z.number(),
+  generatedAt: z.string(),
+  crons: z.array(homeCardCronSchema),
+  webhooks: z.array(homeCardWebhookSchema),
+  cronByTaskId: z.record(z.string(), z.array(cronActivityPointSchema)),
+  webhookByTriggerId: z.record(z.string(), z.array(dailyActivityPointSchema)),
+})
+
+export type HomeCardHealthData = z.infer<typeof homeCardHealthSchema>
+export type HomeCardCron = z.infer<typeof homeCardCronSchema>
+export type HomeCardWebhook = z.infer<typeof homeCardWebhookSchema>


### PR DESCRIPTION
## Summary

Follow-up cleanup and interaction polish for the homepage redesign stack (#531 → #532 → #533 → #262).

- add an explicit Arrange mode available from the `Your Agents` kebab and every homepage agent context menu
- replace `New Agent` with `Cancel` / `Done` while arranging; stage layout changes until Done so Cancel restores the saved layout
- persist phone and desktop grid geometry independently so arranging one breakpoint never overwrites the other
- give every tile a subtle reduced-motion-safe jiggle and a full-card drag surface in Arrange mode
- disable mobile card dragging outside Arrange mode while preserving direct desktop dragging
- suppress touch/pen long-press context menus only on mobile while Arrange mode owns the gesture
- retain the unified agent context menu during desktop Arrange, including portaled menu-item interaction
- unify homepage agent controls in the context menu: Arrange, Expanded, optional Show app, then existing agent actions
- remove the redundant three-dot control from agent cards while retaining dashboard-card options
- restore real-link semantics for agent cards and use native buttons for embedded actions
- keep notification actions available to keyboard and touch users and enlarge carousel controls
- pause tickers/carousels for focus and reduced-motion preferences
- prevent direct desktop drags from swallowing embedded-control clicks
- re-pack overflowing saved layouts when the responsive column count shrinks
- preserve geometry for temporarily missing dashboard cards while their owning agent still exists
- clean up abandoned window drag listeners without committing
- recover Halftone canvases from zero-size mounts, handle one-cell grids, and cap drawing at 30fps
- remove the suite-wide Canvas2D stub in favor of focused test mocks
- use the notable-session fast path and disable unnecessary per-agent activity queries
- remove the obsolete homepage 7-day token usage scan
- trim unused scheduled-task, chat-integration, and preferences enrichment from `/api/agents`
- replace redundant dashboard count/name/slug payload fields with the dashboard summary array already consumed by the UI
- serialize partial user-settings writes and roll back failed optimistic visibility/layout changes with feedback

## Why

The redesign rendered correctly, but mobile reordering was too easy to trigger during normal scrolling and the agent-card actions were split across two menus. Explicit Arrange mode makes reordering intentional, gives touch users a clear edit state, and consolidates per-agent controls without taking desktop context menus or direct dragging away.

The cleanup also closes the accessibility, responsive-layout, animation-lifecycle, persistence, and stale homepage data-fetch issues found in the independent review.

## Impact

Mobile cards scroll normally and do not drag until Arrange is selected. In Arrange mode all visible tiles jiggle, interactions become drag handles, long-press menus are suppressed, and Cancel/Done provide a clear exit. A phone without a customized layout starts from the existing desktop map and responsively reflows it; the first phone save forks into its own `homeGridMobileLayout`.

Desktop keeps direct drag-and-drop outside Arrange mode, retains the unified agent context menu inside Arrange mode, and continues to use `homeGridLayout` without being affected by later phone saves.

Homepage card view no longer loads the removed token statistic, graph view no longer triggers the all-agent 7-day usage scan, and the agent list avoids two stale database lookups plus one preferences-file read per agent. The retained activity-stat queries still power visible cron/webhook charts and remain disabled for agents without those slides.

## Validation

- `npm run test:run -- src/api/routes/agents.test.ts src/renderer/components/home/home-page.test.tsx src/renderer/components/layout/app-sidebar.test.tsx src/renderer/components/search/filter.test.ts` — 269 passed
- `npm run test:run -- src/renderer/components/home/home-page.test.tsx src/renderer/components/home/widget-grid.test.tsx src/renderer/components/ui/context-menu.test.tsx src/renderer/components/agents/halftone.test.tsx src/shared/lib/services/user-settings-schema.test.ts` — 48 passed
- `npx playwright test e2e/specs/home-cards.spec.ts --project=web-chromium --workers=1` — passed; covers real DOM nesting, desktop Arrange context menu, Expanded / Show app, drag, Done persistence, reload, phone arrangement, and desktop-layout isolation
- `npm run typecheck`
- ESLint on all changed source and test files (one pre-existing test warning, no errors)
- `npm run build:web`
- `git diff --check`
- broad Vitest run: 7,480 passed; 29 failures were isolated to three unrelated server/network suites that cannot bind `127.0.0.1` in the sandbox
- verified both card and graph views in the running dev app on port 47916
- live `/api/agents` response returned 200 with only consumed summary fields
