### PR TITLE
Restore sticky session auto-follow

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2016,7 +2016,7 @@ describe('MessageList', () => {
       expect(geometry.scrollTop).toBe(1200)
     })
 
-    it('discards only the reserved room that the user scrolls past', () => {
+    it('discards reserved room before the reader can leave the live edge', () => {
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
       const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       const el = screen.getByTestId('message-list')
@@ -2037,6 +2037,9 @@ describe('MessageList', () => {
       fireEvent.scroll(el)
       expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '0px' })
 
+      fireEvent.wheel(el, { deltaY: -200 })
+      geometry.setScrollTop(500)
+      fireEvent.scroll(el)
       const releasedScrollTop = geometry.scrollTop
       geometry.setNaturalScrollHeight(1900)
       mockStreamState.streamingMessage = 'More output after the user took control'
@@ -2044,6 +2047,42 @@ describe('MessageList', () => {
         <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
       )
       expect(geometry.scrollTop).toBe(releasedScrollTop)
+    })
+
+    it('follows within 80px of the bottom and resumes when the reader returns', () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      // A wheel gesture that remains within the 80px live-edge threshold must
+      // not opt the session out of following.
+      fireEvent.wheel(el, { deltaY: -50 })
+      geometry.setScrollTop(650)
+      fireEvent.scroll(el)
+      geometry.setNaturalScrollHeight(1400)
+      mockStreamState.streamingMessage = 'First streamed update'
+      mockStreamState.isStreaming = true
+      rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(geometry.scrollTop).toBe(800)
+
+      // Moving farther away pauses following.
+      fireEvent.wheel(el, { deltaY: -200 })
+      geometry.setScrollTop(600)
+      fireEvent.scroll(el)
+      geometry.setNaturalScrollHeight(1500)
+      mockStreamState.streamingMessage = 'Second streamed update'
+      rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(geometry.scrollTop).toBe(600)
+
+      // Returning within 80px restores following for subsequent content.
+      fireEvent.wheel(el, { deltaY: 250 })
+      geometry.setScrollTop(850)
+      fireEvent.scroll(el)
+      geometry.setNaturalScrollHeight(1600)
+      mockStreamState.streamingMessage = 'Third streamed update'
+      rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(geometry.scrollTop).toBe(1000)
     })
   })
 

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -313,9 +313,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const bottomSpacerRef = useRef<HTMLDivElement>(null)
   const bottomSpacerHeightRef = useRef(0)
   const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
-  const shouldAutoFollowRef = useRef(true)
   const programmaticScrollTopRef = useRef<number | null>(null)
-  const userScrollIntentRef = useRef(false)
   const lastScrollTopRef = useRef(0)
   const scrollAnimationFrameRef = useRef<number | null>(null)
   const animateNextTurnRef = useRef(false)
@@ -453,13 +451,13 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         return
       }
 
-      if (!shouldAutoFollowRef.current || scrollAnimationFrameRef.current != null) return
+      if (!isScrolledToBottomRef.current || scrollAnimationFrameRef.current != null) return
       setScrollTop(el, targetScrollTop)
       return
     }
 
     animateNextTurnRef.current = false
-    if (!shouldAutoFollowRef.current || scrollAnimationFrameRef.current != null) return
+    if (!isScrolledToBottomRef.current || scrollAnimationFrameRef.current != null) return
     setScrollTop(el, el.scrollHeight)
   }, [animateScrollTop, setBottomSpacerHeight, setScrollTop])
 
@@ -471,8 +469,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     const isProgrammatic =
       scrollAnimationFrameRef.current != null ||
       (programmaticTarget != null && Math.abs(el.scrollTop - programmaticTarget) <= 1)
-    const hasUserScrollIntent = userScrollIntentRef.current
-    userScrollIntentRef.current = false
     if (isProgrammatic) {
       programmaticScrollTopRef.current = null
     }
@@ -480,7 +476,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // Blank reserve is one-way. When the reader moves upward, consume the same
     // number of pixels from the spacer. The new scroll position becomes the
     // reserve's live edge, so that discarded blank area cannot be revisited.
-    let discardedSpacer = false
     const anchoredTurn = anchoredTurnRef.current
     const upwardDelta = Math.max(0, previousScrollTop - el.scrollTop)
     if (!isProgrammatic && anchoredTurn && upwardDelta > 0 && bottomSpacerHeightRef.current > 0) {
@@ -488,17 +483,14 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       const remainingSpacer = bottomSpacerHeightRef.current - discard
       anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
       setBottomSpacerHeight(remainingSpacer)
-      discardedSpacer = discard > 0
       if (remainingSpacer === 0) anchoredTurnRef.current = null
     }
 
-    // Consider "at bottom" if within 80px of the bottom edge
+    // Proximity to the live edge is the auto-follow contract: moving beyond
+    // this threshold pauses following, and returning within it resumes.
     const threshold = 80
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
     isScrolledToBottomRef.current = distanceFromBottom < threshold
-    if (!isProgrammatic && !discardedSpacer && !hasUserScrollIntent) {
-      shouldAutoFollowRef.current = isScrolledToBottomRef.current
-    }
     // Show "scroll to bottom" button when scrolled up more than 300px
     setShowScrollToBottom(distanceFromBottom > 300)
 
@@ -530,7 +522,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     if (!el) return
     cancelScrollAnimation()
     anchoredTurnRef.current = null
-    shouldAutoFollowRef.current = true
     animateNextTurnRef.current = false
     setBottomSpacerHeight(0)
     el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
@@ -769,7 +760,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
     if (hasNewSend) {
       cancelScrollAnimation()
-      shouldAutoFollowRef.current = true
       isScrolledToBottomRef.current = true
       setShowScrollToBottom(false)
 
@@ -837,8 +827,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   }, [syncFollowPosition])
 
   const handleUserScrollIntent = useCallback(() => {
-    userScrollIntentRef.current = true
-    shouldAutoFollowRef.current = false
     programmaticScrollTopRef.current = null
     cancelScrollAnimation()
   }, [cancelScrollAnimation])


### PR DESCRIPTION
## Summary

- restore the original 80px live-edge threshold as the authoritative auto-follow rule
- keep the new send-time turn anchoring and reserved-space behavior
- resume following automatically when the reader scrolls back within the threshold
- add regression coverage for staying sticky near the bottom, pausing farther away, and resuming on return

## Root cause

The turn-anchoring change introduced a separate `shouldAutoFollowRef` that was disabled by any wheel, touch, or scroll-key intent. The corresponding user scroll event was then prevented from restoring that flag, so reaching the bottom no longer re-enabled auto-follow.

## User impact

Incoming session content once again remains pinned while the reader is within 80px of the bottom. Scrolling farther up pauses following, and returning to the live edge resumes it.

## Validation

- `npm test -- --run src/renderer/components/messages/message-list.test.tsx` (88 tests)
- `npm run typecheck`
- `eslint src/renderer/components/messages/message-list.tsx src/renderer/components/messages/message-list.test.tsx`
