### PR TITLE
Narrow the browser stream during credential handoff (SUP-498)

### DIFF
--- a/agent-container/src/browser-viewport.test.ts
+++ b/agent-container/src/browser-viewport.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest'
+import { inputManager } from './input-manager'
+import {
+  setViewportChannel,
+  syncBrowserViewport,
+  requestDesktopWidth,
+  detachViewportChannel,
+  startBrowserViewportSync,
+} from './browser-viewport'
+
+type Sent = { method: string; params?: Record<string, unknown> }
+
+/** Register a recording channel and return the CDP calls it writes into. */
+function recordCdp(): Sent[] {
+  const sent: Sent[] = []
+  setViewportChannel({
+    sendCdp: (method, params) => sent.push({ method, params }),
+    reportDesktopWidth: () => {},
+  })
+  return sent
+}
+
+/** Register a channel and return the modes reported to the viewer. */
+function recordModes(): boolean[] {
+  const modes: boolean[] = []
+  setViewportChannel({ sendCdp: () => {}, reportDesktopWidth: (v) => modes.push(v) })
+  return modes
+}
+
+/** Register a browser_input pending without awaiting it — the promise only
+ *  settles when the user answers, so awaiting here would hang the test. */
+function openHandoff(id: string, sessionId?: string): void {
+  void inputManager
+    .createPendingWithType(id, 'browser_input', { message: 'Log in.' }, sessionId)
+    .catch(() => {})
+}
+
+describe('browser viewport', () => {
+  beforeAll(() => {
+    startBrowserViewportSync()
+  })
+
+  beforeEach(() => {
+    // Drop the sender first so the reset sync below emits nothing, then let the
+    // no-pending sync clear any escape flag through the same path production uses.
+    setViewportChannel(null)
+    inputManager.rejectByType('browser_input', 'test reset')
+    inputManager.rejectByType('secret', 'test reset')
+    syncBrowserViewport()
+  })
+
+  // Literals, not the production constants: importing those would make this
+  // assertion follow any change to them instead of catching it.
+  it('narrows while a browser_input handoff is pending', () => {
+    const sent = recordCdp()
+    openHandoff('t-1')
+
+    expect(sent.at(-1)).toEqual({
+      method: 'Emulation.setDeviceMetricsOverride',
+      params: { width: 450, height: 900, deviceScaleFactor: 1, mobile: false },
+    })
+  })
+
+  it('clears when nothing is pending', () => {
+    const sent = recordCdp()
+
+    syncBrowserViewport()
+
+    expect(sent).toEqual([
+      { method: 'Emulation.clearDeviceMetricsOverride', params: undefined },
+    ])
+  })
+
+  // The tray reads only the latest request, but a second agent can open its own
+  // handoff. Resolving one must not un-narrow the page the user is still typing into.
+  it('stays narrow while a second handoff is still open', () => {
+    openHandoff('t-1')
+    openHandoff('t-2')
+    const sent = recordCdp()
+
+    inputManager.resolve('t-1', 'done')
+    syncBrowserViewport()
+
+    expect(sent.at(-1)!.method).toBe('Emulation.setDeviceMetricsOverride')
+  })
+
+  // Other input types share the pending map. Only browser_input is a handoff.
+  it('ignores pendings of other input types', () => {
+    void inputManager.createPendingWithType('s-1', 'secret', {}).catch(() => {})
+    const sent = recordCdp()
+
+    syncBrowserViewport()
+
+    expect(sent.at(-1)!.method).toBe('Emulation.clearDeviceMetricsOverride')
+  })
+
+  it('clears while the user has asked for desktop width, and narrows again when they toggle back', () => {
+    openHandoff('t-1')
+    const sent = recordCdp()
+
+    requestDesktopWidth(true)
+    expect(sent.at(-1)!.method).toBe('Emulation.clearDeviceMetricsOverride')
+
+    requestDesktopWidth(false)
+    expect(sent.at(-1)!.method).toBe('Emulation.setDeviceMetricsOverride')
+  })
+
+  // The flag is scoped to one handoff. A user who escaped a hostile login page
+  // must not silently get desktop width on their next, unrelated handoff.
+  it('drops the desktop request once the last handoff closes', () => {
+    openHandoff('t-1')
+    const sent = recordCdp()
+    requestDesktopWidth(true)
+
+    inputManager.resolve('t-1', 'done')
+    syncBrowserViewport() // no pendings — resets the flag
+
+    openHandoff('t-2')
+    syncBrowserViewport()
+
+    expect(sent.at(-1)!.method).toBe('Emulation.setDeviceMetricsOverride')
+  })
+
+  // The tray renders the reported mode directly instead of inferring it from
+  // frame width, so a report that disagrees with the CDP call misdraws the toggle.
+  it('reports the mode it applied to the viewer', () => {
+    openHandoff('t-1')
+    const modes = recordModes()
+
+    syncBrowserViewport()
+    expect(modes.at(-1)).toBe(false)
+
+    requestDesktopWidth(true)
+    expect(modes.at(-1)).toBe(true)
+
+    inputManager.resolve('t-1', 'done')
+    syncBrowserViewport()
+    expect(modes.at(-1)).toBe(false)
+  })
+
+  // The toggle is live as soon as the viewer socket opens, which can be before
+  // CDP attaches. A click in that gap has no channel to send on, so the flag has
+  // to survive until attach derives it.
+  it('remembers a desktop request made before a channel exists', () => {
+    openHandoff('t-1')
+    setViewportChannel(null)
+    requestDesktopWidth(true)
+
+    const sent = recordCdp()
+    syncBrowserViewport()
+
+    expect(sent.at(-1)!.method).toBe('Emulation.clearDeviceMetricsOverride')
+  })
+
+  // The whole point of subscribing to the input manager rather than calling sync
+  // at each route: a route that clears the last handoff re-derives even though
+  // nothing here calls syncBrowserViewport. Three of these were missed when the
+  // rule was written out by hand at each call site.
+  describe('re-derives on every route that clears the last handoff', () => {
+    const routes: Array<[string, () => void]> = [
+      ['resolve', () => { inputManager.resolve('r-1', 'done') }],
+      ['reject', () => { inputManager.reject('r-1', 'declined') }],
+      ['reject by type (browser close)', () => { inputManager.rejectByType('browser_input', 'closed') }],
+      ['session delete', () => { inputManager.rejectForSession('sess-1') }],
+      ['stale sweep', () => { inputManager.cleanupStale(Date.now() + 25 * 60 * 60 * 1000) }],
+    ]
+
+    for (const [name, clear] of routes) {
+      it(name, () => {
+        openHandoff('r-1', 'sess-1')
+        const sent = recordCdp()
+        syncBrowserViewport()
+        expect(sent.at(-1)!.method).toBe('Emulation.setDeviceMetricsOverride')
+
+        clear()
+
+        expect(sent.at(-1)!.method).toBe('Emulation.clearDeviceMetricsOverride')
+      })
+    }
+  })
+
+  // Opening a handoff must narrow immediately, not on the next unrelated event.
+  it('re-derives when a handoff opens', () => {
+    const sent = recordCdp()
+    syncBrowserViewport()
+    expect(sent.at(-1)!.method).toBe('Emulation.clearDeviceMetricsOverride')
+
+    openHandoff('r-2')
+
+    expect(sent.at(-1)!.method).toBe('Emulation.setDeviceMetricsOverride')
+  })
+
+  // Viewer reconnect tears the screencast down and attaches again. Escape must
+  // survive that path so the tray and the page stay on desktop width.
+  it('keeps the desktop request across detach while a handoff is pending', () => {
+    openHandoff('t-1')
+    const sent = recordCdp()
+    requestDesktopWidth(true)
+    expect(sent.at(-1)!.method).toBe('Emulation.clearDeviceMetricsOverride')
+
+    detachViewportChannel()
+    const sent2 = recordCdp()
+    syncBrowserViewport()
+
+    expect(sent2.at(-1)!.method).toBe('Emulation.clearDeviceMetricsOverride')
+  })
+})

