### PR TITLE
Fix mobile dictation and question request UX

### DIFF
--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -227,6 +227,12 @@ describe('AgentActivityIndicator', () => {
 
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
+
+    const indicator = screen.getByTestId('activity-indicator')
+    expect(indicator).toHaveClass('rounded-2xl', 'pb-3')
+    expect(indicator).not.toHaveClass('border-b-0', 'pb-8')
+    expect(indicator.parentElement).toHaveClass('mb-2')
+    expect(indicator.parentElement).not.toHaveClass('-mb-5')
   })
 
   it('shows "Waiting for input..." when pending connected account requests exist', () => {

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -289,10 +289,21 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
           : (activeItem?.activeForm || 'Working...')
 
   return (
-    <div className="mx-auto -mb-5 w-full max-w-[740px] px-4">
+    <div className={cn(
+      'mx-auto w-full max-w-[740px] px-4',
+      isAwaitingInput ? 'mb-2' : '-mb-5',
+    )}>
       {/* Capped and scrolled in place: a long action list must not grow the
           card until it pushes the chat history off screen. */}
-      <div className="max-h-[30vh] overflow-y-auto rounded-t-2xl border border-b-0 bg-muted/50 px-3 pt-3 pb-8" data-testid="activity-indicator">
+      <div
+        className={cn(
+          'max-h-[30vh] overflow-y-auto border bg-muted/50 px-3 pt-3',
+          isAwaitingInput
+            ? 'rounded-2xl pb-3'
+            : 'rounded-t-2xl border-b-0 pb-8',
+        )}
+        data-testid="activity-indicator"
+      >
         {/* Header with pulsing indicator */}
         <div className="flex items-center gap-2">
           <span className="relative flex h-3 w-3">

--- a/src/renderer/components/messages/chat-composer-box.tsx
+++ b/src/renderer/components/messages/chat-composer-box.tsx
@@ -126,9 +126,9 @@ export function ChatComposerBox({
           onSecure={secureSecrets.onSecure}
         />
       )}
-      <div className="mt-1 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-1">{leftActions}</div>
-        <div className="flex items-center gap-2">{rightActions}</div>
+      <div className="mt-1 flex min-w-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1">{leftActions}</div>
+        <div className="flex shrink-0 items-center gap-2">{rightActions}</div>
       </div>
       {footer}
     </div>

--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -60,7 +60,10 @@ function Harness({
 describe('ComposerOptionsPopover', () => {
   it('renders the combined "Model · Effort" label, resolving a bare alias to its latest', () => {
     render(<Harness initialModel="opus" initialEffort="high" />)
-    expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Opus 4.8 · High')
+    const trigger = screen.getByTestId('composer-options-trigger')
+    expect(trigger).toHaveTextContent('Opus 4.8 · High')
+    expect(trigger).toHaveClass('max-[420px]:w-[34px]')
+    expect(trigger.querySelector('span')).toHaveClass('max-[420px]:hidden')
   })
 
   it('falls back to Sonnet on the trigger when no model is set', () => {

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -1,5 +1,5 @@
 import { memo, type ReactNode } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, Settings2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
@@ -64,12 +64,13 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true, foo
           variant="outline"
           size="sm"
           disabled={disabled}
-          className="h-[34px] gap-1.5 px-2 text-xs font-medium"
+          className="h-[34px] min-w-0 gap-1.5 px-2 text-xs font-medium max-[420px]:w-[34px] max-[420px]:shrink-0 max-[420px]:justify-center max-[420px]:px-0"
           aria-label={`${includeEffort ? 'Model and effort' : 'Model'}: ${triggerAriaLabel}. Click to change.`}
           data-testid="composer-options-trigger"
         >
-          {selectedModel && <ModelIcon icon={selectedModel.icon} className="h-3.5 w-3.5 shrink-0" />}
-          <span>
+          {selectedModel && <ModelIcon icon={selectedModel.icon} className="h-3.5 w-3.5 shrink-0 max-[420px]:hidden" />}
+          <Settings2 className="hidden h-3.5 w-3.5 max-[420px]:block" aria-hidden="true" />
+          <span className="max-[420px]:hidden">
             {selectedModelLabel}
             {includeEffort && (
               <span className="text-muted-foreground">
@@ -77,7 +78,7 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true, foo
               </span>
             )}
           </span>
-          <ChevronDown className="h-3.5 w-3.5" />
+          <ChevronDown className="h-3.5 w-3.5 max-[420px]:hidden" />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/src/renderer/components/messages/question-request-item.test.tsx
+++ b/src/renderer/components/messages/question-request-item.test.tsx
@@ -114,6 +114,7 @@ describe('QuestionRequestItem', () => {
         expect.objectContaining({
           method: 'POST',
           body: expect.stringContaining('PostgreSQL'),
+          signal: expect.any(AbortSignal),
         })
       )
     })

--- a/src/renderer/components/messages/question-request-item.tsx
+++ b/src/renderer/components/messages/question-request-item.tsx
@@ -159,13 +159,14 @@ export function QuestionRequestItem({
     return (selection as string) || ''
   }
 
-  const postAnswer = async (body: Record<string, unknown>) => {
+  const postAnswer = async (body: Record<string, unknown>, signal: AbortSignal) => {
     const response = await apiFetch(
       `/api/agents/${agentSlug}/sessions/${sessionId}/answer-question`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ toolUseId, ...body }),
+        signal,
       }
     )
     if (!response.ok) {
@@ -182,7 +183,7 @@ export function QuestionRequestItem({
       answers[q.question] = getAnswerForQuestion(i, q)
     })
 
-    submit(() => postAnswer({ answers }), 'answered')
+    submit((signal) => postAnswer({ answers }, signal), 'answered')
   }
 
   // Cmd/Ctrl-Enter inside the "Other" textarea advances to the next question,
@@ -202,7 +203,7 @@ export function QuestionRequestItem({
 
   const handleDecline = (reason?: string) => {
     submit(
-      () => postAnswer({ decline: true, declineReason: reason || 'User declined to answer' }),
+      (signal) => postAnswer({ decline: true, declineReason: reason || 'User declined to answer' }, signal),
       'declined',
     )
   }

--- a/src/renderer/components/ui/voice-input-button.test.tsx
+++ b/src/renderer/components/ui/voice-input-button.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { VoiceInputButton } from './voice-input-button'
+
+vi.mock('@renderer/context/dialog-context', () => ({
+  useDialogs: () => ({ openSettings: vi.fn() }),
+}))
+
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({ isAuthMode: false, isAdmin: true }),
+}))
+
+vi.mock('@renderer/hooks/use-voice-input', () => ({
+  useIsVoiceConfigured: () => true,
+}))
+
+vi.mock('@renderer/components/ui/mini-waveform', () => ({
+  MiniWaveform: ({ color }: { color: string }) => <div data-testid="mini-waveform" data-color={color} />,
+}))
+
+describe('VoiceInputButton', () => {
+  it('uses theme-aware active styling and keeps the stop control visible', () => {
+    render(
+      <VoiceInputButton
+        message=""
+        voiceInput={{
+          state: 'recording',
+          isRecording: true,
+          isConnecting: false,
+          isFinalizing: false,
+          error: null,
+          clearError: vi.fn(),
+          isSupported: true,
+          analyserRef: { current: null },
+          startRecording: vi.fn(),
+          stopRecording: vi.fn(),
+        }}
+      />,
+    )
+
+    const button = screen.getByTestId('voice-input-button')
+    expect(button).toHaveAccessibleName('Stop recording')
+    expect(button).toHaveClass('bg-primary/10', 'text-foreground', 'dark:bg-primary/15')
+    expect(button).not.toHaveClass('bg-background', 'hover:bg-zinc-100')
+    expect(screen.getByTestId('mini-waveform')).toHaveAttribute('data-color', 'currentColor')
+  })
+})

--- a/src/renderer/components/ui/voice-input-button.tsx
+++ b/src/renderer/components/ui/voice-input-button.tsx
@@ -100,9 +100,10 @@ export function VoiceInputButton({ voiceInput, message, disabled, size = 'defaul
         buttonVariants({ variant: 'outline', size: 'icon' }),
         'overflow-hidden px-0 transition-[width,padding,background-color,border-color,color,border-radius] duration-200 ease-out',
         active
-          ? `${config.pill} gap-2 justify-between rounded-md border-input bg-background px-2 text-foreground hover:bg-zinc-100`
+          ? `${config.pill} gap-2 justify-between rounded-md border-primary/30 bg-primary/10 px-2 text-foreground hover:bg-primary/15 dark:border-primary/40 dark:bg-primary/15 dark:hover:bg-primary/20`
           : `gap-0 rounded-md ${config.button}`
       )}
+      aria-label={active ? 'Stop recording' : !hasVoiceConfigured ? 'Set up voice input' : 'Voice input'}
       title={
         active
           ? 'Stop recording'
@@ -117,7 +118,7 @@ export function VoiceInputButton({ voiceInput, message, disabled, size = 'defaul
           active ? 'max-w-[64px] opacity-100' : 'max-w-0 opacity-0'
         )}
       >
-        <MiniWaveform analyserRef={voiceInput.analyserRef} color="black" {...config.waveform} />
+        <MiniWaveform analyserRef={voiceInput.analyserRef} color="currentColor" {...config.waveform} />
       </span>
       {busy ? (
         <Loader2 className="h-4 w-4 shrink-0 animate-spin" />

--- a/src/renderer/hooks/use-request-handler.test.ts
+++ b/src/renderer/hooks/use-request-handler.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useRequestHandler } from './use-request-handler'
+import { REQUEST_SUBMIT_TIMEOUT_MESSAGE, useRequestHandler } from './use-request-handler'
 
 describe('useRequestHandler', () => {
   it('starts with pending status and no error', () => {
@@ -77,5 +77,41 @@ describe('useRequestHandler', () => {
     })
     await act(() => result.current.submit(async () => {}, 'fetch-requested'))
     expect(result.current.status).toBe('fetch-requested')
+  })
+
+  it('aborts a timed-out request, resets to pending, and allows a retry', async () => {
+    vi.useFakeTimers()
+    try {
+      const onComplete = vi.fn()
+      const { result } = renderHook(() => useRequestHandler(onComplete, { timeoutMs: 100 }))
+      let submittedSignal: AbortSignal | undefined
+
+      let firstSubmit!: Promise<void>
+      act(() => {
+        firstSubmit = result.current.submit((signal) => {
+          submittedSignal = signal
+          return new Promise<void>(() => {})
+        }, 'provided')
+      })
+
+      expect(result.current.status).toBe('submitting')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100)
+        await firstSubmit
+      })
+
+      expect(submittedSignal?.aborted).toBe(true)
+      expect(result.current.status).toBe('pending')
+      expect(result.current.error).toBe(REQUEST_SUBMIT_TIMEOUT_MESSAGE)
+      expect(onComplete).not.toHaveBeenCalled()
+
+      await act(() => result.current.submit(async () => {}, 'provided'))
+      expect(result.current.status).toBe('provided')
+      expect(result.current.error).toBeNull()
+      expect(onComplete).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/renderer/hooks/use-request-handler.ts
+++ b/src/renderer/hooks/use-request-handler.ts
@@ -6,12 +6,37 @@
  * with error handling and status reset on failure.
  */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { captureRendererException } from '@renderer/lib/error-reporting'
 
-export function useRequestHandler(onComplete: () => void) {
+export const REQUEST_SUBMIT_TIMEOUT_MS = 15_000
+export const REQUEST_SUBMIT_TIMEOUT_MESSAGE = 'Request timed out. Please try again.'
+
+interface UseRequestHandlerOptions {
+  timeoutMs?: number
+}
+
+class RequestTimeoutError extends Error {
+  constructor() {
+    super(REQUEST_SUBMIT_TIMEOUT_MESSAGE)
+    this.name = 'RequestTimeoutError'
+  }
+}
+
+export function useRequestHandler(
+  onComplete: () => void,
+  { timeoutMs = REQUEST_SUBMIT_TIMEOUT_MS }: UseRequestHandlerOptions = {},
+) {
   const [status, setStatus] = useState<string>('pending')
   const [error, setError] = useState<string | null>(null)
+  const attemptRef = useRef(0)
+  const activeControllerRef = useRef<AbortController | null>(null)
+
+  useEffect(() => () => {
+    attemptRef.current += 1
+    activeControllerRef.current?.abort()
+    activeControllerRef.current = null
+  }, [])
 
   /**
    * Execute an async action with automatic status transitions:
@@ -19,21 +44,43 @@ export function useRequestHandler(onComplete: () => void) {
    *   pending → submitting → pending (on failure, with error set)
    */
   const submit = useCallback(async (
-    fn: () => Promise<void>,
+    fn: (signal: AbortSignal) => Promise<void>,
     successStatus: string,
   ) => {
+    const attempt = ++attemptRef.current
+    activeControllerRef.current?.abort()
+    const controller = new AbortController()
+    activeControllerRef.current = controller
+
     setStatus('submitting')
     setError(null)
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+
     try {
-      await fn()
+      await Promise.race([
+        Promise.resolve().then(() => fn(controller.signal)),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            controller.abort()
+            reject(new RequestTimeoutError())
+          }, timeoutMs)
+        }),
+      ])
+      if (attempt !== attemptRef.current) return
       setStatus(successStatus)
       onComplete()
     } catch (err: unknown) {
+      if (attempt !== attemptRef.current) return
       captureRendererException(err, { tags: { source: 'request-item' } })
       setError(err instanceof Error ? err.message : 'Request failed')
       setStatus('pending')
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId)
+      if (activeControllerRef.current === controller) {
+        activeControllerRef.current = null
+      }
     }
-  }, [onComplete])
+  }, [onComplete, timeoutMs])
 
   return { status, error, submit, setStatus, setError }
 }


### PR DESCRIPTION
## Summary

- make the active dictation control theme-aware so the waveform and stop icon remain visible in dark mode
- collapse the model/effort selector to a settings icon on narrow mobile viewports and make composer actions shrink safely
- separate the waiting activity indicator from pending question cards instead of overlapping their rounded header
- add an abortable 15-second request deadline that resets failed question submissions to a retryable state

## Why

On narrow PWA layouts, the full model selector, recording pill, and create button could overflow the composer. The recording state also used a hard-coded light hover background and black waveform, which produced poor dark-mode contrast. Pending question cards inherited the activity indicator's normal negative overlap intended for the composer, creating a malformed seam. Finally, request submission awaited the API indefinitely, so a stalled response left the Submit button permanently loading.

## User impact

Mobile dictation stays legible and fits on one row, waiting question cards render as separate clean surfaces, and stalled answer submissions now show an error and can be retried after 15 seconds.

## Validation

- `npm test -- --run src/renderer/components/ui/voice-input-button.test.tsx src/renderer/hooks/use-request-handler.test.ts src/renderer/components/messages/question-request-item.test.tsx src/renderer/components/messages/agent-activity-indicator.test.tsx src/renderer/components/messages/composer-options-popover.test.tsx` (87 tests)
- `npm run typecheck`
- targeted ESLint on all changed TypeScript files
- `npm run build:web`
