### PR TITLE
Fix stale thinking blocks in active transcripts

### DIFF
--- a/e2e/specs/thinking-display.spec.ts
+++ b/e2e/specs/thinking-display.spec.ts
@@ -158,4 +158,21 @@ test.describe('Thinking Display', () => {
     await expect(body).toContainText('Let me reason about this')
     await expect(page.getByTestId('thinking-block')).toHaveCount(1)
   })
+
+  test('divergent live text hands off while the session remains active', async ({ page, request }, testInfo) => {
+    const { sessionPage } = await setupThinkingTest(page, request, testInfo, 'ActiveMismatch')
+
+    await sessionPage.sendMessage('please think with missing deltas')
+
+    // The mock persists the full thinking block but delays the terminal result,
+    // reproducing a long-running turn whose live stream only retained a suffix.
+    await expect(page.getByText('Persisted divergent-thinking checkpoint.')).toBeVisible({ timeout: 10000 })
+    await expect(sessionPage.getStopButton()).toBeVisible()
+
+    // String-prefix matching would leave both the persisted card and the
+    // divergent completed live card visible. Stable identity leaves one.
+    await expect(page.getByTestId('thinking-block')).toHaveCount(1)
+
+    await sessionPage.waitForInputEnabled(20000)
+  })
 })

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -53,7 +53,7 @@ const mockStreamState = {
   typingUser: null as { id: string; name?: string } | null,
   peerUserMessages: [] as Array<{ uuid: string; receivedAt: number; content: string; sender: { id: string; name?: string; email?: string }; queued?: boolean }>,
   discardedCommandUuids: [] as string[],
-  thinkingBlocks: [] as Array<{ id: number; text: string; startedAt: number; endedAt: number | null }>,
+  thinkingBlocks: [] as Array<{ id: number; persistedId?: string; text: string; startedAt: number; endedAt: number | null }>,
 }
 
 const mockClearCompacting = vi.fn()
