### PR TITLE
Optimize homepage Halftone Canvas2D runtime (SUP-520)

### DIFF
--- a/docs/halftone-rendering.md
+++ b/docs/halftone-rendering.md
@@ -1,0 +1,90 @@
+# Halftone Canvas2D validation
+
+The homepage Halftone renderer batches visible dots into 32 alpha bands. Each
+non-empty band is emitted as one Canvas2D path and one `fill()`. Alpha uses the
+band midpoint, so the maximum mathematical quantization error is `1 / 64`.
+
+## Performance benchmark
+
+Run both required browser modes:
+
+```sh
+npm run benchmark:halftone
+```
+
+The command compares the former per-dot `beginPath()` / `fill()` path with 8,
+16, 32, and 64 alpha bands. Every variant receives the same precomputed set of
+4,326 dots, so field calculation is excluded. It measures one 576 × 276 card
+and a board of eight such cards at DPR 2.
+
+Defaults are 60 warmup frames followed by 180 samples. Override them when
+iterating locally:
+
+```sh
+npm run benchmark:halftone -- --mode headless-software --warmups 20 --samples 60
+```
+
+`--mode` accepts `headed-gpu`, `headless-software`, or `all`. The default is
+`all`. Chromium version, launch mode/flags, GPU feature status, machine
+architecture, CPU, viewport, card dimensions, dot count, sample counts, median,
+and p95 are written to a timestamped JSON file under
+`test-results/halftone-benchmark/`. Use `--output <path>` to choose another
+location.
+
+The command exits unsuccessfully when an applicable decision gate fails:
+
+- headed 32-band median improvement is less than 35%;
+- headed p95 does not improve;
+- headed eight-card p95 is 16.7 ms or higher;
+- headless/software median or p95 regresses by more than 10%.
+
+The headed run requests GPU rasterization and records Chromium's reported GPU
+feature state. Confirm that `rasterization` is enabled in the JSON before
+using a run as release evidence.
+
+### Reference result
+
+The initial passing reference run used Chromium 145.0.7632.6 on an Apple M2 Max
+(`arm64`, macOS 15.6), a 1440 × 1100 viewport, and DPR 2. Chromium reported
+headed rasterization as `enabled_force`; the explicit software run reported
+`disabled_software`. Each result used 60 warmups and 180 samples.
+
+| Mode / fixture | Per-dot median / p95 | 32-band median / p95 |
+| --- | --- | --- |
+| Headed, one card | 0.90 / 1.00 ms | 0.50 / 0.60 ms |
+| Headed, eight cards | 7.10 / 7.40 ms | 4.10 / 4.40 ms |
+| Software, one card | 0.80 / 0.90 ms | 0.50 / 0.60 ms |
+| Software, eight cards | 6.50 / 6.80 ms | 4.10 / 4.30 ms |
+
+The headed 32-band path reduced median per-card draw cost by 44.4% and p95 by
+40.0%. Its eight-card p95 was 4.4 ms. The software path improved by 37.5% at
+median and 33.3% at p95, so all automated shipping gates passed.
+
+## Deterministic visual comparison
+
+Run:
+
+```sh
+npm run test:halftone:visual
+```
+
+The Playwright suite renders the exact per-dot reference and the 32-band
+candidate in Chromium with controlled motif, state, dimensions, timestamp,
+seed, pointer position, and DPR. Its matrix includes:
+
+- `flow_3d` in working and idle states;
+- `pulse` in alert state;
+- small and wide cards;
+- two fixed timestamps;
+- no pointer, centered pointer, and edge pointer;
+- DPR 1 and DPR 2;
+- zero-size recovery plus one-row and one-column grids.
+
+Both transparent frames are composited over white, converted from sRGB to
+luminance, and compared using average local 8 × 8-window SSIM. The required
+threshold is 0.995. A JSON summary is attached to the Playwright result.
+Reference, candidate, and amplified difference PNGs are attached for every
+failing fixture.
+
+The initial Chromium reference run covered 75 fixtures and observed a minimum
+SSIM of 0.998532, above the required 0.995 threshold.

--- a/docs/halftone-rendering.md
+++ b/docs/halftone-rendering.md
@@ -38,6 +38,49 @@ The command exits unsuccessfully when an applicable decision gate fails:
 - headed eight-card p95 is 16.7 ms or higher;
 - headless/software median or p95 regresses by more than 10%.
 
+### Full-renderer benchmark
+
+The batching benchmark deliberately isolates Canvas submission. To measure the
+complete production path—including motif sampling, hover influence, vignette,
+alpha bucketing, and Canvas drawing—run:
+
+```sh
+npm run benchmark:halftone:runtime
+```
+
+The runtime benchmark bundles the production `HalftoneFrameRenderer` into
+Chromium and exercises one-card and eight-card flow fixtures, an eight-card
+board with one hovered card, and one-card/eight-card pending-input pulse
+fixtures. A same-size `resize()` fixture covers layout churn separately from
+steady-state drawing, and a batched pointer-dispatch microcase compares one
+global listener with the eight-listener card-board case. The command accepts
+the same `--mode`, `--warmups`, `--samples`, and `--output` options as the
+batching benchmark, plus `--label` for naming optimization iterations.
+
+The initial runtime optimization pass used the same Chromium 145 / M2 Max
+environment as the batching reference, with 60 warmups and 180 samples:
+
+| Mode / fixture | Baseline median / p95 | Optimized median / p95 |
+| --- | --- | --- |
+| Headed, one flow card | 1.00 / 1.10 ms | 0.90 / 1.00 ms |
+| Headed, eight flow cards | 8.70 / 9.00 ms | 8.10 / 8.40 ms |
+| Headed, eight flow cards, one hovered | 8.60 / 8.90 ms | 8.10 / 8.40 ms |
+| Headed, one pending-input pulse card | 1.20 / 1.50 ms | 1.10 / 1.30 ms |
+| Headed, eight pending-input pulse cards | 10.30 / 10.90 ms | 8.80 / 9.40 ms |
+| Software, eight flow cards | 8.50 / 8.90 ms | 8.10 / 8.40 ms |
+| Software, eight pending-input pulse cards | 10.40 / 11.10 ms | 8.90 / 9.60 ms |
+
+The retained changes precompute resize-stable grid/vignette values, calculate
+pulse ring constants once per frame, and avoid same-size canvas/renderer
+reinitialization. Same-size renderer resize dropped from 0.10 ms median /
+0.20 ms p95 to below Chromium's timer resolution.
+
+Two renderer experiments were reverted because they did not improve both
+headed and software results: skipping inactive hover bookkeeping and caching
+three pulse-distance arrays. A shared pointer listener was also rejected:
+dispatching to eight listeners cost 1.40 µs/event versus 0.215 µs/event for
+one—only about 0.15 ms total per second at 120 pointer events/second.
+
 The headed run requests GPU rasterization and records Chromium's reported GPU
 feature state. Confirm that `rasterization` is enabled in the JSON before
 using a run as release evidence.

