### PR TITLE
Show running dashboards immediately

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
+import { runInNewContext } from 'node:vm'
 
 // ============================================================================
 // Mocks — must be declared before import
@@ -601,6 +602,56 @@ async function postFormData(app: Hono, url: string, body: FormData): Promise<Res
     body,
   })
 }
+
+// ============================================================================
+// Standalone dashboard wrapper
+// ============================================================================
+
+describe('GET /:id/artifacts/:artifactSlug/view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAgentExists.mockResolvedValue(true)
+  })
+
+  it('reuses the initial running status instead of entering the poll loop', async () => {
+    const res = await getReq(createApp(), '/api/agents/test-agent/artifacts/sales/view')
+    const html = await res.text()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { slug: 'sales', name: 'Sales', status: 'running' },
+      ]), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'running' }), { status: 200 }))
+    const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+    const loadingRemove = vi.fn()
+    const appendChild = vi.fn()
+    const iframe: Record<string, string> = {}
+    const statusElement = { textContent: '', classList: { add: vi.fn() } }
+    const loadingElement = { remove: loadingRemove }
+    const document = {
+      title: '',
+      getElementById: (id: string) => id === 'status' ? statusElement : loadingElement,
+      createElement: () => iframe,
+      body: { appendChild },
+    }
+
+    expect(script).toBeDefined()
+    runInNewContext(script!, {
+      document,
+      fetch: fetchMock,
+      setTimeout,
+    })
+
+    await vi.waitFor(() => {
+      expect(appendChild).toHaveBeenCalledWith(iframe)
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/agents/test-agent/artifacts')
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/agents/test-agent')
+    expect(loadingRemove).toHaveBeenCalledOnce()
+    expect(iframe.src).toBe('/api/agents/test-agent/artifacts/sales/')
+  })
+})
 
 // ============================================================================
 // Shared-agent connection projections

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -650,6 +650,7 @@ describe('GET /:id/artifacts/:artifactSlug/view', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/agents/test-agent')
     expect(loadingRemove).toHaveBeenCalledOnce()
     expect(iframe.src).toBe('/api/agents/test-agent/artifacts/sales/')
+    expect(iframe.sandbox).toContain('allow-downloads')
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -5700,29 +5700,43 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
       document.title = (name || artifactSlug) + ' \\u2014 Gamut';
     }
 
