### PR TITLE
perf: cache warm per-agent session summaries

### DIFF
--- a/src/api/routes/x-agent-chat.ts
+++ b/src/api/routes/x-agent-chat.ts
@@ -25,6 +25,7 @@ import {
   type ChatProvider,
 } from '@shared/lib/chat-integrations/config-schema'
 import { getSessionJsonlPath } from '@shared/lib/utils/file-storage'
+import { recordSessionActivity } from '@shared/lib/services/session-summary-cache'
 import { captureException } from '@shared/lib/error-reporting'
 import { isChatAllowed } from '@shared/lib/services/chat-integration-access-service'
 
@@ -452,6 +453,9 @@ async function notifySessionOfOutboundMessage(
   } catch {
     appendAssistantMessage(agentSlug, sessionId, notificationText)
   }
+  // Both paths advance the transcript without emitting the stream frames the
+  // message persister watches, so the warm summary must be told directly.
+  recordSessionActivity(agentSlug, sessionId)
 }
 
 function appendAssistantMessage(agentSlug: string, sessionId: string, text: string): void {

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -38,6 +38,9 @@ vi.mock('@shared/lib/services/session-service', () => ({
   getSessionMetadata: vi.fn(() => Promise.resolve(null)),
   finalizeAutomationStatus: vi.fn(() => Promise.resolve('updated')),
 }))
+vi.mock('@shared/lib/services/session-summary-cache', () => ({
+  recordSessionActivity: vi.fn(),
+}))
 vi.mock('@shared/lib/services/session-transcript-append', () => ({
   appendInformationalEntry: vi.fn(() => Promise.resolve()),
 }))

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -311,17 +311,18 @@ describe('MessagePersister', () => {
       expect(mockRecordSessionActivity).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, timestamp)
     })
 
