### PR TITLE
fix(mcp-proxy): rewrite non-SSE GET 200 to 405 (SUP-525)

### DIFF
--- a/src/api/routes/mcp-proxy.test.ts
+++ b/src/api/routes/mcp-proxy.test.ts
@@ -124,7 +124,8 @@ function setupSuccessPath(
   const {
     mcpOverrides = {},
     upstreamStatus = 200,
-    upstreamHeaders = { 'content-type': 'application/json' },
+    // Default GET-friendly: non-SSE application/json on GET is rewritten to 405 (SUP-525).
+    upstreamHeaders = { 'content-type': 'text/event-stream' },
     upstreamBody = '{"ok":true}',
   } = overrides
 
@@ -273,7 +274,7 @@ describe('mcp-proxy route', () => {
         .mockResolvedValueOnce(
           new Response('{"ok":true}', {
             status: 200,
-            headers: { 'content-type': 'application/json' },
+            headers: { 'content-type': 'text/event-stream' },
           })
         )
 
@@ -324,7 +325,7 @@ describe('mcp-proxy route', () => {
             { status: 200 }
           )
         )
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
@@ -350,7 +351,7 @@ describe('mcp-proxy route', () => {
             { status: 200 }
           )
         )
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
@@ -376,7 +377,7 @@ describe('mcp-proxy route', () => {
             { status: 200 }
           )
         )
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
@@ -402,7 +403,7 @@ describe('mcp-proxy route', () => {
             { status: 200 }
           )
         )
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
@@ -466,7 +467,7 @@ describe('mcp-proxy route', () => {
       setupDbMocks(mcp)
 
       mockFetch.mockResolvedValueOnce(
-        new Response('{"ok":true}', { status: 200 })
+        new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'text/event-stream' } })
       )
 
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
@@ -493,7 +494,7 @@ describe('mcp-proxy route', () => {
             { status: 200 }
           )
         )
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
@@ -521,7 +522,7 @@ describe('mcp-proxy route', () => {
             { status: 200 }
           )
         )
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
@@ -552,7 +553,7 @@ describe('mcp-proxy route', () => {
             { status: 200 }
           )
         )
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
@@ -623,7 +624,7 @@ describe('mcp-proxy route', () => {
       setupDbMocks(mcp)
 
       mockFetch.mockResolvedValueOnce(
-        new Response('{"ok":true}', { status: 200 })
+        new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'text/event-stream' } })
       )
 
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
@@ -643,7 +644,7 @@ describe('mcp-proxy route', () => {
       setupDbMocks(mcp)
 
       mockFetch.mockResolvedValueOnce(
-        new Response('{"ok":true}', { status: 200 })
+        new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'text/event-stream' } })
       )
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
@@ -774,7 +775,7 @@ describe('mcp-proxy route', () => {
       setupSuccessPath({
         upstreamHeaders: {
           'transfer-encoding': 'chunked',
-          'content-type': 'application/json',
+          'content-type': 'text/event-stream',
         },
       })
 
@@ -789,7 +790,7 @@ describe('mcp-proxy route', () => {
       setupSuccessPath({
         upstreamHeaders: {
           'content-encoding': 'gzip',
-          'content-type': 'application/json',
+          'content-type': 'text/event-stream',
         },
       })
 
@@ -804,7 +805,7 @@ describe('mcp-proxy route', () => {
       setupSuccessPath({
         upstreamHeaders: {
           'content-length': '123',
-          'content-type': 'application/json',
+          'content-type': 'text/event-stream',
         },
       })
 
@@ -825,8 +826,14 @@ describe('mcp-proxy route', () => {
         },
       })
 
+      // POST: non-SSE content-type must not be rewritten (rewrite is GET-only).
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
-        headers: { Authorization: 'Bearer synth_valid' },
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer synth_valid',
+          'Content-Type': 'application/json',
+        },
+        body: '{}',
       })
 
       expect(res.headers.get('content-type')).toBe('application/json')
@@ -1554,11 +1561,11 @@ describe('mcp-proxy route', () => {
 
       // First request setup
       mockDbFrom.mockReturnValueOnce({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ mcp: mcp1 }]) }) }) })
-      mockFetch.mockResolvedValueOnce(new Response('{"server":"one"}', { status: 200 }))
+      mockFetch.mockResolvedValueOnce(new Response('{"server":"one"}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       // Second request setup
       mockDbFrom.mockReturnValueOnce({ innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ mcp: mcp2 }]) }) }) })
