### PR TITLE
Default new installs to Grok 4.5

### DIFF
--- a/agent-container/src/tools/schedule-task.ts
+++ b/agent-container/src/tools/schedule-task.ts
@@ -87,7 +87,7 @@ Avoid recurring intervals shorter than 15 minutes unless truly necessary: freque
         'Optional IANA timezone for interpreting the schedule (e.g., "America/New_York", "Europe/London"). If not specified, uses the creating user\'s timezone.'
       ),
     model: z
-      .enum(['opus', 'sonnet', 'haiku'])
+      .enum(['grok', 'opus', 'sonnet', 'haiku'])
       .optional()
       .describe(
         'Optional model family to use for this task. If not specified, uses the global default.'

--- a/agent-container/src/tools/webhook-triggers.ts
+++ b/agent-container/src/tools/webhook-triggers.ts
@@ -165,7 +165,7 @@ Use get_available_triggers first to discover what triggers are available for an 
       .optional()
       .describe('Optional configuration for the trigger (depends on trigger type)'),
     model: z
-      .enum(['opus', 'sonnet', 'haiku'])
+      .enum(['grok', 'opus', 'sonnet', 'haiku'])
       .optional()
       .describe('Optional model family to use when this trigger fires. If not specified, uses the global default.'),
     effort: z
@@ -241,7 +241,7 @@ If the service reveals a signing secret only AFTER registration, attach it after
       .describe('Optional HMAC signature verification profile, if you already know the signing secret'),
     filter_exp: z.string().optional().describe(FILTER_EXP_DESCRIPTION),
     model: z
-      .enum(['opus', 'sonnet', 'haiku'])
+      .enum(['grok', 'opus', 'sonnet', 'haiku'])
       .optional()
       .describe('Optional model family to use when this endpoint fires. If not specified, uses the global default.'),
     effort: z

--- a/e2e/auth/specs/model-picker-roles.spec.ts
+++ b/e2e/auth/specs/model-picker-roles.spec.ts
@@ -72,8 +72,8 @@ test.describe('Model picker for non-admin users', () => {
     await card.locator('[data-testid="settings-model-trigger"]').click()
 
     // Same catalog, offerLatest surface: family rows carry model-latest-* ids.
-    // Haiku, NOT opus: 'opus' is the seeded global default the trigger already
-    // shows, so picking it would prove nothing about the label updating.
+    // Haiku, because no seed sets it: picking whatever the global default
+    // already resolves to would prove nothing about the label updating.
     const haikuRow = user2Page.locator('[data-testid="model-latest-haiku"]')
     await expect(haikuRow).toBeVisible()
 

--- a/e2e/specs/agent-default-model.spec.ts
+++ b/e2e/specs/agent-default-model.spec.ts
@@ -104,8 +104,8 @@ test.describe('Per-agent default model', () => {
     // Revert via the picker's reset-to-global action (the in-popover
     // replacement for the old reset button): it disables itself once the
     // override is gone, the untouched composer follows the app-wide default
-    // again, and the next session is created with it (bare 'opus' alias,
-    // resolved to the latest concrete id on the wire).
+    // again, and the next session is created with it (a bare alias, resolved
+    // to the latest concrete id on the wire).
     const resetMessage = `Reset to global message ${tag}`
     await page.goBack()
     await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()

--- a/e2e/specs/model-selection.spec.ts
+++ b/e2e/specs/model-selection.spec.ts
@@ -184,9 +184,10 @@ test.describe('Model selection', () => {
   })
 
   test('the default bare-alias model resolves to a concrete id on the wire', async ({ page }, testInfo) => {
-    // The default `agentModel` setting is the bare alias 'opus'. AgentHome's
-    // trigger must display the resolved Opus model, and a send without touching
-    // the popover must put the resolved concrete id on the wire.
+    // The default `agentModel` setting is the bare alias 'grok', which this
+    // provider's catalog does not carry, so both the trigger and the wire fall
+    // through to the provider's own agent default (Opus). The two ladders must
+    // land on the SAME model — a display that disagrees with the wire is the bug.
     const tag = `${testInfo.workerIndex}-${Date.now()}`
 
     await agentPage.createAgent(`First message ${tag}`)
@@ -202,8 +203,8 @@ test.describe('Model selection', () => {
     const record = await waitForRecord(
       (r) => r.type === 'createSession' && r.initialMessage === followUp
     )
-    // Bare 'opus' resolves to its concrete latest id — match family-shape so the
-    // test survives future default-version bumps.
+    // The fallback resolves to a concrete latest id, never a bare alias — match
+    // family-shape so the test survives future default-version bumps.
     expect(record.model).toContain('opus')
     expect(record.model).not.toBe('opus')
   })
@@ -212,7 +213,7 @@ test.describe('Model selection', () => {
     await agentPage.clickCreateAgent()
     await expect(page.locator('[data-testid="home-message-input"]')).toBeVisible()
 
-    // Default starts on Opus — confirm xhigh/max are visible there first.
+    // The default resolves to Opus here — confirm xhigh/max are visible first.
     await page.locator('[data-testid="composer-options-trigger"]').click()
     await expect(page.locator('[data-testid="effort-option-xhigh"]')).toBeVisible()
     await expect(page.locator('[data-testid="effort-option-max"]')).toBeVisible()

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -137,10 +137,9 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
         const session = await createSession.mutateAsync({
           agentSlug: newAgent.slug,
           message: content,
-          // Brand-new agents start their first session on Opus, mirroring
-          // AgentHome's first-session default. The container normalizes the
-          // family alias to the active provider's specific model.
-          model: 'opus',
+          // No model: an untouched first send carries none, exactly as AgentHome's
+          // composer does, so the host resolves the user's default rather than a
+          // pin this form invented.
         })
         track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
         void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: newAgent.displaySlug, sessionId: session.id } })

--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -23,6 +23,7 @@ interface HarnessProps {
   initialEffort?: EffortLevel
   initialSpeed?: SpeedLevel
   initialModel?: string
+  providerDefaultModel?: string
   catalog?: ModelDefinition[]
   onState?: (state: ComposerOptionsState) => void
   disabled?: boolean
@@ -35,6 +36,7 @@ function Harness({
   initialEffort = 'high',
   initialSpeed = 'normal',
   initialModel,
+  providerDefaultModel = 'sonnet',
   catalog = CATALOG,
   onState,
   disabled,
@@ -51,6 +53,7 @@ function Harness({
     model,
     setModel,
     catalog,
+    providerDefaultModel,
     toRuntimeOptions: () => ({ effort, speed, ...(model ? { model } : {}) }),
   }
   onState?.(state)
@@ -63,8 +66,16 @@ describe('ComposerOptionsPopover', () => {
     expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Opus 4.8 · High')
   })
 
-  it('falls back to Sonnet on the trigger when no model is set', () => {
-    render(<Harness initialModel={undefined} initialEffort="medium" />)
+  // The host resolver's last rung is the active provider's own agent default, so
+  // the trigger has to land there too. A selection naming a family this provider
+  // does not carry (e.g. 'gpt' on a Claude-only provider) is the case that bites:
+  // display and wire must agree, or the picker shows a model that never runs.
+  it('falls back to the provider default when the selection is unset or unresolvable', () => {
+    const { unmount } = render(<Harness initialModel={undefined} initialEffort="medium" />)
+    expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Sonnet 4.6 · Medium')
+    unmount()
+
+    render(<Harness initialModel="gpt" initialEffort="medium" />)
     expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Sonnet 4.6 · Medium')
   })
 

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -5,8 +5,8 @@ import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui
 import { Separator } from '@renderer/components/ui/separator'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
 import { EFFORT_LEVELS } from '@shared/lib/container/types'
-import { type ComposerOptionsState } from './composer-options'
-import { ModelFamilyList, findCatalogModel } from './model-family-list'
+import { resolveDisplayModel, type ComposerOptionsState } from './composer-options'
+import { ModelFamilyList } from './model-family-list'
 import { EFFORT_LABELS, EffortSection, useEffortClamp } from './effort-slider'
 import { SPEED_LABELS, SpeedSection, availableSpeeds, useSpeedClamp } from './speed-section'
 
@@ -20,16 +20,11 @@ interface ComposerOptionsPopoverProps {
 }
 
 function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true, footer }: ComposerOptionsPopoverProps) {
-  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, webProvider } = state
+  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, providerDefaultModel, webProvider } = state
 
   // Trigger display fallback for the brief window before useComposerOptions
-  // seeds `model`. Order: resolve the selection against the catalog (exact id
-  // or family-latest) → the catalog's latest Sonnet (codebase-wide default,
-  // beats falling through to the first entry) → first entry.
-  const selectedModel =
-    findCatalogModel(model, catalog)
-    ?? catalog.find((m) => m.family === 'sonnet' && m.isLatest)
-    ?? catalog[0]
+  // seeds `model`, and for a selection this provider's catalog cannot carry.
+  const selectedModel = resolveDisplayModel(model, catalog, providerDefaultModel)
 
   useEffortClamp(includeEffort ? selectedModel : undefined, effort, setEffort)
 

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -31,6 +31,8 @@ export interface ComposerOptionsState {
   setModel: (m: string) => void
   /** The active provider's flat catalog of concrete model ids. */
   catalog: ModelDefinition[]
+  /** The active provider's own agent default — the host resolver's last rung. */
+  providerDefaultModel?: string
   /** Active host web-provider id (settings-derived), so the model picker's web-tools availability
    *  warning knows a configured vendor makes those tools work on any model. Undefined = native. */
   webProvider?: string
@@ -58,6 +60,32 @@ export function findCatalogModel(
   return (
     catalog.find((m) => m.id === selection) ??
     catalog.find((m) => m.family === selection && m.isLatest)
+  )
+}
+
+/**
+ * The catalog entry a selection will actually run as, mirroring the host
+ * resolver's full ladder: exact id / family-latest → the active provider's own
+ * agent default → first entry. The provider rung is what a bare findCatalogModel
+ * misses: a family the active provider's catalog does not carry (e.g. 'gpt' on
+ * a Claude-only provider) resolves host-side to that provider's default, so the
+ * picker has to land on the same row or it displays a model the wire never sends.
+ *
+ * Deliberately WITHOUT the versioned-pin guard SettingsModelSelect carries: this
+ * ladder only picks a row to label, while that one also feeds the effort and speed
+ * clamps, which would persist a rewrite from the wrong model's capabilities. An
+ * unknown versioned pin still mislabels here (the host passes it to the SDK
+ * verbatim); it costs a wrong label, not wrong state.
+ */
+export function resolveDisplayModel(
+  selection: string | undefined,
+  catalog: ModelDefinition[],
+  providerDefaultModel: string | undefined,
+): ModelDefinition | undefined {
+  return (
+    findCatalogModel(selection, catalog) ??
+    findCatalogModel(providerDefaultModel, catalog) ??
+    catalog[0]
   )
 }
 
@@ -258,10 +286,11 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
       model,
       setModel,
       catalog,
+      providerDefaultModel: providerInfo?.defaultModels?.agent,
       webProvider: settings?.webProvider,
       toRuntimeOptions,
     }),
-    [effort, setEffort, speed, setSpeed, model, setModel, catalog, settings, toRuntimeOptions],
+    [effort, setEffort, speed, setSpeed, model, setModel, catalog, providerInfo, settings, toRuntimeOptions],
   )
 }
 

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { AtSign, Check, FileIcon, FolderOpen, Loader2, Search } from 'lucide-react'
 import { cn } from '@shared/lib/utils'
 import { ModelFamilyList } from '@renderer/components/messages/model-family-list'
-import { findCatalogModel, type ComposerOptionsState } from '@renderer/components/messages/composer-options'
+import { resolveDisplayModel, type ComposerOptionsState } from '@renderer/components/messages/composer-options'
 import { EffortSection, useEffortClamp } from '@renderer/components/messages/effort-slider'
 import { SpeedSection, availableSpeeds, useSpeedClamp } from '@renderer/components/messages/speed-section'
 import { EFFORT_LEVELS } from '@shared/lib/container/types'
@@ -95,9 +95,8 @@ export function AgentMenu({
 }
 
 export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsState; maxHeight: number }) {
-  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, webProvider } = state
-  const selected =
-    findCatalogModel(model, catalog) ?? catalog.find((m) => m.family === 'sonnet' && m.isLatest) ?? catalog[0]
+  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, providerDefaultModel, webProvider } = state
+  const selected = resolveDisplayModel(model, catalog, providerDefaultModel)
   const efforts = EFFORT_LEVELS.filter((l) => (selected ? selected.supportedEfforts.includes(l) : true))
   // Without the clamp this menu kept (and dispatched) an unsupported effort
   // after a model switch, while the slider silently rendered at Low.

--- a/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
@@ -73,7 +73,7 @@ vi.mock('@renderer/components/messages/composer-options', () => ({
     setEffort: vi.fn(),
     toRuntimeOptions: () => ({}),
   }),
-  findCatalogModel: () => ({ label: 'Sonnet', icon: 'sonnet' }),
+  resolveDisplayModel: () => ({ label: 'Sonnet', icon: 'sonnet' }),
 }))
 
 // The inline menus + heavy children pull in their own deps; stub them since these

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -12,7 +12,7 @@ import { useCreateSession } from '@renderer/hooks/use-sessions'
 import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import { AttachmentPreview } from '@renderer/components/messages/attachment-preview'
-import { findCatalogModel, useComposerOptions } from '@renderer/components/messages/composer-options'
+import { resolveDisplayModel, useComposerOptions } from '@renderer/components/messages/composer-options'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
 import { useIsVoiceConfigured } from '@renderer/hooks/use-voice-input'
 import { UploadError } from '@renderer/components/ui/upload-error'
@@ -103,10 +103,11 @@ export function QuickDispatch() {
   const createSession = useCreateSession()
   const editorRef = useRef<HTMLDivElement | null>(null)
 
-  const selectedModel =
-    findCatalogModel(composerOptions.model, composerOptions.catalog) ??
-    composerOptions.catalog.find((m) => m.family === 'sonnet' && m.isLatest) ??
-    composerOptions.catalog[0]
+  const selectedModel = resolveDisplayModel(
+    composerOptions.model,
+    composerOptions.catalog,
+    composerOptions.providerDefaultModel,
+  )
 
   const composer = useMessageComposer({
     agentSlug,

--- a/src/renderer/components/settings/browser-tab.tsx
+++ b/src/renderer/components/settings/browser-tab.tsx
@@ -223,6 +223,7 @@ export function BrowserTab() {
             right={
               <SettingsModelSelect
                 model={settings?.models?.browserModel}
+                purpose="browser"
                 onModelChange={(value) => updateSettings.mutate({ models: { browserModel: value } })}
                 disabled={isLoading}
               />

--- a/src/renderer/components/settings/llm-tab.tsx
+++ b/src/renderer/components/settings/llm-tab.tsx
@@ -74,6 +74,8 @@ interface ModelEffortRowProps {
   name: string
   subtitle: string
   model: string | undefined
+  /** Provider-default purpose backing this row; see SettingsModelSelect. */
+  purpose?: 'agent' | 'summarizer' | 'browser' | 'dashboard'
   /** Reasoning effort; only surfaced when `includeEffort` is true. */
   effort?: EffortLevel
   includeEffort?: boolean
@@ -87,6 +89,7 @@ function ModelEffortRow({
   name,
   subtitle,
   model,
+  purpose,
   effort,
   includeEffort,
   disabled,
@@ -100,6 +103,7 @@ function ModelEffortRow({
       right={
         <SettingsModelSelect
           model={model}
+          purpose={purpose}
           onModelChange={onModelChange}
           includeEffort={includeEffort}
           effort={effort}
@@ -268,6 +272,7 @@ export function LlmTab() {
                     name="Summarizer model"
                     subtitle="Used for session name generation and API key validation"
                     model={settings?.models?.summarizerModel}
+                    purpose="summarizer"
                     includeEffort={false}
                     disabled={isLoading}
                     onModelChange={(model) => updateSettings.mutate({ models: { summarizerModel: model } })}
@@ -276,6 +281,7 @@ export function LlmTab() {
                     name="Dashboard model"
                     subtitle="Used by the dashboard-builder subagent that creates and edits artifacts"
                     model={settings?.models?.dashboardBuilderModel}
+                    purpose="dashboard"
                     includeEffort={false}
                     disabled={isLoading}
                     onModelChange={(model) => updateSettings.mutate({ models: { dashboardBuilderModel: model } })}

--- a/src/renderer/components/settings/settings-model-select.test.tsx
+++ b/src/renderer/components/settings/settings-model-select.test.tsx
@@ -96,6 +96,30 @@ describe('SettingsModelSelect (flat picker)', () => {
     expect(screen.getByTestId('settings-model-trigger')).toHaveTextContent('Opus 4.8 · pinned')
   })
 
+  // The host resolver's two miss-paths differ, and the trigger has to match both:
+  // a bare alias this catalog lacks resolves to the provider's own default, while
+  // an unknown VERSIONED string is passed through as a pin. Falling back on the
+  // pin would label a model that never runs — and would let the effort clamp
+  // persist a rewrite based on that wrong model's capabilities.
+  it('falls back to the provider default for an unknown alias, never for a versioned pin', () => {
+    const { unmount } = render(<SettingsModelSelect model="gpt" onModelChange={vi.fn()} />)
+    expect(screen.getByTestId('settings-model-trigger')).toHaveTextContent('Opus 4.8')
+    unmount()
+
+    const onEffortChange = vi.fn()
+    render(
+      <SettingsModelSelect
+        model="some-removed-model-9"
+        onModelChange={vi.fn()}
+        includeEffort
+        effort="max"
+        onEffortChange={onEffortChange}
+      />,
+    )
+    expect(screen.getByTestId('settings-model-trigger')).toHaveTextContent('Select model')
+    expect(onEffortChange).not.toHaveBeenCalled()
+  })
+
   it('does not render the effort section when includeEffort is false', async () => {
     const user = userEvent.setup()
     render(<SettingsModelSelect model="claude-haiku-4-5" onModelChange={vi.fn()} includeEffort={false} />)

--- a/src/renderer/components/settings/settings-model-select.tsx
+++ b/src/renderer/components/settings/settings-model-select.tsx
@@ -11,12 +11,19 @@ import { ModelFamilyList, findCatalogModel, familyDisplayName } from '@renderer/
 import { EFFORT_LABELS, EffortSection, useEffortClamp } from '@renderer/components/messages/effort-slider'
 import { SPEED_LABELS, SpeedSection, availableSpeeds, useSpeedClamp } from '@renderer/components/messages/speed-section'
 import { EFFORT_LEVELS, type EffortLevel, type SpeedLevel } from '@shared/lib/container/types'
+import { hasVersionSegment } from '@shared/lib/llm-provider/model-catalog-schema'
 import type { LlmProviderId } from '@shared/lib/config/settings'
 
 interface SettingsModelSelectProps {
   /** Currently-selected model — a concrete id (pinned) or a bare family alias (latest); undefined while loading. */
   model: string | undefined
   onModelChange: (model: string) => void
+  /**
+   * Which provider default backs this row when the selection is a family the
+   * active provider's catalog does not carry. Matches the purpose the host
+   * resolver uses for the same setting, so the label tracks the wire.
+   */
+  purpose?: 'agent' | 'summarizer' | 'browser' | 'dashboard'
   /** Show the effort picker alongside the model. Off by default for model-only knobs. */
   includeEffort?: boolean
   effort?: EffortLevel
@@ -60,6 +67,7 @@ interface SettingsModelSelectProps {
 function SettingsModelSelectImpl({
   model,
   onModelChange,
+  purpose = 'agent',
   includeEffort = false,
   effort = 'medium',
   onEffortChange,
@@ -79,8 +87,19 @@ function SettingsModelSelectImpl({
     [settings, activeProvider],
   )
 
-  // Resolve the current selection for the trigger label.
-  const resolved = findCatalogModel(model, catalog)
+  // Resolve the current selection for the trigger label. A stored selection this
+  // provider's catalog cannot carry (e.g. 'gpt' on a Claude-only provider) still
+  // runs — the host resolver falls back to the provider's own default — so show
+  // THAT model instead of an empty trigger, matching what the wire will send.
+  // Only for a NON-versioned selection: the host treats an unknown versioned
+  // string as a deliberate pin and sends it verbatim, so falling back there
+  // would label a model that never runs — and would let the effort/speed clamps
+  // below persist a rewrite based on the wrong model's capabilities.
+  const direct = findCatalogModel(model, catalog)
+  const providerFallback = !direct && model && !hasVersionSegment(model)
+    ? findCatalogModel(settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.defaultModels?.[purpose], catalog)
+    : undefined
+  const resolved = direct ?? providerFallback
   const isLatestSelected = model !== undefined && catalog.some((m) => m.family === model)
   const selectedFamily = isLatestSelected ? model : resolved?.family
 
@@ -94,6 +113,8 @@ function SettingsModelSelectImpl({
 
   let triggerLabel: string | undefined
   if (isLatestSelected && selectedFamily) triggerLabel = `${familyDisplayName(selectedFamily)} · latest`
+  // A provider fallback is neither a pin nor a family-latest pick — label it plainly.
+  else if (providerFallback) triggerLabel = providerFallback.label
   else if (resolved?.family) triggerLabel = `${resolved.label} · pinned`
   else if (resolved) triggerLabel = resolved.label
 

--- a/src/renderer/components/wizard/configure-model-step.tsx
+++ b/src/renderer/components/wizard/configure-model-step.tsx
@@ -1,8 +1,8 @@
-import { useSettings, useUpdateSettings, type GlobalSettingsResponse } from '@renderer/hooks/use-settings'
+import { useSettings, useModelSettings, useUpdateSettings, type GlobalSettingsResponse } from '@renderer/hooks/use-settings'
 import { useQueryClient } from '@tanstack/react-query'
 
-/** Onboarding offers just the two headline families; both store a bare alias. */
-type WizardFamily = 'opus' | 'sonnet'
+/** Onboarding offers just the headline families; each stores a bare alias. */
+type WizardFamily = 'grok' | 'opus' | 'sonnet'
 
 const MODEL_OPTIONS: Array<{
   family: WizardFamily
@@ -11,6 +11,13 @@ const MODEL_OPTIONS: Array<{
   description: string
   subdescription: string
 }> = [
+  {
+    family: 'grok',
+    label: 'Grok',
+    tag: 'Best value',
+    description: 'Best for everyday tasks and most agent work.',
+    subdescription: 'The lowest credit cost of the three.',
+  },
   {
     family: 'opus',
     label: 'Opus',
@@ -29,17 +36,35 @@ const MODEL_OPTIONS: Array<{
 
 export function ConfigureModelStep() {
   const { data: settings } = useSettings()
+  const { data: modelSettings } = useModelSettings()
   const updateSettings = useUpdateSettings()
   const queryClient = useQueryClient()
 
+  // Only offer families the active provider can actually serve. The copy below
+  // promises new conversations start with the pick, and a Claude-only setup
+  // (direct key, Bedrock, subscription) carries no Grok — offering it there
+  // would promise a model the resolver silently swaps for the provider default.
+  // An empty catalog means the provider is still loading or unconfigured, so
+  // fall back to the full list rather than rendering an empty step.
+  const activeProvider = modelSettings?.llmProvider ?? settings?.llmProvider
+  const catalog = modelSettings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? []
+  const options = catalog.length
+    ? MODEL_OPTIONS.filter((o) => catalog.some((m) => m.family === o.family))
+    : MODEL_OPTIONS
+
   // The global "Default model" setting (LLM tab) persists `models.agentModel`
-  // as a bare family alias or a pinned id. Derive the headline family from it
-  // so onboarding and settings stay in sync; unknown/other → 'opus'.
+  // as a bare family alias or a pinned id. Derive the headline family from it so
+  // onboarding and settings stay in sync. A stored model outside these families
+  // (GPT, GLM, a custom id) leaves NOTHING selected rather than claiming one of
+  // them — and every row stays clickable, so the pick always persists.
   const agentModel = settings?.models?.agentModel
-  const selectedFamily: WizardFamily = agentModel && /sonnet/.test(agentModel) ? 'sonnet' : 'opus'
+  const selectedFamily = options.find((o) => agentModel?.includes(o.family))?.family
 
   const handleSelect = async (family: WizardFamily) => {
-    if (family === selectedFamily) return
+    // Guard on the STORED value, not the derived row: re-clicking a row that is
+    // already the stored alias is a true no-op, while a stored model outside
+    // these families still writes (that click is not redundant).
+    if (agentModel === family) return
     // Optimistically reflect the choice in the settings cache so the card
     // updates instantly. The mutation's onSuccess invalidation refetches to
     // reconcile with the server; onError rolls back to the previous value.
@@ -71,7 +96,7 @@ export function ConfigureModelStep() {
       </div>
 
       <div className="space-y-3" role="radiogroup" aria-label="Default model">
-        {MODEL_OPTIONS.map((option) => {
+        {options.map((option) => {
           const isSelected = selectedFamily === option.family
           return (
             <div

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -246,7 +246,7 @@ describe('loadSettings', () => {
 
       expect(result.models?.agentModel).toBe('claude-opus-4-7')
       expect(result.models?.summarizerModel).toBe('haiku') // default
-      expect(result.models?.browserModel).toBe('sonnet') // default
+      expect(result.models?.browserModel).toBe('grok') // default
     })
 
     it('migrates legacy concrete model defaults to bare family aliases', () => {
@@ -1136,9 +1136,9 @@ describe('getEffectiveModels', () => {
 
     expect(models).toEqual({
       summarizerModel: 'haiku',
-      agentModel: 'opus',
-      browserModel: 'sonnet',
-      dashboardBuilderModel: 'opus',
+      agentModel: 'grok',
+      browserModel: 'grok',
+      dashboardBuilderModel: 'grok',
       agentEffort: 'medium',
     })
   })
@@ -1160,7 +1160,7 @@ describe('getEffectiveModels', () => {
       summarizerModel: 'custom-summarizer',
       agentModel: 'custom-agent',
       browserModel: 'custom-browser',
-      dashboardBuilderModel: 'opus',
+      dashboardBuilderModel: 'grok',
       agentEffort: 'medium',
     })
   })
@@ -1176,7 +1176,7 @@ describe('getEffectiveModels', () => {
 
     expect(models.agentModel).toBe('custom-agent')
     expect(models.summarizerModel).toBe('haiku')
-    expect(models.browserModel).toBe('sonnet')
+    expect(models.browserModel).toBe('grok')
   })
 
   it('falls back to defaults when model values are empty strings', () => {
@@ -1194,8 +1194,8 @@ describe('getEffectiveModels', () => {
 
     // Empty strings are falsy, so || fallback triggers
     expect(models.summarizerModel).toBe('haiku')
-    expect(models.agentModel).toBe('opus')
-    expect(models.browserModel).toBe('sonnet')
+    expect(models.agentModel).toBe('grok')
+    expect(models.browserModel).toBe('grok')
   })
 
   it('handles models being undefined in settings', () => {
@@ -1205,9 +1205,9 @@ describe('getEffectiveModels', () => {
 
     expect(models).toEqual({
       summarizerModel: 'haiku',
-      agentModel: 'opus',
-      browserModel: 'sonnet',
-      dashboardBuilderModel: 'opus',
+      agentModel: 'grok',
+      browserModel: 'grok',
+      dashboardBuilderModel: 'grok',
       agentEffort: 'medium',
     })
   })
@@ -1335,9 +1335,9 @@ describe('DEFAULT_SETTINGS', () => {
   it('has expected model defaults (bare aliases so fresh installs track latest)', () => {
     expect(DEFAULT_SETTINGS.models).toEqual({
       summarizerModel: 'haiku',
-      agentModel: 'opus',
-      browserModel: 'sonnet',
-      dashboardBuilderModel: 'opus',
+      agentModel: 'grok',
+      browserModel: 'grok',
+      dashboardBuilderModel: 'grok',
       agentEffort: 'medium',
     })
   })

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -416,10 +416,10 @@ const DEFAULT_SETTINGS: AppSettings = {
     // Bare family aliases so fresh installs track each family's latest version.
     // The host resolver maps these to a concrete id per active provider.
     summarizerModel: 'haiku',
-    agentModel: 'opus',
-    browserModel: 'sonnet',
+    agentModel: 'grok',
+    browserModel: 'grok',
     // Dashboard-builder subagent — a capable tier by default (overridable).
-    dashboardBuilderModel: 'opus',
+    dashboardBuilderModel: 'grok',
     agentEffort: 'medium',
   },
   enableToolSearch: true,

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -77,6 +77,7 @@ export interface ProviderDefaultModels {
   agent: string
   summarizer: string
   browser: string
+  dashboard: string
 }
 
 export interface LlmProviderInfo {
@@ -99,6 +100,7 @@ function defaultModelsFor(provider: BaseLlmProvider): ProviderDefaultModels {
     agent: provider.getDefaultModel('agent'),
     summarizer: provider.getDefaultModel('summarizer'),
     browser: provider.getDefaultModel('browser'),
+    dashboard: provider.getDefaultModel('dashboard'),
   }
 }
 

--- a/src/shared/lib/llm-provider/model-catalog-schema.ts
+++ b/src/shared/lib/llm-provider/model-catalog-schema.ts
@@ -2,6 +2,16 @@ import { z } from 'zod'
 import { EFFORT_LEVELS, SPEED_LEVELS } from '../container/types'
 
 /**
+ * True when a string carries a version segment (a hyphen followed by a digit).
+ * Lives here, beside the selection-shape contract it belongs to, so renderer
+ * code can ask the question without importing the resolver — which pulls the
+ * provider registry and host-only settings IO into the browser bundle.
+ */
+export function hasVersionSegment(s: string): boolean {
+  return /-\d/.test(s)
+}
+
+/**
  * A concrete, versioned model offered by a provider's catalog.
  *
  * The `id` is BOTH the catalog key and the exact wire value sent to the SDK

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // getActiveLlmProvider / resolveModelForProvider read settings for the active
 // provider id; stub settings so tests are deterministic and provider-agnostic.
 const settingsMock = vi.fn()
-vi.mock('../config/settings', () => ({
+vi.mock('../config/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config/settings')>()),
   getSettings: () => settingsMock(),
   getModelCatalogSettings: () => settingsMock().modelCatalog ?? {},
 }))
@@ -17,7 +18,8 @@ import {
   hasVersionSegment,
   resolveModelForProvider,
 } from './model-catalog'
-import { resolveActiveProviderModel } from './index'
+import { getLlmProvider, resolveActiveProviderModel } from './index'
+import { DEFAULT_SETTINGS } from '../config/settings'
 
 beforeEach(() => {
   settingsMock.mockReturnValue({ llmProvider: 'anthropic' })
@@ -495,7 +497,7 @@ describe('resolveModelForProvider', () => {
     expect(resolveModelForProvider('gpt-5.6-luna', 'platform', 'agent')).toBe('gpt-5.6-luna')
     expect(resolveModelForProvider('grok', 'platform', 'agent')).toBe('grok-4.5')
     expect(resolveModelForProvider('grok-4.5', 'platform', 'agent')).toBe('grok-4.5')
-    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('claude-opus-5')
+    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('grok-4.5')
   })
 
   it('resolves the SAME bare alias to each provider concrete id (cross-provider portability)', () => {
@@ -580,5 +582,32 @@ describe('resolveActiveProviderModel', () => {
   it('resolves against the active provider from settings', () => {
     settingsMock.mockReturnValue({ llmProvider: 'bedrock' })
     expect(resolveActiveProviderModel('opus', 'agent')).toBe('us.anthropic.claude-opus-4-8')
+  })
+})
+
+describe('shipped defaults vs provider defaults', () => {
+  // Two independent sources set the same thing. DEFAULT_SETTINGS.models is what a
+  // fresh install gets; provider.getDefaultModels() is what PUT /settings stamps
+  // over it whenever the active provider changes — which onboarding does, one step
+  // before it asks the user to pick a model. A provider that CAN serve the shipped
+  // family must therefore name it, or picking that provider silently moves the user
+  // off the default we ship.
+  const PURPOSES = [
+    ['agent', 'agentModel'],
+    ['browser', 'browserModel'],
+    ['dashboard', 'dashboardBuilderModel'],
+    ['summarizer', 'summarizerModel'],
+  ] as const
+
+  it('agree for every provider whose catalog carries the shipped family', () => {
+    for (const providerId of ['anthropic', 'bedrock', 'openrouter', 'platform'] as const) {
+      const catalog = getProviderCatalog(providerId)
+      for (const [purpose, settingsKey] of PURPOSES) {
+        const shipped = DEFAULT_SETTINGS.models![settingsKey]
+        if (!catalog.some(model => model.family === shipped)) continue
+        expect(`${providerId}.${purpose}=${getLlmProvider(providerId).getDefaultModel(purpose)}`)
+          .toBe(`${providerId}.${purpose}=${shipped}`)
+      }
+    }
   })
 })

--- a/src/shared/lib/llm-provider/model-catalog.ts
+++ b/src/shared/lib/llm-provider/model-catalog.ts
@@ -1,11 +1,15 @@
 import type { LlmProviderId, ModelPurpose } from './base-llm-provider'
 import {
+  hasVersionSegment,
   modelDefinitionSchema,
   type CatalogOverrideEntry,
   type ModelDefinition,
 } from './model-catalog-schema'
 import { getLlmProvider } from './index'
 import { getModelCatalogSettings } from '../config/settings'
+
+/** Re-exported from the schema module, which renderer code can import safely. */
+export { hasVersionSegment }
 
 /**
  * Host-side source of truth for which concrete models a provider offers and
@@ -16,11 +20,6 @@ import { getModelCatalogSettings } from '../config/settings'
  *   - bare family alias ('opus')            → that family's isLatest id
  *   - concrete versioned id ('claude-opus-4-8') → pinned exactly
  */
-
-/** True when a string carries a version segment (a hyphen followed by a digit). */
-export function hasVersionSegment(s: string): boolean {
-  return /-\d/.test(s)
-}
 
 /**
  * Normalize a catalog so each family has at most one `isLatest` entry. When

--- a/src/shared/lib/llm-provider/openrouter-provider.test.ts
+++ b/src/shared/lib/llm-provider/openrouter-provider.test.ts
@@ -231,8 +231,8 @@ describe('OpenRouterLlmProvider — capabilities and defaults', () => {
   it('opts into model search and exposes bare-alias purpose defaults', () => {
     expect(provider.supportsModelSearch).toBe(true)
     expect(provider.getDefaultModel('summarizer')).toBe('haiku')
-    expect(provider.getDefaultModel('agent')).toBe('sonnet')
-    expect(provider.getDefaultModel('browser')).toBe('sonnet')
-    expect(provider.getDefaultModel('dashboard')).toBe('opus')
+    expect(provider.getDefaultModel('agent')).toBe('grok')
+    expect(provider.getDefaultModel('browser')).toBe('grok')
+    expect(provider.getDefaultModel('dashboard')).toBe('grok')
   })
 })

--- a/src/shared/lib/llm-provider/openrouter-provider.ts
+++ b/src/shared/lib/llm-provider/openrouter-provider.ts
@@ -156,9 +156,9 @@ export class OpenRouterLlmProvider extends BaseLlmProvider {
   getDefaultModel(purpose: ModelPurpose): string {
     switch (purpose) {
       case 'summarizer': return 'haiku'
-      case 'agent': return 'sonnet'
-      case 'browser': return 'sonnet'
-      case 'dashboard': return 'opus'
+      case 'agent': return 'grok'
+      case 'browser': return 'grok'
+      case 'dashboard': return 'grok'
     }
   }
 

--- a/src/shared/lib/llm-provider/platform-provider.ts
+++ b/src/shared/lib/llm-provider/platform-provider.ts
@@ -58,9 +58,9 @@ export class PlatformLlmProvider extends BaseLlmProvider {
   getDefaultModel(purpose: ModelPurpose): string {
     switch (purpose) {
       case 'summarizer': return 'haiku'
-      case 'agent': return 'opus'
-      case 'browser': return 'sonnet'
-      case 'dashboard': return 'opus'
+      case 'agent': return 'grok'
+      case 'browser': return 'grok'
+      case 'dashboard': return 'grok'
     }
   }
 


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-540/default-new-installs-to-grok-45

New installs default to Grok 4.5 instead of Claude.

## What we flipped

The three defaults are **replaced**. The onboarding picker **gains** an option and keeps the two it had.

| Where | Before | After | |
|---|---|---|---|
| `DEFAULT_SETTINGS.models` — agent / browser / dashboard | opus / sonnet / opus | **grok** | replaced |
| `platform.getDefaultModel()` — same three | opus / sonnet / opus | **grok** | replaced |
| `openrouter.getDefaultModel()` — same three | sonnet / sonnet / opus | **grok** | replaced |
| Onboarding model picker | Opus, Sonnet | **Grok**, Opus, Sonnet | added |
| anthropic, bedrock, generic defaults | — | unchanged, no grok in their catalogs | |
| summarizer, every provider | haiku | unchanged | |

Two sources set the same thing. `DEFAULT_SETTINGS.models` is what a fresh install gets. `provider.getDefaultModels()` is what `PUT /settings` stamps over it whenever the active provider changes, which onboarding does one step before it asks the user to pick a model. Both have to say Grok or the flip does nothing for anyone who finishes onboarding.

`'grok'` is a bare alias, so it resolves per provider:

```
platform     grok-4.5
openrouter   x-ai/grok-4.5
anthropic    claude-opus-5                  (no grok family → provider default)
bedrock      us.anthropic.claude-sonnet-5   (no grok family → provider default)
```

A concrete `'grok-4.5'` would read as a deliberate pin and go straight to the Anthropic SDK, which 404s.

New installs only. A stored value beats the default, so nobody's active model changes under them. No migration.

A regression test pins the agreement: any provider whose catalog carries the shipped family must name it as its default. It fails as `platform.agent=opus` vs `platform.agent=grok`, naming the site that needs editing.

## What we fixed

The flip exposed eight bugs. Every one is downstream of the change.

| # | Bug | What went wrong |
|---|---|---|
| 1 | Composer and quick-dispatch labeled the wrong model | Both fell back to the newest Sonnet when a stored selection was missing from the active provider's catalog. The host falls back to that provider's own default instead, so the picker read Sonnet while the session ran Opus. |
| 2 | Settings rows showed no model at all | Same miss, different invented fallback: the rows rendered "Select model" while a model was running. |
| 3 | Summarizer, browser and dashboard rows showed the agent's model | Each row fell back to the agent default rather than the provider default for its own purpose. |
| 4 | A pinned version silently became a different model | The fallback from #2 also caught deliberate version pins, and the effort and speed controls then wrote the wrong model's limits back to disk. State corruption, not just a label. |
| 5 | Every new agent ran Opus | The new-agent form sent `model: 'opus'` on the first message, overriding the user's default. Its comment claimed it mirrored AgentHome, which sends no model at all. |
| 6 | Agents could not schedule work on the default model | `schedule_task` and the webhook triggers typed the model as an enum of opus/sonnet/haiku, so an agent asked to use the new default was rejected by its own schema. |
| 7 | Onboarding offered Grok where Grok cannot run | The step promises new conversations start with the pick, so a Claude-only setup was promising a model the resolver silently swaps. Options now filter to the active provider's catalog. |
| 8 | Onboarding highlighted a model the user had not chosen | A stored GPT, GLM or custom id matched none of the three rows, and the step claimed one anyway. It now selects nothing. |
| 9 | — | A value import from the shared barrel into a renderer file drags `fs` and `@sentry/node-core` into the browser bundle and fails the build. `hasVersionSegment` moved to a leaf module so the pickers can import it. Typecheck and the unit suite both pass with that break in place, so only a build catches it. |

`resolveDisplayModel` mirrors the host ladder, and the display sites share it. The settings picker takes the purpose whose provider default backs it.

One case deliberately does **not** fall back: an unknown *versioned* selection. The host treats that as a pin and sends it verbatim, so falling back would label a model that never runs, and would let the clamps in #4 persist a rewrite. There is a regression test for both halves.

**Reachable on `main` today, no Grok involved.** Store a GPT or GLM selection, then switch to a direct-Anthropic key. The composer reads Sonnet, the Default Model row reads "Select model", and the wire carries Opus.

## Verification

- `resolveModelForProvider` run across all four providers for each model setting. The table above is its output.
- `XAI_API_KEY` confirmed set on the production proxy.
- typecheck, lint, 8831 unit tests, 286 web e2e tests.
- Clean install launched against staging: onboarding lands on Grok, and the composer reads Grok 4.5 with nothing touched.

## Trade-offs

| | Opus 5 | Grok 4.5 |
|---|---|---|
| Effort levels | low → max | low / medium / high |
| Speed tiers | normal / fast | normal / fast, no flex |
| Context | 1M | 500K |
| Price in/out per Mtok | $5 / $25 | $2 / $6 |
| Web search + fetch | yes | yes |

The browser subagent and the dashboard builder move to Grok. Both were Claude before and neither has been exercised on Grok. Grok carries `GROK_BROWSER_TOOL_PROMPT_HINTS`, prompt patches steering it to the real browser tools instead of shelling out, and those are wired for the agent model. Reverting either setting to a Claude alias is a one-line change.

OpenRouter's agent default was Sonnet, not Opus, so flipping it is a judgment call rather than part of the ask. Left as Sonnet, a fresh install on OpenRouter would get Grok while explicitly selecting OpenRouter downgraded to Sonnet.

## Left alone

- `/api/llm` sends a hardcoded `claude-sonnet-5` that never passes through the resolver, on every provider. Live and pre-existing. Picking the right owner for it is its own decision.
- `findCatalogModel` duplicates the host resolver's exact-or-alias rung across the renderer boundary.
- When a provider's own default family is fully disabled through catalog overrides, the host emits a bare alias instead of a concrete id.
