### PR TITLE
Add mounted dashboard upstream paths

### DIFF
--- a/agent-container/skills/dashboards/SKILL.md
+++ b/agent-container/skills/dashboards/SKILL.md
@@ -118,7 +118,7 @@ Dashboards are served through a proxy chain:
 Browser → Main App (/api/agents/:id/artifacts/:slug/) → Container → Dashboard Server
 ```
 
-Gamut strips the public artifact prefix before forwarding requests to the dashboard server. It communicates that mount through `DASHBOARD_BASE_PATH` in the process, `X-Forwarded-Prefix` on HTTP/WebSocket requests, and `window.__GAMUT_DASHBOARD__` in browser HTML.
+Gamut always communicates the public artifact mount through `DASHBOARD_BASE_PATH` in the process and `window.__GAMUT_DASHBOARD__` in browser HTML. The default `stripped` mode also sends `X-Forwarded-Prefix` on HTTP/WebSocket requests. The opt-in `mounted` mode retains the prefix in the upstream request path and omits that header on the final dashboard hop to avoid applying the prefix twice.
 
 Use the injected helper for dashboard-owned URLs. It stays correct on nested client routes and when another trusted proxy adds its own prefix:
 
@@ -179,7 +179,7 @@ Do not patch generated bundles after Vite hashes them and do not add a query str
 
 ## Interactive Validation
 
-- **Validate every dashboard in container Chromium.** After `start_dashboard`, open its localhost URL with `browser_open(url="http://localhost:<port>", location="container")`. The explicit location forces the bundled browser that can reach private container ports.
+- **Validate every dashboard in container Chromium.** After `start_dashboard`, open the exact localhost URL it returns with `browser_open(..., location="container")`. Mounted dashboards include `DASHBOARD_BASE_PATH` in that URL; do not trim it back to `/`. The explicit location forces the bundled browser that can reach private container ports.
 - **Test behavior, not just appearance.** Exercise the primary controls and workflows, inspect rendered and accessibility state, and check browser console/errors for client-side failures.
 - **Use both diagnostic surfaces.** Use `get_dashboard_logs` for server failures and browser diagnostics for rendering or client-side failures.
 - **Close the browser when validation is complete.**

--- a/agent-container/skills/dashboards/SKILL.md
+++ b/agent-container/skills/dashboards/SKILL.md
@@ -144,11 +144,28 @@ Frameworks that accept a base at startup can consume the manager-provided value 
 import type { OpenSlideConfig } from '@open-slide/core';
 
 const config: OpenSlideConfig = {
-  base: process.env.DASHBOARD_BASE_PATH || './',
+  // OpenSlide uses this value for both Vite assets and BrowserRouter.
+  base: process.env.DASHBOARD_BASE_PATH || '/',
+  port: Number(process.env.DASHBOARD_PORT) || 5173,
 };
 
 export default config;
 ```
+
+OpenSlide's built-in Vite configuration cannot install Gamut's prefix-restoring
+middleware. Opt its dashboard server into mounted upstream paths so HTTP modules
+and HMR WebSockets both reach Vite beneath the same absolute base:
+
+```json
+{
+  "scripts": { "start": "open-slide dev" },
+  "gamut": { "upstreamPath": "mounted" }
+}
+```
+
+The default upstream-path mode is `stripped`, which keeps existing dashboard
+servers receiving root-local paths such as `/api/data`. Use `mounted` only when
+the framework requires inbound requests to retain `DASHBOARD_BASE_PATH`.
 
 For an app-owned React Router, prefer the injected runtime value:
 

--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -171,6 +171,7 @@ describe('DashboardManager log stream lifecycle', () => {
     }>
     stopDashboard(slug: string): Promise<boolean>
     stopAll(): Promise<void>
+    getDashboardUpstreamPathMode(slug: string): 'stripped' | 'mounted'
   }
   let procs: FakeChildProcess[]
   let slugCounter = 0
@@ -202,13 +203,13 @@ describe('DashboardManager log stream lifecycle', () => {
   })
 
   /** Scaffold a dashboard dir whose node_modules is fresh (skips bun install). */
