### PR TITLE
feat: offer template install from signup handoff (SUP-552)

### DIFF
--- a/src/api/routes/platform-sso-start.test.ts
+++ b/src/api/routes/platform-sso-start.test.ts
@@ -103,13 +103,14 @@ describe('GET /auth/platform/start', () => {
     mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
     const prompt = encodeURIComponent('build & ship https://x.com')
     const res = await createApp().request(
-      `/auth/platform/start?return_to=%2F&prompt=${prompt}&model=claude-opus-5`,
+      `/auth/platform/start?return_to=%2F&prompt=${prompt}&model=claude-opus-5&template_slug=my-template`,
     )
     expect(res.status).toBe(302)
     const location = new URL(res.headers.get('location')!, 'http://internal')
     expect(location.pathname).toBe('/')
     expect(location.searchParams.get('prompt')).toBe('build & ship https://x.com')
     expect(location.searchParams.get('model')).toBe('claude-opus-5')
+    expect(location.searchParams.get('template_slug')).toBe('my-template')
   })
 
   it('cold path passes decorated return_to as callbackURL', async () => {
@@ -119,12 +120,12 @@ describe('GET /auth/platform/start', () => {
       response: { url: 'https://auth.example.com/authorize?state=1', redirect: true },
     })
     await createApp().request(
-      '/auth/platform/start?return_to=%2F&prompt=hello&model=gpt-5.6-luna',
+      '/auth/platform/start?return_to=%2F&prompt=hello&model=gpt-5.6-luna&template_slug=research-bot',
     )
     expect(mockSignInWithOAuth2).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({
-          callbackURL: '/?prompt=hello&model=gpt-5.6-luna',
+          callbackURL: '/?prompt=hello&model=gpt-5.6-luna&template_slug=research-bot',
           errorCallbackURL: '/',
         }),
       }),
@@ -135,17 +136,29 @@ describe('GET /auth/platform/start', () => {
     mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
     const longPrompt = 'x'.repeat(500)
     const res = await createApp().request(
-      `/auth/platform/start?return_to=%2F&prompt=${encodeURIComponent(longPrompt)}&model=not%20valid`,
+      `/auth/platform/start?return_to=%2F&prompt=${encodeURIComponent(longPrompt)}&model=not%20valid&template_slug=${encodeURIComponent('bad slug')}`,
     )
     const location = new URL(res.headers.get('location')!, 'http://internal')
     expect(location.searchParams.get('prompt')).toHaveLength(400)
     expect(location.searchParams.get('model')).toBeNull()
+    expect(location.searchParams.get('template_slug')).toBeNull()
+  })
+
+  it('drops a junk template_slug while a valid prompt survives', async () => {
+    mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
+    const res = await createApp().request(
+      `/auth/platform/start?return_to=%2F&prompt=hello&model=opus&template_slug=${encodeURIComponent('bad slug')}`,
+    )
+    const location = new URL(res.headers.get('location')!, 'http://internal')
+    expect(location.searchParams.get('prompt')).toBe('hello')
+    expect(location.searchParams.get('model')).toBe('opus')
+    expect(location.searchParams.get('template_slug')).toBeNull()
   })
 
   it('preserves existing return_to query and fragment when appending handoff', async () => {
     mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
     const res = await createApp().request(
-      `/auth/platform/start?return_to=${encodeURIComponent('/agents?tab=1#panel')}&prompt=hi&model=opus`,
+      `/auth/platform/start?return_to=${encodeURIComponent('/agents?tab=1#panel')}&prompt=hi&model=opus&template_slug=foo.bar`,
     )
     const location = res.headers.get('location')!
     expect(location.startsWith('/agents?')).toBe(true)
@@ -153,17 +166,19 @@ describe('GET /auth/platform/start', () => {
     expect(url.searchParams.get('tab')).toBe('1')
     expect(url.searchParams.get('prompt')).toBe('hi')
     expect(url.searchParams.get('model')).toBe('opus')
+    expect(url.searchParams.get('template_slug')).toBe('foo.bar')
     expect(url.hash).toBe('#panel')
   })
 
   it('keeps return_to sanitizing behavior unchanged for open redirects', async () => {
     mockGetSession.mockResolvedValue({ session: { id: 's1' }, user: { id: 'u1' } })
     const res = await createApp().request(
-      '/auth/platform/start?return_to=https://evil.example&prompt=hello&model=opus',
+      '/auth/platform/start?return_to=https://evil.example&prompt=hello&model=opus&template_slug=valid-slug',
     )
     const location = new URL(res.headers.get('location')!, 'http://internal')
     expect(location.pathname).toBe('/')
     expect(location.searchParams.get('prompt')).toBe('hello')
     expect(location.searchParams.get('model')).toBe('opus')
+    expect(location.searchParams.get('template_slug')).toBe('valid-slug')
   })
 })

--- a/src/api/routes/platform-sso-start.ts
+++ b/src/api/routes/platform-sso-start.ts
@@ -3,6 +3,7 @@ import { getAuth } from '@shared/lib/auth/index'
 import { getGenericOAuthProviderConfigs } from '@shared/lib/auth/provider-config'
 import { sanitizeReturnTo } from '@shared/lib/auth/safe-return-to'
 import { captureException } from '@shared/lib/error-reporting'
+import { TEMPLATE_SLUG_RE } from '@shared/lib/signup-handoff-params'
 
 const PLATFORM_PROVIDER_ID = 'platform'
 const HANDOFF_PROMPT_MAX = 400