-    async function fetchDashboardName() {
+    // undefined means the status check itself was inconclusive; null means
+    // it completed and the requested dashboard was absent.
+    async function fetchDashboard() {
       try {
         const res = await fetch(basePath + '/artifacts');
-        if (res.ok) {
-          const artifacts = await res.json();
-          const d = Array.isArray(artifacts) && artifacts.find(a => a.slug === artifactSlug);
-          if (d && d.name) { setTitle(d.name); return d.name; }
-        }
+        if (!res.ok) return undefined;
+        const artifacts = await res.json();
+        if (!Array.isArray(artifacts)) return undefined;
+        const dashboard = artifacts.find(a => a.slug === artifactSlug) || null;
+        if (dashboard && dashboard.name) setTitle(dashboard.name);
+        return dashboard;
       } catch {}
-      return null;
+      return undefined;
+    }
+
+    function showDashboard() {
+      loadingEl.remove();
+      const iframe = document.createElement('iframe');
+      iframe.src = dashboardUrl;
+      iframe.sandbox = 'allow-scripts allow-same-origin allow-forms allow-popups';
+      iframe.allow = 'microphone; camera';
+      document.body.appendChild(iframe);
     }
 
     async function run() {
       try {
-        // 1. Resolve dashboard name (works even when agent is stopped)
-        await fetchDashboardName();
+        // 1. Seed both dashboard metadata and live status. This works while the
+        // agent is stopped too, though that fallback reports stopped.
+        const initialDashboard = await fetchDashboard();
 
         // 2. Check agent status
         const agentRes = await fetch(basePath);
         if (!agentRes.ok) { throw new Error('Failed to fetch agent info'); }
         const agent = await agentRes.json();
+        const agentWasRunning = agent.status === 'running';
 
-        if (agent.status !== 'running') {
+        if (!agentWasRunning) {
           // 3. Start the agent
           statusEl.textContent = 'Starting agent…';
           const startRes = await fetch(basePath + '/start', { method: 'POST' });
@@ -5732,17 +5746,24 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
           }
         }
 
+        // The initial artifacts request already gave us a fresh status. When
+        // both processes were running, avoid flashing a redundant wait screen
+        // and let the iframe paint immediately.
+        if (agentWasRunning && initialDashboard !== undefined) {
+          if (!initialDashboard) { throw new Error('Dashboard not found.'); }
+          if (initialDashboard.status === 'crashed') { throw new Error('Dashboard crashed.'); }
+          if (initialDashboard.status === 'running') {
+            showDashboard();
+            return;
+          }
+        }
+
         // 4. Poll until dashboard is running
         statusEl.textContent = 'Waiting for dashboard…';
         await pollDashboard();
 
         // 5. Show the dashboard
-        loadingEl.remove();
-        const iframe = document.createElement('iframe');
-        iframe.src = dashboardUrl;
-        iframe.sandbox = 'allow-scripts allow-same-origin allow-forms allow-popups';
-        iframe.allow = 'microphone; camera';
-        document.body.appendChild(iframe);
+        showDashboard();
       } catch (err) {
         statusEl.textContent = err.message;
         statusEl.classList.add('error');

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -5719,7 +5719,7 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
       loadingEl.remove();
       const iframe = document.createElement('iframe');
       iframe.src = dashboardUrl;
-      iframe.sandbox = 'allow-scripts allow-same-origin allow-forms allow-popups';
+      iframe.sandbox = 'allow-scripts allow-same-origin allow-forms allow-popups allow-downloads';
       iframe.allow = 'microphone; camera';
       document.body.appendChild(iframe);
     }

--- a/src/renderer/components/dashboards/dashboard-view-state.test.ts
+++ b/src/renderer/components/dashboards/dashboard-view-state.test.ts
@@ -13,7 +13,6 @@ function input(overrides: Partial<DashboardViewStateInput> = {}): DashboardViewS
     canStart: true,
     startFailed: false,
     waitElapsedMs: 0,
-    iframeLoaded: false,
     ...overrides,
   }
 }
@@ -60,22 +59,10 @@ describe('resolveDashboardViewState', () => {
     })
   })
 
