### PR TITLE
Animate and anchor new session turns

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, fireEvent, act } from '@testing-library/react'
 import { useState } from 'react'
 import { MessageList } from './message-list'
@@ -155,6 +155,10 @@ describe('MessageList', () => {
       discardedCommandUuids: [],
       thinkingBlocks: [],
     })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('shows loading spinner', () => {
@@ -1876,6 +1880,170 @@ describe('MessageList', () => {
       // Pinned to bottom: the slice slides so the DOM stays bounded — m5 drops off.
       expect(screen.queryByText('m5')).not.toBeInTheDocument()
       expect(screen.getByText('m305')).toBeInTheDocument()
+    })
+  })
+
+  describe('new-turn scroll anchoring', () => {
+    const pending = { localId: 'pending-turn', text: 'What changed?', sentAt: Date.now() }
+
+    function mockTurnGeometry(el: HTMLElement, { reducedMotion = true } = {}) {
+      let naturalScrollHeight = 1300
+      let scrollTop = 700
+      const anchorDocumentTop = 1200
+      const spacer = screen.getByTestId('turn-anchor-spacer')
+
+      vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+        matches: reducedMotion && query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as unknown as MediaQueryList)
+
+      Object.defineProperty(el, 'scrollHeight', {
+        configurable: true,
+        get: () => naturalScrollHeight + (Number.parseFloat(spacer.style.height) || 0),
+      })
+      Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => 600 })
+      Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => { scrollTop = value },
+      })
+
+      vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+        const top = this === el
+          ? 0
+          : (this as HTMLElement).dataset.turnAnchorId
+            ? anchorDocumentTop - scrollTop
+            : 0
+        return {
+          x: 0,
+          y: top,
+          top,
+          bottom: top,
+          left: 0,
+          right: 0,
+          width: 0,
+          height: 0,
+          toJSON: () => ({}),
+        }
+      })
+
+      return {
+        get scrollTop() { return scrollTop },
+        setScrollTop(value: number) { scrollTop = value },
+        setNaturalScrollHeight(value: number) { naturalScrollHeight = value },
+      }
+    }
+
+    it('places a newly sent message 100px from the top and reserves room below it', () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      rerender(
+        <MessageList
+          sessionId="s-1"
+          agentSlug="agent-1"
+          pendingUserMessages={[pending]}
+        />,
+      )
+
+      const anchor = screen.getByText('What changed?').closest('[data-turn-anchor-id]') as HTMLElement
+      expect(anchor.getBoundingClientRect().top).toBe(100)
+      expect(geometry.scrollTop).toBe(1100)
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+    })
+
+    it('animates the new turn to its reading line with eased progress', () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el, { reducedMotion: false })
+      const frames: FrameRequestCallback[] = []
+      vi.spyOn(performance, 'now').mockReturnValue(0)
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+        frames.push(callback)
+        return frames.length
+      })
+      vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+
+      expect(geometry.scrollTop).toBe(700)
+      expect(frames).toHaveLength(1)
+
+      act(() => frames.shift()!(110))
+      expect(geometry.scrollTop).toBeGreaterThan(700)
+      expect(geometry.scrollTop).toBeLessThan(1100)
+
+      act(() => frames.shift()!(220))
+      expect(geometry.scrollTop).toBe(1100)
+    })
+
+    it('spends the reserved room before following streamed content at the live edge', () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const geometry = mockTurnGeometry(screen.getByTestId('message-list'))
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+
+      geometry.setNaturalScrollHeight(1550)
+      mockStreamState.streamingMessage = 'The response is growing'
+      mockStreamState.isStreaming = true
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(1100)
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '150px' })
+
+      geometry.setNaturalScrollHeight(1800)
+      mockStreamState.streamingMessage = 'The response has reached the live edge and keeps growing'
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '0px' })
+      expect(geometry.scrollTop).toBe(1200)
+    })
+
+    it('discards only the reserved room that the user scrolls past', () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+
+      fireEvent.wheel(el, { deltaY: -80 })
+      geometry.setScrollTop(1020)
+      fireEvent.scroll(el)
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '320px' })
+      expect(geometry.scrollTop).toBe(1020)
+
+      geometry.setScrollTop(700)
+      fireEvent.scroll(el)
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '0px' })
+
+      const releasedScrollTop = geometry.scrollTop
+      geometry.setNaturalScrollHeight(1900)
+      mockStreamState.streamingMessage = 'More output after the user took control'
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(releasedScrollTop)
     })
   })
 

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -27,7 +27,18 @@ import { useUser } from '@renderer/context/user-context'
 import { appendToSessionDraft, useDraft, useDraftsStore } from '@renderer/context/drafts-context'
 import { useWorkflow } from '@renderer/context/workflow-context'
 import { useRenderTracker } from '@renderer/lib/perf'
