### PR TITLE
fix: complete MCP OAuth against active Cloud toggle target (SUP-560)

### DIFF
--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -1031,6 +1031,48 @@ describe('SSRF protection', () => {
       expect(electron).toBe(false)
       expect(candidates).toEqual(['http://localhost:3000/api/remote-mcps/oauth-callback'])
     })
+
+    it('uses the protocol sent by the Electron client for the scheme candidate (cloud-served initiate, SUP-560)', async () => {
+      mockInitiateNewServerOAuth.mockResolvedValue({
+        authorizationUrl: 'https://auth.example.com/auth',
+        state: 'state-xyz',
+      })
+
+      await app.request('http://localhost/api/remote-mcps/initiate-oauth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Dev MCP',
+          url: 'https://mcp.example.com/mcp',
+          electron: true,
+          protocol: 'superagent-dev',
+        }),
+      })
+
+      const [, , candidates] = mockInitiateNewServerOAuth.mock.calls[0]
+      expect(candidates[0]).toBe('superagent-dev://mcp-oauth-callback')
+    })
+
+    it('ignores a protocol that is not a valid URI scheme and falls back to the default', async () => {
+      mockInitiateNewServerOAuth.mockResolvedValue({
+        authorizationUrl: 'https://auth.example.com/auth',
+        state: 'state-xyz',
+      })
+
+      await app.request('http://localhost/api/remote-mcps/initiate-oauth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Dev MCP',
+          url: 'https://mcp.example.com/mcp',
+          electron: true,
+          protocol: 'javascript:alert(1)//',
+        }),
+      })
+
+      const [, , candidates] = mockInitiateNewServerOAuth.mock.calls[0]
+      expect(candidates[0]).toBe('superagent://mcp-oauth-callback')
+    })
   })
 
   describe('POST /initiate-oauth — surfaces OAuth setup failures', () => {
@@ -1386,5 +1428,43 @@ describe('OAuth callback — postMessage origin', () => {
     expect(html).toContain('mcpId=mcp-new')
     // NOT the web postMessage/BroadcastChannel bridge.
     expect(html).not.toContain("new BroadcastChannel('mcp-oauth-callback')")
+  })
+
+  it('hands back with the scheme recorded on the flow, not the server env (SUP-560)', async () => {
+    mockCompleteOAuthFlow.mockResolvedValue({
+      success: true,
+      mcpId: 'mcp-new',
+      electron: true,
+      redirectWasScheme: false,
+      desktopProtocol: 'superagent-dev',
+    })
+    mockDbFrom.mockReturnValue({ where: mockWhere })
+    mockWhere.mockReturnValue({ limit: mockLimit })
+    mockLimit.mockResolvedValue([
+      { id: 'mcp-new', url: 'https://mcp.example.com', accessToken: 'tok' },
+    ])
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ jsonrpc: '2.0', result: {}, id: 1 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }))
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ jsonrpc: '2.0', result: { tools: [] }, id: 2 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
+    const res = await app.request(
+      'http://localhost/api/remote-mcps/oauth-callback?code=abc&state=xyz'
+    )
+
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('superagent-dev://mcp-oauth-callback?success=true')
+    expect(html).not.toContain('superagent://mcp-oauth-callback')
   })
 })

--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -1073,6 +1073,30 @@ describe('SSRF protection', () => {
       const [, , candidates] = mockInitiateNewServerOAuth.mock.calls[0]
       expect(candidates[0]).toBe('superagent://mcp-oauth-callback')
     })
