### PR TITLE
fix: release automation session streams once they settle

### DIFF
--- a/src/shared/lib/container/base-container-client.close-connecting.test.ts
+++ b/src/shared/lib/container/base-container-client.close-connecting.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import net from 'net'
 import type { AddressInfo } from 'net'
 import type { ContainerConfig, ContainerInfo } from './types'

--- a/src/shared/lib/container/base-container-client.close-connecting.test.ts
+++ b/src/shared/lib/container/base-container-client.close-connecting.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import net from 'net'
+import type { AddressInfo } from 'net'
+import type { ContainerConfig, ContainerInfo } from './types'
+import { BaseContainerClient } from './base-container-client'
+
+vi.mock('@shared/lib/container/host-token-store', () => ({
+  getOrCreateHostToken: () => 'test-host-token',
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ enableToolSearch: true }),
+}))
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: () => ({ getContainerEnvVars: () => ({}) }),
+}))
+
+class RunningPortClient extends BaseContainerClient {
+  constructor(private readonly port: number) {
+    super({ agentId: 'test-agent' } as ContainerConfig)
+  }
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'running', port: this.port }
+  }
+}
+
+describe('closeTrackedWebSocket on a CONNECTING socket', () => {
+  let server: net.Server | undefined
+  const held: net.Socket[] = []
+
+  afterEach(async () => {
+    for (const socket of held) socket.destroy()
+    held.length = 0
+    if (!server) return
+    const closing = server
+    server = undefined
+    await new Promise<void>((resolve) => closing.close(() => resolve()))
+  })
+
+  it('unsubscribe before open does not raise uncaughtException', async () => {
+    server = net.createServer((socket) => {
+      held.push(socket)
+    })
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve))
+    const port = (server.address() as AddressInfo).port
+
+    const client = new RunningPortClient(port)
+    const { unsubscribe, ready } = client.subscribeToStream('sess-connecting', () => {})
+    void ready.catch(() => {})
+
+    const readyState = await Promise.race([
+      ready.then(() => 'opened' as const, (error) => Promise.reject(error)),
+      new Promise<'connecting'>((resolve) => setTimeout(() => resolve('connecting'), 50)),
+    ])
+    expect(readyState).toBe('connecting')
+
+    const uncaught: unknown[] = []
+    const onUncaught = (error: unknown) => {
+      uncaught.push(error)
+    }
+    process.on('uncaughtException', onUncaught)
+    try {
+      unsubscribe()
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(uncaught).toEqual([])
+    } finally {
+      process.off('uncaughtException', onUncaught)
+    }
+  })
+})

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1241,12 +1241,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   async deleteSession(sessionId: string): Promise<boolean> {
     const port = await this.getPortOrThrow()
 
-    // Close WebSocket if exists
-    const ws = this.wsConnections.get(sessionId)
-    if (ws) {
-      ws.close()
-      this.wsConnections.delete(sessionId)
-    }
+    this.closeTrackedWebSocket(sessionId)
 
     const response = await fetch(
       `${this.getBaseUrl(port)}/sessions/${sessionId}`,
@@ -1363,6 +1358,16 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     return response.ok
   }
 
+  // Drop listeners before close so a deliberate teardown cannot fire
+  // connection_closed into a newer socket's map slot (SUP-572).
+  private closeTrackedWebSocket(sessionId: string): void {
+    const ws = this.wsConnections.get(sessionId)
+    if (!ws) return
+    ws.removeAllListeners()
+    ws.close()
+    this.wsConnections.delete(sessionId)
+  }
+
   subscribeToStream(
     sessionId: string,
     callback: (message: StreamMessage) => void
@@ -1377,9 +1382,8 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const setupWebSocket = async () => {
       const port = await this.getPortOrThrow()
 
-      const existing = this.wsConnections.get(sessionId)
-      if (existing) {
-        existing.close()
+      if (this.wsConnections.has(sessionId)) {
+        this.closeTrackedWebSocket(sessionId)
       }
 
       const ws = new WebSocket(
@@ -1452,11 +1456,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     })
 
     const unsubscribe = () => {
-      const ws = this.wsConnections.get(sessionId)
-      if (ws) {
-        ws.close()
-        this.wsConnections.delete(sessionId)
-      }
+      this.closeTrackedWebSocket(sessionId)
     }
 
     return { unsubscribe, ready }

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1364,6 +1364,8 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const ws = this.wsConnections.get(sessionId)
     if (!ws) return
     ws.removeAllListeners()
+    // close() on CONNECTING emits 'error'; zero listeners is an uncaughtException.
+    ws.on('error', () => {})
     ws.close()
     this.wsConnections.delete(sessionId)
   }

--- a/src/shared/lib/container/base-container-client.unsubscribe.test.ts
+++ b/src/shared/lib/container/base-container-client.unsubscribe.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { ContainerConfig, ContainerInfo, StreamMessage } from './types'
+import { BaseContainerClient } from './base-container-client'
+
+const { FakeWebSocket, sockets } = vi.hoisted(() => {
+  class FakeWebSocket {
+    static OPEN = 1
+    url: string
+    private listeners = new Map<string, Array<() => void>>()
+    closed = false
+
+    constructor(url: string) {
+      this.url = url
+      sockets.push(this)
+      queueMicrotask(() => this.emit('open'))
+    }
+
+    on(event: string, fn: () => void): this {
+      const list = this.listeners.get(event) ?? []
+      list.push(fn)
+      this.listeners.set(event, list)
+      return this
+    }
+
+    removeAllListeners(): void {
+      this.listeners.clear()
+    }
+
+    close(): void {
+      this.closed = true
+      queueMicrotask(() => this.emit('close'))
+    }
+
+    emit(event: string): void {
+      for (const fn of [...(this.listeners.get(event) ?? [])]) fn()
+    }
+  }
+
+  const sockets: FakeWebSocket[] = []
+  return { FakeWebSocket, sockets }
+})
+
+vi.mock('ws', () => ({ default: FakeWebSocket }))
+vi.mock('@shared/lib/container/host-token-store', () => ({
+  getOrCreateHostToken: () => 'test-host-token',
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ enableToolSearch: true }),
+}))
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: () => ({ getContainerEnvVars: () => ({}) }),
+}))
+
+class RunningTestClient extends BaseContainerClient {
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'running', port: 12345 }
+  }
+}
+
+function makeClient(): RunningTestClient {
+  return new RunningTestClient({ agentId: 'test-agent' } as ContainerConfig)
+}
+
+describe('subscribeToStream unsubscribe', () => {
+  beforeEach(() => {
+    sockets.length = 0
+  })
+
+  it('does not route connection_closed on a deliberate unsubscribe', async () => {
+    const client = makeClient()
+    const messages: StreamMessage[] = []
+    const { unsubscribe, ready } = client.subscribeToStream('sess-1', (m) => messages.push(m))
+    await ready
+
+    unsubscribe()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sockets[0].closed).toBe(true)
+    expect(messages.some((m) => m.type === 'connection_closed')).toBe(false)
+  })
+
+  it('still routes connection_closed when the socket drops on its own', async () => {
+    const client = makeClient()
+    const messages: StreamMessage[] = []
+    const { ready } = client.subscribeToStream('sess-1', (m) => messages.push(m))
+    await ready
+
+    sockets[0].emit('close')
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].type).toBe('connection_closed')
+    expect(messages[0].sessionId).toBe('sess-1')
+  })
+
+  it('does not let a stale close delete a newer socket after resubscribe', async () => {
+    const client = makeClient()
+    const first: StreamMessage[] = []
+    const second: StreamMessage[] = []
+
+    const firstSub = client.subscribeToStream('sess-1', (m) => first.push(m))
+    await firstSub.ready
+    const firstSocket = sockets[0]
+
+    firstSub.unsubscribe()
+    const secondSub = client.subscribeToStream('sess-1', (m) => second.push(m))
+    await secondSub.ready
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    firstSocket.emit('close')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(first.some((m) => m.type === 'connection_closed')).toBe(false)
+    expect(second.some((m) => m.type === 'connection_closed')).toBe(false)
+
+    secondSub.unsubscribe()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(sockets[1].closed).toBe(true)
+  })
+})

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3925,6 +3925,115 @@ describe('MessagePersister', () => {
     })
   })
 
