### PR TITLE
perf: prioritize the requested dashboard during cold boot

### DIFF
--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -179,11 +179,13 @@ describe('truncateOversizedLog', () => {
 describe('DashboardManager log stream lifecycle', () => {
   let testDir: string
   let manager: {
+    scanAndStartAll(prioritySlug?: string): Promise<void>
     startDashboard(slug: string, opts?: { forceInstall?: boolean }): Promise<{
       status: string
       logStream: fs.WriteStream | null
       restartTimestamps: number[]
     }>
+    listDashboards(): Array<{ slug: string; status: string }>
     stopDashboard(slug: string): Promise<boolean>
     stopAll(): Promise<void>
     getDashboardUpstreamPathMode(slug: string): 'stripped' | 'mounted'
@@ -231,6 +233,38 @@ describe('DashboardManager log stream lifecycle', () => {
     await fs.promises.utimes(path.join(dir, 'node_modules'), future, future)
     return slug
   }
+
+  it('starts the requested dashboard first at boot and still starts every dashboard', async () => {
+    await scaffoldDashboard()
+    await scaffoldDashboard()
+    await scaffoldDashboard()
+    const diskOrder = (await fs.promises.readdir(testDir)).filter((name) => name.startsWith('dash-'))
+    const prioritySlug = diskOrder.at(-1)!
+    const startOrder: string[] = []
+    spawnHolder.impl = (_command, args, options) => {
+      const proc = new FakeChildProcess()
+      procs.push(proc)
+      if (args[0] === 'run') {
+        startOrder.push(path.basename((options as { cwd: string }).cwd))
+      }
+      return proc
+    }
+
+    process.env.SUPERAGENT_DASHBOARD_PRIORITY = prioritySlug
+    vi.useFakeTimers()
+    try {
+      await manager.scanAndStartAll()
+
+      expect(startOrder[0]).toBe(prioritySlug)
+      expect(new Set(startOrder)).toEqual(new Set(diskOrder))
+      expect(manager.listDashboards()).toEqual(expect.arrayContaining(
+        diskOrder.map((slug) => expect.objectContaining({ slug, status: 'running' })),
+      ))
+    } finally {
+      vi.useRealTimers()
+      delete process.env.SUPERAGENT_DASHBOARD_PRIORITY
+    }
+  })
 
   it('closes the log stream when the process exits cleanly', async () => {
     const slug = await scaffoldDashboard()

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -132,10 +132,26 @@ class DashboardManager {
     stream?.end()
   }
 
-  async scanAndStartAll(): Promise<void> {
+  async scanAndStartAll(
+    prioritySlug: string | undefined = process.env.SUPERAGENT_DASHBOARD_PRIORITY,
+  ): Promise<void> {
     try {
       await fs.promises.mkdir(ARTIFACTS_DIR, { recursive: true })
       const entries = await fs.promises.readdir(ARTIFACTS_DIR, { withFileTypes: true })
+
+      // A dashboard view knows exactly which process is blocking its first
+      // paint. Preserve the filesystem order for every other dashboard, but
+      // move that one to the front instead of making it wait behind the whole
+      // workspace. Invalid or stale intent is simply ignored.
+      if (prioritySlug && SLUG_REGEX.test(prioritySlug)) {
+        const priorityIndex = entries.findIndex(
+          (entry) => entry.isDirectory() && entry.name === prioritySlug,
+        )
+        if (priorityIndex > 0) {
+          const [priorityEntry] = entries.splice(priorityIndex, 1)
+          entries.unshift(priorityEntry)
+        }
+      }
 
       const started: string[] = []
       for (const entry of entries) {

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -540,7 +540,7 @@ import {
   exportSkill,
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
-import { getAgent, listAgentsWithStatus } from '@shared/lib/services/agent-service'
+import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
 import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
@@ -651,6 +651,87 @@ describe('GET /:id/artifacts/:artifactSlug/view', () => {
     expect(loadingRemove).toHaveBeenCalledOnce()
     expect(iframe.src).toBe('/api/agents/test-agent/artifacts/sales/')
     expect(iframe.sandbox).toContain('allow-downloads')
+  })
+
+  it('includes the requested dashboard when starting a stopped agent', async () => {
+    const res = await getReq(createApp(), '/api/agents/test-agent/artifacts/sales/view')
+    const html = await res.text()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { slug: 'sales', name: 'Sales', status: 'stopped' },
+      ]), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'stopped' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'running' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { slug: 'sales', name: 'Sales', status: 'running' },
+      ]), { status: 200 }))
+    const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+    const appendChild = vi.fn()
+    const document = {
+      title: '',
+      getElementById: (id: string) => id === 'status'
+        ? { textContent: '', classList: { add: vi.fn() } }
+        : { remove: vi.fn() },
+      createElement: () => ({}),
+      body: { appendChild },
+    }
+
+    expect(script).toBeDefined()
+    runInNewContext(script!, { document, fetch: fetchMock, setTimeout })
+
+    await vi.waitFor(() => expect(appendChild).toHaveBeenCalledOnce())
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/agents/test-agent/start',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dashboardSlug: 'sales' }),
+      },
+    )
+  })
+})
+
+// ============================================================================
+// Intent-aware container start
+// ============================================================================
+
+describe('POST /:id/start dashboard intent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAgentExists.mockResolvedValue(true)
+    vi.mocked(containerManager.ensureRunning).mockResolvedValue({} as never)
+    vi.mocked(getAgentWithStatus).mockResolvedValue({
+      slug: 'test-agent',
+      frontmatter: { name: 'Test Agent' },
+    } as never)
+  })
+
+  it('forwards a valid requested dashboard to the container manager', async () => {
+    const res = await postJson(createApp(), '/api/agents/test-agent/start', {
+      dashboardSlug: 'sales-dashboard',
+    })
+
+    expect(res.status).toBe(200)
+    expect(containerManager.ensureRunning).toHaveBeenCalledWith('test-agent', {
+      dashboardSlug: 'sales-dashboard',
+    })
+  })
+
+  it('keeps an ordinary start request backward compatible', async () => {
+    const res = await postJson(createApp(), '/api/agents/test-agent/start', {})
+
+    expect(res.status).toBe(200)
+    expect(containerManager.ensureRunning).toHaveBeenCalledWith('test-agent')
+  })
+
+  it('rejects an invalid dashboard slug before starting the container', async () => {
+    const res = await postJson(createApp(), '/api/agents/test-agent/start', {
+      dashboardSlug: '../other-agent',
+    })
+
+    expect(res.status).toBe(400)
+    expect(containerManager.ensureRunning).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1428,9 +1428,25 @@ agents.get('/:id/access/search-users', AgentAdmin(), async (c) => {
 agents.post('/:id/start', AgentUser(), async (c) => {
   try {
     const slug = getAgentId(c)
+    const body = await c.req.json().catch(() => undefined) as {
+      dashboardSlug?: unknown
+    } | undefined
+    const dashboardSlug = body?.dashboardSlug
+    if (
+      dashboardSlug !== undefined
+      && (
+        typeof dashboardSlug !== 'string'
+        || !/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(dashboardSlug)
+      )
+    ) {
+      return c.json({ error: 'Invalid dashboard slug' }, 400)
+    }
 
-
-    await containerManager.ensureRunning(slug)
+    if (dashboardSlug) {
+      await containerManager.ensureRunning(slug, { dashboardSlug })
+    } else {
+      await containerManager.ensureRunning(slug)
+    }
     const agent = await getAgentWithStatus(slug)
 
     // Note: agent_status_changed is broadcast by containerManager.ensureRunning()
@@ -5739,7 +5755,11 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
         if (!agentWasRunning) {
           // 3. Start the agent
           statusEl.textContent = 'Starting agent…';
-          const startRes = await fetch(basePath + '/start', { method: 'POST' });
+          const startRes = await fetch(basePath + '/start', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ dashboardSlug: artifactSlug }),
+          });
           if (!startRes.ok) {
             const err = await startRes.json().catch(() => ({}));
             throw new Error(err.error || 'Failed to start agent');

--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DashboardView } from './dashboard-view'
@@ -109,7 +109,24 @@ describe('DashboardView restart', () => {
 
     await act(async () => finishStop())
 
-    expect(mocks.start.mutateAsync).toHaveBeenCalledOnce()
+    expect(mocks.start.mutateAsync).toHaveBeenCalledWith({
+      slug: 'agent',
+      dashboardSlug: 'dashboard',
+    })
+  })
+
+  it('includes the requested dashboard when auto-starting a stopped agent', async () => {
+    mocks.agentStatus = 'stopped'
+    mocks.dashboardStatus = 'stopped'
+
+    render(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+
+    await waitFor(() => {
+      expect(mocks.start.mutate).toHaveBeenCalledWith({
+        slug: 'agent',
+        dashboardSlug: 'dashboard',
+      })
+    })
   })
 
   it('shows a running dashboard without waiting for the iframe load event', () => {

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -101,8 +101,8 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   }, [dashboardAgentSlug, dashboardSlug, dashboard?.name])
 
   const handleStartAgent = useCallback(() => {
-    startAgent.mutate(agentSlug)
-  }, [startAgent, agentSlug])
+    startAgent.mutate({ slug: agentSlug, dashboardSlug })
+  }, [startAgent, agentSlug, dashboardSlug])
 
   const handleRestartAgent = useCallback(async () => {
     // The deliberate stop must not re-trigger this view's auto-start effect.
@@ -114,22 +114,22 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
       if (isAgentRunning) {
         await stopAgent.mutateAsync(agentSlug)
       }
-      await startAgent.mutateAsync(agentSlug)
+      await startAgent.mutateAsync({ slug: agentSlug, dashboardSlug })
     } catch (error) {
       console.error('Failed to restart agent:', error)
       setRestartError(error instanceof Error ? error.message : 'Failed to restart agent')
     } finally {
       setRestarting(false)
     }
-  }, [isAgentRunning, stopAgent, startAgent, agentSlug])
+  }, [isAgentRunning, stopAgent, startAgent, agentSlug, dashboardSlug])
 
   useEffect(() => {
     if (autoStartedRef.current === agentSlug) return
     if (!agent || isAgentRunning || isAgentStarting || !canStart) return
     if (startAgent.isError) return
     autoStartedRef.current = agentSlug
-    startAgent.mutate(agentSlug)
-  }, [agent, agentSlug, isAgentRunning, isAgentStarting, canStart, startAgent])
+    startAgent.mutate({ slug: agentSlug, dashboardSlug })
+  }, [agent, agentSlug, dashboardSlug, isAgentRunning, isAgentStarting, canStart, startAgent])
 
   const showFrame = isAgentRunning && dashboard?.status === 'running'
   const actionPending = restarting || stopAgent.isPending || startAgent.isPending

--- a/src/renderer/hooks/use-agents.test.ts
+++ b/src/renderer/hooks/use-agents.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { ApiAgent } from '@shared/lib/types/api'
-import { resolveRouteAgentId } from './use-agents'
+import { buildStartAgentRequestInit, resolveRouteAgentId } from './use-agents'
 
 // Minimal agent factory — only the id/displaySlug fields the resolver reads.
 function agent(slug: string, displaySlug: string): ApiAgent {
@@ -48,5 +48,26 @@ describe('resolveRouteAgentId', () => {
 
   it('returns undefined for no slug', () => {
     expect(resolveRouteAgentId(undefined, [renamed])).toBeUndefined()
+  })
+})
+
+describe('buildStartAgentRequestInit', () => {
+  it('sends dashboard intent only when one is present', () => {
+    expect(buildStartAgentRequestInit({
+      slug: 'agent-1',
+      dashboardSlug: 'sales-dashboard',
+    })).toEqual({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dashboardSlug: 'sales-dashboard' }),
+    })
+  })
+
+  it('keeps ordinary and warm starts body-free', () => {
+    expect(buildStartAgentRequestInit('agent-1')).toEqual({ method: 'POST' })
+    expect(buildStartAgentRequestInit({
+      slug: 'agent-1',
+      source: 'warm-start',
+    })).toEqual({ method: 'POST' })
   })
 })

