### PR TITLE
perf(renderer): replace post-start refetch polling

### DIFF
--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -16,6 +16,18 @@ import {
 const spawnHolder = vi.hoisted(() => ({
   impl: null as ((command: string, args: string[], options: unknown) => unknown) | null,
 }))
+const screenshotMocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  notifyReady: vi.fn(),
+}))
+
+vi.mock('./dashboard-screenshot', () => ({
+  captureDashboardScreenshot: (...args: unknown[]) => screenshotMocks.capture(...args),
+}))
+
+vi.mock('./host-events', () => ({
+  notifyDashboardScreenshotReady: (...args: unknown[]) => screenshotMocks.notifyReady(...args),
+}))
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>()
@@ -187,6 +199,7 @@ describe('DashboardManager log stream lifecycle', () => {
     stopDashboard(slug: string): Promise<boolean>
     stopAll(): Promise<void>
     getDashboardUpstreamPathMode(slug: string): 'stripped' | 'mounted'
+    captureScreenshot(slug: string): Promise<{ ok: true; path: string } | { ok: false; reason: string }>
   }
   let procs: FakeChildProcess[]
   let slugCounter = 0
@@ -202,6 +215,8 @@ describe('DashboardManager log stream lifecycle', () => {
 
     // waitForPort probes the port over HTTP — pretend the server is up
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'))
+    screenshotMocks.capture.mockReset().mockResolvedValue({ ok: false, reason: 'not captured' })
+    screenshotMocks.notifyReady.mockReset().mockResolvedValue(true)
 
     // Fresh module (and singleton) pointed at the temp artifacts dir
     vi.resetModules()
@@ -231,6 +246,27 @@ describe('DashboardManager log stream lifecycle', () => {
     await fs.promises.utimes(path.join(dir, 'node_modules'), future, future)
     return slug
   }
+
+  it('publishes a precise host event after a dashboard screenshot succeeds', async () => {
+    const slug = await scaffoldDashboard()
+    await manager.startDashboard(slug, { forceInstall: false })
+    const screenshotPath = path.join(testDir, slug, 'screenshot.png')
+    screenshotMocks.capture.mockResolvedValueOnce({ ok: true, path: screenshotPath })
+
+    await expect(manager.captureScreenshot(slug)).resolves.toEqual({ ok: true, path: screenshotPath })
+
+    expect(screenshotMocks.notifyReady).toHaveBeenCalledWith(slug)
+  })
+
+  it('does not publish readiness when screenshot capture fails', async () => {
+    const slug = await scaffoldDashboard()
+    await manager.startDashboard(slug, { forceInstall: false })
+    screenshotMocks.capture.mockResolvedValueOnce({ ok: false, reason: 'browser failed' })
+
+    await expect(manager.captureScreenshot(slug)).resolves.toEqual({ ok: false, reason: 'browser failed' })
+
+    expect(screenshotMocks.notifyReady).not.toHaveBeenCalled()
+  })
 
   it('closes the log stream when the process exits cleanly', async () => {
     const slug = await scaffoldDashboard()

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 import { captureDashboardScreenshot, type ScreenshotResult } from './dashboard-screenshot'
+import { notifyDashboardScreenshotReady } from './host-events'
 import { DashboardPackageSchema } from './dashboard-package-schema'
 
 const SCREENSHOT_FILENAME = 'screenshot.png'
@@ -187,7 +188,13 @@ class DashboardManager {
     }
     const outPath = path.join(ARTIFACTS_DIR, slug, SCREENSHOT_FILENAME)
     const url = getDashboardValidationUrl(slug, info.port, info.upstreamPathMode)
-    return captureDashboardScreenshot(url, outPath)
+    const result = await captureDashboardScreenshot(url, outPath)
+    if (result.ok) {
+      void notifyDashboardScreenshotReady(slug).catch((error) => {
+        console.warn(`[DashboardManager] Failed to publish screenshot event for ${slug}:`, error)
+      })
+    }
+    return result
   }
 
   private readPackageJson(slug: string): {

--- a/agent-container/src/host-events.test.ts
+++ b/agent-container/src/host-events.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { notifyDashboardScreenshotReady } from './host-events'
+
+describe('notifyDashboardScreenshotReady', () => {
+  beforeEach(() => {
+    process.env.SUPERAGENT_HOST_API_URL = 'http://host.internal/api/'
+    process.env.PROXY_TOKEN = 'proxy-token'
+    process.env.SUPERAGENT_AGENT_SLUG = 'agent-a'
+  })
+
+  afterEach(() => {
+    delete process.env.SUPERAGENT_HOST_API_URL
+    delete process.env.PROXY_TOKEN
+    delete process.env.SUPERAGENT_AGENT_SLUG
+    vi.restoreAllMocks()
+  })
+
+  it('posts the precise screenshot event with container authentication', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+
+    await expect(notifyDashboardScreenshotReady('sales-dashboard')).resolves.toBe(true)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://host.internal/api/agent-bootstrap/agent-a/events/dashboard-screenshot-ready',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer proxy-token',
+        },
+        body: JSON.stringify({ dashboardSlug: 'sales-dashboard' }),
+      },
+    )
+  })
+
+  it('is a no-op when host callback configuration is unavailable', async () => {
+    delete process.env.SUPERAGENT_HOST_API_URL
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    await expect(notifyDashboardScreenshotReady('sales-dashboard')).resolves.toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a rejected event so the caller can log it', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 403 }))
+
+    await expect(notifyDashboardScreenshotReady('sales-dashboard')).rejects.toThrow('HTTP 403')
+  })
+})

--- a/agent-container/src/host-events.ts
+++ b/agent-container/src/host-events.ts
@@ -1,0 +1,23 @@
+/** Best-effort container → host events that keep renderer caches precise. */
+export async function notifyDashboardScreenshotReady(dashboardSlug: string): Promise<boolean> {
+  const baseUrl = process.env.SUPERAGENT_HOST_API_URL
+  const token = process.env.PROXY_TOKEN
+  const agentSlug = process.env.SUPERAGENT_AGENT_SLUG
+  if (!baseUrl || !token || !agentSlug) return false
+
+  const response = await fetch(
+    `${baseUrl.replace(/\/$/, '')}/agent-bootstrap/${encodeURIComponent(agentSlug)}/events/dashboard-screenshot-ready`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ dashboardSlug }),
+    },
+  )
+  if (!response.ok) {
+    throw new Error(`Host rejected dashboard screenshot event (HTTP ${response.status})`)
+  }
+  return true
+}