@@ -2097,8 +2097,8 @@ describe('MessageList', () => {
   })
 
   describe('thinking block dedup (live vs persisted)', () => {
-    const liveBlock = (text: string, endedAt: number | null = null) =>
-      ({ id: 1, text, startedAt: Date.now() - 5000, endedAt })
+    const liveBlock = (text: string, endedAt: number | null = null, persistedId?: string) =>
+      ({ id: 1, persistedId, text, startedAt: Date.now() - 5000, endedAt })
 
     it('renders a live thinking card while the turn streams', () => {
       mockMessagesData.data = [createUserMessage({ content: { text: 'Question' } })]
@@ -2124,6 +2124,63 @@ describe('MessageList', () => {
       // collapsed, so identify it by its "Thought" header (a live card reads "Thinking").
       expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
       expect(screen.getByTestId('thinking-block-toggle')).toHaveTextContent('Thought')
+    })
+
+    it('hands off by stable id while active even when streamed text diverges from the transcript', () => {
+      // Regression: a long-running turn can miss SSE reasoning deltas while a
+      // background agent keeps isActive=true. Text-prefix matching then leaves
+      // the completed live card stranded at the transcript tail indefinitely.
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createAssistantMessage({
+          content: { text: 'Persisted checkpoint' },
+          thinking: [{ id: 'msg-1:0', text: 'the full persisted reasoning' }],
+        }),
+      ]
+      mockStreamState.isActive = true
+      mockStreamState.thinkingBlocks = [
+        liveBlock('a suffix received after reconnect', Date.now(), 'msg-1:0'),
+      ]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
+      expect(screen.queryByText('a suffix received after reconnect')).not.toBeInTheDocument()
+      expect(screen.getByTestId('thinking-block-toggle')).toHaveTextContent('Thought')
+    })
+
+    it('hands off an empty live block by stable id while the session remains active', () => {
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createAssistantMessage({
+          content: { text: 'Persisted checkpoint' },
+          thinking: [{ id: 'msg-1:0', text: 'reasoning persisted despite omitted live deltas' }],
+        }),
+      ]
+      mockStreamState.isActive = true
+      mockStreamState.thinkingBlocks = [liveBlock('', Date.now(), 'msg-1:0')]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
+    })
+
+    it('does not suppress a different id merely because its text matches', () => {
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createAssistantMessage({
+          content: { text: '' },
+          thinking: [{ id: 'msg-old:0', text: 'reused stock reasoning' }],
+        }),
+      ]
+      mockStreamState.isActive = true
+      mockStreamState.thinkingBlocks = [
+        liveBlock('reused stock reasoning', null, 'msg-new:0'),
+      ]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(2)
     })
 
     it('does not suppress the live card when only an older turn has matching thinking', () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -577,14 +577,15 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // Filter live thinking blocks to only those NOT yet carried by a persisted
   // message (mirrors unpersistedStreamingToolUses). Once the refetched assistant
   // message arrives with its `thinking` array, the persisted card in MessageItem
-  // takes over and the ephemeral one must not double-render. Matched by text
-  // prefix in either direction since the stream can trail the transcript.
+  // takes over and the ephemeral one must not double-render. Modern runtimes
+  // match by stable message-id + content-index identity. Text-prefix matching
+  // remains only when either side predates that identity.
   // Only the current turn's persisted thinking is compared — live blocks are
   // reset on session_active, so a match against an older turn can only be a
   // false positive (the model reusing a stock opener suppresses the live card).
   const unpersistedThinkingBlocks = useMemo(() => {
     if (!thinkingBlocks.length || !messages?.length) return thinkingBlocks
-    const persisted: string[] = []
+    const persisted: Array<{ id?: string; text: string }> = []
     let interrupted = false
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]
@@ -599,7 +600,12 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       if (isTurnStartingUserMessage(m)) break
       if (m.type === 'assistant' && Array.isArray((m as ApiMessage).thinking)) {
         for (const t of (m as ApiMessage).thinking!) {
-          if (typeof t?.text === 'string' && t.text.trim()) persisted.push(t.text.trim())
+          if (typeof t?.text === 'string' && t.text.trim()) {
+            persisted.push({
+              ...(typeof t.id === 'string' && t.id && { id: t.id }),
+              text: t.text.trim(),
+            })
+          }
         }
       }
     }
@@ -613,11 +619,20 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     if (!isActive && (persisted.length || interrupted)) return []
     return thinkingBlocks.filter(b => {
       const t = b.text.trim()
+      const matched = persisted.some(p => {
+        // When both sides have an identity, text must not override it: models
+        // legitimately reuse stock reasoning across different responses.
+        if (b.persistedId && p.id) return b.persistedId === p.id
+        // Legacy runtime/transcript fallback. Prefix matching tolerates a live
+        // stream that trails the completed transcript.
+        return !!t && (p.text.startsWith(t) || t.startsWith(p.text))
+      })
+      if (matched) return false
       // Blocks with no streamed text (display option off) have no persisted
       // counterpart to collide with — keep them while the turn runs, but don't
       // let them strand in an idle transcript.
       if (!t) return isActive
-      return !persisted.some(p => p.startsWith(t) || t.startsWith(p))
+      return true
     })
   }, [messages, thinkingBlocks, isActive])
 

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -2587,13 +2587,13 @@ describe('useMessageStream — extended thinking blocks', () => {
   it('opens a block on thinking_start and accumulates deltas onto it', async () => {
     const { result, es } = await setup()
 
-    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_start', thinkingId: 'msg-1:0' }) })
     expect(result.current.isThinking).toBe(true)
     expect(result.current.thinkingBlocks).toHaveLength(1)
-    expect(result.current.thinkingBlocks[0]).toMatchObject({ text: '', endedAt: null })
+    expect(result.current.thinkingBlocks[0]).toMatchObject({ persistedId: 'msg-1:0', text: '', endedAt: null })
 
-    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'Let me ' }) })
-    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'reason.' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', thinkingId: 'msg-1:0', text: 'Let me ' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', thinkingId: 'msg-1:0', text: 'reason.' }) })
     expect(result.current.thinkingBlocks).toHaveLength(1)
     expect(result.current.thinkingBlocks[0].text).toBe('Let me reason.')
     expect(result.current.thinkingBlocks[0].endedAt).toBeNull()
