### PR TITLE
feat(create-agent): render the model picker in the create composer

### DIFF
--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -20,10 +20,15 @@ let mockDiscoverableAgentsFailed = false
 let lastDialogProps: { template: unknown; handoffOrigin?: boolean } | null = null
 let latestTranscriptUpdate: ((text: string) => void) | null = null
 let lastComposerAutoFocus: boolean | undefined
-let mockCatalog = [
-  { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true },
-  { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true },
+// The model popover reads icon/supportedEfforts unconditionally, and the
+// override test needs a second model inside one vendor tab to pick.
+const EFFORTS = ['low', 'medium', 'high']
+const catalogFixture = () => [
+  { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true, icon: 'anthropic', supportedEfforts: EFFORTS },
+  { id: 'claude-sonnet-4-6', family: 'sonnet', label: 'Sonnet 4.6', isLatest: true, icon: 'anthropic', supportedEfforts: EFFORTS },
+  { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true, icon: 'kimi', supportedEfforts: EFFORTS },
 ]
+let mockCatalog = catalogFixture()
 
 vi.mock('@renderer/context/nav-transient-context', () => ({
   useNavTransient: () => ({
@@ -194,10 +199,7 @@ describe('CreateAgentForm signup handoff', () => {
     latestTranscriptUpdate = null
     lastComposerAutoFocus = undefined
     lastDialogProps = null
-    mockCatalog = [
-      { id: 'claude-opus-5', family: 'opus', label: 'Opus 5', isLatest: true },
-      { id: 'kimi-k3', family: 'kimi', label: 'Kimi K3', isLatest: true },
-    ]
+    mockCatalog = catalogFixture()
     mockCreateAgent.mockResolvedValue({
       slug: 'agent-1',
       displaySlug: 'agent-1',
@@ -261,6 +263,58 @@ describe('CreateAgentForm signup handoff', () => {
       )
     })
     expect(mockSetSignupHandoff).not.toHaveBeenCalled()
+  })
+
+  it('seeds the model picker from the carried model', async () => {
+    mockSignupHandoff = { prompt: 'hello', model: 'claude-sonnet-4-6' }
+    const user = userEvent.setup()
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Sonnet 4.6')
+    })
+    await user.click(screen.getByTestId('create-agent-submit'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-sonnet-4-6' }),
+      )
+    })
+  })
+
+  it('submits the picked model when the user overrides the carried one', async () => {
+    mockSignupHandoff = { prompt: 'hello', model: 'claude-opus-5' }
+    const user = userEvent.setup()
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Opus 5')
+    })
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    await user.click(await screen.findByTestId('model-pinned-claude-sonnet-4-6'))
+    await waitFor(() => {
+      expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Sonnet 4.6')
+    })
+    await user.keyboard('{Escape}')
+    await user.click(screen.getByTestId('create-agent-submit'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-sonnet-4-6' }),
+      )
+    })
+  })
+
+  it('shows the default model in the picker when the carried model is unknown', async () => {
+    mockSignupHandoff = { prompt: 'hello', model: 'kimi-k2' }
+    renderForm()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-agent-prompt')).toHaveTextContent('hello')
+    })
+    // 'opus' resolves through the catalog to its latest for display, which is
+    // what the unchanged fallback puts on the wire.
+    expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Opus 5')
   })
 
   it('row5: prefill with warm-start enabled does not create an agent until edit', async () => {

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
@@ -22,7 +22,11 @@ import { deriveAgentName } from '@renderer/lib/derive-agent-name'
 import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
 import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
 import { useModelSettings, useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
-import { findCatalogModel } from '@renderer/components/messages/composer-options'
+import {
+  ComposerOptions,
+  findCatalogModel,
+  useComposerOptions,
+} from '@renderer/components/messages/composer-options'
 import { captureRendererException } from '@renderer/lib/error-reporting'
 import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
@@ -40,6 +44,9 @@ import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
  * installs this handoff targets.
  */
 const HANDOFF_TEMPLATE_WAIT_MS = 10000
+
+/** The create flow's own default — no agent exists yet to supply one. */
+const DEFAULT_MODEL = 'opus'
 
 export interface CreateAgentFormProps {
   /** Fires after an agent is successfully created (via any path). Parent uses this to close the overlay/wizard. */
@@ -102,6 +109,27 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
   }, [])
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
   const { data: discoverableAgents, isError: discoverableAgentsFailed } = useDiscoverableAgents()
+
+  const activeProvider = modelSettings?.llmProvider
+  const catalog = useMemo(
+    () => modelSettings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? [],
+    [modelSettings, activeProvider],
+  )
+  // Seed from the carried marketing-handoff model only when the effective
+  // catalog knows it — an unknown versioned id would be passed to the SDK as a
+  // pin and fail at the API. Resolved as the catalog lands: it's a separate
+  // query from settings and may not have answered at mount, so the picker seeds
+  // once it does.
+  const handoffSeedModel = useMemo(
+    () => (handoffModel ? findCatalogModel(handoffModel, catalog)?.id : undefined),
+    [handoffModel, catalog],
+  )
+  const composerOptions = useComposerOptions({
+    initialModel: handoffSeedModel,
+    // No agent exists yet, so there are no per-agent defaults to fall back to;
+    // this pins the create flow's own default above the app-wide one.
+    agentDefaultModel: DEFAULT_MODEL,
+  })
 
   // Warm-precreated Untitled agent; deleted on abandon unless submit consumes it.
   const warmSlugOwnedRef = useRef<string | null>(null)
@@ -176,17 +204,14 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
           ? await updateAgent.mutateAsync({ slug: warmSlug, name: agentName })
           : await createAgent.mutateAsync({ name: agentName })
         if (warmSlug) warmConsumedRef.current = true
-        const activeProvider = modelSettings?.llmProvider
-        const catalog = modelSettings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? []
-        // Carried marketing-handoff model, only when the effective catalog knows it —
-        // an unknown versioned id would be passed to the SDK as a pin and fail at the
-        // API. Resolved at submit time: the catalog is a separate query from settings
-        // and may not exist at mount. Falls back to today's behavior.
-        const model = (handoffModel && findCatalogModel(handoffModel, catalog)?.id) || 'opus'
         const session = await createSession.mutateAsync({
           agentSlug: newAgent.slug,
           message: content,
-          model,
+          ...composerOptions.toRuntimeOptions(),
+          // An untouched model is omitted from the runtime options, but a brand
+          // new agent has no stored default for the server to resolve against —
+          // always send what the picker is showing.
+          model: composerOptions.model ?? DEFAULT_MODEL,
         })
         track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
         void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: newAgent.displaySlug, sessionId: session.id } })