-    it('uses replay timestamps to repair the cache without treating replay as new activity', () => {
-      const timestamp = new Date('2026-08-07T17:00:00.000Z')
-
+    it('ignores replayed catch-up frames whose host timestamp is arrival time', () => {
+      // On the wire, SDK result frames carry no timestamp field, so the host
+      // stamps Date.now() at arrival — a reconnect replay recorded here would
+      // fabricate recency for a session that did nothing.
       mockClient._messageCallback!({
         type: 'message',
         content: { type: 'result', subtype: 'success', replayed: true },
-        timestamp,
+        timestamp: new Date('2026-08-07T17:00:00.000Z'),
         sessionId: SESSION_ID,
       })
 
-      expect(mockRecordSessionActivity).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, timestamp)
+      expect(mockRecordSessionActivity).not.toHaveBeenCalled()
     })
 
     it('does not attribute a sidechain transcript frame to the parent session', () => {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -28,6 +28,10 @@ vi.mock('@shared/lib/services/session-service', () => ({
   getSessionMetadata: vi.fn(() => Promise.resolve(null)),
   finalizeAutomationStatus: vi.fn(() => Promise.resolve('updated')),
 }))
+const mockRecordSessionActivity = vi.fn()
+vi.mock('@shared/lib/services/session-summary-cache', () => ({
+  recordSessionActivity: (...args: unknown[]) => mockRecordSessionActivity(...args),
+}))
 const mockAppendInformationalEntry = vi.fn((..._args: unknown[]) => Promise.resolve())
 vi.mock('@shared/lib/services/session-transcript-append', () => ({
   appendInformationalEntry: (...args: unknown[]) => mockAppendInformationalEntry(...args),
@@ -291,6 +295,45 @@ describe('MessagePersister', () => {
     sseCleanup()
     messagePersister.unsubscribeFromSession(SESSION_ID)
     vi.clearAllMocks()
+  })
+
+  describe('session summary activity', () => {
+    it('records complete top-level transcript frames with their source timestamp', () => {
+      const timestamp = new Date('2026-08-07T18:00:00.000Z')
+
+      mockClient._messageCallback!({
+        type: 'message',
+        content: { type: 'assistant', message: { role: 'assistant', content: 'done' } },
+        timestamp,
+        sessionId: SESSION_ID,
+      })
+
+      expect(mockRecordSessionActivity).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, timestamp)
+    })
+
+    it('uses replay timestamps to repair the cache without treating replay as new activity', () => {
+      const timestamp = new Date('2026-08-07T17:00:00.000Z')
+
+      mockClient._messageCallback!({
+        type: 'message',
+        content: { type: 'result', subtype: 'success', replayed: true },
+        timestamp,
+        sessionId: SESSION_ID,
+      })
+
+      expect(mockRecordSessionActivity).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, timestamp)
+    })
+
+    it('does not attribute a sidechain transcript frame to the parent session', () => {
+      mockClient._messageCallback!({
+        type: 'message',
+        content: { type: 'assistant', parent_tool_use_id: 'tool-1' },
+        timestamp: new Date('2026-08-07T19:00:00.000Z'),
+        sessionId: SESSION_ID,
+      })
+
+      expect(mockRecordSessionActivity).not.toHaveBeenCalled()
+    })
   })
 
   // ============================================================================

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -66,6 +66,7 @@ import { eq } from 'drizzle-orm'
 import { resolveTimezoneForAgent } from '@shared/lib/services/timezone-resolver'
 import { getFrequencyWarning, getScheduleCountWarning, validateScheduleExpression } from '@shared/lib/services/schedule-parser'
 import { finalizeAutomationStatus, getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { recordSessionActivity } from '@shared/lib/services/session-summary-cache'
 import { isHiddenAutomatedSession } from '@shared/lib/services/session-visibility'
 import { appendInformationalEntry } from '@shared/lib/services/session-transcript-append'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
@@ -1406,6 +1407,17 @@ class MessagePersister {
     if (content.parent_tool_use_id != null) {
       this.handleSidechainMessage(sessionId, content, state)
       return
+    }
+
+    // Complete top-level frames correspond to durable parent-transcript writes.
+    // Keep the warm per-agent summary current without restatting every sibling;
+    // replay uses the original timestamp, so reconnect repair cannot masquerade
+    // as new activity.
+    if (
+      state.agentSlug &&
+      (content.type === 'assistant' || content.type === 'user' || content.type === 'result')
+    ) {
+      recordSessionActivity(state.agentSlug, sessionId, message.timestamp)
     }
 
     // Container late-join catch-up: the runtime replays the last turn's

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1410,11 +1410,14 @@ class MessagePersister {
     }
 
     // Complete top-level frames correspond to durable parent-transcript writes.
-    // Keep the warm per-agent summary current without restatting every sibling;
-    // replay uses the original timestamp, so reconnect repair cannot masquerade
-    // as new activity.
+    // Keep the warm per-agent summary current without restatting every sibling.
+    // Replayed catch-up frames are excluded: SDK frames carry no timestamp on
+    // the wire, so the host stamps arrival time, and a late-join replay to an
+    // idle session would masquerade as fresh activity — the directory-mtime and
+    // TTL reconciliation already repair anything a missed turn-end left behind.
     if (
       state.agentSlug &&
+      !content.replayed &&
       (content.type === 'assistant' || content.type === 'user' || content.type === 'result')
     ) {
       recordSessionActivity(state.agentSlug, sessionId, message.timestamp)

--- a/src/shared/lib/services/session-service.summary-cache.test.ts
+++ b/src/shared/lib/services/session-service.summary-cache.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as path from 'path'
+import * as os from 'os'
+
+const statProbe = vi.hoisted(() => ({
+  paths: [] as string[],
+  beforeStat: undefined as ((file: string) => Promise<void>) | undefined,
+}))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      stat: (async (...args: Parameters<typeof actual.promises.stat>) => {
+        const file = String(args[0])
+        statProbe.paths.push(file)
+        await statProbe.beforeStat?.(file)
+        return actual.promises.stat(...args)
+      }) as typeof actual.promises.stat,
+    },
+  }
+})
+
+import * as fs from 'fs'
+import {
+  deleteSession,
+  getSessionSummary,
+  registerSession,
+  reserveSessionOwnership,
+} from './session-service'
+import { recordSessionActivity } from './session-summary-cache'
+import { appendInformationalEntry } from './session-transcript-append'
+
+describe('getSessionSummary cache', () => {
+  let testRoot: string
+  let priorDataDir: string | undefined
+  const agentSlug = 'summary-agent'
+
+  const workspaceDir = () => path.join(testRoot, 'agents', agentSlug, 'workspace')
+  const sessionsDir = () => path.join(workspaceDir(), '.claude', 'projects', '-workspace')
+  const transcriptPath = (sessionId: string) => path.join(sessionsDir(), `${sessionId}.jsonl`)
+
+  beforeEach(async () => {
+    testRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'session-summary-cache-'))
+    priorDataDir = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testRoot
+    await fs.promises.mkdir(workspaceDir(), { recursive: true })
+    statProbe.paths.length = 0
+    statProbe.beforeStat = undefined
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    statProbe.beforeStat = undefined
+    if (priorDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = priorDataDir
+    await fs.promises.rm(testRoot, { recursive: true, force: true })
+  })
+
+  async function createSession(sessionId: string, activityAt: string): Promise<void> {
+    await registerSession(agentSlug, sessionId, sessionId)
+    await fs.promises.mkdir(sessionsDir(), { recursive: true })
+    await fs.promises.writeFile(transcriptPath(sessionId), '{}\n')
+    const timestamp = new Date(activityAt)
+    await fs.promises.utimes(transcriptPath(sessionId), timestamp, timestamp)
+  }
+
+  it('serves a warm summary with one directory stat and no transcript stats', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+
+    expect((await getSessionSummary(agentSlug)).sessionCount).toBe(2)
+    statProbe.paths.length = 0
+
+    const warm = await getSessionSummary(agentSlug)
+
+    expect(warm.sessionIds.sort()).toEqual(['session-a', 'session-b'])
+    expect(warm.lastActivityAt).toEqual(new Date('2026-01-02T00:00:00.000Z'))
+    expect(statProbe.paths).toEqual([sessionsDir()])
+  })
+
+  it('reconciles the full map when a transcript is structurally added', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    await createSession('session-b', '2026-01-03T00:00:00.000Z')
+    const changedAt = new Date('2026-02-01T00:00:00.000Z')
+    await fs.promises.utimes(sessionsDir(), changedAt, changedAt)
+    statProbe.paths.length = 0
+
+    const changed = await getSessionSummary(agentSlug)
+
+    expect(changed.sessionIds.sort()).toEqual(['session-a', 'session-b'])
+    expect(changed.lastActivityAt).toEqual(new Date('2026-01-03T00:00:00.000Z'))
+    expect(statProbe.paths.filter((file) => file.endsWith('.jsonl'))).toHaveLength(2)
+  })
+
+  it('reconciles unchanged directory contents when ownership is newly reserved', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await fs.promises.mkdir(sessionsDir(), { recursive: true })
+    await fs.promises.writeFile(transcriptPath('session-b'), '{}\n')
+    expect((await getSessionSummary(agentSlug)).sessionIds).toEqual(['session-a'])
+
+    await reserveSessionOwnership(agentSlug, 'session-b')
+    const summary = await getSessionSummary(agentSlug)
+
+    expect(summary.sessionIds.sort()).toEqual(['session-a', 'session-b'])
+  })
+
+  it('applies observed activity without restatting unchanged sibling transcripts', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+    statProbe.paths.length = 0
+
+    recordSessionActivity(agentSlug, 'session-a', new Date('2026-01-04T12:00:00.000Z'))
+    const updated = await getSessionSummary(agentSlug)
+
+    expect(updated.lastActivityAt).toEqual(new Date('2026-01-04T12:00:00.000Z'))
+    expect(statProbe.paths).toEqual([sessionsDir()])
+  })
+
+  it('does not fabricate a session from an activity signal alone', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    recordSessionActivity(agentSlug, 'not-on-disk', new Date('2030-01-01T00:00:00.000Z'))
+    const summary = await getSessionSummary(agentSlug)
+
+    expect(summary.sessionIds).toEqual(['session-a'])
+    expect(summary.lastActivityAt).toEqual(new Date('2026-01-01T00:00:00.000Z'))
+  })
+
+  it('merges activity observed while the initial filesystem scan is in flight', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    let releaseStat!: () => void
+    let enteredStat!: () => void
+    const held = new Promise<void>((resolve) => { releaseStat = resolve })
+    const entered = new Promise<void>((resolve) => { enteredStat = resolve })
+    statProbe.beforeStat = async (file) => {
+      if (file === transcriptPath('session-a')) {
+        enteredStat()
+        await held
+      }
+    }
+
+    const loading = getSessionSummary(agentSlug)
+    await entered
+    recordSessionActivity(agentSlug, 'session-a', new Date('2026-01-05T00:00:00.000Z'))
+    releaseStat()
+
+    expect((await loading).lastActivityAt).toEqual(new Date('2026-01-05T00:00:00.000Z'))
+  })
+
+  it('observes a host-authored informational append without fabricating replay activity', async () => {
+    const firstActivity = new Date('2030-01-01T00:00:00.000Z').getTime()
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(firstActivity)
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    const entry = { uuid: 'informational-1', content: 'Prompt blocked', level: 'warning' }
+    await appendInformationalEntry(agentSlug, 'session-a', entry)
+    expect((await getSessionSummary(agentSlug)).lastActivityAt).toEqual(new Date(firstActivity))
+
+    clock.mockReturnValue(firstActivity + 1_000)
+    await appendInformationalEntry(agentSlug, 'session-a', entry)
+    expect((await getSessionSummary(agentSlug)).lastActivityAt).toEqual(new Date(firstActivity))
+  })
+
+  it('drops a deleted session from an already-warm summary', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    await deleteSession(agentSlug, 'session-b')
+    const summary = await getSessionSummary(agentSlug)
+
+    expect(summary.sessionIds).toEqual(['session-a'])
+    expect(summary.lastActivityAt).toEqual(new Date('2026-01-01T00:00:00.000Z'))
+  })
+
+  it('periodically rebuilds unchanged directories to recover missed external writes', async () => {
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000)
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    clock.mockReturnValue(1_800_000_000_000 + 10 * 60 * 1000)
+    statProbe.paths.length = 0
+    await getSessionSummary(agentSlug)
+
+    expect(statProbe.paths).toContain(transcriptPath('session-a'))
+  })
+})

