### PR TITLE
Render Markdown in thinking blocks

### DIFF
--- a/src/renderer/components/messages/thinking-block-item.test.tsx
+++ b/src/renderer/components/messages/thinking-block-item.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ThinkingBlockItem } from './thinking-block-item'
+
+describe('ThinkingBlockItem Markdown', () => {
+  afterEach(cleanup)
+
+  it('renders GitHub-flavored Markdown instead of showing its source syntax', () => {
+    render(
+      <ThinkingBlockItem
+        active
+        text={[
+          '**Considering implementation steps**',
+          '',
+          '- Inspect `input`',
+          '- Choose ~~the first~~ a safe approach',
+          '',
+          '| Item | Status |',
+          '| --- | --- |',
+          '| Parser | Ready |',
+        ].join('\n')}
+      />
+    )
+
+    const heading = screen.getByText('Considering implementation steps')
+    expect(heading.tagName).toBe('STRONG')
+    expect(screen.queryByText('**Considering implementation steps**')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+    expect(screen.getByText('input').tagName).toBe('CODE')
+    expect(screen.getByText('the first').tagName).toBe('DEL')
+    expect(screen.getByRole('table')).toBeInTheDocument()
+  })
+
+  it('uses the shared safe URL policy for links in reasoning text', () => {
+    render(
+      <ThinkingBlockItem
+        active={false}
+        text="[Docs](https://example.com) [Phone](tel:+15551234567) [Bad](javascript:alert(1))"
+      />
+    )
+    fireEvent.click(screen.getByTestId('thinking-block-toggle'))
+
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('href', 'https://example.com')
+    expect(screen.getByRole('link', { name: 'Phone' })).toHaveAttribute('href', 'tel:+15551234567')
+    // An anchor with a blanked href intentionally has no accessible `link`
+    // role, so inspect the rendered element directly.
+    expect(screen.getByText('Bad').closest('a')).toHaveAttribute('href', '')
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('target', '_blank')
+  })
+})

--- a/src/renderer/components/messages/thinking-block-item.tsx
+++ b/src/renderer/components/messages/thinking-block-item.tsx
@@ -1,8 +1,12 @@
 import { cn } from '@shared/lib/utils/cn'
 import { ListTree, ChevronDown, ChevronRight } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import ReactMarkdown, { type Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { useElapsedTimer, formatElapsed } from '@renderer/hooks/use-elapsed-timer'
+import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
 import { StatusIndicator } from './tool-call-item'
+import { splitStreamingMarkdown } from './split-streaming-markdown'
 
 interface ThinkingBlockItemProps {
   text: string
@@ -23,6 +27,41 @@ interface ThinkingBlockItemProps {
 // How close (px) to the bottom counts as "pinned" — tighter than the message
 // list's 80px tolerance since the card body is a small (max-h-64) scroller.
 const PIN_THRESHOLD_PX = 32
+
+const THINKING_REMARK_PLUGINS = [remarkGfm]
+
+// Thinking traces use the same safe URL policy as assistant messages. Keep the
+// renderer deliberately compact: these blocks live in a narrow, capped card,
+// where a wide table should scroll instead of widening the whole transcript.
+const THINKING_MARKDOWN_COMPONENTS: Components = {
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-500 hover:underline"
+    >
+      {children}
+    </a>
+  ),
+  table: ({ children }) => (
+    <div className="code-scrollbar my-2 max-w-full overflow-x-auto">
+      <table className="my-0">{children}</table>
+    </div>
+  ),
+}
+
+const ThinkingMarkdownBlock = memo(function ThinkingMarkdownBlock({ text }: { text: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={THINKING_REMARK_PLUGINS}
+      components={THINKING_MARKDOWN_COMPONENTS}
+      urlTransform={markdownUrlTransform}
+    >
+      {text}
+    </ReactMarkdown>
+  )
+})
 
 /**
  * A thinking episode rendered as a tool-call-style card.
@@ -53,6 +92,11 @@ export function ThinkingBlockItem({ text, active, startedAt, endedAt, durationMs
   // Live timing wins (exact); persisted blocks fall back to the
   // transcript-derived duration; header degrades to plain "Thought" without either.
   const doneDuration = elapsed ?? (durationMs !== undefined ? formatElapsed(durationMs) : null)
+
+  // As with assistant responses, only re-parse the unfinished tail while text
+  // streams. Completed Markdown blocks remain memoized instead of making a long
+  // reasoning trace progressively more expensive on every delta.
+  const streamingSplit = active && text ? splitStreamingMarkdown(text) : null
 
   // Stick-to-bottom: follow the streaming text unless the user scrolls up to read.
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -118,10 +162,34 @@ export function ThinkingBlockItem({ text, active, startedAt, endedAt, durationMs
           className="border-t border-border/70 bg-muted/50 px-3 py-2 max-h-64 overflow-y-auto"
           data-testid="thinking-block-body"
         >
-          <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground select-text font-sans">
-            {text || <span className="italic">Thinking…</span>}
-            {active && <span className="animate-pulse">|</span>}
-          </pre>
+          <div
+            dir="auto"
+            className={cn(
+              'prose prose-sm max-w-none min-w-0 break-words select-text text-xs text-muted-foreground dark:prose-invert',
+              'prose-headings:my-2 prose-headings:text-sm prose-headings:font-medium prose-headings:leading-snug',
+              'prose-p:my-2 prose-p:text-xs prose-p:leading-relaxed prose-li:my-0 prose-li:text-xs',
+              'prose-ul:my-2 prose-ol:my-2 prose-strong:font-medium prose-strong:text-current',
+              'prose-blockquote:my-2 prose-blockquote:text-current',
+              'prose-pre:my-2 prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:rounded-md prose-pre:border prose-pre:border-border/70 prose-pre:bg-background/60 prose-pre:p-2',
+              'prose-code:rounded prose-code:bg-black/[0.05] prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:font-normal prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none dark:prose-code:bg-white/[0.08]',
+              '[&_pre_code]:bg-transparent [&_pre_code]:p-0 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0'
+            )}
+            data-testid="thinking-markdown"
+          >
+            {!text ? (
+              <span className="italic">Thinking…</span>
+            ) : streamingSplit ? (
+              <>
+                {streamingSplit.settled.map((block, i) => (
+                  <ThinkingMarkdownBlock key={i} text={block} />
+                ))}
+                {streamingSplit.tail && <ThinkingMarkdownBlock text={streamingSplit.tail} />}
+              </>
+            ) : (
+              <ThinkingMarkdownBlock text={text} />
+            )}
+            {active && <span className="ml-0.5 inline-block h-3 w-1 animate-pulse bg-current align-text-bottom" />}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Render thinking traces as GitHub-flavored Markdown instead of literal preformatted text.
- Add compact card styling for headings, lists, code, blockquotes, links, and horizontally scrollable tables.
- Reuse the shared safe URL policy and preserve streaming performance by memoizing settled Markdown blocks.
- Add focused coverage for GFM output and safe/blocked link schemes.

## Why

Some models emit Markdown inside reasoning summaries. The thinking card rendered those summaries in a `<pre>`, exposing syntax such as `**bold**` instead of the intended formatting.

## User impact

Expanded thinking cards are easier to scan while streaming and after transcript persistence, without widening the chat layout or loosening link security.

## Validation

- `npm test -- --run src/renderer/components/messages/thinking-block-item.test.tsx src/renderer/components/messages/split-streaming-markdown.test.ts` (17 tests passed)
- `npm run typecheck`
- `npx eslint src/renderer/components/messages/thinking-block-item.tsx src/renderer/components/messages/thinking-block-item.test.tsx`
- `npm run build:web`
