### PR TITLE
fix(skills): open SKILL.md by default in the skill files viewer

### DIFF
--- a/src/renderer/components/agents/skill-files-dialog.test.tsx
+++ b/src/renderer/components/agents/skill-files-dialog.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SkillFilesDialog } from './skill-files-dialog'
+import { renderWithProviders } from '@renderer/test/test-utils'
+import { apiFetch } from '@renderer/lib/api'
+import type { ApiSkillFileEntry } from '@shared/lib/types/api'
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('@renderer/components/ui/code-editor', () => ({
+  CodeEditor: ({ value }: { value: string }) => (
+    <textarea data-testid="code-editor" value={value} readOnly />
+  ),
+}))
+
+const mockApiFetch = vi.mocked(apiFetch)
+
+// jsdom has no ResizeObserver; the file tree's Radix ScrollArea needs one.
+globalThis.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function mockSkillFiles(files: ApiSkillFileEntry[], contents: Record<string, string> = {}) {
+  mockApiFetch.mockImplementation(async (path: string) => {
+    const contentMatch = path.match(/\/files\/content\?path=(.+)$/)
+    if (contentMatch) {
+      const filePath = decodeURIComponent(contentMatch[1])
+      const content = contents[filePath]
+      if (content === undefined) {
+        return { ok: false, status: 404, json: async () => ({}) } as Response
+      }
+      return { ok: true, json: async () => ({ content, path: filePath }) } as Response
+    }
+    if (path.endsWith('/files')) {
+      return { ok: true, json: async () => ({ files }) } as Response
+    }
+    throw new Error(`unexpected request: ${path}`)
+  })
+}
+
+function renderDialog() {
+  return renderWithProviders(
+    <SkillFilesDialog
+      open
+      onOpenChange={() => {}}
+      agentSlug="agent-1"
+      skillDir="my-skill"
+      skillName="My Skill"
+    />
+  )
+}
+
+describe('SkillFilesDialog', () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+  })
+
+  it('opens SKILL.md by default', async () => {
+    mockSkillFiles(
+      [
+        { path: 'helper.py', type: 'file' },
+        { path: 'SKILL.md', type: 'file' },
+      ],
+      { 'SKILL.md': '# My Skill' }
+    )
+
+    renderDialog()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('code-editor')).toHaveValue('# My Skill')
+    )
+    expect(screen.queryByText('Select a file to view')).not.toBeInTheDocument()
+  })
+
+  it('prefers the skill root SKILL.md over a nested one', async () => {
+    mockSkillFiles(
+      [
+        { path: 'references', type: 'directory' },
+        { path: 'references/SKILL.md', type: 'file' },
+        { path: 'SKILL.md', type: 'file' },
+      ],
+      { 'SKILL.md': 'root skill', 'references/SKILL.md': 'nested skill' }
+    )
+
+    renderDialog()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('code-editor')).toHaveValue('root skill')
+    )
+  })
+
+  it('shows the empty state when the skill has no SKILL.md', async () => {
+    mockSkillFiles([{ path: 'helper.py', type: 'file' }], { 'helper.py': 'print(1)' })
+
+    renderDialog()
+
+    await waitFor(() => expect(screen.getByText('helper.py')).toBeInTheDocument())
+    expect(screen.getByText('Select a file to view')).toBeInTheDocument()
+    expect(screen.queryByTestId('code-editor')).not.toBeInTheDocument()
+    expect(
+      mockApiFetch.mock.calls.some(([path]) => path.includes('/files/content'))
+    ).toBe(false)
+  })
+
+  it('keeps a file the user picked instead of reverting to SKILL.md', async () => {
+    mockSkillFiles(
+      [
+        { path: 'SKILL.md', type: 'file' },
+        { path: 'helper.py', type: 'file' },
+      ],
+      { 'SKILL.md': '# My Skill', 'helper.py': 'print(1)' }
+    )
+
+    const user = userEvent.setup()
+    renderDialog()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('code-editor')).toHaveValue('# My Skill')
+    )
+
+    await user.click(screen.getByRole('button', { name: 'helper.py' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('code-editor')).toHaveValue('print(1)')
+    )
+    expect(screen.getByTestId('code-editor')).toHaveValue('print(1)')
+  })
+})

--- a/src/renderer/components/agents/skill-files-dialog.tsx
+++ b/src/renderer/components/agents/skill-files-dialog.tsx
@@ -83,6 +83,15 @@ export function SkillFilesDialog({
     }
   }, [fileContent])
 
+  // Open the skill's own SKILL.md by default, when it has one
+  useEffect(() => {
+    if (!open || selectedPath || !files) return
+    const skillMd = files.find(
+      (entry) => entry.type === 'file' && entry.path.toLowerCase() === 'skill.md',
+    )
+    if (skillMd) setSelectedPath(skillMd.path)
+  }, [open, selectedPath, files])
+
   // Reset state when dialog closes
   useEffect(() => {
     if (!open) {


### PR DESCRIPTION
## What

Opening a skill's files dialog now selects that skill's `SKILL.md` automatically instead of showing "Select a file to view".

Linear: https://linear.app/datawizz/issue/SUP-513/when-opening-skill-files-open-the-markdown-skillmd-by-default

Closes SUP-513

## How

`SkillFilesDialog` gained one effect that runs when the file list arrives: if nothing is selected yet, it picks the entry at the skill root whose name is `SKILL.md` (case-insensitive).

Safety, per the ticket:
- No `SKILL.md` → nothing is selected and the existing empty state renders, exactly as before. No request is made for a file that doesn't exist.
- Matches the **skill root** entry explicitly rather than "first file", so `references/SKILL.md` or an alphabetically-earlier `reference.md` can't win.
- Guarded on `selectedPath` being null, so a file the user clicked is never yanked away by a refetch.

## Tests

New `skill-files-dialog.test.tsx` (first test for this component) covers: default-opens `SKILL.md`; root `SKILL.md` preferred over a nested one; no `SKILL.md` → empty state and no content fetch; a user's pick survives.

`npm run test:run` (8102 passing), `npm run typecheck`, `npm run lint` (0 errors) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
