### PR TITLE
Add frosted session composer overlay

### DIFF
--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -147,11 +147,19 @@ export function SessionChatColumn({
             <div className="relative isolate flex items-center justify-between gap-1.5 overflow-hidden px-6 py-3">
               <div
                 aria-hidden="true"
-                className="pointer-events-none absolute inset-y-0 left-0 z-0 w-[58%] bg-gradient-to-r from-background via-background/90 to-transparent backdrop-blur-sm"
+                className="pointer-events-none absolute inset-y-0 left-0 z-0 w-[52%] bg-gradient-to-r from-background via-background/75 to-transparent backdrop-blur-[2px]"
+                style={{
+                  maskImage: 'linear-gradient(to right, black 0%, black 55%, transparent 100%)',
+                  WebkitMaskImage: 'linear-gradient(to right, black 0%, black 55%, transparent 100%)',
+                }}
               />
               <div
                 aria-hidden="true"
-                className="pointer-events-none absolute inset-y-0 right-0 z-0 w-[58%] bg-gradient-to-l from-background via-background/90 to-transparent backdrop-blur-sm"
+                className="pointer-events-none absolute inset-y-0 right-0 z-0 w-[52%] bg-gradient-to-l from-background via-background/75 to-transparent backdrop-blur-[2px]"
+                style={{
+                  maskImage: 'linear-gradient(to left, black 0%, black 55%, transparent 100%)',
+                  WebkitMaskImage: 'linear-gradient(to left, black 0%, black 55%, transparent 100%)',
+                }}
               />
               {contextPercent != null ? (
                 <TooltipProvider delayDuration={0}>

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -93,7 +93,8 @@ export function SessionChatColumn({
       pendingRequestCount={pendingRequestCount}
       onPendingMessageAppeared={onPendingMessageAppeared}
       suppressScrollToBottom={staleSession.learnMoreOpen}
-      footerClassName="bg-background max-w-[740px] mx-auto w-full"
+      overlayFooter
+      footerClassName="max-w-[740px] mx-auto w-full"
       footer={
         pendingRequestCount > 0 ? (
           <div className="px-4 pb-4" data-testid="pending-request-slot">
@@ -143,12 +144,20 @@ export function SessionChatColumn({
               initialModel={model}
               registerSnapshot={staleSession.registerSnapshot}
             />
-            <div className="flex justify-between items-center gap-1.5 px-6 py-3">
+            <div className="relative isolate flex items-center justify-between gap-1.5 overflow-hidden px-6 py-3">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-y-0 left-0 z-0 w-[58%] bg-gradient-to-r from-background via-background/90 to-transparent backdrop-blur-sm"
+              />
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-y-0 right-0 z-0 w-[58%] bg-gradient-to-l from-background via-background/90 to-transparent backdrop-blur-sm"
+              />
               {contextPercent != null ? (
                 <TooltipProvider delayDuration={0}>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <div className="flex items-center gap-1.5 cursor-default">
+                      <div className="relative z-10 flex cursor-default items-center gap-1.5">
                         <span className="text-xs text-muted-foreground">Context Usage</span>
                         <DonutChart
                           percent={contextPercent}
@@ -164,9 +173,9 @@ export function SessionChatColumn({
                   </Tooltip>
                 </TooltipProvider>
               ) : (
-                <span />
+                <span className="relative z-10" />
               )}
-              <span className="text-xs text-muted-foreground flex items-center gap-1">
+              <span className="relative z-10 flex items-center gap-1 text-xs text-muted-foreground">
                 <kbd className="inline-flex items-center justify-center rounded-sm bg-muted border border-border/50 px-1 h-4 text-xs font-sans leading-none">↵</kbd>
                 <span>Send</span>
                 <span className="mx-1">·</span>

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -251,7 +251,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   return (
     <form
       onSubmit={composer.handleSubmit}
-      className={`relative px-4 pt-0 ${composer.isDragOver ? 'ring-2 ring-primary ring-inset' : ''}`}
+      className={`relative z-10 isolate px-4 pt-0 ${composer.isDragOver ? 'ring-2 ring-primary ring-inset' : ''}`}
       {...composer.dragHandlers}
     >
       <MountChoiceDialog
@@ -267,7 +267,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
         filter={slashFilter ?? ''}
       />
       <ChatComposerBox
-        className="border-border/70 bg-background/85 shadow-lg shadow-background/20 backdrop-blur-sm supports-[backdrop-filter]:bg-background/70"
+        className="relative z-10 border-border/70 bg-background/85 shadow-[0_0_24px_rgba(15,23,42,0.07),0_2px_10px_-4px_rgba(15,23,42,0.08)] backdrop-blur-md supports-[backdrop-filter]:bg-background/65 dark:shadow-[0_0_26px_rgba(0,0,0,0.22),0_2px_12px_-4px_rgba(0,0,0,0.16)]"
         attachments={composer.attachments}
         onRemoveAttachment={composer.removeAttachment}
         textareaRef={textareaRef}

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -267,6 +267,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
         filter={slashFilter ?? ''}
       />
       <ChatComposerBox
+        className="border-border/70 bg-background/85 shadow-lg shadow-background/20 backdrop-blur-sm supports-[backdrop-filter]:bg-background/70"
         attachments={composer.attachments}
         onRemoveAttachment={composer.removeAttachment}
         textareaRef={textareaRef}

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -182,6 +182,16 @@ describe('MessageList', () => {
     expect(screen.getByText('Hello!')).toBeInTheDocument()
   })
 
+  it('reserves clearance for an overlaid session footer', () => {
+    mockMessagesData.data = []
+    renderWithProviders(
+      <MessageList sessionId="s-1" agentSlug="agent-1" bottomInset={180} />
+    )
+
+    const content = screen.getByTestId('turn-anchor-spacer').parentElement
+    expect(content).toHaveStyle({ paddingBottom: '196px' })
+  })
+
   it('renders compact boundaries', () => {
     const boundary = createCompactBoundary({ summary: 'Compacted section' })
     mockMessagesData.data = [boundary as any]

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -81,9 +81,11 @@ interface MessageListProps {
   readOnly?: boolean
   /** Hide the scroll affordance while a footer popover overlaps it. */
   suppressScrollToBottom?: boolean
+  /** Height of an overlaid footer that the live edge must remain above. */
+  bottomInset?: number
 }
 
-export function MessageList({ sessionId, agentSlug, pendingUserMessages, pendingRequestCount = 0, onPendingMessageAppeared, readOnly, suppressScrollToBottom = false }: MessageListProps) {
+export function MessageList({ sessionId, agentSlug, pendingUserMessages, pendingRequestCount = 0, onPendingMessageAppeared, readOnly, suppressScrollToBottom = false, bottomInset = 0 }: MessageListProps) {
   useRenderTracker('MessageList')
   const { data: messages, isLoading, error } = useMessages(sessionId, agentSlug)
   const deleteMessage = useDeleteMessage()
@@ -804,6 +806,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     syncFollowPosition,
     setBottomSpacerHeight,
     cancelScrollAnimation,
+    bottomInset,
   ])
 
   // Markdown, images, and expanded tool cards can change height without a
@@ -1007,7 +1010,10 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         data-testid="message-list"
         data-message-content-area
       >
-        <div className="mx-auto w-full max-w-[720px] px-4 pb-4">
+        <div
+          className="mx-auto w-full max-w-[720px] px-4 pb-4"
+          style={bottomInset > 0 ? { paddingBottom: bottomInset + 16 } : undefined}
+        >
         <div
           ref={contentBodyRef}
           className={`space-y-4 ${readOnly ? 'pt-3' : 'pt-[100px]'}`}
@@ -1222,6 +1228,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         <button
           onClick={scrollToBottom}
           className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 rounded-full bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium shadow-lg hover:bg-primary/90 transition-opacity cursor-pointer"
+          style={bottomInset > 0 ? { bottom: bottomInset + 16 } : undefined}
         >
           <ArrowDown className="h-3.5 w-3.5" />
           Scroll to bottom

--- a/src/renderer/components/messages/session-thread.test.tsx
+++ b/src/renderer/components/messages/session-thread.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { act, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@renderer/test/test-utils'
+import { SessionThread } from './session-thread'
+
+let footerHeight = 0
+let resizeCallback: ResizeObserverCallback | undefined
+
+vi.mock('@renderer/components/messages/message-list', () => ({
+  MessageList: ({ bottomInset }: { bottomInset?: number }) => (
+    <div data-testid="message-list" data-bottom-inset={bottomInset} />
+  ),
+}))
+
+vi.mock('@renderer/components/messages/agent-activity-indicator', () => ({
+  AgentActivityIndicator: () => <div data-testid="activity-indicator" />,
+}))
+
+vi.mock('@renderer/components/tray/tray-manager', () => ({
+  TrayManager: () => null,
+}))
+
+describe('SessionThread footer layout', () => {
+  beforeEach(() => {
+    footerHeight = 180
+    resizeCallback = undefined
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      const height = this.hasAttribute('data-composer-footer') ? footerHeight : 0
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 0,
+        bottom: height,
+        left: 0,
+        width: 0,
+        height,
+        toJSON: () => ({}),
+      }
+    })
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('overlays the footer and keeps measured clearance beneath the live edge', () => {
+    renderWithProviders(
+      <SessionThread
+        sessionId="s-1"
+        agentSlug="agent-1"
+        footer={<div>Composer</div>}
+        overlayFooter
+      />,
+    )
+
+    expect(screen.getByTestId('session-thread-main')).toHaveClass('relative', 'flex')
+    expect(screen.getByText('Composer').parentElement).toHaveAttribute('data-overlay-footer', 'true')
+    expect(screen.getByTestId('message-list')).toHaveAttribute('data-bottom-inset', '180')
+
+    footerHeight = 240
+    act(() => resizeCallback?.([], {} as ResizeObserver))
+    expect(screen.getByTestId('message-list')).toHaveAttribute('data-bottom-inset', '240')
+  })
+
+  it('keeps the shared read-only layout in normal document flow by default', () => {
+    renderWithProviders(
+      <SessionThread
+        sessionId="s-1"
+        agentSlug="agent-1"
+        footer={<div>Read-only footer</div>}
+      />,
+    )
+
+    expect(screen.getByTestId('session-thread-main')).toHaveClass('grid', 'grid-rows-[1fr_auto]')
+    expect(screen.getByText('Read-only footer').parentElement).not.toHaveAttribute('data-overlay-footer')
+    expect(screen.getByTestId('message-list')).toHaveAttribute('data-bottom-inset', '0')
+  })
+})

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -1,4 +1,5 @@
-import { type ReactNode } from 'react'
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { cn } from '@shared/lib/utils'
 import { MessageList } from '@renderer/components/messages/message-list'
 import { AgentActivityIndicator } from '@renderer/components/messages/agent-activity-indicator'
 import { TrayManager } from '@renderer/components/tray/tray-manager'
@@ -11,6 +12,9 @@ interface SessionThreadProps {
   footer: ReactNode
   /** Classes for the footer wrapper — callers set their own max-width/background. */
   footerClassName?: string
+  /** Let transcript content scroll beneath the pinned footer while reserving
+   *  enough live-edge clearance to keep the newest content readable. */
+  overlayFooter?: boolean
   /** Whether the browser tray tab is available (interactive session view only). */
   browserActive?: boolean
   /** Read-only mirror (chat-integration replay): suppress message edit/delete actions. */
@@ -36,6 +40,7 @@ export function SessionThread({
   agentSlug,
   footer,
   footerClassName = 'bg-background',
+  overlayFooter = false,
   browserActive = false,
   readOnly,
   pendingUserMessages,
@@ -43,14 +48,44 @@ export function SessionThread({
   onPendingMessageAppeared,
   suppressScrollToBottom,
 }: SessionThreadProps) {
+  const footerRef = useRef<HTMLDivElement>(null)
+  const [footerHeight, setFooterHeight] = useState(0)
+
+  useLayoutEffect(() => {
+    if (!overlayFooter) {
+      setFooterHeight(0)
+      return
+    }
+
+    const footerElement = footerRef.current
+    if (!footerElement) return
+    const measure = () => {
+      const nextHeight = Math.ceil(footerElement.getBoundingClientRect().height)
+      setFooterHeight((currentHeight) => currentHeight === nextHeight ? currentHeight : nextHeight)
+    }
+
+    measure()
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(measure)
+    observer?.observe(footerElement)
+    window.addEventListener('resize', measure)
+    return () => {
+      observer?.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [overlayFooter])
+
   return (
     <div
       className="file-preview-container relative flex flex-1 min-h-0 min-w-0"
       data-testid="file-preview-container"
     >
-      {/* Chat column — grid pins the footer at the bottom */}
+      {/* Interactive sessions overlay the footer so transcript content can pass
+          underneath it; read-only consumers retain the in-flow grid layout. */}
       <div
-        className="flex-1 min-w-0 grid grid-rows-[1fr_auto] min-h-0"
+        className={cn(
+          'flex-1 min-w-0 min-h-0',
+          overlayFooter ? 'relative flex' : 'grid grid-rows-[1fr_auto]',
+        )}
         data-testid="session-thread-main"
       >
         <MessageList
@@ -62,8 +97,18 @@ export function SessionThread({
           pendingRequestCount={pendingRequestCount}
           onPendingMessageAppeared={onPendingMessageAppeared}
           suppressScrollToBottom={suppressScrollToBottom}
+          bottomInset={overlayFooter ? footerHeight : 0}
         />
-        <div className={`${footerClassName} pb-[env(safe-area-inset-bottom)]`} data-composer-footer>
+        <div
+          ref={footerRef}
+          className={cn(
+            footerClassName,
+            'pb-[env(safe-area-inset-bottom)]',
+            overlayFooter && 'absolute inset-x-0 bottom-0 z-20',
+          )}
+          data-composer-footer
+          data-overlay-footer={overlayFooter || undefined}
+        >
           <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />
           {footer}
         </div>


### PR DESCRIPTION
## Summary

- Overlay the session footer so chat content can scroll beneath the composer.
- Measure the complete footer at runtime and reserve matching live-edge clearance for the newest message, activity indicator, and request panels.
- Add a subtle translucent, blurred composer surface.
- Add left/right gradient blur shields beneath the composer for Context Usage and keyboard-hint contrast.

## Why

This preserves transcript continuity and adds a light frosted-glass treatment without letting the newest content or footer metadata become obscured.

## Validation

- `npm test -- --run src/renderer/components/messages/session-thread.test.tsx src/renderer/components/layout/session-chat-column.test.tsx src/renderer/components/messages/message-list.test.tsx` — 98 tests passed
- `npm run typecheck`
- ESLint on all six changed files
- `git diff --check`
- Local browser visual QA at normal and compact viewport sizes, including live-edge clearance and scrolled-under blur; no console warnings or errors
