### PR TITLE
build(agent-container): slim image 3.23GB → 1.67GB (wire 1218MB → 602MB)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -51,5 +51,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Registry-backed build cache (shared with release.yml). The GHA cache
+          # caps at 10GB per repo and this image's layers exceed that across two
+          # arches, so gha-cache eviction silently broke layer reuse — every
+          # release re-published all layers with fresh digests, forcing clients
+          # to re-pull ~3GB instead of just the changed top layers.
+          # NOTE: ref must be lowercase; github.repository_owner is not.
+          cache-from: type=registry,ref=ghcr.io/skillfulagents/superagent-agent-container-base:buildcache
+          cache-to: type=registry,ref=ghcr.io/skillfulagents/superagent-agent-container-base:buildcache,mode=max,image-manifest=true,oci-mediatypes=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Registry-backed build cache shared with build-container.yml so
+          # release tags reuse main's layers and keep identical digests —
+          # clients then pull only the changed top layers between versions.
+          # NOTE: ref must be lowercase; github.repository_owner is not.
+          cache-from: type=registry,ref=ghcr.io/skillfulagents/superagent-agent-container-base:buildcache
+          cache-to: type=registry,ref=ghcr.io/skillfulagents/superagent-agent-container-base:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
   # Build and push app containers with version tags (regular + auth)
   build-app-container:

--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -95,11 +95,11 @@ RUN npm install -g agent-browser@0.27.2 && \
 
 # Create a stable symlink to whatever chromium binary got installed, so our
 # runtime code can point at a fixed path rather than globbing. Playwright's
-# layout (chrome-linux vs chrome-linux64 vs chrome-headless-shell-linux64) has
-# shifted between versions, so we use find to locate the binary regardless.
-# Prefer headless_shell (smaller); fall back to full chrome. Build fails loudly
-# if neither is present.
-RUN bin=$(find /opt/playwright-browsers -type f -name headless_shell -perm -u+x 2>/dev/null | head -n 1); \
+# layout AND binary name shift across versions and arches: arm64 unpacks to
+# chrome-linux/headless_shell while amd64 unpacks to
+# chrome-headless-shell-linux64/chrome-headless-shell. Find either headless
+# binary name; fall back to full chrome. Build fails loudly if none is present.
+RUN bin=$(find /opt/playwright-browsers -type f \( -name headless_shell -o -name chrome-headless-shell \) -perm -u+x 2>/dev/null | head -n 1); \
     if [ -z "$bin" ]; then \
       bin=$(find /opt/playwright-browsers -type f -name chrome -perm -u+x 2>/dev/null | head -n 1); \
     fi; \

--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -1,13 +1,19 @@
 # Base image is glibc-based. If this ever changes to a musl distro (e.g. Alpine),
 # the Agent SDK native-binary cleanup step below must flip: delete the `-glibc`
 # variant instead of the `-musl` one, or the Claude subprocess will fail to spawn.
-FROM ubuntu:22.04
+#
+# Stage layout: `base` holds the agent's tool environment (apt packages,
+# runtimes, browser) and is shared by `builder` (dev deps + tsc, discarded)
+# and `runtime` (prod deps + dist, published).
+FROM ubuntu:22.04 AS base
 
 # Prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
+# Install system dependencies. --no-install-recommends everywhere: Ubuntu
+# otherwise drags in recommended packages nobody uses; the tools named here
+# arrive via hard Depends.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     wget \
     git \
@@ -36,11 +42,11 @@ RUN apt-get update && apt-get install -y \
 
 # Install Node.js 20.x
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python 3.11 and pip
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.11 \
     python3-pip \
     python3.11-venv \
@@ -51,19 +57,23 @@ RUN apt-get update && apt-get install -y \
 # Install UV (Universal Virtualenv)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Install TypeScript and ts-node globally
-RUN npm install -g typescript ts-node
+# Install TypeScript and ts-node globally. npm's download cache must be
+# flushed in the SAME layer — anything left in /root/.npm ships in the image
+# (and, being pre-compressed tarballs, doesn't even gzip away on the wire).
+RUN npm install -g typescript ts-node && rm -rf /root/.npm
 
 # Install Bun (for running dashboard servers)
 # Install as root then copy binary to /usr/local/bin so the claude user can access it
