### PR TITLE
fix(container): state-aware, idempotent stream WebSocket cleanup (ELECTRON-5J)

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -831,13 +831,43 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   protected terminateWebSocketConnections(): void {
     for (const ws of this.wsConnections.values()) {
       ws.removeAllListeners()
-      try {
-        ws.terminate()
-      } catch {
-        // ws.terminate() throws if the socket is still in CONNECTING state.
-      }
+      // Aborting a CONNECTING socket emits 'error' on the NEXT TICK, so the
+      // try/catch below cannot catch it — and with every listener just
+      // removed, EventEmitter rethrows it as an uncaught exception that takes
+      // down the process ("WebSocket was closed before the connection was
+      // established"). Re-attach a no-op sink before tearing down. [ELECTRON-5J]
+      ws.on('error', () => {})
+      this.closeStreamSocket(ws, { force: true })
     }
     this.wsConnections.clear()
+  }
+
+  /**
+   * State-aware, idempotent teardown for a stream WebSocket.
+   *
+   * `ws.close()` / `ws.terminate()` on a CONNECTING socket aborts the
+   * in-flight handshake, which surfaces asynchronously as an 'error' event
+   * carrying "WebSocket was closed before the connection was established".
+   * That is our own abort, not a failure, so the socket is recorded here and
+   * the 'error' handler suppresses it. CLOSING/CLOSED sockets are left alone —
+   * calling close() again is pointless and repeated cleanup must be safe.
+   *
+   * @returns true when the socket was still CONNECTING (handshake aborted).
+   */
+  private locallyAbortedSockets = new WeakSet<WebSocket>()
+  protected closeStreamSocket(ws: WebSocket, options?: { force?: boolean }): boolean {
+    const wasConnecting = ws.readyState === WebSocket.CONNECTING
+    if (wasConnecting) this.locallyAbortedSockets.add(ws)
+
+    if (wasConnecting || ws.readyState === WebSocket.OPEN) {
+      try {
+        if (options?.force) ws.terminate()
+        else ws.close()
+      } catch {
+        // Socket already torn down by the runtime; nothing left to do.
+      }
+    }
+    return wasConnecting
   }
 
   async stop(options?: StopOptions): Promise<StopResult> {
@@ -1244,8 +1274,8 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     // Close WebSocket if exists
     const ws = this.wsConnections.get(sessionId)
     if (ws) {
-      ws.close()
       this.wsConnections.delete(sessionId)
+      this.closeStreamSocket(ws)
     }
 
     const response = await fetch(
@@ -1379,7 +1409,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       const existing = this.wsConnections.get(sessionId)
       if (existing) {
-        existing.close()
+        this.closeStreamSocket(existing)
       }
 
       const ws = new WebSocket(
@@ -1409,8 +1439,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       })
 
       ws.on('error', (error) => {
-        // Only log and emit if this connection is still tracked (not cleaned up by stop())
-        if (this.wsConnections.has(sessionId)) {
+        // Only log and emit for a genuine remote failure: the socket must
+        // still be the tracked one (not cleaned up by stop(), and not
+        // superseded by a resubscribe) and must not be a handshake we aborted
+        // ourselves in closeStreamSocket().
+        if (this.wsConnections.get(sessionId) === ws && !this.locallyAbortedSockets.has(ws)) {
           console.error(`WebSocket error for session ${sessionId}:`, error)
           this.safeEmitError(error)
         }
@@ -1419,7 +1452,12 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       ws.on('close', () => {
         console.log(`WebSocket closed for session ${sessionId}`)
-        this.wsConnections.delete(sessionId)
+        // Untrack only if this socket is still the tracked one — a resubscribe
+        // may already have replaced it, and deleting then would untrack the
+        // live replacement.
+        if (this.wsConnections.get(sessionId) === ws) {
+          this.wsConnections.delete(sessionId)
+        }
         // Notify the callback that the connection was lost
         // This allows the message persister to handle the disconnection
         const closeMessage: StreamMessage = {
@@ -1453,9 +1491,16 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
     const unsubscribe = () => {
       const ws = this.wsConnections.get(sessionId)
-      if (ws) {
-        ws.close()
-        this.wsConnections.delete(sessionId)
+      // Untracked already (never connected, stopped, or a second unsubscribe):
+      // cleanup is idempotent, so there is nothing to do.
+      if (!ws) return
+      this.wsConnections.delete(sessionId)
+      if (this.closeStreamSocket(ws)) {
+        // We aborted a handshake that was still in flight, so `ready` will
+        // reject with the expected local-abort error. Callers that discard
+        // `ready` (e.g. reconnect paths) would otherwise surface it as an
+        // unhandled rejection — mark it handled here. [ELECTRON-5J]
+        ready.catch(() => {})
       }
     }
 

--- a/src/shared/lib/container/websocket-cleanup.electron5j.test.ts
+++ b/src/shared/lib/container/websocket-cleanup.electron5j.test.ts
@@ -1,0 +1,188 @@
+/**
+ * ELECTRON-5J — "WebSocket was closed before the connection was established".
+ *
+ * Tearing a stream socket down while its handshake is still in flight aborts
+ * the handshake, and `ws` reports that abort as an 'error' event on the NEXT
+ * TICK. Two paths turned our own abort into a reported failure:
+ *
+ *   1. `unsubscribe()` called `ws.close()` on a CONNECTING socket. The abort
+ *      error reached `rejectReady`, and every caller that discards `ready`
+ *      (the reconnect paths) turned it into an unhandled rejection.
+ *   2. `terminateWebSocketConnections()` called `removeAllListeners()` and
+ *      then `terminate()`. With no 'error' listener left, EventEmitter
+ *      rethrows the next-tick abort error as an *uncaught exception* — the
+ *      surrounding try/catch cannot catch it because the emit is async.
+ *
+ * Cleanup is now state-aware (CONNECTING aborts locally and suppresses only
+ * that expected error, OPEN closes gracefully, CLOSING/CLOSED just untrack)
+ * and idempotent. Genuine remote failures must still be reported.
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import net from 'net'
+import { WebSocketServer } from 'ws'
+import { BaseContainerClient } from './base-container-client'
+import type { ContainerInfo, ContainerConfig } from './types'
+
+class RunningTestClient extends BaseContainerClient {
+  constructor(private readonly port: number) {
+    super({ agentId: 'test-agent' } as ContainerConfig)
+  }
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'running', port: this.port }
+  }
+  /** stop() does far more than socket teardown; exercise just that part. */
+  public terminateSockets(): void {
+    this.terminateWebSocketConnections()
+  }
+}
+
+const tick = (ms = 60) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Records process-level fallout that Sentry would otherwise report. */
+function watchProcessFaults() {
+  const unhandled: unknown[] = []
+  const uncaught: unknown[] = []
+  const onRejection = (reason: unknown) => unhandled.push(reason)
+  const onException = (error: unknown) => uncaught.push(error)
+  process.on('unhandledRejection', onRejection)
+  process.on('uncaughtException', onException)
+  return {
+    unhandled,
+    uncaught,
+    dispose: () => {
+      process.off('unhandledRejection', onRejection)
+      process.off('uncaughtException', onException)
+    },
+  }
+}
+
+describe('stream socket cleanup while CONNECTING (ELECTRON-5J)', () => {
+  // A raw TCP server that accepts the connection and never answers the
+  // upgrade request, so the client socket stays in CONNECTING.
+  let hangingServer: net.Server
+  let accepted: net.Socket[]
+  let port: number
+  let faults: ReturnType<typeof watchProcessFaults>
+
+  beforeEach(async () => {
+    faults = watchProcessFaults()
+    accepted = []
+    hangingServer = net.createServer((socket) => {
+      // Never answers the upgrade request; held so close() can reap it.
+      accepted.push(socket)
+    })
+    await new Promise<void>((resolve) => hangingServer.listen(0, '127.0.0.1', resolve))
+    port = (hangingServer.address() as net.AddressInfo).port
+  })
+
+  afterEach(async () => {
+    faults.dispose()
+    for (const socket of accepted) socket.destroy()
+    await new Promise<void>((resolve) => hangingServer.close(() => resolve()))
+  })
+
+  it('unsubscribe() aborts the pending handshake without an unhandled rejection or emitted error', async () => {
+    const client = new RunningTestClient(port)
+    const emitted: unknown[] = []
+    client.on('error', (err) => emitted.push(err))
+
+    const { unsubscribe } = client.subscribeToStream('sess-connecting', () => {})
+    await tick(30) // let setupWebSocket create the socket
+
+    unsubscribe()
+    await tick()
+
+    expect(faults.unhandled).toHaveLength(0)
+    expect(faults.uncaught).toHaveLength(0)
+    // Our own abort is not a session failure — nothing to report.
+    expect(emitted).toHaveLength(0)
+  })
+
+  it('repeated unsubscribe() is safe', async () => {
+    const client = new RunningTestClient(port)
+    client.on('error', () => {})
+
+    const { unsubscribe } = client.subscribeToStream('sess-repeat', () => {})
+    await tick(30)
+
+    expect(() => {
+      unsubscribe()
+      unsubscribe()
+      unsubscribe()
+    }).not.toThrow()
+    await tick()
+
+    expect(faults.unhandled).toHaveLength(0)
+    expect(faults.uncaught).toHaveLength(0)
+  })
+
+  it('terminateWebSocketConnections() does not raise an uncaught exception', async () => {
+    const client = new RunningTestClient(port)
+    client.on('error', () => {})
+
+    const { ready } = client.subscribeToStream('sess-terminate', () => {})
+    ready.catch(() => {})
+    await tick(30)
+
+    client.terminateSockets()
+    await tick()
+
+    expect(faults.uncaught).toHaveLength(0)
+    expect(faults.unhandled).toHaveLength(0)
+  })
+})
+
+describe('stream socket cleanup once established (ELECTRON-5J)', () => {
+  let wss: WebSocketServer
+  let port: number
+
+  beforeEach(async () => {
+    wss = new WebSocketServer({ port: 0, host: '127.0.0.1' })
+    await new Promise<void>((resolve) => wss.once('listening', resolve))
+    port = (wss.address() as net.AddressInfo).port
+  })
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => wss.close(() => resolve()))
+  })
+
+  it('closes an OPEN socket gracefully and reports the disconnect once', async () => {
+    const client = new RunningTestClient(port)
+    const serverClosed = new Promise<void>((resolve) => {
+      wss.on('connection', (socket) => socket.on('close', () => resolve()))
+    })
+    const messages: string[] = []
+
+    const { unsubscribe, ready } = client.subscribeToStream('sess-open', (m) => messages.push(m.type))
+    await ready
+
+    unsubscribe()
+    await serverClosed
+    await tick()
+
+    expect(messages).toContain('connection_closed')
+  })
+})
+
+describe('remote stream failures are still reported (ELECTRON-5J)', () => {
+  it('emits and rejects when the container refuses the connection', async () => {
+    // Bind then immediately release the port so connects are refused.
+    const probe = net.createServer()
+    await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve))
+    const deadPort = (probe.address() as net.AddressInfo).port
+    await new Promise<void>((resolve) => probe.close(() => resolve()))
+
+    const client = new RunningTestClient(deadPort)
+    const emitted: unknown[] = []
+    client.on('error', (err) => emitted.push(err))
+
+    const { ready } = client.subscribeToStream('sess-refused', () => {})
+
+    await expect(ready).rejects.toThrow()
+    await new Promise((resolve) => setTimeout(resolve, 60))
+    expect(emitted).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Sentry issues covered

- **ELECTRON-5J** — `WebSocket was closed before the connection was established` (9 occurrences through 0.5.2)

## Evidence

The session stream socket in `BaseContainerClient.subscribeToStream()` was torn down with a bare `ws.close()` / `removeAllListeners() + terminate()` regardless of its `readyState`. Aborting a **CONNECTING** socket makes `ws` run `abortHandshake()`, which emits `'error'` with exactly `WebSocket was closed before the connection was established` — **on the next tick**, not synchronously.

Reproduced against the pinned `ws` version with a raw TCP server that accepts the connection and never answers the upgrade (`/tmp/ws-probe.mjs` equivalent, now encoded as the tests in this PR):

```
A: calling close() readyState= 0
A error listener: WebSocket was closed before the connection was established
B: removeAllListeners + terminate readyState= 0
UNCAUGHT: WebSocket was closed before the connection was established
```

Two distinct production paths fell out of that:

1. `unsubscribe()` → `ws.close()` on a CONNECTING socket → the abort error reaches `rejectReady(...)`. Every caller that discards `ready` (the reconnect/resubscribe paths, e.g. MessagePersister) turns that into an **unhandled rejection**.
2. `terminateWebSocketConnections()` (called from `stop()` and the start-cleanup path) did `ws.removeAllListeners()` and then `ws.terminate()`. With no `'error'` listener left, EventEmitter rethrows the next-tick abort as an **uncaught exception** — the existing `try { ws.terminate() } catch {}` cannot catch it, because the emit is asynchronous. The stale comment on that catch (`ws.terminate() throws if the socket is still in CONNECTING state`) shows the symptom was seen but not actually contained.

Two related cleanup races were visible in the same code and are fixed here because they feed the same error path:

- `setupWebSocket()` closed the previous socket (`existing.close()`) and then `set()` the new one under the same key. The old socket's `'error'` handler was still guarded by `this.wsConnections.has(sessionId)`, which is `true` again (now holding the *new* socket), so a superseded socket's local abort was reported to Sentry via `safeEmitError`.
- The old socket's `'close'` handler then ran `this.wsConnections.delete(sessionId)`, **untracking the live replacement socket**.

## Fix

Single state-aware, idempotent teardown helper `closeStreamSocket(ws, { force })` used by `unsubscribe()`, `deleteSession()`, the resubscribe replacement path, and `terminateWebSocketConnections()`:

- **CONNECTING** → record the socket as locally aborted, then abort it. The expected abort error is suppressed (only that one — it is identified by *we initiated it*, not by string matching).
- **OPEN** → close gracefully.
- **CLOSING / CLOSED** → untrack only; repeated cleanup is a no-op.
- `terminateWebSocketConnections()` re-attaches a no-op `'error'` sink *after* `removeAllListeners()` and before tearing down, so the next-tick abort can never become an uncaught exception.
- `unsubscribe()` marks `ready` as handled when (and only when) it aborted an in-flight handshake, so a discarded `ready` cannot become an unhandled rejection.
- Socket **identity** (`wsConnections.get(sessionId) === ws`) is now compared before untracking or reporting, so a resubscribe neither untracks its own live replacement nor reports the superseded socket.

Genuine remote failures are unchanged: they still `console.error`, still `safeEmitError`, and still reject `ready`.

No telemetry payload changes; nothing socket-related is logged beyond the session id that was already logged.

## Tests

New: `src/shared/lib/container/websocket-cleanup.electron5j.test.ts` (5 tests, all green; the first three fail on `main`).

| Test | Covers |
| --- | --- |
| `unsubscribe() aborts the pending handshake without an unhandled rejection or emitted error` | Stop while CONNECTING — no unhandled rejection, no uncaught exception, nothing reported |
| `repeated unsubscribe() is safe` | Idempotent cleanup |
| `terminateWebSocketConnections() does not raise an uncaught exception` | The `stop()` crash path |
| `closes an OPEN socket gracefully and reports the disconnect once` | OPEN close still delivers `connection_closed` |
| `emits and rejects when the container refuses the connection` | Remote failure still reported (ECONNREFUSED) |

Verified failing-before/passing-after by reverting only `base-container-client.ts`:

```
× unsubscribe() aborts the pending handshake without an unhandled rejection or emitted error
× repeated unsubscribe() is safe
× terminateWebSocketConnections() does not raise an uncaught exception
✓ closes an OPEN socket gracefully and reports the disconnect once
✓ emits and rejects when the container refuses the connection
```

Regression run (container client + message persister suites): **443 passed / 443**.
`npx tsc --noEmit`: no errors in the touched files (the repo's pre-existing baseline errors — missing optional deps such as `react-qr-code`, `web-push`, `vite-plugin-pwa` — are unchanged).

> Note: `npx eslint` cannot run in this environment (`Cannot find module 'ajv'` from the shared `node_modules`); unrelated to this change.

Sentry issues are intentionally **not** resolved by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
