### PR TITLE
fix: settle finished turns when idle is lost or discarded (SUP-468)

### DIFF
--- a/agent-container/src/claude-code-late-join-replay.test.ts
+++ b/agent-container/src/claude-code-late-join-replay.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression: late-join replay must carry the latest background_tasks_changed
+ * snapshot. Without it, a host holding a task whose terminal signal was lost
+ * parks in waiting-background after reattach announces "turn over".
+ */
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { ClaudeCodeProcess } from './claude-code'
+import { parseBackgroundTasksChanged } from './session-settlement'
+
+const backgroundTasksFrameSchema = z
+  .object({
+    type: z.literal('system'),
+    subtype: z.literal('background_tasks_changed'),
+    tasks: z.array(
+      z.object({
+        task_id: z.string(),
+        task_type: z.string().optional(),
+        description: z.string().optional(),
+      })
+    ),
+  })
+  .superRefine((frame, ctx) => {
+    if (!parseBackgroundTasksChanged(frame)) {
+      ctx.addIssue({ code: 'custom', message: 'rejected by parseBackgroundTasksChanged' })
+    }
+  })
+
+const resultFrameSchema = z.object({
+  type: z.literal('result'),
+  subtype: z.literal('success'),
+})
+
+const sessionStateFrameSchema = z.object({
+  type: z.literal('system'),
+  subtype: z.literal('session_state_changed'),
+  state: z.enum(['idle', 'running']),
+})
+
+describe('getLateJoinReplay — background snapshot', () => {
+  it('includes the latest background_tasks_changed between result and idle', () => {
+    const proc = new ClaudeCodeProcess({
+      sessionId: 'late-join-bg',
+      workingDirectory: '/tmp',
+    })
+
+    const track = (frame: unknown) =>
+      (proc as unknown as { trackForLateJoinReplay(message: unknown): void }).trackForLateJoinReplay(
+        frame
+      )
+
+    track(resultFrameSchema.parse({ type: 'result', subtype: 'success' }))
+    track(
+      backgroundTasksFrameSchema.parse({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        tasks: [],
+      })
+    )
+    track(
+      sessionStateFrameSchema.parse({
+        type: 'system',
+        subtype: 'session_state_changed',
+        state: 'idle',
+      })
+    )
+
+    const replay = proc.getLateJoinReplay() as Array<Record<string, unknown>>
+    const subtypes = replay.map((f) => f.subtype ?? f.type)
+
+    expect(subtypes).toContain('background_tasks_changed')
+    const bgIndex = replay.findIndex((f) => f.subtype === 'background_tasks_changed')
+    const resultIndex = replay.findIndex((f) => f.type === 'result')
+    const idleIndex = replay.findIndex(
+      (f) => f.subtype === 'session_state_changed' && f.state === 'idle'
+    )
+    expect(resultIndex).toBeGreaterThanOrEqual(0)
+    expect(bgIndex).toBeGreaterThan(resultIndex)
+    expect(idleIndex).toBeGreaterThan(bgIndex)
+    expect(replay[bgIndex]).toMatchObject({
+      subtype: 'background_tasks_changed',
+      tasks: [],
+      replayed: true,
+    })
+  })
+})

--- a/agent-container/src/claude-code-late-join-replay.test.ts
+++ b/agent-container/src/claude-code-late-join-replay.test.ts
@@ -54,6 +54,13 @@ describe('getLateJoinReplay — background snapshot', () => {
       backgroundTasksFrameSchema.parse({
         type: 'system',
         subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 'finished-task' }],
+      })
+    )
+    track(
+      backgroundTasksFrameSchema.parse({
+        type: 'system',
+        subtype: 'background_tasks_changed',
         tasks: [],
       })
     )

--- a/agent-container/src/claude-code-stop-race.test.ts
+++ b/agent-container/src/claude-code-stop-race.test.ts
@@ -104,6 +104,36 @@ describe('ClaudeCodeProcess stop/restart teardown race', () => {
     await proc.stop()
   })
 
