### PR TITLE
Make the tray, app menu and agent deep links follow the API target

### DIFF
--- a/docs/cloud-workspace.md
+++ b/docs/cloud-workspace.md
@@ -384,6 +384,13 @@ past the right edge while open.
   that screen.
 - Recording the preference also tears down the quick-dispatch launcher (main does
   that), so the control only owns *this* window.
+- Main's own agent-listing surfaces — the system tray and the app menu's Agents
+  submenu — follow the switch too. They resolve the effective base URL (local, or
+  the keyed proxy prefix) on every poll via `fetchAgentsWithStatus`, and
+  `applyPreferredApiTarget` rebuilds them immediately so the previous
+  Superagent's agents don't sit in the menus for up to a poll interval. Agent
+  deep links resolve their session lookup against the same effective base, since
+  the renderer will interpret the slug on whichever Superagent it is driving.
 
 **The switch is animated from outside the document.** The reload is what makes
 the switch safe — every module-scoped cache, open stream and memoized client
@@ -469,7 +476,7 @@ disagree in a configuration we ship to every browser.
 | --- | --- | --- |
 | this computer, for the agents | `canUseHostFeatures()` | it needs the bridge *and* needs both machines to be the same one |
 | the machine running the API | `!targetIsRemote()` | a web deployment legitimately offers it — the API *is* the machine the user means |
-| the window itself | `isElectron()` | traffic lights, drag regions, tray, updates, the global shortcut: the target is irrelevant |
+| the window itself | `isElectron()` | traffic lights, drag regions, tray, updates, the global shortcut: the target is irrelevant to whether the feature *exists* (what the tray and app menu *list* is a target question — they resolve the effective base URL, see the switch section) |
 
 The first two questions used to be one. Every host-touching feature asked
 `isElectron()`, which was correct for as long as the desktop app could only

--- a/src/api/routes/cloud-proxy.test.ts
+++ b/src/api/routes/cloud-proxy.test.ts
@@ -27,6 +27,7 @@ vi.stubGlobal('fetch', mockFetch)
 
 import cloudProxy, { CLOUD_PROXY_PREFIX, isCloudProxyEnabled } from './cloud-proxy'
 import {
+  SKIP_BOOT_PREFETCH_HEADER,
   startCloudBootPrefetch,
   _resetCloudBootPrefetchForTest,
 } from '@shared/lib/services/cloud-boot-prefetch'