@@ -21,12 +22,14 @@ function withSignupHandoff(
   returnTo: string,
   prompt: string | undefined,
   model: string | undefined,
+  templateSlug: string | undefined,
 ): string {
   try {
     const url = new URL(returnTo, 'http://internal')
     const cleanPrompt = prompt?.replace(/[\r\n\0]/g, '').trim().slice(0, HANDOFF_PROMPT_MAX)
     if (cleanPrompt) url.searchParams.set('prompt', cleanPrompt)
     if (model && HANDOFF_MODEL_RE.test(model)) url.searchParams.set('model', model)
+    if (templateSlug && TEMPLATE_SLUG_RE.test(templateSlug)) url.searchParams.set('template_slug', templateSlug)
     // hash included: sanitizeReturnTo permits fragments and returns them verbatim.
     return `${url.pathname}${url.search}${url.hash}`
   } catch {
@@ -52,7 +55,12 @@ const platformSsoStart = new Hono()
 
 platformSsoStart.get('/platform/start', async (c) => {
   const returnTo = sanitizeReturnTo(c.req.query('return_to'))
-  const target = withSignupHandoff(returnTo, c.req.query('prompt'), c.req.query('model'))
+  const target = withSignupHandoff(
+    returnTo,
+    c.req.query('prompt'),
+    c.req.query('model'),
+    c.req.query('template_slug'),
+  )
   const providerId = resolvePlatformProviderId()
   if (!providerId) {
     return c.redirect('/', 302)

--- a/src/renderer/components/agents/agent-creation-aids.on-aid-opened.test.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.on-aid-opened.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockOnAidOpened = vi.fn()
+const mockOnVoiceResult = vi.fn()
+const mockOnImportComplete = vi.fn()
+
+vi.mock('@renderer/hooks/use-agent-templates', () => ({
+  useDiscoverableAgents: () => ({ data: [{ skillsetId: 's1', path: 'agents/x/' }] }),
+  useImportAgentTemplate: () => ({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@renderer/hooks/use-voice-input', () => ({
+  useIsVoiceAgentConfigured: () => true,
+}))
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ prompt: 'voice system prompt' }),
+  })),
+}))
+
+vi.mock('@renderer/components/agents/agent-template-browse-dialog', () => ({
+  AgentTemplateBrowseDialog: () => null,
+}))
+
+vi.mock('@renderer/components/ui/voice-agent', () => ({
+  VoiceAgent: () => null,
+}))
+
+import { AgentCreationAids } from './agent-creation-aids'
+
+describe('AgentCreationAids onAidOpened', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fires onAidOpened for browse, voice, and import entry points', async () => {
+    const user = userEvent.setup()
+    render(
+      <AgentCreationAids
+        onVoiceResult={mockOnVoiceResult}
+        onImportComplete={mockOnImportComplete}
+        onAidOpened={mockOnAidOpened}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Browse Templates/i }))
+    expect(mockOnAidOpened).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('button', { name: /Brainstorm with Voice/i }))
+    expect(mockOnAidOpened).toHaveBeenCalledTimes(2)
+
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+
+    await user.click(screen.getByRole('button', { name: /Import an Agent/i }))
+    expect(mockOnAidOpened).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -33,6 +33,8 @@ export interface AgentCreationAidsProps {
   onImportComplete: (result: ImportResult) => void | Promise<void>
   /** Optional className forwarded to the cards wrapper. */
   className?: string
+  /** Fires when the user opens browse / voice / import (forfeits signup template handoff). */
+  onAidOpened?: () => void
 }
 
 /**
@@ -41,7 +43,7 @@ export interface AgentCreationAidsProps {
  * home state. Callers decide what to do with the voice result / imported
  * agent — this component is pure UI + dialog plumbing.
  */
-export function AgentCreationAids({ onVoiceResult, onImportComplete, className }: AgentCreationAidsProps) {
+export function AgentCreationAids({ onVoiceResult, onImportComplete, className, onAidOpened }: AgentCreationAidsProps) {
   const hasVoiceConfigured = useIsVoiceAgentConfigured()
   const { data: discoverableAgents } = useDiscoverableAgents()
   const hasMarketplace = !!(discoverableAgents && discoverableAgents.length > 0)
@@ -52,6 +54,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
   const [voiceAgentConfig, setVoiceAgentConfig] = useState<VoiceAgentConfig | null>(null)
 
   const startVoiceAgent = useCallback(async () => {
+    onAidOpened?.()
     try {
       const res = await apiFetch('/api/stt/voice-agent-prompt?name=create-agent')
       if (!res.ok) throw new Error('Failed to load voice agent prompt')
@@ -80,7 +83,7 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
         description: error instanceof Error ? error.message : 'Please try again.',
       })
     }
-  }, [])
+  }, [onAidOpened])
 
   const handleVoiceAgentResult = useCallback(
     (_name: string, argsJson: string) => {
@@ -177,7 +180,10 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
             title="Browse Templates"
             icon={<Shapes className="h-4 w-4" />}
             ariaDescription="Opens the agent template marketplace"
-            onClick={() => setShowTemplatesDialog(true)}
+            onClick={() => {
+              onAidOpened?.()
+              setShowTemplatesDialog(true)
+            }}
           />
         )}
 
@@ -194,7 +200,10 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className }
           title="Import an Agent"
           icon={<ArrowDownToLine className="h-4 w-4" />}
           ariaDescription="Import an agent from a .agent or .zip template file"
-          onClick={() => setShowImportDialog(true)}
+          onClick={() => {
+            onAidOpened?.()
+            setShowImportDialog(true)
+          }}
         />
       </div>
 

--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DraftsProvider } from '@renderer/context/drafts-context'
 import type { SignupHandoff } from '@renderer/context/nav-transient-context'
+import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 const mockCreateSession = vi.fn()
 const mockCreateAgent = vi.fn()
@@ -13,6 +15,11 @@ const mockStartAgent = vi.fn()
 const mockSetSignupHandoff = vi.fn()
 let mockSignupHandoff: SignupHandoff | null = null
 let mockWarmStartEnabled = false
