### PR TITLE
[SUP-558] Support private GitHub skillsets with repository tokens

### DIFF
--- a/e2e/setup-e2e-data.js
+++ b/e2e/setup-e2e-data.js
@@ -41,6 +41,8 @@ try { fs.rmSync(path.join(resolvedDir, 'agents'), { recursive: true }) } catch {
 // up the directory tree and operates on the project's repo instead, silently
 // rewriting our actual origin URL. Real `git init` keeps git scoped here.
 const SKILLSET_ID = 'e2e-test-skillset'
+const SKILLSET_CREDENTIAL_ID = 'skillcred_e2e-private'
+const SKILLSET_TEST_TOKEN = 'github_pat_e2e_placeholder'
 const SKILLSET_REPO_DIR = path.join(resolvedDir, 'skillset-cache', SKILLSET_ID)
 const SKILLSET_FAKE_URL = 'https://localhost.invalid/e2e-test-skillset'
 fs.rmSync(SKILLSET_REPO_DIR, { recursive: true, force: true })
@@ -171,6 +173,7 @@ const settings = {
       description: 'Fake skillset seeded for Playwright tests',
       addedAt: new Date().toISOString(),
       provider: 'github',
+      providerData: { credentialId: SKILLSET_CREDENTIAL_ID },
     },
     {
       id: PUBLIC_SKILLSET_ID,
@@ -181,6 +184,16 @@ const settings = {
       provider: 'public',
     },
   ],
+  skillsetCredentials: {
+    [SKILLSET_CREDENTIAL_ID]: {
+      id: SKILLSET_CREDENTIAL_ID,
+      type: 'token',
+      token: SKILLSET_TEST_TOKEN,
+      tokenPreview: '••••lder',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  },
 }
 
 if (process.env.AUTH_MODE === 'true') {

--- a/e2e/specs/private-skillset-credentials.spec.ts
+++ b/e2e/specs/private-skillset-credentials.spec.ts
@@ -40,4 +40,20 @@ test.describe('Private Git skillset credentials', () => {
     expect(body).not.toContain('github_pat_e2e_placeholder')
     expect(body).toContain('••••lder')
   })
+
+  test('shows remove-token failures beside the affected skillset', async ({ page }) => {
+    await page.route('**/api/skillsets/*/credential', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Simulated credential removal failure' }),
+      })
+    })
+
+    const privateRow = page.locator('div.flex.items-start.gap-3').filter({ hasText: 'E2E Test Skillset' })
+    await privateRow.getByTitle('Replace or remove repository token').click()
+    await privateRow.getByRole('button', { name: 'Remove', exact: true }).click()
+
+    await expect(privateRow.getByRole('alert')).toHaveText(/Simulated credential removal failure/)
+  })
 })

--- a/e2e/specs/private-skillset-credentials.spec.ts
+++ b/e2e/specs/private-skillset-credentials.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+
+test.describe('Private Git skillset credentials', () => {
+  test.beforeEach(async ({ page }) => {
+    const appPage = new AppPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await page.locator('[data-testid="settings-button"]').click()
+    await page.locator('[data-testid="settings-nav-skillsets"]').click()
+  })
+
+  test('renders an optional masked token field and a redacted credential summary', async ({ page }) => {
+    const tokenInput = page.getByLabel('Repository token (optional)')
+    await expect(tokenInput).toBeVisible()
+    await expect(tokenInput).toHaveAttribute('type', 'password')
+
+    const tokenLink = page.getByRole('link', {
+      name: 'Create a fine-grained personal access token',
+    })
+    await expect(tokenLink).toHaveAttribute(
+      'href',
+      'https://github.com/settings/personal-access-tokens/new',
+    )
+    await expect(page.getByText('Contents', { exact: true })).toBeVisible()
+    await expect(page.getByText('Read-only', { exact: true })).toBeVisible()
+    await expect(page.getByText('repo', { exact: true })).toBeVisible()
+    await expect(page.getByText(/organization token as pending/)).toBeVisible()
+
+    const privateRow = page.locator('div.flex.items-start.gap-3').filter({ hasText: 'E2E Test Skillset' })
+    await expect(privateRow.getByText('Private · ••••lder')).toBeVisible()
+    await expect(privateRow.getByTitle('Replace or remove repository token')).toBeVisible()
+    await expect(privateRow).not.toContainText('github_pat_e2e_placeholder')
+  })
+
+  test('never returns the stored token from the skillsets API', async ({ request }) => {
+    const response = await request.get('/api/skillsets')
+    expect(response.ok()).toBe(true)
+    const body = await response.text()
+    expect(body).not.toContain('github_pat_e2e_placeholder')
+    expect(body).toContain('••••lder')
+  })
+})

--- a/scripts/validate-private-github-skillset.ts
+++ b/scripts/validate-private-github-skillset.ts
@@ -67,23 +67,53 @@ async function main(): Promise<void> {
       current.skillsets = [config]
       current.skillsetCredentials = { [credentialId]: credential }
     })
+    const installedMetadataProviderData = { ...config.providerData }
 
     // Force a second clone so the persisted opaque reference—not the transient
     // request credential—is what authenticates Git.
     await service.removeSkillsetCache({ skillsetId, provider: 'github', providerData: config.providerData })
