### PR TITLE
feat: prefill create agent from signup handoff (SUP-552)

### DIFF
--- a/src/api/routes/platform-sso-start.test.ts
+++ b/src/api/routes/platform-sso-start.test.ts
@@ -98,4 +98,72 @@ describe('GET /auth/platform/start', () => {
     expect(res.headers.get('location')).toBe('/')
     expect(mockCaptureException).toHaveBeenCalled()
   })
+
+  it('warm session redirect carries validated prompt and model', async () => {
+    mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
+    const prompt = encodeURIComponent('build & ship https://x.com')
+    const res = await createApp().request(
+      `/auth/platform/start?return_to=%2F&prompt=${prompt}&model=claude-opus-5`,
+    )
+    expect(res.status).toBe(302)
+    const location = new URL(res.headers.get('location')!, 'http://internal')
+    expect(location.pathname).toBe('/')
+    expect(location.searchParams.get('prompt')).toBe('build & ship https://x.com')
+    expect(location.searchParams.get('model')).toBe('claude-opus-5')
+  })
+
+  it('cold path passes decorated return_to as callbackURL', async () => {
+    mockGetSession.mockResolvedValue(null)
+    mockSignInWithOAuth2.mockResolvedValue({
+      headers: new Headers(),
+      response: { url: 'https://auth.example.com/authorize?state=1', redirect: true },
+    })
+    await createApp().request(
+      '/auth/platform/start?return_to=%2F&prompt=hello&model=gpt-5.6-luna',
+    )
+    expect(mockSignInWithOAuth2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          callbackURL: '/?prompt=hello&model=gpt-5.6-luna',
+          errorCallbackURL: '/',
+        }),
+      }),
+    )
+  })
+
+  it('drops a junk model and truncates an overlong prompt', async () => {
+    mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
+    const longPrompt = 'x'.repeat(500)
+    const res = await createApp().request(
+      `/auth/platform/start?return_to=%2F&prompt=${encodeURIComponent(longPrompt)}&model=not%20valid`,
+    )
+    const location = new URL(res.headers.get('location')!, 'http://internal')
+    expect(location.searchParams.get('prompt')).toHaveLength(400)
+    expect(location.searchParams.get('model')).toBeNull()
+  })
+
+  it('preserves existing return_to query and fragment when appending handoff', async () => {
+    mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
+    const res = await createApp().request(
+      `/auth/platform/start?return_to=${encodeURIComponent('/agents?tab=1#panel')}&prompt=hi&model=opus`,
+    )
+    const location = res.headers.get('location')!
+    expect(location.startsWith('/agents?')).toBe(true)
+    const url = new URL(location, 'http://internal')
+    expect(url.searchParams.get('tab')).toBe('1')
+    expect(url.searchParams.get('prompt')).toBe('hi')
+    expect(url.searchParams.get('model')).toBe('opus')
+    expect(url.hash).toBe('#panel')
+  })
+
+  it('keeps return_to sanitizing behavior unchanged for open redirects', async () => {
+    mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
+    const res = await createApp().request(
+      '/auth/platform/start?return_to=https://evil.example&prompt=hello&model=opus',
+    )
+    const location = new URL(res.headers.get('location')!, 'http://internal')
+    expect(location.pathname).toBe('/')
+    expect(location.searchParams.get('prompt')).toBe('hello')
+    expect(location.searchParams.get('model')).toBe('opus')
+  })
 })

--- a/src/api/routes/platform-sso-start.ts
+++ b/src/api/routes/platform-sso-start.ts
@@ -5,6 +5,8 @@ import { sanitizeReturnTo } from '@shared/lib/auth/safe-return-to'
 import { captureException } from '@shared/lib/error-reporting'
 
 const PLATFORM_PROVIDER_ID = 'platform'