+  describe('automation stream release on settle (SUP-572)', () => {
+    // A leaked stream per cron/webhook run holds a container WebSocket open
+    // forever (keepalives defeat idle cuts); runtimes with a per-VM connection
+    // quota then 429 new sessions. The persister must release the stream once
+    // an unpromoted automation session truly settles.
+
+    afterEach(() => {
+      // mockResolvedValue survives clearAllMocks — restore the suite default.
+      vi.mocked(getSessionMetadata).mockImplementation(() => Promise.resolve(null))
+    })
+
+    // Re-subscribe AFTER pointing the metadata mock at the desired session
+    // shape, then let the async subscribe-time resolution land.
+    async function resubscribeWithMetadata(meta: Record<string, unknown> | null) {
+      vi.mocked(getSessionMetadata).mockResolvedValue(meta as never)
+      await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+
+    function settleSession() {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      // State-events authority: the runtime's own idle proves the queue drained.
+      mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
+      mockClient._sendMessage({
+        type: 'result', subtype: 'success', is_error: false, duration_ms: 100, num_turns: 1,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+    }
+
+    it('releases the stream when a scheduled session settles', async () => {
+      await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
+
+      settleSession()
+
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+      const lastSubscription = vi.mocked(mockClient.subscribeToStream).mock.results.at(-1)!
+        .value as { unsubscribe: ReturnType<typeof vi.fn> }
+      expect(lastSubscription.unsubscribe).toHaveBeenCalled()
+    })
+
+    it('releases the stream when a webhook session settles', async () => {
+      await resubscribeWithMetadata({ isWebhookExecution: true, webhookTriggerId: 'trigger-1' })
+
+      settleSession()
+
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+    })
+
+    it('keeps the stream for an interactive session', async () => {
+      await resubscribeWithMetadata(null)
+
+      settleSession()
+
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+    })
+
+    it('keeps the stream for a promoted automation session', async () => {
+      await resubscribeWithMetadata({ isScheduledExecution: true, promotedToInteractive: true })
+
+      settleSession()
+
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+    })
+
+    it('keeps the stream when a scheduled session is promoted mid-run', async () => {
+      await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
+
+      await messagePersister.promoteAutomatedSession(SESSION_ID, AGENT_SLUG)
+
+      settleSession()
+
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+    })
+
+    it('does not release on a legacy result-driven idle (no state-events authority)', async () => {
+      // Without the runtime's own idle event there is no proof the container's
+      // message queue is drained — a queued message could still start a turn
+      // on this stream, so the release must not fire.
+      await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
+
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._sendMessage({
+        type: 'result', subtype: 'success', is_error: false, duration_ms: 100, num_turns: 1,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      })
+
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+    })
+
+    it('a released session re-subscribes cleanly for a later wake', async () => {
+      await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
+      settleSession()
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+
+      // The wake path checks isSubscribed and re-subscribes on demand.
+      await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+
+      // And the resumed run releases again at its own settle.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      settleSession()
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+    })
+  })
+
   // ============================================================================
   // Script run request detection
   // ============================================================================

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3926,10 +3926,10 @@ describe('MessagePersister', () => {
   })
 
   describe('automation stream release on settle (SUP-572)', () => {
-    // A leaked stream per cron/webhook run holds a container WebSocket open
-    // forever (keepalives defeat idle cuts); runtimes with a per-VM connection
-    // quota then 429 new sessions. The persister must release the stream once
-    // an unpromoted automation session truly settles.
+    // A leaked stream per cron/webhook run holds a runtime-container WebSocket
+    // open forever (keepalives defeat idle cuts); runtimes that cap concurrent
+    // connections per container then block new sessions. The persister must
+    // release the stream once an unpromoted automation session truly settles.
 
     afterEach(() => {
       // mockResolvedValue survives clearAllMocks — restore the suite default.

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3967,6 +3967,21 @@ describe('MessagePersister', () => {
       expect(lastSubscription.unsubscribe).toHaveBeenCalled()
     })
 
+    it('releases the stream when a scheduled session settles with an error', async () => {
+      await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
+
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
+      mockClient._sendMessage({
+        type: 'result', subtype: 'error_during_execution', is_error: true, duration_ms: 100, num_turns: 1,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      })
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+    })
+
     it('releases the stream when a webhook session settles', async () => {
       await resubscribeWithMetadata({ isWebhookExecution: true, webhookTriggerId: 'trigger-1' })
 
@@ -3996,6 +4011,28 @@ describe('MessagePersister', () => {
       await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
 
       await messagePersister.promoteAutomatedSession(SESSION_ID, AGENT_SLUG)
+
+      settleSession()
+
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+    })
+
+    it('does not let a stale subscribe-time metadata read undo a promotion', async () => {
+      const unpromoted = { isScheduledExecution: true, scheduledTaskId: 'task-1' }
+      let resolveSubscribeMeta: ((value: typeof unpromoted) => void) | undefined
+      let metaCalls = 0
+      vi.mocked(getSessionMetadata).mockImplementation(() => {
+        metaCalls += 1
+        if (metaCalls === 1) {
+          return new Promise((resolve) => { resolveSubscribeMeta = resolve })
+        }
+        return Promise.resolve(unpromoted as never)
+      })
+
+      await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+      await messagePersister.promoteAutomatedSession(SESSION_ID, AGENT_SLUG)
+      resolveSubscribeMeta!(unpromoted)
+      await new Promise((resolve) => setTimeout(resolve, 0))
 
       settleSession()
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -119,6 +119,10 @@ interface StreamingState {
   isCompacting: boolean // True while compaction is in progress, cleared on compact completion
   agentSlug?: string // The agent slug for this session
   notAutomationSession?: boolean // Cached "not a cron/webhook session" verdict; skips the automation-status metadata write on later results
+  // Unpromoted cron/webhook session: release its container stream when the
+  // session settles. Resolved from session metadata at subscribe time so the
+  // settle-time teardown in finalizeIdle stays synchronous (race-free).
+  releaseStreamOnSettle?: boolean
   // True when the most recent result was a clean success (not error-shaped,
   // not an interrupt, not a resume-exit). Consumed by finalizeIdle: a success
   // result alone is NOT terminal — queued messages or background work can keep
@@ -470,7 +474,12 @@ class MessagePersister {
       lastResultSubtype: null,
       lastResultCleanSuccess: false,
       isRetrying: false,
+      // Carried over so a transport reattach mid-run doesn't lose the verdict
+      // before the refresh below lands.
+      releaseStreamOnSettle: prior?.releaseStreamOnSettle ?? false,
     })
+
+    this.resolveReleaseStreamOnSettle(sessionId, agentSlug)
 
     // Store container client for reconnection checks
     this.containerClients.set(sessionId, client)
@@ -491,6 +500,33 @@ class MessagePersister {
 
     // Wait for the WebSocket connection to be established
     await ready
+  }
+
+  // Resolve whether this subscription belongs to an unpromoted cron/webhook
+  // session. Non-blocking: automation runs last long enough that the verdict
+  // lands well before finalizeIdle consumes it, and an unresolved read just
+  // means the stream is kept (the pre-fix behavior). Scheduler and trigger
+  // paths register metadata before subscribing, so the read can't miss them.
+  private resolveReleaseStreamOnSettle(sessionId: string, agentSlug?: string): void {
+    if (!agentSlug) return
+    const stateRef = this.streamingStates.get(sessionId)
+    void getSessionMetadata(agentSlug, sessionId)
+      .then((meta) => {
+        // A resubscribe replaced the state and kicked off its own resolution.
+        const current = this.streamingStates.get(sessionId)
+        if (!current || current !== stateRef) return
+        current.releaseStreamOnSettle = Boolean(
+          (meta?.isScheduledExecution || meta?.isWebhookExecution) &&
+            !meta?.promotedToInteractive
+        )
+      })
+      .catch((error) => {
+        console.warn('[MessagePersister] Failed to resolve automation stream policy:', error)
+        captureException(error, {
+          tags: { area: 'container', op: 'resolveReleaseStreamOnSettle' },
+          extra: { sessionId, agentSlug },
+        })
+      })
   }
 
   // Unsubscribe from a session
@@ -535,6 +571,24 @@ class MessagePersister {
       agentSlug: state.agentSlug,
       isActive: false,
     })
+    // A settled automation (cron/webhook) session's container WebSocket carries
+    // no further traffic, but stream keepalives hold it open indefinitely.
+    // Runtimes with a per-VM connection quota then reject new sessions once
+    // enough one-shot runs accumulate (SUP-572). Release the stream on settle;
+    // every send/wake path re-subscribes on demand, so a later resume costs one
+    // reconnect. Synchronous on purpose: an async gap here would race the
+    // wake path's isSubscribed check and close a stream a new turn relies on.
+    // Gated on stateEventsAuthority: only the runtime's own idle event proves
+    // the queue is drained — a legacy result-driven idle can still have a
+    // queued message about to start a turn on this stream.
+    if (
+      state.releaseStreamOnSettle &&
+      state.stateEventsAuthority &&
+      this.subscriptions.has(sessionId)
+    ) {
+      console.log(`[MessagePersister] Releasing settled automation stream for session ${sessionId}`)
+      this.unsubscribeFromSession(sessionId)
+    }
   }
 
   // Revert an optimistic markSessionActive when a host-initiated send fails
@@ -1246,6 +1300,11 @@ class MessagePersister {
     await updateSessionMetadata(agentSlug, sessionId, {
       promotedToInteractive: true,
     })
+
+    // Promoted sessions behave interactive from here on — keep their stream
+    // alive across settles like any other interactive session.
+    const state = this.streamingStates.get(sessionId)
+    if (state) state.releaseStreamOnSettle = false
 
     console.log(`[MessagePersister] Promoted automated session ${sessionId} to interactive (agent: ${agentSlug})`)
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -571,10 +571,11 @@ class MessagePersister {
       agentSlug: state.agentSlug,
       isActive: false,
     })
-    // A settled automation (cron/webhook) session's container WebSocket carries
-    // no further traffic, but stream keepalives hold it open indefinitely.
-    // Runtimes with a per-VM connection quota then reject new sessions once
-    // enough one-shot runs accumulate (SUP-572). Release the stream on settle;
+    // A settled automation (cron/webhook) session's WebSocket to the runtime
+    // container carries no further traffic, but stream keepalives hold it open
+    // indefinitely. Runtimes that cap concurrent connections per container
+    // then reject new sessions once enough one-shot runs accumulate (SUP-572).
+    // Release the stream on settle;
     // every send/wake path re-subscribes on demand, so a later resume costs one
     // reconnect. Synchronous on purpose: an async gap here would race the
     // wake path's isSubscribed check and close a stream a new turn relies on.

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -123,6 +123,9 @@ interface StreamingState {
   // session settles. Resolved from session metadata at subscribe time so the
   // settle-time teardown in finalizeIdle stays synchronous (race-free).
   releaseStreamOnSettle?: boolean
+  // Set synchronously on promote so an in-flight subscribe-time metadata read
+  // cannot flip releaseStreamOnSettle back to true.
+  promotedToInteractive?: boolean
   // True when the most recent result was a clean success (not error-shaped,
   // not an interrupt, not a resume-exit). Consumed by finalizeIdle: a success
   // result alone is NOT terminal — queued messages or background work can keep
@@ -477,6 +480,7 @@ class MessagePersister {
       // Carried over so a transport reattach mid-run doesn't lose the verdict
       // before the refresh below lands.
       releaseStreamOnSettle: prior?.releaseStreamOnSettle ?? false,
+      promotedToInteractive: prior?.promotedToInteractive ?? false,
     })
 
     this.resolveReleaseStreamOnSettle(sessionId, agentSlug)
@@ -515,6 +519,8 @@ class MessagePersister {
         // A resubscribe replaced the state and kicked off its own resolution.
         const current = this.streamingStates.get(sessionId)
         if (!current || current !== stateRef) return
+        // Promote wins: its marker is set synchronously, this read may be stale.
+        if (current.promotedToInteractive) return
         current.releaseStreamOnSettle = Boolean(
           (meta?.isScheduledExecution || meta?.isWebhookExecution) &&
             !meta?.promotedToInteractive
@@ -571,17 +577,12 @@ class MessagePersister {
       agentSlug: state.agentSlug,
       isActive: false,
     })
-    // A settled automation (cron/webhook) session's WebSocket to the runtime
-    // container carries no further traffic, but stream keepalives hold it open
-    // indefinitely. Runtimes that cap concurrent connections per container
-    // then reject new sessions once enough one-shot runs accumulate (SUP-572).
-    // Release the stream on settle;
-    // every send/wake path re-subscribes on demand, so a later resume costs one
-    // reconnect. Synchronous on purpose: an async gap here would race the
-    // wake path's isSubscribed check and close a stream a new turn relies on.
-    // Gated on stateEventsAuthority: only the runtime's own idle event proves
-    // the queue is drained — a legacy result-driven idle can still have a
-    // queued message about to start a turn on this stream.
+    this.maybeReleaseSettledAutomationStream(sessionId, state)
+  }
+
+  // Tear down a settled automation stream. Sync: an async gap races the wake path's isSubscribed check.
+  // Gated on stateEventsAuthority so a legacy idle can't drop a queued turn's stream.
+  private maybeReleaseSettledAutomationStream(sessionId: string, state: StreamingState): void {
     if (
       state.releaseStreamOnSettle &&
       state.stateEventsAuthority &&
@@ -1305,7 +1306,10 @@ class MessagePersister {
     // Promoted sessions behave interactive from here on — keep their stream
     // alive across settles like any other interactive session.
     const state = this.streamingStates.get(sessionId)
-    if (state) state.releaseStreamOnSettle = false
+    if (state) {
+      state.promotedToInteractive = true
+      state.releaseStreamOnSettle = false
+    }
 
     console.log(`[MessagePersister] Promoted automated session ${sessionId} to interactive (agent: ${agentSlug})`)
 
@@ -1916,6 +1920,9 @@ class MessagePersister {
                   })
                 }
               }
+            } else if (!state.isActive && state.lastResultSubtype !== null) {
+              // Error path already cleared isActive, so finalizeIdle never ran.
+              this.maybeReleaseSettledAutomationStream(sessionId, state)
             }
           } else if (content.state === 'running' && !state.isActive) {
             // The runtime started a turn we didn't initiate via POST (e.g. a

--- a/src/shared/lib/container/subagent-routing-replay.test.ts
+++ b/src/shared/lib/container/subagent-routing-replay.test.ts
@@ -10,6 +10,7 @@ vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   createScheduledTask: vi.fn(),
 }))
 vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
   updateSessionMetadata: vi.fn(() => Promise.resolve()),
   finalizeAutomationStatus: vi.fn(() => Promise.resolve('not-automation')),
 }))

--- a/src/shared/lib/container/subagent-task-events-replay.test.ts
+++ b/src/shared/lib/container/subagent-task-events-replay.test.ts
@@ -10,6 +10,7 @@ vi.mock('@shared/lib/services/scheduled-task-service', () => ({
   createScheduledTask: vi.fn(),
 }))
 vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: vi.fn(() => Promise.resolve(null)),
   updateSessionMetadata: vi.fn(() => Promise.resolve()),
   finalizeAutomationStatus: vi.fn(() => Promise.resolve('not-automation')),
 }))


