### PR TITLE
perf(renderer): isolate Recharts from activity sparklines

### DIFF
--- a/src/renderer/components/activity/activity-bar-chart.tsx
+++ b/src/renderer/components/activity/activity-bar-chart.tsx
@@ -7,7 +7,7 @@ import {
   type ChartConfig,
 } from '@renderer/components/ui/chart'
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
-import { summarizeDailyActivity } from './activity-spark-chart'
+import { dayLabel, plural, summarizeDailyActivity } from './activity-spark-chart'
 
 const activityChartConfig = {
   succeeded: {
@@ -24,19 +24,6 @@ interface ActivityBarChartProps {
   label: string
   data: DailyActivityPoint[]
   className?: string
-}
-
-function dayLabel(date: string): string {
-  const parsed = new Date(`${date}T00:00:00.000Z`)
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
-  }).format(parsed)
-}
-
-function plural(value: number, singular: string, multiple = `${singular}s`): string {
-  return value === 1 ? singular : multiple
 }
 
 /** Larger companion to ActivitySparkChart with a real date axis + hover data. */

--- a/src/renderer/components/activity/activity-bar-chart.tsx
+++ b/src/renderer/components/activity/activity-bar-chart.tsx
@@ -1,0 +1,101 @@
+import type { DailyActivityPoint } from '@shared/lib/types/activity'
+import { cn } from '@shared/lib/utils/cn'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@renderer/components/ui/chart'
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import { summarizeDailyActivity } from './activity-spark-chart'
+
+const activityChartConfig = {
+  succeeded: {
+    label: 'Succeeded',
+    color: 'hsl(160 84% 39%)',
+  },
+  failed: {
+    label: 'Failed',
+    color: 'hsl(0 84% 60%)',
+  },
+} satisfies ChartConfig
+
+interface ActivityBarChartProps {
+  label: string
+  data: DailyActivityPoint[]
+  className?: string
+}
+
+function dayLabel(date: string): string {
+  const parsed = new Date(`${date}T00:00:00.000Z`)
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(parsed)
+}
+
+function plural(value: number, singular: string, multiple = `${singular}s`): string {
+  return value === 1 ? singular : multiple
+}
+
+/** Larger companion to ActivitySparkChart with a real date axis + hover data. */
+export function ActivityBarChart({ label, data, className }: ActivityBarChartProps) {
+  const { succeeded, failed, total } = summarizeDailyActivity(data)
+  const ticks = data.length > 1
+    ? [data[0].date, data[data.length - 1].date]
+    : data.map((point) => point.date)
+  const accessibleLabel = total === 0
+    ? `${label}: no calls over the last ${data.length} ${plural(data.length, 'day')}.`
+    : `${label}: ${total} ${plural(total, 'call')} over ${data.length} ${plural(data.length, 'day')}, ${succeeded} succeeded and ${failed} failed.`
+
+  return (
+    <ChartContainer
+      config={activityChartConfig}
+      className={cn('h-[150px] w-full aspect-auto', className)}
+      role="img"
+      aria-label={accessibleLabel}
+      data-testid="activity-bar-chart"
+    >
+      <BarChart data={data} margin={{ top: 8, right: 4, bottom: 0, left: 4 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          ticks={ticks}
+          tickFormatter={dayLabel}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          interval={0}
+          padding={{ left: 12, right: 12 }}
+        />
+        <YAxis hide allowDecimals={false} />
+        <ChartTooltip
+          cursor={{ fill: 'hsl(var(--muted) / 0.45)' }}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(value) => dayLabel(String(value))}
+              valueFormatter={(value) => `${value} ${plural(value, 'call')}`}
+            />
+          }
+        />
+        <Bar
+          dataKey="succeeded"
+          stackId="requests"
+          fill="var(--color-succeeded)"
+          radius={[2, 2, 0, 0]}
+          maxBarSize={22}
+          isAnimationActive={false}
+        />
+        <Bar
+          dataKey="failed"
+          stackId="requests"
+          fill="var(--color-failed)"
+          radius={[2, 2, 0, 0]}
+          maxBarSize={22}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ChartContainer>
+  )
+}

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -4,13 +4,6 @@ import {
   type DailyActivityPoint,
 } from '@shared/lib/types/activity'
 import { cn } from '@shared/lib/utils/cn'
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-  type ChartConfig,
-} from '@renderer/components/ui/chart'
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
 const WIDTH = 96
 const HEIGHT = 26
@@ -103,84 +96,6 @@ export function ActivitySparkChart({ label, data, className }: ActivitySparkChar
         )
       })}
     </svg>
