### PR TITLE
feat(observability): classify renderer API failures

### DIFF
--- a/src/renderer/lib/api.test.ts
+++ b/src/renderer/lib/api.test.ts
@@ -10,6 +10,9 @@ vi.mock('./env', () => ({ getApiBaseUrl: () => '' }))
 const signOutMock = vi.fn().mockResolvedValue(undefined)
 vi.mock('./auth-client', () => ({ signOut: signOutMock }))
 
+const { captureMock } = vi.hoisted(() => ({ captureMock: vi.fn() }))
+vi.mock('./error-reporting', () => ({ captureRendererException: captureMock }))
+
 import { _resetApiTargetForTest, setActiveTarget } from './api-target'
 import { _resetCloudSessionForTest, onCloudSessionRejected } from './cloud-session'
 import {
@@ -22,6 +25,8 @@ import {
   clearRedirectStash,
   markDeliberateSignOut,
   clearDeliberateSignOut,
+  ApiRequestError,
+  normalizeApiRoute,
 } from './api'
 
 const KEY = 'superagent.redirect'
@@ -96,6 +101,80 @@ describe('redirect stash (post-login restore)', () => {
       expect(consumeRedirectStash()).toBe('/agents/foo')
       expect(peekRedirectStash()).toBe('/') // now cleared
     })
+  })
+})
+
+describe('apiFetch diagnostics', () => {
+  beforeEach(() => {
+    captureMock.mockClear()
+    vi.stubGlobal('__AUTH_MODE__', false)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('normalizes dynamic segments and strips query, fragment, and encoded secrets', () => {
+    expect(normalizeApiRoute('/api/agents/private-agent/sessions/user-123/messages?token=secret#body'))
+      .toBe('/api/agents/:param/sessions/:param/messages')
+    expect(normalizeApiRoute('/not-api/private?token=secret')).toBe('/api/:unknown')
+  })
+
+  it('reports offline transport failure with bounded request metadata only', async () => {
+    vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError(
+      'Failed to fetch https://host/api/agents/alice?token=top-secret',
+    )))
+
+    const failure = apiFetch('/api/agents/alice?token=top-secret', {
+      method: 'POST',
+      headers: { authorization: 'Bearer top-secret' },
+      body: 'private message',
+    })
+    await expect(failure).rejects.toSatisfy((error: unknown) =>
+      error instanceof ApiRequestError && error.metadata.failureKind === 'offline')
+
+    const serialized = JSON.stringify(captureMock.mock.calls)
+    expect(serialized).toContain('/api/agents/:param')
+    expect(serialized).toContain('offline')
+    expect(serialized).not.toMatch(/alice|top-secret|private message|https:\/\/host/)
+    expect(captureMock.mock.calls[0][1]).toMatchObject({
+      tags: { route: '/api/agents/:param', method: 'POST', failure_kind: 'offline' },
+      fingerprint: ['api-request', '/api/agents/:param', 'POST', 'offline'],
+    })
+  })
+
+  it('splits CORS-like transport, 5xx, and allowlisted 403 policy diagnostics', async () => {
+    vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(true)
+    vi.stubGlobal('fetch', vi.fn()
+      .mockRejectedValueOnce(new TypeError('Load failed'))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response('private response', {
+        status: 403,
+        headers: { 'x-error-code': 'POLICY_DENIED', 'x-request-id': 'private-id' },
+      })))
+
+    await expect(apiFetch('/api/settings')).rejects.toMatchObject({
+      metadata: { failureKind: 'transport_or_cors' },
+    })
+    await apiFetch('/api/settings')
+    await apiFetch('/api/settings')
+
+    expect(captureMock.mock.calls.map((call) => call[1]?.tags?.failure_kind))
+      .toEqual(['transport_or_cors', 'server', 'forbidden'])
+    expect(captureMock.mock.calls[2][1]).toMatchObject({ tags: { policy_code: 'POLICY_DENIED' } })
+    expect(JSON.stringify(captureMock.mock.calls)).not.toMatch(/private response|private-id/)
+  })
+
+  it('does not retain a provider error as a recursively serialized cause', async () => {
+    const providerError = new Error('token=secret and user content')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(providerError))
+
+    let caught: unknown
+    try { await apiFetch('/api/runtime-status') } catch (error) { caught = error }
+    expect(caught).toBeInstanceOf(ApiRequestError)
+    expect(caught).not.toHaveProperty('cause')
+    expect(JSON.stringify(caught)).not.toContain('secret')
   })
 })
 

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -1,6 +1,170 @@
 import { getApiBaseUrl } from './env'
 import { hasInteractiveLogin, isAuthMode } from './auth-mode'
 import { reportCloudSessionRejected } from './cloud-session'
