### PR TITLE
Support container-local browser sessions

### DIFF
--- a/agent-container/skills/dashboards/SKILL.md
+++ b/agent-container/skills/dashboards/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: dashboards
 description: Create interactive web dashboards to visualize data and provide UI elements to the user
 ---
 
@@ -12,14 +13,16 @@ You can create web dashboards that are served to the user through the Gamut UI. 
 - **`start_dashboard`** — Start a dashboard server (or restart it after code changes)
 - **`list_dashboards`** — List all dashboards and their status
 - **`get_dashboard_logs`** — Read stdout/stderr logs from a dashboard (useful for debugging)
+- **Browser tools** — Open the running dashboard with `browser_open(..., location="container")`, inspect its rendered/accessibility state, exercise controls, and check client-side errors
 
 ## Quick Start (React)
 
 1. Copy the template: `cp -r ~/.claude/skills/dashboards/templates/react-vite /workspace/artifacts/<slug>`
 2. Update `package.json` with the dashboard's `name` and `description`
 3. Edit `src/App.jsx` to build the UI (add API routes in `serve.js` if needed). **All fetch calls in the frontend MUST use relative URLs** — `fetch('api/data')` not `fetch('/api/data')` — absolute paths will 404.
-4. Use `start_dashboard` to build and start the server
-5. The user can view the dashboard in the Gamut UI
+4. Use `start_dashboard` to build and start the server; inspect its screenshot and note the returned port
+5. Open `http://localhost:<port>` with `browser_open(..., location="container")`, exercise the important interactions, and check browser errors
+6. Iterate until both visual and functional checks pass; close the browser when validation is complete
 
 ## Directory Structure
 
@@ -127,9 +130,12 @@ fetch('/api/data')
 
 This applies to all fetches, image sources, link hrefs, etc.
 
-## Important Limitations
+## Interactive Validation
 
-- **Do NOT use the browser tool to view your own dashboards.** The browser runs outside the container and cannot access `localhost` URLs served inside it. Dashboard requests will fail. The user views dashboards through the Gamut UI — you do not need to verify them visually. Use `get_dashboard_logs` to debug issues instead.
+- **Validate every dashboard in container Chromium.** After `start_dashboard`, open its localhost URL with `browser_open(url="http://localhost:<port>", location="container")`. The explicit location forces the bundled browser that can reach private container ports.
+- **Test behavior, not just appearance.** Exercise the primary controls and workflows, inspect rendered and accessibility state, and check browser console/errors for client-side failures.
+- **Use both diagnostic surfaces.** Use `get_dashboard_logs` for server failures and browser diagnostics for rendering or client-side failures.
+- **Close the browser when validation is complete.**
 
 ## Built-in APIs
 
