### PR TITLE
Redesign agent-to-agent page as a connections-style toggle list

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -121,6 +121,7 @@ import { isValidApiScope } from '@shared/lib/proxy/scope-matcher'
 import { isLabelDefaultKey } from '@shared/lib/proxy/policy-sentinels'
 import type { ScopeLabel } from '@shared/lib/proxy/scope-metadata'
 import {
+  deletePolicy,
   deletePoliciesForAgent,
   deleteTargetPolicy,
   listPoliciesForCaller,
@@ -128,6 +129,7 @@ import {
   replacePoliciesForCallerInputSchema,
   setPolicy,
   xAgentDecisionSchema,
+  xAgentOperationSchema,
 } from '@shared/lib/services/x-agent-policy-service'
 import {
   exportAgentTemplate,
@@ -5869,6 +5871,48 @@ agents.get('/:id/x-agent-policies', AgentRead(), async (c) => {
         updatedAt: r.updatedAt,
       })),
   })
+})
+
+// PATCH /api/agents/:id/x-agent-policies - Atomically update or clear one
+// policy. The editor sends independent controls through this route so rapid
+// edits never race through the whole-list replacement endpoint below.
+agents.patch('/:id/x-agent-policies', AgentAdmin(), async (c) => {
+  const slug = getAgentId(c)
+  const callerAgent = await getAgent(slug)
+  if (!callerAgent) {
+    return c.json({ error: 'Agent not found' }, 404)
+  }
+
+  const body = await c.req.json().catch(() => ({}))
+  const parsed = z.object({
+    operation: xAgentOperationSchema,
+    targetSlug: z.string().nullable(),
+    decision: z.union([xAgentDecisionSchema, z.literal('default')]),
+  }).safeParse(body)
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid policy payload', details: parsed.error.format() }, 400)
+  }
+
+  const { operation, targetSlug, decision } = parsed.data
+  if (operation === 'list' && targetSlug !== null) {
+    return c.json({ error: 'List policies cannot target an agent' }, 400)
+  }
+  if (targetSlug === slug) {
+    return c.json({ error: 'Cannot set a policy targeting the same agent' }, 400)
+  }
+  if (targetSlug !== null) {
+    const targetAgent = await getAgent(targetSlug)
+    if (!targetAgent || !(await callerCanSeeAgent(c, targetSlug))) {
+      return c.json({ error: 'Agent not found' }, 404)
+    }
+  }
+
+  if (decision === 'default') {
+    const removed = deletePolicy(slug, operation, targetSlug)
+    return c.json({ ok: true, removed })
+  }
+  const result = await setPolicy(slug, operation, targetSlug, decision)
+  return c.json({ ok: true, ...result })
 })
 
 // PUT /api/agents/:id/x-agent-policies - Replace all policies for this caller (batch)

--- a/src/api/routes/x-agent-policies.test.ts
+++ b/src/api/routes/x-agent-policies.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the GET / PUT /api/agents/:id/x-agent-policies routes
+ * Tests for the GET / PATCH / PUT /api/agents/:id/x-agent-policies routes
  * (the per-agent UI for reviewing remembered cross-agent permissions).
  *
  * Uses in-memory SQLite + mocks for file-based services. Mounts agents.ts as a sub-app.
@@ -237,6 +237,80 @@ describe('GET /api/agents/:id/x-agent-policies', () => {
     expect(slugs).toContain(TARGET_A)
     expect(slugs).toContain(null) // 'list' policy still shown
     expect(slugs).not.toContain(TARGET_B)
+  })
+})
+
+// ============================================================================
+// PATCH /api/agents/:id/x-agent-policies
+// ============================================================================
+
+describe('PATCH /api/agents/:id/x-agent-policies', () => {
+  const patchPolicy = (body: unknown) => app.request(`/api/agents/${CALLER}/x-agent-policies`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  it('updates one policy atomically without replacing sibling rows', async () => {
+    await setPolicy(CALLER, 'invoke', TARGET_A, 'allow')
+    await setPolicy(CALLER, 'read', TARGET_B, 'block')
+
+    const res = await patchPolicy({ operation: 'invoke', targetSlug: TARGET_A, decision: 'review' })
+
+    expect(res.status).toBe(200)
+    expect(getPolicy(CALLER, 'invoke', TARGET_A)?.decision).toBe('review')
+    expect(getPolicy(CALLER, 'read', TARGET_B)?.decision).toBe('block')
+  })
+
+  it('clears only the selected row when decision is default', async () => {
+    await setPolicy(CALLER, 'read', null, 'allow')
+    await setPolicy(CALLER, 'read', TARGET_A, 'block')
+
+    const res = await patchPolicy({ operation: 'read', targetSlug: null, decision: 'default' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ ok: true, removed: 1 })
+    expect(getPolicy(CALLER, 'read', null)).toBeNull()
+    expect(getPolicy(CALLER, 'read', TARGET_A)?.decision).toBe('block')
+  })
+
+  it('does not lose either of two concurrent changes', async () => {
+    await setPolicy(CALLER, 'invoke', TARGET_A, 'allow')
+    await setPolicy(CALLER, 'invoke', TARGET_B, 'allow')
+
+    const [a, b] = await Promise.all([
+      patchPolicy({ operation: 'invoke', targetSlug: TARGET_A, decision: 'default' }),
+      patchPolicy({ operation: 'invoke', targetSlug: TARGET_B, decision: 'default' }),
+    ])
+
+    expect(a.status).toBe(200)
+    expect(b.status).toBe(200)
+    expect(getPolicy(CALLER, 'invoke', TARGET_A)).toBeNull()
+    expect(getPolicy(CALLER, 'invoke', TARGET_B)).toBeNull()
+  })
+
+  it('rejects self-targeted and targeted list policies', async () => {
+    const self = await patchPolicy({ operation: 'invoke', targetSlug: CALLER, decision: 'allow' })
+    const targetedList = await patchPolicy({ operation: 'list', targetSlug: TARGET_A, decision: 'allow' })
+
+    expect(self.status).toBe(400)
+    expect(targetedList.status).toBe(400)
+  })
+
+  it('does not write a policy toward an invisible target in auth mode', async () => {
+    authModeEnabled = true
+    currentUserId = 'user-viewer'
+    await testDb.insert(schema.user).values([
+      { id: 'user-viewer', name: 'V', email: 'v@t', emailVerified: false },
+    ])
+    await testDb.insert(schema.agentAcl).values([
+      { id: 'acl-c', userId: 'user-viewer', agentSlug: CALLER, role: 'owner', createdAt: new Date() },
+    ])
+
+    const res = await patchPolicy({ operation: 'read', targetSlug: TARGET_B, decision: 'allow' })
+
+    expect(res.status).toBe(404)
+    expect(getPolicy(CALLER, 'read', TARGET_B)).toBeNull()
   })
 })
 

--- a/src/renderer/components/agents/x-agent-permissions/x-agent-permissions-view.test.tsx
+++ b/src/renderer/components/agents/x-agent-permissions/x-agent-permissions-view.test.tsx
@@ -62,10 +62,14 @@ function renderView(agentSlug = 'caller') {
   )
 }
 