--- a/src/api/routes/agent-bootstrap.test.ts
+++ b/src/api/routes/agent-bootstrap.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const validateProxyToken = vi.fn(async (_token: string): Promise<string | null> => null)
+const broadcastGlobal = vi.fn()
 vi.mock('@shared/lib/proxy/token-store', () => ({
   validateProxyToken: (t: string) => validateProxyToken(t),
+}))
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: { broadcastGlobal: (...args: unknown[]) => broadcastGlobal(...args) },
 }))
 
 import agentBootstrap from './agent-bootstrap'
@@ -12,8 +16,17 @@ function get(path: string, headers: Record<string, string> = {}) {
   return agentBootstrap.request(path, { headers })
 }
 
+function post(path: string, body: unknown, headers: Record<string, string> = {}) {
+  return agentBootstrap.request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  })
+}
+
 beforeEach(() => {
   validateProxyToken.mockReset().mockResolvedValue(null)
+  broadcastGlobal.mockReset()
   resetBootstrapEnvStoreForTests()
 })
 
@@ -61,5 +74,50 @@ describe('GET /:agentSlug/env', () => {
     expect((await get('/agent-1/env', { Authorization: 'Bearer synth_x' })).status).toBe(200)
     clearBootstrapEnv('agent-1')
     expect((await get('/agent-1/env', { Authorization: 'Bearer synth_x' })).status).toBe(404)
+  })
+})
+
+describe('POST /:agentSlug/events/dashboard-screenshot-ready', () => {
+  it('broadcasts an authenticated screenshot event to renderer clients', async () => {
+    validateProxyToken.mockResolvedValue('agent-1')
+
+    const res = await post(
+      '/agent-1/events/dashboard-screenshot-ready',
+      { dashboardSlug: 'sales-dashboard' },
+      { Authorization: 'Bearer synth_x' },
+    )
+
+    expect(res.status).toBe(204)
+    expect(broadcastGlobal).toHaveBeenCalledWith({
+      type: 'dashboard_screenshot_ready',
+      agentSlug: 'agent-1',
+      dashboardSlug: 'sales-dashboard',
+    })
+  })
+
+  it('rejects a token belonging to another agent', async () => {
+    validateProxyToken.mockResolvedValue('agent-2')
+
+    const res = await post(
+      '/agent-1/events/dashboard-screenshot-ready',
+      { dashboardSlug: 'sales-dashboard' },
+      { Authorization: 'Bearer synth_other' },
+    )
+
+    expect(res.status).toBe(403)
+    expect(broadcastGlobal).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsafe dashboard slugs', async () => {
+    validateProxyToken.mockResolvedValue('agent-1')
+
+    const res = await post(
+      '/agent-1/events/dashboard-screenshot-ready',
+      { dashboardSlug: '../sales' },
+      { Authorization: 'Bearer synth_x' },
+    )
+
+    expect(res.status).toBe(400)
+    expect(broadcastGlobal).not.toHaveBeenCalled()
   })
 })

