### PR TITLE
Add reliable dashboard subpath support

### DIFF
--- a/agent-container/skills/dashboards/SKILL.md
+++ b/agent-container/skills/dashboards/SKILL.md
@@ -19,7 +19,7 @@ You can create web dashboards that are served to the user through the Gamut UI. 
 
 1. Copy the template: `cp -r ~/.claude/skills/dashboards/templates/react-vite /workspace/artifacts/<slug>`
 2. Update `package.json` with the dashboard's `name` and `description`
-3. Edit `src/App.jsx` to build the UI (add API routes in `serve.js` if needed). **All fetch calls in the frontend MUST use relative URLs** — `fetch('api/data')` not `fetch('/api/data')` — absolute paths will 404.
+3. Edit `src/App.jsx` to build the UI (add API routes in `serve.js` if needed). Build dashboard-scoped URLs with `window.__GAMUT_DASHBOARD__.url('api/data')`.
 4. Use `start_dashboard` to build and start the server; inspect its screenshot and note the returned port
 5. Open `http://localhost:<port>` with `browser_open(..., location="container")`, exercise the important interactions, and check browser errors
 6. Iterate until both visual and functional checks pass; close the browser when validation is complete
@@ -83,7 +83,8 @@ The template structure:
 ```
 /workspace/artifacts/<slug>/
 ├── package.json        # Update name + description
-├── vite.config.js      # Pre-configured with base: './' (DO NOT remove this)
+├── gamut-dashboard.js  # Gamut base-path + Vite/HMR adapter
+├── vite.config.js      # Uses the Gamut adapter
 ├── serve.js            # Static server with API route support
 ├── index.html
 └── src/
@@ -91,9 +92,9 @@ The template structure:
     └── App.jsx          # Edit this to build your dashboard
 ```
 
-React dashboards are **built to static files** (`vite build`) and served via `serve.js`. The start script runs `bun run build && bun run serve.js`. Vite's dev server cannot be used because dashboards are served through a proxy chain.
+React dashboards are **built to static files** (`vite build`) and served via `serve.js` by default. The start script runs `bun run build && bun run serve.js`. The included adapter also supports the Vite dev server and keeps HMR beneath the artifact mount.
 
-**CRITICAL:** `vite.config.js` must include `base: './'` so that built asset paths are relative. Without this, the built HTML will reference `/assets/...` (absolute), which bypasses the proxy chain and 404s. The template already has this configured — do not remove it.
+**CRITICAL:** Keep `gamutDashboard()` in `vite.config.js`. The dashboard manager supplies `DASHBOARD_BASE_PATH`; in development the adapter applies it to Vite's entry modules and HMR client. Production assets, dynamic imports, CSS/worker URLs, fonts, and images remain relative, while `serve.js` and the injected runtime provide a stable document/router base. This keeps one production build relocatable.
 
 ### Adding API routes to a React dashboard
 
@@ -107,7 +108,7 @@ if (url.pathname === '/api/data') {
 }
 
 // Static files are served automatically for all other paths
-return serveStatic(url.pathname);
+return serveStatic(req, url.pathname);
 ```
 
 ## URL Paths & Proxying
@@ -117,18 +118,47 @@ Dashboards are served through a proxy chain:
 Browser → Main App (/api/agents/:id/artifacts/:slug/) → Container → Dashboard Server
 ```
 
-**IMPORTANT: Always use relative URLs in dashboard code.** The dashboard is served under a subpath, so absolute paths (starting with `/`) will bypass the proxy and hit the main app instead.
+Gamut strips the public artifact prefix before forwarding requests to the dashboard server. It communicates that mount through `DASHBOARD_BASE_PATH` in the process, `X-Forwarded-Prefix` on HTTP/WebSocket requests, and `window.__GAMUT_DASHBOARD__` in browser HTML.
+
+Use the injected helper for dashboard-owned URLs. It stays correct on nested client routes and when another trusted proxy adds its own prefix:
 
 ```javascript
-// CORRECT — relative paths are proxied to your dashboard server
-fetch('api/data')
-fetch('./api/data')
+const { basePath, routerBasePath, url } = window.__GAMUT_DASHBOARD__;
 
-// WRONG — absolute paths bypass the proxy, hitting the main app
-fetch('/api/data')
+fetch(url('api/data'));
+image.src = url('assets/chart.png');
+
+// React Router and similar SPA routers need the runtime router base, which is
+// intentionally separate from Vite's build-time asset base.
+// <BrowserRouter basename={routerBasePath}>...</BrowserRouter>
 ```
 
-This applies to all fetches, image sources, link hrefs, etc.
+Root-relative application URLs such as `/api/data` still target the Gamut host and must not be used for dashboard-owned routes.
+
+### Third-party Vite apps and OpenSlide
+
+Frameworks that accept a base at startup can consume the manager-provided value directly:
+
+```ts
+// open-slide.config.ts
+import type { OpenSlideConfig } from '@open-slide/core';
+
+const config: OpenSlideConfig = {
+  base: process.env.DASHBOARD_BASE_PATH || './',
+};
+
+export default config;
+```
+
+For an app-owned React Router, prefer the injected runtime value:
+
+```tsx
+<BrowserRouter basename={window.__GAMUT_DASHBOARD__?.routerBasePath ?? '/'}>
+  <App />
+</BrowserRouter>
+```
+
+Do not patch generated bundles after Vite hashes them and do not add a query string to only one copy of an entry module. Both approaches violate module/cache identity and can leave stale router code or duplicate React instances.
 
 ## Interactive Validation
 
