### PR TITLE
build: split Dockerfile into multi-stage (2.46GB → 1.07GB, hosted 931MB)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,20 @@ release
 .next
 agent-container/node_modules
 agent-container/dist
+
+# Local dev/test artifacts — keep them out of the build context (and, for
+# anything COPY'd wholesale, out of the image)
+build
+coverage
+test-results
+playwright-report
+.e2e-data
+tmp
+data
+superagent.db
+superagent.db-*
+*.md
+!README.md
+!docs/**/*.md
+!src/**/*.md
+!agent-container/**/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,18 @@
-FROM node:22-slim
+# ---- builder: full install + web/server build ----
+FROM node:22-slim AS builder
 
 WORKDIR /app
 
-# Install dependencies for better-sqlite3 native compilation and Docker CLI
+# Toolchain for better-sqlite3 native compilation
 RUN apt-get update && apt-get install -y \
     python3 \
     make \
     g++ \
-    git \
-    ca-certificates \
-    curl \
-    gnupg \
-    && install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
-    && chmod a+r /etc/apt/keyrings/docker.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list \
-    && apt-get update \
-    && apt-get install -y docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy package files and install dependencies
 COPY package*.json ./
 RUN npm ci
 
-# Copy source code
 COPY . .
 
 # AUTH_MODE is a compile-time setting for the frontend.
@@ -31,8 +20,57 @@ COPY . .
 ARG AUTH_MODE=false
 ENV AUTH_MODE=${AUTH_MODE}
 
-# Build the application
 RUN npm run build
+
+# ---- deps: production-only node_modules ----
+FROM node:22-slim AS deps
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# ---- runtime ----
+FROM node:22-slim AS runtime
+
+WORKDIR /app
+
+# git is used at runtime by the skillset GitHub provider.
+# The Docker CLI is needed for DooD (self-hosted docker-compose); hosted
+# deployments that run agents via MicroVMs can build with
+# --build-arg INCLUDE_DOCKER_CLI=false to drop it.
+ARG INCLUDE_DOCKER_CLI=true
+RUN apt-get update && apt-get install -y git ca-certificates \
+    && if [ "$INCLUDE_DOCKER_CLI" = "true" ]; then \
+        apt-get install -y curl gnupg \
+        && install -m 0755 -d /etc/apt/keyrings \
+        && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+        && chmod a+r /etc/apt/keyrings/docker.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list \
+        && apt-get update \
+        && apt-get install -y docker-ce-cli \
+        && apt-get purge -y curl gnupg \
+        && apt-get autoremove -y; \
+    fi \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY package*.json ./
+# Drizzle migrations are read from cwd at startup (src/shared/lib/db/index.ts)
+COPY src/shared/lib/db/migrations ./src/shared/lib/db/migrations
+# Agent container build context for buildImage() when running DooD without the
+# compose bind-mount (docker-compose mounts ./agent-container over this)
+COPY agent-container ./agent-container
+
+ARG AUTH_MODE=false
+ENV AUTH_MODE=${AUTH_MODE}
 
 EXPOSE 47891
 