+const HANDOFF_PROMPT_MAX = 400
+const HANDOFF_MODEL_RE = /^[A-Za-z0-9._/-]{1,64}$/
 
 function resolvePlatformProviderId(): string | null {
   const providers = getGenericOAuthProviderConfigs()
@@ -12,6 +14,25 @@ function resolvePlatformProviderId(): string | null {
   return providers.some((p) => p.providerId === PLATFORM_PROVIDER_ID)
     ? PLATFORM_PROVIDER_ID
     : null
+}
+
+/** Append validated marketing-handoff params to an already-sanitized internal path. */
+function withSignupHandoff(
+  returnTo: string,
+  prompt: string | undefined,
+  model: string | undefined,
+): string {
+  try {
+    const url = new URL(returnTo, 'http://internal')
+    const cleanPrompt = prompt?.replace(/[\r\n\0]/g, '').trim().slice(0, HANDOFF_PROMPT_MAX)
+    if (cleanPrompt) url.searchParams.set('prompt', cleanPrompt)
+    if (model && HANDOFF_MODEL_RE.test(model)) url.searchParams.set('model', model)
+    // hash included: sanitizeReturnTo permits fragments and returns them verbatim.
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    // Fail open: keep the sanitized return_to rather than strand the SSO hop.
+    return returnTo
+  }
 }
 
 function appendSetCookies(from: Headers, to: Headers): void {
@@ -31,6 +52,7 @@ const platformSsoStart = new Hono()
 
 platformSsoStart.get('/platform/start', async (c) => {
   const returnTo = sanitizeReturnTo(c.req.query('return_to'))
+  const target = withSignupHandoff(returnTo, c.req.query('prompt'), c.req.query('model'))
   const providerId = resolvePlatformProviderId()
   if (!providerId) {
     return c.redirect('/', 302)
@@ -41,13 +63,13 @@ platformSsoStart.get('/platform/start', async (c) => {
     const session = await auth.api.getSession({ headers: c.req.raw.headers })
     if (session?.session) {
       // Reuse an acceptable existing deployment session; account-switch requires logout.
-      return c.redirect(returnTo, 302)
+      return c.redirect(target, 302)
     }
 
     const { headers, response } = await auth.api.signInWithOAuth2({
       body: {
         providerId,
-        callbackURL: returnTo,
+        callbackURL: target,
         errorCallbackURL: '/',
       },
       headers: c.req.raw.headers,

--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DraftsProvider } from '@renderer/context/drafts-context'
+import type { SignupHandoff } from '@renderer/context/nav-transient-context'
+
+const mockCreateSession = vi.fn()
+const mockCreateAgent = vi.fn()
+const mockSetSignupHandoff = vi.fn()
+let mockSignupHandoff: SignupHandoff | null = null
+let mockCatalog = [
+  { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true },
+  { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true },
+]
+
+vi.mock('@renderer/context/nav-transient-context', () => ({
+  useNavTransient: () => ({
+    justCreatedSlug: null,
+    setJustCreatedSlug: vi.fn(),
+    get signupHandoff() {
+      return mockSignupHandoff
+    },
+    setSignupHandoff: (value: SignupHandoff | null) => {
+      mockSignupHandoff = value
+      mockSetSignupHandoff(value)
+    },
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useModelSettings: () => ({
+    data: {
+      llmProvider: 'anthropic',
+      llmProviderStatus: [{ id: 'anthropic', catalog: mockCatalog }],
+    },
+  }),
+  useWarmStartOnTypeEnabled: () => false,
+}))
+
+vi.mock('@renderer/hooks/use-start-onboarding-session', () => ({
+  useStartOnboardingSession: () => vi.fn(),
+}))
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useCreateAgent: () => ({
+    mutateAsync: mockCreateAgent,
+    isPending: false,
+  }),
+  useUpdateAgent: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useDeleteAgent: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useStartAgent: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-sessions', () => ({
+  useCreateSession: () => ({
+    mutateAsync: mockCreateSession,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@renderer/lib/derive-agent-name', () => ({
+  deriveAgentName: vi.fn(async () => 'Test Agent'),
+}))
+
+vi.mock('@renderer/hooks/use-typewriter-placeholder', () => ({
+  useTypewriterPlaceholder: () => 'placeholder',
+  DEFAULT_AGENT_PROMPT_EXAMPLES: [],
+}))
+
+vi.mock('@renderer/components/agents/agent-creation-aids', () => ({
+  AgentCreationAids: () => null,
+}))
+
+vi.mock('@renderer/components/agents/template-install-dialog', () => ({
+  TemplateInstallDialog: () => null,
+}))
+
+vi.mock('@renderer/components/ui/attachment-picker', () => ({
+  AttachmentPicker: () => null,
+}))
+
+vi.mock('@renderer/components/ui/voice-input-button', () => ({
+  VoiceInputButton: () => null,
+  VoiceInputError: () => null,
+}))
+
+import { CreateAgentForm } from './create-agent-form'
+
+function renderForm() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DraftsProvider>
+        <CreateAgentForm />
+      </DraftsProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('CreateAgentForm signup handoff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSignupHandoff = null
+    mockCatalog = [
+      { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true },
+      { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true },
+    ]
+    mockCreateAgent.mockResolvedValue({
+      slug: 'agent-1',
+      displaySlug: 'agent-1',
+      name: 'Test Agent',
+    })
+    mockCreateSession.mockResolvedValue({ id: 'session-1' })
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+  })
+
+  it('seeds the composer, clears the one-shot, and submits with a catalog model', async () => {
+    mockSignupHandoff = { prompt: 'hello', model: 'claude-opus-5' }
+    const user = userEvent.setup()
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-agent-prompt')).toHaveTextContent('hello')
+    })
+    expect(mockSetSignupHandoff).toHaveBeenCalledWith(null)
+    await user.click(screen.getByTestId('create-agent-submit'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-opus-5' }),
+      )
+    })
+  })
+
+  it('falls back to opus when the carried model is unknown', async () => {
+    mockSignupHandoff = { prompt: 'hello', model: 'kimi-k2' }
+    const user = userEvent.setup()
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-agent-prompt')).toHaveTextContent('hello')
+    })
+    await user.click(screen.getByTestId('create-agent-submit'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'opus' }),
+      )
+    })
+  })
+
+  it('uses opus with no behavior change when there is no handoff', async () => {
+    const user = userEvent.setup()
+    renderForm()
+
+    const prompt = screen.getByTestId('create-agent-prompt')
+    await user.click(prompt)
+    await user.keyboard('from scratch')
+    await user.click(screen.getByTestId('create-agent-submit'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'opus', message: 'from scratch' }),
+      )
+    })
+    expect(mockSetSignupHandoff).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -9,8 +9,10 @@ import type { SignupHandoff } from '@renderer/context/nav-transient-context'
 
 const mockCreateSession = vi.fn()
 const mockCreateAgent = vi.fn()
