### PR TITLE
test: stabilize home graph edge e2e

### DIFF
--- a/e2e/specs/home-graph.spec.ts
+++ b/e2e/specs/home-graph.spec.ts
@@ -145,6 +145,12 @@ test.describe('home connections graph', () => {
   })
 
   test('drawing an edge between agents creates the invoke permission; deleting it revokes', async ({ page, request }, testInfo) => {
+    // This case deliberately retries imprecise canvas gestures while sibling
+    // workers keep reshaping the shared graph. The bounded retry paths can
+    // legitimately exceed Playwright's 30s default on CI; all three attempts in
+    // the observed failure exhausted that global budget at different actions.
+    test.slow()
+
     const source = await createAgent(request, uniqueName(testInfo, 'Graph Draw Src'))
     const target = await createAgent(request, uniqueName(testInfo, 'Graph Draw Dst'))
 


### PR DESCRIPTION
## What changed

- mark the home graph edge create/delete E2E case as slow
- give only this gesture-heavy case Playwright's extended timeout budget
- keep the existing assertions and bounded interaction retries unchanged

## Why

The failing CI run exhausted the 30-second per-test budget on all three attempts, but at different canvas operations each time. The test intentionally retries imprecise graph gestures while parallel workers reshape the shared graph, so its valid bounded paths can exceed the default timeout on a loaded runner.

This changes the timeout for this test from 30 seconds to 90 seconds without weakening its behavioral coverage.

## Validation

- `eslint e2e/specs/home-graph.spec.ts`
- `tsc --noEmit --pretty false`
- `git diff --check`

A local repeated browser run could not provide a valid result because the available shared `better-sqlite3` binary was compiled for a different Node ABI; CI remains the authoritative full E2E validation.