-  )
-}
-
-const activityChartConfig = {
-  succeeded: {
-    label: 'Succeeded',
-    color: 'hsl(160 84% 39%)',
-  },
-  failed: {
-    label: 'Failed',
-    color: 'hsl(0 84% 60%)',
-  },
-} satisfies ChartConfig
-
-interface ActivityBarChartProps {
-  label: string
-  data: DailyActivityPoint[]
-  className?: string
-}
-
-/** Larger companion to ActivitySparkChart with a real date axis + hover data. */
-export function ActivityBarChart({ label, data, className }: ActivityBarChartProps) {
-  const { succeeded, failed, total } = summarizeDailyActivity(data)
-  const ticks = data.length > 1
-    ? [data[0].date, data[data.length - 1].date]
-    : data.map((point) => point.date)
-  const accessibleLabel = total === 0
-    ? `${label}: no calls over the last ${data.length} ${plural(data.length, 'day')}.`
-    : `${label}: ${total} ${plural(total, 'call')} over ${data.length} ${plural(data.length, 'day')}, ${succeeded} succeeded and ${failed} failed.`
-
-  return (
-    <ChartContainer
-      config={activityChartConfig}
-      className={cn('h-[150px] w-full aspect-auto', className)}
-      role="img"
-      aria-label={accessibleLabel}
-      data-testid="activity-bar-chart"
-    >
-      <BarChart data={data} margin={{ top: 8, right: 4, bottom: 0, left: 4 }}>
-        <CartesianGrid vertical={false} strokeDasharray="3 3" />
-        <XAxis
-          dataKey="date"
-          ticks={ticks}
-          tickFormatter={dayLabel}
-          tickLine={false}
-          axisLine={false}
-          tickMargin={8}
-          interval={0}
-          padding={{ left: 12, right: 12 }}
-        />
-        <YAxis hide allowDecimals={false} />
-        <ChartTooltip
-          cursor={{ fill: 'hsl(var(--muted) / 0.45)' }}
-          content={
-            <ChartTooltipContent
-              labelFormatter={(value) => dayLabel(String(value))}
-              valueFormatter={(value) => `${value} ${plural(value, 'call')}`}
-            />
-          }
-        />
-        <Bar
-          dataKey="succeeded"
-          stackId="requests"
-          fill="var(--color-succeeded)"
-          radius={[2, 2, 0, 0]}
-          maxBarSize={22}
-          isAnimationActive={false}
-        />
-        <Bar
-          dataKey="failed"
-          stackId="requests"
-          fill="var(--color-failed)"
-          radius={[2, 2, 0, 0]}
-          maxBarSize={22}
-          isAnimationActive={false}
-        />
-      </BarChart>
-    </ChartContainer>
   )
 }
 

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -30,7 +30,7 @@ interface ActivitySparkChartProps {
   className?: string
 }
 
-function dayLabel(date: string): string {
+export function dayLabel(date: string): string {
   const parsed = new Date(`${date}T00:00:00.000Z`)
   return new Intl.DateTimeFormat('en-US', {
     month: 'short',
@@ -39,7 +39,7 @@ function dayLabel(date: string): string {
   }).format(parsed)
 }
 
-function plural(value: number, singular: string, multiple = `${singular}s`): string {
+export function plural(value: number, singular: string, multiple = `${singular}s`): string {
   return value === 1 ? singular : multiple
 }
 

--- a/src/renderer/components/connections/connection-usage-card.tsx
+++ b/src/renderer/components/connections/connection-usage-card.tsx
@@ -1,9 +1,7 @@
 import { ArrowRight, Loader2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
-import {
-  ActivityBarChart,
-  summarizeDailyActivity,
-} from '@renderer/components/activity/activity-spark-chart'
+import { ActivityBarChart } from '@renderer/components/activity/activity-bar-chart'
+import { summarizeDailyActivity } from '@renderer/components/activity/activity-spark-chart'
 import { useConnectionActivityStats } from '@renderer/hooks/use-activity-stats'
 import type { UnifiedRow } from '@renderer/components/connections/unified-rows'
 


### PR DESCRIPTION
## Summary

- move the Recharts-backed detail chart into its own module
- keep Home and other compact activity sparklines on the lightweight SVG-only path
- preserve the existing chart implementation and update its sole consumer import

## Measured impact

A throwaway two-entry esbuild profiler modeled the Home sparkline and deferred connection-detail closures with identical settings before and after:

| Home closure | Before | After | Delta |
|---|---:|---:|---:|
| Minified JS | 425,942 B | 32,519 B | -92.4% |
| Gzip JS | 120,337 B | 11,974 B | -90.0% |
| Source modules | 405 | 8 | -98.0% |
| Recharts modules | 70 | 0 | -100% |

The deferred detail closure grows 657 B gzip (+0.3%). On current `main`, where connection views are still eager, the monolithic renderer chunk changes by only -0.94 KiB gzip; the Home-path reduction is unlocked once route splitting lands.

## Verification

- 42 focused tests pass across spark charts, connection usage, Home health cards, agent triggers, and agent connections
- `npm run typecheck`
- `npm run build:web`
- targeted ESLint pass