--- a/src/shared/lib/services/session-service.summary-cache.test.ts
+++ b/src/shared/lib/services/session-service.summary-cache.test.ts
@@ -181,6 +181,21 @@ describe('getSessionSummary cache', () => {
     expect(summary.lastActivityAt).toEqual(new Date('2026-01-01T00:00:00.000Z'))
   })
 
+  it('omits a transcript deleted between readdir and stat instead of failing the scan', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    statProbe.beforeStat = async (file) => {
+      if (file === transcriptPath('session-b')) {
+        await fs.promises.rm(transcriptPath('session-b'), { force: true })
+      }
+    }
+
+    const summary = await getSessionSummary(agentSlug)
+
+    expect(summary.sessionIds).toEqual(['session-a'])
+    expect(summary.lastActivityAt).toEqual(new Date('2026-01-01T00:00:00.000Z'))
+  })
+
   it('periodically rebuilds unchanged directories to recover missed external writes', async () => {
     const clock = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000)
     await createSession('session-a', '2026-01-01T00:00:00.000Z')

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -600,7 +600,10 @@ async function buildSessionActivityMap(
   const limit = pLimit(10)
   const stats = await Promise.all(
     jsonlFiles.map((file) => limit(async () => {
-      const stat = await fs.promises.stat(path.join(sessionsDir, file))
+      // A transcript deleted between readdir and stat (deleteSession racing a
+      // scan) just drops out of this build instead of failing the whole scan.
+      const stat = await fs.promises.stat(path.join(sessionsDir, file)).catch(() => null)
+      if (!stat) return null
       const sessionId = path.basename(file, '.jsonl')
       if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
       return { sessionId, mtimeMs: stat.mtimeMs }

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -39,6 +39,14 @@ import {
   ContentBlock,
 } from '@shared/lib/types/agent'
 import { captureException } from '@shared/lib/error-reporting'
+import {
+  getSessionSummaryCacheSlot,
+  invalidateSessionSummaryCache,
+  recordSessionActivity,
+  removeSessionFromSummaryCache,
+  SESSION_SUMMARY_CACHE_TTL_MS,
+  type SessionSummaryCacheValue,
+} from './session-summary-cache'
 
 // Session transcripts and metadata live inside the agent workspace, which is
 // bind-mounted read/write into its container. They are therefore evidence that
@@ -150,20 +158,24 @@ async function claimSessionOwnership(agentSlug: string, sessionId: string): Prom
     }
     return false
   })
+  if (newlyClaimed) invalidateSessionSummaryCache(agentSlug)
   return newlyClaimed
 }
 
 async function releaseSessionOwnership(agentSlug: string, sessionIds: string[]): Promise<void> {
+  const released: string[] = []
   await mutateSessionOwnership((owners) => {
     let changed = false
     for (const sessionId of sessionIds) {
       if (owners[sessionId] === agentSlug) {
         delete owners[sessionId]
+        released.push(sessionId)
         changed = true
       }
     }
     return changed
   })
+  for (const sessionId of released) removeSessionFromSummaryCache(agentSlug, sessionId)
 }
 
 async function resolveSessionOwner(sessionId: string): Promise<string | null | undefined> {
@@ -549,24 +561,42 @@ function resolveSessionCreatedAt(
 // Session Operations
 // ============================================================================
 
-/**
- * Lightweight session summary from filesystem stats only (no JSONL parsing).
- * Returns session IDs, count, and latest activity time.
- */
-export async function getSessionSummary(agentSlug: string): Promise<{
+function summaryFromActivityMap(activityBySession: Map<string, number>): {
   sessionIds: string[]
   sessionCount: number
   lastActivityAt: Date | null
-}> {
-  const sessionsDir = getAgentSessionsDir(agentSlug)
-
-  if (!(await directoryExists(sessionsDir))) {
-    return { sessionIds: [], sessionCount: 0, lastActivityAt: null }
+} {
+  const sessionIds = [...activityBySession.keys()]
+  let latestMs: number | null = null
+  for (const activityAtMs of activityBySession.values()) {
+    if (latestMs === null || activityAtMs > latestMs) latestMs = activityAtMs
   }
+  return {
+    sessionIds,
+    sessionCount: sessionIds.length,
+    lastActivityAt: latestMs === null ? null : new Date(latestMs),
+  }
+}
+
+async function getSessionsDirectoryMtime(sessionsDir: string): Promise<number | null> {
+  try {
+    const stat = await fs.promises.stat(sessionsDir)
+    return stat.isDirectory() ? stat.mtimeMs : null
+  } catch {
+    // Preserve directoryExists()'s existing fail-soft behavior.
+    return null
+  }
+}
+
+async function buildSessionActivityMap(
+  agentSlug: string,
+  sessionsDir: string,
+  directoryMtimeMs: number | null,
+): Promise<Map<string, number>> {
+  if (directoryMtimeMs === null) return new Map()
 
   const files = await fs.promises.readdir(sessionsDir)
-  const jsonlFiles = files.filter((f) => f.endsWith('.jsonl'))
-
+  const jsonlFiles = files.filter((file) => file.endsWith('.jsonl'))
   const limit = pLimit(10)
   const stats = await Promise.all(
     jsonlFiles.map((file) => limit(async () => {
@@ -574,21 +604,85 @@ export async function getSessionSummary(agentSlug: string): Promise<{
       const sessionId = path.basename(file, '.jsonl')
       if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
       return { sessionId, mtimeMs: stat.mtimeMs }
-    }))
+    })),
   )
 
-  let lastActivityAt: Date | null = null
-  const sessionIds: string[] = []
+  const activityBySession = new Map<string, number>()
   for (const entry of stats) {
-    if (!entry) continue
-    const { sessionId, mtimeMs } = entry
-    sessionIds.push(sessionId)
-    if (!lastActivityAt || mtimeMs > lastActivityAt.getTime()) {
-      lastActivityAt = new Date(mtimeMs)
-    }
+    if (entry) activityBySession.set(entry.sessionId, entry.mtimeMs)
+  }
+  return activityBySession
+}
+
+/**
+ * Lightweight session summary from filesystem stats only (no JSONL parsing).
+ * Returns session IDs, count, and latest activity time. The first read (and
+ * structural/TTL reconciliation) stats every transcript; warm reads validate
+ * the directory with one stat and use stream-maintained per-session mtimes.
+ */
+export async function getSessionSummary(agentSlug: string): Promise<{
+  sessionIds: string[]
+  sessionCount: number
+  lastActivityAt: Date | null
+}> {
+  const sessionsDir = getAgentSessionsDir(agentSlug)
+  const slot = getSessionSummaryCacheSlot(sessionsDir)
+  const directoryMtimeMs = await getSessionsDirectoryMtime(sessionsDir)
+  const now = Date.now()
+  if (
+    slot.value &&
+    slot.value.directoryMtimeMs === directoryMtimeMs &&
+    now - slot.value.builtAtMs < SESSION_SUMMARY_CACHE_TTL_MS
+  ) {
+    return summaryFromActivityMap(slot.value.activityBySession)
   }
 
-  return { sessionIds, sessionCount: sessionIds.length, lastActivityAt }
+  if (slot.loading) {
+    const loaded = await slot.loading
+    if (
+      slot.value === loaded &&
+      loaded.directoryMtimeMs === directoryMtimeMs &&
+      Date.now() - loaded.builtAtMs < SESSION_SUMMARY_CACHE_TTL_MS
+    ) {
+      return summaryFromActivityMap(loaded.activityBySession)
+    }
+    return getSessionSummary(agentSlug)
+  }
+
+  const revision = slot.revision
+  const loading = buildSessionActivityMap(agentSlug, sessionsDir, directoryMtimeMs)
+    .then((activityBySession): SessionSummaryCacheValue => {
+      if (slot.revision !== revision) {
+        if (slot.loading === loading) slot.loading = undefined
+        return { directoryMtimeMs, builtAtMs: Date.now(), revision, activityBySession }
+      }
+      for (const [sessionId, mutation] of slot.pending) {
+        if (mutation.deleted) {
+          activityBySession.delete(sessionId)
+        } else if (mutation.activityAtMs !== undefined && activityBySession.has(sessionId)) {
+          activityBySession.set(
+            sessionId,
+            Math.max(activityBySession.get(sessionId)!, mutation.activityAtMs),
+          )
+        }
+      }
+      slot.pending.clear()
+      const value = { directoryMtimeMs, builtAtMs: Date.now(), revision, activityBySession }
+      slot.value = value
+      // Clear the in-flight marker before awaiters resume. Any subsequent
+      // mutation can update the completed value directly and need not linger
+      // in the pending map until the next TTL rebuild.
+      if (slot.loading === loading) slot.loading = undefined
+      return value
+    })
+  slot.loading = loading
+  try {
+    const loaded = await loading
+    if (slot.value !== loaded) return getSessionSummary(agentSlug)
+    return summaryFromActivityMap(loaded.activityBySession)
+  } finally {
+    if (slot.loading === loading) slot.loading = undefined
+  }
 }
 
 /**
@@ -1082,6 +1176,7 @@ export async function removeMessage(
   // Write back
   const jsonl = filtered.map((e) => JSON.stringify(e)).join('\n') + (filtered.length > 0 ? '\n' : '')
   await writeFile(jsonlPath, jsonl)
+  recordSessionActivity(agentSlug, sessionId)
   return true
 }
 
@@ -1148,6 +1243,7 @@ export async function removeToolCall(
 
   const jsonl = filtered.map((e) => JSON.stringify(e)).join('\n') + (filtered.length > 0 ? '\n' : '')
   await writeFile(jsonlPath, jsonl)
+  recordSessionActivity(agentSlug, sessionId)
   return true
 }
 

--- a/src/shared/lib/services/session-summary-cache.ts
+++ b/src/shared/lib/services/session-summary-cache.ts
@@ -1,0 +1,75 @@
+import { getAgentSessionsDir } from '@shared/lib/utils/file-storage'
+
+export const SESSION_SUMMARY_CACHE_TTL_MS = 5 * 60 * 1000
+
+export interface SessionSummaryCacheValue {
+  directoryMtimeMs: number | null
+  builtAtMs: number
+  revision: number
+  activityBySession: Map<string, number>
+}
+
+export interface SessionSummaryCacheSlot {
+  value?: SessionSummaryCacheValue
+  loading?: Promise<SessionSummaryCacheValue>
+  revision: number
+  pending: Map<string, { activityAtMs?: number; deleted?: true }>
+}
+
+// Key by the resolved sessions directory rather than slug: tests and embedded
+// deployments can change SUPERAGENT_DATA_DIR in-process, and two roots must
+// never share cached state merely because their agent slugs match.
+const sessionSummaryCache = new Map<string, SessionSummaryCacheSlot>()
+
+export function getSessionSummaryCacheSlot(sessionsDir: string): SessionSummaryCacheSlot {
+  let slot = sessionSummaryCache.get(sessionsDir)
+  if (!slot) {
+    slot = { revision: 0, pending: new Map() }
+    sessionSummaryCache.set(sessionsDir, slot)
+  }
+  return slot
+}
+
+/** Force the next summary read to reconcile ownership and filesystem state. */
+export function invalidateSessionSummaryCache(agentSlug: string): void {
+  const slot = sessionSummaryCache.get(getAgentSessionsDir(agentSlug))
+  if (!slot) return
+  slot.revision++
+  slot.value = undefined
+}
+
+/**
+ * Advance a warm per-agent summary from an authoritative transcript write.
+ * This never creates a session in the summary: structural additions are
+ * reconciled from the directory, preserving the ownership/filesystem gates.
+ */
+export function recordSessionActivity(
+  agentSlug: string,
+  sessionId: string,
+  activityAt: Date | number = Date.now(),
+): void {
+  const activityAtMs = activityAt instanceof Date ? activityAt.getTime() : activityAt
+  if (!Number.isFinite(activityAtMs)) return
+  const slot = sessionSummaryCache.get(getAgentSessionsDir(agentSlug))
+  if (!slot) return
+
+  const cachedActivity = slot.value?.activityBySession.get(sessionId)
+  if (cachedActivity !== undefined) {
+    slot.value!.activityBySession.set(sessionId, Math.max(cachedActivity, activityAtMs))
+  }
+  if (slot.loading) {
+    const pending = slot.pending.get(sessionId)
+    if (!pending?.deleted) {
+      slot.pending.set(sessionId, {
+        activityAtMs: Math.max(pending?.activityAtMs ?? -Infinity, activityAtMs),
+      })
+    }
+  }
+}
+
+export function removeSessionFromSummaryCache(agentSlug: string, sessionId: string): void {
+  const slot = sessionSummaryCache.get(getAgentSessionsDir(agentSlug))
+  if (!slot) return
+  slot.value?.activityBySession.delete(sessionId)
+  if (slot.loading) slot.pending.set(sessionId, { deleted: true })
+}

--- a/src/shared/lib/services/session-transcript-append.ts
+++ b/src/shared/lib/services/session-transcript-append.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { getSessionJsonlPath } from '@shared/lib/utils/file-storage'
 import type { JsonlSystemEntry } from '@shared/lib/types/agent'
+import { recordSessionActivity } from './session-summary-cache'
 
 /**
  * Append a host-authored `system`/`informational` entry to a session's JSONL
@@ -36,4 +37,5 @@ export async function appendInformationalEntry(
   }
   await fs.promises.mkdir(path.dirname(jsonlPath), { recursive: true })
   await fs.promises.appendFile(jsonlPath, JSON.stringify(jsonlEntry) + '\n', 'utf-8')
+  recordSessionActivity(agentSlug, sessionId)
 }


### PR DESCRIPTION
## What changed

- cache each agent's ownership-gated session ID → activity map after the exact filesystem scan
- serve warm summaries after one sessions-directory stat instead of restatting every transcript
- reconcile structural/ownership changes immediately and content-only misses on a five-minute TTL
- advance the cache from durable top-level stream frames, host-authored informational appends, transcript rewrites, and deletions
- preserve replay timestamps, ignore sidechain activity, merge in-flight mutations, and never fabricate unknown sessions

## Why

Agent list/detail enrichment called `getSessionSummary` repeatedly. Even when nothing changed, a 2,000-session agent paid 2,001 filesystem stats on every request.

| 2,000-session warm read | Before | After | Delta |
|---|---:|---:|---:|
| filesystem stats/request | 2,001 | 1 | -99.95% |
| median latency (9 runs) | 43.04 ms | 0.09 ms | -99.8% |

Cold reads and bounded reconciliation still use the original exact ownership-gated scan.

## Correctness and risk

This is a process-local advisory cache. Directory changes and newly reserved ownership force exact rebuilds. Stream/write/delete seams keep ordinary content changes current; a five-minute TTL repairs missed external writes. A restart simply returns to the old cold-scan behavior.

Focused coverage includes structural add/delete, ownership changes, unknown-session rejection, in-flight mutation merging, replay and sidechain behavior, host informational writes, and TTL recovery.

## Validation

- 544 session/agent tests
- 352 direct message-persister tests
- 956 container tests passed, 5 skipped (the 58 localhost-bound Lambda tests passed outside the sandbox)
- `npm run typecheck`
- targeted ESLint
- `npm run build:api`
- `git diff --check`