-# (symlinks to /root/.bun/bin/ won't work because /root/ is not readable by other users)
+# (symlinks to /root/.bun/bin/ won't work because /root/ is not readable by other users).
+# Remove the installer's /root/.bun copy in the same layer or the ~90MB binary ships twice.
 RUN curl -fsSL https://bun.sh/install | bash && \
     cp /root/.bun/bin/bun /usr/local/bin/bun && \
     ln -s /usr/local/bin/bun /usr/local/bin/bunx && \
-    chmod 755 /usr/local/bin/bun
+    chmod 755 /usr/local/bin/bun && \
+    rm -rf /root/.bun
 
 # Install Chromium dependencies (needed by agent-browser)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 \
     libcups2 libdrm2 libdbus-1-3 libxkbcommon0 \
     libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 \
@@ -72,13 +82,16 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install agent-browser (native Rust binary since v0.20.0) and Playwright's
-# Chromium. Both the agent-browser runtime (via find_playwright_chromium) and
-# our dashboard screenshot code (via playwright-core) share a single Chromium
-# install under PLAYWRIGHT_BROWSERS_PATH.
+# Chromium headless shell. Both the agent-browser runtime (via
+# AGENT_BROWSER_EXECUTABLE_PATH) and our dashboard screenshot code (via
+# playwright-core) launch the chromium-current symlink, which resolves to
+# headless_shell — so only the shell is installed (--only-shell). The full
+# chromium build was ~640MB of never-launched weight.
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 RUN npm install -g agent-browser@0.27.2 && \
-    npx playwright install chromium && \
-    chmod -R o+rx /opt/playwright-browsers
+    npx playwright install chromium --only-shell && \
+    chmod -R o+rx /opt/playwright-browsers && \
+    rm -rf /root/.npm
 
 # Create a stable symlink to whatever chromium binary got installed, so our
 # runtime code can point at a fixed path rather than globbing. Playwright's