+let mockDiscoverableAgents: ApiDiscoverableAgent[] | undefined = []
+let mockDiscoverableAgentsFailed = false
+let lastDialogProps: { template: unknown; handoffOrigin?: boolean } | null = null
+let latestTranscriptUpdate: ((text: string) => void) | null = null
+let lastComposerAutoFocus: boolean | undefined
 let mockCatalog = [
   { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true },
   { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true },
@@ -89,11 +96,47 @@ vi.mock('@renderer/hooks/use-typewriter-placeholder', () => ({
 }))
 
 vi.mock('@renderer/components/agents/agent-creation-aids', () => ({
-  AgentCreationAids: () => null,
+  AgentCreationAids: ({ onAidOpened }: { onAidOpened?: () => void }) => (
+    <button type="button" data-testid="aid-opened" onClick={() => onAidOpened?.()}>
+      aid
+    </button>
+  ),
+}))
+
+vi.mock('@renderer/hooks/use-agent-templates', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/hooks/use-agent-templates')>()
+  return {
+    ...actual,
+    useDiscoverableAgents: () => ({
+      data: mockDiscoverableAgents,
+      isError: mockDiscoverableAgentsFailed,
+    }),
+  }
+})
+
+vi.mock('@renderer/hooks/use-voice-input', () => ({
+  useVoiceInput: ({ onTranscriptUpdate }: { onTranscriptUpdate: (text: string) => void }) => {
+    latestTranscriptUpdate = onTranscriptUpdate
+    return {
+      state: 'idle',
+      isRecording: false,
+      isConnecting: false,
+      isFinalizing: false,
+      error: null,
+      clearError: vi.fn(),
+      isSupported: true,
+      analyserRef: { current: null },
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+    }
+  },
 }))
 
 vi.mock('@renderer/components/agents/template-install-dialog', () => ({
-  TemplateInstallDialog: () => null,
+  TemplateInstallDialog: (props: { template: unknown; handoffOrigin?: boolean }) => {
+    lastDialogProps = props
+    return props.template ? <div data-testid="template-install-dialog" /> : null
+  },
 }))
 
 vi.mock('@renderer/components/ui/attachment-picker', () => ({
@@ -105,7 +148,28 @@ vi.mock('@renderer/components/ui/voice-input-button', () => ({
   VoiceInputError: () => null,
 }))
 
+vi.mock('@renderer/components/messages/chat-composer-box', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/components/messages/chat-composer-box')>()
+  return {
+    ChatComposerBox: (props: Parameters<typeof actual.ChatComposerBox>[0]) => {
+      lastComposerAutoFocus = props.autoFocus
+      return actual.ChatComposerBox(props)
+    },
+  }
+})
+
 import { CreateAgentForm } from './create-agent-form'
+
+function discoverable(slug: string, skillsetId: string = DEFAULT_PUBLIC_SKILLSET.id): ApiDiscoverableAgent {
+  return {
+    skillsetId,
+    skillsetName: 'Public',
+    name: `Template ${slug}`,
+    description: '',
+    version: '1.0.0',
+    path: `agents/${slug}/`,
+  }
+}
 
 function renderForm() {
   const queryClient = new QueryClient({
@@ -125,6 +189,11 @@ describe('CreateAgentForm signup handoff', () => {
     vi.clearAllMocks()
     mockSignupHandoff = null
     mockWarmStartEnabled = false
+    mockDiscoverableAgents = []
+    mockDiscoverableAgentsFailed = false
+    latestTranscriptUpdate = null
+    lastComposerAutoFocus = undefined
+    lastDialogProps = null
     mockCatalog = [
       { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true },
       { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true },
@@ -206,5 +275,279 @@ describe('CreateAgentForm signup handoff', () => {
     await new Promise((r) => setTimeout(r, 50))
     expect(mockCreateAgent).not.toHaveBeenCalled()
     expect(mockStartAgent).not.toHaveBeenCalled()
+  })
+
+  it('opens install dialog with matched public template and handoffOrigin', async () => {
+    mockDiscoverableAgents = [discoverable('research-bot')]
+    mockSignupHandoff = { template_slug: 'research-bot' }
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('template-install-dialog')).toBeTruthy()
+    })
+    expect(lastDialogProps?.handoffOrigin).toBe(true)
+    expect(lastDialogProps?.template).toEqual(discoverable('research-bot'))
+  })
+
+  it('suppresses composer autoFocus when a template slug is armed on mount', () => {
+    mockDiscoverableAgents = []
+    mockSignupHandoff = { template_slug: 'focus-bot' }
+    renderForm()
+    expect(lastComposerAutoFocus).toBe(false)
+  })
+
+  it('matches only the public skillset when paths collide', async () => {
+    mockDiscoverableAgents = [
+      discoverable('same-slug', 'private-skillset'),
+      discoverable('same-slug', DEFAULT_PUBLIC_SKILLSET.id),
+    ]
+    mockSignupHandoff = { template_slug: 'same-slug' }
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('template-install-dialog')).toBeTruthy()
+    })
+    expect((lastDialogProps?.template as ApiDiscoverableAgent).skillsetId).toBe(
+      DEFAULT_PUBLIC_SKILLSET.id,
+    )
+  })
+
+  it('settle clears slug permanently when populated list has no match', async () => {
+    mockDiscoverableAgents = [discoverable('other')]
+    mockSignupHandoff = { template_slug: 'missing-slug' }
+    const view = renderForm()
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+    })
+
+    mockDiscoverableAgents = [discoverable('missing-slug')]
+    view.rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+  })
+
+  it('waits on empty discoverable list then opens when a match arrives', async () => {
+    mockDiscoverableAgents = []
+    mockSignupHandoff = { template_slug: 'late-bot' }
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+
+    mockDiscoverableAgents = [discoverable('late-bot')]
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('template-install-dialog')).toBeTruthy()
+    })
+  })
+
+  it('typing in the composer forfeits template handoff including type-then-delete', async () => {
+    mockDiscoverableAgents = []
+    mockSignupHandoff = { template_slug: 'forfeit-bot' }
+    const user = userEvent.setup()
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    const prompt = screen.getByTestId('create-agent-prompt')
+    await user.click(prompt)
+    await user.keyboard('x')
+    await user.keyboard('{Backspace}')
+
+    mockDiscoverableAgents = [discoverable('forfeit-bot')]
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+  })
+
+  it('prompt plus slug seeds composer and never opens install dialog', async () => {
+    mockDiscoverableAgents = [discoverable('ignored-bot')]
+    mockSignupHandoff = { prompt: 'from marketing', template_slug: 'ignored-bot' }
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-agent-prompt')).toHaveTextContent('from marketing')
+    })
+    expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+  })
+
+  it('settles when the populated list only has a private skillset twin', async () => {
+    mockDiscoverableAgents = [discoverable('private-only', 'private-skillset')]
+    mockSignupHandoff = { template_slug: 'private-only' }
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+    })
+
+    mockDiscoverableAgents = [
+      discoverable('private-only', 'private-skillset'),
+      discoverable('private-only', DEFAULT_PUBLIC_SKILLSET.id),
+    ]
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+  })
+
+  it('model plus slug still opens the install offer', async () => {
+    mockDiscoverableAgents = [discoverable('model-bot')]
+    mockSignupHandoff = { model: 'claude-opus-5', template_slug: 'model-bot' }
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('template-install-dialog')).toBeTruthy()
+    })
+    expect(lastDialogProps?.handoffOrigin).toBe(true)
+  })
+
+  it('opening a creation aid forfeits before a late match can open the dialog', async () => {
+    mockDiscoverableAgents = []
+    mockSignupHandoff = { template_slug: 'aid-bot' }
+    const user = userEvent.setup()
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await user.click(screen.getByTestId('aid-opened'))
+
+    mockDiscoverableAgents = [discoverable('aid-bot')]
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+  })
+
+  it('composer mic transcript forfeits template handoff', async () => {
+    mockDiscoverableAgents = []
+    mockSignupHandoff = { template_slug: 'voice-bot' }
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(latestTranscriptUpdate).toBeTypeOf('function')
+    })
+    act(() => {
+      latestTranscriptUpdate?.('spoken prompt')
+    })
+
+    mockDiscoverableAgents = [discoverable('voice-bot')]
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+  })
+
+  it('discoverable query error clears the template offer', async () => {
+    mockDiscoverableAgents = undefined
+    mockDiscoverableAgentsFailed = true
+    mockSignupHandoff = { template_slug: 'error-bot' }
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+    })
+
+    mockDiscoverableAgentsFailed = false
+    mockDiscoverableAgents = [discoverable('error-bot')]
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <DraftsProvider>
+          <CreateAgentForm />
+        </DraftsProvider>
+      </QueryClientProvider>,
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByTestId('template-install-dialog')).toBeNull()
   })
 })