### PR DESCRIPTION
## Bug

Every scheduled-task tick (and webhook trigger) creates a session and subscribes a WebSocket to the runtime container, but nothing ever closes it: idle finalization (`finalizeIdle`) flips session state and broadcasts `session_idle` without touching the subscription, and the stream keepalive ping prevents any transport-level idle cut. Leaked streams accumulate one per automation run.

On runtimes that cap concurrent connections per container, an agent with a frequent cron eventually exhausts the cap and every new `POST /sessions` / `GET /health` is rejected with HTTP 429 (`Failed to create session: Too Many Requests`) until some sockets happen to die. On Docker the same leak just accumulates fds.

## Repro

1. Create an agent with a recurring scheduled task (e.g. every 10 minutes) on a connection-capped runtime.
2. Let it run until the number of completed runs reaches the runtime container's connection cap (host logs show one `WebSocket connection established` per run, zero closes).
3. The next tick fails: `Failed to create session: Too Many Requests`, and the agent's health checks 429 as well.

## Change

- `message-persister.ts`:
  - `doSubscribeToSession` now resolves (non-blocking) whether the subscription belongs to an unpromoted cron/webhook session from session metadata, cached on the streaming state. Both automation paths register metadata before subscribing, so the read can't miss them.
  - `finalizeIdle` synchronously unsubscribes such sessions once they truly settle. Synchronous on purpose: an async gap would race the wake path's `isSubscribed` check. Gated on `stateEventsAuthority` — only the runtime's own idle event proves the container's message queue is drained, so legacy result-driven idles keep their stream (pre-fix behavior).
  - `promoteAutomatedSession` clears the flag: promoted sessions behave interactive and keep one live stream.
- Interactive sessions are untouched. All resume paths (message send route, wake delivery) already re-subscribe on demand, so a released session costs one reconnect if it is ever resumed.
- Tests: settle-releases for scheduled and webhook sessions, keep-alive for interactive/promoted/legacy sessions, and clean re-subscribe + re-release across a wake cycle. Two replay-test mock factories gained the `getSessionMetadata` export the subscribe path now uses.

## Verification

- `src/shared/lib/container/` + `src/shared/lib/scheduler/` suites: 1077 passed.
- Full suite failures (db/migration/policy suites) reproduce identically without this change — environmental, unrelated.
- `eslint` clean on touched files; `tsc` errors limited to pre-existing `tools/verify-*` scripts.