### PR TITLE
Scope session routes to the authorized agent's own sessions (SUP-479)

### DIFF
--- a/e2e/auth/specs/session-scope-roles.spec.ts
+++ b/e2e/auth/specs/session-scope-roles.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Session-scoped routes must be scoped to the session, not just to the agent.
+ *
+ * Auth-mode routes authorize the AGENT in the URL. The session id in the URL was
+ * never checked against it, and the registries these routes drive — the message
+ * persister above all — are keyed by session id ALONE, with no agent dimension.
+ * So a user holding a role on their own agent could name a stranger's session id
+ * and reach it: subscribe to its live event stream, interrupt it, post into it.
+ *
+ * This narrative proves the boundary against the real server: two users, two
+ * agents, no shared access. Every cross-agent call must 404, and every identical
+ * call against the caller's own session must still succeed — a gate that closed
+ * the hole by breaking the feature would pass the first half alone.
+ */
+import { test, expect } from '../fixtures/multi-user.fixture'
+import { AuthPage } from '../pages/auth.page'
+import { AppPage } from '../../pages/app.page'
+
+// Serial narrative — each test builds on state from the previous ones.
+test.describe.configure({ mode: 'serial' })
+
+const attacker = { name: 'Mallory Mine', email: 'mallory@test.com', password: 'password123' }
+const victim = { name: 'Val Victim', email: 'val@test.com', password: 'password123' }
+
+let attackerAgent = ''
+let attackerSession = ''
+let victimAgent = ''
+let victimSession = ''
+
+async function signUp(page: import('@playwright/test').Page, user: typeof attacker) {
+  const authPage = new AuthPage(page)
+  const appPage = new AppPage(page)
+  await authPage.resetToAuthPage()
+  await authPage.signUpOrSignIn(user.name, user.email, user.password)
+  await appPage.waitForAppLoaded()
+  await appPage.dismissWizardIfVisible()
+}
+
+async function createAgentWithSession(
+  page: import('@playwright/test').Page,
+  agentName: string,
+): Promise<{ slug: string; sessionId: string }> {
+  const agentRes = await page.request.post('/api/agents', { data: { name: agentName } })
+  expect(agentRes.ok()).toBeTruthy()
+  const { slug } = (await agentRes.json()) as { slug: string }
+
+  const sessionRes = await page.request.post(`/api/agents/${slug}/sessions`, {
+    data: { message: 'hello' },
+  })
+  expect(sessionRes.ok()).toBeTruthy()
+  const { id } = (await sessionRes.json()) as { id: string }
+
+  expect(slug).toBeTruthy()
+  expect(id).toBeTruthy()
+  return { slug, sessionId: id }
+}
+
+test.describe('Cross-agent session scoping', () => {
+  test('both users sign up and each creates an agent with a live session', async ({
+    user1Page,
+    user2Page,
+  }) => {
+    // The victim signs up FIRST on purpose: the first account in an auth-mode
+    // install is promoted to admin, and admins bypass the agent ACL entirely.
+    // The attacker has to be an ordinary member for this to test anything.
+    await signUp(user2Page, victim)
+    const theirs = await createAgentWithSession(user2Page, 'Val Agent')
+    victimAgent = theirs.slug
+    victimSession = theirs.sessionId
+
+    await signUp(user1Page, attacker)
+    const mine = await createAgentWithSession(user1Page, 'Mallory Agent')
+    attackerAgent = mine.slug
+    attackerSession = mine.sessionId
+
+    // Distinct agents, distinct sessions, no ACL between them.
+    expect(attackerAgent).not.toBe(victimAgent)
+    expect(attackerSession).not.toBe(victimSession)
+  })
+
+  test('the victim’s agent is not reachable directly', async ({ user1Page }) => {
+    // Baseline: the agent-level ACL already blocks the obvious route, and it
+    // confirms the attacker really is unprivileged. The rest of this narrative
+    // is about the session id that the ACL never looked at.
+    const res = await user1Page.request.post(
+      `/api/agents/${victimAgent}/sessions/${victimSession}/interrupt`,
+    )
+    expect(res.status()).toBe(403)
+  })
+
+  test('interrupt with the victim’s session id under the attacker’s agent 404s', async ({
+    user1Page,
+  }) => {
+    const res = await user1Page.request.post(
+      `/api/agents/${attackerAgent}/sessions/${victimSession}/interrupt`,
+    )
+    expect(res.status()).toBe(404)
+  })
+
+  test('the SSE stream for the victim’s session 404s', async ({ user1Page }) => {
+    const res = await user1Page.request.get(
+      `/api/agents/${attackerAgent}/sessions/${victimSession}/stream`,
+    )
+    expect(res.status()).toBe(404)
+  })
+
+  test('posting a message into the victim’s session 404s', async ({ user1Page }) => {
+    const res = await user1Page.request.post(
+      `/api/agents/${attackerAgent}/sessions/${victimSession}/messages`,
+      { data: { content: 'injected' } },
+    )
+    expect(res.status()).toBe(404)
+  })
+
+  test('broadcasting a typing indicator into the victim’s session 404s', async ({ user1Page }) => {
+    const res = await user1Page.request.post(
+      `/api/agents/${attackerAgent}/sessions/${victimSession}/typing`,
+      { data: {} },
+    )
+    expect(res.status()).toBe(404)
+  })
+
+  test('deleting the victim’s session 404s', async ({ user1Page }) => {
+    const res = await user1Page.request.delete(
+      `/api/agents/${attackerAgent}/sessions/${victimSession}`,
+    )
+    expect(res.status()).toBe(404)
+  })
+
+  test('the victim’s session survives every attempt', async ({ user2Page }) => {
+    const res = await user2Page.request.get(
+      `/api/agents/${victimAgent}/sessions/${victimSession}`,
+    )
+    expect(res.ok()).toBeTruthy()
+    const session = (await res.json()) as { id: string }
+    expect(session.id).toBe(victimSession)
+  })
+
+  test('the attacker can still drive their OWN session', async ({ user1Page }) => {
+    const typing = await user1Page.request.post(
+      `/api/agents/${attackerAgent}/sessions/${attackerSession}/typing`,
+      { data: {} },
+    )
+    expect(typing.ok()).toBeTruthy()
+
+    const message = await user1Page.request.post(
+      `/api/agents/${attackerAgent}/sessions/${attackerSession}/messages`,
+      { data: { content: 'my own session' } },
+    )
+    expect(message.ok()).toBeTruthy()
+
+    const interrupt = await user1Page.request.post(
+      `/api/agents/${attackerAgent}/sessions/${attackerSession}/interrupt`,
+    )
+    expect(interrupt.ok()).toBeTruthy()
+  })
+})

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -47,6 +47,13 @@ const authProjects = [
     dataDir: path.join(e2eDataDir, 'models'),
     viteCacheDir: path.join(e2eDataDir, '.vite', 'models'),
   },
+  {
+    name: 'auth-session-scope',
+    testMatch: '**/session-scope-roles.spec.ts',
+    port: e2ePort + 5,
+    dataDir: path.join(e2eDataDir, 'session-scope'),
+    viteCacheDir: path.join(e2eDataDir, '.vite', 'session-scope'),
+  },
 ].map((project, index) => ({
   ...project,
   baseURL: index === 0 && process.env.E2E_BASE_URL

--- a/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
+++ b/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
@@ -176,7 +176,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
-  sessionExists: vi.fn().mockResolvedValue(true), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  sessionExists: vi.fn().mockResolvedValue(true), sessionBelongsToAgent: vi.fn().mockResolvedValue(true), reserveSessionOwnership: vi.fn().mockResolvedValue(undefined), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
 }))

--- a/src/api/routes/agents.delete-ordering.sup208.test.ts
+++ b/src/api/routes/agents.delete-ordering.sup208.test.ts
@@ -166,7 +166,7 @@ vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
-  sessionExists: vi.fn().mockResolvedValue(true), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  sessionExists: vi.fn().mockResolvedValue(true), sessionBelongsToAgent: vi.fn().mockResolvedValue(true), reserveSessionOwnership: vi.fn().mockResolvedValue(undefined), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
 }))

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -102,17 +102,20 @@ const mockContainerFetch = vi.fn()
 const mockSendMessage = vi.fn()
 const mockCancelQueuedMessage = vi.fn()
 const mockKeepAlive = vi.fn()