-function lastPutBody() {
-  const putCall = mocks.apiFetch.mock.calls.findLast(([, init]) => init?.method === 'PUT')
-  expect(putCall).toBeDefined()
-  return JSON.parse(putCall![1].body)
+function patchBodies() {
+  return mocks.apiFetch.mock.calls
+    .filter(([, init]) => init?.method === 'PATCH')
+    .map(([, init]) => JSON.parse(String(init.body)))
+}
+
+function lastPatchBody() {
+  return patchBodies().at(-1)
 }
 
 describe('XAgentPermissionsView', () => {
@@ -73,11 +77,22 @@ describe('XAgentPermissionsView', () => {
     vi.clearAllMocks()
     mocks.canAdmin = true
     policies = [policy('invoke', 'target', 'allow'), policy('read', 'target', 'allow')]
-    mocks.apiFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+    mocks.apiFetch.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === '/api/agents/caller/x-agent-policies' && (!init || !init.method)) {
         return jsonResponse({ policies })
       }
-      if (url === '/api/agents/caller/x-agent-policies' && init?.method === 'PUT') {
+      if (url === '/api/agents/caller/x-agent-policies' && init?.method === 'PATCH') {
+        const change = JSON.parse(String(init.body)) as {
+          operation: string
+          targetSlug: string | null
+          decision: string
+        }
+        policies = policies.filter(
+          (p) => p.operation !== change.operation || p.targetAgentSlug !== change.targetSlug,
+        )
+        if (change.decision !== 'default') {
+          policies.push(policy(change.operation, change.targetSlug, change.decision))
+        }
         return jsonResponse({ ok: true })
       }
       if (url === '/api/agents') return jsonResponse(AGENTS)
@@ -101,9 +116,9 @@ describe('XAgentPermissionsView', () => {
     expect(targetSwitch).toHaveAttribute('aria-checked', 'true')
     expect(helperSwitch).toHaveAttribute('aria-checked', 'false')
 
-    // Connected rows carry a Permissions popover trigger; not-connected rows don't.
+    // Every row carries a Permissions popover so independent Read grants remain editable.
     expect(screen.getByTestId('x-agent-permissions-trigger-target')).toBeInTheDocument()
-    expect(screen.queryByTestId('x-agent-permissions-trigger-helper')).not.toBeInTheDocument()
+    expect(screen.getByTestId('x-agent-permissions-trigger-helper')).toBeInTheDocument()
   })
 
   it('connect flow: toggling on grants Send immediately', async () => {
@@ -111,12 +126,10 @@ describe('XAgentPermissionsView', () => {
     fireEvent.click(await screen.findByTestId('x-agent-connect-switch-helper'))
 
     await waitFor(() => {
-      expect(lastPutBody()).toEqual({
-        policies: [
-          { operation: 'invoke', targetSlug: 'target', decision: 'allow' },
-          { operation: 'read', targetSlug: 'target', decision: 'allow' },
-          { operation: 'invoke', targetSlug: 'helper', decision: 'allow' },
-        ],
+      expect(lastPatchBody()).toEqual({
+        operation: 'invoke',
+        targetSlug: 'helper',
+        decision: 'allow',
       })
     })
     // The row lands in Connected with its Permissions trigger available.
@@ -128,8 +141,10 @@ describe('XAgentPermissionsView', () => {
     fireEvent.click(await screen.findByTestId('x-agent-connect-switch-target'))
 
     await waitFor(() => {
-      expect(lastPutBody()).toEqual({
-        policies: [{ operation: 'read', targetSlug: 'target', decision: 'allow' }],
+      expect(lastPatchBody()).toEqual({
+        operation: 'invoke',
+        targetSlug: 'target',
+        decision: 'default',
       })
     })
   })
@@ -144,13 +159,49 @@ describe('XAgentPermissionsView', () => {
 
     fireEvent.click(helperSwitch)
     await waitFor(() => {
-      expect(lastPutBody()).toEqual({
-        policies: [
-          { operation: 'invoke', targetSlug: null, decision: 'allow' },
-          { operation: 'invoke', targetSlug: 'helper', decision: 'review' },
-        ],
+      expect(lastPatchBody()).toEqual({
+        operation: 'invoke',
+        targetSlug: 'helper',
+        decision: 'review',
       })
     })
+  })
+
+  it('disconnecting an explicit allow also pins Review when the fallback is globally allowed', async () => {
+    policies = [
+      policy('invoke', null, 'allow'),
+      policy('invoke', 'target', 'allow'),
+    ]
+    renderView()
+
+    fireEvent.click(await screen.findByTestId('x-agent-connect-switch-target'))
+
+    await waitFor(() => {
+      expect(lastPatchBody()).toEqual({
+        operation: 'invoke',
+        targetSlug: 'target',
+        decision: 'review',
+      })
+    })
+    expect(await screen.findByTestId('x-agent-connect-switch-target')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('sends rapid edits as independent atomic patches', async () => {
+    renderView()
+    const targetSwitch = await screen.findByTestId('x-agent-connect-switch-target')
+    const helperSwitch = screen.getByTestId('x-agent-connect-switch-helper')
+
+    fireEvent.click(targetSwitch)
+    fireEvent.click(helperSwitch)
+
+    await waitFor(() => {
+      expect(patchBodies()).toEqual(expect.arrayContaining([
+        { operation: 'invoke', targetSlug: 'target', decision: 'default' },
+        { operation: 'invoke', targetSlug: 'helper', decision: 'allow' },
+      ]))
+      expect(patchBodies()).toHaveLength(2)
+    })
+    expect(mocks.apiFetch.mock.calls.some(([, init]) => init?.method === 'PUT')).toBe(false)
   })
 
   it('the Permissions popover on a connected row saves a fine-grained change', async () => {
@@ -164,11 +215,10 @@ describe('XAgentPermissionsView', () => {
     fireEvent.click(await screen.findByTestId('policy-menu-block'))
 
     await waitFor(() => {
-      expect(lastPutBody()).toEqual({
-        policies: [
-          { operation: 'invoke', targetSlug: 'target', decision: 'allow' },
-          { operation: 'read', targetSlug: 'target', decision: 'block' },
-        ],
+      expect(lastPatchBody()).toEqual({
+        operation: 'read',
+        targetSlug: 'target',
+        decision: 'block',
       })
     })
   })
@@ -180,6 +230,33 @@ describe('XAgentPermissionsView', () => {
     const row = await screen.findByTestId('x-agent-policy-row-target')
     expect(within(row).getByText('Blocked')).toBeInTheDocument()
     expect(within(row).getByTestId('x-agent-connect-switch-target')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('edits Read on a disconnected row without granting Send', async () => {
+    policies = [
+      policy('read', 'target', 'allow'),
+      policy('invoke', 'target', 'block'),
+    ]
+    renderView()
+
+    expect(await screen.findByTestId('x-agent-connect-switch-target')).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(screen.getByTestId('x-agent-permissions-trigger-target'))
+    const popover = screen.getByTestId('x-agent-permissions-popover-target')
+    fireEvent.click(within(popover).getAllByTestId('policy-dropdown-trigger')[0])
+    fireEvent.click(await screen.findByTestId('policy-menu-review'))
+
+    await waitFor(() => {
+      expect(lastPatchBody()).toEqual({
+        operation: 'read',
+        targetSlug: 'target',
+        decision: 'review',
+      })
+    })
+    expect(patchBodies()).not.toContainEqual({
+      operation: 'invoke',
+      targetSlug: 'target',
+      decision: 'allow',
+    })
   })
 
   it('shows owner gate and does not fetch for a non-owner', () => {

--- a/src/renderer/components/agents/x-agent-permissions/x-agent-permissions-view.test.tsx
+++ b/src/renderer/components/agents/x-agent-permissions/x-agent-permissions-view.test.tsx
@@ -31,20 +31,21 @@ vi.mock('@renderer/context/user-context', () => ({
 const AGENTS = [
   { slug: 'caller', displaySlug: 'caller', name: 'Caller' },
   { slug: 'target', displaySlug: 'target', name: 'Target' },
+  { slug: 'helper', displaySlug: 'helper', name: 'Helper' },
 ]
 
-const POLICIES = {
-  policies: [
-    {
-      id: 'p1',
-      operation: 'read',
-      targetAgentSlug: 'target',
-      targetAgentName: 'Target',
-      decision: 'allow',
-      updatedAt: '2026-01-01T00:00:00.000Z',
-    },
-  ],
+function policy(operation: string, targetAgentSlug: string | null, decision: string) {
+  return {
+    id: `${operation}-${targetAgentSlug ?? 'global'}`,
+    operation,
+    targetAgentSlug,
+    targetAgentName: targetAgentSlug,
+    decision,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
 }
+
+let policies: ReturnType<typeof policy>[]
 
 function jsonResponse(payload: unknown) {
   return { ok: true, json: async () => payload }
@@ -61,52 +62,124 @@ function renderView(agentSlug = 'caller') {
   )
 }
 
+function lastPutBody() {
+  const putCall = mocks.apiFetch.mock.calls.findLast(([, init]) => init?.method === 'PUT')
+  expect(putCall).toBeDefined()
+  return JSON.parse(putCall![1].body)
+}
+
 describe('XAgentPermissionsView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.canAdmin = true
-    mocks.apiFetch.mockImplementation(async (url: string) => {
-      if (url === '/api/agents/caller/x-agent-policies') return jsonResponse(POLICIES)
+    policies = [policy('invoke', 'target', 'allow'), policy('read', 'target', 'allow')]
+    mocks.apiFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      if (url === '/api/agents/caller/x-agent-policies' && (!init || !init.method)) {
+        return jsonResponse({ policies })
+      }
+      if (url === '/api/agents/caller/x-agent-policies' && init?.method === 'PUT') {
+        return jsonResponse({ ok: true })
+      }
       if (url === '/api/agents') return jsonResponse(AGENTS)
       throw new Error(`Unexpected fetch: ${url}`)
     })
   })
 
-  it('renders global toggles and per-agent rows without the agent itself', async () => {
+  it('splits agents into Connected / Not connected by their effective send policy', async () => {
     renderView()
     expect(mocks.track).toHaveBeenCalledWith('agent_permissions_viewed', { agentSlug: 'caller' })
 
-    expect(await screen.findByText('List Agents')).toBeInTheDocument()
+    // Globals stay on top.
+    expect(await screen.findByText('Allow this agent to see a list of all other agents')).toBeInTheDocument()
     expect(screen.getByTestId('x-agent-policy-global-read')).toBeInTheDocument()
     expect(screen.getByTestId('x-agent-policy-global-invoke')).toBeInTheDocument()
 
-    // Only the OTHER workspace agent gets a row; the stored 'allow' decision
-    // is reflected on its Read toggle.
+    // Target (invoke allow) is connected; Helper is not; the caller has no row.
     expect(screen.queryByTestId('x-agent-policy-row-caller')).not.toBeInTheDocument()
-    const row = screen.getByTestId('x-agent-policy-row-target')
-    const readToggle = within(row).getAllByTestId('policy-toggle-allow')[0]
-    expect(readToggle).toHaveAttribute('data-active', 'true')
+    const targetSwitch = screen.getByTestId('x-agent-connect-switch-target')
+    const helperSwitch = screen.getByTestId('x-agent-connect-switch-helper')
+    expect(targetSwitch).toHaveAttribute('aria-checked', 'true')
+    expect(helperSwitch).toHaveAttribute('aria-checked', 'false')
+
+    // Connected rows carry a Permissions popover trigger; not-connected rows don't.
+    expect(screen.getByTestId('x-agent-permissions-trigger-target')).toBeInTheDocument()
+    expect(screen.queryByTestId('x-agent-permissions-trigger-helper')).not.toBeInTheDocument()
   })
 
-  it('PUTs the full policy set with the change applied', async () => {
+  it('connect flow: toggling on grants Send immediately', async () => {
     renderView()
-    const globalRead = await screen.findByTestId('x-agent-policy-global-read')
-
-    fireEvent.click(within(globalRead).getByTestId('policy-toggle-block'))
+    fireEvent.click(await screen.findByTestId('x-agent-connect-switch-helper'))
 
     await waitFor(() => {
-      expect(mocks.apiFetch).toHaveBeenCalledWith(
-        '/api/agents/caller/x-agent-policies',
-        expect.objectContaining({ method: 'PUT' }),
-      )
+      expect(lastPutBody()).toEqual({
+        policies: [
+          { operation: 'invoke', targetSlug: 'target', decision: 'allow' },
+          { operation: 'read', targetSlug: 'target', decision: 'allow' },
+          { operation: 'invoke', targetSlug: 'helper', decision: 'allow' },
+        ],
+      })
     })
-    const putCall = mocks.apiFetch.mock.calls.find(([, init]) => init?.method === 'PUT')!
-    expect(JSON.parse(putCall[1].body)).toEqual({
-      policies: [
-        { operation: 'read', targetSlug: 'target', decision: 'allow' },
-        { operation: 'read', targetSlug: null, decision: 'block' },
-      ],
+    // The row lands in Connected with its Permissions trigger available.
+    expect(await screen.findByTestId('x-agent-permissions-trigger-helper')).toBeInTheDocument()
+  })
+
+  it('disconnect removes the explicit send grant and keeps read untouched', async () => {
+    renderView()
+    fireEvent.click(await screen.findByTestId('x-agent-connect-switch-target'))
+
+    await waitFor(() => {
+      expect(lastPutBody()).toEqual({
+        policies: [{ operation: 'read', targetSlug: 'target', decision: 'allow' }],
+      })
     })
+  })
+
+  it('disconnecting an agent connected only via the global default pins an explicit Review', async () => {
+    policies = [policy('invoke', null, 'allow')]
+    renderView()
+
+    // Both agents inherit connected from the global send=allow.
+    const helperSwitch = await screen.findByTestId('x-agent-connect-switch-helper')
+    expect(helperSwitch).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.click(helperSwitch)
+    await waitFor(() => {
+      expect(lastPutBody()).toEqual({
+        policies: [
+          { operation: 'invoke', targetSlug: null, decision: 'allow' },
+          { operation: 'invoke', targetSlug: 'helper', decision: 'review' },
+        ],
+      })
+    })
+  })
+
+  it('the Permissions popover on a connected row saves a fine-grained change', async () => {
+    renderView()
+    fireEvent.click(await screen.findByTestId('x-agent-permissions-trigger-target'))
+
+    const popover = screen.getByTestId('x-agent-permissions-popover-target')
+    // Read is the first control; open its dropdown and pick Block (the menu
+    // renders in a portal, so query at screen level).
+    fireEvent.click(within(popover).getAllByTestId('policy-dropdown-trigger')[0])
+    fireEvent.click(await screen.findByTestId('policy-menu-block'))
+
+    await waitFor(() => {
+      expect(lastPutBody()).toEqual({
+        policies: [
+          { operation: 'invoke', targetSlug: 'target', decision: 'allow' },
+          { operation: 'read', targetSlug: 'target', decision: 'block' },
+        ],
+      })
+    })
+  })
+
+  it('badges an explicitly blocked agent in the list', async () => {
+    policies = [policy('invoke', 'target', 'block')]
+    renderView()
+
+    const row = await screen.findByTestId('x-agent-policy-row-target')
+    expect(within(row).getByText('Blocked')).toBeInTheDocument()
+    expect(within(row).getByTestId('x-agent-connect-switch-target')).toHaveAttribute('aria-checked', 'false')
   })
 
   it('shows owner gate and does not fetch for a non-owner', () => {

--- a/src/renderer/components/agents/x-agent-permissions/x-agent-permissions-view.tsx
+++ b/src/renderer/components/agents/x-agent-permissions/x-agent-permissions-view.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useMemo, useState } from 'react'
+import { flushSync } from 'react-dom'
 import { useNavigate } from '@tanstack/react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@renderer/lib/api'
-import { Loader2, Search, AlertCircle, Users, ScrollText, Send } from 'lucide-react'
+import { Loader2, Search, AlertCircle, ChevronDown } from 'lucide-react'
 import { Input } from '@renderer/components/ui/input'
-import { PolicyDecisionToggle } from '@renderer/components/ui/policy-decision-toggle'
+import { Button } from '@renderer/components/ui/button'
+import { Switch } from '@renderer/components/ui/switch'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { PolicyDecisionDropdown } from '@renderer/components/ui/policy-decision-toggle'
+import { IntegrationList, IntegrationRow } from '@renderer/components/connections/integration-row'
 import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
+import { startViewTransition } from '@renderer/lib/view-transition'
 import { useUser } from '@renderer/context/user-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useRenderTracker } from '@renderer/lib/perf'
@@ -32,6 +38,12 @@ interface PoliciesResponse {
   policies: PolicyRow[]
 }
 
+interface PolicyChange {
+  operation: Operation
+  targetSlug: string | null
+  decision: DecisionOrDefault
+}
+
 type AgentsResponse = ApiAgent[]
 
 function policyKey(operation: Operation, targetSlug: string | null): string {
@@ -41,8 +53,11 @@ function policyKey(operation: Operation, targetSlug: string | null): string {
 /**
  * Standalone page for an agent's agent-to-agent connections — the policies
  * this agent has remembered for listing, reading, and messaging other
- * workspace agents. Lived in the agent settings dialog ("Agents" tab) until
- * it moved to its own route like Secrets and API Logs.
+ * workspace agents. Presented like the Agent Connections page: a Switch per
+ * target agent ("connected" = it may send messages, the same relationship a
+ * drawn home-graph edge creates). Connected rows carry a Permissions popover
+ * with the fine-grained controls (Read / Send × Allow / Review / Block);
+ * every state is reachable by connecting first, then tuning there.
  */
 export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps) {
   useRenderTracker('XAgentPermissionsView')
@@ -52,8 +67,14 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
   const { isAuthMode, rolesReady, canAdminAgent } = useUser()
   const canManage = !isAuthMode || (rolesReady && canAdminAgent(agentSlug))
   const [filter, setFilter] = useState('')
-  const [savingKey, setSavingKey] = useState<string | null>(null)
+  const [searchOpen, setSearchOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  /**
+   * Optimistic per-slug connected state so a toggled row animates to its new
+   * section immediately (mirrors connections-list grantOverrides). Cleared by
+   * the catch-up effect below once the server state agrees.
+   */
+  const [connectOverrides, setConnectOverrides] = useState<Record<string, boolean>>({})
 
   useEffect(() => {
     track('agent_permissions_viewed', { agentSlug })
@@ -62,8 +83,9 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
   // Reset transient UI state when switching agents via the sidebar.
   useEffect(() => {
     setFilter('')
-    setSavingKey(null)
+    setSearchOpen(false)
     setError(null)
+    setConnectOverrides({})
   }, [agentSlug])
 
   // Fetch this caller's stored policies
@@ -97,6 +119,43 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
     return map
   }, [policiesQuery.data])
 
+  const getDecision = (operation: Operation, targetSlug: string | null): DecisionOrDefault => {
+    return policyMap.get(policyKey(operation, targetSlug)) ?? 'default'
+  }
+
+  const globalRead = getDecision('read', null)
+  const globalInvoke = getDecision('invoke', null)
+
+  /** Effective send decision: explicit row, else the global default, else review. */
+  const effectiveInvoke = (slug: string): Decision => {
+    const explicit = getDecision('invoke', slug)
+    if (explicit !== 'default') return explicit
+    return globalInvoke !== 'default' ? globalInvoke : 'review'
+  }
+
+  /** "Connected" = this agent may send messages to the target without a prompt. */
+  const serverConnected = (slug: string): boolean => effectiveInvoke(slug) === 'allow'
+  const isConnected = (slug: string): boolean => connectOverrides[slug] ?? serverConnected(slug)
+
+  // Drop overrides the server has caught up to. Self-terminating: the setter
+  // returns the same reference when nothing changed, so React bails out.
+  useEffect(() => {
+    if (Object.keys(connectOverrides).length === 0) return
+    setConnectOverrides((prev) => {
+      let changed = false
+      const next = { ...prev }
+      for (const [slug, v] of Object.entries(prev)) {
+        if (serverConnected(slug) === v) {
+          delete next[slug]
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+    // serverConnected is derived from policyMap; policyMap identity is the real dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [policyMap, connectOverrides])
+
   const otherAgents = useMemo(() => {
     const all = agentsQuery.data ?? []
     return all
@@ -110,26 +169,21 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
       .sort((a, b) => a.name.localeCompare(b.name))
   }, [agentsQuery.data, agentSlug, filter])
 
-  // Single mutation: build the full policy set with the change applied, PUT it.
+  // Single mutation: build the full policy set with the changes applied, PUT it.
   const savePolicies = useMutation({
     meta: { skipGlobalErrorToast: true },
-    mutationFn: async (params: {
-      operation: Operation
-      targetSlug: string | null
-      decision: DecisionOrDefault
-    }) => {
-      const key = policyKey(params.operation, params.targetSlug)
-      setSavingKey(key)
+    mutationFn: async (changes: PolicyChange[]) => {
       setError(null)
-      // Build the next full policy list: existing rows minus the one we're changing,
-      // plus the new one (unless we're setting it to 'default' which means delete).
+      const changed = new Set(changes.map((c) => policyKey(c.operation, c.targetSlug)))
       const nextPolicies: Array<{ operation: Operation; targetSlug: string | null; decision: Decision }> = []
       for (const p of policiesQuery.data?.policies ?? []) {
-        if (policyKey(p.operation, p.targetAgentSlug) === key) continue
+        if (changed.has(policyKey(p.operation, p.targetAgentSlug))) continue
         nextPolicies.push({ operation: p.operation, targetSlug: p.targetAgentSlug, decision: p.decision })
       }
-      if (params.decision !== 'default') {
-        nextPolicies.push({ operation: params.operation, targetSlug: params.targetSlug, decision: params.decision })
+      for (const c of changes) {
+        if (c.decision !== 'default') {
+          nextPolicies.push({ operation: c.operation, targetSlug: c.targetSlug, decision: c.decision })
+        }
       }
       const res = await apiFetch(`/api/agents/${agentSlug}/x-agent-policies`, {
         method: 'PUT',
@@ -147,23 +201,144 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
     onError: (err: Error) => {
       setError(err.message)
     },
-    onSettled: () => {
-      setSavingKey(null)
-    },
   })
 
-  const getDecision = (operation: Operation, targetSlug: string | null): DecisionOrDefault => {
-    return policyMap.get(policyKey(operation, targetSlug)) ?? 'default'
+  const handleChange = (operation: Operation, targetSlug: string | null) => (next: DecisionOrDefault) => {
+    savePolicies.mutate([{ operation, targetSlug, decision: next }])
   }
 
-  const handleChange = (operation: Operation, targetSlug: string | null) => (next: DecisionOrDefault) => {
-    savePolicies.mutate({ operation, targetSlug, decision: next })
+  /** The Switch spinner: an in-flight change to this slug's send policy. */
+  const isSwitchPending = (slug: string): boolean =>
+    savePolicies.isPending &&
+    (savePolicies.variables ?? []).some((c) => c.targetSlug === slug && c.operation === 'invoke')
+
+  /** The detail panel's saving hint: any in-flight change for this slug. */
+  const isRowSaving = (slug: string): boolean =>
+    savePolicies.isPending && (savePolicies.variables ?? []).some((c) => c.targetSlug === slug)
+
+  const setOverride = (slug: string, value: boolean | null) => {
+    startViewTransition(() => {
+      flushSync(() => {
+        setConnectOverrides((prev) => {
+          const next = { ...prev }
+          if (value === null) delete next[slug]
+          else next[slug] = value
+          return next
+        })
+      })
+    })
   }
+
+  const handleToggle = (slug: string, next: boolean) => {
+    if (next) {
+      // Connect = grant Send (the graph-edge relationship). The connected
+      // row's Permissions popover is where Read is granted or Send dialed
+      // back. Deliberately replaces an explicit Block, like drawing the edge
+      // on the graph does.
+      setOverride(slug, true)
+      savePolicies.mutate([{ operation: 'invoke', targetSlug: slug, decision: 'allow' }], {
+        onError: () => setOverride(slug, null),
+      })
+      return
+    }
+    // Disconnect: remove the explicit send grant; when connected only via the
+    // global default, pin an explicit Review so this one agent prompts again.
+    const explicit = getDecision('invoke', slug)
+    const decision: DecisionOrDefault = explicit !== 'default' ? 'default' : 'review'
+    setOverride(slug, false)
+    savePolicies.mutate([{ operation: 'invoke', targetSlug: slug, decision }], {
+      onError: () => setOverride(slug, null),
+    })
+  }
+
+  const renderAgentRow = (agent: ApiAgent) => {
+    const slug = agent.slug
+    const connected = isConnected(slug)
+    const blocked = effectiveInvoke(slug) === 'block'
+    const pending = isSwitchPending(slug)
+    return (
+      <div key={slug} data-testid={`x-agent-policy-row-${slug}`}>
+        <IntegrationRow
+          icon={null}
+          name={agent.name}
+          nameBadge={
+            blocked ? (
+              <span className="rounded px-1 py-0.5 font-medium bg-orange-100 text-orange-700 dark:bg-orange-950/60 dark:text-orange-400">
+                Blocked
+              </span>
+            ) : undefined
+          }
+          subtitle={<span className="font-mono truncate">{agent.displaySlug}</span>}
+          viewTransitionName={`xagent-${slug}`}
+          right={
+            <>
+              {connected && !pending && (
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      className="mr-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground opacity-0 translate-x-1 transition-all duration-200 ease-out group-hover:opacity-100 group-hover:translate-x-0 focus-visible:opacity-100 focus-visible:translate-x-0 data-[state=open]:opacity-100 data-[state=open]:translate-x-0"
+                      aria-label={`Permissions for ${agent.name}`}
+                      data-testid={`x-agent-permissions-trigger-${slug}`}
+                    >
+                      Permissions
+                      <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="end"
+                    className="w-72 p-3 space-y-2.5"
+                    onOpenAutoFocus={(e) => e.preventDefault()}
+                    data-testid={`x-agent-permissions-popover-${slug}`}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="whitespace-nowrap text-xs font-medium">Read sessions</span>
+                      <PolicyDecisionDropdown
+                        value={getDecision('read', slug)}
+                        onChange={handleChange('read', slug)}
+                      />
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="whitespace-nowrap text-xs font-medium">Send messages</span>
+                      <PolicyDecisionDropdown
+                        value={getDecision('invoke', slug)}
+                        onChange={handleChange('invoke', slug)}
+                      />
+                    </div>
+                    {isRowSaving(slug) && (
+                      <div className="text-right text-[10px] text-muted-foreground">Saving…</div>
+                    )}
+                  </PopoverContent>
+                </Popover>
+              )}
+              {pending ? (
+                <Loader2
+                  className="h-4 w-4 animate-spin text-muted-foreground"
+                  aria-label="Saving connection change"
+                  data-testid={`x-agent-connect-pending-${slug}`}
+                />
+              ) : (
+                <Switch
+                  checked={connected}
+                  onCheckedChange={(next) => handleToggle(slug, next)}
+                  aria-label={`${connected ? 'Disconnect' : 'Connect'} ${agent.name}`}
+                  data-testid={`x-agent-connect-switch-${slug}`}
+                />
+              )}
+            </>
+          }
+        />
+      </div>
+    )
+  }
+
+  const connectedAgents = otherAgents.filter((a) => isConnected(a.slug))
+  const notConnectedAgents = otherAgents.filter((a) => !isConnected(a.slug))
 
   return (
     <SettingsPageContainer>
       <PageTitle
-        title="Agent-to-agent Connections"
+        title="Connect this agent to others"
         back={{
           onClick: () => {
             void navigate({ to: '/agents/$slug', params: { slug: agentSlug } })
@@ -187,13 +362,6 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
         </div>
       ) : (
         <div className="space-y-6">
-          <p className="text-sm text-muted-foreground">
-            Decisions this agent has remembered for using other agents in this workspace. Set to{' '}
-            <span className="font-medium">Allow</span> to skip the prompt;{' '}
-            <span className="font-medium">Review</span> (or no policy) prompts every time;{' '}
-            <span className="font-medium">Block</span> denies without prompting.
-          </p>
-
           {error && (
             <div className="flex items-center gap-2 rounded-md bg-amber-50 px-2 py-1.5 text-xs text-amber-700 dark:bg-amber-950/50 dark:text-amber-400">
               <AlertCircle className="h-3.5 w-3.5 shrink-0" />
@@ -205,134 +373,106 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
           <div className="space-y-2">
             <h4 className="text-xs font-medium uppercase text-muted-foreground">Global permissions</h4>
             <div className="rounded-md border p-3">
-              <div className="flex items-center justify-between">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <Users className="h-3.5 w-3.5 text-muted-foreground" />
-                    <span className="text-sm font-medium">List Agents</span>
-                  </div>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    Whether this agent can call <code className="font-mono">list_agents</code> to see other workspace agents.
-                  </p>
-                </div>
-                <PolicyDecisionToggle
+              <div className="flex items-center justify-between gap-3">
+                <span className="min-w-0 flex-1 text-xs font-medium">
+                  Allow this agent to see a list of all other agents
+                </span>
+                <PolicyDecisionDropdown
                   value={getDecision('list', null)}
                   onChange={handleChange('list', null)}
-                  size="md"
                 />
               </div>
             </div>
             <div className="rounded-md border p-3" data-testid="x-agent-policy-global-read">
-              <div className="flex items-center justify-between">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <ScrollText className="h-3.5 w-3.5 text-muted-foreground" />
-                    <span className="text-sm font-medium">Read sessions of all agents</span>
-                  </div>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    Default for any agent without a specific Read setting below. Per-agent rows override this.
-                  </p>
-                </div>
-                <PolicyDecisionToggle
-                  value={getDecision('read', null)}
+              <div className="flex items-center justify-between gap-3">
+                <span className="min-w-0 flex-1 text-xs font-medium">
+                  Allow this agent to read sessions of all other agents
+                </span>
+                <PolicyDecisionDropdown
+                  value={globalRead}
                   onChange={handleChange('read', null)}
-                  size="md"
                 />
               </div>
             </div>
             <div className="rounded-md border p-3" data-testid="x-agent-policy-global-invoke">
-              <div className="flex items-center justify-between">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <Send className="h-3.5 w-3.5 text-muted-foreground" />
-                    <span className="text-sm font-medium">Send messages to all agents</span>
-                  </div>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    Default for any agent without a specific Send setting below. Per-agent rows override this.
-                  </p>
-                </div>
-                <PolicyDecisionToggle
-                  value={getDecision('invoke', null)}
+              <div className="flex items-center justify-between gap-3">
+                <span className="min-w-0 flex-1 text-xs font-medium">
+                  Allow this agent to send messages to all other agents
+                </span>
+                <PolicyDecisionDropdown
+                  value={globalInvoke}
                   onChange={handleChange('invoke', null)}
-                  size="md"
                 />
               </div>
             </div>
           </div>
 
-          {/* Per-agent permissions */}
-          <div>
-            <div className="flex items-center justify-between gap-2">
-              <h4 className="text-xs font-medium uppercase text-muted-foreground">Per-agent permissions</h4>
-              {otherAgents.length > 0 && (
-                <div className="relative w-48">
-                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                  <Input
-                    placeholder="Filter agents..."
-                    value={filter}
-                    onChange={(e) => setFilter(e.target.value)}
-                    className="h-7 pl-7 text-xs"
-                  />
+          {/* Per-agent connections */}
+          {agentsQuery.data && agentsQuery.data.filter((a) => a.slug !== agentSlug).length === 0 ? (
+            <p className="text-sm text-muted-foreground">No other agents in this workspace yet.</p>
+          ) : (
+            <>
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between gap-2 px-1">
+                  <p className="text-[11px] uppercase tracking-wider font-medium text-muted-foreground">
+                    Connected
+                  </p>
+                  {searchOpen ? (
+                    <div className="relative w-44 max-w-full">
+                      <Search className="absolute left-1.5 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+                      <Input
+                        autoFocus
+                        placeholder="Filter agents..."
+                        value={filter}
+                        onChange={(e) => setFilter(e.target.value)}
+                        onBlur={() => {
+                          if (!filter.trim()) setSearchOpen(false)
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Escape') {
+                            setFilter('')
+                            setSearchOpen(false)
+                          }
+                        }}
+                        className="h-6 text-xs pl-6"
+                      />
+                    </div>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      className="h-6 w-6 px-0 text-muted-foreground"
+                      aria-label="Search agents"
+                      data-testid="x-agent-search-toggle"
+                      onClick={() => setSearchOpen(true)}
+                    >
+                      <Search className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
+                </div>
+                {connectedAgents.length > 0 ? (
+                  <IntegrationList>{connectedAgents.map(renderAgentRow)}</IntegrationList>
+                ) : (
+                  <div className="rounded-xl border border-dashed bg-background px-4 py-6 text-center">
+                    <p className="text-xs text-muted-foreground">
+                      {filter
+                        ? 'No connected agents match the filter.'
+                        : "This agent isn't connected to any other agents yet. Toggle one on below."}
+                    </p>
+                  </div>
+                )}
+              </div>
+              {notConnectedAgents.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-[11px] uppercase tracking-wider font-medium text-muted-foreground px-1">
+                    Not connected
+                  </p>
+                  <IntegrationList>{notConnectedAgents.map(renderAgentRow)}</IntegrationList>
                 </div>
               )}
-            </div>
+            </>
+          )}
 
-            {otherAgents.length === 0 ? (
-              <p className="mt-3 text-sm text-muted-foreground">
-                No other agents in this workspace yet.
-              </p>
-            ) : (
-              <div className="mt-2 space-y-1">
-                {/* Column headers */}
-                <div className="grid grid-cols-[1fr_auto_auto] items-center gap-3 px-2 py-1 text-[10px] font-medium uppercase text-muted-foreground">
-                  <span>Agent</span>
-                  <span className="text-center w-[120px]">Read sessions</span>
-                  <span className="text-center w-[120px]">Send messages</span>
-                </div>
-                {otherAgents.map((agent) => {
-                  const readKey = policyKey('read', agent.slug)
-                  const invokeKey = policyKey('invoke', agent.slug)
-                  const isSavingRow = savingKey === readKey || savingKey === invokeKey
-                  const invokeDecision = getDecision('invoke', agent.slug)
-                  const readDecision = getDecision('read', agent.slug)
-                  return (
-                    <div
-                      key={agent.slug}
-                      className="grid grid-cols-[1fr_auto_auto] items-center gap-3 rounded border px-2 py-2"
-                      data-testid={`x-agent-policy-row-${agent.slug}`}
-                    >
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium">{agent.name}</div>
-                        <div className="truncate text-[10px] font-mono text-muted-foreground">{agent.displaySlug}</div>
-                      </div>
-                      <div className="w-[120px] flex justify-center">
-                        <PolicyDecisionToggle
-                          value={readDecision}
-                          onChange={handleChange('read', agent.slug)}
-                        />
-                      </div>
-                      <div className="w-[120px] flex justify-center">
-                        <PolicyDecisionToggle
-                          value={invokeDecision}
-                          onChange={handleChange('invoke', agent.slug)}
-                        />
-                      </div>
-                      {isSavingRow && (
-                        <div className="col-span-3 -mt-1 text-right text-[10px] text-muted-foreground">
-                          Saving…
-                        </div>
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-            <p className="mt-3 text-[11px] text-muted-foreground">
-              <span className="font-medium">Read</span> and <span className="font-medium">Send messages</span> are independent.
-              Allow only Send for &quot;trigger but don&apos;t browse history&quot;; allow only Read for view-only access.
-              Sync invoke responses are always returned to the caller — they don&apos;t require Read.
-            </p>
-          </div>
         </div>
       )}
     </SettingsPageContainer>

--- a/src/renderer/components/agents/x-agent-permissions/x-agent-permissions-view.tsx
+++ b/src/renderer/components/agents/x-agent-permissions/x-agent-permissions-view.tsx
@@ -44,6 +44,10 @@ interface PolicyChange {
   decision: DecisionOrDefault
 }
 
+interface PolicyMutation extends PolicyChange {
+  rollbackConnectionOverride?: boolean
+}
+
 type AgentsResponse = ApiAgent[]
 
 function policyKey(operation: Operation, targetSlug: string | null): string {
@@ -55,9 +59,9 @@ function policyKey(operation: Operation, targetSlug: string | null): string {
  * this agent has remembered for listing, reading, and messaging other
  * workspace agents. Presented like the Agent Connections page: a Switch per
  * target agent ("connected" = it may send messages, the same relationship a
- * drawn home-graph edge creates). Connected rows carry a Permissions popover
- * with the fine-grained controls (Read / Send × Allow / Review / Block);
- * every state is reachable by connecting first, then tuning there.
+ * drawn home-graph edge creates). Every row carries a Permissions popover with
+ * the independent fine-grained controls (Read / Send × Allow / Review /
+ * Block), so inspecting or changing one permission never grants the other.
  */
 export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps) {
   useRenderTracker('XAgentPermissionsView')
@@ -69,6 +73,7 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
   const [filter, setFilter] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [pendingKeys, setPendingKeys] = useState<Set<string>>(() => new Set())
   /**
    * Optimistic per-slug connected state so a toggled row animates to its new
    * section immediately (mirrors connections-list grantOverrides). Cleared by
@@ -85,6 +90,7 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
     setFilter('')
     setSearchOpen(false)
     setError(null)
+    setPendingKeys(new Set())
     setConnectOverrides({})
   }, [agentSlug])
 
@@ -169,53 +175,6 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
       .sort((a, b) => a.name.localeCompare(b.name))
   }, [agentsQuery.data, agentSlug, filter])
 
-  // Single mutation: build the full policy set with the changes applied, PUT it.
-  const savePolicies = useMutation({
-    meta: { skipGlobalErrorToast: true },
-    mutationFn: async (changes: PolicyChange[]) => {
-      setError(null)
-      const changed = new Set(changes.map((c) => policyKey(c.operation, c.targetSlug)))
-      const nextPolicies: Array<{ operation: Operation; targetSlug: string | null; decision: Decision }> = []
-      for (const p of policiesQuery.data?.policies ?? []) {
-        if (changed.has(policyKey(p.operation, p.targetAgentSlug))) continue
-        nextPolicies.push({ operation: p.operation, targetSlug: p.targetAgentSlug, decision: p.decision })
-      }
-      for (const c of changes) {
-        if (c.decision !== 'default') {
-          nextPolicies.push({ operation: c.operation, targetSlug: c.targetSlug, decision: c.decision })
-        }
-      }
-      const res = await apiFetch(`/api/agents/${agentSlug}/x-agent-policies`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ policies: nextPolicies }),
-      })
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        throw new Error(data.error || 'Failed to save policy')
-      }
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['x-agent-policies', agentSlug] })
-    },
-    onError: (err: Error) => {
-      setError(err.message)
-    },
-  })
-
-  const handleChange = (operation: Operation, targetSlug: string | null) => (next: DecisionOrDefault) => {
-    savePolicies.mutate([{ operation, targetSlug, decision: next }])
-  }
-
-  /** The Switch spinner: an in-flight change to this slug's send policy. */
-  const isSwitchPending = (slug: string): boolean =>
-    savePolicies.isPending &&
-    (savePolicies.variables ?? []).some((c) => c.targetSlug === slug && c.operation === 'invoke')
-
-  /** The detail panel's saving hint: any in-flight change for this slug. */
-  const isRowSaving = (slug: string): boolean =>
-    savePolicies.isPending && (savePolicies.variables ?? []).some((c) => c.targetSlug === slug)
-
   const setOverride = (slug: string, value: boolean | null) => {
     startViewTransition(() => {
       flushSync(() => {
@@ -229,25 +188,87 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
     })
   }
 
+  // Each control updates exactly one row. The API applies the change atomically,
+  // so independent edits can be in flight together without whole-list last-write-wins.
+  const savePolicy = useMutation({
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async (change: PolicyMutation) => {
+      setError(null)
+      const res = await apiFetch(`/api/agents/${agentSlug}/x-agent-policies`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          operation: change.operation,
+          targetSlug: change.targetSlug,
+          decision: change.decision,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to save policy')
+      }
+    },
+    onMutate: (change) => {
+      const key = policyKey(change.operation, change.targetSlug)
+      setPendingKeys((prev) => new Set(prev).add(key))
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries({ queryKey: ['x-agent-policies', agentSlug] })
+    },
+    onError: (err: Error, change) => {
+      setError(err.message)
+      if (change.rollbackConnectionOverride && change.targetSlug !== null) {
+        setOverride(change.targetSlug, null)
+      }
+    },
+    onSettled: (_data, _error, change) => {
+      const key = policyKey(change.operation, change.targetSlug)
+      setPendingKeys((prev) => {
+        const next = new Set(prev)
+        next.delete(key)
+        return next
+      })
+    },
+  })
+
+  const handleChange = (operation: Operation, targetSlug: string | null) => (next: DecisionOrDefault) => {
+    if (pendingKeys.has(policyKey(operation, targetSlug))) return
+    savePolicy.mutate({ operation, targetSlug, decision: next })
+  }
+
+  /** The Switch spinner: an in-flight change to this slug's send policy. */
+  const isSwitchPending = (slug: string): boolean => pendingKeys.has(policyKey('invoke', slug))
+
+  /** The detail panel's saving hint: any in-flight change for this slug. */
+  const isRowSaving = (slug: string): boolean =>
+    pendingKeys.has(policyKey('read', slug)) || pendingKeys.has(policyKey('invoke', slug))
+
   const handleToggle = (slug: string, next: boolean) => {
+    if (isSwitchPending(slug)) return
     if (next) {
       // Connect = grant Send (the graph-edge relationship). The connected
       // row's Permissions popover is where Read is granted or Send dialed
       // back. Deliberately replaces an explicit Block, like drawing the edge
       // on the graph does.
       setOverride(slug, true)
-      savePolicies.mutate([{ operation: 'invoke', targetSlug: slug, decision: 'allow' }], {
-        onError: () => setOverride(slug, null),
+      savePolicy.mutate({
+        operation: 'invoke',
+        targetSlug: slug,
+        decision: 'allow',
+        rollbackConnectionOverride: true,
       })
       return
     }
-    // Disconnect: remove the explicit send grant; when connected only via the
-    // global default, pin an explicit Review so this one agent prompts again.
-    const explicit = getDecision('invoke', slug)
-    const decision: DecisionOrDefault = explicit !== 'default' ? 'default' : 'review'
+    // Disconnect: inherit when the fallback is not allowed; if the global
+    // default allows Send, pin Review so removing an explicit allow cannot
+    // leave this target effectively connected.
+    const decision: DecisionOrDefault = globalInvoke === 'allow' ? 'review' : 'default'
     setOverride(slug, false)
-    savePolicies.mutate([{ operation: 'invoke', targetSlug: slug, decision }], {
-      onError: () => setOverride(slug, null),
+    savePolicy.mutate({
+      operation: 'invoke',
+      targetSlug: slug,
+      decision,
+      rollbackConnectionOverride: true,
     })
   }
 
@@ -272,7 +293,7 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
           viewTransitionName={`xagent-${slug}`}
           right={
             <>
-              {connected && !pending && (
+              {!pending && (
                 <Popover>
                   <PopoverTrigger asChild>
                     <button
@@ -296,6 +317,7 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
                       <PolicyDecisionDropdown
                         value={getDecision('read', slug)}
                         onChange={handleChange('read', slug)}
+                        disabled={pendingKeys.has(policyKey('read', slug))}
                       />
                     </div>
                     <div className="flex items-center justify-between gap-3">
@@ -303,6 +325,7 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
                       <PolicyDecisionDropdown
                         value={getDecision('invoke', slug)}
                         onChange={handleChange('invoke', slug)}
+                        disabled={pendingKeys.has(policyKey('invoke', slug))}
                       />
                     </div>
                     {isRowSaving(slug) && (
@@ -380,6 +403,7 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
                 <PolicyDecisionDropdown
                   value={getDecision('list', null)}
                   onChange={handleChange('list', null)}
+                  disabled={pendingKeys.has(policyKey('list', null))}
                 />
               </div>
             </div>
@@ -391,6 +415,7 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
                 <PolicyDecisionDropdown
                   value={globalRead}
                   onChange={handleChange('read', null)}
+                  disabled={pendingKeys.has(policyKey('read', null))}
                 />
               </div>
             </div>
@@ -402,6 +427,7 @@ export function XAgentPermissionsView({ agentSlug }: XAgentPermissionsViewProps)
                 <PolicyDecisionDropdown
                   value={globalInvoke}
                   onChange={handleChange('invoke', null)}
+                  disabled={pendingKeys.has(policyKey('invoke', null))}
                 />
               </div>
             </div>

--- a/src/renderer/components/connections/integration-row.tsx
+++ b/src/renderer/components/connections/integration-row.tsx
@@ -33,7 +33,12 @@ export function IntegrationList({ children, className, variant = 'list' }: Integ
 
 interface IntegrationRowProps {
   iconSlug?: string
-  iconFallback: IntegrationIconFallback
+  iconFallback?: IntegrationIconFallback
+  /**
+   * Custom icon node rendered inside the muted square instead of ServiceIcon;
+   * pass `null` to omit the icon square entirely.
+   */
+  icon?: ReactNode | null
   name: ReactNode
   /** Inline badge/chip rendered next to the name on the same row. */
   nameBadge?: ReactNode
@@ -64,6 +69,7 @@ interface IntegrationRowProps {
 export function IntegrationRow({
   iconSlug,
   iconFallback,
+  icon,
   name,
   nameBadge,
   subtitle,
@@ -102,13 +108,17 @@ export function IntegrationRow({
       }
     >
       <div className="flex items-center gap-3">
-        <div className="h-7 w-7 rounded-md bg-muted dark:bg-zinc-200 flex items-center justify-center shrink-0">
-          <ServiceIcon
-            slug={iconSlug}
-            fallback={iconFallback}
-            className="h-4 w-4 text-muted-foreground/60"
-          />
-        </div>
+        {icon !== null && (
+          <div className="h-7 w-7 rounded-md bg-muted dark:bg-zinc-200 flex items-center justify-center shrink-0">
+            {icon ?? (
+              <ServiceIcon
+                slug={iconSlug}
+                fallback={iconFallback ?? 'blocks'}
+                className="h-4 w-4 text-muted-foreground/60"
+              />
+            )}
+          </div>
+        )}
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 min-w-0">
             <span className="text-xs font-medium truncate">{name}</span>

--- a/src/renderer/components/ui/policy-decision-toggle.tsx
+++ b/src/renderer/components/ui/policy-decision-toggle.tsx
@@ -133,6 +133,7 @@ export function PolicyDecisionDropdown({
   onChange,
   className,
   includeDefault = true,
+  disabled = false,
 }: {
   value: PolicyDecision
   onChange: (value: PolicyDecision) => void
@@ -143,19 +144,23 @@ export function PolicyDecisionDropdown({
    * `allowDeselect={false}`.
    */
   includeDefault?: boolean
+  /** Prevent another write for this policy while its current change is saving. */
+  disabled?: boolean
 }) {
   const [open, setOpen] = useState(false)
   const current = options.find((o) => o.value === value)
   const CurrentIcon = current?.icon
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={(next) => !disabled && setOpen(next)}>
       <PopoverTrigger asChild>
         <button
           type="button"
+          disabled={disabled}
           data-testid="policy-dropdown-trigger"
           data-decision={value}
           className={cn(
             'flex h-7 w-36 items-center gap-1.5 whitespace-nowrap rounded-md border border-input bg-transparent px-2 text-xs shadow-sm focus:outline-none focus:ring-1 focus:ring-ring',
+            disabled && 'cursor-wait opacity-60',
             className,
           )}
         >

--- a/src/shared/lib/services/x-agent-policy-service.ts
+++ b/src/shared/lib/services/x-agent-policy-service.ts
@@ -136,6 +136,25 @@ export async function setPolicy(
   })
 }
 
+/** Delete the exact policy row(s) for (caller, operation, target). */
+export function deletePolicy(
+  callerSlug: string,
+  operation: XAgentOperation,
+  targetSlug: string | null,
+): number {
+  const result = db
+    .delete(xAgentPolicies)
+    .where(
+      and(
+        eq(xAgentPolicies.callerAgentSlug, callerSlug),
+        eq(xAgentPolicies.operation, operation),
+        targetMatch(targetSlug),
+      ),
+    )
+    .run()
+  return result.changes
+}
+
 /**
  * Delete the specific-target policy rows for (caller, operation, target).
  * With `preserveBlock`, 'block' rows survive: revoking a granted edge must
@@ -149,6 +168,9 @@ export function deleteTargetPolicy(
   targetSlug: string,
   options?: { preserveBlock?: boolean },
 ): number {
+  if (!options?.preserveBlock) {
+    return deletePolicy(callerSlug, operation, targetSlug)
+  }
   const conditions = [
     eq(xAgentPolicies.callerAgentSlug, callerSlug),
     eq(xAgentPolicies.operation, operation),


### PR DESCRIPTION
**Stack 3/3** — stacked on #656 (and #655); merge bottom-up.

Replaces the per-agent policy table with the Agent Connections page pattern:

- **Connected / Not connected** sections of `IntegrationRow`s with a Switch per agent. Connected = the target may be messaged without a prompt (send = allow, explicit or inherited from the global send default) — the same relationship a drawn home-graph edge creates.
- **Toggle on** grants Send immediately (deliberately replaces an explicit Block, like drawing the edge). **Toggle off** removes the grant, or pins an explicit Review when the agent was connected only via the global default — so you can carve exceptions out of a global allow.
- A hover-revealed **Permissions** popover on every row holds the fine-grained Read/Send dropdown controls (`PolicyDecisionDropdown`); explicitly blocked agents get a "Blocked" badge, so every state remains reachable without first connecting.
- Policy changes use atomic single-policy updates, preventing concurrent edits from overwriting one another.
- Rows animate between sections with view transitions + optimistic overrides, mirroring `connections-list`.
- Global permissions become one-line rows ("Allow this agent to …") with dropdown selectors; the filter collapses to the icon-button search from the scope-policy editor; page header reads "Connect this agent to others".
- `IntegrationRow` accepts `icon={null}` to omit its icon square (agent rows have no service icon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
