### PR TITLE
Improve working indicator layout

### DIFF
--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -122,6 +122,16 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByTestId('activity-indicator')).toBeInTheDocument()
   })
 
+  it('stacks the active indicator behind the composer', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+    const indicator = screen.getByTestId('activity-indicator')
+    expect(indicator).toHaveClass('rounded-t-2xl', 'border-b-0', 'pb-8')
+    expect(indicator.parentElement).toHaveClass('-mb-5')
+  })
+
   it('shows elapsed timer when active', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now() - 10000

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -289,10 +289,10 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
           : (activeItem?.activeForm || 'Working...')
 
   return (
-    <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
+    <div className="mx-auto -mb-5 w-full max-w-[740px] px-4">
       {/* Capped and scrolled in place: a long action list must not grow the
           card until it pushes the chat history off screen. */}
-      <div className="max-h-[30vh] overflow-y-auto rounded-lg border bg-muted/50 p-3" data-testid="activity-indicator">
+      <div className="max-h-[30vh] overflow-y-auto rounded-t-2xl border border-b-0 bg-muted/50 px-3 pt-3 pb-8" data-testid="activity-indicator">
         {/* Header with pulsing indicator */}
         <div className="flex items-center gap-2">
           <span className="relative flex h-3 w-3">


### PR DESCRIPTION
## Summary

- restyle the active working indicator as the upper layer of a stacked composer card
- use Tailwind’s built-in top radius, bottom-border removal, padding, and negative margin utilities to create the overlap
- add a focused regression test for the stacked layout classes

## Why

The working indicator previously appeared as a separate card above the composer. Integrating it behind the composer creates a clearer visual relationship between in-progress work and the next-message input while preserving all existing status, timer, subagent, background-process, and todo-list behavior.

## User impact

While an agent is working, the activity panel now flows directly into the composer with rounded top corners and a clean overlapping seam. Idle and error states are unchanged.

## Validation

- `npm test -- --run src/renderer/components/messages/agent-activity-indicator.test.tsx` — 46 tests passed
- `npm run typecheck`
- `npx eslint src/renderer/components/messages/agent-activity-indicator.tsx src/renderer/components/messages/agent-activity-indicator.test.tsx`
- `npm run build:web`
- `git diff --check`