--- a/e2e/specs/halftone-visual.spec.ts
+++ b/e2e/specs/halftone-visual.spec.ts
@@ -1,0 +1,435 @@
+import { expect, test } from '@playwright/test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { transformWithEsbuild } from 'vite'
+
+const MINIMUM_SSIM = 0.995
+
+type PointerPosition = 'none' | 'center' | 'edge'
+
+interface VisualFixture {
+  name: string
+  motif: 'flow_3d' | 'pulse'
+  state: 'working' | 'idle' | 'alert'
+  width: number
+  height: number
+  time: number
+  seed: number
+  pointer: PointerPosition
+  dpr: 1 | 2
+  zeroSizeFirst?: boolean
+}
+
+const motifStates: Array<Pick<VisualFixture, 'motif' | 'state' | 'seed'>> = [
+  { motif: 'flow_3d', state: 'working', seed: 7 },
+  { motif: 'flow_3d', state: 'idle', seed: 13 },
+  { motif: 'pulse', state: 'alert', seed: 5 },
+]
+const cardSizes = [
+  { name: 'small', width: 282, height: 132 },
+  { name: 'wide', width: 576, height: 276 },
+]
+const timestamps = [0, 735]
+const pointers: PointerPosition[] = ['none', 'center', 'edge']
+const dprs: Array<1 | 2> = [1, 2]
+
+const fixtures: VisualFixture[] = []
+for (const motifState of motifStates) {
+  for (const size of cardSizes) {
+    for (const time of timestamps) {
+      for (const pointer of pointers) {
+        for (const dpr of dprs) {
+          fixtures.push({
+            ...motifState,
+            ...size,
+            time,
+            pointer,
+            dpr,
+            name: [
+              motifState.motif,
+              motifState.state,
+              size.name,
+              `t${time}`,
+              pointer,
+              `dpr${dpr}`,
+            ].join('-'),
+          })
+        }
+      }
+    }
+  }
+}
+
+fixtures.push(
+  {
+    name: 'zero-size-resize-recovery',
+    motif: 'flow_3d',
+    state: 'working',
+    width: 576,
+    height: 276,
+    time: 321,
+    seed: 11,
+    pointer: 'none',
+    dpr: 1,
+    zeroSizeFirst: true,
+  },
+  {
+    name: 'one-row',
+    motif: 'flow_3d',
+    state: 'working',
+    width: 30,
+    height: 5,
+    time: 123,
+    seed: 3,
+    pointer: 'center',
+    dpr: 2,
+  },
+  {
+    name: 'one-column',
+    motif: 'pulse',
+    state: 'alert',
+    width: 5,
+    height: 30,
+    time: 456,
+    seed: 3,
+    pointer: 'edge',
+    dpr: 2,
+  }
+)
+
+test.describe('halftone alpha-bucket visual fidelity', () => {
+  test('matches per-dot rendering across deterministic fixtures', async ({ page }, testInfo) => {
+    test.setTimeout(120_000)
+    await page.goto('/')
+    await page.setContent('<main id="halftone-visual-harness"></main>')
+    const rendererPath = path.resolve(
+      process.cwd(),
+      'src/renderer/components/agents/halftone-renderer.ts'
+    )
+    const rendererSource = fs.readFileSync(rendererPath, 'utf8')
+    const transformedRenderer = await transformWithEsbuild(
+      rendererSource,
+      rendererPath,
+      { loader: 'ts', format: 'esm', target: 'es2022' }
+    )
+    await page.addScriptTag({
+      type: 'module',
+      content:
+        `${transformedRenderer.code}\n` +
+        'globalThis.__HalftoneFrameRenderer = HalftoneFrameRenderer;',
+    })
+
+    const comparison = await page.evaluate(
+      async ({ visualFixtures, minimumSsim }) => {
+        interface BrowserRenderer {
+          resize(width: number, height: number): boolean
+          draw(
+            context: CanvasRenderingContext2D,
+            time: number,
+            strategy: 'per-dot' | 'alpha-buckets',
+            pointerX?: number,
+            pointerY?: number,
+            pointerActive?: boolean
+          ): number
+        }
+        interface BrowserRendererConstructor {
+          new (options: {
+            motif: string
+            state: 'working' | 'idle' | 'alert'
+            color: string
+            spacing: number
+            maxRadius: number
+            vignette: number
+            contrast: number
+            seed: number
+          }): BrowserRenderer
+        }
+        interface FailureArtifact {
+          name: string
+          reference: string
+          candidate: string
+          difference: string
+        }
+
+        const Renderer = (
+          globalThis as typeof globalThis & {
+            __HalftoneFrameRenderer?: BrowserRendererConstructor
+          }
+        ).__HalftoneFrameRenderer
+        if (!Renderer) throw new Error('Injected Halftone renderer is unavailable')
+        const harnessRoot = document.querySelector('#halftone-visual-harness')
+        if (!harnessRoot) throw new Error('Halftone visual harness root is missing')
+        const harness = harnessRoot
+
+        function createCanvas(width: number, height: number, dpr: number) {
+          const canvas = document.createElement('canvas')
+          canvas.width = Math.round(width * dpr)
+          canvas.height = Math.round(height * dpr)
+          canvas.style.width = `${width}px`
+          canvas.style.height = `${height}px`
+          const context = canvas.getContext('2d')
+          if (!context) throw new Error('Canvas2D is unavailable')
+          context.setTransform(dpr, 0, 0, dpr, 0, 0)
+          harness.appendChild(canvas)
+          return { canvas, context }
+        }
+
+        function normalizedLuminance(image: ImageData): Float32Array {
+          const normalized = new Float32Array(image.width * image.height)
+          for (let pixel = 0; pixel < normalized.length; pixel++) {
+            const offset = pixel * 4
+            const alpha = image.data[offset + 3] / 255
+            const inkLuminance =
+              image.data[offset] * 0.2126 +
+              image.data[offset + 1] * 0.7152 +
+              image.data[offset + 2] * 0.0722
+            normalized[pixel] = 255 * (1 - alpha) + inkLuminance * alpha
+          }
+          return normalized
+        }
+
+        // Local 8×8-window SSIM after compositing both transparent canvases
+        // over white and converting sRGB to luminance.
+        function calculateSsim(
+          reference: Float32Array,
+          candidate: Float32Array,
+          width: number,
+          height: number
+        ): number {
+          const c1 = Math.pow(0.01 * 255, 2)
+          const c2 = Math.pow(0.03 * 255, 2)
+          const windowSize = 8
+          let similarity = 0
+          let windowCount = 0
+
+          for (let top = 0; top < height; top += windowSize) {
+            for (let left = 0; left < width; left += windowSize) {
+              const right = Math.min(width, left + windowSize)
+              const bottom = Math.min(height, top + windowSize)
+              const count = (right - left) * (bottom - top)
+              let referenceMean = 0
+              let candidateMean = 0
+
+              for (let y = top; y < bottom; y++) {
+                for (let x = left; x < right; x++) {
+                  const pixel = y * width + x
+                  referenceMean += reference[pixel]
+                  candidateMean += candidate[pixel]
+                }
+              }
+              referenceMean /= count
+              candidateMean /= count
+
+              let referenceVariance = 0
+              let candidateVariance = 0
+              let covariance = 0
+              for (let y = top; y < bottom; y++) {
+                for (let x = left; x < right; x++) {
+                  const pixel = y * width + x
+                  const referenceDelta = reference[pixel] - referenceMean
+                  const candidateDelta = candidate[pixel] - candidateMean
+                  referenceVariance += referenceDelta * referenceDelta
+                  candidateVariance += candidateDelta * candidateDelta
+                  covariance += referenceDelta * candidateDelta
+                }
+              }
+              const divisor = Math.max(1, count - 1)
+              referenceVariance /= divisor
+              candidateVariance /= divisor
+              covariance /= divisor
+
+              similarity +=
+                ((2 * referenceMean * candidateMean + c1) *
+                  (2 * covariance + c2)) /
+                ((referenceMean * referenceMean +
+                  candidateMean * candidateMean +
+                  c1) *
+                  (referenceVariance + candidateVariance + c2))
+              windowCount++
+            }
+          }
+
+          return similarity / windowCount
+        }
+
+        function createDifference(
+          reference: Float32Array,
+          candidate: Float32Array,
+          width: number,
+          height: number
+        ): HTMLCanvasElement {
+          const canvas = document.createElement('canvas')
+          canvas.width = width
+          canvas.height = height
+          const context = canvas.getContext('2d')
+          if (!context) throw new Error('Difference Canvas2D is unavailable')
+          const difference = context.createImageData(width, height)
+          for (let pixel = 0; pixel < reference.length; pixel++) {
+            const magnitude = Math.min(
+              255,
+              Math.abs(reference[pixel] - candidate[pixel]) * 8
+            )
+            const offset = pixel * 4
+            difference.data[offset] = magnitude
+            difference.data[offset + 1] = 0
+            difference.data[offset + 2] = magnitude
+            difference.data[offset + 3] = 255
+          }
+          context.putImageData(difference, 0, 0)
+          return canvas
+        }
+
+        const results: Array<{
+          name: string
+          ssim: number
+          referenceDots: number
+          candidateDots: number
+        }> = []
+        const failures: FailureArtifact[] = []
+
+        for (const fixture of visualFixtures) {
+          harness.replaceChildren()
+          const referenceCanvas = createCanvas(
+            fixture.width,
+            fixture.height,
+            fixture.dpr
+          )
+          const candidateCanvas = createCanvas(
+            fixture.width,
+            fixture.height,
+            fixture.dpr
+          )
+          const options = {
+            motif: fixture.motif,
+            state: fixture.state,
+            color: '#111827',
+            spacing: 6,
+            maxRadius: 1.6,
+            vignette: 0.22,
+            contrast: 1.6,
+            seed: fixture.seed,
+          }
+          const referenceRenderer = new Renderer(options)
+          const candidateRenderer = new Renderer(options)
+          if (fixture.zeroSizeFirst) {
+            if (referenceRenderer.resize(0, 0) || candidateRenderer.resize(0, 0)) {
+              throw new Error('Zero-sized renderer unexpectedly became ready')
+            }
+          }
+          referenceRenderer.resize(fixture.width, fixture.height)
+          candidateRenderer.resize(fixture.width, fixture.height)
+
+          const pointerActive = fixture.pointer !== 'none'
+          const pointerX =
+            fixture.pointer === 'edge' ? fixture.width - 1 : fixture.width / 2
+          const pointerY = fixture.height / 2
+          let referenceDots = 0
+          let candidateDots = 0
+          // Four identical frames exercise deterministic pointer attack while
+          // keeping animation time fixed.
+          for (let frame = 0; frame < 4; frame++) {
+            referenceDots = referenceRenderer.draw(
+              referenceCanvas.context,
+              fixture.time,
+              'per-dot',
+              pointerX,
+              pointerY,
+              pointerActive
+            )
+            candidateDots = candidateRenderer.draw(
+              candidateCanvas.context,
+              fixture.time,
+              'alpha-buckets',
+              pointerX,
+              pointerY,
+              pointerActive
+            )
+          }
+
+          const physicalWidth = referenceCanvas.canvas.width
+          const physicalHeight = referenceCanvas.canvas.height
+          const referenceImage = referenceCanvas.context.getImageData(
+            0,
+            0,
+            physicalWidth,
+            physicalHeight
+          )
+          const candidateImage = candidateCanvas.context.getImageData(
+            0,
+            0,
+            physicalWidth,
+            physicalHeight
+          )
+          const normalizedReference = normalizedLuminance(referenceImage)
+          const normalizedCandidate = normalizedLuminance(candidateImage)
+          const ssim = calculateSsim(
+            normalizedReference,
+            normalizedCandidate,
+            physicalWidth,
+            physicalHeight
+          )
+          const difference = createDifference(
+            normalizedReference,
+            normalizedCandidate,
+            physicalWidth,
+            physicalHeight
+          )
+
+          results.push({
+            name: fixture.name,
+            ssim,
+            referenceDots,
+            candidateDots,
+          })
+          if (
+            ssim < minimumSsim ||
+            referenceDots !== candidateDots ||
+            referenceDots === 0
+          ) {
+            failures.push({
+              name: fixture.name,
+              reference: referenceCanvas.canvas.toDataURL('image/png'),
+              candidate: candidateCanvas.canvas.toDataURL('image/png'),
+              difference: difference.toDataURL('image/png'),
+            })
+          }
+        }
+
+        return { results, failures }
+      },
+      { visualFixtures: fixtures, minimumSsim: MINIMUM_SSIM }
+    )
+
+    const summary = {
+      normalization:
+        'Composite transparent sRGB pixels over white, convert to luminance, average local 8x8-window SSIM.',
+      threshold: MINIMUM_SSIM,
+      fixtureCount: comparison.results.length,
+      minimumObservedSsim: Math.min(...comparison.results.map((result) => result.ssim)),
+      results: comparison.results,
+    }
+    console.log(
+      `Halftone visual comparison: ${summary.fixtureCount} fixtures, ` +
+        `minimum SSIM ${summary.minimumObservedSsim.toFixed(6)} ` +
+        `(required ${MINIMUM_SSIM.toFixed(3)})`
+    )
+    await testInfo.attach('halftone-visual-summary.json', {
+      body: Buffer.from(JSON.stringify(summary, null, 2)),
+      contentType: 'application/json',
+    })
+
+    for (const failure of comparison.failures) {
+      for (const kind of ['reference', 'candidate', 'difference'] as const) {
+        await testInfo.attach(`${failure.name}-${kind}.png`, {
+          body: Buffer.from(failure[kind].split(',')[1], 'base64'),
+          contentType: 'image/png',
+        })
+      }
+    }
+
+    expect(
+      comparison.failures.map((failure) => failure.name),
+      `All fixtures must meet ${MINIMUM_SSIM} SSIM and render identical non-zero dot counts`
+    ).toEqual([])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:e2e:perf": "RENDER_TRACKING=true E2E_MOCK=true playwright test --project=web-chromium e2e/specs/render-perf.spec.ts",
     "test:halftone:visual": "E2E_MOCK=true playwright test e2e/specs/halftone-visual.spec.ts --project=web-chromium --workers=1",
     "benchmark:halftone": "tsx scripts/benchmark-halftone.ts",
+    "benchmark:halftone:runtime": "tsx scripts/benchmark-halftone-runtime.ts",
     "db:reset": "rm superagent.db* && drizzle-kit migrate",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "test:e2e:auth": "npx playwright test --config=playwright.auth.config.ts",
     "test:e2e:electron": "npm run build:electron && E2E_MOCK=true playwright test --project=electron",
     "test:e2e:perf": "RENDER_TRACKING=true E2E_MOCK=true playwright test --project=web-chromium e2e/specs/render-perf.spec.ts",
+    "test:halftone:visual": "E2E_MOCK=true playwright test e2e/specs/halftone-visual.spec.ts --project=web-chromium --workers=1",
+    "benchmark:halftone": "tsx scripts/benchmark-halftone.ts",
     "db:reset": "rm superagent.db* && drizzle-kit migrate",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/scripts/benchmark-halftone-runtime.ts
+++ b/scripts/benchmark-halftone-runtime.ts
@@ -1,0 +1,571 @@
+import { chromium, type Browser } from '@playwright/test'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { build as viteBuild } from 'vite'
+import {
+  halftoneRuntimeBenchmarkResultSchema,
+  type HalftoneRuntimeBenchmarkFixture,
+  type HalftoneRuntimeBenchmarkMode,
+} from './halftone-runtime-benchmark-schema'
+
+type BenchmarkModeName = 'headed-gpu' | 'headless-software'
+
+const CARD = { width: 576, height: 276 }
+const VIEWPORT = { width: 1440, height: 1100 }
+const DEVICE_PIXEL_RATIO = 2
+const DEFAULT_WARMUP_COUNT = 60
+const DEFAULT_SAMPLE_COUNT = 180
+
+const modeDefinitions: Record<
+  BenchmarkModeName,
+  { headless: boolean; launchArgs: string[] }
+> = {
+  'headed-gpu': {
+    headless: false,
+    launchArgs: [
+      '--enable-gpu-rasterization',
+      '--enable-zero-copy',
+      '--ignore-gpu-blocklist',
+      '--disable-background-timer-throttling',
+      '--disable-renderer-backgrounding',
+      '--disable-backgrounding-occluded-windows',
+    ],
+  },
+  'headless-software': {
+    headless: true,
+    launchArgs: [
+      '--disable-gpu',
+      '--disable-gpu-rasterization',
+      '--disable-accelerated-2d-canvas',
+    ],
+  },
+}
+
+function readOption(name: string): string | undefined {
+  const index = process.argv.indexOf(name)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+function readCount(name: string, fallback: number): number {
+  const value = readOption(name)
+  if (value === undefined) return fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`)
+  }
+  return parsed
+}
+
+function requestedModes(): BenchmarkModeName[] {
+  const requested = readOption('--mode') ?? 'all'
+  if (requested === 'all') return ['headed-gpu', 'headless-software']
+  if (requested === 'headed-gpu' || requested === 'headless-software') {
+    return [requested]
+  }
+  throw new Error('--mode must be headed-gpu, headless-software, or all')
+}
+
+async function bundleRenderer(): Promise<string> {
+  const output = await viteBuild({
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      write: false,
+      minify: false,
+      target: 'es2020',
+      lib: {
+        entry: path.resolve('src/renderer/components/agents/halftone-renderer.ts'),
+        formats: ['iife'],
+        name: 'HalftoneRuntime',
+      },
+    },
+  })
+  const results = (Array.isArray(output) ? output : [output]) as Array<{
+    output: Array<{ type: string; code?: string; isEntry?: boolean }>
+  }>
+  for (const result of results) {
+    const entry = result.output.find(
+      (artifact) => artifact.type === 'chunk' && artifact.isEntry
+    )
+    if (entry?.code) return entry.code
+  }
+  throw new Error('Vite did not emit the Halftone renderer benchmark bundle')
+}
+
+async function readGpuInfo(
+  browser: Browser
+): Promise<HalftoneRuntimeBenchmarkMode['gpu']> {
+  try {
+    const session = await browser.newBrowserCDPSession()
+    const info = (await session.send('SystemInfo.getInfo')) as {
+      gpu?: {
+        devices?: Array<{
+          vendorString?: string
+          deviceString?: string
+          driverVendor?: string
+          driverVersion?: string
+        }>
+        featureStatus?: Record<string, string>
+      }
+    }
+    await session.detach()
+    return {
+      devices: (info.gpu?.devices ?? []).map((device) => ({
+        vendorString: device.vendorString ?? 'unknown',
+        deviceString: device.deviceString ?? 'unknown',
+        driverVendor: device.driverVendor ?? 'unknown',
+        driverVersion: device.driverVersion ?? 'unknown',
+      })),
+      featureStatus: info.gpu?.featureStatus ?? {},
+    }
+  } catch {
+    return { devices: [], featureStatus: {} }
+  }
+}
+
+async function runMode(
+  mode: BenchmarkModeName,
+  rendererBundle: string,
+  warmupCount: number,
+  sampleCount: number
+): Promise<HalftoneRuntimeBenchmarkMode> {
+  const definition = modeDefinitions[mode]
+  const browser = await chromium.launch({
+    headless: definition.headless,
+    args: definition.launchArgs,
+  })
+
+  try {
+    const gpu = await readGpuInfo(browser)
+    const context = await browser.newContext({
+      viewport: VIEWPORT,
+      deviceScaleFactor: DEVICE_PIXEL_RATIO,
+    })
+    const page = await context.newPage()
+    await page.bringToFront()
+    await page.setContent(
+      '<main id="benchmark-root" style="display:grid;grid-template-columns:repeat(2,max-content);gap:8px"></main>'
+    )
+    await page.addScriptTag({ content: rendererBundle })
+    // tsx preserves nested function names with this esbuild helper. Playwright
+    // serializes the evaluate callback without its module-scope helper.
+    await page.addScriptTag({
+      content: 'globalThis.__name = (target) => target;',
+    })
+
+    const fixtures = await page.evaluate(
+      async ({ card, warmups, samples, dpr }) => {
+        interface Renderer {
+          readonly columnCount: number
+          readonly rowCount: number
+          readonly capacity: number
+          resize: (width: number, height: number) => boolean
+          draw: (
+            context: CanvasRenderingContext2D,
+            time: number,
+            strategy: 'alpha-buckets',
+            pointerX: number,
+            pointerY: number,
+            pointerActive: boolean
+          ) => number
+        }
+        interface RendererConstructor {
+          new (options: {
+            motif: 'flow_3d' | 'pulse'
+            state: 'working' | 'alert'
+            color: string
+            spacing?: number
+            maxRadius?: number
+            vignette?: number
+            contrast?: number
+            seed?: number
+          }): Renderer
+        }
+        interface FixtureDefinition {
+          name:
+            | 'flow-one-card-inactive'
+            | 'flow-eight-card-board-inactive'
+            | 'flow-eight-card-board-one-pointer'
+            | 'pulse-one-card-inactive'
+            | 'pulse-eight-card-board-inactive'
+          motif: 'flow_3d' | 'pulse'
+          cards: number
+          pointerCards: number
+          speed: number
+        }
+        interface RuntimeCard {
+          context: CanvasRenderingContext2D
+          renderer: Renderer
+        }
+
+        const runtime = (
+          globalThis as typeof globalThis & {
+            HalftoneRuntime?: {
+              HalftoneFrameRenderer?: RendererConstructor
+            }
+          }
+        ).HalftoneRuntime
+        const RendererClass = runtime?.HalftoneFrameRenderer
+        if (!RendererClass) throw new Error('Bundled Halftone renderer is unavailable')
+        const ProductionRenderer: RendererConstructor = RendererClass
+        const root = document.querySelector('#benchmark-root')
+        if (!root) throw new Error('Benchmark root is missing')
+        const benchmarkRoot = root
+
+        function percentile(sorted: number[], quantile: number): number {
+          const index = Math.min(
+            sorted.length - 1,
+            Math.max(0, Math.ceil(sorted.length * quantile) - 1)
+          )
+          return sorted[index]
+        }
+
+        function createCards(definition: FixtureDefinition): RuntimeCard[] {
+          const cards: RuntimeCard[] = []
+          for (let cardIndex = 0; cardIndex < definition.cards; cardIndex++) {
+            const canvas = document.createElement('canvas')
+            canvas.width = card.width * dpr
+            canvas.height = card.height * dpr
+            canvas.style.width = `${card.width}px`
+            canvas.style.height = `${card.height}px`
+            const context = canvas.getContext('2d')
+            if (!context) throw new Error('Canvas2D is unavailable')
+            context.setTransform(dpr, 0, 0, dpr, 0, 0)
+            const renderer =
+              definition.motif === 'pulse'
+                ? new ProductionRenderer({
+                    motif: 'pulse',
+                    state: 'alert',
+                    color: '#f97316',
+                    spacing: 5,
+                    maxRadius: 1.3,
+                    vignette: 0.4,
+                    contrast: 1.6,
+                    seed: cardIndex * 97,
+                  })
+                : new ProductionRenderer({
+                    motif: 'flow_3d',
+                    state: 'working',
+                    color: '#111827',
+                    spacing: 6,
+                    maxRadius: 1.6,
+                    vignette: 0.22,
+                    contrast: 1.6,
+                    seed: cardIndex * 97,
+                  })
+            renderer.resize(card.width, card.height)
+            benchmarkRoot.appendChild(canvas)
+            cards.push({ context, renderer })
+          }
+          return cards
+        }
+
+        function flushRasterWork(cards: RuntimeCard[]): void {
+          cards[cards.length - 1].context.getImageData(0, 0, 1, 1)
+        }
+
+        const definitions: FixtureDefinition[] = [
+          {
+            name: 'flow-one-card-inactive',
+            motif: 'flow_3d',
+            cards: 1,
+            pointerCards: 0,
+            speed: 0.75,
+          },
+          {
+            name: 'flow-eight-card-board-inactive',
+            motif: 'flow_3d',
+            cards: 8,
+            pointerCards: 0,
+            speed: 0.75,
+          },
+          {
+            name: 'flow-eight-card-board-one-pointer',
+            motif: 'flow_3d',
+            cards: 8,
+            pointerCards: 1,
+            speed: 0.75,
+          },
+          {
+            name: 'pulse-one-card-inactive',
+            motif: 'pulse',
+            cards: 1,
+            pointerCards: 0,
+            speed: 1.6,
+          },
+          {
+            name: 'pulse-eight-card-board-inactive',
+            motif: 'pulse',
+            cards: 8,
+            pointerCards: 0,
+            speed: 1.6,
+          },
+        ]
+        const fixtureResults = []
+
+        for (const definition of definitions) {
+          benchmarkRoot.replaceChildren()
+          const cards = createCards(definition)
+          const durations: number[] = []
+          let time = 0
+          let dotsPerCard = 0
+
+          const draw = () => {
+            let totalDots = 0
+            for (let cardIndex = 0; cardIndex < cards.length; cardIndex++) {
+              const runtimeCard = cards[cardIndex]
+              totalDots += runtimeCard.renderer.draw(
+                runtimeCard.context,
+                time,
+                'alpha-buckets',
+                card.width / 2,
+                card.height / 2,
+                cardIndex < definition.pointerCards
+              )
+            }
+            dotsPerCard = Math.round(totalDots / cards.length)
+            time += definition.speed
+          }
+
+          for (let warmup = 0; warmup < warmups; warmup++) {
+            draw()
+            if ((warmup + 1) % 30 === 0 || warmup + 1 === warmups) {
+              flushRasterWork(cards)
+            }
+          }
+          for (let sample = 0; sample < samples; sample++) {
+            const start = performance.now()
+            draw()
+            durations.push(performance.now() - start)
+            if ((sample + 1) % 30 === 0 || sample + 1 === samples) {
+              flushRasterWork(cards)
+            }
+          }
+
+          const sorted = durations.slice().sort((left, right) => left - right)
+          fixtureResults.push({
+            name: definition.name,
+            motif: definition.motif,
+            cards: definition.cards,
+            pointerCards: definition.pointerCards,
+            cardWidth: card.width,
+            cardHeight: card.height,
+            columns: cards[0].renderer.columnCount,
+            rows: cards[0].renderer.rowCount,
+            dotsPerCard,
+            warmupCount: warmups,
+            sampleCount: samples,
+            medianMs: percentile(sorted, 0.5),
+            p95Ms: percentile(sorted, 0.95),
+            minimumMs: sorted[0],
+            maximumMs: sorted[sorted.length - 1],
+          })
+        }
+
+        benchmarkRoot.replaceChildren()
+        const resizeRenderer = new ProductionRenderer({
+          motif: 'flow_3d',
+          state: 'working',
+          color: '#111827',
+          spacing: 6,
+          maxRadius: 1.6,
+          vignette: 0.22,
+          contrast: 1.6,
+          seed: 0,
+        })
+        resizeRenderer.resize(card.width, card.height)
+        for (let warmup = 0; warmup < warmups; warmup++) {
+          resizeRenderer.resize(card.width, card.height)
+        }
+        const resizeDurations: number[] = []
+        let capacityCheck = 0
+        for (let sample = 0; sample < samples; sample++) {
+          const start = performance.now()
+          resizeRenderer.resize(card.width, card.height)
+          resizeDurations.push(performance.now() - start)
+          capacityCheck += resizeRenderer.capacity
+        }
+        if (capacityCheck === 0) throw new Error('Resize benchmark was optimized away')
+        const sortedResizeDurations = resizeDurations
+          .slice()
+          .sort((left, right) => left - right)
+
+        const pointerIterations = 20_000
+        const pointerTrials = 7
+        const pointerVariants = []
+        for (const listenerCount of [1, 8]) {
+          const trialDurations: number[] = []
+          for (let trial = 0; trial < pointerTrials; trial++) {
+            let observedX = 0
+            let observedY = 0
+            const listeners = Array.from({ length: listenerCount }, () => {
+              const listener = (event: PointerEvent) => {
+                observedX = event.clientX
+                observedY = event.clientY
+              }
+              window.addEventListener('pointermove', listener, { passive: true })
+              return listener
+            })
+            const event = new PointerEvent('pointermove', {
+              clientX: trial + 1,
+              clientY: trial + 2,
+            })
+            for (let warmup = 0; warmup < 1_000; warmup++) {
+              window.dispatchEvent(event)
+            }
+            const start = performance.now()
+            for (let iteration = 0; iteration < pointerIterations; iteration++) {
+              window.dispatchEvent(event)
+            }
+            trialDurations.push(
+              ((performance.now() - start) * 1_000) / pointerIterations
+            )
+            for (const listener of listeners) {
+              window.removeEventListener('pointermove', listener)
+            }
+            if (observedX === 0 || observedY === 0) {
+              throw new Error('Pointer dispatch benchmark did not invoke listeners')
+            }
+          }
+          const sortedTrials = trialDurations
+            .slice()
+            .sort((left, right) => left - right)
+          pointerVariants.push({
+            listenerCount,
+            medianMicrosecondsPerEvent: percentile(sortedTrials, 0.5),
+            p95MicrosecondsPerEvent: percentile(sortedTrials, 0.95),
+          })
+        }
+
+        return {
+          fixtures: fixtureResults,
+          sameSizeResize: {
+            warmupCount: warmups,
+            sampleCount: samples,
+            medianMs: percentile(sortedResizeDurations, 0.5),
+            p95Ms: percentile(sortedResizeDurations, 0.95),
+            minimumMs: sortedResizeDurations[0],
+            maximumMs: sortedResizeDurations[sortedResizeDurations.length - 1],
+          },
+          pointerDispatch: {
+            iterationsPerTrial: pointerIterations,
+            trials: pointerTrials,
+            variants: pointerVariants,
+          },
+        }
+      },
+      {
+        card: CARD,
+        warmups: warmupCount,
+        samples: sampleCount,
+        dpr: DEVICE_PIXEL_RATIO,
+      }
+    )
+
+    await context.close()
+    const measured = fixtures as {
+      fixtures: HalftoneRuntimeBenchmarkFixture[]
+      sameSizeResize: HalftoneRuntimeBenchmarkMode['sameSizeResize']
+      pointerDispatch: HalftoneRuntimeBenchmarkMode['pointerDispatch']
+    }
+    return {
+      mode,
+      headless: definition.headless,
+      browserVersion: browser.version(),
+      launchArgs: definition.launchArgs,
+      gpu,
+      fixtures: measured.fixtures,
+      sameSizeResize: measured.sameSizeResize,
+      pointerDispatch: measured.pointerDispatch,
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
+function printSummary(runs: HalftoneRuntimeBenchmarkMode[]): void {
+  console.log('\nHalftone full-renderer benchmark')
+  for (const run of runs) {
+    console.log(`\n${run.mode} · Chromium ${run.browserVersion}`)
+    for (const fixture of run.fixtures) {
+      console.log(
+        `${fixture.name}: ${fixture.cards} card${fixture.cards === 1 ? '' : 's'}, ` +
+          `${fixture.dotsPerCard.toLocaleString()} dots/card · ` +
+          `median ${fixture.medianMs.toFixed(3)}ms · p95 ${fixture.p95Ms.toFixed(3)}ms`
+      )
+    }
+    console.log(
+      `same-size resize: median ${run.sameSizeResize.medianMs.toFixed(3)}ms · ` +
+        `p95 ${run.sameSizeResize.p95Ms.toFixed(3)}ms`
+    )
+    console.log(
+      `pointer dispatch: ${run.pointerDispatch.variants
+        .map(
+          (variant) =>
+            `${variant.listenerCount} listener${variant.listenerCount === 1 ? '' : 's'} ` +
+            `${variant.medianMicrosecondsPerEvent.toFixed(3)}µs/event`
+        )
+        .join(' · ')}`
+    )
+  }
+}
+
+async function main(): Promise<void> {
+  const warmupCount = readCount('--warmups', DEFAULT_WARMUP_COUNT)
+  const sampleCount = readCount('--samples', DEFAULT_SAMPLE_COUNT)
+  if (sampleCount === 0) throw new Error('--samples must be greater than zero')
+  const label = readOption('--label') ?? 'working-tree'
+  const rendererBundle = await bundleRenderer()
+  const runs: HalftoneRuntimeBenchmarkMode[] = []
+  for (const mode of requestedModes()) {
+    runs.push(await runMode(mode, rendererBundle, warmupCount, sampleCount))
+  }
+  const cpuInfo = os.cpus()
+  const sourceRevision = execFileSync('git', ['rev-parse', '--short=12', 'HEAD'], {
+    encoding: 'utf8',
+  }).trim()
+  const result = halftoneRuntimeBenchmarkResultSchema.parse({
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    label,
+    sourceRevision,
+    environment: {
+      platform: os.platform(),
+      release: os.release(),
+      architecture: os.arch(),
+      cpu: cpuInfo[0]?.model ?? 'unknown',
+      logicalCpuCount: cpuInfo.length,
+      viewportWidth: VIEWPORT.width,
+      viewportHeight: VIEWPORT.height,
+      devicePixelRatio: DEVICE_PIXEL_RATIO,
+    },
+    config: {
+      warmupCount,
+      sampleCount,
+    },
+    runs,
+  })
+
+  const requestedOutput = readOption('--output')
+  const timestamp = result.generatedAt.replaceAll(':', '-')
+  const outputPath = path.resolve(
+    requestedOutput ??
+      path.join(
+        'test-results',
+        'halftone-runtime-benchmark',
+        `halftone-runtime-${timestamp}.json`
+      )
+  )
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  fs.writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`)
+
+  printSummary(result.runs)
+  console.log(`\nMachine-readable results: ${outputPath}`)
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.stack : error)
+  process.exitCode = 1
+})

--- a/scripts/benchmark-halftone.ts
+++ b/scripts/benchmark-halftone.ts
@@ -1,0 +1,576 @@
+import { chromium, type Browser } from '@playwright/test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  halftoneBenchmarkResultSchema,
+  type HalftoneBenchmarkFixture,
+  type HalftoneBenchmarkGate,
+  type HalftoneBenchmarkMode,
+} from './halftone-benchmark-schema'
+
+type BenchmarkModeName = 'headed-gpu' | 'headless-software'
+
+const WIDE_CARD = { width: 576, height: 276, columns: 96, rows: 46 }
+const VIEWPORT = { width: 1440, height: 1100 }
+const DEVICE_PIXEL_RATIO = 2
+const DEFAULT_WARMUP_COUNT = 60
+const DEFAULT_SAMPLE_COUNT = 180
+const CONFIRMATION_BANDS = [8, 16, 32, 64]
+
+const modeDefinitions: Record<
+  BenchmarkModeName,
+  { headless: boolean; launchArgs: string[] }
+> = {
+  'headed-gpu': {
+    headless: false,
+    launchArgs: [
+      '--enable-gpu-rasterization',
+      '--enable-zero-copy',
+      '--ignore-gpu-blocklist',
+      '--disable-background-timer-throttling',
+      '--disable-renderer-backgrounding',
+      '--disable-backgrounding-occluded-windows',
+    ],
+  },
+  'headless-software': {
+    headless: true,
+    launchArgs: [
+      '--disable-gpu',
+      '--disable-gpu-rasterization',
+      '--disable-accelerated-2d-canvas',
+    ],
+  },
+}
+
+function readOption(name: string): string | undefined {
+  const index = process.argv.indexOf(name)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+function readCount(name: string, fallback: number): number {
+  const value = readOption(name)
+  if (value === undefined) return fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`)
+  }
+  return parsed
+}
+
+function requestedModes(): BenchmarkModeName[] {
+  const requested = readOption('--mode') ?? 'all'
+  if (requested === 'all') return ['headed-gpu', 'headless-software']
+  if (requested === 'headed-gpu' || requested === 'headless-software') {
+    return [requested]
+  }
+  throw new Error('--mode must be headed-gpu, headless-software, or all')
+}
+
+async function readGpuInfo(browser: Browser): Promise<HalftoneBenchmarkMode['gpu']> {
+  try {
+    const session = await browser.newBrowserCDPSession()
+    const info = (await session.send('SystemInfo.getInfo')) as {
+      gpu?: {
+        devices?: Array<{
+          vendorString?: string
+          deviceString?: string
+          driverVendor?: string
+          driverVersion?: string
+        }>
+        featureStatus?: Record<string, string>
+      }
+    }
+    await session.detach()
+    return {
+      devices: (info.gpu?.devices ?? []).map((device) => ({
+        vendorString: device.vendorString ?? 'unknown',
+        deviceString: device.deviceString ?? 'unknown',
+        driverVendor: device.driverVendor ?? 'unknown',
+        driverVersion: device.driverVersion ?? 'unknown',
+      })),
+      featureStatus: info.gpu?.featureStatus ?? {},
+    }
+  } catch {
+    return { devices: [], featureStatus: {} }
+  }
+}
+
+async function runMode(
+  mode: BenchmarkModeName,
+  warmupCount: number,
+  sampleCount: number
+): Promise<HalftoneBenchmarkMode> {
+  const definition = modeDefinitions[mode]
+  const browser = await chromium.launch({
+    headless: definition.headless,
+    args: definition.launchArgs,
+  })
+
+  try {
+    const gpu = await readGpuInfo(browser)
+    const context = await browser.newContext({
+      viewport: VIEWPORT,
+      deviceScaleFactor: DEVICE_PIXEL_RATIO,
+    })
+    const page = await context.newPage()
+    await page.bringToFront()
+    await page.setContent(
+      '<main id="benchmark-root" style="display:grid;grid-template-columns:repeat(2,max-content);gap:8px"></main>'
+    )
+    // tsx preserves nested function names with this esbuild helper. Playwright
+    // serializes the evaluate callback without its module-scope helper.
+    await page.addScriptTag({
+      content: 'globalThis.__name = (target) => target;',
+    })
+
+    const fixtures = await page.evaluate(
+      async ({ card, bands, warmups, samples, dpr }) => {
+        interface DotSet {
+          x: Float32Array
+          y: Float32Array
+          radius: Float32Array
+          alpha: Float32Array
+          count: number
+        }
+        interface Variant {
+          name: 'per-dot' | 'alpha-buckets'
+          alphaBands: number | null
+          contexts: CanvasRenderingContext2D[]
+          band: Uint8Array | null
+          sortedIndices: Uint32Array | null
+          bandCounts: Uint32Array | null
+          bandOffsets: Uint32Array | null
+          bandWrites: Uint32Array | null
+          durations: number[]
+          draw: () => void
+        }
+
+        const root = document.querySelector('#benchmark-root')
+        if (!root) throw new Error('Benchmark root is missing')
+        const benchmarkRoot = root
+        const tau = Math.PI * 2
+
+        function flushRasterWork(variants: Variant[]): void {
+          // A one-pixel readback periodically drains the Canvas2D command queue
+          // outside the timed interval. Chromium orders the preceding canvas
+          // work before this readback. Draining every 30 samples avoids an
+          // unbounded backlog without making GPU readback part of every sample.
+          const variant = variants[variants.length - 1]
+          const context = variant.contexts[variant.contexts.length - 1]
+          context.getImageData(0, 0, 1, 1)
+        }
+
+        function createDotSet(): DotSet {
+          const capacity = card.columns * card.rows
+          const x = new Float32Array(capacity)
+          const y = new Float32Array(capacity)
+          const radius = new Float32Array(capacity)
+          const alpha = new Float32Array(capacity)
+          const offsetX = (card.width - (card.columns - 1) * 6) / 2
+          const offsetY = (card.height - (card.rows - 1) * 6) / 2
+          let count = 0
+
+          for (let row = 0; row < card.rows; row++) {
+            for (let column = 0; column < card.columns; column++) {
+              const cell = row * card.columns + column
+              // Match the measured production fixture's approximately 4,326
+              // visible dots while retaining a spatially uniform cull.
+              if (cell < 4410 && cell % 49 === 0) continue
+              const u = column / card.columns
+              const v = row / card.rows
+              const wave =
+                0.5 +
+                0.25 * Math.sin(u * 13 + v * 6) +
+                0.25 * Math.sin(u * 4 + v * 11)
+              const deltaX = (column - (card.columns - 1) / 2) / ((card.columns - 1) / 2)
+              const deltaY = (row - (card.rows - 1) / 2) / ((card.rows - 1) / 2)
+              const vignette = Math.max(
+                0.5,
+                1 - Math.max(0, Math.hypot(deltaX, deltaY) - 0.4) * 0.32
+              )
+              x[count] = offsetX + column * 6
+              y[count] = offsetY + row * 6
+              radius[count] = 0.35 + Math.max(0, wave) * 1.7 * vignette
+              alpha[count] = Math.min(1, (0.2 + Math.max(0, wave) * 0.8) * vignette)
+              count++
+            }
+          }
+
+          return { x, y, radius, alpha, count }
+        }
+
+        function createContexts(cards: number): CanvasRenderingContext2D[] {
+          const contexts: CanvasRenderingContext2D[] = []
+          for (let cardIndex = 0; cardIndex < cards; cardIndex++) {
+            const canvas = document.createElement('canvas')
+            canvas.width = card.width * dpr
+            canvas.height = card.height * dpr
+            canvas.style.width = `${card.width}px`
+            canvas.style.height = `${card.height}px`
+            const context = canvas.getContext('2d')
+            if (!context) throw new Error('Canvas2D is unavailable')
+            context.setTransform(dpr, 0, 0, dpr, 0, 0)
+            context.fillStyle = '#111827'
+            benchmarkRoot.appendChild(canvas)
+            contexts.push(context)
+          }
+          return contexts
+        }
+
+        function createPerDotVariant(cards: number, dots: DotSet): Variant {
+          const contexts = createContexts(cards)
+          const variant: Variant = {
+            name: 'per-dot',
+            alphaBands: null,
+            contexts,
+            band: null,
+            sortedIndices: null,
+            bandCounts: null,
+            bandOffsets: null,
+            bandWrites: null,
+            durations: [],
+            draw: () => {
+              for (let cardIndex = 0; cardIndex < contexts.length; cardIndex++) {
+                const context = contexts[cardIndex]
+                context.clearRect(0, 0, card.width, card.height)
+                context.fillStyle = '#111827'
+                for (let dot = 0; dot < dots.count; dot++) {
+                  context.globalAlpha = dots.alpha[dot]
+                  context.beginPath()
+                  context.arc(dots.x[dot], dots.y[dot], dots.radius[dot], 0, tau)
+                  context.fill()
+                }
+                context.globalAlpha = 1
+              }
+            },
+          }
+          return variant
+        }
+
+        function createBucketVariant(
+          cards: number,
+          dots: DotSet,
+          alphaBands: number
+        ): Variant {
+          const contexts = createContexts(cards)
+          const band = new Uint8Array(dots.count)
+          const sortedIndices = new Uint32Array(dots.count)
+          const bandCounts = new Uint32Array(alphaBands)
+          const bandOffsets = new Uint32Array(alphaBands)
+          const bandWrites = new Uint32Array(alphaBands)
+          for (let dot = 0; dot < dots.count; dot++) {
+            band[dot] = Math.min(
+              alphaBands - 1,
+              Math.floor(dots.alpha[dot] * alphaBands)
+            )
+          }
+
+          const variant: Variant = {
+            name: 'alpha-buckets',
+            alphaBands,
+            contexts,
+            band,
+            sortedIndices,
+            bandCounts,
+            bandOffsets,
+            bandWrites,
+            durations: [],
+            draw: () => {
+              bandCounts.fill(0)
+              for (let dot = 0; dot < dots.count; dot++) {
+                bandCounts[band[dot]]++
+              }
+              let offset = 0
+              for (let alphaBand = 0; alphaBand < alphaBands; alphaBand++) {
+                bandOffsets[alphaBand] = offset
+                bandWrites[alphaBand] = offset
+                offset += bandCounts[alphaBand]
+              }
+              for (let dot = 0; dot < dots.count; dot++) {
+                const alphaBand = band[dot]
+                sortedIndices[bandWrites[alphaBand]++] = dot
+              }
+
+              for (let cardIndex = 0; cardIndex < contexts.length; cardIndex++) {
+                const context = contexts[cardIndex]
+                context.clearRect(0, 0, card.width, card.height)
+                context.fillStyle = '#111827'
+                for (let alphaBand = 0; alphaBand < alphaBands; alphaBand++) {
+                  const count = bandCounts[alphaBand]
+                  if (count === 0) continue
+                  context.globalAlpha = (alphaBand + 0.5) / alphaBands
+                  context.beginPath()
+                  const start = bandOffsets[alphaBand]
+                  const end = start + count
+                  for (let sorted = start; sorted < end; sorted++) {
+                    const dot = sortedIndices[sorted]
+                    context.moveTo(dots.x[dot] + dots.radius[dot], dots.y[dot])
+                    context.arc(dots.x[dot], dots.y[dot], dots.radius[dot], 0, tau)
+                  }
+                  context.fill()
+                }
+                context.globalAlpha = 1
+              }
+            },
+          }
+          return variant
+        }
+
+        function percentile(sorted: number[], quantile: number): number {
+          const index = Math.min(
+            sorted.length - 1,
+            Math.max(0, Math.ceil(sorted.length * quantile) - 1)
+          )
+          return sorted[index]
+        }
+
+        const dots = createDotSet()
+        const fixtureDefinitions = [
+          { name: 'one-wide-card' as const, cards: 1 },
+          { name: 'eight-wide-card-board' as const, cards: 8 },
+        ]
+        const fixtureResults = []
+
+        for (const fixture of fixtureDefinitions) {
+          benchmarkRoot.replaceChildren()
+          const variants = [
+            createPerDotVariant(fixture.cards, dots),
+            ...bands.map((alphaBands) =>
+              createBucketVariant(fixture.cards, dots, alphaBands)
+            ),
+          ]
+
+          for (let warmup = 0; warmup < warmups; warmup++) {
+            for (let offset = 0; offset < variants.length; offset++) {
+              variants[(warmup + offset) % variants.length].draw()
+            }
+            if ((warmup + 1) % 30 === 0 || warmup + 1 === warmups) {
+              flushRasterWork(variants)
+            }
+          }
+
+          for (let sample = 0; sample < samples; sample++) {
+            for (let offset = 0; offset < variants.length; offset++) {
+              const variant = variants[(sample + offset) % variants.length]
+              const start = performance.now()
+              variant.draw()
+              variant.durations.push(performance.now() - start)
+            }
+            if ((sample + 1) % 30 === 0 || sample + 1 === samples) {
+              flushRasterWork(variants)
+            }
+          }
+
+          fixtureResults.push({
+            name: fixture.name,
+            cards: fixture.cards,
+            cardWidth: card.width,
+            cardHeight: card.height,
+            columns: card.columns,
+            rows: card.rows,
+            dotsPerCard: dots.count,
+            warmupCount: warmups,
+            sampleCount: samples,
+            strategies: variants.map((variant) => {
+              const sorted = variant.durations.slice().sort((left, right) => left - right)
+              return {
+                name: variant.name,
+                alphaBands: variant.alphaBands,
+                medianMs: percentile(sorted, 0.5),
+                p95Ms: percentile(sorted, 0.95),
+                minimumMs: sorted[0],
+                maximumMs: sorted[sorted.length - 1],
+              }
+            }),
+          })
+        }
+
+        return fixtureResults
+      },
+      {
+        card: WIDE_CARD,
+        bands: CONFIRMATION_BANDS,
+        warmups: warmupCount,
+        samples: sampleCount,
+        dpr: DEVICE_PIXEL_RATIO,
+      }
+    )
+
+    await context.close()
+    return {
+      mode,
+      headless: definition.headless,
+      browserVersion: browser.version(),
+      launchArgs: definition.launchArgs,
+      gpu,
+      fixtures: fixtures as HalftoneBenchmarkFixture[],
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
+function strategy(
+  fixture: HalftoneBenchmarkFixture,
+  name: 'per-dot' | 'alpha-buckets',
+  alphaBands: number | null
+) {
+  const found = fixture.strategies.find(
+    (candidate) => candidate.name === name && candidate.alphaBands === alphaBands
+  )
+  if (!found) {
+    throw new Error(`${fixture.name} is missing ${name} ${alphaBands ?? ''}`.trim())
+  }
+  return found
+}
+
+function buildGates(runs: HalftoneBenchmarkMode[]): HalftoneBenchmarkGate[] {
+  const gates: HalftoneBenchmarkGate[] = []
+  for (const run of runs) {
+    const oneCard = run.fixtures.find((fixture) => fixture.cards === 1)
+    const board = run.fixtures.find((fixture) => fixture.cards === 8)
+    if (!oneCard || !board) throw new Error(`${run.mode} is missing a benchmark fixture`)
+    const reference = strategy(oneCard, 'per-dot', null)
+    const candidate = strategy(oneCard, 'alpha-buckets', 32)
+    const boardCandidate = strategy(board, 'alpha-buckets', 32)
+    const medianImprovement = 1 - candidate.medianMs / reference.medianMs
+    const p95Improvement = 1 - candidate.p95Ms / reference.p95Ms
+
+    if (run.mode === 'headed-gpu') {
+      gates.push(
+        {
+          name: '32-band median per-card draw reduction',
+          mode: run.mode,
+          actual: medianImprovement,
+          requirement: '>= 35%',
+          passed: medianImprovement >= 0.35,
+        },
+        {
+          name: '32-band p95 per-card draw reduction',
+          mode: run.mode,
+          actual: p95Improvement,
+          requirement: '> 0%',
+          passed: p95Improvement > 0,
+        },
+        {
+          name: 'eight-card p95 main-thread draw time',
+          mode: run.mode,
+          actual: boardCandidate.p95Ms,
+          requirement: '< 16.7ms',
+          passed: boardCandidate.p95Ms < 16.7,
+        }
+      )
+    } else {
+      const medianRatio = candidate.medianMs / reference.medianMs
+      const p95Ratio = candidate.p95Ms / reference.p95Ms
+      gates.push(
+        {
+          name: 'software median regression',
+          mode: run.mode,
+          actual: medianRatio - 1,
+          requirement: '<= 10%',
+          passed: medianRatio <= 1.1,
+        },
+        {
+          name: 'software p95 regression',
+          mode: run.mode,
+          actual: p95Ratio - 1,
+          requirement: '<= 10%',
+          passed: p95Ratio <= 1.1,
+        }
+      )
+    }
+  }
+  return gates
+}
+
+function printSummary(runs: HalftoneBenchmarkMode[], gates: HalftoneBenchmarkGate[]): void {
+  console.log('\nHalftone Canvas2D benchmark')
+  for (const run of runs) {
+    console.log(`\n${run.mode} · Chromium ${run.browserVersion}`)
+    for (const fixture of run.fixtures) {
+      console.log(
+        `${fixture.name}: ${fixture.cardWidth}×${fixture.cardHeight}, ` +
+          `${fixture.dotsPerCard.toLocaleString()} dots/card, ` +
+          `${fixture.sampleCount} samples after ${fixture.warmupCount} warmups`
+      )
+      for (const result of fixture.strategies) {
+        const label =
+          result.name === 'per-dot'
+            ? 'per-dot'
+            : `${result.alphaBands}-band`
+        console.log(
+          `  ${label.padEnd(8)} median ${result.medianMs.toFixed(3)}ms · ` +
+            `p95 ${result.p95Ms.toFixed(3)}ms`
+        )
+      }
+    }
+  }
+
+  console.log('\nDecision gates')
+  for (const gate of gates) {
+    const unit = gate.name.includes('time') ? 'ms' : '%'
+    const actual =
+      unit === 'ms'
+        ? `${gate.actual.toFixed(3)}ms`
+        : `${(gate.actual * 100).toFixed(1)}%`
+    console.log(
+      `  ${gate.passed ? 'PASS' : 'FAIL'} ${gate.mode}: ${gate.name} ` +
+        `${actual} (${gate.requirement})`
+    )
+  }
+}
+
+async function main(): Promise<void> {
+  const warmupCount = readCount('--warmups', DEFAULT_WARMUP_COUNT)
+  const sampleCount = readCount('--samples', DEFAULT_SAMPLE_COUNT)
+  if (sampleCount === 0) throw new Error('--samples must be greater than zero')
+
+  const runs: HalftoneBenchmarkMode[] = []
+  for (const mode of requestedModes()) {
+    runs.push(await runMode(mode, warmupCount, sampleCount))
+  }
+  const gates = buildGates(runs)
+  const cpuInfo = os.cpus()
+  const result = halftoneBenchmarkResultSchema.parse({
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    environment: {
+      platform: os.platform(),
+      release: os.release(),
+      architecture: os.arch(),
+      cpu: cpuInfo[0]?.model ?? 'unknown',
+      logicalCpuCount: cpuInfo.length,
+      viewportWidth: VIEWPORT.width,
+      viewportHeight: VIEWPORT.height,
+      devicePixelRatio: DEVICE_PIXEL_RATIO,
+    },
+    config: {
+      warmupCount,
+      sampleCount,
+      alphaBands: CONFIRMATION_BANDS,
+    },
+    runs,
+    gates,
+    passed: gates.every((gate) => gate.passed),
+  })
+
+  const requestedOutput = readOption('--output')
+  const timestamp = result.generatedAt.replaceAll(':', '-')
+  const outputPath = path.resolve(
+    requestedOutput ??
+      path.join('test-results', 'halftone-benchmark', `halftone-${timestamp}.json`)
+  )
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  fs.writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`)
+
+  printSummary(result.runs, result.gates)
+  console.log(`\nMachine-readable results: ${outputPath}`)
+  if (!result.passed) process.exitCode = 1
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.stack : error)
+  process.exitCode = 1
+})

