### PR TITLE
Add provider-specific model catalog defaults

### DIFF
--- a/src/api/routes/llm.test.ts
+++ b/src/api/routes/llm.test.ts
@@ -8,8 +8,8 @@ import { Hono } from 'hono'
 const state = vi.hoisted(() => ({
   providerId: 'anthropic',
   configured: true,
-  agentModel: 'opus',
-  resolvedModel: 'claude-opus-5',
+  browserModel: 'sonnet',
+  resolvedModel: 'claude-sonnet-5',
   resolveModel: vi.fn(),
 }))
 
@@ -37,7 +37,7 @@ vi.mock('@shared/lib/llm-provider', () => ({
 }))
 
 vi.mock('@shared/lib/config/settings', () => ({
-  getEffectiveModels: () => ({ agentModel: state.agentModel }),
+  getEffectiveModels: () => ({ browserModel: state.browserModel }),
 }))
 
 import llm from './llm'
@@ -74,8 +74,8 @@ describe('LLM proxy endpoint', () => {
     vi.clearAllMocks()
     state.providerId = 'anthropic'
     state.configured = true
-    state.agentModel = 'opus'
-    state.resolvedModel = 'claude-opus-5'
+    state.browserModel = 'sonnet'
+    state.resolvedModel = 'claude-sonnet-5'
   })
 
   describe('GET /api/llm/config', () => {
@@ -85,18 +85,18 @@ describe('LLM proxy endpoint', () => {
       expect(res.status).toBe(200)
       const body = await res.json()
       expect(body.configured).toBe(true)
-      expect(body.defaultModel).toBe('claude-opus-5')
+      expect(body.defaultModel).toBe('claude-sonnet-5')
       expect(body.provider).toBe('anthropic')
-      expect(state.resolveModel).toHaveBeenCalledWith('opus', 'agent')
+      expect(state.resolveModel).toHaveBeenCalledWith('sonnet', 'browser')
     })
 
     it.each([
       ['platform', 'grok', 'grok-4.5'],
       ['bedrock', 'sonnet', 'us.anthropic.claude-sonnet-5'],
       ['generic', 'custom/qwen3', 'custom/qwen3'],
-    ])('returns the resolved %s catalog default', async (providerId, agentModel, resolvedModel) => {
+    ])('returns the resolved %s catalog default', async (providerId, browserModel, resolvedModel) => {
       state.providerId = providerId
-      state.agentModel = agentModel
+      state.browserModel = browserModel
       state.resolvedModel = resolvedModel
 
       const res = await get(createApp(), '/api/llm/config')
@@ -106,7 +106,7 @@ describe('LLM proxy endpoint', () => {
         provider: providerId,
         defaultModel: resolvedModel,
       })
-      expect(state.resolveModel).toHaveBeenCalledWith(agentModel, 'agent')
+      expect(state.resolveModel).toHaveBeenCalledWith(browserModel, 'browser')
     })
   })
 
@@ -130,17 +130,17 @@ describe('LLM proxy endpoint', () => {
       expect(body.content[0].text).toBe('Hello!')
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-opus-5',
+          model: 'claude-sonnet-5',
           messages: [{ role: 'user', content: 'hi' }],
           max_tokens: 100,
         }),
       )
