### PR TITLE
Linkify URLs in request cards (SUP-531)

### DIFF
--- a/src/renderer/components/browser/browser-tray-content.links.test.tsx
+++ b/src/renderer/components/browser/browser-tray-content.links.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const CLAY_URL = 'https://app.clay.com/oauth/device?user_code=LCWW-PKKC'
+
+// The tray action bar renders the same agent-authored prose the in-chat card
+// does, but reaches it through the browser stream rather than RequestItemShell.
+// The shell's linkify call cannot cover it, so this pins its own call site.
+const stream = {
+  aspectRatio: 16 / 9,
+  tabs: [],
+  viewingTargetId: null,
+  autoFollow: true,
+  needsAttention: true,
+  showOverlay: false,
+  pendingBrowserInputRequests: [{ toolUseId: 'tu-1', message: `Sign in at ${CLAY_URL}` }],
+  dismissBrowserInputRequest: vi.fn(),
+  latestRequestId: 'tu-1',
+  connected: true,
+  pageLoading: false,
+  isViewOnly: false,
+  isClosing: false,
+  showCloseWarning: false,
+  setShowCloseWarning: vi.fn(),
+  dismissOverlay: vi.fn(),
+  closeBrowser: vi.fn(),
+  handleCloseClick: vi.fn(),
+  handleMouseDown: vi.fn(),
+  handleMouseUp: vi.fn(),
+  handleMouseMove: vi.fn(),
+  handleWheel: vi.fn(),
+  handleKeyDown: vi.fn(),
+  handleKeyUp: vi.fn(),
+  handlePaste: vi.fn(),
+  handleTabClick: vi.fn(),
+  handleCloseTab: vi.fn(),
+  toggleAutoFollow: vi.fn(),
+}
+
+vi.mock('@renderer/hooks/use-browser-stream', () => ({
+  useBrowserStream: () => stream,
+}))
+
+vi.mock('@renderer/hooks/use-message-stream', () => ({
+  useMessageStream: () => ({ browserActive: true, isActive: true, streamingToolUses: [], activeSubagents: [] }),
+}))
+
+vi.mock('@renderer/hooks/use-browser-input-actions', () => ({
+  useBrowserInputActions: () => ({
+    status: 'idle',
+    submittingAction: null,
+    error: null,
+    complete: vi.fn(),
+    decline: vi.fn(),
+  }),
+}))
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })),
+}))
+
+import { BrowserTrayContent } from './browser-tray-content'
+
+describe('browser tray action bar', () => {
+  it('renders a URL in the pending request message as a clickable link', () => {
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <BrowserTrayContent agentSlug="prospecting" sessionId="s-1" onClose={vi.fn()} />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByRole('link', { name: CLAY_URL })).toHaveAttribute('href', CLAY_URL)
+  })
+})

--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -6,6 +6,7 @@ import { useBrowserStream } from '@renderer/hooks/use-browser-stream'
 import { Button } from '@renderer/components/ui/button'
 import { DeclineButton } from '@renderer/components/messages/decline-button'
 import { apiFetch } from '@renderer/lib/api'
+import { linkify } from '@renderer/lib/linkify'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useBrowserInputActions } from '@renderer/hooks/use-browser-input-actions'
 import { cn } from '@shared/lib/utils/cn'
