### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+Repo-specific agent guidance. General coding/testing conventions live in [CLAUDE.md](CLAUDE.md); dev commands live in [README.md](README.md) and `package.json` scripts. Read those first.
+
+## Cursor Cloud specific instructions
+
+SuperAgent (product name "Gamut") is a single product with two build targets (web + Electron) plus a bundled `agent-container/` sub-package. The startup update script already runs `npm install` (root and `agent-container/`) and `npx playwright install chromium`.
+
+### Running the app here
+
+- This VM has no container runtime (Docker/Podman) and no `ANTHROPIC_API_KEY`. Real agents cannot execute, so `npm run dev` boots the full app but any agent chat fails at container spawn / LLM call.
+- To exercise the full create-agent -> chat -> streamed-response flow without those, run mock mode: `E2E_MOCK=true npm run dev:web`. It swaps in `MockContainerClient` (reports Docker available, returns canned replies like "This is a mock response from the E2E test container."). This is the same harness the E2E suite uses. Set `E2E_CHROMIUM_PATH` to Playwright's chromium if you need the mock browser scenario.
+- Use a throwaway data dir for mock/test runs to avoid polluting `~/.superagent`, e.g. `SUPERAGENT_DATA_DIR=/tmp/mock-data E2E_MOCK=true PORT=3000 npm run dev:web`.
+- Real dev port is 47891 (`dev:electron` uses 5000). The README "Architecture" section's 3000/3001 ports are stale.
+
+### Onboarding gate (non-obvious)
+
+A getting-started wizard blocks the whole UI on first run. It is gated by the user-level `setupCompleted` flag, not global settings. To reach the dashboard headlessly, `PUT /api/user-settings` with `{"setupCompleted":true,"onboardingProgress":null}` (the running server must be hit), or seed `settings.json` with `app.setupCompleted:true` before boot the way `e2e/setup-e2e-data.js` does.
+
+### Database
+
+SQLite at `$SUPERAGENT_DATA_DIR/superagent.db` (default `~/.superagent`); no DB server. Run `npm run db:migrate` once against a fresh data dir before starting the plain dev server. `drizzle.config.ts` derives the path from `SUPERAGENT_DATA_DIR` / `SUPERAGENT_DB_PATH`.
+
+### Tests
+
+- Unit: `npm run test:run` (Vitest, root). Container: `npm run test:container`.
+- E2E: `npm run test:e2e` auto-starts its own mock web server (no manual server needed) and requires the Playwright chromium browser. Per CLAUDE.md, tee output to a file. E2E runs with `retries: 0` locally, so occasional parallel-load flakes (e.g. send-button timeout) can appear - re-run the specific spec to confirm before treating it as a real failure.
+- If the E2E chromium fails to launch on a fresh VM for missing system libraries, run `npx playwright install-deps chromium` once (needs sudo/apt; kept out of the update script).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Cloud Agent development environment for this repo and captures durable, non-obvious run guidance in a new `AGENTS.md`. No application code changed.

## Environment setup

- Node 22.14 (repo requires `>=22.12.0`), package manager `npm`.
- Update script (VM startup): `npm install`, `npm install --prefix agent-container`, `npx playwright install chromium`.
- DB migrations applied to a fresh SQLite data dir (`~/.superagent`).

## Verified in this environment

| Task | Command | Result |
|------|---------|--------|
| Lint | `npm run lint` | 0 errors (38 pre-existing warnings) |
| Typecheck | `npm run typecheck` | clean |
| Unit tests | `npm run test:run` | 8248 passed, 48 skipped |
| Container tests | `npm run test:container` | 776 passed, 8 skipped |
| E2E (mock) | `E2E_MOCK=true npx playwright test --project=web-chromium` | 283 passed (2 parallel-load flakes pass on re-run) |
| Run (real) | `npm run dev` | boots on :47891, `/api/settings` + UI return 200 |
| Run (mock) | `E2E_MOCK=true npm run dev:web` | full create-agent -> chat flow works |

## Hello-world

Because this VM has no container runtime and no `ANTHROPIC_API_KEY`, a real agent cannot execute. Using the repo's first-class mock harness (`E2E_MOCK=true`, same one the E2E suite uses), I created an agent named "Hello World Agent" and chatted with it, receiving a streamed mock response - exercising the full create -> chat -> response pipeline (Vite + Hono API + session/streaming).

[superagent_create_agent_and_chat_demo.mp4](https://cursor.com/agents/bc-6a6dfa6a-9a19-4e4c-b78c-9d542ba610c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuperagent_create_agent_and_chat_demo.mp4)

[Agent chat with mock response](https://cursor.com/agents/bc-6a6dfa6a-9a19-4e4c-b78c-9d542ba610c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuperagent_agent_chat_response.webp)

## AGENTS.md

New `## Cursor Cloud specific instructions` section documents: mock-mode run for the full agent flow, the onboarding `setupCompleted` gate, the SQLite data-dir setup, correct dev ports (47891, not the stale 3000/3001), and E2E flake/browser caveats. Standard commands reference README/CLAUDE.md/`package.json` rather than duplicating them.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a6dfa6a-9a19-4e4c-b78c-9d542ba610c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a6dfa6a-9a19-4e4c-b78c-9d542ba610c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

