### PR TITLE
SUP-186 Handle re-authentication for assigned connections

### DIFF
--- a/agent-container/src/claude-code-connections.test.ts
+++ b/agent-container/src/claude-code-connections.test.ts
@@ -171,13 +171,16 @@ describe('ClaudeCodeProcess runtime connection handling', () => {
     expect(calls[2].options.systemPrompt).not.toContain('Team Calendar')
 
     process.env.CONNECTED_ACCOUNTS = JSON.stringify({
-      gmail: [{ name: 'Work Gmail', id: 'account-gmail' }],
+      gmail: [{ name: 'Work Gmail', id: 'account-gmail', status: 'expired' }],
     })
     await claudeProcess.sendMessage('Check the connected Gmail account')
 
     expect(calls).toHaveLength(4)
     expect(calls[3].options.systemPrompt).toContain('Work Gmail')
     expect(calls[3].options.systemPrompt).toContain('account-gmail')
+    expect(calls[3].options.systemPrompt).toContain('status: `expired`')
+    expect(calls[3].options.systemPrompt).toContain('Make the intended proxy call')
+    expect(calls[3].options.systemPrompt).toContain('Do NOT report them as missing')
 
     process.env.CONNECTED_ACCOUNTS = '{}'
     await claudeProcess.sendMessage('Continue without Gmail')
@@ -211,6 +214,16 @@ describe('ClaudeCodeProcess remote MCP handshake gate', () => {
     {
       id: 'mcp-calendar',
       name: 'Team Calendar',
+      proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
+      tools: [{ name: 'list_events' }],
+    },
+  ])
+
+  const AUTH_REQUIRED_CALENDAR = JSON.stringify([
+    {
+      id: 'mcp-calendar',
+      name: 'Team Calendar',
+      status: 'auth_required',
       proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
       tools: [{ name: 'list_events' }],
     },
@@ -257,6 +270,35 @@ describe('ClaudeCodeProcess remote MCP handshake gate', () => {
     // rather than delivering into a half-connected session.
     expect(calls).toHaveLength(2)
     expect(mcpServerStatusCalls).toBe(3)
+  })
+
+  it('does not restart or block ordinary messages for an assigned MCP that needs re-authentication', async () => {
+    process.env.REMOTE_MCPS = AUTH_REQUIRED_CALENDAR
+    const claude = await startProcess('test-handshake-gate-reauth')
+    mcpServerStatusImpl = async () => [
+      { name: 'team_calendar', status: 'pending' },
+    ]
+
+    await claude.sendMessage('Draft an unrelated note')
+
+    expect(calls).toHaveLength(1)
+    expect(mcpServerStatusCalls).toBe(0)
+    expect(calls[0].options.mcpServers).toHaveProperty('team_calendar')
+    expect(calls[0].options.systemPrompt).toContain('do not report that the')
+  })
+
+  it('restarts for a newly projected auth-required MCP without waiting on its parked handshake', async () => {
+    const claude = await startProcess('test-handshake-gate-new-reauth')
+    mcpServerStatusImpl = async () => [
+      { name: 'team_calendar', status: 'pending' },
+    ]
+
+    process.env.REMOTE_MCPS = AUTH_REQUIRED_CALENDAR
+    await claude.sendMessage('Draft an unrelated note')
+
+    expect(calls).toHaveLength(2)
+    expect(mcpServerStatusCalls).toBe(0)
+    expect(calls[1].options.mcpServers).toHaveProperty('team_calendar')
   })
 
   it('does not wait on MCP servers from other setting scopes', async () => {

--- a/agent-container/src/claude-code-connections.test.ts
+++ b/agent-container/src/claude-code-connections.test.ts
@@ -284,7 +284,7 @@ describe('ClaudeCodeProcess remote MCP handshake gate', () => {
     expect(calls).toHaveLength(1)
     expect(mcpServerStatusCalls).toBe(0)
     expect(calls[0].options.mcpServers).toHaveProperty('team_calendar')
-    expect(calls[0].options.systemPrompt).toContain('do not report that the')
+    expect(calls[0].options.systemPrompt).toContain('Do not report an assigned server as missing')
   })
 
   it('restarts for a newly projected auth-required MCP without waiting on its parked handshake', async () => {
@@ -299,6 +299,31 @@ describe('ClaudeCodeProcess remote MCP handshake gate', () => {
     expect(calls).toHaveLength(2)
     expect(mcpServerStatusCalls).toBe(0)
     expect(calls[1].options.mcpServers).toHaveProperty('team_calendar')
+  })
+
+  it('still waits for a new active MCP when another assigned MCP needs re-authentication', async () => {
+    process.env.REMOTE_MCPS = AUTH_REQUIRED_CALENDAR
+    const claude = await startProcess('test-handshake-gate-mixed')
+    let poll = 0
+    mcpServerStatusImpl = async () => [
+      { name: 'team_calendar', status: 'pending' },
+      { name: 'active_search', status: ++poll < 2 ? 'pending' : 'connected' },
+    ]
+
+    process.env.REMOTE_MCPS = JSON.stringify([
+      ...JSON.parse(AUTH_REQUIRED_CALENDAR),
+      {
+        id: 'mcp-search',
+        name: 'Active Search',
+        status: 'active',
+        proxyUrl: 'http://host/api/mcp-proxy/agent/mcp-search',
+        tools: [{ name: 'search' }],
+      },
+    ])
+    await claude.sendMessage('Search for the latest update')
+
+    expect(calls).toHaveLength(2)
+    expect(mcpServerStatusCalls).toBe(2)
   })
 
   it('does not wait on MCP servers from other setting scopes', async () => {

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -98,6 +98,7 @@ const DASHBOARD_BUILDER_AGENT_PROMPT = loadPrompt('dashboard-builder-agent-promp
 interface RemoteMcpConfig {
   id: string;
   name: string;
+  status?: 'active' | 'auth_required';
   proxyUrl: string;
   tools: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }>;
 }
@@ -143,18 +144,33 @@ function runtimeConnectionConfigSnapshot(): string {
 
 /**
  * Parses connected accounts metadata from the CONNECTED_ACCOUNTS env var.
- * Format: {"toolkit": [{"name": "Display Name", "id": "uuid"}, ...]}
+ * Format: {"toolkit": [{"name": "Display Name", "id": "uuid", "status": "active"}, ...]}
  */
-function parseConnectedAccounts(): Map<string, Array<{ name: string; id: string }>> {
-  const accounts = new Map<string, Array<{ name: string; id: string }>>();
+type ConnectedAccountStatus = 'active' | 'expired' | 'revoked';
+interface ConnectedAccountConfig {
+  name: string;
+  id: string;
+  status?: ConnectedAccountStatus;
+}
+interface ConnectedAccountView extends ConnectedAccountConfig {
+  status: ConnectedAccountStatus;
+}
+
+function parseConnectedAccounts(): Map<string, ConnectedAccountView[]> {
+  const accounts = new Map<string, ConnectedAccountView[]>();
   const raw = process.env.CONNECTED_ACCOUNTS;
   if (!raw) return accounts;
 
   try {
-    const parsed = JSON.parse(raw) as Record<string, Array<{ name: string; id: string }>>;
+    const parsed = JSON.parse(raw) as Record<string, ConnectedAccountConfig[]>;
     for (const [toolkit, entries] of Object.entries(parsed)) {
       if (entries.length > 0) {
-        accounts.set(toolkit, entries);
+        // Older hosts did not serialize status; treat those entries as active
+        // so upgrading a running container remains backward-compatible.
+        accounts.set(toolkit, entries.map((entry) => ({
+          ...entry,
+          status: entry.status ?? 'active',
+        })));
       }
     }
   } catch {
@@ -167,7 +183,7 @@ function parseConnectedAccounts(): Map<string, Array<{ name: string; id: string 
 /** One toolkit's connected accounts, as the template's `connectedAccounts` list. */
 interface ConnectedAccountGroup {
   displayName: string;
-  entries: Array<{ name: string; id: string }>;
+  entries: ConnectedAccountView[];
 }
 
 /** One remote MCP server, as the template's `remoteMcps` list. */
@@ -616,12 +632,11 @@ export class ClaudeCodeProcess extends EventEmitter {
    * model believes it, calls mcp__<server>__<tool>, and gets "No such tool
    * available": the exact symptom of a connection that never arrived.
    *
-   * Only the connection-config-changed path calls this. An unchanged config
-   * means no re-query at all, hence no handshake in flight and nothing to wait
-   * for. The other re-query triggers (effort/speed/capability change, cold-start
-   * restart) race the same handshake, but there the user has not just connected
-   * a server they are about to ask about — and gating every wake-from-idle would
-   * tax a far more common path for a far rarer payoff.
+   * Active connection changes call this. Auth-required servers are excluded
+   * from the gate because the host deliberately parks their handshake while a
+   * person completes OAuth; holding the user message on that handshake would
+   * freeze every turn. Other re-query triggers (effort/speed/capability change)
+   * also do not wait because the remote MCP set itself did not change.
    */
   private async waitForRemoteMcpsReady(
     timeoutMs: number = REMOTE_MCP_READY_TIMEOUT_MS
@@ -1265,6 +1280,9 @@ export class ClaudeCodeProcess extends EventEmitter {
     const model = options?.model;
     const runtimeConnectionConfigChanged =
       runtimeConnectionConfigSnapshot() !== this.runtimeConnectionSnapshot;
+    const hasMcpAwaitingReauth = parseRemoteMcps().some(
+      (mcp) => mcp.status === 'auth_required'
+    );
 
     if (runtimeConnectionConfigChanged) {
       // The prompt's connected-account and remote-MCP sections are generated
@@ -1336,7 +1354,12 @@ export class ClaudeCodeProcess extends EventEmitter {
         await this.currentStop.catch(() => undefined);
       }
       await this.restart();
-    } else if (effortChanged || speedChanged || capabilityBlockChanged || runtimeConnectionConfigChanged) {
+    } else if (
+      effortChanged ||
+      speedChanged ||
+      capabilityBlockChanged ||
+      runtimeConnectionConfigChanged
+    ) {
       // Effort can only be set at query creation time — the SDK has no setEffort
       // facility — so any effort change forces an interrupt + re-query. Speed
       // lives in the query env (ANTHROPIC_CUSTOM_HEADERS), which is likewise
@@ -1370,7 +1393,7 @@ export class ClaudeCodeProcess extends EventEmitter {
     // restart() and the interrupt() re-query rebuild the query with the new
     // connection set, so both race the handshake. Guarded by the flag rather
     // than by the branch, so an effort- or speed-only re-query pays nothing.
-    if (runtimeConnectionConfigChanged) {
+    if (runtimeConnectionConfigChanged && !hasMcpAwaitingReauth) {
       await this.waitForRemoteMcpsReady();
     }
 

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -191,6 +191,8 @@ interface RemoteMcpView {
   name: string;
   tools: string;
   sanitizedName: string;
+  hasTools: boolean;
+  needsReauth: boolean;
 }
 
 function connectedAccountGroups(): ConnectedAccountGroup[] {
@@ -205,6 +207,8 @@ function remoteMcpViews(): RemoteMcpView[] {
     name: mcp.name,
     tools: mcp.tools.map(t => t.name).join(', '),
     sanitizedName: sanitizeMcpName(mcp.name),
+    hasTools: mcp.tools.length > 0,
+    needsReauth: mcp.status === 'auth_required',
   }));
 }
 
@@ -633,17 +637,20 @@ export class ClaudeCodeProcess extends EventEmitter {
    * available": the exact symptom of a connection that never arrived.
    *
    * Active connection changes call this. Auth-required servers are excluded
-   * from the gate because the host deliberately parks their handshake while a
-   * person completes OAuth; holding the user message on that handshake would
-   * freeze every turn. Other re-query triggers (effort/speed/capability change)
-   * also do not wait because the remote MCP set itself did not change.
+   * individually because they complete discovery through the host's local
+   * handshake; an unrelated active server must still reach a terminal status.
+   * Other re-query triggers (effort/speed/capability change) do not wait because
+   * the remote MCP set itself did not change.
    */
   private async waitForRemoteMcpsReady(
     timeoutMs: number = REMOTE_MCP_READY_TIMEOUT_MS
   ): Promise<void> {
     // Keys are already sanitized, and they are exactly the keys handed to
     // query() as mcpServers — so they match the names the SDK reports back.
-    const expected = Object.keys(this.buildRemoteMcpServers());
+    // Only the auth-required entries are exempt; active siblings still gate.
+    const expected = parseRemoteMcps()
+      .filter((mcp) => mcp.status !== 'auth_required')
+      .map((mcp) => sanitizeMcpName(mcp.name));
     if (expected.length === 0 || !this.queryInstance) return;
 
     const deadline = Date.now() + timeoutMs;
@@ -1280,10 +1287,6 @@ export class ClaudeCodeProcess extends EventEmitter {
     const model = options?.model;
     const runtimeConnectionConfigChanged =
       runtimeConnectionConfigSnapshot() !== this.runtimeConnectionSnapshot;
-    const hasMcpAwaitingReauth = parseRemoteMcps().some(
-      (mcp) => mcp.status === 'auth_required'
-    );
-
     if (runtimeConnectionConfigChanged) {
       // The prompt's connected-account and remote-MCP sections are generated
       // from runtime env metadata, so refresh them alongside the query config.
@@ -1391,9 +1394,9 @@ export class ClaudeCodeProcess extends EventEmitter {
 
     // Deliberately outside the branch chain above: BOTH the cold-session
     // restart() and the interrupt() re-query rebuild the query with the new
-    // connection set, so both race the handshake. Guarded by the flag rather
-    // than by the branch, so an effort- or speed-only re-query pays nothing.
-    if (runtimeConnectionConfigChanged && !hasMcpAwaitingReauth) {
+    // connection set, so both race the handshake. Effort- or speed-only
+    // re-queries pay nothing because the runtime connection set is unchanged.
+    if (runtimeConnectionConfigChanged) {
       await this.waitForRemoteMcpsReady();
     }
 

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -52,6 +52,18 @@ describe('generateSystemPrompt rendering', () => {
     expect(out).toContain('Use `schedule_task` only for genuinely independent work')
   })
 
+  it('keeps expired assigned accounts visible and directs the agent through proxy re-auth', () => {
+    process.env.CONNECTED_ACCOUNTS = JSON.stringify({
+      notion: [{ name: 'Notion', id: 'account-notion', status: 'expired' }],
+    })
+
+    const out = generateSystemPrompt()
+    expect(out).toContain('## Connected Accounts (Assigned)')
+    expect(out).toContain('Notion (ID: `account-notion`, status: `expired`)')
+    expect(out).toContain('Make the intended proxy call')
+    expect(out).toContain('Do NOT report them as missing')
+  })
+
   // A heading whose body is entirely gated renders as a title with the next
   // heading directly beneath it. Some headings (`## File Handling`) are static
   // containers of subheadings and are bodyless in every render, which is fine --

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -64,6 +64,21 @@ describe('generateSystemPrompt rendering', () => {
     expect(out).toContain('Do NOT report them as missing')
   })
 
+  it('does not promise an in-chat MCP reconnect when no cached tools exist', () => {
+    process.env.REMOTE_MCPS = JSON.stringify([{
+      id: 'mcp-empty',
+      name: 'Empty MCP',
+      status: 'auth_required',
+      proxyUrl: 'http://host/api/mcp-proxy/agent/mcp-empty',
+      tools: [],
+    }])
+
+    const out = generateSystemPrompt()
+    expect(out).toContain('No cached tools are available for this server.')
+    expect(out).toContain('reconnect it from Connections')
+    expect(out).not.toContain('mcp__Empty_MCP__<tool_name>')
+  })
+
   // A heading whose body is entirely gated renders as a title with the next
   // heading directly beneath it. Some headings (`## File Handling`) are static
   // containers of subheadings and are bodyless in every render, which is fine --

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -896,14 +896,26 @@ resp = requests.get(
 ## Remote MCP Servers (Available)
 
 The following remote MCP servers are assigned to this agent. Their tools are
-available through the listed names. If a server needs re-authentication, its
-connection will pause and ask the user to reconnect; do not report that the
-server is missing or request that it be added again.
+available through the listed names. Do not report an assigned server as missing
+or request that it be added again.
 
 <%#remoteMcps%>
 ### <%name%>
+<%#hasTools%>
 Tools: <%tools%>
 Use these tools via mcp__<%sanitizedName%>__<tool_name>
+<%#needsReauth%>
+This server needs re-authentication. Calling one of its listed tools will pause
+the request and ask the user to reconnect, then resume the call.
+<%/needsReauth%>
+<%/hasTools%>
+<%^hasTools%>
+No cached tools are available for this server.
+<%#needsReauth%>
+Ask the user to reconnect it from Connections before trying to use it. There is
+no callable tool available yet to open the in-chat reconnect flow.
+<%/needsReauth%>
+<%/hasTools%>
 
 <%/remoteMcps%>
 <%/hasRemoteMcps%>

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -368,11 +368,11 @@ Account metadata is stored in `CONNECTED_ACCOUNTS` as JSON mapping toolkit names
 ```json
 {
   "gmail": [
-    {"name": "work@company.com", "id": "abc123"},
-    {"name": "personal@gmail.com", "id": "def456"}
+    {"name": "work@company.com", "id": "abc123", "status": "active"},
+    {"name": "personal@gmail.com", "id": "def456", "status": "expired"}
   ],
   "github": [
-    {"name": "myusername", "id": "ghi789"}
+    {"name": "myusername", "id": "ghi789", "status": "active"}
   ]
 }
 ```
@@ -565,7 +565,7 @@ For <%#composioTriggers%>services with no Composio trigger<%/composioTriggers%><
 **The full loop:**
 1. `create_webhook_endpoint` → you get a public URL like `https://.../v1/hooks/whep_...`
 2. Register that URL with the third-party service YOURSELF whenever possible — only hand it to the user as a last resort:
-   - If the service is available as a connected account, prefer its API through the authenticated proxy<%#hasConnectedAccounts%> (see "Connected Accounts (Already Available)" below)<%/hasConnectedAccounts%>.
+   - If the service is available as a connected account, prefer its API through the authenticated proxy<%#hasConnectedAccounts%> (see "Connected Accounts (Assigned)" below)<%/hasConnectedAccounts%>.
    - Otherwise call the service's API directly (e.g. with curl), using `request_secret` to obtain any API key you need.
    - If there's no API path, offer to register it via the browser (navigate to the service's webhook settings page and fill it in).
    - Only if the user prefers to do it themselves (or it requires access you don't have): give a precise, copy-pasteable walkthrough — the exact settings path for that service, the URL to paste, the content type to pick, which events to enable, and where to enter the signing secret.
@@ -848,14 +848,14 @@ When using request tools (request_secret, request_file, request_connected_accoun
 <%/hasModelHints%>
 <%#hasConnectedAccounts%>
 
-## Connected Accounts (Already Available)
+## Connected Accounts (Assigned)
 
-**IMPORTANT: You already have access to the following connected accounts via the proxy. Do NOT request access to these - you already have it!**
+**IMPORTANT: The following accounts are already assigned to this agent. Do NOT report them as missing or request that they be added again. Make the intended proxy call using the listed account ID. If an account is expired or revoked, the proxy will pause the request and ask the user to reconnect; after reconnection, the original request resumes automatically.**
 
 <%#connectedAccounts%>
 ### <%displayName%>
 <%#entries%>
-- <%name%> (ID: `<%id%>`)
+- <%name%> (ID: `<%id%>`, status: `<%status%>`)
 <%/entries%>
 
 <%/connectedAccounts%>
@@ -888,13 +888,17 @@ resp = requests.get(
 **Important notes:**
 - Replace `<account_id>` with the ID shown above for the account you want to use
 - The proxy handles token refresh automatically
+- If an assigned account is expired or revoked, still make the proxy call so the host can surface the reconnect flow
 - The `CONNECTED_ACCOUNTS` env var contains the full account metadata as JSON
 <%/hasConnectedAccounts%>
 <%#hasRemoteMcps%>
 
 ## Remote MCP Servers (Available)
 
-The following remote MCP servers are connected and their tools are available for use:
+The following remote MCP servers are assigned to this agent. Their tools are
+available through the listed names. If a server needs re-authentication, its
+connection will pause and ask the user to reconnect; do not report that the
+server is missing or request that it be added again.
 
 <%#remoteMcps%>
 ### <%name%>

--- a/agent-container/src/tools/request-connected-account.ts
+++ b/agent-container/src/tools/request-connected-account.ts
@@ -19,7 +19,7 @@ After the user provides access, the CONNECTED_ACCOUNTS environment variable will
 URL pattern: $PROXY_BASE_URL/<account_id>/<target_host>/<api_path>
 Authorization: Bearer $PROXY_TOKEN
 
-The CONNECTED_ACCOUNTS env var contains JSON mapping toolkit names to arrays of {name, id} objects.
+The CONNECTED_ACCOUNTS env var contains JSON mapping toolkit names to arrays of {name, id, status} objects. Accounts already listed there are assigned; if one is expired or revoked, make the intended proxy call so the host can ask the user to reconnect instead of requesting the account again.
 
 Common toolkits include gmail, slack, github, notion, linear, salesforce, and many more. Use search_connected_account_services to discover all available services and their toolkit slugs.`,
   {
@@ -78,10 +78,10 @@ Common toolkits include gmail, slack, github, notion, linear, salesforce, and ma
       let accountInfo = ''
       if (accountsRaw) {
         try {
-          const parsed = JSON.parse(accountsRaw) as Record<string, Array<{ name: string; id: string }>>
+          const parsed = JSON.parse(accountsRaw) as Record<string, Array<{ name: string; id: string; status?: string }>>
           const toolkitAccounts = parsed[toolkitLower]
           if (toolkitAccounts?.length) {
-            accountInfo = `\n\nAvailable ${toolkitLower} accounts:\n${toolkitAccounts.map(a => `- ${a.name} (ID: ${a.id})`).join('\n')}`
+            accountInfo = `\n\nAvailable ${toolkitLower} accounts:\n${toolkitAccounts.map(a => `- ${a.name} (ID: ${a.id}, status: ${a.status ?? 'active'})`).join('\n')}`
           }
         } catch {
           // ignore parse errors

--- a/agent-container/src/tools/request-remote-mcp.test.ts
+++ b/agent-container/src/tools/request-remote-mcp.test.ts
@@ -52,9 +52,8 @@ describe('requestRemoteMcpTool', () => {
   })
 
   it('returns an explicit error when the resolved server is missing from REMOTE_MCPS', async () => {
-    // The host filters non-active servers out of REMOTE_MCPS — a stale server
-    // can be approved yet never registered. The model must not be told
-    // "granted" in that case.
+    // A server that is not assigned to this agent must not look like a
+    // successful grant to the model.
     process.env.REMOTE_MCPS = JSON.stringify([])
     const toolUseId = `mcp-test-${Date.now()}-2`
     inputManager.setCurrentToolUseId(toolUseId)

--- a/src/api/routes/connected-accounts.test.ts
+++ b/src/api/routes/connected-accounts.test.ts
@@ -126,6 +126,7 @@ const mockFindAgentsAssignedConnectedAccount = vi.fn()
   .mockResolvedValue(['agent-a'])
 const mockSyncAgentsAssignedConnectedAccount = vi.fn().mockResolvedValue(true)
 const mockSyncConnectedAccountAgents = vi.fn().mockResolvedValue(true)
+const mockCompleteReauthAccount = vi.fn()
 
 vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
   countActiveTriggersPerAccount: (...args: unknown[]) => mockCountActiveTriggersPerAccount(...args),
@@ -139,6 +140,12 @@ vi.mock('@shared/lib/container/connection-runtime-sync', () => ({
     mockSyncAgentsAssignedConnectedAccount(...args),
   syncConnectedAccountAgents: (...args: unknown[]) =>
     mockSyncConnectedAccountAgents(...args),
+}))
+
+vi.mock('@shared/lib/proxy/account-reauth-manager', () => ({
+  accountReauthManager: {
+    completeAccount: (...args: unknown[]) => mockCompleteReauthAccount(...args),
+  },
 }))
 
 import connectedAccountsRouter from './connected-accounts'
@@ -234,6 +241,7 @@ describe('connected-accounts reconnect flow', () => {
       expect(mockSyncAgentsAssignedConnectedAccount).toHaveBeenCalledWith(
         'existing-acc',
       )
+      expect(mockCompleteReauthAccount).toHaveBeenCalledWith('existing-acc')
     })
 
     it('deletes old remote connection after reconnect', async () => {
@@ -298,6 +306,25 @@ describe('connected-accounts reconnect flow', () => {
       expect(mockSyncAgentsAssignedConnectedAccount).toHaveBeenCalledWith(
         expect.any(String),
       )
+      expect(mockCompleteReauthAccount).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('GET /callback with reconnectAccountId', () => {
+    it('resumes parked proxy requests after the web OAuth callback activates the account', async () => {
+      mockGetConnection.mockResolvedValue({ id: 'new-web-conn', status: 'ACTIVE' })
+      mockGetAccountDisplayName.mockResolvedValue('My GitHub')
+      mockDbSelectLimit.mockResolvedValue([{ providerConnectionId: 'old-conn' }])
+
+      const res = await app.request(
+        'http://localhost/api/connected-accounts/callback' +
+        '?connectedAccountId=new-web-conn&status=success&toolkit=github' +
+        '&reconnectAccountId=existing-acc',
+      )
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('Connected Successfully!')
+      expect(mockCompleteReauthAccount).toHaveBeenCalledWith('existing-acc')
     })
   })
 

--- a/src/api/routes/connected-accounts.ts
+++ b/src/api/routes/connected-accounts.ts
@@ -22,6 +22,7 @@ import {
   syncAgentsAssignedConnectedAccount,
   syncConnectedAccountAgents,
 } from '@shared/lib/container/connection-runtime-sync'
+import { accountReauthManager } from '@shared/lib/proxy/account-reauth-manager'
 
 const connectedAccountsRouter = new Hono()
 
@@ -273,6 +274,11 @@ connectedAccountsRouter.post('/complete', async (c) => {
         .where(eq(connectedAccounts.id, reconnectAccountId))
       id = reconnectAccountId
 
+      // The account row now points at a provider connection that was verified
+      // ACTIVE above. Resume every proxy request parked on this account before
+      // the best-effort runtime refresh, which is unrelated to proxy tokens.
+      accountReauthManager.completeAccount(id)
+
       // Clean up the old remote connection (fire-and-forget)
       if (oldRecord && oldRecord.providerConnectionId !== connectionId) {
         accountProvider.deleteConnection(oldRecord.providerConnectionId, toolkitSlug)
@@ -401,6 +407,8 @@ connectedAccountsRouter.get('/callback', async (c) => {
         })
         .where(eq(connectedAccounts.id, reconnectAccountId))
       id = reconnectAccountId
+
+      accountReauthManager.completeAccount(id)
 
       if (oldRecord && oldRecord.providerConnectionId !== connectionId) {
         accountProvider.deleteConnection(oldRecord.providerConnectionId, toolkitSlug)

--- a/src/api/routes/mcp-proxy.reauth.integration.test.ts
+++ b/src/api/routes/mcp-proxy.reauth.integration.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+
+const mocks = vi.hoisted(() => ({
+  currentMcp: null as Record<string, unknown> | null,
+  safeFetch: vi.fn(),
+  syncAwaiting: vi.fn(),
+}))
+
+vi.mock('@shared/lib/proxy/token-store', () => ({
+  validateProxyToken: vi.fn().mockResolvedValue('agent-1'),
+}))
+
+vi.mock('@shared/lib/proxy/policy-resolver', () => ({
+  resolveMcpPolicy: vi.fn().mockResolvedValue({
+    decision: 'allow',
+    matchedScopes: [],
+    scopeDescriptions: {},
+    resolvedFrom: 'global_default',
+  }),
+}))
+
+vi.mock('@shared/lib/proxy/review-manager', () => ({
+  reviewManager: { requestReview: vi.fn() },
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    syncAgentSessionsAwaiting: (...args: unknown[]) => mocks.syncAwaiting(...args),
+  },
+}))
+
+vi.mock('@shared/lib/mcp/mcp-safe-fetch', () => ({
+  mcpSafeFetch: (...args: unknown[]) => mocks.safeFetch(...args),
+}))
+
+vi.mock('@shared/lib/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({
+            limit: async () => mocks.currentMcp ? [{ mcp: mocks.currentMcp }] : [],
+          }),
+        }),
+      }),
+    }),
+    insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+    update: () => ({
+      set: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+    }),
+  },
+}))
+
+vi.mock('@shared/lib/db/schema', () => ({
+  remoteMcpServers: { id: 'id' },
+  agentRemoteMcps: { agentSlug: 'agent_slug', remoteMcpId: 'remote_mcp_id' },
+  mcpAuditLog: {},
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: (column: string, value: string) => ({ column, value }),
+  and: (...conditions: unknown[]) => conditions,
+}))
+
+import mcpProxy from './mcp-proxy'
+import { mcpReauthManager } from '@shared/lib/proxy/mcp-reauth-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+
+function mcp(status: 'active' | 'auth_required', accessToken: string) {
+  return {
+    id: 'mcp-1',
+    name: 'Stateful MCP',
+    url: 'https://mcp.example.com',
+    authType: 'oauth',
+    accessToken,
+    refreshToken: null,
+    tokenExpiresAt: null,
+    oauthTokenEndpoint: null,
+    oauthClientId: null,
+    oauthClientSecret: null,
+    oauthResource: null,
+    status,
+    errorMessage: status === 'auth_required' ? 'Reconnect required' : null,
+    toolsJson: JSON.stringify([{ name: 'search', inputSchema: { type: 'object' } }]),
+    userId: 'owner-1',
+  }
+}
+
+function rpcHeaders(sessionId?: string): Record<string, string> {
+  return {
+    Authorization: 'Bearer proxy-token',
+    'Content-Type': 'application/json',
+    ...(sessionId ? { 'Mcp-Session-Id': sessionId } : {}),
+  }
+}
+
+function rpcBody(init: RequestInit): { id?: number; method: string } {
+  const raw = init.body instanceof ArrayBuffer
+    ? new TextDecoder().decode(init.body)
+    : String(init.body)
+  return JSON.parse(raw) as { id?: number; method: string }
+}
+
+describe('MCP re-auth park → reconnect → resume integration', () => {
+  let app: Hono
+
+  beforeEach(() => {
+    userInputRequestManager.reset()
+    mcpReauthManager.rejectAll()
+    mocks.safeFetch.mockReset()
+    mocks.syncAwaiting.mockReset()
+    mocks.currentMcp = mcp('auth_required', 'stale-token')
+    app = new Hono().route('/api/mcp-proxy', mcpProxy)
+  })
+
+  afterEach(() => {
+    mcpReauthManager.rejectAll()
+    userInputRequestManager.reset()
+  })
+
+  it('deduplicates the card and resumes concurrent calls on one real upstream session', async () => {
+    const initialize = await app.request('http://localhost/api/mcp-proxy/agent-1/mcp-1', {
+      method: 'POST',
+      headers: rpcHeaders(),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-06-18' },
+      }),
+    })
+    const clientSessionId = initialize.headers.get('Mcp-Session-Id')
+    expect(clientSessionId).toBeTruthy()
+
+    mocks.safeFetch.mockImplementation(async (_url: string, init: RequestInit) => {
+      const body = rpcBody(init)
+      if (body.method === 'initialize') {
+        return new Response(JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            serverInfo: { name: 'Stateful MCP', version: '1.0.0' },
+          },
+        }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Mcp-Session-Id': 'upstream-session-1',
+          },
+        })
+      }
+      if (body.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 })
+      }
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: body.id,
+        result: { content: [{ type: 'text', text: `result-${body.id}` }] },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    })
+
+    const call = (id: number) => app.request(
+      'http://localhost/api/mcp-proxy/agent-1/mcp-1',
+      {
+        method: 'POST',
+        headers: rpcHeaders(clientSessionId!),
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          method: 'tools/call',
+          params: { name: 'search', arguments: { query: `query-${id}` } },
+        }),
+      },
+    )
+
+    const first = call(2)
+    const second = call(3)
+
+    await vi.waitFor(() => {
+      expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(1)
+    })
+    expect(mocks.safeFetch).not.toHaveBeenCalled()
+
+    mocks.currentMcp = mcp('active', 'fresh-token')
+    expect(mcpReauthManager.completeMcp('mcp-1')).toBe(2)
+
+    const responses = await Promise.all([first, second])
+    const responseBodies = await Promise.all(responses.map((response) => response.clone().json()))
+    expect(
+      responses.map((response) => response.status),
+      JSON.stringify(responseBodies),
+    ).toEqual([200, 200])
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(0)
+
+    const forwardedMethods = mocks.safeFetch.mock.calls.map(([, init]) =>
+      rpcBody(init as RequestInit).method)
+    expect(forwardedMethods.filter((method) => method === 'initialize')).toHaveLength(1)
+    expect(forwardedMethods.filter((method) => method === 'notifications/initialized')).toHaveLength(1)
+    expect(forwardedMethods.filter((method) => method === 'tools/call')).toHaveLength(2)
+
+    const toolCalls = mocks.safeFetch.mock.calls.filter(([, init]) =>
+      rpcBody(init as RequestInit).method === 'tools/call')
+    for (const [, init] of toolCalls) {
+      const headers = (init as RequestInit).headers as Headers
+      expect(headers.get('Authorization')).toBe('Bearer fresh-token')
+      expect(headers.get('Mcp-Session-Id')).toBe('upstream-session-1')
+    }
+  })
+})

--- a/src/api/routes/mcp-proxy.test.ts
+++ b/src/api/routes/mcp-proxy.test.ts
@@ -289,8 +289,108 @@ describe('mcp-proxy route', () => {
           serverInfo: { name: 'Test MCP' },
         },
       })
+      expect(res.headers.get('Mcp-Session-Id')).toBeTruthy()
       expect(mockRequestMcpReauth).not.toHaveBeenCalled()
       expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('binds the local session id to a stateful upstream session before resuming', async () => {
+      mockValidateProxyToken.mockResolvedValue('my-agent')
+      const stale = buildMcp({ status: 'auth_required', accessToken: 'stale-token' })
+      const reconnected = buildMcp({ status: 'active', accessToken: 'fresh-token' })
+      setupDbMocks(stale)
+
+      const initialize = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer synth_valid', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: { protocolVersion: '2025-06-18' },
+        }),
+      })
+      const clientSessionId = initialize.headers.get('Mcp-Session-Id')
+      expect(clientSessionId).toBeTruthy()
+
+      mockLimit
+        .mockResolvedValueOnce([{ mcp: stale }])
+        .mockResolvedValueOnce([{ mcp: reconnected }])
+      mockFetch
+        .mockResolvedValueOnce(new Response(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'upstream-init',
+          result: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            serverInfo: { name: 'Stateful MCP', version: '1.0.0' },
+          },
+        }), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'Mcp-Session-Id': 'upstream-session-1',
+          },
+        }))
+        .mockResolvedValueOnce(new Response(null, { status: 202 }))
+        .mockResolvedValueOnce(new Response('{"jsonrpc":"2.0","id":2,"result":{"ok":true}}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }))
+
+      const resumed = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer synth_valid',
+          'Content-Type': 'application/json',
+          'Mcp-Session-Id': clientSessionId!,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: { name: 'search', arguments: { query: 'hello' } },
+        }),
+      })
+
+      expect(resumed.status).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(JSON.parse(String(mockFetch.mock.calls[0][1].body))).toMatchObject({
+        method: 'initialize',
+        params: { protocolVersion: '2025-06-18' },
+      })
+      expect(JSON.parse(String(mockFetch.mock.calls[1][1].body))).toMatchObject({
+        method: 'notifications/initialized',
+      })
+      const resumedHeaders = mockFetch.mock.calls[2][1].headers as Headers
+      expect(resumedHeaders.get('Mcp-Session-Id')).toBe('upstream-session-1')
+      expect(resumedHeaders.get('Authorization')).toBe('Bearer fresh-token')
+
+      // Later calls in the same SDK session keep using the stable synthetic id;
+      // the proxy rewrites it without re-initializing upstream again.
+      mockLimit.mockResolvedValue([{ mcp: reconnected }])
+      mockFetch.mockResolvedValueOnce(new Response('{"jsonrpc":"2.0","id":3,"result":{}}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }))
+      const later = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer synth_valid',
+          'Content-Type': 'application/json',
+          'Mcp-Session-Id': clientSessionId!,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: { name: 'search', arguments: { query: 'again' } },
+        }),
+      })
+      expect(later.status).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(4)
+      expect((mockFetch.mock.calls[3][1].headers as Headers).get('Mcp-Session-Id'))
+        .toBe('upstream-session-1')
     })
 
     it('serves cached tools locally while auth is required', async () => {
@@ -1824,7 +1924,8 @@ describe('mcp-proxy route', () => {
     })
 
     it('tools/call with policy "block" → 403', async () => {
-      setupSuccessPath()
+      mockValidateProxyToken.mockResolvedValue('my-agent')
+      setupDbMocks(buildMcp({ status: 'auth_required' }))
       mockResolveMcpPolicy.mockResolvedValue({
         decision: 'block',
         matchedScopes: ['search'],
@@ -1841,6 +1942,8 @@ describe('mcp-proxy route', () => {
       expect(res.status).toBe(403)
       const json = await res.json()
       expect(json.error).toBe('blocked_by_policy')
+      expect(mockRequestMcpReauth).not.toHaveBeenCalled()
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('tools/call with policy "review" → await decision', async () => {

--- a/src/api/routes/mcp-proxy.test.ts
+++ b/src/api/routes/mcp-proxy.test.ts
@@ -53,6 +53,7 @@ vi.mock('drizzle-orm', () => ({
 // Mock policy enforcement
 const mockResolveMcpPolicy = vi.fn()
 const mockRequestReview = vi.fn()
+const mockRequestMcpReauth = vi.fn()
 
 vi.mock('@shared/lib/proxy/policy-resolver', () => ({
   resolveMcpPolicy: (...args: unknown[]) => mockResolveMcpPolicy(...args),
@@ -61,6 +62,13 @@ vi.mock('@shared/lib/proxy/policy-resolver', () => ({
 vi.mock('@shared/lib/proxy/review-manager', () => ({
   reviewManager: {
     requestReview: (...args: unknown[]) => mockRequestReview(...args),
+  },
+}))
+
+vi.mock('@shared/lib/proxy/mcp-reauth-manager', () => ({
+  mcpReauthManager: {
+    requestReauth: (...args: unknown[]) => mockRequestMcpReauth(...args),
+    completeMcp: vi.fn(),
   },
 }))
 
@@ -98,6 +106,13 @@ function buildMcp(overrides: Record<string, unknown> = {}) {
     oauthResource: null,
     status: 'active',
     errorMessage: null,
+    toolsJson: JSON.stringify([
+      {
+        name: 'search',
+        description: 'Search records',
+        inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+      },
+    ]),
     ...overrides,
   }
 }
@@ -133,11 +148,10 @@ function setupSuccessPath(
   const mcp = buildMcp(mcpOverrides)
   setupDbMocks(mcp)
 
-  const mockResponse = new Response(upstreamBody, {
+  mockFetch.mockImplementation(async () => new Response(upstreamBody, {
     status: upstreamStatus,
     headers: upstreamHeaders,
-  })
-  mockFetch.mockResolvedValue(mockResponse)
+  }))
   return mcp
 }
 
@@ -162,6 +176,7 @@ describe('mcp-proxy route', () => {
       scopeDescriptions: {},
       resolvedFrom: 'global_default',
     })
+    mockRequestMcpReauth.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -245,6 +260,137 @@ describe('mcp-proxy route', () => {
       expect(res.status).toBe(404)
       const body = await res.json()
       expect(body.error).toContain('not found')
+    })
+  })
+
+  describe('MCP re-authentication', () => {
+    it('completes initialize locally for an MCP already marked auth_required', async () => {
+      mockValidateProxyToken.mockResolvedValue('my-agent')
+      setupDbMocks(buildMcp({ status: 'auth_required' }))
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer synth_valid', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 7,
+          method: 'initialize',
+          params: { protocolVersion: '2025-06-18' },
+        }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toMatchObject({
+        jsonrpc: '2.0',
+        id: 7,
+        result: {
+          protocolVersion: '2025-06-18',
+          capabilities: { tools: { listChanged: false } },
+          serverInfo: { name: 'Test MCP' },
+        },
+      })
+      expect(mockRequestMcpReauth).not.toHaveBeenCalled()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('serves cached tools locally while auth is required', async () => {
+      mockValidateProxyToken.mockResolvedValue('my-agent')
+      setupDbMocks(buildMcp({ status: 'auth_required' }))
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer synth_valid', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 'tools-1', method: 'tools/list' }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toMatchObject({
+        id: 'tools-1',
+        result: {
+          tools: [{
+            name: 'search',
+            description: 'Search records',
+            inputSchema: { type: 'object' },
+          }],
+        },
+      })
+      expect(mockRequestMcpReauth).not.toHaveBeenCalled()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('rejects the optional SSE GET without parking session startup', async () => {
+      mockValidateProxyToken.mockResolvedValue('my-agent')
+      setupDbMocks(buildMcp({ status: 'auth_required' }))
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        headers: { Authorization: 'Bearer synth_valid' },
+      })
+
+      expect(res.status).toBe(405)
+      expect(res.headers.get('allow')).toBe('POST')
+      expect(mockRequestMcpReauth).not.toHaveBeenCalled()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('parks an actual tool call for an MCP already marked auth_required, then resumes it', async () => {
+      mockValidateProxyToken.mockResolvedValue('my-agent')
+      const stale = buildMcp({ status: 'auth_required', accessToken: 'stale-token' })
+      const reconnected = buildMcp({ status: 'active', accessToken: 'fresh-token' })
+      setupDbMocks(stale)
+      mockLimit
+        .mockResolvedValueOnce([{ mcp: stale }])
+        .mockResolvedValueOnce([{ mcp: reconnected }])
+      mockFetch.mockResolvedValueOnce(new Response('{"ok":true}', {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }))
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer synth_valid', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'search', arguments: { query: 'hello' } },
+        }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(mockRequestMcpReauth).toHaveBeenCalledWith({
+        agentSlug: 'my-agent',
+        mcpId: 'mcp-1',
+        mcpName: 'Test MCP',
+        authType: 'oauth',
+      }, expect.any(AbortSignal))
+      const [, proxyInit] = mockFetch.mock.calls[0]
+      expect((proxyInit.headers as Headers).get('Authorization')).toBe('Bearer fresh-token')
+    })
+
+    it('retries once after an upstream 401 and returns the resumed response', async () => {
+      mockValidateProxyToken.mockResolvedValue('my-agent')
+      const initial = buildMcp({ accessToken: 'expired-token' })
+      const reconnected = buildMcp({ accessToken: 'fresh-token' })
+      setupDbMocks(initial)
+      mockLimit
+        .mockResolvedValueOnce([{ mcp: initial }])
+        .mockResolvedValueOnce([{ mcp: reconnected }])
+      mockFetch
+        .mockResolvedValueOnce(new Response('{"error":"unauthorized"}', { status: 401 }))
+        .mockResolvedValueOnce(new Response('{"ok":true}', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }))
+
+      const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
+        headers: { Authorization: 'Bearer synth_valid' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ ok: true })
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      const [, retryInit] = mockFetch.mock.calls[1]
+      expect((retryInit.headers as Headers).get('Authorization')).toBe('Bearer fresh-token')
     })
   })
 
@@ -414,24 +560,41 @@ describe('mcp-proxy route', () => {
       expect(body.has('resource')).toBe(false)
     })
 
-    it('returns 401 and marks auth_required when token refresh fails', async () => {
+    it('parks and resumes with the reconnected token when token refresh fails', async () => {
       mockValidateProxyToken.mockResolvedValue('my-agent')
       const mcp = buildMcp({
         tokenExpiresAt: new Date(Date.now() - 60_000), // expired
       })
       setupDbMocks(mcp)
+      const reconnected = buildMcp({
+        accessToken: 'reauthorized-access-token',
+        refreshToken: 'reauthorized-refresh-token',
+      })
+      mockLimit
+        .mockResolvedValueOnce([{ mcp }])
+        .mockResolvedValueOnce([{ mcp: reconnected }])
 
       // Refresh endpoint returns 400 (failure)
-      mockFetch.mockResolvedValueOnce(
-        new Response('{"error":"invalid_grant"}', { status: 400 })
-      )
+      mockFetch
+        .mockResolvedValueOnce(new Response('{"error":"invalid_grant"}', { status: 400 }))
+        .mockResolvedValueOnce(new Response('{"ok":true}', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }))
 
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
       })
-      expect(res.status).toBe(401)
-      const body = await res.json()
-      expect(body.error).toContain('re-authentication')
+      expect(res.status).toBe(200)
+      expect(mockRequestMcpReauth).toHaveBeenCalledWith({
+        agentSlug: 'my-agent',
+        mcpId: 'mcp-1',
+        mcpName: 'Test MCP',
+        authType: 'oauth',
+      }, expect.any(AbortSignal))
+
+      const [, proxyInit] = mockFetch.mock.calls[1]
+      expect((proxyInit.headers as Headers).get('Authorization')).toBe('Bearer reauthorized-access-token')
 
       // Verify status was updated to auth_required
       expect(mockUpdateSet).toHaveBeenCalledWith(
@@ -442,7 +605,7 @@ describe('mcp-proxy route', () => {
       )
     })
 
-    it('returns 401 when token is expired but no refresh token is available', async () => {
+    it('returns a timeout when an expired token has no refresh path and re-auth is abandoned', async () => {
       mockValidateProxyToken.mockResolvedValue('my-agent')
       const mcp = buildMcp({
         tokenExpiresAt: new Date(Date.now() - 60_000),
@@ -450,13 +613,14 @@ describe('mcp-proxy route', () => {
         accessToken: null, // expired, effectively null
       })
       setupDbMocks(mcp)
+      mockRequestMcpReauth.mockRejectedValueOnce(new Error('MCP re-authentication timed out'))
 
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
       })
-      expect(res.status).toBe(401)
+      expect(res.status).toBe(408)
       const body = await res.json()
-      expect(body.error).toContain('no access token')
+      expect(body.error).toBe('mcp_reauth_timeout')
     })
 
     it('skips refresh when token is not expired yet', async () => {
@@ -572,12 +736,13 @@ describe('mcp-proxy route', () => {
         accessToken: null,
       })
       setupDbMocks(mcp)
+      mockRequestMcpReauth.mockRejectedValueOnce(new Error('MCP re-authentication timed out'))
 
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
       })
-      // tryRefreshToken returns null -> accessToken still null -> 401
-      expect(res.status).toBe(401)
+      // tryRefreshToken returns null, so the request waits for interactive re-auth.
+      expect(res.status).toBe(408)
     })
 
     it('returns null from tryRefreshToken when missing oauthClientId', async () => {
@@ -589,11 +754,12 @@ describe('mcp-proxy route', () => {
         accessToken: null,
       })
       setupDbMocks(mcp)
+      mockRequestMcpReauth.mockRejectedValueOnce(new Error('MCP re-authentication timed out'))
 
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
       })
-      expect(res.status).toBe(401)
+      expect(res.status).toBe(408)
     })
 
     it('handles fetch error during token refresh gracefully', async () => {
@@ -605,13 +771,14 @@ describe('mcp-proxy route', () => {
 
       // Refresh fetch throws a network error
       mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      mockRequestMcpReauth.mockRejectedValueOnce(new Error('MCP re-authentication timed out'))
 
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
       })
-      expect(res.status).toBe(401)
+      expect(res.status).toBe(408)
       const body = await res.json()
-      expect(body.error).toContain('re-authentication')
+      expect(body.error).toBe('mcp_reauth_timeout')
     })
 
     it('skips token check entirely when authType is none', async () => {
@@ -1395,7 +1562,7 @@ describe('mcp-proxy route', () => {
       expect(res.status).toBe(200)
     })
 
-    it('logs audit entry with token refresh failure error', async () => {
+    it('logs an abandoned re-auth wait after token refresh failure', async () => {
       mockValidateProxyToken.mockResolvedValue('my-agent')
       const mcp = buildMcp({
         tokenExpiresAt: new Date(Date.now() - 60_000),
@@ -1405,15 +1572,16 @@ describe('mcp-proxy route', () => {
       mockFetch.mockResolvedValueOnce(
         new Response('{"error":"invalid"}', { status: 400 })
       )
+      mockRequestMcpReauth.mockRejectedValueOnce(new Error('MCP re-authentication timed out'))
 
       await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
       })
 
-      // The audit log from the token refresh failure
       expect(mockInsertValues).toHaveBeenCalled()
       const entry = mockInsertValues.mock.calls[0][0]
-      expect(entry.errorMessage).toContain('Token refresh failed')
+      expect(entry.statusCode).toBe(408)
+      expect(entry.errorMessage).toContain('timed out while waiting')
     })
 
     it('records durationMs for successful requests', async () => {
@@ -1532,7 +1700,7 @@ describe('mcp-proxy route', () => {
       expect(headers.get('Authorization')).toBe('Bearer static-api-key-123')
     })
 
-    it('returns 401 when authType is bearer but no accessToken is set', async () => {
+    it('asks for a replacement when authType is bearer but no accessToken is set', async () => {
       mockValidateProxyToken.mockResolvedValue('my-agent')
       const mcp = buildMcp({
         authType: 'bearer',
@@ -1541,14 +1709,19 @@ describe('mcp-proxy route', () => {
         refreshToken: null,
       })
       setupDbMocks(mcp)
+      mockRequestMcpReauth.mockRejectedValueOnce(new Error('MCP re-authentication timed out'))
 
       const res = await makeRequest('/api/mcp-proxy/my-agent/mcp-1/path', {
         headers: { Authorization: 'Bearer synth_valid' },
       })
 
-      expect(res.status).toBe(401)
+      expect(res.status).toBe(408)
       const body = await res.json()
-      expect(body.error).toContain('no access token')
+      expect(body.error).toBe('mcp_reauth_timeout')
+      expect(mockRequestMcpReauth).toHaveBeenCalledWith(expect.objectContaining({
+        mcpId: 'mcp-1',
+        authType: 'bearer',
+      }), expect.any(AbortSignal))
     })
 
     it('handles concurrent requests to different MCP servers', async () => {

--- a/src/api/routes/mcp-proxy.ts
+++ b/src/api/routes/mcp-proxy.ts
@@ -12,6 +12,149 @@ import {
 } from '@shared/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { mcpSafeFetch } from '@shared/lib/mcp/mcp-safe-fetch'
+import { parseMcpResponse } from '@shared/lib/mcp/discover-tools'
+
+const SYNTHETIC_MCP_SESSION_TTL_MS = 24 * 60 * 60 * 1000
+
+interface SyntheticMcpSession {
+  mcpId: string
+  protocolVersion: string
+  upstreamSessionId: string | null | undefined
+  initializationPromise?: Promise<string | null>
+  lastUsedAt: number
+}
+
+class McpSessionInitializationError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message)
+    this.name = 'McpSessionInitializationError'
+  }
+}
+
+// The SDK must receive a session id from the local initialize stub so it keeps
+// sending one after re-authentication. We bind that stable client-facing id to
+// the real upstream id lazily, once fresh credentials are available.
+const syntheticMcpSessions = new Map<string, SyntheticMcpSession>()
+
+function pruneSyntheticMcpSessions(now = Date.now()): void {
+  for (const [id, session] of syntheticMcpSessions) {
+    if (now - session.lastUsedAt > SYNTHETIC_MCP_SESSION_TTL_MS) {
+      syntheticMcpSessions.delete(id)
+    }
+  }
+}
+
+function createSyntheticMcpSession(mcpId: string, protocolVersion: string): string {
+  pruneSyntheticMcpSessions()
+  const id = crypto.randomUUID()
+  syntheticMcpSessions.set(id, {
+    mcpId,
+    protocolVersion,
+    upstreamSessionId: undefined,
+    lastUsedAt: Date.now(),
+  })
+  return id
+}
+
+function getSyntheticMcpSession(
+  mcpId: string,
+  clientSessionId: string | undefined,
+): SyntheticMcpSession | null {
+  if (!clientSessionId) return null
+  const session = syntheticMcpSessions.get(clientSessionId)
+  if (!session || session.mcpId !== mcpId) return null
+  if (Date.now() - session.lastUsedAt > SYNTHETIC_MCP_SESSION_TTL_MS) {
+    syntheticMcpSessions.delete(clientSessionId)
+    return null
+  }
+  session.lastUsedAt = Date.now()
+  return session
+}
+
+async function initializeUpstreamSession(options: {
+  session: SyntheticMcpSession
+  targetUrl: string
+  accessToken: string | null
+  headers: Headers
+}): Promise<string | null> {
+  const { session, targetUrl, accessToken } = options
+  if (session.upstreamSessionId !== undefined) return session.upstreamSessionId
+  if (session.initializationPromise) return session.initializationPromise
+
+  const initializationPromise = (async () => {
+    const headers = new Headers(options.headers)
+    headers.delete('Mcp-Session-Id')
+    headers.set('Content-Type', 'application/json')
+    headers.set('Accept', 'application/json, text/event-stream')
+    if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`)
+
+    const initializeResponse = await mcpSafeFetch(targetUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: `superagent-reauth-${crypto.randomUUID()}`,
+        method: 'initialize',
+        params: {
+          protocolVersion: session.protocolVersion,
+          capabilities: {},
+          clientInfo: { name: 'SuperAgent MCP proxy', version: '1.0.0' },
+        },
+      }),
+    })
+
+    if (!initializeResponse.ok) {
+      await initializeResponse.body?.cancel().catch(() => undefined)
+      throw new McpSessionInitializationError(
+        `MCP session re-initialization failed with status ${initializeResponse.status}`,
+        initializeResponse.status,
+      )
+    }
+
+    const upstreamSessionId = initializeResponse.headers.get('Mcp-Session-Id')
+    try {
+      await parseMcpResponse(initializeResponse)
+    } catch (error) {
+      throw new McpSessionInitializationError(
+        `MCP session re-initialization returned an invalid response: ${error}`,
+      )
+    }
+
+    const initializedHeaders = new Headers(headers)
+    if (upstreamSessionId) {
+      initializedHeaders.set('Mcp-Session-Id', upstreamSessionId)
+    }
+    const initializedResponse = await mcpSafeFetch(targetUrl, {
+      method: 'POST',
+      headers: initializedHeaders,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      }),
+    })
+    if (!initializedResponse.ok) {
+      await initializedResponse.body?.cancel().catch(() => undefined)
+      throw new McpSessionInitializationError(
+        `MCP initialized notification failed with status ${initializedResponse.status}`,
+        initializedResponse.status,
+      )
+    }
+    await initializedResponse.body?.cancel().catch(() => undefined)
+    session.upstreamSessionId = upstreamSessionId
+    session.lastUsedAt = Date.now()
+    return upstreamSessionId
+  })()
+
+  session.initializationPromise = initializationPromise
+  try {
+    return await initializationPromise
+  } finally {
+    session.initializationPromise = undefined
+  }
+}
 
 async function logMcpAuditEntry(entry: {
   agentSlug: string
@@ -168,6 +311,7 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
   }
 
   const method = c.req.method
+  const clientMcpSessionId = c.req.header('Mcp-Session-Id')
 
   // 2.5 Parse JSON-RPC body early for policy enforcement and audit logging
   let bodyBuffer: ArrayBuffer | undefined
@@ -315,7 +459,11 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
       return new Response(null, { status: 202 })
     }
     if (mcpMethodInfo === 'initialize') {
-      return c.json({
+      const syntheticSessionId = createSyntheticMcpSession(
+        mcpId,
+        requestedProtocolVersion,
+      )
+      const response = c.json({
         jsonrpc: '2.0',
         id: jsonRpcId,
         result: {
@@ -324,6 +472,8 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
           serverInfo: { name: mcp!.name, version: '1.0.0' },
         },
       })
+      response.headers.set('Mcp-Session-Id', syntheticSessionId)
+      return response
     }
     if (mcpMethodInfo === 'tools/list') {
       return c.json({
@@ -339,13 +489,11 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
   }
 
   // A previously failed request may already have marked this server. Complete
-  // eager protocol discovery locally; park only an actual invocation (or an
-  // unknown non-protocol request), then reload the fresh token.
+  // eager protocol discovery locally without entering the authorization path.
+  // Non-protocol calls are parked only after their policy gate below.
   if (mcp.status === 'auth_required') {
     const protocolResponse = authRequiredProtocolResponse()
     if (protocolResponse) return protocolResponse
-    const reauthResult = await holdForReauth()
-    if (!reauthResult.ok) return reauthFailureResponse(reauthResult)
   }
 
   // 2.6 Policy enforcement
@@ -441,6 +589,14 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
     }
   }
 
+  // Re-authentication cannot make a policy-blocked tool call permissible.
+  // Wait only after policy enforcement so blocked calls remain immediate 403s
+  // and cannot raise reconnect prompts.
+  if (mcp.status === 'auth_required') {
+    const reauthResult = await holdForReauth()
+    if (!reauthResult.ok) return reauthFailureResponse(reauthResult)
+  }
+
   // 3. Get access token, refreshing if expired
   let accessToken = mcp.accessToken
   if (mcp.authType !== 'none') {
@@ -497,9 +653,21 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
     }
   })
 
-  const forwardRequest = () => {
+  const syntheticSession = getSyntheticMcpSession(mcpId, clientMcpSessionId)
+
+  const forwardRequest = async () => {
     const headers = new Headers(forwardHeaders)
     if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`)
+    if (syntheticSession) {
+      const upstreamSessionId = await initializeUpstreamSession({
+        session: syntheticSession,
+        targetUrl,
+        accessToken,
+        headers,
+      })
+      headers.delete('Mcp-Session-Id')
+      if (upstreamSessionId) headers.set('Mcp-Session-Id', upstreamSessionId)
+    }
     const init: RequestInit = { method, headers }
     if (bodyBuffer) init.body = bodyBuffer
     return mcpSafeFetch(targetUrl, init)
@@ -517,6 +685,7 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
         console.warn('[mcp-proxy] Failed to cancel unauthorized response body:', err)
       }
       await markAuthRequired('Remote server returned 401')
+      if (syntheticSession) syntheticSession.upstreamSessionId = undefined
       const protocolResponse = authRequiredProtocolResponse()
       if (protocolResponse) return protocolResponse
       const reauthResult = await holdForReauth()
@@ -571,6 +740,10 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
       markAuthRequired('Remote server returned 401').catch(() => {})
     }
 
+    if (method === 'DELETE' && clientMcpSessionId && syntheticSession) {
+      syntheticMcpSessions.delete(clientMcpSessionId)
+    }
+
     // Pass response through (including SSE streams)
     const responseHeaders = new Headers()
     const skipResponseHeaders = new Set([
@@ -590,6 +763,10 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
     })
   } catch (error) {
     const durationMs = Date.now() - startTime
+    const sessionInitializationFailed = error instanceof McpSessionInitializationError
+    if (sessionInitializationFailed && error.status === 401) {
+      await markAuthRequired('MCP session re-initialization returned 401')
+    }
     await logMcpAuditEntry({
       agentSlug,
       remoteMcpId: mcp.id,
@@ -601,6 +778,13 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
       policyDecision: resolvedPolicyDecision,
       matchedTool: toolName ?? undefined,
     })
+    if (sessionInitializationFailed) {
+      return c.json({
+        error: 'mcp_session_reinitialize_failed',
+        message: 'The MCP was reconnected, but its session could not be re-initialized. Retry this tool call.',
+        details: error.message,
+      }, 502)
+    }
     return c.json(
       { error: 'MCP proxy request failed', details: String(error) },
       502

--- a/src/api/routes/mcp-proxy.ts
+++ b/src/api/routes/mcp-proxy.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto'
 import { validateProxyToken } from '@shared/lib/proxy/token-store'
 import { resolveMcpPolicy } from '@shared/lib/proxy/policy-resolver'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
+import { mcpReauthManager } from '@shared/lib/proxy/mcp-reauth-manager'
 import { db } from '@shared/lib/db'
 import {
   remoteMcpServers,
@@ -109,6 +110,8 @@ async function tryRefreshToken(mcp: {
       })
       .where(eq(remoteMcpServers.id, mcp.id))
 
+    mcpReauthManager.completeMcp(mcp.id)
+
     return data.access_token
   } catch {
     return null
@@ -141,39 +144,55 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
   }
 
   // 2. Verify agent-MCP mapping exists
-  const mappings = await db
-    .select({ mcp: remoteMcpServers })
-    .from(agentRemoteMcps)
-    .innerJoin(
-      remoteMcpServers,
-      eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id)
-    )
-    .where(
-      and(
-        eq(agentRemoteMcps.agentSlug, agentSlug),
-        eq(agentRemoteMcps.remoteMcpId, mcpId)
+  const loadMappedMcp = async () => {
+    const [mapping] = await db
+      .select({ mcp: remoteMcpServers })
+      .from(agentRemoteMcps)
+      .innerJoin(
+        remoteMcpServers,
+        eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id)
       )
-    )
-    .limit(1)
+      .where(
+        and(
+          eq(agentRemoteMcps.agentSlug, agentSlug),
+          eq(agentRemoteMcps.remoteMcpId, mcpId)
+        )
+      )
+      .limit(1)
+    return mapping?.mcp ?? null
+  }
 
-  if (mappings.length === 0) {
+  let mcp = await loadMappedMcp()
+  if (!mcp) {
     return c.json({ error: 'MCP server not found or not assigned to this agent' }, 404)
   }
 
-  const mcp = mappings[0].mcp
   const method = c.req.method
 
   // 2.5 Parse JSON-RPC body early for policy enforcement and audit logging
   let bodyBuffer: ArrayBuffer | undefined
   let mcpMethodInfo = rest || '/'
   let toolName: string | null = null
+  let jsonRpcId: string | number | null = null
+  let requestedProtocolVersion = '2025-03-26'
   if (method !== 'GET' && method !== 'HEAD') {
     bodyBuffer = await c.req.arrayBuffer()
     try {
       const text = new TextDecoder().decode(bodyBuffer)
       const jsonRpc = JSON.parse(text) as {
+        id?: string | number | null
         method?: string
-        params?: { name?: string }
+        params?: { name?: string; protocolVersion?: string }
+      }
+      if (
+        typeof jsonRpc.id === 'string' ||
+        typeof jsonRpc.id === 'number' ||
+        jsonRpc.id === null
+      ) {
+        jsonRpcId = jsonRpc.id
+      }
+      if (typeof jsonRpc.params?.protocolVersion === 'string') {
+        requestedProtocolVersion = jsonRpc.params.protocolVersion
       }
       if (jsonRpc.method) {
         mcpMethodInfo = jsonRpc.method
@@ -185,6 +204,148 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
     } catch {
       // Not JSON or not JSON-RPC — keep the HTTP path
     }
+  }
+
+  type ReauthResult =
+    | { ok: true }
+    | { ok: false; reason: 'timeout' | 'missing' | 'inactive' }
+
+  const holdForReauth = async (): Promise<ReauthResult> => {
+    try {
+      await mcpReauthManager.requestReauth({
+        agentSlug,
+        mcpId,
+        mcpName: mcp!.name,
+        authType: mcp!.authType,
+      }, c.req.raw.signal)
+    } catch {
+      return { ok: false, reason: 'timeout' }
+    }
+
+    const refreshed = await loadMappedMcp()
+    if (!refreshed) return { ok: false, reason: 'missing' }
+    if (refreshed.status !== 'active') return { ok: false, reason: 'inactive' }
+    mcp = refreshed
+    return { ok: true }
+  }
+
+  const reauthFailureResponse = async (
+    result: Exclude<ReauthResult, { ok: true }>,
+  ) => {
+    const statusCode = result.reason === 'timeout'
+      ? 408
+      : result.reason === 'missing'
+        ? 404
+        : 502
+    const message = result.reason === 'timeout'
+      ? 'The request timed out while waiting for the MCP server to be reconnected.'
+      : result.reason === 'missing'
+        ? 'The MCP server disappeared while re-authenticating.'
+        : 'The MCP server did not become active after re-authentication.'
+
+    await logMcpAuditEntry({
+      agentSlug,
+      remoteMcpId: mcpId,
+      remoteMcpName: mcp?.name ?? mcpId,
+      method,
+      requestPath: mcpMethodInfo,
+      statusCode,
+      errorMessage: message,
+      durationMs: Date.now() - startTime,
+      matchedTool: toolName ?? undefined,
+    })
+
+    return c.json({
+      error: result.reason === 'timeout' ? 'mcp_reauth_timeout' : 'mcp_reauth_failed',
+      message,
+      mcpStatus: 'auth_required',
+    }, statusCode)
+  }
+
+  const markAuthRequired = async (errorMessage: string) => {
+    await db
+      .update(remoteMcpServers)
+      .set({
+        status: 'auth_required',
+        errorMessage,
+        updatedAt: new Date(),
+      })
+      .where(eq(remoteMcpServers.id, mcpId))
+  }
+
+  const cachedTools = () => {
+    if (!mcp?.toolsJson) return []
+    try {
+      const parsed = JSON.parse(mcp.toolsJson) as unknown
+      if (!Array.isArray(parsed)) return []
+      return parsed.flatMap((tool) => {
+        if (
+          typeof tool !== 'object' ||
+          tool === null ||
+          !('name' in tool) ||
+          typeof tool.name !== 'string'
+        ) {
+          return []
+        }
+        const description = 'description' in tool && typeof tool.description === 'string'
+          ? tool.description
+          : undefined
+        const inputSchema = 'inputSchema' in tool &&
+          typeof tool.inputSchema === 'object' &&
+          tool.inputSchema !== null
+          ? tool.inputSchema
+          : { type: 'object', additionalProperties: true }
+        return [{ name: tool.name, description, inputSchema }]
+      })
+    } catch {
+      return []
+    }
+  }
+
+  // Let the SDK complete its eager MCP handshake without contacting an
+  // upstream server whose credentials are known to be invalid. We advertise
+  // cached tool definitions, then park only the eventual tools/call. This
+  // preserves a seamless reconnect/resume flow without freezing session init
+  // or unrelated chat turns.
+  const authRequiredProtocolResponse = (): Response | null => {
+    if ((method === 'GET' || method === 'HEAD') && !rest) {
+      return new Response(null, { status: 405, headers: { Allow: 'POST' } })
+    }
+    if (mcpMethodInfo.startsWith('notifications/')) {
+      return new Response(null, { status: 202 })
+    }
+    if (mcpMethodInfo === 'initialize') {
+      return c.json({
+        jsonrpc: '2.0',
+        id: jsonRpcId,
+        result: {
+          protocolVersion: requestedProtocolVersion,
+          capabilities: { tools: { listChanged: false } },
+          serverInfo: { name: mcp!.name, version: '1.0.0' },
+        },
+      })
+    }
+    if (mcpMethodInfo === 'tools/list') {
+      return c.json({
+        jsonrpc: '2.0',
+        id: jsonRpcId,
+        result: { tools: cachedTools() },
+      })
+    }
+    if (mcpMethodInfo === 'ping') {
+      return c.json({ jsonrpc: '2.0', id: jsonRpcId, result: {} })
+    }
+    return null
+  }
+
+  // A previously failed request may already have marked this server. Complete
+  // eager protocol discovery locally; park only an actual invocation (or an
+  // unknown non-protocol request), then reload the fresh token.
+  if (mcp.status === 'auth_required') {
+    const protocolResponse = authRequiredProtocolResponse()
+    if (protocolResponse) return protocolResponse
+    const reauthResult = await holdForReauth()
+    if (!reauthResult.ok) return reauthFailureResponse(reauthResult)
   }
 
   // 2.6 Policy enforcement
@@ -290,32 +451,24 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
     ) {
       accessToken = await tryRefreshToken(mcp)
       if (!accessToken) {
-        await db
-          .update(remoteMcpServers)
-          .set({
-            status: 'auth_required',
-            errorMessage: 'Token refresh failed',
-            updatedAt: new Date(),
-          })
-          .where(eq(remoteMcpServers.id, mcp.id))
-
-        await logMcpAuditEntry({
-          agentSlug,
-          remoteMcpId: mcp.id,
-          remoteMcpName: mcp.name,
-          method: c.req.method,
-          requestPath: rest,
-          errorMessage: 'Token refresh failed',
-          policyDecision: resolvedPolicyDecision,
-          matchedTool: toolName ?? undefined,
-        })
-
-        return c.json({ error: 'MCP server requires re-authentication' }, 401)
+        await markAuthRequired('Token refresh failed')
+        const protocolResponse = authRequiredProtocolResponse()
+        if (protocolResponse) return protocolResponse
+        const reauthResult = await holdForReauth()
+        if (!reauthResult.ok) return reauthFailureResponse(reauthResult)
+        accessToken = mcp.accessToken
+        if (!accessToken) return reauthFailureResponse({ ok: false, reason: 'inactive' })
       }
     }
 
     if (!accessToken) {
-      return c.json({ error: 'MCP server has no access token configured' }, 401)
+      await markAuthRequired('MCP server has no access token configured')
+      const protocolResponse = authRequiredProtocolResponse()
+      if (protocolResponse) return protocolResponse
+      const reauthResult = await holdForReauth()
+      if (!reauthResult.ok) return reauthFailureResponse(reauthResult)
+      accessToken = mcp.accessToken
+      if (!accessToken) return reauthFailureResponse({ ok: false, reason: 'inactive' })
     }
   }
 
@@ -344,18 +497,34 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
     }
   })
 
-  // Add real auth header
-  if (accessToken) {
-    forwardHeaders.set('Authorization', `Bearer ${accessToken}`)
-  }
-
-  const init: RequestInit = { method, headers: forwardHeaders }
-  if (bodyBuffer) {
-    init.body = bodyBuffer
+  const forwardRequest = () => {
+    const headers = new Headers(forwardHeaders)
+    if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`)
+    const init: RequestInit = { method, headers }
+    if (bodyBuffer) init.body = bodyBuffer
+    return mcpSafeFetch(targetUrl, init)
   }
 
   try {
-    const response = await mcpSafeFetch(targetUrl, init)
+    let response = await forwardRequest()
+
+    // A live server can discover token revocation only when it handles the
+    // request. Hold the original call, reconnect, then retry it exactly once.
+    if (response.status === 401) {
+      try {
+        await response.body?.cancel()
+      } catch (err) {
+        console.warn('[mcp-proxy] Failed to cancel unauthorized response body:', err)
+      }
+      await markAuthRequired('Remote server returned 401')
+      const protocolResponse = authRequiredProtocolResponse()
+      if (protocolResponse) return protocolResponse
+      const reauthResult = await holdForReauth()
+      if (!reauthResult.ok) return reauthFailureResponse(reauthResult)
+      accessToken = mcp.accessToken
+      response = await forwardRequest()
+    }
+
     const durationMs = Date.now() - startTime
 
     if (shouldRewriteNonSseGet(method, response)) {
@@ -396,16 +565,10 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
       matchedTool: toolName ?? undefined,
     })
 
-    // If 401, mark MCP as auth_required
+    // A failed retry stays marked, but is returned rather than opening an
+    // unbounded second reconnect loop for the same proxy request.
     if (response.status === 401) {
-      db.update(remoteMcpServers)
-        .set({
-          status: 'auth_required',
-          errorMessage: 'Remote server returned 401',
-          updatedAt: new Date(),
-        })
-        .where(eq(remoteMcpServers.id, mcp.id))
-        .catch(() => {})
+      markAuthRequired('Remote server returned 401').catch(() => {})
     }
 
     // Pass response through (including SSE streams)

--- a/src/api/routes/provide-connected-account.test.ts
+++ b/src/api/routes/provide-connected-account.test.ts
@@ -413,7 +413,9 @@ describe('provide-connected-account handler', () => {
     const envBody = JSON.parse(envOpts.body)
     expect(envBody.key).toBe('CONNECTED_ACCOUNTS')
     const metadata = JSON.parse(envBody.value)
-    expect(metadata.gmail).toEqual([{ name: 'user@gmail.com', id: 'acc-1' }])
+    expect(metadata.gmail).toEqual([
+      { name: 'user@gmail.com', id: 'acc-1', status: 'active' },
+    ])
 
     // Verify resolve call
     const [resolvePath] = mockContainerFetch.mock.calls[1]
@@ -524,7 +526,7 @@ describe('provide-connected-account handler', () => {
     expect(body.error).toContain('notify agent')
   })
 
-  it('metadata only includes status === active accounts', async () => {
+  it('metadata keeps active and expired assigned accounts with their statuses', async () => {
     mockSelectFrom.mockReturnValueOnce({ where: mockSelectWhere })
     mockSelectWhere.mockResolvedValueOnce([
       { id: 'acc-1', toolkitSlug: 'gmail', displayName: 'active@gmail.com', status: 'active' },
@@ -556,11 +558,13 @@ describe('provide-connected-account handler', () => {
 
     expect(res.status).toBe(200)
 
-    // Verify metadata sent to container only includes active accounts
+    // Verify metadata sent to the container keeps reconnectable assignments.
     const [, envOpts] = mockContainerFetch.mock.calls[0]
     const envBody = JSON.parse(envOpts.body)
     const metadata = JSON.parse(envBody.value)
-    expect(metadata.gmail).toHaveLength(1)
-    expect(metadata.gmail[0].name).toBe('active@gmail.com')
+    expect(metadata.gmail).toEqual([
+      { name: 'active@gmail.com', id: 'acc-1', status: 'active' },
+      { name: 'expired@gmail.com', id: 'acc-2', status: 'expired' },
+    ])
   })
 })

--- a/src/api/routes/provide-remote-mcp.test.ts
+++ b/src/api/routes/provide-remote-mcp.test.ts
@@ -525,6 +525,7 @@ describe('Agent Settings remote MCP live sync', () => {
         id: 'mcp-1',
         name: 'Calendar',
         proxyUrl: 'http://10.20.107.8:3000/api/mcp-proxy/test-agent/mcp-1',
+        status: 'active',
         tools: [{ name: 'list_events' }],
       },
     ])

--- a/src/api/routes/proxy.test.ts
+++ b/src/api/routes/proxy.test.ts
@@ -206,7 +206,7 @@ describe('proxy route', () => {
           toolkitSlug: 'gmail',
           providerConnectionId: 'comp-123',
             providerName: 'composio',
-          status: 'active',
+          status: 'expired',
         },
       },
     ])
@@ -219,6 +219,7 @@ describe('proxy route', () => {
     expect(res.status).toBe(403)
     const body = await res.json()
     expect(body.error).toContain('not allowed')
+    expect(mockRequestReauth).not.toHaveBeenCalled()
   })
 
   it('returns 502 when provider makeApiCall fails', async () => {
@@ -999,7 +1000,7 @@ describe('proxy policy enforcement', () => {
   }
 
   // Set up mocks through host validation, then let policy take over
-  function setupThroughHostValidation() {
+  function setupThroughHostValidation(status: 'active' | 'expired' = 'active') {
     mockValidateProxyToken.mockResolvedValue('my-agent')
     mockDbFrom.mockReturnValue({ innerJoin: mockInnerJoin })
     mockInnerJoin.mockReturnValue({ where: mockWhere })
@@ -1011,7 +1012,7 @@ describe('proxy policy enforcement', () => {
           toolkitSlug: 'gmail',
           providerConnectionId: 'comp-123',
             providerName: 'composio',
-          status: 'active',
+          status,
           userId: 'user-1',
         },
       },
@@ -1039,7 +1040,7 @@ describe('proxy policy enforcement', () => {
   })
 
   it('policy "block" → returns 403, body has error: "blocked_by_policy"', async () => {
-    setupThroughHostValidation()
+    setupThroughHostValidation('expired')
     mockMatchScopes.mockReturnValue({ matched: true, scopes: ['gmail.full'], descriptions: {} })
     mockResolveApiPolicy.mockResolvedValue({
       decision: 'block',
@@ -1055,6 +1056,7 @@ describe('proxy policy enforcement', () => {
     expect(res.status).toBe(403)
     const body = await res.json()
     expect(body.error).toBe('blocked_by_policy')
+    expect(mockRequestReauth).not.toHaveBeenCalled()
   })
 
   it('block does NOT call provider.makeApiCall', async () => {

--- a/src/api/routes/proxy.test.ts
+++ b/src/api/routes/proxy.test.ts
@@ -77,6 +77,7 @@ vi.mock('@shared/lib/platform-attribution', () => ({
 const mockMatchScopes = vi.fn()
 const mockResolveApiPolicy = vi.fn()
 const mockRequestReview = vi.fn()
+const mockRequestReauth = vi.fn()
 
 vi.mock('@shared/lib/proxy/scope-matcher', () => ({
   matchScopes: (...args: unknown[]) => mockMatchScopes(...args),
@@ -89,6 +90,12 @@ vi.mock('@shared/lib/proxy/policy-resolver', () => ({
 vi.mock('@shared/lib/proxy/review-manager', () => ({
   reviewManager: {
     requestReview: (...args: unknown[]) => mockRequestReview(...args),
+  },
+}))
+
+vi.mock('@shared/lib/proxy/account-reauth-manager', () => ({
+  accountReauthManager: {
+    requestReauth: (...args: unknown[]) => mockRequestReauth(...args),
   },
 }))
 
@@ -133,6 +140,7 @@ describe('proxy route', () => {
       scopeDescriptions: {},
       resolvedFrom: 'global_default',
     })
+    mockRequestReauth.mockResolvedValue(undefined)
   })
 
   async function makeRequest(
@@ -733,12 +741,13 @@ describe('proxy route', () => {
   // Account status checks
   // =========================================================================
   describe('account status checks', () => {
-    it('returns 403 when local account status is expired', async () => {
+    it('holds and resumes when local account status is expired', async () => {
       mockValidateProxyToken.mockResolvedValue('my-agent')
       mockDbFrom.mockReturnValue({ innerJoin: mockInnerJoin })
       mockInnerJoin.mockReturnValue({ where: mockWhere })
       mockWhere.mockReturnValue({ limit: mockLimit })
-      mockLimit.mockResolvedValue([
+      mockLimit
+        .mockResolvedValueOnce([
         {
           account: {
             id: 'acc-123',
@@ -748,19 +757,38 @@ describe('proxy route', () => {
             status: 'expired',
           },
         },
-      ])
+        ])
+        .mockResolvedValueOnce([
+          {
+            account: {
+              id: 'acc-123',
+              toolkitSlug: 'gmail',
+              providerConnectionId: 'comp-reconnected',
+              providerName: 'composio',
+              status: 'active',
+            },
+          },
+        ])
+      mockIsHostAllowed.mockReturnValue(true)
+      mockMakeApiCall.mockResolvedValue(new Response('{"ok":true}', { status: 200 }))
 
       const res = await makeRequest(
         '/api/proxy/my-agent/acc-123/gmail.googleapis.com/gmail/v1/messages',
         { headers: { Authorization: 'Bearer synth_valid' } }
       )
-      expect(res.status).toBe(403)
-      const body = await res.json()
-      expect(body.accountStatus).toBe('expired')
-      expect(body.error).toContain('expired')
+      expect(res.status).toBe(200)
+      expect(mockRequestReauth).toHaveBeenCalledWith({
+        agentSlug: 'my-agent',
+        accountId: 'acc-123',
+        toolkit: 'gmail',
+        accountStatus: 'expired',
+      }, expect.any(AbortSignal))
+      expect(mockMakeApiCall).toHaveBeenCalledWith(expect.objectContaining({
+        providerConnectionId: 'comp-reconnected',
+      }))
     })
 
-    it('returns 403 when local account status is revoked', async () => {
+    it('returns a clear timeout when local account re-authentication is abandoned', async () => {
       mockValidateProxyToken.mockResolvedValue('my-agent')
       mockDbFrom.mockReturnValue({ innerJoin: mockInnerJoin })
       mockInnerJoin.mockReturnValue({ where: mockWhere })
@@ -776,22 +804,25 @@ describe('proxy route', () => {
           },
         },
       ])
+      mockRequestReauth.mockRejectedValue(new Error('Account re-authentication timed out'))
 
       const res = await makeRequest(
         '/api/proxy/my-agent/acc-123/gmail.googleapis.com/gmail/v1/messages',
         { headers: { Authorization: 'Bearer synth_valid' } }
       )
-      expect(res.status).toBe(403)
+      expect(res.status).toBe(408)
       const body = await res.json()
       expect(body.accountStatus).toBe('revoked')
+      expect(body.error).toBe('account_reauth_timeout')
     })
 
-    it('does not call makeApiCall when local status is non-active', async () => {
+    it('does not call makeApiCall while local re-authentication is pending', async () => {
       mockValidateProxyToken.mockResolvedValue('my-agent')
       mockDbFrom.mockReturnValue({ innerJoin: mockInnerJoin })
       mockInnerJoin.mockReturnValue({ where: mockWhere })
       mockWhere.mockReturnValue({ limit: mockLimit })
-      mockLimit.mockResolvedValue([
+      mockLimit
+        .mockResolvedValueOnce([
         {
           account: {
             id: 'acc-123',
@@ -801,18 +832,37 @@ describe('proxy route', () => {
             status: 'expired',
           },
         },
-      ])
+        ])
+        .mockResolvedValueOnce([
+          {
+            account: {
+              id: 'acc-123',
+              toolkitSlug: 'gmail',
+              providerConnectionId: 'comp-new',
+              providerName: 'composio',
+              status: 'active',
+            },
+          },
+        ])
+      mockIsHostAllowed.mockReturnValue(true)
+      mockMakeApiCall.mockResolvedValue(new Response('{}', { status: 200 }))
+      let resume!: () => void
+      mockRequestReauth.mockReturnValue(new Promise<void>((resolve) => { resume = resolve }))
 
-      await makeRequest(
+      const request = makeRequest(
         '/api/proxy/my-agent/acc-123/gmail.googleapis.com/gmail/v1/messages',
         { headers: { Authorization: 'Bearer synth_valid' } }
       )
 
+      await vi.waitFor(() => expect(mockRequestReauth).toHaveBeenCalledOnce())
+
       expect(mockMakeApiCall).not.toHaveBeenCalled()
       expect(mockGetConnection).not.toHaveBeenCalled()
+      resume()
+      expect((await request).status).toBe(200)
     })
 
-    it('returns 403 when remote status check returns non-ACTIVE', async () => {
+    it('holds and resumes when remote status check returns non-ACTIVE', async () => {
       setupSuccessPath()
       mockGetConnection.mockResolvedValueOnce({ id: 'comp-123', status: 'EXPIRED' })
 
@@ -821,10 +871,11 @@ describe('proxy route', () => {
         { headers: { Authorization: 'Bearer synth_valid' } }
       )
 
-      expect(res.status).toBe(403)
-      const body = await res.json()
-      expect(body.accountStatus).toBe('expired')
-      expect(mockMakeApiCall).not.toHaveBeenCalled()
+      expect(res.status).toBe(200)
+      expect(mockRequestReauth).toHaveBeenCalledWith(expect.objectContaining({
+        accountStatus: 'expired',
+      }), expect.any(AbortSignal))
+      expect(mockMakeApiCall).toHaveBeenCalledOnce()
     })
 
     it('updates DB status when remote returns EXPIRED', async () => {
@@ -854,7 +905,7 @@ describe('proxy route', () => {
       expect(mockDbUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'revoked' }))
     })
 
-    it('returns 403 with revoked when remote status is FAILED', async () => {
+    it('holds and resumes with revoked when remote status is FAILED', async () => {
       setupSuccessPath()
       mockGetConnection.mockResolvedValueOnce({ id: 'comp-123', status: 'FAILED' })
 
@@ -863,9 +914,10 @@ describe('proxy route', () => {
         { headers: { Authorization: 'Bearer synth_valid' } }
       )
 
-      expect(res.status).toBe(403)
-      const body = await res.json()
-      expect(body.accountStatus).toBe('revoked')
+      expect(res.status).toBe(200)
+      expect(mockRequestReauth).toHaveBeenCalledWith(expect.objectContaining({
+        accountStatus: 'revoked',
+      }), expect.any(AbortSignal))
     })
 
     it('proceeds with request when remote status check fails (network error)', async () => {
@@ -879,6 +931,50 @@ describe('proxy route', () => {
 
       expect(res.status).toBe(200)
       expect(mockMakeApiCall).toHaveBeenCalled()
+    })
+
+    it('re-authenticates and retries once when token retrieval reports expiry', async () => {
+      mockValidateProxyToken.mockResolvedValue('my-agent')
+      mockDbFrom.mockReturnValue({ innerJoin: mockInnerJoin })
+      mockInnerJoin.mockReturnValue({ where: mockWhere })
+      mockWhere.mockReturnValue({ limit: mockLimit })
+      mockLimit
+        .mockResolvedValueOnce([{
+          account: {
+            id: 'acc-123',
+            toolkitSlug: 'gmail',
+            providerConnectionId: 'comp-old',
+            providerName: 'composio',
+            status: 'active',
+          },
+        }])
+        .mockResolvedValueOnce([{
+          account: {
+            id: 'acc-123',
+            toolkitSlug: 'gmail',
+            providerConnectionId: 'comp-new',
+            providerName: 'composio',
+            status: 'active',
+          },
+        }])
+      mockIsHostAllowed.mockReturnValue(true)
+      mockMakeApiCall
+        .mockRejectedValueOnce(new Error('Access token expired'))
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }))
+
+      const res = await makeRequest(
+        '/api/proxy/my-agent/acc-123/gmail.googleapis.com/gmail/v1/messages',
+        { headers: { Authorization: 'Bearer synth_valid' } },
+      )
+
+      expect(res.status).toBe(200)
+      expect(mockRequestReauth).toHaveBeenCalledWith(expect.objectContaining({
+        accountStatus: 'expired',
+      }), expect.any(AbortSignal))
+      expect(mockMakeApiCall).toHaveBeenCalledTimes(2)
+      expect(mockMakeApiCall.mock.calls[1][0]).toEqual(expect.objectContaining({
+        providerConnectionId: 'comp-new',
+      }))
     })
   })
 })

--- a/src/api/routes/proxy.ts
+++ b/src/api/routes/proxy.ts
@@ -193,27 +193,6 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
       result.reason === 'missing' ? 404 : 502)
   }
 
-  // 2b. Park requests for accounts with non-active local status. The OAuth
-  // completion route resolves this wait; then we reload the account so the
-  // original request uses the new provider connection ID.
-  if (account.status !== 'active') {
-    const status = account.status
-    const result = await holdForReauth(status)
-    if (!result.ok) {
-      return reauthFailureResponse(result, status, (errorMessage, statusCode) =>
-        logAuditEntry({
-          agentSlug,
-          accountId,
-          toolkit: account!.toolkitSlug,
-          targetHost,
-          targetPath,
-          method,
-          statusCode,
-          errorMessage,
-        }))
-    }
-  }
-
   // 3. Validate target host against toolkit allowlist
   if (!isHostAllowed(account.toolkitSlug, targetHost)) {
     await logAuditEntry({
@@ -328,6 +307,19 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
       matchedScopes: JSON.stringify(policyResult.matchedScopes),
       ...extras,
     })
+
+  // Park only after the request has passed both the host allowlist and API
+  // policy gate. Re-authentication cannot turn a forbidden request into an
+  // allowed one, so prompting before these checks only interrupts the user
+  // for work that will be rejected immediately afterward.
+  if (account.status !== 'active') {
+    const status = account.status
+    const result = await holdForReauth(status)
+    if (!result.ok) {
+      return reauthFailureResponse(result, status, (errorMessage, statusCode) =>
+        audit({ statusCode, errorMessage }))
+    }
+  }
 
   // 4. Build target URL
   // eslint-disable-next-line local-rules/no-unhandled-throwing-builtins -- c.req.url is always a valid URL

--- a/src/api/routes/proxy.ts
+++ b/src/api/routes/proxy.ts
@@ -5,6 +5,7 @@ import { isHostAllowed } from '@shared/lib/proxy/allowed-hosts'
 import { matchScopes } from '@shared/lib/proxy/scope-matcher'
 import { resolveApiPolicy } from '@shared/lib/proxy/policy-resolver'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
+import { accountReauthManager } from '@shared/lib/proxy/account-reauth-manager'
 import { getAccountProviderByName } from '@shared/lib/account-providers'
 import { attribution, runWithAttribution } from '@shared/lib/platform-attribution'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
@@ -115,22 +116,26 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
   }
 
   // 2. Look up connected account and verify it belongs to this agent
-  const results = await db
-    .select({ account: connectedAccounts })
-    .from(agentConnectedAccounts)
-    .innerJoin(
-      connectedAccounts,
-      eq(agentConnectedAccounts.connectedAccountId, connectedAccounts.id)
-    )
-    .where(
-      and(
-        eq(agentConnectedAccounts.agentSlug, agentSlug),
-        eq(connectedAccounts.id, accountId)
+  const loadMappedAccount = async () => {
+    const [result] = await db
+      .select({ account: connectedAccounts })
+      .from(agentConnectedAccounts)
+      .innerJoin(
+        connectedAccounts,
+        eq(agentConnectedAccounts.connectedAccountId, connectedAccounts.id)
       )
-    )
-    .limit(1)
+      .where(
+        and(
+          eq(agentConnectedAccounts.agentSlug, agentSlug),
+          eq(connectedAccounts.id, accountId)
+        )
+      )
+      .limit(1)
+    return result?.account ?? null
+  }
 
-  if (results.length === 0) {
+  let account = await loadMappedAccount()
+  if (!account) {
     await logAuditEntry({
       agentSlug,
       accountId,
@@ -143,23 +148,70 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
     return c.json({ error: 'Account not found or not mapped to this agent' }, 404)
   }
 
-  const account = results[0].account
+  type ReauthResult =
+    | { ok: true }
+    | { ok: false; reason: 'timeout' | 'missing' | 'inactive' }
 
-  // 2b. Reject requests for accounts with non-active local status
+  const holdForReauth = async (status: 'expired' | 'revoked'): Promise<ReauthResult> => {
+    try {
+      await accountReauthManager.requestReauth({
+        agentSlug,
+        accountId,
+        toolkit: account!.toolkitSlug,
+        accountStatus: status,
+      }, c.req.raw.signal)
+    } catch {
+      return { ok: false, reason: 'timeout' }
+    }
+
+    const refreshed = await loadMappedAccount()
+    if (!refreshed) return { ok: false, reason: 'missing' }
+    if (refreshed.status !== 'active') return { ok: false, reason: 'inactive' }
+    account = refreshed
+    return { ok: true }
+  }
+
+  const reauthFailureResponse = async (
+    result: Exclude<ReauthResult, { ok: true }>,
+    status: 'expired' | 'revoked',
+    auditError: (message: string, statusCode: number) => Promise<void>,
+  ) => {
+    if (result.reason === 'timeout') {
+      await auditError(`Account re-authentication timed out (${status})`, 408)
+      return c.json({
+        error: 'account_reauth_timeout',
+        message: 'The request timed out while waiting for the account to be reconnected.',
+        accountStatus: status,
+      }, 408)
+    }
+
+    const message = result.reason === 'missing'
+      ? 'Connected account disappeared while re-authenticating.'
+      : 'Connected account did not become active after re-authentication.'
+    await auditError(message, result.reason === 'missing' ? 404 : 502)
+    return c.json({ error: 'account_reauth_failed', message, accountStatus: status },
+      result.reason === 'missing' ? 404 : 502)
+  }
+
+  // 2b. Park requests for accounts with non-active local status. The OAuth
+  // completion route resolves this wait; then we reload the account so the
+  // original request uses the new provider connection ID.
   if (account.status !== 'active') {
-    await logAuditEntry({
-      agentSlug,
-      accountId,
-      toolkit: account.toolkitSlug,
-      targetHost,
-      targetPath,
-      method: c.req.method,
-      errorMessage: `Account status is ${account.status}`,
-    })
-    return c.json({
-      error: `Connected account is ${account.status}. Re-authenticate to restore access.`,
-      accountStatus: account.status,
-    }, 403)
+    const status = account.status
+    const result = await holdForReauth(status)
+    if (!result.ok) {
+      return reauthFailureResponse(result, status, (errorMessage, statusCode) =>
+        logAuditEntry({
+          agentSlug,
+          accountId,
+          toolkit: account!.toolkitSlug,
+          targetHost,
+          targetPath,
+          method,
+          statusCode,
+          errorMessage,
+        }))
+    }
   }
 
   // 3. Validate target host against toolkit allowlist
@@ -283,27 +335,34 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
   const targetUrl = `https://${targetHost}/${targetPath}${queryString}`
 
   // 5. Verify remote connection status before forwarding
-  const provider = getAccountProviderByName(account.providerName)
+  let provider = getAccountProviderByName(account.providerName)
 
+  let remoteConnection: Awaited<ReturnType<typeof provider.getConnection>> | null = null
   try {
-    const remoteConnection = await provider.getConnection(
+    remoteConnection = await provider.getConnection(
       account.providerConnectionId,
       account.toolkitSlug,
     )
-    if (remoteConnection.status !== 'ACTIVE') {
-      const newStatus = remoteConnection.status === 'EXPIRED' ? 'expired' as const : 'revoked' as const
-      db.update(connectedAccounts)
-        .set({ status: newStatus, updatedAt: new Date() })
-        .where(eq(connectedAccounts.id, accountId))
-        .catch((err) => console.error('[proxy] Failed to update account status:', err))
-      await audit({ errorMessage: `Remote connection status: ${remoteConnection.status}` })
-      return c.json({
-        error: `Connected account is ${newStatus}. Re-authenticate to restore access.`,
-        accountStatus: newStatus,
-      }, 403)
-    }
   } catch (statusCheckErr) {
     console.warn('[proxy] Remote status check failed, proceeding with request:', statusCheckErr)
+  }
+
+  if (remoteConnection && remoteConnection.status !== 'ACTIVE') {
+    const newStatus = remoteConnection.status === 'EXPIRED' ? 'expired' as const : 'revoked' as const
+    try {
+      await db.update(connectedAccounts)
+        .set({ status: newStatus, updatedAt: new Date() })
+        .where(eq(connectedAccounts.id, accountId))
+    } catch (statusUpdateErr) {
+      console.warn('[proxy] Failed to persist non-active account status:', statusUpdateErr)
+    }
+
+    const reauthResult = await holdForReauth(newStatus)
+    if (!reauthResult.ok) {
+      return reauthFailureResponse(reauthResult, newStatus, (errorMessage, statusCode) =>
+        audit({ statusCode, errorMessage }))
+    }
+    provider = getAccountProviderByName(account.providerName)
   }
 
   // 6. Forward via account provider (handles token retrieval/proxy internally)
@@ -311,9 +370,7 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
     ? null
     : await c.req.arrayBuffer()
 
-  let response: Response
-  try {
-    response = await runWithAttribution(
+  const forwardRequest = () => runWithAttribution(
       attribution.fromResourceCreator(account.userId),
       () => provider.makeApiCall({
         providerConnectionId: account.providerConnectionId,
@@ -324,22 +381,45 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
         body: requestBody,
       }),
     )
+
+  let response: Response
+  try {
+    response = await forwardRequest()
   } catch (error) {
     const isTokenError = String(error).includes('token') || String(error).includes('Token')
     const errorLabel = isTokenError ? 'Failed to fetch access token' : 'Proxy request failed'
 
     if (isTokenError) {
-      db.update(connectedAccounts)
-        .set({ status: 'expired', updatedAt: new Date() })
-        .where(eq(connectedAccounts.id, accountId))
-        .catch((err) => console.error('[proxy] Failed to update account status:', err))
-    }
+      try {
+        await db.update(connectedAccounts)
+          .set({ status: 'expired', updatedAt: new Date() })
+          .where(eq(connectedAccounts.id, accountId))
+      } catch (statusUpdateErr) {
+        console.warn('[proxy] Failed to persist expired account status:', statusUpdateErr)
+      }
 
-    await audit({ errorMessage: `${errorLabel}: ${error}` })
-    return c.json(
-      { error: errorLabel, details: String(error), ...(isTokenError ? { accountStatus: 'expired' } : {}) },
-      502
-    )
+      const reauthResult = await holdForReauth('expired')
+      if (!reauthResult.ok) {
+        return reauthFailureResponse(reauthResult, 'expired', (errorMessage, statusCode) =>
+          audit({ statusCode, errorMessage }))
+      }
+      provider = getAccountProviderByName(account.providerName)
+      try {
+        response = await forwardRequest()
+      } catch (retryError) {
+        await audit({ errorMessage: `${errorLabel} after re-authentication: ${retryError}` })
+        return c.json(
+          { error: errorLabel, details: String(retryError), accountStatus: 'expired' },
+          502,
+        )
+      }
+    } else {
+      await audit({ errorMessage: `${errorLabel}: ${error}` })
+      return c.json(
+        { error: errorLabel, details: String(error) },
+        502
+      )
+    }
   }
 
   audit({

--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -47,6 +47,7 @@ const mockValidateAndConsumeOAuthErrorResponse = vi.fn()
 const mockFindAgentsAssignedRemoteMcp = vi.fn().mockResolvedValue(['agent-a'])
 const mockSyncAgentsAssignedRemoteMcp = vi.fn().mockResolvedValue(true)
 const mockSyncRemoteMcpAgents = vi.fn().mockResolvedValue(true)
+const mockCompleteMcpReauth = vi.fn()
 
 vi.mock('@shared/lib/mcp/oauth', () => ({
   McpOAuthSetupError: class McpOAuthSetupError extends Error {},
@@ -65,6 +66,12 @@ vi.mock('@shared/lib/container/connection-runtime-sync', () => ({
     mockSyncAgentsAssignedRemoteMcp(...args),
   syncRemoteMcpAgents: (...args: unknown[]) =>
     mockSyncRemoteMcpAgents(...args),
+}))
+
+vi.mock('@shared/lib/proxy/mcp-reauth-manager', () => ({
+  mcpReauthManager: {
+    completeMcp: (...args: unknown[]) => mockCompleteMcpReauth(...args),
+  },
 }))
 
 // Mock DB with chainable query builder
@@ -1374,6 +1381,7 @@ describe('OAuth callback — postMessage origin', () => {
     expect(html).not.toContain("'*'")
     expect(mockFindAgentsAssignedRemoteMcp).toHaveBeenCalledWith('mcp-new')
     expect(mockSyncRemoteMcpAgents).toHaveBeenCalledWith(['agent-a'])
+    expect(mockCompleteMcpReauth).toHaveBeenCalledWith('mcp-new')
   })
 
   it('emits callback fallbacks for web popups whose opener was severed', async () => {

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -25,6 +25,7 @@ import {
   syncAgentsAssignedRemoteMcp,
   syncRemoteMcpAgents,
 } from '@shared/lib/container/connection-runtime-sync'
+import { mcpReauthManager } from '@shared/lib/proxy/mcp-reauth-manager'
 
 function safeParseTools(json: string | null): McpToolInfo[] {
   if (!json) return []
@@ -467,6 +468,10 @@ remoteMcps.get('/oauth-callback', async (c) => {
     ))
   }
 
+  // OAuth and tool discovery both succeeded, so every proxy request parked
+  // on this MCP can safely reload its token and retry.
+  mcpReauthManager.completeMcp(result.mcpId)
+
   trackServerEvent('mcp_oauth_succeeded', { url: serverUrl, mcpId: result.mcpId })
   return c.html(mcpOAuthCallbackBody(
     { type: 'mcp-oauth-callback', success: true, mcpId: result.mcpId },
@@ -624,6 +629,7 @@ remoteMcps.post('/:id/discover-tools', Or(UsersMcpServer(), IsAdmin()), async (c
       .where(eq(remoteMcpServers.id, id))
 
     const liveRefresh = await syncAgentsAssignedRemoteMcp(id)
+    mcpReauthManager.completeMcp(id)
     return c.json({ tools, liveRefresh })
   } catch (error: any) {
     const errorMessage = error.message || 'Tool discovery failed'
@@ -705,6 +711,7 @@ remoteMcps.post('/:id/test-connection', Or(UsersMcpServer(), IsAdmin()), async (
       .where(eq(remoteMcpServers.id, id))
 
     const liveRefresh = await syncAgentsAssignedRemoteMcp(id)
+    mcpReauthManager.completeMcp(id)
     return c.json({ success: true, liveRefresh })
   } catch (error: any) {
     const errorMessage = error.message || 'Connection test failed'

--- a/src/renderer/components/agents/agent-home/home-connections.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.test.tsx
@@ -12,6 +12,19 @@ vi.mock('@renderer/lib/api', () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }))
 
+const oauthReconnectMocks = vi.hoisted(() => ({
+  reconnect: vi.fn(),
+  cancelReconnect: vi.fn(),
+}))
+vi.mock('@renderer/hooks/use-oauth-reconnect', () => ({
+  useOAuthReconnect: () => ({
+    reconnect: oauthReconnectMocks.reconnect,
+    pendingAccountId: null,
+    canCancelPendingReconnect: false,
+    cancelReconnect: oauthReconnectMocks.cancelReconnect,
+  }),
+}))
+
 // Capture navigate so we can assert the deep link into the connections page
 // (the rows navigate directly).
 const mockNavigate = vi.fn()
@@ -34,6 +47,11 @@ const ACCOUNT = {
   provider: { slug: 'github', displayName: 'GitHub' },
 }
 
+type AccountFixture = Omit<typeof ACCOUNT, 'status'> & {
+  status: 'active' | 'expired' | 'revoked'
+}
+let accountResponse: AccountFixture[] = [ACCOUNT]
+
 function jsonResponse(body: unknown, ok = true): Response {
   return {
     ok,
@@ -46,11 +64,14 @@ describe('HomeConnections — row navigation', () => {
   beforeEach(() => {
     mockApiFetch.mockReset()
     mockNavigate.mockReset()
+    oauthReconnectMocks.reconnect.mockReset()
+    oauthReconnectMocks.cancelReconnect.mockReset()
+    accountResponse = [ACCOUNT]
 
     mockApiFetch.mockImplementation((path: string, init?: { method?: string }) => {
       const method = init?.method ?? 'GET'
       if (path === '/api/agents/test-agent/connected-accounts' && method === 'GET') {
-        return Promise.resolve(jsonResponse({ accounts: [ACCOUNT] }))
+        return Promise.resolve(jsonResponse({ accounts: accountResponse }))
       }
       if (path === '/api/agents/test-agent/remote-mcps' && method === 'GET') {
         return Promise.resolve(jsonResponse({ mcps: [] }))
@@ -111,6 +132,18 @@ describe('HomeConnections — row navigation', () => {
     expect(mockApiFetch).toHaveBeenCalledWith(
       `/api/activity/agents/test-agent?days=14&tz=${new Date().getTimezoneOffset()}`,
     )
+  })
+
+  it('shows an expired API account and reconnects it from the status badge', async () => {
+    accountResponse = [{ ...ACCOUNT, status: 'expired' }]
+    const user = userEvent.setup()
+    renderWithProviders(<HomeConnections agentSlug="test-agent" />)
+
+    expect(await screen.findByText('GitHub')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /Expired/i }))
+
+    expect(oauthReconnectMocks.reconnect).toHaveBeenCalledWith('acc-1', 'github')
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('shows foreign links as non-navigable shared capabilities', async () => {

--- a/src/renderer/components/agents/agent-home/home-connections.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.tsx
@@ -4,7 +4,9 @@ import { Button } from '@renderer/components/ui/button'
 import { ChevronRight, Plus, Settings2 } from 'lucide-react'
 import { IntegrationRow } from '@renderer/components/connections/integration-row'
 import { McpStatusPill } from '@renderer/components/connections/mcp-status-pill'
-import { useAgentConnectedAccounts } from '@renderer/hooks/use-connected-accounts'
+import { AccountStatusBadge } from '@renderer/components/connections/account-status-badge'
+import { useAgentConnectedAccounts, type ConnectedAccount } from '@renderer/hooks/use-connected-accounts'
+import { useOAuthReconnect } from '@renderer/hooks/use-oauth-reconnect'
 import { useAgentRemoteMcps, type RemoteMcpServer } from '@renderer/hooks/use-remote-mcps'
 import { HomeCollapsible } from './home-collapsible'
 import { formatDistanceToNow } from 'date-fns'
@@ -35,6 +37,9 @@ interface ConnectionRow {
   date?: string | number
   /** Opaque link owned by another member; never navigable. */
   foreign?: true
+  accountId?: string
+  accountStatus?: ConnectedAccount['status']
+  toolkit?: string
   mcpStatus?: RemoteMcpServer['status']
   mcpErrorMessage?: string | null
 }
@@ -44,6 +49,12 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
   const { data: mcpsData } = useAgentRemoteMcps(agentSlug)
   const { data: activityStats, isPending: activityPending } = useAgentActivityStats(agentSlug)
   const navigate = useNavigate()
+  const {
+    reconnect: oauthReconnect,
+    pendingAccountId,
+    canCancelPendingReconnect,
+    cancelReconnect,
+  } = useOAuthReconnect()
 
   const connections = useMemo<ConnectionRow[]>(() => {
     const rows: ConnectionRow[] = []
@@ -61,6 +72,9 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
         iconFallback: 'oauth',
         type: 'oauth',
         date: account.createdAt,
+        accountId: account.id,
+        accountStatus: account.status,
+        toolkit: account.toolkitSlug,
       })
     }
 
@@ -106,7 +120,25 @@ export function HomeConnections({ agentSlug, className }: HomeConnectionsProps) 
               iconSlug={conn.iconSlug}
               iconFallback={conn.iconFallback}
               name={conn.name}
-              nameBadge={<McpStatusPill status={conn.mcpStatus} errorMessage={conn.mcpErrorMessage} />}
+              nameBadge={
+                <>
+                  <McpStatusPill status={conn.mcpStatus} errorMessage={conn.mcpErrorMessage} />
+                  <AccountStatusBadge
+                    status={conn.accountStatus}
+                    onReconnect={
+                      conn.accountId && conn.toolkit && conn.accountStatus !== 'active'
+                        ? () => { void oauthReconnect(conn.accountId!, conn.toolkit!) }
+                        : undefined
+                    }
+                    onCancelReconnect={
+                      pendingAccountId === conn.accountId && canCancelPendingReconnect
+                        ? cancelReconnect
+                        : undefined
+                    }
+                    loading={pendingAccountId === conn.accountId}
+                  />
+                </>
+              }
               subtitle={
                 <>
                   <span className="shrink-0">{conn.type === 'oauth' ? 'API' : 'MCP'}</span>

--- a/src/renderer/components/dashboards/pending-agent-reviews.test.tsx
+++ b/src/renderer/components/dashboards/pending-agent-reviews.test.tsx
@@ -22,6 +22,16 @@ vi.mock('@renderer/components/messages/x-agent-review-request-item', () => ({
     <div data-testid={`xagent-review-${reviewId}`} />
   ),
 }))
+vi.mock('@renderer/components/messages/account-reauth-request-item', () => ({
+  AccountReauthRequestItem: ({ proxyRequestId }: { proxyRequestId: string }) => (
+    <div data-testid={`account-reauth-${proxyRequestId}`} />
+  ),
+}))
+vi.mock('@renderer/components/messages/mcp-reauth-request-item', () => ({
+  McpReauthRequestItem: ({ proxyRequestId }: { proxyRequestId: string }) => (
+    <div data-testid={`mcp-reauth-${proxyRequestId}`} />
+  ),
+}))
 
 function envelope(overrides: Record<string, unknown>) {
   return {
@@ -79,7 +89,40 @@ describe('PendingAgentReviews', () => {
     expect(mockUsePendingUserRequests).toHaveBeenCalledWith('agent-a', undefined)
   })
 
-  it('ignores non-review kinds in the snapshot', () => {
+  it('renders account and MCP re-auth cards from the agent-scoped snapshot', () => {
+    mockUsePendingUserRequests.mockReturnValue({
+      data: [
+        envelope({
+          id: 'account-card-1',
+          kind: 'account_reauth_required',
+          payload: {
+            accountId: 'account-1',
+            toolkit: 'gmail',
+            accountStatus: 'expired',
+            proxyRequestId: 'account-proxy-1',
+          },
+        }),
+        envelope({
+          id: 'mcp-card-1',
+          kind: 'mcp_reauth_required',
+          payload: {
+            mcpId: 'mcp-1',
+            mcpName: 'Cal.com',
+            authType: 'oauth',
+            proxyRequestId: 'mcp-proxy-1',
+          },
+        }),
+      ],
+      refetch: vi.fn(),
+    })
+
+    render(<PendingAgentReviews agentSlug="agent-a" />)
+
+    expect(screen.getByTestId('account-reauth-account-proxy-1')).toBeTruthy()
+    expect(screen.getByTestId('mcp-reauth-mcp-proxy-1')).toBeTruthy()
+  })
+
+  it('ignores non-agent-action kinds in the snapshot', () => {
     mockUsePendingUserRequests.mockReturnValue({
       data: [
         envelope({ id: 'rev-proxy-2' }),

--- a/src/renderer/components/dashboards/pending-agent-reviews.tsx
+++ b/src/renderer/components/dashboards/pending-agent-reviews.tsx
@@ -1,7 +1,16 @@
 import { useMemo } from 'react'
 import { ProxyReviewRequestItem } from '@renderer/components/messages/proxy-review-request-item'
 import { XAgentReviewRequestItem } from '@renderer/components/messages/x-agent-review-request-item'
-import { reviewFromEnvelope, type PendingReview } from '@renderer/components/messages/use-pending-requests'
+import { AccountReauthRequestItem } from '@renderer/components/messages/account-reauth-request-item'
+import { McpReauthRequestItem } from '@renderer/components/messages/mcp-reauth-request-item'
+import {
+  accountReauthFromEnvelope,
+  mcpReauthFromEnvelope,
+  reviewFromEnvelope,
+  type PendingAccountReauth,
+  type PendingMcpReauth,
+  type PendingReview,
+} from '@renderer/components/messages/use-pending-requests'
 import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-requests'
 
 interface PendingAgentReviewsProps {
@@ -11,7 +20,7 @@ interface PendingAgentReviewsProps {
 }
 
 /**
- * Renders pending proxy review prompts for an agent, from the unified
+ * Renders pending agent-scoped review and re-auth prompts from the unified
  * pending-requests snapshot — the same store every other request surface
  * reads. user_request_created / user_request_resolved SSE events invalidate
  * the query (GlobalNotificationHandler); the hook's interval refetch is the
@@ -20,25 +29,68 @@ interface PendingAgentReviewsProps {
 export function PendingAgentReviews({ agentSlug, readOnly, onReviewResolved }: PendingAgentReviewsProps) {
   const { data, refetch } = usePendingUserRequests(agentSlug)
 
-  const reviews = useMemo(() => {
-    const out: PendingReview[] = []
+  const actions = useMemo(() => {
+    const out: Array<
+      | { kind: 'review'; value: PendingReview }
+      | { kind: 'account-reauth'; value: PendingAccountReauth }
+      | { kind: 'mcp-reauth'; value: PendingMcpReauth }
+    > = []
     for (const request of data ?? []) {
-      if (request.kind !== 'proxy_review' && request.kind !== 'x_agent_review') continue
-      const review = reviewFromEnvelope(request, request.payload as Record<string, unknown>)
-      if (review) out.push(review)
+      const payload = request.payload as Record<string, unknown>
+      if (request.kind === 'proxy_review' || request.kind === 'x_agent_review') {
+        const review = reviewFromEnvelope(request, payload)
+        if (review) out.push({ kind: 'review', value: review })
+      } else if (request.kind === 'account_reauth_required') {
+        const reauth = accountReauthFromEnvelope(request, payload)
+        if (reauth) out.push({ kind: 'account-reauth', value: reauth })
+      } else if (request.kind === 'mcp_reauth_required') {
+        const reauth = mcpReauthFromEnvelope(request, payload)
+        if (reauth) out.push({ kind: 'mcp-reauth', value: reauth })
+      }
     }
     return out
   }, [data])
 
-  if (reviews.length === 0) return null
+  if (actions.length === 0) return null
 
   return (
     <div className="space-y-2">
-      {reviews.map((review) => {
+      {actions.map((action) => {
         const onComplete = () => {
           refetch()
           onReviewResolved?.()
         }
+        if (action.kind === 'account-reauth') {
+          const request = action.value
+          return (
+            <AccountReauthRequestItem
+              key={request.id}
+              proxyRequestId={request.proxyRequestId}
+              accountId={request.accountId}
+              toolkit={request.toolkit}
+              accountStatus={request.accountStatus}
+              agentSlug={agentSlug}
+              readOnly={readOnly}
+              onComplete={onComplete}
+            />
+          )
+        }
+        if (action.kind === 'mcp-reauth') {
+          const request = action.value
+          return (
+            <McpReauthRequestItem
+              key={request.id}
+              proxyRequestId={request.proxyRequestId}
+              mcpId={request.mcpId}
+              mcpName={request.mcpName}
+              authType={request.authType}
+              agentSlug={agentSlug}
+              readOnly={readOnly}
+              onComplete={onComplete}
+            />
+          )
+        }
+        const review = action.value
         if (review.xAgent) {
           return (
             <XAgentReviewRequestItem

--- a/src/renderer/components/messages/account-reauth-request-item.test.tsx
+++ b/src/renderer/components/messages/account-reauth-request-item.test.tsx
@@ -5,6 +5,7 @@ import { AccountReauthRequestItem } from './account-reauth-request-item'
 
 const mockReconnect = vi.fn()
 let mockPendingAccountId: string | null = null
+let mockOwnedAccountIds = ['account-1', 'account-2', 'account-3']
 
 vi.mock('@renderer/hooks/use-oauth-reconnect', () => ({
   useOAuthReconnect: () => ({
@@ -13,10 +14,17 @@ vi.mock('@renderer/hooks/use-oauth-reconnect', () => ({
   }),
 }))
 
+vi.mock('@renderer/hooks/use-connected-accounts', () => ({
+  useConnectedAccounts: () => ({
+    data: { accounts: mockOwnedAccountIds.map((id) => ({ id })) },
+  }),
+}))
+
 describe('AccountReauthRequestItem', () => {
   beforeEach(() => {
     mockReconnect.mockReset()
     mockPendingAccountId = null
+    mockOwnedAccountIds = ['account-1', 'account-2', 'account-3']
   })
 
   it('explains the expired access and resumes after a successful reconnect', async () => {
@@ -77,5 +85,22 @@ describe('AccountReauthRequestItem', () => {
 
     expect(screen.queryByTestId('account-reauth-reconnect-btn')).not.toBeInTheDocument()
     expect(screen.getByText('Waiting for reconnection')).toBeInTheDocument()
+  })
+
+  it('shows a non-actionable card to a member who does not own the account', () => {
+    mockOwnedAccountIds = []
+    render(
+      <AccountReauthRequestItem
+        proxyRequestId="proxy-4"
+        accountId="account-4"
+        toolkit="gmail"
+        accountStatus="expired"
+        agentSlug="agent-1"
+        onComplete={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByTestId('account-reauth-reconnect-btn')).not.toBeInTheDocument()
+    expect(screen.getByText(/Only the connection owner can reconnect/)).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/messages/account-reauth-request-item.test.tsx
+++ b/src/renderer/components/messages/account-reauth-request-item.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { AccountReauthRequestItem } from './account-reauth-request-item'
+
+const mockReconnect = vi.fn()
+let mockPendingAccountId: string | null = null
+
+vi.mock('@renderer/hooks/use-oauth-reconnect', () => ({
+  useOAuthReconnect: () => ({
+    reconnect: (...args: unknown[]) => mockReconnect(...args),
+    pendingAccountId: mockPendingAccountId,
+  }),
+}))
+
+describe('AccountReauthRequestItem', () => {
+  beforeEach(() => {
+    mockReconnect.mockReset()
+    mockPendingAccountId = null
+  })
+
+  it('explains the expired access and resumes after a successful reconnect', async () => {
+    const onComplete = vi.fn()
+    mockReconnect.mockResolvedValue(true)
+
+    render(
+      <AccountReauthRequestItem
+        proxyRequestId="proxy-1"
+        accountId="account-1"
+        toolkit="gmail"
+        accountStatus="expired"
+        agentSlug="agent-1"
+        onComplete={onComplete}
+      />,
+    )
+
+    expect(screen.getByText('This request needs Gmail access that has expired.')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('account-reauth-reconnect-btn'))
+
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalledWith('account-1', 'gmail'))
+    expect(onComplete).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the card open when reconnection is not completed', async () => {
+    const onComplete = vi.fn()
+    mockReconnect.mockResolvedValue(false)
+
+    render(
+      <AccountReauthRequestItem
+        proxyRequestId="proxy-2"
+        accountId="account-2"
+        toolkit="gmail"
+        accountStatus="revoked"
+        agentSlug="agent-1"
+        onComplete={onComplete}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('account-reauth-reconnect-btn'))
+
+    expect(await screen.findByText(/Reconnection was not completed/)).toBeInTheDocument()
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('does not render a reconnect action in read-only mode', () => {
+    render(
+      <AccountReauthRequestItem
+        proxyRequestId="proxy-3"
+        accountId="account-3"
+        toolkit="gmail"
+        accountStatus="expired"
+        agentSlug="agent-1"
+        readOnly
+        onComplete={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByTestId('account-reauth-reconnect-btn')).not.toBeInTheDocument()
+    expect(screen.getByText('Waiting for reconnection')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/messages/account-reauth-request-item.tsx
+++ b/src/renderer/components/messages/account-reauth-request-item.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+import { Loader2, RefreshCw } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { ServiceIcon } from '@renderer/components/ui/service-icon'
+import { useOAuthReconnect } from '@renderer/hooks/use-oauth-reconnect'
+import { getProvider } from '@shared/lib/account-providers/service-catalog'
+import { RequestItemActions } from './request-item-actions'
+import { RequestItemShell } from './request-item-shell'
+
+interface AccountReauthRequestItemProps {
+  proxyRequestId: string
+  accountId: string
+  toolkit: string
+  accountStatus: 'expired' | 'revoked'
+  sessionId?: string
+  agentSlug: string
+  readOnly?: boolean
+  onComplete: () => void
+}
+
+export function AccountReauthRequestItem({
+  proxyRequestId,
+  accountId,
+  toolkit,
+  accountStatus,
+  sessionId,
+  agentSlug,
+  readOnly,
+  onComplete,
+}: AccountReauthRequestItemProps) {
+  const [error, setError] = useState<string | null>(null)
+  const { reconnect, pendingAccountId } = useOAuthReconnect()
+  const isReconnecting = pendingAccountId === accountId
+  const providerName = getProvider(toolkit)?.displayName
+    ?? `${toolkit.charAt(0).toUpperCase()}${toolkit.slice(1)}`
+  const statusLabel = accountStatus === 'expired' ? 'expired' : 'been revoked'
+
+  const handleReconnect = async () => {
+    setError(null)
+    const succeeded = await reconnect(accountId, toolkit)
+    if (succeeded) {
+      onComplete()
+    } else {
+      setError('Reconnection was not completed. Try again to continue the request.')
+    }
+  }
+
+  return (
+    <RequestItemShell
+      title={`This request needs ${providerName} access that has ${statusLabel}.`}
+      subtitle="Reconnect to continue. The original request will resume automatically."
+      icon={<ServiceIcon slug={toolkit} fallback="oauth" className="h-4 w-4" />}
+      theme="orange"
+      sessionId={sessionId}
+      agentSlug={agentSlug}
+      readOnly={readOnly ? {} : false}
+      waitingText="Waiting for reconnection"
+      error={error}
+      data-testid="account-reauth-request"
+      data-status={accountStatus}
+    >
+      <RequestItemActions>
+        <Button
+          type="button"
+          size="xs"
+          onClick={handleReconnect}
+          disabled={isReconnecting}
+          data-testid="account-reauth-reconnect-btn"
+        >
+          {isReconnecting ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          {isReconnecting ? 'Reconnecting…' : 'Reconnect'}
+        </Button>
+      </RequestItemActions>
+      <span className="sr-only">Proxy request {proxyRequestId}</span>
+    </RequestItemShell>
+  )
+}

--- a/src/renderer/components/messages/account-reauth-request-item.tsx
+++ b/src/renderer/components/messages/account-reauth-request-item.tsx
@@ -3,6 +3,7 @@ import { Loader2, RefreshCw } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { useOAuthReconnect } from '@renderer/hooks/use-oauth-reconnect'
+import { useConnectedAccounts } from '@renderer/hooks/use-connected-accounts'
 import { getProvider } from '@shared/lib/account-providers/service-catalog'
 import { RequestItemActions } from './request-item-actions'
 import { RequestItemShell } from './request-item-shell'
@@ -30,10 +31,13 @@ export function AccountReauthRequestItem({
 }: AccountReauthRequestItemProps) {
   const [error, setError] = useState<string | null>(null)
   const { reconnect, pendingAccountId } = useOAuthReconnect()
+  const { data: connectedAccounts } = useConnectedAccounts()
   const isReconnecting = pendingAccountId === accountId
   const providerName = getProvider(toolkit)?.displayName
     ?? `${toolkit.charAt(0).toUpperCase()}${toolkit.slice(1)}`
   const statusLabel = accountStatus === 'expired' ? 'expired' : 'been revoked'
+  const ownsAccount = connectedAccounts?.accounts.some((account) => account.id === accountId)
+  const canReconnect = !readOnly && ownsAccount === true
 
   const handleReconnect = async () => {
     setError(null)
@@ -48,33 +52,37 @@ export function AccountReauthRequestItem({
   return (
     <RequestItemShell
       title={`This request needs ${providerName} access that has ${statusLabel}.`}
-      subtitle="Reconnect to continue. The original request will resume automatically."
+      subtitle={ownsAccount === false
+        ? 'Only the connection owner can reconnect it. The request will resume when they do.'
+        : 'Reconnect to continue. The original request will resume automatically.'}
       icon={<ServiceIcon slug={toolkit} fallback="oauth" className="h-4 w-4" />}
       theme="orange"
       sessionId={sessionId}
       agentSlug={agentSlug}
-      readOnly={readOnly ? {} : false}
+      readOnly={canReconnect ? false : {}}
       waitingText="Waiting for reconnection"
       error={error}
       data-testid="account-reauth-request"
       data-status={accountStatus}
     >
-      <RequestItemActions>
-        <Button
-          type="button"
-          size="xs"
-          onClick={handleReconnect}
-          disabled={isReconnecting}
-          data-testid="account-reauth-reconnect-btn"
-        >
-          {isReconnecting ? (
-            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-          )}
-          {isReconnecting ? 'Reconnecting…' : 'Reconnect'}
-        </Button>
-      </RequestItemActions>
+      {canReconnect && (
+        <RequestItemActions>
+          <Button
+            type="button"
+            size="xs"
+            onClick={handleReconnect}
+            disabled={isReconnecting}
+            data-testid="account-reauth-reconnect-btn"
+          >
+            {isReconnecting ? (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            {isReconnecting ? 'Reconnecting…' : 'Reconnect'}
+          </Button>
+        </RequestItemActions>
+      )}
       <span className="sr-only">Proxy request {proxyRequestId}</span>
     </RequestItemShell>
   )

--- a/src/renderer/components/messages/mcp-reauth-request-item.test.tsx
+++ b/src/renderer/components/messages/mcp-reauth-request-item.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { McpReauthRequestItem } from './mcp-reauth-request-item'
+
+const mockInitiateOAuth = vi.fn()
+const mockApiFetch = vi.fn()
+const mockNavigate = vi.fn()
+const mockClose = vi.fn()
+let oauthComplete: ((result: { success: boolean; error?: string }) => void) | null = null
+
+vi.mock('@renderer/hooks/use-remote-mcps', () => ({
+  useInitiateMcpOAuth: () => ({ mutateAsync: (...args: unknown[]) => mockInitiateOAuth(...args) }),
+}))
+
+vi.mock('@renderer/hooks/use-mcp-oauth-listener', () => ({
+  useMcpOAuthListener: (active: boolean, callback: typeof oauthComplete) => {
+    oauthComplete = active ? callback : null
+  },
+}))
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}))
+
+vi.mock('@renderer/lib/oauth-popup', () => ({
+  prepareOAuthPopup: () => ({ navigate: mockNavigate, close: mockClose }),
+}))
+
+function renderItem(overrides: Partial<React.ComponentProps<typeof McpReauthRequestItem>> = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const props: React.ComponentProps<typeof McpReauthRequestItem> = {
+    proxyRequestId: 'proxy-1',
+    mcpId: 'mcp-1',
+    mcpName: 'Cal.com',
+    authType: 'oauth',
+    agentSlug: 'agent-1',
+    onComplete: vi.fn(),
+    ...overrides,
+  }
+  render(
+    <QueryClientProvider client={queryClient}>
+      <McpReauthRequestItem {...props} />
+    </QueryClientProvider>,
+  )
+  return props
+}
+
+describe('McpReauthRequestItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    oauthComplete = null
+  })
+
+  it('starts OAuth for the existing MCP and completes after the callback', async () => {
+    mockInitiateOAuth.mockResolvedValue({ redirectUrl: 'https://auth.example.com', state: 'state-1' })
+    const props = renderItem()
+
+    expect(screen.getByText('This request needs Cal.com, which requires re-authentication.')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('mcp-reauth-reconnect-btn'))
+
+    await waitFor(() => expect(mockInitiateOAuth).toHaveBeenCalledWith({
+      mcpId: 'mcp-1',
+      electron: false,
+    }))
+    expect(mockNavigate).toHaveBeenCalledWith('https://auth.example.com')
+
+    act(() => oauthComplete?.({ success: true }))
+    expect(props.onComplete).toHaveBeenCalledOnce()
+  })
+
+  it('updates a bearer token, verifies the server, and resumes', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+      .mockResolvedValueOnce(new Response('{"tools":[]}', { status: 200 }))
+    const props = renderItem({ authType: 'bearer' })
+
+    fireEvent.change(screen.getByTestId('mcp-reauth-token-input'), {
+      target: { value: 'new-token' },
+    })
+    fireEvent.click(screen.getByTestId('mcp-reauth-reconnect-btn'))
+
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalledTimes(2))
+    expect(mockApiFetch).toHaveBeenNthCalledWith(1, '/api/remote-mcps/mcp-1', expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ accessToken: 'new-token' }),
+    }))
+    expect(mockApiFetch).toHaveBeenNthCalledWith(2, '/api/remote-mcps/mcp-1/discover-tools', {
+      method: 'POST',
+    })
+    expect(props.onComplete).toHaveBeenCalledOnce()
+  })
+
+  it('shows a waiting-only card in read-only mode', () => {
+    renderItem({ readOnly: true })
+
+    expect(screen.queryByTestId('mcp-reauth-reconnect-btn')).not.toBeInTheDocument()
+    expect(screen.getByText('Waiting for reconnection')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/messages/mcp-reauth-request-item.test.tsx
+++ b/src/renderer/components/messages/mcp-reauth-request-item.test.tsx
@@ -9,9 +9,11 @@ const mockApiFetch = vi.fn()
 const mockNavigate = vi.fn()
 const mockClose = vi.fn()
 let oauthComplete: ((result: { success: boolean; error?: string }) => void) | null = null
+let mockCanManage = true
 
 vi.mock('@renderer/hooks/use-remote-mcps', () => ({
   useInitiateMcpOAuth: () => ({ mutateAsync: (...args: unknown[]) => mockInitiateOAuth(...args) }),
+  useCanManageRemoteMcp: () => ({ data: mockCanManage }),
 }))
 
 vi.mock('@renderer/hooks/use-mcp-oauth-listener', () => ({
@@ -51,6 +53,7 @@ describe('McpReauthRequestItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     oauthComplete = null
+    mockCanManage = true
   })
 
   it('starts OAuth for the existing MCP and completes after the callback', async () => {
@@ -97,5 +100,13 @@ describe('McpReauthRequestItem', () => {
 
     expect(screen.queryByTestId('mcp-reauth-reconnect-btn')).not.toBeInTheDocument()
     expect(screen.getByText('Waiting for reconnection')).toBeInTheDocument()
+  })
+
+  it('shows a non-actionable card to a member who cannot manage the MCP', () => {
+    mockCanManage = false
+    renderItem()
+
+    expect(screen.queryByTestId('mcp-reauth-reconnect-btn')).not.toBeInTheDocument()
+    expect(screen.getByText(/Only the connection owner or an administrator/)).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/messages/mcp-reauth-request-item.tsx
+++ b/src/renderer/components/messages/mcp-reauth-request-item.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
-import { useInitiateMcpOAuth } from '@renderer/hooks/use-remote-mcps'
+import { useCanManageRemoteMcp, useInitiateMcpOAuth } from '@renderer/hooks/use-remote-mcps'
 import { useMcpOAuthListener } from '@renderer/hooks/use-mcp-oauth-listener'
 import { apiFetch } from '@renderer/lib/api'
 import { prepareOAuthPopup } from '@renderer/lib/oauth-popup'
@@ -35,6 +35,7 @@ export function McpReauthRequestItem({
 }: McpReauthRequestItemProps) {
   const queryClient = useQueryClient()
   const initiateOAuth = useInitiateMcpOAuth()
+  const { data: canManage } = useCanManageRemoteMcp(mcpId)
   const [pending, setPending] = useState(false)
   const [bearerToken, setBearerToken] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -43,6 +44,7 @@ export function McpReauthRequestItem({
     () => COMMON_MCP_SERVERS.find((server) => server.displayName === mcpName)?.slug,
     [mcpName],
   )
+  const canReconnect = !readOnly && canManage === true
 
   const finish = () => {
     queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
@@ -123,18 +125,20 @@ export function McpReauthRequestItem({
   return (
     <RequestItemShell
       title={`This request needs ${mcpName}, which requires re-authentication.`}
-      subtitle="Reconnect to continue. The original MCP request will resume automatically."
+      subtitle={canManage === false
+        ? 'Only the connection owner or an administrator can reconnect it. The request will resume when they do.'
+        : 'Reconnect to continue. The original MCP request will resume automatically.'}
       icon={<ServiceIcon slug={serviceSlug} fallback="mcp" className="h-4 w-4" />}
       theme="orange"
       sessionId={sessionId}
       agentSlug={agentSlug}
-      readOnly={readOnly ? {} : false}
+      readOnly={canReconnect ? false : {}}
       waitingText="Waiting for reconnection"
       error={error}
       data-testid="mcp-reauth-request"
       data-auth-type={authType}
     >
-      {!readOnly && authType === 'bearer' && (
+      {canReconnect && authType === 'bearer' && (
         <Input
           type="password"
           value={bearerToken}
@@ -144,22 +148,24 @@ export function McpReauthRequestItem({
           data-testid="mcp-reauth-token-input"
         />
       )}
-      <RequestItemActions>
-        <Button
-          type="button"
-          size="xs"
-          onClick={() => void reconnect()}
-          disabled={pending || (authType === 'bearer' && !bearerToken.trim())}
-          data-testid="mcp-reauth-reconnect-btn"
-        >
-          {pending ? (
-            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-          )}
-          {pending ? 'Reconnecting…' : authType === 'none' ? 'Retry' : 'Reconnect'}
-        </Button>
-      </RequestItemActions>
+      {canReconnect && (
+        <RequestItemActions>
+          <Button
+            type="button"
+            size="xs"
+            onClick={() => void reconnect()}
+            disabled={pending || (authType === 'bearer' && !bearerToken.trim())}
+            data-testid="mcp-reauth-reconnect-btn"
+          >
+            {pending ? (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            {pending ? 'Reconnecting…' : authType === 'none' ? 'Retry' : 'Reconnect'}
+          </Button>
+        </RequestItemActions>
+      )}
       <span className="sr-only">MCP proxy request {proxyRequestId}</span>
     </RequestItemShell>
   )

--- a/src/renderer/components/messages/mcp-reauth-request-item.tsx
+++ b/src/renderer/components/messages/mcp-reauth-request-item.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Loader2, RefreshCw } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import { ServiceIcon } from '@renderer/components/ui/service-icon'
+import { useInitiateMcpOAuth } from '@renderer/hooks/use-remote-mcps'
+import { useMcpOAuthListener } from '@renderer/hooks/use-mcp-oauth-listener'
+import { apiFetch } from '@renderer/lib/api'
+import { prepareOAuthPopup } from '@renderer/lib/oauth-popup'
+import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
+import { RequestItemActions } from './request-item-actions'
+import { RequestItemShell } from './request-item-shell'
+
+interface McpReauthRequestItemProps {
+  proxyRequestId: string
+  mcpId: string
+  mcpName: string
+  authType: 'none' | 'oauth' | 'bearer'
+  sessionId?: string
+  agentSlug: string
+  readOnly?: boolean
+  onComplete: () => void
+}
+
+export function McpReauthRequestItem({
+  proxyRequestId,
+  mcpId,
+  mcpName,
+  authType,
+  sessionId,
+  agentSlug,
+  readOnly,
+  onComplete,
+}: McpReauthRequestItemProps) {
+  const queryClient = useQueryClient()
+  const initiateOAuth = useInitiateMcpOAuth()
+  const [pending, setPending] = useState(false)
+  const [bearerToken, setBearerToken] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const popupRef = useRef<ReturnType<typeof prepareOAuthPopup> | null>(null)
+  const serviceSlug = useMemo(
+    () => COMMON_MCP_SERVERS.find((server) => server.displayName === mcpName)?.slug,
+    [mcpName],
+  )
+
+  const finish = () => {
+    queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
+    queryClient.invalidateQueries({ queryKey: ['agent-remote-mcps'] })
+    onComplete()
+  }
+
+  useMcpOAuthListener(pending && authType === 'oauth', ({ success, error: oauthError }) => {
+    popupRef.current?.close()
+    popupRef.current = null
+    setPending(false)
+    if (success) {
+      setError(null)
+      finish()
+    } else {
+      setError(oauthError || 'MCP reconnection failed')
+    }
+  })
+
+  useEffect(() => () => {
+    popupRef.current?.close()
+    popupRef.current = null
+  }, [])
+
+  const parseError = async (response: Response, fallback: string) => {
+    const body = await response.json().catch(() => ({})) as { error?: unknown }
+    return typeof body.error === 'string' ? body.error : fallback
+  }
+
+  const reconnect = async () => {
+    setError(null)
+    setPending(true)
+
+    if (authType === 'oauth') {
+      const popup = prepareOAuthPopup()
+      popupRef.current = popup
+      try {
+        const result = await initiateOAuth.mutateAsync({
+          mcpId,
+          electron: !!window.electronAPI,
+        })
+        await popup.navigate(result.redirectUrl)
+      } catch (reconnectError) {
+        popup.close()
+        popupRef.current = null
+        setPending(false)
+        setError(reconnectError instanceof Error ? reconnectError.message : 'MCP reconnection failed')
+      }
+      return
+    }
+
+    try {
+      if (authType === 'bearer') {
+        const patchResponse = await apiFetch(`/api/remote-mcps/${mcpId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ accessToken: bearerToken.trim() }),
+        })
+        if (!patchResponse.ok) {
+          throw new Error(await parseError(patchResponse, 'Failed to update the bearer token'))
+        }
+      }
+
+      const discoverResponse = await apiFetch(`/api/remote-mcps/${mcpId}/discover-tools`, {
+        method: 'POST',
+      })
+      if (!discoverResponse.ok) {
+        throw new Error(await parseError(discoverResponse, 'The MCP server is still unavailable'))
+      }
+      finish()
+    } catch (reconnectError) {
+      setError(reconnectError instanceof Error ? reconnectError.message : 'MCP reconnection failed')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <RequestItemShell
+      title={`This request needs ${mcpName}, which requires re-authentication.`}
+      subtitle="Reconnect to continue. The original MCP request will resume automatically."
+      icon={<ServiceIcon slug={serviceSlug} fallback="mcp" className="h-4 w-4" />}
+      theme="orange"
+      sessionId={sessionId}
+      agentSlug={agentSlug}
+      readOnly={readOnly ? {} : false}
+      waitingText="Waiting for reconnection"
+      error={error}
+      data-testid="mcp-reauth-request"
+      data-auth-type={authType}
+    >
+      {!readOnly && authType === 'bearer' && (
+        <Input
+          type="password"
+          value={bearerToken}
+          onChange={(event) => setBearerToken(event.target.value)}
+          placeholder="New bearer token"
+          disabled={pending}
+          data-testid="mcp-reauth-token-input"
+        />
+      )}
+      <RequestItemActions>
+        <Button
+          type="button"
+          size="xs"
+          onClick={() => void reconnect()}
+          disabled={pending || (authType === 'bearer' && !bearerToken.trim())}
+          data-testid="mcp-reauth-reconnect-btn"
+        >
+          {pending ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          {pending ? 'Reconnecting…' : authType === 'none' ? 'Retry' : 'Reconnect'}
+        </Button>
+      </RequestItemActions>
+      <span className="sr-only">MCP proxy request {proxyRequestId}</span>
+    </RequestItemShell>
+  )
+}

--- a/src/renderer/components/messages/pending-request-renderer.test.tsx
+++ b/src/renderer/components/messages/pending-request-renderer.test.tsx
@@ -12,6 +12,8 @@ import { ScriptRunRequestItem } from './script-run-request-item'
 import { ComputerUseRequestItem } from './computer-use-request-item'
 import { ProxyReviewRequestItem } from './proxy-review-request-item'
 import { XAgentReviewRequestItem } from './x-agent-review-request-item'
+import { AccountReauthRequestItem } from './account-reauth-request-item'
+import { McpReauthRequestItem } from './mcp-reauth-request-item'
 
 const ctx: RenderContext = {
   sessionId: 'session-xyz',
@@ -167,6 +169,44 @@ const cases: Array<{
     expectedComponent: XAgentReviewRequestItem,
     expectedProps: { reviewId: 'rx', xAgent: { targetAgentSlug: 'r', targetAgentName: 'R', operation: 'invoke' } },
   },
+  {
+    name: 'account_reauth_required',
+    descriptor: {
+      kind: 'account_reauth_required',
+      key: 'k11',
+      proxyRequestId: 'pr-1',
+      accountId: 'a1',
+      toolkit: 'gmail',
+      accountStatus: 'expired',
+      onComplete: noop,
+    },
+    expectedComponent: AccountReauthRequestItem,
+    expectedProps: {
+      proxyRequestId: 'pr-1',
+      accountId: 'a1',
+      toolkit: 'gmail',
+      accountStatus: 'expired',
+    },
+  },
+  {
+    name: 'mcp_reauth_required',
+    descriptor: {
+      kind: 'mcp_reauth_required',
+      key: 'k12',
+      proxyRequestId: 'mpr-1',
+      mcpId: 'mcp-1',
+      mcpName: 'Cal.com',
+      authType: 'oauth',
+      onComplete: noop,
+    },
+    expectedComponent: McpReauthRequestItem,
+    expectedProps: {
+      proxyRequestId: 'mpr-1',
+      mcpId: 'mcp-1',
+      mcpName: 'Cal.com',
+      authType: 'oauth',
+    },
+  },
 ]
 
 describe('renderPendingRequest', () => {
@@ -182,10 +222,7 @@ describe('renderPendingRequest', () => {
       // Context is plumbed through on every kind.
       expect(props.agentSlug).toBe(ctx.agentSlug)
       expect(props.readOnly).toBe(ctx.readOnly)
-      // sessionId is passed to all SSE-based items but NOT to proxy/x-agent reviews.
-      if (c.name !== 'proxy_review' && c.name !== 'x_agent_review') {
-        expect(props.sessionId).toBe(ctx.sessionId)
-      }
+      expect(props.sessionId).toBe(ctx.sessionId)
       // Every descriptor's onComplete is forwarded as the onComplete prop.
       expect(props.onComplete).toBe(c.descriptor.onComplete)
       // The element's React key carries the descriptor key (for stable identity in lists).
@@ -199,6 +236,6 @@ describe('renderPendingRequest', () => {
     // case). This sanity check pins the case count to the test table so we
     // remember to update it in lockstep.
     const kinds = new Set(cases.map((c) => c.descriptor.kind))
-    expect(kinds.size).toBe(10)
+    expect(kinds.size).toBe(12)
   })
 })

--- a/src/renderer/components/messages/pending-request-renderer.tsx
+++ b/src/renderer/components/messages/pending-request-renderer.tsx
@@ -10,6 +10,8 @@ import { ComputerUseRequestItem } from './computer-use-request-item'
 import { CapabilityReviewRequestItem } from './capability-review-request-item'
 import { ProxyReviewRequestItem } from './proxy-review-request-item'
 import { XAgentReviewRequestItem } from './x-agent-review-request-item'
+import { AccountReauthRequestItem } from './account-reauth-request-item'
+import { McpReauthRequestItem } from './mcp-reauth-request-item'
 import type { PendingRequestDescriptor } from './use-pending-requests'
 
 export interface RenderContext {
@@ -171,6 +173,34 @@ export function renderPendingRequest(
           sessionId={ctx.sessionId}
           agentSlug={ctx.agentSlug}
           xAgent={d.xAgent}
+          readOnly={ctx.readOnly}
+          onComplete={d.onComplete}
+        />
+      )
+    case 'account_reauth_required':
+      return (
+        <AccountReauthRequestItem
+          key={d.key}
+          proxyRequestId={d.proxyRequestId}
+          accountId={d.accountId}
+          toolkit={d.toolkit}
+          accountStatus={d.accountStatus}
+          sessionId={ctx.sessionId}
+          agentSlug={ctx.agentSlug}
+          readOnly={ctx.readOnly}
+          onComplete={d.onComplete}
+        />
+      )
+    case 'mcp_reauth_required':
+      return (
+        <McpReauthRequestItem
+          key={d.key}
+          proxyRequestId={d.proxyRequestId}
+          mcpId={d.mcpId}
+          mcpName={d.mcpName}
+          authType={d.authType}
+          sessionId={ctx.sessionId}
+          agentSlug={ctx.agentSlug}
           readOnly={ctx.readOnly}
           onComplete={d.onComplete}
         />

--- a/src/renderer/components/messages/use-pending-requests.test.tsx
+++ b/src/renderer/components/messages/use-pending-requests.test.tsx
@@ -934,6 +934,62 @@ describe('usePendingRequests', () => {
     expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['pending-user-requests'] })
   })
 
+  it('emits an account_reauth_required descriptor with the proxy request id', () => {
+    mockUnified.data = [
+      unified(
+        'account_reauth_required',
+        'reauth-1',
+        {
+          accountId: 'acct-r',
+          toolkit: 'gmail',
+          accountStatus: 'expired',
+          proxyRequestId: 'proxy-request-1',
+        },
+        { agentScoped: true },
+      ),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    expect(result.current.count).toBe(1)
+    expect(ofKind(result.current.items, 'account_reauth_required')).toEqual([
+      expect.objectContaining({
+        proxyRequestId: 'proxy-request-1',
+        accountId: 'acct-r',
+        toolkit: 'gmail',
+        accountStatus: 'expired',
+      }),
+    ])
+  })
+
+  it('emits an mcp_reauth_required descriptor with reconnect metadata', () => {
+    mockUnified.data = [
+      unified(
+        'mcp_reauth_required',
+        'mcp-reauth-1',
+        {
+          mcpId: 'mcp-cal',
+          mcpName: 'Cal.com',
+          authType: 'oauth',
+          proxyRequestId: 'mcp-proxy-request-1',
+        },
+        { agentScoped: true },
+      ),
+    ]
+
+    const { result } = renderHook(() => usePendingRequests(defaultArgs))
+
+    expect(result.current.count).toBe(1)
+    expect(ofKind(result.current.items, 'mcp_reauth_required')).toEqual([
+      expect.objectContaining({
+        proxyRequestId: 'mcp-proxy-request-1',
+        mcpId: 'mcp-cal',
+        mcpName: 'Cal.com',
+        authType: 'oauth',
+      }),
+    ])
+  })
+
   // ---- onComplete wiring: every kind drops its card synchronously ----
 
   it.each([

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -256,6 +256,52 @@ export interface PendingMcpReauth {
   proxyRequestId: string
 }
 
+export function accountReauthFromEnvelope(
+  request: PendingUserInputRequest,
+  payload: Record<string, unknown>,
+): PendingAccountReauth | null {
+  if (
+    request.kind !== 'account_reauth_required' ||
+    typeof payload.accountId !== 'string' ||
+    typeof payload.toolkit !== 'string' ||
+    (payload.accountStatus !== 'expired' && payload.accountStatus !== 'revoked')
+  ) {
+    return null
+  }
+  return {
+    id: request.id,
+    agentSlug: request.scope.agentSlug ?? '',
+    accountId: payload.accountId,
+    toolkit: payload.toolkit,
+    accountStatus: payload.accountStatus,
+    proxyRequestId:
+      typeof payload.proxyRequestId === 'string' ? payload.proxyRequestId : request.id,
+  }
+}
+
+export function mcpReauthFromEnvelope(
+  request: PendingUserInputRequest,
+  payload: Record<string, unknown>,
+): PendingMcpReauth | null {
+  if (
+    request.kind !== 'mcp_reauth_required' ||
+    typeof payload.mcpId !== 'string' ||
+    typeof payload.mcpName !== 'string' ||
+    (payload.authType !== 'none' && payload.authType !== 'oauth' && payload.authType !== 'bearer')
+  ) {
+    return null
+  }
+  return {
+    id: request.id,
+    agentSlug: request.scope.agentSlug ?? '',
+    mcpId: payload.mcpId,
+    mcpName: payload.mcpName,
+    authType: payload.authType,
+    proxyRequestId:
+      typeof payload.proxyRequestId === 'string' ? payload.proxyRequestId : request.id,
+  }
+}
+
 // Rebuild the PendingReview shape from a review envelope. The payload carries
 // the full ReviewDetails (plus the derived displayText), but envelope payloads
 // are lenient by design, so the card-critical fields are re-validated here
@@ -441,37 +487,15 @@ function projectUnifiedRequests(requests: PendingUserInputRequest[]): UnifiedPro
         break
       }
       case 'account_reauth_required':
-        if (
-          typeof payload.accountId === 'string' &&
-          typeof payload.toolkit === 'string' &&
-          (payload.accountStatus === 'expired' || payload.accountStatus === 'revoked')
-        ) {
-          accountReauthRequests.push({
-            id: request.id,
-            agentSlug: request.scope.agentSlug ?? '',
-            accountId: payload.accountId,
-            toolkit: payload.toolkit,
-            accountStatus: payload.accountStatus,
-            proxyRequestId:
-              typeof payload.proxyRequestId === 'string' ? payload.proxyRequestId : request.id,
-          })
+        {
+          const reauth = accountReauthFromEnvelope(request, payload)
+          if (reauth) accountReauthRequests.push(reauth)
         }
         break
       case 'mcp_reauth_required':
-        if (
-          typeof payload.mcpId === 'string' &&
-          typeof payload.mcpName === 'string' &&
-          (payload.authType === 'none' || payload.authType === 'oauth' || payload.authType === 'bearer')
-        ) {
-          mcpReauthRequests.push({
-            id: request.id,
-            agentSlug: request.scope.agentSlug ?? '',
-            mcpId: payload.mcpId,
-            mcpName: payload.mcpName,
-            authType: payload.authType,
-            proxyRequestId:
-              typeof payload.proxyRequestId === 'string' ? payload.proxyRequestId : request.id,
-          })
+        {
+          const reauth = mcpReauthFromEnvelope(request, payload)
+          if (reauth) mcpReauthRequests.push(reauth)
         }
         break
     }

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -193,6 +193,8 @@ interface UnifiedProjection {
   buckets: PendingRequestBuckets
   capabilityReviews: UnifiedCapabilityReview[]
   reviews: PendingReview[]
+  accountReauthRequests: PendingAccountReauth[]
+  mcpReauthRequests: PendingMcpReauth[]
   /**
    * Ids the server auto-approved and is ALREADY executing, per suppressible
    * kind. They are deliberately absent from the buckets — no card is owed for
@@ -234,6 +236,24 @@ export interface PendingReview {
     operation: 'list' | 'read' | 'invoke' | 'create'
     preview?: string
   }
+}
+
+export interface PendingAccountReauth {
+  id: string
+  agentSlug: string
+  accountId: string
+  toolkit: string
+  accountStatus: 'expired' | 'revoked'
+  proxyRequestId: string
+}
+
+export interface PendingMcpReauth {
+  id: string
+  agentSlug: string
+  mcpId: string
+  mcpName: string
+  authType: 'none' | 'oauth' | 'bearer'
+  proxyRequestId: string
 }
 
 // Rebuild the PendingReview shape from a review envelope. The payload carries
@@ -299,6 +319,8 @@ function projectUnifiedRequests(requests: PendingUserInputRequest[]): UnifiedPro
   const buckets = createPendingRequestBuckets()
   const capabilityReviews: UnifiedCapabilityReview[] = []
   const reviews: PendingReview[] = []
+  const accountReauthRequests: PendingAccountReauth[] = []
+  const mcpReauthRequests: PendingMcpReauth[] = []
   const autoApprovedScriptRunIds = new Set<string>()
   const autoApprovedComputerUseIds = new Set<string>()
 
@@ -418,6 +440,40 @@ function projectUnifiedRequests(requests: PendingUserInputRequest[]): UnifiedPro
         if (review) reviews.push(review)
         break
       }
+      case 'account_reauth_required':
+        if (
+          typeof payload.accountId === 'string' &&
+          typeof payload.toolkit === 'string' &&
+          (payload.accountStatus === 'expired' || payload.accountStatus === 'revoked')
+        ) {
+          accountReauthRequests.push({
+            id: request.id,
+            agentSlug: request.scope.agentSlug ?? '',
+            accountId: payload.accountId,
+            toolkit: payload.toolkit,
+            accountStatus: payload.accountStatus,
+            proxyRequestId:
+              typeof payload.proxyRequestId === 'string' ? payload.proxyRequestId : request.id,
+          })
+        }
+        break
+      case 'mcp_reauth_required':
+        if (
+          typeof payload.mcpId === 'string' &&
+          typeof payload.mcpName === 'string' &&
+          (payload.authType === 'none' || payload.authType === 'oauth' || payload.authType === 'bearer')
+        ) {
+          mcpReauthRequests.push({
+            id: request.id,
+            agentSlug: request.scope.agentSlug ?? '',
+            mcpId: payload.mcpId,
+            mcpName: payload.mcpName,
+            authType: payload.authType,
+            proxyRequestId:
+              typeof payload.proxyRequestId === 'string' ? payload.proxyRequestId : request.id,
+          })
+        }
+        break
     }
   }
 
@@ -425,6 +481,8 @@ function projectUnifiedRequests(requests: PendingUserInputRequest[]): UnifiedPro
     buckets,
     capabilityReviews,
     reviews,
+    accountReauthRequests,
+    mcpReauthRequests,
     autoApprovedScriptRunIds,
     autoApprovedComputerUseIds,
   }
@@ -484,6 +542,8 @@ export type PendingRequestDescriptor =
   | { kind: 'capability_review'; key: string; toolUseId: string; capability: 'subagents' | 'workflows'; toolName: string; input: Record<string, unknown>; onComplete: () => void }
   | { kind: 'proxy_review'; key: string; reviewId: string; accountId: string; toolkit: string; method: string; targetPath: string; matchedScopes: string[]; scopeDescriptions: Record<string, string>; displayText?: string; onComplete: () => void }
   | { kind: 'x_agent_review'; key: string; reviewId: string; xAgent: NonNullable<PendingReview['xAgent']>; onComplete: () => void }
+  | { kind: 'account_reauth_required'; key: string; proxyRequestId: string; accountId: string; toolkit: string; accountStatus: 'expired' | 'revoked'; onComplete: () => void }
+  | { kind: 'mcp_reauth_required'; key: string; proxyRequestId: string; mcpId: string; mcpName: string; authType: 'none' | 'oauth' | 'bearer'; onComplete: () => void }
 
 interface UsePendingRequestsResult {
   items: PendingRequestDescriptor[]
@@ -526,6 +586,8 @@ export function usePendingRequests({
     )
   }, [unifiedRequestsData, isActive])
   const pendingProxyReviews = unified.reviews
+  const pendingAccountReauthRequests = unified.accountReauthRequests
+  const pendingMcpReauthRequests = unified.mcpReauthRequests
 
   // Derive pending requests from message history (for page refresh recovery).
   // Tool calls without a result are still pending, but only if there are no
@@ -673,11 +735,15 @@ export function usePendingRequests({
       for (const req of arr) ids.push(req.toolUseId)
     }
     for (const review of pendingProxyReviews) ids.push(review.id)
+    for (const request of pendingAccountReauthRequests) ids.push(request.id)
+    for (const request of pendingMcpReauthRequests) ids.push(request.id)
     return ids
   }, [
     merged.secretRequests, merged.connectedAccountRequests, merged.remoteMcpRequests,
     merged.questionRequests, merged.fileRequests, merged.browserInputRequests,
     merged.scriptRunRequests, merged.computerUseRequests, pendingCapabilityReviewRequests, pendingProxyReviews,
+    pendingAccountReauthRequests,
+    pendingMcpReauthRequests,
   ])
 
   // Effect — not useMemo — because we mutate refs. useMemo may re-run for the
@@ -831,11 +897,35 @@ export function usePendingRequests({
         })
       }
     }
+    for (const request of pendingAccountReauthRequests) {
+      all.push({
+        kind: 'account_reauth_required',
+        key: request.id,
+        proxyRequestId: request.proxyRequestId,
+        accountId: request.accountId,
+        toolkit: request.toolkit,
+        accountStatus: request.accountStatus,
+        onComplete: handleProxyReviewComplete,
+      })
+    }
+    for (const request of pendingMcpReauthRequests) {
+      all.push({
+        kind: 'mcp_reauth_required',
+        key: request.id,
+        proxyRequestId: request.proxyRequestId,
+        mcpId: request.mcpId,
+        mcpName: request.mcpName,
+        authType: request.authType,
+        onComplete: handleProxyReviewComplete,
+      })
+    }
     return all.sort((a, b) => getArrivalOrder(a.key) - getArrivalOrder(b.key))
   }, [
     merged.secretRequests, merged.connectedAccountRequests, merged.remoteMcpRequests,
     merged.questionRequests, merged.fileRequests, merged.browserInputRequests,
     merged.scriptRunRequests, merged.computerUseRequests, pendingCapabilityReviewRequests, pendingProxyReviews,
+    pendingAccountReauthRequests,
+    pendingMcpReauthRequests,
     getArrivalOrder, handleRequestComplete, handleProxyReviewComplete,
   ])
 

--- a/src/renderer/hooks/use-oauth-reconnect.test.tsx
+++ b/src/renderer/hooks/use-oauth-reconnect.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import type { ReactNode } from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useOAuthReconnect } from './use-oauth-reconnect'
+
+const mockApiFetch = vi.fn()
+const mockNavigate = vi.fn()
+const mockClose = vi.fn()
+let oauthCallback: ((params: {
+  connectionId?: string | null
+  status?: string | null
+  toolkit?: string | null
+  error?: string | null
+}) => void) | undefined
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}))
+
+vi.mock('@renderer/lib/oauth-popup', () => ({
+  prepareOAuthPopup: () => ({ navigate: mockNavigate, close: mockClose }),
+}))
+
+vi.mock('@renderer/hooks/use-delayed-oauth-abort', () => ({
+  useDelayedOAuthAbort: () => false,
+}))
+
+describe('useOAuthReconnect', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+    mockNavigate.mockReset().mockResolvedValue(undefined)
+    mockClose.mockReset()
+    oauthCallback = undefined
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    window.electronAPI = {
+      onOAuthCallback: vi.fn((callback) => {
+        oauthCallback = callback
+        return vi.fn()
+      }),
+    } as unknown as Window['electronAPI']
+  })
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+
+  it('returns true only after the Electron completion endpoint succeeds', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify({ redirectUrl: 'https://oauth.test' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }))
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useOAuthReconnect(), { wrapper })
+
+    let reconnectPromise!: Promise<boolean>
+    await act(async () => {
+      reconnectPromise = result.current.reconnect('account-1', 'gmail')
+    })
+    await waitFor(() => expect(oauthCallback).toBeTypeOf('function'))
+
+    await act(async () => {
+      oauthCallback?.({ connectionId: 'connection-new', toolkit: 'gmail' })
+    })
+
+    await expect(reconnectPromise).resolves.toBe(true)
+    expect(mockApiFetch).toHaveBeenNthCalledWith(2, '/api/connected-accounts/complete',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          connectionId: 'connection-new',
+          toolkit: 'gmail',
+          reconnectAccountId: 'account-1',
+        }),
+      }))
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['pending-user-requests'] })
+  })
+
+  it('returns false and leaves the request pending when OAuth completion fails', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify({ redirectUrl: 'https://oauth.test' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'failed' }), { status: 500 }))
+    const { result } = renderHook(() => useOAuthReconnect(), { wrapper })
+
+    let reconnectPromise!: Promise<boolean>
+    await act(async () => {
+      reconnectPromise = result.current.reconnect('account-1', 'gmail')
+    })
+    await waitFor(() => expect(oauthCallback).toBeTypeOf('function'))
+
+    await act(async () => {
+      oauthCallback?.({ connectionId: 'connection-bad', toolkit: 'gmail' })
+    })
+
+    await expect(reconnectPromise).resolves.toBe(false)
+  })
+})

--- a/src/renderer/hooks/use-oauth-reconnect.ts
+++ b/src/renderer/hooks/use-oauth-reconnect.ts
@@ -38,27 +38,29 @@ export function useOAuthReconnect() {
           reconnectAccountId: accountId,
         }),
       })
-      if (canceled) return
+      if (canceled) return false
       if (!res.ok) {
         popup.close()
         const data = await res.json()
         console.error('Failed to initiate reconnection:', data.error)
         setPendingAccountId(null)
-        return
+        return false
       }
       const data = await res.json()
-      if (canceled) return
+      if (canceled) return false
       if (!data.redirectUrl) {
         popup.close()
         setPendingAccountId(null)
-        return
+        return false
       }
 
       await popup.navigate(data.redirectUrl)
-      if (canceled) return
+      if (canceled) return false
+
+      let reconnectSucceeded = false
 
       if (window.electronAPI) {
-        await new Promise<void>((resolve) => {
+        reconnectSucceeded = await new Promise<boolean>((resolve) => {
           let settled = false
           let timeout: number | undefined
           let unsubscribe: (() => void) | undefined
@@ -74,14 +76,14 @@ export function useOAuthReconnect() {
           abortReconnectRef.current = () => {
             canceled = true
             popup.close()
-            if (settle()) resolve()
+            if (settle()) resolve(false)
           }
           // Bound the wait: if the user abandons the OAuth window (or only
           // mismatched-toolkit callbacks ever arrive), settle anyway so we don't
           // leak the listener or hang reconnect() forever. The channel-wide
           // reset that used to sweep orphaned listeners is gone (SUP-215).
           timeout = window.setTimeout(() => {
-            if (settle()) resolve()
+            if (settle()) resolve(false)
           }, OAUTH_RECONNECT_TIMEOUT_MS)
           unsubscribe = window.electronAPI!.onOAuthCallback(async (params) => {
             // Ignore callbacks for other toolkits; keep waiting for ours.
@@ -89,21 +91,27 @@ export function useOAuthReconnect() {
             // Remove only this reconnect listener; other OAuth subscribers stay.
             if (!settle()) return
             if (params.connectionId && params.toolkit) {
-              await apiFetch('/api/connected-accounts/complete', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                  connectionId: params.connectionId,
-                  toolkit: params.toolkit,
-                  reconnectAccountId: accountId,
-                }),
-              }).catch(() => {})
+              try {
+                const completeRes = await apiFetch('/api/connected-accounts/complete', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    connectionId: params.connectionId,
+                    toolkit: params.toolkit,
+                    reconnectAccountId: accountId,
+                  }),
+                })
+                resolve(completeRes.ok)
+              } catch {
+                resolve(false)
+              }
+              return
             }
-            resolve()
+            resolve(false)
           })
         })
       } else {
-        await new Promise<void>((resolve) => {
+        reconnectSucceeded = await new Promise<boolean>((resolve) => {
           let settled = false
           let timeout: number | undefined
 
@@ -118,27 +126,30 @@ export function useOAuthReconnect() {
           function handleMessage(event: MessageEvent) {
             if (event.origin !== window.location.origin) return
             if (event.data?.type === 'oauth-callback') {
-              if (settle()) resolve()
+              if (settle()) resolve(event.data?.success === true)
             }
           }
           abortReconnectRef.current = () => {
             canceled = true
             popup.close()
-            if (settle()) resolve()
+            if (settle()) resolve(false)
           }
           timeout = window.setTimeout(() => {
-            if (settle()) resolve()
+            if (settle()) resolve(false)
           }, OAUTH_RECONNECT_TIMEOUT_MS)
           window.addEventListener('message', handleMessage)
         })
       }
 
-      if (canceled) return
+      if (canceled) return false
       queryClient.invalidateQueries({ queryKey: ['connected-accounts'] })
       queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts'] })
+      queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
+      return reconnectSucceeded
     } catch (err) {
       popup.close()
       console.error('Reconnect failed:', err)
+      return false
     } finally {
       abortReconnectRef.current = null
       setPendingAccountId(null)

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -37,6 +37,21 @@ export function useRemoteMcps() {
   })
 }
 
+/** Whether the current viewer owns this MCP server or is an administrator. */
+export function useCanManageRemoteMcp(mcpId: string) {
+  return useQuery<boolean>({
+    queryKey: ['remote-mcp-manage-access', mcpId],
+    queryFn: async () => {
+      const res = await apiFetch(`/api/remote-mcps/${mcpId}`)
+      if (res.status === 403 || res.status === 404) return false
+      if (!res.ok) throw new Error('Failed to check MCP reconnect access')
+      return true
+    },
+    enabled: !!mcpId,
+    retry: false,
+  })
+}
+
 /**
  * Fetch remote MCPs assigned to a specific agent
  */

--- a/src/shared/lib/chat-integrations/request-card.test.ts
+++ b/src/shared/lib/chat-integrations/request-card.test.ts
@@ -56,17 +56,19 @@ describe('requestCardFromRegistry', () => {
     expect(requestCardFromRegistry(request('script_run', { script: 'ls' }, { autoApproved: true }))).toBeNull()
   })
 
-  it('stays quiet for reviews — those render off the global channel', () => {
+  it('stays quiet for agent-scoped app requests', () => {
     expect(requestCardFromRegistry(request('proxy_review', {}, { sessionId: null }))).toBeNull()
     expect(requestCardFromRegistry(request('x_agent_review', {}, { sessionId: null }))).toBeNull()
+    expect(requestCardFromRegistry(request('account_reauth_required', {}, { sessionId: null }))).toBeNull()
+    expect(requestCardFromRegistry(request('mcp_reauth_required', {}, { sessionId: null }))).toBeNull()
   })
 
   it('maps every request kind to a decision — no kind can go silent by omission', () => {
     // The regression this guards: before the unified wire, a new kind fell
     // through processSSEEvent's else-if chain and chat users waited on a card
     // that was never coming. Every kind must either render or be one of the
-    // two documented quiet cases.
-    const quiet = new Set(['proxy_review', 'x_agent_review'])
+    // documented quiet cases.
+    const quiet = new Set(['proxy_review', 'x_agent_review', 'account_reauth_required', 'mcp_reauth_required'])
     for (const kind of USER_INPUT_REQUEST_KINDS) {
       const card = requestCardFromRegistry(request(kind, {}, { sessionId: quiet.has(kind) ? null : 'session-1' }))
       if (quiet.has(kind)) {

--- a/src/shared/lib/chat-integrations/request-card.ts
+++ b/src/shared/lib/chat-integrations/request-card.ts
@@ -41,6 +41,8 @@ const KIND_TO_CARD_TYPE: Record<UserInputRequestKind, UserRequestEvent['type'] |
   computer_use: 'computer_use_request',
   proxy_review: null,
   x_agent_review: null,
+  account_reauth_required: null,
+  mcp_reauth_required: null,
 }
 
 /**

--- a/src/shared/lib/container/connection-runtime-projections.ts
+++ b/src/shared/lib/container/connection-runtime-projections.ts
@@ -5,6 +5,14 @@ export interface ConnectedAccountProjectionSource {
   status: string
 }
 
+export type ConnectedAccountRuntimeStatus = 'active' | 'expired' | 'revoked'
+
+export interface ConnectedAccountRuntimeEntry {
+  name: string
+  id: string
+  status: ConnectedAccountRuntimeStatus
+}
+
 export interface RemoteMcpProjectionSource {
   id: string
   name: string
@@ -15,6 +23,7 @@ export interface RemoteMcpProjectionSource {
 export interface RemoteMcpRuntimeConfig {
   id: string
   name: string
+  status: 'active' | 'auth_required'
   proxyUrl: string
   tools: Array<{ name: string }>
 }
@@ -42,20 +51,28 @@ function parseToolNames(toolsJson: string | null): Array<{ name: string }> {
 
 export function buildConnectedAccountsProjection(
   accounts: ConnectedAccountProjectionSource[],
-): Record<string, Array<{ name: string; id: string }>> {
-  const metadata: Record<string, Array<{ name: string; id: string }>> = {}
-  const activeAccounts = accounts
-    .filter((account) => account.status === 'active')
+): Record<string, ConnectedAccountRuntimeEntry[]> {
+  const metadata: Record<string, ConnectedAccountRuntimeEntry[]> = {}
+  const assignedAccounts = accounts
+    // Keep reconnectable accounts in the runtime. The first proxy request made
+    // with one of these IDs parks while the host surfaces the reconnect card.
+    // Dropping them here makes an assigned account look entirely unavailable.
+    .filter((account) =>
+      account.status === 'active' ||
+      account.status === 'expired' ||
+      account.status === 'revoked'
+    )
     .sort((a, b) =>
       a.toolkitSlug.localeCompare(b.toolkitSlug) ||
       a.id.localeCompare(b.id),
     )
 
-  for (const account of activeAccounts) {
+  for (const account of assignedAccounts) {
     metadata[account.toolkitSlug] ??= []
     metadata[account.toolkitSlug].push({
       name: account.displayName,
       id: account.id,
+      status: account.status as ConnectedAccountRuntimeStatus,
     })
   }
 
@@ -68,11 +85,15 @@ export function buildRemoteMcpProjection(
   hostApiBaseUrl: string,
 ): RemoteMcpRuntimeConfig[] {
   return mcps
-    .filter((mcp) => mcp.status === 'active')
+    // Keep auth-required servers in the runtime. Their MCP handshake reaches
+    // the host proxy, which parks it and surfaces the reconnect card. Dropping
+    // them here makes the agent believe an assigned MCP does not exist.
+    .filter((mcp) => mcp.status === 'active' || mcp.status === 'auth_required')
     .sort((a, b) => a.id.localeCompare(b.id))
     .map((mcp) => ({
       id: mcp.id,
       name: mcp.name,
+      status: mcp.status as 'active' | 'auth_required',
       proxyUrl: `${hostApiBaseUrl}/api/mcp-proxy/${agentSlug}/${mcp.id}`,
       tools: parseToolNames(mcp.toolsJson),
     }))

--- a/src/shared/lib/container/connection-runtime-projections.ts
+++ b/src/shared/lib/container/connection-runtime-projections.ts
@@ -86,8 +86,9 @@ export function buildRemoteMcpProjection(
 ): RemoteMcpRuntimeConfig[] {
   return mcps
     // Keep auth-required servers in the runtime. Their MCP handshake reaches
-    // the host proxy, which parks it and surfaces the reconnect card. Dropping
-    // them here makes the agent believe an assigned MCP does not exist.
+    // the host proxy, which serves cached discovery locally; the first actual
+    // tool call parks and surfaces the reconnect card. Dropping them here makes
+    // the agent believe an assigned MCP does not exist.
     .filter((mcp) => mcp.status === 'active' || mcp.status === 'auth_required')
     .sort((a, b) => a.id.localeCompare(b.id))
     .map((mcp) => ({

--- a/src/shared/lib/container/connection-runtime-sync.test.ts
+++ b/src/shared/lib/container/connection-runtime-sync.test.ts
@@ -57,7 +57,7 @@ describe('connection runtime synchronization', () => {
     mockFetch.mockResolvedValue(new Response(null, { status: 200 }))
   })
 
-  it('writes the active remote MCP projection with stable ordering', async () => {
+  it('writes active and auth-required MCPs with stable ordering', async () => {
     mockWhere.mockResolvedValue([
       {
         mcp: {
@@ -83,6 +83,14 @@ describe('connection runtime synchronization', () => {
           toolsJson: JSON.stringify([{ name: 'list' }]),
         },
       },
+      {
+        mcp: {
+          id: 'mcp-error',
+          name: 'Broken',
+          status: 'error',
+          toolsJson: null,
+        },
+      },
     ])
 
     await updateRemoteMcpEnvironment('agent-1', {
@@ -97,19 +105,28 @@ describe('connection runtime synchronization', () => {
       {
         id: 'mcp-a',
         name: 'Alpha',
+        status: 'active',
         proxyUrl: 'http://10.20.30.40:3000/api/mcp-proxy/agent-1/mcp-a',
         tools: [{ name: 'list' }],
       },
       {
+        id: 'mcp-disabled',
+        name: 'Disabled',
+        status: 'auth_required',
+        proxyUrl: 'http://10.20.30.40:3000/api/mcp-proxy/agent-1/mcp-disabled',
+        tools: [],
+      },
+      {
         id: 'mcp-z',
         name: 'Zed',
+        status: 'active',
         proxyUrl: 'http://10.20.30.40:3000/api/mcp-proxy/agent-1/mcp-z',
         tools: [{ name: 'search' }],
       },
     ])
   })
 
-  it('writes active connected-account metadata grouped by toolkit', async () => {
+  it('writes active and reconnectable connected-account metadata grouped by toolkit', async () => {
     mockWhere.mockResolvedValue([
       {
         account: {
@@ -146,8 +163,11 @@ describe('connection runtime synchronization', () => {
     const payload = JSON.parse(init.body as string)
     expect(payload.key).toBe('CONNECTED_ACCOUNTS')
     expect(JSON.parse(payload.value)).toEqual({
-      gmail: [{ name: 'Work Gmail', id: 'gmail-1' }],
-      slack: [{ name: 'Work Slack', id: 'slack-1' }],
+      gmail: [
+        { name: 'Work Gmail', id: 'gmail-1', status: 'active' },
+        { name: 'Old Gmail', id: 'gmail-expired', status: 'expired' },
+      ],
+      slack: [{ name: 'Work Slack', id: 'slack-1', status: 'active' }],
     })
   })
 

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -315,7 +315,7 @@ describe('containerManager.ensureRunning — env var construction', () => {
     expect(mockStart.mock.calls[0][0].envVars.AGENT_BROWSER_USE_HOST).toBe('1')
   })
 
-  it('CONNECTED_ACCOUNTS includes only active accounts, grouped by toolkitSlug', async () => {
+  it('CONNECTED_ACCOUNTS includes active and reconnectable assigned accounts, grouped by toolkitSlug', async () => {
     setupAccountMocks([
       { id: 'acc-1', toolkitSlug: 'gmail', displayName: 'user@gmail.com', status: 'active', providerConnectionId: 'c1', providerName: 'composio' },
       { id: 'acc-2', toolkitSlug: 'gmail', displayName: 'user2@gmail.com', status: 'active', providerConnectionId: 'c2', providerName: 'composio' },
@@ -330,10 +330,12 @@ describe('containerManager.ensureRunning — env var construction', () => {
 
     expect(metadata.gmail).toHaveLength(2)
     expect(metadata.slack).toHaveLength(1)
-    expect(metadata.github).toBeUndefined() // expired, excluded
+    expect(metadata.github).toEqual([
+      { name: 'My GH', id: 'acc-4', status: 'expired' },
+    ])
   })
 
-  it('each account entry has { name, id } structure', async () => {
+  it('each account entry has { name, id, status } structure', async () => {
     setupAccountMocks([
       { id: 'acc-1', toolkitSlug: 'gmail', displayName: 'user@gmail.com', status: 'active', providerConnectionId: 'c1', providerName: 'composio' },
     ])
@@ -343,7 +345,7 @@ describe('containerManager.ensureRunning — env var construction', () => {
     const startOpts = mockStart.mock.calls[0][0]
     const metadata = JSON.parse(startOpts.envVars.CONNECTED_ACCOUNTS)
 
-    expect(metadata.gmail[0]).toEqual({ name: 'user@gmail.com', id: 'acc-1' })
+    expect(metadata.gmail[0]).toEqual({ name: 'user@gmail.com', id: 'acc-1', status: 'active' })
   })
 
   it('empty CONNECTED_ACCOUNTS ({}) when no accounts exist', async () => {
@@ -356,11 +358,12 @@ describe('containerManager.ensureRunning — env var construction', () => {
     expect(metadata).toEqual({})
   })
 
-  it('inactive accounts are excluded from metadata', async () => {
+  it('unknown inactive statuses are excluded while expired accounts remain available for reconnect', async () => {
     setupAccountMocks([
       { id: 'acc-1', toolkitSlug: 'gmail', displayName: 'active@gmail.com', status: 'active', providerConnectionId: 'c1', providerName: 'composio' },
       { id: 'acc-2', toolkitSlug: 'gmail', displayName: 'inactive@gmail.com', status: 'inactive', providerConnectionId: 'c2', providerName: 'composio' },
       { id: 'acc-3', toolkitSlug: 'slack', displayName: 'expired-slack', status: 'expired', providerConnectionId: 'c3', providerName: 'composio' },
+      { id: 'acc-4', toolkitSlug: 'notion', displayName: 'revoked-notion', status: 'revoked', providerConnectionId: 'c4', providerName: 'composio' },
     ])
 
     await containerManager.ensureRunning('test-agent')
@@ -370,7 +373,12 @@ describe('containerManager.ensureRunning — env var construction', () => {
 
     expect(metadata.gmail).toHaveLength(1)
     expect(metadata.gmail[0].name).toBe('active@gmail.com')
-    expect(metadata.slack).toBeUndefined()
+    expect(metadata.slack).toEqual([
+      { name: 'expired-slack', id: 'acc-3', status: 'expired' },
+    ])
+    expect(metadata.notion).toEqual([
+      { name: 'revoked-notion', id: 'acc-4', status: 'revoked' },
+    ])
   })
 
   it('serializes connection projections in stable id order', async () => {
@@ -388,6 +396,7 @@ describe('containerManager.ensureRunning — env var construction', () => {
           toolsJson: JSON.stringify([{ name: 'search' }, { invalid: true }]),
         },
         { id: 'mcp-disabled', name: 'Disabled', status: 'auth_required', toolsJson: null },
+        { id: 'mcp-error', name: 'Broken', status: 'error', toolsJson: null },
         { id: 'mcp-a', name: 'Alpha', status: 'active', toolsJson: '[]' },
       ],
     )
@@ -397,15 +406,16 @@ describe('containerManager.ensureRunning — env var construction', () => {
     const envVars = mockStart.mock.calls[0][0].envVars
     expect(JSON.parse(envVars.CONNECTED_ACCOUNTS)).toEqual({
       gmail: [
-        { name: 'Gmail A', id: 'gmail-a' },
-        { name: 'Gmail Z', id: 'gmail-z' },
+        { name: 'Gmail A', id: 'gmail-a', status: 'active' },
+        { name: 'Gmail Z', id: 'gmail-z', status: 'active' },
       ],
-      slack: [{ name: 'Slack Z', id: 'slack-z' }],
+      slack: [{ name: 'Slack Z', id: 'slack-z', status: 'active' }],
     })
     const mcpConfigs = JSON.parse(envVars.REMOTE_MCPS)
     expect(mcpConfigs.map((mcp: { id: string }) => mcp.id))
-      .toEqual(['mcp-a', 'mcp-z'])
-    expect(mcpConfigs[1].tools).toEqual([{ name: 'search' }])
+      .toEqual(['mcp-a', 'mcp-disabled', 'mcp-z'])
+    expect(mcpConfigs[1]).toMatchObject({ status: 'auth_required', tools: [] })
+    expect(mcpConfigs[2].tools).toEqual([{ name: 'search' }])
   })
 
   it('sets TZ env var from resolveTimezoneForAgent', async () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -343,12 +343,13 @@ class MessagePersister {
       return
     }
 
-    // Account re-auth requests are agent-scoped but have no safe actionable
-    // OS-notification flow: OAuth must be opened from the in-app card.
-    if (request.kind === 'account_reauth_required' || request.kind === 'mcp_reauth_required') return
-
     const sessionId = request.scope.sessionId
+    // Agent-scoped reviews and re-auth requests have no session id and no safe
+    // actionable OS-notification flow; their in-app cards are the prompt.
     if (!sessionId) return
+    // Defensive type boundary if a future caller violates the agent-scoped
+    // re-auth invariant; these kinds are not accepted notification categories.
+    if (request.kind === 'account_reauth_required' || request.kind === 'mcp_reauth_required') return
     const waitingFor =
       request.kind === 'capability_review'
         ? (request.payload as { capability?: unknown }).capability === 'workflows'

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -100,7 +100,7 @@ interface SubagentStreamingState {
  */
 type StreamRequestKind = Exclude<
   UserInputRequestKind,
-  'computer_use' | 'proxy_review' | 'x_agent_review'
+  'computer_use' | 'proxy_review' | 'x_agent_review' | 'account_reauth_required' | 'mcp_reauth_required'
 >
 
 // Tracks streaming state for SSE broadcasts
@@ -342,6 +342,10 @@ class MessagePersister {
         })
       return
     }
+
+    // Account re-auth requests are agent-scoped but have no safe actionable
+    // OS-notification flow: OAuth must be opened from the in-app card.
+    if (request.kind === 'account_reauth_required' || request.kind === 'mcp_reauth_required') return
 
     const sessionId = request.scope.sessionId
     if (!sessionId) return

--- a/src/shared/lib/proxy/account-reauth-manager.test.ts
+++ b/src/shared/lib/proxy/account-reauth-manager.test.ts
@@ -70,6 +70,29 @@ describe('AccountReauthManager', () => {
     await expect(unrelated).resolves.toBeUndefined()
   })
 
+  it('deduplicates concurrent waits for one account into a single agent card', async () => {
+    const first = manager.requestReauth(DETAILS)
+    const second = manager.requestReauth(DETAILS)
+
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(1)
+    expect(manager.completeAccount('account-1')).toBe(2)
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+  })
+
+  it('keeps the shared card open when only one concurrent proxy request aborts', async () => {
+    const controller = new AbortController()
+    const aborted = manager.requestReauth(DETAILS, controller.signal)
+    const remaining = manager.requestReauth(DETAILS)
+    const rejection = expect(aborted).rejects.toThrow('aborted')
+
+    controller.abort()
+
+    await rejection
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(1)
+    expect(manager.completeAccount('account-1')).toBe(1)
+    await expect(remaining).resolves.toBeUndefined()
+  })
+
   it('rejects and settles the wait after the timeout', async () => {
     const promise = manager.requestReauth(DETAILS)
     const rejection = expect(promise).rejects.toThrow('timed out')

--- a/src/shared/lib/proxy/account-reauth-manager.test.ts
+++ b/src/shared/lib/proxy/account-reauth-manager.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSyncAgentSessionsAwaiting = vi.fn()
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    syncAgentSessionsAwaiting: (...args: unknown[]) => mockSyncAgentSessionsAwaiting(...args),
+  },
+}))
+
+import {
+  ACCOUNT_REAUTH_TIMEOUT_MS,
+  AccountReauthManager,
+} from './account-reauth-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+
+const DETAILS = {
+  agentSlug: 'agent-1',
+  accountId: 'account-1',
+  toolkit: 'gmail',
+  accountStatus: 'expired' as const,
+}
+
+describe('AccountReauthManager', () => {
+  let manager: AccountReauthManager
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    userInputRequestManager.reset()
+    mockSyncAgentSessionsAwaiting.mockReset()
+    manager = new AccountReauthManager()
+  })
+
+  afterEach(() => {
+    manager.rejectAll()
+    userInputRequestManager.reset()
+    vi.useRealTimers()
+  })
+
+  it('registers an agent-scoped envelope with the proxy request id', () => {
+    const promise = manager.requestReauth(DETAILS)
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+
+    expect(request).toMatchObject({
+      kind: 'account_reauth_required',
+      blocking: true,
+      scope: { agentSlug: 'agent-1' },
+      payload: {
+        accountId: 'account-1',
+        toolkit: 'gmail',
+        accountStatus: 'expired',
+      },
+    })
+    expect((request.payload as Record<string, unknown>).proxyRequestId).toBe(request.id)
+
+    manager.completeAccount('account-1')
+    return expect(promise).resolves.toBeUndefined()
+  })
+
+  it('resumes all proxy requests parked on the reconnected account', async () => {
+    const first = manager.requestReauth(DETAILS)
+    const second = manager.requestReauth({ ...DETAILS, agentSlug: 'agent-2' })
+    const unrelated = manager.requestReauth({ ...DETAILS, accountId: 'account-2' })
+
+    expect(manager.completeAccount('account-1')).toBe(2)
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+    expect(userInputRequestManager.getOpenRequestsForStore('review')).toHaveLength(1)
+
+    manager.completeAccount('account-2')
+    await expect(unrelated).resolves.toBeUndefined()
+  })
+
+  it('rejects and settles the wait after the timeout', async () => {
+    const promise = manager.requestReauth(DETAILS)
+    const rejection = expect(promise).rejects.toThrow('timed out')
+
+    await vi.advanceTimersByTimeAsync(ACCOUNT_REAUTH_TIMEOUT_MS)
+
+    await rejection
+    expect(userInputRequestManager.getOpenRequestsForStore('review')).toHaveLength(0)
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)?.outcome).toBe('timeout')
+  })
+
+  it('cancels the wait when the proxy request is aborted', async () => {
+    const controller = new AbortController()
+    const promise = manager.requestReauth(DETAILS, controller.signal)
+    const rejection = expect(promise).rejects.toThrow('aborted')
+
+    controller.abort()
+
+    await rejection
+    expect(userInputRequestManager.getOpenRequestsForStore('review')).toHaveLength(0)
+  })
+})

--- a/src/shared/lib/proxy/account-reauth-manager.ts
+++ b/src/shared/lib/proxy/account-reauth-manager.ts
@@ -12,10 +12,20 @@ export interface AccountReauthDetails {
   accountStatus: 'expired' | 'revoked'
 }
 
-interface ReauthSettler {
+interface ReauthWaiter {
   resolve: () => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
+  signal?: AbortSignal
+  onAbort?: () => void
+}
+
+interface AccountReauthGroup {
+  key: string
+  entryId: string
+  agentSlug: string
+  accountId: string
+  waiters: Set<ReauthWaiter>
 }
 
 type AccountReauthEntry = Extract<PendingUserInputRequest, { kind: 'account_reauth_required' }>
@@ -31,7 +41,8 @@ type AccountReauthEntry = Extract<PendingUserInputRequest, { kind: 'account_reau
  * request resume after the OAuth completion route activates the account.
  */
 export class AccountReauthManager {
-  private settlers = new Map<string, ReauthSettler>()
+  private groups = new Map<string, AccountReauthGroup>()
+  private entryIdByKey = new Map<string, string>()
 
   private static isAccountReauthEntry(
     request: PendingUserInputRequest,
@@ -39,64 +50,139 @@ export class AccountReauthManager {
     return request.kind === 'account_reauth_required'
   }
 
-  private settle(
-    entry: AccountReauthEntry,
-    outcome: 'answered' | 'cancelled' | 'timeout',
-    action: { type: 'resolve' } | { type: 'reject'; error: Error },
-  ): void {
-    const settler = this.settlers.get(entry.id)
-    this.settlers.delete(entry.id)
-    if (settler) clearTimeout(settler.timer)
-    userInputRequestManager.resolve(entry.id, outcome)
-    if (settler) {
-      if (action.type === 'resolve') settler.resolve()
-      else settler.reject(action.error)
+  private cleanupWaiter(waiter: ReauthWaiter): void {
+    clearTimeout(waiter.timer)
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort)
     }
   }
 
+  private settleGroup(
+    group: AccountReauthGroup,
+    outcome: 'answered' | 'cancelled' | 'timeout',
+    action: { type: 'resolve' } | { type: 'reject'; error: Error },
+  ): number {
+    this.groups.delete(group.entryId)
+    if (this.entryIdByKey.get(group.key) === group.entryId) {
+      this.entryIdByKey.delete(group.key)
+    }
+
+    const entry = userInputRequestManager.getOpenRequest(group.entryId)
+    if (entry && AccountReauthManager.isAccountReauthEntry(entry)) {
+      userInputRequestManager.resolve(entry.id, outcome)
+    }
+
+    const waiters = [...group.waiters]
+    group.waiters.clear()
+    for (const waiter of waiters) {
+      this.cleanupWaiter(waiter)
+      if (action.type === 'resolve') waiter.resolve()
+      else waiter.reject(action.error)
+    }
+    messagePersister.syncAgentSessionsAwaiting(group.agentSlug)
+    return waiters.length
+  }
+
+  private rejectWaiter(
+    group: AccountReauthGroup,
+    waiter: ReauthWaiter,
+    outcome: 'cancelled' | 'timeout',
+    error: Error,
+  ): void {
+    if (!group.waiters.delete(waiter)) return
+    this.cleanupWaiter(waiter)
+    waiter.reject(error)
+
+    // Keep the shared card open while another HTTP request is still parked on
+    // the same credential. The final waiter owns the registry resolution.
+    if (group.waiters.size > 0) return
+
+    this.groups.delete(group.entryId)
+    if (this.entryIdByKey.get(group.key) === group.entryId) {
+      this.entryIdByKey.delete(group.key)
+    }
+    const entry = userInputRequestManager.getOpenRequest(group.entryId)
+    if (entry && AccountReauthManager.isAccountReauthEntry(entry)) {
+      userInputRequestManager.resolve(entry.id, outcome)
+    }
+    messagePersister.syncAgentSessionsAwaiting(group.agentSlug)
+  }
+
   requestReauth(details: AccountReauthDetails, signal?: AbortSignal): Promise<void> {
-    const id = crypto.randomUUID()
+    // Requests share one credential but the registry scope can name only one
+    // agent. Deduplicate within that visible scope; completing the account
+    // still settles every group across every assigned agent.
+    const key = `${details.agentSlug}\0${details.accountId}`
+    const existingId = this.entryIdByKey.get(key)
+    let group = existingId ? this.groups.get(existingId) : undefined
+    let isNewGroup = false
+
+    if (group) {
+      const entry = userInputRequestManager.getOpenRequest(group.entryId)
+      if (!entry || !AccountReauthManager.isAccountReauthEntry(entry)) {
+        this.settleGroup(group, 'cancelled', {
+          type: 'reject',
+          error: new Error('Account re-authentication request was lost'),
+        })
+        group = undefined
+      }
+    }
+
+    if (!group) {
+      if (existingId) this.entryIdByKey.delete(key)
+      const entryId = crypto.randomUUID()
+      group = {
+        key,
+        entryId,
+        agentSlug: details.agentSlug,
+        accountId: details.accountId,
+        waiters: new Set(),
+      }
+      this.groups.set(entryId, group)
+      this.entryIdByKey.set(key, entryId)
+      isNewGroup = true
+    }
+
+    const activeGroup = group
 
     return new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        const entry = userInputRequestManager.getOpenRequest(id)
-        if (!entry || !AccountReauthManager.isAccountReauthEntry(entry)) {
-          const orphan = this.settlers.get(id)
-          if (!orphan) return
-          this.settlers.delete(id)
-          orphan.reject(new Error('Account re-authentication request was lost'))
-          return
-        }
-        this.settle(entry, 'timeout', {
-          type: 'reject',
-          error: new Error('Account re-authentication timed out'),
-        })
-        messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
-      }, ACCOUNT_REAUTH_TIMEOUT_MS)
-
-      this.settlers.set(id, { resolve, reject, timer })
-
       if (signal?.aborted) {
-        clearTimeout(timer)
-        this.settlers.delete(id)
+        if (isNewGroup && activeGroup.waiters.size === 0) {
+          this.groups.delete(activeGroup.entryId)
+          this.entryIdByKey.delete(activeGroup.key)
+        }
         reject(new Error('Proxy request aborted while awaiting re-authentication'))
         return
       }
 
+      let waiter: ReauthWaiter
+      const timer = setTimeout(() => {
+        this.rejectWaiter(
+          activeGroup,
+          waiter,
+          'timeout',
+          new Error('Account re-authentication timed out'),
+        )
+      }, ACCOUNT_REAUTH_TIMEOUT_MS)
+
+      waiter = { resolve, reject, timer, signal }
       if (signal) {
-        signal.addEventListener('abort', () => {
-          const entry = userInputRequestManager.getOpenRequest(id)
-          if (!entry || !AccountReauthManager.isAccountReauthEntry(entry)) return
-          this.settle(entry, 'cancelled', {
-            type: 'reject',
-            error: new Error('Proxy request aborted while awaiting re-authentication'),
-          })
-          messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
-        }, { once: true })
+        waiter.onAbort = () => {
+          this.rejectWaiter(
+            activeGroup,
+            waiter,
+            'cancelled',
+            new Error('Proxy request aborted while awaiting re-authentication'),
+          )
+        }
+        signal.addEventListener('abort', waiter.onAbort, { once: true })
       }
+      activeGroup.waiters.add(waiter)
+
+      if (!isNewGroup) return
 
       const registered = userInputRequestManager.register({
-        id,
+        id: activeGroup.entryId,
         kind: 'account_reauth_required',
         scope: { agentSlug: details.agentSlug },
         blocking: true,
@@ -105,14 +191,15 @@ export class AccountReauthManager {
           accountId: details.accountId,
           toolkit: details.toolkit,
           accountStatus: details.accountStatus,
-          proxyRequestId: id,
+          proxyRequestId: activeGroup.entryId,
         },
       })
 
       if (!registered) {
-        clearTimeout(timer)
-        this.settlers.delete(id)
-        reject(new Error('Failed to register account re-authentication request'))
+        this.settleGroup(activeGroup, 'cancelled', {
+          type: 'reject',
+          error: new Error('Failed to register account re-authentication request'),
+        })
         return
       }
 
@@ -122,44 +209,20 @@ export class AccountReauthManager {
 
   /** Resume every parked proxy request that uses the reconnected account. */
   completeAccount(accountId: string): number {
-    const agentSlugs = new Set<string>()
     let completed = 0
-
-    for (const request of userInputRequestManager.getOpenRequestsForStore('review')) {
-      if (!AccountReauthManager.isAccountReauthEntry(request)) continue
-      const payload = request.payload as Record<string, unknown>
-      if (payload.accountId !== accountId) continue
-      if (request.scope.agentSlug) agentSlugs.add(request.scope.agentSlug)
-      this.settle(request, 'answered', { type: 'resolve' })
-      completed++
-    }
-
-    for (const agentSlug of agentSlugs) {
-      messagePersister.syncAgentSessionsAwaiting(agentSlug)
+    for (const group of [...this.groups.values()]) {
+      if (group.accountId !== accountId) continue
+      completed += this.settleGroup(group, 'answered', { type: 'resolve' })
     }
     return completed
   }
 
   rejectAll(): void {
-    const agentSlugs = new Set<string>()
-    for (const request of userInputRequestManager.getOpenRequestsForStore('review')) {
-      if (!AccountReauthManager.isAccountReauthEntry(request)) continue
-      if (request.scope.agentSlug) agentSlugs.add(request.scope.agentSlug)
-      this.settle(request, 'cancelled', {
+    for (const group of [...this.groups.values()]) {
+      this.settleGroup(group, 'cancelled', {
         type: 'reject',
         error: new Error('Account re-authentication interrupted by shutdown'),
       })
-    }
-
-    // Defensive cleanup for a settler whose registry entry disappeared.
-    for (const [id, settler] of this.settlers) {
-      clearTimeout(settler.timer)
-      this.settlers.delete(id)
-      settler.reject(new Error('Account re-authentication interrupted by shutdown'))
-    }
-
-    for (const agentSlug of agentSlugs) {
-      messagePersister.syncAgentSessionsAwaiting(agentSlug)
     }
   }
 }

--- a/src/shared/lib/proxy/account-reauth-manager.ts
+++ b/src/shared/lib/proxy/account-reauth-manager.ts
@@ -1,0 +1,176 @@
+import crypto from 'crypto'
+import { messagePersister } from '@shared/lib/container/message-persister'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
+
+export const ACCOUNT_REAUTH_TIMEOUT_MS = 5 * 60 * 1000
+
+export interface AccountReauthDetails {
+  agentSlug: string
+  accountId: string
+  toolkit: string
+  accountStatus: 'expired' | 'revoked'
+}
+
+interface ReauthSettler {
+  resolve: () => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+type AccountReauthEntry = Extract<PendingUserInputRequest, { kind: 'account_reauth_required' }>
+
+/**
+ * Parks proxy requests while an expired/revoked account is re-authorized.
+ *
+ * The user-input registry is the durable announcement channel: registering an
+ * account_reauth_required envelope broadcasts the unified SSE created event.
+ * Its payload carries accountId, toolkit, and proxyRequestId. The envelope
+ * also keeps every session for the agent in the awaiting-input state. This
+ * class owns only the in-memory promise settlers that let the original HTTP
+ * request resume after the OAuth completion route activates the account.
+ */
+export class AccountReauthManager {
+  private settlers = new Map<string, ReauthSettler>()
+
+  private static isAccountReauthEntry(
+    request: PendingUserInputRequest,
+  ): request is AccountReauthEntry {
+    return request.kind === 'account_reauth_required'
+  }
+
+  private settle(
+    entry: AccountReauthEntry,
+    outcome: 'answered' | 'cancelled' | 'timeout',
+    action: { type: 'resolve' } | { type: 'reject'; error: Error },
+  ): void {
+    const settler = this.settlers.get(entry.id)
+    this.settlers.delete(entry.id)
+    if (settler) clearTimeout(settler.timer)
+    userInputRequestManager.resolve(entry.id, outcome)
+    if (settler) {
+      if (action.type === 'resolve') settler.resolve()
+      else settler.reject(action.error)
+    }
+  }
+
+  requestReauth(details: AccountReauthDetails, signal?: AbortSignal): Promise<void> {
+    const id = crypto.randomUUID()
+
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const entry = userInputRequestManager.getOpenRequest(id)
+        if (!entry || !AccountReauthManager.isAccountReauthEntry(entry)) {
+          const orphan = this.settlers.get(id)
+          if (!orphan) return
+          this.settlers.delete(id)
+          orphan.reject(new Error('Account re-authentication request was lost'))
+          return
+        }
+        this.settle(entry, 'timeout', {
+          type: 'reject',
+          error: new Error('Account re-authentication timed out'),
+        })
+        messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
+      }, ACCOUNT_REAUTH_TIMEOUT_MS)
+
+      this.settlers.set(id, { resolve, reject, timer })
+
+      if (signal?.aborted) {
+        clearTimeout(timer)
+        this.settlers.delete(id)
+        reject(new Error('Proxy request aborted while awaiting re-authentication'))
+        return
+      }
+
+      if (signal) {
+        signal.addEventListener('abort', () => {
+          const entry = userInputRequestManager.getOpenRequest(id)
+          if (!entry || !AccountReauthManager.isAccountReauthEntry(entry)) return
+          this.settle(entry, 'cancelled', {
+            type: 'reject',
+            error: new Error('Proxy request aborted while awaiting re-authentication'),
+          })
+          messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
+        }, { once: true })
+      }
+
+      const registered = userInputRequestManager.register({
+        id,
+        kind: 'account_reauth_required',
+        scope: { agentSlug: details.agentSlug },
+        blocking: true,
+        autoApproved: false,
+        payload: {
+          accountId: details.accountId,
+          toolkit: details.toolkit,
+          accountStatus: details.accountStatus,
+          proxyRequestId: id,
+        },
+      })
+
+      if (!registered) {
+        clearTimeout(timer)
+        this.settlers.delete(id)
+        reject(new Error('Failed to register account re-authentication request'))
+        return
+      }
+
+      messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
+    })
+  }
+
+  /** Resume every parked proxy request that uses the reconnected account. */
+  completeAccount(accountId: string): number {
+    const agentSlugs = new Set<string>()
+    let completed = 0
+
+    for (const request of userInputRequestManager.getOpenRequestsForStore('review')) {
+      if (!AccountReauthManager.isAccountReauthEntry(request)) continue
+      const payload = request.payload as Record<string, unknown>
+      if (payload.accountId !== accountId) continue
+      if (request.scope.agentSlug) agentSlugs.add(request.scope.agentSlug)
+      this.settle(request, 'answered', { type: 'resolve' })
+      completed++
+    }
+
+    for (const agentSlug of agentSlugs) {
+      messagePersister.syncAgentSessionsAwaiting(agentSlug)
+    }
+    return completed
+  }
+
+  rejectAll(): void {
+    const agentSlugs = new Set<string>()
+    for (const request of userInputRequestManager.getOpenRequestsForStore('review')) {
+      if (!AccountReauthManager.isAccountReauthEntry(request)) continue
+      if (request.scope.agentSlug) agentSlugs.add(request.scope.agentSlug)
+      this.settle(request, 'cancelled', {
+        type: 'reject',
+        error: new Error('Account re-authentication interrupted by shutdown'),
+      })
+    }
+
+    // Defensive cleanup for a settler whose registry entry disappeared.
+    for (const [id, settler] of this.settlers) {
+      clearTimeout(settler.timer)
+      this.settlers.delete(id)
+      settler.reject(new Error('Account re-authentication interrupted by shutdown'))
+    }
+
+    for (const agentSlug of agentSlugs) {
+      messagePersister.syncAgentSessionsAwaiting(agentSlug)
+    }
+  }
+}
+
+const globalForAccountReauthManager = globalThis as unknown as {
+  accountReauthManager: AccountReauthManager | undefined
+}
+
+export const accountReauthManager =
+  globalForAccountReauthManager.accountReauthManager ?? new AccountReauthManager()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForAccountReauthManager.accountReauthManager = accountReauthManager
+}

--- a/src/shared/lib/proxy/mcp-reauth-manager.test.ts
+++ b/src/shared/lib/proxy/mcp-reauth-manager.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSyncAgentSessionsAwaiting = vi.fn()
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    syncAgentSessionsAwaiting: (...args: unknown[]) => mockSyncAgentSessionsAwaiting(...args),
+  },
+}))
+
+import { MCP_REAUTH_TIMEOUT_MS, McpReauthManager } from './mcp-reauth-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+
+const DETAILS = {
+  agentSlug: 'agent-1',
+  mcpId: 'mcp-1',
+  mcpName: 'Cal.com',
+  authType: 'oauth' as const,
+}
+
+describe('McpReauthManager', () => {
+  let manager: McpReauthManager
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    userInputRequestManager.reset()
+    mockSyncAgentSessionsAwaiting.mockReset()
+    manager = new McpReauthManager()
+  })
+
+  afterEach(() => {
+    manager.rejectAll()
+    userInputRequestManager.reset()
+    vi.useRealTimers()
+  })
+
+  it('registers an agent-scoped MCP re-auth envelope', () => {
+    const promise = manager.requestReauth(DETAILS)
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+
+    expect(request).toMatchObject({
+      kind: 'mcp_reauth_required',
+      blocking: true,
+      scope: { agentSlug: 'agent-1' },
+      payload: {
+        mcpId: 'mcp-1',
+        mcpName: 'Cal.com',
+        authType: 'oauth',
+      },
+    })
+    expect((request.payload as Record<string, unknown>).proxyRequestId).toBe(request.id)
+
+    manager.completeMcp('mcp-1')
+    return expect(promise).resolves.toBeUndefined()
+  })
+
+  it('resumes every proxy request parked on the reconnected MCP', async () => {
+    const first = manager.requestReauth(DETAILS)
+    const second = manager.requestReauth({ ...DETAILS, agentSlug: 'agent-2' })
+    const unrelated = manager.requestReauth({ ...DETAILS, mcpId: 'mcp-2' })
+
+    expect(manager.completeMcp('mcp-1')).toBe(2)
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+    expect(userInputRequestManager.getOpenRequestsForStore('review')).toHaveLength(1)
+
+    manager.completeMcp('mcp-2')
+    await expect(unrelated).resolves.toBeUndefined()
+  })
+
+  it('settles an abandoned request after the timeout', async () => {
+    const promise = manager.requestReauth(DETAILS)
+    const rejection = expect(promise).rejects.toThrow('timed out')
+
+    await vi.advanceTimersByTimeAsync(MCP_REAUTH_TIMEOUT_MS)
+
+    await rejection
+    expect(userInputRequestManager.getOpenRequestsForStore('review')).toHaveLength(0)
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)?.outcome).toBe('timeout')
+  })
+
+  it('cancels the wait when the proxy request is aborted', async () => {
+    const controller = new AbortController()
+    const promise = manager.requestReauth(DETAILS, controller.signal)
+    const rejection = expect(promise).rejects.toThrow('aborted')
+
+    controller.abort()
+
+    await rejection
+    expect(userInputRequestManager.getOpenRequestsForStore('review')).toHaveLength(0)
+  })
+})

--- a/src/shared/lib/proxy/mcp-reauth-manager.test.ts
+++ b/src/shared/lib/proxy/mcp-reauth-manager.test.ts
@@ -67,6 +67,29 @@ describe('McpReauthManager', () => {
     await expect(unrelated).resolves.toBeUndefined()
   })
 
+  it('deduplicates concurrent waits for one MCP into a single agent card', async () => {
+    const first = manager.requestReauth(DETAILS)
+    const second = manager.requestReauth(DETAILS)
+
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(1)
+    expect(manager.completeMcp('mcp-1')).toBe(2)
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+  })
+
+  it('keeps the shared card open when only one concurrent MCP request aborts', async () => {
+    const controller = new AbortController()
+    const aborted = manager.requestReauth(DETAILS, controller.signal)
+    const remaining = manager.requestReauth(DETAILS)
+    const rejection = expect(aborted).rejects.toThrow('aborted')
+
+    controller.abort()
+
+    await rejection
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(1)
+    expect(manager.completeMcp('mcp-1')).toBe(1)
+    await expect(remaining).resolves.toBeUndefined()
+  })
+
   it('settles an abandoned request after the timeout', async () => {
     const promise = manager.requestReauth(DETAILS)
     const rejection = expect(promise).rejects.toThrow('timed out')

--- a/src/shared/lib/proxy/mcp-reauth-manager.ts
+++ b/src/shared/lib/proxy/mcp-reauth-manager.ts
@@ -12,10 +12,20 @@ export interface McpReauthDetails {
   authType: 'none' | 'oauth' | 'bearer'
 }
 
-interface ReauthSettler {
+interface ReauthWaiter {
   resolve: () => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
+  signal?: AbortSignal
+  onAbort?: () => void
+}
+
+interface McpReauthGroup {
+  key: string
+  entryId: string
+  agentSlug: string
+  mcpId: string
+  waiters: Set<ReauthWaiter>
 }
 
 type McpReauthEntry = Extract<PendingUserInputRequest, { kind: 'mcp_reauth_required' }>
@@ -26,7 +36,8 @@ type McpReauthEntry = Extract<PendingUserInputRequest, { kind: 'mcp_reauth_requi
  * in-memory promise that resumes the original HTTP request after reconnection.
  */
 export class McpReauthManager {
-  private settlers = new Map<string, ReauthSettler>()
+  private groups = new Map<string, McpReauthGroup>()
+  private entryIdByKey = new Map<string, string>()
 
   private static isMcpReauthEntry(
     request: PendingUserInputRequest,
@@ -34,64 +45,132 @@ export class McpReauthManager {
     return request.kind === 'mcp_reauth_required'
   }
 
-  private settle(
-    entry: McpReauthEntry,
-    outcome: 'answered' | 'cancelled' | 'timeout',
-    action: { type: 'resolve' } | { type: 'reject'; error: Error },
-  ): void {
-    const settler = this.settlers.get(entry.id)
-    this.settlers.delete(entry.id)
-    if (settler) clearTimeout(settler.timer)
-    userInputRequestManager.resolve(entry.id, outcome)
-    if (settler) {
-      if (action.type === 'resolve') settler.resolve()
-      else settler.reject(action.error)
+  private cleanupWaiter(waiter: ReauthWaiter): void {
+    clearTimeout(waiter.timer)
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort)
     }
   }
 
+  private settleGroup(
+    group: McpReauthGroup,
+    outcome: 'answered' | 'cancelled' | 'timeout',
+    action: { type: 'resolve' } | { type: 'reject'; error: Error },
+  ): number {
+    this.groups.delete(group.entryId)
+    if (this.entryIdByKey.get(group.key) === group.entryId) {
+      this.entryIdByKey.delete(group.key)
+    }
+    const entry = userInputRequestManager.getOpenRequest(group.entryId)
+    if (entry && McpReauthManager.isMcpReauthEntry(entry)) {
+      userInputRequestManager.resolve(entry.id, outcome)
+    }
+
+    const waiters = [...group.waiters]
+    group.waiters.clear()
+    for (const waiter of waiters) {
+      this.cleanupWaiter(waiter)
+      if (action.type === 'resolve') waiter.resolve()
+      else waiter.reject(action.error)
+    }
+    messagePersister.syncAgentSessionsAwaiting(group.agentSlug)
+    return waiters.length
+  }
+
+  private rejectWaiter(
+    group: McpReauthGroup,
+    waiter: ReauthWaiter,
+    outcome: 'cancelled' | 'timeout',
+    error: Error,
+  ): void {
+    if (!group.waiters.delete(waiter)) return
+    this.cleanupWaiter(waiter)
+    waiter.reject(error)
+    if (group.waiters.size > 0) return
+
+    this.groups.delete(group.entryId)
+    if (this.entryIdByKey.get(group.key) === group.entryId) {
+      this.entryIdByKey.delete(group.key)
+    }
+    const entry = userInputRequestManager.getOpenRequest(group.entryId)
+    if (entry && McpReauthManager.isMcpReauthEntry(entry)) {
+      userInputRequestManager.resolve(entry.id, outcome)
+    }
+    messagePersister.syncAgentSessionsAwaiting(group.agentSlug)
+  }
+
   requestReauth(details: McpReauthDetails, signal?: AbortSignal): Promise<void> {
-    const id = crypto.randomUUID()
+    const key = `${details.agentSlug}\0${details.mcpId}`
+    const existingId = this.entryIdByKey.get(key)
+    let group = existingId ? this.groups.get(existingId) : undefined
+    let isNewGroup = false
+
+    if (group) {
+      const entry = userInputRequestManager.getOpenRequest(group.entryId)
+      if (!entry || !McpReauthManager.isMcpReauthEntry(entry)) {
+        this.settleGroup(group, 'cancelled', {
+          type: 'reject',
+          error: new Error('MCP re-authentication request was lost'),
+        })
+        group = undefined
+      }
+    }
+
+    if (!group) {
+      if (existingId) this.entryIdByKey.delete(key)
+      const entryId = crypto.randomUUID()
+      group = {
+        key,
+        entryId,
+        agentSlug: details.agentSlug,
+        mcpId: details.mcpId,
+        waiters: new Set(),
+      }
+      this.groups.set(entryId, group)
+      this.entryIdByKey.set(key, entryId)
+      isNewGroup = true
+    }
+
+    const activeGroup = group
 
     return new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        const entry = userInputRequestManager.getOpenRequest(id)
-        if (!entry || !McpReauthManager.isMcpReauthEntry(entry)) {
-          const orphan = this.settlers.get(id)
-          if (!orphan) return
-          this.settlers.delete(id)
-          orphan.reject(new Error('MCP re-authentication request was lost'))
-          return
-        }
-        this.settle(entry, 'timeout', {
-          type: 'reject',
-          error: new Error('MCP re-authentication timed out'),
-        })
-        messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
-      }, MCP_REAUTH_TIMEOUT_MS)
-
-      this.settlers.set(id, { resolve, reject, timer })
-
       if (signal?.aborted) {
-        clearTimeout(timer)
-        this.settlers.delete(id)
+        if (isNewGroup && activeGroup.waiters.size === 0) {
+          this.groups.delete(activeGroup.entryId)
+          this.entryIdByKey.delete(activeGroup.key)
+        }
         reject(new Error('MCP proxy request aborted while awaiting re-authentication'))
         return
       }
 
+      let waiter: ReauthWaiter
+      const timer = setTimeout(() => {
+        this.rejectWaiter(
+          activeGroup,
+          waiter,
+          'timeout',
+          new Error('MCP re-authentication timed out'),
+        )
+      }, MCP_REAUTH_TIMEOUT_MS)
+
+      waiter = { resolve, reject, timer, signal }
       if (signal) {
-        signal.addEventListener('abort', () => {
-          const entry = userInputRequestManager.getOpenRequest(id)
-          if (!entry || !McpReauthManager.isMcpReauthEntry(entry)) return
-          this.settle(entry, 'cancelled', {
-            type: 'reject',
-            error: new Error('MCP proxy request aborted while awaiting re-authentication'),
-          })
-          messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
-        }, { once: true })
+        waiter.onAbort = () => {
+          this.rejectWaiter(
+            activeGroup,
+            waiter,
+            'cancelled',
+            new Error('MCP proxy request aborted while awaiting re-authentication'),
+          )
+        }
+        signal.addEventListener('abort', waiter.onAbort, { once: true })
       }
+      activeGroup.waiters.add(waiter)
+
+      if (!isNewGroup) return
 
       const registered = userInputRequestManager.register({
-        id,
+        id: activeGroup.entryId,
         kind: 'mcp_reauth_required',
         scope: { agentSlug: details.agentSlug },
         blocking: true,
@@ -100,14 +179,15 @@ export class McpReauthManager {
           mcpId: details.mcpId,
           mcpName: details.mcpName,
           authType: details.authType,
-          proxyRequestId: id,
+          proxyRequestId: activeGroup.entryId,
         },
       })
 
       if (!registered) {
-        clearTimeout(timer)
-        this.settlers.delete(id)
-        reject(new Error('Failed to register MCP re-authentication request'))
+        this.settleGroup(activeGroup, 'cancelled', {
+          type: 'reject',
+          error: new Error('Failed to register MCP re-authentication request'),
+        })
         return
       }
 
@@ -117,43 +197,20 @@ export class McpReauthManager {
 
   /** Resume every parked proxy request that uses the reconnected MCP. */
   completeMcp(mcpId: string): number {
-    const agentSlugs = new Set<string>()
     let completed = 0
-
-    for (const request of userInputRequestManager.getOpenRequestsForStore('review')) {
-      if (!McpReauthManager.isMcpReauthEntry(request)) continue
-      const payload = request.payload as Record<string, unknown>
-      if (payload.mcpId !== mcpId) continue
-      if (request.scope.agentSlug) agentSlugs.add(request.scope.agentSlug)
-      this.settle(request, 'answered', { type: 'resolve' })
-      completed++
-    }
-
-    for (const agentSlug of agentSlugs) {
-      messagePersister.syncAgentSessionsAwaiting(agentSlug)
+    for (const group of [...this.groups.values()]) {
+      if (group.mcpId !== mcpId) continue
+      completed += this.settleGroup(group, 'answered', { type: 'resolve' })
     }
     return completed
   }
 
   rejectAll(): void {
-    const agentSlugs = new Set<string>()
-    for (const request of userInputRequestManager.getOpenRequestsForStore('review')) {
-      if (!McpReauthManager.isMcpReauthEntry(request)) continue
-      if (request.scope.agentSlug) agentSlugs.add(request.scope.agentSlug)
-      this.settle(request, 'cancelled', {
+    for (const group of [...this.groups.values()]) {
+      this.settleGroup(group, 'cancelled', {
         type: 'reject',
         error: new Error('MCP re-authentication interrupted by shutdown'),
       })
-    }
-
-    for (const [id, settler] of this.settlers) {
-      clearTimeout(settler.timer)
-      this.settlers.delete(id)
-      settler.reject(new Error('MCP re-authentication interrupted by shutdown'))
-    }
-
-    for (const agentSlug of agentSlugs) {
-      messagePersister.syncAgentSessionsAwaiting(agentSlug)
     }
   }
 }

--- a/src/shared/lib/proxy/mcp-reauth-manager.ts
+++ b/src/shared/lib/proxy/mcp-reauth-manager.ts
@@ -1,0 +1,170 @@
+import crypto from 'crypto'
+import { messagePersister } from '@shared/lib/container/message-persister'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
+
+export const MCP_REAUTH_TIMEOUT_MS = 5 * 60 * 1000
+
+export interface McpReauthDetails {
+  agentSlug: string
+  mcpId: string
+  mcpName: string
+  authType: 'none' | 'oauth' | 'bearer'
+}
+
+interface ReauthSettler {
+  resolve: () => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+type McpReauthEntry = Extract<PendingUserInputRequest, { kind: 'mcp_reauth_required' }>
+
+/**
+ * Parks MCP proxy requests while an inactive remote MCP is re-authorized.
+ * The registry entry broadcasts the in-chat request; this class owns only the
+ * in-memory promise that resumes the original HTTP request after reconnection.
+ */
+export class McpReauthManager {
+  private settlers = new Map<string, ReauthSettler>()
+
+  private static isMcpReauthEntry(
+    request: PendingUserInputRequest,
+  ): request is McpReauthEntry {
+    return request.kind === 'mcp_reauth_required'
+  }
+
+  private settle(
+    entry: McpReauthEntry,
+    outcome: 'answered' | 'cancelled' | 'timeout',
+    action: { type: 'resolve' } | { type: 'reject'; error: Error },
+  ): void {
+    const settler = this.settlers.get(entry.id)
+    this.settlers.delete(entry.id)
+    if (settler) clearTimeout(settler.timer)
+    userInputRequestManager.resolve(entry.id, outcome)
+    if (settler) {
+      if (action.type === 'resolve') settler.resolve()
+      else settler.reject(action.error)
+    }
+  }
+
+  requestReauth(details: McpReauthDetails, signal?: AbortSignal): Promise<void> {
+    const id = crypto.randomUUID()
+
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const entry = userInputRequestManager.getOpenRequest(id)
+        if (!entry || !McpReauthManager.isMcpReauthEntry(entry)) {
+          const orphan = this.settlers.get(id)
+          if (!orphan) return
+          this.settlers.delete(id)
+          orphan.reject(new Error('MCP re-authentication request was lost'))
+          return
+        }
+        this.settle(entry, 'timeout', {
+          type: 'reject',
+          error: new Error('MCP re-authentication timed out'),
+        })
+        messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
+      }, MCP_REAUTH_TIMEOUT_MS)
+
+      this.settlers.set(id, { resolve, reject, timer })
+
+      if (signal?.aborted) {
+        clearTimeout(timer)
+        this.settlers.delete(id)
+        reject(new Error('MCP proxy request aborted while awaiting re-authentication'))
+        return
+      }
+
+      if (signal) {
+        signal.addEventListener('abort', () => {
+          const entry = userInputRequestManager.getOpenRequest(id)
+          if (!entry || !McpReauthManager.isMcpReauthEntry(entry)) return
+          this.settle(entry, 'cancelled', {
+            type: 'reject',
+            error: new Error('MCP proxy request aborted while awaiting re-authentication'),
+          })
+          messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
+        }, { once: true })
+      }
+
+      const registered = userInputRequestManager.register({
+        id,
+        kind: 'mcp_reauth_required',
+        scope: { agentSlug: details.agentSlug },
+        blocking: true,
+        autoApproved: false,
+        payload: {
+          mcpId: details.mcpId,
+          mcpName: details.mcpName,
+          authType: details.authType,
+          proxyRequestId: id,
+        },
+      })
+
+      if (!registered) {
+        clearTimeout(timer)
+        this.settlers.delete(id)
+        reject(new Error('Failed to register MCP re-authentication request'))
+        return
+      }
+
+      messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
+    })
+  }
+
+  /** Resume every parked proxy request that uses the reconnected MCP. */
+  completeMcp(mcpId: string): number {
+    const agentSlugs = new Set<string>()
+    let completed = 0
+
+    for (const request of userInputRequestManager.getOpenRequestsForStore('review')) {
+      if (!McpReauthManager.isMcpReauthEntry(request)) continue
+      const payload = request.payload as Record<string, unknown>
+      if (payload.mcpId !== mcpId) continue
+      if (request.scope.agentSlug) agentSlugs.add(request.scope.agentSlug)
+      this.settle(request, 'answered', { type: 'resolve' })
+      completed++
+    }
+
+    for (const agentSlug of agentSlugs) {
+      messagePersister.syncAgentSessionsAwaiting(agentSlug)
+    }
+    return completed
+  }
+
+  rejectAll(): void {
+    const agentSlugs = new Set<string>()
+    for (const request of userInputRequestManager.getOpenRequestsForStore('review')) {
+      if (!McpReauthManager.isMcpReauthEntry(request)) continue
+      if (request.scope.agentSlug) agentSlugs.add(request.scope.agentSlug)
+      this.settle(request, 'cancelled', {
+        type: 'reject',
+        error: new Error('MCP re-authentication interrupted by shutdown'),
+      })
+    }
+
+    for (const [id, settler] of this.settlers) {
+      clearTimeout(settler.timer)
+      this.settlers.delete(id)
+      settler.reject(new Error('MCP re-authentication interrupted by shutdown'))
+    }
+
+    for (const agentSlug of agentSlugs) {
+      messagePersister.syncAgentSessionsAwaiting(agentSlug)
+    }
+  }
+}
+
+const globalForMcpReauthManager = globalThis as unknown as {
+  mcpReauthManager: McpReauthManager | undefined
+}
+
+export const mcpReauthManager =
+  globalForMcpReauthManager.mcpReauthManager ?? new McpReauthManager()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForMcpReauthManager.mcpReauthManager = mcpReauthManager
+}

--- a/src/shared/lib/scheduler/account-sync-service.test.ts
+++ b/src/shared/lib/scheduler/account-sync-service.test.ts
@@ -7,6 +7,7 @@ const mockUpdateWhere = vi.fn()
 const mockInsert = vi.fn()
 const mockValues = vi.fn()
 const mockOnConflictDoNothing = vi.fn()
+const mockSyncAgentsAssignedConnectedAccount = vi.fn().mockResolvedValue(true)
 
 vi.mock('@shared/lib/db', () => ({
   db: {
@@ -51,6 +52,11 @@ vi.mock('@shared/lib/config/settings', () => ({
   getAccountProviderUserId: () => 'test-user',
 }))
 
+vi.mock('@shared/lib/container/connection-runtime-sync', () => ({
+  syncAgentsAssignedConnectedAccount: (...args: unknown[]) =>
+    mockSyncAgentsAssignedConnectedAccount(...args),
+}))
+
 const mockRequiresActingMember = vi.fn(() => false)
 const mockRunWithRequestUser = vi.fn((_userId: string, fn: () => unknown) => fn())
 vi.mock('@shared/lib/platform-attribution', () => ({
@@ -83,6 +89,7 @@ describe('AccountSyncService', () => {
       await accountSyncService.syncAll()
 
       expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'revoked' }))
+      expect(mockSyncAgentsAssignedConnectedAccount).toHaveBeenCalledWith('local-1')
     })
 
     it('marks local account as expired when remote status is EXPIRED', async () => {
@@ -96,6 +103,7 @@ describe('AccountSyncService', () => {
       await accountSyncService.syncAll()
 
       expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'expired' }))
+      expect(mockSyncAgentsAssignedConnectedAccount).toHaveBeenCalledWith('local-1')
     })
 
     it('marks local account as revoked when remote status is FAILED', async () => {
@@ -109,6 +117,7 @@ describe('AccountSyncService', () => {
       await accountSyncService.syncAll()
 
       expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'revoked' }))
+      expect(mockSyncAgentsAssignedConnectedAccount).toHaveBeenCalledWith('local-1')
     })
 
     it('restores local account to active when remote is ACTIVE but local is not', async () => {
@@ -122,6 +131,7 @@ describe('AccountSyncService', () => {
       await accountSyncService.syncAll()
 
       expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'active' }))
+      expect(mockSyncAgentsAssignedConnectedAccount).toHaveBeenCalledWith('local-1')
     })
 
     it('does not update when local and remote status match (both active)', async () => {
@@ -135,6 +145,7 @@ describe('AccountSyncService', () => {
       await accountSyncService.syncAll()
 
       expect(mockUpdate).not.toHaveBeenCalled()
+      expect(mockSyncAgentsAssignedConnectedAccount).not.toHaveBeenCalled()
     })
 
     it('adds remote ACTIVE connections missing from local DB', async () => {

--- a/src/shared/lib/scheduler/account-sync-service.ts
+++ b/src/shared/lib/scheduler/account-sync-service.ts
@@ -7,6 +7,7 @@ import type { BaseAccountProvider } from '@shared/lib/account-providers'
 import { getProvider } from '@shared/lib/account-providers/service-catalog'
 import { getAccountProviderUserId } from '@shared/lib/config/settings'
 import { attribution, runWithRequestUser } from '@shared/lib/platform-attribution'
+import { syncAgentsAssignedConnectedAccount } from '@shared/lib/container/connection-runtime-sync'
 
 type LocalStatus = 'active' | 'revoked' | 'expired'
 
@@ -148,6 +149,7 @@ class AccountSyncService {
     let updated = 0
     let added = 0
     let restored = 0
+    const statusChangedAccountIds = new Set<string>()
 
     for (const local of localAccounts) {
       const remote = remoteById.get(local.providerConnectionId)
@@ -158,6 +160,7 @@ class AccountSyncService {
             .set({ status: 'revoked', updatedAt: new Date() })
             .where(eq(connectedAccounts.id, local.id))
           updated++
+          statusChangedAccountIds.add(local.id)
         }
         continue
       }
@@ -170,13 +173,23 @@ class AccountSyncService {
           .set({ status: mappedStatus, updatedAt: new Date() })
           .where(eq(connectedAccounts.id, local.id))
         updated++
+        statusChangedAccountIds.add(local.id)
       } else if (mappedStatus === 'active' && local.status !== 'active') {
         await db.update(connectedAccounts)
           .set({ status: 'active', updatedAt: new Date() })
           .where(eq(connectedAccounts.id, local.id))
         restored++
+        statusChangedAccountIds.add(local.id)
       }
     }
+
+    // Keep already-running assigned agents aligned with provider-side status
+    // changes. Stopped agents rebuild this projection when they next start.
+    await Promise.all([...statusChangedAccountIds].map(async (accountId) => {
+      if (!await syncAgentsAssignedConnectedAccount(accountId)) {
+        console.warn(`[AccountSync] Failed to refresh assigned agents for account ${accountId}`)
+      }
+    }))
 
     for (const remote of remoteConnections) {
       if (remote.status !== 'ACTIVE') continue

--- a/src/shared/lib/startup.post-bind.test.ts
+++ b/src/shared/lib/startup.post-bind.test.ts
@@ -80,6 +80,8 @@ vi.mock('../../main/host-browser/profile-maintenance', () => ({
 vi.mock('../../main/browser-stream-proxy', () => ({ setupBrowserStreamProxy: vi.fn() }))
 vi.mock('../../main/cloud-stream-proxy', () => ({ setupCloudStreamProxy: vi.fn() }))
 vi.mock('./proxy/review-manager', () => ({ reviewManager: { rejectAll: vi.fn() } }))
+vi.mock('./proxy/account-reauth-manager', () => ({ accountReauthManager: { rejectAll: vi.fn() } }))
+vi.mock('./proxy/mcp-reauth-manager', () => ({ mcpReauthManager: { rejectAll: vi.fn() } }))
 vi.mock('./scheduler/task-scheduler', () => ({
   taskScheduler: { start: () => taskSchedulerStart(), stop: vi.fn() },
 }))

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -3,6 +3,8 @@ import pLimit from 'p-limit'
 import { containerManager } from './container/container-manager'
 import { shutdownActiveRunner } from './container/client-factory'
 import { reviewManager } from './proxy/review-manager'
+import { accountReauthManager } from './proxy/account-reauth-manager'
+import { mcpReauthManager } from './proxy/mcp-reauth-manager'
 import { taskScheduler } from './scheduler/task-scheduler'
 import { triggerManager } from './scheduler/trigger-manager'
 import { platformNotificationsManager } from './scheduler/platform-notifications-manager'
@@ -275,6 +277,8 @@ export function setupServerHandlers(server: ServerType): void {
 export async function shutdownServices() {
   servicesShuttingDown = true
   reviewManager.rejectAll()
+  accountReauthManager.rejectAll()
+  mcpReauthManager.rejectAll()
   stopBrowserProfileCleanup()
   chatIntegrationManager.stop()
   await credentialBroker.shutdown()

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -266,7 +266,7 @@ export class UserInputRequestManager {
     return [...this.requests.values()].filter((r) => r.scope.agentSlug === agentSlug)
   }
 
-  /** Agent-scoped only (no sessionId) — today: proxy / x-agent reviews. */
+  /** Agent-scoped only (no sessionId) — reviews and account re-auth requests. */
   getAgentScopedRequests(agentSlug: string): PendingUserInputRequest[] {
     return [...this.requests.values()].filter(
       (r) => r.scope.agentSlug === agentSlug && r.scope.sessionId === undefined,

--- a/src/shared/lib/user-input/request-schema.ts
+++ b/src/shared/lib/user-input/request-schema.ts
@@ -20,6 +20,8 @@ export const USER_INPUT_REQUEST_KINDS = [
   'computer_use',
   'proxy_review',
   'x_agent_review',
+  'account_reauth_required',
+  'mcp_reauth_required',
 ] as const
 
 export const userInputRequestKindSchema = z.enum(USER_INPUT_REQUEST_KINDS)
@@ -35,7 +37,7 @@ export const userInputRequestOutcomeSchema = z.enum([
 ])
 export type UserInputRequestOutcome = z.infer<typeof userInputRequestOutcomeSchema>
 
-/** sessionId absent ⇒ agent-scoped (proxy / x-agent reviews). */
+/** sessionId absent ⇒ agent-scoped (proxy/x-agent reviews and account re-auth). */
 const requestScopeSchema = z.object({
   agentSlug: z.string().optional(),
   sessionId: z.string().optional(),
@@ -155,6 +157,24 @@ export const pendingUserInputRequestSchema = z.discriminatedUnion('kind', [
         })
         .optional()
         .catch(undefined),
+      }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('account_reauth_required'),
+    payload: z.looseObject({
+      accountId: lenientString,
+      toolkit: lenientString,
+      accountStatus: z.enum(['expired', 'revoked']).optional().catch(undefined),
+      proxyRequestId: lenientString,
+    }),
+  }),
+  baseRequest.extend({
+    kind: z.literal('mcp_reauth_required'),
+    payload: z.looseObject({
+      mcpId: lenientString,
+      mcpName: lenientString,
+      authType: z.enum(['none', 'oauth', 'bearer']).optional().catch(undefined),
+      proxyRequestId: lenientString,
     }),
   }),
 ])
@@ -183,6 +203,11 @@ export function isReplayableUserInputRequest(request: PendingUserInputRequest): 
 
 export function storeForKind(kind: UserInputRequestKind): UserInputRequestStore {
   if (kind === 'computer_use') return 'computer_use'
-  if (kind === 'proxy_review' || kind === 'x_agent_review') return 'review'
+  if (
+    kind === 'proxy_review' ||
+    kind === 'x_agent_review' ||
+    kind === 'account_reauth_required' ||
+    kind === 'mcp_reauth_required'
+  ) return 'review'
   return 'stream'
 }


### PR DESCRIPTION
## Summary

- keep assigned API accounts and remote MCPs projected into agent containers when they need re-authentication
- surface expired/revoked account status on the agent home Connections card with reconnect actions
- park in-flight account and MCP tool calls during re-auth, render reconnect requests in chat, and resume the original call after credentials refresh
- serve MCP initialization and cached tool discovery locally while an MCP needs re-auth so ordinary messages can still start immediately
- refresh running container connection projections when account sync changes authentication state

## Root cause

Connection runtime projections filtered API accounts to `active` and omitted auth-required MCPs, so assigned connections disappeared from the agent. The agent-home card also rendered only MCP status and dropped API account status. During the expanded re-auth flow, MCP protocol initialization was parked and ordinary messages were gated on re-auth, causing new sessions to time out before Claude emitted a session ID.

## User impact

Agents can now see assigned connections that need re-authentication, explain their state accurately, and request reconnection only when the connection is actually used. Ordinary messages remain available while a connection is expired. An in-flight connection call resumes after the user reconnects.

## Validation

- `npm run lint` — passes with 0 errors (42 pre-existing warnings)
- `npm run typecheck`
- `./node_modules/.bin/tsc --noEmit -p agent-container/tsconfig.json`
- focused root re-auth/proxy tests — 111 passed
- focused agent connection/prompt tests — 49 passed
- full agent-container suite — 853 passed, 8 skipped
- live Electron verification for expired API account and auth-required MCP flows
- affected-agent smoke test created and completed a Claude session in 3.35 seconds

## Test environment note

The full root suite reached 8,589 passing tests, but 584 unrelated database/socket tests could not run in this worktree: `better-sqlite3` is built for the Electron Node ABI (145) while the CLI runner uses ABI 127, and sandboxed listener tests receive `EPERM`. The focused SUP-186 suites and both TypeScript checks pass.
