### PR TITLE
Fix transparent user input cards

### DIFF
--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -103,6 +103,8 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByText('LLM Provider Error')).toBeInTheDocument()
     expect(screen.getByText('API rate limit exceeded')).toBeInTheDocument()
     expect(screen.getByText(/external LLM provider API/)).toBeInTheDocument()
+    expect(screen.getByTestId('provider-error-card')).toHaveClass('bg-amber-50', 'dark:bg-amber-950')
+    expect(screen.getByTestId('provider-error-card')).not.toHaveClass('bg-amber-500/10')
   })
 
   it('shows generic error alert when no apiErrorCode', () => {
@@ -112,6 +114,8 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByText('Error')).toBeInTheDocument()
     expect(screen.getByText('The agent process was terminated unexpectedly.')).toBeInTheDocument()
     expect(screen.getByText('Send another message to retry.')).toBeInTheDocument()
+    expect(screen.getByTestId('error-card')).toHaveClass('bg-red-50', 'dark:bg-red-950')
+    expect(screen.getByTestId('error-card')).not.toHaveClass('bg-destructive/10')
   })
 
   it('shows "Working..." status when active with no todo', () => {

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -274,7 +274,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
         ) : isProviderError ? (
           <ProviderErrorCard message={error} data-testid="provider-error-card" />
         ) : (
-          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 select-text" data-testid="error-card">
+          <div className="rounded-lg border border-destructive/50 bg-red-50 p-3 select-text dark:bg-red-950" data-testid="error-card">
             <div className="flex items-center gap-2">
               <AlertTriangle className="h-4 w-4 text-destructive" />
               <span className="text-sm font-medium text-destructive">Error</span>

--- a/src/renderer/components/messages/insufficient-balance-card.test.tsx
+++ b/src/renderer/components/messages/insufficient-balance-card.test.tsx
@@ -67,6 +67,8 @@ describe('InsufficientBalanceCard', () => {
     render(<InsufficientBalanceCard billingUrl="https://platform.example.com/billing" />)
 
     expect(screen.getByText('Insufficient balance')).toBeInTheDocument()
+    expect(screen.getByTestId('insufficient-balance-card')).toHaveClass('bg-card')
+    expect(screen.getByTestId('insufficient-balance-card')).not.toHaveClass('bg-muted/30')
     const button = screen.getByRole('button', { name: /go to billing/i })
     fireEvent.click(button)
     expect(openExternal).toHaveBeenCalledWith('https://platform.example.com/billing')

--- a/src/renderer/components/messages/insufficient-balance-card.tsx
+++ b/src/renderer/components/messages/insufficient-balance-card.tsx
@@ -51,7 +51,7 @@ export function InsufficientBalanceCard({
 
   return (
     <div
-      className="rounded-[12px] border bg-muted/30 shadow-md p-4"
+      className="rounded-[12px] border bg-card shadow-md p-4"
       data-testid={testId ?? 'insufficient-balance-card'}
     >
       <div className="flex items-start gap-3">

--- a/src/renderer/components/messages/pending-request-error-boundary.test.tsx
+++ b/src/renderer/components/messages/pending-request-error-boundary.test.tsx
@@ -50,6 +50,8 @@ describe('PendingRequestErrorBoundary', () => {
       </PendingRequestErrorBoundary>
     )
     expect(screen.getByTestId('pending-request-error-boundary')).toBeInTheDocument()
+    expect(screen.getByTestId('pending-request-error-boundary')).toHaveClass('dark:bg-amber-950')
+    expect(screen.getByTestId('pending-request-error-boundary')).not.toHaveClass('dark:bg-amber-950/30')
     expect(screen.getByText("This request couldn't be displayed")).toBeInTheDocument()
     spy.mockRestore()
   })

--- a/src/renderer/components/messages/pending-request-error-boundary.tsx
+++ b/src/renderer/components/messages/pending-request-error-boundary.tsx
@@ -99,7 +99,7 @@ function PendingRequestErrorFallback({
 
   return (
     <div
-      className="border border-amber-300/70 dark:border-amber-700/60 rounded-[12px] bg-amber-50 dark:bg-amber-950/30 shadow-md text-sm"
+      className="border border-amber-300/70 dark:border-amber-700/60 rounded-[12px] bg-amber-50 dark:bg-amber-950 shadow-md text-sm"
       data-testid="pending-request-error-boundary"
     >
       <div className="flex items-start gap-2 p-4 text-amber-800 dark:text-amber-200">

--- a/src/renderer/components/messages/pending-request-stack.tsx
+++ b/src/renderer/components/messages/pending-request-stack.tsx
@@ -288,10 +288,11 @@ export function PendingRequestStack({ children }: PendingRequestStackProps) {
                   return (
                     <div
                       key={`peek-${depth}`}
-                      className="rounded-t-[12px] border-x border-t bg-muted/20"
+                      className="rounded-t-[12px] border-x border-t bg-card"
+                      aria-hidden="true"
+                      data-testid="request-stack-peek"
                       style={{
                         height: 10,
-                        opacity: Math.max(0.3, 1 - depth * 0.25),
                         marginLeft: depth * 8,
                         marginRight: depth * 8,
                       }}

--- a/src/renderer/components/messages/pending-request-stack.unified-pagination.test.tsx
+++ b/src/renderer/components/messages/pending-request-stack.unified-pagination.test.tsx
@@ -216,6 +216,25 @@ describe('Unified pagination (stack ↔ per-card sub-pages)', () => {
   })
 
   describe('Multiple cards with sub-pages', () => {
+    it('renders every queued-card peek with an opaque background', () => {
+      render(
+        <PendingRequestStack>
+          {[
+            <SinglePageTestCard key="a" id="A" />,
+            <SinglePageTestCard key="b" id="B" />,
+          ]}
+        </PendingRequestStack>
+      )
+
+      const peeks = screen.getAllByTestId('request-stack-peek')
+      expect(peeks.length).toBeGreaterThan(0)
+      for (const peek of peeks) {
+        expect(peek).toHaveClass('bg-card')
+        expect(peek).not.toHaveClass('bg-muted/20')
+        expect(peek.style.opacity).toBe('')
+      }
+    })
+
     it('totalCount is the sum of all cards\' sub-counts', () => {
       render(
         <PendingRequestStack>

--- a/src/renderer/components/messages/pending-wake-banner.test.tsx
+++ b/src/renderer/components/messages/pending-wake-banner.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@renderer/test/test-utils'
+import { PendingWakeBanner } from './pending-wake-banner'
+
+describe('PendingWakeBanner', () => {
+  it('uses an opaque surface above the transcript', () => {
+    renderWithProviders(
+      <PendingWakeBanner
+        sessionId="session-1"
+        agentSlug="agent-1"
+        wakeAt={new Date(Date.now() + 60_000).toISOString()}
+        taskId="task-1"
+      />,
+    )
+
+    expect(screen.getByTestId('pending-wake-banner')).toHaveClass('bg-card')
+    expect(screen.getByTestId('pending-wake-banner')).not.toHaveClass('bg-muted/50')
+  })
+})

--- a/src/renderer/components/messages/pending-wake-banner.tsx
+++ b/src/renderer/components/messages/pending-wake-banner.tsx
@@ -61,7 +61,7 @@ export function PendingWakeBanner({
 
   return (
     <div
-      className="mx-4 mb-2 flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2 text-xs text-muted-foreground"
+      className="mx-4 mb-2 flex items-center gap-2 rounded-lg border bg-card px-3 py-2 text-xs text-muted-foreground"
       data-testid="pending-wake-banner"
     >
       <MoonStar className="h-3.5 w-3.5 shrink-0" />

--- a/src/renderer/components/messages/request-item-shell.test.tsx
+++ b/src/renderer/components/messages/request-item-shell.test.tsx
@@ -7,6 +7,44 @@ import { PendingRequestStack } from './pending-request-stack'
 import { HelpCircle, Key, Terminal } from 'lucide-react'
 
 describe('RequestItemShell', () => {
+  describe('opaque card background', () => {
+    it.each([
+      {
+        state: 'pending',
+        props: {},
+      },
+      {
+        state: 'read-only',
+        props: { readOnly: {} },
+      },
+      {
+        state: 'completed',
+        props: {
+          completed: {
+            icon: <Key />,
+            label: 'API_KEY',
+            statusLabel: 'Provided',
+            isSuccess: true,
+          },
+        },
+      },
+    ])('uses the opaque card token in the $state state', ({ props }) => {
+      render(
+        <RequestItemShell
+          title="Test Request"
+          theme="blue"
+          data-testid="request-card"
+          {...props}
+        >
+          <div>Content</div>
+        </RequestItemShell>
+      )
+
+      expect(screen.getByTestId('request-card')).toHaveClass('bg-card')
+      expect(screen.getByTestId('request-card')).not.toHaveClass('bg-muted/30')
+    })
+  })
+
   describe('pending state (default)', () => {
     it('renders title chip and children', () => {
       render(

--- a/src/renderer/components/messages/request-item-shell.tsx
+++ b/src/renderer/components/messages/request-item-shell.tsx
@@ -13,6 +13,10 @@ export const THEME_CLASSES: Record<RequestTheme, { waitBadge: string }> = {
   orange: { waitBadge: 'text-orange-600 dark:text-orange-400' },
 }
 
+// Pending requests sit on top of the scrolling transcript. Keep every shell
+// fully opaque so message content cannot bleed through interactive controls.
+const REQUEST_CARD_CLASS = 'border rounded-[12px] bg-card shadow-md text-sm'
+
 interface CompletedConfig {
   icon: ReactNode
   label: ReactNode
@@ -71,7 +75,7 @@ export function RequestItemShell({
 
   if (completed) {
     return (
-      <div className="border rounded-[12px] bg-muted/30 shadow-md text-sm" {...dataAttrs}>
+      <div className={REQUEST_CARD_CLASS} {...dataAttrs}>
         <div className="flex items-center gap-2 p-4">
           {completed.icon}
           <span className="text-sm">{completed.label}</span>
@@ -103,7 +107,7 @@ export function RequestItemShell({
   if (readOnly) {
     const roConfig = typeof readOnly === 'object' ? readOnly : {}
     return (
-      <div className="border rounded-[12px] bg-muted/30 shadow-md text-sm" {...dataAttrs}>
+      <div className={REQUEST_CARD_CLASS} {...dataAttrs}>
         <div className="flex items-start gap-3 p-4">
           <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between gap-3">
@@ -163,7 +167,7 @@ export function RequestItemShell({
 
   return (
     <div
-      className="max-h-[50vh] overflow-y-auto border rounded-[12px] bg-muted/30 shadow-md text-sm"
+      className={cn('max-h-[50vh] overflow-y-auto', REQUEST_CARD_CLASS)}
       {...dataAttrs}
     >
       <div className="p-4">

--- a/src/renderer/components/messages/stale-session-notice.test.tsx
+++ b/src/renderer/components/messages/stale-session-notice.test.tsx
@@ -15,6 +15,8 @@ describe('StaleSessionNotice', () => {
 
     expect(screen.getByText('Start a new conversation?')).toBeInTheDocument()
     expect(screen.getByTestId('stale-toast')).toHaveClass('mb-2')
+    expect(screen.getByTestId('stale-toast-card')).toHaveClass('bg-card')
+    expect(screen.getByTestId('stale-toast-card')).not.toHaveClass('bg-muted/50')
     await user.click(screen.getByTestId('stale-toast-ignore'))
     await user.click(screen.getByTestId('stale-new-chat'))
     expect(onIgnore).toHaveBeenCalledOnce()

--- a/src/renderer/components/messages/stale-session-notice.tsx
+++ b/src/renderer/components/messages/stale-session-notice.tsx
@@ -32,7 +32,10 @@ export function StaleSessionNotice({
 
   return (
     <div data-testid="stale-toast" className="mx-auto mb-2 w-full max-w-[740px] px-4">
-      <div className="flex items-center justify-between gap-4 rounded-2xl border bg-muted/50 p-4">
+      <div
+        className="flex items-center justify-between gap-4 rounded-2xl border bg-card p-4"
+        data-testid="stale-toast-card"
+      >
         <div className="flex min-w-0 max-w-[60%] flex-col gap-1.5">
           <p className="text-sm font-medium">Start a new conversation?</p>
           <p className="text-xs text-muted-foreground">

--- a/src/renderer/components/ui/provider-error-card.tsx
+++ b/src/renderer/components/ui/provider-error-card.tsx
@@ -27,7 +27,7 @@ export function ProviderErrorCard({ message, 'data-testid': testId }: ProviderEr
 
   return (
     <div
-      className="rounded-lg border border-amber-500/50 bg-amber-500/10 p-3"
+      className="rounded-lg border border-amber-500/50 bg-amber-50 p-3 dark:bg-amber-950"
       data-testid={testId ?? 'provider-error-card'}
     >
       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- make the shared pending-request shell fully opaque in pending, read-only, and completed states
- make stacked-card peek surfaces and the malformed-request fallback opaque as well
- make the stale-session hint above the composer opaque
- make the scheduled-wake banner and footer-level error cards opaque while preserving the composer’s intentional glass treatment
- add regression coverage for every affected overlay surface

## Root cause

Pending user-input cards are rendered over the scrolling transcript, but their shared shell used `bg-muted/30`. That alpha background allowed transcript text to bleed through question, secret, connected-account, and approval surfaces. The queued-card peeks and dark-mode error fallback had the same issue. The separate stale-session and scheduled-wake surfaces used `bg-muted/50`, while footer error cards also used alpha-only fills without backdrop blur.

## User impact

All unblurred cards that overlay the transcript now use solid backgrounds, so questions, hints, approvals, scheduled-wake controls, and errors remain readable regardless of the transcript underneath. The intentionally frosted composer and active-work indicator are unchanged.

## Validation

- focused Vitest coverage for request shells, session hints, scheduled wake, billing/provider/generic errors, and stacked requests (111 tests)
- `npm run typecheck`
- targeted ESLint on the changed files
- `npm run build:web`
- `npm run test:e2e -- e2e/specs/user-input-requests.spec.ts --grep "question request: answer a question" --workers=1`
