### PR TITLE
perf(renderer): defer browser folder zipper

### DIFF
--- a/src/renderer/lib/browser-zip.ts
+++ b/src/renderer/lib/browser-zip.ts
@@ -1,0 +1,3 @@
+// Keep the dynamically loaded browser-upload chunk tree-shaken to the one
+// fflate primitive we use. Importing the package namespace pulls every export.
+export { zip } from 'fflate'

--- a/src/renderer/lib/file-utils.folder-upload.test.ts
+++ b/src/renderer/lib/file-utils.folder-upload.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { strFromU8, unzipSync } from 'fflate'
 import {
   getFolderFromDirectoryInput,
   getItemsFromDataTransfer,
@@ -323,6 +324,9 @@ describe('zipFolderFiles', () => {
     expect(blob).toBeInstanceOf(Blob)
     expect(blob.type).toBe('application/zip')
     expect(blob.size).toBeGreaterThan(0)
+    const entries = unzipSync(new Uint8Array(await blob.arrayBuffer()))
+    expect(strFromU8(entries['folder/a.txt'])).toBe('hello')
+    expect(strFromU8(entries['folder/b.txt'])).toBe('world')
   })
 
   it('handles empty file list', async () => {

--- a/src/renderer/lib/file-utils.ts
+++ b/src/renderer/lib/file-utils.ts
@@ -1,4 +1,3 @@
-import { zip } from 'fflate'
 import { canUseHostFeatures } from './host-features'
 
 /**
@@ -181,12 +180,20 @@ export function getFolderFromDirectoryInput(files: FileList): FolderGroup | null
 export async function zipFolderFiles(
   files: { file: File; relativePath: string }[]
 ): Promise<Blob> {
-  // Read files sequentially to avoid memory spikes from parallel reads
-  const data: Record<string, Uint8Array> = {}
-  for (const f of files) {
-    const buffer = await f.file.arrayBuffer()
-    data[f.relativePath] = new Uint8Array(buffer)
-  }
+  // Load the browser-only zipper on demand, in parallel with sequential file
+  // reads. Electron hands the host a folder path and never needs this module.
+  const [{ zip }, data] = await Promise.all([
+    import('./browser-zip'),
+    (async () => {
+      // Read files sequentially to avoid memory spikes from parallel reads.
+      const contents: Record<string, Uint8Array> = {}
+      for (const f of files) {
+        const buffer = await f.file.arrayBuffer()
+        contents[f.relativePath] = new Uint8Array(buffer)
+      }
+      return contents
+    })(),
+  ])
 
   const zipped = await new Promise<Uint8Array>((resolve, reject) => {
     zip(data, { level: 0 }, (err, result) => {


### PR DESCRIPTION
## Summary

- remove `fflate` from the normal message-composer static graph
- load the browser zipper only when a web folder upload actually needs it
- keep the deferred chunk tree-shaken through a one-export wrapper and overlap loading with sequential file reads

## Measured impact

Source-map and manifest analysis of identical production Vite builds:

- composer chunk: 374,109 → 362,981 bytes (-3.0%)
- composer chunk gzip: 133,870 → 128,453 bytes (-4.0%)
- composer static closure gzip: 593,835 → 588,420 bytes (-5,415)
- deferred zipper: 11,064 bytes / 5,511 bytes gzip
- combined gzip when folder upload is actually used: +94 bytes (+0.07%)

The initial Home closure is unchanged because route splitting already keeps the composer off initial boot. The saving applies whenever agent Home/session composer code loads without a web folder upload.

## Verification

- 61 focused file, folder-upload, attachment, and composer tests
- generated zip is opened and both file paths/contents are asserted
- TypeScript and targeted ESLint
- source-mapped production Vite build
- git diff check

## Risk

Very low. The dynamic load is local to the existing browser fallback; Electron passes a host folder path and never enters it. Sequential read behavior and store-only async zipping are unchanged.
