### PR TITLE
fix: externalize grammy so Telegram polling works in the web/cloud bundle

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -52,6 +52,9 @@ const externalExact = new Set([
   'electron',
   'require-in-the-middle',
   'import-in-the-middle',
+  // grammy hardwires node-fetch@2, whose isAbortSignal checks constructor.name;
+  // bundling renames abort-controller's class, so every Telegram call throws.
+  'grammy',
 ])
 const externalPrefix = ['@sentry/', '@opentelemetry/']
 


### PR DESCRIPTION
## What was broken

On cloud host-apps, enabling a Telegram connector never comes up: every `getUpdates` fails, `bot.start()` never fires `onStart` within 10s, the UI/Sentry report a Telegram connection timeout, and after 15 reconnect attempts the agent auto-pauses. CloudWatch shows the real underlying error:

```
HttpError: Network request for 'getUpdates' failed!
  error: TypeError: Expected signal to be an instanceof AbortSignal
```

Telegram egress itself is fine (probes from the same subnet/SG get `getMe` in ~92ms), and desktop Electron works — only the tsup-built `dist/web/server.mjs` is affected.

## Root cause

`tsup.config.ts` bundles all dependencies (`noExternal`) into `dist/web/server.mjs`, including grammy, whose Node build hardwires `node-fetch@2` + `abort-controller`. esbuild rewrites abort-controller's `class AbortSignal extends EventTarget` into an anonymous class expression:

```js
var AbortSignal2 = class extends eventTargetShim.EventTarget { ... }
```

so `constructor.name` becomes `"AbortSignal2"`. node-fetch's guard

```js
function isAbortSignal(signal) {
  const proto = signal && typeof signal === 'object' && Object.getPrototypeOf(signal);
  return !!(proto && proto.constructor.name === 'AbortSignal');
}
```

then rejects the signal grammy passes to every request, so every Telegram API call throws. Same class of bug as node-fetch#784. The Electron main build is unaffected because electron-vite `externalizeDeps` already loads grammy from `node_modules`.

## Repro

1. `npm run build:api` on main
2. `rg -c "Expected signal to be an instanceof AbortSignal" dist/web/server.mjs` → 1 (inlined node-fetch guard)
3. `rg "var AbortSignal2 = class extends" dist/web/server.mjs` → renamed anonymous class from inlined abort-controller

## Fix

Add `grammy` to `externalExact` in `tsup.config.ts`. The web bundle now imports grammy from `node_modules` (present in the runtime image — the Dockerfile `deps` stage ships production node_modules), so the real node-fetch/abort-controller with intact class names are used, matching the Electron build.

## Verified

- `npm run build:api` passes, including the runtime-dependency check (grammy is a direct production dependency, so it's in the closure).
- Built bundle: `import { Bot } from "grammy"` is external; the node-fetch throw string and inlined node-fetch are gone.
- Remaining inlined `abort-controller` consumers (other deps) all do `globalThis.AbortSignal || require_abort_controller()`, so native globals win on Node 22.
- `npm run typecheck`: only pre-existing `tools/verify-e2b-*.ts` errors, identical on clean main.
- Not verified: end-to-end Telegram polling on a cloud host-app — needs a deploy; after release, resume the paused Telegram toggle to confirm.

Made with [Cursor](https://cursor.com)