--- a/scripts/halftone-benchmark-schema.ts
+++ b/scripts/halftone-benchmark-schema.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod'
+
+export const halftoneBenchmarkStrategySchema = z.object({
+  name: z.enum(['per-dot', 'alpha-buckets']),
+  alphaBands: z.number().int().positive().nullable(),
+  medianMs: z.number().nonnegative(),
+  p95Ms: z.number().nonnegative(),
+  minimumMs: z.number().nonnegative(),
+  maximumMs: z.number().nonnegative(),
+})
+
+export const halftoneBenchmarkFixtureSchema = z.object({
+  name: z.enum(['one-wide-card', 'eight-wide-card-board']),
+  cards: z.number().int().positive(),
+  cardWidth: z.number().int().positive(),
+  cardHeight: z.number().int().positive(),
+  columns: z.number().int().positive(),
+  rows: z.number().int().positive(),
+  dotsPerCard: z.number().int().positive(),
+  warmupCount: z.number().int().nonnegative(),
+  sampleCount: z.number().int().positive(),
+  strategies: z.array(halftoneBenchmarkStrategySchema),
+})
+
+export const halftoneBenchmarkModeSchema = z.object({
+  mode: z.enum(['headed-gpu', 'headless-software']),
+  headless: z.boolean(),
+  browserVersion: z.string().min(1),
+  launchArgs: z.array(z.string()),
+  gpu: z.object({
+    devices: z.array(
+      z.object({
+        vendorString: z.string(),
+        deviceString: z.string(),
+        driverVendor: z.string(),
+        driverVersion: z.string(),
+      })
+    ),
+    featureStatus: z.record(z.string(), z.string()),
+  }),
+  fixtures: z.array(halftoneBenchmarkFixtureSchema),
+})
+
+export const halftoneBenchmarkGateSchema = z.object({
+  name: z.string().min(1),
+  mode: z.enum(['headed-gpu', 'headless-software']),
+  actual: z.number(),
+  requirement: z.string().min(1),
+  passed: z.boolean(),
+})
+
+export const halftoneBenchmarkResultSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: z.string().datetime(),
+  environment: z.object({
+    platform: z.string().min(1),
+    release: z.string().min(1),
+    architecture: z.string().min(1),
+    cpu: z.string().min(1),
+    logicalCpuCount: z.number().int().positive(),
+    viewportWidth: z.number().int().positive(),
+    viewportHeight: z.number().int().positive(),
+    devicePixelRatio: z.number().positive(),
+  }),
+  config: z.object({
+    warmupCount: z.number().int().nonnegative(),
+    sampleCount: z.number().int().positive(),
+    alphaBands: z.array(z.number().int().positive()),
+  }),
+  runs: z.array(halftoneBenchmarkModeSchema),
+  gates: z.array(halftoneBenchmarkGateSchema),
+  passed: z.boolean(),
+})
+
+export type HalftoneBenchmarkFixture = z.infer<typeof halftoneBenchmarkFixtureSchema>
+export type HalftoneBenchmarkMode = z.infer<typeof halftoneBenchmarkModeSchema>
+export type HalftoneBenchmarkGate = z.infer<typeof halftoneBenchmarkGateSchema>
+export type HalftoneBenchmarkResult = z.infer<typeof halftoneBenchmarkResultSchema>