--- a/src/api/routes/agent-bootstrap.ts
+++ b/src/api/routes/agent-bootstrap.ts
@@ -2,10 +2,15 @@
 // env. Auth: Bearer PROXY_TOKEN whose resolved slug must match :agentSlug.
 
 import { Hono } from 'hono'
+import { z } from 'zod'
 import { validateProxyToken } from '@shared/lib/proxy/token-store'
 import { readBootstrapEnv } from '@shared/lib/container/agent-bootstrap-env-store'
+import { messagePersister } from '@shared/lib/container/message-persister'
 
 const agentBootstrap = new Hono()
+const DashboardScreenshotReadySchema = z.object({
+  dashboardSlug: z.string().regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/),
+})
 
 agentBootstrap.get('/:agentSlug/env', async (c) => {
   const agentSlug = c.req.param('agentSlug')
@@ -26,6 +31,28 @@ agentBootstrap.get('/:agentSlug/env', async (c) => {
     return c.json({ error: 'No bootstrap env available' }, 404)
   }
   return c.json({ env })
+})
+
+// Container dashboard screenshots are written into the bind-mounted workspace
+// after boot. Push that precise transition to renderer caches so Home does not
+// poll the full agent list at 5/15/30-second guesses.
+agentBootstrap.post('/:agentSlug/events/dashboard-screenshot-ready', async (c) => {
+  const agentSlug = c.req.param('agentSlug')
+  const token = c.req.header('Authorization')?.replace('Bearer ', '')
+  if (!token) return c.json({ error: 'Unauthorized' }, 401)
+  const callerSlug = await validateProxyToken(token)
+  if (!callerSlug) return c.json({ error: 'Unauthorized' }, 401)
+  if (callerSlug !== agentSlug) return c.json({ error: 'Token does not match agent' }, 403)
+
+  const parsed = DashboardScreenshotReadySchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) return c.json({ error: 'Invalid dashboard screenshot event' }, 400)
+
+  messagePersister.broadcastGlobal({
+    type: 'dashboard_screenshot_ready',
+    agentSlug,
+    dashboardSlug: parsed.data.dashboardSlug,
+  })
+  return c.body(null, 204)
 })
 
 export default agentBootstrap

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -473,4 +473,81 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
 
     expect(showOSNotification).not.toHaveBeenCalled()
   })