--- a/agent-container/src/browser-viewport.ts
+++ b/agent-container/src/browser-viewport.ts
@@ -1,0 +1,91 @@
+/**
+ * Viewport override for a browser-input handoff: narrow the streamed page so a
+ * site reflows to its own phone layout and the sign-in form fills the drawer
+ * instead of rendering a desktop page at a third of native scale.
+ */
+import { inputManager } from './input-manager'
+
+/** Under the classic `max-width: 480px` phone breakpoint, and equal to the
+ *  drawer's default width, so the common case renders at 1:1. */
+const HANDOFF_VIEWPORT_WIDTH = 450
+/** Only controls how much page arrives per scroll — the canvas container is
+ *  bounded on the renderer side, so this cannot clip the handoff controls. */
+const HANDOFF_VIEWPORT_HEIGHT = 900
+
+/**
+ * The screencast connection's two outbound paths: CDP to the page, and a mode
+ * report to the viewer so the tray never has to infer the mode from frame size.
+ */
+export interface ViewportChannel {
+  sendCdp: (method: string, params?: Record<string, unknown>) => void
+  reportDesktopWidth: (enabled: boolean) => void
+}
+
+let channel: ViewportChannel | null = null
+let desktopRequested = false
+
+export function setViewportChannel(next: ViewportChannel | null): void {
+  channel = next
+}
+
+/**
+ * Re-derive whenever the pending map changes, wherever that change came from.
+ * Called once at startup. Subscribing beats a sync call at each of the seven
+ * routes that add or clear a handoff, which is a rule three of them missed.
+ */
+export function startBrowserViewportSync(): void {
+  inputManager.onPendingChange(syncBrowserViewport)
+}
+
+/** The user asked for desktop width for the current handoff, or took it back. */
+export function requestDesktopWidth(enabled: boolean): void {
+  desktopRequested = enabled
+  syncBrowserViewport()
+}
+
+/**
+ * Drop the channel on screencast teardown, keeping the escape flag while a
+ * handoff is still pending so a viewer reconnect re-derives desktop width.
+ * Browser-close paths reject pendings and then sync, which clears it.
+ */
+export function detachViewportChannel(): void {
+  channel = null
+  if (!hasPendingHandoff()) desktopRequested = false
+}
+
+function hasPendingHandoff(): boolean {
+  return inputManager.getAllPending().some((p) => p.inputType === 'browser_input')
+}
+
+/**
+ * Derive the correct viewport from current state and issue at most one CDP
+ * command. Safe to call at any time, including with no screencast connected.
+ */
+export function syncBrowserViewport(): void {
+  const hasHandoff = hasPendingHandoff()
+
+  // Scope the escape hatch to a single handoff: once the last one closes, the
+  // next handoff starts narrow again.
+  if (!hasHandoff) desktopRequested = false
+
+  if (!channel) return
+
+  if (hasHandoff && !desktopRequested) {
+    channel.sendCdp('Emulation.setDeviceMetricsOverride', {
+      width: HANDOFF_VIEWPORT_WIDTH,
+      height: HANDOFF_VIEWPORT_HEIGHT,
+      // Required. Omitting it makes CDP reject the call with Invalid parameters.
+      deviceScaleFactor: 1,
+      // Load-bearing. With `mobile: true` a page carrying no viewport meta tag
+      // gets Chrome's 980px fallback scaled to fit, which is worse than doing
+      // nothing. On well-behaved sites the two settings are identical.
+      mobile: false,
+    })
+  } else {
+    channel.sendCdp('Emulation.clearDeviceMetricsOverride')
+  }
+
+  // Tell the viewer what we just applied. The tray renders this directly, so it
+  // never has to guess the mode from the width of an arriving frame.
+  channel.reportDesktopWidth(desktopRequested)
+}

