### PR TITLE
Use dropdown selector for default policies on Connections page

### DIFF
--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -437,27 +437,26 @@ test.describe('Settings persistence', () => {
 
       // The API default-policy row inside the "Default Policies" card.
       const globalSection = page.locator('[data-testid="default-policy-api"]')
-      const reviewToggle = globalSection.locator('[data-testid="policy-toggle-review"]')
-      const allowToggle = globalSection.locator('[data-testid="policy-toggle-allow"]')
+      const trigger = globalSection.locator('[data-testid="policy-dropdown-trigger"]')
 
-      // Review is default, should be active.
-      await expect(reviewToggle).toHaveAttribute('data-active', 'true')
-      await expect(allowToggle).toHaveAttribute('data-active', 'false')
+      // Review is default.
+      await expect(trigger).toHaveAttribute('data-decision', 'review')
 
       // Switch to allow and wait for the user-settings mutation.
+      await trigger.click()
       const savePromise = waitForUserSettingsSave(page)
-      await allowToggle.click()
+      await page.locator('[data-testid="policy-menu-allow"]').click()
       await savePromise
-      await expect(allowToggle).toHaveAttribute('data-active', 'true')
-      await expect(reviewToggle).toHaveAttribute('data-active', 'false')
+      await expect(trigger).toHaveAttribute('data-decision', 'allow')
 
       // Close, reopen, verify the persisted setting is reflected by the UI.
       await closeSettings(page)
       await openSettings(page)
       await goToTab(page, 'connections')
-      const reopenedSection = page.locator('[data-testid="default-policy-api"]')
-      await expect(reopenedSection.locator('[data-testid="policy-toggle-allow"]')).toHaveAttribute('data-active', 'true')
-      await expect(reopenedSection.locator('[data-testid="policy-toggle-review"]')).toHaveAttribute('data-active', 'false')
+      const reopenedTrigger = page
+        .locator('[data-testid="default-policy-api"]')
+        .locator('[data-testid="policy-dropdown-trigger"]')
+      await expect(reopenedTrigger).toHaveAttribute('data-decision', 'allow')
 
       const persisted = await userSettings(request)
       expect(persisted.defaultApiPolicy).toBe('allow')

--- a/src/renderer/components/settings/connections-tab.tsx
+++ b/src/renderer/components/settings/connections-tab.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useCallback } from 'react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { ChevronRight, Loader2, Zap } from 'lucide-react'
-import { PolicyDecisionToggle } from '@renderer/components/ui/policy-decision-toggle'
+import { PolicyDecisionDropdown } from '@renderer/components/ui/policy-decision-toggle'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import {
   useConnectedAccounts,
@@ -166,13 +166,13 @@ export function ConnectionsTab() {
               </div>
             </div>
             <div className="shrink-0">
-              <PolicyDecisionToggle
+              <PolicyDecisionDropdown
                 value={apiPolicy}
+                includeDefault={false}
                 onChange={(value) => {
                   if (value === 'default') return
                   updateSettings.mutate({ defaultApiPolicy: value })
                 }}
-                size="sm"
               />
             </div>
           </div>
@@ -185,13 +185,13 @@ export function ConnectionsTab() {
               </div>
             </div>
             <div className="shrink-0">
-              <PolicyDecisionToggle
+              <PolicyDecisionDropdown
                 value={mcpPolicy}
+                includeDefault={false}
                 onChange={(value) => {
                   if (value === 'default') return
                   updateSettings.mutate({ defaultMcpPolicy: value })
                 }}
-                size="sm"
               />
             </div>
           </div>

--- a/src/renderer/components/ui/policy-decision-toggle.tsx
+++ b/src/renderer/components/ui/policy-decision-toggle.tsx
@@ -132,10 +132,17 @@ export function PolicyDecisionDropdown({
   value,
   onChange,
   className,
+  includeDefault = true,
 }: {
   value: PolicyDecision
   onChange: (value: PolicyDecision) => void
   className?: string
+  /**
+   * When false, the "Default" (inherit) menu item is omitted — for strict
+   * three-way policies with no inherit tier, mirroring the toggle's
+   * `allowDeselect={false}`.
+   */
+  includeDefault?: boolean
 }) {
   const [open, setOpen] = useState(false)
   const current = options.find((o) => o.value === value)
@@ -184,22 +191,24 @@ export function PolicyDecisionDropdown({
             </button>
           )
         })}
-        <button
-          type="button"
-          data-testid="policy-menu-default"
-          data-active={value === 'default'}
-          onClick={() => {
-            onChange('default')
-            setOpen(false)
-          }}
-          className={cn(
-            'flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted',
-            value === 'default' && 'bg-muted',
-          )}
-        >
-          <CircleDashed className="h-3.5 w-3.5 text-muted-foreground" />
-          Default
-        </button>
+        {includeDefault && (
+          <button
+            type="button"
+            data-testid="policy-menu-default"
+            data-active={value === 'default'}
+            onClick={() => {
+              onChange('default')
+              setOpen(false)
+            }}
+            className={cn(
+              'flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted',
+              value === 'default' && 'bg-muted',
+            )}
+          >
+            <CircleDashed className="h-3.5 w-3.5 text-muted-foreground" />
+            Default
+          </button>
+        )}
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
## Summary
- Replace the three-icon `PolicyDecisionToggle` button groups on the **Default API Request Policy** / **Default MCP Tool Policy** rows with the existing `PolicyDecisionDropdown` (same control already used on scope-group headers in the permissions editor).
- Add an `includeDefault` prop to `PolicyDecisionDropdown`: these two settings are strict three-way (they *are* the fallback tier, there is no inherit), so `includeDefault={false}` hides the "Default" menu item — mirroring the toggle's existing `allowDeselect={false}` escape hatch. All other call sites keep the Default option.
- Rewrite the default-policy persistence e2e test to open the dropdown and assert on the trigger's `data-decision` attribute instead of clicking toggle buttons.

## Testing
- `npm run typecheck` + eslint on changed files: clean
- `scope-policy-editor.test.tsx` unit tests: 11/11 pass
- Rewritten e2e test (`settings.spec.ts` "global default API policy toggle persists"): passes with `E2E_MOCK=true`
- Verified visually in mock-web and the Electron dev app: menu shows exactly Always allow / Needs approval / Blocked, selection updates the trigger and persists, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)