### PR TITLE
Refactor settings update validation

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -317,6 +317,123 @@ describe('settings route', () => {
     })
   }
 
+  // =========================================================================
+  // PUT request boundary validation
+  // =========================================================================
+  describe('PUT request boundary validation', () => {
+    it('rejects malformed JSON without reading or writing settings', async () => {
+      const res = await app.request('http://localhost/api/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{not-json',
+      })
+
+      expect(res.status).toBe(400)
+      expect(mockGetSettings).not.toHaveBeenCalled()
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('rejects a non-object request body', async () => {
+      const res = await app.request('http://localhost/api/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([]),
+      })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('rejects unknown root settings instead of silently ignoring them', async () => {
+      const res = await putSettings({ unknownField: 'ignored' })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('rejects unknown nested settings instead of persisting them through object spreads', async () => {
+      const res = await putSettings({ app: { inventedPreference: true } })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('rejects settings owned by another write flow', async () => {
+      const res = await putSettings({ app: { faviconUpdatedAt: '2026-01-01T00:00:00.000Z' } })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ['shareAnalytics', { shareAnalytics: 'yes' }],
+      ['shareErrorReports', { shareErrorReports: 1 }],
+      ['enableToolSearch', { enableToolSearch: 'enabled' }],
+    ])('rejects a non-boolean %s', async (_name, request) => {
+      const res = await putSettings(request)
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ['apiKeys', { apiKeys: { anthropicApiKey: 123 } }],
+      ['agentLimits', { agentLimits: { maxTurns: 'many' } }],
+      ['auth', { auth: { signupMode: 'sometimes' } }],
+      ['voice', { voice: { sttProvider: 'unknown' } }],
+      ['analyticsTargets', { analyticsTargets: [{ type: 'amplitude', config: {}, enabled: 'yes' }] }],
+      ['computerUse', { computerUse: { agentPermissions: { agent: { grants: [{ level: 'root', grantType: 'always' }] } } } }],
+    ])('rejects a malformed %s patch', async (_name, request) => {
+      const res = await putSettings(request)
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unknown LLM provider', async () => {
+      const res = await putSettings({ llmProvider: 'made-up-provider' })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unknown container runner', async () => {
+      const res = await putSettings({ container: { containerRunner: 'made-up-runner' } })
+
+      expect(res.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unsupported agent effort', async () => {
+      const res = await putSettings({ models: { agentEffort: 'extreme' } })
+
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toContain('agentEffort')
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
+    it('accepts a partial agent-capability patch', async () => {
+      const res = await putSettings({ agentCapabilities: { subagents: 'review' } })
+
+      expect(res.status).toBe(200)
+      expect(mockUpdateSettings.mock.calls[0][0].agentCapabilities).toEqual({
+        subagents: 'review',
+        workflows: 'review',
+      })
+    })
+
+    it('rejects invalid or unknown agent-capability values without side effects', async () => {
+      const invalidValue = await putSettings({ agentCapabilities: { subagents: 'sometimes' } })
+      const unknownKey = await putSettings({ agentCapabilities: { hiddenTier: 'allow' } })
+
+      expect(invalidValue.status).toBe(400)
+      expect(unknownKey.status).toBe(400)
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+      expect(mockClearClients).not.toHaveBeenCalled()
+      expect(mockEnsureImageReady).not.toHaveBeenCalled()
+    })
+  })
+
   describe('password manager configuration', () => {
     it('returns provider-scoped connection status without credential metadata', async () => {
       mockCredentialConnectionStatuses.mockResolvedValueOnce([{
@@ -780,6 +897,17 @@ describe('settings route', () => {
       // Setting the same value as current should be allowed
       const res = await putSettings({
         container: { containerRunner: 'docker' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(mockUpdateSettings).toHaveBeenCalledOnce()
+    })
+
+    it('allows a partial resource-limit patch whose merged result is unchanged', async () => {
+      mockHasRunningAgents.mockReturnValue(true)
+
+      const res = await putSettings({
+        container: { resourceLimits: { cpu: 2 } },
       })
 
       expect(res.status).toBe(200)
@@ -1843,11 +1971,6 @@ describe('settings route', () => {
       expect(saved.skillsets).toEqual(defaultSettings().skillsets)
     })
 
-    it('handles body with only non-settings fields gracefully', async () => {
-      const res = await putSettings({ unknownField: 'ignored' } as Record<string, unknown>)
-      expect(res.status).toBe(200)
-      expect(mockUpdateSettings).toHaveBeenCalledOnce()
-    })
   })
 
   // =========================================================================

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -39,7 +39,6 @@ import {
   formatSettingsPatchError,
   settingsPatchSchema,
   validateSettingsTransition,
-  type ContainerRunnerId,
 } from '@shared/lib/config/settings-patch'
 import { getTenantId } from '@shared/lib/analytics/tenant-id'
 import { getSttProvider } from '@shared/lib/stt'
@@ -461,7 +460,7 @@ settings.put(
         context: {
           hasRunningAgents,
           hostTotalMemoryBytes: os.totalmem(),
-          supportsCustomAgentImage: (runner: ContainerRunnerId) =>
+          supportsCustomAgentImage: (runner: ContainerRunner) =>
             getContainerClientClass(runner).supportsCustomAgentImage,
         },
       })[0]

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto'
 import { Hono, type Context } from 'hono'
 import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
-import { getLlmProvider, getAllProviderInfo, modelCatalogSettingsSchema, GenericLlmProvider } from '@shared/lib/llm-provider'
+import { getLlmProvider, getAllProviderInfo, GenericLlmProvider } from '@shared/lib/llm-provider'
 import type { LlmProviderId } from '@shared/lib/llm-provider'
 import type { BedrockLlmProvider } from '@shared/lib/llm-provider/bedrock-provider'
 import { getDataDir, getAgentsDataDir } from '@shared/lib/config/data-dir'
@@ -30,15 +30,17 @@ import {
   getEffectiveAgentLimits,
   getCustomEnvVars,
   type AppSettings,
-  type AppPreferences,
-  type ApiKeySettings,
-  type ContainerSettings,
   type GlobalSettingsResponse,
   type ModelPickerSettingsResponse,
 } from '@shared/lib/config/settings'
-import { agentCapabilitySettingsPatchSchema, DEFAULT_AGENT_CAPABILITIES } from '@shared/lib/config/capability-policy-schema'
-import { validateFaviconDataUrl } from '@shared/lib/config/favicon'
-import { isValidAccelerator } from '@shared/lib/config/shortcuts'
+import { DEFAULT_AGENT_CAPABILITIES } from '@shared/lib/config/capability-policy-schema'
+import {
+  applySettingsPatch,
+  formatSettingsPatchError,
+  settingsPatchSchema,
+  validateSettingsTransition,
+  type ContainerRunnerId,
+} from '@shared/lib/config/settings-patch'
 import { getTenantId } from '@shared/lib/analytics/tenant-id'
 import { getSttProvider } from '@shared/lib/stt'
 import {
@@ -48,9 +50,6 @@ import {
 } from '@shared/lib/web-provider'
 import { containerManager } from '@shared/lib/container/container-manager'
 import { checkAllRunnersAvailability, refreshRunnerAvailability, startRunner, restartRunner, getContainerClientClass, getRunnerDisplayName, SUPPORTED_RUNNERS, type ContainerRunner } from '@shared/lib/container/client-factory'
-import { VALID_LIMA_VM_MEMORY_OPTIONS, EFFORT_LEVELS } from '@shared/lib/container/types'
-import { assessVmMemory } from '@shared/lib/container/vm-memory'
-import { customEnvVarsSchema } from '@shared/lib/container/reserved-env-vars'
 import { detectAllProviders } from '../../main/host-browser'
 import { revokePlatformToken } from '@shared/lib/services/platform-auth-service'
 import { db } from '@shared/lib/db'
@@ -81,8 +80,6 @@ import {
 import fs from 'fs'
 import { credentialBroker } from '../credentials/credential-broker'
 import { CredentialBrokerError } from '../credentials/types'
-
-const WEB_PROVIDER_IDS = ['native', 'exa', 'platform'] as const
 
 const settings = new Hono()
 
@@ -294,27 +291,6 @@ settings.put(
   },
 )
 
-/** All keys in ApiKeySettings — used to generically handle set/delete in PUT. */
-const API_KEY_FIELDS: (keyof ApiKeySettings)[] = [
-  'anthropicApiKey',
-  'openrouterApiKey',
-  'genericApiKey',
-  'genericBaseUrl',
-  'bedrockApiKey',
-  'bedrockAccessKeyId',
-  'bedrockSecretAccessKey',
-  'bedrockRegion',
-  'composioApiKey',
-  'composioUserId',
-  'browserbaseApiKey',
-  'browserbaseProjectId',
-  'deepgramApiKey',
-  'openaiApiKey',
-  'nangoSecretKey',
-  'accountProviderUserId',
-  'exaApiKey',
-]
-
 // GET /api/settings/llm-providers/:providerId/models/search - Provider-native model discovery
 settings.get('/llm-providers/:providerId/models/search', async (c) => {
   try {
@@ -382,11 +358,6 @@ settings.post('/model-icons', async (c) => {
     return c.json({ error: 'Failed to upload model icon' }, 500)
   }
 })
-
-type AppPreferencesPatch = Partial<AppPreferences> & {
-  faviconDataUrl?: unknown
-  hostBrowserProvider?: unknown
-}
 
 /** The generic provider's saved endpoint — displayed (not secret) in Settings. */
 function getGenericBaseUrl(): string | undefined {
@@ -459,297 +430,101 @@ settings.get('/', async (c) => {
   }
 })
 
-// PUT /api/settings - Update settings
-settings.put('/', async (c) => {
-  try {
-    const body = await c.req.json()
-
-    if (
-      body.webProvider !== undefined &&
-      body.webProvider !== null &&
-      !(WEB_PROVIDER_IDS as readonly string[]).includes(body.webProvider)
-    ) {
-      return c.json({ error: `Invalid webProvider: ${String(body.webProvider)}` }, 400)
+// PUT /api/settings - Update settings (patch semantics retained for compatibility)
+settings.put(
+  '/',
+  zValidator('json', settingsPatchSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ error: formatSettingsPatchError(result.error) }, 400)
     }
+  }),
+  async (c) => {
+    try {
+      const body = c.req.valid('json')
 
-    // Read FRESH and fail-closed: never merge onto the possibly-
-    // corruption-defaulted cache (that is what overwrote real API keys/auth). A
-    // corrupt settings.json throws here → caught below → 500, instead of being
-    // silently replaced with defaults. The write path below this point has no
-    // `await`, so the read-merge-write stays atomic (no interleaving).
-    const currentSettings = loadSettingsStrict()
-    const hasRunningAgents = containerManager.hasRunningAgents()
+      // Read FRESH and fail-closed: never merge onto the possibly-
+      // corruption-defaulted cache (that is what overwrote real API keys/auth).
+      // Applying and validating the candidate below are synchronous, so a valid
+      // write still has no await between this strict read and updateSettings.
+      const currentSettings = loadSettingsStrict()
+      const hasRunningAgents = containerManager.hasRunningAgents()
+      const newSettings = applySettingsPatch(currentSettings, body, {
+        now: new Date(),
+        getProviderDefaultModels: (provider) =>
+          getLlmProvider(provider).getDefaultModels(),
+      })
 
-    // Check if trying to change restricted settings while agents are running
-    if (hasRunningAgents && body.container) {
-      const newContainer = body.container as Partial<ContainerSettings>
+      const transitionProblem = validateSettingsTransition({
+        before: currentSettings,
+        after: newSettings,
+        patch: body,
+        context: {
+          hasRunningAgents,
+          hostTotalMemoryBytes: os.totalmem(),
+          supportsCustomAgentImage: (runner: ContainerRunnerId) =>
+            getContainerClientClass(runner).supportsCustomAgentImage,
+        },
+      })[0]
 
-      if (
-        (newContainer.containerRunner !== undefined &&
-          newContainer.containerRunner !==
-            currentSettings.container.containerRunner) ||
-        (newContainer.resourceLimits !== undefined &&
-          JSON.stringify(newContainer.resourceLimits) !==
-            JSON.stringify(currentSettings.container.resourceLimits))
-      ) {
+      if (transitionProblem) {
         return c.json(
           {
-            error:
-              'Cannot change container runner or resource limits while agents are running. Please stop all agents first.',
-            runningAgents: await containerManager.getRunningAgentIds(),
+            error: transitionProblem.message,
+            ...(transitionProblem.includeRunningAgentIds
+              ? { runningAgents: await containerManager.getRunningAgentIds() }
+              : {}),
           },
-          409
+          transitionProblem.status,
         )
       }
-    }
 
-    // Reject agentImage changes for runners whose image is fixed by the
-    // deployment (e.g. lambda-microvm reads only MICROVM_AGENT_IMAGE_ARN).
-    if (body.container?.agentImage !== undefined) {
-      const newContainer = body.container as Partial<ContainerSettings>
-      const effectiveRunner = (newContainer.containerRunner ??
-        currentSettings.container.containerRunner) as ContainerRunner
+      updateSettings(newSettings)
+
+      // If account provider settings changed, re-register providers
+      if (body.apiKeys?.nangoSecretKey !== undefined || body.app?.accountProvider !== undefined) {
+        try {
+          const { registerAllAccountProviders } = await import('@shared/lib/account-providers/register')
+          await registerAllAccountProviders()
+        } catch (err) {
+          console.error('Failed to re-register account providers:', err)
+        }
+      }
+
+      // If auth settings changed, reset the Better Auth singleton so it picks up new config
+      if (body.auth !== undefined && isAuthMode()) {
+        import('@shared/lib/auth/index').then(({ resetAuth }) => resetAuth()).catch(() => {})
+      }
+
+      // If container runner changed, clear cached clients so new ones use the updated runner
+      if (newSettings.container.containerRunner !== currentSettings.container.containerRunner) {
+        containerManager.clearClients()
+      }
+
+      // If image or runner changed, re-check readiness (may need to pull new image)
       if (
-        newContainer.agentImage !== currentSettings.container.agentImage &&
-        !getContainerClientClass(effectiveRunner).supportsCustomAgentImage
+        newSettings.container.agentImage !== currentSettings.container.agentImage ||
+        newSettings.container.containerRunner !== currentSettings.container.containerRunner
       ) {
-        return c.json(
-          { error: `Agent image is managed by the deployment for the ${effectiveRunner} runner and cannot be changed here.` },
-          400
-        )
-      }
-    }
-
-    // Validate enableToolSearch if provided
-    if (body.enableToolSearch !== undefined && typeof body.enableToolSearch !== 'boolean') {
-      return c.json({ error: 'enableToolSearch must be a boolean' }, 400)
-    }
-
-    // Validate agentEffort if provided
-    if (body.models?.agentEffort !== undefined && !EFFORT_LEVELS.includes(body.models.agentEffort)) {
-      return c.json({ error: `agentEffort must be one of: ${EFFORT_LEVELS.join(', ')}` }, 400)
-    }
-
-    // Validate agentCapabilities if provided (partial patch of allow/review/block tiers)
-    if (body.agentCapabilities !== undefined) {
-      const parsed = agentCapabilitySettingsPatchSchema.safeParse(body.agentCapabilities)
-      if (!parsed.success) {
-        return c.json({ error: 'agentCapabilities values must be one of: allow, review, block' }, 400)
-      }
-    }
-
-    // Validate the quick-dispatch global shortcut accelerator. Empty string is
-    // allowed and means "disabled"; any other value must be a plausible
-    // accelerator (main's globalShortcut.register is the authoritative gate).
-    if (body.app?.globalDispatchShortcut !== undefined) {
-      const acc = body.app.globalDispatchShortcut
-      if (typeof acc !== 'string' || (acc !== '' && !isValidAccelerator(acc))) {
-        return c.json(
-          { error: 'globalDispatchShortcut must be an accelerator like "CommandOrControl+Shift+Space" (or "" to disable)' },
-          400,
-        )
-      }
-    }
-
-    if (body.app?.warmStartOnType !== undefined && typeof body.app.warmStartOnType !== 'boolean') {
-      return c.json({ error: 'warmStartOnType must be a boolean' }, 400)
-    }
-
-    // Validate runtimeSettings if provided
-    if (body.container?.runtimeSettings) {
-      const limaSettings = body.container.runtimeSettings.lima
-      if (limaSettings?.vmMemory && !VALID_LIMA_VM_MEMORY_OPTIONS.includes(limaSettings.vmMemory)) {
-        return c.json({ error: `Invalid VM memory setting. Must be one of: ${VALID_LIMA_VM_MEMORY_OPTIONS.join(', ')}` }, 400)
-      }
-      // A VM sized at or beyond physical RAM starves the host and gets agents
-      // OOM-killed mid-turn — refuse it here so it can never be persisted.
-      if (limaSettings?.vmMemory) {
-        const assessment = assessVmMemory(limaSettings.vmMemory, os.totalmem())
-        if (assessment.level === 'refuse') {
-          return c.json({ error: assessment.message }, 400)
-        }
-      }
-    }
-
-    // Validate customEnvVars at the write boundary (defense-in-depth for
-    // SUP-210): reject payloads that try to set reserved runtime env vars so
-    // they never reach persisted settings.
-    if (body.customEnvVars !== undefined) {
-      const parsed = customEnvVarsSchema.safeParse(body.customEnvVars)
-      if (!parsed.success) {
-        return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid customEnvVars' }, 400)
-      }
-    }
-
-    let parsedModelCatalog = currentSettings.modelCatalog
-    if (body.modelCatalog !== undefined) {
-      const parsed = modelCatalogSettingsSchema.safeParse(body.modelCatalog)
-      if (!parsed.success) {
-        return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid modelCatalog' }, 400)
-      }
-      parsedModelCatalog = parsed.data
-    }
-
-    let appPatch = body.app as AppPreferencesPatch | undefined
-    if (appPatch && Object.prototype.hasOwnProperty.call(appPatch, 'faviconDataUrl')) {
-      const validation = validateFaviconDataUrl(appPatch.faviconDataUrl)
-      if (!validation.ok) {
-        return c.json({ error: validation.error }, 400)
+        containerManager.ensureImageReady().catch((error) => {
+          console.error('Failed to re-check image readiness:', error)
+        })
       }
 
-      appPatch = { ...appPatch }
-      appPatch.faviconUpdatedAt = new Date().toISOString()
-      if (appPatch.faviconDataUrl === null || appPatch.faviconDataUrl === '') {
-        appPatch.faviconDataUrl = undefined
-      }
-    }
-
-    // When the active LLM provider changes, reset model selections to the new
-    // provider's defaults (bare aliases) — unless the same request sets `models`
-    // explicitly. Prevents a pin from the old provider's catalog (which may not
-    // exist for the new one, e.g. a bare-Claude id on Bedrock) from leaking across.
-    const currentProvider = currentSettings.llmProvider ?? 'anthropic'
-    const providerChanged =
-      body.llmProvider !== undefined && body.llmProvider !== currentProvider
-    let providerDefaultModels:
-      | { summarizerModel: string; agentModel: string; browserModel: string; dashboardBuilderModel: string }
-      | undefined
-    if (providerChanged && body.models === undefined) {
-      try {
-        providerDefaultModels = getLlmProvider(body.llmProvider).getDefaultModels()
-      } catch {
-        // Unknown provider id — leave models as-is; other guards handle validity.
-        providerDefaultModels = undefined
-      }
-    }
-
-    // Merge new settings with current settings
-    // TODO refactor - pineapple on pizza level gross
-    const newSettings: AppSettings = {
-      container: {
-        ...currentSettings.container,
-        ...body.container,
-        resourceLimits: body.container?.resourceLimits
-          ? { ...currentSettings.container.resourceLimits, ...body.container.resourceLimits }
-          : currentSettings.container.resourceLimits,
-        runtimeSettings: body.container?.runtimeSettings
-          ? { ...currentSettings.container.runtimeSettings, ...body.container.runtimeSettings }
-          : currentSettings.container.runtimeSettings,
-      },
-      app: {
-        ...currentSettings.app,
-        ...appPatch,
-        // If hostBrowserProvider was explicitly set to null (meaning "use container"),
-        // remove it from settings so consumers treat it as "no host provider"
-        ...(appPatch && 'hostBrowserProvider' in appPatch && appPatch.hostBrowserProvider == null
-          ? { hostBrowserProvider: undefined }
-          : {}),
-      },
-      apiKeys: currentSettings.apiKeys,
-      llmProvider: body.llmProvider !== undefined ? body.llmProvider : currentSettings.llmProvider,
-      // null clears to automatic (undefined); omitted preserves.
-      webProvider: body.webProvider === null ? undefined
-        : body.webProvider !== undefined ? body.webProvider : currentSettings.webProvider,
-      webAllowedSites: body.webAllowedSites !== undefined ? body.webAllowedSites : currentSettings.webAllowedSites,
-      webBlockedSites: body.webBlockedSites !== undefined ? body.webBlockedSites : currentSettings.webBlockedSites,
-      models: body.models
-        ? { ...currentSettings.models, ...body.models }
-        : providerDefaultModels
-          ? { ...currentSettings.models, ...providerDefaultModels }
-          : currentSettings.models,
-      modelCatalog: parsedModelCatalog,
-      agentLimits: body.agentLimits !== undefined
-        ? { ...currentSettings.agentLimits, ...body.agentLimits }
-        : currentSettings.agentLimits,
-      customEnvVars: body.customEnvVars !== undefined ? body.customEnvVars : currentSettings.customEnvVars,
-      skillsets: currentSettings.skillsets,
-      platformAuth: currentSettings.platformAuth,
-      // Preserve the maintained cloud-workspace deployment token across global
-      // settings writes; it's owned by the platform-auth flow, not this route.
-      cloudWorkspace: currentSettings.cloudWorkspace,
-      // Likewise owned elsewhere: the desktop's local-or-cloud target (main
-      // process) and the OS-notification dedup watermark. `updateSettings`
-      // REPLACES the whole object, so anything omitted here is deleted — and
-      // every field of AppSettings is optional, so omissions typecheck.
-      apiTarget: currentSettings.apiTarget,
-      platformNotifications: currentSettings.platformNotifications,
-      auth: body.auth !== undefined ? { ...currentSettings.auth, ...body.auth } : currentSettings.auth,
-      voice: body.voice !== undefined ? { ...currentSettings.voice, ...body.voice } : currentSettings.voice,
-      shareAnalytics: body.shareAnalytics !== undefined ? body.shareAnalytics : currentSettings.shareAnalytics,
-      shareErrorReports: body.shareErrorReports !== undefined ? body.shareErrorReports : currentSettings.shareErrorReports,
-      enableToolSearch: body.enableToolSearch !== undefined ? body.enableToolSearch : currentSettings.enableToolSearch,
-      computerUse: body.computerUse !== undefined
-        ? { ...currentSettings.computerUse, ...body.computerUse }
-        : currentSettings.computerUse,
-      agentCapabilities: body.agentCapabilities !== undefined
-        ? { ...DEFAULT_AGENT_CAPABILITIES, ...currentSettings.agentCapabilities, ...body.agentCapabilities }
-        : currentSettings.agentCapabilities,
-      analyticsTargets: body.analyticsTargets !== undefined ? body.analyticsTargets : currentSettings.analyticsTargets,
-    }
-
-    // Handle API key updates: empty string = delete, truthy = set, absent = keep
-    if (body.apiKeys !== undefined) {
-      for (const field of API_KEY_FIELDS) {
-        const value = body.apiKeys[field]
-        if (value === '') {
-          newSettings.apiKeys = { ...newSettings.apiKeys }
-          delete newSettings.apiKeys[field]
-        } else if (value) {
-          newSettings.apiKeys = { ...newSettings.apiKeys, [field]: value }
-        }
-      }
-
-      if (newSettings.apiKeys && Object.keys(newSettings.apiKeys).length === 0) {
-        delete newSettings.apiKeys
-      }
-    }
-
-    updateSettings(newSettings)
-
-    // If account provider settings changed, re-register providers
-    if (body.apiKeys?.nangoSecretKey !== undefined || body.app?.accountProvider !== undefined) {
-      try {
-        const { registerAllAccountProviders } = await import('@shared/lib/account-providers/register')
-        await registerAllAccountProviders()
-      } catch (err) {
-        console.error('Failed to re-register account providers:', err)
-      }
-    }
-
-    // If auth settings changed, reset the Better Auth singleton so it picks up new config
-    if (body.auth !== undefined && isAuthMode()) {
-      import('@shared/lib/auth/index').then(({ resetAuth }) => resetAuth()).catch(() => {})
-    }
-
-    // If container runner changed, clear cached clients so new ones use the updated runner
-    if (newSettings.container.containerRunner !== currentSettings.container.containerRunner) {
-      containerManager.clearClients()
-    }
-
-    // If image or runner changed, re-check readiness (may need to pull new image)
-    if (
-      newSettings.container.agentImage !== currentSettings.container.agentImage ||
-      newSettings.container.containerRunner !== currentSettings.container.containerRunner
-    ) {
-      containerManager.ensureImageReady().catch((error) => {
-        console.error('Failed to re-check image readiness:', error)
+      const runnerAvailability = await checkAllRunnersAvailability()
+      logAuditEvent({
+        userId: getCurrentUserId(c),
+        object: 'settings',
+        objectId: 'global',
+        action: 'updated',
+        details: buildSettingsAuditDetails(currentSettings, newSettings),
       })
+      return c.json(buildSettingsResponse(newSettings, hasRunningAgents, runnerAvailability))
+    } catch (error) {
+      console.error('Failed to update settings:', error)
+      return c.json({ error: 'Failed to update settings' }, 500)
     }
-
-    const runnerAvailability = await checkAllRunnersAvailability()
-    logAuditEvent({
-      userId: getCurrentUserId(c),
-      object: 'settings',
-      objectId: 'global',
-      action: 'updated',
-      details: buildSettingsAuditDetails(currentSettings, newSettings),
-    })
-    return c.json(buildSettingsResponse(newSettings, hasRunningAgents, runnerAvailability))
-  } catch (error) {
-    console.error('Failed to update settings:', error)
-    return c.json({ error: 'Failed to update settings' }, 500)
-  }
-})
+  },
+)
 
 // POST /api/settings/start-runner - Start a container runtime
 settings.post('/start-runner', async (c) => {

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -11,13 +11,11 @@ import type {
   VoiceSettings,
   AnalyticsTarget,
   LlmProviderId,
-  WebProviderId,
-  AgentCapabilitySettings,
 } from '@shared/lib/config/settings'
-import type { ComputerUseSettings } from '@shared/lib/computer-use/types'
+import type { SettingsPatch } from '@shared/lib/config/settings-patch'
 import type { RunnerAvailability } from '@shared/lib/container/client-factory'
 import type { RunnerSetupRemediation } from '@shared/lib/container/wsl2-setup-errors'
-import type { ModelCatalogSettings, ModelSearchResult } from '@shared/lib/llm-provider'
+import type { ModelSearchResult } from '@shared/lib/llm-provider'
 
 export type { GlobalSettingsResponse, ModelPickerSettingsResponse, ContainerSettings, AppPreferences, ModelSettings, AgentLimitsSettings, AuthSettings, VoiceSettings, AnalyticsTarget, LlmProviderId, RunnerAvailability, RunnerSetupRemediation }
 
@@ -91,44 +89,8 @@ export function useProviderModelSearch(
   })
 }
 
-export interface UpdateSettingsParams {
-  container?: Partial<ContainerSettings>
-  app?: Omit<Partial<AppPreferences>, 'faviconDataUrl'> & { faviconDataUrl?: string | null }
-  llmProvider?: LlmProviderId
-  // null clears to auto-resolve (server stores undefined).
-  webProvider?: WebProviderId | null
-  apiKeys?: {
-    anthropicApiKey?: string
-    openrouterApiKey?: string
-    genericApiKey?: string
-    genericBaseUrl?: string
-    bedrockApiKey?: string
-    bedrockAccessKeyId?: string
-    bedrockSecretAccessKey?: string
-    bedrockRegion?: string
-    composioApiKey?: string
-    composioUserId?: string
-    browserbaseApiKey?: string
-    browserbaseProjectId?: string
-    deepgramApiKey?: string
-    openaiApiKey?: string
-    nangoSecretKey?: string
-    accountProviderUserId?: string
-    exaApiKey?: string
-  }
-  models?: Partial<ModelSettings>
-  modelCatalog?: ModelCatalogSettings
-  agentLimits?: Partial<AgentLimitsSettings>
-  customEnvVars?: Record<string, string>
-  auth?: Partial<AuthSettings>
-  voice?: Partial<VoiceSettings>
-  computerUse?: Partial<ComputerUseSettings>
-  shareAnalytics?: boolean
-  analyticsTargets?: AnalyticsTarget[]
-  shareErrorReports?: boolean
-  enableToolSearch?: boolean
-  agentCapabilities?: Partial<AgentCapabilitySettings>
-}
+/** Inferred from the same runtime schema enforced by PUT /api/settings. */
+export type UpdateSettingsParams = SettingsPatch
 
 export interface UpdateSettingsError {
   error: string

--- a/src/shared/lib/config/settings-patch.test.ts
+++ b/src/shared/lib/config/settings-patch.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AppSettings } from './settings'
+import {
+  applySettingsPatch,
+  settingsPatchSchema,
+  validateSettingsTransition,
+  type SettingsApplyContext,
+  type SettingsPatch,
+  type SettingsTransitionContext,
+} from './settings-patch'
+
+function currentSettings(): AppSettings {
+  return {
+    container: {
+      containerRunner: 'docker',
+      agentImage: 'superagent:latest',
+      resourceLimits: { cpu: 2, memory: '4g' },
+      runtimeSettings: {
+        docker: { network: 'bridge' },
+        lima: { vmMemory: '4GiB', cpu: '4' },
+      },
+    },
+    app: {
+      showMenuBarIcon: true,
+      hostBrowserProvider: 'chrome',
+    },
+    apiKeys: {
+      anthropicApiKey: 'sk-old',
+      openrouterApiKey: 'or-old',
+    },
+    llmProvider: 'anthropic',
+    webProvider: 'exa',
+    models: {
+      summarizerModel: 'haiku',
+      agentModel: 'opus',
+      browserModel: 'sonnet',
+      dashboardBuilderModel: 'opus',
+      agentEffort: 'medium',
+    },
+    auth: { signupMode: 'open' },
+    agentCapabilities: { subagents: 'allow', workflows: 'review' },
+    skillsets: [],
+    platformAuth: {
+      token: 'secret',
+      tokenPreview: 'sec…ret',
+      email: 'test@example.com',
+      label: null,
+      orgId: null,
+      orgName: null,
+      role: null,
+      userId: null,
+      memberId: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+  }
+}
+
+const applyContext: SettingsApplyContext = {
+  now: new Date('2026-08-03T12:34:56.000Z'),
+  getProviderDefaultModels: vi.fn(() => ({
+    summarizerModel: 'new-haiku',
+    agentModel: 'new-opus',
+    browserModel: 'new-sonnet',
+    dashboardBuilderModel: 'new-opus',
+  })),
+}
+
+const transitionContext: SettingsTransitionContext = {
+  hasRunningAgents: false,
+  hostTotalMemoryBytes: 64 * 1024 ** 3,
+  supportsCustomAgentImage: (runner) => runner !== 'lambda-microvm',
+}
+
+function parsePatch(input: unknown): SettingsPatch {
+  return settingsPatchSchema.parse(input)
+}
+
+describe('settingsPatchSchema', () => {
+  it('rejects unknown root, nested, and server-owned fields', () => {
+    expect(settingsPatchSchema.safeParse({ futureRoot: true }).success).toBe(false)
+    expect(settingsPatchSchema.safeParse({ app: { futureAppField: true } }).success).toBe(false)
+    expect(
+      settingsPatchSchema.safeParse({ app: { faviconUpdatedAt: 'user-controlled' } }).success,
+    ).toBe(false)
+  })
+
+  it('accepts null and empty-string clear semantics', () => {
+    expect(
+      settingsPatchSchema.safeParse({
+        webProvider: null,
+        app: { hostBrowserProvider: null, faviconDataUrl: '' },
+        apiKeys: { anthropicApiKey: '' },
+      }).success,
+    ).toBe(true)
+  })
+})
+
+describe('applySettingsPatch', () => {
+  it('deep-merges container limits while preserving unrelated runtime settings', () => {
+    const before = currentSettings()
+    const after = applySettingsPatch(
+      before,
+      parsePatch({ container: { resourceLimits: { cpu: 6 } } }),
+      applyContext,
+    )
+
+    expect(after.container.resourceLimits).toEqual({ cpu: 6, memory: '4g' })
+    expect(after.container.runtimeSettings).toEqual(before.container.runtimeSettings)
+    expect(before.container.resourceLimits).toEqual({ cpu: 2, memory: '4g' })
+  })
+
+  it('normalizes app clear semantics and owns the favicon timestamp', () => {
+    const after = applySettingsPatch(
+      currentSettings(),
+      parsePatch({
+        app: { hostBrowserProvider: null, faviconDataUrl: '' },
+      }),
+      applyContext,
+    )
+
+    expect(after.app?.hostBrowserProvider).toBeUndefined()
+    expect(after.app?.faviconDataUrl).toBeUndefined()
+    expect(after.app?.faviconUpdatedAt).toBe('2026-08-03T12:34:56.000Z')
+  })
+
+  it('applies API-key set/delete semantics without mutating the prior object', () => {
+    const before = currentSettings()
+    const after = applySettingsPatch(
+      before,
+      parsePatch({ apiKeys: { anthropicApiKey: '', genericApiKey: 'generic-new' } }),
+      applyContext,
+    )
+
+    expect(after.apiKeys).toEqual({ openrouterApiKey: 'or-old', genericApiKey: 'generic-new' })
+    expect(before.apiKeys).toEqual({ anthropicApiKey: 'sk-old', openrouterApiKey: 'or-old' })
+  })
+
+  it('resets models to provider defaults unless the patch supplies models explicitly', () => {
+    const before = currentSettings()
+    const defaults = applySettingsPatch(
+      before,
+      parsePatch({ llmProvider: 'bedrock' }),
+      applyContext,
+    )
+    const explicit = applySettingsPatch(
+      before,
+      parsePatch({ llmProvider: 'bedrock', models: { agentModel: 'pinned-opus' } }),
+      applyContext,
+    )
+
+    expect(defaults.models).toMatchObject({ agentModel: 'new-opus', browserModel: 'new-sonnet' })
+    expect(explicit.models).toMatchObject({ agentModel: 'pinned-opus', browserModel: 'sonnet' })
+  })
+
+  it('preserves settings fields owned by other flows, including unknown future fields', () => {
+    const before = {
+      ...currentSettings(),
+      futureOwnedSetting: { token: 'do-not-drop' },
+    } as AppSettings & { futureOwnedSetting: { token: string } }
+
+    const after = applySettingsPatch(
+      before,
+      parsePatch({ shareAnalytics: false }),
+      applyContext,
+    ) as AppSettings & { futureOwnedSetting: { token: string } }
+
+    expect(after.platformAuth).toEqual(before.platformAuth)
+    expect(after.futureOwnedSetting).toEqual({ token: 'do-not-drop' })
+  })
+})
+
+describe('validateSettingsTransition', () => {
+  function problemsFor(
+    before: AppSettings,
+    patchInput: unknown,
+    context: Partial<SettingsTransitionContext> = {},
+  ) {
+    const patch = parsePatch(patchInput)
+    const after = applySettingsPatch(before, patch, applyContext)
+    return validateSettingsTransition({
+      before,
+      after,
+      patch,
+      context: { ...transitionContext, ...context },
+    })
+  }
+
+  it('allows an unchanged merged resource limit while agents are running', () => {
+    expect(
+      problemsFor(currentSettings(), { container: { resourceLimits: { cpu: 2 } } }, {
+        hasRunningAgents: true,
+      }),
+    ).toEqual([])
+  })
+
+  it('returns a 409 transition problem for an effective resource change', () => {
+    expect(
+      problemsFor(currentSettings(), { container: { resourceLimits: { cpu: 8 } } }, {
+        hasRunningAgents: true,
+      }),
+    ).toContainEqual(expect.objectContaining({ status: 409, includeRunningAgentIds: true }))
+  })
+
+  it('rejects an image change for a runner whose image is deployment-managed', () => {
+    expect(
+      problemsFor(currentSettings(), {
+        container: { containerRunner: 'lambda-microvm', agentImage: 'custom:v2' },
+      }),
+    ).toContainEqual(expect.objectContaining({ status: 400 }))
+  })
+
+  it('rejects a requested Lima VM size at or above host memory', () => {
+    expect(
+      problemsFor(
+        currentSettings(),
+        { container: { runtimeSettings: { lima: { vmMemory: '16GiB' } } } },
+        { hostTotalMemoryBytes: 16 * 1024 ** 3 },
+      ),
+    ).toContainEqual(expect.objectContaining({ status: 400 }))
+  })
+})

--- a/src/shared/lib/config/settings-patch.ts
+++ b/src/shared/lib/config/settings-patch.ts
@@ -8,30 +8,17 @@ import type {
 import { agentCapabilitySettingsPatchSchema, DEFAULT_AGENT_CAPABILITIES } from './capability-policy-schema'
 import { validateFaviconDataUrl } from './favicon'
 import { isValidAccelerator } from './shortcuts'
-import { EFFORT_LEVELS, VALID_LIMA_VM_MEMORY_OPTIONS } from '../container/types'
+import {
+  CONTAINER_RUNNER_IDS,
+  EFFORT_LEVELS,
+  VALID_LIMA_VM_MEMORY_OPTIONS,
+  type ContainerRunner,
+} from '../container/types'
 import { assessVmMemory } from '../container/vm-memory'
 import { customEnvVarsSchema } from '../container/reserved-env-vars'
 import { modelCatalogSettingsSchema } from '../llm-provider/model-catalog-schema'
-
-export const CONTAINER_RUNNER_IDS = [
-  'docker',
-  'podman',
-  'apple-container',
-  'lima',
-  'wsl2',
-  'kubernetes',
-  'lambda-microvm',
-] as const
-
-export const LLM_PROVIDER_IDS = [
-  'anthropic',
-  'openrouter',
-  'bedrock',
-  'platform',
-  'generic',
-] as const
-
-export const WEB_PROVIDER_IDS = ['native', 'exa', 'platform'] as const
+import { LLM_PROVIDER_IDS, type LlmProviderId } from '../llm-provider/provider-types'
+import { WEB_PROVIDER_IDS } from '../web-provider/types'
 
 const notificationSettingsSchema = z.object({
   enabled: z.boolean(),
@@ -230,8 +217,6 @@ export type AppSettingsPatch = z.infer<typeof appSettingsPatchSchema>
 export type ApiKeySettingsPatch = z.infer<typeof apiKeySettingsPatchSchema>
 export type ProviderSettingsPatch = z.infer<typeof providerSettingsPatchSchema>
 export type GeneralSettingsPatch = z.infer<typeof generalSettingsPatchSchema>
-export type ContainerRunnerId = (typeof CONTAINER_RUNNER_IDS)[number]
-export type LlmProviderId = (typeof LLM_PROVIDER_IDS)[number]
 
 interface ProviderDefaultModels {
   summarizerModel: string
@@ -248,7 +233,7 @@ export interface SettingsApplyContext {
 export interface SettingsTransitionContext {
   hasRunningAgents: boolean
   hostTotalMemoryBytes: number
-  supportsCustomAgentImage(runner: ContainerRunnerId): boolean
+  supportsCustomAgentImage(runner: ContainerRunner): boolean
 }
 
 export interface SettingsProblem {
@@ -322,7 +307,7 @@ export const containerSettingsComponent = {
     }
 
     const imageChanged = after.container.agentImage !== before.container.agentImage
-    const effectiveRunner = after.container.containerRunner as ContainerRunnerId
+    const effectiveRunner = after.container.containerRunner as ContainerRunner
     if (imageChanged && !context.supportsCustomAgentImage(effectiveRunner)) {
       problems.push({
         status: 400,

--- a/src/shared/lib/config/settings-patch.ts
+++ b/src/shared/lib/config/settings-patch.ts
@@ -1,0 +1,588 @@
+import { z } from 'zod'
+import type {
+  ApiKeySettings,
+  AppPreferences,
+  AppSettings,
+  ContainerSettings,
+} from './settings'
+import { agentCapabilitySettingsPatchSchema, DEFAULT_AGENT_CAPABILITIES } from './capability-policy-schema'
+import { validateFaviconDataUrl } from './favicon'
+import { isValidAccelerator } from './shortcuts'
+import { EFFORT_LEVELS, VALID_LIMA_VM_MEMORY_OPTIONS } from '../container/types'
+import { assessVmMemory } from '../container/vm-memory'
+import { customEnvVarsSchema } from '../container/reserved-env-vars'
+import { modelCatalogSettingsSchema } from '../llm-provider/model-catalog-schema'
+
+export const CONTAINER_RUNNER_IDS = [
+  'docker',
+  'podman',
+  'apple-container',
+  'lima',
+  'wsl2',
+  'kubernetes',
+  'lambda-microvm',
+] as const
+
+export const LLM_PROVIDER_IDS = [
+  'anthropic',
+  'openrouter',
+  'bedrock',
+  'platform',
+  'generic',
+] as const
+
+export const WEB_PROVIDER_IDS = ['native', 'exa', 'platform'] as const
+
+const notificationSettingsSchema = z.object({
+  enabled: z.boolean(),
+  sessionComplete: z.boolean(),
+  sessionWaiting: z.boolean(),
+  sessionScheduled: z.boolean(),
+  platformNotification: z.boolean().optional(),
+  notifyWhenUnfocused: z.boolean().optional(),
+}).strict()
+
+const resourceLimitsPatchSchema = z.object({
+  cpu: z.number(),
+  memory: z.string(),
+}).partial().strict()
+
+const runtimeSettingsPatchSchema = z
+  .record(z.string(), z.record(z.string(), z.string()))
+  .superRefine((runtimeSettings, ctx) => {
+    const vmMemory = runtimeSettings.lima?.vmMemory
+    if (
+      vmMemory !== undefined &&
+      !(VALID_LIMA_VM_MEMORY_OPTIONS as readonly string[]).includes(vmMemory)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['lima', 'vmMemory'],
+        message: `Invalid VM memory setting. Must be one of: ${VALID_LIMA_VM_MEMORY_OPTIONS.join(', ')}`,
+      })
+    }
+  })
+
+export const containerSettingsPatchSchema = z.object({
+  // ContainerSettings is intentionally string-typed because runtime eligibility
+  // is platform-dependent. Keep that client-facing type while rejecting names
+  // outside the complete runner registry at the API boundary.
+  containerRunner: z.string().refine(
+    (value) => (CONTAINER_RUNNER_IDS as readonly string[]).includes(value),
+    { message: `containerRunner must be one of: ${CONTAINER_RUNNER_IDS.join(', ')}` },
+  ),
+  agentImage: z.string(),
+  resourceLimits: resourceLimitsPatchSchema,
+  runtimeSettings: runtimeSettingsPatchSchema,
+}).partial().strict()
+
+const faviconDataUrlPatchSchema = z.union([z.string(), z.null()]).superRefine((value, ctx) => {
+  const result = validateFaviconDataUrl(value)
+  if (!result.ok) {
+    ctx.addIssue({ code: 'custom', message: result.error })
+  }
+})
+
+export const appSettingsPatchSchema = z.object({
+  showMenuBarIcon: z.boolean(),
+  notifications: notificationSettingsSchema,
+  autoSleepTimeoutMinutes: z.number(),
+  warmStartOnType: z.boolean(),
+  autoDeleteInactiveDays: z.number(),
+  setupCompleted: z.boolean(),
+  accountProvider: z.enum(['composio', 'nango']),
+  hostBrowserProvider: z.enum(['chrome', 'browserbase', 'platform']).nullable(),
+  chromeProfileId: z.string(),
+  chromeHeadless: z.boolean(),
+  allowPrereleaseUpdates: z.boolean(),
+  theme: z.enum(['system', 'light', 'dark']),
+  globalDispatchShortcut: z.string().refine(
+    (value) => value === '' || isValidAccelerator(value),
+    {
+      message:
+        'globalDispatchShortcut must be an accelerator like "CommandOrControl+Shift+Space" (or "" to disable)',
+    },
+  ),
+  maxBrowserTabs: z.number(),
+  faviconDataUrl: faviconDataUrlPatchSchema,
+  browserbaseAdvancedStealth: z.boolean(),
+  browserbaseStealthOs: z.enum(['linux', 'windows', 'mac', 'mobile', 'tablet']),
+  browserbaseProxies: z.boolean(),
+  browserbaseProxyCountry: z.string(),
+  browserbaseProxyState: z.string(),
+  browserbaseProxyCity: z.string(),
+}).partial().strict()
+
+export const apiKeySettingsPatchSchema = z.object({
+  anthropicApiKey: z.string(),
+  openrouterApiKey: z.string(),
+  genericApiKey: z.string(),
+  genericBaseUrl: z.string(),
+  bedrockApiKey: z.string(),
+  bedrockAccessKeyId: z.string(),
+  bedrockSecretAccessKey: z.string(),
+  bedrockRegion: z.string(),
+  composioApiKey: z.string(),
+  composioUserId: z.string(),
+  browserbaseApiKey: z.string(),
+  browserbaseProjectId: z.string(),
+  deepgramApiKey: z.string(),
+  openaiApiKey: z.string(),
+  nangoSecretKey: z.string(),
+  accountProviderUserId: z.string(),
+  exaApiKey: z.string(),
+}).partial().strict()
+
+const modelSettingsPatchSchema = z.object({
+  summarizerModel: z.string(),
+  agentModel: z.string(),
+  browserModel: z.string(),
+  dashboardBuilderModel: z.string(),
+  agentEffort: z.enum(EFFORT_LEVELS, {
+    error: `agentEffort must be one of: ${EFFORT_LEVELS.join(', ')}`,
+  }),
+}).partial().strict()
+
+export const providerSettingsPatchSchema = z.object({
+  llmProvider: z.enum(LLM_PROVIDER_IDS),
+  webProvider: z.enum(WEB_PROVIDER_IDS, {
+    error: 'Invalid webProvider',
+  }).nullable(),
+  webAllowedSites: z.array(z.string()),
+  webBlockedSites: z.array(z.string()),
+  models: modelSettingsPatchSchema,
+  modelCatalog: modelCatalogSettingsSchema,
+}).partial().strict()
+
+const agentLimitsPatchSchema = z.object({
+  maxOutputTokens: z.number(),
+  maxThinkingTokens: z.number(),
+  maxTurns: z.number(),
+  maxBudgetUsd: z.number(),
+}).partial().strict()
+
+const authSettingsPatchSchema = z.object({
+  trustedOrigins: z.array(z.string()),
+  signupMode: z.enum(['open', 'domain_restricted', 'invitation_only', 'closed']),
+  allowedSignupDomains: z.array(z.string()),
+  requireAdminApproval: z.boolean(),
+  defaultUserRole: z.enum(['member', 'admin']),
+  allowLocalAuth: z.boolean(),
+  allowSocialAuth: z.boolean(),
+  passwordMinLength: z.number(),
+  passwordMaxLength: z.number(),
+  passwordRequireComplexity: z.boolean(),
+  sessionMaxLifetimeHrs: z.number(),
+  sessionIdleTimeoutMin: z.number(),
+  maxConcurrentSessions: z.number(),
+  accountLockoutThreshold: z.number(),
+  accountLockoutDurationMin: z.number(),
+}).partial().strict()
+
+const voiceSettingsPatchSchema = z.object({
+  sttProvider: z.enum(['deepgram', 'openai', 'platform']),
+}).partial().strict()
+
+const computerUseGrantSchema = z.object({
+  level: z.enum(['list_apps_windows', 'use_application', 'use_host_shell']),
+  appName: z.string().optional(),
+  grantType: z.literal('always'),
+}).strict()
+
+const computerUseSettingsPatchSchema = z.object({
+  agentPermissions: z.record(
+    z.string(),
+    z.object({ grants: z.array(computerUseGrantSchema) }).strict(),
+  ),
+}).partial().strict()
+
+const analyticsTargetSchema = z.object({
+  type: z.enum(['amplitude', 'google-analytics', 'mixpanel']),
+  config: z.record(z.string(), z.string()),
+  enabled: z.boolean(),
+}).strict()
+
+export const generalSettingsPatchSchema = z.object({
+  agentLimits: agentLimitsPatchSchema,
+  customEnvVars: customEnvVarsSchema,
+  auth: authSettingsPatchSchema,
+  voice: voiceSettingsPatchSchema,
+  computerUse: computerUseSettingsPatchSchema,
+  shareAnalytics: z.boolean(),
+  analyticsTargets: z.array(analyticsTargetSchema),
+  shareErrorReports: z.boolean(),
+  enableToolSearch: z.boolean(),
+  agentCapabilities: agentCapabilitySettingsPatchSchema.strict(),
+}).partial().strict()
+
+/** The complete, allowlisted patch accepted by PUT /api/settings. */
+export const settingsPatchSchema = z.object({
+  container: containerSettingsPatchSchema.optional(),
+  app: appSettingsPatchSchema.optional(),
+  apiKeys: apiKeySettingsPatchSchema.optional(),
+  ...providerSettingsPatchSchema.shape,
+  ...generalSettingsPatchSchema.shape,
+}).strict()
+
+export type SettingsPatch = z.infer<typeof settingsPatchSchema>
+export type ContainerSettingsPatch = z.infer<typeof containerSettingsPatchSchema>
+export type AppSettingsPatch = z.infer<typeof appSettingsPatchSchema>
+export type ApiKeySettingsPatch = z.infer<typeof apiKeySettingsPatchSchema>
+export type ProviderSettingsPatch = z.infer<typeof providerSettingsPatchSchema>
+export type GeneralSettingsPatch = z.infer<typeof generalSettingsPatchSchema>
+export type ContainerRunnerId = (typeof CONTAINER_RUNNER_IDS)[number]
+export type LlmProviderId = (typeof LLM_PROVIDER_IDS)[number]
+
+interface ProviderDefaultModels {
+  summarizerModel: string
+  agentModel: string
+  browserModel: string
+  dashboardBuilderModel: string
+}
+
+export interface SettingsApplyContext {
+  now: Date
+  getProviderDefaultModels(provider: LlmProviderId): ProviderDefaultModels | undefined
+}
+
+export interface SettingsTransitionContext {
+  hasRunningAgents: boolean
+  hostTotalMemoryBytes: number
+  supportsCustomAgentImage(runner: ContainerRunnerId): boolean
+}
+
+export interface SettingsProblem {
+  status: 400 | 409
+  message: string
+  includeRunningAgentIds?: boolean
+}
+
+interface ComponentApplyArgs<Patch> {
+  before: AppSettings
+  patch: Patch | undefined
+  context: SettingsApplyContext
+}
+
+interface ComponentValidateArgs<Patch> {
+  before: AppSettings
+  after: AppSettings
+  patch: Patch | undefined
+  context: SettingsTransitionContext
+}
+
+/** A cohesive schema/apply/transition bundle for one settings business domain. */
+export interface SettingsComponent<Schema extends z.ZodType> {
+  readonly schema: Schema
+  apply(args: ComponentApplyArgs<z.infer<Schema>>): AppSettings
+  validate(args: ComponentValidateArgs<z.infer<Schema>>): SettingsProblem[]
+}
+
+export const containerSettingsComponent = {
+  schema: containerSettingsPatchSchema,
+
+  apply({ before, patch }: ComponentApplyArgs<ContainerSettingsPatch>): AppSettings {
+    if (!patch) return before
+
+    const resourceLimits: ContainerSettings['resourceLimits'] = patch.resourceLimits
+      ? {
+          cpu: patch.resourceLimits.cpu ?? before.container.resourceLimits.cpu,
+          memory: patch.resourceLimits.memory ?? before.container.resourceLimits.memory,
+        }
+      : before.container.resourceLimits
+
+    return {
+      ...before,
+      container: {
+        ...before.container,
+        ...patch,
+        resourceLimits,
+        runtimeSettings: patch.runtimeSettings
+          ? { ...before.container.runtimeSettings, ...patch.runtimeSettings }
+          : before.container.runtimeSettings,
+      },
+    }
+  },
+
+  validate({ before, after, patch, context }: ComponentValidateArgs<ContainerSettingsPatch>): SettingsProblem[] {
+    if (!patch) return []
+    const problems: SettingsProblem[] = []
+
+    const runnerChanged = after.container.containerRunner !== before.container.containerRunner
+    const resourcesChanged =
+      after.container.resourceLimits.cpu !== before.container.resourceLimits.cpu ||
+      after.container.resourceLimits.memory !== before.container.resourceLimits.memory
+
+    if (context.hasRunningAgents && (runnerChanged || resourcesChanged)) {
+      problems.push({
+        status: 409,
+        message:
+          'Cannot change container runner or resource limits while agents are running. Please stop all agents first.',
+        includeRunningAgentIds: true,
+      })
+    }
+
+    const imageChanged = after.container.agentImage !== before.container.agentImage
+    const effectiveRunner = after.container.containerRunner as ContainerRunnerId
+    if (imageChanged && !context.supportsCustomAgentImage(effectiveRunner)) {
+      problems.push({
+        status: 400,
+        message: `Agent image is managed by the deployment for the ${effectiveRunner} runner and cannot be changed here.`,
+      })
+    }
+
+    const requestedVmMemory = patch.runtimeSettings?.lima?.vmMemory
+    if (requestedVmMemory) {
+      const assessment = assessVmMemory(requestedVmMemory, context.hostTotalMemoryBytes)
+      if (assessment.level === 'refuse') {
+        problems.push({ status: 400, message: assessment.message })
+      }
+    }
+
+    return problems
+  },
+} satisfies SettingsComponent<typeof containerSettingsPatchSchema>
+
+export const appSettingsComponent = {
+  schema: appSettingsPatchSchema,
+
+  apply({ before, patch, context }: ComponentApplyArgs<AppSettingsPatch>): AppSettings {
+    if (!patch) return before
+
+    const { faviconDataUrl, hostBrowserProvider, ...rest } = patch
+    const normalizedPatch: Partial<AppPreferences> = { ...rest }
+
+    if (Object.prototype.hasOwnProperty.call(patch, 'faviconDataUrl')) {
+      normalizedPatch.faviconUpdatedAt = context.now.toISOString()
+      normalizedPatch.faviconDataUrl =
+        faviconDataUrl === null || faviconDataUrl === '' ? undefined : faviconDataUrl
+    }
+
+    if (Object.prototype.hasOwnProperty.call(patch, 'hostBrowserProvider')) {
+      normalizedPatch.hostBrowserProvider = hostBrowserProvider ?? undefined
+    }
+
+    return {
+      ...before,
+      app: {
+        ...before.app,
+        ...normalizedPatch,
+      },
+    }
+  },
+
+  validate(_args: ComponentValidateArgs<AppSettingsPatch>): SettingsProblem[] {
+    return []
+  },
+} satisfies SettingsComponent<typeof appSettingsPatchSchema>
+
+export const apiKeySettingsComponent = {
+  schema: apiKeySettingsPatchSchema,
+
+  apply({ before, patch }: ComponentApplyArgs<ApiKeySettingsPatch>): AppSettings {
+    if (!patch) return before
+
+    let apiKeys = before.apiKeys
+    for (const [field, value] of Object.entries(patch) as [keyof ApiKeySettings, string][]) {
+      apiKeys = { ...apiKeys }
+      if (value === '') delete apiKeys[field]
+      else apiKeys[field] = value
+    }
+
+    return {
+      ...before,
+      apiKeys: apiKeys && Object.keys(apiKeys).length > 0 ? apiKeys : undefined,
+    }
+  },
+
+  validate(_args: ComponentValidateArgs<ApiKeySettingsPatch>): SettingsProblem[] {
+    return []
+  },
+} satisfies SettingsComponent<typeof apiKeySettingsPatchSchema>
+
+export const providerSettingsComponent = {
+  schema: providerSettingsPatchSchema,
+
+  apply({ before, patch, context }: ComponentApplyArgs<ProviderSettingsPatch>): AppSettings {
+    if (!patch) return before
+
+    const currentProvider = before.llmProvider ?? 'anthropic'
+    const providerChanged =
+      patch.llmProvider !== undefined && patch.llmProvider !== currentProvider
+
+    let models = before.models
+    if (patch.models !== undefined) {
+      models = { ...before.models, ...patch.models } as AppSettings['models']
+    } else if (providerChanged && patch.llmProvider) {
+      const defaults = context.getProviderDefaultModels(patch.llmProvider)
+      if (defaults) models = { ...before.models, ...defaults }
+    }
+
+    return {
+      ...before,
+      llmProvider: patch.llmProvider ?? before.llmProvider,
+      webProvider:
+        patch.webProvider === null
+          ? undefined
+          : patch.webProvider !== undefined
+            ? patch.webProvider
+            : before.webProvider,
+      webAllowedSites:
+        patch.webAllowedSites !== undefined ? patch.webAllowedSites : before.webAllowedSites,
+      webBlockedSites:
+        patch.webBlockedSites !== undefined ? patch.webBlockedSites : before.webBlockedSites,
+      models,
+      modelCatalog:
+        patch.modelCatalog !== undefined ? patch.modelCatalog : before.modelCatalog,
+    }
+  },
+
+  validate(_args: ComponentValidateArgs<ProviderSettingsPatch>): SettingsProblem[] {
+    return []
+  },
+} satisfies SettingsComponent<typeof providerSettingsPatchSchema>
+
+export const generalSettingsComponent = {
+  schema: generalSettingsPatchSchema,
+
+  apply({ before, patch }: ComponentApplyArgs<GeneralSettingsPatch>): AppSettings {
+    if (!patch) return before
+
+    return {
+      ...before,
+      agentLimits:
+        patch.agentLimits !== undefined
+          ? { ...before.agentLimits, ...patch.agentLimits }
+          : before.agentLimits,
+      customEnvVars:
+        patch.customEnvVars !== undefined ? patch.customEnvVars : before.customEnvVars,
+      auth: patch.auth !== undefined ? { ...before.auth, ...patch.auth } : before.auth,
+      voice: patch.voice !== undefined ? { ...before.voice, ...patch.voice } : before.voice,
+      computerUse:
+        patch.computerUse !== undefined
+          ? { ...before.computerUse, ...patch.computerUse }
+          : before.computerUse,
+      shareAnalytics:
+        patch.shareAnalytics !== undefined ? patch.shareAnalytics : before.shareAnalytics,
+      analyticsTargets:
+        patch.analyticsTargets !== undefined ? patch.analyticsTargets : before.analyticsTargets,
+      shareErrorReports:
+        patch.shareErrorReports !== undefined
+          ? patch.shareErrorReports
+          : before.shareErrorReports,
+      enableToolSearch:
+        patch.enableToolSearch !== undefined
+          ? patch.enableToolSearch
+          : before.enableToolSearch,
+      agentCapabilities:
+        patch.agentCapabilities !== undefined
+          ? {
+              ...DEFAULT_AGENT_CAPABILITIES,
+              ...before.agentCapabilities,
+              ...patch.agentCapabilities,
+            }
+          : before.agentCapabilities,
+    }
+  },
+
+  validate(_args: ComponentValidateArgs<GeneralSettingsPatch>): SettingsProblem[] {
+    return []
+  },
+} satisfies SettingsComponent<typeof generalSettingsPatchSchema>
+
+function pickProviderPatch(patch: SettingsPatch): ProviderSettingsPatch {
+  return {
+    llmProvider: patch.llmProvider,
+    webProvider: patch.webProvider,
+    webAllowedSites: patch.webAllowedSites,
+    webBlockedSites: patch.webBlockedSites,
+    models: patch.models,
+    modelCatalog: patch.modelCatalog,
+  }
+}
+
+function pickGeneralPatch(patch: SettingsPatch): GeneralSettingsPatch {
+  return {
+    agentLimits: patch.agentLimits,
+    customEnvVars: patch.customEnvVars,
+    auth: patch.auth,
+    voice: patch.voice,
+    computerUse: patch.computerUse,
+    shareAnalytics: patch.shareAnalytics,
+    analyticsTargets: patch.analyticsTargets,
+    shareErrorReports: patch.shareErrorReports,
+    enableToolSearch: patch.enableToolSearch,
+    agentCapabilities: patch.agentCapabilities,
+  }
+}
+
+/** Build the candidate settings value without IO or runtime side effects. */
+export function applySettingsPatch(
+  before: AppSettings,
+  patch: SettingsPatch,
+  context: SettingsApplyContext,
+): AppSettings {
+  let after = containerSettingsComponent.apply({ before, patch: patch.container, context })
+  after = appSettingsComponent.apply({ before: after, patch: patch.app, context })
+  after = apiKeySettingsComponent.apply({ before: after, patch: patch.apiKeys, context })
+  after = providerSettingsComponent.apply({
+    before: after,
+    patch: pickProviderPatch(patch),
+    context,
+  })
+  after = generalSettingsComponent.apply({
+    before: after,
+    patch: pickGeneralPatch(patch),
+    context,
+  })
+  return after
+}
+
+/** Run state-dependent policy against the fully merged candidate value. */
+export function validateSettingsTransition(args: {
+  before: AppSettings
+  after: AppSettings
+  patch: SettingsPatch
+  context: SettingsTransitionContext
+}): SettingsProblem[] {
+  return [
+    ...containerSettingsComponent.validate({
+      before: args.before,
+      after: args.after,
+      patch: args.patch.container,
+      context: args.context,
+    }),
+    ...appSettingsComponent.validate({
+      before: args.before,
+      after: args.after,
+      patch: args.patch.app,
+      context: args.context,
+    }),
+    ...apiKeySettingsComponent.validate({
+      before: args.before,
+      after: args.after,
+      patch: args.patch.apiKeys,
+      context: args.context,
+    }),
+    ...providerSettingsComponent.validate({
+      before: args.before,
+      after: args.after,
+      patch: pickProviderPatch(args.patch),
+      context: args.context,
+    }),
+    ...generalSettingsComponent.validate({
+      before: args.before,
+      after: args.after,
+      patch: pickGeneralPatch(args.patch),
+      context: args.context,
+    }),
+  ]
+}
+
+export function formatSettingsPatchError(error: {
+  issues: readonly { path: readonly PropertyKey[]; message: string }[]
+}): string {
+  const issue = error.issues[0]
+  if (!issue) return 'Invalid settings update'
+  const path = issue.path.join('.')
+  return path ? `${path}: ${issue.message}` : issue.message
+}

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -200,8 +200,8 @@ export interface AnalyticsTarget {
   enabled: boolean
 }
 
-export type { LlmProviderId } from '../llm-provider/base-llm-provider'
-import type { LlmProviderId } from '../llm-provider/base-llm-provider'
+export type { LlmProviderId } from '../llm-provider/provider-types'
+import type { LlmProviderId } from '../llm-provider/provider-types'
 export type { WebProviderId } from '../web-provider/types'
 import type { WebProviderId } from '../web-provider/types'
 

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -1,4 +1,6 @@
-import type { ContainerClient, ContainerConfig, ImagePullProgress } from './types'
+import type { ContainerClient, ContainerConfig, ContainerRunner, ImagePullProgress } from './types'
+export { CONTAINER_RUNNER_IDS } from './types'
+export type { ContainerRunner } from './types'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { DockerContainerClient } from './docker-container-client'
 import { PodmanContainerClient } from './podman-container-client'
@@ -14,8 +16,6 @@ import { BaseContainerClient, execWithPath, spawnWithPath, AGENT_CONTAINER_PATH 
 import { platform, homedir } from 'os'
 import * as fs from 'fs'
 import { statfs } from 'fs/promises'
-
-export type ContainerRunner = 'docker' | 'podman' | 'apple-container' | 'lima' | 'wsl2' | 'kubernetes' | 'lambda-microvm'
 
 /**
  * How long a pull may go without any CLI output before the stall watchdog

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -1,5 +1,16 @@
 import type { RuntimeOptions } from './runtime-options'
 
+export const CONTAINER_RUNNER_IDS = [
+  'docker',
+  'podman',
+  'apple-container',
+  'lima',
+  'wsl2',
+  'kubernetes',
+  'lambda-microvm',
+] as const
+export type ContainerRunner = (typeof CONTAINER_RUNNER_IDS)[number]
+
 export type ContainerStatus = 'stopped' | 'running'
 
 // Effort levels supported by Claude Agent SDK v0.2.111+.

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -1,8 +1,10 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { getSettings, type ApiKeySettings, type ApiKeyStatus } from '../config/settings'
 import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
+import type { LlmProviderId } from './provider-types'
 
-export type LlmProviderId = 'anthropic' | 'openrouter' | 'bedrock' | 'platform' | 'generic'
+export { LLM_PROVIDER_IDS } from './provider-types'
+export type { LlmProviderId } from './provider-types'
 
 export type ModelPurpose = 'agent' | 'summarizer' | 'browser' | 'dashboard'
 

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -1,5 +1,7 @@
 export { BaseLlmProvider } from './base-llm-provider'
-export type { LlmProviderId, ModelPurpose } from './base-llm-provider'
+export { LLM_PROVIDER_IDS } from './provider-types'
+export type { LlmProviderId } from './provider-types'
+export type { ModelPurpose } from './base-llm-provider'
 export { AnthropicLlmProvider } from './anthropic-provider'
 export { OpenRouterLlmProvider } from './openrouter-provider'
 export { BedrockLlmProvider } from './bedrock-provider'
@@ -30,7 +32,8 @@ export {
   resolveModelForProvider,
 } from './model-catalog'
 
-import type { LlmProviderId, ModelPurpose } from './base-llm-provider'
+import type { LlmProviderId } from './provider-types'
+import type { ModelPurpose } from './base-llm-provider'
 import { BaseLlmProvider } from './base-llm-provider'
 import type { ModelDefinition } from './model-catalog-schema'
 import { getEffectiveCatalog, getProviderCatalog, resolveModelForProvider } from './model-catalog'

--- a/src/shared/lib/llm-provider/provider-types.ts
+++ b/src/shared/lib/llm-provider/provider-types.ts
@@ -1,0 +1,9 @@
+export const LLM_PROVIDER_IDS = [
+  'anthropic',
+  'openrouter',
+  'bedrock',
+  'platform',
+  'generic',
+] as const
+
+export type LlmProviderId = (typeof LLM_PROVIDER_IDS)[number]

--- a/src/shared/lib/web-provider/index.ts
+++ b/src/shared/lib/web-provider/index.ts
@@ -1,6 +1,7 @@
 export { BaseWebProvider } from './base-web-provider'
 export { ExaWebProvider } from './exa-web-provider'
 export { PlatformWebProvider } from './platform-web-provider'
+export { WEB_PROVIDER_IDS } from './types'
 export {
   findWebProvider,
   getActiveWebProvider,

--- a/src/shared/lib/web-provider/types.ts
+++ b/src/shared/lib/web-provider/types.ts
@@ -1,4 +1,5 @@
-export type WebProviderId = 'native' | 'exa' | 'platform'
+export const WEB_PROVIDER_IDS = ['native', 'exa', 'platform'] as const
+export type WebProviderId = (typeof WEB_PROVIDER_IDS)[number]
 
 export interface WebSearchOptions {
   numResults?: number // host applies a default + hard max (Exa bills per result)


### PR DESCRIPTION
## Summary

- replace manual `PUT /api/settings` validation with a composed, strict Zod patch schema
- group schema, apply, and transition logic into typed settings components
- derive the renderer update type from the runtime schema
- add route-boundary and component-level regression tests

## Why

The route parsed JSON as an untyped object, validated selected fields manually, and persisted values through object spreads. That mixed structural validation, patch application, and state-dependent transition rules in one handler and left gaps where malformed or unknown nested values could reach persisted settings.

## Impact

Malformed, unknown, and server-owned settings now return a 400 response at the write boundary. Existing clear, delete, and merge semantics remain intact. Running-agent transition checks compare the fully merged result, so effective no-op updates are allowed.

## Validation

- `npm test -- --run src/api/routes/settings.test.ts src/shared/lib/config/settings-patch.test.ts` — 163 tests passed after rebasing onto latest `main`
- `npm run typecheck`
- focused ESLint on all five changed files
- full Vitest suite — 514 files / 8,831 tests passed
- `npm run build`
