### PR TITLE
feat: warm-start agent container on first keystroke

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -1899,6 +1899,20 @@ describe('settings route', () => {
       expect(body.app.showMenuBarIcon).toBe(false)
       expect(body.llmProvider).toBe('openrouter')
     })
+
+    it('PUT accepts warmStartOnType boolean under app', async () => {
+      const res = await putSettings({ app: { warmStartOnType: false } })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.app.warmStartOnType).toBe(false)
+    })
+
+    it('PUT rejects non-boolean warmStartOnType', async () => {
+      const res = await putSettings({ app: { warmStartOnType: 'yes' } })
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toMatch(/warmStartOnType/)
+    })
   })
 
   describe('model icon uploads', () => {

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -551,6 +551,10 @@ settings.put('/', async (c) => {
       }
     }
 
+    if (body.app?.warmStartOnType !== undefined && typeof body.app.warmStartOnType !== 'boolean') {
+      return c.json({ error: 'warmStartOnType must be a boolean' }, 400)
+    }
+
     // Validate runtimeSettings if provided
     if (body.container?.runtimeSettings) {
       const limaSettings = body.container.runtimeSettings.lima

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -47,6 +47,11 @@ vi.mock('@renderer/hooks/use-agents', () => ({
     mutate: mockDeleteAgentMutate,
     isPending: false,
   }),
+  useStartAgent: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
 }))
 
 // Default to "loaded, empty" — most tests don't care. Specific tests that need
@@ -69,6 +74,7 @@ vi.mock('@renderer/hooks/use-settings', () => {
     data: {
       llmProvider: 'anthropic',
       models: { agentModel: 'sonnet' },
+      app: { warmStartOnType: true },
       llmProviderStatus: [
         {
           id: 'anthropic',
@@ -85,8 +91,10 @@ vi.mock('@renderer/hooks/use-settings', () => {
     },
   }
   return {
-    useSettings: () => settings,
+    useSettings: () => ({ ...settings, isSuccess: true }),
     useModelSettings: () => settings,
+    useWarmStartOnTypeEnabled: () => true,
+    isWarmStartOnTypeEnabled: () => true,
   }
 })
 

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -48,6 +48,8 @@ import {
 } from '@renderer/hooks/use-typewriter-placeholder'
 import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
 import { useRenameUntitledAgent } from '@renderer/hooks/use-rename-untitled-agent'
+import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
+import { useSettings } from '@renderer/hooks/use-settings'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { formatDistanceToNow } from 'date-fns'
 import { useNewSessionCarryover } from '@renderer/lib/new-session-carryover'
@@ -209,6 +211,13 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     draftKey: `agent:${agent.slug}`,
     initialAttachments: carryover?.attachments,
     initialSecuredSecrets: carryover?.securedSecrets,
+  })
+
+  const { data: settings } = useSettings()
+  useWarmStartOnType({
+    agentSlug: agent.slug,
+    message: composer.message,
+    enabled: settings?.app?.warmStartOnType !== false,
   })
 
   // Reset the manual-collapse flag once the message clears.

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -49,7 +49,7 @@ import {
 import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
 import { useRenameUntitledAgent } from '@renderer/hooks/use-rename-untitled-agent'
 import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
-import { useSettings } from '@renderer/hooks/use-settings'
+import { useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { formatDistanceToNow } from 'date-fns'
 import { useNewSessionCarryover } from '@renderer/lib/new-session-carryover'
@@ -213,11 +213,11 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     initialSecuredSecrets: carryover?.securedSecrets,
   })
 
-  const { data: settings } = useSettings()
+  const warmStartEnabled = useWarmStartOnTypeEnabled()
   useWarmStartOnType({
     agentSlug: agent.slug,
     message: composer.message,
-    enabled: settings?.app?.warmStartOnType !== false,
+    enabled: warmStartEnabled,
   })
 
   // Reset the manual-collapse flag once the message clears.

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -8,7 +8,7 @@ import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice
 import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
 import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
-import { useCreateAgent } from '@renderer/hooks/use-agents'
+import { useCreateAgent, useUpdateAgent } from '@renderer/hooks/use-agents'
 import { useCreateSession } from '@renderer/hooks/use-sessions'
 import { useNavigate } from '@tanstack/react-router'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
@@ -18,6 +18,9 @@ import {
   DEFAULT_AGENT_PROMPT_EXAMPLES,
 } from '@renderer/hooks/use-typewriter-placeholder'
 import { deriveAgentName } from '@renderer/lib/derive-agent-name'
+import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
+import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
+import { useSettings } from '@renderer/hooks/use-settings'
 import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 export interface CreateAgentFormProps {
@@ -50,10 +53,26 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
   const displayedPlaceholder = useTypewriterPlaceholder(DEFAULT_AGENT_PROMPT_EXAMPLES)
 
   const createAgent = useCreateAgent()
+  const updateAgent = useUpdateAgent()
   const createSession = useCreateSession()
   const navigate = useNavigate()
   const { track } = useAnalyticsTracking()
   const startOnboardingSession = useStartOnboardingSession()
+  const { data: settings } = useSettings()
+  const warmStartEnabled = settings?.app?.warmStartOnType !== false
+
+  const ensureWarmAgent = useCallback(async () => {
+    try {
+      const agent = await createAgent.mutateAsync({ name: UNTITLED_AGENT_NAME })
+      return agent.slug
+    } catch (error) {
+      console.warn('[warm-start] pre-create agent failed:', error)
+      return null
+    }
+  }, [createAgent])
+
+  const awaitWarmStartRef = useRef<() => Promise<string | null>>(async () => null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const finishCreatedAgent = useCallback(
     async (agent: ApiAgent, source: 'new' | 'import' | 'skillset', hasOnboarding?: boolean) => {
@@ -75,9 +94,15 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
     uploadFile: useCallback(async () => { throw new Error('Cannot upload before agent is created') }, []),
     uploadFolder: useCallback(async () => { throw new Error('Cannot upload before agent is created') }, []),
     onSubmit: useCallback(async (content: string) => {
+      // Local flag — do not key off createAgent.isPending; warm-start reuse of
+      // that mutation would freeze the textarea while the user is still typing.
+      setIsSubmitting(true)
       try {
         const agentName = await deriveAgentName(content)
-        const newAgent = await createAgent.mutateAsync({ name: agentName })
+        const warmSlug = await awaitWarmStartRef.current()
+        const newAgent = warmSlug
+          ? await updateAgent.mutateAsync({ slug: warmSlug, name: agentName })
+          : await createAgent.mutateAsync({ name: agentName })
         const session = await createSession.mutateAsync({
           agentSlug: newAgent.slug,
           message: content,
@@ -94,9 +119,19 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
         toast.error('Failed to create agent', {
           description: error instanceof Error ? error.message : 'Please try again.',
         })
+      } finally {
+        setIsSubmitting(false)
       }
-    }, [createAgent, createSession, navigate, track, onAgentCreated]),
+    }, [createAgent, updateAgent, createSession, navigate, track, onAgentCreated]),
   })
+
+  const { awaitWarmStart } = useWarmStartOnType({
+    agentSlug: null,
+    message: composer.message,
+    enabled: warmStartEnabled,
+    ensureAgent: ensureWarmAgent,
+  })
+  awaitWarmStartRef.current = awaitWarmStart
 
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(initialTemplate ?? null)
 
@@ -126,7 +161,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
     }
   }
 
-  const isDisabled = createAgent.isPending || createSession.isPending
+  const isDisabled = isSubmitting
 
   return (
     <div className={className}>

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -8,7 +8,7 @@ import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice
 import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
 import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
-import { useCreateAgent, useUpdateAgent } from '@renderer/hooks/use-agents'
+import { useCreateAgent, useDeleteAgent, useUpdateAgent } from '@renderer/hooks/use-agents'
 import { useCreateSession } from '@renderer/hooks/use-sessions'
 import { useNavigate } from '@tanstack/react-router'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
@@ -20,7 +20,8 @@ import {
 import { deriveAgentName } from '@renderer/lib/derive-agent-name'
 import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
 import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
-import { useSettings } from '@renderer/hooks/use-settings'
+import { useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
+import { captureRendererException } from '@renderer/lib/error-reporting'
 import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 export interface CreateAgentFormProps {
@@ -54,28 +55,57 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
 
   const createAgent = useCreateAgent()
   const updateAgent = useUpdateAgent()
+  const deleteAgent = useDeleteAgent()
   const createSession = useCreateSession()
   const navigate = useNavigate()
   const { track } = useAnalyticsTracking()
   const startOnboardingSession = useStartOnboardingSession()
-  const { data: settings } = useSettings()
-  const warmStartEnabled = settings?.app?.warmStartOnType !== false
+  const warmStartEnabled = useWarmStartOnTypeEnabled()
+
+  // Warm-precreated Untitled agent; deleted on abandon unless submit consumes it.
+  const warmSlugOwnedRef = useRef<string | null>(null)
+  const warmConsumedRef = useRef(false)
+  const mountedRef = useRef(true)
+
+  const discardWarmAgent = useCallback(async () => {
+    const slug = warmSlugOwnedRef.current
+    if (!slug || warmConsumedRef.current) return
+    warmSlugOwnedRef.current = null
+    try {
+      await deleteAgent.mutateAsync(slug)
+    } catch (error) {
+      console.warn('[warm-start] discard pre-created agent failed:', error)
+      captureRendererException(error, {
+        tags: { area: 'warm-start', op: 'discard-agent' },
+      })
+    }
+  }, [deleteAgent])
 
   const ensureWarmAgent = useCallback(async () => {
-    try {
-      const agent = await createAgent.mutateAsync({ name: UNTITLED_AGENT_NAME })
-      return agent.slug
-    } catch (error) {
-      console.warn('[warm-start] pre-create agent failed:', error)
+    const agent = await createAgent.mutateAsync({ name: UNTITLED_AGENT_NAME })
+    // Create finished after the form unmounted — delete immediately.
+    if (!mountedRef.current) {
+      try {
+        await deleteAgent.mutateAsync(agent.slug)
+      } catch (error) {
+        console.warn('[warm-start] discard in-flight pre-create failed:', error)
+        captureRendererException(error, {
+          tags: { area: 'warm-start', op: 'discard-agent' },
+        })
+      }
       return null
     }
-  }, [createAgent])
+    warmSlugOwnedRef.current = agent.slug
+    warmConsumedRef.current = false
+    return agent.slug
+  }, [createAgent, deleteAgent])
 
   const awaitWarmStartRef = useRef<() => Promise<string | null>>(async () => null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const finishCreatedAgent = useCallback(
     async (agent: ApiAgent, source: 'new' | 'import' | 'skillset', hasOnboarding?: boolean) => {
+      await discardWarmAgent()
       track('agent_created', { source, num_skills_added_at_creation: 0 })
       void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
       if (hasOnboarding) {
@@ -83,7 +113,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
       }
       await onAgentCreated?.()
     },
-    [track, navigate, startOnboardingSession, onAgentCreated],
+    [discardWarmAgent, track, navigate, startOnboardingSession, onAgentCreated],
   )
 
   const composer = useMessageComposer({
@@ -103,6 +133,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
         const newAgent = warmSlug
           ? await updateAgent.mutateAsync({ slug: warmSlug, name: agentName })
           : await createAgent.mutateAsync({ name: agentName })
+        if (warmSlug) warmConsumedRef.current = true
         const session = await createSession.mutateAsync({
           agentSlug: newAgent.slug,
           message: content,
@@ -131,7 +162,23 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
     enabled: warmStartEnabled,
     ensureAgent: ensureWarmAgent,
   })
-  awaitWarmStartRef.current = awaitWarmStart
+  useEffect(() => {
+    awaitWarmStartRef.current = awaitWarmStart
+  }, [awaitWarmStart])
+
+  // Abandon path: leave the create form without consuming the warm agent.
+  // Ref + empty deps so mutation identity churn doesn't re-bind cleanup mid-edit.
+  const discardWarmAgentRef = useRef(discardWarmAgent)
+  useEffect(() => {
+    discardWarmAgentRef.current = discardWarmAgent
+  }, [discardWarmAgent])
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      void discardWarmAgentRef.current()
+    }
+  }, [])
 
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(initialTemplate ?? null)
 

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -71,7 +71,8 @@ const mockRefreshAvailability = {
   isPending: false,
 }
 
-vi.mock('@renderer/hooks/use-settings', () => ({
+vi.mock('@renderer/hooks/use-settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@renderer/hooks/use-settings')>()),
   useSettings: () => mockSettings,
   useUpdateSettings: () => mockUpdateSettings,
   useStartRunner: () => mockStartRunner,

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -19,7 +19,14 @@ import {
   SelectValue,
 } from '@renderer/components/ui/select'
 import { Alert, AlertDescription, AlertTitle } from '@renderer/components/ui/alert'
-import { useSettings, useUpdateSettings, useStartRunner, useRestartRunner, useRefreshAvailability } from '@renderer/hooks/use-settings'
+import {
+  useSettings,
+  useUpdateSettings,
+  useStartRunner,
+  useRestartRunner,
+  useRefreshAvailability,
+  isWarmStartOnTypeEnabled,
+} from '@renderer/hooks/use-settings'
 import { AlertCircle, AlertTriangle, Play, Download, Loader2, RefreshCw, Plus, X } from 'lucide-react'
 import { RunnerSetupErrorPanel, getRunnerSetupPayload } from '@renderer/components/settings/runner-setup-error-panel'
 import { RuntimeProvisionProgress } from '@renderer/components/runtime/runtime-provision-progress'
@@ -792,7 +799,7 @@ export function RuntimeTab() {
         </div>
         <Switch
           id="warm-start-on-type"
-          checked={settings?.app?.warmStartOnType !== false}
+          checked={isWarmStartOnTypeEnabled(settings)}
           onCheckedChange={(checked: boolean) => {
             updateSettings.mutate({ app: { warmStartOnType: checked } })
           }}

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Input } from '@renderer/components/ui/input'
 import { Label } from '@renderer/components/ui/label'
+import { Switch } from '@renderer/components/ui/switch'
 import { Button } from '@renderer/components/ui/button'
 import {
   Dialog,
@@ -779,6 +780,24 @@ export function RuntimeTab() {
           />
           <span className="text-sm text-muted-foreground">minutes</span>
         </div>
+      </div>
+
+      {/* Warm-start on typing */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-0.5 min-w-0">
+          <Label htmlFor="warm-start-on-type">Warm start on typing</Label>
+          <p className="text-xs text-muted-foreground">
+            Start the agent container in the background when you begin typing a first message, so it is ready on send.
+          </p>
+        </div>
+        <Switch
+          id="warm-start-on-type"
+          checked={settings?.app?.warmStartOnType !== false}
+          onCheckedChange={(checked: boolean) => {
+            updateSettings.mutate({ app: { warmStartOnType: checked } })
+          }}
+          disabled={isLoading}
+        />
       </div>
 
       {/* Agent Limits */}

--- a/src/renderer/hooks/use-agents.ts
+++ b/src/renderer/hooks/use-agents.ts
@@ -182,13 +182,20 @@ export function useUpdateAgent() {
 // as they arrive without leaning on a poll loop.
 const AGENT_START_REINVALIDATE_DELAYS_MS = [5_000, 15_000, 30_000]
 
+export type StartAgentVars = string | { slug: string; source?: 'user' | 'warm-start' }
+
+function resolveStartAgentSlug(vars: StartAgentVars): string {
+  return typeof vars === 'string' ? vars : vars.slug
+}
+
 export function useStartAgent() {
   const queryClient = useQueryClient()
   const { track } = useAnalyticsTracking()
 
   return useMutation({
     meta: { skipGlobalErrorToast: true },
-    mutationFn: async (slug: string) => {
+    mutationFn: async (vars: StartAgentVars) => {
+      const slug = resolveStartAgentSlug(vars)
       const res = await apiFetch(`/api/agents/${slug}/start`, { method: 'POST' })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
@@ -196,8 +203,13 @@ export function useStartAgent() {
       }
       return res.json()
     },
-    onSuccess: (_, slug) => {
-      track('agent_started')
+    onSuccess: (_, vars) => {
+      const slug = resolveStartAgentSlug(vars)
+      const source = typeof vars === 'string' ? 'user' : (vars.source ?? 'user')
+      // Warm-start is background/speculative — don't inflate agent_started.
+      if (source !== 'warm-start') {
+        track('agent_started')
+      }
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['agents', slug] })
       for (const delay of AGENT_START_REINVALIDATE_DELAYS_MS) {

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -34,6 +34,23 @@ export function useSettings(options?: { enabled?: boolean }) {
   })
 }
 
+/** Default-on preference; treat missing as enabled. */
+export function isWarmStartOnTypeEnabled(
+  settings?: Pick<GlobalSettingsResponse, 'app'> | null,
+): boolean {
+  return settings?.app?.warmStartOnType !== false
+}
+
+/**
+ * Whether warm-start-on-type should fire. Returns false until settings have
+ * loaded so a disabled preference cannot race a speculative start.
+ */
+export function useWarmStartOnTypeEnabled(): boolean {
+  const { data, isSuccess } = useSettings()
+  if (!isSuccess) return false
+  return isWarmStartOnTypeEnabled(data)
+}
+
 /**
  * Picker-safe model settings served to EVERY authenticated user. The composer
  * and default-model pickers must read this — not `useSettings()`, whose

--- a/src/renderer/hooks/use-warm-start-on-type.test.tsx
+++ b/src/renderer/hooks/use-warm-start-on-type.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWarmStartOnType } from './use-warm-start-on-type'
+
+const mutate = vi.fn()
+const ensureAgent = vi.fn()
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useStartAgent: () => ({ mutate }),
+}))
+
+type RuntimeStatusResult = { data: { runtimeReadiness: { status: string } } }
+
+const runtimeStatus = vi.fn(
+  (): RuntimeStatusResult => ({ data: { runtimeReadiness: { status: 'READY' } } }),
+)
+
+vi.mock('@renderer/hooks/use-runtime-status', () => ({
+  useRuntimeStatus: () => runtimeStatus(),
+}))
+
+vi.mock('@renderer/lib/error-reporting', () => ({
+  captureRendererException: vi.fn(),
+}))
+
+vi.mock('@renderer/context/analytics-context', () => ({
+  useAnalyticsTracking: () => ({ track: vi.fn() }),
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+describe('useWarmStartOnType', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ensureAgent.mockResolvedValue('agent-warm')
+    runtimeStatus.mockReturnValue({
+      data: { runtimeReadiness: { status: 'READY' } },
+    })
+  })
+
+  it('starts an existing agent once on first non-empty message', async () => {
+    const { rerender } = renderHook(
+      ({ message }) =>
+        useWarmStartOnType({ agentSlug: 'agent-1', message, enabled: true }),
+      { wrapper, initialProps: { message: '' } },
+    )
+
+    expect(mutate).not.toHaveBeenCalled()
+
+    rerender({ message: 'hello' })
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith('agent-1', expect.any(Object))
+    })
+    expect(mutate).toHaveBeenCalledTimes(1)
+
+    rerender({ message: 'hello world' })
+    await act(async () => {})
+    expect(mutate).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates then starts when ensureAgent is provided', async () => {
+    renderHook(
+      () =>
+        useWarmStartOnType({
+          agentSlug: null,
+          message: 'draft',
+          enabled: true,
+          ensureAgent,
+        }),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(ensureAgent).toHaveBeenCalledTimes(1)
+      expect(mutate).toHaveBeenCalledWith('agent-warm', expect.any(Object))
+    })
+  })
+
+  it('does nothing when disabled', async () => {
+    renderHook(
+      () =>
+        useWarmStartOnType({
+          agentSlug: 'agent-1',
+          message: 'hello',
+          enabled: false,
+        }),
+      { wrapper },
+    )
+
+    await act(async () => {})
+    expect(mutate).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when runtime is not READY', async () => {
+    runtimeStatus.mockReturnValue({
+      data: { runtimeReadiness: { status: 'RUNTIME_UNAVAILABLE' } },
+    })
+
+    renderHook(
+      () =>
+        useWarmStartOnType({
+          agentSlug: 'agent-1',
+          message: 'hello',
+          enabled: true,
+        }),
+      { wrapper },
+    )
+
+    await act(async () => {})
+    expect(mutate).not.toHaveBeenCalled()
+  })
+
+  it('awaitWarmStart joins an in-flight ensure', async () => {
+    let resolveEnsure!: (slug: string) => void
+    ensureAgent.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveEnsure = resolve
+      }),
+    )
+
+    const { result } = renderHook(
+      () =>
+        useWarmStartOnType({
+          agentSlug: null,
+          message: 'hi',
+          enabled: true,
+          ensureAgent,
+        }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(ensureAgent).toHaveBeenCalled())
+
+    let awaited: string | null = 'pending' as unknown as null
+    void result.current.awaitWarmStart().then((slug) => {
+      awaited = slug
+    })
+
+    resolveEnsure('agent-warm')
+    await waitFor(() => expect(awaited).toBe('agent-warm'))
+    expect(mutate).toHaveBeenCalledWith('agent-warm', expect.any(Object))
+  })
+})

--- a/src/renderer/hooks/use-warm-start-on-type.test.tsx
+++ b/src/renderer/hooks/use-warm-start-on-type.test.tsx
@@ -46,7 +46,7 @@ describe('useWarmStartOnType', () => {
     })
   })
 
-  it('starts an existing agent once on first non-empty message', async () => {
+  it('starts an existing agent once on first non-empty message edit', async () => {
     const { rerender } = renderHook(
       ({ message }) =>
         useWarmStartOnType({ agentSlug: 'agent-1', message, enabled: true }),
@@ -58,7 +58,10 @@ describe('useWarmStartOnType', () => {
     rerender({ message: 'hello' })
 
     await waitFor(() => {
-      expect(mutate).toHaveBeenCalledWith('agent-1', expect.any(Object))
+      expect(mutate).toHaveBeenCalledWith(
+        { slug: 'agent-1', source: 'warm-start' },
+        expect.any(Object),
+      )
     })
     expect(mutate).toHaveBeenCalledTimes(1)
 
@@ -67,35 +70,93 @@ describe('useWarmStartOnType', () => {
     expect(mutate).toHaveBeenCalledTimes(1)
   })
 
+  it('does not start from a restored draft until the user edits', async () => {
+    const { rerender } = renderHook(
+      ({ message }) =>
+        useWarmStartOnType({ agentSlug: 'agent-1', message, enabled: true }),
+      { wrapper, initialProps: { message: 'stale draft' } },
+    )
+
+    await act(async () => {})
+    expect(mutate).not.toHaveBeenCalled()
+
+    rerender({ message: 'stale draft edited' })
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith(
+        { slug: 'agent-1', source: 'warm-start' },
+        expect.any(Object),
+      )
+    })
+  })
+
   it('creates then starts when ensureAgent is provided', async () => {
-    renderHook(
-      () =>
+    const { rerender } = renderHook(
+      ({ message }) =>
         useWarmStartOnType({
           agentSlug: null,
-          message: 'draft',
+          message,
           enabled: true,
           ensureAgent,
         }),
-      { wrapper },
+      { wrapper, initialProps: { message: '' } },
     )
+
+    rerender({ message: 'draft' })
 
     await waitFor(() => {
       expect(ensureAgent).toHaveBeenCalledTimes(1)
-      expect(mutate).toHaveBeenCalledWith('agent-warm', expect.any(Object))
+      expect(mutate).toHaveBeenCalledWith(
+        { slug: 'agent-warm', source: 'warm-start' },
+        expect.any(Object),
+      )
+    })
+  })
+
+  it('retries ensureAgent after a failure', async () => {
+    ensureAgent
+      .mockRejectedValueOnce(new Error('create failed'))
+      .mockResolvedValueOnce('agent-warm')
+
+    const { rerender } = renderHook(
+      ({ message }) =>
+        useWarmStartOnType({
+          agentSlug: null,
+          message,
+          enabled: true,
+          ensureAgent,
+        }),
+      { wrapper, initialProps: { message: '' } },
+    )
+
+    rerender({ message: 'hi' })
+    await waitFor(() => expect(ensureAgent).toHaveBeenCalledTimes(1))
+    await act(async () => {})
+    expect(mutate).not.toHaveBeenCalled()
+
+    // Change message again so the effect re-fires after the latch was cleared.
+    rerender({ message: 'hi!' })
+    await waitFor(() => {
+      expect(ensureAgent).toHaveBeenCalledTimes(2)
+      expect(mutate).toHaveBeenCalledWith(
+        { slug: 'agent-warm', source: 'warm-start' },
+        expect.any(Object),
+      )
     })
   })
 
   it('does nothing when disabled', async () => {
-    renderHook(
-      () =>
+    const { rerender } = renderHook(
+      ({ message }) =>
         useWarmStartOnType({
           agentSlug: 'agent-1',
-          message: 'hello',
+          message,
           enabled: false,
         }),
-      { wrapper },
+      { wrapper, initialProps: { message: '' } },
     )
 
+    rerender({ message: 'hello' })
     await act(async () => {})
     expect(mutate).not.toHaveBeenCalled()
   })
@@ -105,16 +166,17 @@ describe('useWarmStartOnType', () => {
       data: { runtimeReadiness: { status: 'RUNTIME_UNAVAILABLE' } },
     })
 
-    renderHook(
-      () =>
+    const { rerender } = renderHook(
+      ({ message }) =>
         useWarmStartOnType({
           agentSlug: 'agent-1',
-          message: 'hello',
+          message,
           enabled: true,
         }),
-      { wrapper },
+      { wrapper, initialProps: { message: '' } },
     )
 
+    rerender({ message: 'hello' })
     await act(async () => {})
     expect(mutate).not.toHaveBeenCalled()
   })
@@ -127,17 +189,18 @@ describe('useWarmStartOnType', () => {
       }),
     )
 
-    const { result } = renderHook(
-      () =>
+    const { result, rerender } = renderHook(
+      ({ message }) =>
         useWarmStartOnType({
           agentSlug: null,
-          message: 'hi',
+          message,
           enabled: true,
           ensureAgent,
         }),
-      { wrapper },
+      { wrapper, initialProps: { message: '' } },
     )
 
+    rerender({ message: 'hi' })
     await waitFor(() => expect(ensureAgent).toHaveBeenCalled())
 
     let awaited: string | null = 'pending' as unknown as null
@@ -147,6 +210,28 @@ describe('useWarmStartOnType', () => {
 
     resolveEnsure('agent-warm')
     await waitFor(() => expect(awaited).toBe('agent-warm'))
-    expect(mutate).toHaveBeenCalledWith('agent-warm', expect.any(Object))
+    expect(mutate).toHaveBeenCalledWith(
+      { slug: 'agent-warm', source: 'warm-start' },
+      expect.any(Object),
+    )
+  })
+
+  it('awaitWarmStart returns an existing warm slug even when disabled', async () => {
+    const { result, rerender } = renderHook(
+      ({ message, enabled }) =>
+        useWarmStartOnType({
+          agentSlug: null,
+          message,
+          enabled,
+          ensureAgent,
+        }),
+      { wrapper, initialProps: { message: '', enabled: true } },
+    )
+
+    rerender({ message: 'hi', enabled: true })
+    await waitFor(() => expect(mutate).toHaveBeenCalled())
+
+    rerender({ message: 'hi', enabled: false })
+    await expect(result.current.awaitWarmStart()).resolves.toBe('agent-warm')
   })
 })

--- a/src/renderer/hooks/use-warm-start-on-type.ts
+++ b/src/renderer/hooks/use-warm-start-on-type.ts
@@ -13,9 +13,10 @@ export interface UseWarmStartOnTypeOptions {
 }
 
 /**
- * One-shot: on first non-empty message while the runtime is READY, ensure an
- * agent exists and fire POST /start. Submit can await the same in-flight work
- * via awaitWarmStart() so create-on-submit does not race a second agent.
+ * One-shot: on the first user edit that leaves a non-empty message while the
+ * runtime is READY, ensure an agent exists and fire POST /start. Restored
+ * drafts do not trigger — only a change from the mount-time baseline does.
+ * Submit can await the same in-flight work via awaitWarmStart().
  */
 export function useWarmStartOnType({
   agentSlug,
@@ -24,6 +25,9 @@ export function useWarmStartOnType({
   ensureAgent,
 }: UseWarmStartOnTypeOptions) {
   const startAgent = useStartAgent()
+  const startMutateRef = useRef(startAgent.mutate)
+  startMutateRef.current = startAgent.mutate
+
   const { data: runtimeStatus } = useRuntimeStatus()
   const isReady = runtimeStatus?.runtimeReadiness?.status === 'READY'
 
@@ -32,6 +36,9 @@ export function useWarmStartOnType({
   const startedRef = useRef(false)
   const ensureAgentRef = useRef(ensureAgent)
   ensureAgentRef.current = ensureAgent
+
+  // Mount-time baseline — restored drafts must not count as "typing".
+  const baselineRef = useRef(message)
 
   useEffect(() => {
     if (agentSlug) slugRef.current = agentSlug
@@ -48,19 +55,25 @@ export function useWarmStartOnType({
         let slug = slugRef.current
         if (!slug) {
           const created = await ensureAgentRef.current?.()
-          if (!created) return null
+          if (!created) {
+            promiseRef.current = null
+            return null
+          }
           slug = created
           slugRef.current = slug
         }
         startedRef.current = true
-        startAgent.mutate(slug, {
-          onError: (error) => {
-            console.warn('[warm-start] container start failed:', error)
-            captureRendererException(error, {
-              tags: { area: 'warm-start', op: 'start' },
-            })
+        startMutateRef.current(
+          { slug, source: 'warm-start' },
+          {
+            onError: (error) => {
+              console.warn('[warm-start] container start failed:', error)
+              captureRendererException(error, {
+                tags: { area: 'warm-start', op: 'start' },
+              })
+            },
           },
-        })
+        )
         return slug
       } catch (error) {
         console.warn('[warm-start] ensure agent failed:', error)
@@ -73,17 +86,22 @@ export function useWarmStartOnType({
     })()
 
     return promiseRef.current
-  }, [startAgent])
+  }, [])
 
   useEffect(() => {
-    if (!enabled || !isReady || !message.trim()) return
+    if (!enabled || !isReady) return
+    if (!message.trim()) return
+    // Only fire after the user changes the field from its mount-time value.
+    if (message === baselineRef.current) return
     void run()
   }, [enabled, isReady, message, run])
 
   const awaitWarmStart = useCallback(async (): Promise<string | null> => {
-    if (!enabled) return null
+    // Prefer an already-created warm agent even if the setting was toggled off
+    // mid-draft, so submit does not create a second agent.
     if (promiseRef.current) return promiseRef.current
     if (startedRef.current && slugRef.current) return slugRef.current
+    if (!enabled) return null
     if (isReady && message.trim()) return run()
     return null
   }, [enabled, isReady, message, run])

--- a/src/renderer/hooks/use-warm-start-on-type.ts
+++ b/src/renderer/hooks/use-warm-start-on-type.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useStartAgent } from '@renderer/hooks/use-agents'
+import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
+import { captureRendererException } from '@renderer/lib/error-reporting'
+
+export interface UseWarmStartOnTypeOptions {
+  /** Existing agent slug (AgentHome). Null when the agent is created on demand. */
+  agentSlug: string | null
+  message: string
+  enabled: boolean
+  /** Create an agent when none exists yet (CreateAgentForm). Returns its slug. */
+  ensureAgent?: () => Promise<string | null>
+}
+
+/**
+ * One-shot: on first non-empty message while the runtime is READY, ensure an
+ * agent exists and fire POST /start. Submit can await the same in-flight work
+ * via awaitWarmStart() so create-on-submit does not race a second agent.
+ */
+export function useWarmStartOnType({
+  agentSlug,
+  message,
+  enabled,
+  ensureAgent,
+}: UseWarmStartOnTypeOptions) {
+  const startAgent = useStartAgent()
+  const { data: runtimeStatus } = useRuntimeStatus()
+  const isReady = runtimeStatus?.runtimeReadiness?.status === 'READY'
+
+  const slugRef = useRef<string | null>(agentSlug)
+  const promiseRef = useRef<Promise<string | null> | null>(null)
+  const startedRef = useRef(false)
+  const ensureAgentRef = useRef(ensureAgent)
+  ensureAgentRef.current = ensureAgent
+
+  useEffect(() => {
+    if (agentSlug) slugRef.current = agentSlug
+  }, [agentSlug])
+
+  const run = useCallback((): Promise<string | null> => {
+    if (promiseRef.current) return promiseRef.current
+    if (startedRef.current && slugRef.current) {
+      return Promise.resolve(slugRef.current)
+    }
+
+    promiseRef.current = (async () => {
+      try {
+        let slug = slugRef.current
+        if (!slug) {
+          const created = await ensureAgentRef.current?.()
+          if (!created) return null
+          slug = created
+          slugRef.current = slug
+        }
+        startedRef.current = true
+        startAgent.mutate(slug, {
+          onError: (error) => {
+            console.warn('[warm-start] container start failed:', error)
+            captureRendererException(error, {
+              tags: { area: 'warm-start', op: 'start' },
+            })
+          },
+        })
+        return slug
+      } catch (error) {
+        console.warn('[warm-start] ensure agent failed:', error)
+        captureRendererException(error, {
+          tags: { area: 'warm-start', op: 'ensure-agent' },
+        })
+        promiseRef.current = null
+        return null
+      }
+    })()
+
+    return promiseRef.current
+  }, [startAgent])
+
+  useEffect(() => {
+    if (!enabled || !isReady || !message.trim()) return
+    void run()
+  }, [enabled, isReady, message, run])
+
+  const awaitWarmStart = useCallback(async (): Promise<string | null> => {
+    if (!enabled) return null
+    if (promiseRef.current) return promiseRef.current
+    if (startedRef.current && slugRef.current) return slugRef.current
+    if (isReady && message.trim()) return run()
+    return null
+  }, [enabled, isReady, message, run])
+
+  return { awaitWarmStart }
+}

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -1320,6 +1320,7 @@ describe('DEFAULT_SETTINGS', () => {
   it('has expected app defaults', () => {
     expect(DEFAULT_SETTINGS.app?.showMenuBarIcon).toBe(true)
     expect(DEFAULT_SETTINGS.app?.autoSleepTimeoutMinutes).toBe(30)
+    expect(DEFAULT_SETTINGS.app?.warmStartOnType).toBe(true)
   })
 
   it('has expected notification defaults', () => {

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -105,6 +105,8 @@ export interface AppPreferences {
   showMenuBarIcon?: boolean
   notifications?: NotificationSettings
   autoSleepTimeoutMinutes?: number
+  /** Pre-start the agent container when the user begins typing a first message. */
+  warmStartOnType?: boolean
   autoDeleteInactiveDays?: number
   setupCompleted?: boolean
   accountProvider?: AccountProviderType
@@ -401,6 +403,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   app: {
     showMenuBarIcon: true,
     autoSleepTimeoutMinutes: 30,
+    warmStartOnType: true,
     globalDispatchShortcut: DEFAULT_GLOBAL_DISPATCH_SHORTCUT,
     notifications: {
       enabled: true,

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -180,6 +180,8 @@ class ContainerManager {
    */
   markAsStopped(agentId: string): void {
     this.updateCachedStatus(agentId, 'stopped', null)
+    this.containerStartedAt.delete(agentId)
+    this.lastKeepAliveAt.delete(agentId)
   }
 
   /**
@@ -303,6 +305,12 @@ class ContainerManager {
     if (this.startingAgents.has(agentId)) return info
 
     this.updateCachedStatus(agentId, info.status, info.port)
+
+    // Host restart clears in-memory start times. Floor the idle clock at
+    // rediscovery so zero-session warm containers are still reaped.
+    if (info.status === 'running' && !this.containerStartedAt.has(agentId)) {
+      this.containerStartedAt.set(agentId, Date.now())
+    }
 
     // Broadcast if status changed (e.g., container was stopped externally)
     if (previousStatus && previousStatus !== info.status) {

--- a/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.test.ts
@@ -73,6 +73,7 @@ describe('AutoSleepMonitor', () => {
     mockListSessions.mockResolvedValue([])
     mockGetContainerStartTime.mockReturnValue(undefined)
     mockGetLastKeepAlive.mockReturnValue(undefined)
+    mockHasActiveSessions.mockReturnValue(false)
     mockStopContainer.mockResolvedValue(undefined)
   })
 
@@ -177,9 +178,34 @@ describe('AutoSleepMonitor', () => {
     expect(mockStopContainer).not.toHaveBeenCalled()
   })
 
-  it('skips agent with no sessions', async () => {
+  it('stops warm-started agent with no sessions after timeout', async () => {
+    const now = Date.now()
     mockGetRunningAgentIds.mockReturnValue(['agent-1'])
     mockListSessions.mockResolvedValue([])
+    mockGetContainerStartTime.mockReturnValue(now - THIRTY_MINUTES_MS - 1000)
+
+    await autoSleepMonitor.start()
+    await tick()
+
+    expect(mockStopContainer).toHaveBeenCalledWith('agent-1', expect.anything())
+  })
+
+  it('keeps recently warm-started agent with no sessions', async () => {
+    const now = Date.now()
+    mockGetRunningAgentIds.mockReturnValue(['agent-1'])
+    mockListSessions.mockResolvedValue([])
+    mockGetContainerStartTime.mockReturnValue(now - 5 * 60 * 1000)
+
+    await autoSleepMonitor.start()
+    await tick()
+
+    expect(mockStopContainer).not.toHaveBeenCalled()
+  })
+
+  it('skips agent with no sessions when start time is unknown', async () => {
+    mockGetRunningAgentIds.mockReturnValue(['agent-1'])
+    mockListSessions.mockResolvedValue([])
+    mockGetContainerStartTime.mockReturnValue(undefined)
 
     await autoSleepMonitor.start()
     await tick()

--- a/src/shared/lib/scheduler/auto-sleep-monitor.ts
+++ b/src/shared/lib/scheduler/auto-sleep-monitor.ts
@@ -84,14 +84,10 @@ class AutoSleepMonitor {
           // Check last activity across all sessions
           const sessions = await listSessions(agentId)
 
-          // No sessions — container was just started, skip it
-          if (sessions.length === 0) {
-            continue
-          }
-
           // Use container start time as a floor — when an agent is woken up
           // to view its dashboard, session timestamps are stale from before
-          // the previous sleep and would cause immediate re-sleep.
+          // the previous sleep and would cause immediate re-sleep. Also covers
+          // warm-started containers that still have zero sessions.
           const containerStartTime =
             containerManager.getContainerStartTime(agentId) ?? 0
           const lastKeepAlive =
@@ -102,6 +98,11 @@ class AutoSleepMonitor {
             lastKeepAlive,
             ...sessions.map((s) => s.lastActivityAt.getTime())
           )
+
+          // No start/keep-alive/session signal yet — do not reap.
+          if (lastActivity === 0) {
+            continue
+          }
 
           if (now - lastActivity > timeoutMs) {
             console.log(

--- a/src/shared/lib/services/settings-audit.ts
+++ b/src/shared/lib/services/settings-audit.ts
@@ -80,6 +80,8 @@ const SECTION_RULES: Array<[prefix: string, label: string]> = [
   ['app.maxBrowserTabs', 'Browser Use'],
   ['app.configuredPasswordManagers', 'Browser Use'],
   ['app.browserbase', 'Browser Use'],
+  ['app.autoSleepTimeoutMinutes', 'Container Runtime'],
+  ['app.warmStartOnType', 'Container Runtime'],
   ['app.', 'General'],
 ]
 


### PR DESCRIPTION
## Summary

When a user starts typing a first message to an agent, start the agent container automatically in the background — by the time they finish typing, it's warm and ready to go. Optional config, **default on**, in the Runtime settings tab (`app.warmStartOnType`).

- New `useWarmStartOnType` hook: one-shot — on the first non-empty keystroke while the runtime is `READY`, ensure an agent exists and fire `POST /start`. Submit joins the same in-flight work via `awaitWarmStart()` so create-on-submit never races a second agent.
- `AgentHome`: warms the already-existing agent.
- `CreateAgentForm`: pre-creates an Untitled agent on first keystroke, then renames it (instead of creating a new one) on submit. Uses a local `isSubmitting` flag instead of `createAgent.isPending` so the warm-start reuse of that mutation doesn't freeze the textarea mid-typing.
- Settings: `app.warmStartOnType` (default `true`), toggle in Runtime tab, boolean-validated in `PUT /api/settings`, audit-labeled under Container Runtime.
- Auto-sleep monitor: zero-session containers are no longer skipped — container start time is used as the activity floor, so abandoned warm starts are reaped after the normal idle timeout.

## Open questions (why draft)

- Abandoned warm starts leave an `Untitled` agent record behind (the container is reaped by auto-sleep, but the agent stays and appears in the sidebar while typing). Decide: acceptable, or delete on abandon?
- `startedRef` latches even if the background `POST /start` fails (no retry on later keystrokes); submit's session creation starts the container anyway. Confirm container start is idempotent under that race.

## Test plan

- [x] `use-warm-start-on-type.test.tsx` — one-shot start, ensure-then-start, disabled, runtime-not-ready, awaitWarmStart joins in-flight ensure
- [x] `auto-sleep-monitor.test.ts` — warm-started zero-session container reaped after timeout, kept when recent, skipped when start time unknown
- [x] `settings` route + defaults tests for `warmStartOnType`
- [x] typecheck clean, touched-file lint clean (4 pre-existing warnings elsewhere in runtime-tab.tsx)
- [ ] Manual: type in AgentHome / CreateAgentForm and observe container pre-start; toggle off in Runtime tab and confirm no pre-start

Made with [Cursor](https://cursor.com)