--- a/scripts/halftone-runtime-benchmark-schema.ts
+++ b/scripts/halftone-runtime-benchmark-schema.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+
+export const halftoneRuntimeBenchmarkFixtureSchema = z.object({
+  name: z.enum([
+    'flow-one-card-inactive',
+    'flow-eight-card-board-inactive',
+    'flow-eight-card-board-one-pointer',
+    'pulse-one-card-inactive',
+    'pulse-eight-card-board-inactive',
+  ]),
+  motif: z.enum(['flow_3d', 'pulse']),
+  cards: z.number().int().positive(),
+  pointerCards: z.number().int().nonnegative(),
+  cardWidth: z.number().int().positive(),
+  cardHeight: z.number().int().positive(),
+  columns: z.number().int().positive(),
+  rows: z.number().int().positive(),
+  dotsPerCard: z.number().int().positive(),
+  warmupCount: z.number().int().nonnegative(),
+  sampleCount: z.number().int().positive(),
+  medianMs: z.number().nonnegative(),
+  p95Ms: z.number().nonnegative(),
+  minimumMs: z.number().nonnegative(),
+  maximumMs: z.number().nonnegative(),
+})
+
+export const halftoneRuntimeBenchmarkModeSchema = z.object({
+  mode: z.enum(['headed-gpu', 'headless-software']),
+  headless: z.boolean(),
+  browserVersion: z.string().min(1),
+  launchArgs: z.array(z.string()),
+  gpu: z.object({
+    devices: z.array(
+      z.object({
+        vendorString: z.string(),
+        deviceString: z.string(),
+        driverVendor: z.string(),
+        driverVersion: z.string(),
+      })
+    ),
+    featureStatus: z.record(z.string(), z.string()),
+  }),
+  fixtures: z.array(halftoneRuntimeBenchmarkFixtureSchema),
+  sameSizeResize: z.object({
+    warmupCount: z.number().int().nonnegative(),
+    sampleCount: z.number().int().positive(),
+    medianMs: z.number().nonnegative(),
+    p95Ms: z.number().nonnegative(),
+    minimumMs: z.number().nonnegative(),
+    maximumMs: z.number().nonnegative(),
+  }),
+  pointerDispatch: z.object({
+    iterationsPerTrial: z.number().int().positive(),
+    trials: z.number().int().positive(),
+    variants: z.array(
+      z.object({
+        listenerCount: z.number().int().positive(),
+        medianMicrosecondsPerEvent: z.number().nonnegative(),
+        p95MicrosecondsPerEvent: z.number().nonnegative(),
+      })
+    ),
+  }),
+})
+
+export const halftoneRuntimeBenchmarkResultSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: z.string().datetime(),
+  label: z.string().min(1),
+  sourceRevision: z.string().min(1),
+  environment: z.object({
+    platform: z.string().min(1),
+    release: z.string().min(1),
+    architecture: z.string().min(1),
+    cpu: z.string().min(1),
+    logicalCpuCount: z.number().int().positive(),
+    viewportWidth: z.number().int().positive(),
+    viewportHeight: z.number().int().positive(),
+    devicePixelRatio: z.number().positive(),
+  }),
+  config: z.object({
+    warmupCount: z.number().int().nonnegative(),
+    sampleCount: z.number().int().positive(),
+  }),
+  runs: z.array(halftoneRuntimeBenchmarkModeSchema),
+})
+
+export type HalftoneRuntimeBenchmarkFixture = z.infer<
+  typeof halftoneRuntimeBenchmarkFixtureSchema
+>
+export type HalftoneRuntimeBenchmarkMode = z.infer<
+  typeof halftoneRuntimeBenchmarkModeSchema
+>