+const mockStartAgent = vi.fn()
 const mockSetSignupHandoff = vi.fn()
 let mockSignupHandoff: SignupHandoff | null = null
+let mockWarmStartEnabled = false
 let mockCatalog = [
   { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true },
   { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true },
@@ -37,7 +39,13 @@ vi.mock('@renderer/hooks/use-settings', () => ({
       llmProviderStatus: [{ id: 'anthropic', catalog: mockCatalog }],
     },
   }),
-  useWarmStartOnTypeEnabled: () => false,
+  useWarmStartOnTypeEnabled: () => mockWarmStartEnabled,
+}))
+
+vi.mock('@renderer/hooks/use-runtime-status', () => ({
+  useRuntimeStatus: () => ({
+    data: { runtimeReadiness: { status: 'READY' } },
+  }),
 }))
 
 vi.mock('@renderer/hooks/use-start-onboarding-session', () => ({
@@ -58,7 +66,7 @@ vi.mock('@renderer/hooks/use-agents', () => ({
     isPending: false,
   }),
   useStartAgent: () => ({
-    mutate: vi.fn(),
+    mutate: mockStartAgent,
     mutateAsync: vi.fn(),
     isPending: false,
   }),
@@ -116,6 +124,7 @@ describe('CreateAgentForm signup handoff', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSignupHandoff = null
+    mockWarmStartEnabled = false
     mockCatalog = [
       { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true },
       { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true },
@@ -183,5 +192,19 @@ describe('CreateAgentForm signup handoff', () => {
       )
     })
     expect(mockSetSignupHandoff).not.toHaveBeenCalled()
+  })
+
+  it('row5: prefill with warm-start enabled does not create an agent until edit', async () => {
+    mockWarmStartEnabled = true
+    mockSignupHandoff = { prompt: 'marketing prompt', model: 'claude-opus-5' }
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-agent-prompt')).toHaveTextContent('marketing prompt')
+    })
+    // Allow warm-start effect to run if it were going to.
+    await new Promise((r) => setTimeout(r, 50))
+    expect(mockCreateAgent).not.toHaveBeenCalled()
+    expect(mockStartAgent).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -12,6 +12,7 @@ import { useCreateAgent, useDeleteAgent, useUpdateAgent } from '@renderer/hooks/
 import { useCreateSession } from '@renderer/hooks/use-sessions'
 import { useNavigate } from '@tanstack/react-router'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
+import { useNavTransient } from '@renderer/context/nav-transient-context'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import {
   useTypewriterPlaceholder,
@@ -20,7 +21,8 @@ import {
 import { deriveAgentName } from '@renderer/lib/derive-agent-name'
 import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
 import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
-import { useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
+import { useModelSettings, useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
+import { findCatalogModel } from '@renderer/components/messages/composer-options'
 import { captureRendererException } from '@renderer/lib/error-reporting'
 import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
@@ -61,6 +63,9 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
   const { track } = useAnalyticsTracking()
   const startOnboardingSession = useStartOnboardingSession()
   const warmStartEnabled = useWarmStartOnTypeEnabled()
+  const { signupHandoff, setSignupHandoff } = useNavTransient()
+  const { data: modelSettings } = useModelSettings()
+  const [handoffModel, setHandoffModel] = useState<string | null>(null)
 
   // Warm-precreated Untitled agent; deleted on abandon unless submit consumes it.
   const warmSlugOwnedRef = useRef<string | null>(null)
@@ -134,13 +139,17 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
           ? await updateAgent.mutateAsync({ slug: warmSlug, name: agentName })
           : await createAgent.mutateAsync({ name: agentName })
         if (warmSlug) warmConsumedRef.current = true
+        const activeProvider = modelSettings?.llmProvider
+        const catalog = modelSettings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? []
+        // Carried marketing-handoff model, only when the effective catalog knows it —
+        // an unknown versioned id would be passed to the SDK as a pin and fail at the
+        // API. Resolved at submit time: the catalog is a separate query from settings
+        // and may not exist at mount. Falls back to today's behavior.
+        const model = (handoffModel && findCatalogModel(handoffModel, catalog)?.id) || 'opus'
         const session = await createSession.mutateAsync({
           agentSlug: newAgent.slug,
           message: content,
-          // Brand-new agents start their first session on Opus, mirroring
-          // AgentHome's first-session default. The container normalizes the
-          // family alias to the active provider's specific model.
-          model: 'opus',
+          model,
         })
         track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
         void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: newAgent.displaySlug, sessionId: session.id } })
@@ -153,10 +162,10 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
       } finally {
         setIsSubmitting(false)
       }
-    }, [createAgent, updateAgent, createSession, navigate, track, onAgentCreated]),
+    }, [createAgent, updateAgent, createSession, navigate, track, onAgentCreated, handoffModel, modelSettings]),
   })
 