--- a/agent-container/src/input-manager.ts
+++ b/agent-container/src/input-manager.ts
@@ -65,6 +65,12 @@ class InputManager {
   // Pending requests keyed by toolUseId
   private pending: Map<string, PendingInput<InputValue>> = new Map()
 
+  // Fired after any change to the pending map. Consumers that derive state from
+  // "what is pending" subscribe here instead of being called by hand at every
+  // route that adds or removes an entry, which is a rule that only holds until
+  // someone adds a seventh route and does not know about it.
+  private pendingChangeListeners: Array<() => void> = []
+
   // Buffered results for resolve/reject calls that arrive before createPending.
   // This handles the race condition where the UI responds to a tool call before
   // the tool handler has registered its pending entry (e.g. parallel tool calls
@@ -182,6 +188,9 @@ class InputManager {
       console.log(
         `[InputManager] Created pending ${inputType} request ${toolUseId}${owner ? ` (session ${owner})` : ''}`
       )
+      // Synchronous, before this promise blocks on the user: a consumer deriving
+      // from the new pending acts now, not on the next unrelated event.
+      this.notifyPendingChange()
     })
   }
 
@@ -192,6 +201,15 @@ class InputManager {
    * still-live awaiter gets a clean error instead of a permanent hang.
    * @returns number of requests rejected
    */
+  /** Subscribe to pending-map changes. Fired after the map reaches its new state. */
+  onPendingChange(listener: () => void): void {
+    this.pendingChangeListeners.push(listener)
+  }
+
+  private notifyPendingChange(): void {
+    for (const listener of this.pendingChangeListeners) listener()
+  }
+
   rejectForSession(sessionId: string, reason = 'Input request abandoned: the session was deleted'): number {
     let rejected = 0
     for (const [toolUseId, pending] of this.pending) {
@@ -203,6 +221,7 @@ class InputManager {
       pending.reject(new Error(reason))
       rejected++
     }
+    if (rejected > 0) this.notifyPendingChange()
     return rejected
   }
 
@@ -227,6 +246,7 @@ class InputManager {
       pending.reject(new Error(reason))
       rejected++
     }
+    if (rejected > 0) this.notifyPendingChange()
     return rejected
   }
 
@@ -256,6 +276,7 @@ class InputManager {
     )
     this.pending.delete(toolUseId)
     pending.resolve(value)
+    this.notifyPendingChange()
     return true
   }
 
@@ -285,6 +306,7 @@ class InputManager {
     )
     this.pending.delete(toolUseId)
     pending.reject(new Error(error))
+    this.notifyPendingChange()
     return true
   }
 
