### PR TITLE
Fix host-browser profile disk growth (SUP-527)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -161,6 +161,7 @@ import { AGENT_PACKAGE_EXTENSION, SKILL_PACKAGE_EXTENSION } from '@shared/lib/ut
 import { readAgentPreferences, updateAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { agentPreferencesUpdateSchema } from '@shared/lib/types/agent-preferences'
 import { cleanupAgentData } from '@shared/lib/services/agent-cleanup-service'
+import { stopInstanceOnAllProviders } from '../../main/host-browser'
 import { deleteBrowserProfile } from '../../main/host-browser/profile-maintenance'
 import { logAuditEvent, logAuditEventOrThrow } from '@shared/lib/services/audit-log-service'
 import { loadSessionUsageTotals } from '@shared/lib/services/usage-service'
@@ -1076,9 +1077,13 @@ agents.delete('/:id', ResolveAgent(), AgentAdmin(), async (c) => {
     }
 
     // Remove the agent's dedicated host-browser Chrome profile. The container
-    // (and with it any host browser) is already stopped by deleteAgent.
-    // Best-effort: a leftover dir is reclaimed by the next startup sweep.
+    // teardown above only stops the browser on the ACTIVE provider — a Chrome
+    // launched before the user switched providers survives it — so stop this
+    // agent's browser on every provider first. deleteBrowserProfile itself
+    // refuses profiles claimed by an in-flight launch. Best-effort throughout:
+    // a leftover dir is reclaimed by a later startup sweep.
     try {
+      await stopInstanceOnAllProviders(slug)
       await deleteBrowserProfile(slug)
     } catch (error) {
       console.error('Failed to delete host-browser profile:', error)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -161,6 +161,7 @@ import { AGENT_PACKAGE_EXTENSION, SKILL_PACKAGE_EXTENSION } from '@shared/lib/ut
 import { readAgentPreferences, updateAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { agentPreferencesUpdateSchema } from '@shared/lib/types/agent-preferences'
 import { cleanupAgentData } from '@shared/lib/services/agent-cleanup-service'
+import { deleteBrowserProfile } from '../../main/host-browser/profile-maintenance'
 import { logAuditEvent, logAuditEventOrThrow } from '@shared/lib/services/audit-log-service'
 import { loadSessionUsageTotals } from '@shared/lib/services/usage-service'
 import { captureException } from '@shared/lib/error-reporting'
@@ -1072,6 +1073,15 @@ agents.delete('/:id', ResolveAgent(), AgentAdmin(), async (c) => {
     const deleted = await deleteAgent(slug)
     if (!deleted) {
       return c.json({ error: 'Agent not found' }, 404)
+    }
+
+    // Remove the agent's dedicated host-browser Chrome profile. The container
+    // (and with it any host browser) is already stopped by deleteAgent.
+    // Best-effort: a leftover dir is reclaimed by the next startup sweep.
+    try {
+      await deleteBrowserProfile(slug)
+    } catch (error) {
+      console.error('Failed to delete host-browser profile:', error)
     }
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'deleted', details: { name: agentBeforeDelete.frontmatter.name } })

--- a/src/main/host-browser/chrome-provider.launch-flags.test.ts
+++ b/src/main/host-browser/chrome-provider.launch-flags.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Pins the disk-growth guardrails on Chrome's launch arg list: automation
+// profiles must never download the on-device Gemini Nano model (4 GB per
+// profile) or browser-level component updates (~130 MB duplicated into every
+// per-agent user-data-dir). Also pins that all disabled features live in ONE
+// --disable-features flag — Chrome honors only the last occurrence, so a
+// second flag would silently re-enable the first flag's features.
+
+const h = vi.hoisted(() => {
+  function makeChild(pid: number) {
+    const handlers: Record<string, Array<(...a: unknown[]) => void>> = {}
+    return {
+      pid,
+      killed: false,
+      stderr: { on: () => {} },
+      on(ev: string, cb: (...a: unknown[]) => void) {
+        ;(handlers[ev] = handlers[ev] || []).push(cb)
+        return this
+      },
+      kill() {
+        this.killed = true
+        queueMicrotask(() => (handlers.exit || []).forEach((cb) => cb(0, null)))
+        return true
+      },
+    }
+  }
+
+  class Socket {
+    private _h: Record<string, () => void> = {}
+    setTimeout() {}
+    on(ev: string, cb: () => void) {
+      this._h[ev] = cb
+      return this
+    }
+    connect() {
+      // Report the port as open so waitForPort() resolves immediately.
+      queueMicrotask(() => this._h.connect?.())
+      return this
+    }
+    destroy() {}
+  }
+
+  function makeServer() {
+    const server: Record<string, unknown> = {
+      listen: (_port: unknown, _host: unknown, cb?: unknown) => {
+        if (typeof cb === 'function') (cb as () => void)()
+        return server
+      },
+      on: () => server,
+      address: () => ({ port: 9999 }),
+      close: (cb?: unknown) => {
+        if (typeof cb === 'function') (cb as () => void)()
+        return server
+      },
+    }
+    return server
+  }
+
+  const createServer = vi.fn(() => makeServer())
+  const connect = vi.fn(() => ({ pipe: () => {}, on: () => {}, destroy: () => {} }))
+  const netMock = { createServer, connect, Socket }
+  const spawnMock = vi.fn((_cmd: string, _args: string[]) => makeChild(4321))
+  const execSyncMock = vi.fn(() => '')
+
+  return { netMock, spawnMock, execSyncMock }
+})
+
+vi.mock('child_process', () => ({ spawn: h.spawnMock, execSync: h.execSyncMock }))
+vi.mock('net', () => ({ default: h.netMock, ...h.netMock }))
+
+vi.mock('fs', () => {
+  const m = {
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+    rmSync: () => undefined,
+    readFileSync: () => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    },
+    writeFileSync: () => undefined,
+    openSync: () => 1,
+    fsyncSync: () => undefined,
+    fchmodSync: () => undefined,
+    closeSync: () => undefined,
+    renameSync: () => undefined,
+    statSync: () => ({ size: 0, mtimeMs: 0 }),
+    accessSync: () => undefined,
+    readdirSync: () => [],
+    readlinkSync: () => '',
+    constants: { X_OK: 1 },
+    promises: {
+      readdir: async () => [],
+      rm: async () => undefined,
+      stat: async () => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      },
+    },
+  }
+  return { default: m, ...m }
+})
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getDataDir: () => '/tmp/sa-launch-flags-data',
+  getAgentDownloadsDir: () => '/tmp/sa-launch-flags-downloads',
+}))
+
+vi.mock('@shared/lib/browser/chrome-profile', () => ({
+  listChromeProfiles: () => [],
+  copyChromeProfileData: () => false,
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: () => {},
+  captureMessage: () => {},
+  addErrorBreadcrumb: () => {},
+}))
+
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    getClient: () => ({
+      getHostBridgeIp: () => null,
+      probeHostPortFromRunner: async () => 'unknown',
+    }),
+  },
+}))
+
+import { ChromeProvider } from './chrome-provider'
+
+const originalPlatform = process.platform
+
+describe('ChromeProvider launch flags (profile disk growth)', () => {
+  let provider: ChromeProvider
+  let args: string[]
+
+  beforeEach(async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    h.spawnMock.mockClear()
+    provider = new ChromeProvider()
+    await provider.launch('agent1')
+    const call = h.spawnMock.mock.calls.find((c) =>
+      Array.isArray(c[1]) && (c[1] as string[]).some((a) => a.startsWith('--remote-debugging-port='))
+    )
+    expect(call, 'Chrome should have been spawned').toBeTruthy()
+    args = call![1] as string[]
+  })
+
+  afterEach(async () => {
+    await provider.stopAll()
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+  })
+
+  it('disables the optimization-guide on-device model download', () => {
+    const disableFeatures = args.filter((a) => a.startsWith('--disable-features='))
+    expect(disableFeatures).toHaveLength(1)
+    const disabled = disableFeatures[0].replace('--disable-features=', '').split(',')
+    expect(disabled).toContain('OptimizationGuideOnDeviceModel')
+    expect(disabled).toContain('OptimizationGuideModelDownloading')
+    expect(disabled).toContain('OptimizationHints')
+    expect(disabled).toContain('TextSafetyClassifier')
+    // The pre-existing occlusion-throttling features must remain disabled in
+    // the same (single) flag.
+    expect(disabled).toContain('CalculateNativeWinOcclusion')
+    expect(disabled).toContain('WebContentsOcclusion')
+  })
+
+  it('disables the component updater', () => {
+    expect(args).toContain('--disable-component-update')
+  })
+})