-  const { awaitWarmStart } = useWarmStartOnType({
+  const { awaitWarmStart, noteProgrammaticChange } = useWarmStartOnType({
     agentSlug: null,
     message: composer.message,
     enabled: warmStartEnabled,
@@ -165,6 +174,19 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
   useEffect(() => {
     awaitWarmStartRef.current = awaitWarmStart
   }, [awaitWarmStart])
+
+  useEffect(() => {
+    if (!signupHandoff) return
+    if (signupHandoff.prompt) {
+      // Seed warm-start baseline first so the prefill is not treated as typing
+      // (success criterion: prefill only — nothing auto-creates).
+      noteProgrammaticChange(signupHandoff.prompt)
+      composer.setMessage(signupHandoff.prompt)
+      setTimeout(() => textareaRef.current?.focus(), 0)
+    }
+    if (signupHandoff.model) setHandoffModel(signupHandoff.model)
+    setSignupHandoff(null) // one-shot
+  }, [signupHandoff, setSignupHandoff, composer, noteProgrammaticChange])
 
   // Abandon path: leave the create form without consuming the warm agent.
   // Ref + empty deps so mutation identity churn doesn't re-bind cleanup mid-edit.

--- a/src/renderer/components/layout/route-layouts.tsx
+++ b/src/renderer/components/layout/route-layouts.tsx
@@ -12,6 +12,7 @@ import { MenuCommandHandler } from '@renderer/components/menu-command-handler'
 import { PackageImportHandler } from '@renderer/components/package-import-handler'
 import { HistoryNavigationHandler } from '@renderer/components/history-navigation-handler'
 import { GlobalNotificationHandler } from '@renderer/components/notifications/global-notification-handler'
+import { SignupHandoffConsumer } from '@renderer/components/signup-handoff-consumer'
 import { OnboardingProvider } from '@renderer/context/onboarding-context'
 import { useSearch } from '@renderer/context/search-context'
 import { useUserSettings } from '@renderer/hooks/use-user-settings'
@@ -153,6 +154,9 @@ export function RootLayout() {
               <SearchDialog />
             </Suspense>
           ) : null}
+          {/* Above the wizard ternary: the wizard replaces the outlet, so a
+              consumer inside the outlet may never commit an effect. */}
+          <SignupHandoffConsumer />
           {wizardOpen ? (
             <Suspense fallback={null}>
               <GettingStartedWizard agentOnly={wizardAgentOnly} onClose={() => setWizardOpen(false)} />

--- a/src/renderer/components/signup-handoff-consumer.test.tsx
+++ b/src/renderer/components/signup-handoff-consumer.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router'
+
+import { NavTransientProvider, useNavTransient } from '@renderer/context/nav-transient-context'
+import { homeSearchSchema } from '@renderer/router/search-schemas'
+import { lenient } from '@renderer/router/zod-search'
+
+import { SignupHandoffConsumer } from './signup-handoff-consumer'
+
+// Global setup stubs useNavigate to a no-op; this file needs a real router.
+vi.unmock('@tanstack/react-router')
+
+function HandoffProbe() {
+  const { signupHandoff } = useNavTransient()
+  return <div data-testid="handoff">{JSON.stringify(signupHandoff)}</div>
+}
+
+function makeRouter(initialEntry: string) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <SignupHandoffConsumer />
+        <HandoffProbe />
+        <Outlet />
+      </>
+    ),
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    validateSearch: lenient(homeSearchSchema),
+    component: () => <div data-testid="home">home</div>,
+  })
+  return createRouter({
+    routeTree: rootRoute.addChildren([homeRoute]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+}
+
+describe('SignupHandoffConsumer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('moves prompt+model into the one-shot and strips those keys from the URL', async () => {
+    const router = makeRouter('/?prompt=hello&model=claude-opus-5&view=graph')
+    const { getByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        prompt: 'hello',
+        model: 'claude-opus-5',
+      })
+    })
+    await waitFor(() => {
+      const search = router.state.location.search as {
+        prompt?: string
+        model?: string
+        view?: string
+      }
+      expect(search.prompt).toBeUndefined()
+      expect(search.model).toBeUndefined()
+      expect(search.view).toBe('graph')
+    })
+  })
+
+  it('is a no-op when neither handoff param is present', async () => {
+    const router = makeRouter('/?view=cards')
+    const { getByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(getByTestId('home')).toBeTruthy()
+    })
+    expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toBeNull()
+    expect((router.state.location.search as { view?: string }).view).toBe('cards')
+  })
+
+  it('truncates prompt and drops an invalid model before writing the one-shot', async () => {
+    const longPrompt = 'x'.repeat(500)
+    const router = makeRouter(`/?prompt=${longPrompt}&model=${encodeURIComponent('not valid')}`)
+    const { getByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+
+    await waitFor(() => {
+      // JSON omits undefined keys — invalid model must not appear at all.
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        prompt: 'x'.repeat(400),
+      })
+    })
+  })
+})

