### PR TITLE
fix(browser): gate stream socket handlers on identity, not mount state (SUP-521)

### DIFF
--- a/src/renderer/hooks/use-browser-stream.test.tsx
+++ b/src/renderer/hooks/use-browser-stream.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createRef, type RefObject } from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { useBrowserStream } from './use-browser-stream'
+
+const mockApiFetch = vi.fn()
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}))
+vi.mock('@renderer/lib/env', () => ({
+  getApiBaseUrl: () => 'http://localhost:47891',
+}))
+const clearBrowserActive = vi.fn()
+vi.mock('@renderer/hooks/use-message-stream', () => ({
+  clearBrowserActive: (...args: unknown[]) => clearBrowserActive(...args),
+}))
+vi.mock('@renderer/components/messages/use-pending-requests', () => ({
+  usePendingBrowserInputRequests: () => ({ requests: [], dismiss: vi.fn() }),
+}))
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({ canUseAgent: () => true }),
+}))
+
+/**
+ * Models the two WebSocket properties this bug depends on:
+ *  - the close event is delivered on a later task, never synchronously from close()
+ *  - close() on an already-CLOSED socket is a no-op and fires nothing
+ */
+class FakeWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSED = 3
+  static instances: FakeWebSocket[] = []
+
+  readyState = FakeWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  completeHandshake() {
+    if (this.readyState !== FakeWebSocket.CONNECTING) return
+    this.readyState = FakeWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  close() {
+    if (this.readyState === FakeWebSocket.CLOSED) return
+    this.readyState = FakeWebSocket.CLOSED
+    queueMicrotask(() => this.onclose?.())
+  }
+}
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function advanceOneSecondAndOpenNewSockets() {
+  await act(async () => {
+    vi.advanceTimersByTime(1000)
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+  act(() => {
+    FakeWebSocket.instances.forEach((ws) => ws.completeHandshake())
+  })
+  await settle()
+}
+
+function baseOpts(canvasRef: RefObject<HTMLCanvasElement | null>) {
+  return {
+    agentSlug: 'a',
+    sessionId: 's',
+    browserActive: true,
+    isConnected: true,
+    isActive: true,
+    canvasRef,
+  }
+}
+
+describe('useBrowserStream reconnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    FakeWebSocket.instances = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    mockApiFetch.mockResolvedValue({
+      json: () => Promise.resolve({ active: true, sessionId: 's' }),
+    })
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not reconnect-storm after an effect re-run while the socket is live', async () => {
+    // Seed the way the real app does: force an effect re-run while a live socket
+    // exists (fresh canvasRef → new renderFrame identity → effect deps change).
+    // Do not seed via StrictMode with browserActive already true — that is not
+    // how the tray mounts.
+    const firstRef = createRef<HTMLCanvasElement | null>()
+    const { rerender } = renderHook(
+      ({ canvasRef }) => useBrowserStream(baseOpts(canvasRef)),
+      { initialProps: { canvasRef: firstRef } },
+    )
+
+    await settle()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    act(() => {
+      FakeWebSocket.instances[0].completeHandshake()
+    })
+    await settle()
+
+    const secondRef = createRef<HTMLCanvasElement | null>()
+    rerender({ canvasRef: secondRef })
+    await settle()
+    act(() => {
+      FakeWebSocket.instances.forEach((ws) => ws.completeHandshake())
+    })
+    await settle()
+
+    // One legitimate replacement from the canvasRef-driven effect re-run.
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    const afterRerun = FakeWebSocket.instances.length
+
+    for (let i = 0; i < 5; i++) {
+      await advanceOneSecondAndOpenNewSockets()
+    }
+
+    expect(FakeWebSocket.instances.length).toBe(afterRerun)
+  })
+
+  it('reconnects once when the current socket dies and the browser is still active', async () => {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+
+    await settle()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    act(() => {
+      FakeWebSocket.instances[0].completeHandshake()
+    })
+    await settle()
+
+    // The server drops the socket the hook is currently using.
+    act(() => {
+      FakeWebSocket.instances[0].close()
+    })
+    await settle()
+
+    // Status fetch says still active → reconnect scheduled for 1s later.
+    await advanceOneSecondAndOpenNewSockets()
+
+    expect(FakeWebSocket.instances).toHaveLength(2)
+
+    // No further growth — genuine death reconnects once, then stops.
+    for (let i = 0; i < 3; i++) {
+      await advanceOneSecondAndOpenNewSockets()
+    }
+    expect(FakeWebSocket.instances).toHaveLength(2)
+
+    // The replacement must reconnect too. Everything above still passes if the
+    // storm is stopped by disabling reconnects after the first teardown, since
+    // the first death happens before any teardown has run. Killing the socket
+    // that a teardown produced is what tells the two apart.
+    act(() => {
+      FakeWebSocket.instances[1].close()
+    })
+    await settle()
+    await advanceOneSecondAndOpenNewSockets()
+
+    expect(FakeWebSocket.instances).toHaveLength(3)
+  })
+})