@@ -423,6 +424,20 @@ describe('cloud proxy boot prefetch', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(prefetchCalls + 1)
     expect(forwardedUrl(prefetchCalls)).toBe(`${TARGET.deploymentUrl}/api/agents`)
+  })
+
+  it('leaves the entry for the renderer when the requester marks itself out', async () => {
+    startCloudBootPrefetch()
+    const prefetchCalls = mockFetch.mock.calls.length
+
+    // A main-process poller (tray, app menu) racing the reload must not consume
+    // the one-shot entry...
+    await call('/api/agents', { headers: { [SKIP_BOOT_PREFETCH_HEADER]: '1' } })
+    expect(mockFetch).toHaveBeenCalledTimes(prefetchCalls + 1)
+
+    // ...so the renderer arriving second still gets its head start.
+    await call('/api/agents')
+    expect(mockFetch).toHaveBeenCalledTimes(prefetchCalls + 1)
   })
 
   it('ignores it for a write to the same path', async () => {

--- a/src/api/routes/cloud-proxy.ts
+++ b/src/api/routes/cloud-proxy.ts
@@ -8,6 +8,7 @@ import {
   type CloudProxyTarget,
 } from '@shared/lib/services/cloud-proxy-target'
 import {
+  SKIP_BOOT_PREFETCH_HEADER,
   takeCloudBootPrefetch,
   type PrefetchedResponse,
 } from '@shared/lib/services/cloud-boot-prefetch'
@@ -205,6 +206,9 @@ const PREFETCH_DISQUALIFYING_HEADERS = [
 
 function canUsePrefetch(request: Request): boolean {
   if (request.method !== 'GET') return false
+  // Main's background pollers mark themselves out: the entries are one-shot
+  // and belong to the reloading renderer, not to whoever asks first.
+  if (request.headers.get(SKIP_BOOT_PREFETCH_HEADER) !== null) return false
   return PREFETCH_DISQUALIFYING_HEADERS.every((name) => request.headers.get(name) === null)
 }
 

--- a/src/main/agent-status.ts
+++ b/src/main/agent-status.ts
@@ -3,6 +3,13 @@
 
 import { type AgentActivityStatus, getAgentActivityStatus } from '@shared/lib/types/agent-activity-status'
 import type { ContainerStatus } from '@shared/lib/container/types'
+import { SKIP_BOOT_PREFETCH_HEADER } from '@shared/lib/services/cloud-boot-prefetch'
+
+// These polls are not made on the renderer's behalf: in cloud mode they travel
+// the same proxy paths as the boot prefetches, which are one-shot and reserved
+// for the reloading renderer. Marked out so a poll racing a switch cannot
+// consume the renderer's head start.
+const POLL_HEADERS = { [SKIP_BOOT_PREFETCH_HEADER]: '1' }
 
 export type ActivityStatus = AgentActivityStatus
 
@@ -61,8 +68,8 @@ export async function fetchAgentsWithStatus(apiBaseUrl: string): Promise<AgentIn
   try {
     // Fetch agents and user settings in parallel
     const [agentsRes, settingsRes] = await Promise.all([
-      fetch(`${apiBaseUrl}/api/agents`),
-      fetch(`${apiBaseUrl}/api/user-settings`).catch(() => null),
+      fetch(`${apiBaseUrl}/api/agents`, { headers: POLL_HEADERS }),
+      fetch(`${apiBaseUrl}/api/user-settings`, { headers: POLL_HEADERS }).catch(() => null),
     ])
     if (!agentsRes.ok) return []
     const agents: ApiAgent[] = await agentsRes.json()
@@ -80,7 +87,8 @@ export async function fetchAgentsWithStatus(apiBaseUrl: string): Promise<AgentIn
         if (agent.status === 'running') {
           try {
             const sessionsRes = await fetch(
-              `${apiBaseUrl}/api/agents/${agent.slug}/sessions`
+              `${apiBaseUrl}/api/agents/${agent.slug}/sessions`,
+              { headers: POLL_HEADERS }
             )
             if (sessionsRes.ok) {
               const sessions: ApiSession[] = await sessionsRes.json()

--- a/src/main/agent-status.ts
+++ b/src/main/agent-status.ts
@@ -52,13 +52,17 @@ function applyAgentOrder(agents: AgentInfo[], savedOrder: string[] | undefined):
 /**
  * Fetch agents with their activity status from the API,
  * sorted by the user's saved agent order.
+ *
+ * `apiBaseUrl` is the *effective* base — in cloud mode it is the keyed proxy
+ * prefix, so the tray and app menu list the same Superagent the renderers are
+ * driving rather than always this machine's.
  */
-export async function fetchAgentsWithStatus(apiPort: number): Promise<AgentInfo[]> {
+export async function fetchAgentsWithStatus(apiBaseUrl: string): Promise<AgentInfo[]> {
   try {
     // Fetch agents and user settings in parallel
     const [agentsRes, settingsRes] = await Promise.all([
-      fetch(`http://localhost:${apiPort}/api/agents`),
-      fetch(`http://localhost:${apiPort}/api/user-settings`).catch(() => null),
+      fetch(`${apiBaseUrl}/api/agents`),
+      fetch(`${apiBaseUrl}/api/user-settings`).catch(() => null),
     ])
     if (!agentsRes.ok) return []
     const agents: ApiAgent[] = await agentsRes.json()
@@ -76,7 +80,7 @@ export async function fetchAgentsWithStatus(apiPort: number): Promise<AgentInfo[
         if (agent.status === 'running') {
           try {
             const sessionsRes = await fetch(
-              `http://localhost:${apiPort}/api/agents/${agent.slug}/sessions`
+              `${apiBaseUrl}/api/agents/${agent.slug}/sessions`
             )
             if (sessionsRes.ok) {
               const sessions: ApiSession[] = await sessionsRes.json()

--- a/src/main/api-target.test.ts
+++ b/src/main/api-target.test.ts
@@ -9,16 +9,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { applyPreferredApiTarget, resolveApiTargetForRenderer } from './api-target'
 
-const { closeQuickDispatchWindow, closeAllDashboardWindows, startCloudBootPrefetch, settings } =
-  vi.hoisted(() => ({
-    closeQuickDispatchWindow: vi.fn(),
-    closeAllDashboardWindows: vi.fn(),
-    startCloudBootPrefetch: vi.fn(),
-    settings: { value: {} as Record<string, unknown> },
-  }))
+const {
+  closeQuickDispatchWindow,
+  closeAllDashboardWindows,
+  startCloudBootPrefetch,
+  refreshTrayMenu,
+  refreshAppMenu,
+  settings,
+} = vi.hoisted(() => ({
+  closeQuickDispatchWindow: vi.fn(),
+  closeAllDashboardWindows: vi.fn(),
+  startCloudBootPrefetch: vi.fn(),
+  refreshTrayMenu: vi.fn(),
+  refreshAppMenu: vi.fn(),
+  settings: { value: {} as Record<string, unknown> },
+}))
 
 vi.mock('./quick-dispatch-window', () => ({ closeQuickDispatchWindow }))
 vi.mock('./dashboard-window', () => ({ closeAllDashboardWindows }))
+vi.mock('./tray', () => ({ refreshTrayMenu }))
+vi.mock('./app-menu', () => ({ refreshAppMenu }))
 vi.mock('@shared/lib/services/cloud-boot-prefetch', () => ({ startCloudBootPrefetch }))
 
 vi.mock('@shared/lib/config/settings', () => ({
@@ -37,6 +47,8 @@ beforeEach(() => {
   closeQuickDispatchWindow.mockClear()
   closeAllDashboardWindows.mockClear()
   startCloudBootPrefetch.mockClear()
+  refreshTrayMenu.mockClear()
+  refreshAppMenu.mockClear()
 })
 
 describe('resolveApiTargetForRenderer', () => {
@@ -111,6 +123,21 @@ describe('applyPreferredApiTarget', () => {
   it('refuses to store an unrecognized target', () => {
     applyPreferredApiTarget('somewhere-else')
     expect(settings.value.apiTarget).toBe('local')
+  })
+
+  it('rebuilds the tray and app menu now, instead of waiting out their poll', () => {
+    // Both list agents from the effective target; on their 30s interval the
+    // previous Superagent's agents would sit in the menus for up to that long.
+    applyPreferredApiTarget('cloud')
+    expect(refreshTrayMenu).toHaveBeenCalled()
+    expect(refreshAppMenu).toHaveBeenCalled()
+  })
+
+  it('rebuilds them switching back to local too', () => {
+    settings.value.apiTarget = 'cloud'
+    applyPreferredApiTarget('local')
+    expect(refreshTrayMenu).toHaveBeenCalled()
+    expect(refreshAppMenu).toHaveBeenCalled()
   })
 
   it('starts the workspace round trips here, before the reload', () => {

--- a/src/main/api-target.ts
+++ b/src/main/api-target.ts
@@ -6,6 +6,8 @@ import {
 import { startCloudBootPrefetch } from '@shared/lib/services/cloud-boot-prefetch'
 import { closeQuickDispatchWindow } from './quick-dispatch-window'
 import { closeAllDashboardWindows } from './dashboard-window'
+import { refreshTrayMenu } from './tray'
+import { refreshAppMenu } from './app-menu'
 
 /**
  * Main-process side of "which Superagent is this app driving?".
@@ -60,4 +62,10 @@ export function applyPreferredApiTarget(target: unknown): void {
   closeQuickDispatchWindow()
   closeAllDashboardWindows()
   if (next === 'cloud') startCloudBootPrefetch()
+  // The tray and the app menu's Agents submenu resolve the effective base URL
+  // on every fetch, so the preference write above is all they need — but they
+  // poll on a 30s interval, which would leave the previous Superagent's agents
+  // on screen for up to that long. Kick them now.
+  refreshTrayMenu()
+  refreshAppMenu()
 }

--- a/src/main/app-menu.stale-poll.test.ts
+++ b/src/main/app-menu.stale-poll.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Menu builds overlap: the 30s poll and the target-switch refresh both run
+// buildAppMenu, which samples the base URL before its await. A slow response
+// from the previous target must not land after a newer build painted the menu
+// and overwrite it — last started wins.
+
+import type { AgentInfo } from './agent-status'
+
+const { fetchAgentsWithStatus } = vi.hoisted(() => ({
+  fetchAgentsWithStatus: vi.fn(),
+}))
+vi.mock('./agent-status', () => ({ fetchAgentsWithStatus }))
+
+const { buildFromTemplate, setApplicationMenu } = vi.hoisted(() => ({
+  buildFromTemplate: vi.fn((template: unknown) => ({ template })),
+  setApplicationMenu: vi.fn(),
+}))
+vi.mock('electron', () => ({
+  Menu: { buildFromTemplate, setApplicationMenu },
+  BrowserWindow: class {},
+  app: { emit: vi.fn() },
+  nativeImage: { createFromPath: vi.fn(() => ({})) },
+}))
+
+import { createAppMenu, refreshAppMenu, destroyAppMenu } from './app-menu'
+
+interface TemplateItem {
+  label?: string
+  submenu?: TemplateItem[]
+}
+
+function menuLabels(): string {
+  const template = (buildFromTemplate.mock.calls.at(-1)?.[0] ?? []) as TemplateItem[]
+  return JSON.stringify(template)
+}
+
+const agent = (name: string): AgentInfo => ({ slug: name, name, activityStatus: 'idle' })
+
+describe('stale poll responses never overwrite a newer menu', () => {
+  const originalRendererUrl = process.env.ELECTRON_RENDERER_URL
+  let resolvers: Array<(agents: AgentInfo[]) => void>
+
+  beforeEach(() => {
+    process.env.ELECTRON_RENDERER_URL = 'http://localhost'
+    buildFromTemplate.mockClear()
+    setApplicationMenu.mockClear()
+    resolvers = []
+    fetchAgentsWithStatus.mockImplementation(
+      () => new Promise<AgentInfo[]>((resolve) => resolvers.push(resolve)),
+    )
+  })
+
+  afterEach(() => {
+    destroyAppMenu()
+    if (originalRendererUrl === undefined) delete process.env.ELECTRON_RENDERER_URL
+    else process.env.ELECTRON_RENDERER_URL = originalRendererUrl
+  })
+
+  it('discards an older build that resolves after a newer one', async () => {
+    createAppMenu(null, () => 'http://localhost:1')
+    refreshAppMenu()
+    expect(resolvers).toHaveLength(2)
+
+    // The newer build (the switch refresh) answers first, with the new target's
+    // agents.
+    resolvers[1]([agent('cloud-agent')])
+    await vi.waitFor(() => expect(setApplicationMenu).toHaveBeenCalledTimes(1))
+    expect(menuLabels()).toContain('cloud-agent')
+
+    // The older build (the poll started against the previous target) straggles
+    // in — it must not be installed.
+    resolvers[0]([agent('local-agent')])
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(setApplicationMenu).toHaveBeenCalledTimes(1)
+    expect(menuLabels()).toContain('cloud-agent')
+  })
+})

--- a/src/main/app-menu.sup264.test.ts
+++ b/src/main/app-menu.sup264.test.ts
@@ -45,7 +45,7 @@ function findItem(items: TemplateItem[], label: string): TemplateItem | undefine
 // createAppMenu kicks off the async buildAppMenu (fire-and-forget); wait for it
 // to finish, then return the captured menu template.
 async function buildMenuWithNoWindow(): Promise<TemplateItem[]> {
-  createAppMenu(null, 0)
+  createAppMenu(null, () => 'http://localhost:0')
   await vi.waitFor(() => expect(setApplicationMenu).toHaveBeenCalled())
   const lastCall = buildFromTemplate.mock.calls.at(-1)
   return (lastCall?.[0] ?? []) as TemplateItem[]

--- a/src/main/app-menu.ts
+++ b/src/main/app-menu.ts
@@ -105,10 +105,20 @@ function sendToRenderer(channel: string, ...args: unknown[]): void {
 }
 
 /**
+ * Builds overlap: the 30s poll and the target-switch refresh both come through
+ * buildAppMenu, and the base URL is sampled before the await. Without this a
+ * slow response from the previous target could land after the switch refresh
+ * painted the new one and overwrite it. Last started wins.
+ */
+let buildGeneration = 0
+
+/**
  * Build and set the application menu
  */
 async function buildAppMenu(): Promise<void> {
+  const generation = ++buildGeneration
   const agents = getApiBaseUrlRef ? await fetchAgentsWithStatus(getApiBaseUrlRef()) : []
+  if (generation !== buildGeneration) return
 
   // Group agents by status
   const awaitingInput = agents.filter(a => a.activityStatus === 'awaiting_input')

--- a/src/main/app-menu.ts
+++ b/src/main/app-menu.ts
@@ -3,7 +3,9 @@ import path from 'path'
 import { fetchAgentsWithStatus, ActivityStatus } from './agent-status'
 
 let mainWindowRef: BrowserWindow | null = null
-let apiPortRef: number = 0
+// A getter rather than a stored URL: in cloud mode the effective base is the
+// keyed proxy prefix, and which one is in force can change on a target switch.
+let getApiBaseUrlRef: (() => string) | null = null
 let updateInterval: NodeJS.Timeout | null = null
 
 /**
@@ -106,7 +108,7 @@ function sendToRenderer(channel: string, ...args: unknown[]): void {
  * Build and set the application menu
  */
 async function buildAppMenu(): Promise<void> {
-  const agents = await fetchAgentsWithStatus(apiPortRef)
+  const agents = getApiBaseUrlRef ? await fetchAgentsWithStatus(getApiBaseUrlRef()) : []
 
   // Group agents by status
   const awaitingInput = agents.filter(a => a.activityStatus === 'awaiting_input')
@@ -268,22 +270,29 @@ async function buildAppMenu(): Promise<void> {
  */
 export function createAppMenu(
   mainWindow: BrowserWindow | null,
-  apiPort: number
+  getApiBaseUrl: () => string
 ): void {
   mainWindowRef = mainWindow
-  apiPortRef = apiPort
+  getApiBaseUrlRef = getApiBaseUrl
 
   // Initial build
-  buildAppMenu().catch((error) => {
-    console.error('Failed to build app menu:', error)
-  })
+  refreshAppMenu()
 
   // Update periodically to refresh agent list (every 30s, same as tray)
   updateInterval = setInterval(() => {
-    buildAppMenu().catch((error) => {
-      console.error('Failed to update app menu:', error)
-    })
+    refreshAppMenu()
   }, 30000)
+}
+
+/**
+ * Rebuild the menu now instead of waiting out the poll. Called on a target
+ * switch, where the 30s interval would leave the previous Superagent's agents
+ * in the Agents menu.
+ */
+export function refreshAppMenu(): void {
+  buildAppMenu().catch((error) => {
+    console.error('Failed to build app menu:', error)
+  })
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1086,7 +1086,10 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
     try {
       const slug = agentLink.agentSlug
       showOrCreateMainWindow()
-      fetch(`http://localhost:${actualApiPort}/api/agents/${encodeURIComponent(slug)}/sessions`)
+      // Resolved against the effective target, not always the local API: the
+      // renderer interprets the slug on whichever Superagent it is driving, so
+      // the session lookup must ask that same one.
+      fetch(`${activeApiTarget().baseUrl}/api/agents/${encodeURIComponent(slug)}/sessions`)
         .then(res => res.ok ? res.json() : [])
         .then((sessions: Array<{ id: string; isActive: boolean; updatedAt?: string }>) => {
           if (!Array.isArray(sessions)) return null
@@ -1447,7 +1450,6 @@ async function startApp() {
   // Bind the API server atomically, retrying on a port race until a port is
   // claimed (no probe-then-bind TOCTOU gap; an EADDRINUSE retries instead of
   // crashing the app via uncaughtException). See bindServerWithRetry.
-  let boundPort: number
   try {
     const bound = await bindServerWithRetry(api.fetch, {
       startPort: DEFAULT_API_PORT,
@@ -1459,7 +1461,6 @@ async function startApp() {
     // server, so update both the module state and process.env.PORT.
     actualApiPort = bound.port
     process.env.PORT = String(bound.port)
-    boundPort = bound.port
     // Wire server-level handlers (WebSocket proxies, etc.) on the bound server.
     setupServerHandlers(bound.server)
     console.log(`API server running on http://localhost:${bound.port}`)
@@ -1503,13 +1504,16 @@ async function startApp() {
 
   createWindow()
 
-  // Create the application menu (macOS menu bar)
-  createAppMenu(mainWindow, boundPort)
+  // Create the application menu (macOS menu bar). The getter re-resolves the
+  // effective base URL on every poll, so the Agents menu and the tray follow a
+  // target switch (via the keyed cloud proxy) instead of always listing this
+  // machine's agents.
+  createAppMenu(mainWindow, () => activeApiTarget().baseUrl)
 
   // Create system tray if enabled in settings
   const settings = getSettings()
   if (settings.app?.showMenuBarIcon !== false) {
-    createTray(mainWindow, boundPort)
+    createTray(mainWindow, () => activeApiTarget().baseUrl)
   }
 
   // Restore keep-awake state from previous session (after window is ready so dialogs display correctly)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1089,7 +1089,8 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
       // Resolved against the effective target, not always the local API: the
       // renderer interprets the slug on whichever Superagent it is driving, so
       // the session lookup must ask that same one.
-      fetch(`${activeApiTarget().baseUrl}/api/agents/${encodeURIComponent(slug)}/sessions`)
+      const linkBaseUrl = activeApiTarget().baseUrl
+      fetch(`${linkBaseUrl}/api/agents/${encodeURIComponent(slug)}/sessions`)
         .then(res => res.ok ? res.json() : [])
         .then((sessions: Array<{ id: string; isActive: boolean; updatedAt?: string }>) => {
           if (!Array.isArray(sessions)) return null
@@ -1098,6 +1099,11 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
         })
         .catch(() => null)
         .then((sessionId: string | null) => {
+          // A switch while the lookup was in flight leaves both the slug and
+          // the session id belonging to the previous Superagent — delivering
+          // them navigates the new renderer to someone else's agent. Drop the
+          // link rather than land it wrong.
+          if (activeApiTarget().baseUrl !== linkBaseUrl) return
           sendToMainWindowWhenReady((win) =>
             win.webContents.send('navigate-to-agent', slug, sessionId),
           )

--- a/src/main/tray.stale-poll.test.ts
+++ b/src/main/tray.stale-poll.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Same race as app-menu.stale-poll.test.ts, on the tray's side: an in-flight
+// poll against the previous target must not overwrite the menu a target-switch
+// refresh already painted.
+
+import type { AgentInfo } from './agent-status'
+
+const { fetchAgentsWithStatus } = vi.hoisted(() => ({
+  fetchAgentsWithStatus: vi.fn(),
+}))
+vi.mock('./agent-status', () => ({ fetchAgentsWithStatus }))
+
+const { buildFromTemplate, setContextMenu } = vi.hoisted(() => ({
+  buildFromTemplate: vi.fn((template: unknown) => ({ template })),
+  setContextMenu: vi.fn(),
+}))
+vi.mock('electron', () => ({
+  Tray: class {
+    setToolTip() {}
+    on() {}
+    setContextMenu = setContextMenu
+    destroy() {}
+  },
+  Menu: { buildFromTemplate },
+  BrowserWindow: class {},
+  app: { emit: vi.fn(), quit: vi.fn() },
+  nativeImage: { createFromPath: vi.fn(() => ({ setTemplateImage: vi.fn() })) },
+}))
+
+import { createTray, refreshTrayMenu, destroyTray } from './tray'
+
+interface TemplateItem {
+  label?: string
+}
+
+function menuLabels(): string {
+  const template = (buildFromTemplate.mock.calls.at(-1)?.[0] ?? []) as TemplateItem[]
+  return JSON.stringify(template)
+}
+
+const agent = (name: string): AgentInfo => ({ slug: name, name, activityStatus: 'idle' })
+
+describe('stale poll responses never overwrite a newer tray menu', () => {
+  const originalRendererUrl = process.env.ELECTRON_RENDERER_URL
+  let resolvers: Array<(agents: AgentInfo[]) => void>
+
+  beforeEach(() => {
+    process.env.ELECTRON_RENDERER_URL = 'http://localhost'
+    buildFromTemplate.mockClear()
+    setContextMenu.mockClear()
+    resolvers = []
+    fetchAgentsWithStatus.mockImplementation(
+      () => new Promise<AgentInfo[]>((resolve) => resolvers.push(resolve)),
+    )
+  })
+
+  afterEach(() => {
+    destroyTray()
+    if (originalRendererUrl === undefined) delete process.env.ELECTRON_RENDERER_URL
+    else process.env.ELECTRON_RENDERER_URL = originalRendererUrl
+  })
+
+  it('discards an older build that resolves after a newer one', async () => {
+    createTray(null, () => 'http://localhost:1')
+    refreshTrayMenu()
+    expect(resolvers).toHaveLength(2)
+
+    resolvers[1]([agent('cloud-agent')])
+    await vi.waitFor(() => expect(setContextMenu).toHaveBeenCalledTimes(1))
+    expect(menuLabels()).toContain('cloud-agent')
+
+    resolvers[0]([agent('local-agent')])
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(setContextMenu).toHaveBeenCalledTimes(1)
+    expect(menuLabels()).toContain('cloud-agent')
+  })
+})

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -193,12 +193,22 @@ export function refreshTrayMenu(): void {
 }
 
 /**
+ * Builds overlap: the 30s poll and the target-switch refresh both come through
+ * updateTrayMenu, and the base URL is sampled before the await. Without this a
+ * slow response from the previous target could land after the switch refresh
+ * painted the new one and overwrite it. Last started wins.
+ */
+let menuGeneration = 0
+
+/**
  * Update the tray context menu with current agent data
  */
 async function updateTrayMenu(): Promise<void> {
   if (!tray || !getApiBaseUrlRef) return
 
+  const generation = ++menuGeneration
   const agents = await fetchAgentsWithStatus(getApiBaseUrlRef())
+  if (generation !== menuGeneration) return
 
   // Group agents by status
   const awaitingInput = agents.filter(a => a.activityStatus === 'awaiting_input')

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -5,17 +5,19 @@ import { fetchAgentsWithStatus, ActivityStatus } from './agent-status'
 let tray: Tray | null = null
 let updateInterval: NodeJS.Timeout | null = null
 let mainWindowRef: BrowserWindow | null = null
-let apiPortRef: number = 0
+// A getter rather than a stored URL: in cloud mode the effective base is the
+// keyed proxy prefix, and which one is in force can change on a target switch.
+let getApiBaseUrlRef: (() => string) | null = null
 
 /**
  * Create the system tray with menu
  */
 export function createTray(
   mainWindow: BrowserWindow | null,
-  apiPort: number
+  getApiBaseUrl: () => string
 ): Tray {
   mainWindowRef = mainWindow
-  apiPortRef = apiPort
+  getApiBaseUrlRef = getApiBaseUrl
 
   // Create programmatic template icon (black circle for macOS menu bar)
   const icon = createTrayIcon()
@@ -66,7 +68,7 @@ export function destroyTray(): void {
 export function setTrayVisible(visible: boolean): void {
   if (visible && !tray) {
     // Create tray if it doesn't exist and we have the required refs
-    if (apiPortRef > 0) {
+    if (getApiBaseUrlRef) {
       const icon = createTrayIcon()
       tray = new Tray(icon)
       tray.setToolTip('Gamut')
@@ -182,12 +184,21 @@ function showWindow(): void {
 }
 
 /**
+ * Rebuild the tray menu now instead of waiting out the poll. Called on a target
+ * switch, where the 30s interval would leave the previous Superagent's agents
+ * on screen. No-op while the tray is hidden.
+ */
+export function refreshTrayMenu(): void {
+  void updateTrayMenu()
+}
+
+/**
  * Update the tray context menu with current agent data
  */
 async function updateTrayMenu(): Promise<void> {
-  if (!tray) return
+  if (!tray || !getApiBaseUrlRef) return
 
-  const agents = await fetchAgentsWithStatus(apiPortRef)
+  const agents = await fetchAgentsWithStatus(getApiBaseUrlRef())
 
   // Group agents by status
   const awaitingInput = agents.filter(a => a.activityStatus === 'awaiting_input')

--- a/src/shared/lib/services/cloud-boot-prefetch.ts
+++ b/src/shared/lib/services/cloud-boot-prefetch.ts
@@ -56,6 +56,15 @@ const PREFETCH_TTL_MS = 15_000
 /** Bodies above this are not worth holding in memory for a head start. */
 const MAX_PREFETCH_BODY_BYTES = 2 * 1024 * 1024
 
+/**
+ * Requests carrying this header never claim a prefetch entry. The entries are
+ * one-shot and exist to give the *reloading renderer* its head start — but
+ * main's own background pollers (the tray, the app menu) request the same
+ * paths through the same proxy at switch time, and whichever asked first would
+ * otherwise consume them.
+ */
+export const SKIP_BOOT_PREFETCH_HEADER = 'x-skip-boot-prefetch'
+
 export interface PrefetchedResponse {
   status: number
   headers: [string, string][]


### PR DESCRIPTION
## Problem

Switching the desktop app to a cloud workspace reroutes only the renderer: the main-process surfaces that list agents kept polling `http://localhost:{port}/api/agents` unconditionally. After a switch:

- The **system tray** and the **app menu's Agents submenu** kept listing this machine's agents.
- Clicking an entry sent a **local** slug to a renderer driving the **cloud** deployment — landing on a 404, or a same-named cloud agent.
- **Agent deep links** (`gamut://agent/<slug>`) resolved the latest session against the local API, then told the renderer to interpret the slug on whatever target it was driving.

## Fix

- `fetchAgentsWithStatus` now takes an API base URL; `createTray` / `createAppMenu` receive a getter (`() => activeApiTarget().baseUrl`) that re-resolves on every poll. In cloud mode this is the keyed cloud-proxy prefix, so both surfaces list the deployment's agents (and use its `agentOrder`); with no reachable workspace it degrades to local, matching the renderer.
- `applyPreferredApiTarget` kicks new `refreshTrayMenu()` / `refreshAppMenu()` exports, so a switch rebuilds both menus immediately instead of leaving the old target's agents up for the remainder of the 30s poll.
- Deep-link session resolution uses the same effective base URL.

Correctly left alone: MCP OAuth and platform-auth callback fetches (owned by the local API by design), quick-dispatch launcher and dashboard popouts (already torn down on switch).

## Tests / verification

- `api-target.test.ts` verifies both refreshes fire on a switch in each direction; existing suite updated for the new signatures.
- All 19 main-process test files pass (267 tests); `tsc --noEmit` and eslint clean.
- Docs: switch-teardown list and the capability-gate table's tray row updated in `docs/cloud-workspace.md` (tray *existence* is a window fact; what it *lists* is a target fact).

## Known gaps (not this PR)

- Native notifications are renderer-driven, so local agents' "needs input" notifications go dark while the UI targets cloud.
- Notifications / queued menu commands created before a switch carry the old target's slug; clicking them after switching navigates to a slug that doesn't exist there.

https://claude.ai/code/session_01BNHEtnhMdDdYzh843tsgdp