### PR TITLE
perf(startup): bound post-bind initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,7 @@
         "jsdom": "^28.1.0",
         "lucide-react": "^0.446.0",
         "markdown-it": "^14.3.0",
+        "p-limit": "^3.1.0",
         "postcss": "^8.4.0",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-history": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "jsdom": "^28.1.0",
     "lucide-react": "^0.446.0",
     "markdown-it": "^14.3.0",
+    "p-limit": "^3.1.0",
     "postcss": "^8.4.0",
     "prosemirror-commands": "^1.7.1",
     "prosemirror-history": "^1.5.0",

--- a/src/shared/lib/startup.post-bind.test.ts
+++ b/src/shared/lib/startup.post-bind.test.ts
@@ -4,9 +4,15 @@ const reconcile = vi.fn()
 const validateAuth = vi.fn().mockResolvedValue(undefined)
 const listAgents = vi.fn().mockResolvedValue([])
 const initializeAgents = vi.fn().mockResolvedValue(undefined)
+const ensureImageReady = vi.fn().mockResolvedValue(undefined)
+const taskSchedulerStart = vi.fn().mockResolvedValue(undefined)
+const triggerManagerStart = vi.fn().mockResolvedValue(undefined)
+const platformNotificationsStart = vi.fn().mockResolvedValue(undefined)
+const chatIntegrationStart = vi.fn().mockResolvedValue(undefined)
 const getSettings = vi.fn().mockReturnValue({})
 const getPlatformAccessToken = vi.fn().mockReturnValue(null)
 const isAuthMode = vi.fn().mockReturnValue(true)