--- a/src/renderer/components/agents/halftone-renderer.test.ts
+++ b/src/renderer/components/agents/halftone-renderer.test.ts
@@ -3,11 +3,13 @@ import {
   HALFTONE_ALPHA_BANDS,
   HALFTONE_MAX_ALPHA_ERROR,
   HalftoneFrameRenderer,
+  type HalftoneDotScratch,
   alphaBandMidpoint,
   alphaToBand,
   countingSortDotIndices,
   createHalftoneDotScratch,
   drawAlphaBuckets,
+  scaleHalftoneEasingRate,
 } from './halftone-renderer'
 
 function createContextMock() {
@@ -106,5 +108,45 @@ describe('HalftoneFrameRenderer edge sizes', () => {
     for (const call of vi.mocked(context.arc).mock.calls) {
       expect(call.slice(0, 3).every(Number.isFinite)).toBe(true)
     }
+  })
+
+  it('reuses typed-array buffers until the grid outgrows their capacity', () => {
+    const renderer = new HalftoneFrameRenderer({
+      motif: 'flow_3d',
+      color: '#111827',
+      spacing: 6,
+    })
+    const internals = renderer as unknown as {
+      scratch: HalftoneDotScratch | null
+      cellVignette: Float32Array
+    }
+    const { context } = createContextMock()
+
+    expect(renderer.resize(240, 120)).toBe(true)
+    const initialScratch = internals.scratch
+    const initialVignette = internals.cellVignette
+    renderer.draw(context, 0, 'alpha-buckets', 120, 60, true)
+    expect(initialScratch?.influence.some((value) => value > 0)).toBe(true)
+
+    expect(renderer.resize(180, 90)).toBe(true)
+    expect(internals.scratch).toBe(initialScratch)
+    expect(internals.cellVignette).toBe(initialVignette)
+    expect(internals.scratch?.influence.slice(0, 450).every((value) => value === 0)).toBe(true)
+
+    expect(renderer.resize(300, 150)).toBe(true)
+    expect(internals.scratch).not.toBe(initialScratch)
+    expect(internals.cellVignette).not.toBe(initialVignette)
+  })
+})
+
+describe('halftone cursor easing', () => {
+  it('preserves the 60 Hz easing response when a draw spans multiple frames', () => {
+    const attack = 0.18
+    const oneFrame = scaleHalftoneEasingRate(attack, 1)
+    const twoFrames = scaleHalftoneEasingRate(attack, 2)
+    const appliedTwice = oneFrame + (1 - oneFrame) * oneFrame
+
+    expect(twoFrames).toBeCloseTo(appliedTwice)
+    expect(scaleHalftoneEasingRate(attack, 0)).toBe(0)
   })
 })

--- a/src/renderer/components/agents/halftone-renderer.test.ts
+++ b/src/renderer/components/agents/halftone-renderer.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  HALFTONE_ALPHA_BANDS,
+  HALFTONE_MAX_ALPHA_ERROR,
+  HalftoneFrameRenderer,
+  alphaBandMidpoint,
+  alphaToBand,
+  countingSortDotIndices,
+  createHalftoneDotScratch,
+  drawAlphaBuckets,
+} from './halftone-renderer'
+
+function createContextMock() {
+  const events: string[] = []
+  const context = {
+    globalAlpha: 1,
+    fillStyle: '',
+    clearRect: vi.fn(),
+    beginPath: vi.fn(() => events.push('beginPath')),
+    moveTo: vi.fn(() => events.push('moveTo')),
+    arc: vi.fn(() => events.push('arc')),
+    fill: vi.fn(() => events.push('fill')),
+  } as unknown as CanvasRenderingContext2D
+  return { context, events }
+}
+
+describe('halftone alpha bands', () => {
+  it('assigns alpha 0/1 and band-boundary values with at most 1/64 error', () => {
+    const samples = [0, Number.EPSILON, 0.5 - Number.EPSILON, 0.5, 1]
+
+    expect(alphaToBand(0)).toBe(0)
+    expect(alphaToBand(0.5 - Number.EPSILON)).toBe(15)
+    expect(alphaToBand(0.5)).toBe(16)
+    expect(alphaToBand(1)).toBe(HALFTONE_ALPHA_BANDS - 1)
+
+    for (const alpha of samples) {
+      const midpoint = alphaBandMidpoint(alphaToBand(alpha))
+      expect(Math.abs(midpoint - alpha)).toBeLessThanOrEqual(HALFTONE_MAX_ALPHA_ERROR)
+    }
+  })
+
+  it('counting-sorts boundaries stably while preserving empty bands', () => {
+    const scratch = createHalftoneDotScratch(6, 4)
+    scratch.band.set([3, 0, 3, 1, 0, 3])
+
+    countingSortDotIndices(scratch, 6)
+
+    expect(Array.from(scratch.bandCounts)).toEqual([2, 1, 0, 3])
+    expect(Array.from(scratch.bandOffsets)).toEqual([0, 2, 3, 3])
+    expect(Array.from(scratch.sortedIndices)).toEqual([1, 4, 3, 0, 2, 5])
+  })
+
+  it('builds one path per non-empty band and moves before every arc', () => {
+    const scratch = createHalftoneDotScratch(3, 4)
+    scratch.x.set([10, 20, 30])
+    scratch.y.set([11, 21, 31])
+    scratch.radius.set([1, 2, 3])
+    scratch.band.set([0, 3, 0])
+    const { context, events } = createContextMock()
+
+    drawAlphaBuckets(context, scratch, 3)
+
+    expect(context.beginPath).toHaveBeenCalledTimes(2)
+    expect(context.fill).toHaveBeenCalledTimes(2)
+    expect(context.moveTo).toHaveBeenCalledTimes(3)
+    expect(context.arc).toHaveBeenCalledTimes(3)
+    expect(events).toEqual([
+      'beginPath',
+      'moveTo',
+      'arc',
+      'moveTo',
+      'arc',
+      'fill',
+      'beginPath',
+      'moveTo',
+      'arc',
+      'fill',
+    ])
+  })
+})
+
+describe('HalftoneFrameRenderer edge sizes', () => {
+  it('recovers from zero size and safely renders one-row and one-column grids', () => {
+    const renderer = new HalftoneFrameRenderer({
+      motif: 'flow_3d',
+      state: 'working',
+      color: '#111827',
+      spacing: 6,
+      seed: 7,
+    })
+    const { context } = createContextMock()
+
+    expect(renderer.resize(0, 0)).toBe(false)
+    expect(renderer.draw(context, 0)).toBe(0)
+
+    expect(renderer.resize(30, 5)).toBe(true)
+    expect(renderer.columnCount).toBe(5)
+    expect(renderer.rowCount).toBe(1)
+    expect(renderer.draw(context, 123)).toBeGreaterThan(0)
+
+    expect(renderer.resize(5, 30)).toBe(true)
+    expect(renderer.columnCount).toBe(1)
+    expect(renderer.rowCount).toBe(5)
+    expect(renderer.draw(context, 456)).toBeGreaterThan(0)
+
+    for (const call of vi.mocked(context.arc).mock.calls) {
+      expect(call.slice(0, 3).every(Number.isFinite)).toBe(true)
+    }
+  })
+})

--- a/src/renderer/components/agents/halftone-renderer.ts
+++ b/src/renderer/components/agents/halftone-renderer.ts
@@ -25,6 +25,13 @@ interface DensitySample {
   radius: number
 }
 
+interface PulseFrame {
+  radius0: number
+  radius1: number
+  weight0: number
+  weight1: number
+}
+
 export interface HalftoneDotScratch {
   readonly capacity: number
   readonly bandCount: number
@@ -191,21 +198,23 @@ function rotatedFlowHeight(
   )
 }
 