--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -357,6 +357,14 @@ describe('CreateAgentForm signup handoff', () => {
       expect(lastComposerAutoFocus).toBe(false)
       expect(screen.getByTestId('create-agent-prompt')).not.toHaveFocus()
 
+      // Still armed well past a cold sync. Probe autoFocus, not focus itself:
+      // clearing the slug flips this prop in the same commit, whereas the focus
+      // call lands in a nested 0ms timer that a single advance does not drain.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+      expect(lastComposerAutoFocus).toBe(false)
+
       await act(async () => {
         await vi.advanceTimersByTimeAsync(6000)
       })

--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -312,6 +312,74 @@ describe('CreateAgentForm signup handoff', () => {
     )
   })
 
+  // The armed slug suppresses the editor's create-once autoFocus. Any path that
+  // disarms without opening the dialog owes the user focus back, or the create box
+  // sits dead until they click it.
+  it('hands focus back to the composer when the list settles with no match', async () => {
+    mockDiscoverableAgents = [discoverable('other')]
+    mockSignupHandoff = { template_slug: 'missing-slug' }
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-agent-prompt')).toHaveFocus()
+    })
+  })
+
+  it('hands focus back to the composer when the discoverable query errors', async () => {
+    mockDiscoverableAgents = undefined
+    mockDiscoverableAgentsFailed = true
+    mockSignupHandoff = { template_slug: 'error-bot' }
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-agent-prompt')).toHaveFocus()
+    })
+  })
+
+  // useDiscoverableAgents is `enabled: hasSkillsets` — with no skillsets the query
+  // never runs, so data stays undefined and isError stays false forever. Without a
+  // bounded wait the offer stays armed and the composer never gets focus.
+  it('settles after the bounded wait when the list never arrives', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      mockDiscoverableAgents = []
+      mockSignupHandoff = { template_slug: 'stranded-bot' }
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      })
+      const view = render(
+        <QueryClientProvider client={queryClient}>
+          <DraftsProvider>
+            <CreateAgentForm />
+          </DraftsProvider>
+        </QueryClientProvider>,
+      )
+      expect(lastComposerAutoFocus).toBe(false)
+      expect(screen.getByTestId('create-agent-prompt')).not.toHaveFocus()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000)
+      })
+      expect(screen.getByTestId('create-agent-prompt')).toHaveFocus()
+
+      // Settled for good — a list that shows up afterwards must not pop the offer.
+      mockDiscoverableAgents = [discoverable('stranded-bot')]
+      view.rerender(
+        <QueryClientProvider client={queryClient}>
+          <DraftsProvider>
+            <CreateAgentForm />
+          </DraftsProvider>
+        </QueryClientProvider>,
+      )
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100)
+      })
+      expect(screen.queryByTestId('template-install-dialog')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('settle clears slug permanently when populated list has no match', async () => {
     mockDiscoverableAgents = [discoverable('other')]
     mockSignupHandoff = { template_slug: 'missing-slug' }

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -24,20 +24,20 @@ import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
 import { useModelSettings, useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
 import { findCatalogModel } from '@renderer/components/messages/composer-options'
 import { captureRendererException } from '@renderer/lib/error-reporting'
+import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
+import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
 import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 export interface CreateAgentFormProps {
   /** Fires after an agent is successfully created (via any path). Parent uses this to close the overlay/wizard. */
   onAgentCreated?: () => Promise<void> | void
-  /** Pre-selects a template and jumps straight to the "name the agent" step. */
-  initialTemplate?: ApiDiscoverableAgent | null
   /** Form max width in the layout. Defaults to no cap (wrapper decides). */
   className?: string
   /** When true, play the reverse (exit) animation on the same items. */
   exiting?: boolean
 }
 
-export function CreateAgentForm({ onAgentCreated, initialTemplate, className, exiting = false }: CreateAgentFormProps) {
+export function CreateAgentForm({ onAgentCreated, className, exiting = false }: CreateAgentFormProps) {
   // Staggered reveal: items start hidden on first render, flip to visible on the next frame,
   // then flip back to hidden when `exiting` becomes true. Reverse the stagger on exit.
   const [revealed, setRevealed] = useState(false)
@@ -66,6 +66,21 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
   const { signupHandoff, setSignupHandoff } = useNavTransient()
   const { data: modelSettings } = useModelSettings()
   const [handoffModel, setHandoffModel] = useState<string | null>(null)
+  // Arm synchronously so mount-time composer autoFocus sees an armed slug
+  // (MarkdownComposerEditor focuses once on create; a later autoFocus=false is a no-op).
+  // Prompt-wins matches the take effect: a prompt in the one-shot never arms the offer.
+  const [handoffTemplateSlug, setHandoffTemplateSlug] = useState<string | null>(() =>
+    signupHandoff && !signupHandoff.prompt ? (signupHandoff.template_slug ?? null) : null,
+  )
+  const composerTouchedRef = useRef(false)
+  // Sync forfeit: ref closes the paint→effect gap so an aid click cannot lose to a
+  // resolve effect still holding the armed slug from the prior commit.
+  const forfeitHandoffTemplate = useCallback(() => {
+    composerTouchedRef.current = true
+    setHandoffTemplateSlug(null)
+  }, [])
+  const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
+  const { data: discoverableAgents, isError: discoverableAgentsFailed } = useDiscoverableAgents()
 
   // Warm-precreated Untitled agent; deleted on abandon unless submit consumes it.
   const warmSlugOwnedRef = useRef<string | null>(null)
@@ -123,6 +138,7 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
 
   const composer = useMessageComposer({
     agentSlug: '',
+    onVoiceTranscript: forfeitHandoffTemplate,
     // Attachments/uploads aren't available in the create-agent flow — the agent
     // doesn't exist yet. These throw if invoked, but AttachmentPicker doesn't
     // expose them in this layout so they're unreachable in practice.
@@ -185,8 +201,29 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
       setTimeout(() => textareaRef.current?.focus(), 0)
     }
     if (signupHandoff.model) setHandoffModel(signupHandoff.model)
+    // PROMPT WINS AT ARM TIME:
+    setHandoffTemplateSlug(signupHandoff.prompt ? null : signupHandoff.template_slug ?? null)
     setSignupHandoff(null) // one-shot
   }, [signupHandoff, setSignupHandoff, composer, noteProgrammaticChange])
+
+  useEffect(() => {
+    if (!handoffTemplateSlug || composerTouchedRef.current) return
+    // Fail-open: a broken list must not leave the offer armed forever.
+    if (discoverableAgentsFailed) {
+      setHandoffTemplateSlug(null)
+      return
+    }
+    if (!discoverableAgents || discoverableAgents.length === 0) return // keep waiting
+    const match = discoverableAgents.find(
+      (a) => a.skillsetId === DEFAULT_PUBLIC_SKILLSET.id && slugFromAgentPath(a.path) === handoffTemplateSlug,
+    )
+    if (match) {
+      setTemplateToInstall(match)
+      setHandoffTemplateSlug(null)
+    } else {
+      setHandoffTemplateSlug(null) // settle: populated + no match
+    }
+  }, [discoverableAgents, discoverableAgentsFailed, handoffTemplateSlug])
 
   // Abandon path: leave the create form without consuming the warm agent.
   // Ref + empty deps so mutation identity churn doesn't re-bind cleanup mid-edit.
@@ -201,12 +238,6 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
       void discardWarmAgentRef.current()
     }
   }, [])
-
-  const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(initialTemplate ?? null)
-
-  useEffect(() => {
-    if (initialTemplate) setTemplateToInstall(initialTemplate)
-  }, [initialTemplate])
 
   const handleVoiceResult = useCallback(
     ({ prompt }: { name: string; prompt: string }) => {
@@ -247,13 +278,16 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
             attachments={composer.attachments}
             onRemoveAttachment={composer.removeAttachment}
             value={composer.message}
-            onChange={composer.setMessage}
+            onChange={(value) => {
+              forfeitHandoffTemplate()
+              composer.setMessage(value)
+            }}
             onKeyDown={handleKeyDown}
             onPaste={composer.handlePaste}
             placeholder={displayedPlaceholder}
             disabled={isDisabled}
             rows={3}
-            autoFocus
+            autoFocus={!templateToInstall && !handoffTemplateSlug}
             dataTestId="create-agent-prompt"
             textareaClassName="min-h-[60px]"
             leftActions={(
@@ -292,12 +326,14 @@ export function CreateAgentForm({ onAgentCreated, initialTemplate, className, ex
           <AgentCreationAids
             onVoiceResult={handleVoiceResult}
             onImportComplete={handleImportComplete}
+            onAidOpened={forfeitHandoffTemplate}
           />
         </div>
       </div>
 
       <TemplateInstallDialog
         template={templateToInstall}
+        handoffOrigin
         onClose={() => setTemplateToInstall(null)}
         onInstalled={(agent, { hasOnboarding }) => finishCreatedAgent(agent, 'skillset', hasOnboarding)}
       />

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -28,6 +28,14 @@ import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-ag
 import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
 import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
+/**
+ * How long the signup template offer waits for the discoverable list before it
+ * gives up and hands the composer back to the user. Long enough to cover a cold
+ * skillset fetch, short enough that the create box is never dead for a
+ * noticeable beat.
+ */
+const HANDOFF_TEMPLATE_WAIT_MS = 5000
+
 export interface CreateAgentFormProps {
   /** Fires after an agent is successfully created (via any path). Parent uses this to close the overlay/wizard. */
   onAgentCreated?: () => Promise<void> | void
@@ -78,6 +86,14 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
   const forfeitHandoffTemplate = useCallback(() => {
     composerTouchedRef.current = true
     setHandoffTemplateSlug(null)
+  }, [])
+  // The editor reads autoFocus ONCE at create, so a slug armed on mount suppresses
+  // focus for good — flipping the prop back to true later does nothing. Every path
+  // that disarms without opening the dialog has to hand focus back by hand.
+  // Not called from forfeitHandoffTemplate: typing already holds focus, and an
+  // aid/mic forfeit is the user moving focus somewhere else on purpose.
+  const focusComposer = useCallback(() => {
+    setTimeout(() => textareaRef.current?.focus(), 0)
   }, [])
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
   const { data: discoverableAgents, isError: discoverableAgentsFailed } = useDiscoverableAgents()
@@ -211,9 +227,21 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
     // Fail-open: a broken list must not leave the offer armed forever.
     if (discoverableAgentsFailed) {
       setHandoffTemplateSlug(null)
+      focusComposer()
       return
     }
-    if (!discoverableAgents || discoverableAgents.length === 0) return // keep waiting
+    if (!discoverableAgents || discoverableAgents.length === 0) {
+      // Bounded wait. useDiscoverableAgents is `enabled: hasSkillsets`, so with no
+      // skillsets the query never runs: data stays undefined and isError stays false
+      // forever, and an unbounded wait would strand the composer unfocused. The timer
+      // also caps how late an offer may appear on a slow list — a dialog opening
+      // minutes after landing reads as a glitch, not an offer.
+      const timer = setTimeout(() => {
+        setHandoffTemplateSlug(null)
+        focusComposer()
+      }, HANDOFF_TEMPLATE_WAIT_MS)
+      return () => clearTimeout(timer)
+    }
     const match = discoverableAgents.find(
       (a) => a.skillsetId === DEFAULT_PUBLIC_SKILLSET.id && slugFromAgentPath(a.path) === handoffTemplateSlug,
     )
@@ -222,8 +250,9 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
       setHandoffTemplateSlug(null)
     } else {
       setHandoffTemplateSlug(null) // settle: populated + no match
+      focusComposer()
     }
-  }, [discoverableAgents, discoverableAgentsFailed, handoffTemplateSlug])
+  }, [discoverableAgents, discoverableAgentsFailed, handoffTemplateSlug, focusComposer])
 
   // Abandon path: leave the create form without consuming the warm agent.
   // Ref + empty deps so mutation identity churn doesn't re-bind cleanup mid-edit.

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -29,12 +29,17 @@ import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-p
 import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 /**
- * How long the signup template offer waits for the discoverable list before it
- * gives up and hands the composer back to the user. Long enough to cover a cold
- * skillset fetch, short enough that the create box is never dead for a
- * noticeable beat.
+ * Ceiling, not a delay: the offer resolves the instant the discoverable list
+ * lands, and this only fires when nothing ever arrives. A cold skillset sync
+ * measured ~1.4s on a fast connection, so the margin here is for slow links.
+ *
+ * Erring long is close to free — a larger value never delays the happy path,
+ * it only extends how long the composer stays unfocused in the already-broken
+ * case. Erring short is not: the offer would settle before a slow list arrives
+ * and no dialog would ever appear, silently, for exactly the cold first-run
+ * installs this handoff targets.
  */
-const HANDOFF_TEMPLATE_WAIT_MS = 5000
+const HANDOFF_TEMPLATE_WAIT_MS = 10000
 
 export interface CreateAgentFormProps {
   /** Fires after an agent is successfully created (via any path). Parent uses this to close the overlay/wizard. */

--- a/src/renderer/components/agents/template-install-dialog.test.tsx
+++ b/src/renderer/components/agents/template-install-dialog.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mutateAsync = vi.fn()
+
+vi.mock('@renderer/hooks/use-agent-templates', () => ({
+  useInstallAgentFromSkillset: () => ({
+    mutateAsync,
+    reset: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}))
+
+import { TemplateInstallDialog } from './template-install-dialog'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+const template: ApiDiscoverableAgent = {
+  skillsetId: 'skillset-1',
+  skillsetName: 'Public',
+  name: 'Research Bot',
+  description: 'Does research',
+  version: '1.0.0',
+  path: 'agents/research-bot/',
+}
+
+describe('TemplateInstallDialog handoffOrigin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('suppresses autoFocus when handoffOrigin is true', () => {
+    render(
+      <TemplateInstallDialog
+        template={template}
+        handoffOrigin
+        onClose={() => {}}
+        onInstalled={() => {}}
+      />,
+    )
+    const input = screen.getByPlaceholderText('Agent name')
+    expect(input).not.toHaveAttribute('autofocus')
+  })
+
+  it('autoFocuses the name field when handoffOrigin is omitted', () => {
+    render(
+      <TemplateInstallDialog template={template} onClose={() => {}} onInstalled={() => {}} />,
+    )
+    const input = screen.getByPlaceholderText('Agent name')
+    expect(input).toHaveFocus()
+  })
+
+  it('closes the install dialog before onInstalled so setup UI is not stacked', async () => {
+    const user = userEvent.setup()
+    const order: string[] = []
+    mutateAsync.mockResolvedValue({
+      slug: 'research-bot',
+      displaySlug: 'research-bot',
+      hasOnboarding: true,
+    })
+
+    render(
+      <TemplateInstallDialog
+        template={template}
+        handoffOrigin
+        onClose={() => {
+          order.push('close')
+        }}
+        onInstalled={async () => {
+          order.push('onInstalled')
+        }}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Install' }))
+    await waitFor(() => expect(order).toEqual(['close', 'onInstalled']))
+  })
+})

--- a/src/renderer/components/agents/template-install-dialog.test.tsx
+++ b/src/renderer/components/agents/template-install-dialog.test.tsx
@@ -53,6 +53,9 @@ describe('TemplateInstallDialog handoffOrigin', () => {
     expect(input).toHaveFocus()
   })
 
+  // No handoffOrigin: the close-before-install ordering is shared by EVERY caller,
+  // including AgentTemplateBrowseDialog, whose onInstalled awaits a refetch and an
+  // onboarding session. Asserting it on the bare props keeps that caller covered.
   it('closes the install dialog before onInstalled so setup UI is not stacked', async () => {
     const user = userEvent.setup()
     const order: string[] = []
@@ -65,7 +68,6 @@ describe('TemplateInstallDialog handoffOrigin', () => {
     render(
       <TemplateInstallDialog
         template={template}
-        handoffOrigin
         onClose={() => {
           order.push('close')
         }}

--- a/src/renderer/components/agents/template-install-dialog.tsx
+++ b/src/renderer/components/agents/template-install-dialog.tsx
@@ -18,6 +18,8 @@ interface TemplateInstallDialogProps {
   onClose: () => void
   /** Called after the agent is fully installed. */
   onInstalled: (agent: ApiAgent, meta: { hasOnboarding?: boolean }) => void | Promise<void>
+  /** Signup handoff: softer name-field focus (no autofocus steal). */
+  handoffOrigin?: boolean
 }
 
 /**
@@ -25,7 +27,7 @@ interface TemplateInstallDialogProps {
  * on success — callers decide what to do with the new agent (select it,
  * track, kick off onboarding, etc).
  */
-export function TemplateInstallDialog({ template, onClose, onInstalled }: TemplateInstallDialogProps) {
+export function TemplateInstallDialog({ template, onClose, onInstalled, handoffOrigin }: TemplateInstallDialogProps) {
   const [name, setName] = useState('')
   const install = useInstallAgentFromSkillset()
 
@@ -50,8 +52,10 @@ export function TemplateInstallDialog({ template, onClose, onInstalled }: Templa
           agentVersion: template.version,
         })
 
-        await onInstalled(agent, { hasOnboarding: agent.hasOnboarding })
+        // Close before onInstalled — that path may open the onboarding
+        // "Setting up your agent..." dialog; stacking both looks broken.
         onClose()
+        await onInstalled(agent, { hasOnboarding: agent.hasOnboarding })
       } catch (error) {
         console.error('Failed to install agent from skillset:', error)
       }
@@ -73,7 +77,7 @@ export function TemplateInstallDialog({ template, onClose, onInstalled }: Templa
             placeholder="Agent name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            autoFocus
+            autoFocus={!handoffOrigin}
             disabled={install.isPending}
           />
           {install.error && (

--- a/src/renderer/components/signup-handoff-consumer.test.tsx
+++ b/src/renderer/components/signup-handoff-consumer.test.tsx
@@ -78,6 +78,44 @@ describe('SignupHandoffConsumer', () => {
     })
   })
 
+  it('moves template_slug into the one-shot and strips it alongside prompt and model', async () => {
+    const router = makeRouter('/?prompt=hello&model=claude-opus-5&template_slug=my-bot')
+    const { getByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        prompt: 'hello',
+        model: 'claude-opus-5',
+        template_slug: 'my-bot',
+      })
+    })
+    await waitFor(() => {
+      const search = router.state.location.search as Record<string, unknown>
+      expect(search.prompt).toBeUndefined()
+      expect(search.model).toBeUndefined()
+      expect(search.template_slug).toBeUndefined()
+    })
+  })
+
+  it('slug-only URL moves template_slug into the one-shot', async () => {
+    const router = makeRouter('/?template_slug=research-agent')
+    const { getByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        template_slug: 'research-agent',
+      })
+    })
+  })
+
   it('is a no-op when neither handoff param is present', async () => {
     const router = makeRouter('/?view=cards')
     const { getByTestId } = render(

--- a/src/renderer/components/signup-handoff-consumer.tsx
+++ b/src/renderer/components/signup-handoff-consumer.tsx
@@ -17,19 +17,24 @@ export function SignupHandoffConsumer() {
   const navigate = useNavigate()
   const { setSignupHandoff } = useNavTransient()
 
-  const { prompt, model } = lenient(homeSearchSchema)(search)
+  const { prompt, model, template_slug } = lenient(homeSearchSchema)(search)
   useEffect(() => {
-    if (!prompt && !model) return
-    setSignupHandoff({ prompt, model })
+    if (!prompt && !model && !template_slug) return
+    setSignupHandoff({ prompt, model, template_slug })
     // Explicit '/' — the params live on homeSearchSchema, registered only on the
     // home route (routes.ts:57); the sibling search mutation uses to: '/' too
     // (home-page.tsx:922).
     void navigate({
       to: '/',
-      search: (prev: Record<string, unknown>) => ({ ...prev, prompt: undefined, model: undefined }),
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        prompt: undefined,
+        model: undefined,
+        template_slug: undefined,
+      }),
       replace: true,
     })
-  }, [prompt, model, setSignupHandoff, navigate])
+  }, [prompt, model, template_slug, setSignupHandoff, navigate])
 
   return null
 }

--- a/src/renderer/context/nav-transient-context.tsx
+++ b/src/renderer/context/nav-transient-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, type ReactNode } from 'react'
 
-export type SignupHandoff = { prompt?: string; model?: string }
+export type SignupHandoff = { prompt?: string; model?: string; template_slug?: string }
 
 interface NavTransientValue {
   justCreatedSlug: string | null

--- a/src/renderer/hooks/use-agent-templates.slug.test.ts
+++ b/src/renderer/hooks/use-agent-templates.slug.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { slugFromAgentPath } from './use-agent-templates'
+
+describe('slugFromAgentPath', () => {
+  it('strips agents/ prefix and trailing slash', () => {
+    expect(slugFromAgentPath('agents/research-bot/')).toBe('research-bot')
+  })
+
+  it('handles path without trailing slash', () => {
+    expect(slugFromAgentPath('agents/foo')).toBe('foo')
+  })
+
+  it('leaves inner segments intact', () => {
+    expect(slugFromAgentPath('agents/my.agent-v2/')).toBe('my.agent-v2')
+  })
+
+  it('keeps nested segments after the agents/ prefix', () => {
+    expect(slugFromAgentPath('agents/a/b/')).toBe('a/b')
+  })
+
+  it('returns empty for agents/ alone', () => {
+    expect(slugFromAgentPath('agents/')).toBe('')
+  })
+
+  it('leaves non-agents paths unchanged', () => {
+    expect(slugFromAgentPath('skills/foo/')).toBe('skills/foo')
+  })
+})

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -8,6 +8,11 @@ import { useSkillsets } from '@renderer/hooks/use-skillsets'
 import type { ApiAgent, ApiDiscoverableAgent, ApiItemStatus } from '@shared/lib/types/api'
 import { AGENT_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
 
+/** Normalize discoverable agent path `agents/<dir>/` → `<dir>` (website template_slug). */
+export function slugFromAgentPath(path: string): string {
+  return path.replace(/^agents\//, '').replace(/\/$/, '')
+}
+
 // Alias preserves the prior export name for downstream consumers while we
 // route everything through the canonical `ApiItemStatus`.
 type ApiAgentTemplateStatus = ApiItemStatus

--- a/src/renderer/hooks/use-message-composer.test.tsx
+++ b/src/renderer/hooks/use-message-composer.test.tsx
@@ -26,9 +26,13 @@ const mockVoiceInput = {
   startRecording: vi.fn(),
   stopRecording: vi.fn(),
 }
+let capturedTranscriptUpdate: ((text: string) => void) | undefined
 
 vi.mock('@renderer/hooks/use-voice-input', () => ({
-  useVoiceInput: () => mockVoiceInput,
+  useVoiceInput: ({ onTranscriptUpdate }: { onTranscriptUpdate: (text: string) => void }) => {
+    capturedTranscriptUpdate = onTranscriptUpdate
+    return mockVoiceInput
+  },
 }))
 
 const mockAttachments = {
@@ -104,6 +108,7 @@ describe('useMessageComposer', () => {
     mockVoiceInput.isConnecting = false
     mockVoiceInput.stopRecording.mockReturnValue(undefined)
     capturedOnFoldersReceived = undefined
+    capturedTranscriptUpdate = undefined
   })
 
   // --- Basic state ---
@@ -124,6 +129,19 @@ describe('useMessageComposer', () => {
     act(() => result.current.setMessage('hello'))
     expect(result.current.message).toBe('hello')
     expect(result.current.canSubmit).toBe(true)
+  })
+
+  it('calls onVoiceTranscript before applying a mic transcript', () => {
+    const onVoiceTranscript = vi.fn()
+    const opts = { ...defaultOptions(), onVoiceTranscript }
+    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+
+    expect(capturedTranscriptUpdate).toBeTypeOf('function')
+    act(() => {
+      capturedTranscriptUpdate?.('spoken')
+    })
+    expect(onVoiceTranscript).toHaveBeenCalledTimes(1)
+    expect(result.current.message).toBe('spoken')
   })
 
   it('detects, dismisses, and re-detects a potential secret after it is removed', () => {

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -155,11 +155,15 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     initialAttachments: options.initialAttachments,
   })
 
+  // Pulled off `options` so the dep is the callback itself. Depending on
+  // `options` instead would rebuild this every render — callers pass an inline
+  // object literal, so its identity is never stable.
+  const { onVoiceTranscript } = options
   const voiceInput = useVoiceInput({
     onTranscriptUpdate: useCallback((text: string) => {
-      options.onVoiceTranscript?.()
+      onVoiceTranscript?.()
       setMessage(text)
-    }, [options.onVoiceTranscript]),
+    }, [onVoiceTranscript]),
   })
 
   const handleMountChoice = useCallback((choice: 'upload' | 'mount' | 'cancel') => {

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -34,6 +34,8 @@ interface UseMessageComposerOptions {
   initialAttachments?: Attachment[]
   /** One-shot secure-pill seed, used when moving a draft into a new session. */
   initialSecuredSecrets?: SecuredSecret[]
+  /** Fires on composer-mic transcript updates (before message state changes). */
+  onVoiceTranscript?: () => void
 }
 
 export function useMessageComposer(options: UseMessageComposerOptions) {
@@ -155,8 +157,9 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
 
   const voiceInput = useVoiceInput({
     onTranscriptUpdate: useCallback((text: string) => {
+      options.onVoiceTranscript?.()
       setMessage(text)
-    }, []),
+    }, [options.onVoiceTranscript]),
   })
 
   const handleMountChoice = useCallback((choice: 'upload' | 'mount' | 'cancel') => {

--- a/src/renderer/router/search-schemas.test.ts
+++ b/src/renderer/router/search-schemas.test.ts
@@ -168,4 +168,17 @@ describe('homeSearchSchema (signup handoff)', () => {
   it('collapses an all-whitespace prompt to falsy so consumers read it as absent', () => {
     expect(lenient(homeSearchSchema)({ prompt: '   \r\n  ' }).prompt).toBe('')
   })
+
+  it('drops a junk template_slug and keeps a valid prompt', () => {
+    const parsed = lenient(homeSearchSchema)({
+      prompt: 'hello',
+      template_slug: 'not valid!',
+    })
+    expect(parsed.prompt).toBe('hello')
+    expect(parsed.template_slug).toBeUndefined()
+  })
+
+  it('accepts a valid template_slug', () => {
+    expect(lenient(homeSearchSchema)({ template_slug: 'my.agent-v2' }).template_slug).toBe('my.agent-v2')
+  })
 })

--- a/src/renderer/router/search-schemas.ts
+++ b/src/renderer/router/search-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { isSafeInternalPath } from '@renderer/lib/api'
+import { TEMPLATE_SLUG_RE } from '@shared/lib/signup-handoff-params'
 
 /**
  * Zod schemas for the router's URL boundary (search params + the settings tab
@@ -70,6 +71,7 @@ export const homeSearchSchema = z.object({
     .transform((s) => s.replace(/[\r\n\0]/g, '').trim().slice(0, 400))
     .optional().catch(undefined),
   model: z.string().regex(/^[A-Za-z0-9._/-]{1,64}$/).optional().catch(undefined),
+  template_slug: z.string().regex(TEMPLATE_SLUG_RE).optional().catch(undefined),
 })
 
 // Settings close-target: the path the gear was opened FROM, so closing returns

--- a/src/shared/lib/signup-handoff-params.ts
+++ b/src/shared/lib/signup-handoff-params.ts
@@ -1,0 +1,1 @@
+export const TEMPLATE_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-552

**Stack (SuperAgent):** base is `feat/signup-prompt-handoff` (#703), not `main`. Merge #703 first, then this PR. Diff is only the template-offer commit on top of prompt+model prefill.

**Cross-repo:** needs platform transport SkillfulAgents/platform#272 (stacked on #271). Alone, a slug in the URL is parsed and offered only if the public catalog matches.

When signup hands off `template_slug` and no prompt wins, resolve it against the public skillset discoverable list and open the existing `TemplateInstallDialog` on first-run create. Forfeit on composer type / creation aid / mic. No new install endpoint or wizard routes.

Production ~73 net lines / 10 files. Tests ~604 net lines / 8 files.

Type: new feature

## Actual flow

```
SSO / URL ?template_slug=
  → SignupHandoffConsumer → one-shot nav context + strip
  → CreateAgentForm arms slug (prompt wins → no offer)
  → wait on empty discoverable list; settle on no match / query error
  → match → TemplateInstallDialog (soft name focus)
  → Install closes dialog before onboarding "Setting up…" overlay
  → type / aid / mic forfeits before a late match can open
```

## Worth reviewing

1. **Identity.** Match is `skillsetId === DEFAULT_PUBLIC_SKILLSET.id` + `slugFromAgentPath(path) === slug`. Never build paths from the user slug.
2. **Prompt wins.** prompt+slug seeds the composer and never opens the install offer.
3. **Forfeit breadth.** Typing (including type-then-delete), aid open, and mic transcript all clear the armed offer permanently.
4. **Mount autofocus.** Slug armed in `useState` initializer so composer `autoFocus` is false before MarkdownComposerEditor's create-once focus.

## Why not a parallel install modal

Browse already uses `TemplateInstallDialog`. Handoff only sets `templateToInstall` plus `handoffOrigin` soft-focus. Install and onboarding stay on the existing path.

## What this does not do

- Platform stash/append of `template_slug` (SkillfulAgents/platform#272 on #271).
- Junk-only URL strip after consume (deferred at Gate 1).
- Model regex consolidation SSO vs schema (settled decided-against for this stack).

## Testing instructions

1. With this build stacked on #703, and a public slug (e.g. `agent-pill`), open `/?template_slug=agent-pill` into first-run create (wizard agent step).
2. Expect Install dialog for that template. Cancel → bare create, no second offer.
3. Install → install dialog dismisses before "Setting up your agent…".
4. `?prompt=hello&template_slug=agent-pill` → prompt prefill, no install dialog.

## Validation

- Focused vitest (handoff form, consumer, dialog, SSO, schemas, composer): 117+ passed. Dialog suite 3/3 including close-before-onInstalled.
- Live smoke: wizard + macOS container + Agent Pill offer. Copy and dialog-before-setup sequencing verified by author.