--- a/src/renderer/components/signup-handoff-consumer.tsx
+++ b/src/renderer/components/signup-handoff-consumer.tsx
@@ -1,0 +1,35 @@
+// Always-mounted (route-layouts, above the wizard branch): moves the marketing
+// signup handoff from the URL into the in-memory one-shot, then strips the
+// params. One effect, one shot.
+import { useEffect } from 'react'
+import { useNavigate, useRouterState } from '@tanstack/react-router'
+
+import { useNavTransient } from '@renderer/context/nav-transient-context'
+import { homeSearchSchema } from '@renderer/router/search-schemas'
+import { lenient } from '@renderer/router/zod-search'
+
+export function SignupHandoffConsumer() {
+  // location.search is raw parseSearch output (router-core) — not route-validated.
+  // Run the home schema here so truncate + model regex actually gate the one-shot.
+  const search = useRouterState({
+    select: (s) => s.location.search as Record<string, unknown>,
+  })
+  const navigate = useNavigate()
+  const { setSignupHandoff } = useNavTransient()
+
+  const { prompt, model } = lenient(homeSearchSchema)(search)
+  useEffect(() => {
+    if (!prompt && !model) return
+    setSignupHandoff({ prompt, model })
+    // Explicit '/' — the params live on homeSearchSchema, registered only on the
+    // home route (routes.ts:57); the sibling search mutation uses to: '/' too
+    // (home-page.tsx:922).
+    void navigate({
+      to: '/',
+      search: (prev: Record<string, unknown>) => ({ ...prev, prompt: undefined, model: undefined }),
+      replace: true,
+    })
+  }, [prompt, model, setSignupHandoff, navigate])
+
+  return null
+}

