### PR TITLE
Point graph "Edit permissions" at the agent-to-agent page; drop dead transient

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -62,7 +62,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   // The new-agent morph tag lives in NavTransientContext — above the router, so
   // it survives in-app nav and dies on hard reload. justCreatedSlug producer =
   // use-create-untitled-agent.
-  const { justCreatedSlug, setJustCreatedSlug, openAgentSettings, setOpenAgentSettings } = useNavTransient()
+  const { justCreatedSlug, setJustCreatedSlug } = useNavTransient()
   const navigate = useNavigate()
   const [introStagger] = useState(() => {
     if (justCreatedSlug !== agent.slug) return false
@@ -132,19 +132,6 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     setSettingsTab(tab)
     setSettingsOpen(true)
   }, [])
-  // One-shot from NavTransientContext: another page (e.g. the home graph's
-  // "edit permissions") navigated here asking for a settings tab. Consume
-  // immediately so it can't replay on a later visit — and drop it unacted
-  // when stale: an abandoned navigation would otherwise pop the dialog on a
-  // much-later organic visit to this agent.
-  useEffect(() => {
-    if (openAgentSettings?.slug !== agent.slug) return
-    if (Date.now() - openAgentSettings.requestedAt < 10_000) {
-      handleOpenSettings(openAgentSettings.tab)
-    }
-    setOpenAgentSettings(null)
-  }, [openAgentSettings, agent.slug, handleOpenSettings, setOpenAgentSettings])
-
   const sessions = useMemo(() => {
     if (!Array.isArray(sessionsData)) return []
     return sessionsData.map((s) => ({

--- a/src/renderer/components/home/graph/agent-graph.tsx
+++ b/src/renderer/components/home/graph/agent-graph.tsx
@@ -34,7 +34,6 @@ import {
 } from '@xyflow/react'
 import { useNavigate } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
-import { useNavTransient } from '@renderer/context/nav-transient-context'
 import { Loader2, RotateCcw } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Switch } from '@renderer/components/ui/switch'
@@ -408,16 +407,14 @@ export function AgentGraph() {
     [deleteEdge],
   )
   // "Edit permissions" on an agent↔agent connector: go to the caller agent's
-  // page with a one-shot asking it to open the policies tab.
-  const { setOpenAgentSettings } = useNavTransient()
+  // permissions page.
   const editEdgePermissions = useCallback(
     (edgeId: string) => {
       const spec = graph.edges.find((e) => e.id === edgeId)
       if (!spec?.policyAgentSlug) return
-      setOpenAgentSettings({ slug: spec.policyAgentSlug, tab: 'x-agent-policies' })
-      void navigate({ to: '/agents/$slug', params: { slug: spec.policyAgentSlug } })
+      void navigate({ to: '/agents/$slug/x-agent-permissions', params: { slug: spec.policyAgentSlug } })
     },
-    [graph.edges, setOpenAgentSettings, navigate],
+    [graph.edges, navigate],
   )
 
   const savedEdgeGeometry = userSettings?.graphEdgeGeometry

--- a/src/renderer/context/nav-transient-context.tsx
+++ b/src/renderer/context/nav-transient-context.tsx
@@ -1,18 +1,8 @@
-import { createContext, useCallback, useContext, useState, type ReactNode } from 'react'
-
-interface OpenAgentSettings {
-  slug: string
-  tab: string
-  /** Stamped by the setter — consumers drop stale requests (abandoned
-   *  navigations must not pop a dialog on a much-later organic visit). */
-  requestedAt: number
-}
+import { createContext, useContext, useState, type ReactNode } from 'react'
 
 interface NavTransientValue {
   justCreatedSlug: string | null
   setJustCreatedSlug: (slug: string | null) => void
-  openAgentSettings: OpenAgentSettings | null
-  setOpenAgentSettings: (value: Omit<OpenAgentSettings, 'requestedAt'> | null) => void
 }
 
 const NavTransientContext = createContext<NavTransientValue | null>(null)
@@ -24,23 +14,12 @@ const NavTransientContext = createContext<NavTransientValue | null>(null)
  *
  * - `justCreatedSlug`: the new-agent "morph" tag. Produced by
  *   `useCreateUntitledAgent` on create and consumed by AgentHome.
- * - `openAgentSettings`: open the agent settings dialog on a given tab once
- *   that agent's page mounts. Produced by cross-page affordances (e.g. the
- *   home graph's "edit permissions" on a connector) and consumed by AgentHome.
  */
 export function NavTransientProvider({ children }: { children: ReactNode }) {
   const [justCreatedSlug, setJustCreatedSlug] = useState<string | null>(null)
-  const [openAgentSettings, setOpenAgentSettingsRaw] = useState<OpenAgentSettings | null>(null)
-  const setOpenAgentSettings = useCallback(
-    (value: Omit<OpenAgentSettings, 'requestedAt'> | null) =>
-      setOpenAgentSettingsRaw(value ? { ...value, requestedAt: Date.now() } : null),
-    [],
-  )
 
   return (
-    <NavTransientContext.Provider
-      value={{ justCreatedSlug, setJustCreatedSlug, openAgentSettings, setOpenAgentSettings }}
-    >
+    <NavTransientContext.Provider value={{ justCreatedSlug, setJustCreatedSlug }}>
       {children}
     </NavTransientContext.Provider>
   )


### PR DESCRIPTION
**Stack 2/3** — stacked on #655; merge bottom-up.

An agent-to-agent connector's "Edit permissions" on the home graph now navigates straight to `/agents/$slug/x-agent-permissions` instead of landing on the agent home with a one-shot asking it to open a settings-dialog tab that #655 removed.

With that, the `openAgentSettings` one-shot in `NavTransientContext` has no producers left, so the transient and its consumer effect in `AgentHome` are removed. `justCreatedSlug` (the new-agent morph) stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
