### PR TITLE
test(e2e): fix home-cards arrange spec hanging on CI

### DIFF
--- a/e2e/specs/home-cards.spec.ts
+++ b/e2e/specs/home-cards.spec.ts
@@ -1,7 +1,44 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Locator, type Page } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
 import { createAgent, uniqueName } from '../helpers/agents'
+
+/**
+ * Drag a grid tile down by `dy` px and only return once the grid has visibly
+ * taken the gesture (the actively-dragged tile carries scale-[1.02]).
+ *
+ * A plain down/move/up sequence engages flakily here for two reasons:
+ * - Radix menus set pointer-events:none on <body> while open and restore it
+ *   asynchronously after close — a pointerdown in that window hits nothing.
+ * - Tiles animate position (transition-[left,top] duration-200), so a
+ *   boundingBox taken mid-reflow points at where the card used to be.
+ * Both produce a silent no-op drag; without retry the spec then hangs on a
+ * layout PUT that never happens. Re-grab coordinates and retry instead.
+ */
+async function dragTile(page: Page, tile: Locator, dy: number): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await tile.scrollIntoViewIfNeeded()
+    const box = await tile.boundingBox()
+    expect(box).not.toBeNull()
+    const cx = box!.x + box!.width / 2
+    const cy = box!.y + box!.height / 2
+    await page.mouse.move(cx, cy)
+    await page.mouse.down()
+    await page.mouse.move(cx, cy + dy, { steps: 8 })
+    try {
+      await expect(tile).toHaveClass(/scale-\[1\.02\]/, { timeout: 2_000 })
+      await page.mouse.up()
+      return
+    } catch (error) {
+      lastError = error
+      await page.mouse.up()
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('dragTile: tile never entered the dragging state')
+}
 
 function seedDashboard(agentSlug: string) {
   const dataDir = process.env.SUPERAGENT_DATA_DIR
@@ -56,30 +93,22 @@ test.describe('home card arrangement', () => {
     await page.keyboard.press('Shift+F10')
     await expect(page.getByRole('menuitemcheckbox', { name: 'Expanded' })).toBeVisible()
     await page.keyboard.press('Escape')
+    // Wait out the Radix menu teardown: it holds pointer-events:none on <body>
+    // slightly past close, which would swallow the pointerdown of the drag.
+    await expect(page.getByRole('menuitemcheckbox', { name: 'Expanded' })).not.toBeVisible()
+    await page.waitForFunction(() => document.body.style.pointerEvents !== 'none')
 
     // Outside Arrange mode, desktop still supports direct pointer reordering.
     // The full-card anchor must not hand the gesture to native HTML link drag.
-    await dashboardWidget.scrollIntoViewIfNeeded()
-    const beforeDirectDrag = await dashboardWidget.boundingBox()
-    expect(beforeDirectDrag).not.toBeNull()
     const directSaved = page.waitForResponse(
       (response) =>
         response.url().includes('/api/user-settings') &&
         response.request().method() === 'PUT' &&
         response.request().postData()?.includes('homeGridLayout') === true &&
-        response.ok()
+        response.ok(),
+      { timeout: 15_000 }
     )
-    await page.mouse.move(
-      beforeDirectDrag!.x + beforeDirectDrag!.width / 2,
-      beforeDirectDrag!.y + beforeDirectDrag!.height / 2
-    )
-    await page.mouse.down()
-    await page.mouse.move(
-      beforeDirectDrag!.x + beforeDirectDrag!.width / 2,
-      beforeDirectDrag!.y + beforeDirectDrag!.height / 2 + 180,
-      { steps: 8 }
-    )
-    await page.mouse.up()
+    await dragTile(page, dashboardWidget, 180)
     await directSaved
 
     await page.getByRole('button', { name: 'Agent layout options' }).click()
@@ -88,21 +117,7 @@ test.describe('home card arrangement', () => {
     await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
 
     // Dashboard anchors also remain grid drag surfaces in desktop Arrange.
-    await dashboardWidget.scrollIntoViewIfNeeded()
-    const beforeDashboardArrangeDrag = await dashboardWidget.boundingBox()
-    expect(beforeDashboardArrangeDrag).not.toBeNull()
-    await page.mouse.move(
-      beforeDashboardArrangeDrag!.x + beforeDashboardArrangeDrag!.width / 2,
-      beforeDashboardArrangeDrag!.y + beforeDashboardArrangeDrag!.height / 2
-    )
-    await page.mouse.down()
-    await page.mouse.move(
-      beforeDashboardArrangeDrag!.x + beforeDashboardArrangeDrag!.width / 2,
-      beforeDashboardArrangeDrag!.y + beforeDashboardArrangeDrag!.height / 2 + 180,
-      { steps: 8 }
-    )
-    await expect(dashboardWidget).toHaveClass(/scale-\[1\.02\]/)
-    await page.mouse.up()
+    await dragTile(page, dashboardWidget, 180)
 
     // Arrange owns pointer dragging, but desktop right-click still bubbles
     // through its overlay to the unified agent context menu.
@@ -122,29 +137,26 @@ test.describe('home card arrangement', () => {
     await expect(dashboardWidget).not.toBeVisible()
     await page.keyboard.press('Escape')
     await expect(page.getByTestId('agent-settings-item')).not.toBeVisible()
+    // Same Radix teardown wait as above before the next pointer gesture.
+    await page.waitForFunction(() => document.body.style.pointerEvents !== 'none')
 
-    const before = await widget.boundingBox()
-    expect(before).not.toBeNull()
-    await page.mouse.move(before!.x + before!.width / 2, before!.y + before!.height / 2)
-    await page.mouse.down()
-    await page.mouse.move(before!.x + before!.width / 2, before!.y + before!.height / 2 + 280, {
-      steps: 8,
-    })
-    await page.mouse.up()
+    await dragTile(page, widget, 280)
 
     const layoutSaved = page.waitForResponse(
       (response) =>
         response.url().includes('/api/user-settings') &&
         response.request().method() === 'PUT' &&
         response.request().postData()?.includes('homeGridLayout') === true &&
-        response.ok()
+        response.ok(),
+      { timeout: 15_000 }
     )
     const visibilitySaved = page.waitForResponse(
       (response) =>
         response.url().includes('/api/user-settings') &&
         response.request().method() === 'PUT' &&
         response.request().postData()?.includes('hiddenAppCards') === true &&
-        response.ok()
+        response.ok(),
+      { timeout: 15_000 }
     )
     await page.getByRole('button', { name: 'Done' }).click()
     await Promise.all([layoutSaved, visibilitySaved])
@@ -172,27 +184,23 @@ test.describe('home card arrangement', () => {
     await mobileWidget.scrollIntoViewIfNeeded()
     await page.getByRole('button', { name: 'Agent layout options' }).click()
     await page.getByTestId('home-arrange-action').click()
+    // Dragging the agent card on mobile is only eligible once Arrange mode
+    // has rendered (dragEnabled flips in the same React commit that shows the
+    // Done button). Starting the drag before that commit lands makes the
+    // pointerdown a no-op: nothing commits, Done PUTs nothing, and the
+    // homeGridMobileLayout wait below hangs to the test timeout — this was a
+    // consistent CI failure on slower runners.
+    await expect(page.getByRole('button', { name: 'Done' })).toBeVisible()
 
-    const beforeMobile = await mobileWidget.boundingBox()
-    expect(beforeMobile).not.toBeNull()
-    await page.mouse.move(
-      beforeMobile!.x + beforeMobile!.width / 2,
-      beforeMobile!.y + beforeMobile!.height / 2
-    )
-    await page.mouse.down()
-    await page.mouse.move(
-      beforeMobile!.x + beforeMobile!.width / 2,
-      beforeMobile!.y + beforeMobile!.height / 2 + 180,
-      { steps: 8 }
-    )
-    await page.mouse.up()
+    await dragTile(page, mobileWidget, 180)
 
     const mobileSaved = page.waitForResponse(
       (response) =>
         response.url().includes('/api/user-settings') &&
         response.request().method() === 'PUT' &&
         response.request().postData()?.includes('homeGridMobileLayout') === true &&
-        response.ok()
+        response.ok(),
+      { timeout: 15_000 }
     )
     await page.getByRole('button', { name: 'Done' }).click()
     await mobileSaved


### PR DESCRIPTION
## Summary

`home-cards.spec.ts › desktop Arrange persists independently from the mobile layout` has been failing 3/3 on CI since the halftone homepage redesign, painting every PR red. The CI trace (retry1 of the PR #641 run) showed the test hanging 60s at the `homeGridMobileLayout` `waitForResponse` — the mobile Done click PUT **nothing**, because the drag before it was a silent no-op.

## Root causes — two ways a drag silently no-ops

1. **Mobile arrange-render race.** Dragging the agent card on mobile is only eligible once Arrange mode has rendered (`dragEnabled` flips in the same React commit that shows the Done button). The spec's mobile phase clicked Arrange and dragged immediately — the desktop phase waits for Done/Cancel, the mobile phase didn't. On slow CI runners the pointerdown landed pre-Arrange → no listeners → nothing to commit → `finishArrange` skips the PUT (`if (nextLayout)`) → 60s hang.
2. **Desktop engagement races** (reproduced locally once fail-fast asserts were added): Radix context menus hold `pointer-events: none` on `<body>` slightly past close, swallowing an immediately-following pointerdown; and tiles animate position (`transition-[left,top] duration-200`), so a `boundingBox` taken mid-reflow aims at where the card used to be.

## Fix

- **`dragTile` helper** used at all four drag sites: re-grabs scroll position + boundingBox on every attempt and only returns once the tile visibly enters the dragging state (`scale-[1.02]`, the class the grid puts on the actively-dragged tile), retrying up to 3×. A grab that never takes now fails fast at the drag site with a pointed error instead of hanging on a network wait 40 lines later.
- Mobile phase waits for the Done button (Arrange rendered) before dragging, mirroring the desktop phase.
- Radix menu teardown is waited out (menu hidden + `body` pointer-events restored) before post-menu drags.
- All `user-settings` `waitForResponse` calls bounded at 15s so residual failures are pointed, not test-timeout hangs.

## Verification

- Pre-fix, fail-fast asserts reproduced the no-op drags locally (2/3 runs).
- Post-fix: **5/5 serial repeats green at ~4.6s each** (previously 60s hangs).
- Full web suite in a clean worktree: **285 passed**, home-cards green among its parallel neighbors; the 2 failures were the suite's known ambient flakes (`session-long-sleep`, `dashboard-and-tasks`), both green re-run in isolation. Typecheck + lint clean.

## Note for future maintenance

Local `--repeat-each` **without** `--workers 1` is an invalid signal for this spec: parallel instances share one dev server and clobber each other's `homeGridLayout` (it's a global user-setting written as a full map). Serial repeats are the valid local reproduction. No other spec writes the layout keys, so CI's single instance is safe.

https://claude.ai/code/session_017HeDukYnjnv1iGdJjGt1ds