### PR TITLE
Restyle Windows scrollbars to thin overlay-like thumbs

### DIFF
--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -389,6 +389,35 @@ html[data-keyboard-open] [data-composer-footer] {
   padding-right: 152px;
 }
 
+/* Windows: Chromium paints classic opaque scrollbars (arrow buttons, full-height
+   track) on every overflow container, unlike macOS's auto-hiding overlays.
+   Restyle them app-wide to the same thin muted thumb the app sidebar uses so
+   scrollable areas read the same on both platforms. Custom webkit scrollbars
+   are always painted when content overflows, so scrollability stays visible. */
+.electron-vibrancy-win ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background: transparent;
+}
+.electron-vibrancy-win ::-webkit-scrollbar-track {
+  background: transparent;
+}
+.electron-vibrancy-win ::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  background-color: hsl(var(--muted-foreground) / 0.25);
+}
+.electron-vibrancy-win ::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.4);
+}
+.electron-vibrancy-win ::-webkit-scrollbar-button {
+  display: none;
+}
+.electron-vibrancy-win ::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 /* Delivered file pill hover animation */
 @keyframes boink-down {
   0% { opacity: 0; transform: translateY(-6px); }


### PR DESCRIPTION
## Summary
- On Windows, Chromium paints classic opaque scrollbars (arrow buttons, full-height track) on every `overflow` container — most visibly on the settings page, where both the sidebar and the content pane showed chunky scrollbars. macOS looks fine because it uses auto-hiding overlay scrollbars (we even force `AppleShowScrollBars: WhenScrolling` in `src/main/index.ts`).
- Adds a Windows-Electron-only global restyle in `globals.css`, scoped under the existing `.electron-vibrancy-win` root class: 8px rounded thumb in `muted-foreground/25` (matching the app sidebar's existing `THIN_SCROLLBAR` style), transparent track/corner, arrow buttons removed, darker thumb on hover.

## Notes
- macOS and web deployments are untouched (the class is only added in Windows Electron).
- Custom webkit scrollbars are always painted when content overflows, so `.code-scrollbar`'s "force visible scrollbar" intent on code blocks is preserved — it just inherits the consistent thumb color on Windows.
- The quick-dispatch window imports `globals.css` and adds the same root class, so it gets the same treatment.

## Test plan
- [ ] On Windows, open Settings — sidebar and content scrollbars render as slim grey pills on an invisible track, no arrow buttons
- [ ] Verify code blocks in chat still show a visible horizontal scrollbar when content overflows
- [ ] Sanity-check macOS unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