-      expect(state.resolveModel).toHaveBeenCalledWith('opus', 'agent')
+      expect(state.resolveModel).toHaveBeenCalledWith('sonnet', 'browser')
     })
 
     it('uses the resolved Generic catalog default when model is omitted', async () => {
       state.providerId = 'generic'
-      state.agentModel = 'custom/qwen3'
+      state.browserModel = 'custom/qwen3'
       state.resolvedModel = 'custom/qwen3'
       mockCreate.mockResolvedValue({ content: [] })
 

--- a/src/api/routes/llm.test.ts
+++ b/src/api/routes/llm.test.ts
@@ -5,6 +5,14 @@ import { Hono } from 'hono'
 // Mock dependencies
 // ---------------------------------------------------------------------------
 
+const state = vi.hoisted(() => ({
+  providerId: 'anthropic',
+  configured: true,
+  agentModel: 'opus',
+  resolvedModel: 'claude-opus-5',
+  resolveModel: vi.fn(),
+}))
+
 const mockCreate = vi.fn()
 
 vi.mock('../middleware/auth', () => ({
@@ -19,9 +27,17 @@ vi.mock('@shared/lib/llm-provider/helpers', () => ({
 
 vi.mock('@shared/lib/llm-provider', () => ({
   getActiveLlmProvider: () => ({
-    id: 'anthropic',
-    getApiKeyStatus: () => ({ isConfigured: true }),
+    id: state.providerId,
+    getApiKeyStatus: () => ({ isConfigured: state.configured }),
   }),
+  resolveActiveProviderModel: (selection: string, purpose: string) => {
+    state.resolveModel(selection, purpose)
+    return state.resolvedModel
+  },
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getEffectiveModels: () => ({ agentModel: state.agentModel }),
 }))
 
 import llm from './llm'
@@ -56,6 +72,10 @@ async function get(app: ReturnType<typeof createApp>, path: string) {
 describe('LLM proxy endpoint', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    state.providerId = 'anthropic'
+    state.configured = true
+    state.agentModel = 'opus'
+    state.resolvedModel = 'claude-opus-5'
   })
 
   describe('GET /api/llm/config', () => {
@@ -65,8 +85,28 @@ describe('LLM proxy endpoint', () => {
       expect(res.status).toBe(200)
       const body = await res.json()
       expect(body.configured).toBe(true)
-      expect(body.defaultModel).toBe('claude-sonnet-5')
+      expect(body.defaultModel).toBe('claude-opus-5')
       expect(body.provider).toBe('anthropic')
+      expect(state.resolveModel).toHaveBeenCalledWith('opus', 'agent')
+    })
+
+    it.each([
+      ['platform', 'grok', 'grok-4.5'],
+      ['bedrock', 'sonnet', 'us.anthropic.claude-sonnet-5'],
+      ['generic', 'custom/qwen3', 'custom/qwen3'],
+    ])('returns the resolved %s catalog default', async (providerId, agentModel, resolvedModel) => {
+      state.providerId = providerId
+      state.agentModel = agentModel
+      state.resolvedModel = resolvedModel
+
+      const res = await get(createApp(), '/api/llm/config')
+
+      expect(res.status).toBe(200)
+      await expect(res.json()).resolves.toMatchObject({
+        provider: providerId,
+        defaultModel: resolvedModel,
+      })
+      expect(state.resolveModel).toHaveBeenCalledWith(agentModel, 'agent')
     })
   })
 
@@ -90,10 +130,27 @@ describe('LLM proxy endpoint', () => {
       expect(body.content[0].text).toBe('Hello!')
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-sonnet-5',
+          model: 'claude-opus-5',
           messages: [{ role: 'user', content: 'hi' }],
           max_tokens: 100,
         }),
+      )
+      expect(state.resolveModel).toHaveBeenCalledWith('opus', 'agent')
+    })
+
+    it('uses the resolved Generic catalog default when model is omitted', async () => {
+      state.providerId = 'generic'
+      state.agentModel = 'custom/qwen3'
+      state.resolvedModel = 'custom/qwen3'
+      mockCreate.mockResolvedValue({ content: [] })
+
+      await post(createApp(), '/api/llm/v1/messages', {
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 10,
+      })
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'custom/qwen3' }),
       )
     })
 

--- a/src/api/routes/llm.ts
+++ b/src/api/routes/llm.ts
@@ -1,13 +1,12 @@
 import { Hono } from 'hono'
 import { Authenticated } from '../middleware/auth'
 import { getConfiguredLlmClient } from '@shared/lib/llm-provider/helpers'
-import { getActiveLlmProvider } from '@shared/lib/llm-provider'
+import { getActiveLlmProvider, resolveActiveProviderModel } from '@shared/lib/llm-provider'
+import { getEffectiveModels } from '@shared/lib/config/settings'
 
 const llm = new Hono()
 
 llm.use('*', Authenticated())
-
-const DEFAULT_MODEL = 'claude-sonnet-5'
 
 // Simple rate limiter: 100 requests per minute
 const requestCounts = new Map<string, { count: number; resetAt: number }>()
@@ -32,12 +31,17 @@ function checkRateLimit(key: string): boolean {
   return true
 }
 
+/** Resolve the global agent default to the active provider's concrete wire id. */
+function getDefaultModel(): string {
+  return resolveActiveProviderModel(getEffectiveModels().agentModel, 'agent')
+}
+
 // GET /api/llm/config
 llm.get('/config', (c) => {
   const provider = getActiveLlmProvider()
   return c.json({
     configured: provider.getApiKeyStatus().isConfigured,
-    defaultModel: DEFAULT_MODEL,
+    defaultModel: getDefaultModel(),
     provider: provider.id,
   })
 })
@@ -68,7 +72,7 @@ llm.post('/v1/messages', async (c) => {
     return c.json({ error: 'Missing required field: messages' }, 400)
   }
 
-  const model = (body.model as string) || DEFAULT_MODEL
+  const model = (body.model as string) || getDefaultModel()
   const stream = !!body.stream
 
   let client

--- a/src/api/routes/llm.ts
+++ b/src/api/routes/llm.ts
@@ -31,9 +31,14 @@ function checkRateLimit(key: string): boolean {
   return true
 }
 
-/** Resolve the global agent default to the active provider's concrete wire id. */
+/**
+ * Resolve the dashboard-runtime default to the active provider's concrete wire
+ * id. The iframe proxy historically used the Sonnet tier; browserModel is the
+ * existing cross-provider Sonnet-tier setting, so using it preserves that cost
+ * profile without hard-coding a Claude model id.
+ */
 function getDefaultModel(): string {
-  return resolveActiveProviderModel(getEffectiveModels().agentModel, 'agent')
+  return resolveActiveProviderModel(getEffectiveModels().browserModel, 'browser')
 }
 
 // GET /api/llm/config

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -1047,6 +1047,19 @@ describe('settings route', () => {
       })
     })
 
+    it('resets the global agent model to Grok when switching to Platform', async () => {
+      const res = await putSettings({ llmProvider: 'platform' })
+
+      expect(res.status).toBe(200)
+      const saved = mockUpdateSettings.mock.calls[0][0]
+      expect(saved.models).toEqual({
+        summarizerModel: 'haiku',
+        agentModel: 'grok',
+        browserModel: 'sonnet',
+        dashboardBuilderModel: 'opus',
+      })
+    })
+
     it('keeps an explicit models payload even when the provider changes', async () => {
       const res = await putSettings({
         llmProvider: 'bedrock',

--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -20,6 +20,7 @@ let mockDiscoverableAgentsFailed = false
 let lastDialogProps: { template: unknown; handoffOrigin?: boolean } | null = null
 let latestTranscriptUpdate: ((text: string) => void) | null = null
 let lastComposerAutoFocus: boolean | undefined
+let mockAgentModel = 'opus'
 // The model popover reads icon/supportedEfforts unconditionally, and the
 // override test needs a second model inside one vendor tab to pick.
 const EFFORTS = ['low', 'medium', 'high']
@@ -48,7 +49,12 @@ vi.mock('@renderer/hooks/use-settings', () => ({
   useModelSettings: () => ({
     data: {
       llmProvider: 'anthropic',
-      llmProviderStatus: [{ id: 'anthropic', catalog: mockCatalog }],
+      models: { agentModel: mockAgentModel },
+      llmProviderStatus: [{
+        id: 'anthropic',
+        catalog: mockCatalog,
+        defaultModels: { agent: 'opus', summarizer: 'haiku', browser: 'sonnet' },
+      }],
     },
   }),
   useWarmStartOnTypeEnabled: () => mockWarmStartEnabled,
@@ -200,6 +206,7 @@ describe('CreateAgentForm signup handoff', () => {
     lastComposerAutoFocus = undefined
     lastDialogProps = null
     mockCatalog = catalogFixture()
+    mockAgentModel = 'opus'
     mockCreateAgent.mockResolvedValue({
       slug: 'agent-1',
       displaySlug: 'agent-1',
@@ -231,7 +238,7 @@ describe('CreateAgentForm signup handoff', () => {
     })
   })
 
-  it('falls back to opus when the carried model is unknown', async () => {
+  it('falls back to the global default when the carried model is unknown', async () => {
     mockSignupHandoff = { prompt: 'hello', model: 'kimi-k2' }
     const user = userEvent.setup()
     renderForm()
@@ -248,7 +255,7 @@ describe('CreateAgentForm signup handoff', () => {
     })
   })
 
-  it('uses opus with no behavior change when there is no handoff', async () => {
+  it('uses the global default when there is no handoff', async () => {
     const user = userEvent.setup()
     renderForm()
 
@@ -263,6 +270,23 @@ describe('CreateAgentForm signup handoff', () => {
       )
     })
     expect(mockSetSignupHandoff).not.toHaveBeenCalled()
+  })
+
+  it('does not hard-code Opus above a different global default', async () => {
+    mockAgentModel = 'sonnet'
+    const user = userEvent.setup()
+    renderForm()
+
+    const prompt = screen.getByTestId('create-agent-prompt')
+    await user.click(prompt)
+    await user.keyboard('from scratch')
+    await user.click(screen.getByTestId('create-agent-submit'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'sonnet', message: 'from scratch' }),
+      )
+    })
   })
 
   it('seeds the model picker from the carried model', async () => {
@@ -312,8 +336,7 @@ describe('CreateAgentForm signup handoff', () => {
     await waitFor(() => {
       expect(screen.getByTestId('create-agent-prompt')).toHaveTextContent('hello')
     })
-    // 'opus' resolves through the catalog to its latest for display, which is
-    // what the unchanged fallback puts on the wire.
+    // The global 'opus' alias resolves through the catalog to its latest for display.
     expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Opus 5')
   })
 

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -45,9 +45,6 @@ import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
  */
 const HANDOFF_TEMPLATE_WAIT_MS = 10000
 
-/** The create flow's own default — no agent exists yet to supply one. */
-const DEFAULT_MODEL = 'opus'
-
 export interface CreateAgentFormProps {
   /** Fires after an agent is successfully created (via any path). Parent uses this to close the overlay/wizard. */
   onAgentCreated?: () => Promise<void> | void
@@ -124,12 +121,9 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
     () => (handoffModel ? findCatalogModel(handoffModel, catalog)?.id : undefined),
     [handoffModel, catalog],
   )
-  const composerOptions = useComposerOptions({
-    initialModel: handoffSeedModel,
-    // No agent exists yet, so there are no per-agent defaults to fall back to;
-    // this pins the create flow's own default above the app-wide one.
-    agentDefaultModel: DEFAULT_MODEL,
-  })
+  // No agent exists yet to supply a per-agent override. The hook falls back
+  // to the app-wide selection, then the active provider's catalog default.
+  const composerOptions = useComposerOptions({ initialModel: handoffSeedModel })
 
   // Warm-precreated Untitled agent; deleted on abandon unless submit consumes it.
   const warmSlugOwnedRef = useRef<string | null>(null)
@@ -211,7 +205,7 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
           // An untouched model is omitted from the runtime options, but a brand
           // new agent has no stored default for the server to resolve against —
           // always send what the picker is showing.
-          model: composerOptions.model ?? DEFAULT_MODEL,
+          model: composerOptions.model ?? composerOptions.defaultModel,
         })
         track('agent_created', { source: 'new', num_skills_added_at_creation: 0 })
         void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: newAgent.displaySlug, sessionId: session.id } })

--- a/src/renderer/components/messages/agent-default-footer.test.tsx
+++ b/src/renderer/components/messages/agent-default-footer.test.tsx
@@ -49,6 +49,7 @@ function stateWith(overrides: Partial<ComposerOptionsState> = {}): ComposerOptio
     model: 'claude-opus-4-8',
     setModel: vi.fn(),
     catalog: CATALOG as ComposerOptionsState['catalog'],
+    defaultModel: 'opus',
     webProvider: undefined,
     toRuntimeOptions: () => ({}),
     ...overrides,

--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -23,6 +23,7 @@ interface HarnessProps {
   initialEffort?: EffortLevel
   initialSpeed?: SpeedLevel
   initialModel?: string
+  defaultModel?: string
   catalog?: ModelDefinition[]
   onState?: (state: ComposerOptionsState) => void
   disabled?: boolean
@@ -35,6 +36,7 @@ function Harness({
   initialEffort = 'high',
   initialSpeed = 'normal',
   initialModel,
+  defaultModel,
   catalog = CATALOG,
   onState,
   disabled,
@@ -51,6 +53,7 @@ function Harness({
     model,
     setModel,
     catalog,
+    defaultModel,
     toRuntimeOptions: () => ({ effort, speed, ...(model ? { model } : {}) }),
   }
   onState?.(state)
@@ -66,9 +69,9 @@ describe('ComposerOptionsPopover', () => {
     expect(trigger.querySelector('span')).toHaveClass('max-[420px]:hidden')
   })
 
-  it('falls back to Sonnet on the trigger when no model is set', () => {
-    render(<Harness initialModel={undefined} initialEffort="medium" />)
-    expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Sonnet 4.6 · Medium')
+  it('uses the provider catalog default on the trigger when no model is set', () => {
+    render(<Harness initialModel={undefined} defaultModel="opus" initialEffort="medium" />)
+    expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Opus 4.8 · Medium')
   })
 
   it('displays the exact pinned version (does not collapse to the family latest)', () => {

--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -113,6 +113,7 @@ describe('ComposerOptionsPopover', () => {
           model: 'claude-sonnet-4-6',
           setModel,
           catalog: CATALOG,
+          defaultModel: 'opus',
           toRuntimeOptions: () => ({ effort: 'high', model: 'claude-sonnet-4-6' }),
         }}
       />
@@ -137,6 +138,7 @@ describe('ComposerOptionsPopover', () => {
           model: 'claude-opus-4-8',
           setModel: vi.fn(),
           catalog: CATALOG,
+          defaultModel: 'opus',
           toRuntimeOptions: () => ({ effort: 'high', model: 'claude-opus-4-8' }),
         }}
       />

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -20,15 +20,14 @@ interface ComposerOptionsPopoverProps {
 }
 
 function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true, footer }: ComposerOptionsPopoverProps) {
-  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, webProvider } = state
+  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, defaultModel, webProvider } = state
 
   // Trigger display fallback for the brief window before useComposerOptions
   // seeds `model`. Order: resolve the selection against the catalog (exact id
-  // or family-latest) → the catalog's latest Sonnet (codebase-wide default,
-  // beats falling through to the first entry) → first entry.
+  // or family-latest) → the active provider's catalog default → first entry.
   const selectedModel =
     findCatalogModel(model, catalog)
-    ?? catalog.find((m) => m.family === 'sonnet' && m.isLatest)
+    ?? findCatalogModel(defaultModel, catalog)
     ?? catalog[0]
 
   useEffortClamp(includeEffort ? selectedModel : undefined, effort, setEffort)

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -32,7 +32,7 @@ export interface ComposerOptionsState {
   /** The active provider's flat catalog of concrete model ids. */
   catalog: ModelDefinition[]
   /** Effective catalog/provider fallback used while a model selection is unresolved. */
-  defaultModel?: string
+  defaultModel: string | undefined
   /** Active host web-provider id (settings-derived), so the model picker's web-tools availability
    *  warning knows a configured vendor makes those tools work on any model. Undefined = native. */
   webProvider?: string

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -31,6 +31,8 @@ export interface ComposerOptionsState {
   setModel: (m: string) => void
   /** The active provider's flat catalog of concrete model ids. */
   catalog: ModelDefinition[]
+  /** Effective catalog/provider fallback used while a model selection is unresolved. */
+  defaultModel?: string
   /** Active host web-provider id (settings-derived), so the model picker's web-tools availability
    *  warning knows a configured vendor makes those tools work on any model. Undefined = native. */
   webProvider?: string
@@ -153,15 +155,13 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
   )
   const catalog = useMemo(() => providerInfo?.catalog ?? [], [providerInfo])
   // Fallback hierarchy: the agent's own default → user's "Default Model" →
-  // provider's agent default → the catalog's latest Sonnet → first catalog
-  // entry. The first non-empty wins. Aliases and concrete ids are both valid
-  // wire values, so any of these is a usable selection string.
+  // provider's catalog default → first catalog entry. The first non-empty
+  // wins. Aliases and concrete ids are both valid selection strings.
   const fallbackModel = useMemo(
     () =>
       agentDefaultModel ??
       settings?.models?.agentModel ??
       providerInfo?.defaultModels?.agent ??
-      catalog.find((m) => m.family === 'sonnet' && m.isLatest)?.id ??
       catalog[0]?.id,
     [agentDefaultModel, settings, providerInfo, catalog],
   )
@@ -258,10 +258,11 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
       model,
       setModel,
       catalog,
+      defaultModel: fallbackModel,
       webProvider: settings?.webProvider,
       toRuntimeOptions,
     }),
-    [effort, setEffort, speed, setSpeed, model, setModel, catalog, settings, toRuntimeOptions],
+    [effort, setEffort, speed, setSpeed, model, setModel, catalog, fallbackModel, settings, toRuntimeOptions],
   )
 }
 

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.test.tsx
@@ -24,6 +24,7 @@ function makeState(overrides: Partial<ComposerOptionsState>): ComposerOptionsSta
     model: 'claude-sonnet-4-6',
     setModel: vi.fn(),
     catalog: CATALOG,
+    defaultModel: 'sonnet',
     toRuntimeOptions: () => ({}),
     ...overrides,
   }

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
@@ -95,9 +95,9 @@ export function AgentMenu({
 }
 
 export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsState; maxHeight: number }) {
-  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, webProvider } = state
+  const { effort, setEffort, speed, setSpeed, model, setModel, catalog, defaultModel, webProvider } = state
   const selected =
-    findCatalogModel(model, catalog) ?? catalog.find((m) => m.family === 'sonnet' && m.isLatest) ?? catalog[0]
+    findCatalogModel(model, catalog) ?? findCatalogModel(defaultModel, catalog) ?? catalog[0]
   const efforts = EFFORT_LEVELS.filter((l) => (selected ? selected.supportedEfforts.includes(l) : true))
   // Without the clamp this menu kept (and dispatched) an unsupported effort
   // after a model switch, while the slider silently rendered at Low.

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -105,7 +105,7 @@ export function QuickDispatch() {
 
   const selectedModel =
     findCatalogModel(composerOptions.model, composerOptions.catalog) ??
-    composerOptions.catalog.find((m) => m.family === 'sonnet' && m.isLatest) ??
+    findCatalogModel(composerOptions.defaultModel, composerOptions.catalog) ??
     composerOptions.catalog[0]
 
   const composer = useMessageComposer({

--- a/src/renderer/components/wizard/configure-model-step.test.tsx
+++ b/src/renderer/components/wizard/configure-model-step.test.tsx
@@ -9,6 +9,7 @@ import type { ModelDefinition, ProviderDefaultModelOption } from '@shared/lib/ll
 const state = vi.hoisted(() => ({
   settings: undefined as GlobalSettingsResponse | undefined,
   mutate: vi.fn(),
+  pickerModel: 'kimi',
 }))
 
 vi.mock('@renderer/hooks/use-settings', () => ({
@@ -18,7 +19,7 @@ vi.mock('@renderer/hooks/use-settings', () => ({
 
 vi.mock('@renderer/components/settings/settings-model-select', () => ({
   SettingsModelSelect: ({ onModelChange }: { onModelChange: (model: string) => void }) => (
-    <button type="button" data-testid="full-catalog-picker" onClick={() => onModelChange('kimi')}>
+    <button type="button" data-testid="full-catalog-picker" onClick={() => onModelChange(state.pickerModel)}>
       Full catalog
     </button>
   ),
@@ -35,8 +36,8 @@ const CATALOG: ModelDefinition[] = [
 
 const OPTIONS: ProviderDefaultModelOption[] = [
   { model: 'opus', label: 'Opus', tag: 'Deep reasoning', description: 'Opus copy' },
-  { model: 'gpt', label: 'GPT-5.6', tag: 'OpenAI flagship', description: 'GPT copy' },
-  { model: 'grok', label: 'Grok 4.5', tag: 'Recommended', description: 'Grok copy' },
+  { model: 'gpt', label: 'GPT', resolveLabelFromCatalog: true, tag: 'OpenAI flagship', description: 'GPT copy' },
+  { model: 'grok', label: 'Grok', resolveLabelFromCatalog: true, tag: 'Recommended', description: 'Grok copy' },
 ]
 
 function platformSettings(agentModel = 'grok'): GlobalSettingsResponse {
@@ -64,16 +65,19 @@ function platformSettings(agentModel = 'grok'): GlobalSettingsResponse {
 function renderStep() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   queryClient.setQueryData(['settings'], state.settings)
-  return render(
+  const step = () => (
     <QueryClientProvider client={queryClient}>
       <ConfigureModelStep />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   )
+  const result = render(step())
+  return { ...result, rerenderStep: () => result.rerender(step()) }
 }
 
 beforeEach(() => {
   state.settings = platformSettings()
   state.mutate.mockReset()
+  state.pickerModel = 'kimi'
 })
 
 describe('ConfigureModelStep', () => {
@@ -81,7 +85,7 @@ describe('ConfigureModelStep', () => {
     renderStep()
 
     expect(screen.getByRole('radio', { name: /Opus/ })).toBeInTheDocument()
-    expect(screen.getByRole('radio', { name: /GPT-5\.6/ })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /GPT-5\.6 Sol/ })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: /Grok 4\.5/ })).toHaveAttribute('aria-checked', 'true')
     expect(screen.queryByRole('radio', { name: /Sonnet/ })).not.toBeInTheDocument()
   })
@@ -109,6 +113,38 @@ describe('ConfigureModelStep', () => {
 
     expect(screen.getByTestId('wizard-model-other')).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByTestId('full-catalog-picker')).toBeInTheDocument()
+  })
+
+  it('clears Other when the full picker selects a curated family', async () => {
+    state.settings = platformSettings('kimi')
+    state.pickerModel = 'claude-opus-5'
+    const user = userEvent.setup()
+    const view = renderStep()
+
+    expect(screen.getByTestId('wizard-model-other')).toHaveAttribute('aria-checked', 'true')
+    await user.click(screen.getByTestId('full-catalog-picker'))
+    await waitFor(() => {
+      expect(state.mutate).toHaveBeenCalledWith(
+        { models: { agentModel: 'claude-opus-5' } },
+        expect.objectContaining({ onError: expect.any(Function) }),
+      )
+    })
+    // The real hook rerenders from the optimistic query-cache update. Mirror
+    // that here because this unit mock reads `state.settings` directly.
+    state.settings = platformSettings('claude-opus-5')
+    view.rerenderStep()
+    expect(screen.getByTestId('wizard-model-opus')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('wizard-model-other')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('does not replace a pinned version when its highlighted family card is clicked', async () => {
+    state.settings = platformSettings('claude-opus-5')
+    const user = userEvent.setup()
+    renderStep()
+
+    expect(screen.getByTestId('wizard-model-opus')).toHaveAttribute('aria-checked', 'true')
+    await user.click(screen.getByTestId('wizard-model-opus'))
+    expect(state.mutate).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/components/wizard/configure-model-step.test.tsx
+++ b/src/renderer/components/wizard/configure-model-step.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { GlobalSettingsResponse } from '@renderer/hooks/use-settings'
+import type { ModelDefinition, ProviderDefaultModelOption } from '@shared/lib/llm-provider'
+
+const state = vi.hoisted(() => ({
+  settings: undefined as GlobalSettingsResponse | undefined,
+  mutate: vi.fn(),
+}))
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => ({ data: state.settings }),
+  useUpdateSettings: () => ({ mutate: state.mutate }),
+}))
+
+vi.mock('@renderer/components/settings/settings-model-select', () => ({
+  SettingsModelSelect: ({ onModelChange }: { onModelChange: (model: string) => void }) => (
+    <button type="button" data-testid="full-catalog-picker" onClick={() => onModelChange('kimi')}>
+      Full catalog
+    </button>
+  ),
+}))
+
+import { ConfigureModelStep, findDefaultModelOption } from './configure-model-step'
+
+const CATALOG: ModelDefinition[] = [
+  { id: 'claude-opus-5', label: 'Opus 5', family: 'opus', isLatest: true, supportedEfforts: ['low', 'medium', 'high'] },
+  { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', family: 'gpt', isLatest: true, supportedEfforts: ['low', 'medium', 'high'] },
+  { id: 'grok-4.5', label: 'Grok 4.5', family: 'grok', isLatest: true, supportedEfforts: ['low', 'medium', 'high'] },
+  { id: 'kimi-k3', label: 'Kimi K3', family: 'kimi', isLatest: true, supportedEfforts: ['low', 'medium', 'high'] },
+]
+
+const OPTIONS: ProviderDefaultModelOption[] = [
+  { model: 'opus', label: 'Opus', tag: 'Deep reasoning', description: 'Opus copy' },
+  { model: 'gpt', label: 'GPT-5.6', tag: 'OpenAI flagship', description: 'GPT copy' },
+  { model: 'grok', label: 'Grok 4.5', tag: 'Recommended', description: 'Grok copy' },
+]
+
+function platformSettings(agentModel = 'grok'): GlobalSettingsResponse {
+  return {
+    llmProvider: 'platform',
+    llmProviderStatus: [{
+      id: 'platform',
+      name: 'Platform',
+      isConfigured: true,
+      catalog: [...CATALOG],
+      defaultModels: { agent: 'grok', summarizer: 'haiku', browser: 'sonnet' },
+      defaultModelOptions: OPTIONS,
+      capabilities: { modelSearch: false },
+    }],
+    models: {
+      agentModel,
+      summarizerModel: 'haiku',
+      browserModel: 'sonnet',
+      dashboardBuilderModel: 'opus',
+      agentEffort: 'medium',
+    },
+  } as unknown as GlobalSettingsResponse
+}
+
+function renderStep() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData(['settings'], state.settings)
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ConfigureModelStep />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  state.settings = platformSettings()
+  state.mutate.mockReset()
+})
+
+describe('ConfigureModelStep', () => {
+  it('renders the provider-owned Platform shortlist with Grok selected by default', () => {
+    renderStep()
+
+    expect(screen.getByRole('radio', { name: /Opus/ })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /GPT-5\.6/ })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /Grok 4\.5/ })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.queryByRole('radio', { name: /Sonnet/ })).not.toBeInTheDocument()
+  })
+
+  it('shows the full catalog picker under Other and persists its selection', async () => {
+    const user = userEvent.setup()
+    renderStep()
+
+    expect(screen.queryByTestId('full-catalog-picker')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('wizard-model-other'))
+    expect(screen.getByTestId('full-catalog-picker')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('full-catalog-picker'))
+    await waitFor(() => {
+      expect(state.mutate).toHaveBeenCalledWith(
+        { models: { agentModel: 'kimi' } },
+        expect.objectContaining({ onError: expect.any(Function) }),
+      )
+    })
+  })
+
+  it('opens Other automatically for a model outside the curated shortlist', () => {
+    state.settings = platformSettings('kimi')
+    renderStep()
+
+    expect(screen.getByTestId('wizard-model-other')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('full-catalog-picker')).toBeInTheDocument()
+  })
+})
+
+describe('findDefaultModelOption', () => {
+  it('matches pinned versions by family while leaving non-shortlisted families to Other', () => {
+    expect(findDefaultModelOption('claude-opus-5', OPTIONS, [...CATALOG])?.model).toBe('opus')
+    expect(findDefaultModelOption('kimi-k3', OPTIONS, [...CATALOG])).toBeUndefined()
+  })
+})

--- a/src/renderer/components/wizard/configure-model-step.tsx
+++ b/src/renderer/components/wizard/configure-model-step.tsx
@@ -41,6 +41,9 @@ export function ConfigureModelStep() {
   const otherSelected = showOther || (Boolean(agentModel) && !matchedOption)
 
   const persistSelection = (model: string) => {
+    // The full-catalog picker may land back on a curated family. Reflect that
+    // immediately, including when it re-selects the same pinned model.
+    setShowOther(!findDefaultModelOption(model, options, catalog))
     if (model === agentModel) return
     // Optimistically reflect the choice in the settings cache so the card
     // updates instantly. The mutation's onSuccess invalidation refetches to
@@ -66,6 +69,9 @@ export function ConfigureModelStep() {
 
   const selectRecommended = (model: string) => {
     setShowOther(false)
+    // A pinned concrete version lights its family card. Clicking that already-
+    // selected card must not replace the pin with the bare family alias.
+    if (matchedOption?.model === model) return
     persistSelection(model)
   }
 
@@ -81,6 +87,9 @@ export function ConfigureModelStep() {
       <div className="space-y-3" role="radiogroup" aria-label="Default model">
         {options.map((option) => {
           const isSelected = !showOther && matchedOption?.model === option.model
+          const label = option.resolveLabelFromCatalog
+            ? findCatalogModel(option.model, catalog)?.label ?? option.label
+            : option.label
           return (
             <div
               key={option.model}
@@ -98,7 +107,7 @@ export function ConfigureModelStep() {
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <span className="font-medium text-sm">{option.label}</span>
+                    <span className="font-medium text-sm">{label}</span>
                     <span className="text-xs text-muted-foreground">{option.tag}</span>
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">

--- a/src/renderer/components/wizard/configure-model-step.tsx
+++ b/src/renderer/components/wizard/configure-model-step.tsx
@@ -1,64 +1,72 @@
-import { useSettings, useUpdateSettings, type GlobalSettingsResponse } from '@renderer/hooks/use-settings'
+import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
+import { findCatalogModel } from '@renderer/components/messages/model-family-list'
+import { useSettings, useUpdateSettings, type GlobalSettingsResponse } from '@renderer/hooks/use-settings'
+import type { ModelDefinition, ProviderDefaultModelOption } from '@shared/lib/llm-provider'
 
-/** Onboarding offers just the two headline families; both store a bare alias. */
-type WizardFamily = 'opus' | 'sonnet'
-
-const MODEL_OPTIONS: Array<{
-  family: WizardFamily
-  label: string
-  tag: string
-  description: string
-  subdescription: string
-}> = [
-  {
-    family: 'opus',
-    label: 'Opus',
-    tag: 'Most capable',
-    description: 'Best for complex, multi-step tasks.',
-    subdescription: 'Slower, and uses 5x more credits than Sonnet.',
-  },
-  {
-    family: 'sonnet',
-    label: 'Sonnet',
-    tag: 'Fast & efficient',
-    description: 'Best for everyday tasks and most agent work.',
-    subdescription: 'Far lower credit cost than Opus.',
-  },
-]
+/**
+ * Match a stored id/alias to a curated option by model family. A pinned Opus
+ * version should still light the Opus card; models outside the shortlist use
+ * the Other card and the full catalog picker.
+ */
+export function findDefaultModelOption(
+  selection: string | undefined,
+  options: readonly ProviderDefaultModelOption[],
+  catalog: ModelDefinition[],
+): ProviderDefaultModelOption | undefined {
+  if (!selection) return undefined
+  const selected = findCatalogModel(selection, catalog)
+  return options.find((option) => {
+    if (option.model === selection) return true
+    const optionModel = findCatalogModel(option.model, catalog)
+    return Boolean(selected?.family && optionModel?.family === selected.family)
+  })
+}
 
 export function ConfigureModelStep() {
   const { data: settings } = useSettings()
   const updateSettings = useUpdateSettings()
   const queryClient = useQueryClient()
+  const [showOther, setShowOther] = useState(false)
 
-  // The global "Default model" setting (LLM tab) persists `models.agentModel`
-  // as a bare family alias or a pinned id. Derive the headline family from it
-  // so onboarding and settings stay in sync; unknown/other → 'opus'.
-  const agentModel = settings?.models?.agentModel
-  const selectedFamily: WizardFamily = agentModel && /sonnet/.test(agentModel) ? 'sonnet' : 'opus'
+  const activeProvider = settings?.llmProvider ?? 'anthropic'
+  const provider = settings?.llmProviderStatus?.find((candidate) => candidate.id === activeProvider)
+  const options = provider?.defaultModelOptions ?? []
+  const catalog = provider?.catalog ?? []
+  // The provider default is the last-resort selection while settings load or
+  // when no global model has been persisted. Platform declares Grok here.
+  const agentModel = settings?.models?.agentModel ?? provider?.defaultModels?.agent
+  const matchedOption = findDefaultModelOption(agentModel, options, catalog)
+  const otherSelected = showOther || (Boolean(agentModel) && !matchedOption)
 
-  const handleSelect = async (family: WizardFamily) => {
-    if (family === selectedFamily) return
+  const persistSelection = (model: string) => {
+    if (model === agentModel) return
     // Optimistically reflect the choice in the settings cache so the card
     // updates instantly. The mutation's onSuccess invalidation refetches to
     // reconcile with the server; onError rolls back to the previous value.
-    await queryClient.cancelQueries({ queryKey: ['settings'] })
-    const previous = queryClient.getQueryData<GlobalSettingsResponse>(['settings'])
-    if (previous) {
-      queryClient.setQueryData<GlobalSettingsResponse>(['settings'], {
-        ...previous,
-        models: { ...previous.models, agentModel: family },
-      })
-    }
-    updateSettings.mutate(
-      { models: { agentModel: family } },
-      {
-        onError: () => {
-          if (previous) queryClient.setQueryData(['settings'], previous)
+    void queryClient.cancelQueries({ queryKey: ['settings'] }).then(() => {
+      const previous = queryClient.getQueryData<GlobalSettingsResponse>(['settings'])
+      if (previous) {
+        queryClient.setQueryData<GlobalSettingsResponse>(['settings'], {
+          ...previous,
+          models: { ...previous.models, agentModel: model },
+        })
+      }
+      updateSettings.mutate(
+        { models: { agentModel: model } },
+        {
+          onError: () => {
+            if (previous) queryClient.setQueryData(['settings'], previous)
+          },
         },
-      },
-    )
+      )
+    })
+  }
+
+  const selectRecommended = (model: string) => {
+    setShowOther(false)
+    persistSelection(model)
   }
 
   return (
@@ -71,11 +79,11 @@ export function ConfigureModelStep() {
       </div>
 
       <div className="space-y-3" role="radiogroup" aria-label="Default model">
-        {MODEL_OPTIONS.map((option) => {
-          const isSelected = selectedFamily === option.family
+        {options.map((option) => {
+          const isSelected = !showOther && matchedOption?.model === option.model
           return (
             <div
-              key={option.family}
+              key={option.model}
               className={`rounded-lg border text-left transition-colors ${
                 isSelected ? 'border-primary bg-muted/50' : 'hover:border-muted-foreground/50'
               }`}
@@ -85,8 +93,8 @@ export function ConfigureModelStep() {
                 role="radio"
                 aria-checked={isSelected}
                 className="w-full flex items-start gap-3 p-3 text-left"
-                onClick={() => handleSelect(option.family)}
-                data-testid={`wizard-model-${option.family}`}
+                onClick={() => selectRecommended(option.model)}
+                data-testid={`wizard-model-${option.model}`}
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
@@ -94,23 +102,63 @@ export function ConfigureModelStep() {
                     <span className="text-xs text-muted-foreground">{option.tag}</span>
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">
-                    {option.description}<br />{option.subdescription}
+                    {option.description}
+                    {option.subdescription && <><br />{option.subdescription}</>}
                   </p>
                 </div>
-                <div className={`mt-1 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
-                  isSelected ? 'border-primary' : 'border-muted-foreground/40'
-                }`}>
-                  {isSelected && <div className="h-2 w-2 rounded-full bg-primary" />}
-                </div>
+                <RadioIndicator selected={isSelected} />
               </button>
             </div>
           )
         })}
+
+        <div
+          className={`rounded-lg border text-left transition-colors ${
+            otherSelected ? 'border-primary bg-muted/50' : 'hover:border-muted-foreground/50'
+          }`}
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={otherSelected}
+            className="w-full flex items-start gap-3 p-3 text-left"
+            onClick={() => setShowOther(true)}
+            data-testid="wizard-model-other"
+          >
+            <div className="flex-1 min-w-0">
+              <span className="font-medium text-sm">Other</span>
+              <p className="text-xs text-muted-foreground mt-1">
+                Choose any model from this provider&apos;s full catalogue.
+              </p>
+            </div>
+            <RadioIndicator selected={otherSelected} />
+          </button>
+          {otherSelected && (
+            <div className="flex items-center justify-between gap-3 border-t px-3 py-3">
+              <span className="text-xs text-muted-foreground">Model</span>
+              <SettingsModelSelect
+                model={agentModel}
+                onModelChange={persistSelection}
+                align="end"
+              />
+            </div>
+          )}
+        </div>
       </div>
 
       <p className="text-sm text-muted-foreground">
         Change this default at any time in the settings.
       </p>
+    </div>
+  )
+}
+
+function RadioIndicator({ selected }: { selected: boolean }) {
+  return (
+    <div className={`mt-1 h-4 w-4 rounded-full border-2 shrink-0 flex items-center justify-center ${
+      selected ? 'border-primary' : 'border-muted-foreground/40'
+    }`}>
+      {selected && <div className="h-2 w-2 rounded-full bg-primary" />}
     </div>
   )
 }

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -1242,6 +1242,20 @@ describe('getEffectiveModels', () => {
       agentEffort: 'medium',
     })
   })
+
+  it('falls back to Anthropic defaults for an unknown persisted provider', () => {
+    // A downgrade can load a provider id written by a newer app version. The
+    // settings file is not schema-validated, so this must remain a soft fallback.
+    mockSettingsFile(JSON.stringify({ llmProvider: 'some-future-provider' }))
+
+    expect(getEffectiveModels()).toEqual({
+      summarizerModel: 'haiku',
+      agentModel: 'opus',
+      browserModel: 'sonnet',
+      dashboardBuilderModel: 'opus',
+      agentEffort: 'medium',
+    })
+  })
 })
 
 // ============================================================================

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -1230,6 +1230,18 @@ describe('getEffectiveModels', () => {
       agentEffort: 'medium',
     })
   })
+
+  it('uses the selected provider catalog defaults when model fields are missing', () => {
+    mockSettingsFile(JSON.stringify({ llmProvider: 'platform' }))
+
+    expect(getEffectiveModels()).toEqual({
+      summarizerModel: 'haiku',
+      agentModel: 'grok',
+      browserModel: 'sonnet',
+      dashboardBuilderModel: 'opus',
+      agentEffort: 'medium',
+    })
+  })
 })
 
 // ============================================================================

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -20,6 +20,7 @@ import {
   modelCatalogSettingsSchema,
   type ModelCatalogSettings,
 } from '../llm-provider/model-catalog-schema'
+import { getCatalogDefaultModels } from '../llm-provider/model-catalog-defaults'
 import {
   capabilityPolicySchema,
   DEFAULT_AGENT_CAPABILITIES,
@@ -418,13 +419,9 @@ const DEFAULT_SETTINGS: AppSettings = {
     },
   },
   models: {
-    // Bare family aliases so fresh installs track each family's latest version.
-    // The host resolver maps these to a concrete id per active provider.
-    summarizerModel: 'haiku',
-    agentModel: 'opus',
-    browserModel: 'sonnet',
-    // Dashboard-builder subagent — a capable tier by default (overridable).
-    dashboardBuilderModel: 'opus',
+    // The default provider is Anthropic. Source its bare aliases from the same
+    // catalog metadata used by provider switching and runtime fallbacks.
+    ...getCatalogDefaultModels('anthropic'),
     agentEffort: 'medium',
   },
   enableToolSearch: true,
@@ -524,7 +521,15 @@ function mergeLoadedSettings(loaded: Record<string, any>): AppSettings {
     webAllowedSites: loaded.webAllowedSites,
     webBlockedSites: loaded.webBlockedSites,
     models: (() => {
-      const merged = { ...DEFAULT_SETTINGS.models!, ...loaded.models }
+      const catalogDefaults = getCatalogDefaultModels(
+        loaded.llmProvider ?? 'anthropic',
+        modelCatalog,
+      )
+      const merged = {
+        ...catalogDefaults,
+        agentEffort: DEFAULT_SETTINGS.models!.agentEffort,
+        ...loaded.models,
+      }
       // One-time normalization of legacy concrete defaults → bare aliases.
       return {
         ...merged,
@@ -868,11 +873,15 @@ export function getEffectiveBrowserbaseProjectId(): string | undefined {
  */
 export function getEffectiveModels(): ModelSettings {
   const settings = getSettings()
+  const catalogDefaults = getCatalogDefaultModels(
+    settings.llmProvider ?? 'anthropic',
+    settings.modelCatalog,
+  )
   return {
-    summarizerModel: settings.models?.summarizerModel || DEFAULT_SETTINGS.models!.summarizerModel,
-    agentModel: settings.models?.agentModel || DEFAULT_SETTINGS.models!.agentModel,
-    browserModel: settings.models?.browserModel || DEFAULT_SETTINGS.models!.browserModel,
-    dashboardBuilderModel: settings.models?.dashboardBuilderModel || DEFAULT_SETTINGS.models!.dashboardBuilderModel,
+    summarizerModel: settings.models?.summarizerModel || catalogDefaults.summarizerModel,
+    agentModel: settings.models?.agentModel || catalogDefaults.agentModel,
+    browserModel: settings.models?.browserModel || catalogDefaults.browserModel,
+    dashboardBuilderModel: settings.models?.dashboardBuilderModel || catalogDefaults.dashboardBuilderModel,
     agentEffort: settings.models?.agentEffort || DEFAULT_SETTINGS.models!.agentEffort,
   }
 }

--- a/src/shared/lib/llm-provider/anthropic-provider.ts
+++ b/src/shared/lib/llm-provider/anthropic-provider.ts
@@ -1,11 +1,14 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
+import { BaseLlmProvider } from './base-llm-provider'
 import type { ModelDefinition } from './model-catalog-schema'
-import { CLAUDE_BARE_CATALOG } from './builtin-catalogs'
+import { CLAUDE_BARE_CATALOG, CLAUDE_DEFAULT_MODEL_OPTIONS } from './builtin-catalogs'
+import { ANTHROPIC_CATALOG_DEFAULT_MODELS } from './model-catalog-defaults'
 
 export class AnthropicLlmProvider extends BaseLlmProvider {
   readonly id = 'anthropic' as const
   readonly name = 'Anthropic'
+  readonly defaultModelOptions = CLAUDE_DEFAULT_MODEL_OPTIONS
+  readonly catalogDefaultModels = ANTHROPIC_CATALOG_DEFAULT_MODELS
   protected readonly settingsKeyField = 'anthropicApiKey' as const
   protected readonly envVarName = 'ANTHROPIC_API_KEY'
 
@@ -17,15 +20,6 @@ export class AnthropicLlmProvider extends BaseLlmProvider {
 
   getBuiltinCatalog(): ModelDefinition[] {
     return CLAUDE_BARE_CATALOG
-  }
-
-  getDefaultModel(purpose: ModelPurpose): string {
-    switch (purpose) {
-      case 'summarizer': return 'haiku'
-      case 'agent': return 'opus'
-      case 'browser': return 'sonnet'
-      case 'dashboard': return 'opus'
-    }
   }
 
   getContainerEnvVars(): Record<string, string | undefined> {

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -1,12 +1,27 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { getSettings, type ApiKeySettings, type ApiKeyStatus } from '../config/settings'
 import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
+import type { CatalogDefaultModels } from './model-catalog-defaults'
 import type { LlmProviderId } from './provider-types'
 
 export { LLM_PROVIDER_IDS } from './provider-types'
 export type { LlmProviderId } from './provider-types'
 
 export type ModelPurpose = 'agent' | 'summarizer' | 'browser' | 'dashboard'
+
+/**
+ * A curated default-model choice shown during onboarding. The selection may be
+ * a bare family alias (so it rides catalog upgrades) or a concrete model id.
+ * Keeping this on the provider lets each provider offer a different shortlist
+ * and provider-specific copy while the renderer remains catalog-agnostic.
+ */
+export interface ProviderDefaultModelOption {
+  model: string
+  label: string
+  tag: string
+  description: string
+  subdescription?: string
+}
 
 /**
  * Identity of the agent a container belongs to, resolved at env-build time.
@@ -23,6 +38,8 @@ export interface AgentIdentity {
 export abstract class BaseLlmProvider {
   abstract readonly id: LlmProviderId
   abstract readonly name: string
+  abstract readonly defaultModelOptions: readonly ProviderDefaultModelOption[]
+  abstract readonly catalogDefaultModels: CatalogDefaultModels
 
   /** Which field in ApiKeySettings stores this provider's key. */
   protected abstract readonly settingsKeyField: keyof ApiKeySettings
@@ -69,7 +86,14 @@ export abstract class BaseLlmProvider {
    * this to a concrete id; it is the ultimate fallback when a selection
    * can't be matched.
    */
-  abstract getDefaultModel(purpose: ModelPurpose): string
+  getDefaultModel(purpose: ModelPurpose): string {
+    switch (purpose) {
+      case 'summarizer': return this.catalogDefaultModels.summarizerModel
+      case 'agent': return this.catalogDefaultModels.agentModel
+      case 'browser': return this.catalogDefaultModels.browserModel
+      case 'dashboard': return this.catalogDefaultModels.dashboardBuilderModel
+    }
+  }
 
   /**
    * All three per-purpose defaults as bare aliases, keyed to match the

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -17,7 +17,10 @@ export type ModelPurpose = 'agent' | 'summarizer' | 'browser' | 'dashboard'
  */
 export interface ProviderDefaultModelOption {
   model: string
+  /** Stable fallback label, also used when the option names a model family. */
   label: string
+  /** Display the currently resolved catalog entry's label when available. */
+  resolveLabelFromCatalog?: boolean
   tag: string
   description: string
   subdescription?: string

--- a/src/shared/lib/llm-provider/bedrock-provider.ts
+++ b/src/shared/lib/llm-provider/bedrock-provider.ts
@@ -1,13 +1,16 @@
 import Anthropic from '@anthropic-ai/sdk'
 import AnthropicBedrock from '@anthropic-ai/bedrock-sdk'
 import { getSettings, type ApiKeyStatus } from '../config/settings'
-import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
+import { BaseLlmProvider } from './base-llm-provider'
 import type { ModelDefinition } from './model-catalog-schema'
-import { BEDROCK_CATALOG } from './builtin-catalogs'
+import { BEDROCK_CATALOG, CLAUDE_DEFAULT_MODEL_OPTIONS } from './builtin-catalogs'
+import { BEDROCK_CATALOG_DEFAULT_MODELS } from './model-catalog-defaults'
 
 export class BedrockLlmProvider extends BaseLlmProvider {
   readonly id = 'bedrock' as const
   readonly name = 'AWS Bedrock'
+  readonly defaultModelOptions = CLAUDE_DEFAULT_MODEL_OPTIONS
+  readonly catalogDefaultModels = BEDROCK_CATALOG_DEFAULT_MODELS
   // Used for simple Bedrock API Key auth (AWS_BEARER_TOKEN_BEDROCK)
   protected readonly settingsKeyField = 'bedrockApiKey' as const
   protected readonly envVarName = 'AWS_BEARER_TOKEN_BEDROCK'
@@ -74,15 +77,6 @@ export class BedrockLlmProvider extends BaseLlmProvider {
 
   getBuiltinCatalog(): ModelDefinition[] {
     return BEDROCK_CATALOG
-  }
-
-  getDefaultModel(purpose: ModelPurpose): string {
-    switch (purpose) {
-      case 'summarizer': return 'haiku'
-      case 'agent': return 'sonnet'
-      case 'browser': return 'sonnet'
-      case 'dashboard': return 'opus'
-    }
   }
 
   getContainerEnvVars(): Record<string, string | undefined> {

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -107,14 +107,16 @@ export const PLATFORM_DEFAULT_MODEL_OPTIONS: readonly ProviderDefaultModelOption
   },
   {
     model: 'gpt',
-    label: 'GPT-5.6',
+    label: 'GPT',
+    resolveLabelFromCatalog: true,
     tag: 'OpenAI flagship',
     description: 'Strong all-around reasoning and tool use.',
     subdescription: 'A versatile choice for demanding agent work.',
   },
   {
     model: 'grok',
-    label: 'Grok 4.5',
+    label: 'Grok',
+    resolveLabelFromCatalog: true,
     tag: 'Recommended',
     description: 'Fast, capable, and efficient for everyday agent work.',
     subdescription: 'The default model for Gamut Platform.',

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -1,4 +1,5 @@
 import type { EffortLevel, SpeedLevel } from '../container/types'
+import type { ProviderDefaultModelOption } from './base-llm-provider'
 import type { ModelDefinition } from './model-catalog-schema'
 import { GPT_TOOL_USE_PROMPT_HINTS, GROK_BROWSER_TOOL_PROMPT_HINTS } from './model-prompt-hints'
 import { pricingFor } from './model-pricing-lookup'
@@ -76,6 +77,49 @@ const GPT_LONG_CONTEXT_CLIFF = {
 } as const
 
 const ICON = 'anthropic'
+
+/** Default-model shortlist for providers whose onboarding catalog is Claude-only. */
+export const CLAUDE_DEFAULT_MODEL_OPTIONS: readonly ProviderDefaultModelOption[] = [
+  {
+    model: 'opus',
+    label: 'Opus',
+    tag: 'Most capable',
+    description: 'Best for complex, multi-step tasks.',
+    subdescription: 'Slower, and uses 5x more credits than Sonnet.',
+  },
+  {
+    model: 'sonnet',
+    label: 'Sonnet',
+    tag: 'Fast & efficient',
+    description: 'Best for everyday tasks and most agent work.',
+    subdescription: 'Far lower credit cost than Opus.',
+  },
+]
+
+/** Platform-specific default-model shortlist. The provider default is Grok. */
+export const PLATFORM_DEFAULT_MODEL_OPTIONS: readonly ProviderDefaultModelOption[] = [
+  {
+    model: 'opus',
+    label: 'Opus',
+    tag: 'Deep reasoning',
+    description: 'Best for complex, multi-step tasks.',
+    subdescription: 'A premium choice for the hardest agent work.',
+  },
+  {
+    model: 'gpt',
+    label: 'GPT-5.6',
+    tag: 'OpenAI flagship',
+    description: 'Strong all-around reasoning and tool use.',
+    subdescription: 'A versatile choice for demanding agent work.',
+  },
+  {
+    model: 'grok',
+    label: 'Grok 4.5',
+    tag: 'Recommended',
+    description: 'Fast, capable, and efficient for everyday agent work.',
+    subdescription: 'The default model for Gamut Platform.',
+  },
+]
 
 /** Anthropic / OpenRouter / Platform — bare Claude ids. */
 export const CLAUDE_BARE_CATALOG: ModelDefinition[] = [

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -4,16 +4,19 @@ import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
 import type { EffortLevel } from '../container/types'
 import { getSettings, getModelCatalogSettings, type ApiKeyStatus } from '../config/settings'
 import { isHostOnlyHostname, rewriteLoopbackForContainer } from './container-url'
+import {
+  GENERIC_CATALOG_DEFAULT_MODELS,
+  getCatalogDefaultModels,
+} from './model-catalog-defaults'
 
 const BASE_URL_ENV = 'GENERIC_BASE_URL'
-const DEFAULT_MODEL_ENV = 'GENERIC_DEFAULT_MODEL'
 
 /**
  * Ultimate fallback model id when the user has added no models and set no
  * GENERIC_DEFAULT_MODEL. A placeholder — the generic provider is only usable
  * once the user adds at least one model via the catalog editor (SUP-276).
  */
-export const GENERIC_FALLBACK_MODEL = 'default'
+export { GENERIC_FALLBACK_MODEL } from './model-catalog-defaults'
 
 /**
  * A user-pointed provider for any Anthropic-wire-compatible endpoint: a
@@ -81,6 +84,8 @@ function mapRemoteModel(model: RemoteModelListing): ModelSearchResult | null {
 export class GenericLlmProvider extends BaseLlmProvider {
   readonly id = 'generic' as const
   readonly name = 'Generic'
+  readonly defaultModelOptions = []
+  readonly catalogDefaultModels = GENERIC_CATALOG_DEFAULT_MODELS
   override readonly supportsModelSearch = true
   protected readonly settingsKeyField = 'genericApiKey' as const
   protected readonly envVarName = 'GENERIC_API_KEY'
@@ -122,10 +127,7 @@ export class GenericLlmProvider extends BaseLlmProvider {
   getDefaultModel(_purpose: ModelPurpose): string {
     // No built-in catalog: default to the first user-added model, then an
     // env-configurable default, then a placeholder the user overrides.
-    const firstUserModel = (getModelCatalogSettings()[this.id]?.overrides ?? [])
-      .find((entry) => entry.disabled !== true)?.id
-    if (firstUserModel) return firstUserModel
-    return process.env[DEFAULT_MODEL_ENV]?.trim() || GENERIC_FALLBACK_MODEL
+    return getCatalogDefaultModels(this.id, getModelCatalogSettings()).agentModel
   }
 
   getContainerEnvVars(): Record<string, string | undefined> {

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -1,7 +1,7 @@
 export { BaseLlmProvider } from './base-llm-provider'
 export { LLM_PROVIDER_IDS } from './provider-types'
 export type { LlmProviderId } from './provider-types'
-export type { ModelPurpose } from './base-llm-provider'
+export type { ModelPurpose, ProviderDefaultModelOption } from './base-llm-provider'
 export { AnthropicLlmProvider } from './anthropic-provider'
 export { OpenRouterLlmProvider } from './openrouter-provider'
 export { BedrockLlmProvider } from './bedrock-provider'
@@ -33,7 +33,7 @@ export {
 } from './model-catalog'
 
 import type { LlmProviderId } from './provider-types'
-import type { ModelPurpose } from './base-llm-provider'
+import type { ModelPurpose, ProviderDefaultModelOption } from './base-llm-provider'
 import { BaseLlmProvider } from './base-llm-provider'
 import type { ModelDefinition } from './model-catalog-schema'
 import { getEffectiveCatalog, getProviderCatalog, resolveModelForProvider } from './model-catalog'
@@ -92,6 +92,8 @@ export interface LlmProviderInfo {
   builtinCatalog?: ModelDefinition[]
   /** Per-purpose default selections (bare aliases). */
   defaultModels: ProviderDefaultModels
+  /** Curated default-model choices and provider-specific onboarding copy. */
+  defaultModelOptions: readonly ProviderDefaultModelOption[]
   capabilities: {
     modelSearch: boolean
   }
@@ -114,6 +116,7 @@ export function getAllProviderInfo(): LlmProviderInfo[] {
     catalog: getEffectiveCatalog(p.id),
     builtinCatalog: getProviderCatalog(p.id),
     defaultModels: defaultModelsFor(p),
+    defaultModelOptions: p.defaultModelOptions,
     capabilities: {
       modelSearch: p.supportsModelSearch,
     },

--- a/src/shared/lib/llm-provider/model-catalog-defaults.ts
+++ b/src/shared/lib/llm-provider/model-catalog-defaults.ts
@@ -1,0 +1,81 @@
+import type { ModelCatalogSettings } from './model-catalog-schema'
+import type { LlmProviderId } from './provider-types'
+
+/** Per-purpose fallback selections owned by a provider's model catalog. */
+export interface CatalogDefaultModels {
+  summarizerModel: string
+  agentModel: string
+  browserModel: string
+  dashboardBuilderModel: string
+}
+
+export const ANTHROPIC_CATALOG_DEFAULT_MODELS: CatalogDefaultModels = {
+  summarizerModel: 'haiku',
+  agentModel: 'opus',
+  browserModel: 'sonnet',
+  dashboardBuilderModel: 'opus',
+}
+
+export const OPENROUTER_CATALOG_DEFAULT_MODELS: CatalogDefaultModels = {
+  summarizerModel: 'haiku',
+  agentModel: 'sonnet',
+  browserModel: 'sonnet',
+  dashboardBuilderModel: 'opus',
+}
+
+export const BEDROCK_CATALOG_DEFAULT_MODELS: CatalogDefaultModels = {
+  summarizerModel: 'haiku',
+  agentModel: 'sonnet',
+  browserModel: 'sonnet',
+  dashboardBuilderModel: 'opus',
+}
+
+export const PLATFORM_CATALOG_DEFAULT_MODELS: CatalogDefaultModels = {
+  summarizerModel: 'haiku',
+  agentModel: 'grok',
+  browserModel: 'sonnet',
+  dashboardBuilderModel: 'opus',
+}
+
+export const GENERIC_FALLBACK_MODEL = 'default'
+export const GENERIC_CATALOG_DEFAULT_MODELS: CatalogDefaultModels = {
+  summarizerModel: GENERIC_FALLBACK_MODEL,
+  agentModel: GENERIC_FALLBACK_MODEL,
+  browserModel: GENERIC_FALLBACK_MODEL,
+  dashboardBuilderModel: GENERIC_FALLBACK_MODEL,
+}
+
+const BUILTIN_DEFAULTS: Record<LlmProviderId, CatalogDefaultModels> = {
+  anthropic: ANTHROPIC_CATALOG_DEFAULT_MODELS,
+  openrouter: OPENROUTER_CATALOG_DEFAULT_MODELS,
+  bedrock: BEDROCK_CATALOG_DEFAULT_MODELS,
+  platform: PLATFORM_CATALOG_DEFAULT_MODELS,
+  generic: GENERIC_CATALOG_DEFAULT_MODELS,
+}
+
+/**
+ * Return provider/catalog-specific defaults without importing provider classes
+ * (and therefore without creating a config ↔ provider runtime cycle).
+ * Generic catalogs have no built-ins, so their first enabled custom entry is
+ * the fallback for every purpose.
+ */
+export function getCatalogDefaultModels(
+  providerId: LlmProviderId,
+  modelCatalog?: ModelCatalogSettings,
+): CatalogDefaultModels {
+  if (providerId === 'generic') {
+    const firstUserModel = (modelCatalog?.generic?.overrides ?? [])
+      .find((entry) => entry.disabled !== true)?.id
+    const genericDefault =
+      firstUserModel || process.env.GENERIC_DEFAULT_MODEL?.trim() || GENERIC_FALLBACK_MODEL
+    if (genericDefault !== GENERIC_FALLBACK_MODEL) {
+      return {
+        summarizerModel: genericDefault,
+        agentModel: genericDefault,
+        browserModel: genericDefault,
+        dashboardBuilderModel: genericDefault,
+      }
+    }
+  }
+  return BUILTIN_DEFAULTS[providerId]
+}

--- a/src/shared/lib/llm-provider/model-catalog-defaults.ts
+++ b/src/shared/lib/llm-provider/model-catalog-defaults.ts
@@ -77,5 +77,9 @@ export function getCatalogDefaultModels(
       }
     }
   }
-  return BUILTIN_DEFAULTS[providerId]
+  // Settings files are deliberately tolerant of unknown keys/values. A newer
+  // build may persist a provider id that an older build does not know after a
+  // downgrade, so the runtime lookup must not assume the TypeScript union was
+  // enforced on disk.
+  return BUILTIN_DEFAULTS[providerId] ?? ANTHROPIC_CATALOG_DEFAULT_MODELS
 }

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -17,13 +17,25 @@ import {
   hasVersionSegment,
   resolveModelForProvider,
 } from './model-catalog'
-import { resolveActiveProviderModel } from './index'
+import { getAllProviderInfo, getLlmProvider, resolveActiveProviderModel } from './index'
 
 beforeEach(() => {
   settingsMock.mockReturnValue({ llmProvider: 'anthropic' })
 })
 
 describe('getProviderCatalog', () => {
+  it('exposes provider-owned onboarding options and uses Grok as the Platform agent fallback', () => {
+    const platform = getAllProviderInfo().find((provider) => provider.id === 'platform')!
+
+    expect(platform.defaultModelOptions.map((option) => [option.model, option.label])).toEqual([
+      ['opus', 'Opus'],
+      ['gpt', 'GPT-5.6'],
+      ['grok', 'Grok 4.5'],
+    ])
+    expect(platform.defaultModels.agent).toBe('grok')
+    expect(getLlmProvider('platform').getDefaultModel('agent')).toBe('grok')
+  })
+
   it('declares one concrete picker default for every built-in model vendor', () => {
     const defaultsByIcon = (providerId: 'anthropic' | 'bedrock' | 'openrouter' | 'platform') =>
       getProviderCatalog(providerId)
@@ -522,7 +534,7 @@ describe('resolveModelForProvider', () => {
     expect(resolveModelForProvider('gpt-5.6-luna', 'platform', 'agent')).toBe('gpt-5.6-luna')
     expect(resolveModelForProvider('grok', 'platform', 'agent')).toBe('grok-4.5')
     expect(resolveModelForProvider('grok-4.5', 'platform', 'agent')).toBe('grok-4.5')
-    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('claude-opus-5')
+    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('grok-4.5')
   })
 
   it('resolves the SAME bare alias to each provider concrete id (cross-provider portability)', () => {

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -27,10 +27,10 @@ describe('getProviderCatalog', () => {
   it('exposes provider-owned onboarding options and uses Grok as the Platform agent fallback', () => {
     const platform = getAllProviderInfo().find((provider) => provider.id === 'platform')!
 
-    expect(platform.defaultModelOptions.map((option) => [option.model, option.label])).toEqual([
-      ['opus', 'Opus'],
-      ['gpt', 'GPT-5.6'],
-      ['grok', 'Grok 4.5'],
+    expect(platform.defaultModelOptions.map((option) => option.model)).toEqual([
+      'opus',
+      'gpt',
+      'grok',
     ])
     expect(platform.defaultModels.agent).toBe('grok')
     expect(getLlmProvider('platform').getDefaultModel('agent')).toBe('grok')

--- a/src/shared/lib/llm-provider/openrouter-provider.ts
+++ b/src/shared/lib/llm-provider/openrouter-provider.ts
@@ -1,7 +1,8 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { BaseLlmProvider, type ModelPurpose } from './base-llm-provider'
+import { BaseLlmProvider } from './base-llm-provider'
 import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
-import { OPENROUTER_CATALOG } from './builtin-catalogs'
+import { CLAUDE_DEFAULT_MODEL_OPTIONS, OPENROUTER_CATALOG } from './builtin-catalogs'
+import { OPENROUTER_CATALOG_DEFAULT_MODELS } from './model-catalog-defaults'
 import type { EffortLevel } from '../container/types'
 import { GPT_TOOL_USE_PROMPT_HINTS } from './model-prompt-hints'
 
@@ -132,6 +133,8 @@ function mapOpenRouterModel(model: OpenRouterModelListing): ModelSearchResult | 
 export class OpenRouterLlmProvider extends BaseLlmProvider {
   readonly id = 'openrouter' as const
   readonly name = 'OpenRouter'
+  readonly defaultModelOptions = CLAUDE_DEFAULT_MODEL_OPTIONS
+  readonly catalogDefaultModels = OPENROUTER_CATALOG_DEFAULT_MODELS
   override readonly supportsModelSearch = true
   protected readonly settingsKeyField = 'openrouterApiKey' as const
   protected readonly envVarName = 'OPENROUTER_API_KEY'
@@ -151,15 +154,6 @@ export class OpenRouterLlmProvider extends BaseLlmProvider {
 
   getBuiltinCatalog(): ModelDefinition[] {
     return OPENROUTER_CATALOG
-  }
-
-  getDefaultModel(purpose: ModelPurpose): string {
-    switch (purpose) {
-      case 'summarizer': return 'haiku'
-      case 'agent': return 'sonnet'
-      case 'browser': return 'sonnet'
-      case 'dashboard': return 'opus'
-    }
   }
 
   getContainerEnvVars(): Record<string, string | undefined> {

--- a/src/shared/lib/llm-provider/platform-provider.ts
+++ b/src/shared/lib/llm-provider/platform-provider.ts
@@ -1,8 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { BaseLlmProvider, type AgentIdentity, type ModelPurpose } from './base-llm-provider'
+import { BaseLlmProvider, type AgentIdentity } from './base-llm-provider'
 import { rewriteLoopbackForContainer } from './container-url'
 import type { ModelDefinition } from './model-catalog-schema'
-import { PLATFORM_CATALOG } from './builtin-catalogs'
+import { PLATFORM_CATALOG, PLATFORM_DEFAULT_MODEL_OPTIONS } from './builtin-catalogs'
+import { PLATFORM_CATALOG_DEFAULT_MODELS } from './model-catalog-defaults'
 import { attribution } from '@shared/lib/platform-attribution'
 import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
 import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
@@ -21,6 +22,8 @@ export function sanitizeAgentName(name: string): string {
 export class PlatformLlmProvider extends BaseLlmProvider {
   readonly id = 'platform' as const
   readonly name = 'Platform'
+  readonly defaultModelOptions = PLATFORM_DEFAULT_MODEL_OPTIONS
+  readonly catalogDefaultModels = PLATFORM_CATALOG_DEFAULT_MODELS
   // Not used — getApiKeyStatus/getEffectiveApiKey are both overridden to
   // read the platform token instead of a settings-stored API key.
   protected readonly settingsKeyField = 'anthropicApiKey' as const
@@ -53,15 +56,6 @@ export class PlatformLlmProvider extends BaseLlmProvider {
 
   getBuiltinCatalog(): ModelDefinition[] {
     return PLATFORM_CATALOG
-  }
-
-  getDefaultModel(purpose: ModelPurpose): string {
-    switch (purpose) {
-      case 'summarizer': return 'haiku'
-      case 'agent': return 'opus'
-      case 'browser': return 'sonnet'
-      case 'dashboard': return 'opus'
-    }
   }
 
   getContainerEnvVars(agent?: AgentIdentity): Record<string, string | undefined> {


### PR DESCRIPTION
## What changed

- Move onboarding default-model options and descriptions onto each LLM provider.
- Add an **Other** option that opens the provider's full model catalog.
- Configure Platform onboarding choices as Opus, GPT-5.6, and Grok 4.5, with Grok selected by default.
- Replace hard-coded Opus/Sonnet fallbacks with provider catalog defaults across settings, agent creation, composer, and quick dispatch flows.
- Make persisted unknown provider IDs degrade safely to Anthropic defaults after a version downgrade.
- Keep curated model labels synced with the resolved catalog, preserve concrete pins, and keep the **Other** selection state consistent.
- Make `/api/llm` resolve its omitted-model default through the active provider catalog.

## Why

Different providers expose different model catalogs and should own both their curated onboarding choices and their global fallback behavior. This keeps the UI and runtime resolution aligned as catalogs evolve and prevents provider-specific IDs from leaking into incompatible runtimes.

## Dashboard-runtime tier decision

`/api/llm` backs the dashboard iframe's `window.claude` / bundled Anthropic SDK polyfill. Its historical omitted-model default was Sonnet-tier. This PR intentionally preserves that cost profile by resolving the effective `browserModel` with the `browser` purpose instead of following `agentModel` (which would move Anthropic dashboards to Opus and Platform dashboards to Grok). The result remains provider-portable: Anthropic, Platform, and Bedrock resolve to their concrete Sonnet model, while Generic resolves to its configured custom model.

## User impact

Platform users now start with Grok 4.5 and can choose Opus or GPT-5.6 directly during onboarding, while **Other** exposes the entire Platform catalog. Other providers retain their own curated choices and catalog-specific defaults. Dashboard runtime calls that omit a model keep their existing Sonnet-tier behavior.

## Validation

- 345 targeted tests across onboarding, provider catalogs, dashboard LLM routing, create-agent conflict resolution, and pending-session behavior
- `npm run typecheck`
- `npm run lint` — 0 errors (42 existing warnings)
- Manual Electron onboarding check with a fresh isolated seed and Gamut Platform endpoints