--- a/src/renderer/components/signup-handoff.smoke.test.tsx
+++ b/src/renderer/components/signup-handoff.smoke.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+/**
+ * Automated Gate 2 smoke for SUP-552 PR1b — consumer validation + strip.
+ * Create-form warm-start row lives in create-agent-form.handoff.test.tsx.
+ */
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router'
+
+import { NavTransientProvider, useNavTransient } from '@renderer/context/nav-transient-context'
+import { homeSearchSchema } from '@renderer/router/search-schemas'
+import { lenient } from '@renderer/router/zod-search'
+
+import { SignupHandoffConsumer } from './signup-handoff-consumer'
+
+vi.unmock('@tanstack/react-router')
+
+function HandoffProbe() {
+  const { signupHandoff } = useNavTransient()
+  return <div data-testid="handoff">{JSON.stringify(signupHandoff)}</div>
+}
+
+function makeRouter(initialEntry: string) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <SignupHandoffConsumer />
+        <HandoffProbe />
+        <Outlet />
+      </>
+    ),
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    validateSearch: lenient(homeSearchSchema),
+    component: () => <div data-testid="home">home</div>,
+  })
+  return createRouter({
+    routeTree: rootRoute.addChildren([homeRoute]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+}
+
+describe('Gate 2 automated smoke — PR1b consumption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('row1 happy: prompt+model move into one-shot and leave the URL', async () => {
+    const router = makeRouter('/?prompt=hello&model=claude-opus-5&view=graph')
+    const { getByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        prompt: 'hello',
+        model: 'claude-opus-5',
+      })
+    })
+    await waitFor(() => {
+      const search = router.state.location.search as {
+        prompt?: string
+        model?: string
+        view?: string
+      }
+      expect(search.prompt).toBeUndefined()
+      expect(search.model).toBeUndefined()
+      expect(search.view).toBe('graph')
+    })
+  })
+
+  it('row2 no-params: consumer is a no-op', async () => {
+    const router = makeRouter('/?view=cards')
+    const { getByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+    await waitFor(() => expect(getByTestId('home')).toBeTruthy())
+    expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toBeNull()
+  })
+
+  it('row1 boundary: invalid view does not wipe a valid prompt', async () => {
+    const router = makeRouter('/?prompt=keep-me&model=claude-opus-5&view=garbage')
+    const { getByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+    await waitFor(() => {
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        prompt: 'keep-me',
+        model: 'claude-opus-5',
+      })
+    })
+  })
+})

--- a/src/renderer/context/nav-transient-context.tsx
+++ b/src/renderer/context/nav-transient-context.tsx
@@ -1,8 +1,12 @@
 import { createContext, useContext, useState, type ReactNode } from 'react'
 
+export type SignupHandoff = { prompt?: string; model?: string }
+
 interface NavTransientValue {
   justCreatedSlug: string | null
   setJustCreatedSlug: (slug: string | null) => void
+  signupHandoff: SignupHandoff | null
+  setSignupHandoff: (value: SignupHandoff | null) => void
 }
 
 const NavTransientContext = createContext<NavTransientValue | null>(null)
@@ -14,12 +18,17 @@ const NavTransientContext = createContext<NavTransientValue | null>(null)
  *
  * - `justCreatedSlug`: the new-agent "morph" tag. Produced by
  *   `useCreateUntitledAgent` on create and consumed by AgentHome.
+ * - `signupHandoff`: marketing-site prompt+model prefill for the first-run
+ *   create box. Produced by SignupHandoffConsumer and consumed by CreateAgentForm.
  */
 export function NavTransientProvider({ children }: { children: ReactNode }) {
   const [justCreatedSlug, setJustCreatedSlug] = useState<string | null>(null)
+  const [signupHandoff, setSignupHandoff] = useState<SignupHandoff | null>(null)
 
   return (
-    <NavTransientContext.Provider value={{ justCreatedSlug, setJustCreatedSlug }}>
+    <NavTransientContext.Provider
+      value={{ justCreatedSlug, setJustCreatedSlug, signupHandoff, setSignupHandoff }}
+    >
       {children}
     </NavTransientContext.Provider>
   )

--- a/src/renderer/hooks/use-warm-start-on-type.test.tsx
+++ b/src/renderer/hooks/use-warm-start-on-type.test.tsx
@@ -90,6 +90,30 @@ describe('useWarmStartOnType', () => {
     })
   })
 
