### PR TITLE
feat(models): add grok-4.6 to platform and OpenRouter catalogs

### DIFF
--- a/src/api/routes/llm.test.ts
+++ b/src/api/routes/llm.test.ts
@@ -91,7 +91,7 @@ describe('LLM proxy endpoint', () => {
     })
 
     it.each([
-      ['platform', 'grok', 'grok-4.5'],
+      ['platform', 'grok', 'grok-4.6'],
       ['bedrock', 'sonnet', 'us.anthropic.claude-sonnet-5'],
       ['generic', 'custom/qwen3', 'custom/qwen3'],
     ])('returns the resolved %s catalog default', async (providerId, browserModel, resolvedModel) => {

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -35,7 +35,7 @@ const NON_CLAUDE_EFFORTS: EffortLevel[] = ['low', 'medium', 'high']
  * Vendor mapping, verified 2026-07-14:
  *   - OpenAI GPT-5.x: `service_tier` flex (0.5x price, slower) / priority
  *     (2x, 2.5x on gpt-5.5) → slow/normal/fast.
- *   - xAI grok-4.5: `service_tier` priority only (2x when granted) → normal/fast.
+ *   - xAI grok: `service_tier` priority only (2x when granted) → normal/fast.
  *   - Anthropic: fast mode (research preview) on Opus 4.8 only → normal/fast.
  *   - Z.AI GLM: no request-level tier → normal only.
  *   - Fireworks (kimi-k3): fast is a separate `-fast` router resource, not a
@@ -74,6 +74,13 @@ const GPT_LONG_CONTEXT_CLIFF = {
   thresholdTokens: 272_000,
   inputMultiplier: 2,
   outputMultiplier: 1.5,
+} as const
+
+// xAI doubles every rate once prompt input reaches 200K tokens.
+const GROK_LONG_CONTEXT_CLIFF = {
+  thresholdTokens: 200_000,
+  inputMultiplier: 2,
+  outputMultiplier: 2,
 } as const
 
 const ICON = 'anthropic'
@@ -322,8 +329,8 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     pricing: { inputPerMtok: 1.2, outputPerMtok: 4.2 },
   },
   {
-    id: 'x-ai/grok-4.5',
-    label: 'Grok 4.5',
+    id: 'x-ai/grok-4.6',
+    label: 'Grok 4.6',
     blurb: 'xAI Grok, routed via OpenRouter',
     family: 'grok',
     isLatest: true,
@@ -331,10 +338,24 @@ const OPENROUTER_EXTRA_MODELS: ModelDefinition[] = [
     icon: 'xai',
     supportedEfforts: NON_CLAUDE_EFFORTS,
     supportsWebSearch: false,
+    pricing: { inputPerMtok: 2, outputPerMtok: 6 },
+    contextWindow: 500_000,
+    longContextPriceCliff: GROK_LONG_CONTEXT_CLIFF,
+    promptHints: GROK_BROWSER_TOOL_PROMPT_HINTS,
+  },
+  {
+    id: 'x-ai/grok-4.5',
+    label: 'Grok 4.5',
+    blurb: 'xAI Grok, routed via OpenRouter',
+    family: 'grok',
+    icon: 'xai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportsWebSearch: false,
     // Baked from OpenRouter's live model list (per-Mtok USD), fetched 2026-07-10.
     pricing: { inputPerMtok: 2, outputPerMtok: 6 },
     // OpenRouter-reported context length for x-ai/grok-4.5, fetched 2026-07-10.
     contextWindow: 500_000,
+    longContextPriceCliff: GROK_LONG_CONTEXT_CLIFF,
     promptHints: GROK_BROWSER_TOOL_PROMPT_HINTS,
   },
   // Kimi, newest first. The K2 line stays listed because it is an order of
@@ -391,7 +412,7 @@ export const OPENROUTER_CATALOG: ModelDefinition[] = [
 
 /**
  * Non-Claude models the Platform proxy can serve. Unlike OpenRouter these use
- * BARE ids (`gpt-5.5`, `grok-4.5`): the proxy's routing/pricing all key off bare
+ * BARE ids (`gpt-5.5`, `grok-4.6`): the proxy's routing/pricing all key off bare
  * ids, so a vendor-prefixed slug would miss every match.
  */
 // Responses hosts web_search but not web_fetch — fetch needs a Settings → Web vendor (Exa).
@@ -540,8 +561,8 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
   },
   {
     // Bare id matches the platform proxy's grok-* → xai-responses route.
-    id: 'grok-4.5',
-    label: 'Grok 4.5',
+    id: 'grok-4.6',
+    label: 'Grok 4.6',
     blurb: 'xAI Grok, served via Platform',
     family: 'grok',
     isLatest: true,
@@ -553,6 +574,21 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     ...PLATFORM_RESPONSES_WEB,
     pricing: { inputPerMtok: 2, outputPerMtok: 6, speedMultipliers: PRIORITY_2X_MULTIPLIERS },
     contextWindow: 500_000,
+    longContextPriceCliff: GROK_LONG_CONTEXT_CLIFF,
+    promptHints: GROK_BROWSER_TOOL_PROMPT_HINTS,
+  },
+  {
+    id: 'grok-4.5',
+    label: 'Grok 4.5',
+    blurb: 'xAI Grok, served via Platform',
+    family: 'grok',
+    icon: 'xai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportedSpeeds: PRIORITY_ONLY_SPEEDS,
+    ...PLATFORM_RESPONSES_WEB,
+    pricing: { inputPerMtok: 2, outputPerMtok: 6, speedMultipliers: PRIORITY_2X_MULTIPLIERS },
+    contextWindow: 500_000,
+    longContextPriceCliff: GROK_LONG_CONTEXT_CLIFF,
     promptHints: GROK_BROWSER_TOOL_PROMPT_HINTS,
   },
   {

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -52,13 +52,13 @@ describe('getProviderCatalog', () => {
       ['anthropic', 'claude-opus-5'],
       ['openai', 'openai/gpt-5.5'],
       ['zai', 'z-ai/glm-5.2'],
-      ['xai', 'x-ai/grok-4.5'],
+      ['xai', 'x-ai/grok-4.6'],
       ['kimi', 'moonshotai/kimi-k3'],
     ])
     expect(defaultsByIcon('platform')).toEqual([
       ['anthropic', 'claude-opus-5'],
       ['openai', 'gpt-5.6-sol'],
-      ['xai', 'grok-4.5'],
+      ['xai', 'grok-4.6'],
       ['kimi', 'kimi-k3'],
       ['meta', 'muse-spark-1.2'],
     ])
@@ -96,7 +96,7 @@ describe('getProviderCatalog', () => {
     const catalog = getProviderCatalog('openrouter')
     const gpt = catalog.find((m) => m.id === 'openai/gpt-5.5')!
     const glm = catalog.find((m) => m.id === 'z-ai/glm-5.2')!
-    const grok = catalog.find((m) => m.id === 'x-ai/grok-4.5')!
+    const grok = catalog.find((m) => m.id === 'x-ai/grok-4.6')!
     expect(gpt).toMatchObject({
       family: 'gpt',
       isLatest: true,
@@ -117,6 +117,14 @@ describe('getProviderCatalog', () => {
       pricing: { inputPerMtok: 2, outputPerMtok: 6 },
       contextWindow: 500_000,
     })
+    expect(catalog.find((m) => m.id === 'x-ai/grok-4.5')).toMatchObject({
+      family: 'grok',
+      icon: 'xai',
+      supportsWebSearch: false,
+      pricing: { inputPerMtok: 2, outputPerMtok: 6 },
+      contextWindow: 500_000,
+    })
+    expect(catalog.find((m) => m.id === 'x-ai/grok-4.5')!.isLatest).toBeFalsy()
     // Anthropic must NOT inherit the OpenRouter-only extras.
     expect(getProviderCatalog('anthropic').some((m) => m.id === 'openai/gpt-5.5')).toBe(false)
     expect(getProviderCatalog('anthropic').some((m) => m.id === 'x-ai/grok-4.5')).toBe(false)
@@ -207,7 +215,7 @@ describe('getProviderCatalog', () => {
     const gptLatest = catalog.filter((m) => m.family === 'gpt' && m.isLatest)
     expect(gptLatest.map((m) => m.id)).toEqual(['gpt-5.6-sol'])
     // Grok rides the same Responses wire (xai-responses upstream); bare id only.
-    expect(catalog.find((m) => m.id === 'grok-4.5')).toMatchObject({
+    expect(catalog.find((m) => m.id === 'grok-4.6')).toMatchObject({
       family: 'grok',
       isLatest: true,
       icon: 'xai',
@@ -216,6 +224,17 @@ describe('getProviderCatalog', () => {
       pricing: { inputPerMtok: 2, outputPerMtok: 6 },
       contextWindow: 500_000,
     })
+    expect(catalog.find((m) => m.id === 'grok-4.5')).toMatchObject({
+      family: 'grok',
+      icon: 'xai',
+      supportsWebSearch: true,
+      supportsWebFetch: false,
+      pricing: { inputPerMtok: 2, outputPerMtok: 6 },
+      contextWindow: 500_000,
+    })
+    expect(catalog.find((m) => m.id === 'grok-4.5')!.isLatest).toBeFalsy()
+    const grokLatest = catalog.filter((m) => m.family === 'grok' && m.isLatest)
+    expect(grokLatest.map((m) => m.id)).toEqual(['grok-4.6'])
     // Kimi rides Fireworks' Anthropic-compatible wire, which strips server tools.
     expect(catalog.find((m) => m.id === 'kimi-k3')).toMatchObject({
       family: 'kimi',
@@ -231,6 +250,7 @@ describe('getProviderCatalog', () => {
     expect(catalog.some((m) => m.id === 'z-ai/glm-5.2')).toBe(false)
     expect(catalog.some((m) => m.id === 'glm-5.2')).toBe(false)
     expect(catalog.some((m) => m.id === 'x-ai/grok-4.5')).toBe(false)
+    expect(catalog.some((m) => m.id === 'x-ai/grok-4.6')).toBe(false)
   })
 })
 
@@ -424,6 +444,7 @@ describe('getModelContextWindow', () => {
   })
 
   it('returns the catalog window for Platform Grok models', () => {
+    expect(getModelContextWindow('grok-4.6', 'platform')).toBe(500_000)
     expect(getModelContextWindow('grok-4.5', 'platform')).toBe(500_000)
   })
 
@@ -453,9 +474,11 @@ describe('getModelPromptHints', () => {
     }
   })
 
-  it('returns browser-integration guidance for Platform and OpenRouter Grok 4.5', () => {
+  it('returns browser-integration guidance for Platform and OpenRouter Grok models', () => {
     for (const [providerId, modelId] of [
+      ['platform', 'grok-4.6'],
       ['platform', 'grok-4.5'],
+      ['openrouter', 'x-ai/grok-4.6'],
       ['openrouter', 'x-ai/grok-4.5'],
     ] as const) {
       const hints = getModelPromptHints(modelId, providerId)
@@ -516,7 +539,8 @@ describe('resolveModelForProvider', () => {
   it('resolves OpenRouter non-Claude models (gpt alias → latest id, glm slug passthrough)', () => {
     expect(resolveModelForProvider('gpt', 'openrouter', 'agent')).toBe('openai/gpt-5.5')
     expect(resolveModelForProvider('z-ai/glm-5.2', 'openrouter', 'agent')).toBe('z-ai/glm-5.2')
-    expect(resolveModelForProvider('grok', 'openrouter', 'agent')).toBe('x-ai/grok-4.5')
+    expect(resolveModelForProvider('grok', 'openrouter', 'agent')).toBe('x-ai/grok-4.6')
+    expect(resolveModelForProvider('x-ai/grok-4.6', 'openrouter', 'agent')).toBe('x-ai/grok-4.6')
     expect(resolveModelForProvider('x-ai/grok-4.5', 'openrouter', 'agent')).toBe('x-ai/grok-4.5')
   })
 
@@ -533,9 +557,10 @@ describe('resolveModelForProvider', () => {
     expect(resolveModelForProvider('gpt', 'platform', 'agent')).toBe('gpt-5.6-sol')
     expect(resolveModelForProvider('gpt-5.4', 'platform', 'agent')).toBe('gpt-5.4')
     expect(resolveModelForProvider('gpt-5.6-luna', 'platform', 'agent')).toBe('gpt-5.6-luna')
-    expect(resolveModelForProvider('grok', 'platform', 'agent')).toBe('grok-4.5')
+    expect(resolveModelForProvider('grok', 'platform', 'agent')).toBe('grok-4.6')
+    expect(resolveModelForProvider('grok-4.6', 'platform', 'agent')).toBe('grok-4.6')
     expect(resolveModelForProvider('grok-4.5', 'platform', 'agent')).toBe('grok-4.5')
-    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('grok-4.5')
+    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('grok-4.6')
   })
 
   it('resolves the SAME bare alias to each provider concrete id (cross-provider portability)', () => {

--- a/src/shared/lib/services/model-pricing.json
+++ b/src/shared/lib/services/model-pricing.json
@@ -238,9 +238,32 @@
     "input": 2,
     "output": 6,
     "cacheCreation": 2,
-    "cacheRead": 0.2,
+    "cacheRead": 0.3,
     "speedMultipliers": {
       "fast": 2
+    },
+    "longContext": {
+      "thresholdTokens": 200000,
+      "input": 4,
+      "output": 12,
+      "cacheCreation": 4,
+      "cacheRead": 0.6
+    }
+  },
+  "grok-4.6": {
+    "input": 2,
+    "output": 6,
+    "cacheCreation": 2,
+    "cacheRead": 0.5,
+    "speedMultipliers": {
+      "fast": 2
+    },
+    "longContext": {
+      "thresholdTokens": 200000,
+      "input": 4,
+      "output": 12,
+      "cacheCreation": 4,
+      "cacheRead": 1
     }
   },
   "openai/gpt-5.4": {

--- a/src/shared/lib/services/usage-service.test.ts
+++ b/src/shared/lib/services/usage-service.test.ts
@@ -338,16 +338,16 @@ describe('usage-service', () => {
       expect(costs.get('anthropic/claude-4.6-opus-20260205')).toBeCloseTo(0.19845875, 10)
       expect(costs.get('anthropic/claude-4.6-sonnet-20260217')).toBeCloseTo(0.1221165, 10)
       expect(costs.get('openai/gpt-5.5-20260423')).toBeCloseTo(0.12104, 10)
-      expect(costs.get('x-ai/grok-4.5-20260708')).toBeCloseTo(0.0552996, 10)
+      expect(costs.get('x-ai/grok-4.5-20260708')).toBeCloseTo(0.0553124, 10)
       expect(costs.get('anthropic/claude-4.5-haiku-20251001')).toBeCloseTo(0.04190125, 10)
-      expect(day.totalCost).toBeCloseTo(0.5388161, 10)
+      expect(day.totalCost).toBeCloseTo(0.5388289, 10)
     })
 
     it('returns corrected all-time totals through the session calculation path', async () => {
       await expect(
         loadSessionUsageTotals({ sessionPath, providerId: 'anthropic' }),
       ).resolves.toEqual({
-        totalCost: 0.8979443,
+        totalCost: 0.8979571,
         totalTokens: 286_966,
         priceMissing: false,
         usageIncomplete: false,
@@ -784,7 +784,32 @@ describe('usage-service', () => {
         9,
       )
     })
+  })
 
+  describe('calculateCost — Grok 200K long-context cliff', () => {
+    it('bills grok-4.6 below 200k at $2 / $6', () => {
+      expect(calculateCost('grok-4.6', 100_000, 1_000, 0, 0)).toBeCloseTo(
+        (100_000 * 2 + 1_000 * 6) / 1_000_000,
+        9,
+      )
+    })
+
+    it('reprices grok-4.6 above 200k at $4 / $12', () => {
+      expect(calculateCost('grok-4.6', 250_000, 2_000, 0, 0)).toBeCloseTo(
+        (250_000 * 4 + 2_000 * 12) / 1_000_000,
+        9,
+      )
+    })
+
+    it('reprices grok-4.5 above 200k at $4 / $12 with cache read $0.60', () => {
+      expect(calculateCost('grok-4.5', 150_000, 2_000, 0, 100_000)).toBeCloseTo(
+        (150_000 * 4 + 2_000 * 12 + 100_000 * 0.6) / 1_000_000,
+        9,
+      )
+    })
+  })
+
+  describe('calculateCost — catalog overrides and unknown ids', () => {
     it('returns 0 for unknown models', () => {
       expect(calculateCost('totally-unknown', 100_000, 1_000, 0, 0)).toBe(0)
     })
@@ -912,6 +937,8 @@ describe('usage-service', () => {
       ['x-ai/grok-4.5-latest', 2, 6],
       ['grok-build-latest', 2, 6],
       ['x-ai/grok-build-latest', 2, 6],
+      ['grok-4.6', 2, 6],
+      ['x-ai/grok-4.6', 2, 6],
     ])('prices %s through its canonical rate card', (model, inputRate, outputRate) => {
       expect(calculateCost(model, 100_000, 1_000, 0, 0)).toBeCloseTo(
         (100_000 * inputRate + 1_000 * outputRate) / 1_000_000,
@@ -1243,6 +1270,7 @@ describe('usage-service', () => {
       )
       const grokBase = (100_000 * 2 + 1_000 * 6) / 1_000_000
       expect(await costOf('grok-4.5', { speed: 'fast' }, 'platform')).toBeCloseTo(grokBase * 2, 9)
+      expect(await costOf('grok-4.6', { speed: 'fast' }, 'platform')).toBeCloseTo(grokBase * 2, 9)
     })
 
     it('bills kimi-k3 on the Fireworks fast router at 1.5x', async () => {


### PR DESCRIPTION
## Summary
- SuperAgent's grok family still resolved to `grok-4.5` / `x-ai/grok-4.5`, so the new xAI model could not be selected (and a `grok` alias would keep routing to 4.5).
- Add `grok-4.6` (platform) and `x-ai/grok-4.6` (OpenRouter) as the family's latest/default. `grok-4.5` stays in both catalogs as a pin.
- Bill both models with xAI's 200k long-context cliff ($2/$6 → $4/$12). grok-4.5 cache read is now $0.30 / $0.60; grok-4.6 is $0.50 / $1.00. Priority/fast remains 2x.

Depends on platform proxy pricing/allowlist: https://github.com/SkillfulAgents/platform/pull/276

## Test plan
- [x] `npx vitest run src/shared/lib/llm-provider/model-catalog.test.ts src/shared/lib/services/usage-service.test.ts src/api/routes/llm.test.ts src/shared/lib/container/subagent-model-catalog.test.ts src/renderer/components/wizard/configure-model-step.test.tsx src/renderer/components/messages/model-family-list.test.tsx`
- [ ] Platform provider: picker shows Grok 4.6 as the grok default; Grok 4.5 remains selectable
- [ ] Selecting the bare `grok` alias sends `grok-4.6` to the proxy
- [ ] OpenRouter provider: same for `x-ai/grok-4.6`
- [ ] Usage tab bills a >200k grok-4.6 prompt at $4/$12


Made with [Cursor](https://cursor.com)