### PR TITLE
fix(test): mock MobileTab in GlobalSettingsPage unit tests

### DIFF
--- a/src/renderer/components/settings/global-settings-page.test.tsx
+++ b/src/renderer/components/settings/global-settings-page.test.tsx
@@ -45,6 +45,7 @@ vi.mock('./auth-tab', () => ({
 }))
 
 vi.mock('./profile-tab', () => ({ ProfileTab: () => null }))
+vi.mock('./mobile-tab', () => ({ MobileTab: () => null }))
 vi.mock('./general-tab', () => ({ GeneralTab: () => null }))
 vi.mock('./runtime-tab', () => ({ RuntimeTab: () => null }))
 vi.mock('./account-provider-tab', () => ({ AccountProviderTab: () => null }))


### PR DESCRIPTION
## Summary
- Main unit tests fail with `No QueryClient set` in `global-settings-page.test.tsx` after Mobile pairing (#645) + SUP-509 (#614).
- The SettingsPage mock eagerly calls `render()` for every section, including Mobile, but the suite never mocked `./mobile-tab`.
- Add `vi.mock('./mobile-tab', …)` consistent with the other tab stubs.

## Test plan
- [x] `npx vitest run src/renderer/components/settings/global-settings-page.test.tsx` — 4/4 passed
- [ ] CI unit-tests green on this PR
- [ ] Confirm main Tests workflow recovers after merge


Made with [Cursor](https://cursor.com)