-import { useEffect, useLayoutEffect, useRef, useState, useCallback, useMemo, Fragment, type ReactNode } from 'react'
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+  Fragment,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  type UIEvent as ReactUIEvent,
+} from 'react'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import type { ApiMessage, ApiCompactBoundary, ApiMemoryRecall, ApiInformational } from '@shared/lib/types/api'
 
@@ -44,6 +55,9 @@ const SYSTEM_MESSAGE_PREFIX = '[SYSTEM] '
 // and is reset when the session changes.
 const BASE_WINDOW = 300
 const LOAD_STEP = 200
+const TURN_ANCHOR_TOP = 100
+const TURN_ANCHOR_ANIMATION_MS = 220
+const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
 
 function DeliveredFiles({ files, agentSlug }: { files: { filePath: string }[]; agentSlug: string }) {
   return (
@@ -295,6 +309,16 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   }, [pendingUserMessages, peerUserMessages, isActive, onPendingMessageAppeared, sessionId, draftsStore])
 
   const scrollRef = useRef<HTMLDivElement>(null)
+  const contentBodyRef = useRef<HTMLDivElement>(null)
+  const bottomSpacerRef = useRef<HTMLDivElement>(null)
+  const bottomSpacerHeightRef = useRef(0)
+  const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
+  const shouldAutoFollowRef = useRef(true)
+  const programmaticScrollTopRef = useRef<number | null>(null)
+  const userScrollIntentRef = useRef(false)
+  const lastScrollTopRef = useRef(0)
+  const scrollAnimationFrameRef = useRef<number | null>(null)
+  const animateNextTurnRef = useRef(false)
   const isScrolledToBottomRef = useRef(true)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
 
