### PR TITLE
Filter completed empty thinking blocks

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2268,5 +2268,17 @@ describe('MessageList', () => {
       renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       expect(screen.queryByTestId('thinking-block')).not.toBeInTheDocument()
     })
+
+    it('drops a completed empty-text block while the wider turn remains active', () => {
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Question' } }),
+        createAssistantMessage({ content: { text: 'Starting a tool next' } }),
+      ]
+      mockStreamState.isActive = true
+      mockStreamState.thinkingBlocks = [liveBlock('', Date.now())]
+
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByTestId('thinking-block')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -584,7 +584,17 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // reset on session_active, so a match against an older turn can only be a
   // false positive (the model reusing a stock opener suppresses the live card).
   const unpersistedThinkingBlocks = useMemo(() => {
-    if (!thinkingBlocks.length || !messages?.length) return thinkingBlocks
+    if (!thinkingBlocks.length) return thinkingBlocks
+
+    // Opus can emit a signed thinking block with no display text. Keep the
+    // placeholder only while that exact block is still open; once thinking_stop
+    // arrives, an empty card has nothing useful to show even if the wider turn
+    // remains active for a following tool call or response.
+    const displayableThinkingBlocks = thinkingBlocks.filter(
+      b => b.text.trim() || (isActive && b.endedAt === null)
+    )
+    if (!displayableThinkingBlocks.length || !messages?.length) return displayableThinkingBlocks
+
     const persisted: Array<{ id?: string; text: string }> = []
     let interrupted = false
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -617,7 +627,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // An interrupted turn is over even when nothing persisted: the SDK
     // discarded whatever the leftover live blocks hold, so they'd strand.
     if (!isActive && (persisted.length || interrupted)) return []
-    return thinkingBlocks.filter(b => {
+    return displayableThinkingBlocks.filter(b => {
       const t = b.text.trim()
       const matched = persisted.some(p => {
         // When both sides have an identity, text must not override it: models
@@ -628,10 +638,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         return !!t && (p.text.startsWith(t) || t.startsWith(p.text))
       })
       if (matched) return false
-      // Blocks with no streamed text (display option off) have no persisted
-      // counterpart to collide with — keep them while the turn runs, but don't
-      // let them strand in an idle transcript.
-      if (!t) return isActive
       return true
     })
   }, [messages, thinkingBlocks, isActive])


### PR DESCRIPTION
## Summary

- filter zero-text thinking blocks as soon as their individual stream block closes
- keep the placeholder visible while that exact block is still open
- add regression coverage for a completed empty block while the wider agent turn remains active

## Root cause

Opus 5 can emit valid signed thinking blocks whose display text is empty. The renderer previously kept every empty live block whenever the overall session was active. When `thinking_stop` closed an empty block and the agent moved on to a tool call or another response, the wider turn stayed active, so the completed card lingered as `Thought for 0s / Thinking…`.

The filter now checks the block's own `endedAt` state. Empty blocks remain visible only while open; populated thinking blocks and persisted-thinking handoff behavior are unchanged.

## User impact

Users no longer accumulate blank thinking cards during multi-step Opus turns, while real summarized thinking remains visible.

## Validation

- real production Anthropic Opus 5 / high-effort calls in an isolated Docker-backed dev instance
  - before: upstream signed empty block (`thinking_len: 0`, `signature_len: 900`) rendered as a completed `Thought for 2s / Thinking…` card while the turn was active
  - after: a fresh upstream signed empty block (`thinking_len: 0`, `signature_len: 720`) produced zero completed placeholder cards while the turn was active; populated thinking cards remained
- `npx vitest run src/renderer/components/messages/message-list.test.tsx` — 93 passed
- targeted Playwright thinking-display suite — 5 passed
- `npm run typecheck`
- targeted ESLint
- `git diff --check`