+const mockInterruptSession = vi.fn()
+const mockGetCachedInfo = vi.fn(() => ({ status: 'running', port: 8080 }))
 vi.mock('@shared/lib/container/container-manager', () => ({
   containerManager: {
     getClient: () => ({
       fetch: (...args: unknown[]) => mockContainerFetch(...args),
       sendMessage: (...args: unknown[]) => mockSendMessage(...args),
       cancelQueuedMessage: (...args: unknown[]) => mockCancelQueuedMessage(...args),
+      interruptSession: (...args: unknown[]) => mockInterruptSession(...args),
       start: vi.fn(),
       stop: vi.fn(),
     }),
     ensureRunning: vi.fn(),
-    getCachedInfo: () => ({ status: 'running', port: 8080 }),
+    getCachedInfo: () => mockGetCachedInfo(),
     removeClient: vi.fn(),
     keepAlive: (...args: unknown[]) => mockKeepAlive(...args),
   },
@@ -361,6 +364,7 @@ const mockGetPendingReviewsForAgent = vi.fn((_slug: string) => [] as any[])
 vi.mock('@shared/lib/proxy/review-manager', () => ({
   reviewManager: {
     getPendingReviewsForAgent: (slug: string) => mockGetPendingReviewsForAgent(slug),
+    denyAllForAgent: vi.fn(),
     submitDecision: vi.fn(),
     resolveMatchingPending: vi.fn(),
     resolveMatchingPendingByLabel: vi.fn(),
@@ -5599,5 +5603,216 @@ describe('POST /:id/sessions/:sessionId/run-script — once-grants are single-us
     expect(
       computerUsePermissionManager.checkPermission('test-agent', 'use_host_shell'),
     ).toBe('granted')
+  })
+})
+
+// ============================================================================
+// Cross-agent session scoping
+// ============================================================================
+
+/**
+ * Session-scoped routes authorize the AGENT in the URL, never the session id in
+ * it. Most siblings are safe by construction because they build a filesystem
+ * path from `agentSlug + sessionId`, so a foreign id is simply a miss — but the
+ * routes that reach the message persister are not: it is a process-global
+ * registry keyed by session id ALONE, with no agent dimension. Without an
+ * explicit ownership gate, a caller holding a role on agent A can pass agent B's
+ * session id and drive B's live session: wipe its streaming state, broadcast a
+ * bogus `session_idle` to everyone watching it, spoof messages into its
+ * transcript view, or grant it a capability.
+ *
+ * Each test below asserts BOTH halves — the 404, and that the global side effect
+ * never fired. The status code alone would pass even if the mutation happened
+ * first and the route merely reported failure afterwards.
+ */
+describe('cross-agent session scoping', () => {
+  const ATTACKER = 'attacker-agent'
+  const OWN_SESSION = 'own-session-id'
+  const VICTIM_SESSION = 'victim-session-id'
+
+  let app: Hono
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockAgentExists.mockResolvedValue(true)
+    mockIsAuthMode.mockReturnValue(true)
+    mockGetCachedInfo.mockReturnValue({ status: 'running', port: 8080 })
+    mockInterruptSession.mockResolvedValue(true)
+    mockSendMessage.mockResolvedValue(undefined)
+    mockContainerFetch.mockResolvedValue({ ok: true, json: async () => ({}) })
+
+    // The attacker owns exactly one session; the victim's id belongs to another
+    // agent, so it resolves to neither a transcript nor a metadata entry here.
+    vi.mocked(sessionIsKnown).mockImplementation(
+      async (agentSlug: string, sessionId: string) =>
+        agentSlug === ATTACKER && sessionId === OWN_SESSION,
+    )
+    vi.mocked(sessionExists).mockImplementation(
+      async (agentSlug: string, sessionId: string) =>
+        agentSlug === ATTACKER && sessionId === OWN_SESSION,
+    )
+    vi.mocked(getSession).mockImplementation(async (agentSlug: string, sessionId: string) =>
+      agentSlug === ATTACKER && sessionId === OWN_SESSION
+        ? ({ id: sessionId, agentSlug, name: 'Own', createdAt: new Date(), lastActivityAt: new Date(), messageCount: 1 } as any)
+        : null,
+    )
+    vi.mocked(deleteSession).mockResolvedValue(false)
+    vi.mocked(getAgent).mockResolvedValue({ frontmatter: { name: 'Attacker' } } as any)
+  })
+
+  afterEach(() => {
+    mockIsAuthMode.mockReturnValue(false)
+    mockGetCachedInfo.mockReturnValue({ status: 'running', port: 8080 })
+  })
+
+  function url(sessionId: string, suffix = ''): string {
+    return `/api/agents/${ATTACKER}/sessions/${sessionId}${suffix}`
+  }
+
+  describe('POST /sessions/:sessionId/interrupt', () => {
+    it('404s on a foreign session and never marks it interrupted', async () => {
+      const res = await postJson(app, url(VICTIM_SESSION, '/interrupt'), {})
+
+      expect(res.status).toBe(404)
+      expect(messagePersister.markSessionInterrupted).not.toHaveBeenCalled()
+      expect(mockInterruptSession).not.toHaveBeenCalled()
+    })
+
+    it('404s on a foreign session even when the container is not running', async () => {
+      // The stopped-container path marks the session interrupted directly,
+      // without going through the container at all.
+      mockGetCachedInfo.mockReturnValue({ status: 'stopped', port: 0 })
+
+      const res = await postJson(app, url(VICTIM_SESSION, '/interrupt'), {})
+
+      expect(res.status).toBe(404)
+      expect(messagePersister.markSessionInterrupted).not.toHaveBeenCalled()
+    })
+
+    it('404s on a foreign session even when the container call throws', async () => {
+      // The handler's catch deliberately marks the session interrupted anyway
+      // (to unstick a stale UI). The gate has to run BEFORE that try, or the
+      // error path becomes a second way in.
+      mockInterruptSession.mockRejectedValue(new Error('container exploded'))
+
+      const res = await postJson(app, url(VICTIM_SESSION, '/interrupt'), {})
+
+      expect(res.status).toBe(404)
+      expect(messagePersister.markSessionInterrupted).not.toHaveBeenCalled()
+    })
+
+    it('404s on a session id that escapes the agent’s session directory', async () => {
+      const res = await postJson(app, url('..%2F..%2Fvictim', '/interrupt'), {})
+
+      expect(res.status).toBe(404)
+      expect(messagePersister.markSessionInterrupted).not.toHaveBeenCalled()
+    })
+
+    it('still interrupts the caller’s own session', async () => {
+      const res = await postJson(app, url(OWN_SESSION, '/interrupt'), {})
+
+      expect(res.status).toBe(200)
+      expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith(OWN_SESSION)
+    })
+
+    it('still marks the caller’s own session interrupted when the container throws', async () => {
+      mockInterruptSession.mockRejectedValue(new Error('container exploded'))
+
+      const res = await postJson(app, url(OWN_SESSION, '/interrupt'), {})
+
+      expect(res.status).toBe(200)
+      expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith(OWN_SESSION)
+    })
+  })
+
+  // GET …/stream is gated too, but by its own inline check with dedicated
+  // coverage above ('session stream access') — not repeated here.
+
+  describe('POST /sessions/:sessionId/messages', () => {
+    it('404s on a foreign session and never touches its live state', async () => {
+      const res = await postJson(app, url(VICTIM_SESSION, '/messages'), { content: 'hi' })
+
+      expect(res.status).toBe(404)
+      expect(messagePersister.cancelAwaitingInput).not.toHaveBeenCalled()
+      expect(messagePersister.markSessionActive).not.toHaveBeenCalled()
+      expect(messagePersister.broadcastSessionEvent).not.toHaveBeenCalled()
+      expect(messagePersister.subscribeToSession).not.toHaveBeenCalled()
+      expect(mockSendMessage).not.toHaveBeenCalled()
+    })
+
+    it('still sends to the caller’s own session', async () => {
+      const res = await postJson(app, url(OWN_SESSION, '/messages'), { content: 'hi' })
+
+      expect(res.status).toBe(201)
+      expect(mockSendMessage).toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /sessions/:sessionId/typing', () => {
+    it('404s on a foreign session and never broadcasts into it', async () => {
+      const res = await postJson(app, url(VICTIM_SESSION, '/typing'), {})
+
+      expect(res.status).toBe(404)
+      expect(messagePersister.broadcastSessionEvent).not.toHaveBeenCalled()
+    })
+
+    it('still broadcasts typing for the caller’s own session', async () => {
+      const res = await postJson(app, url(OWN_SESSION, '/typing'), {})
+
+      expect(res.status).toBe(200)
+      expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith(
+        OWN_SESSION,
+        expect.objectContaining({ type: 'user_typing' }),
+      )
+    })
+  })
+
+  // The decision routes reach the same session-id-keyed registries, but they are
+  // already closed by gateRequestDecision, which binds the toolUseId to the
+  // route's agent AND session. It answers an unknown id with 200
+  // {alreadySettled} rather than a 404 — deliberately, so a stale card dismisses
+  // itself — so these assert the side effect, not the status.
+  describe('POST /sessions/:sessionId/capability-review', () => {
+    it('never grants a capability in a foreign session', async () => {
+      await postJson(app, url(VICTIM_SESSION, '/capability-review'), {
+        toolUseId: 'tool-1',
+        capability: 'subagents',
+        scope: 'session',
+      })
+
+      expect(messagePersister.grantSessionCapability).not.toHaveBeenCalled()
+      expect(messagePersister.completeCapabilityReview).not.toHaveBeenCalled()
+    })
+
+    it('never resolves a foreign session’s review card when declining', async () => {
+      await postJson(app, url(VICTIM_SESSION, '/capability-review'), {
+        toolUseId: 'tool-1',
+        capability: 'subagents',
+        decline: true,
+      })
+
+      expect(messagePersister.completeCapabilityReview).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /sessions/:sessionId/complete-browser-input', () => {
+    it('never marks a foreign session interrupted', async () => {
+      await postJson(app, url(VICTIM_SESSION, '/complete-browser-input'), {
+        toolUseId: 'tool-1',
+        decline: true,
+      })
+
+      expect(messagePersister.markSessionInterrupted).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('DELETE /sessions/:sessionId', () => {
+    it('404s on a foreign session without unsubscribing its persister', async () => {
+      const res = await deleteReq(app, url(VICTIM_SESSION))
+
+      expect(res.status).toBe(404)
+      expect(messagePersister.unsubscribeFromSession).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -272,6 +272,8 @@ vi.mock('@shared/lib/services/session-service', () => ({
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),
+  sessionBelongsToAgent: vi.fn().mockResolvedValue(true),
+  reserveSessionOwnership: vi.fn().mockResolvedValue(undefined),
   sessionIsKnown: vi.fn().mockResolvedValue(true),
   isSessionRegistered: vi.fn().mockResolvedValue(false),
   updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
@@ -516,7 +518,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -543,6 +545,8 @@ function createApp() {
 
 beforeEach(() => {
   mockAuthorizedAgentRole = 'owner'
+  vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
+  vi.mocked(sessionIsKnown).mockResolvedValue(true)
 })
 
 async function patchJson(app: Hono, url: string, body: unknown): Promise<Response> {
@@ -901,23 +905,22 @@ describe('session stream access - GET /:id/sessions/:sessionId/stream', () => {
   })
 
   it('rejects a session that does not belong to the authorized agent', async () => {
-    vi.mocked(sessionExists).mockResolvedValueOnce(false)
+    vi.mocked(sessionIsKnown).mockResolvedValueOnce(false)
 
     const res = await getReq(app, '/api/agents/authorized-agent/sessions/foreign-session/stream')
 
     expect(res.status).toBe(404)
-    expect(sessionExists).toHaveBeenCalledWith('authorized-agent', 'foreign-session')
+    expect(sessionIsKnown).toHaveBeenCalledWith('authorized-agent', 'foreign-session')
     expect(mockStreamSSE).not.toHaveBeenCalled()
   })
 
   it('allows a newly registered session before its transcript exists', async () => {
-    vi.mocked(sessionExists).mockResolvedValueOnce(false)
-    vi.mocked(isSessionRegistered).mockResolvedValueOnce(true)
+    vi.mocked(sessionIsKnown).mockResolvedValueOnce(true)
 
     const res = await getReq(app, '/api/agents/authorized-agent/sessions/new-session/stream')
 
     expect(res.status).toBe(200)
-    expect(isSessionRegistered).toHaveBeenCalledWith('authorized-agent', 'new-session')
+    expect(sessionIsKnown).toHaveBeenCalledWith('authorized-agent', 'new-session')
     expect(mockStreamSSE).toHaveBeenCalledOnce()
   })
 })
@@ -5340,6 +5343,16 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
     expect(args.effort).toBe('high')
   })
 
+  it('reserves ownership before publishing global lifecycle state', async () => {
+    const res = await postJson(app, SESSIONS_URL, { message: 'hello' })
+
+    expect(res.status).toBe(201)
+    expect(reserveSessionOwnership).toHaveBeenCalledWith('test-agent', 'session-123')
+    expect(vi.mocked(reserveSessionOwnership).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(messagePersister.markSessionActive).mock.invocationCallOrder[0],
+    )
+  })
+
   it('explicit per-session model/effort win over agent preference defaults', async () => {
     vi.mocked(readJsonFileStrict).mockResolvedValue({
       defaultModel: 'haiku',
@@ -5648,6 +5661,10 @@ describe('cross-agent session scoping', () => {
       async (agentSlug: string, sessionId: string) =>
         agentSlug === ATTACKER && sessionId === OWN_SESSION,
     )
+    vi.mocked(sessionBelongsToAgent).mockImplementation(
+      async (agentSlug: string, sessionId: string) =>
+        agentSlug === ATTACKER && sessionId === OWN_SESSION,
+    )
     vi.mocked(sessionExists).mockImplementation(
       async (agentSlug: string, sessionId: string) =>
         agentSlug === ATTACKER && sessionId === OWN_SESSION,
@@ -5669,6 +5686,18 @@ describe('cross-agent session scoping', () => {
   function url(sessionId: string, suffix = ''): string {
     return `/api/agents/${ATTACKER}/sessions/${sessionId}${suffix}`
   }
+
+  describe('GET /sessions/:sessionId/messages', () => {
+    it('rejects a foreign id even if a same-named transcript exists locally', async () => {
+      vi.mocked(sessionExists).mockResolvedValue(true)
+
+      const res = await app.request(url(VICTIM_SESSION, '/messages'))
+
+      expect(res.status).toBe(404)
+      expect(messagePersister.getSettledInputRequests).not.toHaveBeenCalled()
+      expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
+    })
+  })
 
   describe('POST /sessions/:sessionId/interrupt', () => {
     it('404s on a foreign session and never marks it interrupted', async () => {
@@ -5813,6 +5842,18 @@ describe('cross-agent session scoping', () => {
 
       expect(res.status).toBe(404)
       expect(messagePersister.unsubscribeFromSession).not.toHaveBeenCalled()
+    })
+
+    it('still deletes an owned metadata-only entry without createdAt', async () => {
+      vi.mocked(sessionExists).mockResolvedValue(false)
+      vi.mocked(isSessionRegistered).mockResolvedValue(true)
+      vi.mocked(deleteSession).mockResolvedValue(true)
+
+      const res = await deleteReq(app, url(OWN_SESSION))
+
+      expect(res.status).toBe(204)
+      expect(messagePersister.unsubscribeFromSession).toHaveBeenCalledWith(OWN_SESSION)
+      expect(deleteSession).toHaveBeenCalledWith(ATTACKER, OWN_SESSION)
     })
   })
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -49,6 +49,8 @@ import {
   getSession,
   getSessionMetadata,
   sessionExists,
+  sessionBelongsToAgent,
+  reserveSessionOwnership,
   sessionIsKnown,
   isSessionRegistered,
   updateSessionMetadata,
@@ -1619,6 +1621,11 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     })
     const sessionId = containerSession.id
 
+    // Claim the globally keyed id before any lifecycle state becomes visible.
+    // Metadata registration below is intentionally later so stream attachment
+    // still wins the race with early container output.
+    await reserveSessionOwnership(slug, sessionId)
+
     // Attach lifecycle state and the stream before slower metadata/DB work. The
     // first turn can start emitting shortly after createSession returns, and a
     // blocking input emitted during that window must not be missed or reset.
@@ -1701,7 +1708,10 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     // No JSONL transcript on disk — e.g. it was deleted by the CLI's retention
     // cleanup while the metadata entry lingers in the nav. Signal this distinctly
     // from an empty (but present) transcript so the UI can show a clear message.
-    if (!(await sessionExists(agentSlug, sessionId))) {
+    if (
+      !(await sessionBelongsToAgent(agentSlug, sessionId)) ||
+      !(await sessionExists(agentSlug, sessionId))
+    ) {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
@@ -2140,7 +2150,11 @@ agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
     // subscription on the way to a 404. This costs no deletability — it accepts
     // exactly the "transcript OR metadata entry exists" condition that
     // deleteSession itself reports success for.
-    if (!(await sessionIsKnown(agentSlug, sessionId))) {
+    if (
+      !(await sessionBelongsToAgent(agentSlug, sessionId)) ||
+      (!(await sessionExists(agentSlug, sessionId)) &&
+        !(await isSessionRegistered(agentSlug, sessionId)))
+    ) {
       return c.json({ error: 'Session not found' }, 404)
     }
 
@@ -2186,10 +2200,7 @@ agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
 agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
   const agentSlug = getAgentId(c)
   const sessionId = c.req.param('sessionId')
-  if (
-    !(await sessionExists(agentSlug, sessionId)) &&
-    !(await isSessionRegistered(agentSlug, sessionId))
-  ) {
+  if (!(await sessionIsKnown(agentSlug, sessionId))) {
     return c.json({ error: 'Session not found' }, 404)
   }
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1901,6 +1901,14 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
 
     const runtimeOptions = parseRuntimeOptions(body)
 
+    // cancelAwaitingInput / markSessionActive / broadcastSessionEvent below are
+    // all keyed by session id alone: an unowned id would cancel another agent's
+    // pending input request, re-bind its session to this agent, and inject a
+    // spoofed user message into every client watching it.
+    if (!(await sessionIsKnown(agentSlug, sessionId))) {
+      return c.json({ error: 'Session not found' }, 404)
+    }
+
     const agent = await getAgent(agentSlug)
     if (!agent) {
       return c.json({ error: 'Agent not found' }, 404)
@@ -2018,6 +2026,12 @@ agents.post('/:id/sessions/:sessionId/typing', AgentUser(), async (c) => {
   const sessionId = c.req.param('sessionId')
   const user = c.get('user' as never) as { id: string; name: string }
 
+  // Otherwise this puts the caller's name in the typing indicator of a session
+  // in someone else's agent.
+  if (!(await sessionIsKnown(getAgentId(c), sessionId))) {
+    return c.json({ error: 'Session not found' }, 404)
+  }
+
   messagePersister.broadcastSessionEvent(sessionId, {
     type: 'user_typing',
     sender: { id: user.id, name: user.name },
@@ -2121,6 +2135,17 @@ agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
     const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
+    // Ownership first: unsubscribeFromSession below is keyed by session id
+    // alone, so on a foreign id it would tear down another agent's live message
+    // subscription on the way to a 404. This costs no deletability — it accepts
+    // exactly the "transcript OR metadata entry exists" condition that
+    // deleteSession itself reports success for.
+    if (!(await sessionIsKnown(agentSlug, sessionId))) {
+      return c.json({ error: 'Session not found' }, 404)
+    }
+
+    // Before the delete, so an in-flight append can't recreate the transcript
+    // just after it is unlinked.
     messagePersister.unsubscribeFromSession(sessionId)
 
     // deleteSession is the authority for existence here: it removes the JSONL
@@ -2247,11 +2272,18 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
 
 // POST /api/agents/:id/sessions/:sessionId/interrupt - Interrupt an active session
 agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
+  const agentSlug = getAgentId(c)
+  const sessionId = c.req.param('sessionId')
+
+  // Outside the try on purpose. Every path below — including the catch — ends in
+  // markSessionInterrupted, which is keyed by session id alone across all agents,
+  // so an unowned id reaching any of them wipes another agent's live session
+  // state and tells its viewers it went idle.
+  if (!(await sessionIsKnown(agentSlug, sessionId))) {
+    return c.json({ error: 'Session not found' }, 404)
+  }
+
   try {
-    const agentSlug = getAgentId(c)
-    const sessionId = c.req.param('sessionId')
-
-
     const client = containerManager.getClient(agentSlug)
     // Use cached status to avoid spawning docker process
     const info = containerManager.getCachedInfo(agentSlug)
@@ -2280,12 +2312,11 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
     return c.json({ success: true })
   } catch (error) {
     console.error('Failed to interrupt session:', error)
-    // Even on error, try to mark session as interrupted to fix UI state
+    // Even on error, try to mark session as interrupted to fix UI state.
+    // Ownership was established above, so this reaches only the caller's session.
     try {
-      const sessionId = c.req.param('sessionId')
-      const agentSlugFallback = getAgentId(c)
       await messagePersister.markSessionInterrupted(sessionId)
-      reviewManager.denyAllForAgent(agentSlugFallback)
+      reviewManager.denyAllForAgent(agentSlug)
       return c.json({ success: true, note: 'Error during interrupt, but session marked inactive' })
     } catch {
       return c.json({ error: 'Failed to interrupt session' }, 500)

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -249,7 +249,7 @@ vi.mock('@shared/lib/services/agent-service', () => ({
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
-  sessionExists: vi.fn().mockResolvedValue(true), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  sessionExists: vi.fn().mockResolvedValue(true), sessionBelongsToAgent: vi.fn().mockResolvedValue(true), reserveSessionOwnership: vi.fn().mockResolvedValue(undefined), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
 }))

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -78,12 +78,14 @@ const mockGetTranscript = vi.fn((..._args: unknown[]): unknown => undefined)
 const mockRegisterSession = vi.fn(async (..._args: unknown[]) => {})
 const mockUpdateSessionMetadata = vi.fn(async (..._args: unknown[]) => {})
 const mockGetSessionMetadata = vi.fn(async (..._args: unknown[]): Promise<unknown> => null)
+const mockSessionIsKnown = vi.fn(async (..._args: unknown[]) => true)
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: (...args: unknown[]) => mockListSessions(...args),
   getSessionMessagesWithCompact: (...args: unknown[]) => mockGetTranscript(...args),
   registerSession: (...args: unknown[]) => mockRegisterSession(...args),
   updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
   getSessionMetadata: (...args: unknown[]) => mockGetSessionMetadata(...args),
+  sessionIsKnown: (...args: unknown[]) => mockSessionIsKnown(...args),
 }))
 
 // Container manager
@@ -105,15 +107,17 @@ vi.mock('@shared/lib/container/container-manager', () => ({
 const mockIsSessionActive = vi.fn((_sessionId?: string): boolean => false)
 const mockIsSessionAwaitingInput = vi.fn((_sessionId?: string): boolean => false)
 const mockWaitForIdle = vi.fn(async (..._args: unknown[]) => {})
+const mockSubscribeToSession = vi.fn()
+const mockMarkSessionActive = vi.fn()
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
     isSessionActive: (sessionId?: string) => mockIsSessionActive(sessionId),
     isSessionAwaitingInput: (sessionId?: string) => mockIsSessionAwaitingInput(sessionId),
     waitForIdle: (...args: unknown[]) => mockWaitForIdle(...args),
-    isSubscribed: vi.fn(() => true),
-    subscribeToSession: vi.fn(),
+    isSubscribed: vi.fn(() => false),
+    subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
     unsubscribeFromSession: vi.fn(),
-    markSessionActive: vi.fn(),
+    markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
     setSlashCommands: vi.fn(),
   },
 }))
@@ -233,6 +237,7 @@ beforeEach(async () => {
   mockIsSessionActive.mockReturnValue(false)
   mockIsSessionAwaitingInput.mockReturnValue(false)
   mockWaitForIdle.mockResolvedValue(undefined)
+  mockSessionIsKnown.mockResolvedValue(true)
   mockReadAgentPreferences.mockResolvedValue({})
   mockGetSessionMetadata.mockResolvedValue(null)
   mockEnsureRunning.mockClear()
@@ -712,6 +717,30 @@ describe('/invoke', () => {
         userId: OTHER_USER_ID,
       }),
     ])
+  })
+
+  it('404s when the continued session belongs to some other agent', async () => {
+    // Invoke rights on the target say nothing about the session id passed with
+    // them. Without an ownership check, a caller allowed to invoke the target
+    // could name a THIRD agent's session and have the persister re-point it at
+    // the target's container — and the target's transcript written under it.
+    reviewDecisions.push('allow')
+    await grantCallerOwnerTargetAccess()
+    mockSessionIsKnown.mockResolvedValue(false)
+
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'follow-up',
+      sessionId: 'third-agent-session',
+    })
+
+    expect(res.status).toBe(404)
+    // Checked against the TARGET, whose container the session would be driven
+    // on — not the caller, who never owns it either way.
+    expect(mockSessionIsKnown).toHaveBeenCalledWith(TARGET_SLUG, 'third-agent-session')
+    expect(mockSubscribeToSession).not.toHaveBeenCalled()
+    expect(mockMarkSessionActive).not.toHaveBeenCalled()
+    expect(mockSendMessage).not.toHaveBeenCalled()
   })
 
   it('removes continued-session attribution when sendMessage fails', async () => {

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -79,10 +79,12 @@ const mockRegisterSession = vi.fn(async (..._args: unknown[]) => {})
 const mockUpdateSessionMetadata = vi.fn(async (..._args: unknown[]) => {})
 const mockGetSessionMetadata = vi.fn(async (..._args: unknown[]): Promise<unknown> => null)
 const mockSessionIsKnown = vi.fn(async (..._args: unknown[]) => true)
+const mockReserveSessionOwnership = vi.fn(async (..._args: unknown[]) => {})
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: (...args: unknown[]) => mockListSessions(...args),
   getSessionMessagesWithCompact: (...args: unknown[]) => mockGetTranscript(...args),
   registerSession: (...args: unknown[]) => mockRegisterSession(...args),
+  reserveSessionOwnership: (...args: unknown[]) => mockReserveSessionOwnership(...args),
   updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
   getSessionMetadata: (...args: unknown[]) => mockGetSessionMetadata(...args),
   sessionIsKnown: (...args: unknown[]) => mockSessionIsKnown(...args),
@@ -476,6 +478,10 @@ describe('/invoke', () => {
       expect.objectContaining({ initialMessage: 'hello' }),
     )
     expect(mockCreateSession.mock.calls[0][0]).not.toHaveProperty('initialMessageUuid')
+    expect(mockReserveSessionOwnership).toHaveBeenCalledWith(TARGET_SLUG, 'new-sess-id')
+    expect(mockReserveSessionOwnership.mock.invocationCallOrder[0]).toBeLessThan(
+      mockMarkSessionActive.mock.invocationCallOrder[0],
+    )
     expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
       TARGET_SLUG,
       'new-sess-id',
@@ -1167,6 +1173,24 @@ describe('/get-transcript', () => {
       content: 'hi\n[tool_use: Bash]',
       toolName: 'Bash',
     })
+  })
+
+  it('404s before consulting global status for a session outside the target', async () => {
+    reviewDecisions.push('allow')
+    mockSessionIsKnown.mockResolvedValue(false)
+
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'third-agent-session',
+      sync: true,
+    })
+
+    expect(res.status).toBe(404)
+    expect(mockSessionIsKnown).toHaveBeenCalledWith(TARGET_SLUG, 'third-agent-session')
+    expect(mockIsSessionActive).not.toHaveBeenCalled()
+    expect(mockIsSessionAwaitingInput).not.toHaveBeenCalled()
+    expect(mockWaitForIdle).not.toHaveBeenCalled()
+    expect(mockGetTranscript).not.toHaveBeenCalled()
   })
 
   it('reports running / awaiting_input status', async () => {

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -32,6 +32,7 @@ import {
   getSessionMessagesWithCompact,
   getSessionMetadata,
   registerSession,
+  reserveSessionOwnership,
   updateSessionMetadata,
   sessionIsKnown,
 } from '@shared/lib/services/session-service'
@@ -508,6 +509,13 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
     return c.json({ error: policy.reason ?? 'Forbidden' }, 403)
   }
 
+  // Status and wait state live in the process-global persister. Validate the
+  // target/session pair before consulting it, not only before reading the
+  // target-scoped transcript below.
+  if (!(await sessionIsKnown(targetSlug, sessionId))) {
+    return c.json({ error: 'Session not found' }, 404)
+  }
+
   if (sync && messagePersister.isSessionActive(sessionId)) {
     try {
       await messagePersister.waitForIdle(sessionId)
@@ -712,6 +720,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         maxBrowserTabs: getSettings().app?.maxBrowserTabs,
       })
       const newSessionId = containerSession.id
+      await reserveSessionOwnership(targetSlug, newSessionId)
       // Mark active before any await so waitForIdle sees state if result arrives early.
       messagePersister.markSessionActive(newSessionId, targetSlug)
 

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -33,6 +33,7 @@ import {
   getSessionMetadata,
   registerSession,
   updateSessionMetadata,
+  sessionIsKnown,
 } from '@shared/lib/services/session-service'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { messagePersister } from '@shared/lib/container/message-persister'
@@ -621,6 +622,13 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
     let stage = 'ensure_running'
     try {
       if (existingSessionId) {
+        // Invoke rights on the target say nothing about the session id sent
+        // with them. The persister is keyed by session id alone, so a third
+        // agent's id would get re-pointed at the target's container here — and
+        // the target's transcript written under it.
+        if (!(await sessionIsKnown(targetSlug, existingSessionId))) {
+          return c.json({ error: 'Session not found' }, 404)
+        }
         if (messagePersister.isSessionActive(existingSessionId)) {
           return c.json({ error: 'Target session is currently running' }, 409)
         }

--- a/src/shared/lib/services/session-service.ownership.test.ts
+++ b/src/shared/lib/services/session-service.ownership.test.ts
@@ -31,6 +31,12 @@ function makeAgent(slug: string): void {
 function writeTranscript(slug: string, sessionId: string): void {
   fs.writeFileSync(path.join(sessionsDir(slug), `${sessionId}.jsonl`), '{}\n')
 }
+function writeMetadata(slug: string, metadata: Record<string, unknown>): void {
+  fs.writeFileSync(
+    path.join(workspaceDir(slug), 'session-metadata.json'),
+    JSON.stringify(metadata),
+  )
+}
 
 beforeEach(() => {
   tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'session-own-')))
@@ -125,6 +131,74 @@ describe('sessionIsKnown', () => {
 
     expect(await sessionIsKnown('agent-a', 'b-on-disk')).toBe(false)
     expect(await sessionIsKnown('agent-a', 'b-registered')).toBe(false)
+  })
+
+  it('rejects a forged duplicate transcript in an agent-writable workspace', async () => {
+    const { sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    writeTranscript('agent-b', 'victim-session')
+
+    // Initialize and persist the host-owned owner before the attacker writes a
+    // same-named file into its own bind-mounted workspace.
+    expect(await sessionIsKnown('agent-b', 'victim-session')).toBe(true)
+    writeTranscript('agent-a', 'victim-session')
+
+    expect(await sessionIsKnown('agent-a', 'victim-session')).toBe(false)
+    expect(await sessionIsKnown('agent-b', 'victim-session')).toBe(true)
+    expect(
+      JSON.parse(fs.readFileSync(path.join(tmpDir, 'session-ownership.json'), 'utf-8')),
+    ).toEqual({ 'victim-session': 'agent-b' })
+  })
+
+  it('fails closed when duplicate transcripts predate ownership migration', async () => {
+    const { sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    writeTranscript('agent-a', 'duplicate-session')
+    writeTranscript('agent-b', 'duplicate-session')
+
+    expect(await sessionIsKnown('agent-a', 'duplicate-session')).toBe(false)
+    expect(await sessionIsKnown('agent-b', 'duplicate-session')).toBe(false)
+    expect(
+      JSON.parse(fs.readFileSync(path.join(tmpDir, 'session-ownership.json'), 'utf-8')),
+    ).toEqual({ 'duplicate-session': null })
+  })
+
+  it('rejects forged metadata for a session registered to another agent', async () => {
+    const { registerSession, sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    await registerSession('agent-b', 'victim-session', 'Victim')
+    writeMetadata('agent-a', {
+      'victim-session': { name: 'Forged', createdAt: new Date().toISOString() },
+    })
+
+    expect(await sessionIsKnown('agent-a', 'victim-session')).toBe(false)
+    expect(await sessionIsKnown('agent-b', 'victim-session')).toBe(true)
+  })
+
+  it('does not discover forged ids after the one-time legacy migration', async () => {
+    const { sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+
+    expect(await sessionIsKnown('agent-a', 'missing-before-migration')).toBe(false)
+    writeTranscript('agent-a', 'forged-after-migration')
+
+    expect(await sessionIsKnown('agent-a', 'forged-after-migration')).toBe(false)
+  })
+
+  it('reserves a new id before either workspace contains its transcript', async () => {
+    const { reserveSessionOwnership, sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+
+    await reserveSessionOwnership('agent-b', 'future-session')
+    writeTranscript('agent-a', 'future-session')
+    writeTranscript('agent-b', 'future-session')
+
+    expect(await sessionIsKnown('agent-a', 'future-session')).toBe(false)
+    expect(await sessionIsKnown('agent-b', 'future-session')).toBe(true)
   })
 
   it('rejects an unknown session id', async () => {

--- a/src/shared/lib/services/session-service.ownership.test.ts
+++ b/src/shared/lib/services/session-service.ownership.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Session ownership: a session id only ever "belongs to" the agent that owns it.
+ *
+ * The process-global registries keyed by session id alone (the message
+ * persister, above all) have no agent dimension, so any route that reaches them
+ * has to establish ownership itself. `sessionIsKnown` is that check, and
+ * these tests pin the three properties it has to hold:
+ *
+ *   1. a session of ANOTHER agent never passes;
+ *   2. a session that exists only on disk, or only in metadata, still passes
+ *      (the two halves are written at different times);
+ *   3. an id that isn't a real key — an inherited `Object.prototype` name, or a
+ *      path that escapes the agent's session directory — never passes.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+let tmpDir: string
+
+function workspaceDir(slug: string): string {
+  return path.join(tmpDir, 'agents', slug, 'workspace')
+}
+function sessionsDir(slug: string): string {
+  return path.join(workspaceDir(slug), '.claude', 'projects', '-workspace')
+}
+function makeAgent(slug: string): void {
+  fs.mkdirSync(sessionsDir(slug), { recursive: true })
+}
+function writeTranscript(slug: string, sessionId: string): void {
+  fs.writeFileSync(path.join(sessionsDir(slug), `${sessionId}.jsonl`), '{}\n')
+}
+
+beforeEach(() => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'session-own-')))
+  process.env.SUPERAGENT_DATA_DIR = tmpDir
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+  delete process.env.SUPERAGENT_DATA_DIR
+  vi.restoreAllMocks()
+})
+
+async function importService() {
+  return import('./session-service')
+}
+
+// Names inherited from Object.prototype. A membership test written with `in`
+// (or a truthiness test on a bare index read) answers "yes" for every one of
+// them, which turns an ownership gate into a no-op for these ids.
+const INHERITED_KEYS = [
+  'constructor',
+  'toString',
+  'hasOwnProperty',
+  'valueOf',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+]
+
+describe('isSessionRegistered', () => {
+  it('is true only for a session actually registered for that agent', async () => {
+    const { registerSession, isSessionRegistered } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    await registerSession('agent-a', 'session-a', 'A')
+    await registerSession('agent-b', 'session-b', 'B')
+
+    expect(await isSessionRegistered('agent-a', 'session-a')).toBe(true)
+    expect(await isSessionRegistered('agent-a', 'session-b')).toBe(false)
+    expect(await isSessionRegistered('agent-b', 'session-a')).toBe(false)
+  })
+
+  it.each(INHERITED_KEYS)('is false for the inherited key %s', async (key) => {
+    const { registerSession, isSessionRegistered } = await importService()
+    makeAgent('agent-a')
+    await registerSession('agent-a', 'session-a', 'A')
+
+    expect(await isSessionRegistered('agent-a', key)).toBe(false)
+  })
+
+  it('is false for inherited keys even when the agent has no metadata at all', async () => {
+    const { isSessionRegistered } = await importService()
+    makeAgent('empty-agent')
+
+    expect(await isSessionRegistered('empty-agent', 'constructor')).toBe(false)
+  })
+})
+
+describe('getSessionMetadata', () => {
+  it.each(INHERITED_KEYS)('returns null for the inherited key %s', async (key) => {
+    const { registerSession, getSessionMetadata } = await importService()
+    makeAgent('agent-a')
+    await registerSession('agent-a', 'session-a', 'A')
+
+    expect(await getSessionMetadata('agent-a', key)).toBeNull()
+  })
+})
+
+describe('sessionIsKnown', () => {
+  it('accepts a session with a transcript but no metadata entry', async () => {
+    const { sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    writeTranscript('agent-a', 'on-disk-only')
+
+    expect(await sessionIsKnown('agent-a', 'on-disk-only')).toBe(true)
+  })
+
+  it('accepts a just-registered session whose transcript does not exist yet', async () => {
+    const { registerSession, sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    await registerSession('agent-a', 'brand-new', 'New Session')
+
+    expect(await sessionIsKnown('agent-a', 'brand-new')).toBe(true)
+  })
+
+  it('rejects another agent’s session, by transcript or by metadata', async () => {
+    const { registerSession, sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    writeTranscript('agent-b', 'b-on-disk')
+    await registerSession('agent-b', 'b-registered', 'B')
+
+    expect(await sessionIsKnown('agent-a', 'b-on-disk')).toBe(false)
+    expect(await sessionIsKnown('agent-a', 'b-registered')).toBe(false)
+  })
+
+  it('rejects an unknown session id', async () => {
+    const { sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+
+    expect(await sessionIsKnown('agent-a', 'never-existed')).toBe(false)
+  })
+
+  it.each(INHERITED_KEYS)('rejects the inherited key %s', async (key) => {
+    const { registerSession, sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    await registerSession('agent-a', 'session-a', 'A')
+
+    expect(await sessionIsKnown('agent-a', key)).toBe(false)
+  })
+
+  it('rejects — without throwing — an id that escapes the agent’s session directory', async () => {
+    const { sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    writeTranscript('agent-b', 'b-session')
+
+    // Resolves onto agent-b's real transcript. A raw sessionExists() call throws
+    // 'Invalid session ID' here; the gate has to answer false, because a caller
+    // that lets the throw escape hands the request to whatever its catch does.
+    const escaping = '../../../../../agent-b/workspace/.claude/projects/-workspace/b-session'
+    await expect(sessionIsKnown('agent-a', escaping)).resolves.toBe(false)
+  })
+
+  it('rejects a bare traversal id without throwing', async () => {
+    const { sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+
+    await expect(sessionIsKnown('agent-a', '../../../etc/passwd')).resolves.toBe(false)
+  })
+})

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -929,7 +929,9 @@ describe('session-service', () => {
 
       try {
         expect(await sessionIsKnown('test-agent', 'test-session')).toBe(true)
-        expect(openSpy).not.toHaveBeenCalled()
+        expect(
+          openSpy.mock.calls.some(([file]) => String(file).endsWith('test-session.jsonl')),
+        ).toBe(false)
       } finally {
         openSpy.mockRestore()
       }

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -168,7 +168,9 @@ export async function getSessionMetadata(
   sessionId: string
 ): Promise<SessionMetadata | null> {
   const metadata = await readSessionMetadata(agentSlug)
-  return metadata[sessionId] || null
+  // Own-property check for the same reason as isSessionRegistered: a bare index
+  // read returns an inherited Object.prototype member for ids like 'constructor'.
+  return Object.hasOwn(metadata, sessionId) ? metadata[sessionId] : null
 }
 
 /**
@@ -192,13 +194,17 @@ export async function registerSession(
 
 /**
  * Check if a session is registered (exists in metadata)
+ *
+ * `Object.hasOwn`, not `in` / a bare index read: the metadata map is an ordinary
+ * object, so every `Object.prototype` name ('constructor', 'toString', …) would
+ * otherwise answer "registered" and walk straight through any gate built on this.
  */
 export async function isSessionRegistered(
   agentSlug: string,
   sessionId: string
 ): Promise<boolean> {
   const metadata = await readSessionMetadata(agentSlug)
-  return sessionId in metadata
+  return Object.hasOwn(metadata, sessionId)
 }
 
 // ============================================================================
@@ -661,7 +667,7 @@ export async function deleteSession(
   // being rewritten without this entry's siblings.
   let hadMetadata = false
   await mutateSessionMetadata(agentSlug, (metadata) => {
-    hadMetadata = metadata[sessionId] !== undefined
+    hadMetadata = Object.hasOwn(metadata, sessionId)
     if (!hadMetadata) return false // nothing to delete — skip the write
     delete metadata[sessionId]
     return true
@@ -704,7 +710,7 @@ export async function deleteSessionsBatch(
     await mutateSessionMetadata(agentSlug, (metadata) => {
       let changed = false
       for (const sessionId of deleted) {
-        if (metadata[sessionId] !== undefined) {
+        if (Object.hasOwn(metadata, sessionId)) {
           delete metadata[sessionId]
           changed = true
         }
@@ -739,17 +745,37 @@ export async function sessionExists(
 }
 
 /**
- * Whether a session exists at all — a written transcript, or a registration for
- * one whose agent hasn't streamed its first message yet. This is exactly the
- * rule getSession returns non-null on, but it costs a stat and a metadata read
- * instead of a full transcript pass. Use it for 404 guards that don't go on to
- * read any SessionInfo field.
+ * Whether `sessionId` names a session OF THIS AGENT — a written transcript, or a
+ * registration for one whose agent hasn't streamed its first message yet. This
+ * is exactly the rule getSession returns non-null on, but it costs a stat and a
+ * metadata read instead of a full transcript pass. Use it for 404 guards that
+ * don't go on to read any SessionInfo field.
+ *
+ * Both halves are needed: the transcript lands only once the first turn writes,
+ * and the metadata entry covers the window from `registerSession` up to then.
+ *
+ * It is also the ownership gate for every route that reaches a registry keyed by
+ * session id ALONE — above all the message persister, which is process-global
+ * and has no agent dimension. Authorizing the agent in the URL says nothing
+ * about the session id in it, so without this a caller with a role on their own
+ * agent drives a stranger's live session.
+ *
+ * Never throws. `getSessionJsonlPath` rejects ids that escape the agent's
+ * session directory, and an id that cannot even name a file under this agent
+ * cannot be one of its sessions. Letting that throw escape would hand the
+ * request to the caller's `catch`, and interrupt's deliberately marks the
+ * session interrupted on the error path — the exact thing the gate exists to
+ * stop.
  */
 export async function sessionIsKnown(
   agentSlug: string,
   sessionId: string
 ): Promise<boolean> {
-  if (await sessionExists(agentSlug, sessionId)) return true
+  try {
+    if (await sessionExists(agentSlug, sessionId)) return true
+  } catch {
+    return false
+  }
   const metadata = await getSessionMetadata(agentSlug, sessionId)
   return Boolean(metadata?.createdAt)
 }

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import pLimit from 'p-limit'
+import { z } from 'zod'
 import {
   getAgentsDir,
   getAgentSessionsDir,
@@ -38,6 +39,167 @@ import {
   ContentBlock,
 } from '@shared/lib/types/agent'
 import { captureException } from '@shared/lib/error-reporting'
+
+// Session transcripts and metadata live inside the agent workspace, which is
+// bind-mounted read/write into its container. They are therefore evidence that
+// a session exists, but NOT authoritative proof of which agent owns a globally
+// keyed session id: an agent can create arbitrary files in its own workspace.
+//
+// Keep the ownership index one directory above all workspaces so containers
+// cannot forge it. `null` is a fail-closed tombstone for a duplicate id found
+// during legacy migration; it must never be claimed implicitly by either agent.
+const sessionOwnershipMapSchema = z.record(z.string(), z.string().nullable())
+type SessionOwnershipMap = z.infer<typeof sessionOwnershipMapSchema>
+const sessionOwnershipByPath = new Map<string, Promise<SessionOwnershipMap>>()
+
+function getSessionOwnershipPath(): string {
+  return path.join(path.dirname(getAgentsDir()), 'session-ownership.json')
+}
+
+async function candidateSessionIdsForAgent(agentSlug: string): Promise<Set<string>> {
+  const ids = new Set(Object.keys(await readSessionMetadata(agentSlug)))
+  const sessionsDir = getAgentSessionsDir(agentSlug)
+  try {
+    const files = await fs.promises.readdir(sessionsDir)
+    for (const file of files) {
+      if (file.endsWith('.jsonl')) ids.add(file.slice(0, -'.jsonl'.length))
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  return new Set([...ids].filter((sessionId) => {
+    try {
+      getSessionJsonlPath(agentSlug, sessionId)
+      return true
+    } catch {
+      return false
+    }
+  }))
+}
+
+async function discoverSessionOwners(): Promise<SessionOwnershipMap> {
+  const discovered = Object.create(null) as SessionOwnershipMap
+  for (const agentSlug of await listDirectories(getAgentsDir())) {
+    const ids = await candidateSessionIdsForAgent(agentSlug)
+    for (const id of ids) {
+      if (!Object.hasOwn(discovered, id)) {
+        discovered[id] = agentSlug
+      } else if (discovered[id] !== agentSlug) {
+        discovered[id] = null
+      }
+    }
+  }
+  return discovered
+}
+
+async function loadSessionOwnershipMap(): Promise<SessionOwnershipMap> {
+  const ownershipPath = getSessionOwnershipPath()
+  const cached = sessionOwnershipByPath.get(ownershipPath)
+  if (cached) return cached
+
+  const loading = withFileLock(ownershipPath, async () => {
+    const existed = await fileExists(ownershipPath)
+    const stored = await readJsonFileStrict(ownershipPath, sessionOwnershipMapSchema, {})
+    if (existed) {
+      return Object.assign(Object.create(null) as SessionOwnershipMap, stored)
+    }
+
+    const migrated = await discoverSessionOwners()
+    await ensureDirectory(path.dirname(ownershipPath))
+    await writeJsonFileAtomic(ownershipPath, migrated)
+    return migrated
+  })
+  sessionOwnershipByPath.set(ownershipPath, loading)
+  try {
+    return await loading
+  } catch (error) {
+    if (sessionOwnershipByPath.get(ownershipPath) === loading) {
+      sessionOwnershipByPath.delete(ownershipPath)
+    }
+    throw error
+  }
+}
+
+async function mutateSessionOwnership(
+  mutator: (owners: SessionOwnershipMap) => boolean,
+): Promise<void> {
+  const ownershipPath = getSessionOwnershipPath()
+  const owners = await loadSessionOwnershipMap()
+  await withFileLock(ownershipPath, async () => {
+    const next = Object.assign(Object.create(null) as SessionOwnershipMap, owners)
+    if (!mutator(next)) return
+    await writeJsonFileAtomic(ownershipPath, next)
+    for (const sessionId of Object.keys(owners)) delete owners[sessionId]
+    Object.assign(owners, next)
+  })
+}
+
+async function claimSessionOwnership(agentSlug: string, sessionId: string): Promise<boolean> {
+  // Apply the same containment check used by transcript operations before an
+  // externally produced id can become a durable registry key.
+  getSessionJsonlPath(agentSlug, sessionId)
+  let newlyClaimed = false
+  await mutateSessionOwnership((owners) => {
+    if (!Object.hasOwn(owners, sessionId)) {
+      owners[sessionId] = agentSlug
+      newlyClaimed = true
+      return true
+    }
+    if (owners[sessionId] !== agentSlug) {
+      throw new Error(`Session ${sessionId} is already owned by another agent`)
+    }
+    return false
+  })
+  return newlyClaimed
+}
+
+async function releaseSessionOwnership(agentSlug: string, sessionIds: string[]): Promise<void> {
+  await mutateSessionOwnership((owners) => {
+    let changed = false
+    for (const sessionId of sessionIds) {
+      if (owners[sessionId] === agentSlug) {
+        delete owners[sessionId]
+        changed = true
+      }
+    }
+    return changed
+  })
+}
+
+async function resolveSessionOwner(sessionId: string): Promise<string | null | undefined> {
+  const owners = await loadSessionOwnershipMap()
+  return Object.hasOwn(owners, sessionId) ? owners[sessionId] : undefined
+}
+
+/**
+ * Reserve a newly allocated session id before exposing it through any
+ * process-global lifecycle registry. Registration calls this again
+ * idempotently when it persists the display metadata.
+ */
+export async function reserveSessionOwnership(
+  agentSlug: string,
+  sessionId: string,
+): Promise<void> {
+  await claimSessionOwnership(agentSlug, sessionId)
+}
+
+/**
+ * Authoritative ownership check for registries keyed by session id alone.
+ * Unlike transcript/metadata existence, this cannot be forged from inside an
+ * agent container because the ownership file is outside its mounted workspace.
+ */
+export async function sessionBelongsToAgent(
+  agentSlug: string,
+  sessionId: string,
+): Promise<boolean> {
+  // Validate the externally supplied id before considering a registry entry.
+  try {
+    getSessionJsonlPath(agentSlug, sessionId)
+  } catch {
+    return false
+  }
+  return (await resolveSessionOwner(sessionId)) === agentSlug
+}
 
 // ============================================================================
 // Session Metadata (custom names, starred status)
@@ -183,13 +345,19 @@ export async function registerSession(
   name?: string,
   initialMetadata?: Partial<SessionMetadata>,
 ): Promise<void> {
-  await mutateSessionMetadata(agentSlug, (metadata) => {
-    metadata[sessionId] = {
-      ...initialMetadata,
-      name: name || 'New Session',
-      createdAt: new Date().toISOString(),
-    }
-  })
+  const newlyClaimed = await claimSessionOwnership(agentSlug, sessionId)
+  try {
+    await mutateSessionMetadata(agentSlug, (metadata) => {
+      metadata[sessionId] = {
+        ...initialMetadata,
+        name: name || 'New Session',
+        createdAt: new Date().toISOString(),
+      }
+    })
+  } catch (error) {
+    if (newlyClaimed) await releaseSessionOwnership(agentSlug, [sessionId]).catch(() => {})
+    throw error
+  }
 }
 
 /**
@@ -403,20 +571,24 @@ export async function getSessionSummary(agentSlug: string): Promise<{
   const stats = await Promise.all(
     jsonlFiles.map((file) => limit(async () => {
       const stat = await fs.promises.stat(path.join(sessionsDir, file))
-      return { sessionId: path.basename(file, '.jsonl'), mtimeMs: stat.mtimeMs }
+      const sessionId = path.basename(file, '.jsonl')
+      if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
+      return { sessionId, mtimeMs: stat.mtimeMs }
     }))
   )
 
   let lastActivityAt: Date | null = null
   const sessionIds: string[] = []
-  for (const { sessionId, mtimeMs } of stats) {
+  for (const entry of stats) {
+    if (!entry) continue
+    const { sessionId, mtimeMs } = entry
     sessionIds.push(sessionId)
     if (!lastActivityAt || mtimeMs > lastActivityAt.getTime()) {
       lastActivityAt = new Date(mtimeMs)
     }
   }
 
-  return { sessionIds, sessionCount: jsonlFiles.length, lastActivityAt }
+  return { sessionIds, sessionCount: sessionIds.length, lastActivityAt }
 }
 
 /**
@@ -463,6 +635,8 @@ export async function listSessions(
       const { sessionId, stat } = result
       processedSessionIds.add(sessionId)
 
+      if (!(await sessionBelongsToAgent(agentSlug, sessionId))) continue
+
       // Skip empty JSONL files that aren't registered in metadata
       // These are typically created by Claude SDK for subagent directories
       if (stat.size === 0 && !metadata[sessionId]) {
@@ -489,6 +663,7 @@ export async function listSessions(
   // (newly created sessions where the agent hasn't streamed yet)
   for (const [sessionId, sessionMeta] of Object.entries(metadata)) {
     if (!processedSessionIds.has(sessionId) && sessionMeta.createdAt) {
+      if (!(await sessionBelongsToAgent(agentSlug, sessionId))) continue
       // Skip scheduled/webhook sessions when requested
       if (options?.excludeAutomated && isAutomated(sessionId)) {
         continue
@@ -524,6 +699,7 @@ export async function listSessionsByIds(
   const sessions = await Promise.all(
     [...new Set(sessionIds)].map((sessionId) =>
       limit(async (): Promise<SessionInfo | null> => {
+        if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
         if (options?.excludeAutomated && isAutomated(sessionId)) return null
         const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
         try {
@@ -557,6 +733,7 @@ export async function getSession(
   agentSlug: string,
   sessionId: string
 ): Promise<SessionInfo | null> {
+  if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   const metadata = await getSessionMetadata(agentSlug, sessionId)
 
@@ -673,7 +850,9 @@ export async function deleteSession(
     return true
   })
 
-  return jsonlExisted || hadMetadata
+  const deleted = jsonlExisted || hadMetadata
+  if (deleted) await releaseSessionOwnership(agentSlug, [sessionId])
+  return deleted
 }
 
 /**
@@ -717,6 +896,7 @@ export async function deleteSessionsBatch(
       }
       return changed
     })
+    await releaseSessionOwnership(agentSlug, deleted)
   }
 
   return deleted
@@ -771,13 +951,14 @@ export async function sessionIsKnown(
   agentSlug: string,
   sessionId: string
 ): Promise<boolean> {
+  if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return false
   try {
     if (await sessionExists(agentSlug, sessionId)) return true
+    const metadata = await getSessionMetadata(agentSlug, sessionId)
+    return Boolean(metadata?.createdAt)
   } catch {
     return false
   }
-  const metadata = await getSessionMetadata(agentSlug, sessionId)
-  return Boolean(metadata?.createdAt)
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes [SUP-479](https://linear.app/datawizz/issue/SUP-479).

`messagePersister` is a **process-global registry keyed by session id alone** — no agent dimension. Routes authorize the agent in the URL and never check the session id against it, so in `AUTH_MODE=true` a user with a role on their own agent can pass a stranger's session id and drive that session.

## Still open on main

| Route | Reached with an unowned session id |
|---|---|
| `POST …/interrupt` | `markSessionInterrupted` — wipes streaming state, clears `isAwaitingInput`, broadcasts `session_idle` to every viewer (the ticket) |
| `POST …/messages` | `cancelAwaitingInput` on their pending input request, `markSessionActive`, and a `user_message` broadcast attributed to the caller injected into every client watching |
| `POST …/typing` | `broadcastSessionEvent` |
| `DELETE …/:sessionId` | `unsubscribeFromSession` ran *before* the 404 |
| `x-agent POST /invoke` | continued-session id re-pointed at the target's container |

Already closed upstream since this ticket was filed, and left alone here: `stream` (its own inline check), the decision routes (`gateRequestDecision`, which binds the toolUseId to the route's agent *and* session), `computer-use`, `PATCH session`.

## Approach

Reuse the existing `sessionIsKnown()` rather than adding a second helper — main had grown one plus an inline two-check, and this converges on one concept.

Two things worth a close look:

**`sessionIsKnown` no longer throws.** `getSessionJsonlPath` rejects ids that escape the agent's session directory. Letting that throw escape hands the request to the caller's `catch` — and `interrupt`'s deliberately calls `markSessionInterrupted` there to unstick a stale UI. A traversal id would have kept the exact behaviour the gate exists to stop.

**Interrupt's gate sits before the `try`,** not inside it, for the same reason: all three of its paths converge on `markSessionInterrupted` and the error path is one of them.

**`DELETE` is gated rather than reordered.** Moving `unsubscribeFromSession` after the delete would let an in-flight append recreate the just-unlinked transcript. The gate accepts exactly the "transcript OR metadata entry" condition `deleteSession` already reports success for, so nothing becomes undeletable.

## Prototype chain

`isSessionRegistered` used `sessionId in metadata`, and `getSessionMetadata` a bare index read — so `constructor`, `toString` and every other `Object.prototype` name answered as a registered session and walked through any gate built on them. Now `Object.hasOwn`, also in `deleteSession` / `deleteSessionsBatch`.

## Testing

TDD — every test written red first.

- `session-service.ownership.test.ts` (new, real FS): 28 tests — inherited keys, both halves of the gate, foreign-agent rejection, traversal ids resolving onto another agent's real transcript.
- `agents.test.ts`: cross-agent suite asserting the 404 **and** that the global side effect never fired. Interrupt covered on all three paths, including a stubbed container throw that forces the `catch`.
- `x-agent.test.ts`: pins that ownership is checked against the *target*, not the caller.
- `e2e/auth/specs/session-scope-roles.spec.ts` (new, + config project): live auth-mode narrative, two real users, two agents, real HTTP.

Proven red end-to-end: with the gate neutralised the attacker's interrupt of the victim's session returns **200**. With it, 404, and the victim's session survives.

Note for anyone writing multi-user auth specs: the **first** account in an auth-mode install is auto-promoted to admin and admins bypass the agent ACL, so the unprivileged actor has to sign up second.

Full unit suite 8378 passed; `tsc` and `eslint` clean; the 9-test live auth E2E green on the rebased tree.

## Follow-up, not in this PR

A Hono middleware on `/:id/sessions/:sessionId/*` would make this structural instead of per-route. Several routes want different existence semantics and it would add a metadata read to hot GETs that already do their own check, so it seemed wrong to fold into a security patch — but it is the durable fix.

Unrelated, noticed in passing: `e2e/auth/specs/typing-indicator.spec.ts` has no project entry in `playwright.auth.config.ts`, so it never runs.

https://claude.ai/code/session_01CgLbChp2ueHnjMKaekxduV