-function pulseHeight(u: number, v: number, time: number): number {
+function updatePulseFrame(time: number, frame: PulseFrame): void {
+  const phase = (time * 0.0024) % 1
+  const age0 = phase
+  const age1 = (phase + 0.5) % 1
+  frame.radius0 = age0 * 0.8
+  frame.radius1 = age1 * 0.8
+  frame.weight0 = 1 - age0
+  frame.weight1 = 1 - age1
+}
+
+function pulseHeight(u: number, v: number, frame: PulseFrame): number {
   const dx = u - 0.5
   const dy = v - 0.5
   const distance = Math.sqrt(dx * dx + dy * dy)
-  const phase = (time * 0.0024) % 1
-  let height = 0
-
-  for (let ring = 0; ring < 2; ring++) {
-    const age = (phase + ring * 0.5) % 1
-    const ringRadius = age * 0.8
-    const band = Math.exp(-Math.pow((distance - ringRadius) * 5.5, 2))
-    height += band * (1 - age)
-  }
-
-  return height
+  const band0 = Math.exp(-Math.pow((distance - frame.radius0) * 5.5, 2))
+  const band1 = Math.exp(-Math.pow((distance - frame.radius1) * 5.5, 2))
+  return band0 * frame.weight0 + band1 * frame.weight1
 }
 
 function shadeInto(
@@ -234,18 +243,14 @@ function shadeInto(
 }
 
 function flowSampleInto(
-  column: number,
-  row: number,
-  columns: number,
-  rows: number,
+  u: number,
+  v: number,
+  epsilon: number,
   time: number,
   rotationCos: number,
   rotationSin: number,
   sample: DensitySample
 ): void {
-  const u = column / columns
-  const v = row / rows
-  const epsilon = 0.5 / columns
   shadeInto(
     rotatedFlowHeight(u, v, time, rotationCos, rotationSin) + 0.65,
     rotatedFlowHeight(u + epsilon, v, time, rotationCos, rotationSin) + 0.65,
@@ -260,17 +265,13 @@ function flowSampleInto(
 }
 
 function pulseSampleInto(
-  column: number,
-  row: number,
-  columns: number,
-  rows: number,
-  time: number,
+  u: number,
+  v: number,
+  epsilon: number,
+  frame: PulseFrame,
   sample: DensitySample
 ): void {
-  const u = column / columns
-  const v = row / rows
-  const epsilon = 0.5 / columns
-  const height = pulseHeight(u, v, time)
+  const height = pulseHeight(u, v, frame)
   if (height < 0.05) {
     sample.alpha = 0
     sample.radius = 0
@@ -279,8 +280,8 @@ function pulseSampleInto(
 
   shadeInto(
     height * 0.6 + 0.05,
-    pulseHeight(u + epsilon, v, time) * 0.6 + 0.05,
-    pulseHeight(u, v + epsilon, time) * 0.6 + 0.05,
+    pulseHeight(u + epsilon, v, frame) * 0.6 + 0.05,
+    pulseHeight(u, v + epsilon, frame) * 0.6 + 0.05,
     epsilon,
     0.12,
     0.85,
@@ -304,6 +305,12 @@ export class HalftoneFrameRenderer {
   private readonly rotationSin: number
   private readonly alphaBands: number
   private readonly sample: DensitySample = { alpha: 0, radius: 0 }
+  private readonly pulseFrame: PulseFrame = {
+    radius0: 0,
+    radius1: 0,
+    weight0: 0,
+    weight1: 0,
+  }
 
   private width = 0
   private height = 0
@@ -313,6 +320,14 @@ export class HalftoneFrameRenderer {
   private offsetY = 0
   private centerColumn = 0
   private centerRow = 0
+  private epsilon = 0
+  private columnX = new Float64Array(0)
+  private columnU = new Float64Array(0)
+  private rowY = new Float64Array(0)
+  private rowV = new Float64Array(0)
+  private cellVignette = new Float64Array(0)
+  private cellAlphaScale = new Float64Array(0)
+  private cellRadiusScale = new Float64Array(0)
   private scratch: HalftoneDotScratch | null = null
 
   constructor(options: HalftoneRendererOptions) {
@@ -332,11 +347,22 @@ export class HalftoneFrameRenderer {
   }
 
   resize(width: number, height: number): boolean {
+    if (width === this.width && height === this.height) {
+      return this.scratch !== null
+    }
     this.width = width
     this.height = height
     if (width <= 0 || height <= 0) {
       this.columns = 0
       this.rows = 0
+      this.epsilon = 0
+      this.columnX = new Float64Array(0)
+      this.columnU = new Float64Array(0)
+      this.rowY = new Float64Array(0)
+      this.rowV = new Float64Array(0)
+      this.cellVignette = new Float64Array(0)
+      this.cellAlphaScale = new Float64Array(0)
+      this.cellRadiusScale = new Float64Array(0)
       this.scratch = null
       return false
     }
@@ -347,8 +373,41 @@ export class HalftoneFrameRenderer {
     this.offsetY = (height - (this.rows - 1) * this.spacing) / 2
     this.centerColumn = (this.columns - 1) / 2
     this.centerRow = (this.rows - 1) / 2
+    this.epsilon = 0.5 / this.columns
+    this.columnX = new Float64Array(this.columns)
+    this.columnU = new Float64Array(this.columns)
+    this.rowY = new Float64Array(this.rows)
+    this.rowV = new Float64Array(this.rows)
+    for (let column = 0; column < this.columns; column++) {
+      this.columnX[column] = this.offsetX + column * this.spacing
+      this.columnU[column] = column / this.columns
+    }
+    for (let row = 0; row < this.rows; row++) {
+      this.rowY[row] = this.offsetY + row * this.spacing
+      this.rowV[row] = row / this.rows
+    }
+
+    const capacity = this.columns * this.rows
+    this.cellVignette = new Float64Array(capacity)
+    this.cellAlphaScale = new Float64Array(capacity)
+    this.cellRadiusScale = new Float64Array(capacity)
+    for (let row = 0; row < this.rows; row++) {
+      const normalizedY =
+        this.centerRow === 0 ? 0 : (row - this.centerRow) / this.centerRow
+      for (let column = 0; column < this.columns; column++) {
+        const normalizedX =
+          this.centerColumn === 0
+            ? 0
+            : (column - this.centerColumn) / this.centerColumn
+        const cell = row * this.columns + column
+        const vignette = this.vignetteAt(normalizedX, normalizedY)
+        this.cellVignette[cell] = vignette
+        this.cellAlphaScale[cell] = vignette * this.dim
+        this.cellRadiusScale[cell] = 0.35 + 0.65 * vignette
+      }
+    }
     this.scratch = createHalftoneDotScratch(
-      this.columns * this.rows,
+      capacity,
       this.alphaBands
     )
     return true
@@ -382,25 +441,29 @@ export class HalftoneFrameRenderer {
 
     const influenceRadiusSquared = CURSOR_INFLUENCE * CURSOR_INFLUENCE
     const fieldTime = time + this.seedTime
+    if (this.motif === 'pulse') updatePulseFrame(fieldTime, this.pulseFrame)
     let dotCount = 0
 
     for (let row = 0; row < this.rows; row++) {
+      const y = this.rowY[row]
+      const v = this.rowV[row]
       for (let column = 0; column < this.columns; column++) {
+        const x = this.columnX[column]
+        const u = this.columnU[column]
+        const cell = row * this.columns + column
         if (this.motif === 'pulse') {
           pulseSampleInto(
-            column,
-            row,
-            this.columns,
-            this.rows,
-            fieldTime,
+            u,
+            v,
+            this.epsilon,
+            this.pulseFrame,
             this.sample
           )
         } else {
           flowSampleInto(
-            column,
-            row,
-            this.columns,
-            this.rows,
+            u,
+            v,
+            this.epsilon,
             fieldTime,
             this.rotationCos,
             this.rotationSin,
@@ -410,9 +473,6 @@ export class HalftoneFrameRenderer {
 
         let alpha = Math.min(1, this.sample.alpha * this.contrast * 0.9)
         let radius = this.sample.radius * (this.maxRadius / 2.4)
-        const x = this.offsetX + column * this.spacing
-        const y = this.offsetY + row * this.spacing
-        const cell = row * this.columns + column
         let target = 0
         if (pointerActive) {
           const deltaX = x - pointerX
@@ -432,17 +492,13 @@ export class HalftoneFrameRenderer {
         scratch.influence[cell] = influence
         if (influence > 0.003) radius += influence * CURSOR_R
 
-        const normalizedX =
-          this.centerColumn === 0 ? 0 : (column - this.centerColumn) / this.centerColumn
-        const normalizedY =
-          this.centerRow === 0 ? 0 : (row - this.centerRow) / this.centerRow
-        const vignette = this.vignetteAt(normalizedX, normalizedY)
+        const vignette = this.cellVignette[cell]
         if (vignette <= 0) continue
 
-        alpha *= vignette * this.dim
+        alpha *= this.cellAlphaScale[cell]
         if (influence > 0.003) alpha += influence * vignette * CURSOR_A
         alpha = Math.min(1, alpha)
-        radius *= 0.35 + 0.65 * vignette
+        radius *= this.cellRadiusScale[cell]
         if (alpha < 0.02 || radius < 0.2) continue
 
         scratch.x[dotCount] = x

--- a/src/renderer/components/agents/halftone-renderer.ts
+++ b/src/renderer/components/agents/halftone-renderer.ts
@@ -2,7 +2,7 @@ export const HALFTONE_ALPHA_BANDS = 32
 export const HALFTONE_MAX_ALPHA_ERROR = 1 / (HALFTONE_ALPHA_BANDS * 2)
 
 const TAU = Math.PI * 2
-const CURSOR_INFLUENCE = 90
+export const HALFTONE_CURSOR_INFLUENCE = 90
 const CURSOR_ATTACK = 0.18
 const CURSOR_RELEASE = 0.04
 const CURSOR_R = 1.6
@@ -58,6 +58,15 @@ export interface HalftoneRendererOptions {
   dim?: number
   seed?: number
   alphaBands?: number
+}
+
+/** Convert a 60 Hz per-frame easing rate into an equivalent wall-clock rate. */
+export function scaleHalftoneEasingRate(rate: number, frameScale: number): number {
+  return 1 - Math.pow(1 - rate, Math.max(0, frameScale))
+}
+
+function ensureFloat32Capacity(buffer: Float32Array, capacity: number): Float32Array {
+  return buffer.length >= capacity ? buffer : new Float32Array(capacity)
 }
 
 export function createHalftoneDotScratch(
@@ -321,13 +330,13 @@ export class HalftoneFrameRenderer {
   private centerColumn = 0
   private centerRow = 0
   private epsilon = 0
-  private columnX = new Float64Array(0)
-  private columnU = new Float64Array(0)
-  private rowY = new Float64Array(0)
-  private rowV = new Float64Array(0)
-  private cellVignette = new Float64Array(0)
-  private cellAlphaScale = new Float64Array(0)
-  private cellRadiusScale = new Float64Array(0)
+  private columnX: Float32Array = new Float32Array(0)
+  private columnU: Float32Array = new Float32Array(0)
+  private rowY: Float32Array = new Float32Array(0)
+  private rowV: Float32Array = new Float32Array(0)
+  private cellVignette: Float32Array = new Float32Array(0)
+  private cellAlphaScale: Float32Array = new Float32Array(0)
+  private cellRadiusScale: Float32Array = new Float32Array(0)
   private scratch: HalftoneDotScratch | null = null
 
   constructor(options: HalftoneRendererOptions) {
@@ -348,7 +357,7 @@ export class HalftoneFrameRenderer {
 
   resize(width: number, height: number): boolean {
     if (width === this.width && height === this.height) {
-      return this.scratch !== null
+      return width > 0 && height > 0 && this.scratch !== null
     }
     this.width = width
     this.height = height
@@ -356,14 +365,6 @@ export class HalftoneFrameRenderer {
       this.columns = 0
       this.rows = 0
       this.epsilon = 0
-      this.columnX = new Float64Array(0)
-      this.columnU = new Float64Array(0)
-      this.rowY = new Float64Array(0)
-      this.rowV = new Float64Array(0)
-      this.cellVignette = new Float64Array(0)
-      this.cellAlphaScale = new Float64Array(0)
-      this.cellRadiusScale = new Float64Array(0)
-      this.scratch = null
       return false
     }
 
@@ -374,10 +375,10 @@ export class HalftoneFrameRenderer {
     this.centerColumn = (this.columns - 1) / 2
     this.centerRow = (this.rows - 1) / 2
     this.epsilon = 0.5 / this.columns
-    this.columnX = new Float64Array(this.columns)
-    this.columnU = new Float64Array(this.columns)
-    this.rowY = new Float64Array(this.rows)
-    this.rowV = new Float64Array(this.rows)
+    this.columnX = ensureFloat32Capacity(this.columnX, this.columns)
+    this.columnU = ensureFloat32Capacity(this.columnU, this.columns)
+    this.rowY = ensureFloat32Capacity(this.rowY, this.rows)
+    this.rowV = ensureFloat32Capacity(this.rowV, this.rows)
     for (let column = 0; column < this.columns; column++) {
       this.columnX[column] = this.offsetX + column * this.spacing
       this.columnU[column] = column / this.columns
@@ -388,9 +389,9 @@ export class HalftoneFrameRenderer {
     }
 
     const capacity = this.columns * this.rows
-    this.cellVignette = new Float64Array(capacity)
-    this.cellAlphaScale = new Float64Array(capacity)
-    this.cellRadiusScale = new Float64Array(capacity)
+    this.cellVignette = ensureFloat32Capacity(this.cellVignette, capacity)
+    this.cellAlphaScale = ensureFloat32Capacity(this.cellAlphaScale, capacity)
+    this.cellRadiusScale = ensureFloat32Capacity(this.cellRadiusScale, capacity)
     for (let row = 0; row < this.rows; row++) {
       const normalizedY =
         this.centerRow === 0 ? 0 : (row - this.centerRow) / this.centerRow
@@ -406,10 +407,18 @@ export class HalftoneFrameRenderer {
         this.cellRadiusScale[cell] = 0.35 + 0.65 * vignette
       }
     }
-    this.scratch = createHalftoneDotScratch(
-      capacity,
-      this.alphaBands
-    )
+    if (
+      this.scratch === null ||
+      this.scratch.capacity < capacity ||
+      this.scratch.bandCount !== this.alphaBands
+    ) {
+      this.scratch = createHalftoneDotScratch(capacity, this.alphaBands)
+    } else {
+      // Grid coordinates may map to different cells after a resize. Retain the
+      // allocation but reset temporal cursor state rather than smearing it into
+      // the new geometry.
+      this.scratch.influence.fill(0, 0, capacity)
+    }
     return true
   }
 
@@ -431,7 +440,8 @@ export class HalftoneFrameRenderer {
     strategy: HalftoneDrawStrategy = 'alpha-buckets',
     pointerX = 0,
     pointerY = 0,
-    pointerActive = false
+    pointerActive = false,
+    frameScale = 1
   ): number {
     const scratch = this.scratch
     if (!scratch) return 0
@@ -439,7 +449,9 @@ export class HalftoneFrameRenderer {
     ctx.clearRect(0, 0, this.width, this.height)
     ctx.fillStyle = this.color
 
-    const influenceRadiusSquared = CURSOR_INFLUENCE * CURSOR_INFLUENCE
+    const influenceRadiusSquared = HALFTONE_CURSOR_INFLUENCE * HALFTONE_CURSOR_INFLUENCE
+    const cursorAttack = scaleHalftoneEasingRate(CURSOR_ATTACK, frameScale)
+    const cursorRelease = scaleHalftoneEasingRate(CURSOR_RELEASE, frameScale)
     const fieldTime = time + this.seedTime
     if (this.motif === 'pulse') updatePulseFrame(fieldTime, this.pulseFrame)
     let dotCount = 0
@@ -479,7 +491,7 @@ export class HalftoneFrameRenderer {
           const deltaY = y - pointerY
           const distanceSquared = deltaX * deltaX + deltaY * deltaY
           if (distanceSquared < influenceRadiusSquared) {
-            const falloff = 1 - Math.sqrt(distanceSquared) / CURSOR_INFLUENCE
+            const falloff = 1 - Math.sqrt(distanceSquared) / HALFTONE_CURSOR_INFLUENCE
             target = falloff * falloff
           }
         }
@@ -488,7 +500,7 @@ export class HalftoneFrameRenderer {
         const influence =
           currentInfluence +
           (target - currentInfluence) *
-            (target > currentInfluence ? CURSOR_ATTACK : CURSOR_RELEASE)
+            (target > currentInfluence ? cursorAttack : cursorRelease)
         scratch.influence[cell] = influence
         if (influence > 0.003) radius += influence * CURSOR_R
 

--- a/src/renderer/components/agents/halftone-renderer.ts
+++ b/src/renderer/components/agents/halftone-renderer.ts
@@ -1,0 +1,475 @@
+export const HALFTONE_ALPHA_BANDS = 32
+export const HALFTONE_MAX_ALPHA_ERROR = 1 / (HALFTONE_ALPHA_BANDS * 2)
+
+const TAU = Math.PI * 2
+const CURSOR_INFLUENCE = 90
+const CURSOR_ATTACK = 0.18
+const CURSOR_RELEASE = 0.04
+const CURSOR_R = 1.6
+const CURSOR_A = 0.75
+
+// Light: slightly upper-left, tilted toward the viewer.
+const LIGHT_X = 0.32
+const LIGHT_Y = -0.55
+const LIGHT_Z = 0.78
+const LIGHT_LENGTH = Math.sqrt(LIGHT_X * LIGHT_X + LIGHT_Y * LIGHT_Y + LIGHT_Z * LIGHT_Z)
+const NORMALIZED_LIGHT_X = LIGHT_X / LIGHT_LENGTH
+const NORMALIZED_LIGHT_Y = LIGHT_Y / LIGHT_LENGTH
+const NORMALIZED_LIGHT_Z = LIGHT_Z / LIGHT_LENGTH
+
+export type HalftoneState = 'working' | 'idle' | 'alert'
+export type HalftoneDrawStrategy = 'per-dot' | 'alpha-buckets'
+
+interface DensitySample {
+  alpha: number
+  radius: number
+}
+
+export interface HalftoneDotScratch {
+  readonly capacity: number
+  readonly bandCount: number
+  readonly x: Float32Array
+  readonly y: Float32Array
+  readonly radius: Float32Array
+  readonly alpha: Float32Array
+  readonly band: Uint8Array
+  readonly sortedIndices: Uint32Array
+  readonly bandCounts: Uint32Array
+  readonly bandOffsets: Uint32Array
+  readonly bandWriteOffsets: Uint32Array
+  readonly influence: Float32Array
+}
+
+export interface HalftoneRendererOptions {
+  motif: string
+  state?: HalftoneState
+  color: string
+  spacing?: number
+  maxRadius?: number
+  vignette?: number
+  contrast?: number
+  dim?: number
+  seed?: number
+  alphaBands?: number
+}
+
+export function createHalftoneDotScratch(
+  capacity: number,
+  bandCount = HALFTONE_ALPHA_BANDS
+): HalftoneDotScratch {
+  if (!Number.isInteger(capacity) || capacity < 0) {
+    throw new RangeError(`Halftone scratch capacity must be a non-negative integer: ${capacity}`)
+  }
+  if (!Number.isInteger(bandCount) || bandCount < 1 || bandCount > 256) {
+    throw new RangeError(`Halftone alpha band count must be an integer from 1 to 256: ${bandCount}`)
+  }
+
+  return {
+    capacity,
+    bandCount,
+    x: new Float32Array(capacity),
+    y: new Float32Array(capacity),
+    radius: new Float32Array(capacity),
+    alpha: new Float32Array(capacity),
+    band: new Uint8Array(capacity),
+    sortedIndices: new Uint32Array(capacity),
+    bandCounts: new Uint32Array(bandCount),
+    bandOffsets: new Uint32Array(bandCount),
+    bandWriteOffsets: new Uint32Array(bandCount),
+    influence: new Float32Array(capacity),
+  }
+}
+
+export function alphaToBand(alpha: number, bandCount = HALFTONE_ALPHA_BANDS): number {
+  const clamped = Math.max(0, Math.min(1, alpha))
+  return Math.min(bandCount - 1, Math.floor(clamped * bandCount))
+}
+
+export function alphaBandMidpoint(
+  band: number,
+  bandCount = HALFTONE_ALPHA_BANDS
+): number {
+  return (band + 0.5) / bandCount
+}
+
+/**
+ * Stable counting sort of visible-dot indices by alpha band.
+ *
+ * Every buffer is allocated by setup/resize. The steady-state path is
+ * O(dots + bands) and does not allocate arrays or per-dot objects.
+ */
+export function countingSortDotIndices(scratch: HalftoneDotScratch, dotCount: number): void {
+  if (dotCount < 0 || dotCount > scratch.capacity) {
+    throw new RangeError(`Halftone dot count ${dotCount} exceeds capacity ${scratch.capacity}`)
+  }
+
+  const counts = scratch.bandCounts
+  const offsets = scratch.bandOffsets
+  const writes = scratch.bandWriteOffsets
+  counts.fill(0)
+
+  for (let dot = 0; dot < dotCount; dot++) {
+    counts[scratch.band[dot]]++
+  }
+
+  let offset = 0
+  for (let band = 0; band < scratch.bandCount; band++) {
+    offsets[band] = offset
+    writes[band] = offset
+    offset += counts[band]
+  }
+
+  for (let dot = 0; dot < dotCount; dot++) {
+    const band = scratch.band[dot]
+    scratch.sortedIndices[writes[band]++] = dot
+  }
+}
+
+export function drawPerDot(
+  ctx: CanvasRenderingContext2D,
+  scratch: HalftoneDotScratch,
+  dotCount: number
+): void {
+  for (let dot = 0; dot < dotCount; dot++) {
+    ctx.globalAlpha = scratch.alpha[dot]
+    ctx.beginPath()
+    ctx.arc(scratch.x[dot], scratch.y[dot], scratch.radius[dot], 0, TAU)
+    ctx.fill()
+  }
+}
+
+export function drawAlphaBuckets(
+  ctx: CanvasRenderingContext2D,
+  scratch: HalftoneDotScratch,
+  dotCount: number
+): void {
+  countingSortDotIndices(scratch, dotCount)
+
+  for (let band = 0; band < scratch.bandCount; band++) {
+    const count = scratch.bandCounts[band]
+    if (count === 0) continue
+
+    ctx.globalAlpha = alphaBandMidpoint(band, scratch.bandCount)
+    ctx.beginPath()
+    const start = scratch.bandOffsets[band]
+    const end = start + count
+    for (let sorted = start; sorted < end; sorted++) {
+      const dot = scratch.sortedIndices[sorted]
+      const x = scratch.x[dot]
+      const y = scratch.y[dot]
+      const radius = scratch.radius[dot]
+      // Canvas joins a new arc to the previous subpath's endpoint unless the
+      // current point is first moved to the new circle's starting point.
+      ctx.moveTo(x + radius, y)
+      ctx.arc(x, y, radius, 0, TAU)
+    }
+    ctx.fill()
+  }
+}
+
+function flowHeight(u: number, v: number, time: number): number {
+  return (
+    0.3 * Math.sin(u * 7 - time * 0.04) +
+    0.2 * Math.sin(u * 13 + v * 6 - time * 0.05) +
+    0.15 * Math.sin(u * 4 + v * 11 + time * 0.03)
+  )
+}
+
+function rotatedFlowHeight(
+  u: number,
+  v: number,
+  time: number,
+  rotationCos: number,
+  rotationSin: number
+): number {
+  const du = u - 0.5
+  const dv = v - 0.5
+  return flowHeight(
+    0.5 + du * rotationCos - dv * rotationSin,
+    0.5 + du * rotationSin + dv * rotationCos,
+    time
+  )
+}
+
+function pulseHeight(u: number, v: number, time: number): number {
+  const dx = u - 0.5
+  const dy = v - 0.5
+  const distance = Math.sqrt(dx * dx + dy * dy)
+  const phase = (time * 0.0024) % 1
+  let height = 0
+
+  for (let ring = 0; ring < 2; ring++) {
+    const age = (phase + ring * 0.5) % 1
+    const ringRadius = age * 0.8
+    const band = Math.exp(-Math.pow((distance - ringRadius) * 5.5, 2))
+    height += band * (1 - age)
+  }
+
+  return height
+}
+
+function shadeInto(
+  height: number,
+  heightX: number,
+  heightY: number,
+  epsilon: number,
+  baseAlpha: number,
+  litAlpha: number,
+  baseRadius: number,
+  heightRadius: number,
+  sample: DensitySample
+): void {
+  const normalX = -(heightX - height) / epsilon
+  const normalY = -(heightY - height) / epsilon
+  const normalLength = Math.sqrt(normalX * normalX + normalY * normalY + 1)
+  const lit = Math.max(
+    0,
+    (normalX * NORMALIZED_LIGHT_X +
+      normalY * NORMALIZED_LIGHT_Y +
+      NORMALIZED_LIGHT_Z) /
+      normalLength
+  )
+  sample.alpha = Math.min(1, baseAlpha + lit * litAlpha)
+  sample.radius = Math.max(0.2, baseRadius + Math.max(0, height) * heightRadius)
+}
+
+function flowSampleInto(
+  column: number,
+  row: number,
+  columns: number,
+  rows: number,
+  time: number,
+  rotationCos: number,
+  rotationSin: number,
+  sample: DensitySample
+): void {
+  const u = column / columns
+  const v = row / rows
+  const epsilon = 0.5 / columns
+  shadeInto(
+    rotatedFlowHeight(u, v, time, rotationCos, rotationSin) + 0.65,
+    rotatedFlowHeight(u + epsilon, v, time, rotationCos, rotationSin) + 0.65,
+    rotatedFlowHeight(u, v + epsilon, time, rotationCos, rotationSin) + 0.65,
+    epsilon,
+    0.18,
+    0.74,
+    0.45,
+    1.9,
+    sample
+  )
+}
+
+function pulseSampleInto(
+  column: number,
+  row: number,
+  columns: number,
+  rows: number,
+  time: number,
+  sample: DensitySample
+): void {
+  const u = column / columns
+  const v = row / rows
+  const epsilon = 0.5 / columns
+  const height = pulseHeight(u, v, time)
+  if (height < 0.05) {
+    sample.alpha = 0
+    sample.radius = 0
+    return
+  }
+
+  shadeInto(
+    height * 0.6 + 0.05,
+    pulseHeight(u + epsilon, v, time) * 0.6 + 0.05,
+    pulseHeight(u, v + epsilon, time) * 0.6 + 0.05,
+    epsilon,
+    0.12,
+    0.85,
+    0.4,
+    2.2,
+    sample
+  )
+  sample.alpha *= Math.min(1, height * 1.6)
+}
+
+export class HalftoneFrameRenderer {
+  private readonly motif: 'flow_3d' | 'pulse'
+  private readonly color: string
+  private readonly spacing: number
+  private readonly maxRadius: number
+  private readonly vignette: number
+  private readonly contrast: number
+  private readonly dim: number
+  private readonly seedTime: number
+  private readonly rotationCos: number
+  private readonly rotationSin: number
+  private readonly alphaBands: number
+  private readonly sample: DensitySample = { alpha: 0, radius: 0 }
+
+  private width = 0
+  private height = 0
+  private columns = 0
+  private rows = 0
+  private offsetX = 0
+  private offsetY = 0
+  private centerColumn = 0
+  private centerRow = 0
+  private scratch: HalftoneDotScratch | null = null
+
+  constructor(options: HalftoneRendererOptions) {
+    const seed = options.seed ?? 0
+    const rotationAngle = (seed % 18) * 20 * (Math.PI / 180)
+    this.motif = options.motif === 'pulse' ? 'pulse' : 'flow_3d'
+    this.color = options.color
+    this.spacing = options.spacing ?? 6
+    this.maxRadius = options.maxRadius ?? 1.6
+    this.vignette = options.vignette ?? 0.22
+    this.contrast = options.contrast ?? 1.6
+    this.dim = options.dim ?? (options.state === 'idle' ? 0.65 : 1)
+    this.seedTime = seed % 1000
+    this.rotationCos = Math.cos(rotationAngle)
+    this.rotationSin = Math.sin(rotationAngle)
+    this.alphaBands = options.alphaBands ?? HALFTONE_ALPHA_BANDS
+  }
+
+  resize(width: number, height: number): boolean {
+    this.width = width
+    this.height = height
+    if (width <= 0 || height <= 0) {
+      this.columns = 0
+      this.rows = 0
+      this.scratch = null
+      return false
+    }
+
+    this.columns = Math.max(1, Math.floor(width / this.spacing))
+    this.rows = Math.max(1, Math.floor(height / this.spacing))
+    this.offsetX = (width - (this.columns - 1) * this.spacing) / 2
+    this.offsetY = (height - (this.rows - 1) * this.spacing) / 2
+    this.centerColumn = (this.columns - 1) / 2
+    this.centerRow = (this.rows - 1) / 2
+    this.scratch = createHalftoneDotScratch(
+      this.columns * this.rows,
+      this.alphaBands
+    )
+    return true
+  }
+
+  get columnCount(): number {
+    return this.columns
+  }
+
+  get rowCount(): number {
+    return this.rows
+  }
+
+  get capacity(): number {
+    return this.scratch?.capacity ?? 0
+  }
+
+  draw(
+    ctx: CanvasRenderingContext2D,
+    time: number,
+    strategy: HalftoneDrawStrategy = 'alpha-buckets',
+    pointerX = 0,
+    pointerY = 0,
+    pointerActive = false
+  ): number {
+    const scratch = this.scratch
+    if (!scratch) return 0
+
+    ctx.clearRect(0, 0, this.width, this.height)
+    ctx.fillStyle = this.color
+
+    const influenceRadiusSquared = CURSOR_INFLUENCE * CURSOR_INFLUENCE
+    const fieldTime = time + this.seedTime
+    let dotCount = 0
+
+    for (let row = 0; row < this.rows; row++) {
+      for (let column = 0; column < this.columns; column++) {
+        if (this.motif === 'pulse') {
+          pulseSampleInto(
+            column,
+            row,
+            this.columns,
+            this.rows,
+            fieldTime,
+            this.sample
+          )
+        } else {
+          flowSampleInto(
+            column,
+            row,
+            this.columns,
+            this.rows,
+            fieldTime,
+            this.rotationCos,
+            this.rotationSin,
+            this.sample
+          )
+        }
+
+        let alpha = Math.min(1, this.sample.alpha * this.contrast * 0.9)
+        let radius = this.sample.radius * (this.maxRadius / 2.4)
+        const x = this.offsetX + column * this.spacing
+        const y = this.offsetY + row * this.spacing
+        const cell = row * this.columns + column
+        let target = 0
+        if (pointerActive) {
+          const deltaX = x - pointerX
+          const deltaY = y - pointerY
+          const distanceSquared = deltaX * deltaX + deltaY * deltaY
+          if (distanceSquared < influenceRadiusSquared) {
+            const falloff = 1 - Math.sqrt(distanceSquared) / CURSOR_INFLUENCE
+            target = falloff * falloff
+          }
+        }
+
+        const currentInfluence = scratch.influence[cell]
+        const influence =
+          currentInfluence +
+          (target - currentInfluence) *
+            (target > currentInfluence ? CURSOR_ATTACK : CURSOR_RELEASE)
+        scratch.influence[cell] = influence
+        if (influence > 0.003) radius += influence * CURSOR_R
+
+        const normalizedX =
+          this.centerColumn === 0 ? 0 : (column - this.centerColumn) / this.centerColumn
+        const normalizedY =
+          this.centerRow === 0 ? 0 : (row - this.centerRow) / this.centerRow
+        const vignette = this.vignetteAt(normalizedX, normalizedY)
+        if (vignette <= 0) continue
+
+        alpha *= vignette * this.dim
+        if (influence > 0.003) alpha += influence * vignette * CURSOR_A
+        alpha = Math.min(1, alpha)
+        radius *= 0.35 + 0.65 * vignette
+        if (alpha < 0.02 || radius < 0.2) continue
+
+        scratch.x[dotCount] = x
+        scratch.y[dotCount] = y
+        scratch.radius[dotCount] = radius
+        scratch.alpha[dotCount] = alpha
+        scratch.band[dotCount] = alphaToBand(alpha, scratch.bandCount)
+        dotCount++
+      }
+    }
+
+    if (strategy === 'per-dot') {
+      drawPerDot(ctx, scratch, dotCount)
+    } else {
+      drawAlphaBuckets(ctx, scratch, dotCount)
+    }
+    ctx.globalAlpha = 1
+    return dotCount
+  }
+
+  private vignetteAt(deltaX: number, deltaY: number): number {
+    if (this.vignette <= 0) return 1
+    const normalizedDistance = Math.hypot(deltaX, deltaY)
+    const start = 0.4 - this.vignette * 0.15
+    let normalizedTime = (normalizedDistance - start) / (1 - start)
+    normalizedTime = Math.max(0, Math.min(1, normalizedTime))
+    const smooth = normalizedTime * normalizedTime * (3 - 2 * normalizedTime)
+    return 1 - (smooth * this.vignette) / 0.45
+  }
+}

--- a/src/renderer/components/agents/halftone.test.tsx
+++ b/src/renderer/components/agents/halftone.test.tsx
@@ -3,6 +3,20 @@ import { act } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import { Halftone } from './halftone'
+import { HalftoneFrameRenderer } from './halftone-renderer'
+
+function createCanvasContext() {
+  return {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    globalAlpha: 1,
+    fillStyle: '',
+  } as unknown as CanvasRenderingContext2D
+}
 
 describe('Halftone animation lifecycle', () => {
   afterEach(() => {
@@ -105,5 +119,110 @@ describe('Halftone animation lifecycle', () => {
 
     expect(setTransform).toHaveBeenCalled()
     expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a static frame for reduced motion without pointer tracking', () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+    } as MediaQueryList)
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(240)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(120)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(createCanvasContext())
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 1)
+    const addWindowListener = vi.spyOn(window, 'addEventListener')
+    const draw = vi.spyOn(HalftoneFrameRenderer.prototype, 'draw')
+
+    renderWithProviders(<Halftone motif="flow_3d" />)
+
+    expect(draw).toHaveBeenCalledTimes(1)
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+    expect(addWindowListener).not.toHaveBeenCalledWith(
+      'pointermove',
+      expect.any(Function),
+      expect.anything()
+    )
+  })
+
+  it('caps draws at 30fps while advancing from elapsed wall-clock time', () => {
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(240)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(120)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(createCanvasContext())
+    const callbacks: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callbacks.push(callback)
+      return callbacks.length
+    })
+    const draw = vi.spyOn(HalftoneFrameRenderer.prototype, 'draw')
+
+    renderWithProviders(<Halftone motif="flow_3d" />)
+
+    act(() => callbacks.shift()?.(100))
+    act(() => callbacks.shift()?.(116))
+    act(() => callbacks.shift()?.(134))
+    act(() => callbacks.shift()?.(168))
+
+    expect(draw).toHaveBeenCalledTimes(3)
+    expect(draw.mock.calls[0][1]).toBe(0)
+    expect(draw.mock.calls[1][1]).toBeCloseTo(1.5)
+    expect(draw.mock.calls[2][1]).toBeCloseTo(1.5 + 0.75 * (34 / (1000 / 60)))
+  })
+
+  it('suspends for background tabs and cleans up listeners and observers on unmount', () => {
+    let hidden = false
+    vi.spyOn(document, 'hidden', 'get').mockImplementation(() => hidden)
+    const resizeDisconnect = vi.fn()
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect = resizeDisconnect
+      }
+    )
+    const intersectionDisconnect = vi.fn()
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(_callback: IntersectionObserverCallback) {}
+        observe() {}
+        unobserve() {}
+        disconnect = intersectionDisconnect
+        takeRecords() {
+          return []
+        }
+        root = null
+        rootMargin = '0px'
+        thresholds = [0]
+      }
+    )
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(240)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(120)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(createCanvasContext())
+    let nextRaf = 1
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => nextRaf++)
+    const cancelAnimationFrame = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => {})
+    const removeWindowListener = vi.spyOn(window, 'removeEventListener')
+    const removeDocumentListener = vi.spyOn(document, 'removeEventListener')
+
+    const { unmount } = renderWithProviders(<Halftone motif="flow_3d" />)
+    hidden = true
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1)
+
+    hidden = false
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+    unmount()
+
+    expect(resizeDisconnect).toHaveBeenCalled()
+    expect(intersectionDisconnect).toHaveBeenCalled()
+    expect(removeDocumentListener).toHaveBeenCalledWith(
+      'visibilitychange',
+      expect.any(Function)
+    )
+    expect(removeWindowListener).toHaveBeenCalledWith('pointermove', expect.any(Function))
   })
 })

--- a/src/renderer/components/agents/halftone.test.tsx
+++ b/src/renderer/components/agents/halftone.test.tsx
@@ -121,6 +121,50 @@ describe('Halftone animation lifecycle', () => {
     expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
   })
 
+  it('does not reset the canvas when ResizeObserver reports the same size', () => {
+    let resizeCallback: ResizeObserverCallback | undefined
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    )
+
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(240)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(120)
+    let pixelRatio = 1
+    vi.spyOn(window, 'devicePixelRatio', 'get').mockImplementation(
+      () => pixelRatio
+    )
+    const setTransform = vi.fn()
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      setTransform,
+    } as unknown as CanvasRenderingContext2D)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+
+    renderWithProviders(<Halftone motif="flow_3d" />)
+    expect(setTransform).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(setTransform).toHaveBeenCalledTimes(1)
+
+    pixelRatio = 2
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(setTransform).toHaveBeenCalledTimes(2)
+    expect(setTransform).toHaveBeenLastCalledWith(2, 0, 0, 2, 0, 0)
+  })
+
   it('renders a static frame for reduced motion without pointer tracking', () => {
     vi.spyOn(window, 'matchMedia').mockReturnValue({
       matches: true,

--- a/src/renderer/components/agents/halftone.test.tsx
+++ b/src/renderer/components/agents/halftone.test.tsx
@@ -189,7 +189,7 @@ describe('Halftone animation lifecycle', () => {
     )
   })
 
-  it('caps draws at 30fps while advancing from elapsed wall-clock time', () => {
+  it('caps draws near 30fps despite vsync jitter and advances from wall-clock time', () => {
     vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(240)
     vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(120)
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(createCanvasContext())
@@ -204,13 +204,16 @@ describe('Halftone animation lifecycle', () => {
 
     act(() => callbacks.shift()?.(100))
     act(() => callbacks.shift()?.(116))
-    act(() => callbacks.shift()?.(134))
-    act(() => callbacks.shift()?.(168))
+    act(() => callbacks.shift()?.(130))
+    act(() => callbacks.shift()?.(160))
 
     expect(draw).toHaveBeenCalledTimes(3)
     expect(draw.mock.calls[0][1]).toBe(0)
     expect(draw.mock.calls[1][1]).toBeCloseTo(1.5)
-    expect(draw.mock.calls[2][1]).toBeCloseTo(1.5 + 0.75 * (34 / (1000 / 60)))
+    expect(draw.mock.calls[2][1]).toBeCloseTo(1.5 + 0.75 * (30 / (1000 / 60)))
+    expect(draw.mock.calls[0][6]).toBeCloseTo(2)
+    expect(draw.mock.calls[1][6]).toBeCloseTo(30 / (1000 / 60))
+    expect(draw.mock.calls[2][6]).toBeCloseTo(30 / (1000 / 60))
   })
 
   it('suspends for background tabs and cleans up listeners and observers on unmount', () => {

--- a/src/renderer/components/agents/halftone.tsx
+++ b/src/renderer/components/agents/halftone.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { cn } from '@shared/lib/utils/cn'
 import {
+  HALFTONE_CURSOR_INFLUENCE,
   HalftoneFrameRenderer,
   type HalftoneState,
 } from './halftone-renderer'
@@ -122,7 +123,7 @@ export function Halftone({
       return true
     }
 
-    function draw() {
+    function draw(frameScale = 1) {
       // Pointer position relative to this canvas (recomputed once per frame).
       let mActive = false, mx = 0, my = 0
       if (pointerSeen) {
@@ -130,12 +131,12 @@ export function Halftone({
         mx = pointerX - rect.left
         my = pointerY - rect.top
         mActive =
-          mx >= -90 &&
-          mx <= W + 90 &&
-          my >= -90 &&
-          my <= H + 90
+          mx >= -HALFTONE_CURSOR_INFLUENCE &&
+          mx <= W + HALFTONE_CURSOR_INFLUENCE &&
+          my >= -HALFTONE_CURSOR_INFLUENCE &&
+          my <= H + HALFTONE_CURSOR_INFLUENCE
       }
-      renderer.draw(ctx!, t, 'alpha-buckets', mx, my, mActive)
+      renderer.draw(ctx!, t, 'alpha-buckets', mx, my, mActive, frameScale)
     }
 
     let intersecting = true
@@ -153,15 +154,17 @@ export function Halftone({
     }
 
     const frameInterval = 1000 / 30
+    const frameTolerance = 4
     function frame(now: number) {
       raf = 0
       if (stopped || !ready || !intersecting || document.hidden) return
       const elapsed = lastDrawTime === 0 ? frameInterval : now - lastDrawTime
-      if (elapsed >= frameInterval) {
-        draw()
+      if (elapsed >= frameInterval - frameTolerance) {
+        const frameScale = elapsed / (1000 / 60)
+        draw(frameScale)
         // Preserve the original 60fps phase velocity while drawing half as
         // often, substantially reducing per-card field math and Canvas2D paths.
-        t += speed * (elapsed / (1000 / 60))
+        t += speed * frameScale
         lastDrawTime = now
       }
       raf = requestAnimationFrame(frame)

--- a/src/renderer/components/agents/halftone.tsx
+++ b/src/renderer/components/agents/halftone.tsx
@@ -86,6 +86,7 @@ export function Halftone({
     let lastDrawTime = 0
     let t = 0
     let W = 0, H = 0
+    let pixelRatio = 0
     let pointerX = 0, pointerY = 0, pointerSeen = false
     const onPointerMove = (e: PointerEvent) => {
       pointerX = e.clientX
@@ -94,16 +95,27 @@ export function Halftone({
     }
 
     function setup(): boolean {
-      W = wrap!.clientWidth
-      H = wrap!.clientHeight
-      if (W <= 0 || H <= 0) {
+      const nextWidth = wrap!.clientWidth
+      const nextHeight = wrap!.clientHeight
+      if (nextWidth <= 0 || nextHeight <= 0) {
         ready = false
         return false
       }
-      const dpr = window.devicePixelRatio || 1
-      canvas!.width = Math.round(W * dpr)
-      canvas!.height = Math.round(H * dpr)
-      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0)
+      const nextPixelRatio = window.devicePixelRatio || 1
+      if (
+        ready &&
+        nextWidth === W &&
+        nextHeight === H &&
+        nextPixelRatio === pixelRatio
+      ) {
+        return true
+      }
+      W = nextWidth
+      H = nextHeight
+      pixelRatio = nextPixelRatio
+      canvas!.width = Math.round(W * pixelRatio)
+      canvas!.height = Math.round(H * pixelRatio)
+      ctx!.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0)
       renderer.resize(W, H)
       ready = true
       lastDrawTime = 0

--- a/src/renderer/components/agents/halftone.tsx
+++ b/src/renderer/components/agents/halftone.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from 'react'
 import { cn } from '@shared/lib/utils/cn'
+import {
+  HalftoneFrameRenderer,
+  type HalftoneState,
+} from './halftone-renderer'
 
 /**
  * Canvas halftone banner: a 3D-ish density field rendered as a grid of animated
@@ -11,98 +15,7 @@ import { cn } from '@shared/lib/utils/cn'
  * State changes the *character* of motion (speed/dim), set by the caller.
  */
 
-/** A cell is either a plain density (0..1) or a shaded {brightness, radius}. */
-type Cell = number | { a: number; r: number }
-/** Optional per-card rotation of the field (cos/sin), so cards flow in different directions. */
-type Rot = { cos: number; sin: number }
-type DensityFn = (i: number, j: number, C: number, R: number, t: number, rot?: Rot) => Cell
-
-// Light: slightly upper-left, tilted toward the viewer.
-const LIGHT = (() => {
-  const lx = 0.32, ly = -0.55, lz = 0.78
-  const nl = Math.sqrt(lx * lx + ly * ly + lz * lz)
-  return { x: lx / nl, y: ly / nl, z: lz / nl }
-})()
-
-interface ShadeOpts { baseA?: number; litA?: number; baseR?: number; heightR?: number }
-
-/** Shade a cell from a height sample + its eps-neighbours (normal vs. LIGHT). */
-function shade(h00: number, hX: number, hY: number, eps: number, opts: ShadeOpts = {}): { a: number; r: number } {
-  const nx = -(hX - h00) / eps
-  const ny = -(hY - h00) / eps
-  const nl = Math.sqrt(nx * nx + ny * ny + 1)
-  const lit = Math.max(0, (nx * LIGHT.x + ny * LIGHT.y + LIGHT.z) / nl)
-  const baseA = opts.baseA ?? 0.15
-  const litA = opts.litA ?? 0.85
-  const baseR = opts.baseR ?? 0.6
-  const heightR = opts.heightR ?? 1.4
-  return { a: Math.min(1, baseA + lit * litA), r: Math.max(0.2, baseR + Math.max(0, h00) * heightR) }
-}
-
-// ---- flow_3d: lit curl-noise streams rippling across the field ----
-const flowH = (u: number, v: number, t: number): number =>
-  0.3 * Math.sin(u * 7 - t * 0.04) + 0.2 * Math.sin(u * 13 + v * 6 - t * 0.05) + 0.15 * Math.sin(u * 4 + v * 11 + t * 0.03)
-const densityFlow3D: DensityFn = (i, j, C, R, t, rot) => {
-  const u = i / C, v = j / R, e = 0.5 / C
-  // Sample the flow field, optionally rotated around center so each card's
-  // streams drift in a different direction.
-  const sample = (uu: number, vv: number): number => {
-    if (!rot) return flowH(uu, vv, t)
-    const du = uu - 0.5, dv = vv - 0.5
-    return flowH(0.5 + du * rot.cos - dv * rot.sin, 0.5 + du * rot.sin + dv * rot.cos, t)
-  }
-  return shade(sample(u, v) + 0.65, sample(u + e, v) + 0.65, sample(u, v + e) + 0.65, e, {
-    baseA: 0.18,
-    litA: 0.74,
-    baseR: 0.45,
-    heightR: 1.9,
-  })
-}
-
-// ---- pulse: slow broad rings emanating from center (the needs-input default) ----
-const pulseH = (u: number, v: number, t: number): number => {
-  const dx = u - 0.5, dy = v - 0.5
-  const r = Math.sqrt(dx * dx + dy * dy)
-  let h = 0
-  const phase = (t * 0.0024) % 1
-  for (let k = 0; k < 2; k++) {
-    const age = (phase + k * 0.5) % 1
-    const ringR = age * 0.8
-    const band = Math.exp(-Math.pow((r - ringR) * 5.5, 2)) // smooth broad ring
-    h += band * (1 - age) // fade out as the ring expands
-  }
-  return h
-}
-const densityPulse: DensityFn = (i, j, C, R, t) => {
-  const u = i / C, v = j / R, e = 0.5 / C
-  const h0 = pulseH(u, v, t)
-  if (h0 < 0.05) return 0 // keep the gaps between rings empty — it's a pulse
-  const sh = shade(h0 * 0.6 + 0.05, pulseH(u + e, v, t) * 0.6 + 0.05, pulseH(u, v + e, t) * 0.6 + 0.05, e, {
-    baseA: 0.12,
-    litA: 0.85,
-    baseR: 0.4,
-    heightR: 2.2,
-  })
-  return { a: sh.a * Math.min(1, h0 * 1.6), r: sh.r }
-}
-
-const DENSITY_FNS: Record<string, DensityFn> = {
-  flow_3d: densityFlow3D,
-  pulse: densityPulse,
-}
-
-// Cursor reactivity (ported from the gamut-website InteractiveDotMatrix): dots
-// within CURSOR_INFLUENCE px of the pointer grow + brighten with a smooth
-// falloff, each easing toward its target so the pull trails and fades.
-const CURSOR_INFLUENCE = 90 // px
-// Asymmetric easing: quick attack as the cursor nears, slow release so the
-// trail lingers and fades gently after it passes.
-const CURSOR_ATTACK = 0.18
-const CURSOR_RELEASE = 0.04
-const CURSOR_R = 1.6 // max added dot radius near the cursor
-const CURSOR_A = 0.75 // max added alpha (darkening) near the cursor
-
-export type HalftoneState = 'working' | 'idle' | 'alert'
+export type { HalftoneState } from './halftone-renderer'
 
 interface HalftoneProps {
   motif: string
@@ -153,21 +66,26 @@ export function Halftone({
     if (!ctx) return
 
     const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
-    const fieldFn = DENSITY_FNS[motif] ?? densityFlow3D
-    // Per-card rotation (from the seed) so flows don't all move the same way —
-    // snapped to 20° increments (18 distinct directions) for clear variety.
-    const rotAngle = (seed % 18) * 20 * (Math.PI / 180)
-    const rot = { cos: Math.cos(rotAngle), sin: Math.sin(rotAngle) }
     const fill = color ?? getComputedStyle(canvas).color
     const speed = (speedProp ?? (state === 'idle' ? 0.2 : state === 'alert' ? 1.6 : 0.75)) * speedScale
+    const renderer = new HalftoneFrameRenderer({
+      motif,
+      state,
+      color: fill,
+      spacing,
+      maxRadius,
+      vignette,
+      contrast,
+      dim,
+      seed,
+    })
 
     let raf = 0
     let stopped = false
     let ready = false
     let lastDrawTime = 0
-    let t = seed % 1000 // phase offset so cards animate out of sync
-    let W = 0, H = 0, COLS = 0, ROWS = 0, offsetX = 0, offsetY = 0, cx = 0, cy = 0
-    let infl = new Float32Array(0) // per-cell eased cursor boost (0..1)
+    let t = 0
+    let W = 0, H = 0
     let pointerX = 0, pointerY = 0, pointerSeen = false
     const onPointerMove = (e: PointerEvent) => {
       pointerX = e.clientX
@@ -186,85 +104,26 @@ export function Halftone({
       canvas!.width = Math.round(W * dpr)
       canvas!.height = Math.round(H * dpr)
       ctx!.setTransform(dpr, 0, 0, dpr, 0, 0)
-      COLS = Math.max(1, Math.floor(W / spacing))
-      ROWS = Math.max(1, Math.floor(H / spacing))
-      offsetX = (W - (COLS - 1) * spacing) / 2
-      offsetY = (H - (ROWS - 1) * spacing) / 2
-      cx = (COLS - 1) / 2
-      cy = (ROWS - 1) / 2
-      infl = new Float32Array(COLS * ROWS)
+      renderer.resize(W, H)
       ready = true
       lastDrawTime = 0
       return true
     }
 
-    // Smoothstep radial vignette: a circular mask (Euclidean distance from
-    // center) fades dots in both alpha and radius toward the edges.
-    function vignetteAt(dx: number, dy: number): number {
-      if (vignette <= 0) return 1
-      const distN = Math.hypot(dx, dy)
-      const start = 0.4 - vignette * 0.15
-      let tNorm = (distN - start) / (1 - start)
-      tNorm = Math.max(0, Math.min(1, tNorm))
-      const smooth = tNorm * tNorm * (3 - 2 * tNorm)
-      return 1 - (smooth * vignette) / 0.45
-    }
-
     function draw() {
-      ctx!.clearRect(0, 0, W, H)
-      ctx!.fillStyle = fill
       // Pointer position relative to this canvas (recomputed once per frame).
       let mActive = false, mx = 0, my = 0
       if (pointerSeen) {
         const rect = wrap!.getBoundingClientRect()
         mx = pointerX - rect.left
         my = pointerY - rect.top
-        mActive = mx >= -CURSOR_INFLUENCE && mx <= W + CURSOR_INFLUENCE && my >= -CURSOR_INFLUENCE && my <= H + CURSOR_INFLUENCE
+        mActive =
+          mx >= -90 &&
+          mx <= W + 90 &&
+          my >= -90 &&
+          my <= H + 90
       }
-      const INF2 = CURSOR_INFLUENCE * CURSOR_INFLUENCE
-      const dimF = dim ?? (state === 'idle' ? 0.65 : 1)
-      for (let j = 0; j < ROWS; j++) {
-        for (let i = 0; i < COLS; i++) {
-          const out = fieldFn(i, j, COLS, ROWS, t, rot)
-          let a: number, r: number
-          if (typeof out === 'number') {
-            a = Math.min(1, out * contrast)
-            r = out * maxRadius
-          } else {
-            a = Math.min(1, out.a * contrast * 0.9)
-            // Shaded radii are tuned for a ~2.4px max; scale to our maxRadius.
-            r = out.r * (maxRadius / 2.4)
-          }
-          const px = offsetX + i * spacing, py = offsetY + j * spacing
-          // Eased cursor pull: dots near the pointer grow + brighten.
-          const idx = j * COLS + i
-          let target = 0
-          if (mActive) {
-            const ddx = px - mx, ddy = py - my
-            const d2 = ddx * ddx + ddy * ddy
-            if (d2 < INF2) {
-              const tt = 1 - Math.sqrt(d2) / CURSOR_INFLUENCE
-              target = tt * tt
-            }
-          }
-          const cur = infl[idx]
-          const h = (infl[idx] = cur + (target - cur) * (target > cur ? CURSOR_ATTACK : CURSOR_RELEASE))
-          if (h > 0.003) r += h * CURSOR_R
-          const v = vignetteAt(cx === 0 ? 0 : (i - cx) / cx, cy === 0 ? 0 : (j - cy) / cy)
-          if (v <= 0) continue
-          // Cursor darkening is added on top of the state-dimmed alpha, so dots
-          // read clearly darker near the pointer even in faint states.
-          let alpha = a * v * dimF
-          if (h > 0.003) alpha += h * v * CURSOR_A
-          alpha = Math.min(1, alpha)
-          const rr = r * (0.35 + 0.65 * v)
-          if (alpha < 0.02 || rr < 0.2) continue
-          ctx!.globalAlpha = alpha
-          ctx!.beginPath()
-          ctx!.arc(px, py, rr, 0, Math.PI * 2)
-          ctx!.fill()
-        }
-      }
+      renderer.draw(ctx!, t, 'alpha-buckets', mx, my, mActive)
     }
 
     let intersecting = true

--- a/src/renderer/test/setup.ts
+++ b/src/renderer/test/setup.ts
@@ -29,6 +29,12 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
   }
 }
 
+// jsdom logs a "Not implemented" error whenever an otherwise unrelated
+// component probes canvas. Focused canvas tests spy on top of this default.
+if (typeof HTMLCanvasElement !== 'undefined') {
+  HTMLCanvasElement.prototype.getContext = () => null
+}
+
 const signIn = {
   email: vi.fn(),
   oauth2: vi.fn(),


### PR DESCRIPTION
## Summary

- batch visible Halftone dots into 32 midpoint-alpha Canvas2D paths using allocation-free typed scratch buffers and a stable counting sort
- add a production full-renderer Chromium benchmark covering flow, hover, pending-input pulse, repeated resize, and pointer dispatch in headed-GPU and explicit software modes
- precompute resize-stable grid coordinates and vignette scales, calculate pending-input pulse ring constants once per frame, and skip same-size canvas/renderer reinitialization while remaining DPR-aware
- preserve PR #618's 30fps elapsed-time lifecycle, reduced-motion frame, visibility/offscreen suspension, pointer easing, orange alert pulse, culling, state dimming, and zero-size recovery
- add deterministic unit and Chromium visual coverage plus machine-readable benchmark schemas and documentation

## Why

The original renderer issued `beginPath()`, `arc()`, and `fill()` for every visible dot. Drawing dominated frame cost with several wide cards. Alpha bucketing reduces thousands of fills to at most 32, while the end-to-end benchmark exposed additional resize-stable math and repeated pulse setup still occurring inside the per-dot loop.

## Canvas batching benchmark

Reference machine: Apple M2 Max (arm64, macOS 15.6), Chromium 145.0.7632.6, DPR 2, 60 warmups, 180 samples, 4,326 dots per card.

| Mode / fixture | Per-dot median / p95 | 32-band median / p95 |
| --- | --- | --- |
| Headed, one card | 0.90 / 1.00 ms | 0.50 / 0.60 ms |
| Headed, eight cards | 7.10 / 7.40 ms | 4.10 / 4.40 ms |
| Software, one card | 0.80 / 0.90 ms | 0.50 / 0.60 ms |
| Software, eight cards | 6.50 / 6.80 ms | 4.10 / 4.30 ms |

- headed median improvement: **44.4%** (required ≥35%)
- headed p95 improvement: **40.0%**
- headed eight-card p95: **4.4 ms** (required <16.7 ms)
- software median/p95: **37.5% / 33.3% faster**

## Full-renderer benchmark

The new `npm run benchmark:halftone:runtime` command bundles the production `HalftoneFrameRenderer`, so the measurements include field sampling, hover influence, vignette, alpha bucketing, and Canvas drawing.

| Headed fixture | Baseline median / p95 | Optimized median / p95 |
| --- | --- | --- |
| One flow card | 1.00 / 1.10 ms | 0.90 / 1.00 ms |
| Eight flow cards | 8.70 / 9.00 ms | 8.10 / 8.40 ms |
| Eight flow cards, one hovered | 8.60 / 8.90 ms | 8.10 / 8.40 ms |
| One pending-input pulse card | 1.20 / 1.50 ms | 1.10 / 1.30 ms |
| Eight pending-input pulse cards | 10.30 / 10.90 ms | 8.80 / 9.40 ms |

The software eight-card results improved from **8.50 / 8.90 → 8.10 / 8.40 ms** for flow and **10.40 / 11.10 → 8.90 / 9.60 ms** for pending-input pulse. Same-size renderer resize fell from **0.10 / 0.20 ms** to below Chromium's timer resolution. Chromium reported headed rasterization `enabled_force` and explicit software rasterization `disabled_software`.

Measured experiments that did not improve both browser modes were reverted: inactive-hover bookkeeping fast-path and three-array pulse-distance caching. A shared pointer listener was rejected after measuring only ~0.15 ms total savings per second at 120 pointer events/second.

## Visual fidelity

The 75-fixture comparison covers flow working/idle, the orange alert pulse, timestamps, centered/edge/no pointer, card sizes, DPR 1/2, zero-size recovery, and one-row/one-column grids. Minimum SSIM remained **0.998532** after white-composite luminance normalization (required ≥0.995).

## Validation

- `npm run benchmark:halftone`
- `npm run benchmark:halftone:runtime`
- `npm run test:halftone:visual` — 75 fixtures, minimum SSIM 0.998532
- `npm run test:run -- src/renderer/components/agents/halftone-renderer.test.ts src/renderer/components/agents/halftone.test.tsx` — 10 passed
- `npm run typecheck`
- targeted ESLint for all changed TypeScript/TSX files
- `npm run build:web`
- `git diff --check`
- `home-cards.spec.ts` passed earlier in the stack; two latest reruns were blocked before page render because the mock `/api/agents` readiness poll did not return the newly created fixture agent

Stacked on #618 as required by [SUP-520](https://linear.app/datawizz/issue/SUP-520/benchmark-and-optimize-homepage-halftone-rendering-with-alpha-bucketed). Retarget/rebase after #618 merges.