@@ -209,7 +210,7 @@ export function BrowserTrayContent({
         <div className="shrink-0 px-4 mt-3">
           <div className="rounded-lg border border-border/60 bg-muted/30 p-3 flex items-center gap-2">
             <span className="text-xs font-medium text-foreground flex-1 truncate">
-              {latestRequest.message || 'Your input needed'}
+              {latestRequest.message ? linkify(latestRequest.message) : 'Your input needed'}
             </span>
             <DeclineButton
               onDecline={(reason) => decline(latestRequest.toolUseId, reason)}

--- a/src/renderer/components/messages/browser-input-request-item.tsx
+++ b/src/renderer/components/messages/browser-input-request-item.tsx
@@ -5,6 +5,7 @@ import { RequestItemActions } from './request-item-actions'
 import { RequestError } from './request-error'
 import { DeclineButton } from './decline-button'
 import { useBrowserInputActions } from '@renderer/hooks/use-browser-input-actions'
+import { linkify } from '@renderer/lib/linkify'
 import { cn } from '@shared/lib/utils/cn'
 import { BrowserCredentialPicker } from './browser-credential-picker'
 
@@ -78,7 +79,7 @@ export function BrowserInputRequestItem({
               {safeRequirements.map((req, i) => (
                 <li key={i} className="flex items-start gap-2 text-foreground">
                   <span className="mt-0.5 shrink-0 text-xs text-muted-foreground">{i + 1}.</span>
-                  <span>{req}</span>
+                  <span>{typeof req === 'string' ? linkify(req) : req}</span>
                 </li>
               ))}
             </ul>

--- a/src/renderer/components/messages/question-request-item.tsx
+++ b/src/renderer/components/messages/question-request-item.tsx
@@ -9,6 +9,7 @@ import { DeclineButton } from './decline-button'
 import { RequestItemShell } from './request-item-shell'
 import { RequestItemActions } from './request-item-actions'
 import { useSubPagination } from './pending-request-stack'
+import { linkify } from '@renderer/lib/linkify'
 import { cn } from '@shared/lib/utils/cn'
 
 interface Question {
@@ -233,7 +234,7 @@ export function QuestionRequestItem({
         description: questions.length > 1 ? (
           <div className="mt-3 space-y-2">
             {questions.slice(1).map((q, i) => (
-              <p key={i} className="whitespace-pre-line text-sm font-medium leading-5 text-foreground">{q.question}</p>
+              <p key={i} className="whitespace-pre-line text-sm font-medium leading-5 text-foreground">{typeof q.question === 'string' ? linkify(q.question) : q.question}</p>
             ))}
           </div>
         ) : undefined,

--- a/src/renderer/components/messages/request-item-shell-links.test.tsx
+++ b/src/renderer/components/messages/request-item-shell-links.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders as render } from '@renderer/test/test-utils'
+import { QuestionRequestItem } from './question-request-item'
+import { BrowserInputRequestItem } from './browser-input-request-item'
+
+// BrowserInputRequestItem mounts BrowserCredentialPicker, which calls
+// apiFetch(...).then(...) in an effect. A bare vi.fn() returns undefined and
+// throws inside that effect, so the double has to resolve a Response.
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ suggestions: [] }) })
+  ),
+}))
+
+// The exact prose Tim hit: an agent asking a human to finish a device login,
+// with the URL sitting inline in the question body.
+const CLAY_URL = 'https://app.clay.com/oauth/device?user_code=LCWW-PKKC'
+const CLAY_QUESTION = [
+  {
+    question:
+      'Clay device login is waiting. Open this URL, approve access for ' +
+      `Graham/DataWizz workspace, then come back here:\n\n${CLAY_URL}`,
+    header: 'Clay login',
+    options: [
+      { label: 'Approved — continue', description: 'You completed the Clay device login in the browser.' },
+      { label: 'Need a fresh code', description: 'Code expired or login failed.' },
+    ],
+    multiSelect: false,
+  },
+]
+
+const questionProps = {
+  toolUseId: 'tu-1',
+  sessionId: 's-1',
+  agentSlug: 'prospecting',
+  onComplete: vi.fn(),
+}
+
+describe('request card link rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a URL in the question prose as a clickable link', () => {
+    render(<QuestionRequestItem {...questionProps} questions={CLAY_QUESTION} />)
+
+    const link = screen.getByRole('link', { name: CLAY_URL })
+    expect(link).toHaveAttribute('href', CLAY_URL)
+  })
+
+  // Gate A invariant: an anchor inside the option <label> would also toggle the
+  // radio when clicked, so option text stays inert no matter what the title does.
+  it('never renders a link inside an option description', () => {
+    const withUrlInOption = [
+      {
+        ...CLAY_QUESTION[0],
+        question: 'Pick one',
+        options: [
+          { label: 'Approved — continue', description: `Approve at ${CLAY_URL} first` },
+        ],
+      },
+    ]
+    render(<QuestionRequestItem {...questionProps} questions={withUrlInOption} />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText(/Approve at/)).toBeInTheDocument()
+  })
+
+  // The shell only linkifies `title`. These two surfaces render the same
+  // agent-authored prose outside it, so each needs its own call site.
+  it('renders a URL in a browser-input requirement as a clickable link', () => {
+    render(
+      <BrowserInputRequestItem
+        toolUseId="tu-2"
+        message="Finish these steps"
+        requirements={[`Open ${CLAY_URL} and approve access`]}
+        sessionId="s-1"
+        agentSlug="prospecting"
+        onComplete={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: CLAY_URL })).toHaveAttribute('href', CLAY_URL)
+  })
+
+  it('renders a URL in a read-only follow-up question as a clickable link', () => {
+    const twoQuestions = [
+      { ...CLAY_QUESTION[0], question: 'First question' },
+      { ...CLAY_QUESTION[0], question: `Then open ${CLAY_URL}` },
+    ]
+    render(<QuestionRequestItem {...questionProps} questions={twoQuestions} readOnly />)
+
+    expect(screen.getByRole('link', { name: CLAY_URL })).toHaveAttribute('href', CLAY_URL)
+  })
+})

