### PR TITLE
feat(sidebar): BYOK presentation for the account menu

### DIFF
--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -60,15 +60,26 @@ vi.mock('@renderer/hooks/use-message-stream', () => ({
   useMessageStream: () => ({ isStreaming: false }),
 }))
 
+const mockUseSettings = vi.fn()
 vi.mock('@renderer/hooks/use-settings', () => ({
-  useSettings: () => ({
-    data: { llmProvider: 'anthropic', apiKeyStatus: { anthropic: { isConfigured: true } } },
-  }),
+  useSettings: (options?: { enabled?: boolean }) => mockUseSettings(options),
 }))
 
+// Account-menu identity: default is the BYOK state (no auth user, platform
+// not connected but reachable). Tests flip these to drive the other states.
 const mockUsePlatformAuthStatus = vi.fn()
+const mockHandleConnect = vi.fn()
 vi.mock('@renderer/hooks/use-platform-auth', () => ({
   usePlatformAuthStatus: () => mockUsePlatformAuthStatus(),
+  usePlatformConnect: () => ({
+    handleConnect: mockHandleConnect,
+    isLaunching: false,
+    error: null,
+    message: null,
+    isConnected: false,
+    platformAuth: undefined,
+    isLoadingPlatformAuth: false,
+  }),
 }))
 
 vi.mock('@renderer/hooks/use-user-settings', () => ({
@@ -137,7 +148,7 @@ vi.mock('@renderer/context/search-context', () => ({
 const mockUserContext = {
   isAuthMode: false,
   isAdmin: true,
-  user: null,
+  user: null as { name: string; email: string; image?: string | null } | null,
   signOut: vi.fn(),
   agentMemberCount: () => 1,
 }
@@ -336,12 +347,16 @@ beforeEach(() => {
   mockGetPlatform.mockReturnValue('web')
   mockUserContext.isAuthMode = false
   mockUserContext.user = null
+  mockUseSettings.mockReturnValue({
+    data: { llmProvider: 'anthropic', apiKeyStatus: { anthropic: { isConfigured: true } } },
+  })
   mockUsePlatformAuthStatus.mockReturnValue({
     data: {
       connected: false,
       email: null,
       orgId: null,
       orgName: null,
+      source: null,
       platformBaseUrl: 'https://platform.test.gamut.so',
     },
   })
@@ -470,26 +485,95 @@ describe('AppSidebar — layout & top nav', () => {
   })
 })
 
-describe('AppSidebar — auth identity enrichment', () => {
-  it('uses Better Auth identity when platform metadata is unavailable', async () => {
+describe('AppSidebar — account menu identity states', () => {
+  it('non-auth mode presents the settings provider, not an account', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('user-menu-trigger')).toHaveTextContent('Personal')
+    expect(screen.getByTestId('user-menu-trigger')).toHaveTextContent('Anthropic API key')
+    expect(mockUseSettings).toHaveBeenCalledWith({ enabled: true })
+
+    await user.click(screen.getByTestId('user-menu-trigger'))
+    expect(await screen.findByText('Using your own Anthropic API key')).toBeInTheDocument()
+    expect(screen.getByTestId('connect-platform-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('upgrade-to-pro-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('sign-out-button')).not.toBeInTheDocument()
+  })
+
+  it('non-auth mode shows the configured provider in the trigger subline', () => {
+    mockUseSettings.mockReturnValue({ data: { llmProvider: 'openrouter' } })
+    renderWithProviders(<AppSidebar />)
+    expect(screen.getByTestId('user-menu-trigger')).toHaveTextContent('OpenRouter')
+  })
+
+  it('non-auth mode can start the platform login flow', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AppSidebar />)
+    await user.click(screen.getByTestId('user-menu-trigger'))
+    await user.click(await screen.findByTestId('connect-platform-button'))
+    expect(mockHandleConnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('non-auth mode omits connect when no platform is configured', async () => {
+    // Self-hosted / platform unreachable: no platformBaseUrl in the status.
+    mockUsePlatformAuthStatus.mockReturnValue({
+      data: { connected: false, email: null, source: null, platformBaseUrl: '' },
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<AppSidebar />)
+    await user.click(screen.getByTestId('user-menu-trigger'))
+    expect(await screen.findByTestId('settings-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('connect-platform-button')).not.toBeInTheDocument()
+  })
+
+  it('non-auth mode keeps the provider fallback when platform is connected', async () => {
+    mockUseSettings.mockReturnValue({ data: { llmProvider: 'platform' } })
+    mockUsePlatformAuthStatus.mockReturnValue({
+      data: {
+        connected: true,
+        email: 'west@example.com',
+        orgId: 'org_west',
+        orgName: 'West Engines',
+        source: 'settings',
+        platformBaseUrl: 'https://platform.test.gamut.so',
+      },
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('user-menu-trigger')).toHaveTextContent('Personal')
+    expect(screen.getByTestId('user-menu-trigger')).toHaveTextContent('Gamut platform')
+
+    await user.click(screen.getByTestId('user-menu-trigger'))
+    expect(await screen.findByText('Using Gamut platform credits')).toBeInTheDocument()
+    expect(screen.queryByTestId('upgrade-to-pro-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('connect-platform-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('sign-out-button')).not.toBeInTheDocument()
+  })
+
+  it('auth mode uses Better Auth identity without a linked platform identity', async () => {
     vi.stubGlobal('__AUTH_MODE__', true)
     mockUserContext.isAuthMode = true
     mockUserContext.user = {
       name: 'Ada Lovelace',
       email: 'ada@example.com',
       image: null,
-    } as never
-
+    }
     const user = userEvent.setup()
     renderWithProviders(<AppSidebar />)
     expect(screen.getByTestId('user-menu-trigger')).toHaveTextContent('Ada Lovelace')
+    expect(screen.getByTestId('user-menu-trigger')).toHaveTextContent('ada@example.com')
+    expect(mockUseSettings).toHaveBeenCalledWith({ enabled: false })
 
     await user.click(screen.getByTestId('user-menu-trigger'))
-    expect(await screen.findByText('ada@example.com')).toBeInTheDocument()
+    expect(screen.getAllByText('ada@example.com')).toHaveLength(2)
     expect(screen.queryByTestId('upgrade-to-pro-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('connect-platform-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('sign-out-button')).not.toBeInTheDocument()
   })
 
-  it('enriches Better Auth identity and billing from connected platform metadata', async () => {
+  it('auth mode enriches Better Auth identity and billing from platform metadata', async () => {
     vi.stubGlobal('__AUTH_MODE__', true)
     mockUserContext.isAuthMode = true
     mockUserContext.user = {
@@ -503,6 +587,7 @@ describe('AppSidebar — auth identity enrichment', () => {
         email: 'ada@platform.example',
         orgId: 'org_ada',
         orgName: 'Analytical Engines',
+        source: 'env',
         platformBaseUrl: 'https://platform.test.gamut.so',
       },
     })
@@ -521,6 +606,7 @@ describe('AppSidebar — auth identity enrichment', () => {
       'noopener,noreferrer'
     )
     openWindow.mockRestore()
+    expect(screen.queryByTestId('sign-out-button')).not.toBeInTheDocument()
   })
 })
 

--- a/src/renderer/components/layout/user-menu.tsx
+++ b/src/renderer/components/layout/user-menu.tsx
@@ -4,7 +4,8 @@ import {
   ChevronDown,
   CircleFadingArrowUp,
   CircleHelp,
-  LogOut,
+  Cloud,
+  KeyRound,
   Mail,
   MessagesSquare,
   Monitor,
@@ -29,7 +30,8 @@ import {
 import { useDialogs } from '@renderer/context/dialog-context'
 import { useUpdateStatus } from '@renderer/context/update-status-context'
 import { useUser } from '@renderer/context/user-context'
-import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
+import { usePlatformAuthStatus, usePlatformConnect } from '@renderer/hooks/use-platform-auth'
+import { useSettings, type LlmProviderId } from '@renderer/hooks/use-settings'
 import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
 import { useUpdateUserSettings, useUserSettings } from '@renderer/hooks/use-user-settings'
 import { hasInteractiveLogin } from '@renderer/lib/auth-mode'
@@ -49,12 +51,36 @@ const HELP_LINKS = [
   { key: 'support_call', label: 'Book a support call', href: SUPPORT_CALL_URL, icon: Calendar },
 ] as const
 
+// BYOK (no account) presentation: `short` is the trigger subline, `detail`
+// the menu-header second line. `platform` shouldn't appear without a
+// connected account, but the map stays total so a mid-transition render
+// (defaults applied before the auth query refetches) doesn't mislabel.
+const PROVIDER_LABELS: Record<LlmProviderId, { short: string; detail: string }> = {
+  anthropic: { short: 'Anthropic API key', detail: 'Using your own Anthropic API key' },
+  openrouter: { short: 'OpenRouter', detail: 'Using your own OpenRouter key' },
+  bedrock: { short: 'AWS Bedrock', detail: 'Using AWS Bedrock credentials' },
+  generic: { short: 'Custom endpoint', detail: 'Using a custom API endpoint' },
+  platform: { short: 'Gamut platform', detail: 'Using Gamut platform credits' },
+}
+
 function openExternal(url: string) {
   if (window.electronAPI?.openExternal) {
     void window.electronAPI.openExternal(url)
     return
   }
   window.open(url, '_blank', 'noopener,noreferrer')
+}
+
+function AvatarCircle({ size = 32, children }: { size?: number; children: React.ReactNode }) {
+  return (
+    <div
+      aria-hidden="true"
+      className="flex shrink-0 items-center justify-center rounded-full border border-border/60 bg-muted text-xs font-semibold"
+      style={{ width: size, height: size }}
+    >
+      {children}
+    </div>
+  )
 }
 
 function AccountAvatar({
@@ -169,29 +195,34 @@ function AppearanceRow() {
 }
 
 // Sidebar-footer account menu, mirroring the platform web app's user menu.
+//
+// Auth mode always presents the Better Auth user as the core identity. A
+// linked platform account enriches that identity and enables billing actions.
+// Non-auth mode presents the local provider/settings workspace fallback.
 export function UserMenu() {
   const { isAuthMode, user } = useUser()
   const { openSettings } = useDialogs()
+  const { data: settings } = useSettings({ enabled: !isAuthMode })
   const { data: platformAuth } = usePlatformAuthStatus()
+  const { handleConnect } = usePlatformConnect()
   const { switching, switchTo } = useTargetSwitch()
   const updateStatus = useUpdateStatus()
   const updateAvailable = updateStatus.state === 'available' || updateStatus.state === 'downloaded'
   const showUseThisComputer = isAuthMode && !!user && !hasInteractiveLogin()
 
-  // Better Auth owns identity in auth mode. Platform account data enriches the
-  // secondary metadata and billing destination, but never determines whether
-  // the user has an identity. PR #661 supplies the provider/settings fallback
-  // for non-auth mode.
-  const displayName = isAuthMode && user
+  const hasAuthIdentity = isAuthMode && !!user
+  const providerLabels = PROVIDER_LABELS[settings?.llmProvider ?? 'anthropic']
+  const displayName = hasAuthIdentity
     ? (user.name.trim() || user.email)
     : 'Personal'
-  const email = isAuthMode && user
+  const email = hasAuthIdentity
     ? (platformAuth?.connected && platformAuth.email ? platformAuth.email : user.email)
     : null
-  const avatarUrl = isAuthMode && user ? user.image : null
-  const upgradeUrl = isAuthMode && platformAuth?.connected && platformAuth.platformBaseUrl && platformAuth.orgId
+  const avatarUrl = hasAuthIdentity ? user.image : null
+  const upgradeUrl = hasAuthIdentity && platformAuth?.connected && platformAuth.platformBaseUrl && platformAuth.orgId
     ? `${platformAuth.platformBaseUrl}/dashboard/organizations/${platformAuth.orgId}?tab=billing`
     : null
+  const canConnectPlatform = !isAuthMode && !platformAuth?.connected && !!platformAuth?.platformBaseUrl
 
   return (
     /* modal={false}: a modal menu can leave `pointer-events: none` stuck on
@@ -205,10 +236,24 @@ export function UserMenu() {
           data-testid="user-menu-trigger"
           className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors hover:bg-foreground/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 data-[state=open]:bg-foreground/5"
         >
-          <AccountAvatar name={displayName} image={avatarUrl} />
+          {hasAuthIdentity ? (
+            <AccountAvatar name={displayName} image={avatarUrl} />
+          ) : (
+            <AvatarCircle>
+              <KeyRound className="size-3.5 text-muted-foreground" aria-hidden="true" />
+            </AvatarCircle>
+          )}
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
-            {upgradeUrl && <p className="truncate text-xs text-brand">Upgrade to Pro</p>}
+            {hasAuthIdentity ? (
+              upgradeUrl ? (
+                <p className="truncate text-xs text-brand">Upgrade to Pro</p>
+              ) : (
+                <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+              )
+            ) : (
+              <p className="truncate text-xs text-muted-foreground">{providerLabels.short}</p>
+            )}
           </div>
           <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
         </button>
@@ -222,12 +267,15 @@ export function UserMenu() {
       >
         <div className="px-2 pb-1.5 pt-1">
           <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
-          {email && <p className="truncate text-xs text-muted-foreground">{email}</p>}
+          <p className="truncate text-xs text-muted-foreground">
+            {hasAuthIdentity ? email : providerLabels.detail}
+          </p>
         </div>
 
         {/* Sized to match the app's small outline buttons, like the platform
-            account menu's upgrade CTA. */}
-        {upgradeUrl && (
+            account menu's upgrade CTA. In non-auth mode this slot is the
+            deliberately quiet platform-connect hook. */}
+        {upgradeUrl ? (
           <DropdownMenuItem
             onSelect={() => openExternal(upgradeUrl)}
             data-testid="upgrade-to-pro-button"
@@ -236,6 +284,17 @@ export function UserMenu() {
             <CircleFadingArrowUp className="size-3.5" aria-hidden="true" />
             Upgrade to Pro
           </DropdownMenuItem>
+        ) : (
+          canConnectPlatform && (
+            <DropdownMenuItem
+              onSelect={() => void handleConnect()}
+              data-testid="connect-platform-button"
+              className="mx-1 mb-2 mt-1 h-8 justify-center rounded-md border border-input bg-background px-3 text-xs font-medium focus:bg-sidebar-accent focus:text-sidebar-accent-foreground"
+            >
+              <Cloud className="size-3.5" aria-hidden="true" />
+              Connect Gamut account
+            </DropdownMenuItem>
+          )
         )}
 
         <DropdownMenuSeparator className="bg-sidebar-border/60" />
@@ -265,7 +324,7 @@ export function UserMenu() {
             className="focus:bg-sidebar-accent focus:text-sidebar-accent-foreground"
           >
             <span className="flex-1">Use this computer</span>
-            <LogOut className="size-4 text-muted-foreground" aria-hidden="true" />
+            <Monitor className="size-4 text-muted-foreground" aria-hidden="true" />
           </DropdownMenuItem>
         )}
 


### PR DESCRIPTION
## Summary

Defines the account-menu fallback for non-auth mode while keeping authenticated identity owned by Better Auth:

- Non-auth mode always presents the local settings and provider workspace: key avatar, **Personal**, and the configured provider label
- A connected platform account remains enrichment and add-on state in non-auth mode; it does not replace the provider presentation with an account identity
- **Connect Gamut account** appears only when non-auth mode is disconnected and a platform base URL is configured
- The admin-only global settings query is disabled in auth mode
- Auth mode works with or without a linked platform identity and never falls back to provider settings
- No account-menu Sign out action

**Stack:** PR 4/4 — based on #456.

## Test plan

- [x] Typecheck
- [x] Lint for the changed account-menu files
- [x] 41/41 app-sidebar unit tests