### PR TITLE
perf: defer rare boot payloads

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -33,7 +33,6 @@ import llmRouter from './routes/llm'
 import faviconRouter from './routes/favicon'
 import { getPolyfillJs } from './speech-recognition-polyfill'
 import { getLlmPolyfillJs } from './llm-polyfill'
-import { ANTHROPIC_SDK_BUNDLE } from './llm-sdk-bundle'
 import adminUsersRouter from './routes/admin-users'
 import auditLogRouter from './routes/audit-log'
 import connectionLogsRouter from './routes/connection-logs'
@@ -191,7 +190,8 @@ app.get('/api/llm/anthropic-polyfill.js', (c) => {
     'Cache-Control': 'public, max-age=3600',
   })
 })
-app.get('/api/llm/anthropic-sdk.js', (c) => {
+app.get('/api/llm/anthropic-sdk.js', async (c) => {
+  const { ANTHROPIC_SDK_BUNDLE } = await import('./llm-sdk-bundle')
   return c.body(ANTHROPIC_SDK_BUNDLE, 200, {
     'Content-Type': 'application/javascript; charset=utf-8',
     'Cache-Control': 'public, max-age=86400',

--- a/src/api/llm-sdk-bundle.test.ts
+++ b/src/api/llm-sdk-bundle.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { ANTHROPIC_SDK_BUNDLE } from './llm-sdk-bundle'
+
+describe('dashboard Anthropic SDK bundle', () => {
+  it('is executable browser JavaScript that installs the SDK constructor', () => {
+    const dashboardWindow: Record<string, unknown> = {}
+    const evaluate = new Function('window', ANTHROPIC_SDK_BUNDLE)
+
+    evaluate(dashboardWindow)
+
+    expect(dashboardWindow.__AnthropicSDK).toBeTypeOf('function')
+  })
+
+  it('contains the browser bridge expected by the lazy dashboard polyfill', () => {
+    expect(ANTHROPIC_SDK_BUNDLE).toContain('window.__AnthropicSDK =')
+  })
+})

--- a/src/renderer/lib/error-reporting.test.ts
+++ b/src/renderer/lib/error-reporting.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sentry = vi.hoisted(() => ({
+  init: vi.fn(),
+  setUser: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+vi.mock('./sentry-browser-provider', () => sentry)
+vi.mock('./env', () => ({ isElectron: () => true }))
+
+let reporting: typeof import('./error-reporting')
+
+describe('renderer error reporting facade', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubEnv('DEV', false)
+    reporting = await import('./error-reporting')
+    reporting.setRendererErrorReportingEnabled(true)
+  })
+
+  it('initializes Sentry with the renderer environment and opt-out gate', async () => {
+    reporting.initRendererErrorReporting()
+
+    await vi.waitFor(() => expect(sentry.init).toHaveBeenCalledOnce())
+    const options = sentry.init.mock.calls[0][0]
+    expect(options).toMatchObject({
+      environment: 'electron-renderer',
+      release: expect.any(String),
+      tracesSampleRate: 0,
+    })
+    expect(options.beforeSend({ id: 'event' })).toEqual({ id: 'event' })
+
+    reporting.setRendererErrorReportingEnabled(false)
+    expect(options.beforeSend({ id: 'event' })).toBeNull()
+  })
+
+  it('forwards user identity and caught exceptions without changing their context', async () => {
+    const error = new Error('boom')
+    const context = { tags: { source: 'test' }, extra: { attempt: 2 } }
+    reporting.initRendererErrorReporting()
+    await vi.waitFor(() => expect(sentry.init).toHaveBeenCalledOnce())
+    vi.clearAllMocks()
+
+    reporting.setRendererErrorReportingUser({ id: 'user-1', email: 'user@example.com' })
+    reporting.captureRendererException(error, context)
+    reporting.setRendererErrorReportingUser(null)
+
+    await vi.waitFor(() => expect(sentry.captureException).toHaveBeenCalledOnce())
+    expect(sentry.setUser).toHaveBeenNthCalledWith(1, {
+      id: 'user-1',
+      email: 'user@example.com',
+    })
+    expect(sentry.captureException).toHaveBeenCalledWith(error, context)
+    expect(sentry.setUser).toHaveBeenNthCalledWith(2, null)
+  })
+
+  it('preserves user identity and exceptions reported before the provider loads', async () => {
+    const error = new Error('early boom')
+    const context = { tags: { phase: 'boot' }, extra: { attempt: 1 } }
+
+    reporting.setRendererErrorReportingUser({ id: 'early-user', email: 'early@example.com' })
+    reporting.captureRendererException(error, context)
+
+    await vi.waitFor(() => expect(sentry.captureException).toHaveBeenCalledOnce())
+    expect(sentry.init).toHaveBeenCalledOnce()
+    expect(sentry.setUser).toHaveBeenCalledWith({
+      id: 'early-user',
+      email: 'early@example.com',
+    })
+    expect(sentry.captureException).toHaveBeenCalledWith(error, context)
+  })
+
+  it('never lets provider failures escape into the renderer', async () => {
+    reporting.initRendererErrorReporting()
+    await vi.waitFor(() => expect(sentry.init).toHaveBeenCalledOnce())
+    vi.clearAllMocks()
+    sentry.captureException.mockImplementationOnce(() => {
+      throw new Error('provider failed')
+    })
+
+    expect(() => reporting.captureRendererException(new Error('app failed'))).not.toThrow()
+    await vi.waitFor(() => expect(sentry.captureException).toHaveBeenCalledOnce())
+  })
+})

--- a/src/renderer/lib/error-reporting.ts
+++ b/src/renderer/lib/error-reporting.ts
@@ -1,38 +1,61 @@
 /**
  * Error reporting for the renderer process.
  *
- * This file is the ONLY place that imports @sentry/browser. To switch to a
+ * This file is the ONLY place that loads @sentry/browser. To switch to a
  * different provider, replace the internals — callers never see Sentry.
  *
  * All exported functions are safe to call anywhere — they never throw,
  * so error reporting can never turn a soft failure into a crash.
  */
 
-import * as Sentry from '@sentry/browser'
 import { ERROR_REPORTING_INGEST_URL } from '@shared/lib/error-reporting/config'
 import type { ErrorReportingUser } from '@shared/lib/error-reporting/types'
 import { isElectron } from './env'
 
 let errorReportingEnabled = true // null/undefined means true — default on for existing users
+let errorReportingUser: ErrorReportingUser | null = null
+let sentry: typeof import('./sentry-browser-provider') | null = null
+let sentryLoad: Promise<typeof import('./sentry-browser-provider') | null> | null = null
+
+function applyUser(provider: typeof import('./sentry-browser-provider')): void {
+  try {
+    provider.setUser(errorReportingUser
+      ? { id: errorReportingUser.id, email: errorReportingUser.email }
+      : null)
+  } catch { /* never crash */ }
+}
+
+function loadSentry(): Promise<typeof import('./sentry-browser-provider') | null> {
+  if (import.meta.env.DEV) return Promise.resolve(null)
+  if (sentryLoad) return sentryLoad
+
+  sentryLoad = import('./sentry-browser-provider')
+    .then((provider) => {
+      provider.init({
+        dsn: ERROR_REPORTING_INGEST_URL,
+        environment: isElectron() ? 'electron-renderer' : 'web',
+        release: __APP_VERSION__,
+        tracesSampleRate: 0,
+        beforeSend(event) {
+          if (!errorReportingEnabled) return null
+          return event
+        },
+      })
+      sentry = provider
+      applyUser(provider)
+      return provider
+    })
+    .catch((err) => {
+      console.warn('[ErrorReporting] Failed to initialize renderer:', err)
+      return null
+    })
+  return sentryLoad
+}
 
 export function initRendererErrorReporting(): void {
-  // Skip in dev mode — dev errors are too noisy and pollute Sentry
-  if (import.meta.env.DEV) return
-
-  try {
-    Sentry.init({
-      dsn: ERROR_REPORTING_INGEST_URL,
-      environment: isElectron() ? 'electron-renderer' : 'web',
-      release: __APP_VERSION__,
-      tracesSampleRate: 0,
-      beforeSend(event) {
-        if (!errorReportingEnabled) return null
-        return event
-      },
-    })
-  } catch (err) {
-    console.warn('[ErrorReporting] Failed to initialize renderer:', err)
-  }
+  // Start loading early, but never put the provider on the renderer's static
+  // boot graph or make first render await it.
+  void loadSentry()
 }
 
 export function setRendererErrorReportingEnabled(enabled: boolean): void {
@@ -40,13 +63,8 @@ export function setRendererErrorReportingEnabled(enabled: boolean): void {
 }
 
 export function setRendererErrorReportingUser(user: ErrorReportingUser | null): void {
-  try {
-    if (user) {
-      Sentry.setUser({ id: user.id, email: user.email })
-    } else {
-      Sentry.setUser(null)
-    }
-  } catch { /* never crash */ }
+  errorReportingUser = user
+  if (sentry) applyUser(sentry)
 }
 
 /**
@@ -59,10 +77,16 @@ export function captureRendererException(
   error: unknown,
   context?: { tags?: Record<string, string>; extra?: Record<string, unknown> }
 ): void {
-  try {
-    Sentry.captureException(error, {
-      tags: context?.tags,
-      extra: context?.extra,
-    })
-  } catch { /* never crash */ }
+  void loadSentry().then((provider) => {
+    if (!provider) return
+    try {
+      provider.captureException(error, {
+        tags: context?.tags,
+        extra: context?.extra,
+      })
+    } catch { /* never crash */ }
+  }).catch(() => {
+    // loadSentry already degrades provider failures; this is defense-in-depth
+    // against a future implementation changing that contract.
+  })
 }

--- a/src/renderer/lib/sentry-browser-provider.ts
+++ b/src/renderer/lib/sentry-browser-provider.ts
@@ -1,0 +1,4 @@
+// Keep the dynamic boundary tree-shakeable. Importing the package namespace
+// through import('@sentry/browser') makes Rollup retain every public export;
+// this wrapper exposes only the three primitives the renderer facade uses.
+export { captureException, init, setUser } from '@sentry/browser'

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -28,11 +28,19 @@ const lazyDashboardSdkPlugin: Plugin = {
   name: 'lazy-dashboard-sdk',
   setup(build) {
     const apiEntryPath = resolve('src/api/index.ts')
-    build.onResolve({ filter: /^\.\/llm-sdk-bundle$/ }, (args) => {
+    // Any specifier for the module (relative or aliased), but not the entry
+    // point itself — entries resolve with their .ts extension.
+    build.onResolve({ filter: /llm-sdk-bundle$/ }, (args) => {
       if (args.kind === 'dynamic-import' && resolve(args.importer) === apiEntryPath) {
         return { path: './llm-sdk-bundle.mjs', external: true }
       }
-      return undefined
+      // Any other import would silently inline the 170 KB payload back into
+      // the boot artifact — fail the build instead.
+      return {
+        errors: [{
+          text: `llm-sdk-bundle must only be loaded via the dynamic import in src/api/index.ts; found a ${args.kind} in ${args.importer}. Route it through that import (or extend lazy-dashboard-sdk in tsup.config.ts) so the payload stays out of the API boot artifact.`,
+        }],
+      }
     })
   },
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -20,6 +20,23 @@ const rawLoaderPlugin: Plugin = {
   },
 }
 
+// Keep the generated browser SDK as its own build entry. In development Vite
+// resolves the source dynamic import normally; the production server instead
+// points at the sibling emitted module so the 170 KB payload is not parsed at
+// API boot.
+const lazyDashboardSdkPlugin: Plugin = {
+  name: 'lazy-dashboard-sdk',
+  setup(build) {
+    const apiEntryPath = resolve('src/api/index.ts')
+    build.onResolve({ filter: /^\.\/llm-sdk-bundle$/ }, (args) => {
+      if (args.kind === 'dynamic-import' && resolve(args.importer) === apiEntryPath) {
+        return { path: './llm-sdk-bundle.mjs', external: true }
+      }
+      return undefined
+    })
+  },
+}
+
 // Stay in node_modules: natives, Electron, and packages that patch require/import.
 const externalExact = new Set([
   'better-sqlite3',
@@ -37,7 +54,10 @@ function isExternal(name: string): boolean {
 const dependencies = Object.keys(pkg.dependencies ?? {})
 
 export default defineConfig({
-  entry: ['src/web/server.ts'],
+  entry: {
+    server: 'src/web/server.ts',
+    'llm-sdk-bundle': 'src/api/llm-sdk-bundle.ts',
+  },
   format: ['esm'],
   outDir: 'dist/web',
   splitting: false,
@@ -56,5 +76,5 @@ export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
-  esbuildPlugins: [rawLoaderPlugin],
+  esbuildPlugins: [rawLoaderPlugin, lazyDashboardSdkPlugin],
 })


### PR DESCRIPTION
## Summary

- move the generated dashboard Anthropic SDK out of the API server boot artifact and load it on the first SDK request
- lazy-load renderer Sentry through a tree-shakeable three-export provider while preserving the existing no-throw facade, opt-out gate, user identity, and early exception calls
- add direct regression coverage for the generated SDK and asynchronous error-reporting behavior

## Measured impact

Same source-map/artifact profiler, before vs. after:

| Critical closure | Before | After | Delta |
| --- | ---: | ---: | ---: |
| API boot raw | 16,716,119 B | 16,545,767 B | -170,352 B |
| API boot gzip | 3,159,381 B | 3,111,835 B | -47,546 B |
| Renderer initial raw | 1,502,584 B | 1,416,397 B | -86,187 B |
| Renderer initial gzip | 452,171 B | 423,500 B | -28,671 B |
| Sentry modules in initial closure | 115 | 0 | -115 |

The deferred Sentry provider is 85,081 B raw / 28,894 B gzip. Aggregate renderer payload is effectively flat (-1,106 B raw / +205 B gzip).

## Verification

- 56 focused unit tests across the SDK/shim, error-reporting facade, error boundaries, query client, and warm-start behavior
- TypeScript and targeted ESLint
- web, API, and Electron production builds
- real built API boot and request of `/api/llm/anthropic-sdk.js`; response retained the original headers and its 169,436-byte body evaluated to the expected browser constructor
