### PR TITLE
Let the activity tree carry the working signal

### DIFF
--- a/src/renderer/components/messages/activity-card.tsx
+++ b/src/renderer/components/messages/activity-card.tsx
@@ -1,9 +1,9 @@
 import { cn } from '@shared/lib/utils'
 import { AlertTriangle, ChevronDown, CircleCheckBig, Ellipsis, Monitor, X } from 'lucide-react'
-import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from 'react'
 
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
-import { ACTIVITY_TREE_CONNECTORS } from '@renderer/components/ui/tree-connectors'
+import { ACTIVITY_TREE_CONNECTORS, ACTIVITY_TREE_TRACER } from '@renderer/components/ui/tree-connectors'
 import type { Todo } from '@shared/lib/utils/derive-task-list'
 import { ActivityOrb, type ActivityOrbState } from './activity-orb'
 
@@ -66,6 +66,7 @@ export function ActivityCard({
 }: ActivityCardProps) {
   const [showAllTodos, setShowAllTodos] = useState(false)
   const [isCollapsed, setIsCollapsed] = useState(false)
+  const listRef = useRef<HTMLUListElement>(null)
 
   // Background subagents are excluded: they already render as named subagent
   // rows above, and counting them here would show the same work twice.
@@ -88,9 +89,19 @@ export function ActivityCard({
     formatActivityCount(pendingTaskCount, 'pending task', 'pending tasks'),
   ].filter(Boolean).join(', ')
 
+  // Row positions on the tree, counted across all groups: the tracer stages each
+  // branch flash off its own index (see .tree-tracer in globals.css).
+  // Computer use leads the tree: it is a hold that lasts the whole turn, so it
+  // keeps a fixed position while subagents come and go beneath it.
+  const computerUseRows = computerUse ? 1 : 0
+  const todoRowStart = computerUseRows
+    + subagents.length
+    + (visibleBackgroundTasks.length > 0 ? 1 : 0)
   const todoRows = todos && pendingTaskCount > 0
-    ? buildTodoRows(todos, showAllTodos, setShowAllTodos)
+    ? buildTodoRows(todos, showAllTodos, setShowAllTodos, todoRowStart)
     : null
+
+  useTracerPhaseLock(listRef)
 
   return (
     <div className={cn(
@@ -153,13 +164,24 @@ export function ActivityCard({
             Every row keeps the same 16px line box (text-xs) so the elbows,
             pinned at half that, stay centered on all three kinds. */}
         {!isCollapsed && hasExpandableDetails && (
-          <ul data-testid="activity-tree" className={cn('mt-2 space-y-1 text-xs pl-6', ACTIVITY_TREE_CONNECTORS)}>
+          <ul ref={listRef} data-testid="activity-tree" className={cn(
+            'mt-2 space-y-1 text-xs pl-6',
+            ACTIVITY_TREE_CONNECTORS,
+            ACTIVITY_TREE_TRACER,
+          )}>
             {computerUse && (
-              <ComputerUseRow computerUse={computerUse} />
+              <ComputerUseRow
+                computerUse={computerUse}
+                tracerRow={0}
+              />
             )}
 
-            {subagents.map((item) => (
-              <li key={item.id}>
+            {subagents.map((item, index) => (
+              <li
+                key={item.id}
+                style={tracerRowStyle(computerUseRows + index)}
+                data-tracer-live={item.status === 'running' ? 'true' : undefined}
+              >
                 <div className="flex flex-col gap-0.5">
                   {/* A finished row recedes as a whole — the mark inherits the
                       muting with its label rather than carrying its own color. */}
@@ -189,7 +211,10 @@ export function ActivityCard({
             ))}
 
             {visibleBackgroundTasks.length > 0 && (
-              <BackgroundTasksRow tasks={visibleBackgroundTasks} />
+              <BackgroundTasksRow
+                tasks={visibleBackgroundTasks}
+                tracerRow={computerUseRows + subagents.length}
+              />
             )}
 
             {todoRows}
@@ -304,15 +329,161 @@ function RowMark({ children }: { children?: ReactNode }) {
 }
 
 /**
+ * Holds the tracer's three animations — the trunk's travel, each branch's flash,
+ * each row's shimmer — to one phase.
+ *
+ * They share a duration and are staggered by row, so on paper they read as a
+ * single band running down the tree. What breaks that is WHEN each one starts: a
+ * CSS animation's clock begins the moment it is applied to the element, not when
+ * the card mounts. A subagent that goes live mid-turn, a task that flips to
+ * in_progress, a row that finishes and drops out — each starts (or restarts) its
+ * own timeline while the trunk is already partway through its cycle, and lands
+ * on the wrong beat. Nothing drifts within one animation; they simply never
+ * agreed on an origin.
+ *
+ * Pinning every one to the earliest start time already running means latecomers
+ * join the band in flight. It settles immediately for animations already in
+ * phase, so re-running it on every commit costs nothing.
+ */
+function useTracerPhaseLock(listRef: RefObject<HTMLUListElement | null>) {
+  useEffect(() => {
+    const list = listRef.current
+    if (!list || typeof list.getAnimations !== 'function') return
+
+    const lock = () => {
+      // An animation does not exist until the style declaring it is
+      // recalculated, and that can land after this commit's effects have run.
+      // Force the flush first — reading getAnimations() without it returns only
+      // the animations from before this render, so a row that just went live is
+      // missed and, with no further commit coming, never gets locked at all.
+      getComputedStyle(list).animationName
+      const animations = list
+        .getAnimations({ subtree: true })
+        .filter((animation) => animation.startTime != null)
+      if (animations.length < 2) return
+
+      const origin = Math.min(...animations.map((animation) => Number(animation.startTime)))
+      for (const animation of animations) {
+        if (Number(animation.startTime) !== origin) animation.startTime = origin
+      }
+    }
+
+    lock()
+    // Second pass next frame, for animations the flush above still raced.
+    const frame = requestAnimationFrame(lock)
+    return () => cancelAnimationFrame(frame)
+  })
+}
+
+/** Relay pacing. Travel is constant-speed, so a row further down takes longer. */
+const RELAY_SPEED_PX_PER_S = 130
+const RELAY_MIN_TRAVEL_MS = 260
+/** Long enough for the branch flash and one shimmer pass to land. */
+const RELAY_DWELL_MS = 780
+const RELAY_REST_MS = 220
+/** Nothing live yet — poll rather than give up; rows arrive as the turn runs. */
+const RELAY_IDLE_MS = 500
+/** Half the band's 28px depth: aligns its peak with the branch it stops at. */
+const RELAY_BAND_HALF = 14
+/** Row's elbow (8px into a 16px row) measured from the rail top (4px above). */
+const RELAY_ELBOW_OFFSET = 12
+
+/**
+ * Relay: sends the band to one live row at a time instead of running the whole
+ * trunk. Each pass picks the next live row, travels only as far as that row,
+ * hands off to its branch and label, rests, then takes the next one.
+ *
+ * Scheduled here rather than in CSS because both the distance and the target
+ * change every pass — no fixed set of keyframes can say "stop at whichever row
+ * is up next". The hook only moves the band and marks the row it reaches;
+ * the branch flash and the shimmer are CSS reacting to that mark.
+ *
+ * Driving it from one timer also sidesteps the phase problem the continuous
+ * tracer has: there is nothing to keep in sync, because the trunk hands over to
+ * the row explicitly instead of two clocks agreeing on when to meet.
+ */
+function useTracerRelay(listRef: RefObject<HTMLUListElement | null>, enabled: boolean) {
+  useEffect(() => {
+    const list = listRef.current
+    if (!list || !enabled || typeof list.animate !== 'function') return
+
+    let stopped = false
+    let timer = 0
+    let lit: HTMLElement | null = null
+    let pass = 0
+
+    const clearLit = () => {
+      lit?.removeAttribute('data-tracer-lit')
+      lit = null
+    }
+
+    const schedule = (fn: () => void, ms: number) => {
+      timer = window.setTimeout(() => { if (!stopped) fn() }, ms)
+    }
+
+    const run = () => {
+      const rows = [...list.children].filter(
+        (row): row is HTMLElement => row instanceof HTMLElement && row.hasAttribute('data-tracer-live')
+      )
+      if (rows.length === 0) {
+        schedule(run, RELAY_IDLE_MS)
+        return
+      }
+
+      const row = rows[pass % rows.length]
+      pass += 1
+      const target = row.offsetTop + RELAY_ELBOW_OFFSET
+      const travelMs = Math.max(RELAY_MIN_TRAVEL_MS, (target / RELAY_SPEED_PX_PER_S) * 1000)
+
+      // No fill: the band returns to its parked position the moment it lands,
+      // so the pulse reads as passing INTO the branch rather than stopping on it.
+      const travel = list.animate(
+        [{ backgroundPositionY: '-28px' }, { backgroundPositionY: `${target - RELAY_BAND_HALF}px` }],
+        { duration: travelMs, easing: 'cubic-bezier(0.35, 0, 0.2, 1)', pseudoElement: '::before' },
+      )
+
+      travel.onfinish = () => {
+        if (stopped) return
+        clearLit()
+        // The row may have finished while the band was on its way.
+        if (row.isConnected && row.hasAttribute('data-tracer-live')) {
+          row.setAttribute('data-tracer-lit', 'true')
+          lit = row
+        }
+        schedule(() => {
+          clearLit()
+          schedule(run, RELAY_REST_MS)
+        }, RELAY_DWELL_MS)
+      }
+    }
+
+    run()
+    return () => {
+      stopped = true
+      window.clearTimeout(timer)
+      clearLit()
+    }
+  }, [listRef, enabled])
+}
+
+/** Inline hook the tracer keyframes read to stage each branch's flash. */
+function tracerRowStyle(index: number): CSSProperties {
+  return { '--tree-tracer-row': index } as CSSProperties
+}
+
+/**
  * The app the turn currently has hold of, as a tree row.
  *
  * Deliberately kept at full strength rather than muted like a finished row: the
  * user granted this, it is still in force, and the row is the only place the UI
  * says so once the header badge is gone. The revoke control travels with it.
  */
-function ComputerUseRow({ computerUse }: { computerUse: ActivityComputerUse }) {
+function ComputerUseRow({ computerUse, tracerRow }: {
+  computerUse: ActivityComputerUse
+  tracerRow: number
+}) {
   return (
-    <li>
+    <li style={tracerRowStyle(tracerRow)} data-tracer-live="true">
       <div className="flex items-center gap-1.5">
         <RowMark>
           {computerUse.iconBase64 ? (
@@ -355,7 +526,10 @@ function ComputerUseRow({ computerUse }: { computerUse: ActivityComputerUse }) {
 }
 
 /** One tree row standing in for all active background work. */
-function BackgroundTasksRow({ tasks }: { tasks: ActivityBackgroundTask[] }) {
+function BackgroundTasksRow({ tasks, tracerRow }: {
+  tasks: ActivityBackgroundTask[]
+  tracerRow: number
+}) {
   const earliest = Math.min(...tasks.map(t => t.startedAt))
   const elapsed = useElapsedTimer(new Date(earliest))
   // Label as "workflow" when every active background task is a dynamic workflow;
@@ -364,7 +538,7 @@ function BackgroundTasksRow({ tasks }: { tasks: ActivityBackgroundTask[] }) {
   const noun = allWorkflows ? 'workflow' : 'process'
   const label = `${tasks.length} background ${tasks.length === 1 ? noun : allWorkflows ? `${noun}s` : `${noun}es`}`
   return (
-    <li>
+    <li style={tracerRowStyle(tracerRow)} data-tracer-live="true">
       <div className="flex items-center gap-1.5">
         <span className="text-muted-foreground">{label}</span>
         {elapsed && (
@@ -384,7 +558,13 @@ function buildTodoRows(
   todos: Todo[],
   showAllTodos: boolean,
   setShowAllTodos: (show: boolean) => void,
+  /** This group's first position on the tree. */
+  tracerRowStart: number,
 ): ReactNode {
+  const rowStyle = (offset: number) => tracerRowStyle(tracerRowStart + offset)
+  // The toggles are rows on the tree too, so they take positions ahead of the
+  // items they hide.
+  let offset = 0
   const MAX_VISIBLE = 5
   const needsTruncation = todos.length > MAX_VISIBLE && !showAllTodos
 
@@ -412,7 +592,7 @@ function buildTodoRows(
   return (
     <>
       {hiddenTodos.length > 0 && (
-        <li>
+        <li style={rowStyle(offset++)}>
           <div className="flex items-center gap-1.5">
             <button
               onClick={() => setShowAllTodos(true)}
@@ -428,7 +608,7 @@ function buildTodoRows(
         </li>
       )}
       {showAllTodos && todos.length > MAX_VISIBLE && (
-        <li>
+        <li style={rowStyle(offset++)}>
           <div className="flex items-center gap-1.5">
             <button
               onClick={() => setShowAllTodos(false)}
@@ -440,7 +620,11 @@ function buildTodoRows(
         </li>
       )}
       {visibleTodos.map((todo, index) => (
-        <li key={index}>
+        <li
+          key={index}
+          style={rowStyle(offset + index)}
+          data-tracer-live={todo.status === 'in_progress' ? 'true' : undefined}
+        >
           <div
             className={cn(
               'flex items-center gap-1.5',

--- a/src/renderer/components/messages/activity-card.tsx
+++ b/src/renderer/components/messages/activity-card.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@shared/lib/utils'
-import { AlertTriangle, ChevronDown, CircleCheckBig, Ellipsis, Monitor, X } from 'lucide-react'
+import { AlertTriangle, ChevronDown, Circle, CircleCheckBig, Ellipsis, Monitor, X } from 'lucide-react'
 import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from 'react'
 
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
@@ -75,10 +75,14 @@ export function ActivityCard({
   const backgroundProcessCount = visibleBackgroundTasks.length - backgroundWorkflowCount
   const activeSubagentCount = subagents.filter((item) => item.status === 'running').length
   const pendingTaskCount = todos?.filter((todo) => todo.status !== 'completed').length ?? 0
-  const hasExpandableDetails = !!computerUse
+  // The tree is live work only — things running right now, hanging off the orb.
+  // The plan is a different kind of thing (intent, not activity), so it sits
+  // below the tree under its own header rather than taking branches.
+  const hasTreeRows = !!computerUse
     || subagents.length > 0
     || visibleBackgroundTasks.length > 0
-    || pendingTaskCount > 0
+  const hasPlan = !!todos && pendingTaskCount > 0
+  const hasExpandableDetails = hasTreeRows || hasPlan
   const collapsedSummary = [
     // Held first, and named: collapsing the tree must not be how a user loses
     // track that the agent still has hold of one of their apps.
@@ -89,17 +93,11 @@ export function ActivityCard({
     formatActivityCount(pendingTaskCount, 'pending task', 'pending tasks'),
   ].filter(Boolean).join(', ')
 
-  // Row positions on the tree, counted across all groups: the tracer stages each
-  // branch flash off its own index (see .tree-tracer in globals.css).
-  // Computer use leads the tree: it is a hold that lasts the whole turn, so it
-  // keeps a fixed position while subagents come and go beneath it.
+  // Row positions on the tree: the tracer stages each branch flash off its own
+  // index (see .tree-tracer in globals.css). Computer use leads the tree: it is
+  // a hold that lasts the whole turn, so it keeps a fixed position while
+  // subagents come and go beneath it.
   const computerUseRows = computerUse ? 1 : 0
-  const todoRowStart = computerUseRows
-    + subagents.length
-    + (visibleBackgroundTasks.length > 0 ? 1 : 0)
-  const todoRows = todos && pendingTaskCount > 0
-    ? buildTodoRows(todos, showAllTodos, setShowAllTodos, todoRowStart)
-    : null
 
   useTracerPhaseLock(listRef)
 
@@ -157,13 +155,12 @@ export function ActivityCard({
         {/* Streamed reasoning renders as a thinking card in the transcript
             (see ThinkingBlockItem) — only the "Thinking..." status shows here. */}
 
-        {/* Everything the turn is doing, on ONE tree hanging off the header
-            orb — subagents, then background work, then the task list. They are
-            a single <ul> rather than three stacked sections so the rail runs
-            unbroken and only the genuinely last row gets the closing elbow.
-            Every row keeps the same 16px line box (text-xs) so the elbows,
-            pinned at half that, stay centered on all three kinds. */}
-        {!isCollapsed && hasExpandableDetails && (
+        {/* Live work, on ONE tree hanging off the header orb — computer use,
+            subagents, then background work. A single <ul> rather than stacked
+            sections so the rail runs unbroken and only the genuinely last row
+            gets the closing elbow. Every row keeps the same 16px line box
+            (text-xs) so the elbows, pinned at half that, stay centered. */}
+        {!isCollapsed && hasTreeRows && (
           <ul ref={listRef} data-testid="activity-tree" className={cn(
             'mt-2 space-y-1 text-xs pl-6',
             ACTIVITY_TREE_CONNECTORS,
@@ -216,9 +213,15 @@ export function ActivityCard({
                 tracerRow={computerUseRows + subagents.length}
               />
             )}
-
-            {todoRows}
           </ul>
+        )}
+
+        {!isCollapsed && hasPlan && todos && (
+          <TodoPlan
+            todos={todos}
+            showAllTodos={showAllTodos}
+            setShowAllTodos={setShowAllTodos}
+          />
         )}
       </div>
     </div>
@@ -357,9 +360,16 @@ function useTracerPhaseLock(listRef: RefObject<HTMLUListElement | null>) {
       // the animations from before this render, so a row that just went live is
       // missed and, with no further commit coming, never gets locked at all.
       getComputedStyle(list).animationName
+      // Only the tracer's own animations. The subtree also carries hover
+      // transitions (transition-colors on the row buttons), and pulling those
+      // back to the tracer's origin — far in the past — completes them
+      // instantly, snapping the fade.
       const animations = list
         .getAnimations({ subtree: true })
-        .filter((animation) => animation.startTime != null)
+        .filter((animation) =>
+          animation.startTime != null &&
+          'animationName' in animation &&
+          (animation as CSSAnimation).animationName.startsWith('tree-tracer'))
       if (animations.length < 2) return
 
       const origin = Math.min(...animations.map((animation) => Number(animation.startTime)))
@@ -373,97 +383,6 @@ function useTracerPhaseLock(listRef: RefObject<HTMLUListElement | null>) {
     const frame = requestAnimationFrame(lock)
     return () => cancelAnimationFrame(frame)
   })
-}
-
-/** Relay pacing. Travel is constant-speed, so a row further down takes longer. */
-const RELAY_SPEED_PX_PER_S = 130
-const RELAY_MIN_TRAVEL_MS = 260
-/** Long enough for the branch flash and one shimmer pass to land. */
-const RELAY_DWELL_MS = 780
-const RELAY_REST_MS = 220
-/** Nothing live yet — poll rather than give up; rows arrive as the turn runs. */
-const RELAY_IDLE_MS = 500
-/** Half the band's 28px depth: aligns its peak with the branch it stops at. */
-const RELAY_BAND_HALF = 14
-/** Row's elbow (8px into a 16px row) measured from the rail top (4px above). */
-const RELAY_ELBOW_OFFSET = 12
-
-/**
- * Relay: sends the band to one live row at a time instead of running the whole
- * trunk. Each pass picks the next live row, travels only as far as that row,
- * hands off to its branch and label, rests, then takes the next one.
- *
- * Scheduled here rather than in CSS because both the distance and the target
- * change every pass — no fixed set of keyframes can say "stop at whichever row
- * is up next". The hook only moves the band and marks the row it reaches;
- * the branch flash and the shimmer are CSS reacting to that mark.
- *
- * Driving it from one timer also sidesteps the phase problem the continuous
- * tracer has: there is nothing to keep in sync, because the trunk hands over to
- * the row explicitly instead of two clocks agreeing on when to meet.
- */
-function useTracerRelay(listRef: RefObject<HTMLUListElement | null>, enabled: boolean) {
-  useEffect(() => {
-    const list = listRef.current
-    if (!list || !enabled || typeof list.animate !== 'function') return
-
-    let stopped = false
-    let timer = 0
-    let lit: HTMLElement | null = null
-    let pass = 0
-
-    const clearLit = () => {
-      lit?.removeAttribute('data-tracer-lit')
-      lit = null
-    }
-
-    const schedule = (fn: () => void, ms: number) => {
-      timer = window.setTimeout(() => { if (!stopped) fn() }, ms)
-    }
-
-    const run = () => {
-      const rows = [...list.children].filter(
-        (row): row is HTMLElement => row instanceof HTMLElement && row.hasAttribute('data-tracer-live')
-      )
-      if (rows.length === 0) {
-        schedule(run, RELAY_IDLE_MS)
-        return
-      }
-
-      const row = rows[pass % rows.length]
-      pass += 1
-      const target = row.offsetTop + RELAY_ELBOW_OFFSET
-      const travelMs = Math.max(RELAY_MIN_TRAVEL_MS, (target / RELAY_SPEED_PX_PER_S) * 1000)
-
-      // No fill: the band returns to its parked position the moment it lands,
-      // so the pulse reads as passing INTO the branch rather than stopping on it.
-      const travel = list.animate(
-        [{ backgroundPositionY: '-28px' }, { backgroundPositionY: `${target - RELAY_BAND_HALF}px` }],
-        { duration: travelMs, easing: 'cubic-bezier(0.35, 0, 0.2, 1)', pseudoElement: '::before' },
-      )
-
-      travel.onfinish = () => {
-        if (stopped) return
-        clearLit()
-        // The row may have finished while the band was on its way.
-        if (row.isConnected && row.hasAttribute('data-tracer-live')) {
-          row.setAttribute('data-tracer-lit', 'true')
-          lit = row
-        }
-        schedule(() => {
-          clearLit()
-          schedule(run, RELAY_REST_MS)
-        }, RELAY_DWELL_MS)
-      }
-    }
-
-    run()
-    return () => {
-      stopped = true
-      window.clearTimeout(timer)
-      clearLit()
-    }
-  }, [listRef, enabled])
 }
 
 /** Inline hook the tracer keyframes read to stage each branch's flash. */
@@ -550,21 +469,20 @@ function BackgroundTasksRow({ tasks, tracerRow }: {
 }
 
 /**
- * The task list as tree rows: the truncation toggles first (so they never take
- * the closing elbow), then pending/in-progress items, then finished ones newest
- * first. Returns bare <li>s for the shared tree <ul> — see ActivityCard.
+ * The task list, under the tree rather than on it: the tree is live work, and
+ * the plan is intent. A small "Plan" header owns the section, with the
+ * truncation toggle beside it instead of spending a row on it. Items run
+ * pending/in-progress first, then finished ones newest first.
  */
-function buildTodoRows(
-  todos: Todo[],
-  showAllTodos: boolean,
-  setShowAllTodos: (show: boolean) => void,
-  /** This group's first position on the tree. */
-  tracerRowStart: number,
-): ReactNode {
-  const rowStyle = (offset: number) => tracerRowStyle(tracerRowStart + offset)
-  // The toggles are rows on the tree too, so they take positions ahead of the
-  // items they hide.
-  let offset = 0
+function TodoPlan({
+  todos,
+  showAllTodos,
+  setShowAllTodos,
+}: {
+  todos: Todo[]
+  showAllTodos: boolean
+  setShowAllTodos: (show: boolean) => void
+}) {
   const MAX_VISIBLE = 5
   const needsTruncation = todos.length > MAX_VISIBLE && !showAllTodos
 
@@ -590,72 +508,67 @@ function buildTodoRows(
   const hiddenDone = hiddenTodos.filter(t => t.status === 'completed').length
 
   return (
-    <>
-      {hiddenTodos.length > 0 && (
-        <li style={rowStyle(offset++)}>
-          <div className="flex items-center gap-1.5">
-            <button
-              onClick={() => setShowAllTodos(true)}
-              className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-            >
-              {hiddenTodos.length} more{': '}
-              {[
-                hiddenPending > 0 && `${hiddenPending} pending`,
-                hiddenDone > 0 && `${hiddenDone} done`,
-              ].filter(Boolean).join(', ')}
-            </button>
-          </div>
-        </li>
-      )}
-      {showAllTodos && todos.length > MAX_VISIBLE && (
-        <li style={rowStyle(offset++)}>
-          <div className="flex items-center gap-1.5">
-            <button
-              onClick={() => setShowAllTodos(false)}
-              className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-            >
-              Show fewer
-            </button>
-          </div>
-        </li>
-      )}
-      {visibleTodos.map((todo, index) => (
-        <li
-          key={index}
-          style={rowStyle(offset + index)}
-          data-tracer-live={todo.status === 'in_progress' ? 'true' : undefined}
-        >
-          <div
-            className={cn(
-              'flex items-center gap-1.5',
-              // Only the task being worked on carries full weight. Pending used
-              // to sit at plain foreground, which made the row NOT being worked
-              // on the darkest thing in the list — and under the tracer, where
-              // the live row is masked down between passes, it outweighed the
-              // active one outright.
-              todo.status === 'in_progress'
-                ? 'font-medium text-foreground'
-                : 'text-muted-foreground'
-            )}
+    <div className="mt-2 pl-6 text-xs" data-testid="activity-plan">
+      {/* Indented to the tree rows' own left edge so the two sections read as
+          one column, plan marks under tree marks. */}
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-muted-foreground">Plan</span>
+        {hiddenTodos.length > 0 && (
+          <button
+            onClick={() => setShowAllTodos(true)}
+            className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
           >
-            <RowMark>
-              {todo.status === 'completed' ? (
-                // No strikethrough — the ringed check plus the muted label is
-                // enough, and it keeps the row readable. Uncolored on purpose:
-                // it inherits the completed row's muted-foreground, so the mark
-                // recedes with its label instead of being the loudest thing in
-                // a finished row.
-                <CircleCheckBig className="h-3 w-3" aria-hidden data-testid="todo-status-completed" />
-              ) : todo.status === 'in_progress' ? (
-                <Ellipsis className="h-3 w-3" aria-hidden data-testid="todo-status-in-progress" />
-              ) : (
-                <span>○</span>
+            {hiddenTodos.length} more{': '}
+            {[
+              hiddenPending > 0 && `${hiddenPending} pending`,
+              hiddenDone > 0 && `${hiddenDone} done`,
+            ].filter(Boolean).join(', ')}
+          </button>
+        )}
+        {showAllTodos && todos.length > MAX_VISIBLE && (
+          <button
+            onClick={() => setShowAllTodos(false)}
+            className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            Show fewer
+          </button>
+        )}
+      </div>
+      <ul className="mt-1 space-y-1">
+        {visibleTodos.map((todo, index) => (
+          <li key={index}>
+            <div
+              className={cn(
+                'flex items-center gap-1.5',
+                // Only the task being worked on carries full weight. Pending
+                // used to sit at plain foreground, which made the row NOT being
+                // worked on the darkest thing in the list.
+                todo.status === 'in_progress'
+                  ? 'font-medium text-foreground'
+                  : 'text-muted-foreground'
               )}
-            </RowMark>
-            <span className="truncate">{todo.content}</span>
-          </div>
-        </li>
-      ))}
-    </>
+            >
+              <RowMark>
+                {todo.status === 'completed' ? (
+                  // No strikethrough — the ringed check plus the muted label is
+                  // enough, and it keeps the row readable. Uncolored on purpose:
+                  // it inherits the completed row's muted-foreground, so the
+                  // mark recedes with its label instead of being the loudest
+                  // thing in a finished row.
+                  <CircleCheckBig className="h-3 w-3" aria-hidden data-testid="todo-status-completed" />
+                ) : todo.status === 'in_progress' ? (
+                  <Ellipsis className="h-3 w-3" aria-hidden data-testid="todo-status-in-progress" />
+                ) : (
+                  // Same 12px box and stroke as the check, so a task's mark
+                  // doesn't change size when it completes.
+                  <Circle className="h-3 w-3" aria-hidden data-testid="todo-status-pending" />
+                )}
+              </RowMark>
+              <span className="truncate">{todo.content}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -192,7 +192,7 @@ describe('AgentActivityIndicator', () => {
     // Shows status indicators
     expect(screen.getByTestId('todo-status-completed')).toBeInTheDocument()
     expect(screen.getByTestId('todo-status-in-progress')).toBeInTheDocument()
-    expect(screen.getByText('○')).toBeInTheDocument()
+    expect(screen.getByTestId('todo-status-pending')).toBeInTheDocument()
   })
 
   it('does not show todo list when all items are completed', () => {
@@ -463,7 +463,7 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByText('Set up database')).toBeInTheDocument()
     expect(screen.getByText('Write API routes')).toBeInTheDocument()
     expect(screen.getByText('Add tests')).toBeInTheDocument()
-    expect(screen.getAllByText('○')).toHaveLength(3)
+    expect(screen.getAllByTestId('todo-status-pending')).toHaveLength(3)
   })
 
   it('applies TaskUpdate status changes to task list', () => {

--- a/src/renderer/components/ui/tree-connectors.ts
+++ b/src/renderer/components/ui/tree-connectors.ts
@@ -63,3 +63,24 @@ export const ACTIVITY_TREE_CONNECTORS =
   '[&>li]:after:absolute [&>li]:after:-left-3 [&>li]:after:-top-1 [&>li]:after:bottom-0 ' +
   '[&>li]:after:border-l [&>li]:after:border-muted-foreground/25 ' +
   '[&>li:last-child]:after:bottom-auto [&>li:last-child]:after:h-3'
+
+/**
+ * The tracer: a bright band travels down the trunk and out along each live
+ * branch, then across that row's own label — the tree carries the "still
+ * working" signal so no row needs a spinner of its own.
+ *
+ * Compose on top of ACTIVITY_TREE_CONNECTORS. It swaps the per-row rail segments
+ * for ONE rail drawn on the list, which is what lets the band travel the whole
+ * path unbroken; the elbows carry over unchanged. The animation itself lives in
+ * `.tree-tracer` in globals.css, and only rows marked data-tracer-live take part.
+ *
+ * The single rail can use fixed offsets because every row on this tree is the
+ * same 16px line box: it starts -top-1 like the segments did, and stops
+ * bottom-2 — 8px up from the last row's bottom, which is exactly its elbow. A
+ * row that wraps to a second line (a subagent progress summary) is taller than
+ * 16px, so if it lands LAST the rail overshoots its elbow by that much.
+ */
+export const ACTIVITY_TREE_TRACER =
+  'tree-tracer relative ' +
+  'before:absolute before:left-3 before:-top-1 before:bottom-2 before:w-px ' +
+  '[&>li]:after:hidden'

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -904,3 +904,139 @@ html[data-keyboard-open] [data-composer-footer] {
     display: none;
   }
 }
+
+/*
+  Tree tracer: rather than marking each running row with an indicator of its own,
+  the branch path carries the motion — a bright band running down the trunk, out
+  along each live branch as it passes, and across that row's own label.
+
+  The trunk is the LIST's own ::before, painted with a tall repeating tile so the
+  band's travel is one unbroken loop with no phase-matching between rows. The
+  branches are the per-row ::before elbows, and the labels are masked; both flash
+  as the band reaches them.
+
+  They stay in step through fixed geometry rather than measurement: every row on
+  this tree is one 16px line box plus the list's 4px gap, so branch N sits exactly
+  N pitches below the first and lights one --tree-tracer-step later. ActivityCard
+  writes each row's N into --tree-tracer-row and pins the animations to a shared
+  start time (useTracerPhaseLock), since a CSS animation's clock otherwise starts
+  whenever its row happens to go live. A row that wraps to a second line is taller
+  than one pitch, so branches below it flash early by that much.
+
+  Only rows marked data-tracer-live take part — a finished subagent or a pending
+  task keeps its resting branch as the band goes by. The trunk runs through all of
+  them: it is one element, and it stands for the turn rather than any single row.
+  The index still counts EVERY row, because the stagger is physical.
+*/
+.tree-tracer {
+  /* Travel per cycle. Longer than the tree usually is, so a single band is in
+     flight at a time; a tree taller than this shows a train of them. */
+  --tree-tracer-span: 200px;
+  --tree-tracer-cycle: 2.2s;
+  /* One row pitch as time: cycle × 20px pitch ÷ span. Keep these three in sync —
+     the branch flashes are positioned by multiplying step by the row index. */
+  --tree-tracer-step: 0.22s;
+}
+
+/* Ends where it started (one whole tile down), so the loop is seamless. */
+@keyframes tree-tracer-trunk {
+  from { background-position-y: 0; }
+  to { background-position-y: var(--tree-tracer-span); }
+}
+
+/* Bright as the band arrives, then back to the resting rail color for the rest
+   of the cycle. 12% ≈ the band's own depth as a fraction of the travel. */
+@keyframes tree-tracer-branch {
+  0% { border-top-color: hsl(var(--foreground) / 0.85); }
+  12%, 100% { border-top-color: hsl(var(--muted-foreground) / 0.25); }
+}
+
+@keyframes tree-tracer-shimmer {
+  /* One tile of travel, so the loop is seamless like the trunk's. */
+  from { -webkit-mask-position: -40px 0; mask-position: -40px 0; }
+  to { -webkit-mask-position: 380px 0; mask-position: 380px 0; }
+}
+
+.tree-tracer::before {
+  background-color: hsl(var(--muted-foreground) / 0.25);
+  /* Band sits at the top of the tile, centered 12px down — which is where the
+     first row's elbow is, so that branch flashes at cycle start with no offset. */
+  background-image: linear-gradient(
+    to bottom,
+    transparent 0px,
+    hsl(var(--foreground) / 0.85) 12px,
+    transparent 24px
+  );
+  background-repeat: repeat-y;
+  background-size: 100% var(--tree-tracer-span);
+  animation: tree-tracer-trunk var(--tree-tracer-cycle) linear infinite;
+  will-change: background-position;
+}
+
+.tree-tracer > li[data-tracer-live]::before {
+  animation: tree-tracer-branch var(--tree-tracer-cycle) linear infinite;
+  animation-delay: calc(var(--tree-tracer-row, 0) * var(--tree-tracer-step));
+}
+
+/*
+  The label picks the pulse up from its branch. Masked rather than recolored, so
+  the row's own colors survive — the mask only modulates alpha, leaving a mono
+  name and its muted description their own weights. Applied to each row's single
+  content wrapper; masking the <li> itself would sweep the branch pseudo-element
+  too, on top of the flash it already has.
+*/
+.tree-tracer > li[data-tracer-live] > * {
+  --tree-tracer-shimmer-tile: 420px;
+  /*
+    How far the text drops between passes. This is the ONE dial for how loud the
+    shimmer reads: a mask can only subtract, so the peak is pinned at the row's
+    normal appearance and prominence has to come from how far it falls away.
+    Lower = more obvious sweep, but a row still working sits dimmer between
+    passes than a finished row beside it, which is the cost of going much below
+    this.
+  */
+  --tree-tracer-shimmer-rest: 0.45;
+  /*
+    A narrow band — full strength at 28px, back to resting by 56px — reads as a
+    defined highlight travelling across the row. Widening it washes the whole
+    row up and down instead. The tile repeats, so a row wider than it shows a
+    second pass.
+  */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    rgba(0, 0, 0, var(--tree-tracer-shimmer-rest)) 0px,
+    rgba(0, 0, 0, 1) 28px,
+    rgba(0, 0, 0, var(--tree-tracer-shimmer-rest)) 56px,
+    rgba(0, 0, 0, var(--tree-tracer-shimmer-rest)) 420px
+  );
+  mask-image: linear-gradient(
+    to right,
+    rgba(0, 0, 0, var(--tree-tracer-shimmer-rest)) 0px,
+    rgba(0, 0, 0, 1) 28px,
+    rgba(0, 0, 0, var(--tree-tracer-shimmer-rest)) 56px,
+    rgba(0, 0, 0, var(--tree-tracer-shimmer-rest)) 420px
+  );
+  -webkit-mask-size: var(--tree-tracer-shimmer-tile) 100%;
+  mask-size: var(--tree-tracer-shimmer-tile) 100%;
+  -webkit-mask-repeat: repeat-x;
+  mask-repeat: repeat-x;
+  animation: tree-tracer-shimmer var(--tree-tracer-cycle) linear infinite;
+  animation-delay: calc(var(--tree-tracer-row, 0) * var(--tree-tracer-step));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tree-tracer::before {
+    background-image: none;
+    animation: none;
+  }
+
+  .tree-tracer > li::before {
+    animation: none;
+  }
+
+  .tree-tracer > li[data-tracer-live] > * {
+    -webkit-mask-image: none;
+    mask-image: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
**Stack 2 of 4** — base is `claude/activity-card-tree` (#729). Next: `claude/unify-error-banners`.

Rows marked themselves busy individually — a pulsing dot per running row, repeated down the list. The tree is already a continuous path, so it can carry that signal itself: a bright band runs down the trunk, out along each live branch as it passes, and across that row's own label. Working rows need no mark at all.

Only rows marked `data-tracer-live` take part — a finished subagent or a pending task keeps its resting branch as the band goes by. The trunk runs through all of them: it's one element, and it stands for the turn rather than any single row.

### Three mechanisms worth knowing before changing any of it

**The trunk is the list's own `::before`**, not per-row segments — that's what lets the band travel unbroken. It can use fixed offsets only because every row here is one 16px line box plus the list's 4px gap. A row that wraps to a second line is taller than one pitch, so branches below it flash early by that much.

**Branch and label timing come from that same fixed pitch, not measurement.** Branch N sits N pitches below the first and lights one `--tree-tracer-step` later, with the index written into `--tree-tracer-row`. The index counts *every* row, live or not, because the stagger is physical — it says when the band reaches that height.

**Sharing a duration isn't enough to keep three animations together.** A CSS animation's clock starts when it's applied to the element, not when the card mounts — so a row going live mid-turn began its own timeline while the trunk was already partway through, and landed on the wrong beat. `useTracerPhaseLock` pins them all to the earliest start time already running. It flushes style before reading, since an animation doesn't exist until the style declaring it is recalculated, which can land *after* the effect looking for it.

### The label highlight

A mask, not a recolor, so a mono name and its muted description keep their own weights. A mask can only subtract, so the peak is the row's normal appearance and `--tree-tracer-shimmer-rest` is how far it falls between passes — the one dial for how loud this reads.

Silent under `prefers-reduced-motion`.

### Testing

Typecheck, lint, and the full renderer suite (2413 tests) pass on this commit alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)