@@ -2615,11 +2615,28 @@ describe('useMessageStream — extended thinking blocks', () => {
   it('a bare thinking_delta opens a block (missed start after reconnect)', async () => {
     const { result, es } = await setup()
 
-    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'resumed mid-block' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', thinkingId: 'msg-2:0', text: 'resumed mid-block' }) })
 
     expect(result.current.isThinking).toBe(true)
     expect(result.current.thinkingBlocks).toHaveLength(1)
-    expect(result.current.thinkingBlocks[0]).toMatchObject({ text: 'resumed mid-block', endedAt: null })
+    expect(result.current.thinkingBlocks[0]).toMatchObject({ persistedId: 'msg-2:0', text: 'resumed mid-block', endedAt: null })
+  })
+
+  it('compact_complete retires completed live blocks that may never persist', async () => {
+    const { result, es } = await setup()
+
+    act(() => { es().simulateMessage({ type: 'connected', isActive: true }) })
+    act(() => { es().simulateMessage({ type: 'thinking_start' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_delta', text: 'internal compaction reasoning' }) })
+    act(() => { es().simulateMessage({ type: 'thinking_stop' }) })
+    expect(result.current.thinkingBlocks).toHaveLength(1)
+
+    act(() => { es().simulateMessage({ type: 'compact_start' }) })
+    act(() => { es().simulateMessage({ type: 'compact_complete' }) })
+
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.isThinking).toBe(false)
+    expect(result.current.thinkingBlocks).toEqual([])
   })
 
   it('a new thinking_start closes the previous block so at most one is live', async () => {

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -123,6 +123,8 @@ const sessionSlashCommands = new Map<string, SlashCommandInfo[]>()
 // hook mirror can bail out of re-renders with a reference check.
 export interface ThinkingBlock {
   id: number
+  /** Stable identity shared with the persisted transcript block, when available. */
+  persistedId?: string
   text: string
   startedAt: number
   /** null while this block is still streaming */
@@ -822,19 +824,36 @@ function getOrCreateEventSource(
         // its stop (dropped event), close it now so at most one block is live.
         const t = sessionThinking.get(sessionId) ?? EMPTY_THINKING
         const blocks = closeOpenThinkingBlocks(t.blocks)
-        blocks.push({ id: nextThinkingBlockId++, text: '', startedAt: Date.now(), endedAt: null })
+        const persistedId = typeof data.thinkingId === 'string' && data.thinkingId
+          ? data.thinkingId
+          : undefined
+        blocks.push({ id: nextThinkingBlockId++, persistedId, text: '', startedAt: Date.now(), endedAt: null })
         sessionThinking.set(sessionId, { blocks, isThinking: true })
       }
       else if (data.type === 'thinking_delta') {
         // Accumulate streamed (summarized) reasoning text on the live block.
         // A delta with no open block (missed start after reconnect) opens one.
         const t = sessionThinking.get(sessionId) ?? EMPTY_THINKING
-        const blocks = [...t.blocks]
+        const persistedId = typeof data.thinkingId === 'string' && data.thinkingId
+          ? data.thinkingId
+          : undefined
+        let blocks = [...t.blocks]
         const last = blocks[blocks.length - 1]
-        if (last && last.endedAt === null) {
-          blocks[blocks.length - 1] = { ...last, text: last.text + (data.text ?? '') }
+        // If a reconnect dropped thinking_start, an indexed delta can identify
+        // a new block even while an unrelated stale block is still open.
+        const belongsToOpenBlock =
+          last &&
+          last.endedAt === null &&
+          (!persistedId || !last.persistedId || last.persistedId === persistedId)
+        if (belongsToOpenBlock) {
+          blocks[blocks.length - 1] = {
+            ...last,
+            ...(persistedId && !last.persistedId && { persistedId }),
+            text: last.text + (data.text ?? ''),
+          }
         } else {
-          blocks.push({ id: nextThinkingBlockId++, text: data.text ?? '', startedAt: Date.now(), endedAt: null })
+          blocks = closeOpenThinkingBlocks(blocks)
+          blocks.push({ id: nextThinkingBlockId++, persistedId, text: data.text ?? '', startedAt: Date.now(), endedAt: null })
         }
         sessionThinking.set(sessionId, { blocks, isThinking: true })
       }
@@ -879,6 +898,13 @@ function getOrCreateEventSource(
       }
       else if (data.type === 'compact_start') {
         // Context compaction started
+        const thinkingAtCompact = sessionThinking.get(sessionId)
+        if (thinkingAtCompact) {
+          sessionThinking.set(sessionId, {
+            blocks: closeOpenThinkingBlocks(thinkingAtCompact.blocks),
+            isThinking: false,
+          })
+        }
         if (current) {
           streamStates.set(sessionId, {
             ...current,
@@ -888,6 +914,10 @@ function getOrCreateEventSource(
       }
       else if (data.type === 'compact_complete') {
         // Context compaction finished — messages_updated will trigger refetch
+        // Compactor reasoning is not a user-visible assistant message and may
+        // never persist. Retire all pre-boundary live blocks; historical cards
+        // now belong to the transcript read path.
+        sessionThinking.delete(sessionId)
         if (current) {
           streamStates.set(sessionId, {
             ...current,

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -508,18 +508,21 @@ describe('MessagePersister', () => {
       // With display:'summarized', thinking_delta carries text; signature_delta does not.
       sseEvents.length = 0
 
-      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
       mockClient._sendMessage({
         type: 'stream_event',
-        event: { type: 'content_block_start', content_block: { type: 'thinking' } },
+        event: { type: 'message_start', message: { id: 'msg-thinking-1' } },
       })
       mockClient._sendMessage({
         type: 'stream_event',
-        event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'Let me ' } },
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } },
       })
       mockClient._sendMessage({
         type: 'stream_event',
-        event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'consider.' } },
+        event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Let me ' } },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'consider.' } },
       })
       mockClient._sendMessage({
         type: 'stream_event',
@@ -531,8 +534,11 @@ describe('MessagePersister', () => {
       const deltas = sseEvents.filter(e => e.type === 'thinking_delta')
       const stops = sseEvents.filter(e => e.type === 'thinking_stop')
       expect(starts).toHaveLength(1)
+      expect(starts[0].thinkingId).toBe('msg-thinking-1:0')
       expect(deltas.map(d => d.text)).toEqual(['Let me ', 'consider.'])
+      expect(deltas.map(d => d.thinkingId)).toEqual(['msg-thinking-1:0', 'msg-thinking-1:0'])
       expect(stops).toHaveLength(1)
+      expect(stops[0].thinkingId).toBe('msg-thinking-1:0')
     })
 
     it('does not emit thinking_stop for a tool_use content_block_stop', () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -77,6 +77,7 @@ import { computerUsePermissionManager } from '@shared/lib/computer-use/permissio
 import { resolveAppFromWindowRef } from '@shared/lib/computer-use/executor'
 import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp, type ComputerUsePermissionLevel } from '@shared/lib/computer-use/types'
 import { getAgentSessionsDir } from '@shared/lib/utils/file-storage'
+import { makeThinkingBlockId } from '@shared/lib/utils/thinking-block-id'
 import { WorkflowJournalTailer } from './workflow-journal-tailer'
 import { SubagentCapture } from './subagent-capture'
 import * as path from 'path'
@@ -110,6 +111,8 @@ interface StreamingState {
   currentToolUse: { id: string; name: string } | null
   currentToolInput: string // Accumulated partial JSON input for current tool
   currentThinking?: boolean // True while an extended-thinking content block is streaming
+  currentAssistantMessageId?: string | null // SDK message id for stable live↔persisted block identity
+  currentThinkingBlockIndex?: number | null // Content index within currentAssistantMessageId
   isActive: boolean // True from user message until result received
   isInterrupted: boolean // True after user interrupts, prevents race conditions
   isCompacting: boolean // True while compaction is in progress, cleared on compact completion
@@ -1038,6 +1041,8 @@ class MessagePersister {
     // event) must not wedge the next turn's label. State is reused across turns.
     state.isCompacting = false
     state.currentThinking = false
+    state.currentAssistantMessageId = null
+    state.currentThinkingBlockIndex = null
     state.lastApiErrorCode = null // Clear previous API error on new message
     // Clear the previous turn's result subtype so a late idle from an
     // already-finished (or interrupted) run can't fire a stale "success"
@@ -2739,7 +2744,7 @@ class MessagePersister {
   // Handle stream events for SSE broadcasting (not for persistence)
   private handleStreamEvent(
     sessionId: string,
-    event: { type: string; content_block?: { type: string; id?: string; name?: string }; delta?: { type: string; text?: string; partial_json?: string; thinking?: string }; usage?: { input_tokens?: number; output_tokens?: number; cache_creation_input_tokens?: number; cache_read_input_tokens?: number } },
+    event: { type: string; index?: number; message?: { id?: string }; content_block?: { type: string; id?: string; name?: string }; delta?: { type: string; text?: string; partial_json?: string; thinking?: string }; usage?: { input_tokens?: number; output_tokens?: number; cache_creation_input_tokens?: number; cache_read_input_tokens?: number } },
     state: StreamingState
   ): void {
     switch (event.type) {
@@ -2748,6 +2753,8 @@ class MessagePersister {
         state.isStreaming = false // text hasn't started; set true at the first text token below
         state.currentToolUse = null
         state.currentThinking = false
+        state.currentAssistantMessageId = event.message?.id ?? null
+        state.currentThinkingBlockIndex = null
         state.isRetrying = false // the response is flowing now, so any retry resolved
         // 'streaming' is deferred to the first text token (set above) so a message that
         // opens with a tool call stays 'working' instead of flipping streaming→working.
@@ -2773,7 +2780,14 @@ class MessagePersister {
           // Reasoning text follows via thinking_delta (the agent requests
           // `display: 'summarized'`; without it newer models omit the text).
           state.currentThinking = true
-          this.broadcastToSSE(sessionId, { type: 'thinking_start' })
+          state.currentThinkingBlockIndex = Number.isInteger(event.index) ? event.index! : null
+          this.broadcastToSSE(sessionId, {
+            type: 'thinking_start',
+            thinkingId: makeThinkingBlockId(
+              state.currentAssistantMessageId,
+              state.currentThinkingBlockIndex,
+            ),
+          })
         }
         break
 
@@ -2788,9 +2802,16 @@ class MessagePersister {
           // message_start so a tool-first message never flips streaming→working).
           state.isStreaming = true
         } else if (event.delta?.type === 'thinking_delta' && event.delta.thinking) {
+          // A reconnect can miss content_block_start while retaining message_start;
+          // recover the index from the delta itself when available.
+          if (Number.isInteger(event.index)) state.currentThinkingBlockIndex = event.index!
           // Stream summarized reasoning text so the UI can accumulate it for "View thinking"
           this.broadcastToSSE(sessionId, {
             type: 'thinking_delta',
+            thinkingId: makeThinkingBlockId(
+              state.currentAssistantMessageId,
+              state.currentThinkingBlockIndex,
+            ),
             text: event.delta.thinking,
           })
         } else if (event.delta?.type === 'input_json_delta') {
@@ -2813,7 +2834,14 @@ class MessagePersister {
         // Thinking block finished streaming — flip back to "Working"
         if (state.currentThinking) {
           state.currentThinking = false
-          this.broadcastToSSE(sessionId, { type: 'thinking_stop' })
+          this.broadcastToSSE(sessionId, {
+            type: 'thinking_stop',
+            thinkingId: makeThinkingBlockId(
+              state.currentAssistantMessageId,
+              state.currentThinkingBlockIndex,
+            ),
+          })
+          state.currentThinkingBlockIndex = null
         }
         // Tool use block finished streaming
         if (state.currentToolUse) {
@@ -3027,8 +3055,16 @@ class MessagePersister {
         // Defensive: ensure thinking state is cleared if a stop was missed
         if (state.currentThinking) {
           state.currentThinking = false
-          this.broadcastToSSE(sessionId, { type: 'thinking_stop' })
+          this.broadcastToSSE(sessionId, {
+            type: 'thinking_stop',
+            thinkingId: makeThinkingBlockId(
+              state.currentAssistantMessageId,
+              state.currentThinkingBlockIndex,
+            ),
+          })
         }
+        state.currentAssistantMessageId = null
+        state.currentThinkingBlockIndex = null
         break
     }
   }

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -230,6 +230,92 @@ export class ThinkingResponseScenario implements MockScenario {
 }
 
 /**
+ * Reproduces a live/persisted thinking mismatch while the session is still
+ * active. The stream intentionally begins mid-thought, but the JSONL contains
+ * the full block under the same stable message/index identity. The delayed
+ * result leaves enough time for E2E to assert the live card was handed off by
+ * identity rather than stranded at the transcript tail.
+ */
+export class ActiveDivergentThinkingScenario implements MockScenario {
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    const messageId = `msg-active-divergent-${sessionId}`
+    const persistedThinking = 'The full persisted reasoning begins before the fragment delivered after reconnect.'
+    const responseText = 'Persisted divergent-thinking checkpoint.'
+
+    setTimeout(() => {
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        message: { content: userMessage },
+        timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: {
+          type: 'stream_event',
+          event: { type: 'message_start', message: { id: messageId } },
+        },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } },
+        },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'thinking_delta', thinking: 'fragment delivered after reconnect' },
+          },
+        },
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'stream_event',
+        content: { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      })
+
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: {
+          id: messageId,
+          content: [
+            { type: 'thinking', thinking: persistedThinking, signature: 'mock-signature' },
+            { type: 'text', text: responseText },
+          ],
+        },
+        timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'assistant',
+        content: {
+          type: 'assistant',
+          message: {
+            id: messageId,
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: persistedThinking, signature: 'mock-signature' },
+              { type: 'text', text: responseText },
+            ],
+          },
+        },
+      })
+    }, 20)
+
+    // Keep the session active well after the persisted message is visible.
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: { type: 'result', subtype: 'success' },
+      })
+    }, 10_000)
+  }
+}
+
+/**
  * Multi-pass extended-thinking scenario — streams several thinking blocks in
  * one turn, persisting each block's assistant JSONL entry as it completes
  * (the real CLI writes one transcript entry per assistant message mid-turn).
@@ -1488,6 +1574,9 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       'so I will stream a few sentences of summarized reasoning before replying.',
       'Done thinking — here is the answer.'
     )],
+    // Persist while active with deliberately divergent live text — regression
+    // for completed thinking cards stranding at the transcript tail.
+    ['think with missing deltas', new ActiveDivergentThinkingScenario()],
     // Register the "list files" scenario for tool use tests
     ['list files', new ToolUseScenario(
       'Bash',

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -166,7 +166,7 @@ export interface ApiMessage {
    * thinking-text persistence. `durationMs` is derived from transcript entry
    * timestamps and absent when underivable.
    */
-  thinking?: Array<{ text: string; durationMs?: number }>
+  thinking?: Array<{ id?: string; text: string; durationMs?: number }>
 }
 
 /**

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -697,8 +697,24 @@ describe('transformMessages', () => {
       // derived from the gap to the previous entry's timestamp
       const message = asMessage(result[1])
       expect(message.content.text).toBe('Here is my answer.')
-      expect(message.thinking).toEqual([{ text: 'Let me think about this...', durationMs: 5000 }])
+      expect(message.thinking).toEqual([{ id: 'msg-1:0', text: 'Let me think about this...', durationMs: 5000 }])
       expect(message.toolCalls).toHaveLength(0)
+    })
+
+    it('assigns persisted thinking the same message-id and content-index identity as the stream', () => {
+      const entries: JsonlMessageEntry[] = [
+        createAssistantMessage('uuid-1', 'msg-stable', [
+          { type: 'text', text: 'Preamble.' },
+          { type: 'thinking', thinking: 'Stable reasoning.' } as ContentBlock,
+          { type: 'tool_use', id: 'tool-1', name: 'Bash', input: {} },
+        ]),
+      ]
+
+      const result = transformMessages(entries)
+
+      expect(asMessage(result[0]).thinking).toEqual([
+        { id: 'msg-stable:1', text: 'Stable reasoning.' },
+      ])
     })
 
     it('extracts multiple thinking blocks in order, skipping empty ones', () => {
@@ -717,7 +733,10 @@ describe('transformMessages', () => {
       const result = transformMessages(entries)
 
       // No preceding entry — durations are underivable and omitted
-      expect(asMessage(result[0]).thinking).toEqual([{ text: 'First episode.' }, { text: 'Second episode.' }])
+      expect(asMessage(result[0]).thinking).toEqual([
+        { id: 'msg-1:0', text: 'First episode.' },
+        { id: 'msg-1:4', text: 'Second episode.' },
+      ])
       expect(asMessage(result[0]).toolCalls).toHaveLength(1)
     })
 
@@ -742,8 +761,8 @@ describe('transformMessages', () => {
       const result = transformMessages(entries)
 
       // Message 1: thinking took user→entry gap; message 2: tool_result→entry gap
-      expect(asMessage(result[1]).thinking).toEqual([{ text: 'First episode.', durationMs: 3000 }])
-      expect(asMessage(result[2]).thinking).toEqual([{ text: 'Second episode.', durationMs: 4000 }])
+      expect(asMessage(result[1]).thinking).toEqual([{ id: 'msg-1:0', text: 'First episode.', durationMs: 3000 }])
+      expect(asMessage(result[2]).thinking).toEqual([{ id: 'msg-2:0', text: 'Second episode.', durationMs: 4000 }])
     })
 
     it('omits durationMs when the previous entry belongs to the same message', () => {
@@ -765,7 +784,7 @@ describe('transformMessages', () => {
 
       // No duration — the 5ms sibling gap must not be reported as thinking time
       expect(asMessage(result[1]).thinking).toEqual([
-        { text: 'Reasoning that arrived after the text entry.' },
+        { id: 'msg-1:1', text: 'Reasoning that arrived after the text entry.' },
       ])
     })
 
@@ -796,7 +815,7 @@ describe('transformMessages', () => {
       const result = transformMessages(entries)
 
       expect(asMessage(result[0]).content.text).toBe('Answer.')
-      expect(asMessage(result[0]).thinking).toEqual([{ text: 'Valid episode.' }])
+      expect(asMessage(result[0]).thinking).toEqual([{ id: 'msg-1:2', text: 'Valid episode.' }])
     })
 
     it('handles tool result for non-existent tool (orphaned result)', () => {
@@ -886,7 +905,7 @@ describe('transformMessages', () => {
       // (no preceding entry, so no derivable duration)
       expect(result).toHaveLength(1)
       expect(asMessage(result[0]).content.text).toBe('')
-      expect(asMessage(result[0]).thinking).toEqual([{ text: 'Deep thoughts...' }])
+      expect(asMessage(result[0]).thinking).toEqual([{ id: 'msg-1:0', text: 'Deep thoughts...' }])
       expect(asMessage(result[0]).toolCalls).toHaveLength(0)
     })
 

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -6,6 +6,14 @@
  */
 
 import { ContentBlock, JsonlMessageEntry, JsonlSystemEntry } from '@shared/lib/types/agent'
+import { makeThinkingBlockId } from '@shared/lib/utils/thinking-block-id'
+
+export interface TransformedThinkingBlock {
+  /** Stable live↔persisted identity when the SDK message id is available. */
+  id?: string
+  text: string
+  durationMs?: number
+}
 
 export interface TransformedMessage {
   id: string
@@ -41,7 +49,7 @@ export interface TransformedMessage {
    * the block with an empty string, which is skipped). `durationMs` is derived
    * from entry timestamps (see thinkingByEntry) and absent when underivable.
    */
-  thinking?: Array<{ text: string; durationMs?: number }>
+  thinking?: TransformedThinkingBlock[]
 }
 
 export interface TransformedCompactBoundary {
@@ -274,7 +282,7 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
   // completes, so (thinking entry ts − previous entry ts) ≈ how long the agent
   // thought. Old transcripts (pre CLI 2.1.181) persist the block with an empty
   // string (signature only) — those are skipped, they carry nothing to show.
-  const thinkingByEntry = new Map<JsonlMessageEntry, Array<{ text: string; durationMs?: number }>>()
+  const thinkingByEntry = new Map<JsonlMessageEntry, TransformedThinkingBlock[]>()
   let prevEntryTs: number | null = null
   // message.id of the entry prevEntryTs came from (null for user entries).
   // Some provider paths flush ALL of a message's block entries in one burst at
@@ -286,6 +294,10 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
   for (const entry of messageEntries) {
     const messageId = entry.message.id
     let target = entry
+    // Offset of this entry's content inside the merged message. The live SDK
+    // identifies content blocks by their index in the complete assistant
+    // message, so the persisted path must count preceding merged blocks too.
+    let mergedContentOffset = 0
     if (entry.type === 'assistant' && messageId) {
       const existingIndex = assistantMessageIds.get(messageId)
       if (existingIndex !== undefined) {
@@ -295,6 +307,7 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
         const newContent = entry.message.content
 
         if (Array.isArray(existingContent) && Array.isArray(newContent)) {
+          mergedContentOffset = existingContent.length
           // Append new content blocks to existing
           ;(existing.message.content as ContentBlock[]).push(...(newContent as ContentBlock[]))
         }
@@ -322,12 +335,17 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
 
     const entryTs = new Date(entry.timestamp).getTime()
     if (entry.type === 'assistant' && Array.isArray(entry.message.content)) {
-      const texts = (entry.message.content as ContentBlock[])
+      const blocks = (entry.message.content as ContentBlock[])
         // typeof guard: this runs server-side on raw JSONL — a malformed
         // non-string `thinking` must be skipped, not throw and 500 the route
-        .filter((b) => b.type === 'thinking' && typeof b.thinking === 'string' && b.thinking.trim())
-        .map((b) => (b as { thinking: string }).thinking)
-      if (texts.length > 0) {
+        .map((block, blockIndex) => ({ block, blockIndex: mergedContentOffset + blockIndex }))
+        .filter(
+          (item): item is { block: ContentBlock & { thinking: string }; blockIndex: number } =>
+            item.block.type === 'thinking' &&
+            typeof (item.block as { thinking?: unknown }).thinking === 'string' &&
+            !!(item.block as { thinking: string }).thinking.trim(),
+        )
+      if (blocks.length > 0) {
         // Only derivable when the previous entry is a different message (user
         // entry or another assistant response) — an intra-message gap is write
         // jitter. Underivable durations are omitted (header reads "Thought").
@@ -339,7 +357,14 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
         const list = thinkingByEntry.get(target) ?? []
         // The duration covers the whole entry — if one entry carries several
         // thinking blocks (rare), attach it to the first
-        texts.forEach((text, i) => list.push(i === 0 && durationMs !== undefined ? { text, durationMs } : { text }))
+        blocks.forEach(({ block, blockIndex }, i) => {
+          const id = makeThinkingBlockId(messageId, blockIndex)
+          list.push({
+            ...(id && { id }),
+            text: block.thinking,
+            ...(i === 0 && durationMs !== undefined && { durationMs }),
+          })
+        })
         thinkingByEntry.set(target, list)
       }
     }

--- a/src/shared/lib/utils/thinking-block-id.ts
+++ b/src/shared/lib/utils/thinking-block-id.ts
@@ -1,0 +1,14 @@
+/**
+ * Stable identity shared by the live SSE path and the persisted JSONL path.
+ * Claude message ids are stable across both representations; the content
+ * index distinguishes multiple thinking blocks within one assistant message.
+ */
+export function makeThinkingBlockId(
+  messageId: string | null | undefined,
+  blockIndex: number | null | undefined,
+): string | undefined {
+  if (!messageId || typeof blockIndex !== 'number' || !Number.isInteger(blockIndex) || blockIndex < 0) {
+    return undefined
+  }
+  return `${messageId}:${blockIndex}`
+}


### PR DESCRIPTION
## Summary

- assign thinking blocks a stable identity from the assistant message ID and content-block index
- carry that identity through the live SSE path and persisted transcript transformation
- hand live thinking cards off to their persisted counterparts by ID, with text matching retained for legacy events
- retire non-persisted thinking at compaction boundaries
- add unit and Playwright regressions for divergent or missing live deltas while a session remains active

## Root cause

The renderer reconciled live and persisted thinking blocks using text-prefix matching. If SSE deltas were missed or the persisted reasoning text differed from the retained live fragment, the two representations could not be matched. Because background work kept the session active, normal idle cleanup did not run and the old live card remained pinned at the transcript tail.

## Impact

Completed thinking cards now transition cleanly from streaming state to transcript state without duplicating or sticking at the bottom of a long-running conversation. Older transcripts and runtimes that do not provide IDs continue to use the legacy text fallback.

## Validation

- `npm run test:run -- src/shared/lib/container/message-persister.test.ts src/shared/lib/utils/message-transform.test.ts src/renderer/hooks/use-message-stream.test.ts src/renderer/components/messages/message-list.test.tsx` — 586 passed
- `npm run test:e2e:web -- e2e/specs/thinking-display.spec.ts` — 5 passed
- `npm run typecheck`
- focused ESLint on all changed files
- `git diff --check`
- broader Vitest audit: 9,016 passed; four unrelated `global-settings-page` tests fail because their harness renders `MobileTab` without a `QueryClientProvider`