@@ -339,18 +363,142 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   useLayoutEffect(() => {
     const grown = visibleMessages.length - prevVisibleLenRef.current
     prevVisibleLenRef.current = visibleMessages.length
-    if (grown > 0 && !isScrolledToBottomRef.current) {
+    if (grown > 0 && (!isScrolledToBottomRef.current || anchoredTurnRef.current)) {
       setWindowSize((n) => n + grown)
     }
   }, [visibleMessages])
 
-  const handleScroll = useCallback(() => {
+  const setBottomSpacerHeight = useCallback((height: number) => {
+    const spacer = bottomSpacerRef.current
+    if (!spacer) return
+    const nextHeight = Math.max(0, Math.ceil(height))
+    bottomSpacerHeightRef.current = nextHeight
+    spacer.style.height = `${nextHeight}px`
+    spacer.hidden = nextHeight === 0
+  }, [])
+
+  const setScrollTop = useCallback((el: HTMLDivElement, scrollTop: number) => {
+    const nextScrollTop = Math.min(
+      Math.max(0, scrollTop),
+      Math.max(0, el.scrollHeight - el.clientHeight),
+    )
+    programmaticScrollTopRef.current = nextScrollTop
+    lastScrollTopRef.current = nextScrollTop
+    el.scrollTop = nextScrollTop
+  }, [])
+
+  const cancelScrollAnimation = useCallback(() => {
+    if (scrollAnimationFrameRef.current == null) return
+    cancelAnimationFrame(scrollAnimationFrameRef.current)
+    scrollAnimationFrameRef.current = null
+  }, [])
+
+  const animateScrollTop = useCallback((el: HTMLDivElement, targetScrollTop: number) => {
+    cancelScrollAnimation()
+    const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
+    const target = Math.min(Math.max(0, targetScrollTop), maxScrollTop)
+    const start = el.scrollTop
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduceMotion || Math.abs(target - start) <= 1) {
+      setScrollTop(el, target)
+      return
+    }
+
+    const startedAt = performance.now()
+    const tick = (now: number) => {
+      const progress = Math.min(1, (now - startedAt) / TURN_ANCHOR_ANIMATION_MS)
+      const eased = 1 - Math.pow(1 - progress, 3)
+      setScrollTop(el, start + (target - start) * eased)
+
+      if (progress < 1) {
+        scrollAnimationFrameRef.current = requestAnimationFrame(tick)
+        return
+      }
+
+      scrollAnimationFrameRef.current = null
+      const anchoredTurn = anchoredTurnRef.current
+      setScrollTop(el, anchoredTurn ? anchoredTurn.scrollTop : el.scrollHeight)
+    }
+    scrollAnimationFrameRef.current = requestAnimationFrame(tick)
+  }, [cancelScrollAnimation, setScrollTop])
+
+  useEffect(() => cancelScrollAnimation, [cancelScrollAnimation])
+
+  // Keep the newly-sent turn fixed at its reading line while the response uses
+  // up the reserved room below it. Once that room reaches zero, following the
+  // live edge naturally takes over.
+  const syncFollowPosition = useCallback(() => {
     const el = scrollRef.current
     if (!el) return
+
+    const anchoredTurn = anchoredTurnRef.current
+    if (anchoredTurn) {
+      const naturalScrollHeight = el.scrollHeight - bottomSpacerHeightRef.current
+      const requiredSpacer = Math.max(
+        0,
+        anchoredTurn.scrollTop + el.clientHeight - naturalScrollHeight,
+      )
+      setBottomSpacerHeight(requiredSpacer)
+
+      const targetScrollTop = requiredSpacer > 0 ? anchoredTurn.scrollTop : el.scrollHeight
+      if (requiredSpacer === 0) {
+        // The response now fills the viewport. Retire the special turn state so
+        // long-thread windowing can return to its bounded trailing slice.
+        anchoredTurnRef.current = null
+      }
+
+      if (animateNextTurnRef.current) {
+        animateNextTurnRef.current = false
+        animateScrollTop(el, targetScrollTop)
+        return
+      }
+
+      if (!shouldAutoFollowRef.current || scrollAnimationFrameRef.current != null) return
+      setScrollTop(el, targetScrollTop)
+      return
+    }
+
+    animateNextTurnRef.current = false
+    if (!shouldAutoFollowRef.current || scrollAnimationFrameRef.current != null) return
+    setScrollTop(el, el.scrollHeight)
+  }, [animateScrollTop, setBottomSpacerHeight, setScrollTop])
+
+  const handleScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
+    const el = event.currentTarget
+    const previousScrollTop = lastScrollTopRef.current
+    lastScrollTopRef.current = el.scrollTop
+    const programmaticTarget = programmaticScrollTopRef.current
+    const isProgrammatic =
+      scrollAnimationFrameRef.current != null ||
+      (programmaticTarget != null && Math.abs(el.scrollTop - programmaticTarget) <= 1)
+    const hasUserScrollIntent = userScrollIntentRef.current
+    userScrollIntentRef.current = false
+    if (isProgrammatic) {
+      programmaticScrollTopRef.current = null
+    }
+
+    // Blank reserve is one-way. When the reader moves upward, consume the same
+    // number of pixels from the spacer. The new scroll position becomes the
+    // reserve's live edge, so that discarded blank area cannot be revisited.
+    let discardedSpacer = false
+    const anchoredTurn = anchoredTurnRef.current
+    const upwardDelta = Math.max(0, previousScrollTop - el.scrollTop)
+    if (!isProgrammatic && anchoredTurn && upwardDelta > 0 && bottomSpacerHeightRef.current > 0) {
+      const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
+      const remainingSpacer = bottomSpacerHeightRef.current - discard
+      anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
+      setBottomSpacerHeight(remainingSpacer)
+      discardedSpacer = discard > 0
+      if (remainingSpacer === 0) anchoredTurnRef.current = null
+    }
+
     // Consider "at bottom" if within 80px of the bottom edge
     const threshold = 80
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
     isScrolledToBottomRef.current = distanceFromBottom < threshold
+    if (!isProgrammatic && !discardedSpacer && !hasUserScrollIntent) {
+      shouldAutoFollowRef.current = isScrolledToBottomRef.current
+    }
     // Show "scroll to bottom" button when scrolled up more than 300px
     setShowScrollToBottom(distanceFromBottom > 300)
 
@@ -365,7 +513,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       isScrolledToBottomRef.current = false
       setWindowSize((n) => n + LOAD_STEP)
     }
-  }, [hiddenCount])
+  }, [hiddenCount, setBottomSpacerHeight])
 
   // After a scroll-up expansion adds older messages above the viewport, restore the
   // scroll position so the content the user was reading stays put (no jump).