--- a/playwright.docker.config.ts
+++ b/playwright.docker.config.ts
@@ -1,0 +1,75 @@
+import { defineConfig, devices } from '@playwright/test'
+import path from 'path'
+
+// Runs the web E2E suite against an ALREADY-RUNNING server — typically the
+// production Docker image — instead of spawning the dev server.
+//
+// Usage:
+//   SUPERAGENT_DATA_DIR=<seed-dir> node e2e/setup-e2e-data.js
+//   docker run -d -p 3199:47891 -e E2E_MOCK=true -e SUPERAGENT_DATA_DIR=/root/.superagent \
+//     -v <seed-dir>:/root/.superagent <image>
+//   E2E_MOCK=true E2E_PORT=3199 SUPERAGENT_DATA_DIR=<seed-dir> \
+//     npx playwright test --config=playwright.docker.config.ts --project=web-chromium
+//
+// Both the container AND this test process need SUPERAGENT_DATA_DIR pointed at
+// the same (mounted) directory: the server's mock recorder writes JSONL there,
+// and specs read .env/JSONL/wire captures from it.
+const defaultE2eDataDir = path.join(__dirname, '.e2e-data', 'docker')
+if (!process.env.SUPERAGENT_DATA_DIR) {
+  process.env.SUPERAGENT_DATA_DIR = defaultE2eDataDir
+}
+const e2ePort = process.env.E2E_PORT ?? '3199'
+const e2eBaseUrl = process.env.E2E_BASE_URL ?? `http://localhost:${e2ePort}`
+const playwrightOutputDir = process.env.PLAYWRIGHT_OUTPUT_DIR ?? 'test-results'
+const playwrightHtmlReportDir = process.env.PLAYWRIGHT_HTML_REPORT ?? 'playwright-report'
+const configuredWorkers = process.env.PLAYWRIGHT_WORKERS
+  ? Number(process.env.PLAYWRIGHT_WORKERS)
+  : undefined
+
+const webTestIgnore = [
+  '**/auth/**',
+  '**/getting-started-wizard.spec.ts',
+  // Mutates the global provider API key — quarantined to the wizard config.
+  '**/provider-api-key.spec.ts',
+  // These specs register a mock MCP server on host loopback
+  // (http://127.0.0.1:<port>/mcp) which is unreachable from inside the
+  // container, so they structurally cannot pass against a containerized server.
+  '**/mcp-policy-enforcement.spec.ts',
+  '**/connections-management.spec.ts',
+  '**/connected-accounts.spec.ts',
+  '**/connection-delete.spec.ts',
+  '**/global-connections.spec.ts',
+  // Launches a host Chromium for the screencast; same host-only topology.
+  '**/browser-stream.spec.ts',
+]
+
+if (process.env.E2E_INCLUDE_A11Y !== 'true') {
+  webTestIgnore.push('**/a11y-audit.spec.ts')
+}
+
+export default defineConfig({
+  testDir: './e2e',
+  testIgnore: ['**/auth/**'],
+  outputDir: playwrightOutputDir,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: configuredWorkers && Number.isFinite(configuredWorkers) ? configuredWorkers : 4,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: playwrightHtmlReportDir }]],
+
+  use: {
+    baseURL: e2eBaseUrl,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'web-chromium',
+      testIgnore: webTestIgnore,
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // No webServer: the target is an externally-managed container.
+})


### PR DESCRIPTION
## Summary

Splits the app `Dockerfile` into builder / deps / runtime stages. The old single-stage image shipped the apt toolchain, full source, and dev `node_modules`; the runtime stage now carries only what the server actually uses. Motivated by the hosted Fargate offering, where pull size directly affects task cold-start.

- **builder**: toolchain + full `npm ci` + `npm run build` (unchanged `AUTH_MODE` build-arg)
- **deps**: fresh `npm ci --omit=dev` (tsup has no `noExternal`, so the server bundle needs prod `node_modules`)
- **runtime**: prod `node_modules`, `dist/`, drizzle migrations (read from cwd at startup), `agent-container/` source (DooD build context), and `git` (execed at runtime by the skillset GitHub provider)
- New `--build-arg INCLUDE_DOCKER_CLI=false` for hosted builds — the MicroVM runtime never shells out to `docker`, so Fargate images can drop the CLI. Default is `true`: self-host/compose behavior is unchanged.
- `.dockerignore` extended so local artifacts (`build/`, `coverage/`, `.e2e-data/`, `superagent.db`, root `*.md`, …) stay out of the context — the old `COPY . .` baked them into locally-built images.
- `playwright.docker.config.ts` checked in: runs the web E2E suite against an already-running container image (no `webServer`), with the 6 specs that structurally can't pass containerized (host-loopback mock-MCP servers, host-Chromium screencast) excluded.

## Measurements (clean git-archive context, arm64)

| | Uncompressed | Wire (gzip) | Boot → HTTP 200 |
|---|---|---|---|
| Baseline single-stage | 2.46 GB | 1030 MB | ~2 s warm |
| Multi-stage (default) | 1.07 GB | 332 MB | ~2 s warm |
| Multi-stage (`INCLUDE_DOCKER_CLI=false`) | **931 MB** | **280 MB** | ~2 s warm |

Boot time is unchanged (module loading dominates); the win is a ~3.7× smaller pull for hosted deployments.

## Validation

Full `web-chromium` E2E suite (265 runnable tests) run against the built images with fresh seeded data each run:

- multi-stage run 1: 260 passed / 5 failed; baseline: 264 passed / 1 failed (a different spec); multi-stage run 2: 264 passed / 1 failed
- every failing spec passes in isolation on **both** images; failure sets are disjoint across runs/images — known parallelism flakiness of the containerized topology, not image behavior
- typecheck + lint clean

https://claude.ai/code/session_01WRqWEL9vVmYcjDY7JvFXkb