### PR TITLE
fix: stream chunked upload assembly to avoid host OOM (SUP-518)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -454,12 +454,34 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
   CorruptFileError: class CorruptFileError extends Error {},
 }))
 
+const mockStoreUploadChunk = vi.fn()
+const mockMoveUploadedFile = vi.fn()
+vi.mock('@shared/lib/utils/chunked-upload', () => {
+  class UploadTooLargeError extends Error {
+    size: number
+    maxBytes: number
+    constructor(size: number, maxBytes: number) {
+      super(`File too large (${(size / 1024 / 1024).toFixed(1)}MB, max ${maxBytes / 1024 / 1024}MB)`)
+      this.name = 'UploadTooLargeError'
+      this.size = size
+      this.maxBytes = maxBytes
+    }
+  }
+  return {
+    MAX_UPLOAD_TOTAL_SIZE: 2 * 1024 * 1024 * 1024,
+    UploadTooLargeError,
+    storeUploadChunk: (...args: unknown[]) => mockStoreUploadChunk(...args),
+    moveUploadedFile: (...args: unknown[]) => mockMoveUploadedFile(...args),
+  }
+})
+
 vi.mock('@anthropic-ai/sdk', () => ({ default: vi.fn() }))
 const mockStreamSSE = vi.fn((..._args: unknown[]) => new Response(null, { status: 200 }))
 vi.mock('hono/streaming', () => ({ streamSSE: (...args: unknown[]) => mockStreamSSE(...args) }))
 
 // Import the agents router after all mocks are set up
 import agents from './agents'
