### PR TITLE
Add local API lifecycle provenance on renderer diagnostics

### DIFF
--- a/src/renderer/lib/api.test.ts
+++ b/src/renderer/lib/api.test.ts
@@ -27,6 +27,7 @@ import {
   clearDeliberateSignOut,
   ApiRequestError,
   normalizeApiRoute,
+  setLocalApiLifecycle,
 } from './api'
 
 const KEY = 'superagent.redirect'
@@ -107,6 +108,7 @@ describe('redirect stash (post-login restore)', () => {
 describe('apiFetch diagnostics', () => {
   beforeEach(() => {
     captureMock.mockClear()
+    setLocalApiLifecycle('unknown')
     vi.stubGlobal('__AUTH_MODE__', false)
   })
 
@@ -164,6 +166,22 @@ describe('apiFetch diagnostics', () => {
       .toEqual(['transport_or_cors', 'server', 'forbidden'])
     expect(captureMock.mock.calls[2][1]).toMatchObject({ tags: { policy_code: 'POLICY_DENIED' } })
     expect(JSON.stringify(captureMock.mock.calls)).not.toMatch(/private response|private-id/)
+  })
+
+  it('adds distinct local API lifecycle and packaged/channel provenance', async () => {
+    setLocalApiLifecycle('quitting')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed with private URL')))
+
+    await expect(apiFetch('/api/files/private-id?filename=pii.txt')).rejects.toBeInstanceOf(ApiRequestError)
+    expect(captureMock.mock.calls[0][1]).toMatchObject({
+      tags: {
+        local_api_lifecycle: 'quitting',
+        packaged: 'yes',
+        app_channel: 'test',
+        route: '/api/files/:param',
+      },
+    })
+    expect(JSON.stringify(captureMock.mock.calls)).not.toMatch(/private-id|filename|pii\.txt/)
   })
 
   it('does not retain a provider error as a recursively serialized cause', async () => {

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -22,6 +22,14 @@ type ApiRequestFailureKind =
   | 'forbidden'
   | 'server'
 
+export type LocalApiLifecycle = 'unknown' | 'ready' | 'quitting' | 'reloading' | 'crashed'
+
+let localApiLifecycle: LocalApiLifecycle = 'unknown'
+
+export function setLocalApiLifecycle(state: LocalApiLifecycle): void {
+  localApiLifecycle = state
+}
+
 type ApiRequestMetadata = {
   route: string
   method: string
@@ -34,6 +42,9 @@ type ApiRequestMetadata = {
   online: 'yes' | 'no' | 'unknown'
   visibility: 'visible' | 'hidden' | 'unknown'
   lifecycle: 'active' | 'pagehide'
+  localApiLifecycle: LocalApiLifecycle
+  packaged: 'yes' | 'no' | 'unknown'
+  channel: 'production' | 'development' | 'test' | 'unknown'
   elapsedMsBucket: '<100' | '100-999' | '1000-9999' | '10000+'
 }
 
@@ -101,6 +112,18 @@ function browserKind(): ApiRequestMetadata['browser'] {
   return 'other'
 }
 
+function appChannel(): ApiRequestMetadata['channel'] {
+  if (import.meta.env.MODE === 'test') return 'test'
+  if (import.meta.env.DEV) return 'development'
+  if (import.meta.env.PROD) return 'production'
+  return 'unknown'
+}
+
+function packagedKind(): ApiRequestMetadata['packaged'] {
+  if (typeof window === 'undefined') return 'unknown'
+  return 'electronAPI' in window ? 'yes' : 'no'
+}
+
 function elapsedBucket(elapsedMs: number): ApiRequestMetadata['elapsedMsBucket'] {
   if (elapsedMs < 100) return '<100'
   if (elapsedMs < 1_000) return '100-999'
@@ -138,6 +161,9 @@ function requestMetadata(
       ? 'unknown'
       : document.visibilityState === 'hidden' ? 'hidden' : 'visible',
     lifecycle: pageLifecycle,
+    localApiLifecycle,
+    packaged: packagedKind(),
+    channel: appChannel(),
     elapsedMsBucket: elapsedBucket(performance.now() - startedAt),
   }
 }
@@ -156,6 +182,9 @@ function reportApiRequestFailure(error: ApiRequestError): void {
       online: metadata.online,
       visibility: metadata.visibility,
       lifecycle: metadata.lifecycle,
+      local_api_lifecycle: metadata.localApiLifecycle,
+      packaged: metadata.packaged,
+      app_channel: metadata.channel,
       ...(metadata.policyCode ? { policy_code: metadata.policyCode } : {}),
     },
     extra: {


### PR DESCRIPTION
## Dependency
This PR is intentionally stacked on #723 (`sentry-inst-integrations`, commit `d9b92bb`) and now contains only the distinct bundle 10 provenance missing there. Review/merge #723 first.

## Sentry coverage
ELECTRON-N6, ELECTRON-CX, ELECTRON-5V, ELECTRON-5K

## Missing evidence
#723 already supplies safe route/method, browser/network classification, pagehide, status, and redaction. Bundle 10 additionally requires packaged/channel provenance and local API lifecycle state so localhost failures can eventually distinguish quit/reload/crash from active-runtime failures.

## Instrumentation
Extends #723's `ApiRequestMetadata` and Sentry tags with low-cardinality `local_api_lifecycle`, `packaged`, and `app_channel`. Adds a focused stacked test for quit-state provenance and URL/entity redaction. The lifecycle setter is the safe correlation seam for main/preload lifecycle wiring; it defaults to `unknown`, so no teardown suppression is introduced without proof.

## Privacy analysis
Queries, fragments, bodies, headers, filenames, paths, upload content, auth, full URLs, ports, and entity IDs remain excluded by #723's allowlist route normalizer. The new values are fixed enums only.

## Tests
Added to #723's `src/renderer/lib/api.test.ts`: validates `quitting`, packaged/test provenance, route normalization, and filename/query/entity-ID redaction. #723's API diagnostic suite had passed before stacking. A rerun is currently blocked because the shared `/workspace/SuperAgent/node_modules` symlink target no longer contains Vitest; full typecheck is likewise blocked by the previously reported incomplete dependency install.