@@ -322,6 +344,7 @@ class InputManager {
    * entries the host never answers live forever.
    */
   cleanupStale(nowMs: number = Date.now()): void {
+    let swept = 0
     for (const [toolUseId, pending] of this.pending) {
       const ttlMs = AUTOMATED_INPUT_TYPES.has(pending.inputType)
         ? AUTOMATED_INPUT_TTL_MS
@@ -332,8 +355,10 @@ class InputManager {
         )
         this.pending.delete(toolUseId)
         pending.reject(new Error('Input request timed out'))
+        swept++
       }
     }
+    if (swept > 0) this.notifyPendingChange()
     for (const [toolUseId, early] of this.earlyResults) {
       if (nowMs - early.createdAt.getTime() > EARLY_RESULT_TTL_MS) {
         console.log(`[InputManager] Dropping expired early result for ${toolUseId}`)

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -15,6 +15,13 @@ import { execFile, execSync } from 'child_process';
 import { promisify } from 'util';
 
 import { inputManager } from './input-manager';
+import {
+  setViewportChannel,
+  syncBrowserViewport,
+  detachViewportChannel,
+  requestDesktopWidth,
+  startBrowserViewportSync,
+} from './browser-viewport';
 import { resolveCdpIp } from './cdp-host';
 import { startScreenshotJanitor } from './screenshot-janitor';
 import { dashboardManager } from './dashboard-manager';
@@ -2167,6 +2174,28 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
   cdpScreencast = { clientWs, cdpWs, currentTargetId: targetId, msgId: 0, lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null, autoFollow: prevAutoFollow, pendingSelections: new Set(), mainFrameId: null as string | null };
   const state = cdpScreencast;
 
+  // Re-derive the handoff viewport on every attach. Tab switches, popups, and
+  // reconnects all re-enter this function, so a target opened mid-handoff picks
+  // up the override without any per-target bookkeeping.
+  const attachViewportToState = () => {
+    // A socket that was still connecting when a newer stream replaced us opens
+    // late. Without this it would claim the channel and drive the wrong target.
+    if (cdpScreencast !== state) return;
+    setViewportChannel({
+      sendCdp: (method, params) => {
+        if (state.cdpWs.readyState === WebSocket.OPEN) {
+          state.cdpWs.send(cdpMsg(state, method, params));
+        }
+      },
+      reportDesktopWidth: (enabled) => {
+        if (state.clientWs.readyState === WebSocket.OPEN) {
+          state.clientWs.send(JSON.stringify({ type: 'viewport_mode', desktopWidth: enabled }));
+        }
+      },
+    });
+    syncBrowserViewport();
+  };
+
   cdpWs.on('open', () => {
     if (requiresSession) {
       // Remote CDP: attach to target with flattened session first
@@ -2186,6 +2215,7 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
       // top-level frame, not iframes/ads that load continuously.
       const frameTreeId = ++state.msgId;
       cdpWs.send(JSON.stringify({ id: frameTreeId, method: 'Page.getFrameTree', ...(state.cdpSessionId ? { sessionId: state.cdpSessionId } : {}) }));
+      attachViewportToState();
     }
   });
 
@@ -2206,6 +2236,7 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
         }));
         // Enable Page domain to receive navigation lifecycle events
         cdpWs.send(cdpMsg(state, 'Page.enable'));
+        attachViewportToState();
         return;
       }
 