@@ -199,7 +224,7 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
       } finally {
         setIsSubmitting(false)
       }
-    }, [createAgent, updateAgent, createSession, navigate, track, onAgentCreated, handoffModel, modelSettings]),
+    }, [createAgent, updateAgent, createSession, navigate, track, onAgentCreated, composerOptions]),
   })
 
   const { awaitWarmStart, noteProgrammaticChange } = useWarmStartOnType({
@@ -325,11 +350,14 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
             dataTestId="create-agent-prompt"
             textareaClassName="min-h-[60px]"
             leftActions={(
-              <AttachmentPicker
-                onFileSelect={composer.handleFileSelect}
-                onFolderSelect={composer.handleFolderSelect}
-                disabled={isDisabled}
-              />
+              <>
+                <AttachmentPicker
+                  onFileSelect={composer.handleFileSelect}
+                  onFolderSelect={composer.handleFolderSelect}
+                  disabled={isDisabled}
+                />
+                <ComposerOptions state={composerOptions} disabled={isDisabled} />
+              </>
             )}
             rightActions={(
               <>


### PR DESCRIPTION
## The gap

`create-agent-form.tsx` is the only composer in the app with no model picker. `message-input.tsx`, `agent-home.tsx` and quick-dispatch all render `ComposerOptions`; the create box never did because its model was hardcoded `'opus'`.

#703 changed that: the first session's model is now derived from a signup-handoff parameter carried in the URL and resolved against the active provider's catalog at submit. So the user's first session can run on a model they never chose, can't see, and can't override — and an unrecognized handoff model silently degrades to `opus` with no signal to anyone.

## What this does

- Renders the real `ComposerOptions` picker in `leftActions`, next to the existing `AttachmentPicker`, mirroring AgentHome. The right side keeps mic + "Create Agent".
- Seeds the picker via `useComposerOptions({ initialModel })` from the handoff model, still gated through `findCatalogModel` — an unknown id never becomes a pin. The resolution moved from submit-time to a `useMemo`, so it re-resolves as the catalog query lands rather than only once at submit.
- `agentDefaultModel: 'opus'` keeps today's default at the top of the hook's fallback chain. Without it an untouched picker would adopt the app-wide default (latest Sonnet), silently changing the create flow's model.
- Submit sends `composerOptions.model` — an explicit user pick always beats the carried handoff value.

## Judgment calls

- **Effort/speed**: AgentHome renders `ComposerOptions` with no `includeEffort` (defaults `true`, so Effort + Speed show), and its session-create path already spreads `composerOptions.toRuntimeOptions()`; `useCreateSession` and the create route accept `effort`/`speed`. So this mirrors AgentHome exactly and threads the same fields — no new API surface. `toRuntimeOptions()` omits untouched knobs, so a user who never opens the popover produces the identical payload as before, plus the explicit `model`.
- **No footer**: AgentHome passes an `AgentDefaultFooter` bound to `agent.slug`. There is no agent yet at create time, so the footer is omitted.

## Stacked

Stacked on #703 (`feat/signup-prompt-handoff`) and **must merge after it**.

## ⚠️ CI does not run on this PR

`.github/workflows/test.yml` and `.github/workflows/agent-e2e-test.yml` both trigger only on `pull_request: branches: [main]`. This PR targets `feat/signup-prompt-handoff`, so **no unit tests, no typecheck, no lint, and no E2E run here** — only "PR Build". Reviewers should not read a green check as test coverage. Local validation below is the substitute evidence.

```
$ npx tsc --noEmit
(no output, exit 0)

$ npx eslint 'src/**/*.{ts,tsx}'
✖ 13 problems (0 errors, 13 warnings)
# all 13 pre-existing, all in unrelated files
# (file-download-pill.test.tsx, config-schema.test.ts,
#  session-auto-delete-monitor.test.ts, webhook-triggers/public.ts, …)
# 0 in the files this PR touches

$ npx vitest run src/renderer/components/agents src/renderer/components/messages
 Test Files  64 passed (64)
      Tests  884 passed (884)
   Duration  19.03s
```

## Tests

`create-agent-form.handoff.test.tsx` now renders a real picker, so its mock catalog gained the fields the popover reads (`icon`, `supportedEfforts`) plus a second Anthropic model to pick. **Every existing assertion kept its intent** — "unknown handoff model falls back to opus" and "no handoff behaves exactly as before" still assert the same submitted model, now via the picker. Nothing was weakened or deleted.

Three tests added:
- picker seeded from the carried model (trigger shows it, submit sends it)
- user override beats the carried model
- unknown carried model still shows/sends the `opus` default

https://claude.ai/code/session_01BUh66WK1jVfYJg7UYd8JUx