@@ -380,8 +528,13 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const scrollToBottom = useCallback(() => {
     const el = scrollRef.current
     if (!el) return
+    cancelScrollAnimation()
+    anchoredTurnRef.current = null
+    shouldAutoFollowRef.current = true
+    animateNextTurnRef.current = false
+    setBottomSpacerHeight(0)
     el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
-  }, [])
+  }, [cancelScrollAnimation, setBottomSpacerHeight])
 
   // Safety net: if isCompacting is true but a NEW compact boundary appears in fetched
   // messages, compaction is done and the SSE compact_complete event was missed.
@@ -597,32 +750,102 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     return result
   }, [messages, isActive, hasTurnStartingPendingMessage])
 
-  // Re-pin to bottom when the user sends a new message. Track ids actually
-  // seen — not a count — so a send racing a ghost removal still re-pins, and
-  // a removal alone never yanks a scrolled-up reader back down.
+  // Detect actual sends by id (rather than list length, since materialization
+  // can remove one ghost as another arrives). A turn-starting send gets a
+  // stable reading line 100px from the viewport top; queued mid-turn sends
+  // retain the regular live-edge behavior.
   const seenPendingIdsRef = useRef(new Set<string>())
-  useEffect(() => {
+  useLayoutEffect(() => {
     const seen = seenPendingIdsRef.current
     let hasNewSend = false
+    let newestTurnStart: PendingMessage | undefined
     for (const pending of pendingUserMessages ?? []) {
       if (!seen.has(pending.localId)) {
         seen.add(pending.localId)
         hasNewSend = true
+        if (!pending.queued) newestTurnStart = pending
       }
     }
+
     if (hasNewSend) {
+      cancelScrollAnimation()
+      shouldAutoFollowRef.current = true
       isScrolledToBottomRef.current = true
       setShowScrollToBottom(false)
-    }
-  }, [pendingUserMessages])
 
-  // Auto-scroll to bottom when new messages arrive or requests appear,
-  // but only if the user hasn't scrolled up to read earlier content.
-  useEffect(() => {
-    if (scrollRef.current && isScrolledToBottomRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+      if (newestTurnStart) {
+        const viewport = scrollRef.current
+        const anchor = Array.from(
+          contentBodyRef.current?.querySelectorAll<HTMLElement>('[data-turn-anchor-id]') ?? [],
+        ).find((element) => element.dataset.turnAnchorId === newestTurnStart.localId)
+
+        if (viewport && anchor) {
+          lastScrollTopRef.current = viewport.scrollTop
+          const anchorTop =
+            anchor.getBoundingClientRect().top -
+            viewport.getBoundingClientRect().top +
+            viewport.scrollTop
+          anchoredTurnRef.current = {
+            localId: newestTurnStart.localId,
+            scrollTop: Math.max(0, anchorTop - TURN_ANCHOR_TOP),
+          }
+          animateNextTurnRef.current = true
+        } else {
+          anchoredTurnRef.current = null
+          animateNextTurnRef.current = false
+        }
+      } else {
+        anchoredTurnRef.current = null
+        animateNextTurnRef.current = false
+        setBottomSpacerHeight(0)
+      }
     }
-  }, [messages, pendingUserMessages, streamingMessage, streamingToolUses, thinkingBlocks, isCompacting, pendingRequestCount, activeSubagents])
+
+    syncFollowPosition()
+  }, [
+    messages,
+    pendingUserMessages,
+    streamingMessage,
+    streamingToolUses,
+    thinkingBlocks,
+    isCompacting,
+    pendingRequestCount,
+    activeSubagents,
+    syncFollowPosition,
+    setBottomSpacerHeight,
+    cancelScrollAnimation,
+  ])
+
+  // Markdown, images, and expanded tool cards can change height without a
+  // message-state update. Feed those layout changes through the same reserve
+  // calculation so they cannot make the anchored turn jump.
+  useEffect(() => {
+    const content = contentBodyRef.current
+    const viewport = scrollRef.current
+    if (!content || !viewport || typeof ResizeObserver === 'undefined') return
+    let frameId = 0
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(frameId)
+      frameId = requestAnimationFrame(syncFollowPosition)
+    })
+    observer.observe(content)
+    observer.observe(viewport)
+    return () => {
+      cancelAnimationFrame(frameId)
+      observer.disconnect()
+    }
+  }, [syncFollowPosition])
+
+  const handleUserScrollIntent = useCallback(() => {
+    userScrollIntentRef.current = true
+    shouldAutoFollowRef.current = false
+    programmaticScrollTopRef.current = null
+    cancelScrollAnimation()
+  }, [cancelScrollAnimation])
+
+  const handleScrollKey = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (SCROLL_KEYS.has(event.key)) handleUserScrollIntent()
+  }, [handleUserScrollIntent])
 
   // Peer messages still worth showing optimistically: not our own, and the
   // persisted copy (by uuid, or — for queued/steering messages whose uuid the