@@ -2275,15 +2306,25 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
 function cleanupCdpScreencast() {
   if (!cdpScreencast) return;
   if (cdpScreencast.cdpWs.readyState === WebSocket.OPEN) {
+    // Unconditional, not derived. A handoff can still be pending here (the
+    // browser was closed under it), and the next process to attach must not
+    // inherit a narrowed page.
+    cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Emulation.clearDeviceMetricsOverride'));
     cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Page.stopScreencast'));
     cdpScreencast.cdpWs.close();
   }
+  // Unconditional CDP clear above. Detach keeps the escape flag when a handoff
+  // is still pending so a viewer reconnect can re-derive desktop width.
+  detachViewportChannel();
   cdpScreencast = null;
 }
 
 /** Switch the CDP screencast to a different target, keeping the client WS alive */
 function switchScreencastTarget(target: PageTarget, clientWs: WebSocket): void {
   if (cdpScreencast?.cdpWs.readyState === WebSocket.OPEN) {
+    // Clear before stopping: the target we are leaving keeps whatever override
+    // it was given, and nothing re-derives it once we stop watching it.
+    cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Emulation.clearDeviceMetricsOverride'));
     cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Page.stopScreencast'));
     cdpScreencast.cdpWs.close();
   }
@@ -2456,6 +2497,15 @@ function handleBrowserStreamConnection(ws: WebSocket) {
   ws.on('message', async (rawData) => {
     try {
       const data = JSON.parse(rawData.toString());
+
+      // Ahead of the screencast guard: the toggle is live as soon as the viewer
+      // socket opens, so a click in the gap before CDP attaches must be kept and
+      // derived at attach rather than dropped.
+      if (data.type === 'set_desktop_width') {
+        requestDesktopWidth(data.enabled === true);
+        return;
+      }
+
       if (!cdpScreencast) return;
 
       if (data.type === 'switch_tab' && data.targetId) {
@@ -2601,6 +2651,11 @@ dashboardManager.scanAndStartAll().catch((error) => {
 // forever — pinning dead tool-handler closures and, via the early-result
 // buffer, secret values. TTLs are type-aware inside cleanupStale.
 setInterval(() => inputManager.cleanupStale(), 60_000).unref();
+
+// Keep the streamed viewport in step with whatever is pending. Every route that
+// opens or clears a handoff flows through the input manager, including the sweep
+// above and session deletion, so this replaces a sync call at each of them.
+startBrowserViewportSync();
 
 // Pin agent-browser's screenshot directory and sweep stale files (boot +
 // hourly). Every screenshot is a uniquely named PNG nothing else deletes.

--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Globe, MousePointerClick, PanelRightClose, Pause, Play, Square, Expand, Shrink } from 'lucide-react'
+import { Globe, MousePointerClick, PanelRightClose, Pause, Play, Square, Expand, Shrink, Monitor, Smartphone } from 'lucide-react'
 import { BrowserActivityLog } from './browser-activity-log'
 import { BrowserTabBar } from './browser-tab-bar'
 import { useBrowserStream } from '@renderer/hooks/use-browser-stream'
@@ -86,6 +86,7 @@ export function BrowserTrayContent({
   const { submittingAction, error: actionError, complete, decline } = useBrowserInputActions({
     agentSlug,
     sessionId,
+    activeToolUseId: latestRequest?.toolUseId ?? null,
     onResolved: (toolUseId) => stream.dismissBrowserInputRequest(toolUseId),
   })
 
@@ -124,7 +125,7 @@ export function BrowserTrayContent({
       )}
 
       {/* Canvas viewport */}
-      <div className={cn('relative shrink-0 overflow-hidden bg-background border-y border-border/40', isActive && !stream.needsAttention && 'browser-glow-container')}>
+      <div className={cn('relative min-h-0 overflow-hidden bg-background border-y border-border/40', isActive && !stream.needsAttention && 'browser-glow-container')}>
         <canvas
           ref={canvasRef}
           className={`w-full block ${stream.isViewOnly ? 'cursor-not-allowed' : 'cursor-default'}`}
@@ -211,6 +212,23 @@ export function BrowserTrayContent({
             <span className="text-xs font-medium text-foreground flex-1 truncate">
               {latestRequest.message || 'Your input needed'}
             </span>
+            <button
+              onClick={stream.toggleDesktopWidth}
+              disabled={!stream.connected}
+              className="p-1.5 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground shrink-0 disabled:opacity-50 disabled:pointer-events-none"
+              title={
+                !stream.connected
+                  ? 'Connecting…'
+                  : stream.desktopWidth
+                    ? 'Fit the page to the panel'
+                    : 'Show the full-width site'
+              }
+              data-testid="browser-tray-width-toggle"
+            >
+              {stream.desktopWidth
+                ? <Smartphone className="h-3.5 w-3.5" />
+                : <Monitor className="h-3.5 w-3.5" />}
+            </button>
             <DeclineButton
               onDecline={(reason) => decline(latestRequest.toolUseId, reason)}
               disabled={submittingAction !== null}

--- a/src/renderer/components/messages/browser-input-request-item.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.tsx
@@ -29,6 +29,7 @@ export function BrowserInputRequestItem({
   const { status, submittingAction, error, complete, decline } = useBrowserInputActions({
     agentSlug,
     sessionId,
+    activeToolUseId: toolUseId,
     onResolved: onComplete,
   })
 

--- a/src/renderer/hooks/use-browser-input-actions.test.tsx
+++ b/src/renderer/hooks/use-browser-input-actions.test.tsx
@@ -38,7 +38,36 @@ describe('useBrowserInputActions', () => {
     expect(mockApiFetch.mock.calls[0][0]).toBe(COMPLETE_URL)
     expect(JSON.parse(mockApiFetch.mock.calls[0][1].body)).toEqual({ toolUseId: 'tu-1' })
     expect(result.current.status).toBe('completed')
+    expect(result.current.submittingAction).toBeNull()
     expect(onResolved).toHaveBeenCalledWith('tu-1')
+  })
+
+  // The tray keeps one hook instance for the session, so a failed request's error
+  // must not stay on screen above the next, unrelated handoff.
+  it('clears a failed request error when the surface moves to the next handoff', async () => {
+    mockApiFetch.mockResolvedValue({ ok: false, json: async () => ({ error: 'boom' }) })
+    const onResolved = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ activeToolUseId }: { activeToolUseId: string | null }) =>
+        useBrowserInputActions({
+          agentSlug: 'a',
+          sessionId: 's',
+          onResolved,
+          activeToolUseId,
+        }),
+      {
+        wrapper: ({ children }) => <DraftsProvider>{children}</DraftsProvider>,
+        initialProps: { activeToolUseId: 'tu-1' },
+      }
+    )
+
+    await act(async () => {
+      await result.current.complete('tu-1')
+    })
+    expect(result.current.error).toBe('boom')
+
+    rerender({ activeToolUseId: 'tu-2' })
+    expect(result.current.error).toBeNull()
   })
 
   it('decline with no reason posts only the decline, no /messages', async () => {

--- a/src/renderer/hooks/use-browser-input-actions.ts
+++ b/src/renderer/hooks/use-browser-input-actions.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { apiFetch } from '@renderer/lib/api'
 import { useDraft } from '@renderer/context/drafts-context'
 
@@ -10,6 +10,12 @@ interface UseBrowserInputActionsArgs {
   sessionId: string
   /** Called with the toolUseId once a request resolves (completed or declined) so the surface can remove it. */
   onResolved: (toolUseId: string) => void
+  /**
+   * Current handoff id for this surface. The tray keeps one hook instance for the
+   * whole session, so a failed request's error would otherwise stay on screen
+   * above the next, unrelated handoff.
+   */
+  activeToolUseId?: string | null
 }
 
 /**
@@ -23,11 +29,22 @@ interface UseBrowserInputActionsArgs {
  * steer. If that send fails the reason is appended to the session composer draft
  * so it is never lost.
  */
-export function useBrowserInputActions({ agentSlug, sessionId, onResolved }: UseBrowserInputActionsArgs) {
+export function useBrowserInputActions({
+  agentSlug,
+  sessionId,
+  onResolved,
+  activeToolUseId = null,
+}: UseBrowserInputActionsArgs) {
   const [status, setStatus] = useState<BrowserInputStatus>('pending')
   const [submittingAction, setSubmittingAction] = useState<SubmittingAction | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [sessionDraft, setSessionDraft] = useDraft<string>(`session:${sessionId}`)
+
+  // Both submit paths already clear submittingAction, so only the error needs
+  // dropping when the surface moves to a different request.
+  useEffect(() => {
+    setError(null)
+  }, [activeToolUseId])
 
   const submit = async (
     body: { toolUseId: string } & Record<string, unknown>,
@@ -54,6 +71,9 @@ export function useBrowserInputActions({ agentSlug, sessionId, onResolved }: Use
       }
 
       setStatus(successStatus)
+      // Clear before onResolved. The tray keeps this hook mounted across handoffs;
+      // leaving 'completing' set disables Done on the next request forever.
+      setSubmittingAction(null)
       onResolved(body.toolUseId)
       return true
     } catch (err: unknown) {

--- a/src/renderer/hooks/use-browser-stream.test.tsx
+++ b/src/renderer/hooks/use-browser-stream.test.tsx
@@ -36,9 +36,15 @@ class FakeWebSocket {
   readyState = FakeWebSocket.CONNECTING
   onopen: (() => void) | null = null
   onclose: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  sent: string[] = []
 
   constructor(public url: string) {
     FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
   }
 
   completeHandshake() {
@@ -178,5 +184,114 @@ describe('useBrowserStream reconnect', () => {
     await advanceOneSecondAndOpenNewSockets()
 
     expect(FakeWebSocket.instances).toHaveLength(3)
+  })
+})
+
+describe('useBrowserStream width toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    FakeWebSocket.instances = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    mockApiFetch.mockResolvedValue({
+      json: () => Promise.resolve({ active: true, sessionId: 's' }),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // The next click derives from the local value, so if only the container's
+  // report could move it, one dropped or late report would latch the toggle:
+  // every later click re-sends the value that is already in effect.
+  it('asks for the opposite mode on the second click even with no report back', async () => {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    const { result } = renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+    await settle()
+    act(() => {
+      FakeWebSocket.instances[0].completeHandshake()
+    })
+    await settle()
+    const ws = FakeWebSocket.instances[0]
+
+    act(() => result.current.toggleDesktopWidth())
+    await settle()
+    act(() => result.current.toggleDesktopWidth())
+    await settle()
+
+    const widthAsks = ws.sent
+      .map((s) => JSON.parse(s))
+      .filter((m) => m.type === 'set_desktop_width')
+    expect(widthAsks).toEqual([
+      { type: 'set_desktop_width', enabled: true },
+      { type: 'set_desktop_width', enabled: false },
+    ])
+  })
+
+  // Two clicks in one frame share a render closure. Deriving the next mode from
+  // state would send `true` twice and the second click would do nothing.
+  it('alternates when two clicks land before a re-render', async () => {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    const { result } = renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+    await settle()
+    act(() => {
+      FakeWebSocket.instances[0].completeHandshake()
+    })
+    await settle()
+    const ws = FakeWebSocket.instances[0]
+
+    act(() => {
+      result.current.toggleDesktopWidth()
+      result.current.toggleDesktopWidth()
+    })
+    await settle()
+
+    const widthAsks = ws.sent
+      .map((s) => JSON.parse(s))
+      .filter((m) => m.type === 'set_desktop_width')
+      .map((m) => m.enabled)
+    expect(widthAsks).toEqual([true, false])
+  })
+
+  // A click can land in the window between the socket closing and the button
+  // re-rendering as disabled. Showing a mode we never managed to ask for is worse
+  // than ignoring the click.
+  it('does not move the toggle when the socket is not open', async () => {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    const { result } = renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+    await settle()
+    act(() => {
+      FakeWebSocket.instances[0].completeHandshake()
+    })
+    await settle()
+
+    FakeWebSocket.instances[0].readyState = FakeWebSocket.CLOSED
+    act(() => result.current.toggleDesktopWidth())
+    await settle()
+
+    expect(result.current.desktopWidth).toBe(false)
+  })
+
+  it('takes the container report as authoritative over the local guess', async () => {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    const { result } = renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+    await settle()
+    act(() => {
+      FakeWebSocket.instances[0].completeHandshake()
+    })
+    await settle()
+
+    act(() => result.current.toggleDesktopWidth())
+    await settle()
+    expect(result.current.desktopWidth).toBe(true)
+
+    act(() => {
+      FakeWebSocket.instances[0].onmessage?.({
+        data: JSON.stringify({ type: 'viewport_mode', desktopWidth: false }),
+      })
+    })
+    await settle()
+
+    expect(result.current.desktopWidth).toBe(false)
   })
 })

--- a/src/renderer/hooks/use-browser-stream.ts
+++ b/src/renderer/hooks/use-browser-stream.ts
@@ -41,6 +41,10 @@ export function useBrowserStream({
   const [agentActiveTargetId, setAgentActiveTargetId] = useState<string | null>(null)
   const [viewingTargetId, setViewingTargetId] = useState<string | null>(null)
   const [autoFollow, setAutoFollow] = useState(true)
+  const [desktopWidth, setDesktopWidth] = useState(false)
+  // Click-time truth. Two clicks in one frame share a render closure, so
+  // deriving the next mode from state would send the same value twice.
+  const desktopWidthRef = useRef(false)
   const autoFollowRef = useRef(autoFollow)
   autoFollowRef.current = autoFollow
 
@@ -173,6 +177,14 @@ export function useBrowserStream({
           return
         }
 
+        // The container reports the mode it applied, so the toggle reflects the
+        // page rather than this hook's mount-time default.
+        if (data.type === 'viewport_mode') {
+          desktopWidthRef.current = data.desktopWidth === true
+          setDesktopWidth(desktopWidthRef.current)
+          return
+        }
+
         if (data.type === 'page_loading') {
           setPageLoading(prev => prev === data.loading ? prev : data.loading)
         } else if (data.type === 'frame' && data.data) {
@@ -294,11 +306,13 @@ export function useBrowserStream({
     [canvasRef]
   )
 
+  /** Returns false when the socket was not open, so callers can avoid acting on
+   *  a message that was never actually sent. */
   const sendMessage = useCallback(
     (message: Record<string, unknown>) => {
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(JSON.stringify(message))
-      }
+      if (wsRef.current?.readyState !== WebSocket.OPEN) return false
+      wsRef.current.send(JSON.stringify(message))
+      return true
     },
     []
   )
@@ -468,6 +482,17 @@ export function useBrowserStream({
     }
   }, [autoFollow, agentActiveTargetId, sendMessage])
 
+  // Flip locally as well as asking the container: the next click derives from
+  // this value, so letting only the report move it means one dropped report
+  // latches the toggle. Commit nothing if the socket was not open, or the icon
+  // would show a mode we never asked for. The report stays authoritative.
+  const toggleDesktopWidth = useCallback(() => {
+    const next = !desktopWidthRef.current
+    if (!sendMessage({ type: 'set_desktop_width', enabled: next })) return
+    desktopWidthRef.current = next
+    setDesktopWidth(next)
+  }, [sendMessage])
+
   const closeBrowser = useCallback(async () => {
     setIsClosing(true)
     try {
@@ -510,6 +535,7 @@ export function useBrowserStream({
     tabs,
     viewingTargetId,
     autoFollow,
+    desktopWidth,
     needsAttention,
     showOverlay,
     pendingBrowserInputRequests,
@@ -527,6 +553,7 @@ export function useBrowserStream({
     handleTabClick,
     handleCloseTab,
     toggleAutoFollow,
+    toggleDesktopWidth,
     // Close handlers
     closeBrowser,
     handleCloseClick,


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-498/narrow-the-browser-viewport-during-a-credential-handoff-so-sign-in

While `request_browser_input` is pending, narrow the streamed page to 450×900 so login forms reflow into the tray. Clear when nothing is pending. Per-handoff desktop escape in the handoff bar. Canvas `min-h-0` so Done/Decline stay on screen.

**Footprint:** prod 7 files / net +237 · test 3 files / net +351

## How the width is decided

```
pending browser handoff?
  no  → clear override, reset escape
  yes → user asked for desktop this handoff?
          yes → clear override
          no  → set 450×900 (mobile:false, deviceScaleFactor:1)
```

The input manager notifies on any change to its pending map and the viewport subscribes once, so every route that opens or clears a handoff re-derives without naming them: Done, Decline, browser close, session delete, the 60s sweep that retires abandoned requests, and handoff create. Screencast attach and the escape toggle derive directly. Tab switch and OAuth popup re-enter attach, so they pick up the current answer with no per-target bookkeeping.

## The container owns the mode

The container reports the mode it applied as a `viewport_mode` stream message and the tray renders that. An earlier revision had the renderer infer the mode from the width of arriving frames against two threshold constants; moving the answer to the side that already knows it removed both thresholds, three mirroring refs, a settling spinner and its timeout.

## Why not widen the drawer or zoom the frame

Measured on GitHub / Google / LinkedIn: the form is ~30% of a 1280px frame. Scaling that into a 450px tray leaves ~130px fields. Widening the drawer magnifies the empty background with the form and still cannot reach 1:1 under the 800px drawer cap. Zoom has the same problem and would rework click coordinate mapping on a password path. Reflow at phone width takes the same sites to ~86-93% form share.

`mobile: true` looks fine on those three sites and fails on a legacy page with no viewport meta (Chrome's 980px fallback scaled to fit → 37% usable). `mobile: false` holds at 81% there. `deviceScaleFactor` is required by CDP; omitting it rejects the call.

## Worth reviewing

1. **The pending-map subscription in `input-manager.ts`.** This started as seven hand-written `syncBrowserViewport()` calls, one per route that opens or clears a handoff. Three of them were missing: session delete, the 60s abandoned-request sweep, and (separately) a tab switch left the departed target narrowed for the rest of the session. Rather than add the three missing calls, the input manager now notifies on any pending-map change and the viewport subscribes once, so a route added later cannot forget. This is the one part of the PR that touches a primitive shared with secret, question and connected-account requests - the change is additive (fire a callback after mutation, one subscriber), but it is the diff to read hardest. It also buys the coverage below.
2. **Escape across viewer reconnect.** Cleanup clears the CDP override always, but keeps the escape flag while a handoff is still pending so reconnect re-derives desktop. Browser close rejects pendings then syncs, so the next handoff still starts narrow. The sticky-escape failure mode is the one to read for.
3. **`mobile: false` and `deviceScaleFactor: 1`.** Easy to "fix" toward a phone UA. Don't - both are load-bearing.
4. **Canvas `min-h-0`.** Unconditional. At today's 1280×720 the box never hits the floor; at 450×900 it stops starving Done/Decline. Same bound-the-slot shape as the activity-card overflow fix.
5. **The toggle does not flip on the report alone.** It flips locally and sends, because the next click derives from that value - letting only the report move it means one dropped report latches the toggle dead. It commits nothing if the socket was not open, so it cannot show a mode we never asked for.

## Known limits (not fixed here)

- UA-sniff sites ignore width → no reflow; escape recovers to today's desktop path (no regression, no gain).
- Centered fixed-width layouts may need pan inside the canvas.
- Overlapping handoffs share one escape flag, so a second handoff opening while the first is escaped inherits desktop width. Scoping it per request costs a wire field, and one shared browser showing one shared page makes the current behaviour defensible.
- Escape is shared across tabs for the whole handoff rather than per tab, so an OAuth popup keeps the width you chose instead of snapping back to narrow mid-login.
- `server.ts` attach/teardown wiring is not unit-tested (the module exports nothing, and refactoring it for testability is out of scope). What remains uncovered there is now three lines of CDP/socket wiring: the override clear on the target a tab switch leaves, the guard that stops a late-opening stale socket claiming the viewport channel, and handling the toggle ahead of the screencast guard. Those rest on code reading plus hand smoke. The pending-map invariant, which is where all three bugs actually were, moved into `input-manager.ts` and is covered.
- Escape is not persisted per site. Wait for a repetition signal before that.

## Validation

- `npm run typecheck` - green
- `npm run lint` - 0 errors
- `cd agent-container && npx tsc --noEmit` - green
- `npx vitest run src/renderer` - 1988 passed
- `npm --prefix agent-container test` - 791 passed, 8 skipped
- One table-driven test covers every route that clears the last handoff - resolve, decline, browser close, session delete, stale sweep - plus the open case. Deleting the notify from the sweep fails only the sweep row; deleting it from session delete fails only that row.
- Hand smoke on a live login: narrow, escape, toggle back, tab switch mid-handoff leaves no stuck-narrow tab, session delete mid-handoff does not leak escape into the next handoff.
- E2E left to CI. Locally it fails to boot on a `better-sqlite3` ABI mismatch after an Electron dev session, which is environmental.

Each new test was verified red against the defect it guards, then green.

Container half ships in the agent image. Existing agents need image rebuild + container recreate before live narrow applies. Renderer half is dormant until a narrowed frame arrives.
