### PR TITLE
Fix browser credential prefilling and add copy fallback

### DIFF
--- a/agent-container/src/active-page-target.test.ts
+++ b/agent-container/src/active-page-target.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { selectActivePageTarget } from './active-page-target';
+
+const urlsMatch = (left: string, right: string) => left === right;
+const targets = [
+  { id: 'background', url: 'about:blank', marker: 'wrong' },
+  { id: 'pge', url: 'https://myaccount.pge.com/myaccount/s/login/', marker: 'right' },
+];
+
+describe('selectActivePageTarget', () => {
+  it('uses the daemon active tab when its URL matches a CDP target', () => {
+    expect(selectActivePageTarget(
+      targets,
+      [{ url: targets[1].url, active: true }],
+      'background',
+      urlsMatch,
+    )).toBe(targets[1]);
+  });
+
+  it('uses the visible viewer target when the daemon URL is stale', () => {
+    expect(selectActivePageTarget(
+      targets,
+      [{ url: 'https://www.pge.com/', active: true }],
+      'pge',
+      urlsMatch,
+    )).toBe(targets[1]);
+  });
+
+  it('falls back to Chrome target ordering without an active match or viewer', () => {
+    expect(selectActivePageTarget(targets, [], null, urlsMatch)).toBe(targets[0]);
+  });
+
+  it('returns null when Chrome has no page targets', () => {
+    expect(selectActivePageTarget([], [], null, urlsMatch)).toBeNull();
+  });
+});

--- a/agent-container/src/active-page-target.test.ts
+++ b/agent-container/src/active-page-target.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { selectActivePageTarget } from './active-page-target';
+import { tabManager } from './tab-manager';
 