@@ -778,8 +1001,32 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
   return (
     <div className="relative flex-1 min-h-0 overflow-hidden">
-      <div className="overflow-y-auto overscroll-contain h-full" style={{ overflowAnchor: 'none' }} ref={scrollRef} onScroll={handleScroll} data-testid="message-list" data-message-content-area>
-        <div className={`mx-auto w-full max-w-[720px] px-4 pb-4 space-y-4 ${readOnly ? 'pt-3' : 'pt-14'}`}>
+      {/* A labelled, focusable scroll region is intentional: keyboard users
+          need to be able to drive the transcript with its scroll keys. */}
+      {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
+      <div
+        className="overflow-y-auto overscroll-contain h-full"
+        style={{ overflowAnchor: 'none' }}
+        ref={scrollRef}
+        onScroll={handleScroll}
+        onWheel={handleUserScrollIntent}
+        onTouchMove={handleUserScrollIntent}
+        onKeyDown={handleScrollKey}
+        role="region"
+        aria-label="Messages"
+        tabIndex={0}
+        data-testid="message-list"
+        data-message-content-area
+      >
+        <div className="mx-auto w-full max-w-[720px] px-4 pb-4">
+        <div
+          ref={contentBodyRef}
+          className={`space-y-4 ${readOnly ? 'pt-3' : 'pt-[100px]'}`}
+          role="log"
+          aria-relevant="additions"
+          aria-busy={isStreaming || undefined}
+        >
         {hiddenCount > 0 && (
           <div className="flex items-center justify-center py-3 text-xs text-muted-foreground">
             {hiddenCount} earlier {hiddenCount === 1 ? 'message' : 'messages'} hidden — scroll up to load
@@ -827,7 +1074,11 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             (sent mid-turn) render at the bottom instead, below the current
             turn's streaming output and running tools. */}
         {visiblePeerMessages.filter((p) => !p.queued).map(renderPeerGhost)}
-        {pendingUserMessages?.filter((p) => !p.queued).map(renderPendingGhost)}
+        {pendingUserMessages?.filter((p) => !p.queued).map((pending) => (
+          <div key={pending.localId} data-turn-anchor-id={pending.localId}>
+            {renderPendingGhost(pending)}
+          </div>
+        ))}
 
         {/* Typing indicator - shown when ANOTHER user is typing. The server echoes
             user_typing back to the sender too, so exclude our own id (mirrors the
@@ -970,7 +1221,15 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
         {/* Pending interactive requests render in the composer slot — see SessionChatColumn. */}
         </div>
+        <div
+          ref={bottomSpacerRef}
+          data-testid="turn-anchor-spacer"
+          aria-hidden="true"
+          hidden
+        />
+        </div>
       </div>
+      {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
       {showScrollToBottom && !suppressScrollToBottom && (
         <button
           onClick={scrollToBottom}


### PR DESCRIPTION
## Summary

- anchor each newly sent turn about 100px below the transcript top
- animate the turn into position and let streamed output consume the reserved room
- discard reserved space incrementally as the reader scrolls away
- preserve long-thread windowing, reduced-motion, and accessibility behavior

## Why

New turns previously appeared at the bottom and streamed against the viewport edge. This gives replies room to grow while respecting user scroll intent.

## Validation

- `npm test -- --run src/renderer/components/messages/message-list.test.tsx src/renderer/components/layout/session-chat-column.test.tsx` (94 tests)
- `npm run typecheck`
- `npx eslint src/renderer/components/messages/message-list.tsx src/renderer/components/messages/message-list.test.tsx`
- `git diff --check`
