### PR TITLE
perf(api): deduplicate session summary scans

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -4817,6 +4817,28 @@ describe('GET /api/agents (enriched summary)', () => {
     // Summary fields should be present even in auth mode
     expect(body[0]).toHaveProperty('hasActiveSessions')
     expect(body[0]).toHaveProperty('dashboards')
+    expect(getAgentWithStatus).toHaveBeenCalledWith('agent-1', { includeSummary: false })
+  })
+
+  it('loads a single agent without a redundant service summary pass', async () => {
+    const { getAgentWithStatus } = await import('@shared/lib/services/agent-service')
+    vi.mocked(getAgentWithStatus).mockResolvedValue(baseAgent)
+    vi.mocked(getSessionSummary).mockResolvedValue({
+      sessionIds: ['sess-1'],
+      sessionCount: 1,
+      lastActivityAt: new Date('2026-01-01T12:00:00Z'),
+    })
+
+    const res = await getReq(app, '/api/agents/agent-1')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({
+      slug: 'agent-1',
+      sessionCount: 1,
+      lastActivityAt: '2026-01-01T12:00:00.000Z',
+    })
+    expect(getAgentWithStatus).toHaveBeenCalledWith('agent-1', { includeSummary: false })
+    expect(getSessionSummary).toHaveBeenCalledTimes(1)
   })
 
   it('sorts the auth-mode list newest-first', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -967,7 +967,10 @@ agents.get('/', async (c) => {
         .where(eq(agentAcl.userId, userId))
       const agentLimit = pLimit(10)
       const agents = await Promise.all(
-        rows.map((r) => agentLimit(() => getAgentWithStatus(r.agentSlug)))
+        rows.map((r) => agentLimit(() => getAgentWithStatus(
+          r.agentSlug,
+          { includeSummary: false },
+        )))
       )
       agentList = agents.filter((a): a is ApiAgent => a !== null)
       // The ACL query has no ORDER BY, so rows arrive in index-scan order — i.e.
@@ -1016,7 +1019,7 @@ agents.post('/', async (c) => {
 agents.get('/:id', ResolveAgent(), AgentRead(), async (c) => {
   try {
     const slug = getAgentId(c)
-    const agent = await getAgentWithStatus(slug)
+    const agent = await getAgentWithStatus(slug, { includeSummary: false })
 
     if (!agent) {
       return c.json({ error: 'Agent not found' }, 404)

--- a/src/shared/lib/services/agent-service.test.ts
+++ b/src/shared/lib/services/agent-service.test.ts
@@ -165,6 +165,10 @@ Instructions
       expect(agent).not.toBeNull()
       expect(agent?.status).toBe('stopped')
       expect(agent?.containerPort).toBeNull()
+      expect(agent?.sessionCount).toBe(0)
+      expect(agent?.lastActivityAt).toBeNull()
+      expect(agent?.hasActiveSessions).toBe(false)
+      expect(agent?.hasSessionsAwaitingInput).toBe(false)
     })
 
     it('returns agent with running status when container is running', async () => {

--- a/src/shared/lib/services/agent-service.ts
+++ b/src/shared/lib/services/agent-service.ts
@@ -143,9 +143,9 @@ export async function getAgentWithStatus(
   const info = containerManager.getCachedInfo(slug)
   const base = toApiAgent(agent, info.status, info.port)
 
-  // Command endpoints such as /start only need the identity + runtime state.
-  // Avoid restatting every transcript to populate optional summary fields that
-  // their callers discard; list/detail reads retain the enriched default.
+  // Routes that either discard the body (/start) or immediately run the richer
+  // enrichAgentsWithSummary pass (list/detail) skip this otherwise-duplicate
+  // O(session-count) stat scan; standalone callers keep the enriched default.
   if (options.includeSummary === false) return base
 
   // Compute session activity flags (same logic as the list endpoint)


### PR DESCRIPTION
## Summary

- let callers that immediately run full agent enrichment skip the lighter service-level session summary
- use that opt-out for authenticated agent lists and single-agent detail reads
- preserve the existing summary behavior by default for start and standalone service callers

## Measured impact

A real-filesystem profiler ran the detail pipeline over 2,000 owned transcript files for nine iterations:

- filesystem stats per request: 4,003.11 → 2,002.11 (-50.0%)
- median: 99.63 ms → 45.23 ms (-54.6%)
- mean: 102.20 ms → 47.44 ms (-53.6%)

Reports: `/private/tmp/superagent-session-summary-before.json` and `/private/tmp/superagent-session-summary-after.json`.

## Verification

- 475 focused agent-service, session-service, and route tests
- TypeScript
- targeted ESLint
- API production build
- git diff check

## Risk

Low. The option is additive and defaults to the old behavior. Only routes that immediately restore the richer summary through `enrichAgentsWithSummary` opt out. Tests cover the default contract, auth listing, and detail response.

## Related draft

#689 independently uses the same additive `includeSummary` option for the start command. This PR aligns with that API so the shared hunk can collapse cleanly whichever change lands first.