+
+    it('ignores well-formed but non-allowlisted schemes (file, vscode, …)', async () => {
+      mockInitiateNewServerOAuth.mockResolvedValue({
+        authorizationUrl: 'https://auth.example.com/auth',
+        state: 'state-xyz',
+      })
+
+      for (const protocol of ['file', 'vscode', 'http', 'https']) {
+        mockInitiateNewServerOAuth.mockClear()
+        await app.request('http://localhost/api/remote-mcps/initiate-oauth', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: 'Dev MCP',
+            url: 'https://mcp.example.com/mcp',
+            electron: true,
+            protocol,
+          }),
+        })
+
+        const [, , candidates] = mockInitiateNewServerOAuth.mock.calls[0]
+        expect(candidates[0]).toBe('superagent://mcp-oauth-callback')
+      }
+    })
   })
 
   describe('POST /initiate-oauth — surfaces OAuth setup failures', () => {

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -105,10 +105,20 @@ function renderMcpOAuthCallbackHtml(payload: McpOAuthCallbackPayload, message: s
  * already completed server-side. It hands the result back into the app via the
  * custom scheme so the main process can notify the renderer over IPC.
  */
+// Only SuperAgent desktop deep-link schemes — never arbitrary URI schemes from the client.
+const DESKTOP_OAUTH_PROTOCOLS = new Set(['superagent', 'superagent-dev'])
+
+function resolveDesktopOAuthProtocol(candidate?: string): string {
+  if (candidate && DESKTOP_OAUTH_PROTOCOLS.has(candidate)) return candidate
+  const fromEnv = process.env.SUPERAGENT_PROTOCOL
+  if (fromEnv && DESKTOP_OAUTH_PROTOCOLS.has(fromEnv)) return fromEnv
+  return 'superagent'
+}
+
 function renderMcpOAuthHandoffHtml(payload: McpOAuthCallbackPayload, desktopProtocol?: string): string {
   // Prefer the scheme recorded on the flow: a cloud deployment serving this
   // callback has no SUPERAGENT_PROTOCOL of its own (SUP-560).
-  const protocol = desktopProtocol || process.env.SUPERAGENT_PROTOCOL || 'superagent'
+  const protocol = resolveDesktopOAuthProtocol(desktopProtocol)
   const params = new URLSearchParams()
   params.set('success', payload.success ? 'true' : 'false')
   if (payload.mcpId) params.set('mcpId', payload.mcpId)
@@ -291,14 +301,11 @@ remoteMcps.post('/initiate-oauth', async (c) => {
   // fetches carry `Origin: null`. The AS redirects the external browser here to complete
   // the flow, so the URL must be one the local API server actually answers on.
   //
-  // The scheme comes from the client when it sends one (validated against the
-  // RFC 3986 scheme grammar): a cloud deployment serving a proxied Electron
-  // client has no SUPERAGENT_PROTOCOL of its own (SUP-560).
-  const clientProtocol =
-    typeof body.protocol === 'string' && /^[a-z][a-z0-9+.-]*$/i.test(body.protocol)
-      ? body.protocol
-      : undefined
-  const protocol = clientProtocol || process.env.SUPERAGENT_PROTOCOL || 'superagent'
+  // Scheme from the Electron client (allowlisted): a cloud deployment serving a
+  // proxied client has no SUPERAGENT_PROTOCOL of its own (SUP-560).
+  const protocol = resolveDesktopOAuthProtocol(
+    typeof body.protocol === 'string' ? body.protocol : undefined,
+  )
   // eslint-disable-next-line local-rules/no-unhandled-throwing-builtins -- c.req.url is always a valid URL
   const loopbackRedirect = `${new URL(c.req.url).origin}/api/remote-mcps/oauth-callback`
   const httpRedirect = body.electron

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -105,8 +105,10 @@ function renderMcpOAuthCallbackHtml(payload: McpOAuthCallbackPayload, message: s
  * already completed server-side. It hands the result back into the app via the
  * custom scheme so the main process can notify the renderer over IPC.
  */
-function renderMcpOAuthHandoffHtml(payload: McpOAuthCallbackPayload): string {
-  const protocol = process.env.SUPERAGENT_PROTOCOL || 'superagent'
+function renderMcpOAuthHandoffHtml(payload: McpOAuthCallbackPayload, desktopProtocol?: string): string {
+  // Prefer the scheme recorded on the flow: a cloud deployment serving this
+  // callback has no SUPERAGENT_PROTOCOL of its own (SUP-560).
+  const protocol = desktopProtocol || process.env.SUPERAGENT_PROTOCOL || 'superagent'
   const params = new URLSearchParams()
   params.set('success', payload.success ? 'true' : 'false')
   if (payload.mcpId) params.set('mcpId', payload.mcpId)
@@ -136,10 +138,10 @@ function renderMcpOAuthHandoffHtml(payload: McpOAuthCallbackPayload): string {
 function mcpOAuthCallbackBody(
   payload: McpOAuthCallbackPayload,
   message: string,
-  delivery: { electron?: boolean; redirectWasScheme?: boolean },
+  delivery: { electron?: boolean; redirectWasScheme?: boolean; desktopProtocol?: string },
 ): string {
   if (delivery.electron && delivery.redirectWasScheme === false) {
-    return renderMcpOAuthHandoffHtml(payload)
+    return renderMcpOAuthHandoffHtml(payload, delivery.desktopProtocol)
   }
   return renderMcpOAuthCallbackHtml(payload, message)
 }
@@ -260,6 +262,7 @@ remoteMcps.post('/initiate-oauth', async (c) => {
     name?: string
     url?: string
     electron?: boolean
+    protocol?: string
     clientName?: string
     clientId?: string
     clientSecret?: string
@@ -287,7 +290,15 @@ remoteMcps.post('/initiate-oauth', async (c) => {
   // not getAppBaseUrlFromRequest: the packaged renderer is served from file://, so its
   // fetches carry `Origin: null`. The AS redirects the external browser here to complete
   // the flow, so the URL must be one the local API server actually answers on.
-  const protocol = process.env.SUPERAGENT_PROTOCOL || 'superagent'
+  //
+  // The scheme comes from the client when it sends one (validated against the
+  // RFC 3986 scheme grammar): a cloud deployment serving a proxied Electron
+  // client has no SUPERAGENT_PROTOCOL of its own (SUP-560).
+  const clientProtocol =
+    typeof body.protocol === 'string' && /^[a-z][a-z0-9+.-]*$/i.test(body.protocol)
+      ? body.protocol
+      : undefined
+  const protocol = clientProtocol || process.env.SUPERAGENT_PROTOCOL || 'superagent'
   // eslint-disable-next-line local-rules/no-unhandled-throwing-builtins -- c.req.url is always a valid URL
   const loopbackRedirect = `${new URL(c.req.url).origin}/api/remote-mcps/oauth-callback`
   const httpRedirect = body.electron
@@ -389,7 +400,11 @@ remoteMcps.get('/oauth-callback', async (c) => {
   }
 
   const result = await completeOAuthFlow(state, code, iss)
-  const delivery = { electron: result.electron, redirectWasScheme: result.redirectWasScheme }
+  const delivery = {
+    electron: result.electron,
+    redirectWasScheme: result.redirectWasScheme,
+    desktopProtocol: result.desktopProtocol,
+  }
 
   if (!result.success || !result.mcpId) {
     return c.html(mcpOAuthCallbackBody(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -54,6 +54,7 @@ import {
 import { registerGlobalDispatchShortcut, unregisterGlobalDispatchShortcut } from './global-dispatch-shortcut'
 import { filesFromCommandLine } from './opened-files'
 import { parseAgentDeepLink } from './agent-deep-link'
+import { planMcpOAuthCallback, parseMcpOAuthCompletionResponse } from './mcp-oauth-callback'
 import { classifyImportPackage } from './import-packages'
 import { isImportPackagePath } from '@shared/lib/utils/package-extensions'
 import { safeOpenExternalFromApp } from './safe-open-external'
@@ -1185,52 +1186,45 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
 
   // MCP OAuth callback
   if (url.startsWith(`${PROTOCOL_SCHEME}://mcp-oauth-callback`)) {
-    try {
-      const callbackUrl = new URL(url)
-      const params = callbackUrl.searchParams
-
-      if (params.has('success')) {
-        // http-loopback path: the local API server already completed the token
-        // exchange (and any error/issuer validation) in the external browser and
-        // bounced the result back here — the hand-off page always carries
-        // `success`. Notify the renderer directly; no second exchange needed.
-        const success = params.get('success') === 'true'
-        mainWindow?.webContents.send('mcp-oauth-callback', {
-          success,
-          mcpId: params.get('mcpId') || null,
-          error: success ? null : (params.get('error') || 'OAuth failed'),
-        })
-      } else {
-        // Custom-scheme path: the app received the raw code/state, so forward to
-        // the local API server to complete the token exchange.
-        const apiUrl = `http://localhost:${actualApiPort}/api/remote-mcps/oauth-callback${callbackUrl.search}`
-        fetch(apiUrl)
-          .then(async (res) => {
-            const text = await res.text()
-            const success = text.includes('OAuth successful')
-            const mcpIdMatch = text.match(/mcpId:\s*'([^']+)'/)
-            mainWindow?.webContents.send('mcp-oauth-callback', {
-              success,
-              mcpId: mcpIdMatch?.[1] || null,
-              error: success ? null : 'OAuth failed',
-            })
-          })
-          .catch((err) => {
-            console.error('Failed to complete MCP OAuth callback:', err)
-            mainWindow?.webContents.send('mcp-oauth-callback', {
-              success: false,
-              error: err.message || 'Failed to complete OAuth',
-            })
-          })
-      }
-      mainWindow?.focus()
-    } catch (error) {
-      console.error('Failed to parse MCP OAuth callback URL:', error)
+    // Planned against the active target, not always the local API: with the
+    // Cloud toggle on, the pending OAuth state lives in the cloud deployment's
+    // memory, so the completion fetch must go through the cloud proxy (SUP-560).
+    const plan = planMcpOAuthCallback(url, activeApiTarget().baseUrl)
+    if (!plan) {
+      console.error('Failed to parse MCP OAuth callback URL:', url)
       mainWindow?.webContents.send('mcp-oauth-callback', {
         success: false,
         error: 'Invalid callback URL',
       })
+      return
     }
+
+    if (plan.action === 'notify') {
+      // http-loopback path: the initiating API server already completed the
+      // token exchange (and any error/issuer validation) in the external
+      // browser and bounced the result back here — the hand-off page always
+      // carries `success`. Notify the renderer directly; no second exchange.
+      mainWindow?.webContents.send('mcp-oauth-callback', plan.result)
+    } else {
+      // Custom-scheme path: the app received the raw code/state, so forward to
+      // the active Superagent's API to complete the token exchange.
+      fetch(plan.completionUrl)
+        .then(async (res) => {
+          const text = await res.text()
+          mainWindow?.webContents.send(
+            'mcp-oauth-callback',
+            parseMcpOAuthCompletionResponse(text),
+          )
+        })
+        .catch((err) => {
+          console.error('Failed to complete MCP OAuth callback:', err)
+          mainWindow?.webContents.send('mcp-oauth-callback', {
+            success: false,
+            error: err.message || 'Failed to complete OAuth',
+          })
+        })
+    }
+    mainWindow?.focus()
   }
 
   if (url.startsWith(`${PROTOCOL_SCHEME}://platform-auth-callback`)) {

--- a/src/main/mcp-oauth-callback.test.ts
+++ b/src/main/mcp-oauth-callback.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { planMcpOAuthCallback, parseMcpOAuthCompletionResponse } from './mcp-oauth-callback'
+
+describe('planMcpOAuthCallback', () => {
+  it('completes against the cloud proxy base URL when the cloud target is active (SUP-560)', () => {
+    const plan = planMcpOAuthCallback(
+      'superagent://mcp-oauth-callback?code=abc&state=xyz',
+      'http://localhost:4823/cloud/pr0xy-k3y',
+    )
+    expect(plan).toEqual({
+      action: 'complete',
+      completionUrl:
+        'http://localhost:4823/cloud/pr0xy-k3y/api/remote-mcps/oauth-callback?code=abc&state=xyz',
+    })
+  })
+
+  it('completes against the local API when the local target is active', () => {
+    const plan = planMcpOAuthCallback(
+      'superagent://mcp-oauth-callback?code=abc&state=xyz&iss=https%3A%2F%2Fauth.example.com',
+      'http://localhost:4823',
+    )
+    expect(plan).toEqual({
+      action: 'complete',
+      completionUrl:
+        'http://localhost:4823/api/remote-mcps/oauth-callback?code=abc&state=xyz&iss=https%3A%2F%2Fauth.example.com',
+    })
+  })
+
+  it('notifies directly when the hand-off page already carries a success result', () => {
+    const plan = planMcpOAuthCallback(
+      'superagent://mcp-oauth-callback?success=true&mcpId=mcp-1',
+      'http://localhost:4823/cloud/pr0xy-k3y',
+    )
+    expect(plan).toEqual({
+      action: 'notify',
+      result: { success: true, mcpId: 'mcp-1', error: null },
+    })
+  })
+
+  it('notifies a failure with the carried error when success=false', () => {
+    const plan = planMcpOAuthCallback(
+      'superagent://mcp-oauth-callback?success=false&error=Token%20exchange%20failed',
+      'http://localhost:4823',
+    )
+    expect(plan).toEqual({
+      action: 'notify',
+      result: { success: false, mcpId: null, error: 'Token exchange failed' },
+    })
+  })
+
+  it('returns null for an unparseable callback URL', () => {
+    expect(planMcpOAuthCallback('not a url', 'http://localhost:4823')).toBeNull()
+  })
+})
+
+describe('parseMcpOAuthCompletionResponse', () => {
+  it('reads success and mcpId from the callback page JSON payload', () => {
+    const html = `
+      <html><body><script>
+        const payload = {"type":"mcp-oauth-callback","success":true,"mcpId":"mcp-new"};
+      </script><p>OAuth successful! You can close this window.</p></body></html>
+    `
+    expect(parseMcpOAuthCompletionResponse(html)).toEqual({
+      success: true,
+      mcpId: 'mcp-new',
+      error: null,
+    })
+  })
+
+  it('reports failure when the page does not announce success', () => {
+    const html = '<html><body><p>OAuth failed. You can close this window.</p></body></html>'
+    expect(parseMcpOAuthCompletionResponse(html)).toEqual({
+      success: false,
+      mcpId: null,
+      error: 'OAuth failed',
+    })
+  })
+})

--- a/src/main/mcp-oauth-callback.ts
+++ b/src/main/mcp-oauth-callback.ts
@@ -1,0 +1,62 @@
+export interface McpOAuthCallbackResult {
+  success: boolean
+  mcpId: string | null
+  error: string | null
+}
+
+export type McpOAuthCallbackPlan =
+  // http-loopback path: the API server already completed the token exchange in
+  // the external browser and bounced the finished result back via deep link.
+  | { action: 'notify'; result: McpOAuthCallbackResult }
+  // Custom-scheme path: the app received the raw code/state, so the token
+  // exchange still has to run — against the Superagent that initiated the flow.
+  | { action: 'complete'; completionUrl: string }
+
+/**
+ * Decide how to handle an mcp-oauth-callback deep link. `apiBaseUrl` must be
+ * the *active* target's base URL: with the Cloud toggle on, the pending OAuth
+ * state lives in the cloud deployment's memory, so completing against the
+ * local API is guaranteed to miss it (SUP-560).
+ */
+export function planMcpOAuthCallback(
+  deepLinkUrl: string,
+  apiBaseUrl: string,
+): McpOAuthCallbackPlan | null {
+  let callbackUrl: URL
+  try {
+    callbackUrl = new URL(deepLinkUrl)
+  } catch {
+    return null
+  }
+  const params = callbackUrl.searchParams
+
+  if (params.has('success')) {
+    const success = params.get('success') === 'true'
+    return {
+      action: 'notify',
+      result: {
+        success,
+        mcpId: params.get('mcpId') || null,
+        error: success ? null : (params.get('error') || 'OAuth failed'),
+      },
+    }
+  }
+
+  return {
+    action: 'complete',
+    completionUrl: `${apiBaseUrl}/api/remote-mcps/oauth-callback${callbackUrl.search}`,
+  }
+}
+
+/** Read the completion result out of the callback route's HTML response. */
+export function parseMcpOAuthCompletionResponse(html: string): McpOAuthCallbackResult {
+  const success = html.includes('OAuth successful')
+  // The callback page embeds the result payload as JSON; the single-quote form
+  // is kept for older servers that inlined it as a JS object literal.
+  const mcpIdMatch = html.match(/"mcpId":"([^"]+)"/) ?? html.match(/mcpId:\s*'([^']+)'/)
+  return {
+    success,
+    mcpId: mcpIdMatch?.[1] || null,
+    error: success ? null : 'OAuth failed',
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   platform: process.platform,
   osVersion: process.getSystemVersion(),
+  // The app's deep-link scheme (superagent / superagent-dev). Main assigns the
+  // env var before any window spawns, so the renderer's copy always has it.
+  desktopProtocol: process.env.SUPERAGENT_PROTOCOL || 'superagent',
 
   // OAuth callback handling - receives parsed callback params from main process.
   // Returns a per-listener unsubscribe so concurrent subscribers (multiple
@@ -472,6 +475,7 @@ declare global {
       setPreferredApiTarget?: (target: ApiTarget) => Promise<void>
       platform: string
       osVersion: string
+      desktopProtocol?: string
       onOAuthCallback: (callback: (params: OAuthCallbackParams) => void) => () => void
       removeOAuthCallback: () => void
       onMcpOAuthCallback: (callback: (params: { success: boolean; mcpId?: string | null; error?: string | null }) => void) => () => void

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -286,10 +286,15 @@ export function useInitiateMcpOAuth() {
   return useMutation<{ redirectUrl: string; state: string }, Error, { mcpId?: string; name?: string; url?: string; electron?: boolean; clientName?: string; clientId?: string; clientSecret?: string }>({
     meta: { skipGlobalErrorToast: true },
     mutationFn: async (data) => {
+      // The deep-link scheme travels with the request: a cloud deployment
+      // serving this initiate has no SUPERAGENT_PROTOCOL of its own (SUP-560).
+      const payload = data.electron
+        ? { protocol: window.electronAPI?.desktopProtocol, ...data }
+        : data
       const res = await apiFetch('/api/remote-mcps/initiate-oauth', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
+        body: JSON.stringify(payload),
       })
       if (!res.ok) {
         const error = await res.json()

--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -1288,6 +1288,7 @@ describe('oauth', () => {
       // The custom app scheme won registration, so the callback route keeps the
       // main-process-parsed HTML rather than the external-browser hand-off.
       expect(result.redirectWasScheme).toBe(true)
+      expect(result.desktopProtocol).toBe('superagent')
     })
 
     it('reports a non-scheme (loopback) redirect so the callback hands back via the external browser', async () => {
@@ -1328,7 +1329,7 @@ describe('oauth', () => {
       const initiated = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',
         'Loopback Electron',
-        ['superagent://mcp-oauth-callback', 'http://localhost:47891/api/remote-mcps/oauth-callback'],
+        ['superagent-dev://mcp-oauth-callback', 'http://localhost:47891/api/remote-mcps/oauth-callback'],
         true,
         'user-1'
       )
@@ -1347,6 +1348,9 @@ describe('oauth', () => {
       expect(result.success).toBe(true)
       expect(result.electron).toBe(true)
       expect(result.redirectWasScheme).toBe(false)
+      // The scheme candidate's protocol survives on the flow even though the
+      // loopback won registration — the hand-off page needs it (SUP-560).
+      expect(result.desktopProtocol).toBe('superagent-dev')
     })
 
     it('stores issuer metadata and accepts a matching iss when advertised as supported', async () => {

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -289,6 +289,9 @@ type PendingOAuthFlow = {
   // the winning redirect is the custom app scheme, this tells the callback route
   // how to hand the result back (see completeOAuthFlow's return).
   electron?: boolean
+  // The desktop app's deep-link scheme, kept on the flow because the callback
+  // may be served by a cloud deployment with no SUPERAGENT_PROTOCOL of its own.
+  desktopProtocol?: string
 }
 
 type OAuthIssuerValidationResult =
@@ -308,11 +311,18 @@ const pendingOAuthFlows = new Map<string, PendingOAuthFlow>()
 function flowDeliveryFlags(flow: PendingOAuthFlow): {
   electron: boolean
   redirectWasScheme: boolean
+  desktopProtocol?: string
 } {
   return {
     electron: flow.electron === true,
     redirectWasScheme: !/^https?:/i.test(flow.redirectUri),
+    desktopProtocol: flow.desktopProtocol,
   }
+}
+
+// The custom app scheme candidate (if any) names the desktop deep-link protocol.
+function desktopProtocolFromCandidates(redirectCandidates: string[]): string | undefined {
+  return redirectCandidates.find((c) => !/^https?:/i.test(c))?.split('://')[0]
 }
 
 function validateAuthorizationResponseIssuer(
@@ -352,7 +362,11 @@ function validateAuthorizationResponseIssuer(
 export function validateAndConsumeOAuthErrorResponse(
   state: string | null | undefined,
   iss: string | null | undefined,
-): OAuthIssuerValidationResult & { electron?: boolean; redirectWasScheme?: boolean } {
+): OAuthIssuerValidationResult & {
+  electron?: boolean
+  redirectWasScheme?: boolean
+  desktopProtocol?: string
+} {
   if (!state) {
     return {
       valid: false,
@@ -496,6 +510,7 @@ export async function initiateOAuthFlow(
     clientSecret,
     mcpId,
     electron,
+    desktopProtocol: desktopProtocolFromCandidates(redirectCandidates),
   })
 
   // Build authorization URL
@@ -610,6 +625,7 @@ export async function initiateNewServerOAuth(
     newServer: { name, url: mcpUrl },
     userId,
     electron,
+    desktopProtocol: desktopProtocolFromCandidates(redirectCandidates),
   })
 
   let authUrl: URL
@@ -652,7 +668,13 @@ export async function completeOAuthFlow(
   state: string,
   code: string,
   iss?: string | null,
-): Promise<{ success: boolean; mcpId?: string; electron?: boolean; redirectWasScheme?: boolean }> {
+): Promise<{
+  success: boolean
+  mcpId?: string
+  electron?: boolean
+  redirectWasScheme?: boolean
+  desktopProtocol?: string
+}> {
   const flow = pendingOAuthFlows.get(state)
   if (!flow) {
     console.error('[mcp/oauth] No pending flow for state:', state)
@@ -663,12 +685,12 @@ export async function completeOAuthFlow(
   // path is fetched+parsed by the Electron main process (parseable HTML), while
   // the http loopback path is loaded in the external browser (needs a hand-off
   // back to the app).
-  const { electron, redirectWasScheme } = flowDeliveryFlags(flow)
+  const delivery = flowDeliveryFlags(flow)
 
   const issuerValidation = validateAuthorizationResponseIssuer(flow, iss)
   if (!issuerValidation.valid) {
     console.error('[mcp/oauth] Authorization response issuer validation failed:', issuerValidation.error)
-    return { success: false, electron, redirectWasScheme }
+    return { success: false, ...delivery }
   }
 
   pendingOAuthFlows.delete(state)
@@ -695,7 +717,7 @@ export async function completeOAuthFlow(
     if (!res.ok) {
       const errorBody = await res.text()
       console.error('[mcp/oauth] Token exchange failed:', res.status, errorBody)
-      return { success: false, electron, redirectWasScheme }
+      return { success: false, ...delivery }
     }
 
     const tokens: OAuthTokenResponse = await res.json()
@@ -724,7 +746,7 @@ export async function completeOAuthFlow(
         createdAt: now,
         updatedAt: now,
       })
-      return { success: true, mcpId: id, electron, redirectWasScheme }
+      return { success: true, mcpId: id, ...delivery }
     } else if (flow.mcpId) {
       // Existing server: UPDATE with tokens
       await db
@@ -738,13 +760,13 @@ export async function completeOAuthFlow(
           updatedAt: now,
         })
         .where(eq(remoteMcpServers.id, flow.mcpId))
-      return { success: true, mcpId: flow.mcpId, electron, redirectWasScheme }
+      return { success: true, mcpId: flow.mcpId, ...delivery }
     }
 
-    return { success: false, electron, redirectWasScheme }
+    return { success: false, ...delivery }
   } catch (error) {
     console.error('[mcp/oauth] Token exchange error:', error)
-    return { success: false, electron, redirectWasScheme }
+    return { success: false, ...delivery }
   }
 }
 


### PR DESCRIPTION
## Summary
- When Cloud toggle is on, MCP OAuth pending state lives in the cloud deployment — complete the deep-link callback against the **active** API base URL (cloud proxy), not always `localhost` (SUP-560).
- Pass the desktop deep-link scheme (`superagent` / `superagent-dev`) from Electron through initiate → pending flow → handoff HTML so cloud-hosted initiate still returns to the correct desktop app.
- Extract `planMcpOAuthCallback` / `parseMcpOAuthCompletionResponse` for testable main-process routing.

## Bug
With Cloud toggle on, finishing MCP OAuth completed against the local API (or used the cloud host’s default `superagent://` scheme). Result: missing pending state and/or the packaged Gamut.app opening instead of Dev Electron (`superagent-dev://`).

## Repro
1. Desktop Electron with Cloud toggle on (org cloud workspace reachable).
2. Connect a remote MCP that requires OAuth.
3. Complete OAuth in the browser.
4. Before: callback completed against local API / opened prod app. After: completes against cloud proxy; handoff uses the client’s scheme.

## Test plan
- [x] Unit: `mcp-oauth-callback.test.ts`, remote-mcps initiate/callback protocol tests, oauth flow `desktopProtocol` assertions
- [ ] Local toggle off: MCP OAuth handoff URL is `superagent-dev://…` and Dev Electron receives the callback
- [ ] Cloud toggle on (host with this build): OAuth completes successfully; pending state found on cloud
- [ ] Malformed `protocol` body rejected; falls back to default scheme
- [ ] Packaged app still uses `superagent://`


Made with [Cursor](https://cursor.com)