### PR TITLE
perf: make Chrome profile synchronization incremental

### DIFF
--- a/src/main/host-browser/chrome-provider.launch-flags.test.ts
+++ b/src/main/host-browser/chrome-provider.launch-flags.test.ts
@@ -65,7 +65,7 @@ const h = vi.hoisted(() => {
 
   // When set, fs.mkdirSync throws ENOSPC — simulates disk pressure failing a
   // launch before Chrome is spawned or the instance registered.
-  const state = { failMkdir: false }
+  const state = { failMkdir: false, hasCopiedProfile: true }
 
   return { netMock, spawnMock, execSyncMock, state }
 })
@@ -82,7 +82,9 @@ vi.mock('net', () => ({ default: h.netMock, ...h.netMock }))
 
 vi.mock('fs', () => {
   const m = {
-    existsSync: () => true,
+    existsSync: (filePath: string) => filePath.endsWith('/Default/Cookies')
+      ? h.state.hasCopiedProfile
+      : true,
     mkdirSync: () => {
       if (h.state.failMkdir) {
         throw Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' })
@@ -120,9 +122,12 @@ vi.mock('@shared/lib/config/data-dir', () => ({
   getAgentDownloadsDir: () => '/tmp/sa-launch-flags-downloads',
 }))
 
+const chromeProfile = vi.hoisted(() => ({
+  copy: vi.fn((_profileId: string, _destDir: string): boolean | Promise<boolean> => false),
+}))
 vi.mock('@shared/lib/browser/chrome-profile', () => ({
   listChromeProfiles: () => [],
-  copyChromeProfileData: () => false,
+  copyChromeProfileData: chromeProfile.copy,
 }))
 
 vi.mock('@shared/lib/error-reporting', () => ({
@@ -151,6 +156,8 @@ describe('ChromeProvider launch flags (profile disk growth)', () => {
   beforeEach(async () => {
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
     h.spawnMock.mockClear()
+    h.state.hasCopiedProfile = true
+    chromeProfile.copy.mockClear().mockReturnValue(false)
     pm.markProfileInUse.mockClear()
     pm.unmarkProfileInUse.mockClear()
     pm.waitForBrowserProfileCleanup.mockClear()
@@ -196,6 +203,24 @@ describe('ChromeProvider launch flags (profile disk growth)', () => {
     const spawnOrder = h.spawnMock.mock.invocationCallOrder[0]
     expect(markOrder).toBeLessThan(waitOrder)
     expect(waitOrder).toBeLessThan(spawnOrder)
+  })
+
+  it('waits for an asynchronous source-profile copy before spawning Chrome', async () => {
+    h.spawnMock.mockClear()
+    h.state.hasCopiedProfile = false
+    let finishCopy!: (copied: boolean) => void
+    chromeProfile.copy.mockReturnValueOnce(new Promise<boolean>((resolve) => {
+      finishCopy = resolve
+    }))
+
+    const launchPromise = provider.launch('agent-with-profile', { chromeProfileId: 'Default' })
+    await vi.waitFor(() => expect(chromeProfile.copy).toHaveBeenCalled())
+    expect(h.spawnMock).not.toHaveBeenCalled()
+
+    finishCopy(true)
+    await launchPromise
+    expect(h.spawnMock).toHaveBeenCalledOnce()
+    h.state.hasCopiedProfile = true
   })
 
   it('releases the profile claim on stop', async () => {

--- a/src/main/host-browser/chrome-provider.ts
+++ b/src/main/host-browser/chrome-provider.ts
@@ -322,7 +322,7 @@ export class ChromeProvider implements HostBrowserProvider {
       // should keep the session data (cookies, local storage, etc.) that the
       // agent accumulated during its browsing sessions.
       const alreadyHasProfile = fs.existsSync(path.join(destProfileDir, 'Cookies'))
-      if (!alreadyHasProfile && copyChromeProfileData(profileId, destProfileDir)) {
+      if (!alreadyHasProfile && await copyChromeProfileData(profileId, destProfileDir)) {
         console.log(`[ChromeProvider] Copied Chrome profile "${profileId}" for instance ${instanceId}`)
       }
     }

--- a/src/shared/lib/browser/chrome-profile-schema.ts
+++ b/src/shared/lib/browser/chrome-profile-schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const ProfileFileFingerprintSchema = z.object({
+  size: z.number(),
+  mtimeMs: z.number(),
+  ctimeMs: z.number(),
+})
+
+export const ProfileSyncManifestSchema = z.object({
+  version: z.literal(1),
+  profileId: z.string(),
+  files: z.record(z.string(), ProfileFileFingerprintSchema),
+})
+
+export type ProfileFileFingerprint = z.infer<typeof ProfileFileFingerprintSchema>
+export type ProfileSyncManifest = z.infer<typeof ProfileSyncManifestSchema>

--- a/src/shared/lib/browser/chrome-profile.test.ts
+++ b/src/shared/lib/browser/chrome-profile.test.ts
@@ -106,6 +106,38 @@ describe('copyChromeProfileData', () => {
     )).not.toThrow()
   })
 
+  it('fails safe by re-seeding when the manifest is valid JSON of the wrong shape', async () => {
+    createProfile()
+    await copyChromeProfileData('Default', destination)
+    fs.writeFileSync(path.join(destination, 'Cookies'), 'agent-session-cookie')
+    fs.writeFileSync(
+      path.join(destination, '.superagent-profile-sync.json'),
+      JSON.stringify({ version: 2, files: 'nope' }),
+    )
+
+    await copyChromeProfileData('Default', destination)
+
+    expect(fs.readFileSync(path.join(destination, 'Cookies'), 'utf8')).toBe('source-cookie')
+  })
+
+  it('tolerates a transient source file that vanishes between fingerprinting and copy', async () => {
+    const profileDir = createProfile()
+    fs.writeFileSync(path.join(profileDir, 'Cookies-journal'), 'hot-journal')
+
+    const realCopyFile = fs.promises.copyFile.bind(fs.promises)
+    vi.spyOn(fs.promises, 'copyFile').mockImplementation(async (src, dest, mode?) => {
+      if (String(src).endsWith('Cookies-journal')) {
+        fs.rmSync(path.join(profileDir, 'Cookies-journal'), { force: true })
+        throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+      }
+      return realCopyFile(src, dest, mode)
+    })
+
+    expect(await copyChromeProfileData('Default', destination)).toBe(true)
+    expect(fs.readFileSync(path.join(destination, 'Cookies'), 'utf8')).toBe('source-cookie')
+    expect(fs.existsSync(path.join(destination, 'Cookies-journal'))).toBe(false)
+  })
+
   it('refuses a profile id that escapes Chrome user-data storage', async () => {
     fs.mkdirSync(chromeDataDir, { recursive: true })
     fs.mkdirSync(path.join(chromeDataDir, '..', 'outside'), { recursive: true })

--- a/src/shared/lib/browser/chrome-profile.test.ts
+++ b/src/shared/lib/browser/chrome-profile.test.ts
@@ -1,0 +1,136 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { copyChromeProfileData } from './chrome-profile'
+
+const ORIGINAL_PLATFORM = process.platform
+
+describe('copyChromeProfileData', () => {
+  let testHome: string
+  let chromeDataDir: string
+  let destination: string
+
+  beforeEach(() => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'superagent-chrome-profile-'))
+    chromeDataDir = path.join(testHome, '.config', 'google-chrome')
+    destination = path.join(testHome, 'destination')
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    vi.spyOn(os, 'homedir').mockReturnValue(testHome)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM, configurable: true })
+    fs.rmSync(testHome, { recursive: true, force: true })
+  })
+
+  function createProfile(profileId = 'Default', cookie = 'source-cookie'): string {
+    const profileDir = path.join(chromeDataDir, profileId)
+    fs.mkdirSync(path.join(profileDir, 'Local Storage', 'leveldb'), { recursive: true })
+    fs.mkdirSync(path.join(profileDir, 'Session Storage'), { recursive: true })
+    fs.mkdirSync(path.join(profileDir, 'Cache'), { recursive: true })
+    fs.writeFileSync(path.join(profileDir, 'Cookies'), cookie)
+    fs.writeFileSync(path.join(profileDir, 'Login Data'), 'login-data')
+    fs.writeFileSync(path.join(profileDir, 'Local Storage', 'leveldb', '000001.ldb'), 'local-data')
+    fs.writeFileSync(path.join(profileDir, 'Session Storage', 'session'), 'session-data')
+    fs.writeFileSync(path.join(profileDir, 'History'), 'must-not-copy')
+    fs.writeFileSync(path.join(profileDir, 'Cache', 'cache-entry'), 'must-not-copy')
+    return profileDir
+  }
+
+  it('copies only the selected session files and storage trees', async () => {
+    createProfile()
+
+    expect(await copyChromeProfileData('Default', destination)).toBe(true)
+
+    expect(fs.readFileSync(path.join(destination, 'Cookies'), 'utf8')).toBe('source-cookie')
+    expect(fs.readFileSync(path.join(destination, 'Login Data'), 'utf8')).toBe('login-data')
+    expect(fs.readFileSync(path.join(destination, 'Local Storage', 'leveldb', '000001.ldb'), 'utf8'))
+      .toBe('local-data')
+    expect(fs.readFileSync(path.join(destination, 'Session Storage', 'session'), 'utf8'))
+      .toBe('session-data')
+    expect(fs.existsSync(path.join(destination, 'History'))).toBe(false)
+    expect(fs.existsSync(path.join(destination, 'Cache'))).toBe(false)
+  })
+
+  it('returns false when the selected source profile does not exist', async () => {
+    fs.mkdirSync(chromeDataDir, { recursive: true })
+
+    expect(await copyChromeProfileData('Missing', destination)).toBe(false)
+    expect(fs.existsSync(destination)).toBe(false)
+  })
+
+  it('refreshes data whose source changed since the previous sync', async () => {
+    const profileDir = createProfile()
+    await copyChromeProfileData('Default', destination)
+
+    fs.writeFileSync(path.join(profileDir, 'Cookies'), 'new-and-longer-source-cookie')
+    await copyChromeProfileData('Default', destination)
+
+    expect(fs.readFileSync(path.join(destination, 'Cookies'), 'utf8'))
+      .toBe('new-and-longer-source-cookie')
+  })
+
+  it('re-seeds the destination when the selected source profile changes', async () => {
+    createProfile('Default', 'default-cookie')
+    createProfile('Profile 1', 'profile-one-cookie')
+    await copyChromeProfileData('Default', destination)
+
+    await copyChromeProfileData('Profile 1', destination)
+
+    expect(fs.readFileSync(path.join(destination, 'Cookies'), 'utf8')).toBe('profile-one-cookie')
+  })
+
+  it('repairs a destination file that disappeared after a successful sync', async () => {
+    createProfile()
+    await copyChromeProfileData('Default', destination)
+    fs.rmSync(path.join(destination, 'Login Data'))
+
+    await copyChromeProfileData('Default', destination)
+
+    expect(fs.readFileSync(path.join(destination, 'Login Data'), 'utf8')).toBe('login-data')
+  })
+
+  it('fails safe by re-seeding when the incremental-sync manifest is corrupt', async () => {
+    createProfile()
+    await copyChromeProfileData('Default', destination)
+    fs.writeFileSync(path.join(destination, 'Cookies'), 'agent-session-cookie')
+    fs.writeFileSync(path.join(destination, '.superagent-profile-sync.json'), '{not-json')
+
+    await copyChromeProfileData('Default', destination)
+
+    expect(fs.readFileSync(path.join(destination, 'Cookies'), 'utf8')).toBe('source-cookie')
+    expect(() => JSON.parse(
+      fs.readFileSync(path.join(destination, '.superagent-profile-sync.json'), 'utf8'),
+    )).not.toThrow()
+  })
+
+  it('refuses a profile id that escapes Chrome user-data storage', async () => {
+    fs.mkdirSync(chromeDataDir, { recursive: true })
+    fs.mkdirSync(path.join(chromeDataDir, '..', 'outside'), { recursive: true })
+    fs.writeFileSync(path.join(chromeDataDir, '..', 'outside', 'Cookies'), 'outside-cookie')
+
+    expect(await copyChromeProfileData('../outside', destination)).toBe(false)
+    expect(fs.existsSync(destination)).toBe(false)
+  })
+
+  it('preserves agent-side profile changes when the source is unchanged', async () => {
+    createProfile()
+    await copyChromeProfileData('Default', destination)
+    fs.writeFileSync(path.join(destination, 'Cookies'), 'agent-session-cookie')
+
+    await copyChromeProfileData('Default', destination)
+
+    expect(fs.readFileSync(path.join(destination, 'Cookies'), 'utf8')).toBe('agent-session-cookie')
+  })
+
+  it('uses asynchronous filesystem work so profile copies do not block the host event loop', async () => {
+    createProfile()
+
+    const result = copyChromeProfileData('Default', destination)
+
+    expect(result).toBeInstanceOf(Promise)
+    await result
+  })
+})

--- a/src/shared/lib/browser/chrome-profile.ts
+++ b/src/shared/lib/browser/chrome-profile.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { writeFileAtomic } from '@shared/lib/utils/file-storage'
 
 export interface ChromeProfile {
   id: string
@@ -11,6 +12,20 @@ export interface ChromeProfile {
 
 const PROFILE_FILES = ['Cookies', 'Cookies-journal', 'Login Data', 'Login Data-journal', 'Web Data', 'Web Data-journal']
 const PROFILE_DIRS = ['Local Storage', 'Session Storage']
+const PROFILE_SYNC_MANIFEST = '.superagent-profile-sync.json'
+const COPY_CONCURRENCY = 16
+
+interface ProfileFileFingerprint {
+  size: number
+  mtimeMs: number
+  ctimeMs: number
+}
+
+interface ProfileSyncManifest {
+  version: 1
+  profileId: string
+  files: Record<string, ProfileFileFingerprint>
+}
 
 /**
  * Returns the platform-specific Chrome user data directory, or null if not found.
@@ -60,36 +75,202 @@ export function listChromeProfiles(): ChromeProfile[] {
 }
 
 /**
- * Copies session data (cookies, login data, local/session storage) from a
- * Chrome profile into a destination directory.
+ * Asynchronously synchronizes session data (cookies, login data,
+ * local/session storage) from a Chrome profile into a destination directory.
+ * A source-metadata manifest makes subsequent syncs incremental: files are
+ * copied only when the selected source profile changed or a destination file
+ * disappeared. Destination files modified by the agent are therefore kept
+ * when the user's source profile is unchanged.
  *
  * @param profileId - Chrome profile directory name (e.g. "Default", "Profile 1")
  * @param destDir - Destination directory to copy files into
- * @returns true if files were copied, false if source profile wasn't found
+ * @returns true if the source profile exists, false otherwise
  */
-export function copyChromeProfileData(profileId: string, destDir: string): boolean {
+export async function copyChromeProfileData(profileId: string, destDir: string): Promise<boolean> {
   const chromeDataDir = getChromeUserDataDir()
   if (!chromeDataDir) return false
 
-  const profileSourceDir = path.join(chromeDataDir, profileId)
-  if (!fs.existsSync(profileSourceDir)) return false
-
-  fs.mkdirSync(destDir, { recursive: true })
-
-  for (const file of PROFILE_FILES) {
-    const src = path.join(profileSourceDir, file)
-    if (fs.existsSync(src)) {
-      fs.copyFileSync(src, path.join(destDir, file))
-    }
+  // Chrome profile IDs are direct children of the user-data directory. Refuse
+  // a tampered setting that would make this host-side copy read elsewhere.
+  const profileSourceDir = path.resolve(chromeDataDir, profileId)
+  if (path.dirname(profileSourceDir) !== path.resolve(chromeDataDir)) return false
+  try {
+    if (!(await fs.promises.stat(profileSourceDir)).isDirectory()) return false
+  } catch (error) {
+    if (isNotFound(error)) return false
+    throw error
   }
 
-  for (const dir of PROFILE_DIRS) {
-    const src = path.join(profileSourceDir, dir)
-    const dest = path.join(destDir, dir)
-    if (fs.existsSync(src)) {
-      fs.cpSync(src, dest, { recursive: true })
+  const [previousManifest, sourceFiles] = await Promise.all([
+    readProfileSyncManifest(destDir),
+    collectSourceFiles(profileSourceDir),
+  ])
+  const previousFiles = previousManifest?.profileId === profileId
+    ? previousManifest.files
+    : {}
+
+  await fs.promises.mkdir(destDir, { recursive: true })
+  const entries = Object.entries(sourceFiles)
+  await forEachConcurrent(entries, COPY_CONCURRENCY, async ([relativePath, fingerprint]) => {
+    const destinationPath = path.join(destDir, relativePath)
+    const unchanged = fingerprintsEqual(previousFiles[relativePath], fingerprint)
+    if (unchanged && await isRegularFile(destinationPath)) {
+      return
     }
+    await copyProfileFile(path.join(profileSourceDir, relativePath), destinationPath)
+  })
+
+  const nextManifest: ProfileSyncManifest = {
+    version: 1,
+    profileId,
+    files: sourceFiles,
+  }
+  if (!manifestsEqual(previousManifest, nextManifest)) {
+    await writeFileAtomic(
+      path.join(destDir, PROFILE_SYNC_MANIFEST),
+      JSON.stringify(nextManifest),
+      { mode: 0o600 },
+    )
   }
 
   return true
+}
+
+function isNotFound(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === 'ENOENT'
+}
+
+async function collectSourceFiles(
+  profileSourceDir: string,
+): Promise<Record<string, ProfileFileFingerprint>> {
+  const relativePaths = [...PROFILE_FILES]
+  await Promise.all(PROFILE_DIRS.map(
+    (relativePath) => collectDirectoryPaths(profileSourceDir, relativePath, relativePaths),
+  ))
+  const files: Record<string, ProfileFileFingerprint> = Object.create(null)
+  await forEachConcurrent(relativePaths, COPY_CONCURRENCY, async (relativePath) => {
+    await collectFile(profileSourceDir, relativePath, files)
+  })
+  return Object.fromEntries(Object.entries(files).sort(([left], [right]) => left.localeCompare(right)))
+}
+
+async function collectDirectoryPaths(
+  profileSourceDir: string,
+  relativeDir: string,
+  relativePaths: string[],
+): Promise<void> {
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(path.join(profileSourceDir, relativeDir), { withFileTypes: true })
+  } catch (error) {
+    if (isNotFound(error)) return
+    throw error
+  }
+
+  await Promise.all(entries.map(async (entry) => {
+    const relativePath = path.join(relativeDir, entry.name)
+    if (entry.isDirectory()) {
+      await collectDirectoryPaths(profileSourceDir, relativePath, relativePaths)
+    } else if (entry.isFile()) {
+      relativePaths.push(relativePath)
+    }
+  }))
+}
+
+async function collectFile(
+  profileSourceDir: string,
+  relativePath: string,
+  files: Record<string, ProfileFileFingerprint>,
+): Promise<void> {
+  try {
+    const stat = await fs.promises.stat(path.join(profileSourceDir, relativePath))
+    if (!stat.isFile()) return
+    files[relativePath] = {
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      ctimeMs: stat.ctimeMs,
+    }
+  } catch (error) {
+    if (!isNotFound(error)) throw error
+  }
+}
+
+async function readProfileSyncManifest(destDir: string): Promise<ProfileSyncManifest | null> {
+  try {
+    const parsed = JSON.parse(
+      await fs.promises.readFile(path.join(destDir, PROFILE_SYNC_MANIFEST), 'utf8'),
+    ) as Partial<ProfileSyncManifest>
+    if (
+      parsed.version !== 1
+      || typeof parsed.profileId !== 'string'
+      || !parsed.files
+      || typeof parsed.files !== 'object'
+      || Array.isArray(parsed.files)
+    ) {
+      return null
+    }
+    for (const value of Object.values(parsed.files)) {
+      if (
+        !value
+        || typeof value.size !== 'number'
+        || typeof value.mtimeMs !== 'number'
+        || typeof value.ctimeMs !== 'number'
+      ) {
+        return null
+      }
+    }
+    return parsed as ProfileSyncManifest
+  } catch (error) {
+    if (isNotFound(error) || error instanceof SyntaxError) return null
+    throw error
+  }
+}
+
+async function isRegularFile(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.promises.stat(filePath)).isFile()
+  } catch (error) {
+    if (isNotFound(error)) return false
+    throw error
+  }
+}
+
+async function copyProfileFile(sourcePath: string, destinationPath: string): Promise<void> {
+  await fs.promises.mkdir(path.dirname(destinationPath), { recursive: true })
+  await fs.promises.copyFile(sourcePath, destinationPath)
+}
+
+function fingerprintsEqual(
+  left: ProfileFileFingerprint | undefined,
+  right: ProfileFileFingerprint,
+): boolean {
+  return left?.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs
+}
+
+function manifestsEqual(
+  left: ProfileSyncManifest | null,
+  right: ProfileSyncManifest,
+): boolean {
+  if (!left || left.profileId !== right.profileId) return false
+  const leftPaths = Object.keys(left.files)
+  const rightPaths = Object.keys(right.files)
+  return leftPaths.length === rightPaths.length
+    && rightPaths.every((relativePath) => fingerprintsEqual(left.files[relativePath], right.files[relativePath]))
+}
+
+async function forEachConcurrent<T>(
+  values: T[],
+  concurrency: number,
+  work: (value: T) => Promise<void>,
+): Promise<void> {
+  let nextIndex = 0
+  const workers = Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+    while (nextIndex < values.length) {
+      const value = values[nextIndex++]
+      await work(value)
+    }
+  })
+  await Promise.all(workers)
 }

--- a/src/shared/lib/browser/chrome-profile.ts
+++ b/src/shared/lib/browser/chrome-profile.ts
@@ -2,6 +2,11 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { writeFileAtomic } from '@shared/lib/utils/file-storage'
+import {
+  ProfileSyncManifestSchema,
+  type ProfileFileFingerprint,
+  type ProfileSyncManifest,
+} from './chrome-profile-schema'
 
 export interface ChromeProfile {
   id: string
@@ -14,18 +19,6 @@ const PROFILE_FILES = ['Cookies', 'Cookies-journal', 'Login Data', 'Login Data-j
 const PROFILE_DIRS = ['Local Storage', 'Session Storage']
 const PROFILE_SYNC_MANIFEST = '.superagent-profile-sync.json'
 const COPY_CONCURRENCY = 16
-
-interface ProfileFileFingerprint {
-  size: number
-  mtimeMs: number
-  ctimeMs: number
-}
-
-interface ProfileSyncManifest {
-  version: 1
-  profileId: string
-  files: Record<string, ProfileFileFingerprint>
-}
 
 /**
  * Returns the platform-specific Chrome user data directory, or null if not found.
@@ -195,35 +188,24 @@ async function collectFile(
   }
 }
 
+// The manifest is advisory: any unreadable or invalid state resolves to null
+// so the sync falls back to a full re-seed instead of trusting stale data.
 async function readProfileSyncManifest(destDir: string): Promise<ProfileSyncManifest | null> {
+  let raw: string
   try {
-    const parsed = JSON.parse(
-      await fs.promises.readFile(path.join(destDir, PROFILE_SYNC_MANIFEST), 'utf8'),
-    ) as Partial<ProfileSyncManifest>
-    if (
-      parsed.version !== 1
-      || typeof parsed.profileId !== 'string'
-      || !parsed.files
-      || typeof parsed.files !== 'object'
-      || Array.isArray(parsed.files)
-    ) {
-      return null
-    }
-    for (const value of Object.values(parsed.files)) {
-      if (
-        !value
-        || typeof value.size !== 'number'
-        || typeof value.mtimeMs !== 'number'
-        || typeof value.ctimeMs !== 'number'
-      ) {
-        return null
-      }
-    }
-    return parsed as ProfileSyncManifest
+    raw = await fs.promises.readFile(path.join(destDir, PROFILE_SYNC_MANIFEST), 'utf8')
   } catch (error) {
-    if (isNotFound(error) || error instanceof SyntaxError) return null
+    if (isNotFound(error)) return null
     throw error
   }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  const result = ProfileSyncManifestSchema.safeParse(parsed)
+  return result.success ? result.data : null
 }
 
 async function isRegularFile(filePath: string): Promise<boolean> {
@@ -237,7 +219,15 @@ async function isRegularFile(filePath: string): Promise<boolean> {
 
 async function copyProfileFile(sourcePath: string, destinationPath: string): Promise<void> {
   await fs.promises.mkdir(path.dirname(destinationPath), { recursive: true })
-  await fs.promises.copyFile(sourcePath, destinationPath)
+  try {
+    await fs.promises.copyFile(sourcePath, destinationPath)
+  } catch (error) {
+    // A running Chrome deletes transient files (SQLite hot journals, leveldb
+    // tables) at any time, so a source that vanished after fingerprinting must
+    // not fail the sync — and with it the agent start. The next run's source
+    // scan simply won't include the file.
+    if (!isNotFound(error)) throw error
+  }
 }
 
 function fingerprintsEqual(

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -111,12 +111,17 @@ vi.mock('drizzle-orm', () => ({
 
 const mockSettingsState = {
   containerRunner: 'docker' as string,
+  chromeProfileId: undefined as string | undefined,
+  hostBrowserProvider: undefined as string | undefined,
 }
 
 vi.mock('@shared/lib/config/settings', () => ({
   getSettings: () => ({
     container: { agentImage: 'test-image', containerRunner: mockSettingsState.containerRunner },
-    app: {},
+    app: {
+      chromeProfileId: mockSettingsState.chromeProfileId,
+      hostBrowserProvider: mockSettingsState.hostBrowserProvider,
+    },
   }),
   updateSettings: vi.fn(),
   // the runner auto-switch now persists via mutateSettings; apply the
@@ -149,8 +154,9 @@ vi.mock('./health-monitor', () => ({
   },
 }))
 
+const mockCopyChromeProfileData = vi.fn().mockReturnValue(false)
 vi.mock('@shared/lib/browser/chrome-profile', () => ({
-  copyChromeProfileData: vi.fn().mockReturnValue(false),
+  copyChromeProfileData: (...args: unknown[]) => mockCopyChromeProfileData(...args),
 }))
 
 vi.mock('@shared/lib/services/agent-service', () => ({}))
@@ -187,6 +193,8 @@ describe('containerManager.ensureRunning — env var construction', () => {
     vi.clearAllMocks()
     // Clear internal state by removing the client
     containerManager.removeClient('test-agent')
+    mockSettingsState.chromeProfileId = undefined
+    mockSettingsState.hostBrowserProvider = undefined
 
     mockGetOrCreateProxyToken.mockResolvedValue('synth-token-123')
     mockGetContainerHostUrl.mockReturnValue('192.168.1.100')
@@ -261,6 +269,37 @@ describe('containerManager.ensureRunning — env var construction', () => {
     const startOpts = mockStart.mock.calls[0][0]
     expect(startOpts.envVars.SUPERAGENT_HOST_TOKEN).toBe('hostc_test-token')
     expect(mockGetOrCreateHostToken).toHaveBeenCalledWith('test-agent')
+  })
+
+  it('waits for an asynchronous Chrome profile sync before starting the container', async () => {
+    setupAccountMocks([])
+    mockSettingsState.chromeProfileId = 'Default'
+    let finishProfileSync!: (copied: boolean) => void
+    mockCopyChromeProfileData.mockReturnValueOnce(new Promise<boolean>((resolve) => {
+      finishProfileSync = resolve
+    }))
+
+    const startPromise = containerManager.ensureRunning('test-agent')
+    await vi.waitFor(() => expect(mockCopyChromeProfileData).toHaveBeenCalledWith(
+      'Default',
+      '/workspace/test-agent/.browser-profile',
+    ))
+
+    expect(mockStart).not.toHaveBeenCalled()
+    finishProfileSync(true)
+    await startPromise
+    expect(mockStart).toHaveBeenCalledOnce()
+  })
+
+  it('does not copy a local profile into a workspace that uses the host browser', async () => {
+    setupAccountMocks([])
+    mockSettingsState.chromeProfileId = 'Default'
+    mockSettingsState.hostBrowserProvider = 'chrome'
+
+    await containerManager.ensureRunning('test-agent')
+
+    expect(mockCopyChromeProfileData).not.toHaveBeenCalled()
+    expect(mockStart.mock.calls[0][0].envVars.AGENT_BROWSER_USE_HOST).toBe('1')
   })
 
   it('CONNECTED_ACCOUNTS includes only active accounts, grouped by toolkitSlug', async () => {

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -610,13 +610,15 @@ class ContainerManager {
         envVars['AGENT_ID'] = agentId
       }
 
-      // Copy Chrome profile data into workspace if configured
+      // Seed the built-in container browser from the selected Chrome profile.
+      // A host-browser provider uses its own dedicated profile, so copying the
+      // same data into the mounted workspace would only delay container start.
       const chromeProfileId = settings.app?.chromeProfileId
-      if (chromeProfileId) {
+      if (chromeProfileId && !settings.app?.hostBrowserProvider) {
         const workspaceDir = getAgentWorkspaceDir(agentId)
         const browserProfileDir = path.join(workspaceDir, '.browser-profile')
-        if (copyChromeProfileData(chromeProfileId, browserProfileDir)) {
-          console.log(`[ContainerManager] Copied Chrome profile "${chromeProfileId}" to workspace`)
+        if (await copyChromeProfileData(chromeProfileId, browserProfileDir)) {
+          console.log(`[ContainerManager] Synchronized Chrome profile "${chromeProfileId}" to workspace`)
         }
       }
 


### PR DESCRIPTION
## Summary

- replace synchronous bulk Chrome-profile copies with a bounded asynchronous, per-file incremental sync
- track source size/mtime/ctime in an atomic manifest so unchanged starts preserve agent-side session changes and write no profile bytes
- still repair changed source files and missing destinations, fully re-seed when the selected profile changes, and fail safe to a full sync when the manifest is missing or corrupt
- await sync before Chrome/container launch, but skip the workspace copy entirely when a host-browser provider is configured because that path uses its own profile

## Measured impact

A real-filesystem profiler synchronized an unchanged synthetic profile containing 406 files / 17,760,256 bytes for seven iterations:

- warm-sync median: **73.85 ms -> 6.54 ms** (**-91.2%**)
- warm-sync p95: **91.11 ms -> 7.82 ms** (**-91.4%**)
- median event-loop delay: **73.84 ms -> 0.07 ms** (**-99.9%**)
- unchanged data rewritten per start: **406 files / 17.8 MB -> 0**
- agent-side cookie state: overwritten before, preserved in every after iteration

The host-browser configuration also removes the redundant container-workspace copy altogether.

## Validation

- 156 broad browser/container tests passed
- full root suite: 9,054 tests passed in-sandbox; all 89 tests in the five localhost-binding files passed when rerun with bind permission, resolving the 43 sandbox-only `listen EPERM` failures
- TypeScript and targeted ESLint passed
- web, API, and Electron production builds passed
- `git diff --check` passed

## Risk notes

The manifest is advisory and atomically written. Missing/corrupt state falls back to a full re-seed, callers still wait for required copies, and source changes are detected across size, mtime, and ctime. The sync remains limited to the same cookie/login/local/session-storage allowlist.
