### PR TITLE
Redesign Settings usage analytics

### DIFF
--- a/src/api/routes/usage.test.ts
+++ b/src/api/routes/usage.test.ts
@@ -177,7 +177,7 @@ describe('usage route', () => {
         { agentSlug: 'agent-1', agentName: 'Agent One', cost: 1.50, totalTokens: 0 },
       ])
       expect(dayEntry.byModel).toEqual([
-        { model: 'claude-sonnet', cost: 1.50 },
+        { model: 'claude-sonnet', cost: 1.50, totalTokens: 0 },
       ])
     })
 
@@ -526,7 +526,7 @@ describe('usage route', () => {
       }
     })
 
-    it('converts byModel map entries to array of {model, cost}', async () => {
+    it('converts byModel map entries to array of model usage totals', async () => {
       const agent = makeAgent('agent-1', 'Agent One')
       mockListAgents.mockResolvedValue([agent])
       mockGetAgentClaudeConfigDir.mockReturnValue('/data/agents/agent-1/.claude')
@@ -547,9 +547,38 @@ describe('usage route', () => {
       for (const modelUsage of dayEntry.byModel) {
         expect(modelUsage).toHaveProperty('model')
         expect(modelUsage).toHaveProperty('cost')
+        expect(modelUsage).toHaveProperty('totalTokens')
         expect(typeof modelUsage.model).toBe('string')
         expect(typeof modelUsage.cost).toBe('number')
+        expect(typeof modelUsage.totalTokens).toBe('number')
       }
+    })
+
+    it('aggregates token totals by model', async () => {
+      const agent = makeAgent('agent-1', 'Agent One')
+      mockListAgents.mockResolvedValue([agent])
+      mockGetAgentClaudeConfigDir.mockReturnValue('/data/agents/agent-1/.claude')
+
+      mockLoadDailyUsageData.mockResolvedValue([
+        makeDay('2025-01-15', 1.25, [
+          {
+            modelName: 'claude-sonnet',
+            cost: 1.25,
+            inputTokens: 1_000,
+            outputTokens: 250,
+            cacheCreationTokens: 100,
+            cacheReadTokens: 2_000,
+          },
+        ]),
+      ])
+
+      const res = await getUsage('days=7')
+      const body = await res.json()
+      const dayEntry = body.daily.find((d: { date: string }) => d.date === '2025-01-15')
+
+      expect(dayEntry.byModel).toEqual([
+        { model: 'claude-sonnet', cost: 1.25, totalTokens: 3_350 },
+      ])
     })
 
     it('handles rejected agent promises gracefully (skips them)', async () => {

--- a/src/api/routes/usage.ts
+++ b/src/api/routes/usage.ts
@@ -79,7 +79,7 @@ usage.get('/', async (c) => {
     totalCost: number
     totalTokens: number
     byAgent: Map<string, { agentSlug: string; agentName: string; cost: number; totalTokens: number }>
-    byModel: Map<string, number>
+    byModel: Map<string, { cost: number; totalTokens: number }>
   }>()
 
   // Process agents in batches to balance throughput and memory usage.
@@ -129,8 +129,12 @@ usage.get('/', async (c) => {
 
         for (const mb of day.modelBreakdowns) {
           const normalizedName = normalizeModelName(mb.modelName)
-          const prev = entry.byModel.get(normalizedName) || 0
-          entry.byModel.set(normalizedName, prev + mb.cost)
+          const totalTokens = mb.inputTokens + mb.outputTokens + mb.cacheCreationTokens + mb.cacheReadTokens
+          const prev = entry.byModel.get(normalizedName)
+          entry.byModel.set(normalizedName, {
+            cost: (prev?.cost ?? 0) + mb.cost,
+            totalTokens: (prev?.totalTokens ?? 0) + totalTokens,
+          })
         }
       }
     }
@@ -151,9 +155,10 @@ usage.get('/', async (c) => {
       totalCost: data.totalCost,
       totalTokens: data.totalTokens,
       byAgent: Array.from(data.byAgent.values()),
-      byModel: Array.from(data.byModel.entries()).map(([model, cost]) => ({
+      byModel: Array.from(data.byModel.entries()).map(([model, usage]) => ({
         model,
-        cost,
+        cost: usage.cost,
+        totalTokens: usage.totalTokens,
       })),
     }))
 

--- a/src/renderer/components/settings/usage-tab.test.tsx
+++ b/src/renderer/components/settings/usage-tab.test.tsx
@@ -5,6 +5,7 @@ import { UsageTab } from './usage-tab'
 import type { LlmProviderId } from '@shared/lib/config/settings'
 
 const useSettingsMock = vi.fn()
+const useUsageMock = vi.fn()
 const refetchMock = vi.fn()
 
 vi.mock('@renderer/hooks/use-settings', () => ({
@@ -12,12 +13,7 @@ vi.mock('@renderer/hooks/use-settings', () => ({
 }))
 
 vi.mock('@renderer/hooks/use-usage', () => ({
-  useUsageData: () => ({
-    data: { daily: [] },
-    isLoading: false,
-    isFetching: false,
-    refetch: refetchMock,
-  }),
+  useUsageData: (...args: unknown[]) => useUsageMock(...args),
 }))
 
 vi.mock('@renderer/context/user-context', () => ({
@@ -25,7 +21,15 @@ vi.mock('@renderer/context/user-context', () => ({
 }))
 
 describe('UsageTab', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useUsageMock.mockReturnValue({
+      data: { daily: [] },
+      isLoading: false,
+      isFetching: false,
+      refetch: refetchMock,
+    })
+  })
 
   it('relies on the query lifecycle instead of forcing a second mount refetch', () => {
     useSettingsMock.mockReturnValue({ data: {} })
@@ -78,4 +82,121 @@ describe('UsageTab', () => {
     expect(screen.getByRole('alert')).toHaveTextContent("check your provider's billing dashboard")
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
+
+  it('surfaces real summary metrics and switches the ranked breakdown', () => {
+    useSettingsMock.mockReturnValue({ data: { llmProvider: 'anthropic' } })
+    useUsageMock.mockReturnValue({
+      data: {
+        daily: [{
+          date: '2026-08-10',
+          totalCost: 12,
+          totalTokens: 1_500,
+          byModel: [{ model: 'claude-sonnet-4-6', cost: 12, totalTokens: 1_500 }],
+          byAgent: [{
+            agentSlug: 'research',
+            agentName: 'Research Agent',
+            cost: 12,
+            totalTokens: 1_500,
+          }],
+        }],
+      },
+      isLoading: false,
+      isFetching: false,
+      refetch: refetchMock,
+    })
+
+    render(<UsageTab />)
+
+    expect(screen.getByRole('heading', { name: '$12.00' })).toBeInTheDocument()
+    expect(screen.getAllByText('1.5K').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('claude-sonnet-4-6')).toHaveLength(2)
+    expect(document.querySelector('[data-provider-icon="anthropic"]')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agent' }))
+
+    expect(screen.getAllByText('Research Agent')).toHaveLength(2)
+    expect(screen.getByRole('button', { name: 'Agent' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('switches the daily chart between cost and token views', () => {
+    useSettingsMock.mockReturnValue({ data: {} })
+    useUsageMock.mockReturnValue({
+      data: {
+        daily: [{
+          date: '2026-08-10',
+          totalCost: 1,
+          totalTokens: 100,
+          byModel: [{ model: 'test-model', cost: 1, totalTokens: 100 }],
+          byAgent: [],
+        }],
+      },
+      isLoading: false,
+      isFetching: false,
+      refetch: refetchMock,
+    })
+
+    render(<UsageTab />)
+    const tokensButton = screen.getByRole('button', { name: /tokens/i })
+
+    fireEvent.click(tokensButton)
+
+    expect(tokensButton).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /cost/i })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('isolates a selected series and compares its metrics with the overall totals', () => {
+    useSettingsMock.mockReturnValue({ data: { llmProvider: 'anthropic' } })
+    useUsageMock.mockReturnValue({
+      data: {
+        daily: [
+          {
+            date: '2026-08-09',
+            totalCost: 14,
+            totalTokens: 1_400,
+            byModel: [
+              { model: 'claude-sonnet-4-6', cost: 12, totalTokens: 1_200 },
+              { model: 'gpt-5', cost: 2, totalTokens: 200 },
+            ],
+            byAgent: [],
+          },
+          {
+            date: '2026-08-10',
+            totalCost: 6,
+            totalTokens: 600,
+            byModel: [{ model: 'gpt-5', cost: 6, totalTokens: 600 }],
+            byAgent: [],
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      refetch: refetchMock,
+    })
+
+    render(<UsageTab />)
+
+    const legendButton = screen.getByRole('button', { name: /^claude-sonnet-4-6$/ })
+    const breakdownButton = screen.getByRole('button', { name: /claude-sonnet-4-6.*\$12\.00/ })
+    const spendHeading = document.getElementById('usage-overview-heading')
+
+    fireEvent.click(legendButton)
+
+    expect(legendButton).toHaveAttribute('aria-pressed', 'true')
+    expect(breakdownButton).toHaveAttribute('aria-pressed', 'true')
+    expect(spendHeading).toHaveTextContent('$12.00 / $20.00')
+    expect(screen.getByText('Processed tokens').parentElement).toHaveTextContent('1.2K / 2K')
+    expect(screen.getByText('Active days').parentElement).toHaveTextContent('1 / 2')
+    expect(screen.getByText('Peak spend').parentElement).toHaveTextContent('$12.00 / $14.00')
+    expect(screen.getByText('Models in view').parentElement).toHaveTextContent('1 / 2')
+
+    fireEvent.click(breakdownButton)
+
+    expect(legendButton).toHaveAttribute('aria-pressed', 'false')
+    expect(spendHeading).toHaveTextContent('$20.00')
+    expect(spendHeading).not.toHaveTextContent('/')
+
+    fireEvent.click(breakdownButton)
+    expect(breakdownButton).toHaveAttribute('aria-pressed', 'true')
+  })
+
 })

--- a/src/renderer/components/settings/usage-tab.tsx
+++ b/src/renderer/components/settings/usage-tab.tsx
@@ -1,6 +1,23 @@
-import { useState, useMemo } from 'react'
-import { Button } from '@renderer/components/ui/button'
+import { useMemo, useState } from 'react'
+import { format, parseISO } from 'date-fns'
+import {
+  AlertTriangle,
+  Bot,
+  CalendarDays,
+  ExternalLink,
+  Gauge,
+  RefreshCw,
+  Sparkles,
+} from 'lucide-react'
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { Alert, AlertDescription, AlertTitle } from '@renderer/components/ui/alert'
+import { Button } from '@renderer/components/ui/button'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@renderer/components/ui/chart'
 import {
   Select,
   SelectContent,
@@ -9,38 +26,48 @@ import {
   SelectValue,
 } from '@renderer/components/ui/select'
 import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-  ChartLegend,
-  ChartLegendContent,
-  type ChartConfig,
-} from '@renderer/components/ui/chart'
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from 'recharts'
-import { AlertTriangle, ExternalLink, RefreshCw, Loader2 } from 'lucide-react'
-import { useUsageData } from '@renderer/hooks/use-usage'
-import { useSettings } from '@renderer/hooks/use-settings'
+  useFullWidthSettingsContent,
+  useHideSettingsHeader,
+} from '@renderer/components/settings/settings-page'
 import { useUser } from '@renderer/context/user-context'
-import { format, parseISO } from 'date-fns'
+import { useSettings } from '@renderer/hooks/use-settings'
+import { useUsageData } from '@renderer/hooks/use-usage'
 import type { LlmProviderId } from '@shared/lib/config/settings'
+import { cn } from '@shared/lib/utils/cn'
 
-type Segmentation = 'total' | 'byModel' | 'byAgent'
+type Segmentation = 'byModel' | 'byAgent'
+type Metric = 'cost' | 'tokens'
 
-const DAY_OPTIONS = [
-  { value: '7', label: 'Last 7 days' },
-  { value: '14', label: 'Last 14 days' },
-  { value: '30', label: 'Last 30 days' },
-]
+interface BreakdownRow {
+  key: string
+  label: string
+  cost: number
+  totalTokens: number
+}
 
-const COLORS = [
-  'hsl(215, 70%, 60%)',
-  'hsl(150, 60%, 45%)',
-  'hsl(35, 90%, 55%)',
-  'hsl(280, 60%, 60%)',
-  'hsl(0, 70%, 55%)',
-  'hsl(180, 50%, 50%)',
-  'hsl(60, 70%, 50%)',
-  'hsl(320, 60%, 55%)',
+interface ChartSegment {
+  key: string
+  label: string
+  sourceKeys: Set<string>
+}
+
+interface UsageSelection {
+  key: string
+  label: string
+  sourceKeys: string[]
+  colorIndex: number
+}
+
+const DAY_OPTIONS = [7, 14, 30]
+const MAX_CHART_SEGMENTS = 5
+
+const CHART_COLORS = [
+  { light: 'hsl(12 76% 54%)', dark: 'hsl(12 76% 61%)' },
+  { light: 'hsl(173 58% 36%)', dark: 'hsl(160 60% 45%)' },
+  { light: 'hsl(215 62% 48%)', dark: 'hsl(220 70% 58%)' },
+  { light: 'hsl(36 82% 52%)', dark: 'hsl(30 80% 58%)' },
+  { light: 'hsl(278 52% 55%)', dark: 'hsl(280 65% 66%)' },
+  { light: 'hsl(210 10% 56%)', dark: 'hsl(210 10% 50%)' },
 ]
 
 const PROVIDER_USAGE_LINKS: Partial<Record<LlmProviderId, { label: string; href: string }>> = {
@@ -58,82 +85,536 @@ const PROVIDER_USAGE_LINKS: Partial<Record<LlmProviderId, { label: string; href:
   },
 }
 
+const compactNumberFormatter = new Intl.NumberFormat(undefined, {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})
+
+function formatCompactNumber(value: number): string {
+  return compactNumberFormatter.format(value)
+}
+
+function formatCurrency(value: number, compact = false): string {
+  if (compact && Math.abs(value) >= 1_000) {
+    return `$${formatCompactNumber(value)}`
+  }
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function dateRangeLabel(dates: string[]): string {
+  if (dates.length === 0) return ''
+  const first = parseISO(dates[0])
+  const last = parseISO(dates[dates.length - 1])
+  if (dates.length === 1) return format(first, 'MMM d, yyyy')
+  if (first.getFullYear() !== last.getFullYear()) {
+    return `${format(first, 'MMM d, yyyy')} – ${format(last, 'MMM d, yyyy')}`
+  }
+  return `${format(first, 'MMM d')} – ${format(last, 'MMM d, yyyy')}`
+}
+
+/** Infer the bundled vendor mark from the provider-qualified or canonical model id. */
+function modelProviderIcon(model: string): string | undefined {
+  const id = model.toLowerCase()
+  if (id.startsWith('anthropic/') || id.includes('claude')) return 'anthropic'
+  if (
+    id.startsWith('openai/') ||
+    id.includes('/gpt-') ||
+    /^(?:gpt|codex|o[134](?:-|$))/.test(id)
+  ) return 'openai'
+  if (id.startsWith('x-ai/') || id.startsWith('xai/') || id.includes('grok')) return 'xai'
+  if (id.startsWith('moonshot/') || id.includes('kimi')) return 'kimi'
+  if (id.startsWith('z-ai/') || id.startsWith('zai/') || id.includes('glm')) return 'zai'
+  if (id.startsWith('meta/') || id.includes('llama')) return 'meta'
+  return undefined
+}
+
 export function UsageTab() {
+  useFullWidthSettingsContent(true)
+  useHideSettingsHeader(true)
+
   const { isAuthMode, isAdmin } = useUser()
   const { data: settings } = useSettings()
   const [days, setDays] = useState(7)
   const [globalView, setGlobalView] = useState(!isAuthMode || isAdmin)
-  const [segmentation, setSegmentation] = useState<Segmentation>('total')
+  const [segmentation, setSegmentation] = useState<Segmentation>('byModel')
+  const [metric, setMetric] = useState<Metric>('cost')
+  const [selection, setSelection] = useState<UsageSelection | null>(null)
   const { data, isLoading, isFetching, refetch } = useUsageData(days, globalView)
 
-  const segments = useMemo(() => {
-    if (segmentation === 'total') return [{ key: 'cost', label: 'Cost' }]
+  const daily = useMemo(() => data?.daily ?? [], [data?.daily])
+  const totalCost = daily.reduce((sum, day) => sum + day.totalCost, 0)
+  const totalTokens = daily.reduce((sum, day) => sum + day.totalTokens, 0)
+  const activeDays = daily.filter((day) => day.totalCost > 0 || day.totalTokens > 0).length
+  const dateRange = dateRangeLabel(daily.map((day) => day.date))
+  const hasUsage = totalCost > 0 || totalTokens > 0
 
-    const seen = new Map<string, string>()
-    for (const day of data?.daily || []) {
+  const breakdown = useMemo<BreakdownRow[]>(() => {
+    const aggregate = new Map<string, BreakdownRow>()
+
+    for (const day of daily) {
       if (segmentation === 'byModel') {
-        for (const m of day.byModel) seen.set(m.model, m.model)
-      } else {
-        for (const a of day.byAgent) seen.set(a.agentSlug, a.agentName)
-      }
-    }
-    return Array.from(seen.entries()).map(([key, label]) => ({ key, label }))
-  }, [data, segmentation])
-
-  const chartConfig = useMemo(() => {
-    const config: ChartConfig = {}
-    for (let i = 0; i < segments.length; i++) {
-      const { key, label } = segments[i]
-      config[key] = {
-        label,
-        color: COLORS[i % COLORS.length],
-      }
-    }
-    return config
-  }, [segments])
-
-  const chartData = useMemo(() => {
-    if (!data?.daily) return []
-
-    return data.daily.map((day) => {
-      const entry: Record<string, unknown> = {
-        date: format(parseISO(day.date), 'MMM d'),
-      }
-
-      if (segmentation === 'total') {
-        entry.cost = day.totalCost
-      } else if (segmentation === 'byModel') {
-        for (const m of day.byModel) {
-          entry[m.model] = m.cost
+        for (const item of day.byModel) {
+          const existing = aggregate.get(item.model)
+          aggregate.set(item.model, {
+            key: item.model,
+            label: item.model,
+            cost: (existing?.cost ?? 0) + item.cost,
+            totalTokens: (existing?.totalTokens ?? 0) + (item.totalTokens ?? 0),
+          })
         }
       } else {
-        for (const a of day.byAgent) {
-          entry[a.agentSlug] = a.cost
+        for (const item of day.byAgent) {
+          const existing = aggregate.get(item.agentSlug)
+          aggregate.set(item.agentSlug, {
+            key: item.agentSlug,
+            label: item.agentName,
+            cost: (existing?.cost ?? 0) + item.cost,
+            totalTokens: (existing?.totalTokens ?? 0) + item.totalTokens,
+          })
         }
       }
+    }
 
-      return entry
+    return Array.from(aggregate.values()).sort((a, b) => b.cost - a.cost)
+  }, [daily, segmentation])
+
+  const chartSegments = useMemo<ChartSegment[]>(() => {
+    const ranked = [...breakdown].sort((a, b) => {
+      const aValue = metric === 'cost' ? a.cost : a.totalTokens
+      const bValue = metric === 'cost' ? b.cost : b.totalTokens
+      return bValue - aValue
     })
-  }, [data, segmentation])
+    const visible = ranked.slice(0, MAX_CHART_SEGMENTS).map((row, index) => ({
+      key: `series${index}`,
+      label: row.label,
+      sourceKeys: new Set([row.key]),
+    }))
 
-  const totalCost = data?.daily?.reduce((sum, d) => sum + d.totalCost, 0) ?? 0
+    if (ranked.length > MAX_CHART_SEGMENTS) {
+      visible.push({
+        key: `series${MAX_CHART_SEGMENTS}`,
+        label: 'Other',
+        sourceKeys: new Set(ranked.slice(MAX_CHART_SEGMENTS).map((row) => row.key)),
+      })
+    }
+
+    return visible
+  }, [breakdown, metric])
+
+  const activeSelection = useMemo(() => {
+    if (!selection) return null
+    const availableKeys = new Set(breakdown.map((row) => row.key))
+    const sourceKeys = selection.sourceKeys.filter((key) => availableKeys.has(key))
+    return sourceKeys.length > 0 ? { ...selection, sourceKeys } : null
+  }, [breakdown, selection])
+
+  const displayedChartSegments = useMemo<ChartSegment[]>(() => activeSelection
+    ? [{
+        key: 'selectedSeries',
+        label: activeSelection.label,
+        sourceKeys: new Set(activeSelection.sourceKeys),
+      }]
+    : chartSegments,
+  [activeSelection, chartSegments])
+
+  const chartConfig = useMemo<ChartConfig>(() => {
+    const config: ChartConfig = {}
+    displayedChartSegments.forEach((segment, index) => {
+      const colorIndex = activeSelection?.colorIndex ?? index
+      config[segment.key] = {
+        label: segment.label,
+        theme: CHART_COLORS[colorIndex % CHART_COLORS.length],
+      }
+    })
+    return config
+  }, [activeSelection, displayedChartSegments])
+
+  const chartData = useMemo(() => daily.map((day) => {
+    const entry: Record<string, string | number> = {
+      date: format(parseISO(day.date), 'MMM d'),
+    }
+    const source = segmentation === 'byModel'
+      ? day.byModel.map((item) => ({
+          key: item.model,
+          value: metric === 'cost' ? item.cost : (item.totalTokens ?? 0),
+        }))
+      : day.byAgent.map((item) => ({
+          key: item.agentSlug,
+          value: metric === 'cost' ? item.cost : item.totalTokens,
+        }))
+
+    for (const segment of displayedChartSegments) {
+      entry[segment.key] = source.reduce(
+        (sum, item) => sum + (segment.sourceKeys.has(item.key) ? item.value : 0),
+        0,
+      )
+    }
+    return entry
+  }), [daily, displayedChartSegments, metric, segmentation])
+
+  const peakDay = useMemo(() => {
+    if (!hasUsage) return undefined
+    return daily.reduce((peak, day) => day.totalCost > peak.totalCost ? day : peak, daily[0])
+  }, [daily, hasUsage])
+
+  const uniqueAgents = useMemo(() => new Set(
+    daily.flatMap((day) => day.byAgent.filter((agent) => agent.cost > 0 || agent.totalTokens > 0).map((agent) => agent.agentSlug)),
+  ).size, [daily])
+
+  const selectedDaily = useMemo(() => {
+    if (!activeSelection) return []
+    const selectedKeys = new Set(activeSelection.sourceKeys)
+    return daily.map((day) => {
+      const source = segmentation === 'byModel'
+        ? day.byModel.map((item) => ({ key: item.model, cost: item.cost, totalTokens: item.totalTokens ?? 0 }))
+        : day.byAgent.map((item) => ({ key: item.agentSlug, cost: item.cost, totalTokens: item.totalTokens }))
+      return source.reduce(
+        (totals, item) => selectedKeys.has(item.key)
+          ? { cost: totals.cost + item.cost, totalTokens: totals.totalTokens + item.totalTokens }
+          : totals,
+        { cost: 0, totalTokens: 0 },
+      )
+    })
+  }, [activeSelection, daily, segmentation])
+
+  const selectedTotalCost = selectedDaily.reduce((sum, day) => sum + day.cost, 0)
+  const selectedTotalTokens = selectedDaily.reduce((sum, day) => sum + day.totalTokens, 0)
+  const selectedActiveDays = selectedDaily.filter((day) => day.cost > 0 || day.totalTokens > 0).length
+  const selectedPeakSpend = selectedDaily.reduce((peak, day) => Math.max(peak, day.cost), 0)
+  const selectedColor = activeSelection
+    ? CHART_COLORS[activeSelection.colorIndex % CHART_COLORS.length].light
+    : undefined
+
+  const toggleSelection = (next: UsageSelection) => {
+    setSelection((current) => {
+      if (!current || current.sourceKeys.length !== next.sourceKeys.length) return next
+      const currentKeys = new Set(current.sourceKeys)
+      return next.sourceKeys.every((key) => currentKeys.has(key)) ? null : next
+    })
+  }
+
+  const changeSegmentation = (next: Segmentation) => {
+    setSelection(null)
+    setSegmentation(next)
+  }
+
+  const changeMetric = (next: Metric) => {
+    setSelection(null)
+    setMetric(next)
+  }
+
   const providerUsageLink = settings?.llmProvider
     ? PROVIDER_USAGE_LINKS[settings.llmProvider]
     : undefined
 
   return (
-    <div className="space-y-4">
+    <div className="mx-auto w-full max-w-[1180px] space-y-6 pb-8">
       <div>
-        <h3 className="text-sm font-medium mb-1">LLM Usage</h3>
-        <p className="text-xs text-muted-foreground">
-          Token costs across {isAuthMode && !globalView ? 'your' : 'all'} agents, computed from session logs.
-        </p>
+        <h2 className="mb-8 hidden text-xl font-medium md:block">Usage</h2>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-sm text-muted-foreground">
+              Estimated model usage across {isAuthMode && !globalView ? 'your agents' : 'all agents'}.
+            </p>
+            {dateRange && (
+              <div className="mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                {dateRange}
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            {isAuthMode && isAdmin && (
+              <Select
+                value={globalView ? 'global' : 'mine'}
+                onValueChange={(value) => {
+                  setSelection(null)
+                  setGlobalView(value === 'global')
+                }}
+              >
+                <SelectTrigger className="h-8 w-[130px] bg-background text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="mine">My agents</SelectItem>
+                  <SelectItem value="global">All agents</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+
+            <div className="flex h-8 items-center rounded-md border bg-muted/40 p-0.5" aria-label="Usage period">
+              {DAY_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={cn(
+                    'h-7 rounded px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    days === option && 'bg-background text-foreground shadow-sm',
+                  )}
+                  aria-pressed={days === option}
+                  onClick={() => {
+                    setSelection(null)
+                    setDays(option)
+                  }}
+                >
+                  {option}d
+                </button>
+              ))}
+            </div>
+
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 px-2.5 text-xs"
+              onClick={() => refetch()}
+              disabled={isFetching}
+            >
+              <RefreshCw className={cn('h-3.5 w-3.5', isFetching && 'animate-spin')} aria-hidden="true" />
+              Refresh
+            </Button>
+          </div>
+        </div>
       </div>
 
-      <Alert className="border-amber-500/30 bg-amber-500/5">
+      {isLoading || (isFetching && !data) ? (
+        <UsageSkeleton />
+      ) : !hasUsage ? (
+        <div className="flex min-h-[360px] flex-col items-center justify-center rounded-xl border bg-card/50 px-6 text-center">
+          <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-full bg-muted">
+            <Gauge className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <h3 className="text-sm font-medium">No usage in this period</h3>
+          <p className="mt-1 max-w-sm text-xs leading-5 text-muted-foreground">
+            Model activity will appear here after an agent completes a request.
+          </p>
+        </div>
+      ) : (
+        <>
+          <section className="overflow-hidden rounded-xl border bg-card/70 shadow-sm" aria-labelledby="usage-overview-heading">
+            <div className="flex flex-col gap-5 border-b px-5 py-5 sm:px-6 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">Estimated spend</p>
+                <div className="mt-1.5 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <h3 id="usage-overview-heading" className="text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">
+                    {activeSelection && selectedColor ? (
+                      <MetricFraction
+                        selected={formatCurrency(selectedTotalCost)}
+                        total={formatCurrency(totalCost)}
+                        accent={selectedColor}
+                      />
+                    ) : formatCurrency(totalCost)}
+                  </h3>
+                  <span className="text-xs text-muted-foreground">
+                    {formatCurrency(
+                      (activeSelection ? selectedTotalCost : totalCost) /
+                      Math.max(activeSelection ? selectedActiveDays : activeDays, 1),
+                    )} per active day
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Select value={segmentation} onValueChange={(value) => changeSegmentation(value as Segmentation)}>
+                  <SelectTrigger className="h-8 w-[126px] bg-background text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="byModel">By model</SelectItem>
+                    <SelectItem value="byAgent">By agent</SelectItem>
+                  </SelectContent>
+                </Select>
+                <MetricToggle metric={metric} onChange={changeMetric} />
+              </div>
+            </div>
+
+            <div className="px-2 pb-3 pt-5 sm:px-5">
+              <ChartContainer config={chartConfig} className="h-[235px] w-full aspect-auto">
+                <AreaChart data={chartData} margin={{ top: 8, right: 8, left: 4, bottom: 0 }}>
+                  <defs>
+                    {displayedChartSegments.map((segment, index) => (
+                      <linearGradient key={segment.key} id={`usage-fill-${index}`} x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor={`var(--color-${segment.key})`} stopOpacity={0.42} />
+                        <stop offset="100%" stopColor={`var(--color-${segment.key})`} stopOpacity={0.04} />
+                      </linearGradient>
+                    ))}
+                  </defs>
+                  <CartesianGrid vertical={false} strokeDasharray="3 4" />
+                  <XAxis
+                    dataKey="date"
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={10}
+                    interval={days > 14 ? 4 : days > 7 ? 2 : 'preserveStartEnd'}
+                    minTickGap={18}
+                  />
+                  <YAxis
+                    width={52}
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(value) => metric === 'cost' ? formatCurrency(value, true) : formatCompactNumber(value)}
+                  />
+                  <ChartTooltip
+                    content={(
+                      <ChartTooltipContent
+                        indicator="line"
+                        valueFormatter={(value) => metric === 'cost' ? formatCurrency(value) : `${formatCompactNumber(value)} tokens`}
+                      />
+                    )}
+                  />
+                  {displayedChartSegments.map((segment, index) => (
+                    <Area
+                      key={segment.key}
+                      type="monotone"
+                      dataKey={segment.key}
+                      stackId="usage"
+                      stroke={`var(--color-${segment.key})`}
+                      strokeWidth={2}
+                      fill={`url(#usage-fill-${index})`}
+                      fillOpacity={1}
+                      activeDot={{ r: 3, strokeWidth: 0 }}
+                    />
+                  ))}
+                </AreaChart>
+              </ChartContainer>
+              <ChartSeriesLegend
+                segments={chartSegments}
+                selection={activeSelection}
+                onSelect={toggleSelection}
+              />
+            </div>
+
+            <div className="grid border-t sm:grid-cols-2 xl:grid-cols-4">
+              <SummaryStat
+                label="Processed tokens"
+                value={formatCompactNumber(totalTokens)}
+                selectedValue={activeSelection ? formatCompactNumber(selectedTotalTokens) : undefined}
+                accent={selectedColor}
+                detail={activeSelection
+                  ? `${formatCompactNumber(selectedTotalTokens / Math.max(selectedActiveDays, 1))} selected per active day`
+                  : `${formatCompactNumber(totalTokens / Math.max(activeDays, 1))} per active day`}
+              />
+              <SummaryStat
+                label="Active days"
+                value={`${activeDays}`}
+                selectedValue={activeSelection ? `${selectedActiveDays}` : undefined}
+                accent={selectedColor}
+                detail={activeSelection ? `of ${activeDays} total active days` : `of ${daily.length} days observed`}
+              />
+              <SummaryStat
+                label="Peak spend"
+                value={formatCurrency(peakDay?.totalCost ?? 0)}
+                selectedValue={activeSelection ? formatCurrency(selectedPeakSpend) : undefined}
+                accent={selectedColor}
+                detail={activeSelection
+                  ? `${activeSelection.label} peak / overall peak`
+                  : peakDay ? format(parseISO(peakDay.date), 'EEEE, MMM d') : '—'}
+              />
+              <SummaryStat
+                label={segmentation === 'byModel' ? 'Models in view' : 'Active agents'}
+                value={`${segmentation === 'byModel' ? breakdown.length : uniqueAgents}`}
+                selectedValue={activeSelection ? `${activeSelection.sourceKeys.length}` : undefined}
+                accent={selectedColor}
+                detail={activeSelection
+                  ? `${activeSelection.label} selected`
+                  : `${breakdown.length} ${segmentation === 'byModel' ? 'models' : 'agents'} in this view`}
+              />
+            </div>
+          </section>
+
+          <section className="overflow-hidden rounded-xl border bg-card/70" aria-labelledby="usage-breakdown-heading">
+            <div className="flex flex-col gap-3 border-b px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+              <div>
+                <h3 id="usage-breakdown-heading" className="text-sm font-medium">Breakdown</h3>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Click a row or chart legend item to isolate it. Ranked by estimated cost.
+                </p>
+              </div>
+              <div className="flex rounded-md bg-muted p-0.5">
+                <BreakdownButton active={segmentation === 'byModel'} onClick={() => changeSegmentation('byModel')}>
+                  Model
+                </BreakdownButton>
+                <BreakdownButton active={segmentation === 'byAgent'} onClick={() => changeSegmentation('byAgent')}>
+                  Agent
+                </BreakdownButton>
+              </div>
+            </div>
+
+            <div className="overflow-x-auto">
+              <div className="min-w-[620px]">
+                <div className="grid grid-cols-[minmax(220px,1fr)_110px_160px_110px] gap-5 border-b px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground sm:px-6">
+                  <span>{segmentation === 'byModel' ? 'Model' : 'Agent'}</span>
+                  <span className="text-right">Tokens</span>
+                  <span>Share</span>
+                  <span className="text-right">Cost</span>
+                </div>
+                {breakdown.map((row) => {
+                  const share = totalCost > 0 ? (row.cost / totalCost) * 100 : 0
+                  const segmentIndex = chartSegments.findIndex((segment) => segment.sourceKeys.has(row.key))
+                  const colorIndex = Math.max(segmentIndex, 0)
+                  const color = CHART_COLORS[colorIndex % CHART_COLORS.length]
+                  const isIncluded = activeSelection?.sourceKeys.includes(row.key) ?? false
+                  return (
+                    <button
+                      key={row.key}
+                      type="button"
+                      className={cn(
+                        'grid w-full grid-cols-[minmax(220px,1fr)_110px_160px_110px] items-center gap-5 border-b px-5 py-3 text-left transition-colors last:border-b-0 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-6',
+                        isIncluded && 'bg-muted/60',
+                      )}
+                      aria-pressed={isIncluded}
+                      onClick={() => toggleSelection({
+                        key: `item:${row.key}`,
+                        label: row.label,
+                        sourceKeys: [row.key],
+                        colorIndex,
+                      })}
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <div
+                          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+                          style={{
+                            color: color.light,
+                            backgroundColor: `color-mix(in srgb, ${color.light} 12%, transparent)`,
+                          }}
+                        >
+                          {segmentation === 'byModel'
+                            ? <UsageProviderIcon model={row.key} />
+                            : <Bot className="h-3.5 w-3.5" aria-hidden="true" />}
+                        </div>
+                        <span className="truncate text-sm font-medium" title={row.label}>{row.label}</span>
+                      </div>
+                      <span className="text-right text-sm tabular-nums text-muted-foreground">
+                        {formatCompactNumber(row.totalTokens)}
+                      </span>
+                      <div className="flex items-center gap-2.5">
+                        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+                          <div
+                            className="h-full rounded-full"
+                            style={{ width: `${Math.max(share, share > 0 ? 1.5 : 0)}%`, backgroundColor: color.light }}
+                          />
+                        </div>
+                        <span className="w-10 text-right text-xs tabular-nums text-muted-foreground">{share.toFixed(1)}%</span>
+                      </div>
+                      <span className="text-right text-sm font-medium tabular-nums">{formatCurrency(row.cost)}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          </section>
+        </>
+      )}
+
+      <Alert className="border-amber-500/25 bg-amber-500/[0.04] py-3">
         <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-        <AlertTitle>Usage and cost estimates may be incomplete</AlertTitle>
-        <AlertDescription className="text-xs text-muted-foreground">
+        <AlertTitle className="text-xs font-medium">Usage and cost estimates may be incomplete</AlertTitle>
+        <AlertDescription className="text-xs leading-5 text-muted-foreground">
           These estimates only include agents and sessions that haven&apos;t been deleted, so your
           actual usage and costs may be higher. For definitive totals, check{' '}
           {providerUsageLink ? (
@@ -152,123 +633,176 @@ export function UsageTab() {
           .
         </AlertDescription>
       </Alert>
+    </div>
+  )
+}
 
-      <div className="flex items-center gap-3">
-        <Select value={String(days)} onValueChange={(v) => setDays(Number(v))}>
-          <SelectTrigger className="w-[140px] h-8">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {DAY_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={segmentation}
-          onValueChange={(v) => setSegmentation(v as Segmentation)}
+function MetricToggle({ metric, onChange }: { metric: Metric; onChange: (metric: Metric) => void }) {
+  return (
+    <div className="flex h-8 items-center rounded-md bg-muted p-0.5" aria-label="Chart metric">
+      {(['cost', 'tokens'] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          className={cn(
+            'h-7 rounded px-2.5 text-xs font-medium capitalize text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            metric === option && 'bg-background text-foreground shadow-sm',
+          )}
+          aria-pressed={metric === option}
+          onClick={() => onChange(option)}
         >
-          <SelectTrigger className="w-[140px] h-8">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="total">Total</SelectItem>
-            <SelectItem value="byModel">By Model</SelectItem>
-            <SelectItem value="byAgent">By Agent</SelectItem>
-          </SelectContent>
-        </Select>
+          {option}
+        </button>
+      ))}
+    </div>
+  )
+}
 
-        {isAuthMode && isAdmin && (
-          <Select value={globalView ? 'global' : 'mine'} onValueChange={(v) => setGlobalView(v === 'global')}>
-            <SelectTrigger className="w-[140px] h-8">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="mine">My Agents</SelectItem>
-              <SelectItem value="global">All Agents</SelectItem>
-            </SelectContent>
-          </Select>
-        )}
-
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => refetch()}
-          disabled={isFetching}
-        >
-          <RefreshCw
-            className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`}
-          />
-          Refresh
-        </Button>
-      </div>
-
-      {isLoading || (isFetching && !data) ? (
-        <div className="flex items-center justify-center py-12">
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-          <span className="ml-2 text-sm text-muted-foreground">
-            Loading usage data...
-          </span>
-        </div>
-      ) : !data?.daily?.length ? (
-        <div className="text-center py-12">
-          <p className="text-sm text-muted-foreground">
-            No usage data found for the selected period.
-          </p>
-        </div>
-      ) : (
-        <>
-          <ChartContainer
-            config={chartConfig}
-            className="min-h-[200px] max-h-[240px] w-full"
+function ChartSeriesLegend({
+  segments,
+  selection,
+  onSelect,
+}: {
+  segments: ChartSegment[]
+  selection: UsageSelection | null
+  onSelect: (selection: UsageSelection) => void
+}) {
+  const selectedKeys = new Set(selection?.sourceKeys ?? [])
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 px-3 pb-1 pt-3" aria-label="Filter chart series">
+      {segments.map((segment, index) => {
+        const color = CHART_COLORS[index % CHART_COLORS.length]
+        const isActive = segment.sourceKeys.size === selectedKeys.size &&
+          Array.from(segment.sourceKeys).every((key) => selectedKeys.has(key))
+        return (
+          <button
+            key={segment.key}
+            type="button"
+            className={cn(
+              'flex items-center gap-1.5 rounded px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              isActive && 'bg-muted text-foreground',
+            )}
+            aria-pressed={isActive}
+            onClick={() => onSelect({
+              key: `legend:${segment.key}`,
+              label: segment.label,
+              sourceKeys: Array.from(segment.sourceKeys),
+              colorIndex: index,
+            })}
           >
-            <BarChart data={chartData}>
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="date" tickLine={false} axisLine={false} />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={(v) => `$${v.toFixed(2)}`}
-              />
-              <ChartTooltip
-                content={
-                  <ChartTooltipContent
-                    valueFormatter={(value) =>
-                      `$${(value as number).toFixed(2)}`
-                    }
-                  />
-                }
-              />
-              {segmentation !== 'total' && (
-                <ChartLegend content={<ChartLegendContent />} />
-              )}
-              {segments.map(({ key }) => (
-                <Bar
-                  key={key}
-                  dataKey={key}
-                  stackId={segmentation !== 'total' ? 'stack' : undefined}
-                  fill={`var(--color-${key})`}
-                  radius={
-                    segmentation === 'total' ? [4, 4, 0, 0] : undefined
-                  }
-                />
-              ))}
-            </BarChart>
-          </ChartContainer>
+            <span className="h-2.5 w-2.5 rounded-[2px]" style={{ backgroundColor: color.light }} aria-hidden="true" />
+            <span>{segment.label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
 
-          <div className="text-right">
-            <span className="text-sm text-muted-foreground">
-              Total:{' '}
-              <span className="font-medium text-foreground">
-                ${totalCost.toFixed(2)}
-              </span>
-            </span>
-          </div>
-        </>
+function MetricFraction({ selected, total, accent }: { selected: string; total: string; accent: string }) {
+  return (
+    <>
+      <span style={{ color: accent }}>{selected}</span>
+      <span className="font-normal text-muted-foreground"> / {total}</span>
+    </>
+  )
+}
+
+function UsageProviderIcon({ model }: { model: string }) {
+  const provider = modelProviderIcon(model)
+  if (!provider) {
+    return <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+  }
+
+  const iconUrl = `${import.meta.env.BASE_URL}model-icons/${provider}.svg`
+  return (
+    <span
+      className="h-3.5 w-3.5 bg-current"
+      style={{
+        WebkitMaskImage: `url("${iconUrl}")`,
+        WebkitMaskPosition: 'center',
+        WebkitMaskRepeat: 'no-repeat',
+        WebkitMaskSize: 'contain',
+        maskImage: `url("${iconUrl}")`,
+        maskPosition: 'center',
+        maskRepeat: 'no-repeat',
+        maskSize: 'contain',
+      }}
+      data-provider-icon={provider}
+      aria-hidden="true"
+    />
+  )
+}
+
+function BreakdownButton({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean
+  children: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'h-7 rounded px-3 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        active && 'bg-background text-foreground shadow-sm',
       )}
+      aria-pressed={active}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  )
+}
+
+function SummaryStat({
+  label,
+  value,
+  selectedValue,
+  accent,
+  detail,
+}: {
+  label: string
+  value: string
+  selectedValue?: string
+  accent?: string
+  detail: string
+}) {
+  return (
+    <div className="border-t px-5 py-4 first:border-t-0 sm:border-t sm:px-6 sm:even:border-l sm:[&:nth-child(-n+2)]:border-t-0 xl:border-l xl:border-t-0 xl:first:border-l-0">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-medium tabular-nums">
+        {selectedValue && accent
+          ? <MetricFraction selected={selectedValue} total={value} accent={accent} />
+          : value}
+      </p>
+      <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{detail}</p>
+    </div>
+  )
+}
+
+function UsageSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card/70" role="status" aria-label="Loading usage data">
+      <div className="flex items-start justify-between border-b p-6">
+        <div className="space-y-3">
+          <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+          <div className="h-9 w-40 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="h-8 w-52 animate-pulse rounded bg-muted" />
+      </div>
+      <div className="h-[320px] animate-pulse bg-gradient-to-b from-muted/20 to-muted/60" />
+      <div className="grid grid-cols-2 border-t xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="space-y-2 border-l p-5 first:border-l-0">
+            <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+            <div className="h-6 w-24 animate-pulse rounded bg-muted" />
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/shared/lib/types/usage.ts
+++ b/src/shared/lib/types/usage.ts
@@ -8,6 +8,7 @@ export interface UsageByAgent {
 export interface UsageByModel {
   model: string
   cost: number
+  totalTokens: number
 }
 
 export interface DailyUsageEntry {


### PR DESCRIPTION
## Summary

- replace the existing Settings > Usage tab with a structured analytics dashboard
- add cost/token charting with model and agent breakdowns, date-range controls, summary metrics, and provider-aware color treatment
- let users isolate a model or agent from either the chart legend or breakdown, with selected-versus-total values across the dashboard
- expose per-model token totals from the usage API and cover the aggregation and interactions with tests

## Why

The previous Usage tab made it difficult to understand spend, token volume, and which models or agents were driving usage. This redesign makes the information scannable and adds direct exploratory controls without leaving Settings.

## User impact

Users can compare cost and tokens over time, switch between model and agent views, identify dominant usage sources, and click any series or row to focus the chart and metrics on that selection.

## Validation

- `npm test -- --run src/renderer/components/settings/usage-tab.test.tsx src/api/routes/usage.test.ts` (43 tests)
- `npm run typecheck`
- `npx eslint src/renderer/components/settings/usage-tab.tsx src/renderer/components/settings/usage-tab.test.tsx src/api/routes/usage.ts src/api/routes/usage.test.ts src/shared/lib/types/usage.ts`
- `git diff --check`