--- a/src/renderer/components/messages/request-item-shell.test.tsx
+++ b/src/renderer/components/messages/request-item-shell.test.tsx
@@ -245,4 +245,35 @@ describe('RequestItemShell', () => {
       expect(screen.queryByText(/of/)).not.toBeInTheDocument()
     })
   })
+
+  // Pins the fix site: a dual per-card patch that leaves the shell as plain text
+  // would still green the question-card regression, but fails here.
+  describe('title linkify', () => {
+    it('renders a bare URL in a string title as a clickable link', () => {
+      const url = 'https://app.clay.com/oauth/device?user_code=LCWW-PKKC'
+      render(
+        <RequestItemShell title={`Open this URL: ${url}`} theme="blue">
+          <div />
+        </RequestItemShell>
+      )
+
+      expect(screen.getByRole('link', { name: url })).toHaveAttribute('href', url)
+    })
+
+    it('does not interpret markdown in a string title', () => {
+      // Rejected shape A (MarkdownBlock) would bold this and collapse the blank line.
+      render(
+        <RequestItemShell
+          title={'Line one\n\n**not bold** https://example.com/path'}
+          theme="blue"
+        >
+          <div />
+        </RequestItemShell>
+      )
+
+      expect(screen.getByRole('link')).toHaveAttribute('href', 'https://example.com/path')
+      expect(screen.getByText(/\*\*not bold\*\*/)).toBeInTheDocument()
+      expect(document.querySelector('strong')).toBeNull()
+    })
+  })
 })

--- a/src/renderer/components/messages/request-item-shell.tsx
+++ b/src/renderer/components/messages/request-item-shell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
+import { linkify } from '@renderer/lib/linkify'
 import { RequestItemErrorContext } from './request-item-actions'
 import { usePagination } from './pending-request-stack'
 import { StopSessionButton } from './stop-session-button'
@@ -90,7 +91,7 @@ export function RequestItemShell({
         </span>
       )}
       <div className="flex-1 min-w-0 text-sm font-medium leading-5 text-foreground whitespace-pre-line">
-        {title}
+        {typeof title === 'string' ? linkify(title) : title}
       </div>
     </div>
   )

