### PR TITLE
Bake document/media read tools into the agent container

### DIFF
--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -38,6 +38,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     file \
     tree \
+    # Document/media reading (formats the product renders)
+    poppler-utils \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20.x

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -832,6 +832,7 @@ When using request tools (request_secret, request_file, request_connected_accoun
 
 - Use UV to run Python code: `uv run --env-file .env --with <packages> script.py`
 - ALWAYS include `--env-file .env` when running Python scripts to ensure secrets are available
+- You are not root and cannot install system packages (`apt-get`/`sudo` will fail). Get missing tools with `uv run --with <package>` (Python) or `npx <package>` (Node) instead
 - You have full filesystem access
 - Your job is to solve tasks with code, not build apps
 <%#hasModelHints%>

--- a/src/renderer/components/file-preview/container-file-capability.test.ts
+++ b/src/renderer/components/file-preview/container-file-capability.test.ts
@@ -1,0 +1,70 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every format the product renders must have a matching read capability in the
+ * agent container. Native = SDK Read handles text/images directly; otherwise
+ * the apt package(s) that provide the binary must appear in the Dockerfile.
+ */
+const CONTAINER_CAPABILITY: Record<string, string[]> = {
+  audio: ['ffmpeg'],
+  csv: [],
+  html: [],
+  image: [],
+  markdown: [],
+  pdf: ['poppler-utils'],
+  text: [],
+  video: ['ffmpeg'],
+}
+
+const here = dirname(fileURLToPath(import.meta.url))
+const renderersDir = join(here, 'renderers')
+const dockerfilePath = resolve(here, '../../../../agent-container/Dockerfile')
+
+function declaredFormats(): string[] {
+  return readdirSync(renderersDir)
+    .filter(name => name.endsWith('-renderer.tsx'))
+    .filter(name => name !== 'file-renderer.tsx' && name !== 'unsupported-renderer.tsx')
+    .map(name => name.replace(/-renderer\.tsx$/, ''))
+    .sort()
+}
+
+describe('container file-format capability', () => {
+  const formats = declaredFormats()
+  const dockerfile = readFileSync(dockerfilePath, 'utf8')
+
+  it('declares a container capability for every renderer format', () => {
+    for (const format of formats) {
+      expect(
+        CONTAINER_CAPABILITY,
+        `New renderer "${format}" must declare its container read capability in CONTAINER_CAPABILITY`,
+      ).toHaveProperty(format)
+    }
+  })
+
+  it('has no stale capability entries without a renderer', () => {
+    const declared = new Set(formats)
+    for (const format of Object.keys(CONTAINER_CAPABILITY)) {
+      expect(
+        declared.has(format),
+        `Stale CONTAINER_CAPABILITY key "${format}" has no matching *-renderer.tsx`,
+      ).toBe(true)
+    }
+  })
+
+  it('bakes every required apt package into the agent-container Dockerfile', () => {
+    const missing: string[] = []
+    for (const format of formats) {
+      for (const pkg of CONTAINER_CAPABILITY[format] ?? []) {
+        if (!new RegExp(`\\b${pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(dockerfile)) {
+          missing.push(`${format} → ${pkg}`)
+        }
+      }
+    }
+    expect(missing, `Missing apt packages in agent-container/Dockerfile: ${missing.join(', ')}`).toEqual(
+      [],
+    )
+  })
+})


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-549/container-must-read-every-file-format-the-product-renders

Footprint: 3 files, +74/0. Two apt packages, one prompt line, one new test.

A user attaches a PDF. The app renders it in its viewer, but the agent beside it cannot read it. `Read` with `pages` fails on missing `pdftoppm`. The suggested remedy (`apt-get install poppler-utils`) also fails: the agent is not root. Audio and video have the same gap. The renderer directory is the product's declared format list, and the container never got the matching capability.

**Dockerfile.** Add `poppler-utils` and `ffmpeg` to the apt block. `pdftoppm`/`pdfinfo` are hard dependencies of the SDK's PDF page extraction. The SDK's base64 fallback is gated on model PDF support, so for non-Anthropic models page extraction is the only read path. `ffmpeg` is what makes audio and video workable: probe metadata, extract frames, cut segments.

**Capability test.** Walks `renderers/` and asserts two things. Every format with a renderer declares a container read capability. Every required package appears in the Dockerfile. Adding a renderer without container support now fails CI. Proven red on pdf/audio/video before the Dockerfile change, green after.

**System prompt.** The agent is not root and cannot install system packages. Missing tools come from `uv run --with <package>` (Python) or `npx <package>` (Node). In the observed session the agent burned four attempts following the SDK error's apt advice.

Out of scope: OCR, Office formats, pandoc (no renderer declares them). Uploads-directory scoping is SUP-551.

Verified end to end: image rebuilt from this branch, container recreated from it, PDF attached through the app. The agent read page 2 via the Read tool and returned the page's contents. `pdftoppm`/`pdfinfo`/`ffmpeg`/`ffprobe` all resolve in the container. Image size: 2.33GB to 2.71GB (+380MB, ffmpeg is nearly all of it).