@@ -146,4 +152,5 @@ The following APIs are automatically available in all dashboards (injected by th
 - **Use Bun APIs** — `Bun.serve()`, `Bun.file()`, etc. are fast and built-in
 - **Check logs on errors** — use `get_dashboard_logs` to debug crashes
 - **Restart after changes** — use `start_dashboard` after modifying source code
+- **Verify interactively** — use `browser_open(..., location="container")` after every restart and exercise the changed behavior
 - **Static assets** — serve them from the same directory or use inline styles/scripts for simplicity

--- a/agent-container/src/agent-browser-upgrade.test.ts
+++ b/agent-container/src/agent-browser-upgrade.test.ts
@@ -111,3 +111,19 @@ describe('macEditingCommands inlined', () => {
     expect(source).not.toMatch(/from\s+['"]playwright/)
   })
 })
+
+describe('container-local browser guidance', () => {
+  it('teaches dashboard agents to use bundled Chromium instead of forbidding browser validation', () => {
+    const files = [
+      'system-prompt.md',
+      'dashboard-builder-agent-prompt.md',
+      'tools/start-dashboard.ts',
+      'tools/browser.ts',
+    ]
+    for (const file of files) {
+      const source = fs.readFileSync(path.resolve(__dirname, file), 'utf-8')
+      expect(source, `${file} does not document container browser selection`).toContain('location="container"')
+      expect(source, `${file} still forbids dashboard browser validation`).not.toMatch(/NEVER use the browser tool|Do NOT use the browser tool/)
+    }
+  })
+})

--- a/agent-container/src/agent-browser-upgrade.test.ts
+++ b/agent-container/src/agent-browser-upgrade.test.ts
@@ -119,6 +119,7 @@ describe('container-local browser guidance', () => {
       'dashboard-builder-agent-prompt.md',
       'tools/start-dashboard.ts',
       'tools/browser.ts',
+      '../skills/dashboards/SKILL.md',
     ]
     for (const file of files) {
       const source = fs.readFileSync(path.resolve(__dirname, file), 'utf-8')

--- a/agent-container/src/browser-location.test.ts
+++ b/agent-container/src/browser-location.test.ts
@@ -3,19 +3,32 @@ import {
   isLoopbackBrowserUrl,
   requiresBrowserLocationSwitch,
   resolveBrowserRuntimeLocation,
+  shouldRefuseImplicitHostLoopback,
 } from './browser-location'
 
 describe('resolveBrowserRuntimeLocation', () => {
-  it('uses the configured host provider by default when one is available', () => {
-    expect(resolveBrowserRuntimeLocation('configured', true)).toBe('host')
+  it('uses the configured host provider when no browser is live', () => {
+    expect(resolveBrowserRuntimeLocation(undefined, null, true)).toBe('host')
   })
 
   it('falls back to bundled Chromium when no host provider is configured', () => {
-    expect(resolveBrowserRuntimeLocation('configured', false)).toBe('container')
+    expect(resolveBrowserRuntimeLocation(undefined, null, false)).toBe('container')
+  })
+
+  it('keeps an existing container browser when location is omitted', () => {
+    expect(resolveBrowserRuntimeLocation(undefined, 'container', true)).toBe('container')
+  })
+
+  it('keeps an existing host browser when location is omitted', () => {
+    expect(resolveBrowserRuntimeLocation(undefined, 'host', true)).toBe('host')
   })
 
   it('forces bundled Chromium even when a host provider is configured', () => {
-    expect(resolveBrowserRuntimeLocation('container', true)).toBe('container')
+    expect(resolveBrowserRuntimeLocation('container', 'host', true)).toBe('container')
+  })
+
+  it('switches back to the configured host only when explicitly requested', () => {
+    expect(resolveBrowserRuntimeLocation('configured', 'container', true)).toBe('host')
   })
 })
 
@@ -40,5 +53,17 @@ describe('isLoopbackBrowserUrl', () => {
   it('does not treat external or malformed URLs as loopback', () => {
     expect(isLoopbackBrowserUrl('https://example.com')).toBe(false)
     expect(isLoopbackBrowserUrl('not a url')).toBe(false)
+  })
+})
+
+describe('shouldRefuseImplicitHostLoopback', () => {
+  it('refuses an omitted-location loopback open that would target the host', () => {
+    expect(shouldRefuseImplicitHostLoopback('http://localhost:5000', undefined, 'host')).toBe(true)
+  })
+
+  it('allows loopback in container Chromium and explicit host-loopback requests', () => {
+    expect(shouldRefuseImplicitHostLoopback('http://localhost:5000', undefined, 'container')).toBe(false)
+    expect(shouldRefuseImplicitHostLoopback('http://localhost:5000', 'configured', 'host')).toBe(false)
+    expect(shouldRefuseImplicitHostLoopback('http://localhost:5000', 'container', 'container')).toBe(false)
   })
 })

--- a/agent-container/src/browser-location.test.ts
+++ b/agent-container/src/browser-location.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isLoopbackBrowserUrl,
+  requiresBrowserLocationSwitch,
+  resolveBrowserRuntimeLocation,
+} from './browser-location'
+
+describe('resolveBrowserRuntimeLocation', () => {
+  it('uses the configured host provider by default when one is available', () => {
+    expect(resolveBrowserRuntimeLocation('configured', true)).toBe('host')
+  })
+
+  it('falls back to bundled Chromium when no host provider is configured', () => {
+    expect(resolveBrowserRuntimeLocation('configured', false)).toBe('container')
+  })
+
+  it('forces bundled Chromium even when a host provider is configured', () => {
+    expect(resolveBrowserRuntimeLocation('container', true)).toBe('container')
+  })
+})
+
+describe('requiresBrowserLocationSwitch', () => {
+  it('switches only when a live browser is in a different location', () => {
+    expect(requiresBrowserLocationSwitch('host', 'container')).toBe(true)
+    expect(requiresBrowserLocationSwitch('container', 'container')).toBe(false)
+    expect(requiresBrowserLocationSwitch(null, 'host')).toBe(false)
+  })
+})
+
+describe('isLoopbackBrowserUrl', () => {
+  it.each([
+    'http://localhost:3000',
+    'https://127.0.0.1/app',
+    'http://0.0.0.0:5173',
+    'http://[::1]:8080',
+  ])('recognizes %s', (url) => {
+    expect(isLoopbackBrowserUrl(url)).toBe(true)
+  })
+
+  it('does not treat external or malformed URLs as loopback', () => {
+    expect(isLoopbackBrowserUrl('https://example.com')).toBe(false)
+    expect(isLoopbackBrowserUrl('not a url')).toBe(false)
+  })
+})

--- a/agent-container/src/browser-location.ts
+++ b/agent-container/src/browser-location.ts
@@ -8,13 +8,15 @@ export type BrowserRuntimeLocation = 'host' | 'container'
 
 /**
  * Resolve the model-facing location onto the browser process we should use.
- * "configured" preserves the existing host-provider preference, while an
- * explicit "container" always bypasses it.
+ * An omitted location keeps a live browser where it is; with no live browser,
+ * it falls back to the configured provider. Explicit values always win.
  */
 export function resolveBrowserRuntimeLocation(
-  requested: BrowserOpenLocation = 'configured',
+  requested: BrowserOpenLocation | undefined,
+  current: BrowserRuntimeLocation | null = null,
   hostBrowserConfigured: boolean = !!process.env.AGENT_BROWSER_USE_HOST,
 ): BrowserRuntimeLocation {
+  if (requested === undefined && current !== null) return current
   return requested === 'container' || !hostBrowserConfigured ? 'container' : 'host'
 }
 
@@ -37,4 +39,16 @@ export function isLoopbackBrowserUrl(url: string): boolean {
   } catch {
     return false
   }
+}
+
+/**
+ * Teaching guard for likely model mistakes, not a network security boundary.
+ * Host-loopback remains available when explicitly requested with "configured".
+ */
+export function shouldRefuseImplicitHostLoopback(
+  url: string,
+  requested: BrowserOpenLocation | undefined,
+  resolved: BrowserRuntimeLocation,
+): boolean {
+  return requested === undefined && resolved === 'host' && isLoopbackBrowserUrl(url)
 }

--- a/agent-container/src/browser-location.ts
+++ b/agent-container/src/browser-location.ts
@@ -1,0 +1,40 @@
+export const BROWSER_OPEN_LOCATIONS = ['configured', 'container'] as const
+
+/** Location requested by the model when opening a browser. */
+export type BrowserOpenLocation = typeof BROWSER_OPEN_LOCATIONS[number]
+
+/** Location of the Chromium process that is actually active. */
+export type BrowserRuntimeLocation = 'host' | 'container'
+
+/**
+ * Resolve the model-facing location onto the browser process we should use.
+ * "configured" preserves the existing host-provider preference, while an
+ * explicit "container" always bypasses it.
+ */
+export function resolveBrowserRuntimeLocation(
+  requested: BrowserOpenLocation = 'configured',
+  hostBrowserConfigured: boolean = !!process.env.AGENT_BROWSER_USE_HOST,
+): BrowserRuntimeLocation {
+  return requested === 'container' || !hostBrowserConfigured ? 'container' : 'host'
+}
+
+/** Whether an open request must tear down the current provider before launch. */
+export function requiresBrowserLocationSwitch(
+  current: BrowserRuntimeLocation | null,
+  requested: BrowserRuntimeLocation,
+): boolean {
+  return current !== null && current !== requested
+}
+
+/** URLs that normally refer to a service in the browser's own network namespace. */
+export function isLoopbackBrowserUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase()
+    return hostname === 'localhost'
+      || hostname === '127.0.0.1'
+      || hostname === '0.0.0.0'
+      || hostname === '[::1]'
+  } catch {
+    return false
+  }
+}

--- a/agent-container/src/browser-state.test.ts
+++ b/agent-container/src/browser-state.test.ts
@@ -20,12 +20,12 @@ describe('browser-state', () => {
     })
 
     it('allows access when the requesting session owns the browser', () => {
-      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: null })
+      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: null, location: 'container' })
       expect(validateBrowserSession('session-1')).toBeNull()
     })
 
     it('blocks access when a different session owns the browser', () => {
-      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: null })
+      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: null, location: 'container' })
       const error = validateBrowserSession('session-2')
       expect(error).toBe('Browser is owned by session session-1')
     })
@@ -33,14 +33,14 @@ describe('browser-state', () => {
 
   describe('releaseBrowserLock', () => {
     it('releases the lock when the owning session calls it', () => {
-      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: 'ws://localhost:9222' })
+      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: 'ws://localhost:9222', location: 'host' })
       const released = releaseBrowserLock('session-1')
       expect(released).toBe(true)
-      expect(getBrowserState()).toEqual({ active: false, sessionId: null, cdpUrl: null })
+      expect(getBrowserState()).toEqual({ active: false, sessionId: null, cdpUrl: 'ws://localhost:9222', location: 'host' })
     })
 
     it('does not release the lock when a non-owning session calls it', () => {
-      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: 'ws://localhost:9222' })
+      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: 'ws://localhost:9222', location: 'host' })
       const released = releaseBrowserLock('session-2')
       expect(released).toBe(false)
       expect(getBrowserState().active).toBe(true)
@@ -53,7 +53,7 @@ describe('browser-state', () => {
     })
 
     it('allows a new session to acquire the browser after release', () => {
-      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: null })
+      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: null, location: 'container' })
 
       // session-2 is blocked
       expect(validateBrowserSession('session-2')).not.toBeNull()