@@ -98,26 +111,46 @@ RUN bin=$(find /opt/playwright-browsers -type f -name headless_shell -perm -u+x 
     ln -sf "$bin" /opt/playwright-browsers/chromium-current; \
     echo "Linked /opt/playwright-browsers/chromium-current -> $bin"
 
-# Create workspace directory
-RUN mkdir -p /workspace
+# Create the non-root user and its directories up front so every layer below
+# can create files with the right owner. Ownership fixes must happen in the
+# SAME layer that creates the files: a later `chown -R` (or `rm`) of a lower
+# layer copies up (or merely whiteouts) every file, shipping ~400MB twice.
+RUN useradd -m -s /bin/bash claude && \
+    install -d -o claude -g claude /app /workspace /home/claude/.claude
 WORKDIR /app
 
-# Copy package files
+# ---- builder: dev install + TypeScript build ----
+# Nothing from this stage ships except /app/dist, so devDeps (typescript,
+# ts-node, vitest, @types/*) never reach the runtime image.
+FROM base AS builder
+
 COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
 
-# Install dependencies. The Agent SDK ships per-platform native Claude Code
-# binaries as optional dependencies; npm picks the matching one for this arch
-# (e.g. @anthropic-ai/claude-agent-sdk-linux-arm64/claude).
-RUN npm install
+# ---- runtime ----
+FROM base AS runtime
 
-# Drop the musl variant if npm installed it alongside the glibc one. Our base
-# image is glibc-based Ubuntu (see note at top of file), but npm sometimes
-# ignores the package's `libc` field and installs both. The SDK's resolver
-# prefers the musl binary when present, which then fails at runtime with
-# "binary not found" (the kernel can't load it because ld-musl-<arch>.so isn't
-# on the image). If the base image ever switches to musl (Alpine), invert this:
-# delete the non-musl variants instead.
-RUN rm -rf /app/node_modules/@anthropic-ai/claude-agent-sdk-linux-*-musl
+# Copy package files
+COPY --chown=claude:claude package*.json ./
+
+# Install production dependencies only. The Agent SDK ships per-platform
+# native Claude Code binaries as optional dependencies; npm picks the matching
+# one for this arch (e.g. @anthropic-ai/claude-agent-sdk-linux-arm64/claude).
+#
+# In the same layer (see note above), drop the musl SDK variant if npm
+# installed it alongside the glibc one. Our base image is glibc-based Ubuntu
+# (see note at top of file), but npm sometimes ignores the package's `libc`
+# field and installs both. The SDK's resolver prefers the musl binary when
+# present, which then fails at runtime with "binary not found" (the kernel
+# can't load it because ld-musl-<arch>.so isn't on the image). If the base
+# image ever switches to musl (Alpine), invert this: delete the non-musl
+# variants instead.
+RUN npm ci --omit=dev && \
+    rm -rf /app/node_modules/@anthropic-ai/claude-agent-sdk-linux-*-musl /root/.npm && \
+    chown -R claude:claude /app
 
 # Expose the SDK-bundled claude binary on PATH so shell invocations
 # (`claude -p ...`) inside the container still work. Find-based resolution
@@ -133,12 +166,8 @@ RUN bin=$(find /app/node_modules/@anthropic-ai -maxdepth 2 -type d -name 'claude
       exit 1; \
     fi
 
-# Copy source code
-COPY tsconfig.json ./
-COPY src ./src
-
-# Build TypeScript
-RUN npm run build
+# Compiled output from the builder stage
+COPY --from=builder --chown=claude:claude /app/dist ./dist
 
 # Functional smoke test: the bash step above confirms a binary exists under
 # /opt/playwright-browsers and is marked executable. This step additionally
@@ -147,10 +176,9 @@ RUN npm run build
 # catch a non-functional install (corrupt file, missing shared libs, etc.).
 RUN node dist/scripts/assert-chromium-available.js
 
-# Create non-root user for running Claude Code
-RUN useradd -m -s /bin/bash claude && \
-    chown -R claude:claude /app /workspace && \
-    if [ -d /root/.agent-browser/browsers ]; then \
+# Legacy agent-browser (<0.20) downloaded browsers into /root; move them where
+# the claude user can reach them. No-op with the native-binary versions.
+RUN if [ -d /root/.agent-browser/browsers ]; then \
       mkdir -p /home/claude/.agent-browser && \
       mv /root/.agent-browser/browsers /home/claude/.agent-browser/browsers && \
       chown -R claude:claude /home/claude/.agent-browser; \
@@ -162,8 +190,7 @@ RUN useradd -m -s /bin/bash claude && \
 # not ~/.claude, so a settings.json baked in here would be ignored. The
 # SessionManager provisions /workspace/.claude/settings.json at runtime instead
 # (see agent-container/src/session-manager.ts:ensureClaudeSettings).
-COPY skills/ /home/claude/.claude/skills/
-RUN chown -R claude:claude /home/claude/.claude
+COPY --chown=claude:claude skills/ /home/claude/.claude/skills/
 
 # Switch to non-root user
 USER claude

--- a/agent-container/test-browser-integration.sh
+++ b/agent-container/test-browser-integration.sh
@@ -115,7 +115,7 @@ echo "── Host Browser Path (--cdp simulation) ──"
 # Find Chrome binary dynamically — it may be in agent-browser's cache (x86_64)
 # or in Playwright's cache (ARM64).
 docker exec "$CONTAINER_NAME" bash -c '
-  CHROME=$(find /home/claude/.agent-browser/browsers /opt/playwright-browsers -name chrome -type f 2>/dev/null | head -1)
+  CHROME=$(find /home/claude/.agent-browser/browsers /opt/playwright-browsers \( -name chrome -o -name headless_shell \) -type f 2>/dev/null | head -1)
   if [ -z "$CHROME" ]; then echo "No Chrome binary found" >&2; exit 1; fi
   "$CHROME" --headless --no-sandbox --disable-gpu \
     --remote-debugging-port=9444 \

--- a/agent-container/test-browser-integration.sh
+++ b/agent-container/test-browser-integration.sh
@@ -115,7 +115,7 @@ echo "── Host Browser Path (--cdp simulation) ──"
 # Find Chrome binary dynamically — it may be in agent-browser's cache (x86_64)
 # or in Playwright's cache (ARM64).
 docker exec "$CONTAINER_NAME" bash -c '
-  CHROME=$(find /home/claude/.agent-browser/browsers /opt/playwright-browsers \( -name chrome -o -name headless_shell \) -type f 2>/dev/null | head -1)
+  CHROME=$(find /home/claude/.agent-browser/browsers /opt/playwright-browsers \( -name chrome -o -name headless_shell -o -name chrome-headless-shell \) -type f 2>/dev/null | head -1)
   if [ -z "$CHROME" ]; then echo "No Chrome binary found" >&2; exit 1; fi
   "$CHROME" --headless --no-sandbox --disable-gpu \
     --remote-debugging-port=9444 \


### PR DESCRIPTION
## Summary

Slims the agent-container image by **48% uncompressed / 51% on the wire** without removing anything the agent actually uses — the "comfortable environment" (build-essential, python 3.11 + uv, bun, node, global tsc/ts-node, git, network toolbox) is fully intact, verified by a tool-presence sweep.

| | Uncompressed (arm64) | Wire (same-method gzip) |
|---|---|---|
| Published 0.4.20 | 3.23 GB | 1218 MB |
| This PR | **1.67 GB** | **602 MB** |

## What was actually in those 1.5 GB

- **409 MB — overlayfs copy-up from `chown -R claude:claude /app`**: a post-hoc chown re-ships every file into a new layer. The `claude` user is now created *before* `/app` is populated, copies use `--chown`, and installs chown their output in the creating layer.
- **641 MB — a full Chromium build that was never launched**: agent-browser (`AGENT_BROWSER_EXECUTABLE_PATH`), the dashboard screenshotter, and the `/browser/stream` screencast all resolve `chromium-current` → **headless_shell**. Now installed with `playwright install chromium --only-shell`.
- **239 MB — npm's download cache baked into layers** (`/root/.npm` from the global installs and `npm ci`). Being pre-compressed tarballs, these carried near-full weight on the wire. Flushed in the same layer, every npm-touching RUN.
- **~90 MB — bun installed twice** (installer's `/root/.bun` left behind next to the `/usr/local/bin` copy).
- **~60 MB — devDeps in the runtime image**: new base/builder/runtime stage split; typescript/ts-node/vitest/@types stay in the discarded builder, runtime does `npm ci --omit=dev`. `npm install` → `npm ci` throughout.
- **~60 MB — apt Recommends**: `--no-install-recommends` on all four apt layers (everything named installs via hard Depends).
- The musl SDK-variant cleanup moved into the install layer (a later `rm` only hides files behind a whiteout; on builds where npm wrongly installs it, it no longer ships).

## CI: layer-digest stability across releases

Both `build-container.yml` and `release.yml` switch from `cache-from: type=gha` to a **shared registry build cache** (`…-container-base:buildcache`). The GHA cache caps at 10 GB/repo; this image's multi-arch layer set exceeded that, so eviction silently re-published *all* layers with fresh digests every release — forcing hosts into full ~3 GB re-pulls even for src-only changes. With the registry cache, consecutive tags share lower-layer digests and clients pull only the changed top layers (~4 MB for src-only, ~350 MB on an SDK bump). Notes: the cache ref is hardcoded lowercase (`github.repository_owner` isn't), and the first run after merge builds cold to seed the cache.

## Validation (rerun after every round)

- Build-time chromium smoke test (`assert-chromium-available.js`) and `/health` boot as the `claude` user
- `test-browser-integration.sh`: **18/18** — local browser path (open/snapshot/click/screenshot/tabs/eval) + host-CDP path (script updated to accept `headless_shell` as the simulated host browser, since no `chrome` binary exists with `--only-shell`)
- **Live frame-streaming probe**: opened a page, connected to `/browser/stream`, received binary JPEG screencast frames + viewport metadata from headless_shell — the same binary production already streams from
- Tool-presence sweep: gcc/g++/make, git, python3/pip3/uv, bun (`1.3.14` as `claude`), node, tsc/ts-node, `claude` (SDK binary, 2.1.219), jq/dig/nc/ping/vim/zip/unzip/file/tree/less/whois/traceroute — nothing missing; `/root/.npm` and `/root/.bun` confirmed absent

Known follow-up (not in this PR): pin the floating installers (bun, `uv:latest`, npx playwright — the latter to match `playwright-core` in package.json); currently masked by layer caching but drifts on cache-miss rebuilds.

https://claude.ai/code/session_01WRqWEL9vVmYcjDY7JvFXkb