-      mockFetch.mockResolvedValueOnce(new Response('{"server":"two"}', { status: 200 }))
+      mockFetch.mockResolvedValueOnce(new Response('{"server":"two"}', { status: 200, headers: { 'content-type': 'text/event-stream' } }))
 
       const [res1, res2] = await Promise.all([
         makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
@@ -1795,6 +1802,95 @@ describe('mcp-proxy route', () => {
       expect(res.status).toBe(200)
       // The key assertion: reviewManager was called because fallback is 'review'
       expect(mockRequestReview).toHaveBeenCalledOnce()
+    })
+  })
+
+  // Non-SSE GET rewrite (SUP-525 / Attio reconnect storm)
+  describe('non-SSE GET rewrite', () => {
+    it('rewrites GET 200 text/html to 405 so Streamable HTTP clients stop reconnecting', async () => {
+      setupSuccessPath({
+        upstreamStatus: 200,
+        upstreamHeaders: { 'content-type': 'text/html; charset=utf-8' },
+        upstreamBody: '<!DOCTYPE html><title>MCP Server</title>',
+      })
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer synth_valid',
+          Accept: 'text/event-stream',
+        },
+      })
+
+      expect(res.status).toBe(405)
+      expect(res.headers.get('Allow')).toBe('POST')
+      expect(mockInsertValues).toHaveBeenCalled()
+      const entry = mockInsertValues.mock.calls[0][0]
+      expect(entry.statusCode).toBe(405)
+      expect(entry.method).toBe('GET')
+      expect(entry.errorMessage).toContain('rewrote non-SSE GET 200')
+      expect(entry.errorMessage).toContain('text/html')
+    })
+
+    it('passes through GET 200 text/event-stream unchanged', async () => {
+      setupSuccessPath({
+        upstreamStatus: 200,
+        upstreamHeaders: { 'content-type': 'text/event-stream' },
+        upstreamBody: 'event: ping\ndata: {}\n\n',
+      })
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer synth_valid',
+          Accept: 'text/event-stream',
+        },
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toContain('text/event-stream')
+      expect(await res.text()).toContain('event: ping')
+      const entry = mockInsertValues.mock.calls[0][0]
+      expect(entry.statusCode).toBe(200)
+      expect(entry.errorMessage).toBeNull()
+    })
+
+    it('passes through upstream GET 405 unchanged', async () => {
+      setupSuccessPath({
+        upstreamStatus: 405,
+        upstreamHeaders: { allow: 'POST' },
+        upstreamBody: '',
+      })
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer synth_valid', Accept: 'text/event-stream' },
+      })
+
+      expect(res.status).toBe(405)
+      const entry = mockInsertValues.mock.calls[0][0]
+      expect(entry.statusCode).toBe(405)
+      expect(entry.errorMessage).toBeNull()
+    })
+
+    it('does not rewrite POST 200 text/html', async () => {
+      setupSuccessPath({
+        upstreamStatus: 200,
+        upstreamHeaders: { 'content-type': 'text/html' },
+        upstreamBody: '<html>nope</html>',
+      })
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer synth_valid',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('<html>')
     })
   })
 })

--- a/src/api/routes/mcp-proxy.ts
+++ b/src/api/routes/mcp-proxy.ts
@@ -40,6 +40,15 @@ async function logMcpAuditEntry(entry: {
   }
 }
 
+// GET listen must be SSE or 405; 200+HTML (Attio) makes Claude Agent SDK reconnect forever.
+function isSseContentType(contentType: string | null): boolean {
+  return (contentType ?? '').toLowerCase().includes('text/event-stream')
+}
+
+function shouldRewriteNonSseGet(method: string, response: Response): boolean {
+  return method === 'GET' && response.status === 200 && !isSseContentType(response.headers.get('content-type'))
+}
+
 /**
  * Attempt to refresh an expired OAuth token.
  * Returns the new access token on success, null on failure.
@@ -348,6 +357,31 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
   try {
     const response = await mcpSafeFetch(targetUrl, init)
     const durationMs = Date.now() - startTime
+
+    if (shouldRewriteNonSseGet(method, response)) {
+      const upstreamType = response.headers.get('content-type') ?? 'missing'
+      try {
+        await response.body?.cancel()
+      } catch (err) {
+        console.warn('[mcp-proxy] Failed to cancel non-SSE GET body:', err)
+      }
+      logMcpAuditEntry({
+        agentSlug,
+        remoteMcpId: mcp.id,
+        remoteMcpName: mcp.name,
+        method,
+        requestPath: mcpMethodInfo,
+        statusCode: 405,
+        errorMessage: `rewrote non-SSE GET 200 (${upstreamType}) to 405`,
+        durationMs,
+        policyDecision: resolvedPolicyDecision,
+        matchedTool: toolName ?? undefined,
+      })
+      return new Response(null, {
+        status: 405,
+        headers: { Allow: 'POST' },
+      })
+    }
 
     // Fire-and-forget audit log
     logMcpAuditEntry({


### PR DESCRIPTION
## Summary
- Fixes [SUP-525](https://linear.app/datawizz/issue/SUP-525/attio-mcp-get-reconnect-storm-goke-200-html-treated-as-sse): Attio’s Streamable HTTP optional `GET` returns `200` + `text/html` instead of SSE or `405`. Claude Agent SDK treats that as a dead SSE stream and reconnects ~1 req/s for the life of the session.
- Gamut amplifies this because every proxied GET is audited into `mcp_audit_log` (goke had tens of millions of Attio rows). Reproduced locally on Superagent-Dev; bare Claude Agent SDK + Attio (no Gamut) storms the same way.
- MCP proxy now rewrites `GET` + upstream `200` with non-`text/event-stream` `Content-Type` to `405` + `Allow: POST`, cancels the body, and audits with `rewrote non-SSE GET 200 (…) to 405`. Real SSE and upstream `405` pass through; POST is unchanged.

## Test plan
- [x] Unit tests in `mcp-proxy.test.ts` (rewrite HTML → 405, pass through SSE, pass through upstream 405, POST not rewritten)
- [x] Live A/B on Superagent-Dev: with fix → one rewritten `GET 405`, audit count flat; on `main` → `GET 200` storm resumes (~1+/s)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)