### PR TITLE
Add word-level blur to streamed responses

### DIFF
--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -143,6 +143,70 @@ describe('MessageItem', () => {
     })
   })
 
+  describe('streaming word reveal', () => {
+    it('adds a reveal hook to prose words in the active Markdown tail', () => {
+      const msg = createAssistantMessage({ content: { text: 'Hello **bright** world' } })
+      const { container } = render(<MessageItem message={msg} isStreaming />)
+      const words = Array.from(container.querySelectorAll<HTMLElement>('.streaming-word-reveal'))
+
+      expect(words.map((word) => word.textContent)).toEqual(['Hello', 'bright', 'world'])
+      expect(words.map((word) => word.style.animationDelay)).toEqual(['0ms', '36ms', '72ms'])
+    })
+
+    it('keeps settled paragraphs and inline code crisp', () => {
+      const msg = createAssistantMessage({
+        content: { text: 'Already settled.\n\nRun `npm test` next' },
+      })
+      const { container } = render(<MessageItem message={msg} isStreaming />)
+      const paragraphs = container.querySelectorAll('p')
+
+      expect(paragraphs[0].querySelector('.streaming-word-reveal')).toBeNull()
+      expect(paragraphs[1].querySelectorAll('.streaming-word-reveal')).toHaveLength(2)
+      expect(paragraphs[1].querySelector('code .streaming-word-reveal')).toBeNull()
+    })
+
+    it('does not replay the reveal on words that were already mounted', () => {
+      const first = createAssistantMessage({ content: { text: 'Hello' } })
+      const { container, rerender } = render(<MessageItem message={first} isStreaming />)
+      const hello = container.querySelector('.streaming-word-reveal')
+
+      const next = createAssistantMessage({ ...first, content: { text: 'Hello world' } })
+      rerender(<MessageItem message={next} isStreaming />)
+
+      const words = container.querySelectorAll('.streaming-word-reveal')
+      expect(words).toHaveLength(2)
+      expect(words[0]).toBe(hello)
+      expect(words[1]).toHaveTextContent('world')
+    })
+
+    it('starts each appended paragraph chunk as a fresh compact word wave', () => {
+      const first = createAssistantMessage({ content: { text: 'Already visible' } })
+      const { container, rerender } = render(<MessageItem message={first} isStreaming />)
+      const existing = Array.from(
+        container.querySelectorAll<HTMLElement>('.streaming-word-reveal')
+      ).map((word) => word.style.animationDelay)
+
+      const next = createAssistantMessage({
+        ...first,
+        content: { text: 'Already visible and now four more words' },
+      })
+      rerender(<MessageItem message={next} isStreaming />)
+
+      const delays = Array.from(
+        container.querySelectorAll<HTMLElement>('.streaming-word-reveal')
+      ).map((word) => word.style.animationDelay)
+      expect(delays.slice(0, 2)).toEqual(existing)
+      expect(delays.slice(2)).toEqual(['0ms', '36ms', '72ms', '108ms', '144ms'])
+    })
+
+    it('renders persisted responses without reveal wrappers', () => {
+      const msg = createAssistantMessage({ content: { text: 'All done' } })
+      const { container } = render(<MessageItem message={msg} />)
+
+      expect(container.querySelector('.streaming-word-reveal')).toBeNull()
+    })
+  })
+
   describe('streaming markdown splitting', () => {
     it('renders every block of a multi-block streaming message', () => {
       const text = '# Heading\n\nSome text\n\n```js\nconsole.log("hi")\n```\n\nMore text'
@@ -151,7 +215,7 @@ describe('MessageItem', () => {
       expect(screen.getByText('Heading')).toBeInTheDocument()
       expect(screen.getByText('Some text')).toBeInTheDocument()
       expect(screen.getByText('console.log("hi")')).toBeInTheDocument()
-      expect(screen.getByText('More text')).toBeInTheDocument()
+      expect(screen.getByTestId('message-assistant')).toHaveTextContent('More text')
     })
 
     it('keeps an in-progress code fence (with an internal blank line) intact while streaming', () => {

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -16,12 +16,14 @@ import { parseAttachedFiles, parseMountedFolders } from '@shared/lib/utils/attac
 import { parseSenderPrefix } from '@shared/lib/utils/sender-prefix'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import type { PluggableList } from 'unified'
 import { splitStreamingMarkdown } from './split-streaming-markdown'
 import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 import type { ApiMessage, ApiToolCall } from '@shared/lib/types/api'
 import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
+import { rehypeStreamingWordReveal } from './streaming-word-reveal'
 
 // Re-export for use by other components
 export type { ApiToolCall }
@@ -201,6 +203,42 @@ const MARKDOWN_COMPONENTS: Components = {
 export const MarkdownBlock = memo(function MarkdownBlock({ text }: { text: string }) {
   return (
     <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MARKDOWN_COMPONENTS} urlTransform={markdownUrlTransform}>
+      {text}
+    </ReactMarkdown>
+  )
+})
+
+// Only the still-growing Markdown tail uses the word wrapper. Settled blocks
+// switch back to MarkdownBlock, keeping the filter-animation surface small even
+// during long responses.
+const StreamingMarkdownBlock = memo(function StreamingMarkdownBlock({ text }: { text: string }) {
+  const previousTextRef = useRef('')
+  const batchStartsRef = useRef<number[]>([0])
+  const previousText = previousTextRef.current
+
+  if (text !== previousText) {
+    if (previousText && text.startsWith(previousText)) {
+      batchStartsRef.current = [...batchStartsRef.current, previousText.length]
+    } else {
+      batchStartsRef.current = [0]
+    }
+    previousTextRef.current = text
+  }
+
+  // The plugin keeps each batch's delays stable across subsequent renders, so
+  // existing words do not restart while newly appended words get their own
+  // compact stagger sequence.
+  const rehypePlugins: PluggableList = [[rehypeStreamingWordReveal, {
+    batchStarts: batchStartsRef.current,
+  }]]
+
+  return (
+    <ReactMarkdown
+      remarkPlugins={REMARK_PLUGINS}
+      rehypePlugins={rehypePlugins}
+      components={MARKDOWN_COMPONENTS}
+      urlTransform={markdownUrlTransform}
+    >
       {text}
     </ReactMarkdown>
   )
@@ -387,7 +425,12 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                       {streamingSplit.settled.map((block, i) => (
                         <MarkdownBlock key={i} text={block} />
                       ))}
-                      {streamingSplit.tail && <MarkdownBlock text={streamingSplit.tail} />}
+                      {streamingSplit.tail && (
+                        <StreamingMarkdownBlock
+                          key={`tail-${streamingSplit.settled.length}`}
+                          text={streamingSplit.tail}
+                        />
+                      )}
                     </>
                   ) : (
                     <MarkdownBlock text={text} />

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -14,9 +14,8 @@ import { MessageErrorBoundary } from './message-error-boundary'
 import { FileDownloadPill } from '@renderer/components/ui/file-download-pill'
 import { parseAttachedFiles, parseMountedFolders } from '@shared/lib/utils/attached-files'
 import { parseSenderPrefix } from '@shared/lib/utils/sender-prefix'
-import ReactMarkdown, { type Components } from 'react-markdown'
+import ReactMarkdown, { type Components, type Options as ReactMarkdownOptions } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import type { PluggableList } from 'unified'
 import { splitStreamingMarkdown } from './split-streaming-markdown'
 import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 import type { ApiMessage, ApiToolCall } from '@shared/lib/types/api'
@@ -228,7 +227,7 @@ const StreamingMarkdownBlock = memo(function StreamingMarkdownBlock({ text }: { 
   // The plugin keeps each batch's delays stable across subsequent renders, so
   // existing words do not restart while newly appended words get their own
   // compact stagger sequence.
-  const rehypePlugins: PluggableList = [[rehypeStreamingWordReveal, {
+  const rehypePlugins: ReactMarkdownOptions['rehypePlugins'] = [[rehypeStreamingWordReveal, {
     batchStarts: batchStartsRef.current,
   }]]
 

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -251,7 +251,8 @@ describe('MessageList', () => {
     renderWithProviders(
       <MessageList sessionId="s-1" agentSlug="agent-1" />
     )
-    expect(screen.getByText('Streaming response...')).toBeInTheDocument()
+    // Streamed prose is split into per-word reveal spans, so match on textContent.
+    expect(screen.getByTestId('message-assistant')).toHaveTextContent('Streaming response...')
   })
 
   it('hides streaming message when persisted', () => {
@@ -581,7 +582,12 @@ describe('MessageList', () => {
 
     expect(screen.getByText('Inspecting first.')).toBeInTheDocument()
     expect(screen.getByTestId('tool-call-Bash')).toBeInTheDocument()
-    expect(screen.getByText('Writing the final response...')).toBeInTheDocument()
+    // The live streaming message is the last assistant item; its prose is split
+    // into per-word reveal spans, so match on textContent.
+    const assistantMessages = screen.getAllByTestId('message-assistant')
+    expect(assistantMessages[assistantMessages.length - 1]).toHaveTextContent(
+      'Writing the final response...'
+    )
     expect(screen.queryByTestId('turn-summary')).not.toBeInTheDocument()
   })
 
@@ -1322,7 +1328,8 @@ describe('MessageList', () => {
       <MessageList sessionId="s-1" agentSlug="agent-1" />
     )
 
-    expect(screen.getByText('New streaming content')).toBeInTheDocument()
+    // Streamed prose is split into per-word reveal spans, so match on textContent.
+    expect(screen.getByTestId('message-assistant')).toHaveTextContent('New streaming content')
   })
 
   // ---- Turn elapsed time not shown during active session's last turn ----

--- a/src/renderer/components/messages/streaming-word-reveal.test.ts
+++ b/src/renderer/components/messages/streaming-word-reveal.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { rehypeStreamingWordReveal } from './streaming-word-reveal'
+
+interface TestNode {
+  type?: string
+  tagName?: string
+  value?: string
+  properties?: Record<string, unknown>
+  children?: TestNode[]
+  position?: { start?: { offset?: number } }
+}
+
+function paragraph(children: TestNode[]): TestNode {
+  return {
+    type: 'root',
+    children: [{ type: 'element', tagName: 'p', children }],
+  }
+}
+
+function spansOf(tree: TestNode): TestNode[] {
+  const found: TestNode[] = []
+  const visit = (node: TestNode) => {
+    if (node.tagName === 'span') found.push(node)
+    for (const child of node.children ?? []) visit(child)
+  }
+  visit(tree)
+  return found
+}
+
+describe('rehypeStreamingWordReveal', () => {
+  it('wraps sourced words and staggers their delays', () => {
+    const tree = paragraph([
+      { type: 'text', value: 'two words', position: { start: { offset: 0 } } },
+    ])
+
+    rehypeStreamingWordReveal({ batchStarts: [0] })(tree)
+
+    const spans = spansOf(tree)
+    expect(spans.map((s) => s.children?.[0].value)).toEqual(['two', 'words'])
+    expect(spans.map((s) => s.properties?.style)).toEqual([
+      'animation-delay: 0ms',
+      'animation-delay: 36ms',
+    ])
+  })
+
+  it('leaves generated (position-less) text unwrapped and its batch delays unshifted', () => {
+    const generated: TestNode = { type: 'text', value: 'generated scaffolding' }
+    const tree = paragraph([
+      { type: 'text', value: 'sourced words', position: { start: { offset: 0 } } },
+      generated,
+    ])
+
+    rehypeStreamingWordReveal({ batchStarts: [0] })(tree)
+
+    const spans = spansOf(tree)
+    // Only the sourced words are wrapped; the generated text node survives as-is,
+    // so it can neither replay with a stale delay nor shift batch 0's stagger.
+    expect(spans.map((s) => s.children?.[0].value)).toEqual(['sourced', 'words'])
+    expect(spans.map((s) => s.properties?.style)).toEqual([
+      'animation-delay: 0ms',
+      'animation-delay: 36ms',
+    ])
+    expect(tree.children?.[0].children).toContain(generated)
+  })
+})

--- a/src/renderer/components/messages/streaming-word-reveal.ts
+++ b/src/renderer/components/messages/streaming-word-reveal.ts
@@ -5,6 +5,9 @@
  *
  * Code-like elements are deliberately left alone: blurring individual tokens
  * makes code shimmer and can disturb its whitespace-sensitive presentation.
+ * Text without a source position (nodes a plugin generated rather than parsed,
+ * e.g. GFM footnote scaffolding) is also left alone — it has no offset to batch
+ * by, and lumping it into batch 0 would retroactively shift that batch's delays.
  */
 
 interface HastNode {
@@ -54,14 +57,14 @@ function batchForOffset(offset: number, batchStarts: readonly number[]): number 
 
 function revealedText(
   value: string,
-  sourceStart: number | undefined,
+  sourceStart: number,
   batchStarts: readonly number[],
   spans: RevealSpan[],
 ): HastNode[] {
   let relativeOffset = 0
 
   return value.split(/(\s+)/u).filter(Boolean).map((part) => {
-    const partOffset = sourceStart === undefined ? 0 : sourceStart + relativeOffset
+    const partOffset = sourceStart + relativeOffset
     relativeOffset += part.length
     if (WHITESPACE.test(part)) return { type: 'text', value: part }
 
@@ -94,13 +97,14 @@ function wrapTextChildren(
       continue
     }
 
-    if (!keepStatic && child.type === 'text' && typeof child.value === 'string') {
-      children.push(...revealedText(
-        child.value,
-        child.position?.start?.offset,
-        batchStarts,
-        spans,
-      ))
+    const sourceStart = child.position?.start?.offset
+    if (
+      !keepStatic &&
+      child.type === 'text' &&
+      typeof child.value === 'string' &&
+      typeof sourceStart === 'number'
+    ) {
+      children.push(...revealedText(child.value, sourceStart, batchStarts, spans))
       continue
     }
 

--- a/src/renderer/components/messages/streaming-word-reveal.ts
+++ b/src/renderer/components/messages/streaming-word-reveal.ts
@@ -1,0 +1,145 @@
+/**
+ * Rehype plugin that gives each prose token in a live Markdown tail its own
+ * reveal hook. Existing spans keep their position as text is appended, so React
+ * only mounts (and animates) the words that just arrived.
+ *
+ * Code-like elements are deliberately left alone: blurring individual tokens
+ * makes code shimmer and can disturb its whitespace-sensitive presentation.
+ */
+
+interface HastNode {
+  type?: string
+  tagName?: string
+  value?: unknown
+  properties?: Record<string, unknown>
+  children?: unknown[]
+  position?: {
+    start?: { offset?: number }
+  }
+}
+
+const STATIC_TEXT_ELEMENTS = new Set(['code', 'pre', 'kbd', 'samp'])
+const WHITESPACE = /^\s+$/u
+// Preserve a natural word cadence for small chunks, but compress large chunks
+// into a short wave so the UI never falls noticeably behind the stream.
+const MAX_WORD_STAGGER_MS = 36
+const MAX_BATCH_WAVE_MS = 320
+
+export interface StreamingWordRevealOptions {
+  /** Source offsets where each received stream batch begins. */
+  batchStarts?: readonly number[]
+}
+
+interface RevealSpan {
+  node: HastNode
+  batch: number
+}
+
+function isHastNode(value: unknown): value is HastNode {
+  return typeof value === 'object' && value !== null
+}
+
+function batchForOffset(offset: number, batchStarts: readonly number[]): number {
+  let low = 0
+  let high = batchStarts.length - 1
+
+  while (low <= high) {
+    const middle = (low + high) >> 1
+    if (batchStarts[middle] <= offset) low = middle + 1
+    else high = middle - 1
+  }
+
+  return Math.max(0, high)
+}
+
+function revealedText(
+  value: string,
+  sourceStart: number | undefined,
+  batchStarts: readonly number[],
+  spans: RevealSpan[],
+): HastNode[] {
+  let relativeOffset = 0
+
+  return value.split(/(\s+)/u).filter(Boolean).map((part) => {
+    const partOffset = sourceStart === undefined ? 0 : sourceStart + relativeOffset
+    relativeOffset += part.length
+    if (WHITESPACE.test(part)) return { type: 'text', value: part }
+
+    const node: HastNode = {
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['streaming-word-reveal'] },
+      children: [{ type: 'text', value: part }],
+    }
+
+    spans.push({ node, batch: batchForOffset(partOffset, batchStarts) })
+    return node
+  })
+}
+
+function wrapTextChildren(
+  node: HastNode,
+  batchStarts: readonly number[],
+  spans: RevealSpan[],
+  insideStaticText = false,
+): void {
+  if (!Array.isArray(node.children)) return
+
+  const keepStatic = insideStaticText || (node.tagName ? STATIC_TEXT_ELEMENTS.has(node.tagName) : false)
+  const children: unknown[] = []
+
+  for (const child of node.children) {
+    if (!isHastNode(child)) {
+      children.push(child)
+      continue
+    }
+
+    if (!keepStatic && child.type === 'text' && typeof child.value === 'string') {
+      children.push(...revealedText(
+        child.value,
+        child.position?.start?.offset,
+        batchStarts,
+        spans,
+      ))
+      continue
+    }
+
+    wrapTextChildren(child, batchStarts, spans, keepStatic)
+    children.push(child)
+  }
+
+  node.children = children
+}
+
+function applyBatchDelays(spans: RevealSpan[]): void {
+  const totals = new Map<number, number>()
+  const ordinals = new Map<number, number>()
+
+  for (const span of spans) totals.set(span.batch, (totals.get(span.batch) ?? 0) + 1)
+
+  for (const span of spans) {
+    const total = totals.get(span.batch) ?? 1
+    const ordinal = ordinals.get(span.batch) ?? 0
+    const step = total > 1
+      ? Math.min(MAX_WORD_STAGGER_MS, MAX_BATCH_WAVE_MS / (total - 1))
+      : 0
+    const delay = Math.round(ordinal * step)
+
+    span.node.properties = {
+      ...span.node.properties,
+      style: `animation-delay: ${delay}ms`,
+    }
+    ordinals.set(span.batch, ordinal + 1)
+  }
+}
+
+export function rehypeStreamingWordReveal(options: StreamingWordRevealOptions = {}) {
+  return (tree: unknown) => {
+    if (!isHastNode(tree)) return
+
+    const batchStarts = options.batchStarts?.length ? options.batchStarts : [0]
+    const spans: RevealSpan[] = []
+    wrapTextChildren(tree, batchStarts, spans)
+    applyBatchDelays(spans)
+  }
+}

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -131,9 +131,15 @@ html[data-keyboard-open] [data-composer-footer] {
   }
 }
 
+/* `backwards` (not `both`): a forwards fill would keep `filter: blur(0)` applied
+   after the animation ends, leaving every revealed word layer-promoted and a
+   stacking context for the life of the tail — tables and lists have no blank
+   lines, so they stay "tail" (and would accumulate promoted layers) until the
+   stream moves past them. No `will-change` for the same reason: browsers already
+   promote during an active filter animation, and it would otherwise pin a layer
+   per word. */
 .streaming-word-reveal {
-  animation: streaming-word-reveal 420ms cubic-bezier(0.22, 0.61, 0.25, 1) both;
-  will-change: filter, opacity;
+  animation: streaming-word-reveal 420ms cubic-bezier(0.22, 0.61, 0.25, 1) backwards;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -117,6 +117,31 @@ html[data-keyboard-open] [data-composer-footer] {
   padding-bottom: 0;
 }
 
+/* Newly streamed prose resolves from a soft blur. Each word is mounted once in
+   the growing Markdown tail, so previously revealed text stays crisp while the
+   next chunk arrives. */
+@keyframes streaming-word-reveal {
+  from {
+    opacity: 0.18;
+    filter: blur(3.5px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+.streaming-word-reveal {
+  animation: streaming-word-reveal 420ms cubic-bezier(0.22, 0.61, 0.25, 1) both;
+  will-change: filter, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .streaming-word-reveal {
+    animation: none;
+  }
+}
+
 /* The composer uses a ProseMirror document model but its controlled value is
    always serialized Markdown. Keep block spacing compact enough for chat while
    still making each Markdown construct immediately legible as it is typed. */


### PR DESCRIPTION
## Summary

- reveal newly streamed prose with a soft blur-to-crisp animation
- split incoming Markdown text into word-level reveal spans while preserving formatting
- stagger words within each received batch, capped to a short 320ms wave so large chunks do not lag behind the stream
- keep settled content and code crisp, avoid replaying animation on existing words, and respect reduced-motion preferences

## Why

Assistant responses currently appear in paragraph-sized stream updates, which makes incoming text feel chunky. This gives each batch a smoother word-level cadence without changing the underlying stream transport or delaying long responses.

## Impact

Streaming assistant prose now resolves progressively word by word. Persisted messages render normally, code remains stable, and users who prefer reduced motion see no reveal animation.

## Validation

- `npm run typecheck`
- `npm test -- --run src/renderer/components/messages/message-item.test.tsx src/renderer/components/messages/split-streaming-markdown.test.ts` (47 tests)
- ESLint on the changed TypeScript and test files
- manually exercised in the Electron dev app