--- a/src/renderer/lib/linkify.test.tsx
+++ b/src/renderer/lib/linkify.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { linkify } from './linkify'
+
+describe('linkify', () => {
+  it('returns the input string unchanged when it holds no URL', () => {
+    // The no-visual-change guarantee for the ten request cards whose prose has
+    // no link: identical return value means identical DOM, not merely similar.
+    const text = 'Approve access for the DataWizz workspace, then come back here.'
+    expect(linkify(text)).toBe(text)
+  })
+
+  it('links a bare https URL and keeps the surrounding prose', () => {
+    render(<>{linkify('Open https://app.clay.com/oauth/device?user_code=LCWW-PKKC then return')}</>)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://app.clay.com/oauth/device?user_code=LCWW-PKKC')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(screen.getByText(/then return/)).toBeInTheDocument()
+  })
+
+  it('refuses dangerous schemes, leaving them as plain text', () => {
+    // Card prose is agent-authored. These schemes never enter the candidate
+    // regex (https?/mailto/tel/sms only); safeHref is the second gate for
+    // candidates that do match, shared with the markdown renderer.
+    for (const hostile of ['javascript:alert(1)', 'data:text/html;base64,PHNjcmlwdD4=', 'file:///etc/passwd']) {
+      const { container, unmount } = render(<>{linkify(`click ${hostile} now`)}</>)
+      expect(container.querySelector('a')).toBeNull()
+      unmount()
+    }
+  })
+
+  it('keeps tel: and mailto: linkable, matching the markdown renderer', () => {
+    render(<>{linkify('call tel:+15551234567 or mailto:ops@example.com')}</>)
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(2)
+    expect(links[0]).toHaveAttribute('href', 'tel:+15551234567')
+    expect(links[1]).toHaveAttribute('href', 'mailto:ops@example.com')
+  })
+
+  it('does not swallow trailing sentence punctuation into the href', () => {
+    const { container } = render(<>{linkify('Approve at https://example.com/path.')}</>)
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://example.com/path')
+    // Trimming the period off the href must hand it back to the prose, not eat
+    // it: a loop that advanced past the untrimmed match would drop it silently.
+    expect(container.textContent).toBe('Approve at https://example.com/path.')
+  })
+
+  it('keeps balanced parentheses that belong to the URL', () => {
+    render(<>{linkify('see https://en.wikipedia.org/wiki/Foo_(bar) for detail')}</>)
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://en.wikipedia.org/wiki/Foo_(bar)')
+  })
+
+  it('returns an unbalanced closing bracket to the prose', () => {
+    const { container } = render(<>{linkify('see https://example.com/a(b)) now')}</>)
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://example.com/a(b)')
+    expect(container.textContent).toBe('see https://example.com/a(b)) now')
+  })
+
+  it('keeps prose delimiters that wrap a URL out of the href', () => {
+    for (const [prose, text] of [
+      ['Open <https://example.com/login>', 'https://example.com/login'],
+      ['Open "https://example.com/login" now', 'https://example.com/login'],
+      ['Open `https://example.com/login` now', 'https://example.com/login'],
+    ]) {
+      const { container, unmount } = render(<>{linkify(prose)}</>)
+      expect(screen.getByRole('link')).toHaveAttribute('href', text)
+      expect(container.textContent).toBe(prose)
+      unmount()
+    }
+  })
+
+  it('keeps a single quote that is legal inside the URL', () => {
+    // RFC 3986 sub-delim. Excluding it to catch 'https://x'-style wrappers cost
+    // more than it bought: real API URLs carry raw quotes, agents do not wrap in
+    // them, and telling the two apart is not decidable from the string.
+    const url = "https://graph.microsoft.com/v1.0/users?$filter=startswith(displayName,'J')"
+    const { container } = render(<>{linkify(`Open ${url} now`)}</>)
+    expect(screen.getByRole('link')).toHaveAttribute('href', url)
+    expect(container.textContent).toBe(`Open ${url} now`)
+  })
+})