--- a/src/renderer/hooks/use-agents.ts
+++ b/src/renderer/hooks/use-agents.ts
@@ -182,10 +182,28 @@ export function useUpdateAgent() {
 // as they arrive without leaning on a poll loop.
 const AGENT_START_REINVALIDATE_DELAYS_MS = [5_000, 15_000, 30_000]
 
-export type StartAgentVars = string | { slug: string; source?: 'user' | 'warm-start' }
+export type StartAgentVars = string | {
+  slug: string
+  source?: 'user' | 'warm-start'
+  /** Dashboard the user is actively waiting for during a cold container boot. */
+  dashboardSlug?: string
+}
 
 function resolveStartAgentSlug(vars: StartAgentVars): string {
   return typeof vars === 'string' ? vars : vars.slug
+}
+
+export function buildStartAgentRequestInit(vars: StartAgentVars): RequestInit {
+  const dashboardSlug = typeof vars === 'string' ? undefined : vars.dashboardSlug
+  return {
+    method: 'POST',
+    ...(dashboardSlug
+      ? {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dashboardSlug }),
+        }
+      : {}),
+  }
 }
 
 export function useStartAgent() {
@@ -196,7 +214,7 @@ export function useStartAgent() {
     meta: { skipGlobalErrorToast: true },
     mutationFn: async (vars: StartAgentVars) => {
       const slug = resolveStartAgentSlug(vars)
-      const res = await apiFetch(`/api/agents/${slug}/start`, { method: 'POST' })
+      const res = await apiFetch(`/api/agents/${slug}/start`, buildStartAgentRequestInit(vars))
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
         throw new Error(body.error || 'Failed to start agent')

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -263,6 +263,17 @@ describe('containerManager.ensureRunning — env var construction', () => {
     expect(mockGetOrCreateHostToken).toHaveBeenCalledWith('test-agent')
   })
 
+  it('passes a requested dashboard to the container as boot priority', async () => {
+    setupAccountMocks([])
+
+    await containerManager.ensureRunning('test-agent', {
+      dashboardSlug: 'sales-dashboard',
+    })
+
+    const startOpts = mockStart.mock.calls[0][0]
+    expect(startOpts.envVars.SUPERAGENT_DASHBOARD_PRIORITY).toBe('sales-dashboard')
+  })
+
   it('CONNECTED_ACCOUNTS includes only active accounts, grouped by toolkitSlug', async () => {
     setupAccountMocks([
       { id: 'acc-1', toolkitSlug: 'gmail', displayName: 'user@gmail.com', status: 'active', providerConnectionId: 'c1', providerName: 'composio' },

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -57,6 +57,11 @@ interface CachedContainerStatus {
   lastSyncedAt: number
 }
 
+export interface ContainerStartIntent {
+  /** Start this dashboard before the workspace's other dashboards. */
+  dashboardSlug?: string
+}
+
 // Singleton to manage all container clients
 class ContainerManager {
   private clients: Map<string, ContainerClient> = new Map()
@@ -503,7 +508,10 @@ class ContainerManager {
   // not passed as env vars. Only connected account tokens are injected.
   //
   // Parameter is agentId for backwards compatibility, but will be slug after migration
-  async ensureRunning(agentId: string): Promise<ContainerClient> {
+  async ensureRunning(
+    agentId: string,
+    intent?: ContainerStartIntent,
+  ): Promise<ContainerClient> {
     const inflight = this.startingAgents.get(agentId)
     if (inflight) return inflight
 
@@ -536,7 +544,7 @@ class ContainerManager {
       const racedInflight = this.startingAgents.get(agentId)
       if (racedInflight) return racedInflight
 
-      const startPromise = this.doStartContainer(agentId, client)
+      const startPromise = this.doStartContainer(agentId, client, intent)
       this.startingAgents.set(agentId, startPromise)
       try {
         await startPromise
@@ -548,7 +556,11 @@ class ContainerManager {
     return client
   }
 
-  private async doStartContainer(agentId: string, client: ContainerClient): Promise<ContainerClient> {
+  private async doStartContainer(
+    agentId: string,
+    client: ContainerClient,
+    intent?: ContainerStartIntent,
+  ): Promise<ContainerClient> {
       // Pass proxy config and account metadata (no raw tokens)
       const envVars: Record<string, string> = {}
 
@@ -561,6 +573,9 @@ class ContainerManager {
       // X-Agent Work: cross-agent calls. Container POSTs to host with PROXY_TOKEN.
       envVars['SUPERAGENT_HOST_API_URL'] = `${hostApiBaseUrl}/api`
       envVars['SUPERAGENT_AGENT_SLUG'] = agentId
+      if (intent?.dashboardSlug) {
+        envVars['SUPERAGENT_DASHBOARD_PRIORITY'] = intent.dashboardSlug
+      }
 
       // Authenticates the HOST to the container API (the reverse direction of
       // PROXY_TOKEN, which the agent legitimately holds). The container server

--- a/src/shared/lib/container/reserved-env-vars.test.ts
+++ b/src/shared/lib/container/reserved-env-vars.test.ts
@@ -18,6 +18,7 @@ describe('reserved-env-vars', () => {
       'PROXY_TOKEN',
       'SUPERAGENT_HOST_API_URL',
       'SUPERAGENT_AGENT_SLUG',
+      'SUPERAGENT_DASHBOARD_PRIORITY',
       'CONNECTED_ACCOUNTS',
       'REMOTE_MCPS',
       'AGENT_BROWSER_USE_HOST',

--- a/src/shared/lib/container/reserved-env-vars.ts
+++ b/src/shared/lib/container/reserved-env-vars.ts
@@ -21,6 +21,7 @@ export const RESERVED_ENV_VAR_KEYS: ReadonlySet<string> = new Set([
   // Cross-agent / host API wiring
   'SUPERAGENT_HOST_API_URL',
   'SUPERAGENT_AGENT_SLUG',
+  'SUPERAGENT_DASHBOARD_PRIORITY',
   // Host→container API auth (never agent-visible)
   'SUPERAGENT_HOST_TOKEN',
   // Agent identity for LLM-usage attribution (platform provider injects these;


### PR DESCRIPTION
## Summary

- send an optional dashboard intent when an in-app or standalone dashboard view cold-starts its agent
- validate and propagate that hint through the API and container environment
- start the requested dashboard first while preserving sequential startup and the relative order of every other dashboard
- keep ordinary and warm starts body-free and fall back to existing filesystem order when intent is absent or stale

## Measured impact

A controlled profiler booted 16 dashboards with a 10 ms readiness cost and placed the requested dashboard last. Across seven iterations:

- selected-dashboard median readiness: **197.66 ms -> 11.60 ms** (**-94.1%**)
- selected-dashboard start index: **15 -> 0**
- all-dashboard median readiness: **197.66 ms -> 193.84 ms** (effectively unchanged)

This targets perceived dashboard readiness without adding concurrency or removing any startup work.

## Validation

- 467 affected root tests passed
- full agent-container suite: 846 passed, 8 skipped
- root TypeScript and targeted ESLint passed
- root web, API, and Electron production builds passed
- agent-container production build passed
- `git diff --check` passed