+import { captureRendererException } from './error-reporting'
+
+const SAFE_ROUTE_SEGMENTS = new Set([
+  'api', 'accounts', 'agents', 'answer', 'auth', 'automations', 'billing', 'browser',
+  'cancel', 'chat-integrations', 'connections', 'credential', 'dashboards', 'deploy',
+  'events', 'files', 'folders', 'health', 'history', 'import', 'integrations', 'logs',
+  'messages', 'models', 'notifications', 'platform', 'preferences', 'refresh', 'roles',
+  'runtime-status', 'secrets', 'sessions', 'settings', 'skillsets', 'status', 'subagents',
+  'sync', 'typing', 'unread', 'update', 'usage', 'validate', 'workflows',
+])
+
+const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'])
+
+type ApiRequestFailureKind =
+  | 'offline'
+  | 'intentional_navigation_abort'
+  | 'aborted'
+  | 'transport_or_cors'
+  | 'forbidden'
+  | 'server'
+
+type ApiRequestMetadata = {
+  route: string
+  method: string
+  failureKind: ApiRequestFailureKind
+  statusClass: 'none' | '4xx' | '5xx'
+  status?: number
+  policyCode?: string
+  apiBaseKind: 'same-origin' | 'loopback' | 'other-first-party'
+  browser: 'firefox' | 'safari' | 'chromium' | 'embedded' | 'other'
+  online: 'yes' | 'no' | 'unknown'
+  visibility: 'visible' | 'hidden' | 'unknown'
+  lifecycle: 'active' | 'pagehide'
+  elapsedMsBucket: '<100' | '100-999' | '1000-9999' | '10000+'
+}
+
+let pageLifecycle: 'active' | 'pagehide' = 'active'
+if (typeof window !== 'undefined') {
+  window.addEventListener('pagehide', () => { pageLifecycle = 'pagehide' })
+  window.addEventListener('pageshow', () => { pageLifecycle = 'active' })
+}
+
+/**
+ * A request failure whose public fields are safe to send to diagnostics. The
+ * original URL, response body, headers and provider error are deliberately not
+ * retained, including as `cause` (Sentry recursively serializes causes).
+ */
+export class ApiRequestError extends Error {
+  constructor(public readonly metadata: ApiRequestMetadata) {
+    super(`API request failed: ${metadata.method} ${metadata.route} (${metadata.failureKind})`)
+    this.name = 'ApiRequestError'
+  }
+}
+
+/** Only a caller-owned abort coincident with page teardown is proven intentional. */
+export function isProvenIntentionalApiAbort(error: unknown): boolean {
+  return error instanceof ApiRequestError && error.metadata.failureKind === 'intentional_navigation_abort'
+}
+
+function normalizedMethod(init?: RequestInit): string {
+  const method = (init?.method ?? 'GET').toUpperCase()
+  return HTTP_METHODS.has(method) ? method : 'OTHER'
+}
+
+/**
+ * Retain only a small allowlist of route vocabulary. Every other segment is a
+ * parameter, so slugs, account/session IDs, tokens and encoded values cannot
+ * enter diagnostics. Query strings and fragments are discarded before parsing.
+ */
+export function normalizeApiRoute(path: string): string {
+  const pathname = path.split(/[?#]/, 1)[0]
+  if (!pathname.startsWith('/api/')) return '/api/:unknown'
+  const segments = pathname.split('/').filter(Boolean)
+  return `/${segments.map((segment) => SAFE_ROUTE_SEGMENTS.has(segment.toLowerCase())
+    ? segment.toLowerCase()
+    : ':param').join('/')}`
+}
+
+function apiBaseKind(baseUrl: string): ApiRequestMetadata['apiBaseKind'] {
+  if (!baseUrl) return 'same-origin'
+  try {
+    const host = new URL(baseUrl).hostname
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+      ? 'loopback'
+      : 'other-first-party'
+  } catch {
+    return 'other-first-party'
+  }
+}
+
+function browserKind(): ApiRequestMetadata['browser'] {
+  if (typeof navigator === 'undefined') return 'other'
+  const ua = navigator.userAgent.toLowerCase()
+  if (/\b(fbav|instagram|line|wv)\b/.test(ua)) return 'embedded'
+  if (ua.includes('firefox')) return 'firefox'
+  if (ua.includes('safari') && !ua.includes('chrome') && !ua.includes('chromium')) return 'safari'
+  if (ua.includes('chrome') || ua.includes('chromium')) return 'chromium'
+  return 'other'
+}
+
+function elapsedBucket(elapsedMs: number): ApiRequestMetadata['elapsedMsBucket'] {
+  if (elapsedMs < 100) return '<100'
+  if (elapsedMs < 1_000) return '100-999'
+  if (elapsedMs < 10_000) return '1000-9999'
+  return '10000+'
+}
+
+function safePolicyCode(response: Response): string | undefined {
+  // This explicitly allowlisted machine code is the only response metadata read.
+  // Request IDs and bodies are intentionally excluded by the global privacy rule.
+  const value = response.headers?.get?.('x-error-code')
+  return value && /^[A-Z][A-Z0-9_]{0,31}$/.test(value) ? value : undefined
+}
+
+function requestMetadata(
+  path: string,
+  init: RequestInit | undefined,
+  baseUrl: string,
+  startedAt: number,
+  failureKind: ApiRequestFailureKind,
+  status?: number,
+  policyCode?: string,
+): ApiRequestMetadata {
+  return {
+    route: normalizeApiRoute(path),
+    method: normalizedMethod(init),
+    failureKind,
+    statusClass: status === undefined ? 'none' : status >= 500 ? '5xx' : '4xx',
+    ...(status === undefined ? {} : { status }),
+    ...(policyCode ? { policyCode } : {}),
+    apiBaseKind: apiBaseKind(baseUrl),
+    browser: browserKind(),
+    online: typeof navigator === 'undefined' ? 'unknown' : navigator.onLine ? 'yes' : 'no',
+    visibility: typeof document === 'undefined'
+      ? 'unknown'
+      : document.visibilityState === 'hidden' ? 'hidden' : 'visible',
+    lifecycle: pageLifecycle,
+    elapsedMsBucket: elapsedBucket(performance.now() - startedAt),
+  }
+}
+
+function reportApiRequestFailure(error: ApiRequestError): void {
+  const { metadata } = error
+  captureRendererException(error, {
+    tags: {
+      source: 'api-fetch',
+      route: metadata.route,
+      method: metadata.method,
+      failure_kind: metadata.failureKind,
+      status_class: metadata.statusClass,
+      api_base_kind: metadata.apiBaseKind,
+      browser: metadata.browser,
+      online: metadata.online,
+      visibility: metadata.visibility,
+      lifecycle: metadata.lifecycle,
+      ...(metadata.policyCode ? { policy_code: metadata.policyCode } : {}),
+    },
+    extra: {
+      status: metadata.status,
+      elapsed_ms_bucket: metadata.elapsedMsBucket,
+    },
+    fingerprint: ['api-request', metadata.route, metadata.method, metadata.failureKind],
+  })
+}
 
 /**
  * Fetch wrapper that prepends the API base URL.
@@ -14,7 +178,36 @@ export async function apiFetch(
   init?: RequestInit
 ): Promise<Response> {
   const baseUrl = getApiBaseUrl()
-  const response = await fetch(`${baseUrl}${path}`, init)
+  const startedAt = performance.now()
+  let response: Response
+  try {
+    response = await fetch(`${baseUrl}${path}`, init)
+  } catch (cause) {
+    const aborted = init?.signal?.aborted === true || (cause instanceof DOMException && cause.name === 'AbortError')
+    const failureKind: ApiRequestFailureKind = typeof navigator !== 'undefined' && navigator.onLine === false
+      ? 'offline'
+      : aborted && pageLifecycle === 'pagehide'
+        ? 'intentional_navigation_abort'
+        : aborted
+          ? 'aborted'
+          : 'transport_or_cors'
+    const error = new ApiRequestError(requestMetadata(path, init, baseUrl, startedAt, failureKind))
+    if (failureKind !== 'intentional_navigation_abort') reportApiRequestFailure(error)
+    throw error
+  }
+
+  if (response.status === 403 || response.status >= 500) {
+    const failureKind: ApiRequestFailureKind = response.status === 403 ? 'forbidden' : 'server'
+    reportApiRequestFailure(new ApiRequestError(requestMetadata(
+      path,
+      init,
+      baseUrl,
+      startedAt,
+      failureKind,
+      response.status,
+      response.status === 403 ? safePolicyCode(response) : undefined,
+    )))
+  }
 
   // A 401 means three different things depending on what we're talking to, so
   // the handling is three-way (skip auth endpoints throughout, to avoid loops):

--- a/src/renderer/lib/error-reporting.ts
+++ b/src/renderer/lib/error-reporting.ts
@@ -75,7 +75,11 @@ export function setRendererErrorReportingUser(user: ErrorReportingUser | null): 
  */
 export function captureRendererException(
   error: unknown,
-  context?: { tags?: Record<string, string>; extra?: Record<string, unknown> }
+  context?: {
+    tags?: Record<string, string>
+    extra?: Record<string, unknown>
+    fingerprint?: string[]
+  }
 ): void {
   void loadSentry().then((provider) => {
     if (!provider) return
@@ -83,6 +87,7 @@ export function captureRendererException(
       provider.captureException(error, {
         tags: context?.tags,
         extra: context?.extra,
+        fingerprint: context?.fingerprint,
       })
     } catch { /* never crash */ }
   }).catch(() => {

--- a/src/renderer/lib/query-client.ts
+++ b/src/renderer/lib/query-client.ts
@@ -22,6 +22,7 @@ import { QueryClient, QueryCache, MutationCache, CancelledError } from '@tanstac
 import type { MutationMeta, QueryMeta } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { captureRendererException } from './error-reporting'
+import { ApiRequestError, isProvenIntentionalApiAbort } from './api'
 
 // Type the meta fields the global handlers read. Augmenting `Register` makes
 // `mutation.options.meta` / `query.meta` strongly typed everywhere.
@@ -58,7 +59,12 @@ function messageFromError(error: unknown): string {
 
 /** Exported for unit tests. Report to Sentry, then toast unless opted out. */
 export function handleMutationError(error: unknown, meta?: MutationMeta): void {
-  captureRendererException(error, { tags: { source: 'mutation' } })
+  // apiFetch already reports typed transport/HTTP failures at the request
+  // boundary. Only suppress a teardown abort when that boundary proved it.
+  if (isProvenIntentionalApiAbort(error)) return
+  if (!(error instanceof ApiRequestError)) {
+    captureRendererException(error, { tags: { source: 'mutation' } })
+  }
   if (meta?.skipGlobalErrorToast) return
   toast.error(meta?.errorMessage ?? messageFromError(error))
 }
@@ -66,8 +72,10 @@ export function handleMutationError(error: unknown, meta?: MutationMeta): void {
 /** Exported for unit tests. Report to Sentry; toast only if the query opted in. */
 export function handleQueryError(error: unknown, meta?: QueryMeta): void {
   // A cancelled fetch (navigation / unmount / refetch supersede) is not a failure.
-  if (error instanceof CancelledError) return
-  captureRendererException(error, { tags: { source: 'query' } })
+  if (error instanceof CancelledError || isProvenIntentionalApiAbort(error)) return
+  if (!(error instanceof ApiRequestError)) {
+    captureRendererException(error, { tags: { source: 'query' } })
+  }
   if (meta?.showErrorToast) toast.error(meta.errorMessage ?? messageFromError(error))
 }
 


### PR DESCRIPTION
## Sentry sweep

Adds shared renderer API failure instrumentation for:

- ELECTRON-M0
- ELECTRON-52
- ELECTRON-5G
- ELECTRON-5R
- ELECTRON-7F
- ELECTRON-7Y
- ELECTRON-7Z
- ELECTRON-80
- ELECTRON-82
- ELECTRON-88
- ELECTRON-8V
- ELECTRON-90
- ELECTRON-9A
- ELECTRON-AK
- ELECTRON-B9
- ELECTRON-BD
- ELECTRON-BR
- ELECTRON-D4
- ELECTRON-E2
- ELECTRON-ER
- ELECTRON-ES
- ELECTRON-F1
- ELECTRON-FK
- ELECTRON-H2
- ELECTRON-H8
- ELECTRON-HK
- ELECTRON-HX
- ELECTRON-HY
- ELECTRON-J5
- ELECTRON-J7
- ELECTRON-J8
- ELECTRON-J9
- ELECTRON-K1
- ELECTRON-KD
- ELECTRON-KF
- ELECTRON-KH
- ELECTRON-KN
- ELECTRON-M2
- ELECTRON-M3
- ELECTRON-MC
- ELECTRON-MF
- ELECTRON-MV
- ELECTRON-T
- ELECTRON-6P
- ELECTRON-7G
- ELECTRON-8J
- ELECTRON-FA

## What changed

- Adds sanitized route-template and HTTP-method fingerprints.
- Classifies offline, transport/CORS, abort, policy/403, and upstream 5xx failures.
- Suppresses only page-teardown aborts proven at the request boundary.
- Excludes dynamic IDs, full URLs, query strings, bodies, headers, tokens, provider messages, and request IDs.

## Validation

- 43 focused tests passed.
- ESLint passed.
- Full typecheck is blocked by unrelated missing dependencies and pre-existing errors.

This is an instrumentation PR; the listed Sentry issues should remain open until the new context is deployed and evaluated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)