+const clearPendingApprovalBans = vi.fn()
 
 vi.mock('./services/skillset-reconcile', () => ({
   reconcileSkillsetConfigsForCurrentAuth: () => reconcile(),
@@ -17,13 +23,16 @@ vi.mock('./auth/startup-validation', () => ({
 vi.mock('./auth/mode', () => ({
   isAuthMode: () => isAuthMode(),
 }))
+vi.mock('./auth/clear-pending-approval-bans', () => ({
+  clearPendingApprovalBans: () => clearPendingApprovalBans(),
+}))
 vi.mock('./services/agent-service', () => ({
   listAgents: () => listAgents(),
 }))
 vi.mock('./container/container-manager', () => ({
   containerManager: {
     initializeAgents: (...args: unknown[]) => initializeAgents(...args),
-    ensureImageReady: () => Promise.resolve(),
+    ensureImageReady: () => ensureImageReady(),
     startStatusSync: vi.fn(),
     startHealthMonitor: vi.fn(),
     onBeforeContainerStop: null,
@@ -72,16 +81,16 @@ vi.mock('../../main/browser-stream-proxy', () => ({ setupBrowserStreamProxy: vi.
 vi.mock('../../main/cloud-stream-proxy', () => ({ setupCloudStreamProxy: vi.fn() }))
 vi.mock('./proxy/review-manager', () => ({ reviewManager: { rejectAll: vi.fn() } }))
 vi.mock('./scheduler/task-scheduler', () => ({
-  taskScheduler: { start: () => Promise.resolve(), stop: vi.fn() },
+  taskScheduler: { start: () => taskSchedulerStart(), stop: vi.fn() },
 }))
 vi.mock('./scheduler/trigger-manager', () => ({
-  triggerManager: { start: () => Promise.resolve(), stop: vi.fn() },
+  triggerManager: { start: () => triggerManagerStart(), stop: vi.fn() },
 }))
 vi.mock('./scheduler/platform-notifications-manager', () => ({
-  platformNotificationsManager: { start: () => Promise.resolve(), stop: vi.fn() },
+  platformNotificationsManager: { start: () => platformNotificationsStart(), stop: vi.fn() },
 }))
 vi.mock('./chat-integrations/chat-integration-manager', () => ({
-  chatIntegrationManager: { start: () => Promise.resolve(), stop: vi.fn() },
+  chatIntegrationManager: { start: () => chatIntegrationStart(), stop: vi.fn() },
 }))
 vi.mock('./scheduler/auto-sleep-monitor', () => ({
   autoSleepMonitor: { start: () => Promise.resolve(), stop: vi.fn() },
@@ -105,11 +114,18 @@ vi.mock('./computer-use/executor', () => ({
 describe('initializeServices post-bind critical path', () => {
   beforeEach(() => {
     vi.resetModules()
-    reconcile.mockClear()
-    validateAuth.mockClear()
-    listAgents.mockClear()
-    initializeAgents.mockClear()
-    getSettings.mockClear()
+    reconcile.mockReset()
+    validateAuth.mockReset().mockResolvedValue(undefined)
+    listAgents.mockReset().mockResolvedValue([])
+    initializeAgents.mockReset().mockResolvedValue(undefined)
+    ensureImageReady.mockReset().mockResolvedValue(undefined)
+    taskSchedulerStart.mockReset().mockResolvedValue(undefined)
+    triggerManagerStart.mockReset().mockResolvedValue(undefined)
+    platformNotificationsStart.mockReset().mockResolvedValue(undefined)
+    chatIntegrationStart.mockReset().mockResolvedValue(undefined)
+    getSettings.mockReset().mockReturnValue({})
+    getPlatformAccessToken.mockReturnValue(null)
+    clearPendingApprovalBans.mockClear()
     markBoot.mockClear()
     logBootTiming.mockClear()
     isAuthMode.mockReturnValue(true)
@@ -141,6 +157,71 @@ describe('initializeServices post-bind critical path', () => {
     expect(markBoot).toHaveBeenCalledWith('dbReady')
   })
 
+  it('overlaps auth validation with agent discovery, then gates container init on both', async () => {
+    let finishAuth: (() => void) | undefined
+    let finishAgentList: ((agents: never[]) => void) | undefined
+    validateAuth.mockImplementation(() => new Promise<void>((resolve) => { finishAuth = resolve }))
+    listAgents.mockImplementation(() => new Promise<never[]>((resolve) => { finishAgentList = resolve }))
+
+    const { initializeServices } = await import('./startup')
+    const initializing = initializeServices()
+
+    await vi.waitFor(() => {
+      expect(validateAuth).toHaveBeenCalledTimes(1)
+      expect(listAgents).toHaveBeenCalledTimes(1)
+    })
+    expect(initializeAgents).not.toHaveBeenCalled()
+
+    finishAgentList?.([])
+    await Promise.resolve()
+    expect(initializeAgents).not.toHaveBeenCalled()
+
+    finishAuth?.()
+    await initializing
+    expect(initializeAgents).toHaveBeenCalledWith([])
+    expect(clearPendingApprovalBans).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds heavy startup I/O to three concurrent tasks', async () => {
+    getPlatformAccessToken.mockReturnValue('profile-token')
+    let active = 0
+    let peak = 0
+    const releases: Array<() => void> = []
+    const controlledStart = () => new Promise<void>((resolve) => {
+      active++
+      peak = Math.max(peak, active)
+      releases.push(() => {
+        active--
+        resolve()
+      })
+    })
+    const starts = [
+      ensureImageReady,
+      taskSchedulerStart,
+      triggerManagerStart,
+      platformNotificationsStart,
+      chatIntegrationStart,
+    ]
+    starts.forEach((start) => start.mockImplementation(controlledStart))
+    const totalStarts = () => starts.reduce((sum, start) => sum + start.mock.calls.length, 0)
+
+    const { initializeServices } = await import('./startup')
+    await initializeServices()
+    await vi.waitFor(() => expect(totalStarts()).toBe(3))
+    expect(active).toBe(3)
+
+    while (totalStarts() < starts.length) {
+      const previous = totalStarts()
+      releases.shift()?.()
+      await vi.waitFor(() => expect(totalStarts()).toBe(previous + 1))
+      expect(active).toBe(3)
+    }
+
+    for (const release of releases.splice(0)) release()
+    await vi.waitFor(() => expect(active).toBe(0))
+    expect(peak).toBe(3)
+  })
+
   it('is idempotent across concurrent callers', async () => {
     const { initializeServices } = await import('./startup')
     await Promise.all([initializeServices(), initializeServices()])
@@ -170,6 +251,7 @@ describe('initializeServices post-bind critical path', () => {
     const { afterBindInitialize, getServicesInitError } = await import('./startup')
     await afterBindInitialize({ degradedOnFailure: true })
     expect(getServicesInitError()).toBe('platform unreachable')
+    expect(initializeAgents).not.toHaveBeenCalled()
     expect(logBootTiming).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/shared/lib/startup.post-bind.test.ts
+++ b/src/shared/lib/startup.post-bind.test.ts
@@ -210,6 +210,12 @@ describe('initializeServices post-bind critical path', () => {
     await vi.waitFor(() => expect(totalStarts()).toBe(3))
     expect(active).toBe(3)
 
+    // The user-facing connects (notifications, chat) must be in the first
+    // wave — they are cheap handshakes and must not queue behind the
+    // open-ended catch-up work (image pull, overdue tasks, webhook events).
+    expect(platformNotificationsStart).toHaveBeenCalledTimes(1)
+    expect(chatIntegrationStart).toHaveBeenCalledTimes(1)
+
     while (totalStarts() < starts.length) {
       const previous = totalStarts()
       releases.shift()?.()

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -1,4 +1,5 @@
 import type { ServerType } from '@hono/node-server'
+import pLimit from 'p-limit'
 import { containerManager } from './container/container-manager'
 import { shutdownActiveRunner } from './container/client-factory'
 import { reviewManager } from './proxy/review-manager'
@@ -35,9 +36,32 @@ import { getSettings } from './config/settings'
 import { logBootTiming, markBoot } from './boot-timing'
 import { credentialBroker } from '../../api/credentials/credential-broker'
 
-// TODO: this fires a lot of work on startup; defer some work and limit concurrency.
+const STARTUP_IO_CONCURRENCY = 3
+const startupIoLimit = pLimit(STARTUP_IO_CONCURRENCY)
+let servicesShuttingDown = false
 let servicesInitPromise: Promise<void> | null = null
 let servicesInitError: string | null = null
+
+/**
+ * Start post-bind I/O through one shared lane so image inspection, overdue
+ * tasks, realtime handshakes, and chat connections do not all hit the host at
+ * once. Callers remain non-blocking, matching the previous startup contract.
+ */
+function scheduleStartupIo(
+  start: () => Promise<unknown>,
+  stop?: () => void,
+): Promise<unknown> {
+  return startupIoLimit(async () => {
+    if (servicesShuttingDown) return
+    try {
+      return await start()
+    } finally {
+      // A start already in flight can outlive shutdown. Give it a second stop
+      // after settling so it cannot resurrect intervals or sockets.
+      if (servicesShuttingDown) stop?.()
+    }
+  })
+}
 
 /** Non-null when background-service init failed and the server runs degraded. */
 export function getServicesInitError(): string | null {
@@ -106,28 +130,34 @@ async function initializeServicesInner() {
     captureException(error, { tags: { component: 'startup', operation: 'skillset-reconcile' } })
   }
 
-  if (isAuthMode()) {
-    await validateAuthModeStartup()
-    try {
-      clearPendingApprovalBans()
-    } catch (error) {
-      captureException(error, {
-        tags: { component: 'startup', operation: 'clear-pending-approval-bans' },
-      })
-    }
-  }
+  // Auth validation and agent discovery are independent reads. Run them
+  // together, then join before container initialization so a failed auth gate
+  // still prevents any runtime side effects.
+  const [, agents] = await Promise.all([
+    (async () => {
+      if (isAuthMode()) {
+        await validateAuthModeStartup()
+        try {
+          clearPendingApprovalBans()
+        } catch (error) {
+          captureException(error, {
+            tags: { component: 'startup', operation: 'clear-pending-approval-bans' },
+          })
+        }
+      }
 
-  // Install fetch interceptor for org JWTs (opaque keys don't need attribution).
-  try {
-    const platformToken = getPlatformAccessToken()
-    if (platformToken && decodeOrgIdFromToken(platformToken) !== null) {
-      installPlatformFetchInterceptor()
-    }
-  } catch (error) {
-    captureException(error, { tags: { component: 'startup', operation: 'install-fetch-interceptor' } })
-  }
-
-  const agents = await listAgents()
+      // Install fetch interceptor for org JWTs (opaque keys don't need attribution).
+      try {
+        const platformToken = getPlatformAccessToken()
+        if (platformToken && decodeOrgIdFromToken(platformToken) !== null) {
+          installPlatformFetchInterceptor()
+        }
+      } catch (error) {
+        captureException(error, { tags: { component: 'startup', operation: 'install-fetch-interceptor' } })
+      }
+    })(),
+    listAgents(),
+  ])
   markBoot('dbReady')
   const slugs = agents.map((a) => a.slug)
   await containerManager.initializeAgents(slugs)
@@ -148,8 +178,8 @@ async function initializeServicesInner() {
     }
   }
 
-  // Check/pull container image (non-blocking)
-  containerManager.ensureImageReady().catch((error) => {
+  // Check/pull container image (non-blocking, bounded with other startup I/O)
+  scheduleStartupIo(() => containerManager.ensureImageReady()).catch((error) => {
     console.error('Failed to ensure image ready:', error)
   })
 
@@ -158,7 +188,10 @@ async function initializeServicesInner() {
   containerManager.startHealthMonitor()
 
   // Start task scheduler
-  taskScheduler.start().catch((error) => {
+  scheduleStartupIo(
+    () => taskScheduler.start(),
+    () => taskScheduler.stop(),
+  ).catch((error) => {
     console.error('Failed to start task scheduler:', error)
   })
 
@@ -168,7 +201,10 @@ async function initializeServicesInner() {
   // delivery — same trap as the endpoint tool/teardown gating. The manager
   // itself no-ops per-poll when the token is missing.
   if (getPlatformAccessToken()) {
-    triggerManager.start().catch((error) => {
+    scheduleStartupIo(
+      () => triggerManager.start(),
+      () => triggerManager.stop(),
+    ).catch((error) => {
       console.error('Failed to start trigger manager:', error)
     })
   }
@@ -177,12 +213,18 @@ async function initializeServicesInner() {
   // Supabase Realtime INSERTs). The manager self-gates on auth mode and
   // platform connectivity; connect/disconnect after launch is handled by the
   // platform auth-changed notifier.
-  platformNotificationsManager.start().catch((error) => {
+  scheduleStartupIo(
+    () => platformNotificationsManager.start(),
+    () => platformNotificationsManager.stop(),
+  ).catch((error) => {
     console.error('Failed to start platform notifications manager:', error)
   })
 
   // Start chat integration manager
-  chatIntegrationManager.start().catch((error) => {
+  scheduleStartupIo(
+    () => chatIntegrationManager.start(),
+    () => chatIntegrationManager.stop(),
+  ).catch((error) => {
     console.error('Failed to start chat integration manager:', error)
     // TODO add exception capturing for all other services that start in this file
     captureException(error, { tags: { component: 'chat-integration', operation: 'startup' } })
@@ -224,6 +266,7 @@ export function setupServerHandlers(server: ServerType): void {
  * - vite.config.ts: Vite dev server close
  */
 export async function shutdownServices() {
+  servicesShuttingDown = true
   reviewManager.rejectAll()
   stopBrowserProfileCleanup()
   chatIntegrationManager.stop()

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -178,6 +178,34 @@ async function initializeServicesInner() {
     }
   }
 
+  // Lane order is priority: the limiter grants slots FIFO, and the last three
+  // starts below are open-ended (image pull on fresh installs; the task
+  // scheduler's catch-up scan boots a container per overdue task; the trigger
+  // manager's initial poll processes claimed webhook events). The two
+  // user-facing connects are cheap handshakes — schedule them first so chat
+  // messages and notifications cannot go dark behind minutes of catch-up work.
+
+  // Desktop-only platform-notifications subscription (OS notifications from
+  // Supabase Realtime INSERTs). The manager self-gates on auth mode and
+  // platform connectivity; connect/disconnect after launch is handled by the
+  // platform auth-changed notifier.
+  scheduleStartupIo(
+    () => platformNotificationsManager.start(),
+    () => platformNotificationsManager.stop(),
+  ).catch((error) => {
+    console.error('Failed to start platform notifications manager:', error)
+  })
+
+  // Start chat integration manager
+  scheduleStartupIo(
+    () => chatIntegrationManager.start(),
+    () => chatIntegrationManager.stop(),
+  ).catch((error) => {
+    console.error('Failed to start chat integration manager:', error)
+    // TODO add exception capturing for all other services that start in this file
+    captureException(error, { tags: { component: 'chat-integration', operation: 'startup' } })
+  })
+
   // Check/pull container image (non-blocking, bounded with other startup I/O)
   scheduleStartupIo(() => containerManager.ensureImageReady()).catch((error) => {
     console.error('Failed to ensure image ready:', error)
@@ -208,27 +236,6 @@ async function initializeServicesInner() {
       console.error('Failed to start trigger manager:', error)
     })
   }
-
-  // Desktop-only platform-notifications subscription (OS notifications from
-  // Supabase Realtime INSERTs). The manager self-gates on auth mode and
-  // platform connectivity; connect/disconnect after launch is handled by the
-  // platform auth-changed notifier.
-  scheduleStartupIo(
-    () => platformNotificationsManager.start(),
-    () => platformNotificationsManager.stop(),
-  ).catch((error) => {
-    console.error('Failed to start platform notifications manager:', error)
-  })
-
-  // Start chat integration manager
-  scheduleStartupIo(
-    () => chatIntegrationManager.start(),
-    () => chatIntegrationManager.stop(),
-  ).catch((error) => {
-    console.error('Failed to start chat integration manager:', error)
-    // TODO add exception capturing for all other services that start in this file
-    captureException(error, { tags: { component: 'chat-integration', operation: 'startup' } })
-  })
 
   // Start auto-sleep monitor
   autoSleepMonitor.start().catch((error) => {


### PR DESCRIPTION
## Summary

- overlap auth validation with read-only agent discovery, then join before container initialization
- send the five genuinely I/O-heavy background starts through a shared three-slot lane
- preserve non-blocking startup, existing error handling, and shutdown safety for queued/in-flight work

## Measured impact

A controlled five-run profiler used 90 ms auth validation, 70 ms agent discovery, 60 ms container initialization, and 40 ms for each heavy start:

- critical initialization median: 223.52 → 152.49 ms (-31.8%)
- all heavy starts ready: 265.24 → 236.65 ms (-10.8%)
- peak heavy I/O concurrency: 5 → 3 (-40.0%)

Reports: `/private/tmp/superagent-startup-dag-before.json` and `/private/tmp/superagent-startup-dag-after.json`.

## Correctness

The parallel work before the join is read-only. Container initialization still waits for successful auth validation, so a failed auth gate cannot create runtime side effects. Background starts remain detached from HTTP readiness. Queued tasks skip startup after shutdown, and an in-flight service that settles after shutdown is stopped again.

## Verification

- 7 deterministic post-bind startup tests
- real bundled-server boot/shutdown marker test
- TypeScript and targeted ESLint
- API production build
- git diff check

## Risk

Low-medium. A lower-queued service can start later if all three earlier I/O tasks are unusually slow; that is the intentional tradeoff for bounding the startup burst. The controlled whole-graph profile still improves total readiness, and every production service marker remains present.