+  it('does not start from a programmatic prefill until the user edits further', async () => {
+    const { result, rerender } = renderHook(
+      ({ message }) =>
+        useWarmStartOnType({ agentSlug: 'agent-1', message, enabled: true }),
+      { wrapper, initialProps: { message: '' } },
+    )
+
+    act(() => {
+      result.current.noteProgrammaticChange('marketing prompt')
+    })
+    rerender({ message: 'marketing prompt' })
+
+    await act(async () => {})
+    expect(mutate).not.toHaveBeenCalled()
+
+    rerender({ message: 'marketing prompt edited' })
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith(
+        { slug: 'agent-1', source: 'warm-start' },
+        expect.any(Object),
+      )
+    })
+  })
+
   it('creates then starts when ensureAgent is provided', async () => {
     const { rerender } = renderHook(
       ({ message }) =>

--- a/src/renderer/hooks/use-warm-start-on-type.ts
+++ b/src/renderer/hooks/use-warm-start-on-type.ts
@@ -37,8 +37,13 @@ export function useWarmStartOnType({
   const ensureAgentRef = useRef(ensureAgent)
   ensureAgentRef.current = ensureAgent
 
-  // Mount-time baseline — restored drafts must not count as "typing".
+  // Mount-time baseline — restored drafts / programmatic prefills must not
+  // count as "typing". Call noteProgrammaticChange(next) before setMessage(next).
   const baselineRef = useRef(message)
+
+  const noteProgrammaticChange = useCallback((next: string) => {
+    baselineRef.current = next
+  }, [])
 
   useEffect(() => {
     if (agentSlug) slugRef.current = agentSlug
@@ -106,5 +111,5 @@ export function useWarmStartOnType({
     return null
   }, [enabled, isReady, message, run])
 
-  return { awaitWarmStart }
+  return { awaitWarmStart, noteProgrammaticChange }
 }

--- a/src/renderer/router/search-schemas.test.ts
+++ b/src/renderer/router/search-schemas.test.ts
@@ -152,4 +152,20 @@ describe('homeSearchSchema (signup handoff)', () => {
       }),
     ).toEqual({ prompt: 'hello', model: 'claude-opus-5' })
   })
+
+  // Parity with withSignupHandoff (platform-sso-start.ts): a directly-visited
+  // URL skips the SSO hop, so the schema has to be the same gate on its own.
+  it('strips control characters and trims, matching the SSO hop', () => {
+    expect(lenient(homeSearchSchema)({ prompt: '  build\r\nand ship\0  ' }).prompt)
+      .toBe('buildand ship')
+  })
+
+  it('strips before capping so control characters do not eat the budget', () => {
+    const parsed = lenient(homeSearchSchema)({ prompt: `${'\n'.repeat(200)}${'x'.repeat(500)}` })
+    expect(parsed.prompt).toBe('x'.repeat(400))
+  })
+
+  it('collapses an all-whitespace prompt to falsy so consumers read it as absent', () => {
+    expect(lenient(homeSearchSchema)({ prompt: '   \r\n  ' }).prompt).toBe('')
+  })
 })

--- a/src/renderer/router/search-schemas.test.ts
+++ b/src/renderer/router/search-schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   chatSearchSchema,
   connectionsSearchSchema,
+  homeSearchSchema,
   rootSearchSchema,
   settingsSearchSchema,
   settingsTabSchema,
@@ -126,5 +127,29 @@ describe('rootSearchSchema.redirect == api.ts isSafeInternalPath (unified guard)
   it('still accepts a normal internal path and a deeper (non-leading) encoded separator', () => {
     expect(rootSearchSchema.safeParse({ redirect: '/agents/foo' }).success).toBe(true)
     expect(rootSearchSchema.safeParse({ redirect: '/settings/general?from=%2Fagents%2Ffoo' }).success).toBe(true)
+  })
+})
+
+describe('homeSearchSchema (signup handoff)', () => {
+  it('truncates an over-length prompt instead of dropping it', () => {
+    const parsed = lenient(homeSearchSchema)({ prompt: 'x'.repeat(500) })
+    expect(parsed.prompt).toHaveLength(400)
+  })
+
+  it('applies per-field catch: keeps a valid prompt when the model is junk', () => {
+    const parsed = lenient(homeSearchSchema)({ prompt: 'hello', model: 'not valid' })
+    expect(parsed.prompt).toBe('hello')
+    expect(parsed.model).toBeUndefined()
+    expect(lenient(homeSearchSchema)({ prompt: 1, model: '!!!' })).toEqual({})
+  })
+
+  it('keeps handoff params when view is invalid', () => {
+    expect(
+      lenient(homeSearchSchema)({
+        view: 'garbage',
+        prompt: 'hello',
+        model: 'claude-opus-5',
+      }),
+    ).toEqual({ prompt: 'hello', model: 'claude-opus-5' })
   })
 })