@@ -68,17 +68,18 @@ describe('browser-state', () => {
 
   describe('renameBrowserSession', () => {
     it('re-keys the lock when the old id owns it (query restart mid-browse)', () => {
-      setBrowserState({ active: true, sessionId: 'old-id', cdpUrl: 'ws://localhost:9222' })
+      setBrowserState({ active: true, sessionId: 'old-id', cdpUrl: 'ws://localhost:9222', location: 'host' })
       expect(renameBrowserSession('old-id', 'new-id')).toBe(true)
       expect(getBrowserState().sessionId).toBe('new-id')
       expect(getBrowserState().cdpUrl).toBe('ws://localhost:9222')
+      expect(getBrowserState().location).toBe('host')
       // requests under the new id now pass; old id no longer matches
       expect(validateBrowserSession('new-id')).toBeNull()
       expect(validateBrowserSession('old-id')).not.toBeNull()
     })
 
     it('does nothing when the old id does not own the lock', () => {
-      setBrowserState({ active: true, sessionId: 'other-session', cdpUrl: null })
+      setBrowserState({ active: true, sessionId: 'other-session', cdpUrl: null, location: 'container' })
       expect(renameBrowserSession('old-id', 'new-id')).toBe(false)
       expect(getBrowserState().sessionId).toBe('other-session')
     })
@@ -91,9 +92,9 @@ describe('browser-state', () => {
 
   describe('transferBrowserLock', () => {
     it('reassigns ownership while preserving the live connection', () => {
-      setBrowserState({ active: true, sessionId: 'dead-session', cdpUrl: 'ws://localhost:9222' })
+      setBrowserState({ active: true, sessionId: 'dead-session', cdpUrl: 'ws://localhost:9222', location: 'host' })
       transferBrowserLock('live-session')
-      expect(getBrowserState()).toEqual({ active: true, sessionId: 'live-session', cdpUrl: 'ws://localhost:9222' })
+      expect(getBrowserState()).toEqual({ active: true, sessionId: 'live-session', cdpUrl: 'ws://localhost:9222', location: 'host' })
       expect(validateBrowserSession('live-session')).toBeNull()
     })
 
@@ -107,7 +108,7 @@ describe('browser-state', () => {
   describe('stale lock scenario (SUP-167)', () => {
     it('a finished cron session should not block the next cron session', () => {
       // Cron run #1 opens the browser
-      setBrowserState({ active: true, sessionId: 'cron-session-1', cdpUrl: 'ws://localhost:9222' })
+      setBrowserState({ active: true, sessionId: 'cron-session-1', cdpUrl: 'ws://localhost:9222', location: 'host' })
 
       // Cron run #1 finishes and releases
       releaseBrowserLock('cron-session-1')
@@ -118,7 +119,7 @@ describe('browser-state', () => {
 
     it('without release, a finished cron session blocks the next one', () => {
       // Cron run #1 opens the browser
-      setBrowserState({ active: true, sessionId: 'cron-session-1', cdpUrl: 'ws://localhost:9222' })
+      setBrowserState({ active: true, sessionId: 'cron-session-1', cdpUrl: 'ws://localhost:9222', location: 'host' })
 
       // Cron run #1 finishes but does NOT release (the bug)
       // Cron run #2 tries to use the browser — blocked

--- a/agent-container/src/browser-state.test.ts
+++ b/agent-container/src/browser-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   getBrowserState,
   setBrowserState,
@@ -37,6 +37,26 @@ describe('browser-state', () => {
       const released = releaseBrowserLock('session-1')
       expect(released).toBe(true)
       expect(getBrowserState()).toEqual({ active: false, sessionId: null, cdpUrl: 'ws://localhost:9222', location: 'host' })
+    })
+
+    it('notifies the pre-release owner after clearing the lock', () => {
+      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: null, location: 'container' })
+      const onReleased = vi.fn((releasedSessionId: string) => {
+        expect(releasedSessionId).toBe('session-1')
+        expect(getBrowserState().sessionId).toBeNull()
+        expect(getBrowserState().active).toBe(false)
+      })
+
+      expect(releaseBrowserLock('session-1', onReleased)).toBe(true)
+      expect(onReleased).toHaveBeenCalledOnce()
+    })
+
+    it('does not notify when the requester does not own the lock', () => {
+      setBrowserState({ active: true, sessionId: 'session-1', cdpUrl: null, location: 'container' })
+      const onReleased = vi.fn()
+
+      expect(releaseBrowserLock('session-2', onReleased)).toBe(false)
+      expect(onReleased).not.toHaveBeenCalled()
     })
 
     it('does not release the lock when a non-owning session calls it', () => {

--- a/agent-container/src/browser-state.ts
+++ b/agent-container/src/browser-state.ts
@@ -1,10 +1,13 @@
+import type { BrowserRuntimeLocation } from './browser-location'
+
 export interface BrowserState {
   active: boolean;
   sessionId: string | null;
   cdpUrl: string | null;
+  location: BrowserRuntimeLocation | null;
 }
 
-const initialState: BrowserState = { active: false, sessionId: null, cdpUrl: null };
+const initialState: BrowserState = { active: false, sessionId: null, cdpUrl: null, location: null };
 
 let browserState: BrowserState = { ...initialState };
 
@@ -40,7 +43,7 @@ export function validateBrowserSession(requestSessionId: string): string | null 
  */
 export function releaseBrowserLock(sessionId: string): boolean {
   if (browserState.active && browserState.sessionId === sessionId) {
-    browserState = { active: false, sessionId: null, cdpUrl: null };
+    browserState = { ...browserState, active: false, sessionId: null };
     return true;
   }
   return false;

--- a/agent-container/src/browser-state.ts
+++ b/agent-container/src/browser-state.ts
@@ -39,11 +39,18 @@ export function validateBrowserSession(requestSessionId: string): string | null 
  * Does NOT close the browser or kill chromium — only drops the ownership lock
  * so another session can acquire it. The Chrome process and cookies are preserved.
  *
- * Returns true if the lock was released, false if the session didn't own it.
+ * `onReleased` receives the pre-release owner after state is cleared. This lets
+ * callers send lifecycle events to the right session without reimplementing
+ * the ownership check or reading a now-null sessionId.
  */
-export function releaseBrowserLock(sessionId: string): boolean {
+export function releaseBrowserLock(
+  sessionId: string,
+  onReleased?: (releasedSessionId: string) => void,
+): boolean {
   if (browserState.active && browserState.sessionId === sessionId) {
+    const releasedSessionId = browserState.sessionId
     browserState = { ...browserState, active: false, sessionId: null };
+    onReleased?.(releasedSessionId)
     return true;
   }
   return false;

--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -83,7 +83,13 @@ vi.mock('./mcp-server', () => ({
 }))
 
 vi.mock('./tools/browser', () => ({
-  createBrowserTools: () => [],
+  createBrowserTools: () => [
+    { name: 'browser_open' },
+    { name: 'browser_get_state' },
+    { name: 'browser_snapshot' },
+    { name: 'browser_click' },
+    { name: 'browser_close' },
+  ],
 }))
 
 vi.mock('./tools/computer-use', () => ({
@@ -441,5 +447,26 @@ describe('ClaudeCodeProcess static tool bans', () => {
     expect(calls).toHaveLength(1)
     const disallowed = calls[0].options.disallowedTools as string[]
     expect(disallowed).toContain('DesignSync')
+  })
+})
+
+describe('ClaudeCodeProcess dashboard browser tools', () => {
+  beforeEach(() => {
+    calls.length = 0
+  })
+
+  it('lets the dashboard builder open and validate container-local dashboards', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-dashboard-browser-tools',
+      workingDirectory: '/tmp',
+    })
+
+    await process.start()
+    const agents = calls[0].options.agents as Record<string, { tools: string[] }>
+    const tools = agents['dashboard-builder'].tools
+    expect(tools).toContain('mcp__browser__browser_open')
+    expect(tools).toContain('mcp__browser__browser_get_state')
+    expect(tools).toContain('mcp__browser__browser_click')
+    expect(tools).toContain('mcp__browser__browser_close')
   })
 })

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -818,6 +818,10 @@ export class ClaudeCodeProcess extends EventEmitter {
             'mcp__dashboards__start_dashboard',
             'mcp__dashboards__list_dashboards',
             'mcp__dashboards__get_dashboard_logs',
+            // Intentional product tradeoff: interactive dashboard validation
+            // needs the full browser surface. This also permits configured-host
+            // browsing; location="container" is prompt-guided, not capability-
+            // enforced, matching the existing web-browser agent's authority.
             ...mcpToolNames('browser', browserMcpTools),
             'Read',
             'Write',

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -809,7 +809,7 @@ export class ClaudeCodeProcess extends EventEmitter {
           maxTurns: 500,
         },
         'dashboard-builder': {
-          description: 'Dashboard building specialist. Delegate any task that involves creating, editing, or debugging dashboards (artifacts) — designing layouts, writing HTML/CSS/JS or React code, adding charts, connecting to data sources, fixing visual issues, or iterating on dashboard design. This agent handles the full build cycle: scaffolding, coding, starting, and verifying via screenshots.',
+          description: 'Dashboard building specialist. Delegate any task that involves creating, editing, or debugging dashboards (artifacts) — designing layouts, writing HTML/CSS/JS or React code, adding charts, connecting to data sources, fixing visual issues, or iterating on dashboard design. This agent handles the full build cycle: scaffolding, coding, starting, and interactive validation in container Chromium.',
           // Host-resolved dashboard-builder model (its own setting); falls back to
           // the main model rather than a hardcoded Claude alias.
           model: this.dashboardBuilderModel || this.model,
@@ -818,6 +818,7 @@ export class ClaudeCodeProcess extends EventEmitter {
             'mcp__dashboards__start_dashboard',
             'mcp__dashboards__list_dashboards',
             'mcp__dashboards__get_dashboard_logs',
+            ...mcpToolNames('browser', browserMcpTools),
             'Read',
             'Write',
             'Edit',

--- a/agent-container/src/dashboard-builder-agent-prompt.md
+++ b/agent-container/src/dashboard-builder-agent-prompt.md
@@ -8,6 +8,13 @@ You are a dashboard builder agent. You receive high-level objectives and build o
 - `list_dashboards()` — List all dashboards with slug, name, status, and port.
 - `get_dashboard_logs(slug, clear?)` — Read stdout/stderr logs. Essential for debugging crashes.
 
+**Interactive browser validation:**
+- `browser_open(url, location)` — Open the running dashboard. Always pass `location="container"` for the localhost URL returned by `start_dashboard`.
+- `browser_get_state()` / `browser_snapshot()` / `browser_screenshot()` — Inspect rendered and accessibility state.
+- `browser_click`, `browser_fill`, `browser_select`, `browser_press`, `browser_type` — Exercise controls and workflows.
+- `browser_run("console")` / `browser_run("errors")` — Check client-side diagnostics.
+- `browser_close()` — Close Chromium when dashboard validation is complete.
+
 **File tools:**
 - `Read(file_path)` — Read file contents. Use to inspect existing dashboard code before editing.
 - `Write(file_path, content)` — Create or overwrite a file.
@@ -49,11 +56,12 @@ Best for: complex interactive dashboards, multi-view apps, dashboards with rich 
 
 1. **Create**: `create_dashboard` with a descriptive slug and name
 2. **Build**: Write/edit the source files at `/workspace/artifacts/<slug>/`
-3. **Start**: `start_dashboard` to launch — inspect the returned screenshot
-4. **Iterate**: Edit files, restart, check screenshot and logs until satisfied
-5. **Debug**: Use `get_dashboard_logs` when a dashboard crashes or misbehaves
+3. **Start**: `start_dashboard` to launch — inspect the returned screenshot and note its port
+4. **Validate**: Open it with `browser_open(url="http://localhost:<port>", location="container")`; exercise the important interactions and check browser errors
+5. **Iterate**: Edit files, restart, and repeat visual and functional checks until satisfied
+6. **Debug**: Use `get_dashboard_logs` for server failures and browser console/errors for client failures
 
-Always call `start_dashboard` after making changes. The screenshot in the response is your only way to verify the visual output — inspect it carefully.
+Always call `start_dashboard` after making changes. Treat its screenshot as the quick visual check, then use container Chromium for interactive verification.
 
 ## Building Great Dashboards
 
@@ -178,12 +186,13 @@ function renderTable(data, sortKey, sortDir) {
 When a dashboard crashes or shows unexpected behavior:
 1. **Check logs first**: `get_dashboard_logs(slug)` — look for syntax errors, runtime exceptions, or port conflicts
 2. **Check the screenshot**: The `start_dashboard` response includes a screenshot — look for rendering issues
-3. **Common issues**:
+3. **Check the browser**: Open the returned localhost port with `location="container"`, inspect state, and run `browser_run("errors")` for client-side failures
+4. **Common issues**:
    - Port not binding: Make sure you read `process.env.DASHBOARD_PORT`
    - Blank page: Check for JS errors in the HTML, missing closing tags
    - Crash loop: The platform auto-restarts up to 3 times in 5 minutes, then stops. Fix the root cause before restarting.
    - Module not found: Run `bun install` or `bun add <package>` in the dashboard directory
-4. **Clear logs**: Use `get_dashboard_logs(slug, clear: true)` to reset before a fresh test run
+5. **Clear logs**: Use `get_dashboard_logs(slug, clear: true)` to reset before a fresh test run
 
 ## Built-in APIs
 
@@ -247,9 +256,10 @@ Rate limited to 100 req/min. This is the full Anthropic JS SDK (lazy-loaded) —
 
 ## Critical Rules
 
-- **NEVER use the browser tool** to view dashboards. The browser runs outside the container and cannot access localhost URLs. Use `start_dashboard` screenshots and `get_dashboard_logs` instead.
+- **Use container Chromium for dashboard validation.** Open the localhost URL from `start_dashboard` with `location="container"`; the default configured browser may run outside the container and cannot reach the private port.
 - **Always call `start_dashboard` after making changes.** This is how you verify your work.
-- **Inspect the screenshot carefully.** It is your only visual feedback. Look for layout issues, missing content, broken styling.
+- **Inspect the screenshot and interact with the page.** Check layout, missing content, broken styling, key controls, and browser errors.
+- **Close the browser when validation is complete.**
 - **Install dependencies before starting.** If you add npm packages to `package.json`, run `bun install` in the dashboard directory, or just use `bun add <package>` which both installs and updates package.json.
 - **Use the DASHBOARD_PORT environment variable.** Never hardcode a port number.
 - **Always use relative URLs in client-side code, never absolute.** Dashboards are served under a subpath (`/api/agents/:id/artifacts/:slug/`), so `fetch('/api/data')` bypasses the proxy and 404s - write `fetch('api/data')` instead. Applies to every fetch, `img src`, and `href`.

--- a/agent-container/src/input-manager.test.ts
+++ b/agent-container/src/input-manager.test.ts
@@ -477,7 +477,7 @@ describe('InputManager', () => {
       // The handler only registers a pending while a browser is active
       // (see the browser-lifecycle guard test file)
       const { setBrowserState, resetBrowserState } = await import('./browser-state')
-      setBrowserState({ active: true, sessionId: 'rbt-sess', cdpUrl: 'ws://127.0.0.1:9222' })
+      setBrowserState({ active: true, sessionId: 'rbt-sess', cdpUrl: 'ws://127.0.0.1:9222', location: 'host' })
 
       const { requestBrowserInputTool } = await import('./tools/request-browser-input')
       const handler = (requestBrowserInputTool as any).handler

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -626,6 +626,7 @@ import {
   type BrowserRuntimeLocation,
   requiresBrowserLocationSwitch,
   resolveBrowserRuntimeLocation,
+  shouldRefuseImplicitHostLoopback,
 } from './browser-location';
 
 // Proxy object so existing code can read `browserState.active` etc. without changes.
@@ -1008,13 +1009,13 @@ async function stopHostBrowserIfNeeded(location: BrowserRuntimeLocation | null):
   }
 }
 
-// Broadcast a browser_active event to the owning session's WebSocket subscribers
-function broadcastBrowserEvent(active: boolean): void {
-  if (!browserState.sessionId) return;
-  const sessionId = browserState.sessionId;
+// Broadcast a browser_active event to the owning session's WebSocket subscribers.
+// Callers releasing a lock can supply the pre-release owner explicitly.
+function broadcastBrowserEvent(active: boolean, targetSessionId: string | null = browserState.sessionId): void {
+  if (!targetSessionId) return;
 
   // Broadcast through the session manager's subscriber system
-  sessionManager.broadcast(sessionId, {
+  sessionManager.broadcast(targetSessionId, {
     type: 'browser_active',
     active,
     timestamp: new Date().toISOString(),
@@ -1050,7 +1051,15 @@ app.post('/browser/open', async (c) => {
       return c.json({ error: validationError }, 409);
     }
 
-    const location = resolveBrowserRuntimeLocation(body.location);
+    const location = resolveBrowserRuntimeLocation(body.location, browserState.location);
+    if (shouldRefuseImplicitHostLoopback(body.url, body.location, location)) {
+      return c.json({
+        error:
+          'This loopback URL would open on the host machine because no browser location was specified. ' +
+          'Retry with location="container" for a service inside the agent container, or explicitly pass ' +
+          'location="configured" to open the host browser\'s loopback interface. The current browser was left unchanged.',
+      }, 400);
+    }
     let switchedFrom: BrowserRuntimeLocation | null = null;
 
     // The browser tools expose one active browser abstraction. Changing its
@@ -1201,9 +1210,10 @@ app.post('/browser/release', async (c) => {
       return c.json({ error: 'sessionId is required' }, 400);
     }
 
-    const ownedByRequester = browserState.active && browserState.sessionId === body.sessionId;
-    if (ownedByRequester) broadcastBrowserEvent(false);
-    const released = releaseBrowserLock(body.sessionId);
+    const released = releaseBrowserLock(
+      body.sessionId,
+      releasedSessionId => broadcastBrowserEvent(false, releasedSessionId),
+    );
     if (released) {
       console.log(`[Browser] Lock released by session ${body.sessionId} (browser still running)`);
     }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -620,6 +620,13 @@ import {
   releaseBrowserLock,
   transferBrowserLock,
 } from './browser-state';
+import {
+  BROWSER_OPEN_LOCATIONS,
+  type BrowserOpenLocation,
+  type BrowserRuntimeLocation,
+  requiresBrowserLocationSwitch,
+  resolveBrowserRuntimeLocation,
+} from './browser-location';
 
 // Proxy object so existing code can read `browserState.active` etc. without changes.
 // Writes must go through _setBrowserState() to keep the canonical module state in sync.
@@ -806,11 +813,11 @@ function reportHostBrowserLaunchError(
   }).catch(() => {});
 }
 
-// Launch the host browser via CDP if AGENT_BROWSER_USE_HOST is set.
+// Launch the host browser via CDP when this open request resolved to the host.
 // Returns the CDP WebSocket URL and host download dir, or undefined if not using host browser.
-// Throws if host browser mode is enabled but the browser fails to launch.
-async function launchHostBrowserIfNeeded(): Promise<HostBrowserInfo | undefined> {
-  if (!process.env.AGENT_BROWSER_USE_HOST) {
+// Throws if the request resolves to the host but that browser fails to launch.
+async function launchHostBrowserIfNeeded(location: BrowserRuntimeLocation): Promise<HostBrowserInfo | undefined> {
+  if (location !== 'host') {
     return undefined;
   }
 
@@ -978,8 +985,8 @@ async function reapplyDownloadBehavior(): Promise<void> {
 }
 
 // Tell the host to stop the Chrome process for this agent.
-async function stopHostBrowserIfNeeded(): Promise<void> {
-  if (!process.env.AGENT_BROWSER_USE_HOST) return;
+async function stopHostBrowserIfNeeded(location: BrowserRuntimeLocation | null): Promise<void> {
+  if (location !== 'host') return;
 
   const hostAppUrl = process.env.HOST_APP_URL;
   if (!hostAppUrl) return;
@@ -1025,15 +1032,43 @@ app.get('/browser/status', (c) => {
 // POST /browser/open - Start browser and navigate to URL
 app.post('/browser/open', async (c) => {
   try {
-    const body = await c.req.json<{ sessionId: string; url: string }>();
+    const body = await c.req.json<{
+      sessionId: string;
+      url: string;
+      location?: BrowserOpenLocation;
+    }>();
 
     if (!body.sessionId || !body.url) {
       return c.json({ error: 'sessionId and url are required' }, 400);
+    }
+    if (body.location !== undefined && !BROWSER_OPEN_LOCATIONS.some(value => value === body.location)) {
+      return c.json({ error: `location must be one of: ${BROWSER_OPEN_LOCATIONS.join(', ')}` }, 400);
     }
 
     const validationError = validateBrowserSessionWithRecovery(body.sessionId);
     if (validationError) {
       return c.json({ error: validationError }, 409);
+    }
+
+    const location = resolveBrowserRuntimeLocation(body.location);
+    let switchedFrom: BrowserRuntimeLocation | null = null;
+
+    // The browser tools expose one active browser abstraction. Changing its
+    // process location therefore closes the old provider before launching the
+    // new one, rather than leaving an unreachable browser consuming resources.
+    if (requiresBrowserLocationSwitch(browserState.location, location)) {
+      switchedFrom = browserState.location;
+      await execBrowser(['close'], browserState.cdpUrl || undefined);
+      cleanupAgentBrowserDaemon();
+      await stopHostBrowserIfNeeded(browserState.location);
+      cleanupCdpScreencast();
+      broadcastBrowserEvent(false);
+      _setBrowserState({ active: false, sessionId: null, cdpUrl: null, location: null });
+      tabManager.resetTabCount();
+      inputManager.rejectByType(
+        'browser_input',
+        'The browser provider changed before the user completed this request'
+      );
     }
 
     // If browser is already active, check for a matching tab before opening a new one
@@ -1044,11 +1079,17 @@ app.post('/browser/open', async (c) => {
         await tabManager.syncTabCount();
         observeUrl(matchingTab.url); // seed URL baseline for post-action digests
         notifyBrowserAction();
-        return c.json({ success: true, switchedToExisting: true, tabId: matchingTab.tabId, url: matchingTab.url });
+        return c.json({
+          success: true,
+          switchedToExisting: true,
+          tabId: matchingTab.tabId,
+          url: matchingTab.url,
+          location,
+        });
       }
     }
 
-    const hostBrowser = await launchHostBrowserIfNeeded();
+    const hostBrowser = await launchHostBrowserIfNeeded(location);
     const cdpUrl = hostBrowser?.cdpUrl;
     const profile = process.env.AGENT_BROWSER_PROFILE || '/workspace/.browser-profile';
 
@@ -1069,7 +1110,7 @@ app.post('/browser/open', async (c) => {
     }
 
     if (result.exitCode !== 0) {
-      const debugInfo = cdpUrl ? ` [cdp=${cdpUrl}, mode=host, attempts=2]` : ' [mode=local, attempts=2]';
+      const debugInfo = ` [location=${location}, attempts=2]`;
       return c.json({ error: `${result.stdout}${debugInfo}`, success: false }, 500);
     }
 
@@ -1087,7 +1128,7 @@ app.post('/browser/open', async (c) => {
       }
     }
 
-    _setBrowserState({ active: true, sessionId: body.sessionId, cdpUrl: cdpUrl || null });
+    _setBrowserState({ active: true, sessionId: body.sessionId, cdpUrl: cdpUrl || null, location });
     tabManager.resetTabCount();
     resetUrlTracking();
     // Seed the URL baseline so the FIRST post-action digest can distinguish
@@ -1099,7 +1140,7 @@ app.post('/browser/open', async (c) => {
     }
     broadcastBrowserEvent(true);
 
-    return c.json({ success: true });
+    return c.json({ success: true, location, switchedFrom });
   } catch (error: any) {
     console.error('[Browser] Error opening browser:', error);
     return c.json({ error: error.message || 'Failed to open browser' }, 500);
@@ -1120,15 +1161,16 @@ app.post('/browser/close', async (c) => {
       return c.json({ error: validationError }, 409);
     }
 
+    const activeLocation = browserState.location;
     await execBrowser(['close'], browserState.cdpUrl || undefined);
     cleanupAgentBrowserDaemon();
 
     // If using host browser, tell the host to kill the Chrome process
-    await stopHostBrowserIfNeeded();
+    await stopHostBrowserIfNeeded(activeLocation);
 
     cleanupCdpScreencast();
     broadcastBrowserEvent(false);
-    _setBrowserState({ active: false, sessionId: null, cdpUrl: null });
+    _setBrowserState({ active: false, sessionId: null, cdpUrl: null, location: null });
     tabManager.resetTabCount();
 
     // A browser_input request is only answerable while the browser exists —
@@ -1159,9 +1201,10 @@ app.post('/browser/release', async (c) => {
       return c.json({ error: 'sessionId is required' }, 400);
     }
 
+    const ownedByRequester = browserState.active && browserState.sessionId === body.sessionId;
+    if (ownedByRequester) broadcastBrowserEvent(false);
     const released = releaseBrowserLock(body.sessionId);
     if (released) {
-      broadcastBrowserEvent(false);
       console.log(`[Browser] Lock released by session ${body.sessionId} (browser still running)`);
     }
     return c.json({ success: true, released });
@@ -1173,11 +1216,11 @@ app.post('/browser/release', async (c) => {
 
 // POST /browser/notify-closed - Host browser was closed externally, clean up state
 app.post('/browser/notify-closed', (c) => {
-  if (browserState.active) {
+  if (browserState.location) {
     cleanupAgentBrowserDaemon();
     cleanupCdpScreencast();
     broadcastBrowserEvent(false);
-    _setBrowserState({ active: false, sessionId: null, cdpUrl: null });
+    _setBrowserState({ active: false, sessionId: null, cdpUrl: null, location: null });
     tabManager.resetTabCount();
     console.log('[Browser] Browser closed externally, state cleaned up');
   }
@@ -2649,12 +2692,12 @@ async function gracefulShutdown(signal: string) {
 
   console.log(`\nReceived ${signal}, shutting down gracefully...`);
 
-  // Close browser if active
-  if (browserState.active) {
+  // Close the browser even if an automated session released its ownership lock.
+  if (browserState.location) {
     try {
       await execBrowser(['close'], browserState.cdpUrl || undefined);
-      await stopHostBrowserIfNeeded();
-      _setBrowserState({ active: false, sessionId: null, cdpUrl: null });
+      await stopHostBrowserIfNeeded(browserState.location);
+      _setBrowserState({ active: false, sessionId: null, cdpUrl: null, location: null });
     } catch (error) {
       console.error('Error closing browser:', error);
     }

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -674,7 +674,7 @@ The file is a JSON array — each item has a `name` and exactly one of: `link` (
 You have a web browser for interacting with websites. The user can see the browser live and interact with it directly.
 
 ### Browser Lifecycle Tools (use these directly)
-- `browser_open(url)` — Open browser and navigate to URL. Call this before any browsing work.
+- `browser_open(url, location?)` — Open browser and navigate to URL. Use `location="container"` for services running inside the agent container; otherwise omit it to use the configured provider.
 - `browser_close()` — Close the browser and free resources. Call when done with all browsing.
 - `browser_get_state()` — Get the current URL, a screenshot, and accessibility snapshot in one call. Use to check what the browser is showing.
 
@@ -721,14 +721,14 @@ The web-browser agent:
 For creating, editing, or debugging dashboards (artifacts), **delegate to the dashboard-builder agent** using the Agent tool. This agent runs on its own dedicated model and handles the full dashboard lifecycle: scaffolding, coding, starting, verifying via screenshots, and iterating.
 
 The dashboard-builder agent:
-- Has access to all dashboard tools (create, start, list, logs) and file tools (Read, Write, Edit, Bash)
+- Has access to dashboard lifecycle tools, browser interaction tools, and file tools (Read, Write, Edit, Bash)
 - Handles both plain (Bun.serve) and React (Vite) dashboards
-- Verifies its work via screenshots returned by `start_dashboard`
-- Will NOT use the browser — it works entirely through file editing and dashboard tools
+- Uses screenshots returned by `start_dashboard` for a quick visual check
+- Can open the returned localhost URL with `browser_open(..., location="container")` to interactively test controls, responsive behavior, accessibility state, and client-side errors
 
 ### Workflow
 1. Delegate: `Agent(subagent_type="dashboard-builder", prompt="<describe the dashboard you want>")` — the agent builds it
-2. The agent will create, code, start, and verify the dashboard autonomously
+2. The agent will create, code, start, and verify the dashboard autonomously using screenshots and container-browser interaction
 3. When editing existing dashboards, include the slug in your prompt so the agent knows which one to modify
 
 ### When to Use
@@ -746,7 +746,7 @@ The dashboard-builder agent:
 <%^subagentsEnabled%>
 ## Building Dashboards
 
-For creating, editing, or debugging dashboards (artifacts), use the dashboard tools directly: `mcp__dashboards__create_dashboard` to scaffold, file tools (Read, Write, Edit, Bash) to code, `mcp__dashboards__start_dashboard` to run it, and `mcp__dashboards__get_dashboard_logs` to debug. Verify your work via the screenshot returned by `start_dashboard` and iterate until it looks right. Both plain (Bun.serve) and React (Vite) dashboards are supported. When editing an existing dashboard, find its slug via `mcp__dashboards__list_dashboards` first.
+For creating, editing, or debugging dashboards (artifacts), use the dashboard tools directly: `mcp__dashboards__create_dashboard` to scaffold, file tools (Read, Write, Edit, Bash) to code, `mcp__dashboards__start_dashboard` to run it, and `mcp__dashboards__get_dashboard_logs` to debug. Inspect the screenshot returned by `start_dashboard`, then open its localhost URL with `browser_open(..., location="container")` to test interactions and client-side behavior. Iterate until both visual and functional checks pass. Both plain (Bun.serve) and React (Vite) dashboards are supported. When editing an existing dashboard, find its slug via `mcp__dashboards__list_dashboards` first.
 <%/subagentsEnabled%>
 
 <%#computerUse%>

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -674,7 +674,7 @@ The file is a JSON array — each item has a `name` and exactly one of: `link` (
 You have a web browser for interacting with websites. The user can see the browser live and interact with it directly.
 
 ### Browser Lifecycle Tools (use these directly)
-- `browser_open(url, location?)` — Open browser and navigate to URL. Use `location="container"` for services running inside the agent container; otherwise omit it to use the configured provider.
+- `browser_open(url, location?)` — Open browser and navigate to URL. Omit location to keep the current browser where it is (or use the configured provider when none is live). Use `location="container"` for services inside the agent container and `location="configured"` to explicitly switch back.
 - `browser_close()` — Close the browser and free resources. Call when done with all browsing.
 - `browser_get_state()` — Get the current URL, a screenshot, and accessibility snapshot in one call. Use to check what the browser is showing.
 

--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { stripAnsi, extractScreenshotPath } from './browser'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { createBrowserTools, stripAnsi, extractScreenshotPath } from './browser'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('stripAnsi', () => {
   it('removes color codes', () => {
@@ -59,5 +63,54 @@ describe('extractScreenshotPath', () => {
   it('handles path with spaces in surrounding text but not in path', () => {
     const output = '\x1b[32m✓\x1b[0m Saved to \x1b[32m/var/data/img.png\x1b[0m done'
     expect(extractScreenshotPath(output)).toBe('/var/data/img.png')
+  })
+})
+
+describe('browser_open location', () => {
+  it('forwards an explicit container location to the browser endpoint', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      location: 'container',
+      switchedFrom: 'host',
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const openTool = createBrowserTools(() => 'session-1')
+      .find(candidate => candidate.name === 'browser_open') as any
+    const result = await openTool.handler({
+      url: 'http://localhost:5173',
+      location: 'container',
+    })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [, request] = fetchMock.mock.calls[0]
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      sessionId: 'session-1',
+      url: 'http://localhost:5173',
+      location: 'container',
+    })
+    expect(result.content[0].text).toContain('bundled Chromium inside the agent container')
+    expect(result.content[0].text).toContain('previous host browser was closed')
+  })
+
+  it('keeps configured provider behavior as the backwards-compatible default', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      location: 'host',
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const openTool = createBrowserTools(() => 'session-2')
+      .find(candidate => candidate.name === 'browser_open') as any
+    await openTool.handler({ url: 'https://example.com' })
+
+    const [, request] = fetchMock.mock.calls[0]
+    expect(JSON.parse(String(request?.body)).location).toBe('configured')
   })
 })

--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -96,10 +96,10 @@ describe('browser_open location', () => {
     expect(result.content[0].text).toContain('previous host browser was closed')
   })
 
-  it('keeps configured provider behavior as the backwards-compatible default', async () => {
+  it('omits location so the server can preserve the current browser', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       success: true,
-      location: 'host',
+      location: 'container',
     }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -111,6 +111,6 @@ describe('browser_open location', () => {
     await openTool.handler({ url: 'https://example.com' })
 
     const [, request] = fetchMock.mock.calls[0]
-    expect(JSON.parse(String(request?.body)).location).toBe('configured')
+    expect(JSON.parse(String(request?.body))).not.toHaveProperty('location')
   })
 })

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -13,7 +13,6 @@ import { resizeScreenshot } from '../image-utils'
 import {
   BROWSER_OPEN_LOCATIONS,
   isLoopbackBrowserUrl,
-  resolveBrowserRuntimeLocation,
 } from '../browser-location'
 import { hostAuthHeaders } from '../host-auth'
 import { tabManager } from '../tab-manager'
@@ -95,26 +94,19 @@ export function createBrowserTools(getSessionId: () => string | null) {
 
 Use this to start browsing a website. The browser preserves cookies/sessions via a persistent profile, so the user only needs to log in once.
 
-By default, the browser uses the provider selected in the user's settings. Set location="container" for dashboards, development servers, and other URLs served inside the agent container. Changing location closes the current browser before opening the requested one.`,
+Omit location to keep using the current browser where it is; when no browser is live, the user's configured provider is used. Set location="container" for dashboards, development servers, and other URLs served inside the agent container. Set location="configured" to intentionally switch back to the user's configured provider. Changing location closes the current browser before opening the requested one.`,
   {
     url: z.string().describe('The URL to navigate to'),
     location: z
       .enum(BROWSER_OPEN_LOCATIONS)
       .optional()
-      .default('configured')
-      .describe('Where to run the browser. "configured" uses the provider selected in settings (default); "container" forces bundled Chromium so it can reach private container ports.'),
+      .describe('Where to run the browser. Omit to keep the current location (or use settings when no browser is live); "configured" explicitly selects the provider in settings; "container" forces bundled Chromium for private container ports.'),
   },
   async (args) => {
-    const requestedLocation = args.location || 'configured'
-    const runtimeLocation = resolveBrowserRuntimeLocation(requestedLocation)
-    const localhostWarning = isLoopbackBrowserUrl(args.url) && runtimeLocation === 'host'
-      ? '\n\nWARNING: This is a container-local URL, but the configured browser runs outside the container. Reopen it with location="container" to use bundled Chromium.'
-      : ''
-
-    const result = await browserFetch('open', { url: args.url, location: requestedLocation })
+    const result = await browserFetch('open', { url: args.url, location: args.location })
     if (!result.success) {
       return {
-        content: [{ type: 'text' as const, text: `Error: ${result.error}${localhostWarning}` }],
+        content: [{ type: 'text' as const, text: `Error: ${result.error}` }],
         isError: true,
       }
     }
@@ -125,6 +117,9 @@ By default, the browser uses the provider selected in the user's settings. Set l
       : 'the configured browser provider'
     const switchText = data?.switchedFrom
       ? ` The previous ${data.switchedFrom} browser was closed before switching locations.`
+      : ''
+    const localhostWarning = isLoopbackBrowserUrl(args.url) && activeLocation === 'host'
+      ? '\n\nWARNING: This URL points at the host browser\'s own loopback interface. If you meant a service inside the agent container, reopen it with location="container".'
       : ''
 
     if (data?.switchedToExisting) {

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -10,6 +10,11 @@ import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { readFile } from 'fs/promises'
 import { z } from 'zod'
 import { resizeScreenshot } from '../image-utils'
+import {
+  BROWSER_OPEN_LOCATIONS,
+  isLoopbackBrowserUrl,
+  resolveBrowserRuntimeLocation,
+} from '../browser-location'
 import { hostAuthHeaders } from '../host-auth'
 import { tabManager } from '../tab-manager'
 import { formatUrlDigest, formatUrlDigestBrief, formatFillReadback, formatScrollDigest, type UrlDigest, type ScrollInfo } from '../browser-digest'
@@ -88,19 +93,25 @@ export function createBrowserTools(getSessionId: () => string | null) {
   'browser_open',
   `Open a headless browser and navigate to a URL. The user can see the browser live in their interface and interact with it directly.
 
-Use this to start browsing a website. The browser preserves cookies/sessions via a persistent profile, so the user only needs to log in once.`,
+Use this to start browsing a website. The browser preserves cookies/sessions via a persistent profile, so the user only needs to log in once.
+
+By default, the browser uses the provider selected in the user's settings. Set location="container" for dashboards, development servers, and other URLs served inside the agent container. Changing location closes the current browser before opening the requested one.`,
   {
     url: z.string().describe('The URL to navigate to'),
+    location: z
+      .enum(BROWSER_OPEN_LOCATIONS)
+      .optional()
+      .default('configured')
+      .describe('Where to run the browser. "configured" uses the provider selected in settings (default); "container" forces bundled Chromium so it can reach private container ports.'),
   },
   async (args) => {
-    // Warn if the agent is trying to open a localhost URL — the browser runs outside
-    // the container and cannot reach servers running inside it (e.g. dashboards).
-    const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/i.test(args.url)
-    const localhostWarning = isLocalhost
-      ? '\n\nWARNING: This is a localhost URL. The browser runs outside the container and cannot access servers running inside it. If you are trying to view a dashboard, stop — the user can already see dashboards through the Gamut UI. Use get_dashboard_logs to debug any issues instead.'
+    const requestedLocation = args.location || 'configured'
+    const runtimeLocation = resolveBrowserRuntimeLocation(requestedLocation)
+    const localhostWarning = isLoopbackBrowserUrl(args.url) && runtimeLocation === 'host'
+      ? '\n\nWARNING: This is a container-local URL, but the configured browser runs outside the container. Reopen it with location="container" to use bundled Chromium.'
       : ''
 
-    const result = await browserFetch('open', { url: args.url })
+    const result = await browserFetch('open', { url: args.url, location: requestedLocation })
     if (!result.success) {
       return {
         content: [{ type: 'text' as const, text: `Error: ${result.error}${localhostWarning}` }],
@@ -108,13 +119,20 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
       }
     }
     const data = result.data as Record<string, unknown> | undefined
+    const activeLocation = data?.location === 'container' ? 'container' : 'host'
+    const locationText = activeLocation === 'container'
+      ? 'bundled Chromium inside the agent container'
+      : 'the configured browser provider'
+    const switchText = data?.switchedFrom
+      ? ` The previous ${data.switchedFrom} browser was closed before switching locations.`
+      : ''
 
     if (data?.switchedToExisting) {
       return {
         content: [
           {
             type: 'text' as const,
-            text: `Switched to existing tab ${data.tabId} which already has ${data.url} open. Use browser_snapshot to see the page content.${localhostWarning}`,
+            text: `Switched to existing tab ${data.tabId} in ${locationText}, which already has ${data.url} open. Use browser_snapshot to see the page content.${localhostWarning}`,
           },
         ],
       }
@@ -124,7 +142,7 @@ Use this to start browsing a website. The browser preserves cookies/sessions via
       content: [
         {
           type: 'text' as const,
-          text: `Browser opened and navigating to ${args.url}. The user can see the browser live. Use browser_snapshot to see the page content.${localhostWarning}`,
+          text: `Browser opened in ${locationText} and navigating to ${args.url}.${switchText} The user can see the browser live. Use browser_snapshot to see the page content.${localhostWarning}`,
         },
       ],
     }

--- a/agent-container/src/tools/request-browser-input.test.ts
+++ b/agent-container/src/tools/request-browser-input.test.ts
@@ -38,7 +38,7 @@ describe('requestBrowserInputTool browser-lifecycle guard', () => {
   })
 
   it('creates a pending normally while the browser is active', async () => {
-    setBrowserState({ active: true, sessionId: 'sess-1', cdpUrl: 'ws://127.0.0.1:9222' })
+    setBrowserState({ active: true, sessionId: 'sess-1', cdpUrl: 'ws://127.0.0.1:9222', location: 'host' })
     const toolUseId = `guard-live-${Date.now()}`
     inputManager.setCurrentToolUseId(toolUseId)
 

--- a/agent-container/src/tools/start-dashboard.ts
+++ b/agent-container/src/tools/start-dashboard.ts
@@ -29,7 +29,7 @@ The dashboard must exist at /workspace/artifacts/<slug>/ with a valid package.js
       if (info.status === 'running') {
         text += '\n\nThe dashboard is accessible to the user through the Gamut UI.'
         text +=
-          '\n\nDo NOT use the browser tool to view this dashboard. The browser runs outside the container and cannot access localhost URLs served inside it. The user can already see it through the Gamut UI — use get_dashboard_logs to debug any issues.'
+          `\n\nFor interactive validation, open http://localhost:${info.port} with browser_open using location="container". This forces the bundled Chromium that can reach the dashboard's private container port.`
 
         // Await screenshot so the agent can sanity-check rendering in the same
         // tool result. Best-effort: if capture fails we still return success.

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -20,7 +20,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_screenshot(full?)` — Take a screenshot (returns file path; use Read to see the image)
 
 **Navigation:**
-- `browser_open(url)` — Navigate to a URL
+- `browser_open(url, location?)` — Navigate to a URL. Use `location="container"` for dashboards, development servers, and other services running on private agent-container ports; omit it for the configured external-site provider.
 
 **JavaScript:**
 - `browser_eval(script)` — Run JavaScript in the page and get the result. A single expression returns its value; a statement body runs in a fresh scope — use `return` to get a value (top-level `return`/`await` work, `const`/`let` won't collide across calls). Return `JSON.stringify(...)` for structured data. TOP FRAME ONLY — cross-origin iframes (payment frames) are unreachable from JS.

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -20,7 +20,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_screenshot(full?)` — Take a screenshot (returns file path; use Read to see the image)
 
 **Navigation:**
-- `browser_open(url, location?)` — Navigate to a URL. Use `location="container"` for dashboards, development servers, and other services running on private agent-container ports; omit it for the configured external-site provider.
+- `browser_open(url, location?)` — Navigate to a URL. Omit location to keep the current browser where it is. Use `location="container"` for dashboards, development servers, and other services on private agent-container ports; use `location="configured"` to explicitly switch back to the configured external-site provider.
 
 **JavaScript:**
 - `browser_eval(script)` — Run JavaScript in the page and get the result. A single expression returns its value; a statement body runs in a fresh scope — use `return` to get a value (top-level `return`/`await` work, `const`/`let` won't collide across calls). Return `JSON.stringify(...)` for structured data. TOP FRAME ONLY — cross-origin iframes (payment frames) are unreachable from JS.


### PR DESCRIPTION
## Summary

- add an optional `location` selector to `browser_open`, with `container` forcing bundled Chromium and `configured` explicitly selecting the provider in settings
- make an omitted location sticky: it keeps a live browser in its current runtime and only falls back to settings when no browser exists
- refuse implicit host-loopback opens before teardown, while preserving explicit host-loopback access via `location="configured"`
- track the live browser runtime so provider switching, release, external-close handling, and shutdown clean up the correct process
- give the dashboard-builder browser tools and replace the old localhost prohibition with an interactive container-browser validation workflow
- add regression coverage for location resolution, request forwarding, release event delivery, browser-state lifecycle, dashboard-builder access, and model-facing guidance

## Why

Configured host browsers and Browserbase work well for external sites, but they cannot reach services listening on private agent-container ports. The container already ships Chromium, so browser selection needs to be overridable per open request without an omitted argument unexpectedly destroying the browser that is already active.

## Behavior

Agents can open dashboards and development servers with:

```text
browser_open(url="http://localhost:<port>", location="container")
```

After that, ordinary `browser_open(url=...)` calls remain in container Chromium. Returning to the configured host provider requires an intentional `location="configured"`. If an omitted-location loopback URL would resolve to the host browser, the request is rejected before tabs, pending input, or browser state are touched.

## Lifecycle improvements

- releasing ownership retains `cdpUrl` and `location`, allowing a released-but-running browser to be stopped or switched correctly later
- release now delivers `browser_active: false` to the pre-release owner; previously the owner ID was cleared before broadcasting, making the event a no-op
- model-visible launch failures no longer include raw CDP URLs

## Dashboard-builder capability note

The dashboard-builder intentionally receives the full existing browser tool surface so it can exercise forms, controls, responsive behavior, accessibility state, console errors, uploads, and downloads during validation. This also permits explicit use of the configured host browser, including its persistent profile. Container-only use is prompt-guided rather than capability-enforced, matching the existing web-browser agent's browser authority.

## Validation

- `npm --prefix agent-container run build`
- `npm --prefix agent-container test` — 796 passed, 8 skipped
- macOS and Windows PR artifact builds passed on the original PR revision

## Tracking

- [SUP-528](https://linear.app/datawizz/issue/SUP-528/allow-browser-open-to-use-bundled-chromium-for-container-local)
