### PR TITLE
Add collapsible agent activity indicator

### DIFF
--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -120,15 +120,24 @@ describe('AgentActivityIndicator', () => {
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Working...')).toBeInTheDocument()
     expect(screen.getByTestId('activity-indicator')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /activity details/i })).not.toBeInTheDocument()
   })
 
-  it('stacks the active indicator behind the composer', () => {
+  it('stacks the active indicator behind the composer with a frosted surface', () => {
     mockStreamState.isActive = true
     mockStreamState.activeStartTime = Date.now()
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
 
     const indicator = screen.getByTestId('activity-indicator')
-    expect(indicator).toHaveClass('rounded-t-2xl', 'border-b-0', 'pb-8')
+    expect(indicator).toHaveClass(
+      'rounded-t-2xl',
+      'border-b-0',
+      'border-border/70',
+      'bg-background/85',
+      'backdrop-blur-md',
+      'supports-[backdrop-filter]:bg-background/65',
+      'pb-8',
+    )
     expect(indicator.parentElement).toHaveClass('-mb-5')
   })
 
@@ -716,6 +725,122 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByText('1 background process')).toBeInTheDocument()
   })
 
+  it('collapses activity details into an active-only summary', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockStreamState.backgroundTasks = [
+      { taskId: 'bg-1', startedAt: Date.now() - 5000 },
+      { taskId: 'bg-2', startedAt: Date.now() - 4000 },
+      { taskId: 'wf-1', startedAt: Date.now() - 3000, isWorkflow: true },
+      { taskId: 'subagent-bg', startedAt: Date.now() - 2000, isSubagent: true },
+    ]
+    mockStreamState.activeSubagents = [
+      { parentToolId: 'tc-running', agentId: 'agent-running', progressSummary: null },
+      { parentToolId: 'tc-completed', agentId: 'agent-completed', progressSummary: null },
+    ]
+    mockStreamState.completedSubagents = new Set(['tc-completed'])
+    mockMessages.push({
+      id: 'msg-1',
+      type: 'assistant',
+      content: { text: '' },
+      toolCalls: [
+        {
+          id: 'tc-running',
+          name: 'Agent',
+          input: { subagent_type: 'Explore', description: 'Running subagent' },
+          subagent: { agentId: 'agent-running', status: 'async_launched' },
+        },
+        {
+          id: 'tc-completed',
+          name: 'Agent',
+          input: { subagent_type: 'Review', description: 'Finished subagent' },
+          subagent: { agentId: 'agent-completed', status: 'async_launched' },
+        },
+        {
+          id: 'tc-todos',
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { content: 'Pending one', status: 'pending', activeForm: 'Pending one' },
+              { content: 'Pending two', status: 'pending', activeForm: 'Pending two' },
+              { content: 'In progress', status: 'in_progress', activeForm: 'Doing work' },
+              { content: 'Already done', status: 'completed', activeForm: 'Already done' },
+            ],
+          },
+          result: 'ok',
+        },
+      ],
+      createdAt: new Date(),
+    })
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+    const collapseButton = screen.getByRole('button', { name: 'Collapse activity details' })
+    expect(collapseButton).toHaveAttribute('aria-expanded', 'true')
+    expect(collapseButton).toHaveClass('absolute', 'right-2.5', 'top-2.5')
+    expect(collapseButton.querySelector('svg')).toHaveClass('rotate-180')
+    expect(screen.getByText('Running subagent')).toBeInTheDocument()
+    expect(screen.getByText('Finished subagent')).toBeInTheDocument()
+    expect(screen.getByText('Already done')).toBeInTheDocument()
+    expect(screen.queryByText('2 background processes, 1 background workflow, 1 subagent, 3 pending tasks')).not.toBeInTheDocument()
+
+    act(() => { collapseButton.click() })
+
+    const expandButton = screen.getByRole('button', { name: 'Expand activity details' })
+    expect(expandButton).toHaveAttribute('aria-expanded', 'false')
+    expect(expandButton.querySelector('svg')).not.toHaveClass('rotate-180')
+    const summary = screen.getByTestId('activity-summary-ticker')
+    expect(summary).toHaveTextContent('2 background processes, 1 background workflow, 1 subagent, 3 pending tasks')
+    expect(summary).toHaveClass('text-xs', 'italic', 'whitespace-nowrap')
+    expect(summary).toHaveAttribute('data-overflowing', 'false')
+    expect(summary.parentElement).toBe(screen.getByTestId('activity-indicator-header'))
+    expect(screen.queryByText('Running subagent')).not.toBeInTheDocument()
+    expect(screen.queryByText('Finished subagent')).not.toBeInTheDocument()
+    expect(screen.queryByText('Already done')).not.toBeInTheDocument()
+
+    act(() => { expandButton.click() })
+
+    expect(screen.getByRole('button', { name: 'Collapse activity details' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Running subagent')).toBeInTheDocument()
+  })
+
+  it('turns an overflowing collapsed summary into a measured ticker', () => {
+    mockStreamState.isActive = true
+    mockStreamState.activeStartTime = Date.now()
+    mockMessages.push({
+      id: 'msg-1',
+      type: 'assistant',
+      content: { text: '' },
+      toolCalls: [{
+        id: 'tc-todos',
+        name: 'TodoWrite',
+        input: {
+          todos: [{ content: 'A pending task', status: 'pending', activeForm: 'Working' }],
+        },
+        result: 'ok',
+      }],
+      createdAt: new Date(),
+    })
+
+    const clientWidth = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.getAttribute('data-testid') === 'activity-summary-ticker' ? 100 : 0
+    })
+    const scrollWidth = vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.hasAttribute('data-activity-summary-ticker-content') ? 260 : 0
+    })
+
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    act(() => { screen.getByRole('button', { name: 'Collapse activity details' }).click() })
+
+    const ticker = screen.getByTestId('activity-summary-ticker')
+    expect(ticker).toHaveAttribute('data-overflowing', 'true')
+    expect(ticker.style.getPropertyValue('--activity-summary-ticker-distance')).toBe('160px')
+    expect(ticker.style.getPropertyValue('--activity-summary-ticker-duration')).toBe('8s')
+
+    clientWidth.mockRestore()
+    scrollWidth.mockRestore()
+  })
+
   describe('subagent status', () => {
     const renderWithSubagent = (opts: { result?: unknown; subagentStatus?: string; completed?: boolean }) => {
       mockStreamState.isActive = true
@@ -750,6 +875,16 @@ describe('AgentActivityIndicator', () => {
       renderWithSubagent({ result: { status: 'async_launched' }, subagentStatus: 'async_launched', completed: true })
       expect(screen.getByText('Explore')).toBeInTheDocument()
       expect(screen.getByText('✓')).toBeInTheDocument()
+    })
+
+    it('shows no collapsed summary when every detail is completed', () => {
+      renderWithSubagent({ result: { status: 'async_launched' }, subagentStatus: 'async_launched', completed: true })
+
+      act(() => { screen.getByRole('button', { name: 'Collapse activity details' }).click() })
+
+      expect(screen.queryByTestId('activity-summary-ticker')).not.toBeInTheDocument()
+      expect(screen.queryByText('No active items')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Expand activity details' })).toBeInTheDocument()
     })
 
     it('marks a foreground subagent completed when its tool result lands', () => {

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -9,8 +9,8 @@ import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-b
 import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 import { isTurnStartingUserMessage } from './pending-message'
 import { cn } from '@shared/lib/utils'
-import { AlertTriangle, Monitor, X } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { AlertTriangle, ChevronDown, Monitor, X } from 'lucide-react'
+import { useCallback, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 
 import { deriveTaskList, Todo } from '@shared/lib/utils/derive-task-list'
 
@@ -58,6 +58,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
   const [revoking, setRevoking] = useState(false)
   const [revokeError, setRevokeError] = useState(false)
   const [showAllTodos, setShowAllTodos] = useState(false)
+  const [isCollapsed, setIsCollapsed] = useState(false)
 
   // Non-null only for a platform billing 402 the workspace can act on (see hook).
   const billingUrl = usePlatformBillingUrl(error ?? '')
@@ -248,6 +249,21 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     [messages]
   )
 
+  const visibleBackgroundTasks = backgroundTasks.filter((task) => !task.isSubagent)
+  const backgroundWorkflowCount = visibleBackgroundTasks.filter((task) => task.isWorkflow).length
+  const backgroundProcessCount = visibleBackgroundTasks.length - backgroundWorkflowCount
+  const activeSubagentCount = subagentItems.filter((item) => item.status === 'running').length
+  const pendingTaskCount = todos?.filter((todo) => todo.status !== 'completed').length ?? 0
+  const hasExpandableDetails = subagentItems.length > 0
+    || visibleBackgroundTasks.length > 0
+    || pendingTaskCount > 0
+  const collapsedSummary = [
+    formatActivityCount(backgroundProcessCount, 'background process', 'background processes'),
+    formatActivityCount(backgroundWorkflowCount, 'background workflow', 'background workflows'),
+    formatActivityCount(activeSubagentCount, 'subagent', 'subagents'),
+    formatActivityCount(pendingTaskCount, 'pending task', 'pending tasks'),
+  ].filter(Boolean).join(', ')
+
   // Show error if present
   if (error) {
     const isProviderError = apiErrorCode != null && PROVIDER_ERROR_CODES.has(apiErrorCode)
@@ -292,10 +308,30 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
     <div className="mx-auto -mb-5 w-full max-w-[740px] px-4">
       {/* Capped and scrolled in place: a long action list must not grow the
           card until it pushes the chat history off screen. */}
-      <div className="max-h-[30vh] overflow-y-auto rounded-t-2xl border border-b-0 bg-muted/50 px-3 pt-3 pb-8" data-testid="activity-indicator">
+      <div
+        className="relative max-h-[30vh] overflow-y-auto rounded-t-2xl border border-b-0 border-border/70 bg-background/85 px-3 pt-3 pb-8 shadow-[0_0_24px_rgba(15,23,42,0.07),0_2px_10px_-4px_rgba(15,23,42,0.08)] backdrop-blur-md supports-[backdrop-filter]:bg-background/65 dark:shadow-[0_0_26px_rgba(0,0,0,0.22),0_2px_12px_-4px_rgba(0,0,0,0.16)]"
+        data-testid="activity-indicator"
+      >
+        {hasExpandableDetails && (
+          <button
+            type="button"
+            onClick={() => setIsCollapsed((collapsed) => !collapsed)}
+            className="absolute right-2.5 top-2.5 z-10 cursor-pointer rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-expanded={!isCollapsed}
+            aria-label={isCollapsed ? 'Expand activity details' : 'Collapse activity details'}
+          >
+            <ChevronDown
+              className={cn('h-4 w-4 transition-transform', !isCollapsed && 'rotate-180')}
+              aria-hidden="true"
+            />
+          </button>
+        )}
         {/* Header with pulsing indicator */}
-        <div className="flex items-center gap-2">
-          <span className="relative flex h-3 w-3">
+        <div
+          className={cn('flex min-w-0 items-center gap-2', hasExpandableDetails && 'pr-7')}
+          data-testid="activity-indicator-header"
+        >
+          <span className="relative flex h-3 w-3 shrink-0">
             <span className={cn(
               "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
               (isAwaitingInput || apiRetry) ? "bg-orange-500" : "bg-primary"
@@ -305,9 +341,9 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
               (isAwaitingInput || apiRetry) ? "bg-orange-500" : "bg-primary"
             )}></span>
           </span>
-          <span className="text-sm font-medium">{statusText}</span>
+          <span className="min-w-0 truncate text-sm font-medium">{statusText}</span>
           {computerUseApp && (
-            <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300">
+            <span className="inline-flex shrink-0 items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300">
               {computerUseAppIcon ? (
                 <img src={`data:image/png;base64,${computerUseAppIcon}`} alt="" className="h-4 w-4" />
               ) : (
@@ -328,7 +364,10 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
             </span>
           )}
           {elapsed && (
-            <span className="text-xs text-muted-foreground tabular-nums">{elapsed}</span>
+            <span className="shrink-0 text-xs text-muted-foreground tabular-nums">{elapsed}</span>
+          )}
+          {isCollapsed && collapsedSummary && (
+            <ActivitySummaryTicker text={collapsedSummary} />
           )}
         </div>
 
@@ -336,7 +375,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
             (see ThinkingBlockItem) — only the "Thinking..." status shows here. */}
 
         {/* Active subagents */}
-        {subagentItems.length > 0 && (
+        {!isCollapsed && subagentItems.length > 0 && (
           <ul className="mt-2 space-y-1 text-sm pl-5">
             {subagentItems.map((item) => (
               <li key={item.id} className="flex flex-col gap-0.5">
@@ -374,12 +413,12 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         {/* Active background processes. Background subagents are excluded: they
             already render as named subagent rows above, and counting them here
             would show the same work twice. */}
-        {backgroundTasks.some((t) => !t.isSubagent) && (
-          <BackgroundTasksSection tasks={backgroundTasks.filter((t) => !t.isSubagent)} />
+        {!isCollapsed && visibleBackgroundTasks.length > 0 && (
+          <BackgroundTasksSection tasks={visibleBackgroundTasks} />
         )}
 
         {/* Todo list if available and at least one item is not completed */}
-        {todos && todos.length > 0 && todos.some((t) => t.status !== 'completed') && (() => {
+        {!isCollapsed && todos && todos.length > 0 && pendingTaskCount > 0 && (() => {
           const MAX_VISIBLE = 5
           const needsTruncation = todos.length > MAX_VISIBLE && !showAllTodos
 
@@ -452,6 +491,68 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         })()}
       </div>
     </div>
+  )
+}
+
+function formatActivityCount(count: number, singular: string, plural: string): string {
+  if (count === 0) return ''
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+type ActivitySummaryTickerStyle = CSSProperties & {
+  '--activity-summary-ticker-distance': string
+  '--activity-summary-ticker-duration': string
+}
+
+function ActivitySummaryTicker({ text }: { text: string }) {
+  const viewportRef = useRef<HTMLSpanElement>(null)
+  const contentRef = useRef<HTMLSpanElement>(null)
+  const [scrollDistance, setScrollDistance] = useState(0)
+
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current
+    const content = contentRef.current
+    if (!viewport || !content) return
+
+    const measure = () => {
+      const nextDistance = Math.max(0, Math.ceil(content.scrollWidth - viewport.clientWidth))
+      setScrollDistance((currentDistance) => currentDistance === nextDistance ? currentDistance : nextDistance)
+    }
+
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(measure)
+    observer.observe(viewport)
+    observer.observe(content)
+    return () => observer.disconnect()
+  }, [text])
+
+  // The middle 64% of each animation leg is motion; the remaining time pauses
+  // at either end so the summary can be read before it pans and before it resets.
+  const durationSeconds = Math.max(5, scrollDistance / 20)
+  const style: ActivitySummaryTickerStyle = {
+    '--activity-summary-ticker-distance': `${scrollDistance}px`,
+    '--activity-summary-ticker-duration': `${Math.round(durationSeconds * 100) / 100}s`,
+  }
+
+  return (
+    <span
+      ref={viewportRef}
+      className="activity-summary-ticker min-w-0 flex-1 overflow-hidden whitespace-nowrap text-xs italic text-muted-foreground"
+      data-overflowing={scrollDistance > 0}
+      data-testid="activity-summary-ticker"
+      style={style}
+      title={text}
+    >
+      <span
+        ref={contentRef}
+        className="activity-summary-ticker-content block truncate"
+        data-activity-summary-ticker-content
+      >
+        {text}
+      </span>
+    </span>
   )
 }
 

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -779,6 +779,39 @@ html[data-keyboard-open] [data-composer-footer] {
 }
 
 /*
+  The collapsed activity summary stays in the status row. When its measured
+  width exceeds the available space, pause at the beginning before gently
+  panning to the hidden end, pause again, then return like a compact ticker.
+*/
+@keyframes activity-summary-ticker {
+  0%, 18% { transform: translateX(0); }
+  82%, 100% { transform: translateX(calc(-1 * var(--activity-summary-ticker-distance))); }
+}
+
+.activity-summary-ticker[data-overflowing="true"] .activity-summary-ticker-content {
+  width: max-content;
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
+  animation: activity-summary-ticker var(--activity-summary-ticker-duration) ease-in-out 1.25s infinite alternate both;
+  will-change: transform;
+}
+
+.activity-summary-ticker:hover .activity-summary-ticker-content {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-summary-ticker[data-overflowing="true"] .activity-summary-ticker-content {
+    width: auto;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    animation: none;
+  }
+}
+
+/*
   Long sidebar labels stay ellipsized until the user has briefly dwelled on
   them, then ease into one pass that reveals the hidden end. Removing
   data-scrolling on mouse leave removes the animation and restores the start


### PR DESCRIPTION
## Summary

- give the working indicator the same frosted background, blur, border, and shadow treatment as the composer
- keep activity details expanded by default and add an accessible chevron to collapse or restore them
- summarize only active background processes, workflows, subagents, and incomplete tasks in the collapsed header row
- animate overflowing summaries as a measured, reduced-motion-aware ticker and omit the summary when no active items remain

## Why

Transcript content now scrolls beneath the composer footer, but the activity indicator still used a translucent muted background without blur. That made transcript text show through the status card. Large activity lists also needed a compact state that preserves the current status while keeping active workload counts visible.

## Impact

The working surface remains readable over transcript content, and busy sessions can be collapsed into a single status row without counting completed work. Summaries that fit remain static; longer summaries pause and pan so their full contents stay accessible.

## Validation

- `npm run test:run -- src/renderer/components/messages/agent-activity-indicator.test.tsx` (49 tests)
- `npm run typecheck`
- `npx eslint src/renderer/components/messages/agent-activity-indicator.tsx src/renderer/components/messages/agent-activity-indicator.test.tsx`
- `git diff --check`
