### PR TITLE
Fix slash command slugs in session composer

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -58,6 +58,7 @@ import {
   buildModelSubagentDefinitions,
   type SubagentModelDefinition,
 } from './subagent-model-catalog';
+import { mergeCanonicalSlashCommands } from './slash-commands';
 
 // Prefix for system-injected user messages that should be hidden in the UI.
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in src/renderer/components/messages/message-list.tsx
@@ -1163,10 +1164,15 @@ export class ClaudeCodeProcess extends EventEmitter {
           }
           console.log(`[Session ${this.sessionId}] Captured Claude session ID:`, this.claudeSessionId);
           this.emit('claude-session-id', this.claudeSessionId);
-          // Fetch rich slash command info from SDK
+          // The init list owns the executable names. supportedCommands adds
+          // descriptions/hints, but skill entries may use display titles there.
+          const canonicalCommandNames = Array.isArray(message.slash_commands)
+            ? message.slash_commands.filter((name): name is string => typeof name === 'string')
+            : [];
+          this.slashCommands = mergeCanonicalSlashCommands(canonicalCommandNames, []);
           try {
             const cmds = await this.queryInstance!.supportedCommands();
-            this.slashCommands = cmds.map(c => ({ name: c.name, description: c.description, argumentHint: c.argumentHint }));
+            this.slashCommands = mergeCanonicalSlashCommands(canonicalCommandNames, cmds);
           } catch (err) {
             console.error(`[Session ${this.sessionId}] Failed to fetch slash commands:`, err);
           }

--- a/agent-container/src/slash-commands.test.ts
+++ b/agent-container/src/slash-commands.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { mergeCanonicalSlashCommands } from './slash-commands';
+
+describe('mergeCanonicalSlashCommands', () => {
+  it('keeps executable slugs and attaches rich skill details', () => {
+    expect(mergeCanonicalSlashCommands(
+      ['compact', 'order-canvas-print'],
+      [
+        { name: 'compact', description: 'Free up context', argumentHint: '<instructions>' },
+        { name: 'Order Canvas Print', description: 'Order a framed canvas', argumentHint: '<image>' },
+      ],
+    )).toEqual([
+      { name: 'compact', description: 'Free up context', argumentHint: '<instructions>' },
+      { name: 'order-canvas-print', description: 'Order a framed canvas', argumentHint: '<image>' },
+    ]);
+  });
+
+  it('keeps every canonical command and leaves unmatched details empty', () => {
+    expect(mergeCanonicalSlashCommands(
+      ['review', 'new-command'],
+      [{ name: 'review', description: 'Review a PR', argumentHint: '[number]' }],
+    )).toEqual([
+      { name: 'review', description: 'Review a PR', argumentHint: '[number]' },
+      { name: 'new-command', description: '', argumentHint: '' },
+    ]);
+  });
+
+  it('falls back to rich commands when an older init has no canonical list', () => {
+    const commands = [{ name: 'review', description: 'Review a PR', argumentHint: '[number]' }];
+    expect(mergeCanonicalSlashCommands([], commands)).toEqual(commands);
+  });
+});