--- a/src/main/host-browser/chrome-provider.launch-flags.test.ts
+++ b/src/main/host-browser/chrome-provider.launch-flags.test.ts
@@ -63,7 +63,11 @@ const h = vi.hoisted(() => {
   const spawnMock = vi.fn((_cmd: string, _args: string[]) => makeChild(4321))
   const execSyncMock = vi.fn(() => '')
 
-  return { netMock, spawnMock, execSyncMock }
+  // When set, fs.mkdirSync throws ENOSPC — simulates disk pressure failing a
+  // launch before Chrome is spawned or the instance registered.
+  const state = { failMkdir: false }
+
+  return { netMock, spawnMock, execSyncMock, state }
 })
 
 const pm = vi.hoisted(() => ({
@@ -79,7 +83,12 @@ vi.mock('net', () => ({ default: h.netMock, ...h.netMock }))
 vi.mock('fs', () => {
   const m = {
     existsSync: () => true,
-    mkdirSync: () => undefined,
+    mkdirSync: () => {
+      if (h.state.failMkdir) {
+        throw Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' })
+      }
+      return undefined
+    },
     rmSync: () => undefined,
     readFileSync: () => {
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
@@ -193,5 +202,20 @@ describe('ChromeProvider launch flags (profile disk growth)', () => {
     expect(pm.unmarkProfileInUse).not.toHaveBeenCalledWith('agent1')
     await provider.stop('agent1')
     expect(pm.unmarkProfileInUse).toHaveBeenCalledWith('agent1')
+  })
+
+  it('releases the claim when a pre-registration launch step fails (disk pressure)', async () => {
+    // mkdirSync throws before Chrome is spawned or the instance registered —
+    // none of the stop()-based paths run, so only the centralized catch in
+    // launch() can release the claim. A leaked claim here would make the
+    // sweep skip exactly the profile that filled the disk.
+    h.state.failMkdir = true
+    try {
+      await expect(provider.launch('agent-diskfull')).rejects.toThrow(/ENOSPC/)
+    } finally {
+      h.state.failMkdir = false
+    }
+    expect(pm.markProfileInUse).toHaveBeenCalledWith('agent-diskfull')
+    expect(pm.unmarkProfileInUse).toHaveBeenCalledWith('agent-diskfull')
   })
 })

--- a/src/main/host-browser/chrome-provider.launch-flags.test.ts
+++ b/src/main/host-browser/chrome-provider.launch-flags.test.ts
@@ -66,6 +66,13 @@ const h = vi.hoisted(() => {
   return { netMock, spawnMock, execSyncMock }
 })
 
+const pm = vi.hoisted(() => ({
+  markProfileInUse: vi.fn(),
+  unmarkProfileInUse: vi.fn(),
+  waitForBrowserProfileCleanup: vi.fn(async () => {}),
+}))
+vi.mock('./profile-maintenance', () => pm)
+
 vi.mock('child_process', () => ({ spawn: h.spawnMock, execSync: h.execSyncMock }))
 vi.mock('net', () => ({ default: h.netMock, ...h.netMock }))
 
@@ -135,6 +142,9 @@ describe('ChromeProvider launch flags (profile disk growth)', () => {
   beforeEach(async () => {
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
     h.spawnMock.mockClear()
+    pm.markProfileInUse.mockClear()
+    pm.unmarkProfileInUse.mockClear()
+    pm.waitForBrowserProfileCleanup.mockClear()
     provider = new ChromeProvider()
     await provider.launch('agent1')
     const call = h.spawnMock.mock.calls.find((c) =>
@@ -165,5 +175,23 @@ describe('ChromeProvider launch flags (profile disk growth)', () => {
 
   it('disables the component updater', () => {
     expect(args).toContain('--disable-component-update')
+  })
+
+  it('claims the profile before waiting on the cleanup sweep, which precedes the spawn', () => {
+    // Mark BEFORE wait: a sweep firing between the two would see the claim and
+    // skip this profile; marking after the wait leaves a window where the
+    // sweep deletes directories under a spawning Chrome.
+    expect(pm.markProfileInUse).toHaveBeenCalledWith('agent1')
+    const markOrder = pm.markProfileInUse.mock.invocationCallOrder[0]
+    const waitOrder = pm.waitForBrowserProfileCleanup.mock.invocationCallOrder[0]
+    const spawnOrder = h.spawnMock.mock.invocationCallOrder[0]
+    expect(markOrder).toBeLessThan(waitOrder)
+    expect(waitOrder).toBeLessThan(spawnOrder)
+  })
+
+  it('releases the profile claim on stop', async () => {
+    expect(pm.unmarkProfileInUse).not.toHaveBeenCalledWith('agent1')
+    await provider.stop('agent1')
+    expect(pm.unmarkProfileInUse).toHaveBeenCalledWith('agent1')
   })
 })

--- a/src/main/host-browser/chrome-provider.sup217.test.ts
+++ b/src/main/host-browser/chrome-provider.sup217.test.ts
@@ -196,6 +196,7 @@ vi.mock('@shared/lib/browser/chrome-profile', () => ({
 
 vi.mock('@shared/lib/error-reporting', () => ({
   captureException: () => {},
+  captureMessage: () => {},
   addErrorBreadcrumb: () => {},
 }))
 

--- a/src/main/host-browser/chrome-provider.ts
+++ b/src/main/host-browser/chrome-provider.ts
@@ -272,9 +272,28 @@ export class ChromeProvider implements HostBrowserProvider {
     // started yet, the mark makes it skip this profile; if it's already
     // running, the await keeps us out of its way. Marking after the await
     // would leave a window where a sweep firing right now could delete
-    // directories under a spawning Chrome. The mark is released in stop() /
-    // handleExit, or below on launch-failure paths that bypass stop().
+    // directories under a spawning Chrome. On success the claim is held until
+    // stop()/handleExit; on ANY launch failure it's released here, so no
+    // throw site inside the claimed phase can leak it (a leaked claim would
+    // make the sweep skip this profile until the next restart — the exact
+    // wrong outcome when the failure was disk pressure).
     markProfileInUse(instanceId)
+    try {
+      return await this.launchClaimed(instanceId, options)
+    } catch (err) {
+      // Idempotent with the release in stop() for failure paths that got far
+      // enough to call it.
+      unmarkProfileInUse(instanceId)
+      throw err
+    }
+  }
+
+  /** The launch phase that runs with the profile claim held. The caller owns
+   *  the claim: it is released there if this throws, and by stop()/handleExit
+   *  once the instance is registered and running. */
+  private async launchClaimed(instanceId: string, options?: Record<string, string>): Promise<BrowserConnectionInfo> {
+    // If the startup profile-storage sweep is still running, let it finish
+    // before touching (or launching Chrome onto) this profile dir.
     await waitForBrowserProfileCleanup()
 
     const port = await this.findFreePort()
@@ -434,7 +453,6 @@ export class ChromeProvider implements HostBrowserProvider {
           tags: { component: 'browser', operation: 'launch' },
           extra: { instanceId, platform: 'darwin', stage: 'open-dispatch' },
         })
-        unmarkProfileInUse(instanceId)
         throw err
       }
 
@@ -446,7 +464,6 @@ export class ChromeProvider implements HostBrowserProvider {
           tags: { component: 'browser', operation: 'launch' },
           extra: { instanceId, platform: 'darwin', stage: 'pid-lookup', userDataDir },
         })
-        unmarkProfileInUse(instanceId)
         throw err
       }
       chromePid = foundPid
@@ -477,7 +494,6 @@ export class ChromeProvider implements HostBrowserProvider {
           tags: { component: 'browser', operation: 'launch' },
           extra: { instanceId, platform: process.platform },
         })
-        unmarkProfileInUse(instanceId)
         throw err
       }
       chromePid = browserProcess.pid
@@ -548,7 +564,6 @@ export class ChromeProvider implements HostBrowserProvider {
         earlyExitPromise.catch(() => {})
         proxyServer?.close()
         this.killSpawnedChrome(browserProcess, chromePid)
-        unmarkProfileInUse(instanceId)
         throw new Error(
           `Failed to bind host-browser CDP proxy on ${bridgeIp}: ${err instanceof Error ? err.message : String(err)}`
         )

--- a/src/main/host-browser/chrome-provider.ts
+++ b/src/main/host-browser/chrome-provider.ts
@@ -9,7 +9,7 @@ import { containerManager } from '@shared/lib/container/container-manager'
 import type { HostBrowserProvider, HostBrowserProviderStatus, BrowserConnectionInfo } from './types'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { readJsonFileStrictSync, writeFileAtomicSync, CorruptFileError } from '@shared/lib/utils/file-storage'
-import { waitForBrowserProfileCleanup } from './profile-maintenance'
+import { waitForBrowserProfileCleanup, markProfileInUse, unmarkProfileInUse } from './profile-maintenance'
 import { z } from 'zod'
 
 // Chrome's DevTools Protocol has no auth token: any host/process that can reach
@@ -268,8 +268,13 @@ export class ChromeProvider implements HostBrowserProvider {
       throw err
     }
 
-    // If the startup profile-storage sweep is still running, let it finish
-    // before touching (or launching Chrome onto) this profile dir.
+    // Claim this profile BEFORE waiting on the sweep: if the sweep hasn't
+    // started yet, the mark makes it skip this profile; if it's already
+    // running, the await keeps us out of its way. Marking after the await
+    // would leave a window where a sweep firing right now could delete
+    // directories under a spawning Chrome. The mark is released in stop() /
+    // handleExit, or below on launch-failure paths that bypass stop().
+    markProfileInUse(instanceId)
     await waitForBrowserProfileCleanup()
 
     const port = await this.findFreePort()
@@ -429,6 +434,7 @@ export class ChromeProvider implements HostBrowserProvider {
           tags: { component: 'browser', operation: 'launch' },
           extra: { instanceId, platform: 'darwin', stage: 'open-dispatch' },
         })
+        unmarkProfileInUse(instanceId)
         throw err
       }
 
@@ -440,6 +446,7 @@ export class ChromeProvider implements HostBrowserProvider {
           tags: { component: 'browser', operation: 'launch' },
           extra: { instanceId, platform: 'darwin', stage: 'pid-lookup', userDataDir },
         })
+        unmarkProfileInUse(instanceId)
         throw err
       }
       chromePid = foundPid
@@ -470,6 +477,7 @@ export class ChromeProvider implements HostBrowserProvider {
           tags: { component: 'browser', operation: 'launch' },
           extra: { instanceId, platform: process.platform },
         })
+        unmarkProfileInUse(instanceId)
         throw err
       }
       chromePid = browserProcess.pid
@@ -540,6 +548,7 @@ export class ChromeProvider implements HostBrowserProvider {
         earlyExitPromise.catch(() => {})
         proxyServer?.close()
         this.killSpawnedChrome(browserProcess, chromePid)
+        unmarkProfileInUse(instanceId)
         throw new Error(
           `Failed to bind host-browser CDP proxy on ${bridgeIp}: ${err instanceof Error ? err.message : String(err)}`
         )
@@ -570,6 +579,7 @@ export class ChromeProvider implements HostBrowserProvider {
         instance.externalCloseWatcher = null
       }
       this.instances.delete(instanceId)
+      unmarkProfileInUse(instanceId)
       if (!wasIntentional) {
         console.log(`[ChromeProvider] Browser for instance ${instanceId} closed externally, notifying listeners`)
         Promise.resolve(this.onExternalClose?.(instanceId)).catch((err) => {
@@ -709,6 +719,7 @@ export class ChromeProvider implements HostBrowserProvider {
       }
     }
     this.instances.delete(instanceId)
+    unmarkProfileInUse(instanceId)
   }
 
   async stopAll(): Promise<void> {

--- a/src/main/host-browser/chrome-provider.ts
+++ b/src/main/host-browser/chrome-provider.ts
@@ -9,6 +9,7 @@ import { containerManager } from '@shared/lib/container/container-manager'
 import type { HostBrowserProvider, HostBrowserProviderStatus, BrowserConnectionInfo } from './types'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { readJsonFileStrictSync, writeFileAtomicSync, CorruptFileError } from '@shared/lib/utils/file-storage'
+import { waitForBrowserProfileCleanup } from './profile-maintenance'
 import { z } from 'zod'
 
 // Chrome's DevTools Protocol has no auth token: any host/process that can reach
@@ -267,6 +268,10 @@ export class ChromeProvider implements HostBrowserProvider {
       throw err
     }
 
+    // If the startup profile-storage sweep is still running, let it finish
+    // before touching (or launching Chrome onto) this profile dir.
+    await waitForBrowserProfileCleanup()
+
     const port = await this.findFreePort()
     const profileId = options?.chromeProfileId
 
@@ -342,7 +347,18 @@ export class ChromeProvider implements HostBrowserProvider {
       '--disable-backgrounding-occluded-windows',
       '--disable-renderer-backgrounding',
       '--disable-background-timer-throttling',
-      '--disable-features=CalculateNativeWinOcclusion,WebContentsOcclusion',
+      // Chrome honors only the LAST --disable-features occurrence, so every
+      // disabled feature must live in this single flag.
+      // CalculateNativeWinOcclusion/WebContentsOcclusion: occlusion throttling
+      // (see above). The optimization-guide features stop Chrome from
+      // downloading the on-device Gemini Nano model (4 GB per profile) and
+      // per-page optimization hints into these automation profiles.
+      '--disable-features=CalculateNativeWinOcclusion,WebContentsOcclusion,OptimizationGuideOnDeviceModel,OptimizationGuideModelDownloading,OptimizationHints,TextSafetyClassifier',
+      // Component updater re-downloads browser-level components (safe-browsing
+      // lists, TTS engines, CRX caches, optimization-guide model store —
+      // ~130 MB) into every per-agent user-data-dir. None of it is needed for
+      // automation; disabling it keeps each profile at just its session state.
+      '--disable-component-update',
       // Start with about:blank instead of chrome://newtab so agent-browser's
       // target discovery sees a trackable page and reuses it rather than
       // creating an extra tab (it filters out chrome:// URLs).

--- a/src/main/host-browser/index.test.ts
+++ b/src/main/host-browser/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// stopInstanceOnAllProviders must stop an instance's browser on EVERY
+// provider, independent of which provider is currently selected in settings —
+// the user can switch providers while a browser from the previous one is
+// still running, and agent deletion must not leave that browser alive while
+// its profile directory is removed.
+
+const h = vi.hoisted(() => {
+  const created: Array<{ id: string; isRunning: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }> = []
+  function makeProviderClass(id: string, running: (instanceId: string) => boolean) {
+    return class {
+      id = id
+      name = id
+      onExternalClose = null
+      isRunning = vi.fn(running)
+      stop = vi.fn(async () => {})
+      stopAll = vi.fn(async () => {})
+      detect = vi.fn()
+      launch = vi.fn()
+      constructor() {
+        created.push(this as never)
+      }
+    }
+  }
+  return { created, makeProviderClass }
+})
+
+vi.mock('./chrome-provider', () => ({
+  ChromeProvider: h.makeProviderClass('chrome', (instanceId: string) => instanceId === 'agent1'),
+}))
+vi.mock('./browserbase-provider', () => ({
+  BrowserbaseProvider: h.makeProviderClass('browserbase', () => false),
+}))
+vi.mock('./platform-provider', () => ({
+  PlatformBrowserProvider: h.makeProviderClass('platform', () => false),
+}))
+
+// The active provider is NOT chrome — proves the stop is provider-independent.
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ app: { hostBrowserProvider: 'browserbase' } }),
+}))
+
+import { stopInstanceOnAllProviders } from './index'
+
+describe('stopInstanceOnAllProviders', () => {
+  it('stops a running instance on a non-active provider and skips idle providers', async () => {
+    await stopInstanceOnAllProviders('agent1')
+
+    const chrome = h.created.find((p) => p.id === 'chrome')!
+    const browserbase = h.created.find((p) => p.id === 'browserbase')!
+    const platform = h.created.find((p) => p.id === 'platform')!
+
+    expect(chrome.stop).toHaveBeenCalledWith('agent1')
+    expect(browserbase.stop).not.toHaveBeenCalled()
+    expect(platform.stop).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op for an instance no provider is running', async () => {
+    await stopInstanceOnAllProviders('agent-unknown')
+    for (const provider of h.created) {
+      expect(provider.stop).not.toHaveBeenCalledWith('agent-unknown')
+    }
+  })
+})

--- a/src/main/host-browser/index.ts
+++ b/src/main/host-browser/index.ts
@@ -38,6 +38,23 @@ export function detectAllProviders(): HostBrowserProviderStatus[] {
 }
 
 /**
+ * Stop one instance's browser on EVERY provider, not just the currently
+ * selected one. The active provider setting can change while a browser is
+ * running (e.g. Chrome launched, then the user switches to Browserbase), so
+ * teardown keyed to getActiveProvider() would miss it. Used by agent deletion
+ * before the profile directory is removed.
+ */
+export async function stopInstanceOnAllProviders(instanceId: string): Promise<void> {
+  await Promise.all(
+    Object.values(providerMap).map(async (provider) => {
+      if (provider.isRunning(instanceId)) {
+        await provider.stop(instanceId)
+      }
+    })
+  )
+}
+
+/**
  * Stop all provider instances. Used during graceful shutdown.
  */
 export async function stopAllProviders(): Promise<void> {

--- a/src/main/host-browser/profile-maintenance.test.ts
+++ b/src/main/host-browser/profile-maintenance.test.ts
@@ -21,6 +21,8 @@ vi.mock('@shared/lib/error-reporting', () => ({
 import {
   cleanupBrowserProfiles,
   deleteBrowserProfile,
+  markProfileInUse,
+  unmarkProfileInUse,
   startBrowserProfileCleanup,
   stopBrowserProfileCleanup,
   waitForBrowserProfileCleanup,
@@ -105,18 +107,25 @@ describe('browser profile maintenance', () => {
     expect(fs.existsSync(path.join(dir, 'Default', 'Local Storage', 'data'))).toBe(true)
   })
 
-  it('leaves profiles reported in-use completely alone', async () => {
+  it('leaves profiles marked in-use completely alone until unmarked', async () => {
     const busy = makeProfile('agent-busy', ['component_crx_cache'])
     const idle = makeProfile('agent-idle', ['component_crx_cache'])
 
-    await cleanupBrowserProfiles(['agent-idle'], {
-      isProfileInUse: (id) => id === 'agent-busy',
-    })
+    markProfileInUse('agent-busy')
+    try {
+      await cleanupBrowserProfiles(['agent-idle'])
+    } finally {
+      unmarkProfileInUse('agent-busy')
+    }
 
     // agent-busy is not in the agent list (would be orphan-deleted) AND has
-    // strippable caches — in-use must win over both.
+    // strippable caches — the in-use mark must win over both.
     expect(fs.existsSync(path.join(busy, 'component_crx_cache'))).toBe(true)
     expect(fs.existsSync(path.join(idle, 'component_crx_cache'))).toBe(false)
+
+    // After unmarking, the next sweep reclaims it.
+    await cleanupBrowserProfiles(['agent-idle'])
+    expect(fs.existsSync(busy)).toBe(false)
   })
 
   it('is a no-op when the profiles directory does not exist', async () => {
@@ -177,16 +186,32 @@ describe('browser profile maintenance', () => {
 
     it('runs the sweep after the configured delay and exposes it to waitForBrowserProfileCleanup', async () => {
       const orphaned = makeProfile('agent-deleted')
-      startBrowserProfileCleanup(['agent-alive'], { delayMs: 0 })
+      startBrowserProfileCleanup(() => ['agent-alive'], { delayMs: 0 })
       // waitForBrowserProfileCleanup resolves immediately until the timer
       // fires (launches proceed pre-sweep by design), so wait for the effect.
       await vi.waitFor(() => expect(fs.existsSync(orphaned)).toBe(false))
       await waitForBrowserProfileCleanup()
     })
 
+    it('resolves the agent list when the timer fires, not when scheduled', async () => {
+      // An agent created AFTER scheduling but before the sweep fires must not
+      // be classified as an orphan — that would delete its cookies/session.
+      const agents = ['agent-old']
+      makeProfile('agent-old')
+      startBrowserProfileCleanup(async () => [...agents], { delayMs: 30 })
+
+      agents.push('agent-created-during-delay')
+      const created = makeProfile('agent-created-during-delay')
+      const orphaned = makeProfile('agent-deleted')
+
+      await vi.waitFor(() => expect(fs.existsSync(orphaned)).toBe(false))
+      await waitForBrowserProfileCleanup()
+      expect(fs.existsSync(path.join(created, 'Default', 'Cookies'))).toBe(true)
+    })
+
     it('does not sweep before the delay elapses, and stop cancels a pending sweep', async () => {
       const orphaned = makeProfile('agent-deleted')
-      startBrowserProfileCleanup(['agent-alive'], { delayMs: 60_000 })
+      startBrowserProfileCleanup(() => ['agent-alive'], { delayMs: 60_000 })
       stopBrowserProfileCleanup()
       await new Promise((r) => setTimeout(r, 25))
       expect(fs.existsSync(orphaned)).toBe(true)
@@ -199,9 +224,21 @@ describe('browser profile maintenance', () => {
       fs.writeFileSync(file, '')
       h.dataDir = file
 
-      startBrowserProfileCleanup(['agent1'], { delayMs: 0 })
+      startBrowserProfileCleanup(() => ['agent1'], { delayMs: 0 })
       await vi.waitFor(() => expect(captureException).toHaveBeenCalledTimes(1))
       await waitForBrowserProfileCleanup()
+    })
+
+    it('captures a failing agent-list supplier instead of rejecting', async () => {
+      const orphaned = makeProfile('agent-deleted')
+      startBrowserProfileCleanup(
+        async () => { throw new Error('agent listing failed') },
+        { delayMs: 0 },
+      )
+      await vi.waitFor(() => expect(captureException).toHaveBeenCalledTimes(1))
+      await waitForBrowserProfileCleanup()
+      // A failed listing must never be treated as "no agents exist".
+      expect(fs.existsSync(orphaned)).toBe(true)
     })
   })
 })

--- a/src/main/host-browser/profile-maintenance.test.ts
+++ b/src/main/host-browser/profile-maintenance.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+// Real filesystem in a temp data dir — the module under test is pure fs
+// manipulation, so mocking fs would just re-state the implementation.
+const h = vi.hoisted(() => ({ dataDir: '' }))
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getDataDir: () => h.dataDir,
+}))
+
+const captureMessage = vi.fn()
+const captureException = vi.fn()
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureMessage: (...args: unknown[]) => captureMessage(...args),
+  captureException: (...args: unknown[]) => captureException(...args),
+}))
+
+import {
+  cleanupBrowserProfiles,
+  deleteBrowserProfile,
+  startBrowserProfileCleanup,
+  stopBrowserProfileCleanup,
+  waitForBrowserProfileCleanup,
+} from './profile-maintenance'
+
+const PROFILES = 'host-browser-profiles'
+const LEGACY = 'host-browser-profile'
+
+function makeProfile(agentId: string, extras: string[] = []) {
+  const dir = path.join(h.dataDir, PROFILES, agentId)
+  // Session state that must survive every sweep.
+  fs.mkdirSync(path.join(dir, 'Default'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'Default', 'Cookies'), 'cookies')
+  for (const extra of extras) {
+    fs.mkdirSync(path.join(dir, extra), { recursive: true })
+    fs.writeFileSync(path.join(dir, extra, 'blob.bin'), 'x'.repeat(1024))
+  }
+  return dir
+}
+
+describe('browser profile maintenance', () => {
+  beforeEach(() => {
+    h.dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-browser-profiles-'))
+    captureMessage.mockClear()
+    captureException.mockClear()
+  })
+
+  afterEach(() => {
+    fs.rmSync(h.dataDir, { recursive: true, force: true })
+  })
+
+  it('removes the legacy singular host-browser-profile directory', async () => {
+    const legacyDir = path.join(h.dataDir, LEGACY)
+    fs.mkdirSync(path.join(legacyDir, 'Default'), { recursive: true })
+    fs.writeFileSync(path.join(legacyDir, 'Local State'), '{}')
+
+    await cleanupBrowserProfiles([])
+
+    expect(fs.existsSync(legacyDir)).toBe(false)
+  })
+
+  it('removes orphaned profile dirs and keeps profiles of existing agents', async () => {
+    const kept = makeProfile('agent-alive')
+    const orphaned = makeProfile('agent-deleted')
+
+    await cleanupBrowserProfiles(['agent-alive'])
+
+    expect(fs.existsSync(kept)).toBe(true)
+    expect(fs.existsSync(orphaned)).toBe(false)
+  })
+
+  it('strips regenerable caches but preserves Default session state', async () => {
+    const dir = makeProfile('agent1', [
+      'OptGuideOnDeviceModel/2025.8.8.1141',
+      'optimization_guide_model_store',
+      'component_crx_cache',
+      'WasmTtsEngine',
+      'Safe Browsing',
+      'GrShaderCache',
+      path.join('Default', 'Cache'),
+      path.join('Default', 'Code Cache'),
+      path.join('Default', 'GPUCache'),
+    ])
+    fs.writeFileSync(path.join(dir, 'Default', 'Login Data'), 'logins')
+    fs.mkdirSync(path.join(dir, 'Default', 'Local Storage'), { recursive: true })
+    fs.writeFileSync(path.join(dir, 'Default', 'Local Storage', 'data'), 'ls')
+
+    await cleanupBrowserProfiles(['agent1'])
+
+    // Regenerable caches are gone…
+    expect(fs.existsSync(path.join(dir, 'OptGuideOnDeviceModel'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'optimization_guide_model_store'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'component_crx_cache'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'WasmTtsEngine'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'Safe Browsing'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'Default', 'Cache'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'Default', 'Code Cache'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'Default', 'GPUCache'))).toBe(false)
+    // …while session state survives.
+    expect(fs.readFileSync(path.join(dir, 'Default', 'Cookies'), 'utf-8')).toBe('cookies')
+    expect(fs.readFileSync(path.join(dir, 'Default', 'Login Data'), 'utf-8')).toBe('logins')
+    expect(fs.existsSync(path.join(dir, 'Default', 'Local Storage', 'data'))).toBe(true)
+  })
+
+  it('leaves profiles reported in-use completely alone', async () => {
+    const busy = makeProfile('agent-busy', ['component_crx_cache'])
+    const idle = makeProfile('agent-idle', ['component_crx_cache'])
+
+    await cleanupBrowserProfiles(['agent-idle'], {
+      isProfileInUse: (id) => id === 'agent-busy',
+    })
+
+    // agent-busy is not in the agent list (would be orphan-deleted) AND has
+    // strippable caches — in-use must win over both.
+    expect(fs.existsSync(path.join(busy, 'component_crx_cache'))).toBe(true)
+    expect(fs.existsSync(path.join(idle, 'component_crx_cache'))).toBe(false)
+  })
+
+  it('is a no-op when the profiles directory does not exist', async () => {
+    await expect(cleanupBrowserProfiles(['agent1'])).resolves.toBeUndefined()
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  it('reports when the swept directory still exceeds the size budget', async () => {
+    const dir = makeProfile('agent1')
+    // A sparse file whose stat size exceeds the 2 GiB threshold without
+    // actually consuming disk.
+    const bigFile = path.join(dir, 'Default', 'huge.bin')
+    fs.writeFileSync(bigFile, '')
+    fs.truncateSync(bigFile, 3 * 1024 * 1024 * 1024)
+
+    await cleanupBrowserProfiles(['agent1'])
+
+    expect(captureMessage).toHaveBeenCalledTimes(1)
+    expect(String(captureMessage.mock.calls[0][0])).toMatch(/size budget/i)
+  })
+
+  it('does not report when the directory is within budget', async () => {
+    makeProfile('agent1')
+    await cleanupBrowserProfiles(['agent1'])
+    expect(captureMessage).not.toHaveBeenCalled()
+  })
+
+  describe('deleteBrowserProfile', () => {
+    it('removes the profile dir for the agent', async () => {
+      const dir = makeProfile('agent1')
+      await deleteBrowserProfile('agent1')
+      expect(fs.existsSync(dir)).toBe(false)
+    })
+
+    it('resolves when the profile dir never existed', async () => {
+      await expect(deleteBrowserProfile('never-launched')).resolves.toBeUndefined()
+    })
+
+    it('refuses ids that escape the profiles root', async () => {
+      const outside = path.join(h.dataDir, 'victim')
+      fs.mkdirSync(outside)
+      await expect(deleteBrowserProfile('../victim')).rejects.toThrow(/outside profiles root/)
+      expect(fs.existsSync(outside)).toBe(true)
+    })
+
+    it('refuses ids that resolve to the profiles root itself', async () => {
+      const kept = makeProfile('agent1')
+      await expect(deleteBrowserProfile('')).rejects.toThrow(/outside profiles root/)
+      await expect(deleteBrowserProfile('.')).rejects.toThrow(/outside profiles root/)
+      expect(fs.existsSync(kept)).toBe(true)
+    })
+  })
+
+  describe('startBrowserProfileCleanup', () => {
+    afterEach(() => {
+      stopBrowserProfileCleanup()
+    })
+
+    it('runs the sweep after the configured delay and exposes it to waitForBrowserProfileCleanup', async () => {
+      const orphaned = makeProfile('agent-deleted')
+      startBrowserProfileCleanup(['agent-alive'], { delayMs: 0 })
+      // waitForBrowserProfileCleanup resolves immediately until the timer
+      // fires (launches proceed pre-sweep by design), so wait for the effect.
+      await vi.waitFor(() => expect(fs.existsSync(orphaned)).toBe(false))
+      await waitForBrowserProfileCleanup()
+    })
+
+    it('does not sweep before the delay elapses, and stop cancels a pending sweep', async () => {
+      const orphaned = makeProfile('agent-deleted')
+      startBrowserProfileCleanup(['agent-alive'], { delayMs: 60_000 })
+      stopBrowserProfileCleanup()
+      await new Promise((r) => setTimeout(r, 25))
+      expect(fs.existsSync(orphaned)).toBe(true)
+    })
+
+    it('captures sweep failures instead of rejecting', async () => {
+      // Point the data dir at a path whose parent is a FILE so readdir fails
+      // with ENOTDIR (not the tolerated ENOENT).
+      const file = path.join(h.dataDir, 'not-a-dir')
+      fs.writeFileSync(file, '')
+      h.dataDir = file
+
+      startBrowserProfileCleanup(['agent1'], { delayMs: 0 })
+      await vi.waitFor(() => expect(captureException).toHaveBeenCalledTimes(1))
+      await waitForBrowserProfileCleanup()
+    })
+  })
+})

--- a/src/main/host-browser/profile-maintenance.test.ts
+++ b/src/main/host-browser/profile-maintenance.test.ts
@@ -164,6 +164,20 @@ describe('browser profile maintenance', () => {
       await expect(deleteBrowserProfile('never-launched')).resolves.toBeUndefined()
     })
 
+    it('refuses to delete a profile claimed by a launching or running browser', async () => {
+      const dir = makeProfile('agent1')
+      markProfileInUse('agent1')
+      try {
+        await expect(deleteBrowserProfile('agent1')).rejects.toThrow(/claimed/)
+        expect(fs.existsSync(path.join(dir, 'Default', 'Cookies'))).toBe(true)
+      } finally {
+        unmarkProfileInUse('agent1')
+      }
+      // Once released, deletion proceeds.
+      await deleteBrowserProfile('agent1')
+      expect(fs.existsSync(dir)).toBe(false)
+    })
+
     it('refuses ids that escape the profiles root', async () => {
       const outside = path.join(h.dataDir, 'victim')
       fs.mkdirSync(outside)

--- a/src/main/host-browser/profile-maintenance.ts
+++ b/src/main/host-browser/profile-maintenance.ts
@@ -47,10 +47,16 @@ export function getBrowserProfilesRoot(): string {
 
 /**
  * Delete an agent's dedicated Chrome user-data-dir. Called when the agent is
- * deleted, after its container (and therefore its host browser) has been
- * stopped. Best-effort: a leftover dir is reclaimed by the next startup sweep.
+ * deleted, after its browser has been stopped on every provider. Refuses to
+ * delete while the profile is claimed by an in-flight launch (a spawning
+ * Chrome isn't registered anywhere yet, so no stop call can reach it — the
+ * claim is the only signal it exists). Best-effort either way: a leftover dir
+ * is reclaimed by a later startup sweep once the agent no longer exists.
  */
 export async function deleteBrowserProfile(agentId: string): Promise<void> {
+  if (profilesInUse.has(agentId)) {
+    throw new Error(`Browser profile for "${agentId}" is claimed by a launching or running browser; skipping deletion`)
+  }
   const root = getBrowserProfilesRoot()
   const profileDir = path.join(root, agentId)
   // agentId is a validated slug by the time we're called, but this deletes

--- a/src/main/host-browser/profile-maintenance.ts
+++ b/src/main/host-browser/profile-maintenance.ts
@@ -1,0 +1,220 @@
+import fs from 'fs'
+import path from 'path'
+import { getDataDir } from '@shared/lib/config/data-dir'
+import { isPathWithinDir } from '@shared/lib/utils/path-safety'
+import { captureException, captureMessage } from '@shared/lib/error-reporting'
+
+// Dedicated Chrome user-data-dirs for host-browser automation, one per agent
+// (see chrome-provider.ts). Only `Default/` inside each dir is real per-agent
+// state (cookies, logins, local storage); everything else Chrome writes there
+// is a regenerable browser-level cache. Left alone, those caches grew a single
+// dev machine to 10 GB — a 4 GB Gemini Nano model download per long-lived
+// profile plus ~130 MB of duplicated component downloads in every profile.
+// Launch flags now block the downloads (chrome-provider.ts); this module
+// reclaims what already accumulated and keeps the directory bounded.
+const PROFILES_DIR_NAME = 'host-browser-profiles'
+
+// Pre-refactor single shared profile dir (singular). The rename to the plural,
+// per-agent layout never removed it, stranding a stale user-data-dir.
+const LEGACY_PROFILE_DIR_NAME = 'host-browser-profile'
+
+// Browser-level (user-data-dir root) caches that are safe to delete while the
+// profile's Chrome is not running: Chrome re-creates them on demand. The first
+// five are component/optimization-guide downloads that the launch flags now
+// prevent from re-downloading at all.
+const USER_DATA_CACHE_DIRS = [
+  'OptGuideOnDeviceModel',
+  'optimization_guide_model_store',
+  'component_crx_cache',
+  'WasmTtsEngine',
+  'Safe Browsing',
+  'GrShaderCache',
+  'ShaderCache',
+  'GraphiteDawnCache',
+]
+
+// Regenerable caches inside the `Default/` profile. Session state (Cookies,
+// Login Data, Local Storage, Service Worker, ...) must never be listed here.
+const DEFAULT_PROFILE_CACHE_DIRS = ['Cache', 'Code Cache', 'GPUCache', 'DawnGraphiteCache', 'DawnWebGPUCache']
+
+// Alert threshold for the whole profiles directory. Expected steady state is
+// ~500 MB; crossing this means a new unbounded-growth vector appeared.
+const PROFILES_SIZE_ALERT_BYTES = 2 * 1024 * 1024 * 1024
+
+export function getBrowserProfilesRoot(): string {
+  return path.join(getDataDir(), PROFILES_DIR_NAME)
+}
+
+/**
+ * Delete an agent's dedicated Chrome user-data-dir. Called when the agent is
+ * deleted, after its container (and therefore its host browser) has been
+ * stopped. Best-effort: a leftover dir is reclaimed by the next startup sweep.
+ */
+export async function deleteBrowserProfile(agentId: string): Promise<void> {
+  const root = getBrowserProfilesRoot()
+  const profileDir = path.join(root, agentId)
+  // agentId is a validated slug by the time we're called, but this deletes
+  // recursively — refuse anything that escapes the profiles root, and refuse
+  // the root itself (isPathWithinDir treats base === candidate as contained,
+  // so an empty/'.' agentId would otherwise wipe every profile).
+  if (!isPathWithinDir(root, profileDir) || path.resolve(profileDir) === path.resolve(root)) {
+    throw new Error(`Refusing to delete browser profile outside profiles root: ${agentId}`)
+  }
+  await fs.promises.rm(profileDir, { recursive: true, force: true })
+}
+
+export interface CleanupOptions {
+  /**
+   * Returns true when the agent's browser is currently running (or launching).
+   * The sweep leaves such profiles alone — deleting caches under a live Chrome
+   * invites corruption; they're picked up on a later sweep instead.
+   */
+  isProfileInUse?: (agentId: string) => boolean
+}
+
+/**
+ * Sweep over the host-browser profile storage:
+ *  1. removes the legacy singular `host-browser-profile` dir left by a rename,
+ *  2. removes profile dirs whose agent no longer exists,
+ *  3. strips regenerable Chrome caches from surviving profiles (per-agent
+ *     session state in `Default/` is preserved, minus its cache subdirs),
+ *  4. measures what remains and reports if it exceeds the size budget, so the
+ *     directory can never silently grow to GB scale again.
+ *
+ * Runs shortly after startup (delayed so it doesn't pile onto launch work).
+ * Profiles reported in-use by `isProfileInUse` are skipped, and browser
+ * launches await the in-flight sweep, so sweep and Chrome never touch a
+ * profile at the same time. (A launch that starts in the instant before the
+ * sweep fires can slip past the in-use check; that window is seconds wide and
+ * Chrome recreates missing cache dirs lazily, so the worst case is a dropped
+ * cache write.)
+ */
+export async function cleanupBrowserProfiles(
+  agentIds: string[],
+  options: CleanupOptions = {},
+): Promise<void> {
+  await removeLegacyProfileDir()
+
+  const root = getBrowserProfilesRoot()
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(root, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
+  }
+
+  const known = new Set(agentIds)
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    if (options.isProfileInUse?.(entry.name)) continue
+    const profileDir = path.join(root, entry.name)
+    if (!known.has(entry.name)) {
+      // Orphaned: the agent this profile belonged to no longer exists.
+      console.log(`[BrowserProfiles] Removing orphaned profile ${entry.name}`)
+      await fs.promises.rm(profileDir, { recursive: true, force: true })
+      continue
+    }
+    await stripRegenerableCaches(profileDir)
+  }
+
+  await reportOversizedProfiles(root)
+}
+
+async function removeLegacyProfileDir(): Promise<void> {
+  const legacyDir = path.join(getDataDir(), LEGACY_PROFILE_DIR_NAME)
+  try {
+    const stat = await fs.promises.stat(legacyDir)
+    if (!stat.isDirectory()) return
+    console.log(`[BrowserProfiles] Removing legacy profile dir ${legacyDir}`)
+    await fs.promises.rm(legacyDir, { recursive: true, force: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+}
+
+async function stripRegenerableCaches(profileDir: string): Promise<void> {
+  for (const name of USER_DATA_CACHE_DIRS) {
+    await fs.promises.rm(path.join(profileDir, name), { recursive: true, force: true })
+  }
+  for (const name of DEFAULT_PROFILE_CACHE_DIRS) {
+    await fs.promises.rm(path.join(profileDir, 'Default', name), { recursive: true, force: true })
+  }
+}
+
+async function reportOversizedProfiles(root: string): Promise<void> {
+  const totalBytes = await directorySize(root)
+  const totalMb = Math.round(totalBytes / 1048576)
+  console.log(`[BrowserProfiles] Profile storage after sweep: ${totalMb} MB`)
+  if (totalBytes > PROFILES_SIZE_ALERT_BYTES) {
+    captureMessage('Host browser profile storage exceeds size budget after cleanup sweep', {
+      tags: { component: 'browser', operation: 'profile-cleanup' },
+      extra: { totalMb, alertThresholdMb: Math.round(PROFILES_SIZE_ALERT_BYTES / 1048576) },
+    })
+  }
+}
+
+async function directorySize(dir: string): Promise<number> {
+  let total = 0
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true })
+  } catch {
+    return 0
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      total += await directorySize(entryPath)
+    } else if (entry.isFile()) {
+      try {
+        total += (await fs.promises.stat(entryPath)).size
+      } catch {
+        // File disappeared mid-walk; skip.
+      }
+    }
+  }
+  return total
+}
+
+// Delay before the startup sweep runs, so it doesn't pile onto the burst of
+// work (container init, schedulers, image checks) happening right at launch.
+const STARTUP_SWEEP_DELAY_MS = 3 * 60_000
+
+let cleanupInFlight: Promise<void> = Promise.resolve()
+let pendingSweep: NodeJS.Timeout | null = null
+
+/**
+ * Schedule the sweep to run once, shortly after startup. Never blocks or fails
+ * service initialization. Browser launches await {@link waitForBrowserProfileCleanup}
+ * so a launch cannot race an in-flight sweep's deletions.
+ */
+export function startBrowserProfileCleanup(
+  agentIds: string[],
+  options: CleanupOptions & { delayMs?: number } = {},
+): void {
+  stopBrowserProfileCleanup()
+  pendingSweep = setTimeout(() => {
+    pendingSweep = null
+    cleanupInFlight = cleanupBrowserProfiles(agentIds, options).catch((error) => {
+      console.error('[BrowserProfiles] Profile cleanup sweep failed:', error)
+      captureException(error, { tags: { component: 'browser', operation: 'profile-cleanup' } })
+    })
+  }, options.delayMs ?? STARTUP_SWEEP_DELAY_MS)
+  // Never hold the process open just for a pending sweep (matters for the web
+  // server, whose event loop must drain on shutdown).
+  pendingSweep.unref?.()
+}
+
+/** Cancel a scheduled-but-not-started sweep (shutdown). In-flight sweeps finish. */
+export function stopBrowserProfileCleanup(): void {
+  if (pendingSweep) {
+    clearTimeout(pendingSweep)
+    pendingSweep = null
+  }
+}
+
+/** Resolves when no cleanup sweep is running. Never rejects. */
+export function waitForBrowserProfileCleanup(): Promise<void> {
+  return cleanupInFlight
+}

--- a/src/main/host-browser/profile-maintenance.ts
+++ b/src/main/host-browser/profile-maintenance.ts
@@ -63,13 +63,20 @@ export async function deleteBrowserProfile(agentId: string): Promise<void> {
   await fs.promises.rm(profileDir, { recursive: true, force: true })
 }
 
-export interface CleanupOptions {
-  /**
-   * Returns true when the agent's browser is currently running (or launching).
-   * The sweep leaves such profiles alone — deleting caches under a live Chrome
-   * invites corruption; they're picked up on a later sweep instead.
-   */
-  isProfileInUse?: (agentId: string) => boolean
+// Profiles currently claimed by a browser launch. ChromeProvider marks the
+// profile BEFORE it awaits the in-flight sweep (and only unmarks after the
+// browser is fully stopped), so the sweep and Chrome can never touch a profile
+// concurrently: either the sweep sees the mark and skips the profile, or the
+// launch sees the sweep's promise and waits for it. A mark leaked by a crash
+// only makes the sweep skip that profile — the safe direction.
+const profilesInUse = new Set<string>()
+
+export function markProfileInUse(agentId: string): void {
+  profilesInUse.add(agentId)
+}
+
+export function unmarkProfileInUse(agentId: string): void {
+  profilesInUse.delete(agentId)
 }
 
 /**
@@ -82,17 +89,10 @@ export interface CleanupOptions {
  *     directory can never silently grow to GB scale again.
  *
  * Runs shortly after startup (delayed so it doesn't pile onto launch work).
- * Profiles reported in-use by `isProfileInUse` are skipped, and browser
- * launches await the in-flight sweep, so sweep and Chrome never touch a
- * profile at the same time. (A launch that starts in the instant before the
- * sweep fires can slip past the in-use check; that window is seconds wide and
- * Chrome recreates missing cache dirs lazily, so the worst case is a dropped
- * cache write.)
+ * Profiles marked in-use by a launch are skipped — they're picked up on a
+ * later restart's sweep instead.
  */
-export async function cleanupBrowserProfiles(
-  agentIds: string[],
-  options: CleanupOptions = {},
-): Promise<void> {
+export async function cleanupBrowserProfiles(agentIds: string[]): Promise<void> {
   await removeLegacyProfileDir()
 
   const root = getBrowserProfilesRoot()
@@ -107,7 +107,7 @@ export async function cleanupBrowserProfiles(
   const known = new Set(agentIds)
   for (const entry of entries) {
     if (!entry.isDirectory()) continue
-    if (options.isProfileInUse?.(entry.name)) continue
+    if (profilesInUse.has(entry.name)) continue
     const profileDir = path.join(root, entry.name)
     if (!known.has(entry.name)) {
       // Orphaned: the agent this profile belonged to no longer exists.
@@ -188,18 +188,24 @@ let pendingSweep: NodeJS.Timeout | null = null
  * Schedule the sweep to run once, shortly after startup. Never blocks or fails
  * service initialization. Browser launches await {@link waitForBrowserProfileCleanup}
  * so a launch cannot race an in-flight sweep's deletions.
+ *
+ * `getAgentIds` is a supplier, not a snapshot: it resolves when the timer
+ * fires, so an agent created during the delay is never misclassified as an
+ * orphan (which would recursively delete its cookies and session state).
  */
 export function startBrowserProfileCleanup(
-  agentIds: string[],
-  options: CleanupOptions & { delayMs?: number } = {},
+  getAgentIds: () => Promise<string[]> | string[],
+  options: { delayMs?: number } = {},
 ): void {
   stopBrowserProfileCleanup()
   pendingSweep = setTimeout(() => {
     pendingSweep = null
-    cleanupInFlight = cleanupBrowserProfiles(agentIds, options).catch((error) => {
-      console.error('[BrowserProfiles] Profile cleanup sweep failed:', error)
-      captureException(error, { tags: { component: 'browser', operation: 'profile-cleanup' } })
-    })
+    cleanupInFlight = Promise.resolve()
+      .then(async () => cleanupBrowserProfiles(await getAgentIds()))
+      .catch((error) => {
+        console.error('[BrowserProfiles] Profile cleanup sweep failed:', error)
+        captureException(error, { tags: { component: 'browser', operation: 'profile-cleanup' } })
+      })
   }, options.delayMs ?? STARTUP_SWEEP_DELAY_MS)
   // Never hold the process open just for a pending sweep (matters for the web
   // server, whose event loop must drain on shutdown).

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -97,10 +97,10 @@ export async function initializeServices() {
 
   // Reclaim host-browser profile storage (orphaned/legacy dirs, regenerable
   // Chrome caches). Scheduled a few minutes out so it doesn't pile onto the
-  // startup burst; profiles whose browser is running by then are skipped.
-  startBrowserProfileCleanup(slugs, {
-    isProfileInUse: (agentId) => getActiveProvider()?.isRunning(agentId) ?? false,
-  })
+  // startup burst. The agent list is a supplier resolved when the sweep fires,
+  // not a snapshot — an agent created during the delay must not be treated as
+  // an orphan. Profiles claimed by a browser launch are skipped internally.
+  startBrowserProfileCleanup(async () => (await listAgents()).map((a) => a.slug))
 
   // Stop the host browser for an agent before its container is torn down,
   // so the browser closes gracefully instead of getting a "socket hang up".

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -13,6 +13,7 @@ import { sessionAutoDeleteMonitor } from './scheduler/session-auto-delete-monito
 import { accountSyncService } from './scheduler/account-sync-service'
 import { platformService } from './services/platform-service'
 import { getActiveProvider, stopAllProviders } from '../../main/host-browser'
+import { startBrowserProfileCleanup, stopBrowserProfileCleanup } from '../../main/host-browser/profile-maintenance'
 import { listAgents } from './services/agent-service'
 import { isAuthMode } from './auth/mode'
 import { validateAuthModeStartup } from './auth/startup-validation'
@@ -93,6 +94,13 @@ export async function initializeServices() {
   const agents = await listAgents()
   const slugs = agents.map((a) => a.slug)
   await containerManager.initializeAgents(slugs)
+
+  // Reclaim host-browser profile storage (orphaned/legacy dirs, regenerable
+  // Chrome caches). Scheduled a few minutes out so it doesn't pile onto the
+  // startup burst; profiles whose browser is running by then are skipped.
+  startBrowserProfileCleanup(slugs, {
+    isProfileInUse: (agentId) => getActiveProvider()?.isRunning(agentId) ?? false,
+  })
 
   // Stop the host browser for an agent before its container is torn down,
   // so the browser closes gracefully instead of getting a "socket hang up".
@@ -184,6 +192,7 @@ export function setupServerHandlers(server: ServerType): void {
  */
 export async function shutdownServices() {
   reviewManager.rejectAll()
+  stopBrowserProfileCleanup()
   chatIntegrationManager.stop()
   await stopAllProviders()
   taskScheduler.stop()


### PR DESCRIPTION
Browser automation profiles under `host-browser-profiles/` grew to 10 GB on a dev machine (expected steady state ~500 MB). Four stacked causes, fixed as follows — see SUP-527 for the full forensics.

## Changes

**Prevention (Chrome launch flags, `chrome-provider.ts`)**
- Disable the optimization-guide features (`OptimizationGuideOnDeviceModel`, `OptimizationGuideModelDownloading`, `OptimizationHints`, `TextSafetyClassifier`) so Chrome stops downloading the 4 GB Gemini Nano model into automation profiles. Merged into the *existing* `--disable-features` flag — Chrome only honors the last occurrence, so a second flag would silently re-enable the occlusion-throttling workaround. A test pins the single-occurrence invariant.
- `--disable-component-update` stops browser-level components (`optimization_guide_model_store`, `component_crx_cache`, `WasmTtsEngine`, `Safe Browsing` — ~130 MB) from being re-downloaded into every per-agent user-data-dir.

**Reclamation (`profile-maintenance.ts`, new)**
- Sweep scheduled 3 minutes after startup (off the startup burst): removes the legacy singular `host-browser-profile` dir, deletes profile dirs whose agent no longer exists, strips regenerable caches from surviving profiles. `Default/` session state (cookies, logins, local storage) is never touched.
- Profiles whose browser is running when the sweep fires are skipped; launches await an in-flight sweep, so sweep and Chrome never touch a profile concurrently. Pending timer is unref'd + cancelled on shutdown.
- After sweeping, the directory is measured; >2 GiB reports to Sentry so GB-scale growth can't recur silently.

**GC on agent delete (`agents.ts`)**
- `DELETE /api/agents/:id` now removes the agent's profile dir (best-effort — the sweep is the safety net).

## Why not the ticket's proposed single user-data-dir + `--profile-directory`?

Chrome enforces one running process per user-data-dir (singleton lock), and we run concurrent per-agent Chrome instances, each with its own CDP port, headless setting, and download prefs. A shared dir would serialize all agents onto one process and break CDP target isolation. `--disable-component-update` removes the duplication vector with the same disk outcome and no architecture change.

## Validation
- 41 host-browser tests pass (15 new: real-filesystem sweep tests incl. session-state preservation, traversal/root-deletion guards, sparse-file telemetry threshold, in-use skip, delay/cancellation; launch-flag pinning via a real `launch()`)
- 310 agent-route tests pass (delete path)
- Typecheck + lint clean

Not live-validated: no real-Chrome launch or sweep against an actual 10 GB directory.

https://claude.ai/code/session_01FQsFpTFRiz9JafLHprwWwR