--- a/src/renderer/hooks/use-browser-stream.ts
+++ b/src/renderer/hooks/use-browser-stream.ts
@@ -45,7 +45,6 @@ export function useBrowserStream({
   autoFollowRef.current = autoFollow
 
   // Lifecycle refs for cleanup
-  const isMountedRef = useRef(true)
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { requests: pendingBrowserInputRequests, dismiss: dismissBrowserInputRequest } =
@@ -134,7 +133,6 @@ export function useBrowserStream({
       return
     }
 
-    isMountedRef.current = true
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current)
       reconnectTimerRef.current = null
@@ -153,6 +151,7 @@ export function useBrowserStream({
     }
 
     ws.onmessage = (event) => {
+      if (wsRef.current !== ws) return
       try {
         // During window resize, skip frame rendering entirely to keep resize smooth
         const resizing = isResizingWindowRef.current
@@ -212,13 +211,13 @@ export function useBrowserStream({
     }
 
     ws.onclose = () => {
-      if (!isMountedRef.current) return
+      if (wsRef.current !== ws) return
       setConnected(false)
       setPageLoading(false)
       apiFetch(`/api/agents/${agentSlug}/browser/status`)
         .then((res) => res.json())
         .then((status: { active?: boolean; sessionId?: string }) => {
-          if (!isMountedRef.current) return
+          if (wsRef.current !== ws) return
           if (!status.active || status.sessionId !== sessionId) {
             clearBrowserActive(sessionId)
           } else {
@@ -226,16 +225,15 @@ export function useBrowserStream({
           }
         })
         .catch(() => {
-          if (isMountedRef.current) clearBrowserActive(sessionId)
+          if (wsRef.current === ws) clearBrowserActive(sessionId)
         })
     }
 
     ws.onerror = () => {
-      if (isMountedRef.current) setConnected(false)
+      if (wsRef.current === ws) setConnected(false)
     }
 
     return () => {
-      isMountedRef.current = false
       if (reconnectTimerRef.current) {
         clearTimeout(reconnectTimerRef.current)
         reconnectTimerRef.current = null


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-521/browser-stream-reconnect-storm-a-superseded-sockets-close-handler

The browser tray opened a new stream socket about once a second and never stopped. This gates the socket's handlers on socket identity instead of a hook-lifetime flag.

**Footprint:** one production file, 5 added / 7 removed. One new test file, 182 lines.

## The loop

```
before:  socket closes → "is this component still mounted?"
                       → yes → ask server → browser alive → reconnect in 1s
```

An effect re-run tears the socket down and builds a replacement in the same synchronous pass. The old socket's close event is delivered afterwards. It reads the mount flag as true, because the new effect body just re-armed it, and concludes the stream died on its own. So it asks the server, sees the browser still active, and schedules a reconnect. `reconnectKey` sits in the effect's dependency array, so that reconnect closes the healthy replacement and produces the next late close event. Measured at 29 connections in 30 seconds, still climbing.

```
after:   socket closes → "am I still the socket in use?"
                       → yes → ask server → browser alive → reconnect in 1s
                       → no  → stay quiet
```

A socket that genuinely dies still reconnects exactly once. It is already closed when the reconnect runs, so teardown's `close()` is a no-op and fires nothing.

`isMountedRef` has no remaining job once identity answers the question, so it goes. One concept now covers both "superseded" and "unmounted". The container answers the same question one layer down the same way, at `agent-container/src/server.ts:2578`.

## Worth reviewing

1. **The new guard subsumes the old one rather than merely resembling it.** `wsRef.current` is written in exactly three places: assigned at socket creation, nulled in cleanup, nulled in the inactive-browser early return. React always runs cleanup N before body N+1, so `wsRef.current !== ws` holds exactly when a cleanup ran for this socket's effect run. The old flag was false exactly when a cleanup ran without a subsequent socket-creating body, and in that state the ref is already null. No legitimate reconnect can be swallowed.

2. **`ws.close()` still precedes `wsRef.current = null` in teardown.** That is safe because a close event is dispatched from a queued task, never synchronously, so the guard always reads the later value. Left as it was rather than reordered, but it is the one line relying on a spec guarantee instead of local ordering.

3. **`onmessage` is gated too, which is slightly wider than the storm strictly required.** Without it, a replaced socket still paints its stale tab list into the newly-opened session's tray. That self-corrects within a frame or two, so it is cosmetic. Leaving one handler ungated would contradict the rule the rest of the change establishes.

## Why not just stop re-arming the flag

Deleting the `isMountedRef.current = true` line is a one-line change and it does stop the storm. It also leaves the flag false forever after the first effect re-run, so a stream that genuinely dies never reconnects and the browser state never clears. It trades a loud bug for a silent one.

That failure mode is exactly what the second test pins. Built against that variant, it fails with two sockets where three are correct.

Also considered: detaching handlers in cleanup (the in-flight status reply still resolves afterwards, so a guard is needed regardless), removing `reconnectKey` from the dependency array (a larger rewrite that treats the re-run rather than the stale handler), and rate-limiting reconnects (caps the damage, leaves the defect).

## What this does not fix

- **The reconnect loop's only terminal condition is the server reporting the browser inactive.** If the socket upgrade fails while status keeps reporting active, the retry runs indefinitely at the same visible rate as the bug above. Pre-existing, unchanged, different cause. Not a regression.
- **The unreachable `if (wsRef.current)` in the inactive-browser early return.** Every path that sets the ref registers a cleanup that nulls it. Pre-existing dead code, flagged rather than removed.
- **Whether the storm reaches packaged builds.** The measured seed is a hot reload, which exists only in dev. Any effect-dependency change while a socket is live is the same seed, and switching sessions with the tray open is one, but that path was not reproduced. SUP-521 records this as unverified.

## Validation

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors, none in the touched files
- `npx vitest run src/renderer/hooks/use-browser-stream.test.tsx` 2 passed
- `npm run test:run` 462 files, 8239 tests passed
- Red proven by reverting the source in the working tree and re-running: the storm test fails with 7 sockets where 2 are correct
- The reconnect test verified against a constructed no-re-arm variant: fails with 2 sockets where 3 are correct