-  async function scaffoldDashboard(): Promise<string> {
+  async function scaffoldDashboard(packageFields: Record<string, unknown> = {}): Promise<string> {
     const slug = `dash-${++slugCounter}`
     const dir = path.join(testDir, slug)
     await fs.promises.mkdir(path.join(dir, 'node_modules'), { recursive: true })
     await fs.promises.writeFile(
       path.join(dir, 'package.json'),
-      JSON.stringify({ name: slug, scripts: { start: 'true' } })
+      JSON.stringify({ name: slug, scripts: { start: 'true' }, ...packageFields })
     )
     // node_modules must be at least as new as package.json to skip install
     const future = new Date(Date.now() + 60_000)
@@ -291,6 +292,22 @@ describe('DashboardManager log stream lifecycle', () => {
 
     const stat = await fs.promises.stat(logPath)
     expect(stat.size).toBeLessThan(1024 * 1024)
+  })
+
+  it('loads an explicit mounted upstream path contract from package metadata', async () => {
+    const slug = await scaffoldDashboard({ gamut: { upstreamPath: 'mounted' } })
+
+    await manager.startDashboard(slug, { forceInstall: false })
+
+    expect(manager.getDashboardUpstreamPathMode(slug)).toBe('mounted')
+  })
+
+  it('defaults dashboards to the stripped upstream path contract', async () => {
+    const slug = await scaffoldDashboard()
+
+    await manager.startDashboard(slug, { forceInstall: false })
+
+    expect(manager.getDashboardUpstreamPathMode(slug)).toBe('stripped')
   })
 
   describe('install semantics', () => {

--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -9,6 +9,7 @@ import {
   SLUG_REGEX,
   ARTIFACTS_DIR,
   getDashboardBasePath,
+  getDashboardValidationUrl,
   truncateOversizedLog,
 } from './dashboard-manager'
 
@@ -120,6 +121,20 @@ describe('getDashboardBasePath', () => {
   it('omits startup metadata when no valid agent identity is available', () => {
     expect(getDashboardBasePath('open-slide', '')).toBeNull()
     expect(getDashboardBasePath('open-slide', '../spoofed')).toBeNull()
+  })
+})
+
+describe('getDashboardValidationUrl', () => {
+  it('uses the local root for stripped dashboards', () => {
+    expect(getDashboardValidationUrl('slides', 5000, 'stripped', 'agent-123')).toBe(
+      'http://localhost:5000/',
+    )
+  })
+
+  it('uses the public mount for mounted dashboards', () => {
+    expect(getDashboardValidationUrl('slides', 5000, 'mounted', 'agent-123')).toBe(
+      'http://localhost:5000/api/agents/agent-123/artifacts/slides/',
+    )
   })
 })
 
@@ -308,6 +323,19 @@ describe('DashboardManager log stream lifecycle', () => {
     await manager.startDashboard(slug, { forceInstall: false })
 
     expect(manager.getDashboardUpstreamPathMode(slug)).toBe('stripped')
+  })
+
+  it('warns and safely defaults an invalid upstream path mode', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const slug = await scaffoldDashboard({ gamut: { upstreamPath: 'Mounted' } })
+
+    await manager.startDashboard(slug, { forceInstall: false })
+
+    expect(manager.getDashboardUpstreamPathMode(slug)).toBe('stripped')
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`Invalid package.json metadata for ${slug}`),
+      expect.anything(),
+    )
   })
 
   describe('install semantics', () => {

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 import { captureDashboardScreenshot, type ScreenshotResult } from './dashboard-screenshot'
+import { DashboardPackageSchema } from './dashboard-package-schema'
 
 const SCREENSHOT_FILENAME = 'screenshot.png'
 
@@ -92,6 +93,16 @@ export function getDashboardBasePath(
 export type DashboardStatus = 'running' | 'stopped' | 'crashed' | 'starting'
 export type DashboardUpstreamPathMode = 'stripped' | 'mounted'
 
+export function getDashboardValidationUrl(
+  slug: string,
+  port: number,
+  mode: DashboardUpstreamPathMode,
+  agentId?: string,
+): string {
+  const pathname = mode === 'mounted' ? (getDashboardBasePath(slug, agentId) ?? '/') : '/'
+  return `http://localhost:${port}${pathname}`
+}
+
 interface DashboardInfo {
   slug: string
   name: string
@@ -175,7 +186,8 @@ class DashboardManager {
       return { ok: false, reason: `Dashboard ${slug} is not running` }
     }
     const outPath = path.join(ARTIFACTS_DIR, slug, SCREENSHOT_FILENAME)
-    return captureDashboardScreenshot(`http://localhost:${info.port}/`, outPath)
+    const url = getDashboardValidationUrl(slug, info.port, info.upstreamPathMode)
+    return captureDashboardScreenshot(url, outPath)
   }
 
   private readPackageJson(slug: string): {
@@ -185,13 +197,17 @@ class DashboardManager {
   } {
     try {
       const pkgPath = path.join(ARTIFACTS_DIR, slug, 'package.json')
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+      const pkg = DashboardPackageSchema.parse(JSON.parse(fs.readFileSync(pkgPath, 'utf-8')))
       return {
         name: pkg.name || slug,
         description: pkg.description || '',
         upstreamPathMode: pkg.gamut?.upstreamPath === 'mounted' ? 'mounted' : 'stripped',
       }
-    } catch {
+    } catch (error) {
+      console.warn(
+        `[DashboardManager] Invalid package.json metadata for ${slug}; using safe defaults:`,
+        error,
+      )
       return { name: slug, description: '', upstreamPathMode: 'stripped' }
     }
   }

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -90,11 +90,13 @@ export function getDashboardBasePath(
 }
 
 export type DashboardStatus = 'running' | 'stopped' | 'crashed' | 'starting'
+export type DashboardUpstreamPathMode = 'stripped' | 'mounted'
 
 interface DashboardInfo {
   slug: string
   name: string
   description: string
+  upstreamPathMode: DashboardUpstreamPathMode
   port: number
   status: DashboardStatus
   process: ChildProcess | null
@@ -176,16 +178,21 @@ class DashboardManager {
     return captureDashboardScreenshot(`http://localhost:${info.port}/`, outPath)
   }
 
-  private readPackageJson(slug: string): { name: string; description: string } {
+  private readPackageJson(slug: string): {
+    name: string
+    description: string
+    upstreamPathMode: DashboardUpstreamPathMode
+  } {
     try {
       const pkgPath = path.join(ARTIFACTS_DIR, slug, 'package.json')
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
       return {
         name: pkg.name || slug,
         description: pkg.description || '',
+        upstreamPathMode: pkg.gamut?.upstreamPath === 'mounted' ? 'mounted' : 'stripped',
       }
     } catch {
-      return { name: slug, description: '' }
+      return { name: slug, description: '', upstreamPathMode: 'stripped' }
     }
   }
 
@@ -217,7 +224,7 @@ class DashboardManager {
       this.closeLogStream(existing)
     }
 
-    const { name, description } = this.readPackageJson(slug)
+    const { name, description, upstreamPathMode } = this.readPackageJson(slug)
     const port = existing?.port ?? this.nextPort++
     const dashboardDir = path.join(ARTIFACTS_DIR, slug)
     const logPath = path.join(dashboardDir, 'dashboard.log')
@@ -226,6 +233,7 @@ class DashboardManager {
       slug,
       name,
       description,
+      upstreamPathMode,
       port,
       status: 'starting',
       process: null,
@@ -531,6 +539,10 @@ class DashboardManager {
     const info = this.dashboards.get(slug)
     if (!info || info.status !== 'running') return null
     return info.port
+  }
+
+  getDashboardUpstreamPathMode(slug: string): DashboardUpstreamPathMode {
+    return this.dashboards.get(slug)?.upstreamPathMode ?? 'stripped'
   }
 
   async getDashboardLogs(slug: string, clear: boolean = false): Promise<string> {

--- a/agent-container/src/dashboard-package-schema.ts
+++ b/agent-container/src/dashboard-package-schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const DashboardPackageSchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    gamut: z
+      .object({
+        upstreamPath: z.enum(['stripped', 'mounted']).optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()

--- a/agent-container/src/dashboard-proxy.test.ts
+++ b/agent-container/src/dashboard-proxy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   dashboardHttpForwardHeaders,
+  dashboardHttpUpstreamPath,
   dashboardWebSocketForwardHeaders,
   dashboardWebSocketUpstreamPath,
   parseDashboardProxyRoute,
@@ -21,6 +22,27 @@ describe('dashboard HTTP headers', () => {
       cookie: 'dashboard=abc',
       'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
     })
+  })
+})
+
+describe('dashboard HTTP upstream path', () => {
+  const basePath = '/api/agents/agent-1/artifacts/open-slide/'
+
+  it('keeps the compatibility contract stripped by default', () => {
+    expect(dashboardHttpUpstreamPath('/@vite/client', basePath, 'stripped')).toBe(
+      '/@vite/client',
+    )
+  })
+
+  it('restores the public mount for opted-in dashboard servers', () => {
+    expect(dashboardHttpUpstreamPath('/@vite/client', basePath, 'mounted')).toBe(
+      `${basePath}@vite/client`,
+    )
+    expect(dashboardHttpUpstreamPath('/', basePath, 'mounted')).toBe(basePath)
+  })
+
+  it('falls back to the stripped path when host mount metadata is unavailable', () => {
+    expect(dashboardHttpUpstreamPath('/@vite/client', null, 'mounted')).toBe('/@vite/client')
   })
 })
 
@@ -77,5 +99,11 @@ describe('dashboard WebSocket upstream path', () => {
   it('leaves application WebSocket paths stripped', () => {
     expect(dashboardWebSocketUpstreamPath('/socket', ['dashboard-v1'], basePath)).toBe('/socket')
     expect(dashboardWebSocketUpstreamPath('/socket', ['vite-hmr'], null)).toBe('/socket')
+  })
+
+  it('restores application WebSocket paths for mounted dashboards', () => {
+    expect(dashboardWebSocketUpstreamPath('/socket', ['dashboard-v1'], basePath, 'mounted')).toBe(
+      `${basePath}socket`,
+    )
   })
 })

--- a/agent-container/src/dashboard-proxy.test.ts
+++ b/agent-container/src/dashboard-proxy.test.ts
@@ -11,17 +11,32 @@ import {
 
 describe('dashboard HTTP headers', () => {
   it('preserves request metadata without exposing the host credential', () => {
-    const headers = dashboardHttpForwardHeaders({
-      host: 'container.internal',
-      cookie: 'dashboard=abc',
-      'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
-      'x-superagent-host-token': 'secret',
-    })
+    const headers = dashboardHttpForwardHeaders(
+      {
+        host: 'container.internal',
+        cookie: 'dashboard=abc',
+        'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
+        'x-superagent-host-token': 'secret',
+      },
+      'stripped',
+    )
 
     expect(Object.fromEntries(headers)).toEqual({
       cookie: 'dashboard=abc',
       'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
     })
+  })
+
+  it('omits the stripped-prefix signal when the path remains mounted', () => {
+    const headers = dashboardHttpForwardHeaders(
+      {
+        cookie: 'dashboard=abc',
+        'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
+      },
+      'mounted',
+    )
+
+    expect(Object.fromEntries(headers)).toEqual({ cookie: 'dashboard=abc' })
   })
 })
 
@@ -78,11 +93,24 @@ describe('dashboard WebSocket headers', () => {
       },
     } as any
 
-    expect(dashboardWebSocketForwardHeaders(request)).toEqual({
+    expect(dashboardWebSocketForwardHeaders(request, 'stripped')).toEqual({
       cookie: 'dashboard=abc',
       'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
     })
     expect(requestedWebSocketProtocols(request)).toEqual(['vite-hmr', 'second'])
+  })
+
+  it('omits the stripped-prefix signal for mounted WebSockets', () => {
+    const request = {
+      headers: {
+        cookie: 'dashboard=abc',
+        'x-forwarded-prefix': '/api/agents/a/artifacts/slides',
+      },
+    } as any
+
+    expect(dashboardWebSocketForwardHeaders(request, 'mounted')).toEqual({
+      cookie: 'dashboard=abc',
+    })
   })
 })
 
@@ -90,15 +118,19 @@ describe('dashboard WebSocket upstream path', () => {
   const basePath = '/api/agents/agent-1/artifacts/open-slide/'
 
   it('restores the public Vite base for HMR handshakes', () => {
-    expect(dashboardWebSocketUpstreamPath('/', ['vite-hmr'], basePath)).toBe(basePath)
-    expect(dashboardWebSocketUpstreamPath('/custom-hmr', ['vite-ping'], basePath)).toBe(
+    expect(dashboardWebSocketUpstreamPath('/', ['vite-hmr'], basePath, 'stripped')).toBe(basePath)
+    expect(dashboardWebSocketUpstreamPath('/custom-hmr', ['vite-ping'], basePath, 'stripped')).toBe(
       `${basePath}custom-hmr`,
     )
   })
 
   it('leaves application WebSocket paths stripped', () => {
-    expect(dashboardWebSocketUpstreamPath('/socket', ['dashboard-v1'], basePath)).toBe('/socket')
-    expect(dashboardWebSocketUpstreamPath('/socket', ['vite-hmr'], null)).toBe('/socket')
+    expect(
+      dashboardWebSocketUpstreamPath('/socket', ['dashboard-v1'], basePath, 'stripped'),
+    ).toBe('/socket')
+    expect(
+      dashboardWebSocketUpstreamPath('/socket', ['vite-hmr'], null, 'stripped'),
+    ).toBe('/socket')
   })
 
   it('restores application WebSocket paths for mounted dashboards', () => {

--- a/agent-container/src/dashboard-proxy.ts
+++ b/agent-container/src/dashboard-proxy.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from 'http'
+import type { DashboardUpstreamPathMode } from './dashboard-manager'
 
 export interface DashboardProxyRoute {
   slug: string
@@ -60,20 +61,36 @@ export function requestedWebSocketProtocols(
   return value ? value.split(',').map((protocol) => protocol.trim()).filter(Boolean) : []
 }
 
+function mountedDashboardPath(subPath: string, publicBasePath: string | null): string {
+  if (!publicBasePath?.startsWith('/')) return subPath
+
+  const mount = publicBasePath.endsWith('/') ? publicBasePath.slice(0, -1) : publicBasePath
+  return subPath === '/' ? `${mount}/` : `${mount}${subPath.startsWith('/') ? '' : '/'}${subPath}`
+}
+
+/** Select the URL path presented to the dashboard's HTTP server. */
+export function dashboardHttpUpstreamPath(
+  subPath: string,
+  publicBasePath: string | null,
+  mode: DashboardUpstreamPathMode,
+): string {
+  return mode === 'mounted' ? mountedDashboardPath(subPath, publicBasePath) : subPath
+}
+
 /**
- * Vite validates upgrade paths against its browser-visible `base`. Regular
- * dashboard sockets keep the platform contract and receive a stripped path.
+ * Mounted dashboards retain their public base for every socket. In the default
+ * stripped mode, Vite HMR is the sole exception because Vite validates upgrade
+ * paths against its browser-visible `base`.
  */
 export function dashboardWebSocketUpstreamPath(
   subPath: string,
   protocols: string[],
   publicBasePath: string | null,
+  mode: DashboardUpstreamPathMode = 'stripped',
 ): string {
+  if (mode === 'mounted') return mountedDashboardPath(subPath, publicBasePath)
   if (!protocols.some((protocol) => protocol === 'vite-hmr' || protocol === 'vite-ping')) {
     return subPath
   }
-  if (!publicBasePath?.startsWith('/')) return subPath
-
-  const mount = publicBasePath.endsWith('/') ? publicBasePath.slice(0, -1) : publicBasePath
-  return subPath === '/' ? `${mount}/` : `${mount}${subPath.startsWith('/') ? '' : '/'}${subPath}`
+  return mountedDashboardPath(subPath, publicBasePath)
 }

--- a/agent-container/src/dashboard-proxy.ts
+++ b/agent-container/src/dashboard-proxy.ts
@@ -9,10 +9,14 @@ export interface DashboardProxyRoute {
 const DASHBOARD_SLUG = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 
 /** Do not expose the host-to-container credential to agent-authored servers. */
-export function dashboardHttpForwardHeaders(source: Record<string, string>): Headers {
+export function dashboardHttpForwardHeaders(
+  source: Record<string, string>,
+  mode: DashboardUpstreamPathMode,
+): Headers {
   const headers = new Headers(source)
   headers.delete('host')
   headers.delete('x-superagent-host-token')
+  if (mode === 'mounted') headers.delete('x-forwarded-prefix')
   return headers
 }
 
@@ -44,10 +48,12 @@ const SKIP_WEBSOCKET_HEADERS = new Set([
 
 export function dashboardWebSocketForwardHeaders(
   request: Pick<IncomingMessage, 'headers'>,
+  mode: DashboardUpstreamPathMode,
 ): Record<string, string> {
   const headers: Record<string, string> = {}
   for (const [name, value] of Object.entries(request.headers)) {
     if (value === undefined || SKIP_WEBSOCKET_HEADERS.has(name.toLowerCase())) continue
+    if (mode === 'mounted' && name.toLowerCase() === 'x-forwarded-prefix') continue
     headers[name] = Array.isArray(value) ? value.join(', ') : value
   }
   return headers
@@ -86,7 +92,7 @@ export function dashboardWebSocketUpstreamPath(
   subPath: string,
   protocols: string[],
   publicBasePath: string | null,
-  mode: DashboardUpstreamPathMode = 'stripped',
+  mode: DashboardUpstreamPathMode,
 ): string {
   if (mode === 'mounted') return mountedDashboardPath(subPath, publicBasePath)
   if (!protocols.some((protocol) => protocol === 'vite-hmr' || protocol === 'vite-ping')) {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -21,6 +21,7 @@ import { startScreenshotJanitor } from './screenshot-janitor';
 import { dashboardManager, getDashboardBasePath } from './dashboard-manager';
 import {
   dashboardHttpForwardHeaders,
+  dashboardHttpUpstreamPath,
   dashboardWebSocketForwardHeaders,
   dashboardWebSocketUpstreamPath,
   parseDashboardProxyRoute,
@@ -578,7 +579,12 @@ async function proxyToDashboard(c: any) {
   const url = new URL(c.req.url);
   const prefixPattern = `/artifacts/${slug}`;
   const subPath = url.pathname.slice(url.pathname.indexOf(prefixPattern) + prefixPattern.length) || '/';
-  const targetUrl = `http://localhost:${port}${subPath}${url.search}`;
+  const targetPath = dashboardHttpUpstreamPath(
+    subPath,
+    getDashboardBasePath(slug),
+    dashboardManager.getDashboardUpstreamPathMode(slug),
+  );
+  const targetUrl = `http://localhost:${port}${targetPath}${url.search}`;
 
   const headers = dashboardHttpForwardHeaders(c.req.header());
 
@@ -1997,6 +2003,7 @@ server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) 
       dashboardRoute.subPath,
       protocols,
       getDashboardBasePath(dashboardRoute.slug),
+      dashboardManager.getDashboardUpstreamPathMode(dashboardRoute.slug),
     );
     const upstream = new WebSocket(
       `ws://127.0.0.1:${dashboardPort}${upstreamPath}${url.search}`,

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -579,14 +579,15 @@ async function proxyToDashboard(c: any) {
   const url = new URL(c.req.url);
   const prefixPattern = `/artifacts/${slug}`;
   const subPath = url.pathname.slice(url.pathname.indexOf(prefixPattern) + prefixPattern.length) || '/';
+  const upstreamPathMode = dashboardManager.getDashboardUpstreamPathMode(slug);
   const targetPath = dashboardHttpUpstreamPath(
     subPath,
     getDashboardBasePath(slug),
-    dashboardManager.getDashboardUpstreamPathMode(slug),
+    upstreamPathMode,
   );
   const targetUrl = `http://localhost:${port}${targetPath}${url.search}`;
 
-  const headers = dashboardHttpForwardHeaders(c.req.header());
+  const headers = dashboardHttpForwardHeaders(c.req.header(), upstreamPathMode);
 
   const response = await fetch(targetUrl, {
     method: c.req.method,
@@ -1986,9 +1987,8 @@ server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) 
     return;
   }
 
-  // Dashboard application sockets and Vite HMR use the same artifact mount as
-  // HTTP. The public prefix was stripped by the host proxy; strip the remaining
-  // container prefix before dialing the dashboard process.
+  // Dashboard application sockets and Vite HMR use the same upstream path
+  // contract as HTTP after the container artifact prefix is removed.
   const dashboardRoute = parseDashboardProxyRoute(pathname);
   if (dashboardRoute) {
     const dashboardPort = dashboardManager.getDashboardPort(dashboardRoute.slug);
@@ -1999,16 +1999,17 @@ server.on('upgrade', (request: http.IncomingMessage, socket: any, head: Buffer) 
     }
 
     const protocols = requestedWebSocketProtocols(request);
+    const upstreamPathMode = dashboardManager.getDashboardUpstreamPathMode(dashboardRoute.slug);
     const upstreamPath = dashboardWebSocketUpstreamPath(
       dashboardRoute.subPath,
       protocols,
       getDashboardBasePath(dashboardRoute.slug),
-      dashboardManager.getDashboardUpstreamPathMode(dashboardRoute.slug),
+      upstreamPathMode,
     );
     const upstream = new WebSocket(
       `ws://127.0.0.1:${dashboardPort}${upstreamPath}${url.search}`,
       protocols,
-      { headers: dashboardWebSocketForwardHeaders(request) },
+      { headers: dashboardWebSocketForwardHeaders(request, upstreamPathMode) },
     );
     let settled = false;
 

--- a/agent-container/src/tools/start-dashboard.ts
+++ b/agent-container/src/tools/start-dashboard.ts
@@ -2,7 +2,11 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { tool } from '@anthropic-ai/claude-agent-sdk'
 import { z } from 'zod'
-import { dashboardManager, ARTIFACTS_DIR } from '../dashboard-manager'
+import {
+  dashboardManager,
+  ARTIFACTS_DIR,
+  getDashboardValidationUrl,
+} from '../dashboard-manager'
 import { resizeScreenshot } from '../image-utils'
 import { lintDashboardDir, formatUrlFindings } from '../dashboard-url-lint'
 
@@ -27,9 +31,14 @@ The dashboard must exist at /workspace/artifacts/<slug>/ with a valid package.js
       const content: ToolContentBlock[] = []
 
       if (info.status === 'running') {
+        const validationUrl = getDashboardValidationUrl(
+          args.slug,
+          info.port,
+          info.upstreamPathMode,
+        )
         text += '\n\nThe dashboard is accessible to the user through the Gamut UI.'
         text +=
-          `\n\nFor interactive validation, open http://localhost:${info.port} with browser_open using location="container". This forces the bundled Chromium that can reach the dashboard's private container port.`
+          `\n\nFor interactive validation, open ${validationUrl} with browser_open using location="container". This forces the bundled Chromium that can reach the dashboard's private container port.`
 
         // Await screenshot so the agent can sanity-check rendering in the same
         // tool result. Best-effort: if capture fails we still return success.


### PR DESCRIPTION
## Summary

- add an opt-in `gamut.upstreamPath: "mounted"` dashboard contract
- present `DASHBOARD_BASE_PATH` to mounted dashboard servers for both HTTP and WebSocket traffic
- keep the existing stripped-path behavior as the compatibility default
- make screenshots and interactive validation use the mounted URL when opted in
- omit `X-Forwarded-Prefix` on the final mounted dashboard hop and validate dashboard package metadata with Zod
- correct the OpenSlide base fallback from `./` to `/` and document its mounted HMR setup

## Root cause

OpenSlide uses one absolute base for both Vite assets and React Router, but its built-in Vite configuration is sealed with `configFile: false` and cannot install Gamut's prefix-restoring middleware. Gamut therefore delivered mount-stripped HTTP paths to Vite while already restoring the mount for Vite HMR WebSockets.

An explicit mounted upstream mode makes both transports present the same browser-visible base without an additional dashboard-side proxy process.

## Impact

OpenSlide and similarly constrained frameworks can run their development server directly on `DASHBOARD_PORT` with working module loading and HMR. Existing dashboards continue receiving root-local paths unless they explicitly opt in.

Builds on #659, which is now merged into `main`.

## Validation

- `npm --prefix agent-container test` — 55 files passed, 827 tests passed
- `npm --prefix agent-container run build`
- `npm run typecheck`
- `git diff --check`