-    const repoDir = await service.ensureSkillsetCached({
+    await service.ensureSkillsetCached({
       skillsetId,
       skillsetUrl: repoUrl,
       skillsetName: config.name,
       provider: 'github',
       providerData: config.providerData,
     })
+
+    // Simulate an installed skill retaining its install-time credential ID
+    // while the token is removed and re-added under a new ID in Settings.
+    const replacementCredentialId = `skillcred_${crypto.randomUUID()}`
+    settings.mutateSettings((current) => {
+      const currentConfig = current.skillsets?.find((item) => item.id === skillsetId)
+      if (!currentConfig) throw new Error('Skillset disappeared during credential replacement.')
+      currentConfig.providerData = { credentialId: replacementCredentialId }
+      current.skillsetCredentials = {
+        [replacementCredentialId]: {
+          ...credential,
+          id: replacementCredentialId,
+          updatedAt: new Date().toISOString(),
+        },
+      }
+    })
+
+    await service.removeSkillsetCache({
+      skillsetId,
+      provider: 'github',
+      providerData: installedMetadataProviderData,
+    })
+    const repoDir = await service.ensureSkillsetCached({
+      skillsetId,
+      skillsetUrl: repoUrl,
+      skillsetName: config.name,
+      provider: 'github',
+      providerData: installedMetadataProviderData,
+    })
     const refreshedIndex = await service.refreshSkillset({
       skillsetId,
       skillsetUrl: repoUrl,
       skillsetName: config.name,
       provider: 'github',
-      providerData: config.providerData,
+      providerData: installedMetadataProviderData,
     })
 
     const persisted = fs.readFileSync(path.join(dataDir, 'settings.json'), 'utf8')
@@ -112,6 +142,7 @@ async function main(): Promise<void> {
     console.log(JSON.stringify({
       validated: true,
       clonedFromStoredCredential: true,
+      reboundCredentialFromCurrentSkillset: true,
       refreshed: true,
       skillCount: refreshedIndex.skills.length,
       agentCount: refreshedIndex.agents?.length ?? 0,

--- a/scripts/validate-private-github-skillset.ts
+++ b/scripts/validate-private-github-skillset.ts
@@ -1,0 +1,131 @@
+/**
+ * Live private-GitHub validation harness.
+ *
+ * Reads a GitHub token from stdin so it never appears in argv or shell history:
+ *   gh auth token | E2E_PRIVATE_SKILLSET_URL=https://github.com/owner/repo \
+ *     npx tsx scripts/validate-private-github-skillset.ts
+ */
+import crypto from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+async function readTokenFromStdin(): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks).toString('utf8').trim()
+}
+
+async function main(): Promise<void> {
+  const repoUrl = process.env.E2E_PRIVATE_SKILLSET_URL?.trim()
+  if (!repoUrl) throw new Error('E2E_PRIVATE_SKILLSET_URL is required.')
+
+  const token = await readTokenFromStdin()
+  if (!token) throw new Error('A GitHub token must be provided on stdin.')
+
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gamut-private-skillset-e2e-'))
+  process.env.SUPERAGENT_DATA_DIR = dataDir
+
+  try {
+    const settings = await import('../src/shared/lib/config/settings')
+    const service = await import('../src/shared/lib/services/skillset-service')
+
+    const skillsetId = service.urlToSkillsetId(repoUrl)
+    const credentialId = `skillcred_${crypto.randomUUID()}`
+    const credential = {
+      id: credentialId,
+      type: 'token' as const,
+      token,
+      tokenPreview: `••••${token.slice(-4)}`,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+
+    const initialIndex = await service.validateSkillsetUrl(
+      repoUrl,
+      'github',
+      { type: 'token', token },
+    )
+
+    const config = {
+      id: skillsetId,
+      url: repoUrl,
+      name: initialIndex.skillset_name,
+      description: initialIndex.description || '',
+      addedAt: new Date().toISOString(),
+      provider: 'github' as const,
+      providerData: { credentialId },
+    }
+
+    settings.mutateSettings((current) => {
+      current.skillsets = [config]
+      current.skillsetCredentials = { [credentialId]: credential }
+    })
+
+    // Force a second clone so the persisted opaque reference—not the transient
+    // request credential—is what authenticates Git.
+    await service.removeSkillsetCache({ skillsetId, provider: 'github', providerData: config.providerData })
+    const repoDir = await service.ensureSkillsetCached({
+      skillsetId,
+      skillsetUrl: repoUrl,
+      skillsetName: config.name,
+      provider: 'github',
+      providerData: config.providerData,
+    })
+    const refreshedIndex = await service.refreshSkillset({
+      skillsetId,
+      skillsetUrl: repoUrl,
+      skillsetName: config.name,
+      provider: 'github',
+      providerData: config.providerData,
+    })
+
+    const persisted = fs.readFileSync(path.join(dataDir, 'settings.json'), 'utf8')
+    const publicConfig = JSON.stringify(config)
+    if (publicConfig.includes(token) || repoUrl.includes(token)) {
+      throw new Error('Token leaked into public skillset metadata.')
+    }
+
+    let localExtraHeader = ''
+    try {
+      const result = await execFileAsync('git', ['config', '--local', '--get-regexp', 'extraheader'], {
+        cwd: repoDir,
+        timeout: 5000,
+      })
+      localExtraHeader = result.stdout.trim()
+    } catch {
+      // Expected: authentication is process-scoped, not persisted in .git/config.
+    }
+    if (localExtraHeader) throw new Error('Git authentication header was persisted in .git/config.')
+    if (!persisted.includes(token)) throw new Error('Credential was not persisted in the private settings store.')
+
+    const settingsMode = process.platform === 'win32'
+      ? null
+      : (fs.statSync(path.join(dataDir, 'settings.json')).mode & 0o777).toString(8)
+
+    console.log(JSON.stringify({
+      validated: true,
+      clonedFromStoredCredential: true,
+      refreshed: true,
+      skillCount: refreshedIndex.skills.length,
+      agentCount: refreshedIndex.agents?.length ?? 0,
+      tokenAbsentFromPublicMetadata: true,
+      tokenAbsentFromGitConfig: true,
+      settingsMode,
+    }))
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true })
+    delete process.env.SUPERAGENT_DATA_DIR
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : 'Private GitHub skillset validation failed.')
+  process.exitCode = 1
+})

--- a/src/api/routes/skillsets.test.ts
+++ b/src/api/routes/skillsets.test.ts
@@ -235,7 +235,7 @@ describe('skillsets routes', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(mockValidateSkillsetUrl).toHaveBeenCalledWith('https://github.com/Org/repo', 'public')
+    expect(mockValidateSkillsetUrl).toHaveBeenCalledWith('https://github.com/Org/repo', 'public', undefined)
   })
 
   it('POST /validate does not override explicit provider', async () => {
@@ -252,7 +252,7 @@ describe('skillsets routes', () => {
       body: JSON.stringify({ url: 'https://github.com/Org/repo', provider: 'github' }),
     })
 
-    expect(mockValidateSkillsetUrl).toHaveBeenCalledWith('https://github.com/Org/repo', 'github')
+    expect(mockValidateSkillsetUrl).toHaveBeenCalledWith('https://github.com/Org/repo', 'github', undefined)
   })
 
   it('POST /validate falls through to default when git is available', async () => {
@@ -269,7 +269,7 @@ describe('skillsets routes', () => {
       body: JSON.stringify({ url: 'https://github.com/Org/repo' }),
     })
 
-    expect(mockValidateSkillsetUrl).toHaveBeenCalledWith('https://github.com/Org/repo', undefined)
+    expect(mockValidateSkillsetUrl).toHaveBeenCalledWith('https://github.com/Org/repo', undefined, undefined)
   })
 
   it('POST / saves resolved provider in config', async () => {
@@ -292,5 +292,127 @@ describe('skillsets routes', () => {
     expect(mockUpdateSettings).toHaveBeenCalledTimes(1)
     const saved = mockUpdateSettings.mock.calls[0][0]
     expect(saved.skillsets[0].provider).toBe('public')
+  })
+
+  it('POST / stores a private repository token separately and never returns it', async () => {
+    const token = 'github_pat_private_test_1234'
+    let settingsState: Record<string, unknown> = { skillsets: [], skillsetCredentials: {} }
+    mockUrlToSkillsetId.mockReturnValue('github-com-org-private-repo')
+    mockGetSettings.mockImplementation(() => settingsState)
+    mockUpdateSettings.mockImplementation((next) => { settingsState = next })
+    mockValidateSkillsetUrl.mockResolvedValue({
+      skillset_name: 'Private', skills: [{ name: 'a' }], description: 'desc', version: '1.0.0',
+    })
+
+    const app = new Hono()
+    app.route('/api/skillsets', skillsets)
+    const res = await app.request('/api/skillsets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: 'https://github.com/Org/private-repo', token }),
+    })
+
+    expect(res.status).toBe(201)
+    expect(mockValidateSkillsetUrl).toHaveBeenCalledWith(
+      'https://github.com/Org/private-repo',
+      'github',
+      { type: 'token', token },
+    )
+
+    const saved = mockUpdateSettings.mock.calls[0][0]
+    const credentialId = saved.skillsets[0].providerData.credentialId
+    expect(credentialId).toMatch(/^skillcred_/)
+    expect(saved.skillsetCredentials[credentialId]).toMatchObject({
+      type: 'token',
+      token,
+      tokenPreview: '••••1234',
+    })
+    expect(saved.skillsets[0].url).toBe('https://github.com/Org/private-repo')
+    const responseBody = JSON.stringify(await res.json())
+    expect(responseBody).not.toContain(token)
+    expect(responseBody).toContain('••••1234')
+  })
+
+  it('PATCH /:id/credential validates and rotates a token without changing its opaque id', async () => {
+    const oldToken = 'github_pat_old_1111'
+    const newToken = 'github_pat_new_2222'
+    let settingsState: any = {
+      skillsets: [{
+        id: 'private-repo',
+        url: 'https://github.com/Org/private-repo',
+        name: 'Private',
+        description: '',
+        addedAt: '2026-01-01T00:00:00.000Z',
+        provider: 'github',
+        providerData: { credentialId: 'skillcred_test' },
+      }],
+      skillsetCredentials: {
+        skillcred_test: {
+          id: 'skillcred_test', type: 'token', token: oldToken, tokenPreview: '••••1111',
+          createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    }
+    mockGetSettings.mockImplementation(() => settingsState)
+    mockUpdateSettings.mockImplementation((next) => { settingsState = next })
+    mockValidateSkillsetUrl.mockResolvedValue({
+      skillset_name: 'Private', skills: [{ name: 'a' }], description: '', version: '1.0.0',
+    })
+    mockGetSkillsetIndex.mockResolvedValue({ skills: [{ name: 'a' }], agents: [] })
+
+    const app = new Hono()
+    app.route('/api/skillsets', skillsets)
+    const res = await app.request('/api/skillsets/private-repo/credential', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: newToken }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockValidateSkillsetUrl).toHaveBeenCalledWith(
+      'https://github.com/Org/private-repo',
+      'github',
+      { type: 'token', token: newToken },
+    )
+    expect(settingsState.skillsets[0].providerData.credentialId).toBe('skillcred_test')
+    expect(settingsState.skillsetCredentials.skillcred_test).toMatchObject({
+      token: newToken,
+      tokenPreview: '••••2222',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    })
+    const responseBody = JSON.stringify(await res.json())
+    expect(responseBody).not.toContain(oldToken)
+    expect(responseBody).not.toContain(newToken)
+    expect(responseBody).toContain('••••2222')
+  })
+
+  it('DELETE / removes the credential owned by the skillset', async () => {
+    const config = {
+      id: 'private-repo',
+      url: 'https://github.com/Org/private-repo',
+      name: 'Private',
+      description: '',
+      addedAt: '2026-01-01T00:00:00.000Z',
+      provider: 'github' as const,
+      providerData: { credentialId: 'skillcred_test' },
+    }
+    mockGetSettings.mockReturnValue({
+      skillsets: [config],
+      skillsetCredentials: {
+        skillcred_test: {
+          id: 'skillcred_test', type: 'token', token: 'secret', tokenPreview: '••••cret',
+          createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    })
+
+    const app = new Hono()
+    app.route('/api/skillsets', skillsets)
+    const res = await app.request('/api/skillsets/private-repo', { method: 'DELETE' })
+
+    expect(res.status).toBe(204)
+    const saved = mockUpdateSettings.mock.calls[0][0]
+    expect(saved.skillsets).toEqual([])
+    expect(saved.skillsetCredentials).toEqual({})
   })
 })

--- a/src/api/routes/skillsets.test.ts
+++ b/src/api/routes/skillsets.test.ts
@@ -386,6 +386,41 @@ describe('skillsets routes', () => {
     expect(responseBody).toContain('••••2222')
   })
 
+  it('PATCH /:id/credential returns 404 when the skillset is deleted concurrently', async () => {
+    let settingsState: Record<string, unknown> = {
+      skillsets: [{
+        id: 'private-repo',
+        url: 'https://github.com/Org/private-repo',
+        name: 'Private',
+        description: '',
+        addedAt: '2026-01-01T00:00:00.000Z',
+        provider: 'github',
+        providerData: { credentialId: 'skillcred_test' },
+      }],
+      skillsetCredentials: {
+        skillcred_test: {
+          id: 'skillcred_test', type: 'token', token: 'secret', tokenPreview: '••••cret',
+          createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    }
+    mockGetSettings.mockImplementation(() => settingsState)
+    mockUpdateSettings.mockImplementation(() => {
+      settingsState = { skillsets: [], skillsetCredentials: {} }
+    })
+
+    const app = new Hono()
+    app.route('/api/skillsets', skillsets)
+    const res = await app.request('/api/skillsets/private-repo/credential', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: null }),
+    })
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Skillset not found' })
+  })
+
   it('DELETE / removes the credential owned by the skillset', async () => {
     const config = {
       id: 'private-repo',

--- a/src/api/routes/skillsets.ts
+++ b/src/api/routes/skillsets.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import crypto from 'crypto'
 import {
   getSettings,
   mutateSettings,
@@ -14,10 +15,25 @@ import {
   isGitAvailable,
 } from '@shared/lib/services/skillset-service'
 import { getSkillsetProvider } from '@shared/lib/skillset-provider'
-import type { SkillsetConfig, SkillProvider } from '@shared/lib/types/skillset'
+import type {
+  SkillsetConfig,
+  SkillsetCredential,
+  SkillsetCredentialInput,
+  SkillProvider,
+} from '@shared/lib/types/skillset'
 import type { ApiSkillsetConfig } from '@shared/lib/types/api'
 
-async function resolveProvider(url: string, explicit?: SkillProvider): Promise<SkillProvider | undefined> {
+async function resolveProvider(
+  url: string,
+  explicit?: SkillProvider,
+  hasToken: boolean = false,
+): Promise<SkillProvider | undefined> {
+  if (hasToken) {
+    if (explicit && explicit !== 'github') {
+      throw new Error('Repository tokens are currently supported by the GitHub provider only.')
+    }
+    return 'github'
+  }
   if (explicit) return explicit
   try {
     const hostname = new URL(url).hostname
@@ -28,6 +44,48 @@ async function resolveProvider(url: string, explicit?: SkillProvider): Promise<S
     // invalid URL — let downstream validation handle it
   }
   return undefined
+}
+
+type SkillsetRequestBody = {
+  url?: string
+  provider?: SkillProvider
+  token?: string
+}
+
+function parseToken(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  if (typeof value !== 'string') throw new Error('Token must be a string.')
+  const token = value.trim()
+  if (!token) return undefined
+  if (token.length > 4096 || /\s/.test(token)) {
+    throw new Error('Token must not contain whitespace and must be 4096 characters or fewer.')
+  }
+  return token
+}
+
+function tokenPreview(token: string): string {
+  return `••••${token.slice(-4)}`
+}
+
+function createCredential(token: string, existing?: SkillsetCredential): SkillsetCredential {
+  const now = new Date().toISOString()
+  return {
+    id: existing?.id ?? `skillcred_${crypto.randomUUID()}`,
+    type: 'token',
+    token,
+    tokenPreview: tokenPreview(token),
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  }
+}
+
+function getCredentialId(config: Pick<SkillsetConfig, 'providerData'>): string | undefined {
+  const id = config.providerData?.credentialId
+  return typeof id === 'string' ? id : undefined
+}
+
+function transientCredential(token?: string): SkillsetCredentialInput | undefined {
+  return token ? { type: 'token', token } : undefined
 }
 
 function toSkillsetRef(config: Pick<SkillsetConfig, 'id' | 'url' | 'name' | 'provider' | 'providerData'>) {
@@ -48,6 +106,8 @@ skillsets.use('*', Authenticated())
 function configToApiResponse(config: SkillsetConfig, skillCount: number, agentCount: number = 0, error?: string): ApiSkillsetConfig {
   const provider = getSkillsetProvider(config.provider)
   const display = provider.getDisplayInfo()
+  const credentialId = getCredentialId(config)
+  const credential = credentialId ? getSettings().skillsetCredentials?.[credentialId] : undefined
   return {
     id: config.id,
     url: config.url,
@@ -60,6 +120,7 @@ function configToApiResponse(config: SkillsetConfig, skillCount: number, agentCo
     badgeLabel: display.badgeLabel,
     showUrl: display.showUrl,
     publishMode: provider.publishMode,
+    credential: credential ? { type: credential.type, tokenPreview: credential.tokenPreview } : undefined,
     error,
   }
 }
@@ -94,13 +155,14 @@ skillsets.get('/', async (c) => {
 // POST /api/skillsets/validate - Validate a skillset URL
 skillsets.post('/validate', IsAdmin(), async (c) => {
   try {
-    const { url, provider: explicitProvider } = await c.req.json() as { url?: string; provider?: SkillProvider }
+    const { url, provider: explicitProvider, token: rawToken } = await c.req.json() as SkillsetRequestBody
     if (!url || typeof url !== 'string') {
       return c.json({ valid: false, error: 'URL is required' }, 400)
     }
 
-    const provider = await resolveProvider(url.trim(), explicitProvider)
-    const index = await validateSkillsetUrl(url.trim(), provider)
+    const token = parseToken(rawToken)
+    const provider = await resolveProvider(url.trim(), explicitProvider, Boolean(token))
+    const index = await validateSkillsetUrl(url.trim(), provider, transientCredential(token))
     return c.json({ valid: true, index })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to validate skillset URL'
@@ -111,13 +173,14 @@ skillsets.post('/validate', IsAdmin(), async (c) => {
 // POST /api/skillsets - Add a skillset (validates first)
 skillsets.post('/', IsAdmin(), async (c) => {
   try {
-    const { url, provider: explicitProvider } = await c.req.json() as { url?: string; provider?: SkillProvider }
+    const { url, provider: explicitProvider, token: rawToken } = await c.req.json() as SkillsetRequestBody
     if (!url || typeof url !== 'string') {
       return c.json({ error: 'URL is required' }, 400)
     }
 
     const trimmedUrl = url.trim()
-    const provider = await resolveProvider(trimmedUrl, explicitProvider)
+    const token = parseToken(rawToken)
+    const provider = await resolveProvider(trimmedUrl, explicitProvider, Boolean(token))
     const skillsetId = urlToSkillsetId(trimmedUrl)
 
     // Check for duplicates
@@ -128,7 +191,9 @@ skillsets.post('/', IsAdmin(), async (c) => {
     }
 
     // Validate and fetch index
-    const index = await validateSkillsetUrl(trimmedUrl, provider)
+    const index = await validateSkillsetUrl(trimmedUrl, provider, transientCredential(token))
+
+    const credential = token ? createCredential(token) : undefined
 
     // Save to settings
     const config: SkillsetConfig = {
@@ -138,12 +203,16 @@ skillsets.post('/', IsAdmin(), async (c) => {
       description: index.description || '',
       addedAt: new Date().toISOString(),
       provider,
+      providerData: credential ? { credentialId: credential.id } : undefined,
     }
 
     // Upsert by id against a FRESH read inside the serialized mutation so a
     // concurrent add of a different skillset isn't lost.
     mutateSettings((s) => {
       s.skillsets = [...(s.skillsets ?? []).filter((x) => x.id !== config.id), config]
+      if (credential) {
+        s.skillsetCredentials = { ...s.skillsetCredentials, [credential.id]: credential }
+      }
     })
 
     return c.json(configToApiResponse(config, index.skills.length, index.agents?.length ?? 0), 201)
@@ -159,6 +228,7 @@ skillsets.delete('/:id', IsAdmin(), async (c) => {
     const id = c.req.param('id')
     const settings = getSettings()
     const existing = settings.skillsets || []
+    const removed = existing.find((s) => s.id === id)
     const filtered = existing.filter((s) => s.id !== id)
 
     if (filtered.length === existing.length) {
@@ -168,7 +238,14 @@ skillsets.delete('/:id', IsAdmin(), async (c) => {
     // Remove from settings — filter against a FRESH read inside the serialized
     // mutation so a concurrent change to another skillset isn't lost.
     mutateSettings((s) => {
+      const current = (s.skillsets ?? []).find((x) => x.id === id)
       s.skillsets = (s.skillsets ?? []).filter((x) => x.id !== id)
+      const credentialId = current ? getCredentialId(current) : undefined
+      if (credentialId && s.skillsetCredentials) {
+        const remainingCredentials = { ...s.skillsetCredentials }
+        delete remainingCredentials[credentialId]
+        s.skillsetCredentials = remainingCredentials
+      }
     })
 
     // Clean up cache
@@ -178,6 +255,59 @@ skillsets.delete('/:id', IsAdmin(), async (c) => {
   } catch (error) {
     console.error('Failed to remove skillset:', error)
     return c.json({ error: 'Failed to remove skillset' }, 500)
+  }
+})
+
+// PATCH /api/skillsets/:id/credential - Add, rotate, or remove a repository token
+skillsets.patch('/:id/credential', IsAdmin(), async (c) => {
+  try {
+    const id = c.req.param('id')
+    const body = await c.req.json<{ token?: string | null }>()
+    const config = (getSettings().skillsets || []).find((item) => item.id === id)
+    if (!config) return c.json({ error: 'Skillset not found' }, 404)
+    if (body.token === undefined) return c.json({ error: 'Token is required (use null to remove it)' }, 400)
+
+    const previousCredentialId = getCredentialId(config)
+    if (body.token === null || body.token === '') {
+      mutateSettings((s) => {
+        const target = (s.skillsets ?? []).find((item) => item.id === id)
+        if (!target) return
+        const providerData = { ...target.providerData }
+        delete providerData.credentialId
+        target.providerData = Object.keys(providerData).length ? providerData : undefined
+        if (previousCredentialId && s.skillsetCredentials) {
+          const remainingCredentials = { ...s.skillsetCredentials }
+          delete remainingCredentials[previousCredentialId]
+          s.skillsetCredentials = remainingCredentials
+        }
+      })
+    } else {
+      const token = parseToken(body.token)
+      if (!token) return c.json({ error: 'Token cannot be empty (use null to remove it)' }, 400)
+      const provider = await resolveProvider(config.url, config.provider, true)
+      const index = await validateSkillsetUrl(config.url, provider, transientCredential(token))
+      const existingCredential = previousCredentialId
+        ? getSettings().skillsetCredentials?.[previousCredentialId]
+        : undefined
+      const credential = createCredential(token, existingCredential)
+
+      mutateSettings((s) => {
+        const target = (s.skillsets ?? []).find((item) => item.id === id)
+        if (!target) return
+        target.provider = provider
+        target.providerData = { ...target.providerData, credentialId: credential.id }
+        target.name = index.skillset_name
+        target.description = index.description || ''
+        s.skillsetCredentials = { ...s.skillsetCredentials, [credential.id]: credential }
+      })
+    }
+
+    const updated = (getSettings().skillsets || []).find((item) => item.id === id)!
+    const index = await getSkillsetIndex(toSkillsetRef(updated))
+    return c.json(configToApiResponse(updated, index?.skills.length ?? 0, index?.agents?.length ?? 0))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to update repository token'
+    return c.json({ error: message }, 400)
   }
 })
 

--- a/src/api/routes/skillsets.ts
+++ b/src/api/routes/skillsets.ts
@@ -229,9 +229,8 @@ skillsets.delete('/:id', IsAdmin(), async (c) => {
     const settings = getSettings()
     const existing = settings.skillsets || []
     const removed = existing.find((s) => s.id === id)
-    const filtered = existing.filter((s) => s.id !== id)
 
-    if (filtered.length === existing.length) {
+    if (!removed) {
       return c.json({ error: 'Skillset not found' }, 404)
     }
 
@@ -249,7 +248,7 @@ skillsets.delete('/:id', IsAdmin(), async (c) => {
     })
 
     // Clean up cache
-    await removeSkillsetCache(toSkillsetRef(existing.find((s) => s.id === id)!))
+    await removeSkillsetCache(toSkillsetRef(removed))
 
     return c.body(null, 204)
   } catch (error) {
@@ -302,7 +301,8 @@ skillsets.patch('/:id/credential', IsAdmin(), async (c) => {
       })
     }
 
-    const updated = (getSettings().skillsets || []).find((item) => item.id === id)!
+    const updated = (getSettings().skillsets || []).find((item) => item.id === id)
+    if (!updated) return c.json({ error: 'Skillset not found' }, 404)
     const index = await getSkillsetIndex(toSkillsetRef(updated))
     return c.json(configToApiResponse(updated, index?.skills.length ?? 0, index?.agents?.length ?? 0))
   } catch (error) {

--- a/src/renderer/components/settings/skillsets-tab.tsx
+++ b/src/renderer/components/settings/skillsets-tab.tsx
@@ -32,6 +32,10 @@ export function SkillsetsTab() {
   const [tokenInput, setTokenInput] = useState('')
   const [editingCredentialId, setEditingCredentialId] = useState<string | null>(null)
   const [replacementToken, setReplacementToken] = useState('')
+  const [credentialError, setCredentialError] = useState<{
+    skillsetId: string
+    message: string
+  } | null>(null)
   const [validationResult, setValidationResult] = useState<{
     valid: boolean
     error?: string
@@ -65,15 +69,29 @@ export function SkillsetsTab() {
 
   const handleSaveCredential = async (id: string) => {
     if (!replacementToken.trim()) return
-    setValidationResult(null)
+    setCredentialError(null)
     try {
       await updateCredential.mutateAsync({ id, token: replacementToken.trim() })
       setReplacementToken('')
       setEditingCredentialId(null)
     } catch (error) {
-      setValidationResult({
-        valid: false,
-        error: error instanceof Error ? error.message : 'Failed to update repository token',
+      setCredentialError({
+        skillsetId: id,
+        message: error instanceof Error ? error.message : 'Failed to update repository token',
+      })
+    }
+  }
+
+  const handleRemoveCredential = async (id: string) => {
+    setCredentialError(null)
+    try {
+      await updateCredential.mutateAsync({ id, token: null })
+      setReplacementToken('')
+      setEditingCredentialId(null)
+    } catch (error) {
+      setCredentialError({
+        skillsetId: id,
+        message: error instanceof Error ? error.message : 'Failed to remove repository token',
       })
     }
   }
@@ -246,41 +264,55 @@ export function SkillsetsTab() {
                   </div>
                 )}
                 {editingCredentialId === ss.id && (
-                  <div className="flex items-center gap-2 mt-2">
-                    <Input
-                      type="password"
-                      autoComplete="off"
-                      aria-label={`Repository token for ${ss.name}`}
-                      placeholder={ss.credential ? 'Replace repository token' : 'Add repository token'}
-                      value={replacementToken}
-                      onChange={(e) => setReplacementToken(e.target.value)}
-                      className="h-8"
-                      disabled={updateCredential.isPending}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault()
-                          handleSaveCredential(ss.id)
-                        }
-                      }}
-                    />
-                    <Button
-                      size="sm"
-                      className="h-8"
-                      disabled={!replacementToken.trim() || updateCredential.isPending}
-                      onClick={() => handleSaveCredential(ss.id)}
-                    >
-                      Save
-                    </Button>
-                    {ss.credential && (
-                      <Button
-                        size="sm"
-                        variant="outline"
+                  <div className="mt-2 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="password"
+                        autoComplete="off"
+                        aria-label={`Repository token for ${ss.name}`}
+                        placeholder={ss.credential ? 'Replace repository token' : 'Add repository token'}
+                        value={replacementToken}
+                        onChange={(e) => {
+                          setReplacementToken(e.target.value)
+                          setCredentialError(null)
+                        }}
                         className="h-8"
                         disabled={updateCredential.isPending}
-                        onClick={() => updateCredential.mutate({ id: ss.id, token: null })}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault()
+                            handleSaveCredential(ss.id)
+                          }
+                        }}
+                      />
+                      <Button
+                        size="sm"
+                        className="h-8"
+                        disabled={!replacementToken.trim() || updateCredential.isPending}
+                        onClick={() => handleSaveCredential(ss.id)}
                       >
-                        Remove
+                        Save
                       </Button>
+                      {ss.credential && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-8"
+                          disabled={updateCredential.isPending}
+                          onClick={() => handleRemoveCredential(ss.id)}
+                        >
+                          Remove
+                        </Button>
+                      )}
+                    </div>
+                    {credentialError?.skillsetId === ss.id && (
+                      <div
+                        role="alert"
+                        className="flex items-start gap-1.5 text-xs text-destructive"
+                      >
+                        <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                        <span>{credentialError.message}</span>
+                      </div>
                     )}
                   </div>
                 )}
@@ -294,7 +326,7 @@ export function SkillsetsTab() {
                     const nextId = editingCredentialId === ss.id ? null : ss.id
                     setEditingCredentialId(nextId)
                     setReplacementToken('')
-                    setValidationResult(null)
+                    setCredentialError(null)
                   }}
                   disabled={updateCredential.isPending || (ss.provider ?? 'github') !== 'github'}
                   title={ss.credential ? 'Replace or remove repository token' : 'Add repository token'}

--- a/src/renderer/components/settings/skillsets-tab.tsx
+++ b/src/renderer/components/settings/skillsets-tab.tsx
@@ -8,8 +8,18 @@ import {
   useAddSkillset,
   useRemoveSkillset,
   useRefreshSkillset,
+  useUpdateSkillsetCredential,
 } from '@renderer/hooks/use-skillsets'
-import { AlertTriangle, Loader2, Trash2, RefreshCw, Library } from 'lucide-react'
+import {
+  AlertTriangle,
+  ExternalLink,
+  KeyRound,
+  Loader2,
+  Trash2,
+  RefreshCw,
+  Library,
+  X,
+} from 'lucide-react'
 
 export function SkillsetsTab() {
   const { data: skillsets, isLoading } = useSkillsets()
@@ -17,7 +27,11 @@ export function SkillsetsTab() {
   const addSkillset = useAddSkillset()
   const removeSkillset = useRemoveSkillset()
   const refreshSkillset = useRefreshSkillset()
+  const updateCredential = useUpdateSkillsetCredential()
   const [urlInput, setUrlInput] = useState('')
+  const [tokenInput, setTokenInput] = useState('')
+  const [editingCredentialId, setEditingCredentialId] = useState<string | null>(null)
+  const [replacementToken, setReplacementToken] = useState('')
   const [validationResult, setValidationResult] = useState<{
     valid: boolean
     error?: string
@@ -28,11 +42,13 @@ export function SkillsetsTab() {
     setValidationResult(null)
 
     try {
-      const result = await validateSkillset.mutateAsync(urlInput.trim())
+      const input = { url: urlInput.trim(), token: tokenInput.trim() || undefined }
+      const result = await validateSkillset.mutateAsync(input)
 
       if (result.valid) {
-        await addSkillset.mutateAsync(urlInput.trim())
+        await addSkillset.mutateAsync(input)
         setUrlInput('')
+        setTokenInput('')
         setValidationResult(null)
       } else {
         setValidationResult({ valid: false, error: result.error })
@@ -46,6 +62,21 @@ export function SkillsetsTab() {
   }
 
   const isBusy = validateSkillset.isPending || addSkillset.isPending
+
+  const handleSaveCredential = async (id: string) => {
+    if (!replacementToken.trim()) return
+    setValidationResult(null)
+    try {
+      await updateCredential.mutateAsync({ id, token: replacementToken.trim() })
+      setReplacementToken('')
+      setEditingCredentialId(null)
+    } catch (error) {
+      setValidationResult({
+        valid: false,
+        error: error instanceof Error ? error.message : 'Failed to update repository token',
+      })
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -90,6 +121,63 @@ export function SkillsetsTab() {
           </Button>
         </div>
 
+        <Input
+          type="password"
+          autoComplete="off"
+          aria-label="Repository token (optional)"
+          placeholder="Repository token (optional, for private GitHub repositories)"
+          value={tokenInput}
+          onChange={(e) => {
+            setTokenInput(e.target.value)
+            setValidationResult(null)
+          }}
+          disabled={isBusy}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              handleValidateAndAdd()
+            }
+          }}
+        />
+
+        <div className="rounded-md border bg-muted/30 p-3 text-xs">
+          <p className="font-medium">Private GitHub repository token</p>
+          <ol className="mt-1.5 list-decimal space-y-1 pl-4 text-muted-foreground">
+            <li>
+              <a
+                href="https://github.com/settings/personal-access-tokens/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-primary hover:underline"
+              >
+                Create a fine-grained personal access token
+                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+              </a>{' '}
+              and choose the repository owner.
+            </li>
+            <li>
+              Under <span className="font-medium text-foreground">Repository access</span>, choose{' '}
+              <span className="font-medium text-foreground">Only select repositories</span> and
+              select this skillset repository.
+            </li>
+            <li>
+              Under <span className="font-medium text-foreground">Repository permissions</span>,
+              set <span className="font-medium text-foreground">Contents</span> to{' '}
+              <span className="font-medium text-foreground">Read-only</span>. GitHub adds Metadata
+              read access automatically.
+            </li>
+            <li>Generate the token and paste it above.</li>
+          </ol>
+          <p className="mt-2 text-muted-foreground">
+            This minimum permission supports discovering, installing, and refreshing skills. A
+            classic token also works with the broader{' '}
+            <code className="rounded bg-muted px-1 py-0.5 text-foreground">repo</code> scope, but a
+            fine-grained token is recommended. Publishing pull requests requires additional write
+            and fork permissions. If GitHub marks an organization token as pending, an organization
+            owner must approve it before it can read private repositories.
+          </p>
+        </div>
+
         {validationResult && !validationResult.valid && (
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />
@@ -98,7 +186,8 @@ export function SkillsetsTab() {
         )}
 
         <p className="text-xs text-muted-foreground">
-          Enter a git repository URL containing an index.json file. Supports HTTPS and SSH URLs.
+          Enter a git repository URL containing an index.json file. Private GitHub repositories
+          must use an HTTPS URL.
         </p>
       </div>
 
@@ -134,6 +223,11 @@ export function SkillsetsTab() {
                       {ss.badgeLabel}
                     </span>
                   )}
+                  {ss.credential && (
+                    <span className="text-2xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">
+                      Private · {ss.credential.tokenPreview}
+                    </span>
+                  )}
                 </div>
                 {ss.description && (
                   <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
@@ -151,8 +245,62 @@ export function SkillsetsTab() {
                     <p className="text-xs text-destructive line-clamp-2">{ss.error}</p>
                   </div>
                 )}
+                {editingCredentialId === ss.id && (
+                  <div className="flex items-center gap-2 mt-2">
+                    <Input
+                      type="password"
+                      autoComplete="off"
+                      aria-label={`Repository token for ${ss.name}`}
+                      placeholder={ss.credential ? 'Replace repository token' : 'Add repository token'}
+                      value={replacementToken}
+                      onChange={(e) => setReplacementToken(e.target.value)}
+                      className="h-8"
+                      disabled={updateCredential.isPending}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          handleSaveCredential(ss.id)
+                        }
+                      }}
+                    />
+                    <Button
+                      size="sm"
+                      className="h-8"
+                      disabled={!replacementToken.trim() || updateCredential.isPending}
+                      onClick={() => handleSaveCredential(ss.id)}
+                    >
+                      Save
+                    </Button>
+                    {ss.credential && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-8"
+                        disabled={updateCredential.isPending}
+                        onClick={() => updateCredential.mutate({ id: ss.id, token: null })}
+                      >
+                        Remove
+                      </Button>
+                    )}
+                  </div>
+                )}
               </div>
               <div className="flex gap-1 shrink-0">
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7"
+                  onClick={() => {
+                    const nextId = editingCredentialId === ss.id ? null : ss.id
+                    setEditingCredentialId(nextId)
+                    setReplacementToken('')
+                    setValidationResult(null)
+                  }}
+                  disabled={updateCredential.isPending || (ss.provider ?? 'github') !== 'github'}
+                  title={ss.credential ? 'Replace or remove repository token' : 'Add repository token'}
+                >
+                  {editingCredentialId === ss.id ? <X className="h-3.5 w-3.5" /> : <KeyRound className="h-3.5 w-3.5" />}
+                </Button>
                 <Button
                   size="icon"
                   variant="ghost"

--- a/src/renderer/hooks/use-skillsets.ts
+++ b/src/renderer/hooks/use-skillsets.ts
@@ -4,6 +4,11 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ApiSkillsetConfig } from '@shared/lib/types/api'
 import type { SkillsetIndex } from '@shared/lib/types/skillset'
 
+export type SkillsetMutationInput = {
+  url: string
+  token?: string
+}
+
 export function useSkillsets() {
   return useQuery<ApiSkillsetConfig[]>({
     queryKey: ['skillsets'],
@@ -19,14 +24,14 @@ export function useValidateSkillset() {
   return useMutation<
     { valid: boolean; error?: string; index?: SkillsetIndex },
     Error,
-    string
+    SkillsetMutationInput
   >({
     meta: { skipGlobalErrorToast: true },
-    mutationFn: async (url: string) => {
+    mutationFn: async (input: SkillsetMutationInput) => {
       const res = await apiFetch('/api/skillsets/validate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify(input),
       })
       return res.json()
     },
@@ -36,17 +41,40 @@ export function useValidateSkillset() {
 export function useAddSkillset() {
   const queryClient = useQueryClient()
 
-  return useMutation<ApiSkillsetConfig, Error, string>({
+  return useMutation<ApiSkillsetConfig, Error, SkillsetMutationInput>({
     meta: { skipGlobalErrorToast: true },
-    mutationFn: async (url: string) => {
+    mutationFn: async (input: SkillsetMutationInput) => {
       const res = await apiFetch('/api/skillsets', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify(input),
       })
       if (!res.ok) {
         const data = await res.json()
         throw new Error(data.error || 'Failed to add skillset')
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['skillsets'] })
+    },
+  })
+}
+
+export function useUpdateSkillsetCredential() {
+  const queryClient = useQueryClient()
+
+  return useMutation<ApiSkillsetConfig, Error, { id: string; token: string | null }>({
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async ({ id, token }) => {
+      const res = await apiFetch(`/api/skillsets/${encodeURIComponent(id)}/credential`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to update repository token')
       }
       return res.json()
     },
@@ -100,5 +128,4 @@ export function useRefreshSkillset() {
     },
   })
 }
-
 

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -429,6 +429,25 @@ describe('loadSettings', () => {
       expect(result.skillsets).toEqual(skillsets)
     })
 
+    it('preserves skillset credentials without copying them into skillset metadata', () => {
+      const skillsetCredentials = {
+        skillcred_test: {
+          id: 'skillcred_test',
+          type: 'token',
+          token: 'github_pat_secret',
+          tokenPreview: '••••cret',
+          createdAt: '2026-08-06T00:00:00.000Z',
+          updatedAt: '2026-08-06T00:00:00.000Z',
+        },
+      }
+      mockSettingsFile(JSON.stringify({ skillsetCredentials }))
+
+      const result = loadSettings()
+
+      expect(result.skillsetCredentials).toEqual(skillsetCredentials)
+      expect(JSON.stringify(result.skillsets)).not.toContain('github_pat_secret')
+    })
+
     it('handles completely empty JSON object', () => {
       mockSettingsFile('{}')
 

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -12,7 +12,7 @@ import { captureException } from '@shared/lib/error-reporting'
 import { persistedSettingsSchema } from './settings-schema'
 import { coerceApiTarget, type ApiTarget } from '@shared/lib/api-target'
 import { DEFAULT_GLOBAL_DISPATCH_SHORTCUT } from './shortcuts'
-import type { SkillsetConfig } from '@shared/lib/types/skillset'
+import type { SkillsetConfig, SkillsetCredential } from '@shared/lib/types/skillset'
 import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
 import type { ComputerUseSettings } from '@shared/lib/computer-use/types'
 import type { EffortLevel } from '@shared/lib/container/types'
@@ -254,6 +254,8 @@ export interface AppSettings {
   agentLimits?: AgentLimitsSettings
   customEnvVars?: Record<string, string>
   skillsets?: SkillsetConfig[]
+  /** Secrets keyed by opaque id; skillset providerData stores only the id. */
+  skillsetCredentials?: Record<string, SkillsetCredential>
   auth?: AuthSettings
   voice?: VoiceSettings
   computerUse?: ComputerUseSettings
@@ -542,6 +544,7 @@ function mergeLoadedSettings(loaded: Record<string, any>): AppSettings {
     skillsets: loaded.skillsets !== undefined
       ? loaded.skillsets
       : structuredClone(DEFAULT_SETTINGS.skillsets),
+    skillsetCredentials: loaded.skillsetCredentials,
     auth: {
       ...DEFAULT_AUTH_SETTINGS,
       ...loaded.auth,

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -1162,7 +1162,7 @@ export async function getAgentPRInfo(
     throw new Error('Agent has no skillset metadata - cannot create PR')
   }
 
-  await getSkillsetProvider(meta.provider).ensurePublishPreconditions()
+  await getSkillsetProvider(meta.provider).ensurePublishPreconditions(toSkillsetRefFromMeta(meta))
 
   const suggestions = await generateAgentPRSuggestions(meta, agentSlug)
 
@@ -1282,7 +1282,7 @@ export async function getAgentPublishInfo(
     throw new Error('CLAUDE.md not found')
   }
 
-  await getSkillsetProvider(skillsetConfig.provider).ensurePublishPreconditions()
+  await getSkillsetProvider(skillsetConfig.provider).ensurePublishPreconditions(toSkillsetRefFromConfig(skillsetConfig))
 
   const { frontmatter } = parseMarkdownWithFrontmatter<AgentFrontmatter>(claudeMdContent)
   const agentName = frontmatter.name || agentSlug

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -33,6 +33,7 @@ import type {
   SkillWithStatus,
   SkillStatus,
   SkillProvider,
+  SkillsetCredentialInput,
 } from '@shared/lib/types/skillset'
 import { InstalledSkillMetadataSchema } from '@shared/lib/types/skillset-schema'
 import { getSkillsetProvider } from '@shared/lib/skillset-provider'
@@ -112,6 +113,7 @@ type SkillsetRef = {
   provider?: SkillProvider
   skillsetName?: string
   providerData?: SkillsetConfig['providerData']
+  credential?: SkillsetCredentialInput
 }
 
 function toSkillsetRefFromConfig(config: Pick<SkillsetConfig, 'id' | 'url' | 'name' | 'provider' | 'providerData'>): SkillsetRef {
@@ -417,11 +419,11 @@ function getDisplayName(dirName: string): string {
 // ============================================================================
 
 
-async function gitClone(url: string, dest: string): Promise<void> {
+async function gitClone(url: string, dest: string, environment: NodeJS.ProcessEnv): Promise<void> {
   try {
     await execFileAsync('git', ['clone', '--depth', '1', url, dest], {
       timeout: 60000,
-      env: GIT_ENV,
+      env: environment,
     })
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error)
@@ -429,8 +431,8 @@ async function gitClone(url: string, dest: string): Promise<void> {
     if (/not found|does not exist|Could not read from remote|Permission denied/i.test(msg)) {
       throw new Error(
         `Could not access repository: ${url}\n\n` +
-        'This may be a private repository. To access private repos, configure SSH authentication:\n' +
-        'https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent'
+        'This may be a private repository. Add a repository token in Skillset settings, or configure SSH authentication:\n' +
+        'https://docs.github.com/en/authentication/connecting-to-github-with-ssh'
       )
     }
     throw error
@@ -512,12 +514,15 @@ type DefaultBranchResolution =
  * When it can't be determined, says whether that's because the remote is
  * unavailable (offline/auth) or the cache itself is unresolvable.
  */
-async function resolveDefaultBranch(repoDir: string): Promise<DefaultBranchResolution> {
+async function resolveDefaultBranch(
+  repoDir: string,
+  environment: NodeJS.ProcessEnv,
+): Promise<DefaultBranchResolution> {
   const readSymref = async (): Promise<string | null> => {
     try {
       const { stdout } = await execFileAsync(
         'git', ['symbolic-ref', 'refs/remotes/origin/HEAD'],
-        { cwd: repoDir, timeout: 5000, env: getRepoGitEnv(repoDir) },
+        { cwd: repoDir, timeout: 5000, env: environment },
       )
       const branch = stdout.trim().replace('refs/remotes/origin/', '')
       return branch || null
@@ -537,7 +542,7 @@ async function resolveDefaultBranch(repoDir: string): Promise<DefaultBranchResol
   let setHeadError: unknown = null
   try {
     await execFileAsync('git', ['remote', 'set-head', 'origin', '--auto'], {
-      cwd: repoDir, timeout: 10000, env: getRepoGitEnv(repoDir),
+      cwd: repoDir, timeout: 10000, env: environment,
     })
   } catch (err) {
     setHeadError = err
@@ -561,11 +566,11 @@ async function resolveDefaultBranch(repoDir: string): Promise<DefaultBranchResol
 
 type GitPullResult = 'pulled' | 'skipped-offline'
 
-async function gitPull(repoDir: string): Promise<GitPullResult> {
+async function gitPull(repoDir: string, environment: NodeJS.ProcessEnv): Promise<GitPullResult> {
   // Resolve the repo's real default branch instead of guessing main/master.
   // After a PR flow the repo may be left on a detached HEAD, a stale branch,
   // or with a drifted branch.<name>.merge config.
-  const resolved = await resolveDefaultBranch(repoDir)
+  const resolved = await resolveDefaultBranch(repoDir, environment)
 
   if (resolved.branch === null) {
     if (resolved.reason === 'offline') {
@@ -584,7 +589,7 @@ async function gitPull(repoDir: string): Promise<GitPullResult> {
 
   try {
     await execFileAsync('git', ['checkout', defaultBranch], {
-      cwd: repoDir, timeout: 10000, env: getRepoGitEnv(repoDir),
+      cwd: repoDir, timeout: 10000, env: environment,
     })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
@@ -604,10 +609,10 @@ async function gitPull(repoDir: string): Promise<GitPullResult> {
   // would break `reset --hard origin/<branch>` / `git pull`.
   try {
     await execFileAsync('git', ['fetch', '--depth', '1', 'origin', defaultBranch], {
-      cwd: repoDir, timeout: 30000, env: getRepoGitEnv(repoDir),
+      cwd: repoDir, timeout: 30000, env: environment,
     })
     await execFileAsync('git', ['reset', '--hard', 'FETCH_HEAD'], {
-      cwd: repoDir, timeout: 10000, env: getRepoGitEnv(repoDir),
+      cwd: repoDir, timeout: 10000, env: environment,
     })
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error)
@@ -718,7 +723,8 @@ export async function ensureSkillsetCached(ref: SkillsetRef): Promise<string> {
 
   await ensureGitInstalled()
   const cloneUrl = await hostingProvider.resolveCloneUrl(ref.skillsetUrl, ref)
-  await gitClone(cloneUrl, repoDir)
+  const gitEnvironment = hostingProvider.getGitEnvironment(ref, GIT_ENV)
+  await gitClone(cloneUrl, repoDir, gitEnvironment)
   return repoDir
 }
 
@@ -755,9 +761,32 @@ export async function readIndexJson(repoDir: string): Promise<SkillsetIndex> {
  * Validate a skillset URL by cloning the repo and reading index.json.
  * Returns the parsed index on success.
  */
-export async function validateSkillsetUrl(url: string, provider?: SkillProvider): Promise<SkillsetIndex> {
+export async function validateSkillsetUrl(
+  url: string,
+  provider?: SkillProvider,
+  credential?: SkillsetCredentialInput,
+): Promise<SkillsetIndex> {
   const skillsetId = urlToSkillsetId(url)
-  const repoDir = await ensureSkillsetCached({ skillsetId, skillsetUrl: url, provider })
+  const ref: SkillsetRef = { skillsetId, skillsetUrl: url, provider, credential }
+
+  // A cached public clone must not let an invalid replacement token appear to
+  // validate. Explicit credentials always prove remote access first.
+  if (credential) {
+    await ensureGitInstalled()
+    const hostingProvider = getSkillsetProvider(provider)
+    const cloneUrl = await hostingProvider.resolveCloneUrl(url, ref)
+    const environment = hostingProvider.getGitEnvironment(ref, GIT_ENV)
+    try {
+      await execFileAsync('git', ['ls-remote', '--exit-code', cloneUrl, 'HEAD'], {
+        timeout: 30000,
+        env: environment,
+      })
+    } catch {
+      throw new Error('Could not access this repository with the supplied token. Check its repository access and Contents permission.')
+    }
+  }
+
+  const repoDir = await ensureSkillsetCached(ref)
   return readIndexJson(repoDir)
 }
 
@@ -816,6 +845,7 @@ async function refreshSkillsetCache(
     // For platform, the URL embeds a short-lived token that needs refreshing.
     // For github, set-url is a cheap no-op when unchanged.
     const freshUrl = await hostingProvider.resolveCloneUrl(ref.skillsetUrl, ref)
+    const gitEnvironment = hostingProvider.getGitEnvironment(ref, getRepoGitEnv(repoDir))
 
     let pullResult: GitPullResult
     try {
@@ -824,9 +854,9 @@ async function refreshSkillsetCache(
       // corrupt-cache shape as an unresolvable origin/HEAD, so it recovers
       // through the same nuke-and-reclone.
       await execFileAsync('git', ['remote', 'set-url', 'origin', freshUrl], {
-        cwd: repoDir, timeout: 5000, env: getRepoGitEnv(repoDir),
+        cwd: repoDir, timeout: 5000, env: gitEnvironment,
       })
-      pullResult = await gitPull(repoDir)
+      pullResult = await gitPull(repoDir, gitEnvironment)
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
       const isCorrupt = error instanceof SkillsetCacheCorruptError || /No such remote/i.test(msg)
@@ -1517,7 +1547,7 @@ export async function getSkillPRInfo(
     throw new Error('Skill has no skillset metadata - cannot create PR')
   }
 
-  await getSkillsetProvider(meta.provider).ensurePublishPreconditions()
+  await getSkillsetProvider(meta.provider).ensurePublishPreconditions(toSkillsetRefFromMeta(meta))
 
   const suggestions = await generatePRSuggestions(meta, agentSlug, skillDirName)
 
@@ -1740,7 +1770,7 @@ export async function getSkillPublishInfo(
     throw new Error('SKILL.md not found')
   }
 
-  await getSkillsetProvider(skillsetConfig.provider).ensurePublishPreconditions()
+  await getSkillsetProvider(skillsetConfig.provider).ensurePublishPreconditions(toSkillsetRefFromConfig(skillsetConfig))
 
   const skillName = getDisplayName(skillDirName)
   const suggestions = await generatePublishSuggestions(skillContent, skillName)

--- a/src/shared/lib/skillset-provider/base-skillset-provider.ts
+++ b/src/shared/lib/skillset-provider/base-skillset-provider.ts
@@ -5,6 +5,7 @@ import type {
   InstalledSkillMetadata,
   SkillProvider,
   SkillsetConfig,
+  SkillsetCredentialInput,
   SkillsetProviderData,
 } from '@shared/lib/types/skillset'
 
@@ -22,6 +23,8 @@ export type SkillsetHostedUpdateInput = {
   skillsetUrl: string
   skillsetName?: string
   providerData?: SkillsetProviderData
+  /** Request-scoped secret for validation/add flows. Never serialize this ref. */
+  credential?: SkillsetCredentialInput
   targetName: string
   targetType: SkillsetHostedUpdateType
   files: SkillsetHostedUpdateFile[]
@@ -58,6 +61,8 @@ export type SkillsetProviderRef = {
   skillsetUrl?: string
   skillsetName?: string
   providerData?: SkillsetProviderData
+  /** Request-scoped secret for validation/add flows. Never serialize this ref. */
+  credential?: SkillsetCredentialInput
 }
 
 export type SkillsetSourceInfo = {
@@ -119,7 +124,23 @@ export abstract class BaseSkillsetProvider {
     return url
   }
 
-  async ensurePublishPreconditions(): Promise<void> {}
+  /** Add provider-specific authentication to a Git child process environment. */
+  getGitEnvironment(
+    _ref: SkillsetProviderRef,
+    baseEnvironment: NodeJS.ProcessEnv,
+  ): NodeJS.ProcessEnv {
+    return baseEnvironment
+  }
+
+  /** Add provider-specific authentication to a provider CLI child process. */
+  getCliEnvironment(
+    _ref: SkillsetProviderRef,
+    baseEnvironment: NodeJS.ProcessEnv,
+  ): NodeJS.ProcessEnv {
+    return baseEnvironment
+  }
+
+  async ensurePublishPreconditions(_ref?: SkillsetProviderRef): Promise<void> {}
 
   getRegistrationUrl(url: string): string {
     return url

--- a/src/shared/lib/skillset-provider/github-provider.test.ts
+++ b/src/shared/lib/skillset-provider/github-provider.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetSettings = vi.fn()
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: (...args: unknown[]) => mockGetSettings(...args),
+}))
+
+import { GithubSkillsetProvider } from './github-provider'
+
+describe('GithubSkillsetProvider repository credentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSettings.mockReturnValue({ skillsetCredentials: {} })
+  })
+
+  it('passes a transient token through a process-scoped Git extraHeader', () => {
+    const provider = new GithubSkillsetProvider()
+    const token = 'github_pat_test_secret'
+    const environment = provider.getGitEnvironment({
+      skillsetId: 'private',
+      skillsetUrl: 'https://github.com/Org/private.git',
+      credential: { type: 'token', token },
+    }, { GIT_TERMINAL_PROMPT: '0' })
+
+    expect(environment.GIT_CONFIG_COUNT).toBe('2')
+    expect(environment.GIT_CONFIG_KEY_0).toBe('http.https://github.com/.extraHeader')
+    expect(environment.GIT_CONFIG_VALUE_0).toBe('')
+    expect(environment.GIT_CONFIG_KEY_1).toBe('http.https://github.com/.extraHeader')
+    expect(environment.GIT_CONFIG_VALUE_1).toBe(
+      `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`,
+    )
+    expect(JSON.stringify(environment)).not.toContain(`x-access-token:${token}`)
+  })
+
+  it('resolves a stored token from an opaque providerData reference', () => {
+    mockGetSettings.mockReturnValue({
+      skillsetCredentials: {
+        skillcred_1: { type: 'token', token: 'stored-secret' },
+      },
+    })
+    const provider = new GithubSkillsetProvider()
+    const environment = provider.getCliEnvironment({
+      skillsetId: 'private',
+      skillsetUrl: 'https://github.com/Org/private.git',
+      providerData: { credentialId: 'skillcred_1' },
+    }, {})
+
+    expect(environment.GH_TOKEN).toBe('stored-secret')
+  })
+
+  it('rejects embedded URL credentials', async () => {
+    const provider = new GithubSkillsetProvider()
+    await expect(provider.resolveCloneUrl(
+      'https://user:secret@github.com/Org/private.git',
+      { skillsetId: 'private', skillsetUrl: 'https://user:secret@github.com/Org/private.git' },
+    )).rejects.toThrow('Do not put credentials in the repository URL')
+  })
+
+  it('rejects tokens for SSH URLs', () => {
+    const provider = new GithubSkillsetProvider()
+    expect(() => provider.getGitEnvironment({
+      skillsetId: 'private',
+      skillsetUrl: 'git@github.com:Org/private.git',
+      credential: { type: 'token', token: 'secret' },
+    }, {})).toThrow('HTTPS github.com URLs only')
+  })
+
+  it('fails clearly when an opaque credential reference is missing', () => {
+    const provider = new GithubSkillsetProvider()
+    expect(() => provider.getGitEnvironment({
+      skillsetId: 'private',
+      skillsetUrl: 'https://github.com/Org/private.git',
+      providerData: { credentialId: 'missing' },
+    }, {})).toThrow('repository credential is missing')
+  })
+})

--- a/src/shared/lib/skillset-provider/github-provider.test.ts
+++ b/src/shared/lib/skillset-provider/github-provider.test.ts
@@ -35,6 +35,7 @@ describe('GithubSkillsetProvider repository credentials', () => {
 
   it('resolves a stored token from an opaque providerData reference', () => {
     mockGetSettings.mockReturnValue({
+      skillsets: [],
       skillsetCredentials: {
         skillcred_1: { type: 'token', token: 'stored-secret' },
       },
@@ -47,6 +48,57 @@ describe('GithubSkillsetProvider repository credentials', () => {
     }, {})
 
     expect(environment.GH_TOKEN).toBe('stored-secret')
+  })
+
+  it('prefers the current skillset credential over an installed metadata snapshot', () => {
+    mockGetSettings.mockReturnValue({
+      skillsets: [{ id: 'private', providerData: { credentialId: 'skillcred_current' } }],
+      skillsetCredentials: {
+        skillcred_snapshot: { type: 'token', token: 'stale-secret' },
+        skillcred_current: { type: 'token', token: 'current-secret' },
+      },
+    })
+    const provider = new GithubSkillsetProvider()
+    const environment = provider.getCliEnvironment({
+      skillsetId: 'private',
+      skillsetUrl: 'https://github.com/Org/private.git',
+      providerData: { credentialId: 'skillcred_snapshot' },
+    }, {})
+
+    expect(environment.GH_TOKEN).toBe('current-secret')
+  })
+
+  it('uses a credential added after the skill was installed from a public repository', () => {
+    mockGetSettings.mockReturnValue({
+      skillsets: [{ id: 'private', providerData: { credentialId: 'skillcred_current' } }],
+      skillsetCredentials: {
+        skillcred_current: { type: 'token', token: 'new-secret' },
+      },
+    })
+    const provider = new GithubSkillsetProvider()
+    const environment = provider.getCliEnvironment({
+      skillsetId: 'private',
+      skillsetUrl: 'https://github.com/Org/private.git',
+    }, {})
+
+    expect(environment.GH_TOKEN).toBe('new-secret')
+  })
+
+  it('does not fall back to a stale snapshot after the current token is removed', () => {
+    mockGetSettings.mockReturnValue({
+      skillsets: [{ id: 'private' }],
+      skillsetCredentials: {
+        skillcred_snapshot: { type: 'token', token: 'stale-secret' },
+      },
+    })
+    const provider = new GithubSkillsetProvider()
+    const environment = provider.getCliEnvironment({
+      skillsetId: 'private',
+      skillsetUrl: 'https://github.com/Org/private.git',
+      providerData: { credentialId: 'skillcred_snapshot' },
+    }, {})
+
+    expect(environment.GH_TOKEN).toBeUndefined()
   })
 
   it('rejects embedded URL credentials', async () => {

--- a/src/shared/lib/skillset-provider/github-provider.ts
+++ b/src/shared/lib/skillset-provider/github-provider.ts
@@ -51,10 +51,18 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
   private getToken(ref: SkillsetProviderRef): string | undefined {
     if (ref.credential?.type === 'token') return ref.credential.token
 
-    const credentialId = ref.providerData?.credentialId
+    const settings = getSettings()
+    const currentSkillset = settings.skillsets?.find((skillset) => skillset.id === ref.skillsetId)
+    // Installed skill/agent metadata is a historical snapshot. Prefer the
+    // live skillset binding so adding, removing, or replacing a credential
+    // takes effect without reinstalling. Fall back only when the skillset is
+    // no longer configured, preserving legacy metadata behavior.
+    const credentialId = currentSkillset
+      ? currentSkillset.providerData?.credentialId
+      : ref.providerData?.credentialId
     if (typeof credentialId !== 'string') return undefined
 
-    const credential = getSettings().skillsetCredentials?.[credentialId]
+    const credential = settings.skillsetCredentials?.[credentialId]
     if (!credential) {
       throw new Error('The repository credential is missing. Add the token again in Skillset settings.')
     }

--- a/src/shared/lib/skillset-provider/github-provider.ts
+++ b/src/shared/lib/skillset-provider/github-provider.ts
@@ -2,18 +2,35 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import path from 'path'
 import fs from 'fs'
+import { getSettings } from '@shared/lib/config/settings'
 import { ensureDirectory } from '@shared/lib/utils/file-storage'
 import {
   BaseSkillsetProvider,
+  type SkillsetProviderRef,
   type SkillsetPublishInput,
   type SkillsetPublishResult,
 } from './base-skillset-provider'
 
 const execFileAsync = promisify(execFile)
 
-const GIT_ENV = {
+const BASE_GIT_ENV = {
   ...process.env,
   GIT_TERMINAL_PROMPT: '0',
+}
+
+function appendGitConfig(
+  environment: NodeJS.ProcessEnv,
+  key: string,
+  value: string,
+): NodeJS.ProcessEnv {
+  const rawCount = Number.parseInt(environment.GIT_CONFIG_COUNT ?? '0', 10)
+  const index = Number.isInteger(rawCount) && rawCount >= 0 ? rawCount : 0
+  return {
+    ...environment,
+    GIT_CONFIG_COUNT: String(index + 1),
+    [`GIT_CONFIG_KEY_${index}`]: key,
+    [`GIT_CONFIG_VALUE_${index}`]: value,
+  }
 }
 
 interface ForkBranchContext {
@@ -22,6 +39,8 @@ interface ForkBranchContext {
   forkOwner: string
   baseBranch: string
   branchName: string
+  gitEnvironment: NodeJS.ProcessEnv
+  cliEnvironment: NodeJS.ProcessEnv
 }
 
 export class GithubSkillsetProvider extends BaseSkillsetProvider {
@@ -29,11 +48,88 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
   readonly name = 'GitHub'
   readonly publishMode = 'pull_request' as const
 
-  async ensurePublishPreconditions(): Promise<void> {
-    await this.ensureAuthenticated()
+  private getToken(ref: SkillsetProviderRef): string | undefined {
+    if (ref.credential?.type === 'token') return ref.credential.token
+
+    const credentialId = ref.providerData?.credentialId
+    if (typeof credentialId !== 'string') return undefined
+
+    const credential = getSettings().skillsetCredentials?.[credentialId]
+    if (!credential) {
+      throw new Error('The repository credential is missing. Add the token again in Skillset settings.')
+    }
+    if (credential.type !== 'token' || !credential.token) {
+      throw new Error('The repository credential is invalid. Add the token again in Skillset settings.')
+    }
+    return credential.token
   }
 
-  private async ensureAuthenticated(): Promise<void> {
+  private validateUrlForToken(url: string, token: string | undefined): void {
+    if (!token) return
+
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      throw new Error('Repository tokens currently support HTTPS github.com URLs only.')
+    }
+    if (parsed.protocol !== 'https:' || parsed.hostname.toLowerCase() !== 'github.com') {
+      throw new Error('Repository tokens currently support HTTPS github.com URLs only.')
+    }
+    if (parsed.username || parsed.password) {
+      throw new Error('Do not put credentials in the repository URL. Use the token field instead.')
+    }
+  }
+
+  override async resolveCloneUrl(url: string, options?: SkillsetProviderRef): Promise<string> {
+    const token = options ? this.getToken(options) : undefined
+    this.validateUrlForToken(url, token)
+
+    if (/^https?:\/\//i.test(url)) {
+      let parsed: URL
+      try {
+        parsed = new URL(url)
+      } catch {
+        throw new Error('Repository URL is invalid.')
+      }
+      if (parsed.username || parsed.password) {
+        throw new Error('Do not put credentials in the repository URL. Use the token field instead.')
+      }
+    }
+    return url
+  }
+
+  override getGitEnvironment(ref: SkillsetProviderRef, baseEnvironment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    const token = this.getToken(ref)
+    this.validateUrlForToken(ref.skillsetUrl ?? '', token)
+    if (!token) return baseEnvironment
+
+    const basicCredential = Buffer.from(`x-access-token:${token}`, 'utf8').toString('base64')
+    // extraHeader is multi-valued. Reset any inherited GitHub headers first so
+    // a host-level credential cannot produce two competing Authorization lines.
+    const resetEnvironment = appendGitConfig(
+      baseEnvironment,
+      'http.https://github.com/.extraHeader',
+      '',
+    )
+    return appendGitConfig(
+      resetEnvironment,
+      'http.https://github.com/.extraHeader',
+      `AUTHORIZATION: basic ${basicCredential}`,
+    )
+  }
+
+  override getCliEnvironment(ref: SkillsetProviderRef, baseEnvironment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    const token = this.getToken(ref)
+    return token ? { ...baseEnvironment, GH_TOKEN: token } : baseEnvironment
+  }
+
+  async ensurePublishPreconditions(ref?: SkillsetProviderRef): Promise<void> {
+    await this.ensureAuthenticated(ref)
+  }
+
+  private async ensureAuthenticated(ref?: SkillsetProviderRef): Promise<void> {
+    const repositoryToken = ref ? this.getToken(ref) : undefined
     try {
       await execFileAsync('gh', ['--version'], { timeout: 5000 })
     } catch {
@@ -41,14 +137,19 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
     }
 
     try {
-      await execFileAsync('gh', ['auth', 'status'], { timeout: 5000 })
+      const env = ref ? this.getCliEnvironment(ref, process.env) : process.env
+      await execFileAsync('gh', ['auth', 'status'], { timeout: 5000, env })
     } catch {
+      if (repositoryToken) {
+        throw new Error('The repository token could not authenticate GitHub CLI. Check its repository access and permissions.')
+      }
       throw new Error('GitHub CLI is not authenticated. Run `gh auth login` to sign in. See https://cli.github.com')
     }
   }
 
   override async publishUpdate(input: SkillsetPublishInput): Promise<SkillsetPublishResult> {
-    const ctx = await this.prepareForkBranch(input.repoDir, input.branchPrefix)
+    const ctx = await this.prepareForkBranch(input, input.branchPrefix)
+    const gitEnvironment = this.getGitEnvironment(input, BASE_GIT_ENV)
 
     for (const file of input.files) {
       const fullPath = path.join(input.repoDir, file.path)
@@ -58,11 +159,11 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
 
     const addPaths = input.gitAddPaths ?? ['.']
     await execFileAsync('git', ['add', ...addPaths], {
-      cwd: input.repoDir, timeout: 10000, env: GIT_ENV,
+      cwd: input.repoDir, timeout: 10000, env: gitEnvironment,
     })
 
     await execFileAsync('git', ['commit', '-m', input.title], {
-      cwd: input.repoDir, timeout: 10000, env: GIT_ENV,
+      cwd: input.repoDir, timeout: 10000, env: gitEnvironment,
     })
 
     const prUrl = await this.pushAndCreatePR(ctx, {
@@ -74,27 +175,30 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
   }
 
   private async prepareForkBranch(
-    repoDir: string,
+    input: SkillsetPublishInput,
     branchPrefix: string,
   ): Promise<ForkBranchContext> {
+    const repoDir = input.repoDir
+    const gitEnvironment = this.getGitEnvironment(input, BASE_GIT_ENV)
+    const cliEnvironment = this.getCliEnvironment(input, process.env)
     await execFileAsync('git', ['checkout', '.'], {
-      cwd: repoDir, timeout: 5000, env: GIT_ENV,
+      cwd: repoDir, timeout: 5000, env: gitEnvironment,
     }).catch(() => { /* ignore */ })
 
     const { stdout: upstreamNwoRaw } = await execFileAsync(
       'gh',
       ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
-      { cwd: repoDir, timeout: 10000 }
+      { cwd: repoDir, timeout: 10000, env: cliEnvironment }
     )
     const upstreamNwo = upstreamNwoRaw.trim()
 
     await execFileAsync('gh', ['repo', 'fork', '--clone=false', '--remote=false'], {
-      cwd: repoDir, timeout: 30000,
+      cwd: repoDir, timeout: 30000, env: cliEnvironment,
     })
 
     const { stdout: userLogin } = await execFileAsync(
       'gh', ['api', 'user', '--jq', '.login'],
-      { timeout: 10000 }
+      { timeout: 10000, env: cliEnvironment }
     )
     const forkOwner = userLogin.trim()
     const repoName = upstreamNwo.split('/')[1]
@@ -104,11 +208,11 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
 
     try {
       await execFileAsync('git', ['remote', 'add', forkRemoteName, forkUrl], {
-        cwd: repoDir, timeout: 5000, env: GIT_ENV,
+        cwd: repoDir, timeout: 5000, env: gitEnvironment,
       })
     } catch {
       await execFileAsync('git', ['remote', 'set-url', forkRemoteName, forkUrl], {
-        cwd: repoDir, timeout: 5000, env: GIT_ENV,
+        cwd: repoDir, timeout: 5000, env: gitEnvironment,
       })
     }
 
@@ -116,13 +220,13 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
     try {
       const { stdout: originHead } = await execFileAsync(
         'git', ['symbolic-ref', 'refs/remotes/origin/HEAD'],
-        { cwd: repoDir, timeout: 5000, env: GIT_ENV }
+        { cwd: repoDir, timeout: 5000, env: gitEnvironment }
       )
       baseBranch = originHead.trim().replace('refs/remotes/origin/', '')
     } catch {
       try {
         await execFileAsync('git', ['rev-parse', '--verify', 'origin/main'],
-          { cwd: repoDir, timeout: 5000, env: GIT_ENV })
+          { cwd: repoDir, timeout: 5000, env: gitEnvironment })
         baseBranch = 'main'
       } catch {
         baseBranch = 'master'
@@ -130,15 +234,23 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
     }
 
     await execFileAsync('git', ['checkout', baseBranch], {
-      cwd: repoDir, timeout: 10000, env: GIT_ENV,
+      cwd: repoDir, timeout: 10000, env: gitEnvironment,
     })
 
     const branchName = `${branchPrefix}-${Date.now()}`
     await execFileAsync('git', ['checkout', '-b', branchName], {
-      cwd: repoDir, timeout: 10000, env: GIT_ENV,
+      cwd: repoDir, timeout: 10000, env: gitEnvironment,
     })
 
-    return { repoDir, upstreamNwo, forkOwner, baseBranch, branchName }
+    return {
+      repoDir,
+      upstreamNwo,
+      forkOwner,
+      baseBranch,
+      branchName,
+      gitEnvironment,
+      cliEnvironment,
+    }
   }
 
   private async pushAndCreatePR(
@@ -146,7 +258,7 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
     options: { title: string; body: string },
   ): Promise<string> {
     await execFileAsync('git', ['push', 'fork', ctx.branchName], {
-      cwd: ctx.repoDir, timeout: 30000, env: GIT_ENV,
+      cwd: ctx.repoDir, timeout: 30000, env: ctx.gitEnvironment,
     })
 
     try {
@@ -160,16 +272,16 @@ export class GithubSkillsetProvider extends BaseSkillsetProvider {
           '--head', `${ctx.forkOwner}:${ctx.branchName}`,
           '--base', ctx.baseBranch,
         ],
-        { cwd: ctx.repoDir, timeout: 30000 }
+        { cwd: ctx.repoDir, timeout: 30000, env: ctx.cliEnvironment }
       )
       return prStdout.trim()
     } finally {
       await execFileAsync('git', ['checkout', ctx.baseBranch], {
-        cwd: ctx.repoDir, timeout: 10000, env: GIT_ENV,
+        cwd: ctx.repoDir, timeout: 10000, env: ctx.gitEnvironment,
       }).catch(() => { /* ignore */ })
 
       await execFileAsync('git', ['branch', '-D', ctx.branchName], {
-        cwd: ctx.repoDir, timeout: 5000, env: GIT_ENV,
+        cwd: ctx.repoDir, timeout: 5000, env: ctx.gitEnvironment,
       }).catch(() => { /* ignore */ })
     }
   }

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -305,6 +305,10 @@ export interface ApiSkillsetConfig {
   badgeLabel?: string
   showUrl: boolean
   publishMode: 'pull_request' | 'hosted_submit' | 'none'
+  credential?: {
+    type: 'token'
+    tokenPreview: string
+  }
   error?: string
 }
 

--- a/src/shared/lib/types/skillset.ts
+++ b/src/shared/lib/types/skillset.ts
@@ -36,6 +36,22 @@ export type SkillProvider = 'github' | 'platform' | 'public'
 /** Provider-specific serialized data owned by the concrete provider */
 export type SkillsetProviderData = Record<string, unknown>
 
+/** A secret credential stored separately from skillset/provider metadata. */
+export interface SkillsetCredential {
+  id: string
+  type: 'token'
+  token: string
+  tokenPreview: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** Request-scoped credential used while validating a repository. Never persisted. */
+export type SkillsetCredentialInput = {
+  type: 'token'
+  token: string
+}
+
 /** A configured skillset in user settings */
 export interface SkillsetConfig {
   id: string // deterministic slug from URL


### PR DESCRIPTION
## Summary

- add optional repository tokens for GitHub-backed skillsets, including add, validate, rotate, remove, refresh, and publish flows
- keep credentials separate from public skillset/provider metadata and return only a masked preview to clients
- pass Git and GitHub CLI authentication through process-scoped environment variables so tokens never enter repository URLs, command arguments, or persistent Git config
- preserve existing public, SSH, and inherited-auth behavior when no token is supplied
- add in-product fine-grained PAT setup guidance with the minimum `Contents: Read-only` permission
- add API, provider, configuration, browser E2E, and live private-repository validation coverage

## Why

Hosted Gamut cannot inherit a user's local GitHub credentials. Private GitHub skillset repositories therefore failed with terminal prompts disabled, even though the same repository worked in the desktop app.

This gives hosted and self-hosted users a provider-owned credential path without depending on platform-side repository cloning.

## Security model

- tokens are stored separately in `settings.skillsetCredentials`; skillset/provider data retains only a credential ID
- API responses expose only a redacted token preview
- Git receives an ephemeral HTTPS authorization header through process-scoped Git configuration
- GitHub CLI receives the token through `GH_TOKEN`
- repository URLs, process arguments, and persistent Git configuration remain token-free
- settings file permissions are restricted to the current user

## Validation

- `npm run typecheck`
- `npm run lint`
- focused skillset, agent, provider, and API tests: 323 passed
- focused Playwright browser E2E: 3 passed
- production build completed successfully
- live private GitHub repository harness validated add, forced clone, stored-credential reload, stale installed-metadata rebinding to a newly created credential ID, and refresh against a private six-skill repository; it also verified that the token was absent from public metadata and persistent Git config
- full Vitest suite: 9,019 passed; 4 pre-existing failures remain in `global-settings-page.test.tsx` because those tests render Query hooks without a `QueryClientProvider`

Linear: SUP-558