--- a/src/renderer/lib/linkify.tsx
+++ b/src/renderer/lib/linkify.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from 'react'
+import { safeHref } from './markdown-url-transform'
+
+// Agents write prose, not markdown, into request-card titles, so a URL there
+// arrives bare. Match the schemes the renderer is willing to link at all — the
+// rest of the policy (blanking javascript:/file:/data:) stays in safeHref, so
+// this regex decides *where a URL starts*, never *whether it is safe*.
+//
+// Today the two agree, so the safeHref call below cannot reject anything this
+// regex produces. It is kept as the structural gate anyway: widening the scheme
+// list here must not be able to widen what gets linked without going through the
+// one policy the markdown renderer also obeys.
+//
+// The body stops at whitespace and at the characters prose wraps a URL in —
+// <https://x>, "https://x", `https://x` — none of which are legal raw in a URL.
+// A single quote is deliberately still allowed: it is a legal sub-delim that
+// ?$filter=eq(name,'J') needs.
+const URL_CANDIDATE = /(?:https?:\/\/|(?:mailto|tel|sms):)[^\s<>"`]+/gi
+
+function countOf(text: string, ch: string): number {
+  let n = 0
+  for (const c of text) if (c === ch) n++
+  return n
+}
+
+/**
+ * Drop the prose punctuation a URL collected on its right edge.
+ *
+ * Sentence punctuation always goes. A bracket goes only when it is unbalanced,
+ * so https://en.wikipedia.org/wiki/Foo_(bar) survives whole while the stray ")"
+ * in "(see https://example.com/a)" is handed back to the prose.
+ */
+function trimTrailingPunctuation(url: string): string {
+  let end = url.length
+  while (end > 0) {
+    const ch = url[end - 1]
+    if ('.,;:!?'.includes(ch)) {
+      end--
+      continue
+    }
+    const kept = url.slice(0, end)
+    const isProse =
+      ch === ')' ? countOf(kept, '(') < countOf(kept, ')')
+      : ch === ']' ? countOf(kept, '[') < countOf(kept, ']')
+      : false
+    if (!isProse) break
+    end--
+  }
+  return url.slice(0, end)
+}
+
+/**
+ * Turn bare URLs in plain agent prose into anchors, leaving every other
+ * character untouched.
+ *
+ * Returns the input string unchanged when it holds no linkable URL, so callers
+ * that render prose without URLs produce byte-identical DOM to before.
+ *
+ * Deliberately not markdown: these strings are shown in compact cards where
+ * emphasis, headings and tables would be noise, and where markdown's collapsing
+ * of single newlines would drop line breaks `whitespace-pre-line` preserves.
+ * Anchor attributes match the markdown renderer's (message-item.tsx) so both
+ * reach the Electron shell opener through setWindowOpenHandler.
+ */
+export function linkify(text: string): ReactNode {
+  const nodes: ReactNode[] = []
+  let lastIndex = 0
+  let key = 0
+
+  for (const match of text.matchAll(URL_CANDIDATE)) {
+    const raw = match[0]
+    const index = match.index
+    const candidate = trimTrailingPunctuation(raw)
+    const href = safeHref(candidate)
+    if (!href) continue
+
+    if (index > lastIndex) nodes.push(text.slice(lastIndex, index))
+    nodes.push(
+      <a
+        key={key++}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:underline text-blue-500"
+      >
+        {candidate}
+      </a>
+    )
+    lastIndex = index + candidate.length
+  }
+
+  if (nodes.length === 0) return text
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex))
+  return nodes
+}