-  it('keeps waiting (no fast poll) until the iframe has painted after status is running', () => {
-    const beforePaint = resolveDashboardViewState(
-      input({ dashboard: { status: 'running' }, iframeLoaded: false }),
-    )
-    const afterPaint = resolveDashboardViewState(
-      input({ dashboard: { status: 'running' }, iframeLoaded: true }),
-    )
-
-    expect(beforePaint).toEqual({
-      kind: 'waiting',
-      message: 'Waiting for dashboard…',
-      showSpinner: true,
-      slow: false,
-      pollFast: false,
-    })
-    expect(afterPaint).toEqual({ kind: 'ready' })
+  it('is ready as soon as dashboard status is running', () => {
+    expect(
+      resolveDashboardViewState(input({ dashboard: { status: 'running' } })),
+    ).toEqual({ kind: 'ready' })
   })
 
   it('treats starting the same as queued: one wait label', () => {
@@ -105,11 +92,6 @@ describe('resolveDashboardViewState', () => {
       condition: 'the dashboard is queued',
       overrides: { dashboard: { status: 'stopped' as const } },
       pollFastBeforeBound: true,
-    },
-    {
-      condition: 'the iframe has not loaded',
-      overrides: { dashboard: { status: 'running' as const }, iframeLoaded: false },
-      pollFastBeforeBound: false,
     },
   ])('acknowledges every slow wait after 120s when $condition', ({
     overrides,

--- a/src/renderer/components/dashboards/dashboard-view-state.ts
+++ b/src/renderer/components/dashboards/dashboard-view-state.ts
@@ -24,7 +24,6 @@ export type DashboardViewStateInput = {
   canStart: boolean
   startFailed: boolean
   waitElapsedMs: number
-  iframeLoaded: boolean
 }
 
 function waiting(slow: boolean, pollFast: boolean): Extract<DashboardViewState, { kind: 'waiting' }> {
@@ -47,7 +46,6 @@ export function resolveDashboardViewState(input: DashboardViewStateInput): Dashb
     canStart,
     startFailed,
     waitElapsedMs,
-    iframeLoaded,
   } = input
 
   if (!agentRunning) {
@@ -85,9 +83,6 @@ export function resolveDashboardViewState(input: DashboardViewStateInput): Dashb
   }
 
   if (dashboard.status === 'running') {
-    if (!iframeLoaded) {
-      return waiting(slow, false)
-    }
     return { kind: 'ready' }
   }
 

--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DashboardView } from './dashboard-view'
@@ -146,5 +146,19 @@ describe('DashboardView restart', () => {
     expect(document.querySelector('iframe')?.getAttribute('src')).toBe(
       '/api/agents/abc1234567/artifacts/dashboard/',
     )
+  })
+
+  it('shows refresh progress until the new iframe document loads', async () => {
+    mocks.dashboardStatus = 'running'
+    render(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    const frame = document.querySelector('iframe')!
+
+    await userEvent.click(screen.getByRole('button', { name: 'Refresh dashboard' }))
+
+    expect(screen.getByRole('button', { name: 'Refreshing dashboard' })).toBeDisabled()
+
+    fireEvent.load(frame)
+
+    expect(screen.getByRole('button', { name: 'Refresh dashboard' })).not.toBeDisabled()
   })
 })

--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DashboardView } from './dashboard-view'
@@ -112,7 +112,7 @@ describe('DashboardView restart', () => {
     expect(mocks.start.mutateAsync).toHaveBeenCalledOnce()
   })
 
-  it('waits for the new document when the frame remounts after the agent left running', () => {
+  it('shows a running dashboard without waiting for the iframe load event', () => {
     mocks.dashboardStatus = 'running'
     const frame = () => document.querySelector('iframe')
     const waiting = () => screen.queryByText('Waiting for dashboard…')
@@ -120,7 +120,7 @@ describe('DashboardView restart', () => {
     const view = render(
       <DashboardView agentSlug="agent" dashboardSlug="dashboard" />,
     )
-    fireEvent.load(frame()!)
+    expect(frame()).not.toBeNull()
     expect(waiting()).toBeNull()
 
     // The agent leaves running through a control outside this view.
@@ -131,7 +131,8 @@ describe('DashboardView restart', () => {
     mocks.agentStatus = 'running'
     view.rerender(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
 
-    expect(waiting()).not.toBeNull()
+    expect(frame()).not.toBeNull()
+    expect(waiting()).toBeNull()
   })
 
   it('uses the canonical agent id for the mounted dashboard URL', () => {

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -27,6 +27,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const [pollFast, setPollFast] = useState(false)
   const [now, setNow] = useState(() => Date.now())
   const [restarting, setRestarting] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const [restartError, setRestartError] = useState<string | null>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const waitStartedAtRef = useRef<number | null>(null)
@@ -90,6 +91,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
 
   const handleRefresh = useCallback(() => {
     if (iframeRef.current) {
+      setRefreshing(true)
       iframeRef.current.src = iframeSrc
     }
   }, [iframeSrc])
@@ -174,8 +176,17 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
           <Button variant="ghost" size="sm" onClick={handlePopOut} title="Open in new window">
             <ExternalLink className="h-3 w-3" />
           </Button>
-          <Button variant="ghost" size="sm" onClick={handleRefresh} title="Refresh">
-            <RefreshCw className="h-3 w-3" />
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={refreshing}
+            title={refreshing ? 'Refreshing…' : 'Refresh'}
+            aria-label={refreshing ? 'Refreshing dashboard' : 'Refresh dashboard'}
+          >
+            {refreshing
+              ? <Loader2 className="h-3 w-3 animate-spin" />
+              : <RefreshCw className="h-3 w-3" />}
           </Button>
         </div>
       </div>
@@ -195,6 +206,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
           title={dashboard?.name || dashboardSlug}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
           allow="microphone; camera"
+          onLoad={() => setRefreshing(false)}
         />
       </div>
     </div>

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -24,7 +24,6 @@ interface DashboardViewProps {
 export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) {
   useRenderTracker('DashboardView')
   const [dockDialogOpen, setDockDialogOpen] = useState(false)
-  const [iframeLoaded, setIframeLoaded] = useState(false)
   const [pollFast, setPollFast] = useState(false)
   const [now, setNow] = useState(() => Date.now())
   const [restarting, setRestarting] = useState(false)
@@ -48,7 +47,6 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const trackingWait = isAgentRunning && (
     !artifactsLoaded
     || (dashboard != null && (dashboard.status === 'starting' || dashboard.status === 'stopped'))
-    || (dashboard?.status === 'running' && !iframeLoaded)
   )
 
   const waitElapsedMs = waitStartedAtRef.current === null
@@ -76,7 +74,6 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     canStart,
     startFailed: startAgent.isError,
     waitElapsedMs,
-    iframeLoaded,
   })
 
   const nextPollFast = viewState.kind === 'waiting' && viewState.pollFast
@@ -91,12 +88,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const dashboardAgentSlug = agent?.slug ?? agentSlug
   const iframeSrc = `${baseUrl}${buildDashboardArtifactPath(dashboardAgentSlug, dashboardSlug)}`
 
-  useEffect(() => {
-    setIframeLoaded(false)
-  }, [iframeSrc])
-
   const handleRefresh = useCallback(() => {
-    setIframeLoaded(false)
     if (iframeRef.current) {
       iframeRef.current.src = iframeSrc
     }
@@ -115,7 +107,6 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     autoStartedRef.current = agentSlug
     setRestarting(true)
     setRestartError(null)
-    setIframeLoaded(false)
     waitStartedAtRef.current = Date.now()
     try {
       if (isAgentRunning) {
@@ -139,14 +130,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   }, [agent, agentSlug, isAgentRunning, isAgentStarting, canStart, startAgent])
 
   const showFrame = isAgentRunning && dashboard?.status === 'running'
-  const showOverlay = viewState.kind !== 'ready'
   const actionPending = restarting || stopAgent.isPending || startAgent.isPending
-
-  // The iframe unmounts whenever the frame is hidden, so its load state must not
-  // outlive it and mark the next mount ready before that document loads.
-  useEffect(() => {
-    if (!showFrame) setIframeLoaded(false)
-  }, [showFrame])
 
   if (!showFrame) {
     return (
@@ -204,20 +188,6 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
         dashboardName={dashboard?.name || dashboardSlug}
       />
       <div className="flex-1 min-h-0 relative">
-        {showOverlay && (
-          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-background text-muted-foreground p-8">
-            <DashboardStatusBody
-              viewState={viewState}
-              startErrorMessage={startAgent.error?.message}
-              restartErrorMessage={restartError ?? undefined}
-              onRetry={handleStartAgent}
-              onRestart={handleRestartAgent}
-              retryPending={startAgent.isPending}
-              restartPending={actionPending}
-              canStart={canStart}
-            />
-          </div>
-        )}
         <iframe
           ref={iframeRef}
           src={iframeSrc}
@@ -225,7 +195,6 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
           title={dashboard?.name || dashboardSlug}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
           allow="microphone; camera"
-          onLoad={() => setIframeLoaded(true)}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- reveal embedded dashboards as soon as their server status is `running`, allowing the iframe to paint incrementally
- remove iframe `load` as a blocking readiness condition
- seed standalone/pop-out dashboard state from its initial `/artifacts` request and skip redundant waiting/polling when the agent and dashboard are already running
- retain the existing startup polling path for stopped or starting dashboards

## Why

The UI conflated dashboard process readiness with completion of the iframe `load` event. A dashboard could already be reachable or painting while an opaque “Waiting for dashboard…” overlay remained visible. Pop-outs also discarded their initial live dashboard status and always entered a second polling phase.

## Impact

Running dashboards become visible immediately in the main view, and already-running pop-outs avoid flashing a misleading waiting state. Genuine startup cases continue to show the existing status UI.

## Validation

- `npm test -- --run src/renderer/components/dashboards/dashboard-view-state.test.ts src/renderer/components/dashboards/dashboard-view.test.tsx src/api/routes/agents.test.ts` — 349 tests passed
- `npm run typecheck`
- ESLint on all changed files
- `git diff --check`
