### PR TITLE
fix: webhook/cron Run History shows epoch dates on S3 Files

### DIFF
--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -2599,6 +2599,22 @@ describe('session-service', () => {
       expect(sessions.length).toBe(1)
       expect(sessions[0].id).toBe('sess-1')
     })
+
+    it('uses metadata createdAt instead of filesystem birthtime', async () => {
+      await createSessionFile('test-agent', 'sess-1', SAMPLE_JSONL_ENTRIES)
+      await createSessionMetadata('test-agent', {
+        'sess-1': {
+          name: 'Webhook Run',
+          createdAt: '2026-07-30T19:44:31.000Z',
+          webhookTriggerId: 'trigger-abc',
+          isWebhookExecution: true,
+        },
+      })
+
+      const sessions = await getSessionsByWebhookTrigger('test-agent', 'trigger-abc')
+      expect(sessions).toHaveLength(1)
+      expect(sessions[0].createdAt).toEqual(new Date('2026-07-30T19:44:31.000Z'))
+    })
   })
 
   describe('listSessionsByIds', () => {

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -360,6 +360,17 @@ function emptySessionFromMetadata(
   }
 }
 
+// Prefer metadata createdAt; birthtime is unsupported (epoch 0) on
+// network filesystems like S3 Files / EFS used by the k8s / microVM runtime.
+function resolveSessionCreatedAt(
+  meta: SessionMetadata | undefined,
+  stat: { birthtimeMs: number; birthtime: Date; mtimeMs: number },
+): Date {
+  if (meta?.createdAt) return new Date(meta.createdAt)
+  if (stat.birthtimeMs > 0) return stat.birthtime
+  return new Date(stat.mtimeMs)
+}
+
 // ============================================================================
 // Session Operations
 // ============================================================================
@@ -457,20 +468,11 @@ export async function listSessions(
         continue
       }
 
-      // Prefer metadata createdAt; birthtime is unsupported (epoch 0) on
-      // network filesystems like S3 Files / EFS used by the k8s runtime.
-      const metaCreatedAt = metadata[sessionId]?.createdAt
-      const createdAt = metaCreatedAt
-        ? new Date(metaCreatedAt)
-        : stat.birthtimeMs > 0
-          ? stat.birthtime
-          : new Date(stat.mtimeMs)
-
       sessions.push({
         id: sessionId,
         agentSlug,
         name: metadata[sessionId]?.name || 'New Session',
-        createdAt,
+        createdAt: resolveSessionCreatedAt(metadata[sessionId], stat),
         lastActivityAt: new Date(stat.mtimeMs),
         messageCount: 0,
       })
@@ -523,17 +525,11 @@ export async function listSessionsByIds(
           // Same rule as listSessions: unregistered empty JSONLs are SDK
           // subagent artifacts, not sessions.
           if (stat.size === 0 && !metadata[sessionId]) return null
-          const metaCreatedAt = metadata[sessionId]?.createdAt
-          const createdAt = metaCreatedAt
-            ? new Date(metaCreatedAt)
-            : stat.birthtimeMs > 0
-              ? stat.birthtime
-              : new Date(stat.mtimeMs)
           return {
             id: sessionId,
             agentSlug,
             name: metadata[sessionId]?.name || 'New Session',
-            createdAt,
+            createdAt: resolveSessionCreatedAt(metadata[sessionId], stat),
             lastActivityAt: new Date(stat.mtimeMs),
             messageCount: 0,
           }
@@ -970,26 +966,22 @@ async function getSessionsByMetadata(
   const sessions: SessionInfo[] = []
   for (const sessionId of matchingIds) {
     const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+    const meta = metadata[sessionId]
     try {
       const stat = await fs.promises.stat(jsonlPath)
       sessions.push({
         id: sessionId,
         agentSlug,
-        name: metadata[sessionId]?.name || 'New Session',
-        createdAt: stat.birthtime,
+        name: meta?.name || 'New Session',
+        createdAt: resolveSessionCreatedAt(meta, stat),
         lastActivityAt: new Date(stat.mtimeMs),
         messageCount: 0,
       })
     } catch {
       // JSONL doesn't exist yet — use metadata createdAt
-      sessions.push({
-        id: sessionId,
-        agentSlug,
-        name: metadata[sessionId]?.name || 'New Session',
-        createdAt: new Date(metadata[sessionId]?.createdAt || Date.now()),
-        lastActivityAt: new Date(metadata[sessionId]?.createdAt || Date.now()),
-        messageCount: 0,
-      })
+      if (meta) {
+        sessions.push(emptySessionFromMetadata(sessionId, agentSlug, meta))
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- **Bug:** Webhook (and cron) Run History lists every session as `12/31/1969 4:00:00 PM` on cloud / microVM deployments, while Details → Last Fired shows the correct time.
- **Repro:** Open a webhook trigger on a cloud agent (e.g. `datawizz.ongamut.so`) that has fired at least once — Run History dates are epoch; Last Fired is not.
- **Cause:** `getSessionsByMetadata` used raw `stat.birthtime`. On S3 Files / EFS that returns epoch 0. Last Fired comes from the DB (`last_fired_at`), so it stayed correct. `listSessions` already preferred metadata `createdAt`.
- **Fix:** Share `resolveSessionCreatedAt` (metadata → birthtime if non-zero → mtime) and use it in `getSessionsByMetadata` for both webhook and scheduled-task run history.

## Test plan
- [x] `npm run test:run -- src/shared/lib/services/session-service.test.ts -t getSessionsByWebhookTrigger`
- [ ] On cloud: open a webhook trigger with prior fires and confirm Run History dates match real fire times (not 1969)
- [ ] Spot-check a scheduled task Run History on the same runtime

Made with [Cursor](https://cursor.com)