--- a/src/renderer/lib/markdown-url-transform.ts
+++ b/src/renderer/lib/markdown-url-transform.ts
@@ -13,6 +13,20 @@ import { defaultUrlTransform, type UrlTransform } from 'react-markdown'
 const EXTRA_ALLOWED_HREF_SCHEME = /^(?:tel|sms):/i
 
 /**
+ * The renderer's single link-href policy: the URL to use, or '' to refuse it.
+ *
+ * Both link surfaces go through here — <ReactMarkdown> via markdownUrlTransform
+ * below, and plain-prose autolinking via src/renderer/lib/linkify.tsx — so the
+ * two can never drift apart, or from safe-open-external.ts.
+ */
+export function safeHref(url: string): string {
+  if (EXTRA_ALLOWED_HREF_SCHEME.test(url)) {
+    return url
+  }
+  return defaultUrlTransform(url)
+}
+
+/**
  * Shared `urlTransform` for every <ReactMarkdown> renderer.
  *
  * Composes react-markdown's defaultUrlTransform — so dangerous schemes
@@ -23,8 +37,8 @@ const EXTRA_ALLOWED_HREF_SCHEME = /^(?:tel|sms):/i
  * what images/other resources may load.
  */
 export const markdownUrlTransform: UrlTransform = (url, key) => {
-  if (key === 'href' && typeof url === 'string' && EXTRA_ALLOWED_HREF_SCHEME.test(url)) {
-    return url
+  if (key === 'href' && typeof url === 'string') {
+    return safeHref(url)
   }
   return defaultUrlTransform(url)
 }


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-531/make-urls-in-request-card-titles-clickable

**Footprint:** 10 files, +406/-6. Six of them are tests (+301). The four production call sites are one line each.

## The bug

Tim connected Clay. The agent replied with a device-login URL, the card rendered it as plain text, and he retyped it by hand.

`RequestItemShell` dropped its `title` prop into a plain JSX text node. Eleven request cards route agent-authored prose through that prop, so all eleven had the same defect.

## The fix

Add a `linkify` helper and call it once at the shell. That fixes eleven cards with one change instead of eleven patches. Three more surfaces render the same agent prose outside `title` and get the same call:

- `browser-tray-content.tsx` action-bar message
- `browser-input-request-item.tsx` requirement bullets
- `question-request-item.tsx` read-only follow-up questions

Link-scheme policy is not duplicated. `markdownUrlTransform`'s rules move into a shared `safeHref` that both the markdown renderer and `linkify` call, so the renderer stays in lockstep with `safe-open-external.ts`. That is what SUP-238 established. Pure refactor, no behavior change.

The helper is deliberately not markdown. These cards are compact, and markdown would bold agent prose and collapse the newlines `whitespace-pre-line` preserves. Option labels and descriptions also stay inert, because they sit inside the `<label>` wrapping the radio input and an anchor there would toggle the radio on click. Both are pinned by tests so a later widening cannot quietly reach them.

## What linkify does

```
find    one regex: http(s)/mailto/tel/sms, body stops at whitespace and <>"`
trim    strip prose punctuation the regex over-captured on the right edge
build   walk matches, emit alternating text and anchor nodes
        no match, return the input string itself
```

`safeHref` decides whether to link. The regex only decides where a URL starts and ends. Today those two agree, so `safeHref` cannot reject anything the regex produces, which makes the call unreachable as a runtime gate. I kept it as the structural guarantee that widening the scheme list cannot widen what gets linked without going through the one policy the markdown renderer also obeys. Happy to drop it if you would rather not carry a branch nothing can currently take.

Trailing prose punctuation comes off the href, and an unbalanced bracket goes back to the prose so `wiki/Foo_(bar)` survives whole. A single quote stays inside the URL: it is a legal RFC 3986 sub-delim that real API URLs carry (`?$filter=startswith(displayName,'J')`), and a wrapping quote is not decidable from a URL that ends in one, so trying to strip it broke more than it fixed.

The no-match path returns the original string, so cards whose prose holds no URL render byte-identical DOM. A test pins that identity rather than the appearance.

## Verification

- 2195 renderer tests pass across 208 files. Seven new tests, each confirmed failing before its fix and passing after.
- Typecheck and lint clean.
- Confirmed on a running Electron build that a rendered link opens the OS browser through `setWindowOpenHandler` rather than navigating the app window.
- Five rounds of cross-model adversarial review against the diff, each scoped to the previous round's delta.