+
+  it('applies agent status events directly and refreshes only that agent\'s artifacts', () => {
+    queryClient.setQueryData(['agents'], [{
+      slug: 'agent-a',
+      displaySlug: 'agent-a-display',
+      name: 'Agent A',
+      status: 'stopped',
+      containerPort: null,
+      sessionCount: 9,
+    }])
+    queryClient.setQueryData(['agents', 'agent-a'], {
+      slug: 'agent-a',
+      displaySlug: 'agent-a-display',
+      name: 'Agent A',
+      status: 'stopped',
+      containerPort: null,
+      sessionCount: 9,
+    })
+    queryClient.setQueryData(['artifacts', 'agent-a'], [])
+    queryClient.setQueryData(['artifacts', 'agent-a-display'], [])
+    queryClient.setQueryData(['artifacts', 'agent-b'], [])
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    simulateSSEMessage(getLatestEventSource(), {
+      type: 'agent_status_changed',
+      agentSlug: 'agent-a',
+      status: 'running',
+    })
+
+    expect(queryClient.getQueryData<Array<{ status: string; sessionCount: number }>>(['agents'])?.[0])
+      .toMatchObject({ status: 'running', sessionCount: 9 })
+    expect(queryClient.getQueryData<{ status: string }>(['agents', 'agent-a'])?.status).toBe('running')
+    expect(queryClient.getQueryState(['artifacts', 'agent-a'])?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(['artifacts', 'agent-a-display'])?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(['artifacts', 'agent-b'])?.isInvalidated).toBe(false)
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['agents'] })
+  })
+
+  it('marks only the announced dashboard thumbnail ready without a refetch', () => {
+    queryClient.setQueryData(['agents'], [{
+      slug: 'agent-a',
+      displaySlug: 'agent-a',
+      name: 'Agent A',
+      status: 'running',
+      containerPort: 3456,
+      dashboards: [
+        { slug: 'sales', name: 'Sales' },
+        { slug: 'support', name: 'Support' },
+      ],
+    }])
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    simulateSSEMessage(getLatestEventSource(), {
+      type: 'dashboard_screenshot_ready',
+      agentSlug: 'agent-a',
+      dashboardSlug: 'sales',
+    })
+
+    expect(queryClient.getQueryData<Array<{ dashboards: Array<Record<string, unknown>> }>>(['agents'])?.[0].dashboards)
+      .toEqual([
+        { slug: 'sales', name: 'Sales', hasScreenshot: true },
+        { slug: 'support', name: 'Support' },
+      ])
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -22,6 +22,11 @@ import { useUnreadNotificationCount } from '@renderer/hooks/use-notifications'
 import { usePlatformUnreadCount } from '@renderer/hooks/use-platform-notifications'
 import { useUserSettings } from '@renderer/hooks/use-user-settings'
 import { setMountWarning } from '@renderer/hooks/use-mount-warnings'
+import {
+  invalidateAgentArtifacts,
+  markDashboardScreenshotReady,
+  updateAgentRuntimeCache,
+} from '@renderer/lib/agent-cache'
 import type { UserSettingsData } from '@shared/lib/services/user-settings-service'
 import {
   NotificationActionContextSchema,
@@ -360,11 +365,28 @@ export function GlobalNotificationHandler() {
             queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
             break
 
-          case 'agent_status_changed':
-            // Agent started/stopped - update agent list and artifacts
-            queryClient.invalidateQueries({ queryKey: ['agents'] })
-            queryClient.invalidateQueries({ queryKey: ['artifacts'] })
+          case 'agent_status_changed': {
+            // Status is already in the event; preserve cached summaries instead
+            // of refetching every agent. Artifact runtime state is agent-scoped.
+            const agentSlug = data.agentSlug as string | undefined
+            const status = data.status === 'running' || data.status === 'stopped'
+              ? data.status
+              : undefined
+            if (agentSlug && status) {
+              updateAgentRuntimeCache(queryClient, agentSlug, status)
+              invalidateAgentArtifacts(queryClient, agentSlug)
+            }
             break
+          }
+
+          case 'dashboard_screenshot_ready': {
+            const agentSlug = data.agentSlug as string | undefined
+            const dashboardSlug = data.dashboardSlug as string | undefined
+            if (agentSlug && dashboardSlug) {
+              markDashboardScreenshotReady(queryClient, agentSlug, dashboardSlug)
+            }
+            break
+          }
 
           case 'container_health_changed':
             // Container health warnings changed - update agent list

--- a/src/renderer/hooks/use-agents.ts
+++ b/src/renderer/hooks/use-agents.ts
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams } from '@tanstack/react-router'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import type { ApiAgent } from '@shared/lib/types/api'
+import { updateAgentRuntimeCache } from '@renderer/lib/agent-cache'
 
 // Re-export for convenience
 export type { ApiAgent }
@@ -174,14 +175,6 @@ export function useUpdateAgent() {
   })
 }
 
-// TODO: GROSS time based rechecks
-// Delays (ms) for re-invalidating ['agents'] after an agent starts. The
-// container's scanAndStartAll kicks off dashboard startup + screenshot capture
-// asynchronously after /start returns, so the first invalidation fires before
-// any new screenshot.png lands on disk. These follow-ups pick up the thumbnails
-// as they arrive without leaning on a poll loop.
-const AGENT_START_REINVALIDATE_DELAYS_MS = [5_000, 15_000, 30_000]
-
 export type StartAgentVars = string | { slug: string; source?: 'user' | 'warm-start' }
 
 function resolveStartAgentSlug(vars: StartAgentVars): string {
@@ -201,22 +194,25 @@ export function useStartAgent() {
         const body = await res.json().catch(() => ({}))
         throw new Error(body.error || 'Failed to start agent')
       }
-      return res.json()
+      return res.json() as Promise<ApiAgent | null>
     },
-    onSuccess: (_, vars) => {
-      const slug = resolveStartAgentSlug(vars)
+    onSuccess: (agent, vars) => {
       const source = typeof vars === 'string' ? 'user' : (vars.source ?? 'user')
       // Warm-start is background/speculative — don't inflate agent_started.
       if (source !== 'warm-start') {
         track('agent_started')
       }
-      queryClient.invalidateQueries({ queryKey: ['agents'] })
-      queryClient.invalidateQueries({ queryKey: ['agents', slug] })
-      for (const delay of AGENT_START_REINVALIDATE_DELAYS_MS) {
-        setTimeout(() => {
-          queryClient.invalidateQueries({ queryKey: ['agents'] })
-          queryClient.invalidateQueries({ queryKey: ['agents', slug] })
-        }, delay)
+      // The command response and agent_status_changed SSE carry the state we
+      // need. Keep optional summaries intact instead of refetching them; late
+      // dashboard thumbnails arrive through dashboard_screenshot_ready.
+      if (agent) {
+        updateAgentRuntimeCache(queryClient, agent.slug, agent.status, agent.containerPort)
+      } else {
+        // A concurrent delete can make the route's identity lookup return null.
+        // Preserve the old recovery behavior for that exceptional race.
+        const slug = resolveStartAgentSlug(vars)
+        queryClient.invalidateQueries({ queryKey: ['agents'] })
+        queryClient.invalidateQueries({ queryKey: ['agents', slug] })
       }
     },
   })

--- a/src/renderer/hooks/use-start-agent.test.tsx
+++ b/src/renderer/hooks/use-start-agent.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PropsWithChildren } from 'react'
+import type { ApiAgent } from '@shared/lib/types/api'
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  track: vi.fn(),
+}))
+
+vi.mock('@renderer/lib/api', () => ({ apiFetch: mocks.apiFetch }))
+vi.mock('@renderer/context/analytics-context', () => ({
+  useAnalyticsTracking: () => ({ track: mocks.track }),
+}))
+vi.mock('@tanstack/react-router', () => ({ useParams: () => ({}) }))
+
+import { useAgent, useAgents, useStartAgent } from './use-agents'
+
+const stoppedAgent: ApiAgent = {
+  slug: 'agent-a',
+  displaySlug: 'agent-a',
+  name: 'Agent A',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  status: 'stopped',
+  containerPort: null,
+  dashboards: [{ slug: 'sales', name: 'Sales' }],
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('useStartAgent', () => {
+  let queryClient: QueryClient
+  let serverAgent: ApiAgent
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    serverAgent = { ...stoppedAgent }
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    mocks.apiFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/agents/agent-a/start' && init?.method === 'POST') {
+        serverAgent = { ...serverAgent, status: 'running', containerPort: 3456 }
+        return jsonResponse(serverAgent)
+      }
+      if (url === '/api/agents') return jsonResponse([serverAgent])
+      if (url === '/api/agents/agent-a') return jsonResponse(serverAgent)
+      throw new Error(`Unexpected request: ${url}`)
+    })
+  })
+
+  function wrapper({ children }: PropsWithChildren) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+
+  function useStartHarness() {
+    const list = useAgents()
+    const detail = useAgent('agent-a')
+    const start = useStartAgent()
+    return { list, detail, start }
+  }
+
+  it('publishes the running status to list and detail consumers after health succeeds', async () => {
+    const { result } = renderHook(useStartHarness, { wrapper })
+    await waitFor(() => expect(result.current.detail.data?.status).toBe('stopped'))
+    mocks.apiFetch.mockClear()
+
+    await act(async () => {
+      await result.current.start.mutateAsync('agent-a')
+    })
+
+    await waitFor(() => {
+      expect(result.current.list.data?.[0]).toMatchObject({ status: 'running', containerPort: 3456 })
+      expect(result.current.detail.data).toMatchObject({ status: 'running', containerPort: 3456 })
+    })
+    expect(mocks.track).toHaveBeenCalledWith('agent_started')
+    expect(mocks.apiFetch.mock.calls.map(([url]) => url)).toEqual(['/api/agents/agent-a/start'])
+  })
+
+  it('does not record speculative warm starts as user starts', async () => {
+    const { result } = renderHook(() => useStartAgent(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({ slug: 'agent-a', source: 'warm-start' })
+    })
+
+    expect(mocks.track).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/agent-cache.test.ts
+++ b/src/renderer/lib/agent-cache.test.ts
@@ -1,0 +1,86 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import type { ApiAgent } from '@shared/lib/types/api'
+import { invalidateAgentArtifacts, markDashboardScreenshotReady, updateAgentRuntimeCache } from './agent-cache'
+
+const agent: ApiAgent = {
+  slug: 'agent-a',
+  displaySlug: 'agent-a-display',
+  name: 'Agent A',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  status: 'stopped',
+  containerPort: null,
+  sessionCount: 7,
+  dashboards: [
+    { slug: 'sales', name: 'Sales' },
+    { slug: 'support', name: 'Support' },
+  ],
+}
+
+function seededClient() {
+  const client = new QueryClient()
+  client.setQueryData(['agents'], [agent, { ...agent, slug: 'agent-b', displaySlug: 'agent-b' }])
+  client.setQueryData(['agents', 'agent-a'], agent)
+  client.setQueryData(['agents', 'agent-a-display'], agent)
+  return client
+}
+
+describe('targeted agent cache updates', () => {
+  it('updates runtime state in list and every cached detail alias without losing summaries', () => {
+    const client = seededClient()
+
+    updateAgentRuntimeCache(client, 'agent-a', 'running', 3456)
+
+    expect(client.getQueryData<ApiAgent[]>(['agents'])?.[0]).toMatchObject({
+      status: 'running',
+      containerPort: 3456,
+      sessionCount: 7,
+    })
+    expect(client.getQueryData<ApiAgent>(['agents', 'agent-a'])).toMatchObject({
+      status: 'running',
+      containerPort: 3456,
+    })
+    expect(client.getQueryData<ApiAgent>(['agents', 'agent-a-display'])).toMatchObject({
+      status: 'running',
+      containerPort: 3456,
+    })
+    expect(client.getQueryData<ApiAgent[]>(['agents'])?.[1].status).toBe('stopped')
+  })
+
+  it('clears a stale port on stop events that carry no port', () => {
+    const client = seededClient()
+    updateAgentRuntimeCache(client, 'agent-a', 'running', 3456)
+
+    updateAgentRuntimeCache(client, 'agent-a', 'stopped')
+
+    expect(client.getQueryData<ApiAgent>(['agents', 'agent-a'])).toMatchObject({
+      status: 'stopped',
+      containerPort: null,
+    })
+  })
+
+  it('marks only the announced dashboard screenshot ready', () => {
+    const client = seededClient()
+
+    markDashboardScreenshotReady(client, 'agent-a', 'sales')
+
+    expect(client.getQueryData<ApiAgent>(['agents', 'agent-a'])?.dashboards).toEqual([
+      { slug: 'sales', name: 'Sales', hasScreenshot: true },
+      { slug: 'support', name: 'Support' },
+    ])
+    expect(client.getQueryData<ApiAgent[]>(['agents'])?.[1].dashboards?.[0]).not.toHaveProperty('hasScreenshot')
+  })
+
+  it('invalidates only the matching agent artifact queries, including its display alias', () => {
+    const client = seededClient()
+    client.setQueryData(['artifacts', 'agent-a'], [])
+    client.setQueryData(['artifacts', 'agent-a-display'], [])
+    client.setQueryData(['artifacts', 'agent-b'], [])
+
+    invalidateAgentArtifacts(client, 'agent-a')
+
+    expect(client.getQueryState(['artifacts', 'agent-a'])?.isInvalidated).toBe(true)
+    expect(client.getQueryState(['artifacts', 'agent-a-display'])?.isInvalidated).toBe(true)
+    expect(client.getQueryState(['artifacts', 'agent-b'])?.isInvalidated).toBe(false)
+  })
+})

--- a/src/renderer/lib/agent-cache.ts
+++ b/src/renderer/lib/agent-cache.ts
@@ -1,0 +1,83 @@
+import type { QueryClient } from '@tanstack/react-query'
+import type { ApiAgent } from '@shared/lib/types/api'
+
+function matchesAgent(agent: ApiAgent, slug: string): boolean {
+  return agent.slug === slug || agent.displaySlug === slug
+}
+
+function updateMatchingAgents(
+  queryClient: QueryClient,
+  slug: string,
+  update: (agent: ApiAgent) => ApiAgent,
+): void {
+  queryClient.setQueryData<ApiAgent[]>(['agents'], (agents) => (
+    agents?.map((agent) => matchesAgent(agent, slug) ? update(agent) : agent)
+  ))
+  queryClient.setQueriesData<ApiAgent>(
+    {
+      predicate: (query) => query.queryKey[0] === 'agents' && query.queryKey.length === 2,
+    },
+    (agent) => agent && matchesAgent(agent, slug) ? update(agent) : agent,
+  )
+}
+
+/** Apply a pushed/command runtime transition without refetching agent summaries. */
+export function updateAgentRuntimeCache(
+  queryClient: QueryClient,
+  slug: string,
+  status: ApiAgent['status'],
+  containerPort?: number | null,
+): void {
+  updateMatchingAgents(queryClient, slug, (agent) => ({
+    ...agent,
+    status,
+    containerPort: status === 'stopped'
+      ? null
+      : containerPort === undefined
+        ? agent.containerPort
+        : containerPort,
+  }))
+}
+
+/** Invalidate artifact queries for one agent, including decorative route aliases. */
+export function invalidateAgentArtifacts(queryClient: QueryClient, slug: string): void {
+  const aliases = new Set([slug])
+  const addAliases = (agent: ApiAgent | undefined) => {
+    if (!agent || !matchesAgent(agent, slug)) return
+    aliases.add(agent.slug)
+    aliases.add(agent.displaySlug)
+  }
+  queryClient.getQueryData<ApiAgent[]>(['agents'])?.forEach(addAliases)
+  for (const [, agent] of queryClient.getQueriesData<ApiAgent>({
+    predicate: (query) => query.queryKey[0] === 'agents' && query.queryKey.length === 2,
+  })) {
+    addAliases(agent)
+  }
+
+  queryClient.invalidateQueries({
+    predicate: (query) => (
+      query.queryKey[0] === 'artifacts'
+      && typeof query.queryKey[1] === 'string'
+      && aliases.has(query.queryKey[1])
+    ),
+  })
+}
+
+/** Mark one dashboard thumbnail ready in every cached projection of its agent. */
+export function markDashboardScreenshotReady(
+  queryClient: QueryClient,
+  agentSlug: string,
+  dashboardSlug: string,
+): void {
+  updateMatchingAgents(queryClient, agentSlug, (agent) => {
+    if (!agent.dashboards?.some((dashboard) => dashboard.slug === dashboardSlug)) return agent
+    return {
+      ...agent,
+      dashboards: agent.dashboards.map((dashboard) => (
+        dashboard.slug === dashboardSlug
+          ? { ...dashboard, hasScreenshot: true }
+          : dashboard
+      )),
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- replace eight post-start full-agent invalidation waves with synchronous list/detail cache updates
- patch agent status SSE events directly and invalidate artifacts only for the affected agent
- publish a precise, authenticated screenshot-ready event so dashboard thumbnails update without time-based refetches

## Measured impact

The same throwaway hook profiler measured:

- before: 8 broad agent invalidations, 0 direct cache writes
- after: 0 broad agent invalidations, 3 direct cache writes
- delta: 100% of the successful-start mutation full-agent refresh waves removed

The status SSE path also drops its broad agent-list invalidation. Existing 60-second polling remains as recovery if a best-effort screenshot event cannot be delivered.

## Verification

- 28 focused renderer/API tests
- 50 container dashboard/event tests
- root TypeScript and targeted ESLint
- root web/API production build
- agent-container production build
- git diff check

## Risk

Low-medium. Cache helpers preserve summary fields and cover canonical/display aliases. The container event is scoped by the existing proxy token, rejects cross-agent calls and malformed dashboard slugs, and never blocks screenshot capture or startup.