+  it('a restart clears process-local background replay state', async () => {
+    const proc = new ClaudeCodeProcess({ sessionId: 'replay-reset', workingDirectory: '/tmp' })
+    const track = (message: unknown) =>
+      (
+        proc as unknown as {
+          trackForLateJoinReplay(frame: unknown): void
+        }
+      ).trackForLateJoinReplay(message)
+
+    await proc.start()
+    track({ type: 'result', subtype: 'success' })
+    track({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [{ task_id: 'old-process-task' }],
+    })
+    track({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+    await proc.stop()
+    await proc.sendMessage('follow-up')
+    expect(proc.getLateJoinReplay()).toEqual([])
+    track({ type: 'result', subtype: 'success' })
+    track({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+    const replay = proc.getLateJoinReplay() as Array<Record<string, unknown>>
+    expect(replay.some((frame) => frame.subtype === 'background_tasks_changed')).toBe(false)
+
+    await proc.stop()
+  })
+
   it('interrupt() landing during a stop() teardown must not revive the query', async () => {
     const proc = new ClaudeCodeProcess({ sessionId: 's4', workingDirectory: '/tmp' })
     await proc.start()

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -487,6 +487,10 @@ export class ClaudeCodeProcess extends EventEmitter {
   private lastTurnInformationals: SDKMessage[] = [];
   private lastResultMessage: SDKMessage | null = null;
   private lastSessionState: string | null = null;
+  // Latest authoritative background-task snapshot, replayed to a late joiner:
+  // a host holding a task whose terminal signal was lost would otherwise stay
+  // pinned forever (the live consumer self-heals when a snapshot arrives).
+  private lastBackgroundTasksChanged: SDKMessage | null = null;
   // Pre-spawned CLI subprocess from prewarm(), waiting for a prompt. Claimed
   // (once) by the next createQuery; see prewarm() for why the handle lives on
   // the process rather than in a detached pool.
@@ -1528,6 +1532,8 @@ export class ClaudeCodeProcess extends EventEmitter {
       this.lastResultMessage = message;
       this.lastTurnInformationals = this.currentTurnInformationals;
       this.currentTurnInformationals = [];
+    } else if (msg.type === 'system' && msg.subtype === 'background_tasks_changed') {
+      this.lastBackgroundTasksChanged = message;
     } else if (msg.type === 'system' && msg.subtype === 'session_state_changed') {
       this.lastSessionState = msg.state ?? null;
     }
@@ -1552,6 +1558,7 @@ export class ClaudeCodeProcess extends EventEmitter {
     return [
       ...this.lastTurnInformationals,
       this.lastResultMessage,
+      ...(this.lastBackgroundTasksChanged ? [this.lastBackgroundTasksChanged] : []),
       {
         type: 'system',
         subtype: 'session_state_changed',

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -1088,6 +1088,10 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.lastResultMessage = null;
     this.lastSessionState = null;
     this.lastBackgroundTasksChanged = null;
+    // Background tasks are process-local and die with the old process too; the
+    // SessionManager listens for this to reset its settlement bookkeeping —
+    // a task id carried across the replacement would pin the session
+    // unevictable forever (no terminal signal or snapshot ever comes).
     this.emit('query-start');
   }
 

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -1080,10 +1080,14 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.messageQueue = new MessageQueue();
     this.queryInstance = this.createQuery();
     this.isReady = true;
-    // Background tasks are process-local and die with the old process; the
-    // SessionManager listens for this to reset its settlement bookkeeping —
-    // a task id carried across the replacement would pin the session
-    // unevictable forever (no terminal signal or snapshot ever comes).
+    // Late-join replay is process-local. Carrying a terminal frame across a
+    // replacement could settle the new process before it emits its own result;
+    // carrying a background task could pin it forever without a terminal frame.
+    this.currentTurnInformationals = [];
+    this.lastTurnInformationals = [];
+    this.lastResultMessage = null;
+    this.lastSessionState = null;
+    this.lastBackgroundTasksChanged = null;
     this.emit('query-start');
   }
 

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -109,6 +109,7 @@ app.get('/sessions/:id', async (c) => {
   return c.json({
     ...session,
     isRunning: sessionManager.isSessionRunning(sessionId),
+    turnSettled: sessionManager.isTurnSettled(sessionId),
   });
 });
 

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -934,6 +934,20 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
+   * Whether nothing is in flight for this session: turn over (result-gated
+   * idle), no live background work, past the completion-wake grace. The
+   * per-TURN answer, unlike isSessionRunning(), which reports the CLI process
+   * and stays true for the life of the query loop.
+   *
+   * An unknown session is not settled — "unknown" must never read as "finished".
+   */
+  isTurnSettled(sessionId: string): boolean {
+    const sessionData = this.sessions.get(sessionId);
+    if (!sessionData) return false;
+    return sessionData.settlement.isSettled();
+  }
+
+  /**
    * Terminal frames of the session's most recent turn, for a WebSocket
    * subscriber that attached after the turn already ended. Empty when the
    * session is live mid-turn (frames arrive normally) or cold.

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import WebSocket, { WebSocketServer } from 'ws'
 import { writeEnvFile, parseMemoryValue, shellQuote, isConnectionError, getEnhancedPath, BaseContainerClient } from './base-container-client'
 import type { ContainerInfo, ContainerConfig, StreamMessage } from './types'
 
@@ -646,6 +649,20 @@ class StoppedTestClient extends BaseContainerClient {
   }
 }
 
+class RunningStreamTestClient extends BaseContainerClient {
+  constructor(private readonly port: number) {
+    super({ agentId: 'test-agent' } as ContainerConfig)
+  }
+
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'running', port: this.port }
+  }
+}
+
 function makeStoppedClient(): StoppedTestClient {
   return new StoppedTestClient({ agentId: 'test-agent' } as ContainerConfig)
 }
@@ -683,6 +700,41 @@ describe('subscribeToStream failure handling', () => {
 
     expect(errors).toHaveLength(1)
     expect((errors[0] as Error).message).toContain('Container is not running')
+  })
+
+  it('a late close from the replaced socket cannot evict the replacement', async () => {
+    const server = createServer()
+    const wss = new WebSocketServer({ server })
+    const peers: WebSocket[] = []
+    wss.on('connection', (peer) => peers.push(peer))
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const port = (server.address() as AddressInfo).port
+      const client = new RunningStreamTestClient(port)
+      const first = client.subscribeToStream('replacement-owner', () => {})
+      await first.ready
+      const oldSocket = (
+        client as unknown as { wsConnections: Map<string, WebSocket> }
+      ).wsConnections.get('replacement-owner')
+      expect(oldSocket).toBeDefined()
+
+      // Hold the peer's close handshake so the old close lands after replacement.
+      peers[0].pause()
+      first.unsubscribe()
+      const replacement = client.subscribeToStream('replacement-owner', () => {})
+      await replacement.ready
+      expect(peers).toHaveLength(2)
+
+      oldSocket?.emit('close', 1006, Buffer.alloc(0))
+      replacement.unsubscribe()
+
+      await vi.waitFor(() => expect(peers[1].readyState).toBe(WebSocket.CLOSED))
+    } finally {
+      for (const peer of peers) peer.terminate()
+      await new Promise<void>((resolve) => wss.close(() => resolve()))
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
   })
 })
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1366,9 +1366,15 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       resolveReady = resolve
       rejectReady = reject
     })
+    let ownedSocket: WebSocket | null = null
+    let unsubscribed = false
 
     const setupWebSocket = async () => {
       const port = await this.getPortOrThrow()
+      if (unsubscribed) {
+        resolveReady()
+        return
+      }
 
       const existing = this.wsConnections.get(sessionId)
       if (existing) {
@@ -1379,6 +1385,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         `${this.getWebSocketBaseUrl(port)}/sessions/${sessionId}/stream`,
         { headers: this.getHostAuthHeaders() }
       )
+      ownedSocket = ws
 
       ws.on('open', () => {
         console.log(`WebSocket connected for session ${sessionId}`)
@@ -1403,7 +1410,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       ws.on('error', (error) => {
         // Only log and emit if this connection is still tracked (not cleaned up by stop())
-        if (this.wsConnections.has(sessionId)) {
+        if (this.wsConnections.get(sessionId) === ws) {
           console.error(`WebSocket error for session ${sessionId}:`, error)
           this.safeEmitError(error)
         }
@@ -1412,7 +1419,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       ws.on('close', () => {
         console.log(`WebSocket closed for session ${sessionId}`)
-        this.wsConnections.delete(sessionId)
+        if (this.wsConnections.get(sessionId) === ws) {
+          this.wsConnections.delete(sessionId)
+        }
         // Notify the callback that the connection was lost
         // This allows the message persister to handle the disconnection
         const closeMessage: StreamMessage = {
@@ -1428,6 +1437,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     }
 
     setupWebSocket().catch((error) => {
+      if (unsubscribed) {
+        resolveReady()
+        return
+      }
       console.error('Failed to set up WebSocket:', error)
       this.safeEmitError(error)
       // Notify the callback so the consumer (e.g. MessagePersister) can react to
@@ -1445,10 +1458,12 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     })
 
     const unsubscribe = () => {
-      const ws = this.wsConnections.get(sessionId)
-      if (ws) {
-        ws.close()
-        this.wsConnections.delete(sessionId)
+      unsubscribed = true
+      if (ownedSocket) {
+        ownedSocket.close()
+        if (this.wsConnections.get(sessionId) === ownedSocket) {
+          this.wsConnections.delete(sessionId)
+        }
       }
     }
 

--- a/src/shared/lib/container/message-persister.settle-silence.test.ts
+++ b/src/shared/lib/container/message-persister.settle-silence.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Regression: a finished turn never settles when a settle frame is lost or
+ * discarded (SUP-468). One case per cause, plus a positive control.
+ *
+ * Wire frames are built through Zod (and the production background-tasks
+ * parser) so a hand-rolled shape cannot pin a dead path.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { z } from 'zod'
+import type { ContainerClient, StreamMessage } from './types'
+import { parseBackgroundTasksChanged } from './background-tasks-changed'
+
+vi.mock('@shared/lib/services/scheduled-task-service', () => ({
+  createScheduledTask: vi.fn(() => Promise.resolve('t')),
+  createSessionWake: vi.fn(() => Promise.resolve({ taskId: 'w', replaced: null })),
+  listPendingScheduledTasks: vi.fn(() => Promise.resolve([])),
+  getScheduledTask: vi.fn(() => Promise.resolve(null)),
+  cancelScheduledTask: vi.fn(() => Promise.resolve(true)),
+  pauseScheduledTask: vi.fn(() => Promise.resolve(true)),
+  resumeScheduledTask: vi.fn(() => Promise.resolve(true)),
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  updateSessionMetadata: vi.fn(() => Promise.resolve()),
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
+  finalizeAutomationStatus: vi.fn(() => Promise.resolve('updated')),
+}))
+vi.mock('@shared/lib/services/session-transcript-append', () => ({
+  appendInformationalEntry: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@shared/lib/services/timezone-resolver', () => ({
+  resolveTimezoneForAgent: vi.fn(() => 'UTC'),
+}))
+vi.mock('@shared/lib/notifications/notification-manager', () => ({
+  notificationManager: {
+    triggerSessionComplete: vi.fn(() => Promise.resolve()),
+    triggerSessionWaitingInput: vi.fn(() => Promise.resolve()),
+  },
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({}),
+  getAgentCapabilitySettings: () => ({ subagents: 'allow', workflows: 'review' }),
+  getModelCatalogSettings: () => ({}),
+  VALID_SCRIPT_TYPES: { darwin: ['applescript', 'shell'], linux: ['shell'], win32: ['powershell'] },
+}))
+vi.mock('@shared/lib/utils/file-storage', () => ({
+  getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
+}))
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: () => ({ getContainerEnvVars: () => ({}) }),
+}))
+vi.mock('@shared/lib/db', () => ({ db: { select: vi.fn() } }))
+vi.mock('@shared/lib/db/schema', () => ({ connectedAccounts: {} }))
+vi.mock('./container-manager', () => ({
+  containerManager: { getClient: () => ({ fetch: vi.fn(() => Promise.resolve({ ok: true })) }) },
+}))
+
+import { messagePersister, STREAM_SILENCE_REATTACH_MS } from './message-persister'
+
+const capabilitiesFrameSchema = z.object({
+  type: z.literal('system'),
+  subtype: z.literal('capabilities'),
+  session_state_events: z.boolean(),
+})
+
+const sessionStateFrameSchema = z.object({
+  type: z.literal('system'),
+  subtype: z.literal('session_state_changed'),
+  state: z.enum(['idle', 'running']),
+  replayed: z.boolean().optional(),
+})
+
+const resultFrameSchema = z.object({
+  type: z.literal('result'),
+  subtype: z.string(),
+  result: z.string().optional(),
+  is_error: z.boolean().optional(),
+  replayed: z.boolean().optional(),
+})
+
+const backgroundTasksFrameSchema = z
+  .object({
+    type: z.literal('system'),
+    subtype: z.literal('background_tasks_changed'),
+    tasks: z.array(
+      z.object({
+        task_id: z.string(),
+        task_type: z.string().optional(),
+        description: z.string().optional(),
+      })
+    ),
+    replayed: z.boolean().optional(),
+  })
+  .superRefine((frame, ctx) => {
+    // Production parser is the authority for the tasks payload.
+    if (!parseBackgroundTasksChanged(frame)) {
+      ctx.addIssue({ code: 'custom', message: 'rejected by parseBackgroundTasksChanged' })
+    }
+  })
+
+function capabilitiesFrame() {
+  return capabilitiesFrameSchema.parse({
+    type: 'system',
+    subtype: 'capabilities',
+    session_state_events: true,
+  })
+}
+
+function sessionStateFrame(state: 'idle' | 'running', opts?: { replayed?: boolean }) {
+  return sessionStateFrameSchema.parse({
+    type: 'system',
+    subtype: 'session_state_changed',
+    state,
+    ...(opts?.replayed ? { replayed: true } : {}),
+  })
+}
+
+function resultFrame(opts?: { replayed?: boolean }) {
+  return resultFrameSchema.parse({
+    type: 'result',
+    subtype: 'success',
+    result: 'Updated files.',
+    is_error: false,
+    ...(opts?.replayed ? { replayed: true } : {}),
+  })
+}
+
+function backgroundTasksFrame(
+  tasks: Array<{ task_id: string; task_type?: string }>,
+  opts?: { replayed?: boolean }
+) {
+  return backgroundTasksFrameSchema.parse({
+    type: 'system',
+    subtype: 'background_tasks_changed',
+    tasks,
+    ...(opts?.replayed ? { replayed: true } : {}),
+  })
+}
+
+function createMockClient(): ContainerClient & {
+  _sendMessage: (content: unknown) => void
+} {
+  let messageCallback: ((message: StreamMessage) => void) | null = null
+  const client = {
+    _sendMessage(content: unknown) {
+      if (!messageCallback) return
+      messageCallback({
+        type: 'message',
+        content,
+        timestamp: new Date(),
+        sessionId: 'settle-silence',
+      })
+    },
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopSync: vi.fn(),
+    getInfoFromRuntime: vi.fn(),
+    getInfo: vi.fn(),
+    fetch: vi.fn(),
+    waitForHealthy: vi.fn(),
+    isHealthy: vi.fn(),
+    getStats: vi.fn(),
+    createSession: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve({ isRunning: true })),
+    deleteSession: vi.fn(),
+    sendMessage: vi.fn(),
+    interruptSession: vi.fn(),
+    subscribeToStream: vi.fn((_sessionId: string, callback: (message: StreamMessage) => void) => {
+      messageCallback = callback
+      // Mirror base-container-client: intentional close synthesizes
+      // connection_closed on the callback that owned the socket.
+      const unsubscribe = vi.fn(() => {
+        const closed = messageCallback
+        messageCallback = null
+        closed?.({
+          type: 'connection_closed',
+          content: { type: 'connection_closed' },
+          timestamp: new Date(),
+          sessionId: 'settle-silence',
+        })
+      })
+      return { unsubscribe, ready: Promise.resolve() }
+    }),
+    on: vi.fn(),
+    off: vi.fn(),
+  }
+  return client as unknown as ContainerClient & { _sendMessage: (content: unknown) => void }
+}
+
+describe('settle silence / discarded settle memory', () => {
+  const SESSION = 'settle-silence-session'
+  const AGENT = 'settle-silence-agent'
+  let client: ReturnType<typeof createMockClient>
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    client = createMockClient()
+    await messagePersister.subscribeToSession(SESSION, client, SESSION, AGENT)
+  })
+
+  afterEach(() => {
+    messagePersister.unsubscribeFromSession(SESSION)
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('POSITIVE CONTROL: result then idle on a healthy socket settles', () => {
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+    client._sendMessage(resultFrame())
+    client._sendMessage(sessionStateFrame('idle'))
+    expect(messagePersister.getSessionActivity(SESSION)).toBe('idle')
+  })
+
+  it('external re-subscribe between result and idle must not discard the idle', async () => {
+    // Cause: subscribeToSession wiped lastResultSubtype; the idle guard then
+    // treated a correctly-delivered idle as stale. No transport failure.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+    client._sendMessage(resultFrame())
+
+    await messagePersister.subscribeToSession(SESSION, client, SESSION, AGENT)
+    client._sendMessage(sessionStateFrame('idle'))
+
+    expect(messagePersister.getSessionActivity(SESSION)).toBe('idle')
+  })
+
+  it('stream silence while a turn is live reattaches and settles from late-join replay', async () => {
+    // Cause: half-open (or any lost terminal frames). Nothing detects the dead
+    // peer; reattach is the recovery road close never reaches.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+    client._sendMessage(resultFrame())
+    // Idle never arrives.
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+    // Flush getSession().then from any connection_closed the detach synthesized.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Exactly one replacement subscribe — not silence reattach PLUS a stacked
+    // handleConnectionClosed resubscribe (that double-applied stream_deltas).
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
+    // Container late-join replay for a finished turn (result + idle).
+    client._sendMessage(resultFrame({ replayed: true }))
+    client._sendMessage(sessionStateFrame('idle', { replayed: true }))
+
+    expect(messagePersister.getSessionActivity(SESSION)).toBe('idle')
+  })
+
+  it('silence reattach must not stack a connection_closed resubscribe', async () => {
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+    client._sendMessage(resultFrame())
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
+    expect(client.getSession).not.toHaveBeenCalled()
+  })
+
+  it('late-join replay with an empty background snapshot unpins a lost task terminal', async () => {
+    // Cause: host holds a task whose removal snapshot was destroyed. Replay
+    // must carry the container's latest background_tasks_changed, or the host
+    // stays in waiting-background after the synthetic idle.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+    client._sendMessage(resultFrame())
+    client._sendMessage(
+      backgroundTasksFrame([{ task_id: 'bg-1', task_type: 'local_bash' }])
+    )
+    client._sendMessage(sessionStateFrame('idle'))
+    expect(messagePersister.getSessionActivity(SESSION)).not.toBe('idle')
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
+
+    client._sendMessage(resultFrame({ replayed: true }))
+    client._sendMessage(backgroundTasksFrame([], { replayed: true }))
+    client._sendMessage(sessionStateFrame('idle', { replayed: true }))
+
+    expect(messagePersister.getSessionActivity(SESSION)).toBe('idle')
+  })
+})

--- a/src/shared/lib/container/message-persister.settle-silence.test.ts
+++ b/src/shared/lib/container/message-persister.settle-silence.test.ts
@@ -1,6 +1,6 @@
 /**
  * Regression: a finished turn never settles when a settle frame is lost or
- * discarded (SUP-468). One case per cause, plus a positive control.
+ * discarded. One case per cause, plus a positive control.
  *
  * Wire frames are built through Zod (and the production background-tasks
  * parser) so a hand-rolled shape cannot pin a dead path.
@@ -138,8 +138,19 @@ function backgroundTasksFrame(
 
 function createMockClient(): ContainerClient & {
   _sendMessage: (content: unknown) => void
+  _flushCloses: () => void
+  _failNextSubscribe: () => void
 } {
   let messageCallback: ((message: StreamMessage) => void) | null = null
+  let failNextSubscribe = false
+  const pendingCloses: Array<() => void> = []
+  const connectionClosed = (callback: (message: StreamMessage) => void) =>
+    callback({
+      type: 'connection_closed',
+      content: { type: 'connection_closed' },
+      timestamp: new Date(),
+      sessionId: 'settle-silence',
+    })
   const client = {
     _sendMessage(content: unknown) {
       if (!messageCallback) return
@@ -149,6 +160,12 @@ function createMockClient(): ContainerClient & {
         timestamp: new Date(),
         sessionId: 'settle-silence',
       })
+    },
+    _flushCloses() {
+      for (const close of pendingCloses.splice(0)) close()
+    },
+    _failNextSubscribe() {
+      failNextSubscribe = true
     },
     start: vi.fn(),
     stop: vi.fn(),
@@ -165,25 +182,31 @@ function createMockClient(): ContainerClient & {
     sendMessage: vi.fn(),
     interruptSession: vi.fn(),
     subscribeToStream: vi.fn((_sessionId: string, callback: (message: StreamMessage) => void) => {
+      if (failNextSubscribe) {
+        failNextSubscribe = false
+        connectionClosed(callback)
+        return {
+          unsubscribe: vi.fn(),
+          ready: Promise.reject(new Error('replacement failed')),
+        }
+      }
       messageCallback = callback
-      // Mirror base-container-client: intentional close synthesizes
-      // connection_closed on the callback that owned the socket.
+      // Real half-open sockets deliver their close after the replacement is
+      // installed. Keep each callback bound to the socket that owned it.
       const unsubscribe = vi.fn(() => {
-        const closed = messageCallback
-        messageCallback = null
-        closed?.({
-          type: 'connection_closed',
-          content: { type: 'connection_closed' },
-          timestamp: new Date(),
-          sessionId: 'settle-silence',
-        })
+        if (messageCallback === callback) messageCallback = null
+        pendingCloses.push(() => connectionClosed(callback))
       })
       return { unsubscribe, ready: Promise.resolve() }
     }),
     on: vi.fn(),
     off: vi.fn(),
   }
-  return client as unknown as ContainerClient & { _sendMessage: (content: unknown) => void }
+  return client as unknown as ContainerClient & {
+    _sendMessage: (content: unknown) => void
+    _flushCloses: () => void
+    _failNextSubscribe: () => void
+  }
 }
 
 describe('settle silence / discarded settle memory', () => {
@@ -219,9 +242,29 @@ describe('settle silence / discarded settle memory', () => {
     client._sendMessage(resultFrame())
 
     await messagePersister.subscribeToSession(SESSION, client, SESSION, AGENT)
+    client._flushCloses()
     client._sendMessage(sessionStateFrame('idle'))
 
     expect(messagePersister.getSessionActivity(SESSION)).toBe('idle')
+  })
+
+  it('external re-subscribe does not let a bare idle settle a new turn', async () => {
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+
+    await messagePersister.subscribeToSession(SESSION, client, SESSION, AGENT)
+    client._flushCloses()
+    client._sendMessage(sessionStateFrame('idle'))
+
+    expect(messagePersister.getSessionActivity(SESSION)).not.toBe('idle')
+  })
+
+  it('a turn that starts on an already-quiet stream arms recovery', async () => {
+    messagePersister.markSessionActive(SESSION, AGENT)
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
   })
 
   it('stream silence while a turn is live reattaches and settles from late-join replay', async () => {
@@ -234,13 +277,17 @@ describe('settle silence / discarded settle memory', () => {
     expect(client.subscribeToStream).toHaveBeenCalledTimes(1)
 
     await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+    client._flushCloses()
     // Flush getSession().then from any connection_closed the detach synthesized.
     await Promise.resolve()
     await Promise.resolve()
 
+    // Reattach is only transport recovery. Time alone never settles the turn.
+    expect(messagePersister.getSessionActivity(SESSION)).not.toBe('idle')
     // Exactly one replacement subscribe — not silence reattach PLUS a stacked
     // handleConnectionClosed resubscribe (that double-applied stream_deltas).
     expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
+    expect(client.getSession).not.toHaveBeenCalled()
     // Container late-join replay for a finished turn (result + idle).
     client._sendMessage(resultFrame({ replayed: true }))
     client._sendMessage(sessionStateFrame('idle', { replayed: true }))
@@ -248,17 +295,18 @@ describe('settle silence / discarded settle memory', () => {
     expect(messagePersister.getSessionActivity(SESSION)).toBe('idle')
   })
 
-  it('silence reattach must not stack a connection_closed resubscribe', async () => {
+  it('a failed silence replacement is handled as the current connection closing', async () => {
     messagePersister.markSessionActive(SESSION, AGENT)
     client._sendMessage(capabilitiesFrame())
     client._sendMessage(resultFrame())
+    client._failNextSubscribe()
 
     await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
-    expect(client.getSession).not.toHaveBeenCalled()
+    expect(client.getSession).toHaveBeenCalledTimes(1)
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(3)
   })
 
   it('late-join replay with an empty background snapshot unpins a lost task terminal', async () => {

--- a/src/shared/lib/container/message-persister.settle-silence.test.ts
+++ b/src/shared/lib/container/message-persister.settle-silence.test.ts
@@ -54,7 +54,12 @@ vi.mock('./container-manager', () => ({
   containerManager: { getClient: () => ({ fetch: vi.fn(() => Promise.resolve({ ok: true })) }) },
 }))
 
-import { messagePersister, STREAM_SILENCE_REATTACH_MS } from './message-persister'
+import {
+  messagePersister,
+  isReplayOfProcessedResult,
+  STREAM_SILENCE_REATTACH_MS,
+} from './message-persister'
+import { notificationManager } from '@shared/lib/notifications/notification-manager'
 
 const capabilitiesFrameSchema = z.object({
   type: z.literal('system'),
@@ -74,6 +79,9 @@ const resultFrameSchema = z.object({
   subtype: z.string(),
   result: z.string().optional(),
   is_error: z.boolean().optional(),
+  // Present on every real result frame (see the sdk206-* captures) and the only
+  // turn identity a replayed frame carries.
+  uuid: z.string().min(1),
   replayed: z.boolean().optional(),
 })
 
@@ -114,12 +122,26 @@ function sessionStateFrame(state: 'idle' | 'running', opts?: { replayed?: boolea
   })
 }
 
-function resultFrame(opts?: { replayed?: boolean }) {
+const TURN_RESULT_UUID = '97469a01-fc94-42a0-a9e0-4064206cfccb'
+
+// Replay leads with the finished turn's informationals, before its result.
+function informationalFrame(opts?: { replayed?: boolean }) {
+  return {
+    type: 'system' as const,
+    subtype: 'informational' as const,
+    message: 'Context low',
+    uuid: 'a1b2c3d4-0000-4000-8000-00000000000a',
+    ...(opts?.replayed ? { replayed: true } : {}),
+  }
+}
+
+function resultFrame(opts?: { replayed?: boolean; uuid?: string }) {
   return resultFrameSchema.parse({
     type: 'result',
     subtype: 'success',
     result: 'Updated files.',
     is_error: false,
+    uuid: opts?.uuid ?? TURN_RESULT_UUID,
     ...(opts?.replayed ? { replayed: true } : {}),
   })
 }
@@ -140,9 +162,15 @@ function createMockClient(): ContainerClient & {
   _sendMessage: (content: unknown) => void
   _flushCloses: () => void
   _failNextSubscribe: () => void
+  _setTurnSettled: (settled: boolean) => void
+  _armReplay: (frames: unknown[]) => void
 } {
   let messageCallback: ((message: StreamMessage) => void) | null = null
   let failNextSubscribe = false
+  let replayBatch: unknown[] = []
+  // What the container reports about its own turn. Default false = a turn is
+  // genuinely running, which is the healthy long-tool-call case.
+  let turnSettled = false
   const pendingCloses: Array<() => void> = []
   const connectionClosed = (callback: (message: StreamMessage) => void) =>
     callback({
@@ -167,6 +195,13 @@ function createMockClient(): ContainerClient & {
     _failNextSubscribe() {
       failNextSubscribe = true
     },
+    _setTurnSettled(settled: boolean) {
+      turnSettled = settled
+    },
+    /** Frames the container will replay to every subsequent attach. */
+    _armReplay(frames: unknown[]) {
+      replayBatch = frames
+    },
     start: vi.fn(),
     stop: vi.fn(),
     stopSync: vi.fn(),
@@ -177,7 +212,7 @@ function createMockClient(): ContainerClient & {
     isHealthy: vi.fn(),
     getStats: vi.fn(),
     createSession: vi.fn(),
-    getSession: vi.fn(() => Promise.resolve({ isRunning: true })),
+    getSession: vi.fn(() => Promise.resolve({ isRunning: true, turnSettled })),
     deleteSession: vi.fn(),
     sendMessage: vi.fn(),
     interruptSession: vi.fn(),
@@ -191,6 +226,13 @@ function createMockClient(): ContainerClient & {
         }
       }
       messageCallback = callback
+      // The container replays its last finished turn to EVERY late joiner, not
+      // just the first — so a reattach re-delivers the same batch. A double
+      // that replays only once cannot see a recovery that loops on its own
+      // replay.
+      for (const content of replayBatch) {
+        callback({ type: 'message', content, timestamp: new Date(), sessionId: 'settle-silence' })
+      }
       // Real half-open sockets deliver their close after the replacement is
       // installed. Keep each callback bound to the socket that owned it.
       const unsubscribe = vi.fn(() => {
@@ -206,8 +248,29 @@ function createMockClient(): ContainerClient & {
     _sendMessage: (content: unknown) => void
     _flushCloses: () => void
     _failNextSubscribe: () => void
+    _setTurnSettled: (settled: boolean) => void
+    _armReplay: (frames: unknown[]) => void
   }
 }
+
+describe('isReplayOfProcessedResult', () => {
+  const SEEN = '97469a01-fc94-42a0-a9e0-4064206cfccb'
+
+  it('a host with no result memory has nothing to be stale against', () => {
+    expect(isReplayOfProcessedResult(null, SEEN)).toBe(false)
+  })
+
+  it('an unidentifiable result counts as already processed, never as new', () => {
+    // Fail-safe direction: cannot prove new, so it must not be allowed to settle.
+    expect(isReplayOfProcessedResult(SEEN, undefined)).toBe(true)
+    expect(isReplayOfProcessedResult(SEEN, '')).toBe(true)
+  })
+
+  it('separates the turn already seen from the one that was missed', () => {
+    expect(isReplayOfProcessedResult(SEEN, SEEN)).toBe(true)
+    expect(isReplayOfProcessedResult(SEEN, 'b2f0a1c4-0000-4000-8000-000000000002')).toBe(false)
+  })
+})
 
 describe('settle silence / discarded settle memory', () => {
   const SESSION = 'settle-silence-session'
@@ -259,15 +322,33 @@ describe('settle silence / discarded settle memory', () => {
     expect(messagePersister.getSessionActivity(SESSION)).not.toBe('idle')
   })
 
-  it('a turn that starts on an already-quiet stream arms recovery', async () => {
+  it('a quiet stream on a turn the container is still running never touches the transport', async () => {
+    // The reason quiet alone must not trigger recovery: long builds, test runs
+    // and a session parked on a permission card are all silent for minutes. The
+    // stream is unbuffered fan-out, so a swap loses whatever is emitted in the
+    // close/open gap - permission requests included.
     messagePersister.markSessionActive(SESSION, AGENT)
+    client._setTurnSettled(false)
 
-    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS * 10)
 
-    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
+    expect(client.getSession).toHaveBeenCalledTimes(10)
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(1)
+    expect(messagePersister.getSessionActivity(SESSION)).not.toBe('idle')
   })
 
-  it('stream silence while a turn is live reattaches and settles from late-join replay', async () => {
+  it('a container that cannot answer is not evidence the turn ended', async () => {
+    messagePersister.markSessionActive(SESSION, AGENT)
+    // A build older than turnSettled omits the field. Unknown is not "finished".
+    ;(client.getSession as ReturnType<typeof vi.fn>).mockResolvedValue({ isRunning: true })
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS * 3)
+
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(1)
+    expect(messagePersister.getSessionActivity(SESSION)).not.toBe('idle')
+  })
+
+  it('stream silence on a turn the container has finished reattaches and settles from replay', async () => {
     // Cause: half-open (or any lost terminal frames). Nothing detects the dead
     // peer; reattach is the recovery road close never reaches.
     messagePersister.markSessionActive(SESSION, AGENT)
@@ -275,6 +356,7 @@ describe('settle silence / discarded settle memory', () => {
     client._sendMessage(resultFrame())
     // Idle never arrives.
     expect(client.subscribeToStream).toHaveBeenCalledTimes(1)
+    client._setTurnSettled(true)
 
     await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
     client._flushCloses()
@@ -287,8 +369,9 @@ describe('settle silence / discarded settle memory', () => {
     // Exactly one replacement subscribe — not silence reattach PLUS a stacked
     // handleConnectionClosed resubscribe (that double-applied stream_deltas).
     expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
-    expect(client.getSession).not.toHaveBeenCalled()
-    // Container late-join replay for a finished turn (result + idle).
+    // Container late-join replay for a finished turn (result + idle). The result
+    // is one the host already processed, so it is dropped; the idle behind it
+    // still settles, because a result WAS seen for this turn.
     client._sendMessage(resultFrame({ replayed: true }))
     client._sendMessage(sessionStateFrame('idle', { replayed: true }))
 
@@ -300,13 +383,116 @@ describe('settle silence / discarded settle memory', () => {
     client._sendMessage(capabilitiesFrame())
     client._sendMessage(resultFrame())
     client._failNextSubscribe()
+    client._setTurnSettled(true)
 
     await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(client.getSession).toHaveBeenCalledTimes(1)
     expect(client.subscribeToStream).toHaveBeenCalledTimes(3)
+  })
+
+  it('a replay of an already-finished turn never settles the turn waiting on it', async () => {
+    // A send that wedges leaves the session marked active while the container
+    // sits idle from the PREVIOUS turn. The probe finds a settled container,
+    // reattaches, and the container replays that earlier turn's terminal
+    // frames. Settling on them reports a completion - and persists a success -
+    // for a message that never reached the agent.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+    client._sendMessage(resultFrame())
+    client._sendMessage(sessionStateFrame('idle'))
+    expect(messagePersister.getSessionActivity(SESSION)).toBe('idle')
+    ;(notificationManager.triggerSessionComplete as ReturnType<typeof vi.fn>).mockClear()
+
+    // Next turn: marked active, send never lands, container stays idle.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._setTurnSettled(true)
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+    // Replay of the PREVIOUS turn - same result uuid the host already processed.
+    client._sendMessage(resultFrame({ replayed: true }))
+    client._sendMessage(sessionStateFrame('idle', { replayed: true }))
+
+    expect(messagePersister.getSessionActivity(SESSION)).not.toBe('idle')
+    expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
+  })
+
+  it('a replay of a turn the host never saw end does settle it', async () => {
+    // The mirror of the case above, so the guard cannot pass by rejecting every
+    // replay: this is the genuine loss the recovery exists for.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+    client._sendMessage(resultFrame())
+    client._sendMessage(sessionStateFrame('idle'))
+
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._setTurnSettled(true)
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+    // This turn's own ending, never delivered live - a different result uuid.
+    client._sendMessage(resultFrame({ replayed: true, uuid: 'b2f0a1c4-0000-4000-8000-000000000002' }))
+    client._sendMessage(sessionStateFrame('idle', { replayed: true }))
+
+    expect(messagePersister.getSessionActivity(SESSION)).toBe('idle')
+  })
+
+  it('a container that accepts the probe but never answers keeps the probe running', async () => {
+    // The half-open case this recovery exists for reaches the HTTP probe too.
+    // If the next probe were only scheduled after the answer came back, a hang
+    // would silently end the recovery for the rest of the session.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    ;(client.getSession as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}))
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS * 4)
+
+    expect(client.getSession).toHaveBeenCalledTimes(4)
+  })
+
+  it('a rejected replay does not strand the turn it was rejected for', async () => {
+    // The counterpart to the guard above: dropping the stale result stops the
+    // false completion, but leaves a turn nothing can settle. It must reach a
+    // terminal state rather than sit active forever.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._sendMessage(capabilitiesFrame())
+    client._sendMessage(resultFrame())
+    client._sendMessage(sessionStateFrame('idle'))
+    ;(notificationManager.triggerSessionComplete as ReturnType<typeof vi.fn>).mockClear()
+
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._setTurnSettled(true)
+
+    // The container will replay this batch to every attach, in FIFO order. The
+    // leading informational must not be mistaken for live traffic: doing so
+    // clears the pending verdict, so each reattach triggers a replay that
+    // resets the recovery and it never ends.
+    client._armReplay([
+      informationalFrame({ replayed: true }),
+      resultFrame({ replayed: true }),
+      sessionStateFrame('idle', { replayed: true }),
+    ])
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS * 4)
+
+    expect(messagePersister.isSessionActive(SESSION)).toBe(false)
+    expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
+  })
+
+  it('a settled container with nothing left to replay is not reattached repeatedly', async () => {
+    // A container-side process replacement clears the replay, so the reattach
+    // has nothing to deliver. Repeating the swap would only re-run the frame
+    // loss without learning anything new.
+    messagePersister.markSessionActive(SESSION, AGENT)
+    client._setTurnSettled(true)
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS * 5)
+
+    expect(client.subscribeToStream).toHaveBeenCalledTimes(2)
+    // Not a completion: nothing here proved the work succeeded.
+    expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
   })
 
   it('late-join replay with an empty background snapshot unpins a lost task terminal', async () => {
@@ -321,6 +507,7 @@ describe('settle silence / discarded settle memory', () => {
     )
     client._sendMessage(sessionStateFrame('idle'))
     expect(messagePersister.getSessionActivity(SESSION)).not.toBe('idle')
+    client._setTurnSettled(true)
 
     await vi.advanceTimersByTimeAsync(STREAM_SILENCE_REATTACH_MS)
     expect(client.subscribeToStream).toHaveBeenCalledTimes(2)

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1,4 +1,4 @@
-import type { ContainerClient, StreamMessage, SlashCommandInfo } from './types'
+import type { ContainerClient, ContainerSession, StreamMessage, SlashCommandInfo } from './types'
 import type { SessionUsage, SessionActivity } from '@shared/lib/types/agent'
 import type { AskUserQuestionInput } from '@shared/lib/tool-definitions/ask-user-question'
 import type { RequestSecretInput } from '@shared/lib/tool-definitions/request-secret'
@@ -184,6 +184,16 @@ interface StreamingState {
   // Subtype of the most recent result — gates the completion notification when
   // idle arrives via session_state_changed (resume-exits pause, not finish).
   lastResultSubtype: string | null
+  // uuid of the most recent result processed LIVE. Replayed frames carry no
+  // turn identity, so this is what separates "my turn ended" from "an earlier
+  // turn ended and is being replayed at me".
+  lastProcessedResultUuid: string | null
+  // Set when the probe found the container settled while this host still
+  // believed a turn was running, and reattached to collect what it missed. A
+  // second such probe means that reattach produced nothing actionable, which
+  // bounds the recovery instead of leaving the turn active with nothing left
+  // to settle it.
+  sawSettledContainerWhileActive: boolean
   isRetrying: boolean // True while an API retry is in progress, cleared when the next message starts
 }
 
@@ -252,14 +262,28 @@ export function redactStreamedToolInput(toolName: string | undefined, partialInp
   return partialInput.replace(/("secret"\s*:\s*")(?:\\.|[^"\\])*/g, '$1***')
 }
 
+/**
+ * Whether a replayed result describes a turn this host already saw end. A
+ * result with no usable uuid cannot be proven new, so it counts as already
+ * processed: a false "already processed" costs a stuck indicator, a false "new"
+ * costs a completion notification and a persisted success for a turn never run.
+ */
+export function isReplayOfProcessedResult(
+  lastProcessedResultUuid: string | null,
+  resultUuid: unknown
+): boolean {
+  if (lastProcessedResultUuid === null) return false
+  if (typeof resultUuid !== 'string' || resultUuid.length === 0) return true
+  return resultUuid === lastProcessedResultUuid
+}
+
 // TODO this file is too big, this class is HUGE. Needs breaking up
 
 /**
- * Quiet window before reattaching a stream the host still believes is live.
- * Same 30s family as the SSE keep-alive that reconciles isActive one hop up
- * (api/routes/agents.ts ping), the idle-eviction sweep, and the completion-wake
- * grace. Not a wall-clock settle: the only action is reattach; settling still
- * requires a frame the container actually emitted.
+ * How often to ask the container whether a turn is still in flight, once its
+ * stream has gone quiet. A poll period, not a threshold: silence is never
+ * itself treated as the turn ending, so no measurement of "normal quiet"
+ * rides on this value.
  */
 export const STREAM_SILENCE_REATTACH_MS = 30_000
 
@@ -289,6 +313,7 @@ class MessagePersister {
   // subscribeToSession() calls for the same session share the underlying
   // promise so we don't double-install listeners or double-tear-down state.
   private subscribingNow: Map<string, Promise<void>> = new Map()
+
   constructor() {
     // Unified wire: every registry transition — no matter which of the many
     // mutation paths drove it — broadcasts ONE typed event, to the global
@@ -466,6 +491,9 @@ class MessagePersister {
       stateEventsAuthority: prior?.stateEventsAuthority ?? false,
       lastResultSubtype: priorLastResultSubtype,
       lastResultCleanSuccess: priorLastResultCleanSuccess,
+      // Must survive a reattach — judging the replay it triggers is the point.
+      lastProcessedResultUuid: prior?.lastProcessedResultUuid ?? null,
+      sawSettledContainerWhileActive: prior?.sawSettledContainerWhileActive ?? false,
       isRetrying: false,
     })
 
@@ -496,7 +524,6 @@ class MessagePersister {
     // Safe to drop: the container's persisted grants are authoritative, so a
     // resubscribed session repopulates this on the next launch with one GET.
     this.sessionCapabilityGrants.delete(sessionId)
-    this.streamTokens.delete(sessionId)
   }
 
   /**
@@ -524,7 +551,10 @@ class MessagePersister {
   }
 
   private detachStreamTransport(sessionId: string): void {
-    this.streamTokens.set(sessionId, {})
+    // Drop rather than replace: an absent entry fails the identity guard just
+    // as a fresh one does, and leaves nothing behind for callers that detach
+    // without tearing down (markAllSessionsInactiveForAgent).
+    this.streamTokens.delete(sessionId)
     const existingUnsubscribe = this.subscriptions.get(sessionId)
     if (!existingUnsubscribe) return
     existingUnsubscribe()
@@ -533,14 +563,18 @@ class MessagePersister {
     }
   }
 
-  private armSettleProbe(sessionId: string): void {
+  /** Returns the armed timer, which doubles as the probe's freshness token. */
+  private armSettleProbe(sessionId: string): ReturnType<typeof setTimeout> | null {
     this.cancelSettleProbe(sessionId)
-    if (!this.streamingStates.get(sessionId)?.isActive) return
+    if (!this.streamingStates.get(sessionId)?.isActive) return null
     const timer = setTimeout(() => {
       this.settleProbeTimers.delete(sessionId)
-      this.reattachAfterSilence(sessionId)
+      this.reattachAfterSilence(sessionId).catch((err) => {
+        console.error(`[MessagePersister] Silence probe errored for session ${sessionId}:`, err)
+      })
     }, STREAM_SILENCE_REATTACH_MS)
     this.settleProbeTimers.set(sessionId, timer)
+    return timer
   }
 
   private cancelSettleProbe(sessionId: string): void {
@@ -551,24 +585,72 @@ class MessagePersister {
   }
 
   /**
-   * The stream went quiet while we still believe a turn is running. Reattach
-   * the transport: the container replays the terminal frames of its last turn
-   * to any late joiner, which is the recovery road a silently-dead socket never
-   * reaches (no close event, so no connection_closed). Reuses existing
-   * machinery on both sides — no new container contract.
+   * The stream went quiet while we still believe a turn is running.
+   *
+   * Quiet is not evidence the turn ended — long builds and a session parked on
+   * a permission card are both silent for minutes — so ask the container, which
+   * answers per-turn. While it says a turn is running the socket is left alone:
+   * the stream is unbuffered fan-out, so a swap loses whatever is emitted in
+   * the close/open gap, permission requests included.
    */
-  private reattachAfterSilence(sessionId: string): void {
-    const state = this.streamingStates.get(sessionId)
-    if (!state?.isActive) return
+  private async reattachAfterSilence(sessionId: string): Promise<void> {
+    if (!this.streamingStates.get(sessionId)?.isActive) return
     const client = this.containerClients.get(sessionId)
     if (!client) return
+
+    // Re-arm before the round trip: a container that accepts the connection but
+    // never answers is the half-open case this recovery exists for, and arming
+    // afterwards would let that hang leave the session unwatched. The armed
+    // timer is also this probe's freshness token — anything that re-arms while
+    // the request is in flight (a frame, a new turn) replaces it, and the
+    // answer this probe is holding is then about a window that has moved on.
+    const probeToken = this.armSettleProbe(sessionId)
+
+    let containerSession: ContainerSession | null
+    try {
+      containerSession = await client.getSession(sessionId)
+    } catch (err) {
+      // Unreachable is not evidence about the turn.
+      console.error(`[MessagePersister] Silence probe failed for session ${sessionId}:`, err)
+      return
+    }
+
+    // Re-read after the await: the turn may have settled, or been replaced by a
+    // later one, while the request was in flight.
+    if (this.settleProbeTimers.get(sessionId) !== probeToken) return
+    const state = this.streamingStates.get(sessionId)
+    if (!state?.isActive) return
+
+    if (!containerSession) {
+      console.log(`[MessagePersister] Session ${sessionId} gone from container during silence, marking inactive`)
+      this.markSessionInactive(sessionId, state)
+      return
+    }
+
+    // Unknown (a container predating the field) is not "finished".
+    if (containerSession.turnSettled !== true) {
+      state.sawSettledContainerWhileActive = false
+      return
+    }
+
+    if (state.sawSettledContainerWhileActive) {
+      // The previous reattach delivered nothing this host could act on — either
+      // no replay survived a container-side process replacement, or the replay
+      // described a turn already processed. Nothing further is coming, and
+      // reattaching again only re-runs the frame loss. A turn the container is
+      // not running and this host never saw end is a turn whose runtime went
+      // away, which markSessionInactive surfaces. Deliberately not a
+      // completion: nothing here proves the work succeeded.
+      console.log(`[MessagePersister] Session ${sessionId} settled container-side with nothing to replay, marking inactive`)
+      this.markSessionInactive(sessionId, state)
+      return
+    }
+
+    state.sawSettledContainerWhileActive = true
     const ready = this.attachStreamTransport(sessionId, client, sessionId)
     ready.catch((err) => {
       console.error(`[MessagePersister] Silence reattach failed for session ${sessionId}:`, err)
     })
-    // Keep watching: a reattach that replays nothing must be retried, not
-    // treated as evidence the turn ended.
-    this.armSettleProbe(sessionId)
   }
 
   // Single idle finalizer — flips state and broadcasts to session + global
@@ -1087,6 +1169,8 @@ class MessagePersister {
         processInstanceId: null,
         pendingDeliverFiles: new Map(),
         stateEventsAuthority: false,
+        lastProcessedResultUuid: null,
+        sawSettledContainerWhileActive: false,
         lastResultSubtype: null,
       lastResultCleanSuccess: false,
         isRetrying: false,
@@ -1113,6 +1197,9 @@ class MessagePersister {
     // completion notification against the turn this message is starting.
     state.lastResultSubtype = null
     state.lastResultCleanSuccess = false
+    // NOT lastProcessedResultUuid: rejecting a replay of the previous turn is
+    // exactly what the new turn needs it for.
+    state.sawSettledContainerWhileActive = false
     this.armSettleProbe(sessionId)
     if (agentSlug) {
       state.agentSlug = agentSlug
@@ -1433,6 +1520,13 @@ class MessagePersister {
     if (!state) return
 
     this.armSettleProbe(sessionId)
+    // A LIVE frame proves the stream is delivering new work, so a pending
+    // reattach got its answer. Replayed frames are that reattach's own output
+    // and are the very thing being judged — an informational leading the replay
+    // batch must not clear the verdict before the result behind it is read.
+    if (!message.content?.replayed) {
+      state.sawSettledContainerWhileActive = false
+    }
 
     // Skip processing if session was interrupted (prevents race conditions)
     // Allow 'result' through as it indicates the container actually stopped.
@@ -1488,8 +1582,20 @@ class MessagePersister {
     // exists. Only act on them when this session actually missed the turn
     // (still marked active); a settled session already processed the live
     // copies, and replaying them would re-fire terminal broadcasts.
-    if (content.replayed && !state.isActive) {
-      return
+    if (content.replayed) {
+      if (!state.isActive) return
+      // A replayed result the host already processed must not re-arm the turn's
+      // result memory, or the idle behind it settles the CURRENT turn and
+      // reports a completion for work that never ran. Only the result is
+      // dropped, deliberately not the batch: the idle behind it is then judged
+      // by the existing guard, which settles only on a result seen for THIS
+      // turn — preserving a result delivered live whose idle was lost.
+      if (
+        content.type === 'result' &&
+        isReplayOfProcessedResult(state.lastProcessedResultUuid, content.uuid)
+      ) {
+        return
+      }
     }
 
     switch (content.type) {
@@ -2004,6 +2110,12 @@ class MessagePersister {
         }
         state.currentText = ''
         state.lastResultSubtype = typeof content.subtype === 'string' ? content.subtype : null
+        // Turn identity for the replay guard. A replay reaching here is the
+        // first sighting of this turn's end, so recording it stops the next
+        // reattach from re-settling the same turn.
+        if (typeof content.uuid === 'string' && content.uuid.length > 0) {
+          state.lastProcessedResultUuid = content.uuid
+        }
 
         // A clean success with zero turns means the main loop never ran — the
         // signature of a settings-file hook blocking the prompt. (duration_api_ms

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -272,6 +272,7 @@ class MessagePersister {
   // with no pending entry, so we must stop broadcasting review cards for them.
   private sessionCapabilityGrants: Map<string, Set<'subagents' | 'workflows'>> = new Map()
   private subscriptions: Map<string, () => void> = new Map()
+  private streamTokens: Map<string, object> = new Map()
   private sseClients: Map<string, Set<(data: unknown) => void>> = new Map()
   // Per-run journal tailers driving the live workflow drawer, keyed `${sessionId}::${runId}`
   private workflowTailers: Map<string, WorkflowJournalTailer> = new Map()
@@ -288,15 +289,6 @@ class MessagePersister {
   // subscribeToSession() calls for the same session share the underlying
   // promise so we don't double-install listeners or double-tear-down state.
   private subscribingNow: Map<string, Promise<void>> = new Map()
-  // Intentional transport detach (silence reattach / re-subscribe) closes the
-  // socket itself. That close still synthesizes connection_closed on the old
-  // callback — which must NOT run handleConnectionClosed's resubscribe, or we
-  // stack a second live stream and double-apply stream_deltas in the UI.
-  private ignoreNextConnectionClosed: Set<string> = new Set()
-  // Bumped on intentional detach so an in-flight handleConnectionClosed
-  // (getSession already started) cannot overwrite the replacement subscribe.
-  private connectionRecoveryEpoch: Map<string, number> = new Map()
-
   constructor() {
     // Unified wire: every registry transition — no matter which of the many
     // mutation paths drove it — broadcasts ONE typed event, to the global
@@ -446,11 +438,6 @@ class MessagePersister {
     const priorLastResultSubtype = prior?.lastResultSubtype ?? null
     const priorLastResultCleanSuccess = prior?.lastResultCleanSuccess ?? false
 
-    // Detach only the transport if already subscribed. NOT unsubscribeFromSession:
-    // that is a full teardown — it drops the session's registry entries, which
-    // must outlive a transport reattach for the same live session.
-    this.detachStreamTransport(sessionId)
-
     // Initialize state
     this.streamingStates.set(sessionId, {
       currentText: '',
@@ -486,12 +473,7 @@ class MessagePersister {
     this.containerClients.set(sessionId, client)
 
     // Subscribe to the container's message stream
-    const { unsubscribe, ready } = client.subscribeToStream(
-      containerSessionId,
-      (message) => this.handleMessage(sessionId, message)
-    )
-
-    this.subscriptions.set(sessionId, unsubscribe)
+    const ready = this.attachStreamTransport(sessionId, client, containerSessionId)
 
     if (this.capture && agentSlug) {
       const subagentsDir = path.join(getAgentSessionsDir(agentSlug), sessionId, 'subagents')
@@ -506,8 +488,6 @@ class MessagePersister {
   // Unsubscribe from a session
   unsubscribeFromSession(sessionId: string): void {
     this.cancelSettleProbe(sessionId)
-    // Full teardown: ignore the synthetic close from our own unsubscribe so it
-    // cannot race a resubscribe after streamingStates/containerClients are gone.
     this.detachStreamTransport(sessionId)
     this.streamingStates.delete(sessionId)
     // Shadow registry (Phase 2): every session-scoped entry dies with the state.
@@ -516,26 +496,41 @@ class MessagePersister {
     // Safe to drop: the container's persisted grants are authoritative, so a
     // resubscribed session repopulates this on the next launch with one GET.
     this.sessionCapabilityGrants.delete(sessionId)
-    this.ignoreNextConnectionClosed.delete(sessionId)
-    this.connectionRecoveryEpoch.delete(sessionId)
+    this.streamTokens.delete(sessionId)
   }
 
   /**
-   * Drop the live transport without treating the resulting close as peer death.
-   * Real ws.close() synthesizes connection_closed on the old callback; that
-   * path must not stack handleConnectionClosed's resubscribe on top of the
-   * replacement we are about to install.
+   * Install the only current stream callback for a session. Every replacement
+   * installs its token before closing the old socket, so late frames from
+   * that socket cannot affect the replacement or start another recovery.
    */
+  private attachStreamTransport(
+    sessionId: string,
+    client: ContainerClient,
+    containerSessionId: string
+  ): Promise<void> {
+    const streamToken = {}
+    this.streamTokens.set(sessionId, streamToken)
+
+    const existingUnsubscribe = this.subscriptions.get(sessionId)
+    existingUnsubscribe?.()
+
+    const { unsubscribe, ready } = client.subscribeToStream(containerSessionId, (message) => {
+      if (this.streamTokens.get(sessionId) !== streamToken) return
+      this.handleMessage(sessionId, message, streamToken)
+    })
+    this.subscriptions.set(sessionId, unsubscribe)
+    return ready
+  }
+
   private detachStreamTransport(sessionId: string): void {
-    this.connectionRecoveryEpoch.set(
-      sessionId,
-      (this.connectionRecoveryEpoch.get(sessionId) ?? 0) + 1
-    )
+    this.streamTokens.set(sessionId, {})
     const existingUnsubscribe = this.subscriptions.get(sessionId)
     if (!existingUnsubscribe) return
-    this.ignoreNextConnectionClosed.add(sessionId)
     existingUnsubscribe()
-    this.subscriptions.delete(sessionId)
+    if (this.subscriptions.get(sessionId) === existingUnsubscribe) {
+      this.subscriptions.delete(sessionId)
+    }
   }
 
   private armSettleProbe(sessionId: string): void {
@@ -567,14 +562,7 @@ class MessagePersister {
     if (!state?.isActive) return
     const client = this.containerClients.get(sessionId)
     if (!client) return
-    // Detach only the transport — same boundary as doSubscribeToSession.
-    // Silence can fire while the old socket is still half-open or merely quiet;
-    // closing it ourselves must not look like an unexpected peer death.
-    this.detachStreamTransport(sessionId)
-    const { unsubscribe, ready } = client.subscribeToStream(sessionId, (message) =>
-      this.handleMessage(sessionId, message)
-    )
-    this.subscriptions.set(sessionId, unsubscribe)
+    const ready = this.attachStreamTransport(sessionId, client, sessionId)
     ready.catch((err) => {
       console.error(`[MessagePersister] Silence reattach failed for session ${sessionId}:`, err)
     })
@@ -972,11 +960,7 @@ class MessagePersister {
           this.markSessionInactive(sessionId, state)
         }
         // Clean up stale WebSocket subscription so next message re-subscribes to the new container
-        const unsubscribe = this.subscriptions.get(sessionId)
-        if (unsubscribe) {
-          unsubscribe()
-          this.subscriptions.delete(sessionId)
-        }
+        this.detachStreamTransport(sessionId)
         this.containerClients.delete(sessionId)
       }
     }
@@ -1129,6 +1113,7 @@ class MessagePersister {
     // completion notification against the turn this message is starting.
     state.lastResultSubtype = null
     state.lastResultCleanSuccess = false
+    this.armSettleProbe(sessionId)
     if (agentSlug) {
       state.agentSlug = agentSlug
     }
@@ -1440,7 +1425,8 @@ class MessagePersister {
   // Handle incoming message from container
   private handleMessage(
     sessionId: string,
-    message: StreamMessage
+    message: StreamMessage,
+    streamToken: object
   ): void {
     this.capture?.recordInput(sessionId, message)
     const state = this.streamingStates.get(sessionId)
@@ -2010,6 +1996,7 @@ class MessagePersister {
         if (isError || classification.isInterrupt) {
           state.isActive = false
           state.isAwaitingInput = false
+          this.cancelSettleProbe(sessionId)
         } else if (state.stateEventsAuthority || this.openBackgroundWorkCount(state) > 0) {
           this.syncSessionAwaiting(sessionId)
         } else {
@@ -2170,15 +2157,10 @@ class MessagePersister {
         break
 
       case 'connection_closed':
-        // Intentional detach (silence reattach / re-subscribe) closes the socket
-        // itself — that synthetic close is not peer death.
-        if (this.ignoreNextConnectionClosed.delete(sessionId)) {
-          return
-        }
         // WebSocket connection to container was lost
         // Check if session is still actually running in the container
         console.log(`[MessagePersister] Connection closed for session ${sessionId}, checking container state`)
-        this.handleConnectionClosed(sessionId, state)
+        this.handleConnectionClosed(sessionId, state, streamToken)
         break
 
       case 'stream_event':
@@ -2197,7 +2179,11 @@ class MessagePersister {
   }
 
   // Handle connection closed - check container and mark inactive if session is done
-  private handleConnectionClosed(sessionId: string, state: StreamingState): void {
+  private handleConnectionClosed(
+    sessionId: string,
+    state: StreamingState,
+    streamToken: object
+  ): void {
     const client = this.containerClients.get(sessionId)
     if (!client) {
       // No client reference, assume session is done
@@ -2205,14 +2191,10 @@ class MessagePersister {
       return
     }
 
-    // Capture epoch before the async hop. An intentional detach (or a newer
-    // recovery) bumps it; stale then-handlers must not stack another subscribe.
-    const epoch = this.connectionRecoveryEpoch.get(sessionId) ?? 0
-
     // Check container asynchronously
     client.getSession(sessionId)
       .then((containerSession) => {
-        if ((this.connectionRecoveryEpoch.get(sessionId) ?? 0) !== epoch) {
+        if (this.streamTokens.get(sessionId) !== streamToken) {
           return
         }
         if (!containerSession) {
@@ -2228,20 +2210,7 @@ class MessagePersister {
         if (isRunning) {
           // Session still running, try to re-subscribe
           console.log(`[MessagePersister] Session ${sessionId} still running, re-subscribing`)
-          // Peer already closed the socket — do not call unsubscribe() (and do
-          // not set ignoreNext). On the real client unsubscribe is a no-op once
-          // close cleared wsConnections; calling detachStreamTransport would
-          // leave ignoreNext sticky and swallow the next real close.
-          this.connectionRecoveryEpoch.set(
-            sessionId,
-            (this.connectionRecoveryEpoch.get(sessionId) ?? 0) + 1
-          )
-          this.subscriptions.delete(sessionId)
-          const { unsubscribe, ready } = client.subscribeToStream(
-            sessionId,
-            (message) => this.handleMessage(sessionId, message)
-          )
-          this.subscriptions.set(sessionId, unsubscribe)
+          const ready = this.attachStreamTransport(sessionId, client, sessionId)
           // Defense-in-depth: we don't await the re-subscribe here, so attach a
           // handler to the `ready` promise. A failed reconnect routes a
           // synthesized connection_closed message through the callback above;
@@ -2256,7 +2225,7 @@ class MessagePersister {
         }
       })
       .catch((error) => {
-        if ((this.connectionRecoveryEpoch.get(sessionId) ?? 0) !== epoch) {
+        if (this.streamTokens.get(sessionId) !== streamToken) {
           return
         }
         // Can't reach container, assume session is done

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -253,8 +253,19 @@ export function redactStreamedToolInput(toolName: string | undefined, partialInp
 }
 
 // TODO this file is too big, this class is HUGE. Needs breaking up
+
+/**
+ * Quiet window before reattaching a stream the host still believes is live.
+ * Same 30s family as the SSE keep-alive that reconciles isActive one hop up
+ * (api/routes/agents.ts ping), the idle-eviction sweep, and the completion-wake
+ * grace. Not a wall-clock settle: the only action is reattach; settling still
+ * requires a frame the container actually emitted.
+ */
+export const STREAM_SILENCE_REATTACH_MS = 30_000
+
 class MessagePersister {
   private streamingStates: Map<string, StreamingState> = new Map()
+  private settleProbeTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   // "Allow for this session" capability grants, keyed by sessionId. Display
   // bookkeeping ONLY — enforcement lives in the container (which persists its
   // copy with the session). Once granted, launches auto-allow container-side
@@ -277,6 +288,14 @@ class MessagePersister {
   // subscribeToSession() calls for the same session share the underlying
   // promise so we don't double-install listeners or double-tear-down state.
   private subscribingNow: Map<string, Promise<void>> = new Map()
+  // Intentional transport detach (silence reattach / re-subscribe) closes the
+  // socket itself. That close still synthesizes connection_closed on the old
+  // callback — which must NOT run handleConnectionClosed's resubscribe, or we
+  // stack a second live stream and double-apply stream_deltas in the UI.
+  private ignoreNextConnectionClosed: Set<string> = new Set()
+  // Bumped on intentional detach so an in-flight handleConnectionClosed
+  // (getSession already started) cannot overwrite the replacement subscribe.
+  private connectionRecoveryEpoch: Map<string, number> = new Map()
 
   constructor() {
     // Unified wire: every registry transition — no matter which of the many
@@ -421,15 +440,16 @@ class MessagePersister {
     const priorIsAwaitingInput = prior?.isAwaitingInput ?? false
     const priorBackgroundTasks = prior?.activeBackgroundTasks ?? new Map()
     const priorSettledInputRequests = prior?.settledInputRequests ?? new Map()
+    // Reply memory is settle-relevant and must survive a transport reattach:
+    // wiping it makes the next idle look like a stale idle from a prior turn,
+    // and the idle guard then discards it. Nothing was lost on the wire.
+    const priorLastResultSubtype = prior?.lastResultSubtype ?? null
+    const priorLastResultCleanSuccess = prior?.lastResultCleanSuccess ?? false
 
     // Detach only the transport if already subscribed. NOT unsubscribeFromSession:
     // that is a full teardown — it drops the session's registry entries, which
     // must outlive a transport reattach for the same live session.
-    const existingUnsubscribe = this.subscriptions.get(sessionId)
-    if (existingUnsubscribe) {
-      existingUnsubscribe()
-      this.subscriptions.delete(sessionId)
-    }
+    this.detachStreamTransport(sessionId)
 
     // Initialize state
     this.streamingStates.set(sessionId, {
@@ -457,8 +477,8 @@ class MessagePersister {
       processInstanceId: prior?.processInstanceId ?? null,
       pendingDeliverFiles: new Map(),
       stateEventsAuthority: prior?.stateEventsAuthority ?? false,
-      lastResultSubtype: null,
-      lastResultCleanSuccess: false,
+      lastResultSubtype: priorLastResultSubtype,
+      lastResultCleanSuccess: priorLastResultCleanSuccess,
       isRetrying: false,
     })
 
@@ -485,11 +505,10 @@ class MessagePersister {
 
   // Unsubscribe from a session
   unsubscribeFromSession(sessionId: string): void {
-    const unsubscribe = this.subscriptions.get(sessionId)
-    if (unsubscribe) {
-      unsubscribe()
-      this.subscriptions.delete(sessionId)
-    }
+    this.cancelSettleProbe(sessionId)
+    // Full teardown: ignore the synthetic close from our own unsubscribe so it
+    // cannot race a resubscribe after streamingStates/containerClients are gone.
+    this.detachStreamTransport(sessionId)
     this.streamingStates.delete(sessionId)
     // Shadow registry (Phase 2): every session-scoped entry dies with the state.
     userInputRequestManager.dropSessionRequests(sessionId, 'invalidated')
@@ -497,12 +516,78 @@ class MessagePersister {
     // Safe to drop: the container's persisted grants are authoritative, so a
     // resubscribed session repopulates this on the next launch with one GET.
     this.sessionCapabilityGrants.delete(sessionId)
+    this.ignoreNextConnectionClosed.delete(sessionId)
+    this.connectionRecoveryEpoch.delete(sessionId)
+  }
+
+  /**
+   * Drop the live transport without treating the resulting close as peer death.
+   * Real ws.close() synthesizes connection_closed on the old callback; that
+   * path must not stack handleConnectionClosed's resubscribe on top of the
+   * replacement we are about to install.
+   */
+  private detachStreamTransport(sessionId: string): void {
+    this.connectionRecoveryEpoch.set(
+      sessionId,
+      (this.connectionRecoveryEpoch.get(sessionId) ?? 0) + 1
+    )
+    const existingUnsubscribe = this.subscriptions.get(sessionId)
+    if (!existingUnsubscribe) return
+    this.ignoreNextConnectionClosed.add(sessionId)
+    existingUnsubscribe()
+    this.subscriptions.delete(sessionId)
+  }
+
+  private armSettleProbe(sessionId: string): void {
+    this.cancelSettleProbe(sessionId)
+    if (!this.streamingStates.get(sessionId)?.isActive) return
+    const timer = setTimeout(() => {
+      this.settleProbeTimers.delete(sessionId)
+      this.reattachAfterSilence(sessionId)
+    }, STREAM_SILENCE_REATTACH_MS)
+    this.settleProbeTimers.set(sessionId, timer)
+  }
+
+  private cancelSettleProbe(sessionId: string): void {
+    const timer = this.settleProbeTimers.get(sessionId)
+    if (!timer) return
+    clearTimeout(timer)
+    this.settleProbeTimers.delete(sessionId)
+  }
+
+  /**
+   * The stream went quiet while we still believe a turn is running. Reattach
+   * the transport: the container replays the terminal frames of its last turn
+   * to any late joiner, which is the recovery road a silently-dead socket never
+   * reaches (no close event, so no connection_closed). Reuses existing
+   * machinery on both sides — no new container contract.
+   */
+  private reattachAfterSilence(sessionId: string): void {
+    const state = this.streamingStates.get(sessionId)
+    if (!state?.isActive) return
+    const client = this.containerClients.get(sessionId)
+    if (!client) return
+    // Detach only the transport — same boundary as doSubscribeToSession.
+    // Silence can fire while the old socket is still half-open or merely quiet;
+    // closing it ourselves must not look like an unexpected peer death.
+    this.detachStreamTransport(sessionId)
+    const { unsubscribe, ready } = client.subscribeToStream(sessionId, (message) =>
+      this.handleMessage(sessionId, message)
+    )
+    this.subscriptions.set(sessionId, unsubscribe)
+    ready.catch((err) => {
+      console.error(`[MessagePersister] Silence reattach failed for session ${sessionId}:`, err)
+    })
+    // Keep watching: a reattach that replays nothing must be retried, not
+    // treated as evidence the turn ended.
+    this.armSettleProbe(sessionId)
   }
 
   // Single idle finalizer — flips state and broadcasts to session + global
   // listeners. Used by the result handler (legacy result-driven idle), the
   // session_state_changed handler (authoritative idle), and markSessionInactive.
   private finalizeIdle(sessionId: string, state: StreamingState): void {
+    this.cancelSettleProbe(sessionId)
     // The session is truly settled: persist the automation outcome for a turn
     // that ended in a clean success. (Failures were already persisted at their
     // result — an error ends the turn immediately. Interrupts never set the
@@ -931,6 +1016,7 @@ class MessagePersister {
 
   // Mark a session as interrupted (not active)
   async markSessionInterrupted(sessionId: string): Promise<void> {
+    this.cancelSettleProbe(sessionId)
     const state = this.streamingStates.get(sessionId)
 
     // Set interrupted flag FIRST to prevent race conditions with incoming events
@@ -1359,6 +1445,8 @@ class MessagePersister {
     this.capture?.recordInput(sessionId, message)
     const state = this.streamingStates.get(sessionId)
     if (!state) return
+
+    this.armSettleProbe(sessionId)
 
     // Skip processing if session was interrupted (prevents race conditions)
     // Allow 'result' through as it indicates the container actually stopped.
@@ -2082,6 +2170,11 @@ class MessagePersister {
         break
 
       case 'connection_closed':
+        // Intentional detach (silence reattach / re-subscribe) closes the socket
+        // itself — that synthetic close is not peer death.
+        if (this.ignoreNextConnectionClosed.delete(sessionId)) {
+          return
+        }
         // WebSocket connection to container was lost
         // Check if session is still actually running in the container
         console.log(`[MessagePersister] Connection closed for session ${sessionId}, checking container state`)
@@ -2112,9 +2205,16 @@ class MessagePersister {
       return
     }
 
+    // Capture epoch before the async hop. An intentional detach (or a newer
+    // recovery) bumps it; stale then-handlers must not stack another subscribe.
+    const epoch = this.connectionRecoveryEpoch.get(sessionId) ?? 0
+
     // Check container asynchronously
     client.getSession(sessionId)
       .then((containerSession) => {
+        if ((this.connectionRecoveryEpoch.get(sessionId) ?? 0) !== epoch) {
+          return
+        }
         if (!containerSession) {
           // Session doesn't exist in container anymore
           console.log(`[MessagePersister] Session ${sessionId} not found in container, marking inactive`)
@@ -2128,6 +2228,15 @@ class MessagePersister {
         if (isRunning) {
           // Session still running, try to re-subscribe
           console.log(`[MessagePersister] Session ${sessionId} still running, re-subscribing`)
+          // Peer already closed the socket — do not call unsubscribe() (and do
+          // not set ignoreNext). On the real client unsubscribe is a no-op once
+          // close cleared wsConnections; calling detachStreamTransport would
+          // leave ignoreNext sticky and swallow the next real close.
+          this.connectionRecoveryEpoch.set(
+            sessionId,
+            (this.connectionRecoveryEpoch.get(sessionId) ?? 0) + 1
+          )
+          this.subscriptions.delete(sessionId)
           const { unsubscribe, ready } = client.subscribeToStream(
             sessionId,
             (message) => this.handleMessage(sessionId, message)
@@ -2147,6 +2256,9 @@ class MessagePersister {
         }
       })
       .catch((error) => {
+        if ((this.connectionRecoveryEpoch.get(sessionId) ?? 0) !== epoch) {
+          return
+        }
         // Can't reach container, assume session is done
         console.error(`[MessagePersister] Failed to check container for session ${sessionId}:`, error)
         this.markSessionInactive(sessionId, state)
@@ -2155,6 +2267,7 @@ class MessagePersister {
 
   // Mark a session as inactive and broadcast the update
   private markSessionInactive(sessionId: string, state: StreamingState): void {
+    this.cancelSettleProbe(sessionId)
     // A session that was mid-turn (user message sent, no result yet) and not
     // deliberately interrupted didn't finish — its runtime vanished (container
     // crash, guest OOM kill of the agent process, VM death). Surface that as an

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -38,6 +38,12 @@ export interface ContainerSession {
   lastActivity: string
   workingDirectory: string
   slashCommands?: SlashCommandInfo[]
+  /**
+   * Whether nothing is in flight for this session: turn over, no background
+   * work, past the completion-wake grace. Optional because an older container
+   * omits it — absent means "unknown", never "finished".
+   */
+  turnSettled?: boolean
 }
 
 export interface StreamMessage {


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-468/fix-stuck-working-settle-signal-loss-class-reply-memory-reattach-on

Settle a finished turn when the host loses or discards a settle frame, without inventing idle from a timer.

Footprint: 6 production files, +245 net. 4 test files, +696 net. Supersedes #572.

Likely match for the stuck Working / Thinking card Graham reported in `#champagne-gulping` on local Apple Container: flapping network plus no stream recovery.
Not claimed for his second symptom (reply invisible until container stop) - that is SUP-517.

## What each part does

Three independent fixes.
Together they settle a finished turn when a settle frame is lost or thrown away.

**Part 1 - stop forgetting "we already got a result"**

When the app reopens a conversation (or SSE reconnects), it reattaches the stream.
It used to wipe "last result" memory.

```
result arrives → host remembers "got a result"
external reattach → OLD: forget that memory
idle arrives     → host thinks "stale idle" → ignores it → spinner forever

NEW: reattach keeps the memory → idle settles
```

Nothing was lost on the wire.
The host threw away the note it needed.

File: `src/shared/lib/container/message-persister.ts`

**Part 2 - if the stream goes quiet mid-turn, ask the container whether the turn ended**

The host only recovered when the socket cleanly closed.
A half-open or wedged link never closes, so recovery never ran.

Quiet is not evidence a turn ended.
A long build is quiet. A session parked on a permission card is quiet for as long as the human takes.
So the host asks instead of assuming.

```
turn believed live
  + no frames for 30s
       → ask the container: is a turn actually in flight?
            ├─ still running → do nothing, socket untouched, ask again in 30s
            ├─ nothing running → we missed the ending: reattach once,
            │                    collect the replay
            └─ no answer / older container → unknown, never "finished"
```

The container already tracks this per turn - it is what gates its own idle-eviction reaper.
That answer is now `turnSettled` on `GET /sessions/:id`.
`isRunning` cannot answer it: that reports the CLI process and stays true for the life of the query loop.

Measured on a live container, same session across a turn boundary:

```
t+0.0s  isRunning=true  turnSettled=false   turn in flight
t+2.5s  isRunning=true  turnSettled=true    turn ended
```

Why it matters that the socket is left alone: the stream is unbuffered fan-out, so anything emitted
during a close/open gap is gone. Assistant text survives via the 15s transcript poll. Permission
requests, background-task updates and command lifecycle frames do not, and a lost input request
parks the session invisibly until the 24h TTL.

A/B on a rebuilt image - same container, same prompt, same five minutes, host code the only variable:

```
gate in place   1 WebSocket connection   (session start only)
gate removed    5 WebSocket connections  (one per probe window)
```

30s is a poll period, not a threshold. Silence is never itself treated as the turn ending, so no
measurement of "normal quiet" rides on the value.

Settling still needs a real container frame. A reattach that replays nothing actionable marks the
session inactive on the next probe rather than retrying forever - deliberately not a completion,
since nothing there proves the work succeeded.

Each stream replacement gets a unique token.
Late frames from the old socket cannot evict the replacement or start a second reconnect.
The container client also binds unsubscribe and map cleanup to the socket that owns them.

```
old muted socket closes late
  → must NOT steal the replacement's ownership
  → must NOT start a second reconnect
  → failed replacement still counts as a real close
```

Files:
- `src/shared/lib/container/message-persister.ts` - silence probe, attach/detach, stream tokens
- `src/shared/lib/container/base-container-client.ts` - socket owns its map entry / unsubscribe
- `agent-container/src/session-manager.ts` + `server.ts` - `turnSettled` on the session endpoint

**Part 3 - replay also says "no background jobs left"**

On late-join / reconnect replay, include the latest bg job list between result and idle.
The host already knows what to do with that frame.
(Usually the frame is absent, not empty: a session that never ran a background task has no snapshot
to replay, so it is simply omitted.)

Without that list, reconnect alone could say "turn over" while the host still held a ghost background job.
The session stayed parked.

```
OLD replay:  result → idle
NEW replay:  result → background snapshot → idle
                              └─ empty list clears the stuck job
```

```
host holding ghost job
  + replay says idle only     → stays "waiting on background"
  + replay says jobs=[] + idle → clears job → settles
```

Replay state is process-local.
A restarted process clears the previous process's result, background snapshot, and idle before accepting a new turn.

```
process restart → clear old result / bg / idle
                → only the new process can settle
```

File: `agent-container/src/claude-code.ts`

**Part 4 - a replay only settles the turn it belongs to**

Replayed terminal frames carry no turn identity, so an active host could not tell "the turn I am
waiting on ended" from "an earlier turn ended and is being replayed at me". Adopting the second as
the first reports a completion, and persists a success, for work that never ran.

The result uuid supplies that identity.

```
replayed result the host already processed  → dropped
replayed result the host has never seen     → processed, settles the turn
```

Only the result frame is dropped, deliberately not the batch. The idle behind it is still judged by
the existing result-gated guard, which settles only on a result seen for THIS turn - preserving the
case Part 1 and Part 2 exist for, a result delivered live whose idle was lost.

File: `src/shared/lib/container/message-persister.ts`

**How they fit**

```
Part 1  fixes: idle arrived, host discarded it
Part 2  fixes: idle/result never arrived (dead quiet socket)
Part 3  fixes: replay said "done" but not "no jobs left"
Part 4  fixes: replay said "done" about a different turn
```

Fast path unchanged: if result and idle arrive normally, settle immediately.
These only matter when that path breaks.

## Worth reviewing

1. **Turn identity on replay.** A replayed result the host already processed must not re-arm the turn's result memory, or the idle behind it settles the current turn. Dropping only the result, not the batch, is what keeps the lost-idle case working.
2. **The evidence gate, not the interval.** The probe never settles from elapsed time; it asks, and only a container reporting nothing in flight leads to a reattach. Idle still requires a container-emitted result + idle (and an empty background hold when one exists).
3. **Silence reattach ownership.** A muted old socket closes ~30s after replacement. The map delete and stream token must keep that close from stacking a second subscribe or orphaning the live socket.
4. **Process-local replay reset.** Clearing late-join state on query restart stops an old result/idle from settling a new process. Same-process late-join replay must still work.

## Why not the obvious alternatives

- **#572's 5s grace after result.** Measured green only when idle alone was lost. Red when result and idle were both lost, when idle was discarded on reconnect, and when a ghost background job remained. Also no longer typechecks against main.
- **False-idle / wall-clock watchdog.** Settles without a container frame and re-breaks the honesty rule from #339. A long tool call is also quiet.
- **Query a new `isSettled` field.** Larger, masks the wiped-memory bug, and does not repair a dead stream for the next turn.
- **Ping/pong alone.** Covers only socket death. Discarded idle and missing background snapshot happen on a healthy socket.

## What this does not fix

- **SUP-517** - reply invisible until the container is restarted. Messages come from the on-disk transcript and already poll every 15s, so a dead settle socket cannot hide a persisted reply. Separate defect.
- **Chat-surface indicator freezes** owned by other work (#564 / #565). This PR fixes the shared host settle copy those surfaces read.
- **Cloud ingress reaping itself.** Reattach recovers the host after a quiet stream dies. It does not change the cloud keepalive policy.
- **Containers older than `turnSettled`.** Silence recovery needs the container to answer. An older one omits the field, which the host reads as "unknown" and never as "finished", so it cannot false-complete - but it also will not self-recover. The image ships with the app, so this only spans a rolling upgrade.

## Validation

- `npm run typecheck` - pass
- `npm run lint` - 0 errors (40 pre-existing warnings)
- `npx vitest run src/shared/lib/container` - 949 passed, 5 skipped
- `cd agent-container && npx tsc --noEmit && npm test` - 778 passed, 8 skipped
- Live Apple Container smoke with rebuilt `superagent-container:settle-smoke`:
  - healthy turn settled in 4s with one exact assistant reply
  - SIGSTOP / CONT mid-turn: one replacement connect, one live socket, one exact final reply, settled
  - two real blackholed WebSocket cycles retained replacement ownership and closed the final socket
  - abrupt process loss left the app inactive
  - same-process interrupt / restart stayed active past the old-replay window and settled once from the new process
- Live A/B for the evidence gate, rebuilt image, same container / prompt / duration, host code the only variable:
  - `turnSettled` observed flipping false → true across a real turn boundary while `isRunning` stayed true
  - gate in place: 1 WebSocket connection over a five-minute quiet turn
  - gate removed: 5 WebSocket connections, one per probe window (the control, proving the probe fires)
