### PR TITLE
Collapse completed conversation turns

### DIFF
--- a/e2e/pages/session.page.ts
+++ b/e2e/pages/session.page.ts
@@ -123,6 +123,21 @@ export class SessionPage {
   }
 
   /**
+   * Expand the newest completed turn so assertions can inspect work that is
+   * intentionally hidden behind the turn summary once the agent is idle.
+   */
+  async expandLatestCompletedTurn(timeout = 10000) {
+    const summary = this.page.getByTestId('turn-summary').last()
+    await expect(summary).toBeVisible({ timeout })
+
+    if (await summary.getAttribute('aria-expanded') !== 'true') {
+      await summary.click()
+    }
+
+    await expect(summary).toHaveAttribute('aria-expanded', 'true', { timeout })
+  }
+
+  /**
    * Type a message into the input
    */
   async typeMessage(content: string) {

--- a/e2e/specs/activity-spark-charts.spec.ts
+++ b/e2e/specs/activity-spark-charts.spec.ts
@@ -39,6 +39,7 @@ test.describe('Activity spark charts', () => {
 
     await sessionPage.sendMessage('schedule task for daily issues')
     await sessionPage.waitForResponse(15000)
+    await sessionPage.expandLatestCompletedTurn(15000)
     await sessionPage.expectToolCall('mcp__user-input__schedule_task', 15000)
     await waitForDailyIssueSummaryTask(request, agentSlug)
 

--- a/e2e/specs/background-bash.spec.ts
+++ b/e2e/specs/background-bash.spec.ts
@@ -37,7 +37,7 @@ test.describe('Background Bash Task Tracking', () => {
 
     // Wait for the background task to complete and agent to respond.
     // The BackgroundBashScenario has a 2s delay, then the agent processes the notification.
-    await sessionPage.expectAssistantMessage('Background command completed', 1, 30000)
+    await sessionPage.expectAssistantMessage('Background command completed', 0, 30000)
     await sessionPage.waitForInputEnabled(30000)
 
     // Agent should go back to idle after everything completes
@@ -60,7 +60,7 @@ test.describe('Background Bash Task Tracking', () => {
     await sessionPage.sendMessage('run background command')
 
     // Should have the final response mentioning the command output
-    await sessionPage.expectAssistantMessage('Background command completed', 1, 30000)
+    await sessionPage.expectAssistantMessage('Background command completed', 0, 30000)
     await sessionPage.waitForInputEnabled(30000)
   })
 

--- a/e2e/specs/chat-flow.spec.ts
+++ b/e2e/specs/chat-flow.spec.ts
@@ -76,7 +76,8 @@ test.describe('Chat Flow', () => {
     // Wait for response (MockContainerClient auto-responds with tool use)
     await sessionPage.waitForResponse(15000)
 
-    // Verify tool call is visible
+    // Completed turns hide their work until the summary is expanded.
+    await sessionPage.expandLatestCompletedTurn(15000)
     await sessionPage.expectToolCall('Bash', 15000)
   })
 

--- a/e2e/specs/computer-use.spec.ts
+++ b/e2e/specs/computer-use.spec.ts
@@ -56,12 +56,12 @@ test.describe('Computer Use requests', () => {
     // turn must wipe it, or the stale entry reads as a live wait.)
     await sessionPage.sendMessage('carry on without the computer')
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('This is a mock response from the E2E test container.', 1, 15000)
+    await sessionPage.expectAssistantMessage('This is a mock response from the E2E test container.', 0, 15000)
 
     // Reload: the /stream replay must NOT resurrect the abandoned approval
     // card, and the agent must read idle — not needing input.
     await page.reload()
-    await sessionPage.expectAssistantMessage('This is a mock response from the E2E test container.', 1, 15000)
+    await sessionPage.expectAssistantMessage('This is a mock response from the E2E test container.', 0, 15000)
     await expect(sessionPage.getComputerUseRequests()).toHaveCount(0)
     await agentPage.waitForStatus('idle', 15000)
   })

--- a/e2e/specs/computer-use.spec.ts
+++ b/e2e/specs/computer-use.spec.ts
@@ -40,7 +40,7 @@ test.describe('Computer Use requests', () => {
 
     // Session should complete
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('Thank you for providing the information.', 1, 15000)
+    await sessionPage.expectAssistantMessage('Thank you for providing the information.', 0, 15000)
   })
 
   test('an abandoned approval does not survive into the next turn', async ({ page }) => {
@@ -79,6 +79,6 @@ test.describe('Computer Use requests', () => {
 
     // Session should complete
     await sessionPage.waitForInputEnabled(15000)
-    await sessionPage.expectAssistantMessage('Thank you for providing the information.', 1, 15000)
+    await sessionPage.expectAssistantMessage('Thank you for providing the information.', 0, 15000)
   })
 })

--- a/e2e/specs/dashboard-and-tasks.spec.ts
+++ b/e2e/specs/dashboard-and-tasks.spec.ts
@@ -63,6 +63,7 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     await sessionPage.waitForResponse(15000)
 
     // Verify the schedule task tool call is rendered
+    await sessionPage.expandLatestCompletedTurn(15000)
     await sessionPage.expectToolCall('mcp__user-input__schedule_task', 15000)
     const toolCall = sessionPage.getToolCall('mcp__user-input__schedule_task')
     await expect(toolCall).toBeVisible()
@@ -77,6 +78,7 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
 
     await sessionPage.sendMessage('schedule task for daily issues')
     await sessionPage.waitForResponse(15000)
+    await sessionPage.expandLatestCompletedTurn(15000)
 
     const toolCall = sessionPage.getToolCall('mcp__user-input__schedule_task')
     await expect(toolCall).toBeVisible()
@@ -100,6 +102,7 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     await sessionPage.waitForResponse(15000)
 
     // Wait for the tool call to complete
+    await sessionPage.expandLatestCompletedTurn(15000)
     await sessionPage.expectToolCall('mcp__user-input__schedule_task', 15000)
     await waitForDailyIssueSummaryTask(request, agentSlug)
 
@@ -123,6 +126,7 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
 
     await sessionPage.sendMessage('schedule task for daily issues')
     await sessionPage.waitForResponse(15000)
+    await sessionPage.expandLatestCompletedTurn(15000)
     await sessionPage.expectToolCall('mcp__user-input__schedule_task', 15000)
     await waitForDailyIssueSummaryTask(request, agentSlug)
 
@@ -156,6 +160,7 @@ test.describe('Dashboard & Scheduled Task Tool Rendering', () => {
     const ownerApiSlug = getCurrentAgentSlug(page)
     await sessionPage.sendMessage('schedule task for daily issues')
     await sessionPage.waitForResponse(15000)
+    await sessionPage.expandLatestCompletedTurn(15000)
     await sessionPage.expectToolCall('mcp__user-input__schedule_task', 15000)
     await waitForDailyIssueSummaryTask(request, ownerApiSlug)
 

--- a/e2e/specs/session-long-sleep.spec.ts
+++ b/e2e/specs/session-long-sleep.spec.ts
@@ -59,6 +59,8 @@ test.describe('Session long sleep (schedule_resume)', () => {
     await agentPage.createAgent(agentName, { waitForSidebarName: false })
 
     await sessionPage.sendMessage('schedule resume until the review is approved')
+    await sessionPage.waitForInputEnabled(15000)
+    await sessionPage.expandLatestCompletedTurn(15000)
     await sessionPage.expectToolCall('mcp__user-input__schedule_resume', 15000)
 
     const agentSlug = getCurrentAgentSlug(page)

--- a/e2e/specs/thinking-display.spec.ts
+++ b/e2e/specs/thinking-display.spec.ts
@@ -51,6 +51,7 @@ test.describe('Thinking Display', () => {
     // the refetched message) with no duplication, collapsed to a summary header.
     await sessionPage.waitForInputEnabled(30000)
     await expect(page.getByText('Done thinking — here is the answer.')).toBeVisible({ timeout: 10000 })
+    await page.getByTestId('turn-summary').last().click()
     await expect(page.getByTestId('thinking-block')).toHaveCount(1, { timeout: 15000 })
     await expect(toggle).toContainText('Thought for', { timeout: 10000 })
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
@@ -115,6 +116,7 @@ test.describe('Thinking Display', () => {
     // The CLI appends the interrupt marker as a user message ending the turn
     const marker = sessionPage.getUserMessages().filter({ hasText: '[Request interrupted by user]' })
     await expect(marker).toBeVisible({ timeout: 10000 })
+    await page.getByTestId('turn-summary').last().click()
 
     // The persisted passes stay inline above the marker...
     await expect(page.getByTestId('thinking-block').first()).toBeVisible()
@@ -144,6 +146,7 @@ test.describe('Thinking Display', () => {
     await appPage.waitForAgentsLoaded()
     await openAgentSession(page, agent, setupSession)
     await sessionPage.waitForInputEnabled(15000)
+    await page.getByTestId('turn-summary').last().click()
 
     const card = page.getByTestId('thinking-block').last()
     const toggle = card.getByTestId('thinking-block-toggle')

--- a/e2e/specs/tool-rendering.spec.ts
+++ b/e2e/specs/tool-rendering.spec.ts
@@ -70,6 +70,7 @@ test.describe('Tool Call Rendering', () => {
     await sessionPage.waitForInputEnabled(20000)
 
     // Verify Bash tool call is rendered
+    await sessionPage.expandLatestCompletedTurn(20000)
     await sessionPage.expectToolCall('Bash', 20000)
     const toolCall = renderedToolCall(sessionPage, 'Bash')
     await expect(toolCall).toBeVisible()
@@ -88,6 +89,7 @@ test.describe('Tool Call Rendering', () => {
     await sessionPage.waitForInputEnabled(20000)
 
     // Verify Read tool call is rendered
+    await sessionPage.expandLatestCompletedTurn(20000)
     await sessionPage.expectToolCall('Read', 20000)
     const toolCall = renderedToolCall(sessionPage, 'Read')
     await expect(toolCall).toBeVisible()
@@ -103,6 +105,7 @@ test.describe('Tool Call Rendering', () => {
     await sessionPage.waitForInputEnabled(20000)
 
     // Verify Write tool call is rendered
+    await sessionPage.expandLatestCompletedTurn(20000)
     await sessionPage.expectToolCall('Write', 20000)
     const toolCall = renderedToolCall(sessionPage, 'Write')
     await expect(toolCall).toBeVisible()
@@ -118,6 +121,7 @@ test.describe('Tool Call Rendering', () => {
     await sessionPage.waitForInputEnabled(20000)
 
     // Verify Grep tool call is rendered
+    await sessionPage.expandLatestCompletedTurn(20000)
     await sessionPage.expectToolCall('Grep', 20000)
     const toolCall = renderedToolCall(sessionPage, 'Grep')
     await expect(toolCall).toBeVisible()
@@ -130,6 +134,7 @@ test.describe('Tool Call Rendering', () => {
     await sessionPage.waitForInputEnabled(20000)
 
     // Verify Glob tool call is rendered
+    await sessionPage.expandLatestCompletedTurn(20000)
     await sessionPage.expectToolCall('Glob', 20000)
   })
 
@@ -140,6 +145,7 @@ test.describe('Tool Call Rendering', () => {
     await sessionPage.waitForInputEnabled(20000)
 
     // Verify WebSearch tool call is rendered
+    await sessionPage.expandLatestCompletedTurn(20000)
     await sessionPage.expectToolCall('WebSearch', 20000)
     const toolCall = renderedToolCall(sessionPage, 'WebSearch')
     await expect(toolCall).toBeVisible()
@@ -153,6 +159,7 @@ test.describe('Tool Call Rendering', () => {
 
     await sessionPage.sendMessage('list files in the current directory')
     await sessionPage.waitForInputEnabled(20000)
+    await sessionPage.expandLatestCompletedTurn(20000)
 
     const toolCall = renderedToolCall(sessionPage, 'Bash')
     await expect(toolCall).toBeVisible({ timeout: 20000 })

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -219,6 +219,10 @@ interface MessageItemProps {
   /** Read-only mirror (chat-integration replay): no edit actions; lift the
    *  connector's inline sender prefix into the sender label. */
   readOnly?: boolean
+  /** Optional reveal animation for work restored on turn expansion. */
+  workDetailClassName?: string
+  /** Tool calls that were hidden while the containing work phase was collapsed. */
+  revealedToolCallIds?: ReadonlySet<string>
 }
 
 function resolveSubagentRun(
@@ -243,7 +247,7 @@ function resolveSubagentRun(
   }
 }
 
-function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSessionActive, activeSubagents, completedSubagents, onRemoveMessage, onRemoveToolCall, readOnly }: MessageItemProps) {
+function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSessionActive, activeSubagents, completedSubagents, onRemoveMessage, onRemoveToolCall, readOnly, workDetailClassName, revealedToolCallIds }: MessageItemProps) {
   useRenderTracker('MessageItem')
   const isUser = message.type === 'user'
   const isAssistant = message.type === 'assistant'
@@ -324,7 +328,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
             episode. Same card the live stream uses, minus timing (the transcript
             doesn't carry it). */}
         {thinking.length > 0 && (
-          <div className="w-full space-y-2">
+          <div className={cn('w-full space-y-2', workDetailClassName)}>
             {thinking.map((t, i) => (
               <MessageErrorBoundary key={i} kind="thinking block" raw={t} itemId={`${message.id}-thinking-${i}`}>
                 <ThinkingBlockItem text={t.text} durationMs={t.durationMs} active={false} />
@@ -444,7 +448,13 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
               const subagentRun = resolveSubagentRun(toolCall, activeSubagents, completedSubagents)
               return (
                 <MessageContextMenu key={toolCall.id} text={toolCall.name} onRemove={onRemoveToolCall ? () => onRemoveToolCall(toolCall.id) : undefined}>
-                  <div>
+                  <div
+                    className={
+                      revealedToolCallIds?.has(toolCall.id)
+                        ? workDetailClassName
+                        : undefined
+                    }
+                  >
                     <MessageErrorBoundary kind="tool call" raw={toolCall} itemId={toolCall.id}>
                       {(toolCall.name === 'Task' || toolCall.name === 'Agent') && sessionId ? (
                         <SubAgentBlock

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -123,6 +123,12 @@ vi.mock('./subagent-block', () => ({
   SubAgentBlock: ({ toolCall }: any) => <div data-testid="subagent-block">{toolCall.name}</div>,
 }))
 
+vi.mock('./informational-item', () => ({
+  InformationalItem: ({ item }: any) => (
+    <div data-testid="informational-item">{item.content}</div>
+  ),
+}))
+
 vi.mock('./message-context-menu', () => ({
   MessageContextMenu: ({ children }: any) => <>{children}</>,
 }))
@@ -316,7 +322,7 @@ describe('MessageList', () => {
 
   // Pending-request derivation/rendering is covered by use-pending-requests.test.tsx.
 
-  it('shows turn elapsed times for completed turns', () => {
+  it('does not show a disclosure row for completed turns with only text', () => {
     const userMsg = createUserMessage({
       content: { text: 'Hello' },
       createdAt: new Date('2025-01-01T00:00:00Z'),
@@ -340,10 +346,243 @@ describe('MessageList', () => {
       <MessageList sessionId="s-1" agentSlug="agent-1" />
     )
 
-    // First turn: 60s
-    expect(screen.getByText('Worked for 60s')).toBeInTheDocument()
-    // Second turn not shown (session is active=false so it should be shown)
+    expect(screen.queryByTestId('turn-summary')).not.toBeInTheDocument()
+    expect(screen.getByText('Response')).toBeInTheDocument()
+    expect(screen.getByText('Second response')).toBeInTheDocument()
+  })
+
+  it('collapses completed turn work and keeps the final text visible', () => {
+    mockMessagesData.data = [
+      createUserMessage({
+        content: { text: 'Build it' },
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      }),
+      createAssistantMessage({
+        content: { text: 'I am inspecting the project.' },
+        createdAt: new Date('2025-01-01T00:00:10Z'),
+        toolCalls: [createToolCall({ name: 'Bash' })],
+        usage: {
+          inputTokens: 60,
+          outputTokens: 20,
+          cacheCreationInputTokens: 50,
+          cacheReadInputTokens: 0,
+        },
+      }),
+      createAssistantMessage({
+        content: { text: 'Implemented the change.' },
+        createdAt: new Date('2025-01-01T00:00:30Z'),
+        toolCalls: [createToolCall({ name: 'Read' })],
+        usage: {
+          inputTokens: 200,
+          outputTokens: 30,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+        },
+      }),
+    ]
+
+    renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('Implemented the change.')).toBeInTheDocument()
+    expect(screen.queryByText('I am inspecting the project.')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('tool-call-Bash')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('tool-call-Read')).not.toBeInTheDocument()
     expect(screen.getByText('Worked for 30s')).toBeInTheDocument()
+    expect(screen.getByText('2 tool calls')).toBeInTheDocument()
+    // Uses the same raw-field sum as the session usage popup. In the first
+    // response inputTokens already covers the cache subset, but billed usage
+    // still reports both fields: 60 + 20 + 50 + 200 + 30 = 360.
+    expect(screen.getByText('360 tokens')).toBeInTheDocument()
+
+    const summary = screen.getByTestId('turn-summary')
+    expect(summary).toHaveAccessibleName('Expand completed turn work')
+    fireEvent.click(summary)
+
+    expect(screen.getByText('I am inspecting the project.')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-call-Bash')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-call-Read')).toBeInTheDocument()
+    expect(screen.getByTestId('turn-summary')).toHaveAttribute('aria-expanded', 'true')
+    expect(summary).toHaveAccessibleName('Collapse completed turn work')
+    expect(screen.getByTestId('turn-work-detail')).toHaveClass(
+      'animate-in',
+      'fade-in-0',
+      'slide-in-from-top-2',
+    )
+    expect(screen.getByTestId('tool-call-Read').closest('.animate-in')).toHaveClass(
+      'fade-in-0',
+      'slide-in-from-top-2',
+    )
+  })
+
+  it('splits completed work around queued steering messages', () => {
+    mockMessagesData.data = [
+      createUserMessage({
+        content: { text: 'Start the slow work' },
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      }),
+      createAssistantMessage({
+        content: { text: 'Working through the task.' },
+        createdAt: new Date('2025-01-01T00:00:05Z'),
+        toolCalls: [createToolCall({ name: 'Bash' })],
+      }),
+      createAssistantMessage({
+        content: { text: 'Finished the slow work.' },
+        createdAt: new Date('2025-01-01T00:00:10Z'),
+      }),
+      createUserMessage({
+        content: { text: 'late instruction' },
+        queued: true,
+        createdAt: new Date('2025-01-01T00:00:11Z'),
+      }),
+      createAssistantMessage({
+        content: { text: 'Adapting the work.' },
+        createdAt: new Date('2025-01-01T00:00:15Z'),
+        toolCalls: [createToolCall({ name: 'Read' })],
+      }),
+      createAssistantMessage({
+        content: { text: 'Adjusting based on: late instruction' },
+        createdAt: new Date('2025-01-01T00:00:20Z'),
+      }),
+    ]
+
+    renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('Finished the slow work.')).toBeInTheDocument()
+    expect(screen.getByText('Adjusting based on: late instruction')).toBeInTheDocument()
+    expect(screen.queryByText('Working through the task.')).not.toBeInTheDocument()
+    expect(screen.queryByText('Adapting the work.')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('tool-call-Bash')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('tool-call-Read')).not.toBeInTheDocument()
+
+    const summaries = screen.getAllByTestId('turn-summary')
+    expect(summaries).toHaveLength(2)
+    expect(summaries[0]).toHaveTextContent('Worked for 10s')
+    expect(summaries[1]).toHaveTextContent('Worked for 9s')
+
+    const transcript = screen.getByTestId('message-list').textContent ?? ''
+    expect(transcript.indexOf('Start the slow work')).toBeLessThan(
+      transcript.indexOf('Worked for 10s'),
+    )
+    expect(transcript.indexOf('Worked for 10s')).toBeLessThan(
+      transcript.indexOf('late instruction'),
+    )
+    expect(transcript.indexOf('late instruction')).toBeLessThan(
+      transcript.indexOf('Worked for 9s'),
+    )
+    expect(transcript.indexOf('Worked for 9s')).toBeLessThan(
+      transcript.indexOf('Adjusting based on: late instruction'),
+    )
+  })
+
+  it('keeps structural notices visible inside a collapsed turn', () => {
+    mockMessagesData.data = [
+      createUserMessage({ content: { text: 'Do the work' } }),
+      createAssistantMessage({
+        content: { text: 'Hidden intermediate work.' },
+        toolCalls: [createToolCall({ name: 'Bash' })],
+      }),
+      {
+        id: 'notice-1',
+        type: 'informational',
+        content: 'A mid-turn agent notice.',
+        createdAt: new Date('2025-01-01T00:00:02Z'),
+      },
+      createAssistantMessage({ content: { text: 'Final answer.' } }),
+    ]
+
+    renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('A mid-turn agent notice.')).toBeInTheDocument()
+    expect(screen.getByText('Final answer.')).toBeInTheDocument()
+    expect(screen.queryByText('Hidden intermediate work.')).not.toBeInTheDocument()
+  })
+
+  it('keeps a cancelled terminal tool call visible without an empty disclosure row', () => {
+    mockMessagesData.data = [
+      createUserMessage({
+        content: { text: 'Sign me in' },
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      }),
+      createAssistantMessage({
+        content: { text: 'This step needs you.' },
+        createdAt: new Date('2025-01-01T00:00:30Z'),
+        toolCalls: [
+          createToolCall({
+            name: 'mcp__user-input__request_browser_input',
+            result: undefined,
+          }),
+        ],
+      }),
+    ]
+
+    renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('This step needs you.')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('tool-call-mcp__user-input__request_browser_input'),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('turn-summary')).not.toBeInTheDocument()
+  })
+
+  it('keeps only terminal user-input calls visible when parallel calls complete out of order', () => {
+    mockMessagesData.data = [
+      createUserMessage({ content: { text: 'Finish the workflow' } }),
+      createAssistantMessage({
+        content: { text: 'Doing the hidden setup.' },
+        toolCalls: [createToolCall({ name: 'Bash' })],
+      }),
+      createAssistantMessage({
+        content: { text: 'This step needs you.' },
+        toolCalls: [
+          createToolCall({
+            name: 'mcp__user-input__request_browser_input',
+            result: undefined,
+          }),
+          createToolCall({ name: 'Read' }),
+        ],
+      }),
+    ]
+
+    renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('This step needs you.')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('tool-call-mcp__user-input__request_browser_input'),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('tool-call-Read')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('tool-call-Bash')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('turn-summary'))
+    expect(screen.getByTestId('tool-call-Read')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-call-Bash')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-call-Read').closest('.animate-in')).toHaveClass(
+      'fade-in-0',
+      'slide-in-from-top-2',
+    )
+    expect(
+      screen
+        .getByTestId('tool-call-mcp__user-input__request_browser_input')
+        .closest('.animate-in'),
+    ).toBeNull()
+  })
+
+  it('leaves the current streaming turn fully expanded', () => {
+    mockStreamState.isActive = true
+    mockStreamState.isStreaming = true
+    mockStreamState.streamingMessage = 'Writing the final response...'
+    mockMessagesData.data = [
+      createUserMessage({ content: { text: 'Build it' } }),
+      createAssistantMessage({
+        content: { text: 'Inspecting first.' },
+        toolCalls: [createToolCall({ name: 'Bash' })],
+      }),
+    ]
+
+    renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('Inspecting first.')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-call-Bash')).toBeInTheDocument()
+    expect(screen.getByText('Writing the final response...')).toBeInTheDocument()
+    expect(screen.queryByTestId('turn-summary')).not.toBeInTheDocument()
   })
 
   it('detects running tool calls only for trailing assistant messages when active', () => {
@@ -628,7 +867,10 @@ describe('MessageList', () => {
       createUserMessage({ content: { text: 'Start' }, createdAt: new Date('2025-01-01T00:00:00Z') }),
       createAssistantMessage({ content: { text: 'Searching' }, createdAt: new Date('2025-01-01T00:00:09Z') }),
       createUserMessage({ content: { text: 'Steer' }, createdAt: new Date('2025-01-01T00:00:10Z'), queued: true }),
-      createAssistantMessage({ content: { text: 'Continuing' }, createdAt: new Date('2025-01-01T00:00:20Z') }),
+      createAssistantMessage({
+        content: { text: 'Continuing' },
+        createdAt: new Date('2025-01-01T00:00:20Z'),
+      }),
     ]
 
     renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
@@ -636,20 +878,25 @@ describe('MessageList', () => {
     expect(screen.queryByText(/Worked for/)).not.toBeInTheDocument()
   })
 
-  it('attributes the whole turn duration across steering segments once idle', () => {
+  it('attributes elapsed time to the steered work phase once idle', () => {
     mockStreamState.isActive = false
     mockMessagesData.data = [
       createUserMessage({ content: { text: 'Start' }, createdAt: new Date('2025-01-01T00:00:00Z') }),
       createAssistantMessage({ content: { text: 'Searching' }, createdAt: new Date('2025-01-01T00:00:09Z') }),
       createUserMessage({ content: { text: 'Steer' }, createdAt: new Date('2025-01-01T00:00:10Z'), queued: true }),
-      createAssistantMessage({ content: { text: 'Continuing' }, createdAt: new Date('2025-01-01T00:00:20Z') }),
+      createAssistantMessage({
+        content: { text: 'Continuing' },
+        createdAt: new Date('2025-01-01T00:00:20Z'),
+        thinking: [{ text: 'Hidden reasoning' }],
+      }),
     ]
 
     renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
 
-    // One elapsed entry, from the turn-starting message to the final assistant message
-    expect(screen.getByText('Worked for 20s')).toBeInTheDocument()
-    expect(screen.queryByText('Worked for 9s')).not.toBeInTheDocument()
+    // The queued message starts a visual work phase without becoming a new
+    // agent turn. Its elapsed time starts at the steering message.
+    expect(screen.getByText('Worked for 10s')).toBeInTheDocument()
+    expect(screen.queryByText('Worked for 20s')).not.toBeInTheDocument()
   })
 
   it('keeps tools running when a persisted queued message follows them', () => {
@@ -1111,6 +1358,11 @@ describe('MessageList', () => {
       createAssistantMessage({
         content: { text: 'Response' },
         createdAt: new Date('2025-01-01T00:01:00Z'),
+        thinking: [{ text: 'Hidden reasoning' }],
+        toolCalls: [
+          createToolCall({ name: 'Bash' }),
+          createToolCall({ name: 'Read' }),
+        ],
       }),
     ]
 
@@ -1139,7 +1391,9 @@ describe('MessageList', () => {
       createAssistantMessage({
         content: { text: 'Done' },
         createdAt: new Date('2025-01-01T00:01:00Z'),
+        thinking: [{ text: 'Hidden reasoning' }],
         toolCalls: [
+          createToolCall({ name: 'Read' }),
           createToolCall({
             name: 'mcp__user-input__deliver_file',
             input: { filePath: '/workspace/result.csv' },
@@ -1185,7 +1439,9 @@ describe('MessageList', () => {
       createAssistantMessage({
         content: { text: 'Done' },
         createdAt: new Date('2025-01-01T00:01:00Z'),
+        thinking: [{ text: 'Hidden reasoning' }],
         toolCalls: [
+          createToolCall({ name: 'Read' }),
           createToolCall({
             name: 'mcp__user-input__deliver_file',
             input: { filePath: '/workspace/output.csv' },
@@ -1253,6 +1509,11 @@ describe('MessageList', () => {
       createAssistantMessage({
         content: { text: 'First response' },
         createdAt: new Date('2025-01-01T00:01:00Z'),
+        thinking: [{ text: 'Hidden reasoning' }],
+        toolCalls: [
+          createToolCall({ name: 'Bash' }),
+          createToolCall({ name: 'Read' }),
+        ],
       }),
       createUserMessage({
         content: { text: 'Follow up' },
@@ -1282,6 +1543,7 @@ describe('MessageList', () => {
       createAssistantMessage({
         content: { text: 'Partial response' },
         createdAt: new Date('2025-01-01T00:01:00Z'),
+        toolCalls: [createToolCall({ name: 'Read' })],
       }),
       // No user message after — streaming is same turn
     ]
@@ -1293,10 +1555,16 @@ describe('MessageList', () => {
       <MessageList sessionId="s-1" agentSlug="agent-1" />
     )
 
-    // Elapsed is deferred (after streaming), not inline
+    // A divergent live buffer may be stale. Keep the latest persisted response
+    // visible, while its ordinary tool work stays in the disclosure.
     expect(screen.getByText('Worked for 60s')).toBeInTheDocument()
     const allText = container.textContent || ''
-    expect(allText.indexOf('Still going...')).toBeLessThan(allText.indexOf('Worked for 60s'))
+    expect(allText.indexOf('Worked for 60s')).toBeLessThan(
+      allText.indexOf('Partial response'),
+    )
+    expect(allText.indexOf('Partial response')).toBeLessThan(allText.indexOf('Still going...'))
+    expect(screen.getByText('Partial response')).toBeInTheDocument()
+    expect(screen.queryByTestId('tool-call-Read')).not.toBeInTheDocument()
   })
 
   // ---- Shows loading spinner only when no pending message ----
@@ -2196,7 +2464,10 @@ describe('MessageList', () => {
       mockStreamState.thinkingBlocks = [liveBlock('Let me check')]
 
       renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
-      // Old turn's persisted card + the new turn's live card
+      // The old completed turn is collapsed, while the new turn's live card
+      // remains visible and must not be falsely de-duplicated.
+      expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
+      fireEvent.click(screen.getByTestId('turn-summary'))
       expect(screen.getAllByTestId('thinking-block')).toHaveLength(2)
     })
 
@@ -2211,6 +2482,8 @@ describe('MessageList', () => {
       mockStreamState.thinkingBlocks = [liveBlock('divergent streamed fragment', Date.now())]
 
       renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByTestId('thinking-block')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('turn-summary'))
       expect(screen.getAllByTestId('thinking-block')).toHaveLength(1)
       expect(screen.queryByText('divergent streamed fragment')).not.toBeInTheDocument()
     })
@@ -2233,7 +2506,10 @@ describe('MessageList', () => {
       ]
 
       renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
-      // Only the two persisted cards — the live copies must not double-render.
+      // Completed work is collapsed by default. Expansion reveals only the two
+      // persisted cards — the live copies must not double-render.
+      expect(screen.queryByTestId('thinking-block')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('turn-summary'))
       expect(screen.getAllByTestId('thinking-block')).toHaveLength(2)
     })
 

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -20,7 +20,7 @@ import { CompactBoundaryItem } from './compact-boundary-item'
 import { MemoryRecallItem } from './memory-recall-item'
 import { InformationalItem } from './informational-item'
 import { MessageErrorBoundary } from './message-error-boundary'
-import { ArrowDown, FileX2, Loader2, MessageSquarePlus, WifiOff } from 'lucide-react'
+import { ArrowDown, ChevronRight, FileX2, Loader2, MessageSquarePlus, WifiOff } from 'lucide-react'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
 import { useIsOnline } from '@renderer/context/connectivity-context'
 import { useUser } from '@renderer/context/user-context'
@@ -41,6 +41,7 @@ import {
 } from 'react'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import type { ApiMessage, ApiCompactBoundary, ApiMemoryRecall, ApiInformational } from '@shared/lib/types/api'
+import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 
 // Prefix for system-injected user messages that should be hidden in the UI.
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in agent-container/src/claude-code.ts
@@ -57,7 +58,72 @@ const BASE_WINDOW = 300
 const LOAD_STEP = 200
 const TURN_ANCHOR_TOP = 100
 const TURN_ANCHOR_ANIMATION_MS = 220
+const TURN_WORK_REVEAL_CLASS = 'animate-in fade-in-0 slide-in-from-top-2 duration-200 ease-out motion-reduce:animate-none'
 const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
+
+interface CompletedTurn {
+  id: string
+  startMessageId: string
+  /** Null during the brief idle window before the streamed final text persists. */
+  finalAssistantMessageId: string | null
+  /** The final textual response for this visual work phase. */
+  answerMessageIds: ReadonlySet<string>
+  /** Tool cards on the answer message that appear only after expansion. */
+  revealedToolCallIds: ReadonlySet<string>
+  elapsedMs: number
+  toolCallCount: number
+  tokenCount: number
+  hasTokenUsage: boolean
+}
+
+function TurnSummaryRow({
+  turn,
+  expanded,
+  onToggle,
+  onProvideFeedback,
+}: {
+  turn: CompletedTurn
+  expanded: boolean
+  onToggle: () => void
+  onProvideFeedback?: () => void
+}) {
+  return (
+    <div className="flex items-center gap-3 border-b border-border text-muted-foreground">
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 items-center gap-1.5 py-3 text-left text-sm tabular-nums transition-colors hover:text-foreground"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-label={expanded ? 'Collapse completed turn work' : 'Expand completed turn work'}
+        data-testid="turn-summary"
+      >
+        <span>Worked for {formatElapsed(turn.elapsedMs)}</span>
+        <span aria-hidden="true">·</span>
+        <span>{turn.toolCallCount} {turn.toolCallCount === 1 ? 'tool call' : 'tool calls'}</span>
+        {turn.hasTokenUsage && (
+          <>
+            <span aria-hidden="true">·</span>
+            <span>{turn.tokenCount.toLocaleString('en-US')} tokens</span>
+          </>
+        )}
+        <ChevronRight
+          className={`h-4 w-4 shrink-0 transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+      {onProvideFeedback && (
+        <button
+          type="button"
+          onClick={onProvideFeedback}
+          className="flex shrink-0 items-center gap-1 text-xs transition-colors hover:text-foreground"
+        >
+          <MessageSquarePlus className="h-3 w-3" />
+          <span>Voice feedback</span>
+        </button>
+      )}
+    </div>
+  )
+}
 
 function DeliveredFiles({ files, agentSlug }: { files: { filePath: string }[]; agentSlug: string }) {
   return (
@@ -121,13 +187,23 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const { data: agentData } = useAgent(agentSlug)
   const hasVoiceConfigured = useIsVoiceAgentConfigured()
   const [feedbackDialogOpen, setFeedbackDialogOpen] = useState(false)
+  const [expandedTurnIds, setExpandedTurnIds] = useState<Set<string>>(new Set())
 
   const handleProvideFeedback = useCallback(() => {
     setFeedbackDialogOpen(true)
   }, [])
 
-  // Find the last assistant message that has an elapsed time (for voice feedback button)
-  const lastAssistantElapsedId = useMemo(() => {
+  const toggleTurn = useCallback((turnId: string) => {
+    setExpandedTurnIds((current) => {
+      const next = new Set(current)
+      if (next.has(turnId)) next.delete(turnId)
+      else next.add(turnId)
+      return next
+    })
+  }, [])
+
+  // Find the latest assistant response (for the voice feedback button).
+  const lastAssistantMessageId = useMemo(() => {
     if (!messages) return null
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]
@@ -656,42 +732,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     return streamingToolUses.filter(t => !persistedToolIds.has(t.id))
   }, [messages, streamingToolUses])
 
-  // Compute elapsed time for each completed response turn
-  // A turn starts with a user message and ends at the last assistant message before the next user message (or end of messages when idle)
-  const turnElapsedTimes = useMemo(() => {
-    const elapsed = new Map<string, number>()
-    if (!messages) return elapsed
-
-    let lastUserMessageTime: number | null = null
-    let lastAssistantMessageId: string | null = null
-    let lastAssistantMessageTime: number | null = null
-
-    for (const msg of messages) {
-      // Queued (mid-turn) user messages don't end the turn they appear in
-      if (isTurnStartingUserMessage(msg)) {
-        // Close previous turn
-        if (lastUserMessageTime && lastAssistantMessageId && lastAssistantMessageTime) {
-          elapsed.set(lastAssistantMessageId, lastAssistantMessageTime - lastUserMessageTime)
-        }
-        lastUserMessageTime = new Date(msg.createdAt).getTime()
-        lastAssistantMessageId = null
-        lastAssistantMessageTime = null
-      } else if (msg.type === 'assistant') {
-        lastAssistantMessageId = msg.id
-        lastAssistantMessageTime = new Date(msg.createdAt).getTime()
-      }
-    }
-
-    // Close the last turn if session is idle, or if the user has sent a new message
-    // (a pending message means a new turn started, so the previous one is complete)
-    if ((!isActive || hasTurnStartingPendingMessage) && lastUserMessageTime && lastAssistantMessageId && lastAssistantMessageTime) {
-      elapsed.set(lastAssistantMessageId, lastAssistantMessageTime - lastUserMessageTime)
-    }
-
-    return elapsed
-  }, [messages, isActive, hasTurnStartingPendingMessage])
-
-  // Collect delivered files for each completed turn (same turn boundaries as turnElapsedTimes)
+  // Collect delivered files for each completed turn.
   const turnDeliveredFiles = useMemo(() => {
     const filesMap = new Map<string, { filePath: string }[]>()
     if (!messages) return filesMap
@@ -745,6 +786,187 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     }
     return null
   }, [messages, hasTurnStartingPendingMessage, streamingMessage, isStreamingMessagePersisted, unpersistedStreamingToolUses])
+
+  // Group persisted history into user-initiated turns, then split each completed
+  // turn into visual work phases at queued steering messages. The actual turn
+  // remains fully expanded until it completes; afterward each steering message
+  // floats between the summary for the work before it and the summary for the
+  // work it initiated.
+  const hasUnpersistedStreamingMessage =
+    !!streamingMessage && !isStreamingMessagePersisted
+  const hasUnpersistedStreamingTools = unpersistedStreamingToolUses.length > 0
+  const hasUnpersistedThinking = unpersistedThinkingBlocks.length > 0
+
+  const { completedTurns, completedTurnByItemId, collapsedMessageById } = useMemo(() => {
+    const turns: CompletedTurn[] = []
+    const byItemId = new Map<string, CompletedTurn>()
+    const collapsedById = new Map<string, ApiMessage>()
+    let actualTurnStartIndex: number | null = null
+
+    const finishWorkPhase = (
+      startIndex: number,
+      endIndex: number,
+      isTerminalPhase: boolean,
+      finalTextIsStillStreaming = false,
+    ) => {
+      if (endIndex <= startIndex + 1) return
+      const items = visibleMessages.slice(startIndex, endIndex)
+      const start = items[0]
+      if (!start || start.type !== 'user') return
+
+      const assistantMessages = items.filter(
+        (item): item is ApiMessage => item.type === 'assistant'
+      )
+      const finalAssistant = assistantMessages[assistantMessages.length - 1]
+      if (!finalAssistant) return
+
+      // The persisted tail may already be the completed answer even while an
+      // older, divergent live text buffer is still waiting to reconcile. Never
+      // hide that tail: at worst it is the latest visible checkpoint until the
+      // streamed answer persists, and hiding it loses real output in the
+      // queued-message cancellation race.
+      const answerMessageIds = new Set([finalAssistant.id])
+
+      // A declined/cancelled user-input request can itself be the terminal
+      // output. Keep those historical cards visible, regardless of parallel
+      // call order. Ordinary tool work stays behind the phase disclosure.
+      const visibleTerminalToolCalls = isTerminalPhase
+        ? finalAssistant.toolCalls.filter((toolCall) =>
+            isBlockingUserInputToolName(toolCall.name),
+          )
+        : []
+      const visibleTerminalToolCallIds = new Set(
+        visibleTerminalToolCalls.map((toolCall) => toolCall.id),
+      )
+      const revealedToolCallIds = new Set(
+        finalAssistant.toolCalls
+          .filter((toolCall) => !visibleTerminalToolCallIds.has(toolCall.id))
+          .map((toolCall) => toolCall.id),
+      )
+
+      const answerHasHiddenThinking =
+        finalAssistant.thinking?.some((block) => block.text.trim().length > 0) === true
+      const hasCollapsibleWork =
+        assistantMessages.some((message) => !answerMessageIds.has(message.id)) ||
+        answerHasHiddenThinking ||
+        finalAssistant.toolCalls.length > visibleTerminalToolCalls.length
+      // Turns with no hidden work don't need a disclosure row, but they also
+      // don't need an entry in the completed-turn map: the answer and any
+      // terminal user-input outcome already render naturally.
+      if (!hasCollapsibleWork) return
+
+      collapsedById.set(finalAssistant.id, {
+        ...finalAssistant,
+        thinking: undefined,
+        toolCalls: visibleTerminalToolCalls,
+      })
+
+      let toolCallCount = 0
+      let tokenCount = 0
+      let hasTokenUsage = false
+      for (const message of assistantMessages) {
+        for (const toolCall of message.toolCalls) {
+          toolCallCount += 1 + (toolCall.subagent?.totalToolUseCount ?? 0)
+          if (toolCall.subagent?.totalTokens !== undefined) {
+            tokenCount += toolCall.subagent.totalTokens
+            hasTokenUsage = true
+          }
+        }
+        if (message.usage) {
+          // Match loadSessionUsageTotals: cumulative billed/processed tokens,
+          // including the four raw provider usage fields for every response.
+          tokenCount +=
+            message.usage.inputTokens +
+            message.usage.outputTokens +
+            message.usage.cacheCreationInputTokens +
+            message.usage.cacheReadInputTokens
+          hasTokenUsage = true
+        }
+      }
+
+      const startTime = new Date(start.createdAt).getTime()
+      const endTime = new Date(finalAssistant.createdAt).getTime()
+      const turn: CompletedTurn = {
+        id: start.id,
+        startMessageId: start.id,
+        finalAssistantMessageId: finalTextIsStillStreaming ? null : finalAssistant.id,
+        answerMessageIds,
+        revealedToolCallIds,
+        elapsedMs:
+          Number.isFinite(startTime) && Number.isFinite(endTime)
+            ? Math.max(0, endTime - startTime)
+            : 0,
+        toolCallCount,
+        tokenCount,
+        hasTokenUsage,
+      }
+      turns.push(turn)
+      for (const item of items) byItemId.set(item.id, turn)
+    }
+
+    const finishActualTurn = (endIndex: number, finalTextIsStillStreaming = false) => {
+      if (
+        actualTurnStartIndex === null ||
+        endIndex <= actualTurnStartIndex + 1
+      ) return
+
+      let phaseStartIndex = actualTurnStartIndex
+      for (let i = actualTurnStartIndex + 1; i < endIndex; i++) {
+        const item = visibleMessages[i]
+        if (item.type !== 'user' || !item.queued) continue
+        finishWorkPhase(phaseStartIndex, i, false)
+        phaseStartIndex = i
+      }
+      finishWorkPhase(
+        phaseStartIndex,
+        endIndex,
+        true,
+        finalTextIsStillStreaming,
+      )
+    }
+
+    for (let i = 0; i < visibleMessages.length; i++) {
+      if (!isTurnStartingUserMessage(visibleMessages[i])) continue
+      if (actualTurnStartIndex !== null) finishActualTurn(i)
+      actualTurnStartIndex = i
+    }
+
+    const hasUnreconciledOutput =
+      hasUnpersistedStreamingMessage ||
+      hasUnpersistedStreamingTools ||
+      hasUnpersistedThinking
+    if (actualTurnStartIndex !== null && (!isActive || hasTurnStartingPendingMessage)) {
+      // session_idle can precede the final messages refetch. Collapse the
+      // persisted work immediately, but don't mistake its last interim text
+      // for the final answer — the still-streamed final text below owns that.
+      finishActualTurn(
+        visibleMessages.length,
+        hasUnreconciledOutput && !hasTurnStartingPendingMessage,
+      )
+    }
+
+    return {
+      completedTurns: turns,
+      completedTurnByItemId: byItemId,
+      collapsedMessageById: collapsedById,
+    }
+  }, [
+    visibleMessages,
+    hasUnpersistedStreamingMessage,
+    hasUnpersistedStreamingTools,
+    hasUnpersistedThinking,
+    isActive,
+    hasTurnStartingPendingMessage,
+  ])
+
+  // Drop expansion state for turns that no longer exist after edits/refetches.
+  useEffect(() => {
+    const validIds = new Set(completedTurns.map((turn) => turn.id))
+    setExpandedTurnIds((current) => {
+      if ([...current].every((id) => validIds.has(id))) return current
+      return new Set([...current].filter((id) => validIds.has(id)))
+    })
+  }, [completedTurns])
 
   // Determine which messages could have tool calls that are still running.
   // Only the trailing assistant messages (after the last user message) can have running tools,
@@ -1047,42 +1269,106 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             {hiddenCount} earlier {hiddenCount === 1 ? 'message' : 'messages'} hidden — scroll up to load
           </div>
         )}
-        {windowedMessages.map((item) => (
-          <Fragment key={item.id}>
-            {item.type === 'memory_recall' ? (
-              <MemoryRecallItem recall={item as ApiMemoryRecall} />
-            ) : item.type === 'compact_boundary' ? (
-              <CompactBoundaryItem boundary={item as ApiCompactBoundary} />
-            ) : item.type === 'informational' ? (
-              <InformationalItem item={item as ApiInformational} />
-            ) : (
-              <>
-                <MessageErrorBoundary kind="message" raw={item} itemId={item.id}>
-                  <MessageItem message={item as ApiMessage} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={canHaveRunningToolCalls.has(item.id)} activeSubagents={activeSubagents} completedSubagents={completedSubagents} onRemoveMessage={readOnly ? undefined : handleRemoveMessage} onRemoveToolCall={readOnly ? undefined : handleRemoveToolCall} readOnly={readOnly} />
-                </MessageErrorBoundary>
-                {turnDeliveredFiles.has(item.id) && item.id !== deferredElapsedMessageId && (
-                  <DeliveredFiles files={turnDeliveredFiles.get(item.id)!} agentSlug={agentSlug} />
-                )}
-                {turnElapsedTimes.has(item.id) && item.id !== deferredElapsedMessageId && (
-                  <div className="flex items-center gap-3 pb-1 -mt-3 text-xs text-muted-foreground tabular-nums italic">
-                    <span>Worked for {formatElapsed(turnElapsedTimes.get(item.id)!)}</span>
-                    <div className="h-px flex-1 bg-border" />
-                    {hasVoiceConfigured && (item as ApiMessage).type === 'assistant' && item.id === lastAssistantElapsedId && (
-                      <button
-                        type="button"
-                        onClick={handleProvideFeedback}
-                        className="flex items-center gap-1 not-italic text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <MessageSquarePlus className="h-3 w-3" />
-                        <span>Voice feedback</span>
-                      </button>
-                    )}
-                  </div>
-                )}
-              </>
-            )}
-          </Fragment>
-        ))}
+        {windowedMessages.map((item, index) => {
+          const turn = completedTurnByItemId.get(item.id)
+          const expanded = !!turn && expandedTurnIds.has(turn.id)
+          const previousItem = index > 0 ? windowedMessages[index - 1] : null
+          const previousTurn = previousItem
+            ? completedTurnByItemId.get(previousItem.id)
+            : undefined
+          const showTurnSummary =
+            !!turn &&
+            item.id !== turn.startMessageId &&
+            (!previousTurn ||
+              previousTurn.id !== turn.id ||
+              previousItem?.id === turn.startMessageId)
+          const collapsed = !!turn && !expanded
+          const isAssistantItem = item.type === 'assistant'
+          const isAnswerMessage =
+            !!turn && isAssistantItem && turn.answerMessageIds.has(item.id)
+          const hideItem =
+            collapsed &&
+            isAssistantItem &&
+            !isAnswerMessage
+          const isRevealedWorkItem =
+            expanded &&
+            isAssistantItem &&
+            !isAnswerMessage
+
+          let renderedItem: ReactNode = null
+          if (!hideItem) {
+            if (item.type === 'memory_recall') {
+              renderedItem = <MemoryRecallItem recall={item as ApiMemoryRecall} />
+            } else if (item.type === 'compact_boundary') {
+              renderedItem = <CompactBoundaryItem boundary={item as ApiCompactBoundary} />
+            } else if (item.type === 'informational') {
+              renderedItem = <InformationalItem item={item as ApiInformational} />
+            } else {
+              const message = item as ApiMessage
+              // Collapsed answer shapes are memoized with the turn grouping so
+              // streaming deltas don't allocate and re-render past messages.
+              const displayedMessage = collapsed
+                ? collapsedMessageById.get(message.id) ?? message
+                : message
+              const messageItem = (
+                <>
+                  <MessageErrorBoundary kind="message" raw={item} itemId={item.id}>
+                    <MessageItem
+                      message={displayedMessage}
+                      agentSlug={agentSlug}
+                      sessionId={sessionId}
+                      isSessionActive={canHaveRunningToolCalls.has(item.id)}
+                      activeSubagents={activeSubagents}
+                      completedSubagents={completedSubagents}
+                      onRemoveMessage={readOnly ? undefined : handleRemoveMessage}
+                      onRemoveToolCall={readOnly ? undefined : handleRemoveToolCall}
+                      readOnly={readOnly}
+                      workDetailClassName={
+                        expanded && isAnswerMessage
+                          ? TURN_WORK_REVEAL_CLASS
+                          : undefined
+                      }
+                      revealedToolCallIds={
+                        expanded && isAnswerMessage
+                          ? turn.revealedToolCallIds
+                          : undefined
+                      }
+                    />
+                  </MessageErrorBoundary>
+                  {turnDeliveredFiles.has(item.id) && item.id !== deferredElapsedMessageId && (
+                    <DeliveredFiles files={turnDeliveredFiles.get(item.id)!} agentSlug={agentSlug} />
+                  )}
+                </>
+              )
+              renderedItem = isRevealedWorkItem ? (
+                <div
+                  className={TURN_WORK_REVEAL_CLASS}
+                  data-testid="turn-work-detail"
+                >
+                  {messageItem}
+                </div>
+              ) : messageItem
+            }
+          }
+
+          return (
+            <Fragment key={item.id}>
+              {showTurnSummary && (
+                <TurnSummaryRow
+                  turn={turn}
+                  expanded={expanded}
+                  onToggle={() => toggleTurn(turn.id)}
+                  onProvideFeedback={
+                    hasVoiceConfigured && turn.finalAssistantMessageId === lastAssistantMessageId
+                      ? handleProvideFeedback
+                      : undefined
+                  }
+                />
+              )}
+              {renderedItem}
+            </Fragment>
+          )
+        })}
 
         {/* Turn-starting ghosts (sent while idle) — the next turn belongs to
             them, so they render before any streaming content. Queued ghosts
@@ -1197,15 +1483,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
           )
         })}
 
-        {/* Deferred delivered files + elapsed time — shown after streaming content */}
+        {/* Deferred delivered files — shown after streaming content */}
         {deferredElapsedMessageId && turnDeliveredFiles.has(deferredElapsedMessageId) && (
           <DeliveredFiles files={turnDeliveredFiles.get(deferredElapsedMessageId)!} agentSlug={agentSlug} />
-        )}
-        {deferredElapsedMessageId && turnElapsedTimes.has(deferredElapsedMessageId) && (
-          <div className="flex items-center gap-3 pb-1 -mt-3 text-xs text-muted-foreground tabular-nums italic">
-            <span>Worked for {formatElapsed(turnElapsedTimes.get(deferredElapsedMessageId)!)}</span>
-            <div className="h-px flex-1 bg-border" />
-          </div>
         )}
 
         {/* Queued ghosts — waiting for the agent loop to pick them up, so they

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -155,6 +155,8 @@ export interface JsonlMessageEntry {
     usage?: {
       input_tokens: number
       output_tokens: number
+      cache_creation_input_tokens?: number
+      cache_read_input_tokens?: number
     }
   }
   // Tool result specific fields (present when type is 'user' with tool_result content)

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -167,6 +167,13 @@ export interface ApiMessage {
    * timestamps and absent when underivable.
    */
   thinking?: Array<{ id?: string; text: string; durationMs?: number }>
+  /** Per-model-response token usage preserved from the session transcript. */
+  usage?: {
+    inputTokens: number
+    outputTokens: number
+    cacheCreationInputTokens: number
+    cacheReadInputTokens: number
+  }
 }
 
 /**

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -313,6 +313,40 @@ describe('transformMessages', () => {
       expect(asMessage(result[1]).content.text).toBe('Second')
     })
 
+    it('preserves the highest usage snapshot for a merged provider response', () => {
+      const first = createAssistantMessage(
+        'uuid-1',
+        'msg-shared',
+        [{ type: 'text', text: 'Working' }]
+      )
+      first.message.usage = {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_input_tokens: 20,
+        cache_read_input_tokens: 30,
+      }
+      const final = createAssistantMessage(
+        'uuid-2',
+        'msg-shared',
+        [{ type: 'text', text: ' done' }]
+      )
+      final.message.usage = {
+        input_tokens: 10,
+        output_tokens: 15,
+        cache_creation_input_tokens: 20,
+        cache_read_input_tokens: 30,
+      }
+
+      const result = transformMessages([first, final])
+
+      expect(asMessage(result[0]).usage).toEqual({
+        inputTokens: 10,
+        outputTokens: 15,
+        cacheCreationInputTokens: 20,
+        cacheReadInputTokens: 30,
+      })
+    })
+
     it('handles three-way merge (text + tool_use + more text)', () => {
       const entries: JsonlMessageEntry[] = [
         createAssistantMessage('uuid-1', 'msg-shared', [{ type: 'text', text: 'Starting. ' }]),

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -50,6 +50,13 @@ export interface TransformedMessage {
    * from entry timestamps (see thinkingByEntry) and absent when underivable.
    */
   thinking?: TransformedThinkingBlock[]
+  /** Per-model-response token usage, de-duplicated by the merge pass above. */
+  usage?: {
+    inputTokens: number
+    outputTokens: number
+    cacheCreationInputTokens: number
+    cacheReadInputTokens: number
+  }
 }
 
 export interface TransformedCompactBoundary {
@@ -310,6 +317,17 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
           mergedContentOffset = existingContent.length
           // Append new content blocks to existing
           ;(existing.message.content as ContentBlock[]).push(...(newContent as ContentBlock[]))
+        }
+        // Transcript snapshots for one provider response repeat the same input
+        // usage while output_tokens grows. Keep the latest/highest snapshot so
+        // consumers can count this response once without understating it.
+        const existingUsage = existing.message.usage
+        const incomingUsage = entry.message.usage
+        if (
+          incomingUsage &&
+          (!existingUsage || incomingUsage.output_tokens >= existingUsage.output_tokens)
+        ) {
+          existing.message.usage = { ...incomingUsage }
         }
         // Keep the original entry's uuid and timestamp for correct ordering
         target = existing
@@ -583,6 +601,14 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
       ...(entry.error && { apiError: entry.error }),
       ...(entry.isQueuedCommand && { queued: true }),
       ...(thinking && thinking.length > 0 && { thinking }),
+      ...(entry.message.usage && {
+        usage: {
+          inputTokens: entry.message.usage.input_tokens ?? 0,
+          outputTokens: entry.message.usage.output_tokens ?? 0,
+          cacheCreationInputTokens: entry.message.usage.cache_creation_input_tokens ?? 0,
+          cacheReadInputTokens: entry.message.usage.cache_read_input_tokens ?? 0,
+        },
+      }),
     })
   }
 


### PR DESCRIPTION
## Summary

- Collapse completed conversation turns into disclosure rows showing elapsed time, tool-call count, and cumulative processed token usage while keeping every answer checkpoint visible.
- Split completed turns into visual work phases at queued steering messages, so steering instructions sit between the summaries for the work before and after them.
- Preserve replies on both sides of queued steering messages, the newest persisted reply during stream reconciliation, structural notices, and terminal user-input outcomes.
- Keep ordinary tool calls inside their work-phase disclosures instead of leaking them into the collapsed transcript.
- Leave the active streaming turn fully expanded, animate revealed work, omit the disclosure when a turn has no hidden work, and memoize collapsed answer shapes.
- Preserve per-response usage from session transcripts, de-duplicate streaming usage snapshots, and include subagent totals in turn metrics.

## Why

Long completed turns currently leave every intermediate message, thinking block, and tool card expanded in the transcript. This makes past conversations hard to scan. The compact presentation keeps history readable without losing multiple answers within a steered turn, terminal tool outcomes, or informational transcript items.

## Validation

- `npm test -- --run src/renderer/components/messages/message-list.test.tsx src/shared/lib/utils/message-transform.test.ts` (222 tests passed)
- `npm run typecheck`
- Targeted ESLint for all changed TypeScript files
- Affected Playwright scenarios in `message-queueing`, `thinking-display`, `computer-use`, and `background-bash` (17 total; two rerun serially to clear timing and verify the reconciliation fix)
- `git diff --check`
- Manual visual verification in the Electron development app