+import { UploadTooLargeError } from '@shared/lib/utils/chunked-upload'
 import {
   importAgentFromTemplate,
   hasOnboardingSkill,
@@ -973,10 +995,7 @@ describe('POST /api/agents/import-template (chunked)', () => {
   }
 
   it('accepts intermediate chunks and returns chunk_received', async () => {
-    // Simulate first of 2 chunks — readdir returns only 1 file
-    mockFsWriteFile.mockResolvedValue(undefined)
-    mockFsMkdir.mockResolvedValue(undefined)
-    mockFsReaddir.mockResolvedValue(['chunk-0'])
+    mockStoreUploadChunk.mockResolvedValue({ status: 'received' })
 
     const form = buildChunkForm({
       chunk: 'data-part-0',
@@ -993,19 +1012,21 @@ describe('POST /api/agents/import-template (chunked)', () => {
     expect(body.status).toBe('chunk_received')
     expect(body.chunkIndex).toBe(0)
     expect(importAgentFromTemplate).not.toHaveBeenCalled()
+    expect(mockStoreUploadChunk).toHaveBeenCalledWith(
+      '11111111-1111-1111-1111-111111111111',
+      0,
+      2,
+      expect.any(Buffer),
+      500 * 1024 * 1024,
+    )
   })
 
   it('assembles and processes on final chunk', async () => {
-    mockFsWriteFile.mockResolvedValue(undefined)
-    mockFsMkdir.mockResolvedValue(undefined)
-    // readdir returns both chunks → triggers assembly
-    mockFsReaddir.mockResolvedValue(['chunk-0', 'chunk-1'])
-    // readFile for each chunk during assembly
-    mockFsReadFile.mockImplementation((filePath: string) => {
-      if (filePath.endsWith('chunk-0')) return Promise.resolve(Buffer.from('part0'))
-      if (filePath.endsWith('chunk-1')) return Promise.resolve(Buffer.from('part1'))
-      return Promise.reject(new Error('unexpected read'))
-    })
+    const assembledPath = '/mock/tmp/uploads/22222222-2222-2222-2222-222222222222.assembled'
+    mockStoreUploadChunk.mockResolvedValue({ status: 'assembled', filePath: assembledPath })
+    mockFsStat.mockResolvedValue({ size: 10 })
+    mockFsReadFile.mockResolvedValue(Buffer.from('part0part1'))
+    mockFsUnlink.mockResolvedValue(undefined)
 
     const form = buildChunkForm({
       chunk: 'data-part-1',
@@ -1021,17 +1042,19 @@ describe('POST /api/agents/import-template (chunked)', () => {
     const body = await res.json()
     expect(body.slug).toBe('imported-agent')
     expect(importAgentFromTemplate).toHaveBeenCalledWith(
-      Buffer.concat([Buffer.from('part0'), Buffer.from('part1')]),
+      Buffer.from('part0part1'),
       undefined,
       'full',
     )
+    expect(mockFsUnlink).toHaveBeenCalledWith(assembledPath)
   })
 
   it('passes name override on final chunk', async () => {
-    mockFsWriteFile.mockResolvedValue(undefined)
-    mockFsMkdir.mockResolvedValue(undefined)
-    mockFsReaddir.mockResolvedValue(['chunk-0'])
+    const assembledPath = '/mock/tmp/uploads/33333333-3333-3333-3333-333333333333.assembled'
+    mockStoreUploadChunk.mockResolvedValue({ status: 'assembled', filePath: assembledPath })
+    mockFsStat.mockResolvedValue({ size: 7 })
     mockFsReadFile.mockResolvedValue(Buffer.from('zipdata'))
+    mockFsUnlink.mockResolvedValue(undefined)
 
     const form = buildChunkForm({
       chunk: 'zipdata',
@@ -1064,6 +1087,7 @@ describe('POST /api/agents/import-template (chunked)', () => {
 
     const body = await res.json()
     expect(body.error).toContain('Invalid uploadId')
+    expect(mockStoreUploadChunk).not.toHaveBeenCalled()
   })
 
   it('rejects missing chunked upload fields', async () => {
@@ -1121,52 +1145,38 @@ describe('POST /api/agents/import-template (chunked)', () => {
 
   it('handles duplicate chunk index by overwriting and still assembles correctly', async () => {
     const uploadId = '66666666-6666-6666-6666-666666666666'
-    mockFsWriteFile.mockResolvedValue(undefined)
-    mockFsMkdir.mockResolvedValue(undefined)
+    mockStoreUploadChunk
+      .mockResolvedValueOnce({ status: 'received' })
+      .mockResolvedValueOnce({
+        status: 'assembled',
+        filePath: `/mock/tmp/uploads/${uploadId}.assembled`,
+      })
+    mockFsStat.mockResolvedValue({ size: 12 })
+    mockFsReadFile.mockResolvedValue(Buffer.from('new-datapart1'))
+    mockFsUnlink.mockResolvedValue(undefined)
 
-    // First send of chunk 0 — not all chunks present yet
-    mockFsReaddir.mockResolvedValue(['chunk-0'])
     const form1 = buildChunkForm({ chunk: 'old-data', uploadId, chunkIndex: 0, totalChunks: 2 })
     const res1 = await postFormData(app, '/api/agents/import-template', form1)
     expect(res1.status).toBe(200)
     expect((await res1.json()).status).toBe('chunk_received')
 
-    // Re-send chunk 0 with different data (duplicate), then send chunk 1 as final
-    mockFsReaddir.mockResolvedValue(['chunk-0', 'chunk-1'])
-    mockFsReadFile.mockImplementation((filePath: string) => {
-      if (filePath.endsWith('chunk-0')) return Promise.resolve(Buffer.from('new-data'))
-      if (filePath.endsWith('chunk-1')) return Promise.resolve(Buffer.from('part1'))
-      return Promise.reject(new Error('unexpected read'))
-    })
-
     const form2 = buildChunkForm({ chunk: 'part1', uploadId, chunkIndex: 1, totalChunks: 2, mode: 'template' })
     const res2 = await postFormData(app, '/api/agents/import-template', form2)
     expect(res2.status).toBe(201)
     expect(importAgentFromTemplate).toHaveBeenCalledWith(
-      Buffer.concat([Buffer.from('new-data'), Buffer.from('part1')]),
+      Buffer.from('new-datapart1'),
       undefined,
       'template',
     )
   })
 
   it('rejects when assembled compressed size exceeds limit', async () => {
-    mockFsWriteFile.mockResolvedValue(undefined)
-    mockFsMkdir.mockResolvedValue(undefined)
-    // Simulate a single chunk that, once assembled, exceeds MAX_COMPRESSED_SIZE (500MB)
-    // We can't actually allocate 500MB+ in a test, so we verify the check is in processImport
-    // by creating a buffer just over the limit via mock readFile responses
     const uploadId = '77777777-7777-7777-7777-777777777777'
-    mockFsReaddir.mockResolvedValue(['chunk-0'])
-
-    // Create a buffer that's larger than 500MB limit
-    // Instead of allocating a huge buffer, mock readFile to return a large length indicator
-    const oversizedBuffer = Buffer.alloc(100)
-    // We can't easily test with real 500MB+ buffers in unit tests, but we can verify
-    // the route correctly rejects via the processImport guard by setting up a mock
-    // that returns a buffer larger than MAX_COMPRESSED_SIZE
+    const assembledPath = `/mock/tmp/uploads/${uploadId}.assembled`
     const MAX = 500 * 1024 * 1024
-    const mockBuf = { length: MAX + 1 } as Buffer
-    mockFsReadFile.mockResolvedValue(oversizedBuffer)
+    mockStoreUploadChunk.mockResolvedValue({ status: 'assembled', filePath: assembledPath })
+    mockFsStat.mockResolvedValue({ size: MAX + 1 })
+    mockFsUnlink.mockResolvedValue(undefined)
 
     const form = buildChunkForm({
       chunk: 'data',
@@ -1175,12 +1185,43 @@ describe('POST /api/agents/import-template (chunked)', () => {
       totalChunks: 1,
     })
 
-    // For this test, we directly verify that processImport would reject
-    // We can't easily simulate >500MB in a unit test, so this is a sanity check
-    // that the route handler calls through correctly for small payloads
     const res = await postFormData(app, '/api/agents/import-template', form)
-    // The small payload will succeed (pass size check) then fail at import (mock)
-    expect(res.status).toBe(201)
+    expect(res.status).toBe(413)
+    expect(importAgentFromTemplate).not.toHaveBeenCalled()
+    expect(mockFsReadFile).not.toHaveBeenCalled()
+    expect(mockFsUnlink).toHaveBeenCalledWith(assembledPath)
+  })
+
+  it('returns 413 when storeUploadChunk throws UploadTooLargeError', async () => {
+    mockStoreUploadChunk.mockRejectedValue(new UploadTooLargeError(600 * 1024 * 1024, 500 * 1024 * 1024))
+
+    const form = buildChunkForm({
+      chunk: 'data',
+      uploadId: '88888888-8888-8888-8888-888888888888',
+      chunkIndex: 0,
+      totalChunks: 1,
+    })
+
+    const res = await postFormData(app, '/api/agents/import-template', form)
+    expect(res.status).toBe(413)
+    const body = await res.json()
+    expect(body.error).toContain('File too large')
+  })
+
+  it('rejects single-request upload when file.size exceeds limit before arrayBuffer', async () => {
+    const file = new File(['x'], 'big.zip', { type: 'application/zip' })
+    const sizeSpy = vi.spyOn(File.prototype, 'size', 'get').mockReturnValue(500 * 1024 * 1024 + 1)
+    const form = new FormData()
+    form.append('file', file)
+    form.append('mode', 'template')
+
+    try {
+      const res = await postFormData(app, '/api/agents/import-template', form)
+      expect(res.status).toBe(413)
+      expect(importAgentFromTemplate).not.toHaveBeenCalled()
+    } finally {
+      sizeSpy.mockRestore()
+    }
   })
 })
 
@@ -2868,6 +2909,53 @@ describe('file upload with relativePath — POST /:id/upload-file', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toBe('No file provided')
+  })
+
+  it('returns 413 when file.size exceeds MAX_UPLOAD_TOTAL_SIZE before reading', async () => {
+    const file = new File(['x'], 'huge.bin', { type: 'application/octet-stream' })
+    const sizeSpy = vi.spyOn(File.prototype, 'size', 'get').mockReturnValue(2 * 1024 * 1024 * 1024 + 1)
+    const formData = new FormData()
+    formData.append('file', file)
+
+    try {
+      const res = await postFormData(app, '/api/agents/test-agent/upload-file', formData)
+      expect(res.status).toBe(413)
+      expect(mockFsWriteFile).not.toHaveBeenCalled()
+    } finally {
+      sizeSpy.mockRestore()
+    }
+  })
+
+  it('moves assembled chunked upload via moveUploadedFile', async () => {
+    const assembledPath = '/mock/tmp/uploads/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.assembled'
+    mockStoreUploadChunk.mockResolvedValue({ status: 'assembled', filePath: assembledPath })
+    mockMoveUploadedFile.mockResolvedValue(11)
+    mockFsUnlink.mockResolvedValue(undefined)
+
+    const form = new FormData()
+    form.append('chunk', new File(['final'], 'chunk.bin'))
+    form.append('uploadId', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    form.append('chunkIndex', '0')
+    form.append('totalChunks', '1')
+    form.append('filename', 'report.pdf')
+
+    const res = await postFormData(app, '/api/agents/test-agent/upload-file', form)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.filename).toBe('report.pdf')
+    expect(body.size).toBe(11)
+    expect(mockMoveUploadedFile).toHaveBeenCalledWith(
+      assembledPath,
+      expect.stringContaining('/mock/workspace/uploads/'),
+    )
+    expect(mockStoreUploadChunk).toHaveBeenCalledWith(
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      0,
+      1,
+      expect.any(Buffer),
+      2 * 1024 * 1024 * 1024,
+    )
   })
 })
 
@@ -4835,6 +4923,21 @@ describe('POST /api/agents/:id/skills/import-zip', () => {
 
     const body = await res.json()
     expect(body.error).toBe('No file provided')
+  })
+
+  it('returns 413 when file.size exceeds SKILL_MAX_COMPRESSED_SIZE before reading', async () => {
+    const file = new File(['x'], 'skill.zip', { type: 'application/zip' })
+    const sizeSpy = vi.spyOn(File.prototype, 'size', 'get').mockReturnValue(100 * 1024 * 1024 + 1)
+    const form = new FormData()
+    form.append('file', file)
+
+    try {
+      const res = await postFormData(app, '/api/agents/my-agent/skills/import-zip', form)
+      expect(res.status).toBe(413)
+      expect(importSkillFromZip).not.toHaveBeenCalled()
+    } finally {
+      sizeSpy.mockRestore()
+    }
   })
 
   it('returns 500 when service throws', async () => {

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -457,11 +457,14 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
 const mockStoreUploadChunk = vi.fn()
 const mockMoveUploadedFile = vi.fn()
 vi.mock('@shared/lib/utils/chunked-upload', () => {
+  function formatUploadTooLargeMessage(size: number, maxBytes: number): string {
+    return `File too large (${(size / 1024 / 1024).toFixed(1)}MB, max ${maxBytes / 1024 / 1024}MB)`
+  }
   class UploadTooLargeError extends Error {
     size: number
     maxBytes: number
     constructor(size: number, maxBytes: number) {
-      super(`File too large (${(size / 1024 / 1024).toFixed(1)}MB, max ${maxBytes / 1024 / 1024}MB)`)
+      super(formatUploadTooLargeMessage(size, maxBytes))
       this.name = 'UploadTooLargeError'
       this.size = size
       this.maxBytes = maxBytes
@@ -469,6 +472,7 @@ vi.mock('@shared/lib/utils/chunked-upload', () => {
   }
   return {
     MAX_UPLOAD_TOTAL_SIZE: 2 * 1024 * 1024 * 1024,
+    formatUploadTooLargeMessage,
     UploadTooLargeError,
     storeUploadChunk: (...args: unknown[]) => mockStoreUploadChunk(...args),
     moveUploadedFile: (...args: unknown[]) => mockMoveUploadedFile(...args),

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -472,6 +472,7 @@ vi.mock('@shared/lib/utils/chunked-upload', () => {
     UploadTooLargeError,
     storeUploadChunk: (...args: unknown[]) => mockStoreUploadChunk(...args),
     moveUploadedFile: (...args: unknown[]) => mockMoveUploadedFile(...args),
+    cleanupStaleTempUploads: vi.fn(async () => undefined),
   }
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -4617,12 +4617,13 @@ async function handleChunkedFileUpload(c: Context, agentSlug: string, formData: 
       await fs.promises.unlink(result.filePath)
     } catch (err) {
       // rename may have already moved the file
-      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return
-      console.warn('[agents] failed to unlink assembled file upload:', err)
-      captureException(err, {
-        tags: { component: 'agents', operation: 'unlink-assembled-upload' },
-        extra: { filePath: result.filePath, agentSlug },
-      })
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        console.warn('[agents] failed to unlink assembled file upload:', err)
+        captureException(err, {
+          tags: { component: 'agents', operation: 'unlink-assembled-upload' },
+          extra: { filePath: result.filePath, agentSlug },
+        })
+      }
     }
   }
 }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -61,6 +61,7 @@ import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
   cleanupStaleTempUploads,
+  formatUploadTooLargeMessage,
   moveUploadedFile,
   storeUploadChunk,
 } from '@shared/lib/utils/chunked-upload'
@@ -582,10 +583,6 @@ agents.use('*', Authenticated())
 // (paths like /import-template would otherwise match as :id)
 // ============================================================
 
-function tooLargeMessage(size: number, maxBytes: number): string {
-  return `File too large (${(size / 1024 / 1024).toFixed(1)}MB, max ${maxBytes / 1024 / 1024}MB)`
-}
-
 // POST /api/agents/import-template - Import agent from uploaded ZIP
 // Supports both single-request (file field) and chunked upload (chunk field)
 agents.post('/import-template', async (c) => {
@@ -605,7 +602,7 @@ agents.post('/import-template', async (c) => {
     }
 
     if (file.size > MAX_COMPRESSED_SIZE) {
-      return c.json({ error: tooLargeMessage(file.size, MAX_COMPRESSED_SIZE) }, 413)
+      return c.json({ error: formatUploadTooLargeMessage(file.size, MAX_COMPRESSED_SIZE) }, 413)
     }
 
     const arrayBuffer = await file.arrayBuffer()
@@ -670,18 +667,27 @@ async function handleChunkedImport(c: Context, formData: FormData, chunk: File) 
   try {
     const size = (await fs.promises.stat(result.filePath)).size
     if (size > MAX_COMPRESSED_SIZE) {
-      return c.json({ error: tooLargeMessage(size, MAX_COMPRESSED_SIZE) }, 413)
+      return c.json({ error: formatUploadTooLargeMessage(size, MAX_COMPRESSED_SIZE) }, 413)
     }
     const zipBuffer = await fs.promises.readFile(result.filePath)
     return await processImport(c, zipBuffer, formData)
   } finally {
-    try { await fs.promises.unlink(result.filePath) } catch { /* ignore */ }
+    try {
+      await fs.promises.unlink(result.filePath)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return
+      console.warn('[agents] failed to unlink assembled import upload:', err)
+      captureException(err, {
+        tags: { component: 'agents', operation: 'unlink-assembled-import' },
+        extra: { filePath: result.filePath },
+      })
+    }
   }
 }
 
 async function processImport(c: Context, zipBuffer: Buffer, formData: FormData) {
   if (zipBuffer.length > MAX_COMPRESSED_SIZE) {
-    return c.json({ error: tooLargeMessage(zipBuffer.length, MAX_COMPRESSED_SIZE) }, 413)
+    return c.json({ error: formatUploadTooLargeMessage(zipBuffer.length, MAX_COMPRESSED_SIZE) }, 413)
   }
 
   const nameOverride = formData.get('name') as string | null
@@ -4340,14 +4346,14 @@ agents.post('/:id/skills/import-zip', AgentAdmin(), async (c) => {
     }
 
     if (file.size > SKILL_MAX_COMPRESSED_SIZE) {
-      return c.json({ error: tooLargeMessage(file.size, SKILL_MAX_COMPRESSED_SIZE) }, 413)
+      return c.json({ error: formatUploadTooLargeMessage(file.size, SKILL_MAX_COMPRESSED_SIZE) }, 413)
     }
 
     const arrayBuffer = await file.arrayBuffer()
     const zipBuffer = Buffer.from(arrayBuffer)
 
     if (zipBuffer.length > SKILL_MAX_COMPRESSED_SIZE) {
-      return c.json({ error: tooLargeMessage(zipBuffer.length, SKILL_MAX_COMPRESSED_SIZE) }, 413)
+      return c.json({ error: formatUploadTooLargeMessage(zipBuffer.length, SKILL_MAX_COMPRESSED_SIZE) }, 413)
     }
 
     const result = await importSkillFromZip(agentSlug, zipBuffer)
@@ -4607,7 +4613,17 @@ async function handleChunkedFileUpload(c: Context, agentSlug: string, formData: 
     const uploadResult = await writeUploadedFileFromPath(agentSlug, filename, result.filePath, relativePath || undefined)
     return { pending: null, uploadResult }
   } finally {
-    try { await fs.promises.unlink(result.filePath) } catch { /* rename may have moved it */ }
+    try {
+      await fs.promises.unlink(result.filePath)
+    } catch (err) {
+      // rename may have already moved the file
+      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return
+      console.warn('[agents] failed to unlink assembled file upload:', err)
+      captureException(err, {
+        tags: { component: 'agents', operation: 'unlink-assembled-upload' },
+        extra: { filePath: result.filePath, agentSlug },
+      })
+    }
   }
 }
 
@@ -5577,8 +5593,9 @@ const STALE_UPLOAD_MS = 60 * 60 * 1000 // 1 hour
 async function cleanupStaleUploads() {
   try {
     await cleanupStaleTempUploads(STALE_UPLOAD_MS)
-  } catch {
-    // Ignore cleanup errors
+  } catch (err) {
+    console.warn('[agents] stale upload cleanup failed:', err)
+    captureException(err, { tags: { component: 'agents', operation: 'cleanup-stale-uploads' } })
   }
 }
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -56,7 +56,14 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, getTempUploadsDir, ensureDirectory, removeDirectory, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
+import {
+  MAX_UPLOAD_TOTAL_SIZE,
+  UploadTooLargeError,
+  cleanupStaleTempUploads,
+  moveUploadedFile,
+  storeUploadChunk,
+} from '@shared/lib/utils/chunked-upload'
 import { getMountsWithHealth, addMount, removeMount } from '@shared/lib/services/mount-service'
 import { readAgentHooks, removeAgentHook } from '@shared/lib/services/agent-hooks-service'
 import { removeAgentHookSchema } from '@shared/lib/services/agent-hooks-schema'
@@ -575,6 +582,10 @@ agents.use('*', Authenticated())
 // (paths like /import-template would otherwise match as :id)
 // ============================================================
 
+function tooLargeMessage(size: number, maxBytes: number): string {
+  return `File too large (${(size / 1024 / 1024).toFixed(1)}MB, max ${maxBytes / 1024 / 1024}MB)`
+}
+
 // POST /api/agents/import-template - Import agent from uploaded ZIP
 // Supports both single-request (file field) and chunked upload (chunk field)
 agents.post('/import-template', async (c) => {
@@ -593,11 +604,18 @@ agents.post('/import-template', async (c) => {
       return c.json({ error: 'No file or chunk provided' }, 400)
     }
 
+    if (file.size > MAX_COMPRESSED_SIZE) {
+      return c.json({ error: tooLargeMessage(file.size, MAX_COMPRESSED_SIZE) }, 413)
+    }
+
     const arrayBuffer = await file.arrayBuffer()
     const zipBuffer = Buffer.from(arrayBuffer)
 
     return await processImport(c, zipBuffer, formData)
   } catch (error) {
+    if (error instanceof UploadTooLargeError) {
+      return c.json({ error: error.message }, 413)
+    }
     const message = error instanceof Error ? error.message : 'Failed to import template'
     console.error('Failed to import template:', error)
     captureException(error, { tags: { component: 'agents', operation: 'import-template' } })
@@ -633,56 +651,37 @@ function parseChunkFields(formData: FormData): ParsedChunkFields {
   return { ok: true, uploadId, chunkIndex, totalChunks }
 }
 
-type StoreChunkResult = { status: 'received' } | { status: 'assembled'; buffer: Buffer }
-
-// Persist one chunk; assemble once all arrive (`.assembling` lock prevents double assembly).
-// TODO(upload-memory): cap total size before reading; stream to disk instead of Buffer.concat.
-async function storeUploadChunk(uploadId: string, chunkIndex: number, totalChunks: number, chunk: Buffer): Promise<StoreChunkResult> {
-  const uploadDir = path.join(getTempUploadsDir(), uploadId)
-  await ensureDirectory(uploadDir)
-
-  await fs.promises.writeFile(path.join(uploadDir, `chunk-${chunkIndex}`), chunk)
-
-  const files = await fs.promises.readdir(uploadDir)
-  const chunkFiles = files.filter((f) => f.startsWith('chunk-'))
-  if (chunkFiles.length < totalChunks) {
-    return { status: 'received' }
-  }
-
-  const lockPath = path.join(uploadDir, '.assembling')
-  try {
-    await fs.promises.writeFile(lockPath, '', { flag: 'wx' }) // fails if already exists
-  } catch {
-    return { status: 'received' }
-  }
-
-  try {
-    const buffers: Buffer[] = []
-    for (let i = 0; i < totalChunks; i++) {
-      buffers.push(await fs.promises.readFile(path.join(uploadDir, `chunk-${i}`)))
-    }
-    return { status: 'assembled', buffer: Buffer.concat(buffers) }
-  } finally {
-    try { await removeDirectory(uploadDir) } catch { /* ignore cleanup errors */ }
-  }
-}
-
 async function handleChunkedImport(c: Context, formData: FormData, chunk: File) {
   const parsed = parseChunkFields(formData)
   if (!parsed.ok) return c.json({ error: parsed.error }, 400)
 
-  const result = await storeUploadChunk(parsed.uploadId, parsed.chunkIndex, parsed.totalChunks, Buffer.from(await chunk.arrayBuffer()))
+  const result = await storeUploadChunk(
+    parsed.uploadId,
+    parsed.chunkIndex,
+    parsed.totalChunks,
+    Buffer.from(await chunk.arrayBuffer()),
+    MAX_COMPRESSED_SIZE,
+  )
 
   if (result.status === 'received') {
     return c.json({ status: 'chunk_received', chunkIndex: parsed.chunkIndex })
   }
 
-  return await processImport(c, result.buffer, formData)
+  try {
+    const size = (await fs.promises.stat(result.filePath)).size
+    if (size > MAX_COMPRESSED_SIZE) {
+      return c.json({ error: tooLargeMessage(size, MAX_COMPRESSED_SIZE) }, 413)
+    }
+    const zipBuffer = await fs.promises.readFile(result.filePath)
+    return await processImport(c, zipBuffer, formData)
+  } finally {
+    try { await fs.promises.unlink(result.filePath) } catch { /* ignore */ }
+  }
 }
 
 async function processImport(c: Context, zipBuffer: Buffer, formData: FormData) {
   if (zipBuffer.length > MAX_COMPRESSED_SIZE) {
-    return c.json({ error: `File too large (${(zipBuffer.length / 1024 / 1024).toFixed(1)}MB, max ${MAX_COMPRESSED_SIZE / 1024 / 1024}MB)` }, 413)
+    return c.json({ error: tooLargeMessage(zipBuffer.length, MAX_COMPRESSED_SIZE) }, 413)
   }
 
   const nameOverride = formData.get('name') as string | null
@@ -4340,11 +4339,15 @@ agents.post('/:id/skills/import-zip', AgentAdmin(), async (c) => {
       return c.json({ error: 'No file provided' }, 400)
     }
 
+    if (file.size > SKILL_MAX_COMPRESSED_SIZE) {
+      return c.json({ error: tooLargeMessage(file.size, SKILL_MAX_COMPRESSED_SIZE) }, 413)
+    }
+
     const arrayBuffer = await file.arrayBuffer()
     const zipBuffer = Buffer.from(arrayBuffer)
 
     if (zipBuffer.length > SKILL_MAX_COMPRESSED_SIZE) {
-      return c.json({ error: `File too large (${(zipBuffer.length / 1024 / 1024).toFixed(1)}MB, max ${SKILL_MAX_COMPRESSED_SIZE / 1024 / 1024}MB)` }, 413)
+      return c.json({ error: tooLargeMessage(zipBuffer.length, SKILL_MAX_COMPRESSED_SIZE) }, 413)
     }
 
     const result = await importSkillFromZip(agentSlug, zipBuffer)
@@ -4513,8 +4516,7 @@ agents.get('/:id/audit-log', AgentAdmin(), async (c) => {
   }
 })
 
-// Shared upload logic - writes a buffer to the agent workspace
-async function writeUploadedFile(agentSlug: string, filename: string, buffer: Buffer, relativePath?: string) {
+function resolveUploadDestPath(agentSlug: string, filename: string, relativePath?: string) {
   // If relativePath is provided (folder upload), preserve directory structure
   let uploadPath: string
   if (relativePath) {
@@ -4535,6 +4537,13 @@ async function writeUploadedFile(agentSlug: string, filename: string, buffer: Bu
     throw new Error('Invalid file path')
   }
 
+  return { uploadPath, fullPath }
+}
+
+// Shared upload logic - writes a buffer to the agent workspace
+async function writeUploadedFile(agentSlug: string, filename: string, buffer: Buffer, relativePath?: string) {
+  const { uploadPath, fullPath } = resolveUploadDestPath(agentSlug, filename, relativePath)
+
   // Write directly to host filesystem (volume-mounted into container)
   await fs.promises.mkdir(path.dirname(fullPath), { recursive: true })
   await fs.promises.writeFile(fullPath, buffer)
@@ -4547,14 +4556,28 @@ async function writeUploadedFile(agentSlug: string, filename: string, buffer: Bu
   }
 }
 
+async function writeUploadedFileFromPath(agentSlug: string, filename: string, srcPath: string, relativePath?: string) {
+  const { uploadPath, fullPath } = resolveUploadDestPath(agentSlug, filename, relativePath)
+  const size = await moveUploadedFile(srcPath, fullPath)
+  return {
+    success: true,
+    path: `/workspace/${uploadPath}`,
+    filename,
+    size,
+  }
+}
+
 async function handleFileUpload(agentSlug: string, file: File, relativePath?: string) {
+  if (file.size > MAX_UPLOAD_TOTAL_SIZE) {
+    throw new UploadTooLargeError(file.size, MAX_UPLOAD_TOTAL_SIZE)
+  }
   const buffer = Buffer.from(await file.arrayBuffer())
   return writeUploadedFile(agentSlug, file.name, buffer, relativePath)
 }
 
 // Shared by both upload-file routes. When a `chunk` field is present, persist it
 // and only write the final file once every chunk has arrived. Returns
-// `{ pending }` (a Response to return immediately — either a 400 or the interim
+// `{ pending }` (a Response to return immediately — either a 400/413 or the interim
 // `chunk_received` ack) or `{ uploadResult }` once the file is fully assembled.
 type ChunkedFileUploadOutcome = {
   pending: Response | null
@@ -4568,14 +4591,24 @@ async function handleChunkedFileUpload(c: Context, agentSlug: string, formData: 
   const filename = (formData.get('filename') as string | null) || 'upload'
   const relativePath = formData.get('relativePath') as string | null
 
-  const result = await storeUploadChunk(parsed.uploadId, parsed.chunkIndex, parsed.totalChunks, Buffer.from(await chunk.arrayBuffer()))
+  const result = await storeUploadChunk(
+    parsed.uploadId,
+    parsed.chunkIndex,
+    parsed.totalChunks,
+    Buffer.from(await chunk.arrayBuffer()),
+    MAX_UPLOAD_TOTAL_SIZE,
+  )
 
   if (result.status === 'received') {
     return { pending: c.json({ status: 'chunk_received', chunkIndex: parsed.chunkIndex }) }
   }
 
-  const uploadResult = await writeUploadedFile(agentSlug, filename, result.buffer, relativePath || undefined)
-  return { pending: null, uploadResult }
+  try {
+    const uploadResult = await writeUploadedFileFromPath(agentSlug, filename, result.filePath, relativePath || undefined)
+    return { pending: null, uploadResult }
+  } finally {
+    try { await fs.promises.unlink(result.filePath) } catch { /* rename may have moved it */ }
+  }
 }
 
 // Shared handler for both agent-level and session-level upload-file routes.
@@ -4607,6 +4640,9 @@ async function respondUploadFile(c: Context) {
     logAuditEvent({ userId: getCurrentUserId(c), object: 'file', objectId: `${agentSlug}/${result.filename}`, action: 'uploaded' })
     return c.json(result)
   } catch (error) {
+    if (error instanceof UploadTooLargeError) {
+      return c.json({ error: error.message }, 413)
+    }
     console.error('Failed to upload file:', error)
     captureException(error, { tags: { component: 'agents', operation: 'upload-file' }, extra: { agentSlug: getAgentId(c) } })
     return c.json({ error: 'Failed to upload file' }, 500)
@@ -5540,17 +5576,7 @@ const STALE_UPLOAD_MS = 60 * 60 * 1000 // 1 hour
 
 async function cleanupStaleUploads() {
   try {
-    const uploadsDir = getTempUploadsDir()
-    const entries = await fs.promises.readdir(uploadsDir, { withFileTypes: true }).catch(() => [])
-    const now = Date.now()
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue
-      const dirPath = path.join(uploadsDir, entry.name)
-      const stat = await fs.promises.stat(dirPath).catch(() => null)
-      if (stat && now - stat.mtimeMs > STALE_UPLOAD_MS) {
-        await removeDirectory(dirPath).catch(() => {})
-      }
-    }
+    await cleanupStaleTempUploads(STALE_UPLOAD_MS)
   } catch {
     // Ignore cleanup errors
   }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -675,12 +675,13 @@ async function handleChunkedImport(c: Context, formData: FormData, chunk: File) 
     try {
       await fs.promises.unlink(result.filePath)
     } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return
-      console.warn('[agents] failed to unlink assembled import upload:', err)
-      captureException(err, {
-        tags: { component: 'agents', operation: 'unlink-assembled-import' },
-        extra: { filePath: result.filePath },
-      })
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        console.warn('[agents] failed to unlink assembled import upload:', err)
+        captureException(err, {
+          tags: { component: 'agents', operation: 'unlink-assembled-import' },
+          extra: { filePath: result.filePath },
+        })
+      }
     }
   }
 }

--- a/src/shared/lib/utils/chunked-upload.test.ts
+++ b/src/shared/lib/utils/chunked-upload.test.ts
@@ -6,9 +6,14 @@ import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
   cleanupStaleTempUploads,
+  formatUploadTooLargeMessage,
   moveUploadedFile,
   storeUploadChunk,
 } from './chunked-upload'
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+}))
 
 const tmpRoot = path.join(os.tmpdir(), `chunked-upload-${process.pid}-${Date.now()}`)
 const tempUploadsDir = path.join(tmpRoot, 'tmp', 'uploads')
@@ -151,6 +156,14 @@ describe('cleanupStaleTempUploads', () => {
     expect(fs.existsSync(staleAssembled)).toBe(false)
     expect(fs.existsSync(freshDir)).toBe(true)
     expect(fs.existsSync(freshAssembled)).toBe(true)
+  })
+})
+
+describe('formatUploadTooLargeMessage', () => {
+  it('matches UploadTooLargeError message', () => {
+    const message = formatUploadTooLargeMessage(150 * 1024 * 1024, 100 * 1024 * 1024)
+    expect(message).toBe('File too large (150.0MB, max 100MB)')
+    expect(new UploadTooLargeError(150 * 1024 * 1024, 100 * 1024 * 1024).message).toBe(message)
   })
 })
 

--- a/src/shared/lib/utils/chunked-upload.test.ts
+++ b/src/shared/lib/utils/chunked-upload.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  MAX_UPLOAD_TOTAL_SIZE,
+  UploadTooLargeError,
+  cleanupStaleTempUploads,
+  moveUploadedFile,
+  storeUploadChunk,
+} from './chunked-upload'
+
+const tmpRoot = path.join(os.tmpdir(), `chunked-upload-${process.pid}-${Date.now()}`)
+const tempUploadsDir = path.join(tmpRoot, 'tmp', 'uploads')
+
+vi.mock('./file-storage', async () => {
+  const actual = await vi.importActual<typeof import('./file-storage')>('./file-storage')
+  return {
+    ...actual,
+    getTempUploadsDir: () => tempUploadsDir,
+  }
+})
+
+describe('storeUploadChunk', () => {
+  beforeEach(async () => {
+    await fs.promises.mkdir(tempUploadsDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('returns received until all chunks arrive', async () => {
+    const uploadId = '11111111-1111-1111-1111-111111111111'
+    const r0 = await storeUploadChunk(uploadId, 0, 2, Buffer.from('aa'))
+    expect(r0).toEqual({ status: 'received' })
+    expect(fs.existsSync(path.join(tempUploadsDir, uploadId, 'chunk-0'))).toBe(true)
+  })
+
+  it('streams chunks to an assembled temp file without reading chunk files whole', async () => {
+    const uploadId = '22222222-2222-2222-2222-222222222222'
+    const readFileSpy = vi.spyOn(fs.promises, 'readFile')
+
+    await storeUploadChunk(uploadId, 0, 2, Buffer.from('hello '))
+    const result = await storeUploadChunk(uploadId, 1, 2, Buffer.from('world'))
+
+    expect(result.status).toBe('assembled')
+    if (result.status !== 'assembled') return
+
+    expect(readFileSpy).not.toHaveBeenCalled()
+    readFileSpy.mockRestore()
+
+    const assembled = await fs.promises.readFile(result.filePath)
+    expect(assembled.toString()).toBe('hello world')
+    expect(fs.existsSync(path.join(tempUploadsDir, uploadId))).toBe(false)
+
+    await fs.promises.unlink(result.filePath)
+  })
+
+  it('rejects when projected size exceeds maxTotalBytes and cleans the upload dir', async () => {
+    const uploadId = '33333333-3333-3333-3333-333333333333'
+    await storeUploadChunk(uploadId, 0, 2, Buffer.from('0123456789'), 15)
+
+    await expect(storeUploadChunk(uploadId, 1, 2, Buffer.from('0123456789'), 15)).rejects.toBeInstanceOf(
+      UploadTooLargeError,
+    )
+    expect(fs.existsSync(path.join(tempUploadsDir, uploadId))).toBe(false)
+  })
+
+  it('accounts for overwriting an existing chunk index when capping', async () => {
+    const uploadId = '44444444-4444-4444-4444-444444444444'
+    await storeUploadChunk(uploadId, 0, 2, Buffer.from('aaaa'), 10)
+    // Overwrite chunk-0 with same size — still under cap
+    const r = await storeUploadChunk(uploadId, 0, 2, Buffer.from('bbbb'), 10)
+    expect(r.status).toBe('received')
+
+    const assembled = await storeUploadChunk(uploadId, 1, 2, Buffer.from('cc'), 10)
+    expect(assembled.status).toBe('assembled')
+    if (assembled.status === 'assembled') {
+      expect(await fs.promises.readFile(assembled.filePath, 'utf8')).toBe('bbbbcc')
+      await fs.promises.unlink(assembled.filePath)
+    }
+  })
+})
+
+describe('moveUploadedFile', () => {
+  beforeEach(async () => {
+    await fs.promises.mkdir(tmpRoot, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('renames when source and dest share a filesystem', async () => {
+    const src = path.join(tmpRoot, 'src.bin')
+    const dest = path.join(tmpRoot, 'dest', 'out.bin')
+    await fs.promises.writeFile(src, 'payload')
+
+    const size = await moveUploadedFile(src, dest)
+    expect(size).toBe(7)
+    expect(await fs.promises.readFile(dest, 'utf8')).toBe('payload')
+    expect(fs.existsSync(src)).toBe(false)
+  })
+
+  it('falls back to stream copy on EXDEV', async () => {
+    const src = path.join(tmpRoot, 'exdev-src.bin')
+    const dest = path.join(tmpRoot, 'exdev-dest', 'out.bin')
+    await fs.promises.writeFile(src, 'cross-device')
+
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockRejectedValueOnce(
+      Object.assign(new Error('cross-device'), { code: 'EXDEV' }),
+    )
+
+    const size = await moveUploadedFile(src, dest)
+    expect(size).toBe(Buffer.byteLength('cross-device'))
+    expect(await fs.promises.readFile(dest, 'utf8')).toBe('cross-device')
+    expect(fs.existsSync(src)).toBe(false)
+    renameSpy.mockRestore()
+  })
+})
+
+describe('cleanupStaleTempUploads', () => {
+  beforeEach(async () => {
+    await fs.promises.mkdir(tempUploadsDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('removes stale chunk dirs and orphaned .assembled files', async () => {
+    const staleDir = path.join(tempUploadsDir, '11111111-1111-1111-1111-111111111111')
+    const freshDir = path.join(tempUploadsDir, '22222222-2222-2222-2222-222222222222')
+    const staleAssembled = path.join(tempUploadsDir, '33333333-3333-3333-3333-333333333333.assembled')
+    const freshAssembled = path.join(tempUploadsDir, '44444444-4444-4444-4444-444444444444.assembled')
+
+    await fs.promises.mkdir(staleDir)
+    await fs.promises.mkdir(freshDir)
+    await fs.promises.writeFile(staleAssembled, 'orphan')
+    await fs.promises.writeFile(freshAssembled, 'in-flight')
+
+    const now = Date.now()
+    const old = new Date(now - 2 * 60 * 60 * 1000)
+    await fs.promises.utimes(staleDir, old, old)
+    await fs.promises.utimes(staleAssembled, old, old)
+
+    await cleanupStaleTempUploads(60 * 60 * 1000, now)
+
+    expect(fs.existsSync(staleDir)).toBe(false)
+    expect(fs.existsSync(staleAssembled)).toBe(false)
+    expect(fs.existsSync(freshDir)).toBe(true)
+    expect(fs.existsSync(freshAssembled)).toBe(true)
+  })
+})
+
+describe('MAX_UPLOAD_TOTAL_SIZE', () => {
+  it('is 2 GiB', () => {
+    expect(MAX_UPLOAD_TOTAL_SIZE).toBe(2 * 1024 * 1024 * 1024)
+  })
+})

--- a/src/shared/lib/utils/chunked-upload.ts
+++ b/src/shared/lib/utils/chunked-upload.ts
@@ -1,10 +1,15 @@
 import * as fs from 'fs'
 import path from 'path'
 import { pipeline } from 'stream/promises'
+import { captureException } from '@shared/lib/error-reporting'
 import { ensureDirectory, getTempUploadsDir, removeDirectory } from './file-storage'
 
 // Workspace chat/file uploads. Streaming assembly keeps RAM O(chunk); this caps disk.
 export const MAX_UPLOAD_TOTAL_SIZE = 2 * 1024 * 1024 * 1024
+
+export function formatUploadTooLargeMessage(size: number, maxBytes: number): string {
+  return `File too large (${(size / 1024 / 1024).toFixed(1)}MB, max ${maxBytes / 1024 / 1024}MB)`
+}
 
 // Throw from storeUploadChunk so routes can map to HTTP 413 without reading bytes.
 export class UploadTooLargeError extends Error {
@@ -12,7 +17,7 @@ export class UploadTooLargeError extends Error {
   readonly maxBytes: number
 
   constructor(size: number, maxBytes: number) {
-    super(`File too large (${(size / 1024 / 1024).toFixed(1)}MB, max ${maxBytes / 1024 / 1024}MB)`)
+    super(formatUploadTooLargeMessage(size, maxBytes))
     this.name = 'UploadTooLargeError'
     this.size = size
     this.maxBytes = maxBytes
@@ -23,6 +28,13 @@ export type StoreChunkResult =
   | { status: 'received' }
   | { status: 'assembled'; filePath: string }
 
+function ignoreCleanupError(err: unknown, op: string, extra?: Record<string, unknown>): void {
+  if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return
+  console.warn(`[chunked-upload] ${op} failed:`, err)
+  captureException(err, { tags: { area: 'chunked-upload', op }, extra })
+}
+
+// O(chunks) per call; fine while totalChunks is capped at 200 by parseChunkFields.
 async function sumChunkBytes(uploadDir: string, chunkIndexToReplace?: number): Promise<{ total: number; replaced: number }> {
   let total = 0
   let replaced = 0
@@ -60,7 +72,11 @@ export async function storeUploadChunk(
     const { total, replaced } = await sumChunkBytes(uploadDir, chunkIndex)
     const projected = total - replaced + chunk.byteLength
     if (projected > maxTotalBytes) {
-      try { await removeDirectory(uploadDir) } catch { /* ignore cleanup errors */ }
+      try {
+        await removeDirectory(uploadDir)
+      } catch (err) {
+        ignoreCleanupError(err, 'remove-oversized-upload-dir', { uploadId })
+      }
       throw new UploadTooLargeError(projected, maxTotalBytes)
     }
   }
@@ -90,10 +106,18 @@ export async function storeUploadChunk(
     }
     return { status: 'assembled', filePath: assembledPath }
   } catch (err) {
-    try { await fs.promises.unlink(assembledPath) } catch { /* ignore */ }
+    try {
+      await fs.promises.unlink(assembledPath)
+    } catch (cleanupErr) {
+      ignoreCleanupError(cleanupErr, 'unlink-partial-assembled', { uploadId })
+    }
     throw err
   } finally {
-    try { await removeDirectory(uploadDir) } catch { /* ignore cleanup errors */ }
+    try {
+      await removeDirectory(uploadDir)
+    } catch (err) {
+      ignoreCleanupError(err, 'remove-chunk-dir-after-assemble', { uploadId })
+    }
   }
 }
 
@@ -105,7 +129,11 @@ export async function moveUploadedFile(srcPath: string, destPath: string): Promi
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err
     await pipeline(fs.createReadStream(srcPath), fs.createWriteStream(destPath))
-    try { await fs.promises.unlink(srcPath) } catch { /* ignore */ }
+    try {
+      await fs.promises.unlink(srcPath)
+    } catch (cleanupErr) {
+      ignoreCleanupError(cleanupErr, 'unlink-src-after-exdev-copy', { srcPath, destPath })
+    }
   }
   return (await fs.promises.stat(destPath)).size
 }
@@ -113,15 +141,36 @@ export async function moveUploadedFile(srcPath: string, destPath: string): Promi
 // Remove stale chunk dirs and orphaned `.assembled` files (crash between assemble and consume).
 export async function cleanupStaleTempUploads(maxAgeMs: number, nowMs: number = Date.now()): Promise<void> {
   const uploadsDir = getTempUploadsDir()
-  const entries = await fs.promises.readdir(uploadsDir, { withFileTypes: true }).catch(() => [])
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(uploadsDir, { withFileTypes: true })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return
+    ignoreCleanupError(err, 'readdir-temp-uploads', { uploadsDir })
+    return
+  }
   for (const entry of entries) {
     const entryPath = path.join(uploadsDir, entry.name)
-    const stat = await fs.promises.stat(entryPath).catch(() => null)
-    if (!stat || nowMs - stat.mtimeMs <= maxAgeMs) continue
+    let stat: fs.Stats
+    try {
+      stat = await fs.promises.stat(entryPath)
+    } catch (err) {
+      ignoreCleanupError(err, 'stat-temp-upload-entry', { entryPath })
+      continue
+    }
+    if (nowMs - stat.mtimeMs <= maxAgeMs) continue
     if (entry.isDirectory()) {
-      await removeDirectory(entryPath).catch(() => {})
+      try {
+        await removeDirectory(entryPath)
+      } catch (err) {
+        ignoreCleanupError(err, 'remove-stale-upload-dir', { entryPath })
+      }
     } else {
-      await fs.promises.unlink(entryPath).catch(() => {})
+      try {
+        await fs.promises.unlink(entryPath)
+      } catch (err) {
+        ignoreCleanupError(err, 'unlink-stale-assembled', { entryPath })
+      }
     }
   }
 }

--- a/src/shared/lib/utils/chunked-upload.ts
+++ b/src/shared/lib/utils/chunked-upload.ts
@@ -1,0 +1,127 @@
+import * as fs from 'fs'
+import path from 'path'
+import { pipeline } from 'stream/promises'
+import { ensureDirectory, getTempUploadsDir, removeDirectory } from './file-storage'
+
+// Workspace chat/file uploads. Streaming assembly keeps RAM O(chunk); this caps disk.
+export const MAX_UPLOAD_TOTAL_SIZE = 2 * 1024 * 1024 * 1024
+
+// Throw from storeUploadChunk so routes can map to HTTP 413 without reading bytes.
+export class UploadTooLargeError extends Error {
+  readonly size: number
+  readonly maxBytes: number
+
+  constructor(size: number, maxBytes: number) {
+    super(`File too large (${(size / 1024 / 1024).toFixed(1)}MB, max ${maxBytes / 1024 / 1024}MB)`)
+    this.name = 'UploadTooLargeError'
+    this.size = size
+    this.maxBytes = maxBytes
+  }
+}
+
+export type StoreChunkResult =
+  | { status: 'received' }
+  | { status: 'assembled'; filePath: string }
+
+async function sumChunkBytes(uploadDir: string, chunkIndexToReplace?: number): Promise<{ total: number; replaced: number }> {
+  let total = 0
+  let replaced = 0
+  let entries: string[]
+  try {
+    entries = await fs.promises.readdir(uploadDir)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { total: 0, replaced: 0 }
+    throw err
+  }
+  for (const name of entries) {
+    if (!name.startsWith('chunk-')) continue
+    const size = (await fs.promises.stat(path.join(uploadDir, name))).size
+    total += size
+    if (chunkIndexToReplace !== undefined && name === `chunk-${chunkIndexToReplace}`) {
+      replaced = size
+    }
+  }
+  return { total, replaced }
+}
+
+// Persist one chunk; stream-assemble to a temp file once all arrive.
+// Caller owns deleting the assembled filePath after consuming it.
+export async function storeUploadChunk(
+  uploadId: string,
+  chunkIndex: number,
+  totalChunks: number,
+  chunk: Buffer,
+  maxTotalBytes?: number,
+): Promise<StoreChunkResult> {
+  const uploadDir = path.join(getTempUploadsDir(), uploadId)
+  await ensureDirectory(uploadDir)
+
+  if (maxTotalBytes !== undefined) {
+    const { total, replaced } = await sumChunkBytes(uploadDir, chunkIndex)
+    const projected = total - replaced + chunk.byteLength
+    if (projected > maxTotalBytes) {
+      try { await removeDirectory(uploadDir) } catch { /* ignore cleanup errors */ }
+      throw new UploadTooLargeError(projected, maxTotalBytes)
+    }
+  }
+
+  await fs.promises.writeFile(path.join(uploadDir, `chunk-${chunkIndex}`), chunk)
+
+  const files = await fs.promises.readdir(uploadDir)
+  const chunkFiles = files.filter((f) => f.startsWith('chunk-'))
+  if (chunkFiles.length < totalChunks) {
+    return { status: 'received' }
+  }
+
+  const lockPath = path.join(uploadDir, '.assembling')
+  try {
+    await fs.promises.writeFile(lockPath, '', { flag: 'wx' })
+  } catch {
+    return { status: 'received' }
+  }
+
+  const assembledPath = path.join(getTempUploadsDir(), `${uploadId}.assembled`)
+  try {
+    for (let i = 0; i < totalChunks; i++) {
+      await pipeline(
+        fs.createReadStream(path.join(uploadDir, `chunk-${i}`)),
+        fs.createWriteStream(assembledPath, { flags: i === 0 ? 'w' : 'a' }),
+      )
+    }
+    return { status: 'assembled', filePath: assembledPath }
+  } catch (err) {
+    try { await fs.promises.unlink(assembledPath) } catch { /* ignore */ }
+    throw err
+  } finally {
+    try { await removeDirectory(uploadDir) } catch { /* ignore cleanup errors */ }
+  }
+}
+
+// Move an assembled temp file into dest; stream-copy on cross-device rename failure.
+export async function moveUploadedFile(srcPath: string, destPath: string): Promise<number> {
+  await fs.promises.mkdir(path.dirname(destPath), { recursive: true })
+  try {
+    await fs.promises.rename(srcPath, destPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err
+    await pipeline(fs.createReadStream(srcPath), fs.createWriteStream(destPath))
+    try { await fs.promises.unlink(srcPath) } catch { /* ignore */ }
+  }
+  return (await fs.promises.stat(destPath)).size
+}
+
+// Remove stale chunk dirs and orphaned `.assembled` files (crash between assemble and consume).
+export async function cleanupStaleTempUploads(maxAgeMs: number, nowMs: number = Date.now()): Promise<void> {
+  const uploadsDir = getTempUploadsDir()
+  const entries = await fs.promises.readdir(uploadsDir, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    const entryPath = path.join(uploadsDir, entry.name)
+    const stat = await fs.promises.stat(entryPath).catch(() => null)
+    if (!stat || nowMs - stat.mtimeMs <= maxAgeMs) continue
+    if (entry.isDirectory()) {
+      await removeDirectory(entryPath).catch(() => {})
+    } else {
+      await fs.promises.unlink(entryPath).catch(() => {})
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes [SUP-518](https://linear.app/datawizz/issue/SUP-518/host-oom-on-large-file-upload-reassemble-chunks-with-bufferconcat): chunked uploads no longer `Buffer.concat` the full file in RAM.
- Stream-assemble chunks to a temp `.assembled` file, then `rename` (with EXDEV stream-copy fallback) into the workspace; cap total size before write and map oversize to HTTP 413.
- Stale cleanup now also removes orphaned `.assembled` files (crash between assemble and consume).

## Bug / repro
Large chat/file uploads on small cloud hosts (1–2 GB) caused host OOM near the final chunk because assembly held the whole payload in memory.

Repro on staging canary (`yitian-superagent`, image `sup-518-20260730220828`): upload `/tmp/oom-repro-1gb.bin` via the UI.

## Verified on staging
- 1 GB chunked upload completed; task stayed `RUNNING` / `HEALTHY` (no restart).
- CloudWatch `MemoryUtilized`: baseline ~243 MB → peak **584 MB** (~341 MB delta) on a 2048 MB task. Old path would have held ~1 GB+ at assemble time.

## Test plan
- [x] `vitest` `chunked-upload.test.ts` + `agents.test.ts` (310 tests)
- [x] Staging canary: 1 GB upload + memory curve


Made with [Cursor](https://cursor.com)