-const urlsMatch = (left: string, right: string) => left === right;
+const urlsMatch = (left: string, right: string) => tabManager.urlsMatch(left, right);
 const targets = [
   { id: 'background', url: 'about:blank', marker: 'wrong' },
   { id: 'pge', url: 'https://myaccount.pge.com/myaccount/s/login/', marker: 'right' },
@@ -28,13 +29,17 @@ describe('selectActivePageTarget', () => {
 
   it('keeps the viewer authoritative even when the daemon matches another tab', () => {
     const duplicateUrlTargets = [
-      { id: 'background', url: 'https://myaccount.pge.com/myaccount/s/login/' },
-      { id: 'viewer', url: 'https://myaccount.pge.com/myaccount/s/login/' },
+      { id: 'background', url: 'https://myaccount.pge.com/myaccount/s/login/?language=en_US#background' },
+      { id: 'viewer', url: 'https://myaccount.pge.com/myaccount/s/login?language=en_US#viewer' },
     ];
+    const normalizedDaemonUrl = 'https://myaccount.pge.com/myaccount/s/login?language=en_US';
+
+    expect(urlsMatch(duplicateUrlTargets[0].url, normalizedDaemonUrl)).toBe(true);
+    expect(urlsMatch(duplicateUrlTargets[1].url, normalizedDaemonUrl)).toBe(true);
 
     expect(selectActivePageTarget(
       duplicateUrlTargets,
-      [{ url: duplicateUrlTargets[0].url, active: true }],
+      [{ url: normalizedDaemonUrl, active: true }],
       urlsMatch,
       { viewerTargetId: 'viewer', preferViewer: true },
     )).toBe(duplicateUrlTargets[1]);

--- a/agent-container/src/active-page-target.test.ts
+++ b/agent-container/src/active-page-target.test.ts
@@ -12,25 +12,48 @@ describe('selectActivePageTarget', () => {
     expect(selectActivePageTarget(
       targets,
       [{ url: targets[1].url, active: true }],
-      'background',
       urlsMatch,
+      { viewerTargetId: 'background' },
     )).toBe(targets[1]);
   });
 
-  it('uses the visible viewer target when the daemon URL is stale', () => {
+  it('uses the visible viewer target first when the caller opts in', () => {
     expect(selectActivePageTarget(
       targets,
       [{ url: 'https://www.pge.com/', active: true }],
-      'pge',
       urlsMatch,
+      { viewerTargetId: 'pge', preferViewer: true },
     )).toBe(targets[1]);
   });
 
+  it('keeps the viewer authoritative even when the daemon matches another tab', () => {
+    const duplicateUrlTargets = [
+      { id: 'background', url: 'https://myaccount.pge.com/myaccount/s/login/' },
+      { id: 'viewer', url: 'https://myaccount.pge.com/myaccount/s/login/' },
+    ];
+
+    expect(selectActivePageTarget(
+      duplicateUrlTargets,
+      [{ url: duplicateUrlTargets[0].url, active: true }],
+      urlsMatch,
+      { viewerTargetId: 'viewer', preferViewer: true },
+    )).toBe(duplicateUrlTargets[1]);
+  });
+
+  it('does not make auto-follow sticky when the daemon URL is stale', () => {
+    expect(selectActivePageTarget(
+      targets,
+      [{ url: 'https://www.pge.com/', active: true }],
+      urlsMatch,
+      { viewerTargetId: 'pge' },
+    )).toBe(targets[0]);
+  });
+
   it('falls back to Chrome target ordering without an active match or viewer', () => {
-    expect(selectActivePageTarget(targets, [], null, urlsMatch)).toBe(targets[0]);
+    expect(selectActivePageTarget(targets, [], urlsMatch)).toBe(targets[0]);
   });
 
   it('returns null when Chrome has no page targets', () => {
-    expect(selectActivePageTarget([], [], null, urlsMatch)).toBeNull();
+    expect(selectActivePageTarget([], [], urlsMatch)).toBeNull();
   });
 });

--- a/agent-container/src/active-page-target.ts
+++ b/agent-container/src/active-page-target.ts
@@ -8,31 +8,39 @@ export interface BrowserTabCandidate {
   active: boolean;
 }
 
+export interface ActivePageTargetSelectionOptions {
+  /** The CDP target currently rendered in the browser viewer. */
+  viewerTargetId?: string | null;
+  /** Use the viewer before daemon/MRU resolution for user-directed actions. */
+  preferViewer?: boolean;
+}
+
 /**
- * Resolve the page the user is actually viewing.
+ * Resolve Chrome's active page, optionally giving a user-selected viewer page
+ * priority for operations that act on exactly what the user is looking at.
  *
- * The daemon URL is preferred while it is current. In host-browser/CDP mode
- * the daemon can retain the pre-navigation URL, so the viewer's current CDP
- * target is the safest fallback before relying on Chrome's target ordering.
+ * Viewer priority must stay opt-in: auto-follow callers are trying to discover
+ * where the viewer should move and would become sticky if its current target
+ * were used as their fallback.
  */
 export function selectActivePageTarget<T extends PageTargetCandidate>(
   targets: T[],
   daemonTabs: BrowserTabCandidate[],
-  viewerTargetId: string | null,
   urlsMatch: (left: string, right: string) => boolean,
+  options: ActivePageTargetSelectionOptions = {},
 ): T | null {
   if (targets.length === 0) return null;
   if (targets.length === 1) return targets[0];
+
+  if (options.preferViewer && options.viewerTargetId) {
+    const viewerTarget = targets.find((target) => target.id === options.viewerTargetId);
+    if (viewerTarget) return viewerTarget;
+  }
 
   const activeDaemonTab = daemonTabs.find((tab) => tab.active);
   if (activeDaemonTab) {
     const daemonTarget = targets.find((target) => urlsMatch(target.url, activeDaemonTab.url));
     if (daemonTarget) return daemonTarget;
-  }
-
-  if (viewerTargetId) {
-    const viewerTarget = targets.find((target) => target.id === viewerTargetId);
-    if (viewerTarget) return viewerTarget;
   }
 
   return targets[0];

--- a/agent-container/src/active-page-target.ts
+++ b/agent-container/src/active-page-target.ts
@@ -1,0 +1,39 @@
+export interface PageTargetCandidate {
+  id: string;
+  url: string;
+}
+
+export interface BrowserTabCandidate {
+  url: string;
+  active: boolean;
+}
+
+/**
+ * Resolve the page the user is actually viewing.
+ *
+ * The daemon URL is preferred while it is current. In host-browser/CDP mode
+ * the daemon can retain the pre-navigation URL, so the viewer's current CDP
+ * target is the safest fallback before relying on Chrome's target ordering.
+ */
+export function selectActivePageTarget<T extends PageTargetCandidate>(
+  targets: T[],
+  daemonTabs: BrowserTabCandidate[],
+  viewerTargetId: string | null,
+  urlsMatch: (left: string, right: string) => boolean,
+): T | null {
+  if (targets.length === 0) return null;
+  if (targets.length === 1) return targets[0];
+
+  const activeDaemonTab = daemonTabs.find((tab) => tab.active);
+  if (activeDaemonTab) {
+    const daemonTarget = targets.find((target) => urlsMatch(target.url, activeDaemonTab.url));
+    if (daemonTarget) return daemonTarget;
+  }
+
+  if (viewerTargetId) {
+    const viewerTarget = targets.find((target) => target.id === viewerTargetId);
+    if (viewerTarget) return viewerTarget;
+  }
+
+  return targets[0];
+}

--- a/agent-container/src/credential-autofill-script.test.ts
+++ b/agent-container/src/credential-autofill-script.test.ts
@@ -66,16 +66,19 @@ describe('credential autofill page function', () => {
 
   it('fills login fields inside a same-origin iframe', () => {
     const frame = document.createElement('iframe');
+    frame.src = `${location.origin}/embedded-login`;
     document.body.append(frame);
     vi.spyOn(frame.contentWindow!.HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
       x: 0, y: 0, width: 200, height: 30, top: 0, right: 200, bottom: 30, left: 0,
       toJSON: () => ({}),
     });
-    frame.contentDocument!.body.innerHTML = `
+    frame.contentDocument!.open();
+    frame.contentDocument!.write(`<!doctype html><body>
       <form>
         <input id="email" type="email" autocomplete="username">
         <input id="password" type="password" autocomplete="current-password">
-      </form>`;
+      </form></body>`);
+    frame.contentDocument!.close();
 
     expect(autofill('person@example.com', 's3cret', location.origin)).toEqual({
       ok: true,
@@ -86,6 +89,32 @@ describe('credential autofill page function', () => {
       .toBe('person@example.com');
     expect(frame.contentDocument!.querySelector<HTMLInputElement>('#password')!.value)
       .toBe('s3cret');
+  });
+
+  it('does not fill an accessible iframe from a different origin', () => {
+    const frame = document.createElement('iframe');
+    frame.src = 'https://accounts.other.example/embedded-login';
+    document.body.append(frame);
+    vi.spyOn(frame.contentWindow!.HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0, y: 0, width: 200, height: 30, top: 0, right: 200, bottom: 30, left: 0,
+      toJSON: () => ({}),
+    });
+    frame.contentDocument!.open();
+    frame.contentDocument!.write(`<!doctype html><body>
+      <form>
+        <input id="email" type="email" autocomplete="username">
+        <input id="password" type="password" autocomplete="current-password">
+      </form></body>`);
+    frame.contentDocument!.close();
+
+    expect(autofill('person@example.com', 's3cret', location.origin)).toEqual({
+      ok: false,
+      reason: 'no_password_field',
+      usernameFilled: false,
+      passwordFilled: false,
+    });
+    expect(frame.contentDocument!.querySelector<HTMLInputElement>('#email')!.value).toBe('');
+    expect(frame.contentDocument!.querySelector<HTMLInputElement>('#password')!.value).toBe('');
   });
 
   it('does not mutate the DOM when the expected origin differs', () => {

--- a/agent-container/src/credential-autofill-script.test.ts
+++ b/agent-container/src/credential-autofill-script.test.ts
@@ -45,6 +45,49 @@ describe('credential autofill page function', () => {
     expect(passwordInput).toHaveBeenCalledOnce();
   });
 
+  it('fills login fields inside an open shadow root', () => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <form>
+        <input id="email" type="email" autocomplete="username">
+        <input id="password" type="password" autocomplete="current-password">
+      </form>`;
+    document.body.append(host);
+
+    expect(autofill('person@example.com', 's3cret', location.origin)).toEqual({
+      ok: true,
+      usernameFilled: true,
+      passwordFilled: true,
+    });
+    expect(shadow.querySelector<HTMLInputElement>('#email')!.value).toBe('person@example.com');
+    expect(shadow.querySelector<HTMLInputElement>('#password')!.value).toBe('s3cret');
+  });
+
+  it('fills login fields inside a same-origin iframe', () => {
+    const frame = document.createElement('iframe');
+    document.body.append(frame);
+    vi.spyOn(frame.contentWindow!.HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0, y: 0, width: 200, height: 30, top: 0, right: 200, bottom: 30, left: 0,
+      toJSON: () => ({}),
+    });
+    frame.contentDocument!.body.innerHTML = `
+      <form>
+        <input id="email" type="email" autocomplete="username">
+        <input id="password" type="password" autocomplete="current-password">
+      </form>`;
+
+    expect(autofill('person@example.com', 's3cret', location.origin)).toEqual({
+      ok: true,
+      usernameFilled: true,
+      passwordFilled: true,
+    });
+    expect(frame.contentDocument!.querySelector<HTMLInputElement>('#email')!.value)
+      .toBe('person@example.com');
+    expect(frame.contentDocument!.querySelector<HTMLInputElement>('#password')!.value)
+      .toBe('s3cret');
+  });
+
   it('does not mutate the DOM when the expected origin differs', () => {
     document.body.innerHTML = '<input id="password" type="password">';
     const password = document.querySelector<HTMLInputElement>('#password')!;

--- a/agent-container/src/credential-autofill-script.ts
+++ b/agent-container/src/credential-autofill-script.ts
@@ -65,7 +65,9 @@ export const CREDENTIAL_AUTOFILL_FUNCTION = `function(username, password, expect
     if (input.type === 'email') value += 60;
     if (/(user|login|email|account)/i.test(identity)) value += 40;
     const position = input.compareDocumentPosition(passwordField);
-    if (!(position & 1) && (position & 4)) value += 20;
+    const NodeConstructor = input.ownerDocument.defaultView.Node;
+    if (!(position & NodeConstructor.DOCUMENT_POSITION_DISCONNECTED) &&
+        (position & NodeConstructor.DOCUMENT_POSITION_FOLLOWING)) value += 20;
     return value;
   };
   const usernameField = pool.sort((a, b) => score(b) - score(a))[0];

--- a/agent-container/src/credential-autofill-script.ts
+++ b/agent-container/src/credential-autofill-script.ts
@@ -5,13 +5,39 @@ export const CREDENTIAL_AUTOFILL_FUNCTION = `function(username, password, expect
     return { ok: false, reason: 'origin_changed', usernameFilled: false, passwordFilled: false };
   }
 
-  const visible = (input) => {
-    const style = getComputedStyle(input);
-    const rect = input.getBoundingClientRect();
-    return !input.disabled && !input.readOnly && input.type !== 'hidden' &&
-      style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+  const rendered = (element) => {
+    const view = element.ownerDocument.defaultView;
+    if (!view) return false;
+    const style = view.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0' &&
+      rect.width > 0 && rect.height > 0;
   };
-  const inputs = Array.from(document.querySelectorAll('input')).filter(visible);
+  const collectInputs = (root, seen = new Set()) => {
+    if (!root || seen.has(root)) return [];
+    seen.add(root);
+
+    const inputs = Array.from(root.querySelectorAll('input'));
+    for (const element of root.querySelectorAll('*')) {
+      if (element.shadowRoot) inputs.push(...collectInputs(element.shadowRoot, seen));
+    }
+    for (const frame of root.querySelectorAll('iframe, frame')) {
+      try {
+        // Access throws for cross-origin frames. Never weaken that browser
+        // boundary: those cases fall back to an explicit user copy instead.
+        if (rendered(frame) && frame.contentDocument) {
+          inputs.push(...collectInputs(frame.contentDocument, seen));
+        }
+      } catch {
+        // Cross-origin or otherwise inaccessible frame.
+      }
+    }
+    return inputs;
+  };
+  const visible = (input) => {
+    return !input.disabled && !input.readOnly && input.type !== 'hidden' && rendered(input);
+  };
+  const inputs = collectInputs(document).filter(visible);
   const passwordField = inputs.find((input) => input.type === 'password');
   if (!passwordField) {
     return { ok: false, reason: 'no_password_field', usernameFilled: false, passwordFilled: false };
@@ -31,20 +57,25 @@ export const CREDENTIAL_AUTOFILL_FUNCTION = `function(username, password, expect
       .filter(Boolean).join(' ').toLowerCase();
     let value = 0;
     if (passwordForm && input.form === passwordForm) value += 100;
+    if (input.getRootNode() === passwordField.getRootNode()) value += 50;
+    if (input.ownerDocument === passwordField.ownerDocument) value += 30;
     if (autocomplete.includes('username')) value += 80;
     if (autocomplete.includes('email')) value += 70;
     if (input.type === 'email') value += 60;
     if (/(user|login|email|account)/i.test(identity)) value += 40;
-    if (input.compareDocumentPosition(passwordField) & Node.DOCUMENT_POSITION_FOLLOWING) value += 20;
+    const position = input.compareDocumentPosition(passwordField);
+    if (!(position & 1) && (position & 4)) value += 20;
     return value;
   };
   const usernameField = pool.sort((a, b) => score(b) - score(a))[0];
 
   const setValue = (input, value) => {
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    const view = input.ownerDocument.defaultView;
+    const inputPrototype = view.HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(inputPrototype, 'value').set;
     setter.call(input, value);
-    input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
-    input.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+    input.dispatchEvent(new view.Event('input', { bubbles: true, composed: true }));
+    input.dispatchEvent(new view.Event('change', { bubbles: true, composed: true }));
   };
 
   let usernameFilled = false;

--- a/agent-container/src/credential-autofill-script.ts
+++ b/agent-container/src/credential-autofill-script.ts
@@ -23,9 +23,10 @@ export const CREDENTIAL_AUTOFILL_FUNCTION = `function(username, password, expect
     }
     for (const frame of root.querySelectorAll('iframe, frame')) {
       try {
-        // Access throws for cross-origin frames. Never weaken that browser
-        // boundary: those cases fall back to an explicit user copy instead.
-        if (rendered(frame) && frame.contentDocument) {
+        // Cross-origin access normally throws, but legacy document.domain can
+        // relax it. Require the frame's actual origin to preserve the boundary.
+        if (rendered(frame) && frame.contentWindow?.location.origin === expectedOrigin &&
+            frame.contentDocument) {
           inputs.push(...collectInputs(frame.contentDocument, seen));
         }
       } catch {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -43,6 +43,7 @@ import {
 
 import { getEditingCommands } from './cdp-editing-commands';
 import { CREDENTIAL_AUTOFILL_FUNCTION } from './credential-autofill-script';
+import { selectActivePageTarget } from './active-page-target';
 
 // Global error handlers to prevent crashes from AbortError during interrupts
 // The SDK throws AbortError when queries are aborted, which can propagate uncaught
@@ -2269,19 +2270,19 @@ async function findActivePageTarget(): Promise<PageTarget | null> {
   if (allTargets.length === 0) return null;
   if (allTargets.length === 1) return allTargets[0];
 
-  // Use daemon to find which is active
+  let daemonTabs: Awaited<ReturnType<typeof tabManager.queryTabs>> = [];
   try {
-    const tabs = await tabManager.queryTabs();
-    const active = tabs.find(t => t.active);
-    if (active) {
-      const byUrl = allTargets.find(p => tabManager.urlsMatch(p.url, active.url));
-      if (byUrl) return byUrl;
-    }
+    daemonTabs = await tabManager.queryTabs();
   } catch (err) {
     console.error('[CDP] Daemon tab query failed:', err);
   }
 
-  return allTargets[0]; // fallback: first target (most recently active per Chrome's /json ordering)
+  return selectActivePageTarget(
+    allTargets,
+    daemonTabs,
+    cdpScreencast?.currentTargetId ?? null,
+    (left, right) => tabManager.urlsMatch(left, right),
+  );
 }
 
 /** Discover page targets via CDP WebSocket protocol (for remote providers) */
@@ -2737,12 +2738,14 @@ function notifyBrowserAction() {
         tabManager.queryTabs(),
       ]);
 
-      // Resolve the active target from daemon info
-      const activeDaemonTab = daemonTabs.find(t => t.active);
-      let activeTarget: PageTarget | null = allTargets[0] ?? null;
-      if (activeDaemonTab && allTargets.length > 1) {
-        activeTarget = allTargets.find(p => tabManager.urlsMatch(p.url, activeDaemonTab.url)) ?? activeTarget;
-      }
+      // Resolve the active target from daemon info, retaining the page already
+      // shown in the viewer when host-browser daemon navigation state is stale.
+      const activeTarget = selectActivePageTarget(
+        allTargets,
+        daemonTabs,
+        cdpScreencast.currentTargetId,
+        (left, right) => tabManager.urlsMatch(left, right),
+      );
 
       // Switch screencast only if auto-following and target changed
       if (activeTarget && activeTarget.id !== cdpScreencast.currentTargetId && cdpScreencast.autoFollow) {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -2264,8 +2264,8 @@ async function getAllPageTargets(): Promise<PageTarget[]> {
   return target ? [target] : [];
 }
 
-/** Find the CDP page target that corresponds to agent-browser's active page */
-async function findActivePageTarget(): Promise<PageTarget | null> {
+/** Find Chrome's active page. Credential actions opt into the viewer page. */
+async function findActivePageTarget(preferViewer = false): Promise<PageTarget | null> {
   const allTargets = await getAllPageTargets();
   if (allTargets.length === 0) return null;
   if (allTargets.length === 1) return allTargets[0];
@@ -2280,8 +2280,10 @@ async function findActivePageTarget(): Promise<PageTarget | null> {
   return selectActivePageTarget(
     allTargets,
     daemonTabs,
-    cdpScreencast?.currentTargetId ?? null,
     (left, right) => tabManager.urlsMatch(left, right),
+    preferViewer
+      ? { preferViewer: true, viewerTargetId: cdpScreencast?.currentTargetId ?? null }
+      : {},
   );
 }
 
@@ -2445,7 +2447,7 @@ app.get('/browser/credential-context', async (c) => {
   if (validationError) return c.json({ error: validationError }, 409);
   if (!browserState.active) return c.json({ error: 'Browser is not active' }, 409);
 
-  const target = await findActivePageTarget();
+  const target = await findActivePageTarget(true);
   if (!target?.url) return c.json({ error: 'No active browser page was found' }, 409);
   return c.json({ url: target.url });
 });
@@ -2462,7 +2464,7 @@ app.post('/browser/fill-credential', async (c) => {
     if (validationError) return c.json({ error: validationError }, 409);
     if (!browserState.active) return c.json({ error: 'Browser is not active' }, 409);
 
-    const target = await findActivePageTarget();
+    const target = await findActivePageTarget(true);
     if (!target) return c.json({ error: 'No active browser page was found' }, 409);
     const result = await autofillCredentialViaCdp(
       target,
@@ -2738,12 +2740,11 @@ function notifyBrowserAction() {
         tabManager.queryTabs(),
       ]);
 
-      // Resolve the active target from daemon info, retaining the page already
-      // shown in the viewer when host-browser daemon navigation state is stale.
+      // Resolve where the viewer should move. Do not prefer its current target:
+      // a stale daemon URL must retain Chrome's MRU fallback for auto-follow.
       const activeTarget = selectActivePageTarget(
         allTargets,
         daemonTabs,
-        cdpScreencast.currentTargetId,
         (left, right) => tabManager.urlsMatch(left, right),
       );
 

--- a/docs/credential-broker-spike.md
+++ b/docs/credential-broker-spike.md
@@ -34,9 +34,14 @@ sequenceDiagram
   Host->>Browser: username, password, expected origin
   Browser->>Browser: origin check + DOM fill in one CDP turn
   Browser-->>Host: field-filled booleans only
-  Host-->>UI: success (no credential values)
-  Host->>Agent: resolve request with submit-login guidance
-  Agent->>Browser: click login; request input again if 2FA appears
+  alt Fields are reachable
+    Host-->>UI: success (no credential values)
+    Host->>Agent: resolve request with submit-login guidance
+    Agent->>Browser: click login; request input again if 2FA appears
+  else Fields are inaccessible
+    Host-->>UI: selected credential (no-store response)
+    UI->>Browser: user copies and pastes values
+  end
 ```
 
 The host discovers the user-installed Apple Passwords Chrome extension and
@@ -89,12 +94,18 @@ Apple password, PIN, or PAKE secret is persisted by Superagent.
 
 ## Security properties
 
-- The renderer receives usernames, titles, domains, and opaque random IDs only.
+- Suggestion and successful-fill responses contain only usernames, titles,
+  domains, and opaque random IDs. If a selected credential cannot reach any
+  password field, the global-admin renderer receives that one credential in a
+  `no-store` response so the user can copy it manually; it is not persisted.
 - IDs expire after five minutes, are one-shot, and are bound to the exact agent,
   session, `browser_input` tool call, and origin.
 - The host harness captures the active URL onto `browser_input`; the host then
   refreshes stale or explicitly retried context and re-checks the live origin
   immediately before retrieving a password.
+- Active-page resolution prefers an exact daemon URL match and then the CDP
+  target currently shown in the browser viewer. This prevents a stale
+  pre-navigation daemon URL from sending lookup or fill to a background page.
 - The browser repeats the expected-origin check in the same JavaScript turn as
   the field mutation, preventing a navigation race from filling another site.
 - The agent-container credential endpoints require the existing host token. The
@@ -105,8 +116,9 @@ Apple password, PIN, or PAKE secret is persisted by Superagent.
 - A credential fill claims the open `browser_input` request before retrieval.
   Competing Done/Decline actions cannot settle it while a secret is in flight;
   every non-settling path releases the claim.
-- Secrets are not put in a tool result, renderer API response, environment
-  variable, process argument, analytics event, or log line.
+- Secrets are not put in a tool result, environment variable, process argument,
+  analytics event, or log line. The only renderer API exception is the explicit
+  missing-field manual-copy fallback described above.
 - Autofill does not submit the form. It resolves `browser_input` with an explicit
   tool result telling the agent to submit the login and request user input again
   if 2FA or another manual step appears.
@@ -114,8 +126,9 @@ Apple password, PIN, or PAKE secret is persisted by Superagent.
   shutdown sequence clears pending selections and stops the Apple broker Chrome.
 
 The password necessarily exists briefly as a JavaScript string in the host API,
-the host-to-container request body, and the CDP request. This is an MVP boundary,
-not hardware-backed secret isolation.
+the host-to-container request body, and the CDP request. During manual fallback
+it also exists in the renderer and, after a copy action, the system clipboard.
+This is an MVP boundary, not hardware-backed secret isolation.
 
 ## Local prerequisites
 
@@ -148,8 +161,9 @@ password.
   its lifetime. Chrome's Origin checks remain enabled (the broker does not use
   `--remote-allow-origins`), but prefer the debugging pipe or an authenticated
   proxy before production hardening.
-- Top-level document fields only; login forms in cross-origin iframes are not
-  filled.
+- Top-level, open-shadow-root, and same-origin iframe fields are filled. Login
+  forms in closed shadow roots or cross-origin iframes use the manual copy
+  fallback instead.
 - The heuristic targets a visible password field and the highest-confidence
   username/email field. Passkeys, federated login, and OTP fill are out of scope.
 - A two-page login works only if `browser_input` is raised on the relevant page;

--- a/docs/credential-broker-spike.md
+++ b/docs/credential-broker-spike.md
@@ -103,9 +103,9 @@ Apple password, PIN, or PAKE secret is persisted by Superagent.
 - The host harness captures the active URL onto `browser_input`; the host then
   refreshes stale or explicitly retried context and re-checks the live origin
   immediately before retrieving a password.
-- Active-page resolution prefers an exact daemon URL match and then the CDP
-  target currently shown in the browser viewer. This prevents a stale
-  pre-navigation daemon URL from sending lookup or fill to a background page.
+- Credential context and fill treat the CDP target currently shown in the
+  browser viewer as authoritative. Auto-follow resolution remains separate and
+  uses daemon state with Chrome target ordering as its stale-state fallback.
 - The browser repeats the expected-origin check in the same JavaScript turn as
   the field mutation, preventing a navigation race from filling another site.
 - The agent-container credential endpoints require the existing host token. The

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -3780,13 +3780,16 @@ describe('browser credential broker routes', () => {
     expect(messagePersister.completeInputRequest).toHaveBeenCalledTimes(1)
   })
 
-  it('releases the request claim when autofill fails before settlement', async () => {
+  it('returns a no-store manual copy fallback when no password field can be reached', async () => {
     mockContainerFetch
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ url: 'https://example.com/login' }), { status: 200 }),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: 'No visible password field was found' }), { status: 409 }),
+        new Response(JSON.stringify({
+          error: 'No visible password field was found',
+          reason: 'no_password_field',
+        }), { status: 409 }),
       )
     mockCredentialRetrieve.mockResolvedValueOnce({
       credential: { username: 'person@example.com', password: 'host-only-secret' },
@@ -3800,9 +3803,44 @@ describe('browser credential broker routes', () => {
     )
 
     expect(res.status).toBe(409)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(await res.json()).toEqual({
+      error: 'No visible password field was found',
+      reason: 'no_password_field',
+      manualCredential: {
+        username: 'person@example.com',
+        password: 'host-only-secret',
+      },
+    })
     const reclaimed = userInputRequestManager.claimRequest('tool-credential')
     expect(reclaimed?.id).toBe('tool-credential')
     userInputRequestManager.releaseClaim('tool-credential')
+  })
+
+  it('does not disclose credentials when the page origin changes', async () => {
+    mockContainerFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ url: 'https://example.com/login' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          error: 'The browser page changed before autofill',
+          reason: 'origin_changed',
+        }), { status: 409 }),
+      )
+    mockCredentialRetrieve.mockResolvedValueOnce({
+      credential: { username: 'person@example.com', password: 'host-only-secret' },
+      expectedOrigin: 'https://example.com',
+    })
+
+    const res = await postJson(
+      app,
+      '/api/agents/test-agent/sessions/sess-1/autofill-browser-credential',
+      { toolUseId: 'tool-credential', credentialId: 'opaque-id' },
+    )
+
+    expect(res.status).toBe(409)
+    expect(JSON.stringify(await res.json())).not.toContain('host-only-secret')
   })
 
   it('rejects a malformed autofill response from the container', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2964,6 +2964,7 @@ const credentialFillResponseSchema = z.object({
 })
 const credentialErrorResponseSchema = z.object({
   error: z.string(),
+  reason: z.enum(['origin_changed', 'no_password_field']).optional(),
 })
 const browserInputContextSchema = z.object({
   url: z.string().min(1),
@@ -3123,6 +3124,22 @@ agents.post(
       const fillError = credentialErrorResponseSchema.safeParse(
         await fillResponse.json().catch(() => null),
       )
+      if (fillResponse.status === 409 && fillError.success &&
+          fillError.data.reason === 'no_password_field') {
+        // Keep the browser request open so the user can paste the values and
+        // complete the step themselves. This is intentionally limited to the
+        // stable-origin, missing-field case; never disclose on navigation or
+        // an unclassified browser failure.
+        c.header('Cache-Control', 'no-store')
+        return c.json({
+          error: fillError.data.error,
+          reason: fillError.data.reason,
+          manualCredential: {
+            username: credential.username,
+            password: credential.password,
+          },
+        }, 409)
+      }
       return c.json({
         error: fillError.success ? fillError.data.error : 'Credential autofill failed',
       }, fillResponse.status === 409 ? 409 : 502)

--- a/src/renderer/components/messages/browser-credential-picker.test.tsx
+++ b/src/renderer/components/messages/browser-credential-picker.test.tsx
@@ -105,6 +105,18 @@ describe('BrowserCredentialPicker', () => {
           password: 'host-only-secret',
         },
       }, false))
+      .mockResolvedValueOnce(response({
+        provider: 'apple-passwords',
+        providerLabel: 'Apple Passwords',
+        status: 'ready',
+        installable: true,
+        origin: 'https://example.com',
+        suggestions: [{
+          id: 'opaque-2',
+          username: 'person@example.com',
+          domain: 'example.com',
+        }],
+      }))
 
     render(<BrowserCredentialPicker {...props} />)
     await user.click(await screen.findByTestId('credential-suggestion-opaque-1'))
@@ -112,14 +124,54 @@ describe('BrowserCredentialPicker', () => {
     expect(await screen.findByTestId('credential-picker-manual')).toBeInTheDocument()
     expect(screen.getByText('person@example.com')).toBeInTheDocument()
     expect(screen.queryByText('host-only-secret')).not.toBeInTheDocument()
+    expect(screen.getByText('Password hidden')).toHaveClass('sr-only')
 
     await user.click(screen.getByRole('button', { name: 'Copy username' }))
     expect(writeText).toHaveBeenLastCalledWith('person@example.com')
 
     await user.click(screen.getByRole('button', { name: 'Show password' }))
     expect(screen.getByText('host-only-secret')).toBeInTheDocument()
+    expect(screen.getByText('host-only-secret')).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.getByText('Password: host-only-secret')).toHaveClass('sr-only')
     await user.click(screen.getByRole('button', { name: 'Copy password' }))
     expect(writeText).toHaveBeenLastCalledWith('host-only-secret')
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByTestId('credential-suggestion-opaque-2')).toBeInTheDocument()
+    expect(mockApiFetch.mock.calls[2][0]).toBe(
+      '/api/agents/agent%20a/sessions/session%2F1/browser-credentials' +
+        '?toolUseId=tool%3F1&refresh=true',
+    )
+  })
+
+  it('clears the copied-state timer when the manual panel unmounts', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined)
+    const clearTimeout = vi.spyOn(window, 'clearTimeout')
+    mockApiFetch
+      .mockResolvedValueOnce(response({
+        provider: 'apple-passwords',
+        providerLabel: 'Apple Passwords',
+        status: 'ready',
+        installable: true,
+        origin: 'https://example.com',
+        suggestions: [{ id: 'opaque-1', username: 'person@example.com', domain: 'example.com' }],
+      }))
+      .mockResolvedValueOnce(response({
+        error: 'No visible password field was found',
+        reason: 'no_password_field',
+        manualCredential: { username: 'person@example.com', password: 'host-only-secret' },
+      }, false))
+
+    const view = render(<BrowserCredentialPicker {...props} />)
+    await user.click(await screen.findByTestId('credential-suggestion-opaque-1'))
+    await user.click(await screen.findByRole('button', { name: 'Copy password' }))
+    const callsBeforeUnmount = clearTimeout.mock.calls.length
+
+    view.unmount()
+
+    expect(clearTimeout.mock.calls.length).toBeGreaterThan(callsBeforeUnmount)
+    clearTimeout.mockRestore()
   })
 
   it('links to Browser Use settings when no password manager is configured', async () => {

--- a/src/renderer/components/messages/browser-credential-picker.test.tsx
+++ b/src/renderer/components/messages/browser-credential-picker.test.tsx
@@ -81,6 +81,47 @@ describe('BrowserCredentialPicker', () => {
     })
   })
 
+  it('shows reveal and copy controls when the browser fields cannot be reached', async () => {
+    const user = userEvent.setup()
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined)
+    mockApiFetch
+      .mockResolvedValueOnce(response({
+        provider: 'apple-passwords',
+        providerLabel: 'Apple Passwords',
+        status: 'ready',
+        installable: true,
+        origin: 'https://example.com',
+        suggestions: [{
+          id: 'opaque-1',
+          username: 'person@example.com',
+          domain: 'example.com',
+        }],
+      }))
+      .mockResolvedValueOnce(response({
+        error: 'No visible password field was found',
+        reason: 'no_password_field',
+        manualCredential: {
+          username: 'person@example.com',
+          password: 'host-only-secret',
+        },
+      }, false))
+
+    render(<BrowserCredentialPicker {...props} />)
+    await user.click(await screen.findByTestId('credential-suggestion-opaque-1'))
+
+    expect(await screen.findByTestId('credential-picker-manual')).toBeInTheDocument()
+    expect(screen.getByText('person@example.com')).toBeInTheDocument()
+    expect(screen.queryByText('host-only-secret')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Copy username' }))
+    expect(writeText).toHaveBeenLastCalledWith('person@example.com')
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }))
+    expect(screen.getByText('host-only-secret')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Copy password' }))
+    expect(writeText).toHaveBeenLastCalledWith('host-only-secret')
+  })
+
   it('links to Browser Use settings when no password manager is configured', async () => {
     const user = userEvent.setup()
     mockApiFetch.mockResolvedValueOnce(response({

--- a/src/renderer/components/messages/browser-credential-picker.tsx
+++ b/src/renderer/components/messages/browser-credential-picker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Check, Copy, Eye, EyeOff, KeyRound, RefreshCw } from 'lucide-react'
 import { apiFetch } from '@renderer/lib/api'
 import { Button } from '@renderer/components/ui/button'
@@ -63,6 +63,18 @@ export function BrowserCredentialPicker({
   const [passwordRevealed, setPasswordRevealed] = useState(false)
   const [copiedField, setCopiedField] = useState<'username' | 'password' | null>(null)
   const [copyError, setCopyError] = useState<string | null>(null)
+  const copiedResetTimer = useRef<number | null>(null)
+
+  const clearCopiedResetTimer = useCallback(() => {
+    if (copiedResetTimer.current !== null) {
+      window.clearTimeout(copiedResetTimer.current)
+      copiedResetTimer.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => clearCopiedResetTimer()
+  }, [clearCopiedResetTimer])
 
   useEffect(() => {
     if (!canUsePasswordManagers) {
@@ -75,6 +87,7 @@ export function BrowserCredentialPicker({
     setFilled(false)
     setManualCredential(null)
     setPasswordRevealed(false)
+    clearCopiedResetTimer()
     setCopiedField(null)
     setCopyError(null)
     const refreshQuery = reload > 0 ? '&refresh=true' : ''
@@ -94,7 +107,7 @@ export function BrowserCredentialPicker({
       if (!controller.signal.aborted) setLoading(false)
     })
     return () => controller.abort()
-  }, [agentSlug, canUsePasswordManagers, sessionId, toolUseId, reload])
+  }, [agentSlug, canUsePasswordManagers, clearCopiedResetTimer, sessionId, toolUseId, reload])
 
   const fill = useCallback(async (credentialId: string) => {
     setFillingId(credentialId)
@@ -134,13 +147,15 @@ export function BrowserCredentialPicker({
       await navigator.clipboard.writeText(manualCredential[field])
       setCopyError(null)
       setCopiedField(field)
-      window.setTimeout(() => {
+      clearCopiedResetTimer()
+      copiedResetTimer.current = window.setTimeout(() => {
         setCopiedField((current) => current === field ? null : current)
+        copiedResetTimer.current = null
       }, 2000)
     } catch {
       setCopyError('Could not copy automatically. Reveal and select the value instead.')
     }
-  }, [manualCredential])
+  }, [clearCopiedResetTimer, manualCredential])
 
   const checkPasswordManager = useCallback(async () => {
     if (!data || data.provider === 'none') return
@@ -262,10 +277,13 @@ export function BrowserCredentialPicker({
             <div className="flex items-center gap-1.5">
               <code
                 className="min-w-0 flex-1 select-all truncate rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground"
-                aria-label={passwordRevealed ? manualCredential.password : 'Password hidden'}
+                aria-hidden="true"
               >
                 {passwordRevealed ? manualCredential.password : '••••••••••••'}
               </code>
+              <span className="sr-only" aria-live="polite">
+                {passwordRevealed ? `Password: ${manualCredential.password}` : 'Password hidden'}
+              </span>
               <Button
                 type="button"
                 variant="ghost"
@@ -291,6 +309,21 @@ export function BrowserCredentialPicker({
           </div>
         </div>
         {copyError && <p className="mt-2 text-destructive">{copyError}</p>}
+        <div className="mt-3 flex items-center gap-2 border-t border-border/60 pt-3">
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            onClick={() => setReload((value) => value + 1)}
+            disabled={disabled}
+          >
+            <RefreshCw className="mr-1 h-3 w-3" />
+            Retry
+          </Button>
+          <p className="text-2xs text-muted-foreground">
+            Refresh saved logins, then select this login again.
+          </p>
+        </div>
       </div>
     )
   }

--- a/src/renderer/components/messages/browser-credential-picker.tsx
+++ b/src/renderer/components/messages/browser-credential-picker.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { KeyRound, RefreshCw } from 'lucide-react'
+import { Check, Copy, Eye, EyeOff, KeyRound, RefreshCw } from 'lucide-react'
 import { apiFetch } from '@renderer/lib/api'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
@@ -29,6 +29,11 @@ interface VerificationRequest {
   message: string
 }
 
+interface ManualCredential {
+  username: string
+  password: string
+}
+
 interface BrowserCredentialPickerProps {
   agentSlug: string
   sessionId: string
@@ -54,6 +59,10 @@ export function BrowserCredentialPicker({
   const [checking, setChecking] = useState(false)
   const [verification, setVerification] = useState<VerificationRequest | null>(null)
   const [code, setCode] = useState('')
+  const [manualCredential, setManualCredential] = useState<ManualCredential | null>(null)
+  const [passwordRevealed, setPasswordRevealed] = useState(false)
+  const [copiedField, setCopiedField] = useState<'username' | 'password' | null>(null)
+  const [copyError, setCopyError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!canUsePasswordManagers) {
@@ -63,6 +72,11 @@ export function BrowserCredentialPicker({
     const controller = new AbortController()
     setLoading(true)
     setError(null)
+    setFilled(false)
+    setManualCredential(null)
+    setPasswordRevealed(false)
+    setCopiedField(null)
+    setCopyError(null)
     const refreshQuery = reload > 0 ? '&refresh=true' : ''
     void apiFetch(
       `/api/agents/${encodeURIComponent(agentSlug)}/sessions/${encodeURIComponent(sessionId)}` +
@@ -95,7 +109,15 @@ export function BrowserCredentialPicker({
           body: JSON.stringify({ toolUseId, credentialId }),
         },
       )
-      const result = await response.json() as { error?: string }
+      const result = await response.json() as {
+        error?: string
+        reason?: string
+        manualCredential?: ManualCredential
+      }
+      if (!response.ok && result.reason === 'no_password_field' && result.manualCredential) {
+        setManualCredential(result.manualCredential)
+        return
+      }
       if (!response.ok) throw new Error(result.error || 'Credential autofill failed')
       setFilled(true)
     } catch (reason) {
@@ -104,6 +126,21 @@ export function BrowserCredentialPicker({
       setFillingId(null)
     }
   }, [agentSlug, sessionId, toolUseId])
+
+  const copyManualCredential = useCallback(async (field: 'username' | 'password') => {
+    if (!manualCredential) return
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error('Clipboard unavailable')
+      await navigator.clipboard.writeText(manualCredential[field])
+      setCopyError(null)
+      setCopiedField(field)
+      window.setTimeout(() => {
+        setCopiedField((current) => current === field ? null : current)
+      }, 2000)
+    } catch {
+      setCopyError('Could not copy automatically. Reveal and select the value instead.')
+    }
+  }, [manualCredential])
 
   const checkPasswordManager = useCallback(async () => {
     if (!data || data.provider === 'none') return
@@ -186,6 +223,74 @@ export function BrowserCredentialPicker({
           Credentials filled
         </div>
         <p className="mt-1 text-muted-foreground">Continue signing in in the browser.</p>
+      </div>
+    )
+  }
+
+  if (manualCredential) {
+    return (
+      <div className="mt-3 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-xs" data-testid="credential-picker-manual">
+        <div className="flex items-center gap-2 font-medium text-foreground">
+          <KeyRound className="h-3.5 w-3.5 text-amber-600" />
+          Copy saved login
+        </div>
+        <p className="mt-1 text-muted-foreground">
+          Autofill couldn&apos;t reach this page&apos;s sign-in fields. Copy and paste each value in the browser, then click Done.
+        </p>
+        <div className="mt-3 space-y-2">
+          <div>
+            <p className="mb-1 text-2xs font-medium text-muted-foreground">Username</p>
+            <div className="flex items-center gap-1.5">
+              <code className="min-w-0 flex-1 select-all truncate rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground">
+                {manualCredential.username || '(empty)'}
+              </code>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                onClick={() => void copyManualCredential('username')}
+                aria-label="Copy username"
+                disabled={disabled}
+              >
+                {copiedField === 'username' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                <span className="ml-1">{copiedField === 'username' ? 'Copied' : 'Copy'}</span>
+              </Button>
+            </div>
+          </div>
+          <div>
+            <p className="mb-1 text-2xs font-medium text-muted-foreground">Password</p>
+            <div className="flex items-center gap-1.5">
+              <code
+                className="min-w-0 flex-1 select-all truncate rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground"
+                aria-label={passwordRevealed ? manualCredential.password : 'Password hidden'}
+              >
+                {passwordRevealed ? manualCredential.password : '••••••••••••'}
+              </code>
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                onClick={() => setPasswordRevealed((value) => !value)}
+                aria-label={passwordRevealed ? 'Hide password' : 'Show password'}
+                disabled={disabled}
+              >
+                {passwordRevealed ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                onClick={() => void copyManualCredential('password')}
+                aria-label="Copy password"
+                disabled={disabled}
+              >
+                {copiedField === 'password' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                <span className="ml-1">{copiedField === 'password' ? 'Copied' : 'Copy'}</span>
+              </Button>
+            </div>
+          </div>
+        </div>
+        {copyError && <p className="mt-2 text-destructive">{copyError}</p>}
       </div>
     )
   }


### PR DESCRIPTION
## Summary

- resolve credential autofill against the active CDP page, falling back to the page currently shown in the browser viewer when daemon navigation state is stale
- discover visible login fields in the top-level document, open shadow roots, and same-origin frames
- show a manual username/password reveal-and-copy fallback when the selected page has no reachable password field
- keep origin-change and unclassified failures from disclosing credential values
- update the credential broker documentation and add regression coverage

## Root cause

A live test against the PG&E login page showed that its username and password are ordinary, visible, top-level inputs and that programmatic filling works. The original field predicate detects them correctly.

The failure could instead occur after navigation from `www.pge.com` to `myaccount.pge.com`: in host-browser/CDP mode, the browser daemon can retain the pre-navigation URL. When its active URL no longer matched a CDP target, credential lookup and fill fell back to Chrome target ordering and could execute against a background page while the viewer displayed PG&E.

## User impact

Saved credentials now target the page the user is actually viewing. If a site still hides its fields in a closed shadow root or cross-origin frame, users can reveal or copy the selected username and password and paste them manually without losing the browser input request.

The manual response is restricted to the stable-origin `no_password_field` case and uses `Cache-Control: no-store`. Origin changes and unknown browser failures never include the credential.

## Validation

- live PG&E login test with dummy values; both fields accepted programmatic input, values were cleared, and the form was not submitted
- `npm test` in `agent-container`: 859 passed, 8 skipped
- `npm run build` in `agent-container`
- targeted API/UI tests: 347 passed
- root TypeScript check and focused ESLint checks
