### PR TITLE
Fix halftone viewport performance

### DIFF
--- a/src/renderer/components/agents/halftone.test.tsx
+++ b/src/renderer/components/agents/halftone.test.tsx
@@ -2,7 +2,7 @@
 import { act } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@renderer/test/test-utils'
-import { Halftone } from './halftone'
+import { Halftone, LazyHalftone } from './halftone'
 import { HalftoneFrameRenderer } from './halftone-renderer'
 
 function createCanvasContext() {
@@ -24,7 +24,7 @@ describe('Halftone animation lifecycle', () => {
     vi.unstubAllGlobals()
   })
 
-  it('pauses its animation while the card is offscreen and resumes on re-entry', () => {
+  it('waits for visibility before starting, then pauses and resumes with intersection', () => {
     let intersectionCallback: IntersectionObserverCallback | undefined
     const disconnectObserver = vi.fn()
     vi.stubGlobal(
@@ -58,8 +58,16 @@ describe('Halftone animation lifecycle', () => {
     const cancelAnimationFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
 
     const { unmount } = renderWithProviders(<Halftone motif="flow_3d" />)
-    expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
     expect(intersectionCallback).toBeTypeOf('function')
+
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
 
     act(() => {
       intersectionCallback?.(
@@ -79,6 +87,79 @@ describe('Halftone animation lifecycle', () => {
 
     unmount()
     expect(disconnectObserver).toHaveBeenCalled()
+  })
+
+  it('does not mount a lazy canvas until its card is near the viewport', () => {
+    const intersectionCallbacks: IntersectionObserverCallback[] = []
+    const disconnectObservers: ReturnType<typeof vi.fn>[] = []
+    const rootMargins: string[] = []
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        disconnect = vi.fn()
+        root = null
+        rootMargin: string
+        thresholds = [0]
+
+        constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+          intersectionCallbacks.push(callback)
+          disconnectObservers.push(this.disconnect)
+          this.rootMargin = options?.rootMargin ?? '0px'
+          rootMargins.push(this.rootMargin)
+        }
+
+        observe() {}
+        unobserve() {}
+        takeRecords() {
+          return []
+        }
+      }
+    )
+
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(240)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(120)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      setTransform: vi.fn(),
+    } as unknown as CanvasRenderingContext2D)
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 1)
+    const cancelAnimationFrame = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => {})
+
+    const { container } = renderWithProviders(<LazyHalftone motif="flow_3d" />)
+    expect(container.querySelector('canvas')).not.toBeInTheDocument()
+    expect(intersectionCallbacks).toHaveLength(1)
+    expect(rootMargins).toEqual(['320px 0px'])
+
+    act(() => {
+      intersectionCallbacks[0](
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    expect(container.querySelector('canvas')).toBeInTheDocument()
+    expect(intersectionCallbacks).toHaveLength(2)
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+
+    act(() => {
+      intersectionCallbacks[1](
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      intersectionCallbacks[0](
+        [{ isIntersecting: false } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    expect(container.querySelector('canvas')).not.toBeInTheDocument()
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1)
+    expect(disconnectObservers[1]).toHaveBeenCalled()
   })
 
   it('recovers when its first measurement is zero-sized', () => {
@@ -229,10 +310,13 @@ describe('Halftone animation lifecycle', () => {
       }
     )
     const intersectionDisconnect = vi.fn()
+    let intersectionCallback: IntersectionObserverCallback | undefined
     vi.stubGlobal(
       'IntersectionObserver',
       class {
-        constructor(_callback: IntersectionObserverCallback) {}
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
         observe() {}
         unobserve() {}
         disconnect = intersectionDisconnect
@@ -256,6 +340,12 @@ describe('Halftone animation lifecycle', () => {
     const removeDocumentListener = vi.spyOn(document, 'removeEventListener')
 
     const { unmount } = renderWithProviders(<Halftone motif="flow_3d" />)
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
     hidden = true
     act(() => document.dispatchEvent(new Event('visibilitychange')))
     expect(cancelAnimationFrame).toHaveBeenCalledWith(1)

--- a/src/renderer/components/agents/halftone.test.tsx
+++ b/src/renderer/components/agents/halftone.test.tsx
@@ -162,6 +162,70 @@ describe('Halftone animation lifecycle', () => {
     expect(disconnectObservers[1]).toHaveBeenCalled()
   })
 
+  it('settles on the newest entry when intersection transitions batch into one callback', () => {
+    const intersectionCallbacks: IntersectionObserverCallback[] = []
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallbacks.push(callback)
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+          return []
+        }
+        root = null
+        rootMargin = '0px'
+        thresholds = [0]
+      }
+    )
+
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(240)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(120)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      setTransform: vi.fn(),
+    } as unknown as CanvasRenderingContext2D)
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 1)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+
+    const { container } = renderWithProviders(<LazyHalftone motif="flow_3d" />)
+
+    // A fast scroll across the lazy margin can deliver enter + exit together.
+    act(() => {
+      intersectionCallbacks[0](
+        [
+          { isIntersecting: true } as IntersectionObserverEntry,
+          { isIntersecting: false } as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver
+      )
+    })
+    expect(container.querySelector('canvas')).not.toBeInTheDocument()
+
+    act(() => {
+      intersectionCallbacks[0](
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    expect(container.querySelector('canvas')).toBeInTheDocument()
+
+    act(() => {
+      intersectionCallbacks[1](
+        [
+          { isIntersecting: true } as IntersectionObserverEntry,
+          { isIntersecting: false } as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver
+      )
+    })
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+  })
+
   it('recovers when its first measurement is zero-sized', () => {
     let resizeCallback: ResizeObserverCallback | undefined
     const observe = vi.fn()

--- a/src/renderer/components/agents/halftone.tsx
+++ b/src/renderer/components/agents/halftone.tsx
@@ -64,7 +64,9 @@ export function LazyHalftone({ className, ...props }: HalftoneProps) {
     }
 
     const observer = new IntersectionObserver(
-      ([entry]) => setShouldMount(entry?.isIntersecting ?? false),
+      // Batched entries arrive oldest-first; only the last reflects the
+      // current state.
+      (entries) => setShouldMount(entries[entries.length - 1]?.isIntersecting ?? false),
       { rootMargin: LAZY_ROOT_MARGIN }
     )
     observer.observe(host)
@@ -237,8 +239,10 @@ export function Halftone({
     const io =
       typeof IntersectionObserver === 'undefined'
         ? null
-        : new IntersectionObserver(([entry]) => {
-            intersecting = entry?.isIntersecting ?? true
+        : new IntersectionObserver((entries) => {
+            // Batched entries arrive oldest-first; only the last reflects the
+            // current state.
+            intersecting = entries[entries.length - 1]?.isIntersecting ?? false
             if (reduce) {
               if (intersecting && ready) draw()
             } else {

--- a/src/renderer/components/agents/halftone.tsx
+++ b/src/renderer/components/agents/halftone.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { cn } from '@shared/lib/utils/cn'
 import {
   HALFTONE_CURSOR_INFLUENCE,
@@ -40,6 +40,42 @@ interface HalftoneProps {
   /** Per-card phase offset so cards aren't all animating in sync. */
   seed?: number
   className?: string
+}
+
+const LAZY_ROOT_MARGIN = '320px 0px'
+
+/**
+ * Keep the decorative canvas out of the DOM until its card is near the
+ * viewport. The lightweight wrapper preserves the widget's geometry while
+ * avoiding canvas backing stores and renderer buffers for distant cards.
+ */
+export function LazyHalftone({ className, ...props }: HalftoneProps) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const [shouldMount, setShouldMount] = useState(
+    () => typeof IntersectionObserver === 'undefined'
+  )
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    if (typeof IntersectionObserver === 'undefined') {
+      setShouldMount(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setShouldMount(entry?.isIntersecting ?? false),
+      { rootMargin: LAZY_ROOT_MARGIN }
+    )
+    observer.observe(host)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={hostRef} className={cn('h-full w-full', className)} aria-hidden>
+      {shouldMount && <Halftone {...props} />}
+    </div>
+  )
 }
 
 export function Halftone({
@@ -139,7 +175,11 @@ export function Halftone({
       renderer.draw(ctx!, t, 'alpha-buckets', mx, my, mActive, frameScale)
     }
 
-    let intersecting = true
+    // IntersectionObserver callbacks are asynchronous. Starting as visible
+    // lets every offscreen card enter its RAF loop before the observer can
+    // classify it, which can starve those callbacks on large home boards.
+    // Browsers without IntersectionObserver retain the eager fallback.
+    let intersecting = typeof IntersectionObserver === 'undefined'
     let pointerListening = false
 
     const setPointerListening = (next: boolean) => {
@@ -184,13 +224,13 @@ export function Halftone({
 
     const ro = new ResizeObserver(() => {
       const measured = setup()
-      if (measured && reduce) draw()
+      if (measured && reduce && intersecting) draw()
       syncAnimation()
     })
     ro.observe(wrap)
 
     if (setup()) {
-      if (reduce) draw()
+      if (reduce && intersecting) draw()
       else syncAnimation()
     }
 

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -8,7 +8,7 @@ import { useMarkSessionNotificationsRead } from '@renderer/hooks/use-notificatio
 import { useHomeCardHealth } from '@renderer/hooks/use-home-card-health'
 import { applyAgentOrder } from '@renderer/lib/agent-ordering'
 import { useNotableSessions } from '@renderer/hooks/use-sessions'
-import { Halftone } from '@renderer/components/agents/halftone'
+import { LazyHalftone } from '@renderer/components/agents/halftone'
 import {
   ActivitySparkChart,
   CronSparkChart,
@@ -180,7 +180,7 @@ function AgentCardMatrix({
       aria-hidden="true"
       className={cn('w-full overflow-hidden', className ?? 'aspect-[32/9]', HALFTONE_INK[activityStatus])}
     >
-      <Halftone
+      <LazyHalftone
         motif={activityStatus === 'awaiting_input' ? 'pulse' : 'flow_3d'}
         state={activityStatus === 'working' ? 'working' : activityStatus === 'awaiting_input' ? 'alert' : 'idle'}
         speed={stateTweak?.speed}


### PR DESCRIPTION
## What changed

- Fix the halftone IntersectionObserver/RAF initialization race so observed canvases do not start animating before their first positive intersection callback.
- Gate reduced-motion drawing on visibility as well.
- Add a `LazyHalftone` wrapper that mounts canvases only near the viewport and unmounts them after they leave.
- Use lazy-mounted halftones for home agent cards.
- Add regression coverage for RAF scheduling, intersection transitions, reduced motion, and lazy mounting.

## Why

Offscreen agent cards created canvases and briefly entered the animation loop before IntersectionObserver had reported their visibility. With dozens or hundreds of agents, that produced enough main-thread work to starve Playwright timers and make the E2E suite appear hung. It was also a real board performance and memory risk, not only a test issue.

## Validation

- Focused Vitest suite: 45/45 passed.
- TypeScript typecheck passed.
- Targeted ESLint passed.
- 204-agent browser profile:
  - only 6 canvases mounted near the top and 5 near the bottom
  - a 2-second browser timer completed in 2.003 seconds (previously approximately 3 minutes)
  - ScriptDuration reduced from 83.9s to 1.50s
  - TaskDuration reduced from 105s to 2.65s
- Full 6-worker web E2E run completed in 9 minutes without the former timeout cascade: 283 passed, 22 skipped, 2 isolated failures, and 2 retry-pass flakes.
- Both isolated failures passed together in a clean targeted rerun: 7/7 in 37.3 seconds.
- The halftone visual test passed in the full run.