--- a/src/renderer/router/search-schemas.ts
+++ b/src/renderer/router/search-schemas.ts
@@ -61,7 +61,14 @@ export const rootSearchSchema = z.object({
 export const homeSearchSchema = z.object({
   // Per-field .catch: invalid view must not wipe prompt/model via lenient().
   view: z.enum(['cards', 'graph']).optional().catch(undefined),
-  prompt: z.string().transform((s) => s.slice(0, 400)).optional().catch(undefined),
+  // Same gate as the SSO hop's withSignupHandoff (platform-sso-start.ts): a URL
+  // typed or shared directly, with no SSO hop in front of it, has to be cleaned
+  // to the same shape. Strip/trim BEFORE the cap so control characters can't eat
+  // into the 400 budget. An all-whitespace prompt collapses to '' — falsy, so
+  // every consumer reads it as absent.
+  prompt: z.string()
+    .transform((s) => s.replace(/[\r\n\0]/g, '').trim().slice(0, 400))
+    .optional().catch(undefined),
   model: z.string().regex(/^[A-Za-z0-9._/-]{1,64}$/).optional().catch(undefined),
 })
 

--- a/src/renderer/router/search-schemas.ts
+++ b/src/renderer/router/search-schemas.ts
@@ -55,8 +55,14 @@ export const rootSearchSchema = z.object({
 
 // Home view toggle (cards ⇄ graph). URL-driven so back/forward navigation and
 // reloads keep the selected view; absent = cards.
+// Marketing-site signup handoff (one-shot: consumed + stripped by
+// SignupHandoffConsumer). Per-field .catch so a bad model never drops a valid
+// prompt through lenient()'s all-or-nothing parse.
 export const homeSearchSchema = z.object({
-  view: z.enum(['cards', 'graph']).optional(),
+  // Per-field .catch: invalid view must not wipe prompt/model via lenient().
+  view: z.enum(['cards', 'graph']).optional().catch(undefined),
+  prompt: z.string().transform((s) => s.slice(0, 400)).optional().catch(undefined),
+  model: z.string().regex(/^[A-Za-z0-9._/-]{1,64}$/).optional().catch(undefined),
 })
 
 // Settings close-target: the path the gear was opened FROM, so closing returns


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-552

SuperAgent half of the marketing → signup → create-box handoff. Reads `prompt` and `model` after platform SSO, moves them into a one-shot, prefills the create box, and uses a recognized model for that first session only. Never writes default-model settings.

Production ~103 net lines / 7 files. Tests ~416 net lines / 5 files.

Type: new feature

Depends on the platform transport PR (`SkillfulAgents/platform` `feat/signup-handoff`). Alone, unknown query keys are ignored.

## How consumption works

```
SSO start URL (?prompt=&model= after sanitizeReturnTo)
  → re-attach capped prompt/model onto return_to
  → home lands with params
  → SignupHandoffConsumer (RootLayout)
       validate via homeSearchSchema (truncate + model regex + per-field catch)
       write in-memory one-shot, strip params from URL
  → CreateAgentForm
       prefill composer (warm-start baseline seeded so prefill ≠ typing)
       resolve model against catalog at submit, else opus
       clear one-shot
```

Prefill only. Submit is still the user's click.

## Worth reviewing

1. **Schema runs in the consumer, not only on the home route.** `location.search` is raw router parse output. The consumer runs `lenient(homeSearchSchema)` so the 400-char cap and model regex actually gate the one-shot. Invalid `view` uses `.catch(undefined)` so it cannot wipe a valid prompt.
2. **Warm-start must not treat prefill as a keystroke.** Prefill calls `noteProgrammaticChange` before `setMessage`, matching the hook's "restored drafts do not trigger" contract and success criterion 2 (nothing auto-creates).
3. **Model is catalog-gated at submit.** Unknown or unloaded catalog → `opus`. No write to `settings.models.agentModel` / `agentPrefs.defaultModel`.

## Why not seed HomePage box-B or auto-submit

Both were rejected in design. Prefill of the existing create composer is the whole product surface for PR1.

## What this does not do

- Platform transport (sibling PR)
- Returning-user redirect into the app
- Model label / picker UI for the handoff
- Effort, speed, or template params
- Persisting the handed-off model as a default

## Reviewer smoke

Staging SuperAgent on this branch plus platform transport that appends the params.

1. Land on `/?prompt=hello&model=claude-opus-5` (or complete a real marketing signup). Create box shows `hello`. URL no longer carries the params after load.
2. Submit. First session uses `claude-opus-5` when it is in the active catalog. Unknown model → `opus`.
3. Defaults in Settings unchanged after create.
4. With warm-start enabled, landing on a prefilled prompt should not create an Untitled agent until the user edits.

## Validation

- `npm run typecheck` clean
- `npm run lint` 0 errors (pre-existing warnings elsewhere)
- Focused vitest: `platform-sso-start`, `search-schemas`, `signup-handoff-consumer`, `create-agent-form.handoff`, `use-warm-start-on-type` - **57 passed**
- No full `npm run build` (repo rule)