@@ -148,7 +178,7 @@ The following APIs are automatically available in all dashboards (injected by th
 
 - **Keep dependencies minimal** — fewer deps means faster installs and starts
 - **Always use `process.env.DASHBOARD_PORT`** — never hardcode ports
-- **Always use relative URLs** — absolute paths bypass the dashboard proxy (see above)
+- **Use the dashboard URL helper** — `window.__GAMUT_DASHBOARD__.url(...)` keeps URLs inside the mount
 - **Use Bun APIs** — `Bun.serve()`, `Bun.file()`, etc. are fast and built-in
 - **Check logs on errors** — use `get_dashboard_logs` to debug crashes
 - **Restart after changes** — use `start_dashboard` after modifying source code

--- a/agent-container/skills/dashboards/templates/react-vite/gamut-dashboard.js
+++ b/agent-container/skills/dashboards/templates/react-vite/gamut-dashboard.js
@@ -6,6 +6,54 @@
  * stays relative so the same build can be relocated; the static server/runtime
  * supplies the document base and routers use the injected runtime basename.
  */
+function scriptString(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+/** Runtime used only when a dashboard is opened directly, outside the host proxy. */
+export function getGamutDashboardRuntimeFallbackJs(
+  slug = process.env.DASHBOARD_ARTIFACT_SLUG || '',
+) {
+  return `
+(function () {
+  if (window.__GAMUT_DASHBOARD__) return;
+
+  var marker = "/api/agents/";
+  var pathname = window.location.pathname || "/";
+  var markerAt = pathname.indexOf(marker);
+  var basePath = "/";
+
+  if (markerAt >= 0) {
+    var segments = pathname.slice(markerAt + marker.length).split("/");
+    if (segments.length >= 3 && segments[0] && segments[1] === "artifacts" && segments[2]) {
+      basePath = pathname.slice(0, markerAt) + marker + segments[0] + "/artifacts/" + segments[2] + "/";
+    }
+  }
+
+  function dashboardUrl(path) {
+    var value = path == null ? "" : String(path);
+    if (!value || value === ".") return basePath;
+    if (value.charAt(0) === "?" || value.charAt(0) === "#") return basePath + value;
+    value = value.replace(/^\\.\\//, "").replace(/^\\/+/, "");
+
+    var origin = "http://gamut.invalid";
+    var resolved = new URL(value, origin + basePath);
+    if (resolved.origin !== origin || resolved.pathname.indexOf(basePath) !== 0) {
+      throw new TypeError("Dashboard URLs cannot escape the dashboard mount");
+    }
+    return resolved.pathname + resolved.search + resolved.hash;
+  }
+
+  window.__GAMUT_DASHBOARD__ = Object.freeze({
+    basePath: basePath,
+    routerBasePath: basePath === "/" ? "/" : basePath.slice(0, -1),
+    slug: ${scriptString(slug)},
+    url: dashboardUrl
+  });
+})();
+`;
+}
+
 export function gamutDashboard() {
   const basePath = process.env.DASHBOARD_BASE_PATH || './';
 
@@ -28,6 +76,14 @@ export function gamutDashboard() {
             }
           : {}),
       };
+    },
+    transformIndexHtml() {
+      return [{
+        tag: 'script',
+        attrs: { 'data-gamut-dashboard-fallback': 'true' },
+        children: getGamutDashboardRuntimeFallbackJs(),
+        injectTo: 'head-prepend',
+      }];
     },
     configureServer(server) {
       if (!basePath.startsWith('/') || basePath === '/') return;

--- a/agent-container/skills/dashboards/templates/react-vite/gamut-dashboard.js
+++ b/agent-container/skills/dashboards/templates/react-vite/gamut-dashboard.js
@@ -1,0 +1,49 @@
+/**
+ * Minimal Vite adapter for Gamut's prefix-stripping dashboard proxy.
+ *
+ * The dashboard manager supplies DASHBOARD_BASE_PATH at process startup. Vite
+ * then emits dev modules and its HMR client beneath the public mount. Production
+ * stays relative so the same build can be relocated; the static server/runtime
+ * supplies the document base and routers use the injected runtime basename.
+ */
+export function gamutDashboard() {
+  const basePath = process.env.DASHBOARD_BASE_PATH || './';
+
+  return {
+    name: 'gamut-dashboard',
+    config(_config, env) {
+      const port = Number(process.env.DASHBOARD_PORT);
+      const viteBase = env.command === 'serve' ? basePath : './';
+
+      return {
+        base: viteBase,
+        appType: 'spa',
+        ...(env.command === 'serve' && Number.isInteger(port) && port > 0
+          ? {
+              server: {
+                host: '0.0.0.0',
+                port,
+                strictPort: true,
+              },
+            }
+          : {}),
+      };
+    },
+    configureServer(server) {
+      if (!basePath.startsWith('/') || basePath === '/') return;
+
+      const mount = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+
+      // Gamut removes the browser-visible artifact mount before dialing a
+      // dashboard. Vite expects inbound dev-module URLs to contain the same
+      // `base` it emitted into HTML, so restore it inside Vite only.
+      server.middlewares.use((request, _response, next) => {
+        const requestUrl = request.url || '/';
+        if (requestUrl !== mount && !requestUrl.startsWith(`${mount}/`)) {
+          request.url = `${mount}${requestUrl.startsWith('/') ? '' : '/'}${requestUrl}`;
+        }
+        next();
+      });
+    },
+  };
+}

--- a/agent-container/skills/dashboards/templates/react-vite/package.json
+++ b/agent-container/skills/dashboards/templates/react-vite/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "bunx --bun vite build",
+    "dev": "bunx --bun vite",
     "start": "bun run build && bun run serve.js"
   },
   "dependencies": {

--- a/agent-container/skills/dashboards/templates/react-vite/serve.js
+++ b/agent-container/skills/dashboards/templates/react-vite/serve.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const port = process.env.DASHBOARD_PORT || 3000;
 const distDir = path.join(__dirname, 'dist');
+const publicBasePath = process.env.DASHBOARD_BASE_PATH || '';
 
 const mimeTypes = {
   '.html': 'text/html',
@@ -13,14 +14,70 @@ const mimeTypes = {
   '.json': 'application/json',
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
   '.svg': 'image/svg+xml',
   '.ico': 'image/x-icon',
   '.woff': 'font/woff',
   '.woff2': 'font/woff2',
 };
 
-function serveStatic(pathname) {
-  let filePath = path.join(distDir, pathname === '/' ? 'index.html' : pathname);
+function stripPublicBase(pathname) {
+  if (!publicBasePath) return pathname;
+  const mount = publicBasePath.endsWith('/') ? publicBasePath.slice(0, -1) : publicBasePath;
+  if (pathname === mount) return '/';
+  if (pathname.startsWith(`${mount}/`)) return pathname.slice(mount.length) || '/';
+  return pathname;
+}
+
+function cacheControl(filePath) {
+  if (filePath.endsWith('index.html')) return 'no-cache';
+  if (/[/\\]assets[/\\].+-[A-Za-z0-9_-]{8,}\.[^/\\]+$/.test(filePath)) {
+    return 'public, max-age=31536000, immutable';
+  }
+  return 'no-cache';
+}
+
+function escapeHtmlAttribute(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function withDocumentBase(html) {
+  if (/<base\b[^>]*>/i.test(html)) return html;
+  const href = publicBasePath || '/';
+  const tag = `<base data-gamut-dashboard-base href="${escapeHtmlAttribute(href)}">`;
+  return html.replace(/<head(\s[^>]*)?>/i, (head) => `${head}${tag}`);
+}
+
+function responseForFile(filePath) {
+  try {
+    const ext = path.extname(filePath).toLowerCase();
+    const file = fs.readFileSync(filePath);
+    const content = ext === '.html' ? withDocumentBase(file.toString('utf8')) : file;
+    return new Response(content, {
+      headers: {
+        'Cache-Control': cacheControl(filePath),
+        'Content-Type': mimeTypes[ext] || 'application/octet-stream',
+      },
+    });
+  } catch {
+    return new Response('Not Found', { status: 404 });
+  }
+}
+
+function serveStatic(request, rawPathname) {
+  const pathname = stripPublicBase(rawPathname);
+  const relativePath = pathname === '/' ? 'index.html' : pathname.replace(/^\/+/, '');
+  let filePath = path.resolve(distDir, relativePath);
+
+  if (filePath !== distDir && !filePath.startsWith(`${distDir}${path.sep}`)) {
+    return new Response('Not Found', { status: 404 });
+  }
 
   try {
     const stat = fs.statSync(filePath);
@@ -28,23 +85,17 @@ function serveStatic(pathname) {
       filePath = path.join(filePath, 'index.html');
     }
   } catch {
-    // File not found — serve index.html for SPA client-side routing,
-    // but only for non-API paths (API misses should 404, not return HTML)
-    if (pathname.startsWith('/api/') || pathname.startsWith('/api')) {
+    // Only document navigations receive SPA fallback. A missing module, style,
+    // image, worker, or API route must be a real 404 rather than index.html with
+    // a misleading text/html MIME type.
+    const acceptsHtml = request.headers.get('accept')?.includes('text/html');
+    if (request.method !== 'GET' || !acceptsHtml || pathname.startsWith('/api')) {
       return new Response('Not Found', { status: 404 });
     }
     filePath = path.join(distDir, 'index.html');
   }
 
-  try {
-    const content = fs.readFileSync(filePath);
-    const ext = path.extname(filePath);
-    return new Response(content, {
-      headers: { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' },
-    });
-  } catch {
-    return new Response('Not Found', { status: 404 });
-  }
+  return responseForFile(filePath);
 }
 
 const server = Bun.serve({
@@ -58,7 +109,7 @@ const server = Bun.serve({
     //     return Response.json({ items: [1, 2, 3] });
     //   }
 
-    return serveStatic(url.pathname);
+    return serveStatic(req, url.pathname);
   },
 });
 

--- a/agent-container/skills/dashboards/templates/react-vite/serve.js
+++ b/agent-container/skills/dashboards/templates/react-vite/serve.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
+import { getGamutDashboardRuntimeFallbackJs } from './gamut-dashboard.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const port = process.env.DASHBOARD_PORT || 3000;
@@ -48,10 +49,14 @@ function escapeHtmlAttribute(value) {
 }
 
 function withDocumentBase(html) {
-  if (/<base\b[^>]*>/i.test(html)) return html;
   const href = publicBasePath || '/';
-  const tag = `<base data-gamut-dashboard-base href="${escapeHtmlAttribute(href)}">`;
-  return html.replace(/<head(\s[^>]*)?>/i, (head) => `${head}${tag}`);
+  const baseTag = /<base\b[^>]*>/i.test(html)
+    ? ''
+    : `<base data-gamut-dashboard-base href="${escapeHtmlAttribute(href)}">`;
+  const runtimeTag = html.includes('data-gamut-dashboard-fallback')
+    ? ''
+    : `<script data-gamut-dashboard-fallback="true">${getGamutDashboardRuntimeFallbackJs()}</script>`;
+  return html.replace(/<head(\s[^>]*)?>/i, (head) => `${head}${baseTag}${runtimeTag}`);
 }
 
 function responseForFile(filePath) {

--- a/agent-container/skills/dashboards/templates/react-vite/src/App.jsx
+++ b/agent-container/skills/dashboards/templates/react-vite/src/App.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-// IMPORTANT: All fetch calls MUST use relative URLs (no leading slash).
-//   CORRECT: fetch('api/data')
-//   WRONG:   fetch('/api/data')   <-- absolute paths bypass the proxy and will 404
+// Use the injected mount helper for URLs that must remain dashboard-scoped.
+//   window.__GAMUT_DASHBOARD__.url('api/data')
 
 export default function App() {
   return (

--- a/agent-container/skills/dashboards/templates/react-vite/vite.config.js
+++ b/agent-container/skills/dashboards/templates/react-vite/vite.config.js
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { gamutDashboard } from './gamut-dashboard.js';
 
 export default defineConfig({
-  plugins: [react()],
-  base: './',
+  plugins: [react(), gamutDashboard()],
   build: {
     outDir: 'dist',
   },

--- a/agent-container/src/dashboard-builder-agent-prompt.md
+++ b/agent-container/src/dashboard-builder-agent-prompt.md
@@ -100,7 +100,7 @@ Bun.serve({
 **Client-side periodic refresh:**
 ```javascript
 async function refreshData() {
-  const res = await fetch('api/data');      // client: relative, NOT '/api/data' (absolute bypasses the proxy and 404s)
+  const res = await fetch(window.__GAMUT_DASHBOARD__.url('api/data'));
   const data = await res.json();
   renderChart(data);
 }
@@ -262,7 +262,7 @@ Rate limited to 100 req/min. This is the full Anthropic JS SDK (lazy-loaded) —
 - **Close the browser when validation is complete.**
 - **Install dependencies before starting.** If you add npm packages to `package.json`, run `bun install` in the dashboard directory, or just use `bun add <package>` which both installs and updates package.json.
 - **Use the DASHBOARD_PORT environment variable.** Never hardcode a port number.
-- **Always use relative URLs in client-side code, never absolute.** Dashboards are served under a subpath (`/api/agents/:id/artifacts/:slug/`), so `fetch('/api/data')` bypasses the proxy and 404s - write `fetch('api/data')` instead. Applies to every fetch, `img src`, and `href`.
+- **Use the injected dashboard URL helper for client-side URLs.** Dashboards are served under a subpath, so `fetch('/api/data')` bypasses the proxy. Write `fetch(window.__GAMUT_DASHBOARD__.url('api/data'))`; the same helper applies to images and links. SPA routers should use `window.__GAMUT_DASHBOARD__.routerBasePath` as their basename.
 
 ## Response Format
 

--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -8,6 +8,7 @@ import {
   validateSlug,
   SLUG_REGEX,
   ARTIFACTS_DIR,
+  getDashboardBasePath,
   truncateOversizedLog,
 } from './dashboard-manager'
 
@@ -106,6 +107,19 @@ describe('validateSlug', () => {
       const resolved = path.resolve(ARTIFACTS_DIR, '..', 'etc')
       expect(resolved.startsWith(ARTIFACTS_DIR + '/')).toBe(false)
     })
+  })
+})
+
+describe('getDashboardBasePath', () => {
+  it('builds the browser-visible artifact prefix from trusted startup identity', () => {
+    expect(getDashboardBasePath('open-slide', 'agent-123')).toBe(
+      '/api/agents/agent-123/artifacts/open-slide/',
+    )
+  })
+
+  it('omits startup metadata when no valid agent identity is available', () => {
+    expect(getDashboardBasePath('open-slide', '')).toBeNull()
+    expect(getDashboardBasePath('open-slide', '../spoofed')).toBeNull()
   })
 })
 
@@ -304,6 +318,33 @@ describe('DashboardManager log stream lifecycle', () => {
 
       expect(spawns.map((s) => s.args)).toEqual([['install'], ['run', 'start']])
       expect(info.status).toBe('running')
+    })
+
+    it('passes dashboard mount metadata to the dashboard process', async () => {
+      const slug = await scaffoldDashboard()
+      let dashboardEnv: NodeJS.ProcessEnv | undefined
+      process.env.SUPERAGENT_AGENT_ID = 'agent-123'
+      spawnHolder.impl = (_command, args, options) => {
+        const proc = new FakeChildProcess()
+        procs.push(proc)
+        if (args[0] === 'install') {
+          setImmediate(() => proc.exit(0))
+        } else {
+          dashboardEnv = (options as { env?: NodeJS.ProcessEnv }).env
+        }
+        return proc
+      }
+
+      try {
+        await manager.startDashboard(slug)
+      } finally {
+        delete process.env.SUPERAGENT_AGENT_ID
+      }
+
+      expect(dashboardEnv?.DASHBOARD_BASE_PATH).toBe(
+        `/api/agents/agent-123/artifacts/${slug}/`,
+      )
+      expect(dashboardEnv?.DASHBOARD_ARTIFACT_SLUG).toBe(slug)
     })
 
     it('boot start skips install when node_modules is fresh', async () => {

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -70,6 +70,25 @@ export function validateSlug(slug: string): void {
   }
 }
 
+/**
+ * Browser-visible mount supplied to framework build/dev tooling.
+ *
+ * The agent id is injected by the host when the container starts. Dashboards
+ * still work without it (for direct development and older hosts), but only a
+ * host-provided id can form the public Gamut path without hardcoding it in the
+ * dashboard itself.
+ */
+export function getDashboardBasePath(
+  slug: string,
+  agentId: string | undefined = process.env.SUPERAGENT_AGENT_SLUG
+    || process.env.SUPERAGENT_AGENT_ID,
+): string | null {
+  validateSlug(slug)
+  const normalizedAgentId = agentId?.trim()
+  if (!normalizedAgentId || !/^[A-Za-z0-9._-]+$/.test(normalizedAgentId)) return null
+  return `/api/agents/${encodeURIComponent(normalizedAgentId)}/artifacts/${slug}/`
+}
+
 export type DashboardStatus = 'running' | 'stopped' | 'crashed' | 'starting'
 
 interface DashboardInfo {
@@ -234,11 +253,14 @@ class DashboardManager {
       await this.runBunInstallIfNeeded(dashboardDir, info.logStream, forceInstall)
 
       // Start the dashboard server
+      const dashboardBasePath = getDashboardBasePath(slug)
       const proc = spawn('bun', ['run', 'start'], {
         cwd: dashboardDir,
         env: {
           ...process.env,
           DASHBOARD_PORT: String(port),
+          ...(dashboardBasePath ? { DASHBOARD_BASE_PATH: dashboardBasePath } : {}),
+          DASHBOARD_ARTIFACT_SLUG: slug,
           PORT: String(port),
           NODE_ENV: 'production',
         },

--- a/agent-container/src/dashboard-proxy.test.ts
+++ b/agent-container/src/dashboard-proxy.test.ts
@@ -1,11 +1,28 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  dashboardHttpForwardHeaders,
   dashboardWebSocketForwardHeaders,
   dashboardWebSocketUpstreamPath,
   parseDashboardProxyRoute,
   requestedWebSocketProtocols,
 } from './dashboard-proxy'
+
+describe('dashboard HTTP headers', () => {
+  it('preserves request metadata without exposing the host credential', () => {
+    const headers = dashboardHttpForwardHeaders({
+      host: 'container.internal',
+      cookie: 'dashboard=abc',
+      'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
+      'x-superagent-host-token': 'secret',
+    })
+
+    expect(Object.fromEntries(headers)).toEqual({
+      cookie: 'dashboard=abc',
+      'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
+    })
+  })
+})
 
 describe('dashboard proxy route', () => {
   it('strips the container artifact prefix for a dashboard WebSocket', () => {

--- a/agent-container/src/dashboard-proxy.test.ts
+++ b/agent-container/src/dashboard-proxy.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  dashboardWebSocketForwardHeaders,
+  dashboardWebSocketUpstreamPath,
+  parseDashboardProxyRoute,
+  requestedWebSocketProtocols,
+} from './dashboard-proxy'
+
+describe('dashboard proxy route', () => {
+  it('strips the container artifact prefix for a dashboard WebSocket', () => {
+    expect(parseDashboardProxyRoute('/artifacts/open-slide/__vite_hmr')).toEqual({
+      slug: 'open-slide',
+      subPath: '/__vite_hmr',
+    })
+    expect(parseDashboardProxyRoute('/artifacts/open-slide')).toEqual({
+      slug: 'open-slide',
+      subPath: '/',
+    })
+  })
+
+  it('rejects invalid slugs and unrelated paths', () => {
+    expect(parseDashboardProxyRoute('/sessions/a/stream')).toBeNull()
+    expect(parseDashboardProxyRoute('/artifacts/../socket')).toBeNull()
+    expect(parseDashboardProxyRoute('/artifacts/OpenSlide/socket')).toBeNull()
+  })
+})
+
+describe('dashboard WebSocket headers', () => {
+  it('preserves proxy metadata but removes both handshake and host secrets', () => {
+    const request = {
+      headers: {
+        cookie: 'dashboard=abc',
+        'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
+        'x-superagent-host-token': 'secret',
+        'sec-websocket-key': 'key',
+        'sec-websocket-protocol': 'vite-hmr, second',
+        upgrade: 'websocket',
+      },
+    } as any
+
+    expect(dashboardWebSocketForwardHeaders(request)).toEqual({
+      cookie: 'dashboard=abc',
+      'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
+    })
+    expect(requestedWebSocketProtocols(request)).toEqual(['vite-hmr', 'second'])
+  })
+})
+
+describe('dashboard WebSocket upstream path', () => {
+  const basePath = '/api/agents/agent-1/artifacts/open-slide/'
+
+  it('restores the public Vite base for HMR handshakes', () => {
+    expect(dashboardWebSocketUpstreamPath('/', ['vite-hmr'], basePath)).toBe(basePath)
+    expect(dashboardWebSocketUpstreamPath('/custom-hmr', ['vite-ping'], basePath)).toBe(
+      `${basePath}custom-hmr`,
+    )
+  })
+
+  it('leaves application WebSocket paths stripped', () => {
+    expect(dashboardWebSocketUpstreamPath('/socket', ['dashboard-v1'], basePath)).toBe('/socket')
+    expect(dashboardWebSocketUpstreamPath('/socket', ['vite-hmr'], null)).toBe('/socket')
+  })
+})

--- a/agent-container/src/dashboard-proxy.ts
+++ b/agent-container/src/dashboard-proxy.ts
@@ -1,0 +1,71 @@
+import type { IncomingMessage } from 'http'
+
+export interface DashboardProxyRoute {
+  slug: string
+  subPath: string
+}
+
+const DASHBOARD_SLUG = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+
+export function parseDashboardProxyRoute(pathname: string): DashboardProxyRoute | null {
+  const match = pathname.match(/^\/artifacts\/([^/]+)(\/.*)?$/)
+  if (!match) return null
+
+  let slug: string
+  try {
+    slug = decodeURIComponent(match[1])
+  } catch {
+    return null
+  }
+  if (!DASHBOARD_SLUG.test(slug)) return null
+  return { slug, subPath: match[2] || '/' }
+}
+
+const SKIP_WEBSOCKET_HEADERS = new Set([
+  'connection',
+  'host',
+  'sec-websocket-accept',
+  'sec-websocket-extensions',
+  'sec-websocket-key',
+  'sec-websocket-protocol',
+  'sec-websocket-version',
+  'upgrade',
+  'x-superagent-host-token',
+])
+
+export function dashboardWebSocketForwardHeaders(
+  request: Pick<IncomingMessage, 'headers'>,
+): Record<string, string> {
+  const headers: Record<string, string> = {}
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (value === undefined || SKIP_WEBSOCKET_HEADERS.has(name.toLowerCase())) continue
+    headers[name] = Array.isArray(value) ? value.join(', ') : value
+  }
+  return headers
+}
+
+export function requestedWebSocketProtocols(
+  request: Pick<IncomingMessage, 'headers'>,
+): string[] {
+  const raw = request.headers['sec-websocket-protocol']
+  const value = Array.isArray(raw) ? raw.join(',') : raw
+  return value ? value.split(',').map((protocol) => protocol.trim()).filter(Boolean) : []
+}
+
+/**
+ * Vite validates upgrade paths against its browser-visible `base`. Regular
+ * dashboard sockets keep the platform contract and receive a stripped path.
+ */
+export function dashboardWebSocketUpstreamPath(
+  subPath: string,
+  protocols: string[],
+  publicBasePath: string | null,
+): string {
+  if (!protocols.some((protocol) => protocol === 'vite-hmr' || protocol === 'vite-ping')) {
+    return subPath
+  }
+  if (!publicBasePath?.startsWith('/')) return subPath
+
+  const mount = publicBasePath.endsWith('/') ? publicBasePath.slice(0, -1) : publicBasePath
+  return subPath === '/' ? `${mount}/` : `${mount}${subPath.startsWith('/') ? '' : '/'}${subPath}`
+}

--- a/agent-container/src/dashboard-proxy.ts
+++ b/agent-container/src/dashboard-proxy.ts
@@ -7,6 +7,14 @@ export interface DashboardProxyRoute {
 
 const DASHBOARD_SLUG = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 
+/** Do not expose the host-to-container credential to agent-authored servers. */
+export function dashboardHttpForwardHeaders(source: Record<string, string>): Headers {
+  const headers = new Headers(source)
+  headers.delete('host')
+  headers.delete('x-superagent-host-token')
+  return headers
+}
+
 export function parseDashboardProxyRoute(pathname: string): DashboardProxyRoute | null {
   const match = pathname.match(/^\/artifacts\/([^/]+)(\/.*)?$/)
   if (!match) return null

--- a/agent-container/src/gamut-dashboard-template.test.ts
+++ b/agent-container/src/gamut-dashboard-template.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+// The copied dashboard template is plain ESM JavaScript by design.
+// @ts-expect-error -- it intentionally ships without a declaration file.
+import {
+  gamutDashboard,
+  getGamutDashboardRuntimeFallbackJs,
+} from '../skills/dashboards/templates/react-vite/gamut-dashboard.js'
+
+function runtimeFor(pathname: string) {
+  const windowObject: Record<string, unknown> = { location: { pathname } }
+  const source = getGamutDashboardRuntimeFallbackJs('slides')
+  new Function('window', 'URL', source)(windowObject, URL)
+  return windowObject.__GAMUT_DASHBOARD__ as {
+    basePath: string
+    routerBasePath: string
+    slug: string
+    url(path?: string): string
+  }
+}
+
+describe('dashboard template runtime fallback', () => {
+  it('supports the documented direct-local validation flow', () => {
+    const runtime = runtimeFor('/')
+
+    expect(runtime).toMatchObject({
+      basePath: '/',
+      routerBasePath: '/',
+      slug: 'slides',
+    })
+    expect(runtime.url('api/data')).toBe('/api/data')
+  })
+
+  it('derives an artifact mount when opened at its public path', () => {
+    const runtime = runtimeFor('/api/agents/a/artifacts/slides/s/deck')
+
+    expect(runtime.basePath).toBe('/api/agents/a/artifacts/slides/')
+    expect(runtime.url('assets/app.js')).toBe(
+      '/api/agents/a/artifacts/slides/assets/app.js',
+    )
+  })
+
+  it('normalizes joins before rejecting mount traversal', () => {
+    const runtime = runtimeFor('/api/agents/a/artifacts/slides/')
+
+    expect(() => runtime.url('nested/../../escape')).toThrow(/cannot escape/)
+    expect(() => runtime.url('nested/%2e%2e/%2e%2e/escape')).toThrow(/cannot escape/)
+  })
+
+  it('injects the fallback before Vite application scripts', () => {
+    const plugin = gamutDashboard()
+    const tags = plugin.transformIndexHtml()
+
+    expect(tags).toHaveLength(1)
+    expect(tags[0]).toMatchObject({
+      tag: 'script',
+      attrs: { 'data-gamut-dashboard-fallback': 'true' },
+      injectTo: 'head-prepend',
+    })
+    expect(tags[0].children).toContain('__GAMUT_DASHBOARD__')
+  })
+})

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -20,6 +20,7 @@ import { resolveCdpIp } from './cdp-host';
 import { startScreenshotJanitor } from './screenshot-janitor';
 import { dashboardManager, getDashboardBasePath } from './dashboard-manager';
 import {
+  dashboardHttpForwardHeaders,
   dashboardWebSocketForwardHeaders,
   dashboardWebSocketUpstreamPath,
   parseDashboardProxyRoute,
@@ -579,8 +580,7 @@ async function proxyToDashboard(c: any) {
   const subPath = url.pathname.slice(url.pathname.indexOf(prefixPattern) + prefixPattern.length) || '/';
   const targetUrl = `http://localhost:${port}${subPath}${url.search}`;
 
-  const headers = new Headers(c.req.header());
-  headers.delete('host');
+  const headers = dashboardHttpForwardHeaders(c.req.header());
 
   const response = await fetch(targetUrl, {
     method: c.req.method,

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -18,7 +18,13 @@ import { z } from 'zod';
 import { inputManager } from './input-manager';
 import { resolveCdpIp } from './cdp-host';
 import { startScreenshotJanitor } from './screenshot-janitor';
-import { dashboardManager } from './dashboard-manager';
+import { dashboardManager, getDashboardBasePath } from './dashboard-manager';
+import {
+  dashboardWebSocketForwardHeaders,
+  dashboardWebSocketUpstreamPath,
+  parseDashboardProxyRoute,
+  requestedWebSocketProtocols,
+} from './dashboard-proxy';
 import { tabManager } from './tab-manager';
 import { startTabPolling, stopTabPolling } from './tab-poll';
 import { runBrowserUpload } from './browser-upload';
@@ -579,6 +585,7 @@ async function proxyToDashboard(c: any) {
   const response = await fetch(targetUrl, {
     method: c.req.method,
     headers,
+    redirect: 'manual',
     body: c.req.method !== 'GET' && c.req.method !== 'HEAD'
       ? await c.req.arrayBuffer()
       : undefined,
@@ -1902,6 +1909,40 @@ const wss = new WebSocketServer({ noServer: true });
 // Create a separate WebSocket server for browser stream proxying
 const browserWss = new WebSocketServer({ noServer: true });
 
+interface DashboardProtocolRequest extends http.IncomingMessage {
+  _dashboardProtocol?: string;
+}
+
+const dashboardWss = new WebSocketServer({
+  noServer: true,
+  handleProtocols(protocols, request) {
+    const selected = (request as DashboardProtocolRequest)._dashboardProtocol;
+    return selected && protocols.has(selected) ? selected : false;
+  },
+});
+
+function closeDashboardPeer(peer: WebSocket, code?: number, reason?: Buffer): void {
+  if (peer.readyState !== WebSocket.OPEN) return;
+  const relayCode = code === 1000 || (code !== undefined && code >= 3000) ? code : 1011;
+  peer.close(relayCode, reason?.toString().slice(0, 120));
+}
+
+function bridgeDashboardWebSocket(browser: WebSocket, dashboard: WebSocket): void {
+  dashboard.on('message', (data, isBinary) => {
+    if (browser.readyState === WebSocket.OPEN) browser.send(data, { binary: isBinary });
+  });
+  browser.on('message', (data, isBinary) => {
+    if (dashboard.readyState === WebSocket.OPEN) dashboard.send(data, { binary: isBinary });
+  });
+  dashboard.on('close', (code, reason) => closeDashboardPeer(browser, code, reason));
+  browser.on('close', (code, reason) => closeDashboardPeer(dashboard, code, reason));
+  dashboard.on('error', (error) => {
+    console.error('[Artifacts] Dashboard WebSocket error:', error);
+    closeDashboardPeer(browser);
+  });
+  browser.on('error', () => closeDashboardPeer(dashboard));
+}
+
 // Handle WebSocket upgrade
 server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) => {
   // Upgrades bypass the Hono middleware chain — enforce host auth here too.
@@ -1935,6 +1976,64 @@ server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) 
 
     browserWss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
       handleBrowserStreamConnection(ws);
+    });
+    return;
+  }
+
+  // Dashboard application sockets and Vite HMR use the same artifact mount as
+  // HTTP. The public prefix was stripped by the host proxy; strip the remaining
+  // container prefix before dialing the dashboard process.
+  const dashboardRoute = parseDashboardProxyRoute(pathname);
+  if (dashboardRoute) {
+    const dashboardPort = dashboardManager.getDashboardPort(dashboardRoute.slug);
+    if (!dashboardPort) {
+      socket.write('HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    const protocols = requestedWebSocketProtocols(request);
+    const upstreamPath = dashboardWebSocketUpstreamPath(
+      dashboardRoute.subPath,
+      protocols,
+      getDashboardBasePath(dashboardRoute.slug),
+    );
+    const upstream = new WebSocket(
+      `ws://127.0.0.1:${dashboardPort}${upstreamPath}${url.search}`,
+      protocols,
+      { headers: dashboardWebSocketForwardHeaders(request) },
+    );
+    let settled = false;
+
+    const fail = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      upstream.terminate();
+      if (error) console.error('[Artifacts] Failed to connect dashboard WebSocket:', error);
+      if (!socket.destroyed) {
+        socket.write('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n');
+        socket.destroy();
+      }
+    };
+
+    socket.once('close', () => {
+      if (!settled) upstream.terminate();
+    });
+    upstream.once('unexpected-response', (_req, response) => {
+      response.resume();
+      fail(new Error(`Dashboard refused WebSocket upgrade (${response.statusCode})`));
+    });
+    upstream.once('error', fail);
+    upstream.once('open', () => {
+      if (settled || socket.destroyed) {
+        upstream.terminate();
+        return;
+      }
+      settled = true;
+      (request as DashboardProtocolRequest)._dashboardProtocol = upstream.protocol || undefined;
+      dashboardWss.handleUpgrade(request, socket, head, (browser) => {
+        bridgeDashboardWebSocket(browser, upstream);
+      });
     });
     return;
   }

--- a/src/api/dashboard-runtime.test.ts
+++ b/src/api/dashboard-runtime.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  dashboardMountPath,
+  dashboardResponseHeaders,
+  getDashboardRuntimeJs,
+  injectDashboardRuntime,
+  rewriteDashboardCookiePath,
+  rewriteDashboardLocation,
+} from './dashboard-runtime'
+
+function runtimeFor(documentHref: string, fallback: string, slug = 'slides') {
+  const url = new URL(documentHref)
+  const source = getDashboardRuntimeJs(fallback, slug)
+  const windowObject: Record<string, unknown> = {
+    location: { pathname: url.pathname },
+  }
+  const documentObject = {
+    querySelector: () => null,
+  }
+  new Function('window', 'document', source)(windowObject, documentObject)
+  return windowObject.__GAMUT_DASHBOARD__ as {
+    basePath: string
+    routerBasePath: string
+    slug: string
+    url(path?: string): string
+  }
+}
+
+describe('dashboard runtime injection', () => {
+  it('builds a trailing-slash artifact mount', () => {
+    expect(dashboardMountPath('agent-1', 'open-slide')).toBe(
+      '/api/agents/agent-1/artifacts/open-slide/',
+    )
+  })
+
+  it('injects the runtime and base before existing head assets', () => {
+    const result = injectDashboardRuntime(
+      '<!doctype html><html><head><script src="./assets/app.js"></script></head></html>',
+      {
+        basePath: '/api/agents/a/artifacts/slides/',
+        slug: 'slides',
+        polyfillJs: 'window.polyfillLoaded=true;',
+      },
+    )
+
+    expect(result).toContain(
+      '<head><base data-gamut-dashboard-base href="/api/agents/a/artifacts/slides/">',
+    )
+    expect(result.indexOf('__GAMUT_DASHBOARD__')).toBeLessThan(result.indexOf('./assets/app.js'))
+    expect(result).toContain('window.polyfillLoaded=true;')
+  })
+
+  it('preserves an application-provided base element', () => {
+    const result = injectDashboardRuntime(
+      '<html><head><base href="/custom/"></head></html>',
+      { basePath: '/api/agents/a/artifacts/slides/', slug: 'slides' },
+    )
+    expect(result.match(/<base\b/g)).toHaveLength(1)
+    expect(result).toContain('<base href="/custom/">')
+  })
+
+  it('uses the exact browser-visible prefix behind the desktop cloud proxy', () => {
+    const runtime = runtimeFor(
+      'http://127.0.0.1/cloud/KEY/api/agents/a/artifacts/slides/s/my-deck',
+      '/api/agents/a/artifacts/slides/',
+    )
+    expect(runtime.basePath).toBe('/cloud/KEY/api/agents/a/artifacts/slides/')
+    expect(runtime.routerBasePath).toBe('/cloud/KEY/api/agents/a/artifacts/slides')
+    expect(runtime.url('assets/app.js')).toBe(
+      '/cloud/KEY/api/agents/a/artifacts/slides/assets/app.js',
+    )
+  })
+
+  it('falls back to server metadata outside an artifact URL', () => {
+    const runtime = runtimeFor(
+      'http://localhost:5000/',
+      '/api/agents/a/artifacts/slides/',
+    )
+    expect(runtime.basePath).toBe('/api/agents/a/artifacts/slides/')
+    expect(() => runtime.url('../escape')).toThrow(/cannot escape/)
+  })
+})
+
+describe('dashboard response scoping', () => {
+  const basePath = '/api/agents/a/artifacts/slides/'
+
+  it('keeps redirects inside the dashboard mount', () => {
+    expect(rewriteDashboardLocation('/login?next=%2F', basePath)).toBe(
+      '/api/agents/a/artifacts/slides/login?next=%2F',
+    )
+    expect(rewriteDashboardLocation('https://example.com/callback', basePath)).toBe(
+      'https://example.com/callback',
+    )
+    expect(rewriteDashboardLocation(basePath.slice(0, -1), basePath)).toBe(
+      basePath.slice(0, -1),
+    )
+  })
+
+  it('scopes default and explicit cookie paths', () => {
+    expect(rewriteDashboardCookiePath('session=abc; HttpOnly', basePath)).toBe(
+      'session=abc; HttpOnly; Path=/api/agents/a/artifacts/slides/',
+    )
+    expect(rewriteDashboardCookiePath('session=abc; Path=/; HttpOnly', basePath)).toBe(
+      'session=abc; Path=/api/agents/a/artifacts/slides/; HttpOnly',
+    )
+    expect(rewriteDashboardCookiePath('session=abc; Path=/account; HttpOnly', basePath)).toBe(
+      'session=abc; Path=/api/agents/a/artifacts/slides/account; HttpOnly',
+    )
+  })
+
+  it('invalidates representation headers when HTML was injected', () => {
+    const upstream = new Headers({
+      'cache-control': 'public, max-age=31536000, immutable',
+      'content-encoding': 'gzip',
+      'content-length': '100',
+      etag: '"old"',
+      location: '/login',
+      'set-cookie': 'session=abc; Path=/; HttpOnly',
+    })
+    const result = dashboardResponseHeaders(upstream, basePath, { transformedHtml: true })
+
+    expect(result.get('cache-control')).toBe('no-cache')
+    expect(result.has('content-encoding')).toBe(false)
+    expect(result.has('content-length')).toBe(false)
+    expect(result.has('etag')).toBe(false)
+    expect(result.get('location')).toBe('/api/agents/a/artifacts/slides/login')
+    expect(result.get('set-cookie')).toContain('Path=/api/agents/a/artifacts/slides/')
+  })
+})

--- a/src/api/dashboard-runtime.test.ts
+++ b/src/api/dashboard-runtime.test.ts
@@ -60,6 +60,21 @@ describe('dashboard runtime injection', () => {
     expect(result).toContain('<base href="/custom/">')
   })
 
+  it('runs after a managed base and before existing dashboard scripts', () => {
+    const result = injectDashboardRuntime(
+      '<html><head><base data-gamut-dashboard-base href="/api/agents/a/artifacts/slides/"><script data-gamut-dashboard-fallback="true">window.fallback=true;</script><script src="./assets/app.js"></script></head></html>',
+      { basePath: '/api/agents/a/artifacts/slides/', slug: 'slides' },
+    )
+
+    const baseAt = result.indexOf('<base data-gamut-dashboard-base')
+    const runtimeAt = result.indexOf('var fallbackBasePath =')
+    const fallbackAt = result.indexOf('data-gamut-dashboard-fallback')
+    const assetAt = result.indexOf('./assets/app.js')
+    expect(baseAt).toBeLessThan(runtimeAt)
+    expect(runtimeAt).toBeLessThan(fallbackAt)
+    expect(runtimeAt).toBeLessThan(assetAt)
+  })
+
   it('uses the exact browser-visible prefix behind the desktop cloud proxy', () => {
     const runtime = runtimeFor(
       'http://127.0.0.1/cloud/KEY/api/agents/a/artifacts/slides/s/my-deck',
@@ -79,6 +94,11 @@ describe('dashboard runtime injection', () => {
     )
     expect(runtime.basePath).toBe('/api/agents/a/artifacts/slides/')
     expect(() => runtime.url('../escape')).toThrow(/cannot escape/)
+    expect(() => runtime.url('nested/../../escape')).toThrow(/cannot escape/)
+    expect(() => runtime.url('nested/%2e%2e/%2e%2e/escape')).toThrow(/cannot escape/)
+    expect(runtime.url('api/data?limit=2#items')).toBe(
+      '/api/agents/a/artifacts/slides/api/data?limit=2#items',
+    )
   })
 })
 

--- a/src/api/dashboard-runtime.ts
+++ b/src/api/dashboard-runtime.ts
@@ -59,10 +59,13 @@ export function getDashboardRuntimeJs(basePath: string, slug: string): string {
     if (!value || value === ".") return basePath;
     if (value.charAt(0) === "?" || value.charAt(0) === "#") return basePath + value;
     value = value.replace(/^\\.\\//, "").replace(/^\\/+/, "");
-    if (value === ".." || value.indexOf("../") === 0) {
+
+    var origin = "http://gamut.invalid";
+    var resolved = new URL(value, origin + basePath);
+    if (resolved.origin !== origin || resolved.pathname.indexOf(basePath) !== 0) {
       throw new TypeError("Dashboard URLs cannot escape the dashboard mount");
     }
-    return basePath + value;
+    return resolved.pathname + resolved.search + resolved.hash;
   }
 
   var runtime = {
@@ -82,10 +85,22 @@ export function injectDashboardRuntime(
   options: DashboardRuntimeInjectionOptions,
 ): string {
   const basePath = withTrailingSlash(options.basePath)
+  const existingManagedBase = html.match(
+    /<base\b(?=[^>]*\bdata-gamut-dashboard-base\b)[^>]*>/i,
+  )
   const baseTag = /<base\b[^>]*>/i.test(html)
     ? ''
     : `<base data-gamut-dashboard-base href="${escapeHtmlAttribute(basePath)}">`
-  const tag = `${baseTag}<script>${getDashboardRuntimeJs(basePath, options.slug)}${options.polyfillJs ?? ''}</script>`
+  const scriptTag = `<script>${getDashboardRuntimeJs(basePath, options.slug)}${options.polyfillJs ?? ''}</script>`
+
+  // The browser must parse the managed base before the runtime can update it
+  // with an outer proxy prefix, but the runtime must still precede app assets.
+  if (existingManagedBase) {
+    const pos = existingManagedBase.index! + existingManagedBase[0].length
+    return html.slice(0, pos) + scriptTag + html.slice(pos)
+  }
+
+  const tag = baseTag + scriptTag
   const headMatch = html.match(/<head(\s[^>]*)?>/i)
 
   if (!headMatch) return tag + html

--- a/src/api/dashboard-runtime.ts
+++ b/src/api/dashboard-runtime.ts
@@ -1,0 +1,162 @@
+export interface DashboardRuntimeInjectionOptions {
+  basePath: string
+  slug: string
+  polyfillJs?: string
+}
+
+function withTrailingSlash(pathname: string): string {
+  return pathname.endsWith('/') ? pathname : `${pathname}/`
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function scriptString(value: string): string {
+  // Prevent user-controlled route segments from ending the inline script.
+  return JSON.stringify(value).replace(/</g, '\\u003c')
+}
+
+export function dashboardMountPath(routeSlug: string, artifactSlug: string): string {
+  return withTrailingSlash(`/api/agents/${routeSlug}/artifacts/${artifactSlug}`)
+}
+
+/**
+ * Runtime contract injected before a dashboard's own scripts execute.
+ *
+ * The server-provided base is authoritative for ordinary deployments. The
+ * browser derives the same mount from location.pathname when another trusted
+ * proxy adds a prefix (for example `/cloud/<key>` in the desktop app), because
+ * that outer prefix is intentionally not disclosed to the remote deployment.
+ */
+export function getDashboardRuntimeJs(basePath: string, slug: string): string {
+  const fallbackBasePath = withTrailingSlash(basePath)
+
+  return /* js */ `
+(function () {
+  var fallbackBasePath = ${scriptString(fallbackBasePath)};
+  var marker = "/api/agents/";
+  var pathname = window.location.pathname;
+  var markerAt = pathname.indexOf(marker);
+  var basePath = fallbackBasePath;
+
+  if (markerAt >= 0) {
+    var segments = pathname.slice(markerAt + marker.length).split("/");
+    if (segments.length >= 3 && segments[0] && segments[1] === "artifacts" && segments[2]) {
+      basePath = pathname.slice(0, markerAt) + marker + segments[0] + "/artifacts/" + segments[2] + "/";
+    }
+  }
+
+  var injectedBase = document.querySelector("base[data-gamut-dashboard-base]");
+  if (injectedBase) injectedBase.setAttribute("href", basePath);
+
+  function dashboardUrl(path) {
+    var value = path == null ? "" : String(path);
+    if (!value || value === ".") return basePath;
+    if (value.charAt(0) === "?" || value.charAt(0) === "#") return basePath + value;
+    value = value.replace(/^\\.\\//, "").replace(/^\\/+/, "");
+    if (value === ".." || value.indexOf("../") === 0) {
+      throw new TypeError("Dashboard URLs cannot escape the dashboard mount");
+    }
+    return basePath + value;
+  }
+
+  var runtime = {
+    basePath: basePath,
+    routerBasePath: basePath === "/" ? "/" : basePath.slice(0, -1),
+    slug: ${scriptString(slug)},
+    url: dashboardUrl
+  };
+  window.__GAMUT_DASHBOARD__ = Object.freeze(runtime);
+})();
+`
+}
+
+/** Inject the dashboard runtime and a stable document base before app assets. */
+export function injectDashboardRuntime(
+  html: string,
+  options: DashboardRuntimeInjectionOptions,
+): string {
+  const basePath = withTrailingSlash(options.basePath)
+  const baseTag = /<base\b[^>]*>/i.test(html)
+    ? ''
+    : `<base data-gamut-dashboard-base href="${escapeHtmlAttribute(basePath)}">`
+  const tag = `${baseTag}<script>${getDashboardRuntimeJs(basePath, options.slug)}${options.polyfillJs ?? ''}</script>`
+  const headMatch = html.match(/<head(\s[^>]*)?>/i)
+
+  if (!headMatch) return tag + html
+  const pos = headMatch.index! + headMatch[0].length
+  return html.slice(0, pos) + tag + html.slice(pos)
+}
+
+export function rewriteDashboardLocation(location: string, basePath: string): string {
+  const mount = withTrailingSlash(basePath)
+  const mountWithoutSlash = mount.slice(0, -1)
+  if (
+    !location.startsWith('/')
+    || location.startsWith('//')
+    || location === mountWithoutSlash
+    || location.startsWith(mount)
+  ) {
+    return location
+  }
+  return mount + location.replace(/^\/+/, '')
+}
+
+export function rewriteDashboardCookiePath(cookie: string, basePath: string): string {
+  const mount = withTrailingSlash(basePath)
+  const pathAttribute = /(^|;)\s*Path=([^;]*)/i
+  const match = cookie.match(pathAttribute)
+
+  if (!match) return `${cookie}; Path=${mount}`
+
+  const existingPath = match[2].trim()
+  if (existingPath === mount.slice(0, -1) || existingPath.startsWith(mount)) return cookie
+
+  const scopedPath = mount + existingPath.replace(/^\/+/, '')
+  return cookie.replace(pathAttribute, `${match[1]} Path=${scopedPath}`)
+}
+
+function getSetCookieValues(headers: Headers): string[] {
+  const values = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.()
+  if (values && values.length > 0) return values
+  const combined = headers.get('set-cookie')
+  return combined ? [combined] : []
+}
+
+/** Copy upstream headers while applying browser-visible dashboard scoping. */
+export function dashboardResponseHeaders(
+  upstream: Headers,
+  basePath: string,
+  options?: { transformedHtml?: boolean },
+): Headers {
+  const headers = new Headers()
+  const cookies = getSetCookieValues(upstream)
+
+  upstream.forEach((value, name) => {
+    if (name.toLowerCase() !== 'set-cookie') headers.append(name, value)
+  })
+
+  headers.delete('location')
+  const location = upstream.get('location')
+  if (location) headers.set('location', rewriteDashboardLocation(location, basePath))
+
+  for (const cookie of cookies) {
+    headers.append('set-cookie', rewriteDashboardCookiePath(cookie, basePath))
+  }
+
+  if (options?.transformedHtml) {
+    // fetch transparently decodes upstream bodies; all representation metadata
+    // must describe the injected bytes rather than the dashboard's old body.
+    headers.delete('content-encoding')
+    headers.delete('content-length')
+    headers.delete('etag')
+    headers.set('cache-control', 'no-cache')
+  }
+
+  return headers
+}

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -4782,7 +4782,10 @@ describe('artifact proxy — subPath uses the raw display-slug URL', () => {
       new Response('ok', { headers: { 'content-type': 'application/javascript' } }),
     )
 
-    const res = await getReq(app, '/api/agents/my-dash-abc1234567/artifacts/dash/static/app.js')
+    const res = await app.request(
+      'http://localhost/api/agents/my-dash-abc1234567/artifacts/dash/static/app.js',
+      { headers: { 'if-none-match': '"asset-v1"' } },
+    )
 
     expect(res.status).toBe(200)
     expect(mockContainerFetch).toHaveBeenCalledTimes(1)
@@ -4795,8 +4798,33 @@ describe('artifact proxy — subPath uses the raw display-slug URL', () => {
         'x-forwarded-prefix': '/api/agents/my-dash-abc1234567/artifacts/dash',
         'x-forwarded-host': 'localhost',
         'x-forwarded-proto': 'http',
+        'if-none-match': '"asset-v1"',
       }),
     })
+  })
+
+  it('removes upstream validators only for transformed HTML documents', async () => {
+    mockContainerFetch.mockResolvedValue(
+      new Response('<html><head></head><body>ok</body></html>', {
+        headers: { 'content-type': 'text/html' },
+      }),
+    )
+
+    const res = await app.request(
+      'http://localhost/api/agents/abc1234567/artifacts/dash/s/deck',
+      {
+        headers: {
+          accept: 'text/html',
+          'if-modified-since': 'Tue, 04 Aug 2026 18:00:00 GMT',
+          'if-none-match': '"document-v1"',
+        },
+      },
+    )
+
+    expect(res.status).toBe(200)
+    const init = mockContainerFetch.mock.calls[0]?.[1] as RequestInit
+    expect(init.headers).not.toHaveProperty('if-modified-since')
+    expect(init.headers).not.toHaveProperty('if-none-match')
   })
 
   it('canonicalizes display-slug document navigations to match the dashboard router base', async () => {

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -4788,6 +4788,28 @@ describe('artifact proxy — subPath uses the raw display-slug URL', () => {
     expect(mockContainerFetch).toHaveBeenCalledTimes(1)
     // Bug repro: an id-based prefix yields indexOf(prefix) === -1, corrupting this path.
     expect(mockContainerFetch.mock.calls[0]?.[0]).toBe('/artifacts/dash/static/app.js')
+    expect(mockContainerFetch.mock.calls[0]?.[1]).toMatchObject({
+      redirect: 'manual',
+      headers: expect.objectContaining({
+        'accept-encoding': 'identity',
+        'x-forwarded-prefix': '/api/agents/my-dash-abc1234567/artifacts/dash',
+        'x-forwarded-host': 'localhost',
+        'x-forwarded-proto': 'http',
+      }),
+    })
+  })
+
+  it('canonicalizes display-slug document navigations to match the dashboard router base', async () => {
+    const res = await app.request(
+      'http://localhost/api/agents/my-dash-abc1234567/artifacts/dash/s/deck?present=1',
+      { headers: { accept: 'text/html' } },
+    )
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe(
+      '/api/agents/abc1234567/artifacts/dash/s/deck?present=1',
+    )
+    expect(mockContainerFetch).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1,11 +1,17 @@
 import { Hono, type Context } from 'hono'
 import { streamSSE } from 'hono/streaming'
+import { getConnInfo } from '@hono/node-server/conninfo'
 import type Anthropic from '@anthropic-ai/sdk'
 import { randomUUID } from 'crypto'
 import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
 import { getPolyfillJs } from '../speech-recognition-polyfill'
 import { getLlmPolyfillJs } from '../llm-polyfill'
+import {
+  dashboardMountPath,
+  dashboardResponseHeaders,
+  injectDashboardRuntime,
+} from '../dashboard-runtime'
 import { parsePagination } from '../pagination'
 import { Authenticated, AgentRead, AgentUser, AgentAdmin, IsAdmin, ResolveAgent, getAgentId, getAuthorizedAgentRole } from '../middleware/auth'
 import {
@@ -5759,6 +5765,12 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
 // Shared handler for proxying artifact requests to the container
 const skipProxyRequestHeaders = new Set([
   'host', 'connection', 'transfer-encoding',
+  // Node fetch transparently decodes upstream bodies. Ask every hop for the
+  // identity representation so body bytes and response metadata cannot drift.
+  'accept-encoding',
+  // Dashboard HTML is injected per request, so an upstream 304 cannot safely
+  // stand in for the browser's transformed representation.
+  'if-modified-since', 'if-none-match',
 ])
 
 async function proxyArtifactRequest(c: any) {
@@ -5782,8 +5794,22 @@ async function proxyArtifactRequest(c: any) {
   const url = new URL(c.req.url)
   const routeSlug = c.req.param('id')
   const prefix = `/api/agents/${routeSlug}/artifacts/${artifactSlug}`
+  const publicBasePath = dashboardMountPath(routeSlug, artifactSlug)
   const subPath = url.pathname.slice(url.pathname.indexOf(prefix) + prefix.length) || '/'
   const containerPath = `/artifacts/${artifactSlug}${subPath}${url.search}`
+
+  // Framework router bases are compiled from the canonical id passed to the
+  // dashboard process. A display-slug document URL would therefore disagree
+  // with that router base. Canonicalize navigations while continuing to proxy
+  // non-document assets for compatibility with older relative builds.
+  if (
+    routeSlug !== agentSlug
+    && (c.req.method === 'GET' || c.req.method === 'HEAD')
+    && c.req.header('accept')?.includes('text/html')
+  ) {
+    const canonicalBasePath = dashboardMountPath(encodeURIComponent(agentSlug), artifactSlug)
+    return c.redirect(`${canonicalBasePath.slice(0, -1)}${subPath}${url.search}`, 307)
+  }
 
   // Forward request headers (minus hop-by-hop headers)
   const reqHeaders = c.req.header() as Record<string, string>
@@ -5793,8 +5819,25 @@ async function proxyArtifactRequest(c: any) {
       headers[key] = reqHeaders[key]
     }
   }
+  headers['accept-encoding'] = 'identity'
+  headers['x-forwarded-prefix'] = publicBasePath.slice(0, -1)
+  headers['x-forwarded-host'] = c.req.header('x-forwarded-host') || url.host
+  headers['x-forwarded-proto'] = c.req.header('x-forwarded-proto') || url.protocol.slice(0, -1)
+  // Hono's Node connection metadata is unavailable in direct app.request()
+  // calls (including tests and some embedded adapters). Existing forwarded
+  // metadata is still preserved in that case.
+  let remoteAddress: string | undefined
+  try {
+    remoteAddress = getConnInfo(c).remote.address
+  } catch {
+    remoteAddress = undefined
+  }
+  if (remoteAddress) {
+    const forwardedFor = c.req.header('x-forwarded-for')
+    headers['x-forwarded-for'] = forwardedFor ? `${forwardedFor}, ${remoteAddress}` : remoteAddress
+  }
 
-  const init: RequestInit = { method: c.req.method, headers }
+  const init: RequestInit = { method: c.req.method, headers, redirect: 'manual' }
   if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
     init.body = await c.req.arrayBuffer()
   }
@@ -5803,23 +5846,20 @@ async function proxyArtifactRequest(c: any) {
 
   const contentType = response.headers.get('content-type') || ''
   if (contentType.includes('text/html')) {
-    let html = await response.text()
-    const tags = `<script>${getPolyfillJs()}${getLlmPolyfillJs()}</script>`
-    const headMatch = html.match(/<head(\s[^>]*)?>/i)
-    if (headMatch) {
-      const pos = headMatch.index! + headMatch[0].length
-      html = html.slice(0, pos) + tags + html.slice(pos)
-    } else {
-      html = tags + html
-    }
-    const headers = new Headers(response.headers)
-    headers.delete('content-length')
-    return new Response(html, { status: response.status, headers })
+    const html = injectDashboardRuntime(await response.text(), {
+      basePath: publicBasePath,
+      slug: artifactSlug,
+      polyfillJs: getPolyfillJs() + getLlmPolyfillJs(),
+    })
+    return new Response(html, {
+      status: response.status,
+      headers: dashboardResponseHeaders(response.headers, publicBasePath, { transformedHtml: true }),
+    })
   }
 
   return new Response(response.body, {
     status: response.status,
-    headers: new Headers(response.headers),
+    headers: dashboardResponseHeaders(response.headers, publicBasePath),
   })
 }
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -5768,10 +5768,8 @@ const skipProxyRequestHeaders = new Set([
   // Node fetch transparently decodes upstream bodies. Ask every hop for the
   // identity representation so body bytes and response metadata cannot drift.
   'accept-encoding',
-  // Dashboard HTML is injected per request, so an upstream 304 cannot safely
-  // stand in for the browser's transformed representation.
-  'if-modified-since', 'if-none-match',
 ])
+const conditionalRequestHeaders = new Set(['if-modified-since', 'if-none-match'])
 
 async function proxyArtifactRequest(c: any) {
   const agentSlug = getAgentId(c)
@@ -5814,8 +5812,17 @@ async function proxyArtifactRequest(c: any) {
   // Forward request headers (minus hop-by-hop headers)
   const reqHeaders = c.req.header() as Record<string, string>
   const headers: Record<string, string> = {}
+  // Dashboard HTML is injected per request, so an upstream 304 cannot safely
+  // stand in for the browser's transformed representation. Assets are not
+  // transformed and retain normal ETag/Last-Modified revalidation.
+  const isDocumentRequest = (c.req.method === 'GET' || c.req.method === 'HEAD')
+    && c.req.header('accept')?.includes('text/html')
   for (const key of Object.keys(reqHeaders)) {
-    if (!skipProxyRequestHeaders.has(key.toLowerCase())) {
+    const normalizedKey = key.toLowerCase()
+    if (
+      !skipProxyRequestHeaders.has(normalizedKey)
+      && !(isDocumentRequest && conditionalRequestHeaders.has(normalizedKey))
+    ) {
       headers[key] = reqHeaders[key]
     }
   }

--- a/src/api/routes/artifact-polyfill-injection.test.ts
+++ b/src/api/routes/artifact-polyfill-injection.test.ts
@@ -1,45 +1,44 @@
 import { describe, it, expect } from 'vitest'
 import { getPolyfillJs } from '../speech-recognition-polyfill'
 import { getLlmPolyfillJs } from '../llm-polyfill'
+import { injectDashboardRuntime } from '../dashboard-runtime'
 
 /**
  * Tests for the polyfill injection logic used in proxyArtifactRequest.
  * This replicates the injection logic to verify it handles various HTML structures.
  */
 function injectPolyfill(html: string): string {
-  const tag = `<script>${getPolyfillJs()}${getLlmPolyfillJs()}</script>`
-  const headMatch = html.match(/<head(\s[^>]*)?>/i)
-  if (headMatch) {
-    const pos = headMatch.index! + headMatch[0].length
-    return html.slice(0, pos) + tag + html.slice(pos)
-  }
-  return tag + html
+  return injectDashboardRuntime(html, {
+    basePath: '/api/agents/agent-1/artifacts/test/',
+    slug: 'test',
+    polyfillJs: getPolyfillJs() + getLlmPolyfillJs(),
+  })
 }
 
 describe('artifact polyfill injection', () => {
   it('injects after <head> tag', () => {
     const html = '<!DOCTYPE html><html><head><title>Test</title></head><body></body></html>'
     const result = injectPolyfill(html)
-    expect(result).toContain('<head><script>')
+    expect(result).toContain('<head><base data-gamut-dashboard-base href="/api/agents/agent-1/artifacts/test/"><script>')
     expect(result).toContain('</script><title>Test</title>')
   })
 
   it('injects after <head> with attributes', () => {
     const html = '<html><head lang="en"><meta charset="utf-8"></head></html>'
     const result = injectPolyfill(html)
-    expect(result).toContain('<head lang="en"><script>')
+    expect(result).toContain('<head lang="en"><base data-gamut-dashboard-base href="/api/agents/agent-1/artifacts/test/"><script>')
   })
 
   it('is case-insensitive for <HEAD>', () => {
     const html = '<HTML><HEAD><TITLE>Hi</TITLE></HEAD></HTML>'
     const result = injectPolyfill(html)
-    expect(result).toContain('<HEAD><script>')
+    expect(result).toContain('<HEAD><base data-gamut-dashboard-base href="/api/agents/agent-1/artifacts/test/"><script>')
   })
 
   it('prepends to document when no <head> tag', () => {
     const html = '<html><body><h1>Hello</h1></body></html>'
     const result = injectPolyfill(html)
-    expect(result.startsWith('<script>')).toBe(true)
+    expect(result.startsWith('<base data-gamut-dashboard-base href="/api/agents/agent-1/artifacts/test/"><script>')).toBe(true)
     expect(result).toContain('</script><html><body>')
   })
 

--- a/src/main/agent-websocket-auth.ts
+++ b/src/main/agent-websocket-auth.ts
@@ -1,0 +1,52 @@
+import type { IncomingMessage } from 'http'
+import { and, eq } from 'drizzle-orm'
+
+import { isAuthMode } from '@shared/lib/auth/mode'
+import { db } from '@shared/lib/db'
+import { agentAcl } from '@shared/lib/db/schema'
+import { type AgentRole, ROLE_HIERARCHY } from '@shared/lib/types/agent'
+
+const LOCALHOST_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
+
+/** Authenticate an upgrade request, which bypasses Hono's HTTP middleware. */
+export async function authenticateAgentWebSocket(
+  request: IncomingMessage,
+  agentSlug: string,
+  minRole: AgentRole,
+): Promise<boolean> {
+  if (!isAuthMode()) {
+    // The Electron API binds beyond loopback so containers can reach it. Do not
+    // let another machine on that interface upgrade into an agent endpoint.
+    if (process.type === 'browser') {
+      const addr = request.socket?.remoteAddress
+      if (!addr || !LOCALHOST_ADDRS.has(addr)) return false
+    }
+    return true
+  }
+
+  try {
+    // Lazy import avoids pulling Better Auth's ESM graph into desktop startup.
+    const { getAuth } = await import('@shared/lib/auth/index')
+    const auth = getAuth()
+    const headers = new Headers()
+    for (const [key, value] of Object.entries(request.headers)) {
+      if (value) headers.set(key, Array.isArray(value) ? value[0] : value)
+    }
+
+    const session = await auth.api.getSession({ headers })
+    if (!session?.user) return false
+
+    const [row] = await db
+      .select({ role: agentAcl.role })
+      .from(agentAcl)
+      .where(and(eq(agentAcl.userId, session.user.id), eq(agentAcl.agentSlug, agentSlug)))
+      .limit(1)
+
+    if (!row) return false
+    const userRole = row.role as AgentRole
+    return ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[minRole]
+  } catch (error) {
+    console.error('[WebSocketAuth] Auth check failed:', error)
+    return false
+  }
+}

--- a/src/main/artifact-stream-proxy.test.ts
+++ b/src/main/artifact-stream-proxy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { EventEmitter } from 'events'
+
+import {
+  artifactWebSocketForwardHeaders,
+  parseArtifactWebSocketRoute,
+} from './artifact-stream-proxy'
+
+function request(headers: Record<string, string>) {
+  return {
+    headers,
+    socket: Object.assign(new EventEmitter(), {
+      encrypted: false,
+      remoteAddress: '127.0.0.1',
+    }),
+  } as any
+}
+
+describe('artifact WebSocket route', () => {
+  it('maps the public dashboard path to the container proxy path', () => {
+    expect(
+      parseArtifactWebSocketRoute('/api/agents/agent-1/artifacts/open-slide/__vite_hmr'),
+    ).toEqual({
+      routeAgentId: 'agent-1',
+      artifactSlug: 'open-slide',
+      publicBasePath: '/api/agents/agent-1/artifacts/open-slide/',
+      containerPath: '/artifacts/open-slide/__vite_hmr',
+    })
+  })
+
+  it('rejects malformed and invalid artifact paths', () => {
+    expect(parseArtifactWebSocketRoute('/api/agents/a/browser/stream')).toBeNull()
+    expect(parseArtifactWebSocketRoute('/api/agents/a/artifacts/../hmr')).toBeNull()
+    expect(parseArtifactWebSocketRoute('/api/agents/a/artifacts/OpenSlide/hmr')).toBeNull()
+  })
+})
+
+describe('artifact WebSocket forwarding headers', () => {
+  it('adds the mount contract and strips handshake/host-auth internals', () => {
+    const result = artifactWebSocketForwardHeaders(
+      request({
+        host: 'gamut.example',
+        origin: 'https://gamut.example',
+        cookie: 'dashboard=abc',
+        connection: 'Upgrade',
+        upgrade: 'websocket',
+        'sec-websocket-key': 'secret',
+        'x-superagent-host-token': 'do-not-forward',
+      }),
+      '/api/agents/a/artifacts/slides/',
+    )
+
+    expect(result['x-forwarded-prefix']).toBe('/api/agents/a/artifacts/slides')
+    expect(result['x-forwarded-host']).toBe('gamut.example')
+    expect(result['x-forwarded-proto']).toBe('https')
+    expect(result['x-forwarded-for']).toBe('127.0.0.1')
+    expect(result.cookie).toBe('dashboard=abc')
+    expect(result).not.toHaveProperty('sec-websocket-key')
+    expect(result).not.toHaveProperty('x-superagent-host-token')
+  })
+})

--- a/src/main/artifact-stream-proxy.ts
+++ b/src/main/artifact-stream-proxy.ts
@@ -1,0 +1,227 @@
+/** WebSocket half of the dashboard artifact reverse proxy (Vite HMR + app sockets). */
+
+import type { IncomingMessage } from 'http'
+import type { Duplex } from 'stream'
+import type { ServerType } from '@hono/node-server'
+import { WebSocketServer, WebSocket } from 'ws'
+
+import { containerManager } from '@shared/lib/container/container-manager'
+import { captureException } from '@shared/lib/error-reporting'
+import { resolveAgentId } from '@shared/lib/utils/file-storage'
+import { authenticateAgentWebSocket } from './agent-websocket-auth'
+
+interface ArtifactWebSocketRoute {
+  routeAgentId: string
+  artifactSlug: string
+  publicBasePath: string
+  containerPath: string
+}
+
+interface ProtocolAwareRequest extends IncomingMessage {
+  _gamutDashboardProtocol?: string
+}
+
+const artifactWss = new WebSocketServer({
+  noServer: true,
+  handleProtocols(protocols, request) {
+    const selected = (request as ProtocolAwareRequest)._gamutDashboardProtocol
+    return selected && protocols.has(selected) ? selected : false
+  },
+})
+
+const SKIP_UPSTREAM_HEADERS = new Set([
+  'connection',
+  'host',
+  'sec-websocket-accept',
+  'sec-websocket-extensions',
+  'sec-websocket-key',
+  'sec-websocket-protocol',
+  'sec-websocket-version',
+  'upgrade',
+  'x-superagent-host-token',
+])
+
+function decodePathSegment(value: string): string | null {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return null
+  }
+}
+
+export function parseArtifactWebSocketRoute(pathname: string): ArtifactWebSocketRoute | null {
+  const match = pathname.match(/^\/api\/agents\/([^/]+)\/artifacts\/([^/]+)(\/.*)?$/)
+  if (!match) return null
+
+  const routeAgentId = decodePathSegment(match[1])
+  const artifactSlug = decodePathSegment(match[2])
+  if (!routeAgentId || !artifactSlug || !/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(artifactSlug)) {
+    return null
+  }
+
+  const publicMount = `/api/agents/${match[1]}/artifacts/${match[2]}`
+  return {
+    routeAgentId,
+    artifactSlug,
+    publicBasePath: `${publicMount}/`,
+    containerPath: `/artifacts/${encodeURIComponent(artifactSlug)}${match[3] || '/'}`,
+  }
+}
+
+function requestProtocol(request: IncomingMessage): string {
+  const forwarded = request.headers['x-forwarded-proto']
+  const value = Array.isArray(forwarded) ? forwarded[0] : forwarded
+  if (value) return value.split(',')[0].trim()
+
+  const origin = request.headers.origin
+  if (origin) {
+    try {
+      return new URL(origin).protocol.replace(/:$/, '')
+    } catch {
+      // Fall through to socket encryption state.
+    }
+  }
+  return (request.socket as { encrypted?: boolean }).encrypted ? 'https' : 'http'
+}
+
+export function artifactWebSocketForwardHeaders(
+  request: IncomingMessage,
+  publicBasePath: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {}
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (value === undefined || SKIP_UPSTREAM_HEADERS.has(name.toLowerCase())) continue
+    headers[name] = Array.isArray(value) ? value.join(', ') : value
+  }
+  headers['x-forwarded-prefix'] = publicBasePath.slice(0, -1)
+  headers['x-forwarded-host'] = request.headers['x-forwarded-host']?.toString()
+    || request.headers.host
+    || ''
+  headers['x-forwarded-proto'] = requestProtocol(request)
+  const remoteAddress = request.socket.remoteAddress
+  if (remoteAddress) {
+    const forwardedFor = request.headers['x-forwarded-for']
+    const existing = Array.isArray(forwardedFor) ? forwardedFor.join(', ') : forwardedFor
+    headers['x-forwarded-for'] = existing ? `${existing}, ${remoteAddress}` : remoteAddress
+  }
+  return headers
+}
+
+function requestedProtocols(request: IncomingMessage): string[] {
+  const raw = request.headers['sec-websocket-protocol']
+  const value = Array.isArray(raw) ? raw.join(',') : raw
+  return value ? value.split(',').map((protocol) => protocol.trim()).filter(Boolean) : []
+}
+
+function deny(socket: Duplex, status: string): void {
+  if (socket.destroyed) return
+  socket.write(`HTTP/1.1 ${status}\r\nConnection: close\r\n\r\n`)
+  socket.destroy()
+}
+
+function closePeer(peer: WebSocket, code?: number, reason?: Buffer): void {
+  if (peer.readyState !== WebSocket.OPEN) return
+  const relayCode = code === 1000 || (code !== undefined && code >= 3000) ? code : 1011
+  peer.close(relayCode, reason?.toString().slice(0, 120))
+}
+
+function bridge(client: WebSocket, upstream: WebSocket, route: ArtifactWebSocketRoute): void {
+  upstream.on('message', (data, isBinary) => {
+    if (client.readyState === WebSocket.OPEN) client.send(data, { binary: isBinary })
+  })
+  client.on('message', (data, isBinary) => {
+    if (upstream.readyState === WebSocket.OPEN) upstream.send(data, { binary: isBinary })
+  })
+  upstream.on('close', (code, reason) => closePeer(client, code, reason))
+  client.on('close', (code, reason) => closePeer(upstream, code, reason))
+
+  for (const [side, socket, peer] of [
+    ['dashboard', upstream, client],
+    ['browser', client, upstream],
+  ] as const) {
+    socket.on('error', (error) => {
+      if (!(error instanceof Error && error.message.includes('ECONNRESET'))) {
+        captureException(error, {
+          tags: { component: 'artifact-stream-proxy', operation: `${side}-ws` },
+          extra: { artifactSlug: route.artifactSlug, routeAgentId: route.routeAgentId },
+          level: side === 'browser' ? 'warning' : 'error',
+        })
+      }
+      closePeer(peer)
+    })
+  }
+}
+
+export function setupArtifactStreamProxy(server: ServerType): void {
+  server.on('upgrade', (request: IncomingMessage, socket: Duplex, head: Buffer) => {
+    // eslint-disable-next-line local-rules/no-unhandled-throwing-builtins -- server request URLs always parse
+    const url = new URL(request.url || '', `http://${request.headers.host}`)
+    const route = parseArtifactWebSocketRoute(url.pathname)
+    if (!route) return
+
+    resolveAgentId(route.routeAgentId)
+      .then(async (agentSlug) => {
+        if (!agentSlug) return deny(socket, '404 Not Found')
+        if (!(await authenticateAgentWebSocket(request, agentSlug, 'viewer'))) {
+          return deny(socket, '403 Forbidden')
+        }
+
+        const client = containerManager.getClient(agentSlug)
+        const info = containerManager.getCachedInfo(agentSlug)
+        if (info.status !== 'running' || !info.port) return deny(socket, '503 Service Unavailable')
+
+        const protocols = requestedProtocols(request)
+        const upstream = new WebSocket(
+          `${client.getWebSocketBaseUrl(info.port)}${route.containerPath}${url.search}`,
+          protocols,
+          {
+            headers: {
+              ...artifactWebSocketForwardHeaders(request, route.publicBasePath),
+              ...client.getHostAuthHeaders(),
+            },
+          },
+        )
+
+        let settled = false
+        const fail = (error?: unknown) => {
+          if (settled) return
+          settled = true
+          upstream.terminate()
+          if (error) {
+            captureException(error, {
+              tags: { component: 'artifact-stream-proxy', operation: 'connect' },
+              extra: { agentSlug, artifactSlug: route.artifactSlug },
+            })
+          }
+          deny(socket, '502 Bad Gateway')
+        }
+
+        socket.once('close', () => {
+          if (!settled) upstream.terminate()
+        })
+        upstream.once('unexpected-response', (_req, response) => {
+          response.resume()
+          fail(new Error(`Dashboard WebSocket refused upgrade (${response.statusCode})`))
+        })
+        upstream.once('error', fail)
+        upstream.once('open', () => {
+          if (settled || socket.destroyed) {
+            upstream.terminate()
+            return
+          }
+          settled = true
+          ;(request as ProtocolAwareRequest)._gamutDashboardProtocol = upstream.protocol || undefined
+          artifactWss.handleUpgrade(request, socket, head, (browser) => {
+            bridge(browser, upstream, route)
+          })
+        })
+      })
+      .catch((error) => {
+        captureException(error, {
+          tags: { component: 'artifact-stream-proxy', operation: 'authorize' },
+          extra: { routeAgentId: route.routeAgentId, artifactSlug: route.artifactSlug },
+        })
+        deny(socket, '502 Bad Gateway')
+      })
+  })
+}

--- a/src/main/browser-stream-proxy.ts
+++ b/src/main/browser-stream-proxy.ts
@@ -13,61 +13,10 @@ import { containerManager } from '@shared/lib/container/container-manager'
 import { resolveAgentId } from '@shared/lib/utils/file-storage'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { getSettings } from '@shared/lib/config/settings'
-import { isAuthMode } from '@shared/lib/auth/mode'
 import { captureException } from '@shared/lib/error-reporting'
-import { db } from '@shared/lib/db'
-import { agentAcl } from '@shared/lib/db/schema'
-import { and, eq } from 'drizzle-orm'
+import { authenticateAgentWebSocket } from './agent-websocket-auth'
 
 const browserWss = new WebSocketServer({ noServer: true })
-
-const LOCALHOST_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
-
-import { type AgentRole, ROLE_HIERARCHY } from '@shared/lib/types/agent'
-
-async function authenticateWs(
-  request: IncomingMessage,
-  agentSlug: string,
-  minRole: AgentRole,
-): Promise<boolean> {
-  if (!isAuthMode()) {
-    // Only restrict to localhost in Electron
-    if (process.type === 'browser') {
-      const addr = request.socket?.remoteAddress
-      if (!addr || !LOCALHOST_ADDRS.has(addr)) return false
-    }
-    return true
-  }
-
-  try {
-    // Lazy import to avoid pulling in better-auth ESM at startup
-    const { getAuth } = await import('@shared/lib/auth/index')
-    const auth = getAuth()
-
-    // Convert raw headers to Headers for Better Auth
-    const headers = new Headers()
-    for (const [key, value] of Object.entries(request.headers)) {
-      if (value) headers.set(key, Array.isArray(value) ? value[0] : value)
-    }
-
-    const session = await auth.api.getSession({ headers })
-    if (!session?.user) return false
-
-    // Check agent-level ACL
-    const [row] = await db
-      .select({ role: agentAcl.role })
-      .from(agentAcl)
-      .where(and(eq(agentAcl.userId, session.user.id), eq(agentAcl.agentSlug, agentSlug)))
-      .limit(1)
-
-    if (!row) return false
-    const userRole = row.role as AgentRole
-    return ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[minRole]
-  } catch (error) {
-    console.error('[BrowserProxy] Auth check failed:', error)
-    return false
-  }
-}
 
 export function setupBrowserStreamProxy(server: ServerType): void {
   server.on('upgrade', (request: IncomingMessage, socket: Duplex, head: Buffer) => {
@@ -93,7 +42,7 @@ export function setupBrowserStreamProxy(server: ServerType): void {
       ;(request as any)._agentId = agentSlug
 
       // Authenticate before upgrading — viewer+ can watch, but input is filtered per-role below
-      authenticateWs(request, agentSlug, 'viewer').then((allowed) => {
+      authenticateAgentWebSocket(request, agentSlug, 'viewer').then((allowed) => {
         if (!allowed) {
           socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
           socket.destroy()
@@ -101,7 +50,7 @@ export function setupBrowserStreamProxy(server: ServerType): void {
         }
 
         // Check if user has 'user' role (can send input) — stash on the request object
-        authenticateWs(request, agentSlug, 'user').then((canInput) => {
+        authenticateAgentWebSocket(request, agentSlug, 'user').then((canInput) => {
           ;(request as any)._canInput = canInput
           browserWss.handleUpgrade(request, socket, head, (ws) => {
             browserWss.emit('connection', ws, request)

--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DashboardView } from './dashboard-view'
 
 const mocks = vi.hoisted(() => ({
+  agentSlug: 'agent',
   agentStatus: 'running',
   dashboardStatus: 'crashed',
   start: {
@@ -18,12 +19,13 @@ const mocks = vi.hoisted(() => ({
     mutateAsync: vi.fn(),
     isPending: false,
   },
+  openDashboardExternal: vi.fn(),
 }))
 
 vi.mock('@renderer/hooks/use-agents', () => ({
   useAgent: () => ({
     data: {
-      slug: 'agent',
+      slug: mocks.agentSlug,
       status: mocks.agentStatus,
     },
   }),
@@ -65,6 +67,7 @@ vi.mock('@renderer/lib/env', () => ({
   getApiBaseUrl: () => '',
   getPlatform: () => 'web',
   isElectron: () => false,
+  openDashboardExternal: mocks.openDashboardExternal,
 }))
 
 vi.mock('@renderer/lib/dashboard-utils', () => ({
@@ -78,6 +81,7 @@ vi.mock('@renderer/lib/perf', () => ({
 describe('DashboardView restart', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.agentSlug = 'agent'
     mocks.agentStatus = 'running'
     mocks.dashboardStatus = 'crashed'
     mocks.start.mutateAsync.mockResolvedValue({})
@@ -128,5 +132,18 @@ describe('DashboardView restart', () => {
     view.rerender(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
 
     expect(waiting()).not.toBeNull()
+  })
+
+  it('uses the canonical agent id for the mounted dashboard URL', () => {
+    mocks.agentSlug = 'abc1234567'
+    mocks.dashboardStatus = 'running'
+
+    render(
+      <DashboardView agentSlug="My Agent-abc1234567" dashboardSlug="dashboard" />,
+    )
+
+    expect(document.querySelector('iframe')?.getAttribute('src')).toBe(
+      '/api/agents/abc1234567/artifacts/dashboard/',
+    )
   })
 })

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -85,7 +85,11 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   }, [nextPollFast])
 
   const baseUrl = getApiBaseUrl()
-  const iframeSrc = `${baseUrl}${buildDashboardArtifactPath(agentSlug, dashboardSlug)}`
+  // Dashboard processes receive the canonical agent id in
+  // DASHBOARD_BASE_PATH. Keep their browser-visible URL on that same stable
+  // id even when the surrounding app route uses a decorative display slug.
+  const dashboardAgentSlug = agent?.slug ?? agentSlug
+  const iframeSrc = `${baseUrl}${buildDashboardArtifactPath(dashboardAgentSlug, dashboardSlug)}`
 
   useEffect(() => {
     setIframeLoaded(false)
@@ -99,8 +103,8 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   }, [iframeSrc])
 
   const handlePopOut = useCallback(() => {
-    openDashboardExternal(agentSlug, dashboardSlug, dashboard?.name)
-  }, [agentSlug, dashboardSlug, dashboard?.name])
+    openDashboardExternal(dashboardAgentSlug, dashboardSlug, dashboard?.name)
+  }, [dashboardAgentSlug, dashboardSlug, dashboard?.name])
 
   const handleStartAgent = useCallback(() => {
     startAgent.mutate(agentSlug)
@@ -195,7 +199,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
       <AddToDockDialog
         open={dockDialogOpen}
         onOpenChange={setDockDialogOpen}
-        agentSlug={agentSlug}
+        agentSlug={dashboardAgentSlug}
         dashboardSlug={dashboardSlug}
         dashboardName={dashboard?.name || dashboardSlug}
       />

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -24,6 +24,7 @@ import {
 import { getPlatformAccessToken } from './services/platform-auth-service'
 import { setupBrowserStreamProxy } from '../../main/browser-stream-proxy'
 import { setupCloudStreamProxy } from '../../main/cloud-stream-proxy'
+import { setupArtifactStreamProxy } from '../../main/artifact-stream-proxy'
 import { setServerAnalyticsVersion } from './analytics/server-analytics'
 import { APP_VERSION } from './config/version'
 import { shutdownAC } from './computer-use/executor'
@@ -182,6 +183,7 @@ export async function initializeServices() {
  */
 export function setupServerHandlers(server: ServerType): void {
   setupBrowserStreamProxy(server)
+  setupArtifactStreamProxy(server)
   // Self-gated to Electron main outside auth mode; a no-op everywhere else.
   setupCloudStreamProxy(server)
 }


### PR DESCRIPTION
## Summary

- define a first-class dashboard mount contract through `DASHBOARD_BASE_PATH`, forwarded proxy headers, and an injected `window.__GAMUT_DASHBOARD__` runtime
- keep HTTP redirects, cookies, cache metadata, MIME types, status codes, streaming responses, and canonical dashboard URLs scoped to the artifact mount
- proxy dashboard application WebSockets and Vite HMR through both Gamut proxy hops
- add a Vite adapter with mounted development modules/HMR and relocatable production assets
- make SPA fallback document-only so missing modules and assets return real 404 responses
- document runtime URL/router helpers and the OpenSlide integration
- add a direct-localhost runtime fallback, prevent host-token forwarding, preserve asset validators, and reject URL traversal outside the mount

## Root cause

Gamut exposes dashboards beneath `/api/agents/:id/artifacts/:slug/` but strips that prefix before forwarding requests to the dashboard process. Vite and React Router had no authoritative browser-visible mount, so root-relative development modules escaped the proxy, relative production assets broke on deep routes, and OpenSlide could receive an invalid router basename.

## Impact

Vite/React dashboards can now run beneath arbitrary artifact mounts without hardcoded agent IDs. Deep links survive refreshes, production builds are relocatable, HMR uses the artifact WebSocket path, and redirects/cookies remain dashboard-scoped.

The exported OpenSlide fixture successfully rendered its 25-slide nested deck route with scripts, styles, fonts, images, and dynamic chunks beneath the Gamut prefix. OpenSlide 1.17.1 still hardcodes several editor-only fetch endpoints at host root; adopting the runtime URL helper or a custom wrapper remains an upstream integration follow-up.

## Validation

- `npm test -- --run` — 520 files passed, 8,873 tests passed
- `npm --prefix agent-container test` — 55 files passed, 816 tests passed
- `npm run build`
- `npm run typecheck`
- focused ESLint on all changed TypeScript/TSX files
- Vite dev module and `vite-hmr` WebSocket verification through stripped proxy paths
- relocatable production fixture loaded from a mounted deep route with zero browser errors
- direct-localhost and mounted deep-route runtime verification in both Vite dev and the production static server
- exported OpenSlide production build and mounted deep-route browser render
