### PR TITLE
Fix onboarding completion after template install

### DIFF
--- a/e2e/setup-e2e-data.js
+++ b/e2e/setup-e2e-data.js
@@ -112,6 +112,14 @@ fs.writeFileSync(
         version: '1.0.0',
       },
     ],
+    agents: [
+      {
+        name: 'E2E Onboarding Template',
+        path: 'agents/e2e-onboarding-template/',
+        description: 'An agent template that exercises the onboarding handoff',
+        version: '1.0.0',
+      },
+    ],
   }, null, 2),
 )
 
@@ -129,6 +137,31 @@ metadata:
 # E2E Public Skill
 
 This skill is seeded from a public provider for end-to-end tests.
+`,
+)
+
+const PUBLIC_AGENT_DIR = path.join(PUBLIC_SKILLSET_DIR, 'agents', 'e2e-onboarding-template')
+fs.mkdirSync(path.join(PUBLIC_AGENT_DIR, '.claude', 'skills', 'agent-onboarding'), { recursive: true })
+fs.writeFileSync(
+  path.join(PUBLIC_AGENT_DIR, 'CLAUDE.md'),
+  `---
+name: E2E Onboarding Template
+description: An agent template that exercises the onboarding handoff
+---
+
+# E2E Onboarding Template
+
+This agent is seeded for end-to-end tests.
+`,
+)
+fs.writeFileSync(
+  path.join(PUBLIC_AGENT_DIR, '.claude', 'skills', 'agent-onboarding', 'SKILL.md'),
+  `---
+name: agent-onboarding
+description: Helps configure a freshly-installed agent.
+---
+
+Help the user configure this agent.
 `,
 )
 

--- a/e2e/specs/getting-started-wizard.spec.ts
+++ b/e2e/specs/getting-started-wizard.spec.ts
@@ -201,6 +201,51 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.expectNotVisible()
   })
 
+  test('finishes onboarding after creating the first agent from a template', async ({ page, request }) => {
+    await request.put('/api/user-settings', {
+      data: { setupCompleted: false, onboardingProgress: null },
+    })
+
+    await appPage.goto()
+    await appPage.waitForAppLoaded()
+    await wizardPage.expectVisible()
+    await wizardPage.chooseManualSetup()
+
+    await wizardPage.clickNext() // LLM -> Model
+    await wizardPage.expectStep(1)
+    await wizardPage.clickNext() // Model -> Browser
+    await wizardPage.expectStep(2)
+    await wizardPage.clickNext() // Browser -> Composio
+    await wizardPage.expectStep(3)
+    await wizardPage.clickSkip() // Composio -> Runtime
+    await wizardPage.expectStep(4)
+    await wizardPage.clickNext() // Runtime -> Privacy
+    await wizardPage.expectStep(5)
+    await wizardPage.clickNext() // Privacy -> Agent
+    await wizardPage.expectStep(6)
+
+    await page.getByRole('button', { name: /Browse Templates/ }).click()
+    const marketplace = page.locator('[data-testid="agent-template-browse-dialog"]')
+    await expect(marketplace).toBeVisible()
+    await marketplace.getByRole('button', { name: /E2E Onboarding Template/ }).click()
+
+    const installDialog = page.getByRole('dialog', { name: 'Install E2E Onboarding Template' })
+    const agentName = `Onboarding Template Agent ${Date.now()}`
+    await installDialog.getByPlaceholder('Agent name').fill(agentName)
+    await installDialog.getByRole('button', { name: 'Install' }).click()
+
+    // Installing a template is a successful completion of the final onboarding
+    // step, just like creating from a prompt or importing a local template.
+    await wizardPage.expectNotVisible()
+    await expect(page.locator('[data-testid="app-sidebar"]')).toBeVisible()
+    await expect(page.getByText(agentName, { exact: true }).first()).toBeVisible()
+
+    const response = await request.get('/api/user-settings')
+    const settings = await response.json()
+    expect(settings.setupCompleted).toBe(true)
+    expect(settings.onboardingProgress).toBeNull()
+  })
+
   test('sets setupCompleted after finishing', async ({ request }) => {
     await request.put('/api/user-settings', {
       data: { setupCompleted: false },

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -35,6 +35,8 @@ export interface AgentCreationAidsProps {
   className?: string
   /** Fires when the user opens browse / voice / import (forfeits signup template handoff). */
   onAidOpened?: () => void
+  /** Called after a marketplace template has been installed and opened. */
+  onTemplateInstalled?: () => void | Promise<void>
 }
 
 /**
@@ -43,7 +45,13 @@ export interface AgentCreationAidsProps {
  * home state. Callers decide what to do with the voice result / imported
  * agent — this component is pure UI + dialog plumbing.
  */
-export function AgentCreationAids({ onVoiceResult, onImportComplete, className, onAidOpened }: AgentCreationAidsProps) {
+export function AgentCreationAids({
+  onVoiceResult,
+  onImportComplete,
+  className,
+  onAidOpened,
+  onTemplateInstalled,
+}: AgentCreationAidsProps) {
   const hasVoiceConfigured = useIsVoiceAgentConfigured()
   const { data: discoverableAgents } = useDiscoverableAgents()
   const hasMarketplace = !!(discoverableAgents && discoverableAgents.length > 0)
@@ -207,7 +215,11 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className, 
         />
       </div>
 
-      <AgentTemplateBrowseDialog open={showTemplatesDialog} onOpenChange={setShowTemplatesDialog} />
+      <AgentTemplateBrowseDialog
+        open={showTemplatesDialog}
+        onOpenChange={setShowTemplatesDialog}
+        onInstalled={onTemplateInstalled}
+      />
 
       <Dialog open={showVoiceAgent} onOpenChange={(open) => { if (!open) closeVoiceAgent() }}>
         <DialogContent className="max-w-2xl p-0 overflow-hidden h-[420px] [grid-template-rows:minmax(0,1fr)] gap-0">
@@ -370,4 +382,3 @@ export function AgentCreationAids({ onVoiceResult, onImportComplete, className, 
     </div>
   )
 }
-

--- a/src/renderer/components/agents/agent-template-browse-dialog.tsx
+++ b/src/renderer/components/agents/agent-template-browse-dialog.tsx
@@ -18,11 +18,14 @@ import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
 interface AgentTemplateBrowseDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  /** Fires after the selected template has been installed and opened. */
+  onInstalled?: () => void | Promise<void>
 }
 
 export function AgentTemplateBrowseDialog({
   open,
   onOpenChange,
+  onInstalled,
 }: AgentTemplateBrowseDialogProps) {
   const { data: discoverableAgents } = useDiscoverableAgents()
   const navigate = useNavigate()
@@ -44,8 +47,9 @@ export function AgentTemplateBrowseDialog({
         await startOnboardingSession(agent.slug)
       }
       onOpenChange(false)
+      await onInstalled?.()
     },
-    [track, queryClient, navigate, startOnboardingSession, onOpenChange],
+    [track, queryClient, navigate, startOnboardingSession, onOpenChange, onInstalled],
   )
 
   const hasTemplates = discoverableAgents && discoverableAgents.length > 0

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -419,6 +419,7 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
             onVoiceResult={handleVoiceResult}
             onImportComplete={handleImportComplete}
             onAidOpened={forfeitHandoffTemplate}
+            onTemplateInstalled={onAgentCreated}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- propagate successful marketplace template installs back through the create-agent flow so onboarding runs its existing completion handler
- close the onboarding wizard and persist setup completion after the template agent and its onboarding session are ready
- seed an onboarding-enabled agent template for Playwright and add an end-to-end regression covering naming, installation, setup, dismissal, and persistence

## Root cause

The prompt and local-import creation paths notified `GettingStartedWizard` through `onAgentCreated`, but the Browse Templates path used a self-contained marketplace dialog. That dialog installed and opened the agent without forwarding a successful completion event to the wizard, leaving the wizard mounted over the newly created agent.

## Validation

- regression reproduced before the fix: the new agent/session were created while the wizard remained visible
- `npm run typecheck`
- ESLint on all touched files
- focused renderer tests: 3 files, 8 tests passed
- `npm run test:e2e:wizard -- e2e/specs/getting-started-wizard.spec.ts`: 8 tests passed