--- a/agent-container/src/slash-commands.ts
+++ b/agent-container/src/slash-commands.ts
@@ -1,0 +1,40 @@
+export interface SlashCommandDetails {
+  name: string;
+  description: string;
+  argumentHint: string;
+}
+
+function commandIdentity(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/**
+ * Keep the CLI init event's executable command names while enriching them with
+ * the SDK control response's descriptions and argument hints. For skills, the
+ * latter may expose a display title ("Order Canvas Print") where the former
+ * exposes the invocable slug ("order-canvas-print").
+ */
+export function mergeCanonicalSlashCommands(
+  canonicalNames: readonly string[],
+  richCommands: readonly SlashCommandDetails[],
+): SlashCommandDetails[] {
+  if (canonicalNames.length === 0) return [...richCommands];
+
+  const byExactName = new Map(richCommands.map((command) => [command.name, command]));
+  const byIdentity = new Map<string, SlashCommandDetails | null>();
+
+  for (const command of richCommands) {
+    const identity = commandIdentity(command.name);
+    if (!identity) continue;
+    byIdentity.set(identity, byIdentity.has(identity) ? null : command);
+  }
+
+  return canonicalNames.map((name) => {
+    const details = byExactName.get(name) ?? byIdentity.get(commandIdentity(name)) ?? undefined;
+    return {
+      name,
+      description: details?.description ?? '',
+      argumentHint: details?.argumentHint ?? '',
+    };
+  });
+}

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -39,6 +39,7 @@ import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { guessMimeType } from '@shared/lib/utils/mime'
 import { parseByteRange } from '@shared/lib/utils/http-range'
 import { messagePersister } from '@shared/lib/container/message-persister'
+import { repairLegacySlashCommands } from '@shared/lib/container/slash-commands'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { credentialBroker } from '../credentials/credential-broker'
 import { CredentialBrokerError } from '../credentials/types'
@@ -2253,8 +2254,12 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
       if (slashCommands.length === 0) {
         const meta = await getSessionMetadata(agentSlug, sessionId)
         if (meta?.slashCommands && meta.slashCommands.length > 0) {
-          slashCommands = meta.slashCommands
+          const repaired = repairLegacySlashCommands(meta.slashCommands)
+          slashCommands = repaired.commands
           messagePersister.setSlashCommands(sessionId, slashCommands)
+          if (repaired.changed) {
+            updateSessionMetadata(agentSlug, sessionId, { slashCommands }).catch(console.error)
+          }
         }
       }
       const backgroundTasks = messagePersister.getActiveBackgroundTasks(sessionId)

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2189,10 +2189,10 @@ describe('MessagePersister', () => {
       expect(stored[0].name).toBe('compact')
     })
 
-    it('does not overwrite rich slash commands with init event strings', () => {
-      // Pre-set rich commands (e.g. from container HTTP response)
+    it('uses init slugs without losing rich command details', () => {
+      // Pre-set rich commands (e.g. legacy metadata or a container HTTP response)
       const richCommands = [
-        { name: 'compact', description: 'Clear conversation history', argumentHint: '<instructions>' },
+        { name: 'Order Canvas Print', description: 'Order a framed canvas', argumentHint: '<image>' },
       ]
       messagePersister.setSlashCommands(SESSION_ID, richCommands)
 
@@ -2203,16 +2203,17 @@ describe('MessagePersister', () => {
         type: 'system',
         subtype: 'init',
         session_id: 'claude-session-1',
-        slash_commands: ['compact', 'review'],
+        slash_commands: ['order-canvas-print', 'review'],
       })
 
-      // Should still have the rich commands, NOT overwritten by strings
       const stored = messagePersister.getSlashCommands(SESSION_ID)
-      expect(stored).toEqual(richCommands)
+      expect(stored).toEqual([
+        { name: 'order-canvas-print', description: 'Order a framed canvas', argumentHint: '<image>' },
+        { name: 'review', description: '', argumentHint: '' },
+      ])
 
-      // stream_start should include the rich commands
       const streamStarts = sseEvents.filter(e => e.type === 'stream_start')
-      expect(streamStarts[0].slashCommands).toEqual(richCommands)
+      expect(streamStarts[0].slashCommands).toEqual(stored)
     })
 
     it('broadcasts slash commands in stream_start when available', () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1,4 +1,5 @@
 import type { ContainerClient, StreamMessage, SlashCommandInfo } from './types'
+import { mergeCanonicalSlashCommands } from './slash-commands'
 import type { SessionUsage, SessionActivity } from '@shared/lib/types/agent'
 import type { AskUserQuestionInput } from '@shared/lib/tool-definitions/ask-user-question'
 import type { RequestSecretInput } from '@shared/lib/tool-definitions/request-secret'
@@ -445,7 +446,7 @@ class MessagePersister {
       lastAssistantUsage: null,
       completedSubagentIds: new Set(),
       activeSubagents: new Map(),
-      slashCommands: [],
+      slashCommands: prior?.slashCommands ?? [],
       isAwaitingInput: priorIsAwaitingInput,
       settledInputRequests: priorSettledInputRequests,
       cancelledCapabilityReviews: new Set(),
@@ -1583,13 +1584,13 @@ class MessagePersister {
       case 'system':
         // System messages (init, etc.)
         if (content.subtype === 'init') {
-          // Capture slash commands from init event as fallback (e.g. resumed sessions)
-          if (state.slashCommands.length === 0 && Array.isArray(content.slash_commands)) {
-            state.slashCommands = content.slash_commands.map((name: string) => ({
-              name,
-              description: '',
-              argumentHint: '',
-            }))
+          // The init strings are the executable names. Reconcile even when we
+          // already have rich/persisted commands so display titles cannot win.
+          if (Array.isArray(content.slash_commands)) {
+            state.slashCommands = mergeCanonicalSlashCommands(
+              content.slash_commands.filter((name: unknown): name is string => typeof name === 'string'),
+              state.slashCommands,
+            )
           }
           this.broadcastToSSE(sessionId, {
             type: 'stream_start',

--- a/src/shared/lib/container/slash-commands.test.ts
+++ b/src/shared/lib/container/slash-commands.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { mergeCanonicalSlashCommands, repairLegacySlashCommands } from './slash-commands'
+
+describe('mergeCanonicalSlashCommands', () => {
+  it('uses CLI slugs with SDK descriptions and argument hints', () => {
+    expect(mergeCanonicalSlashCommands(
+      ['order-canvas-print'],
+      [{ name: 'Order Canvas Print', description: 'Order a framed canvas', argumentHint: '<image>' }],
+    )).toEqual([
+      { name: 'order-canvas-print', description: 'Order a framed canvas', argumentHint: '<image>' },
+    ])
+  })
+
+  it('does not attach ambiguous rich details to a canonical command', () => {
+    expect(mergeCanonicalSlashCommands(
+      ['foo-bar'],
+      [
+        { name: 'Foo Bar', description: 'First', argumentHint: '' },
+        { name: 'foo_bar', description: 'Second', argumentHint: '' },
+      ],
+    )).toEqual([{ name: 'foo-bar', description: '', argumentHint: '' }])
+  })
+})
+
+describe('repairLegacySlashCommands', () => {
+  it('repairs persisted display titles without losing help text', () => {
+    expect(repairLegacySlashCommands([
+      { name: 'Order Canvas Print', description: 'Order a framed canvas', argumentHint: '<image>' },
+      { name: 'compact', description: 'Free up context', argumentHint: '' },
+    ])).toEqual({
+      changed: true,
+      commands: [
+        { name: 'order-canvas-print', description: 'Order a framed canvas', argumentHint: '<image>' },
+        { name: 'compact', description: 'Free up context', argumentHint: '' },
+      ],
+    })
+  })
+
+  it('leaves canonical names untouched', () => {
+    const commands = [{ name: '__remote-workflow', description: 'Run it', argumentHint: '' }]
+    expect(repairLegacySlashCommands(commands)).toEqual({ changed: false, commands })
+  })
+
+  it('preserves plugin namespaces while repairing their display title', () => {
+    expect(repairLegacySlashCommands([
+      { name: 'canvas-tools:Order Canvas Print', description: 'Order it', argumentHint: '' },
+    ]).commands[0].name).toBe('canvas-tools:order-canvas-print')
+  })
+})

--- a/src/shared/lib/container/slash-commands.ts
+++ b/src/shared/lib/container/slash-commands.ts
@@ -1,0 +1,60 @@
+import type { SlashCommandInfo } from './types'
+
+function commandIdentity(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '')
+}
+
+/** Use CLI-provided executable names while retaining SDK-provided help text. */
+export function mergeCanonicalSlashCommands(
+  canonicalNames: readonly string[],
+  richCommands: readonly SlashCommandInfo[],
+): SlashCommandInfo[] {
+  if (canonicalNames.length === 0) return [...richCommands]
+
+  const byExactName = new Map(richCommands.map((command) => [command.name, command]))
+  const byIdentity = new Map<string, SlashCommandInfo | null>()
+
+  for (const command of richCommands) {
+    const identity = commandIdentity(command.name)
+    if (!identity) continue
+    byIdentity.set(identity, byIdentity.has(identity) ? null : command)
+  }
+
+  return canonicalNames.map((name) => {
+    const details = byExactName.get(name) ?? byIdentity.get(commandIdentity(name)) ?? undefined
+    return {
+      name,
+      description: details?.description ?? '',
+      argumentHint: details?.argumentHint ?? '',
+    }
+  })
+}
+
+/**
+ * Old session metadata stored SDK display titles as command names. Repair the
+ * known-invalid whitespace form lazily so cold sessions created before the
+ * canonical-name fix remain usable and keep their descriptions.
+ */
+export function repairLegacySlashCommands(
+  commands: readonly SlashCommandInfo[],
+): { commands: SlashCommandInfo[]; changed: boolean } {
+  let changed = false
+  const repaired = commands.map((command) => {
+    if (!/\s/.test(command.name)) return command
+
+    const name = command.name
+      .split(':')
+      .map((segment) => segment
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, ''))
+      .filter(Boolean)
+      .join(':')
+    if (!name || name === command.name) return command
+
+    changed = true
+    return { ...command, name }
+  })
+
+  return { commands: repaired, changed }
+}


### PR DESCRIPTION
## Summary

- use CLI init-event command slugs as the authoritative executable names
- enrich those slugs with descriptions and argument hints from the SDK command metadata
- repair legacy cold-session metadata that stored display titles with spaces
- preserve rich slash-command metadata across reconnects

## Root cause

The CLI init event exposes invocable skill slugs such as `order-canvas-print`, while `supportedCommands()` can expose the skill's display title, such as `Order Canvas Print`. The container persisted the display title as the command name, and cold sessions replayed that value directly into the composer. Selecting it produced an invalid slash command.

## Impact

Slash suggestions now insert canonical command slugs while continuing to show the available descriptions and argument hints. Previously persisted cold sessions are repaired lazily when their metadata is loaded.

## Validation

- `agent-container: npm test` — 840 passed, 8 skipped
- `agent-container: npm run build`
- slash-command helper tests — 5 passed
- targeted message-persister regression test — passed
- targeted ESLint — passed
