### PR TITLE
Restore Gamut wordmark in browser sidebar

### DIFF
--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -345,8 +345,15 @@ beforeEach(() => {
 })
 
 describe('AppSidebar — layout & top nav', () => {
-  it('does not name the app in the sidebar', () => {
-    // The wordmark cost a whole row to repeat what the window already says.
+  it('restores the Gamut wordmark when browser chrome leaves the title bar empty', () => {
+    renderWithProviders(<AppSidebar />)
+    expect(screen.getByText('Gamut')).toBeInTheDocument()
+  })
+
+  it('does not repeat the Gamut wordmark beside Electron window controls', () => {
+    vi.stubGlobal('__WEB__', false)
+    mockIsElectron.mockReturnValue(true)
+
     renderWithProviders(<AppSidebar />)
     expect(screen.queryByText('Gamut')).not.toBeInTheDocument()
   })

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -844,10 +844,9 @@ export function AppSidebar() {
       {/*
         The sidebar's title bar: one 48px row holding everything that acts on the
         window rather than on an agent — where agents run, history, search — and,
-        on macOS, the traffic lights it leaves room for. There is no app name
-        here on purpose: it named the window in a window that is already named,
-        and its row was the only thing standing between the traffic lights and
-        the controls.
+        on macOS, the traffic lights it leaves room for. The browser restores the
+        app name in the space left by the Electron-only target and history
+        controls.
 
         The left padding (not the height) is what changes on a fullscreen
         toggle, so the row itself never moves and only the traffic-light gap
@@ -861,6 +860,10 @@ export function AppSidebar() {
             expands it in place, which pushes the buttons after it past the right
             edge rather than squeezing them. */}
         <div className="flex items-center h-12 px-2 gap-1 overflow-hidden">
+          {__WEB__ && (
+            <span className="shrink-0 select-none text-base font-medium">Gamut</span>
+          )}
+
           {isWindowsElectron && (
             <button
               className="app-no-drag shrink-0 p-0.5 rounded hover:bg-foreground/10 transition-colors cursor-default"


### PR DESCRIPTION
## Summary

- restore the Gamut wordmark in the browser sidebar title bar
- keep the Electron title bar unchanged, with no duplicate wordmark beside its workspace and history controls
- add regression coverage for both browser and Electron rendering

## Why

The shared sidebar title bar stopped rendering the wordmark when Electron controls were moved into that row. Those controls are intentionally absent from the browser build, leaving the top-left area empty. Rendering the wordmark only for `__WEB__` fills that gap without changing Electron chrome.

## Impact

Browser users see the Gamut identity restored in the sidebar header. Electron users continue to see the existing local/cloud and history controls without duplicated branding.

## Validation

- `vitest run src/renderer/components/layout/app-sidebar.test.tsx` (35 tests passed)
- ESLint on the changed implementation and test files
- `tsc --noEmit`
