### PR TITLE
Give every failure above the composer one treatment

### DIFF
--- a/src/renderer/components/messages/activity-card.tsx
+++ b/src/renderer/components/messages/activity-card.tsx
@@ -1,8 +1,9 @@
 import { cn } from '@shared/lib/utils'
-import { AlertTriangle, ChevronDown, CircleCheckBig, Ellipsis, Monitor, X } from 'lucide-react'
+import { ChevronDown, CircleCheckBig, Ellipsis, Monitor, X } from 'lucide-react'
 import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from 'react'
 
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
+import { RequestError } from './request-error'
 import { ACTIVITY_TREE_CONNECTORS, ACTIVITY_TREE_TRACER } from '@renderer/components/ui/tree-connectors'
 import type { Todo } from '@shared/lib/utils/derive-task-list'
 import { ActivityOrb, type ActivityOrbState } from './activity-orb'
@@ -232,16 +233,15 @@ export function ActivityCard({
  */
 export function ActivityErrorCard({ message }: { message: string }) {
   return (
-    <div className="rounded-lg border border-destructive/50 bg-red-50 p-3 select-text dark:bg-red-950" data-testid="error-card">
-      <div className="flex items-center gap-2">
-        <AlertTriangle className="h-4 w-4 text-destructive" />
-        <span className="text-sm font-medium text-destructive">Error</span>
-      </div>
-      <p className="mt-1 text-sm text-destructive/90">{message}</p>
-      <p className="mt-2 text-xs text-muted-foreground">
-        Send another message to retry.
-      </p>
-    </div>
+    <RequestError
+      message={message}
+      hint="Send another message to retry."
+      // Opaque in dark too: this sits in the overlay footer with the transcript
+      // scrolling behind it, where the shared banner's translucent dark fill
+      // would let the messages show through.
+      className="mt-0 dark:bg-red-950"
+      data-testid="error-card"
+    />
   )
 }
 

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -109,6 +109,8 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByTestId('provider-error-card')).toHaveClass('bg-red-50', 'dark:bg-red-950')
     // Opaque in dark: the transcript scrolls behind this in the overlay footer.
     expect(screen.getByTestId('provider-error-card')).not.toHaveClass('dark:bg-red-950/30')
+    // Selectable despite the app-wide user-select: none — errors get copied.
+    expect(screen.getByTestId('provider-error-card')).toHaveClass('select-text', '[&_*]:select-text')
   })
 
   it('shows generic error alert when no apiErrorCode', () => {
@@ -125,6 +127,8 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByTestId('error-card')).toHaveClass('bg-red-50', 'dark:bg-red-950')
     // Opaque in dark: the transcript scrolls behind this in the overlay footer.
     expect(screen.getByTestId('error-card')).not.toHaveClass('dark:bg-red-950/30')
+    // Selectable despite the app-wide user-select: none — errors get copied.
+    expect(screen.getByTestId('error-card')).toHaveClass('select-text', '[&_*]:select-text')
   })
 
   it('shows "Working..." status when active with no todo', () => {

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -100,22 +100,28 @@ describe('AgentActivityIndicator', () => {
     mockStreamState.error = 'API rate limit exceeded'
     mockStreamState.apiErrorCode = 'rate_limit'
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
-    expect(screen.getByText('LLM Provider Error')).toBeInTheDocument()
-    expect(screen.getByText('API rate limit exceeded')).toBeInTheDocument()
+    // The shared RequestError banner, labelled so the provider is named.
+    expect(screen.getByTestId('provider-error-card')).toHaveTextContent('LLM Provider Error: API rate limit exceeded')
+    // The hint is folded away until asked for — clicking the banner opens it.
+    expect(screen.queryByText(/external LLM provider API/)).not.toBeInTheDocument()
+    act(() => { screen.getByTestId('provider-error-card').click() })
     expect(screen.getByText(/external LLM provider API/)).toBeInTheDocument()
-    expect(screen.getByTestId('provider-error-card')).toHaveClass('bg-amber-50', 'dark:bg-amber-950')
-    expect(screen.getByTestId('provider-error-card')).not.toHaveClass('bg-amber-500/10')
+    expect(screen.getByTestId('provider-error-card')).toHaveClass('bg-red-50', 'dark:bg-red-950')
+    // Opaque in dark: the transcript scrolls behind this in the overlay footer.
+    expect(screen.getByTestId('provider-error-card')).not.toHaveClass('dark:bg-red-950/30')
   })
 
   it('shows generic error alert when no apiErrorCode', () => {
     mockStreamState.error = 'The agent process was terminated unexpectedly.'
     mockStreamState.apiErrorCode = null
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
-    expect(screen.getByText('Error')).toBeInTheDocument()
-    expect(screen.getByText('The agent process was terminated unexpectedly.')).toBeInTheDocument()
+    expect(screen.getByTestId('error-card')).toHaveTextContent('Error: The agent process was terminated unexpectedly.')
+    expect(screen.queryByText('Send another message to retry.')).not.toBeInTheDocument()
+    act(() => { screen.getByTestId('error-card').click() })
     expect(screen.getByText('Send another message to retry.')).toBeInTheDocument()
-    expect(screen.getByTestId('error-card')).toHaveClass('bg-red-50', 'dark:bg-red-950')
-    expect(screen.getByTestId('error-card')).not.toHaveClass('bg-destructive/10')
+    // ...and folds back up.
+    act(() => { screen.getByTestId('error-card').click() })
+    expect(screen.queryByText('Send another message to retry.')).not.toBeInTheDocument()
     expect(screen.getByTestId('error-card')).toHaveClass('bg-red-50', 'dark:bg-red-950')
     // Opaque in dark: the transcript scrolls behind this in the overlay footer.
     expect(screen.getByTestId('error-card')).not.toHaveClass('dark:bg-red-950/30')

--- a/src/renderer/components/messages/insufficient-balance-card.test.tsx
+++ b/src/renderer/components/messages/insufficient-balance-card.test.tsx
@@ -66,9 +66,12 @@ describe('InsufficientBalanceCard', () => {
 
     render(<InsufficientBalanceCard billingUrl="https://platform.example.com/billing" />)
 
-    expect(screen.getByText('Insufficient balance')).toBeInTheDocument()
-    expect(screen.getByTestId('insufficient-balance-card')).toHaveClass('bg-card')
-    expect(screen.getByTestId('insufficient-balance-card')).not.toHaveClass('bg-muted/30')
+    const card = screen.getByTestId('insufficient-balance-card')
+    expect(card).toHaveTextContent('Insufficient balance: Subscribe or top up to continue running agents.')
+    // The error banner's frame and palette — opaque in dark, since the
+    // transcript scrolls behind the overlay footer.
+    expect(card).toHaveClass('rounded-md', 'bg-red-50', 'dark:bg-red-950')
+    expect(card).not.toHaveClass('bg-card')
     const button = screen.getByRole('button', { name: /go to billing/i })
     fireEvent.click(button)
     expect(openExternal).toHaveBeenCalledWith('https://platform.example.com/billing')

--- a/src/renderer/components/messages/insufficient-balance-card.tsx
+++ b/src/renderer/components/messages/insufficient-balance-card.tsx
@@ -1,6 +1,7 @@
-import { ArrowUpRight, Wallet } from 'lucide-react'
+import { ArrowUpRight, Info } from 'lucide-react'
 
-import { Button } from '@renderer/components/ui/button'
+import { cn } from '@shared/lib/utils'
+
 import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
 import { useSettings } from '@renderer/hooks/use-settings'
 
@@ -34,12 +35,34 @@ export function usePlatformBillingUrl(message: string): string | null {
   return `${platformBaseUrl}/dashboard/organizations/${orgId}?tab=billing`
 }
 
-export function InsufficientBalanceCard({
+/**
+ * The two billing banners, in the error banner's frame and metrics (see
+ * RequestError): a leading glyph, one line of copy, and the billing link where
+ * the error banner puts "More details".
+ *
+ * Red, like the other error banners. What sets this one apart is that it
+ * carries an action; every other error can only be retried.
+ *
+ * Tinted fills stay opaque in dark for the same reason as the red banner — the
+ * transcript scrolls behind the overlay footer.
+ */
+const BANNER_TONES = {
+  stop: {
+    container: 'bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300',
+    action: 'text-red-700/85 hover:text-red-700 dark:text-red-300/85 dark:hover:text-red-300',
+  },
+} as const
+
+function BillingBanner({
+  message,
   billingUrl,
-  'data-testid': testId,
+  tone,
+  testId,
 }: {
+  message: string
   billingUrl: string
-  'data-testid'?: string
+  tone: keyof typeof BANNER_TONES
+  testId: string
 }) {
   async function handleGoToBilling() {
     if (window.electronAPI?.openExternal) {
@@ -51,24 +74,42 @@ export function InsufficientBalanceCard({
 
   return (
     <div
-      className="rounded-[12px] border bg-card shadow-md p-4"
-      data-testid={testId ?? 'insufficient-balance-card'}
+      className={cn('rounded-md px-3 py-2 text-xs', BANNER_TONES[tone].container)}
+      data-testid={testId}
     >
-      <div className="flex items-start gap-3">
-        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-500/15">
-          <Wallet className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <h4 className="text-sm font-medium text-foreground">Insufficient balance</h4>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Subscribe or top up to continue running agents.
-          </p>
-          <Button size="sm" className="mt-3 gap-1.5" onClick={() => void handleGoToBilling()}>
-            Go to billing
-            <ArrowUpRight className="h-3.5 w-3.5" />
-          </Button>
-        </div>
+      <div className="flex items-start gap-2">
+        <Info className="mt-px h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 flex-1">{message}</span>
+        <button
+          type="button"
+          onClick={() => void handleGoToBilling()}
+          className={cn(
+            'inline-flex shrink-0 cursor-pointer items-center gap-1 rounded font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            BANNER_TONES[tone].action,
+          )}
+        >
+          Go to billing
+          <ArrowUpRight className="h-3 w-3" />
+        </button>
       </div>
     </div>
+  )
+}
+
+/** The turn is already dead: the 402 has landed and nothing runs until paid. */
+export function InsufficientBalanceCard({
+  billingUrl,
+  'data-testid': testId,
+}: {
+  billingUrl: string
+  'data-testid'?: string
+}) {
+  return (
+    <BillingBanner
+      message="Insufficient balance: Subscribe or top up to continue running agents."
+      billingUrl={billingUrl}
+      tone="stop"
+      testId={testId ?? 'insufficient-balance-card'}
+    />
   )
 }

--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import { MessageItem } from './message-item'
 import { createUserMessage, createAssistantMessage, createToolCall } from '@renderer/test/factories'
 
@@ -337,8 +337,8 @@ describe('MessageItem', () => {
         apiError: 'authentication_failed',
       })
       render(<MessageItem message={msg} />)
-      expect(screen.getByText('LLM Provider Error')).toBeInTheDocument()
-      expect(screen.getByText('Invalid API key')).toBeInTheDocument()
+      expect(screen.getByTestId('provider-error-card')).toHaveTextContent('LLM Provider Error: Invalid API key')
+      act(() => { screen.getByTestId('provider-error-card').click() })
       expect(screen.getByText(/external LLM provider API/)).toBeInTheDocument()
     })
 

--- a/src/renderer/components/messages/request-error.tsx
+++ b/src/renderer/components/messages/request-error.tsx
@@ -72,6 +72,11 @@ export function RequestError({
       } : {})}
       className={cn(
         'mt-4 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300',
+        // Globals disable selection app-wide (`* { user-select: none }`), and
+        // that rule hits every descendant — so re-enable on the descendants
+        // too, not just the container. Without this the message can't be
+        // copied, and the drag-to-copy guard in handleClick never fires.
+        'select-text [&_*]:select-text',
         hint && 'group cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         VARIANT_CLASSES[variant],
         className,

--- a/src/renderer/components/messages/request-error.tsx
+++ b/src/renderer/components/messages/request-error.tsx
@@ -1,8 +1,20 @@
+import { useState, type KeyboardEvent, type ReactNode } from 'react'
+import { ChevronDown, Info } from 'lucide-react'
+
 import { cn } from '@shared/lib/utils/cn'
 
 interface RequestErrorProps {
   message: string | null
   className?: string
+  'data-testid'?: string
+  /** Leading label before the message. Name the source when it is not this app. */
+  label?: string
+  /**
+   * Guidance about the error, folded behind a "More details" toggle inside the
+   * banner. Kept out of the way by default so the failure itself is the whole
+   * of the first read. Without one the banner is inert, as it has always been.
+   */
+  hint?: ReactNode
   /**
    * Visual treatment. `default` is the standalone red banner; `compact` is the
    * tight, borderless destructive style used inline at the bottom of settings forms.
@@ -17,18 +29,78 @@ const VARIANT_CLASSES: Record<NonNullable<RequestErrorProps['variant']>, string>
   compact: 'mt-0 px-2',
 }
 
-export function RequestError({ message, className, variant = 'default' }: RequestErrorProps) {
+export function RequestError({
+  message,
+  className,
+  variant = 'default',
+  'data-testid': testId,
+  label = 'Error',
+  hint,
+}: RequestErrorProps) {
+  const [showDetails, setShowDetails] = useState(false)
+
   if (!message) return null
+
+  const toggle = () => setShowDetails((shown) => !shown)
+
+  const handleClick = () => {
+    // A click that ends a drag is someone copying the error, not asking for
+    // details — leave the selection alone and don't toggle under them.
+    if (window.getSelection()?.toString()) return
+    toggle()
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    toggle()
+  }
 
   return (
     <div
+      data-testid={testId}
+      // The whole banner is the target, so the affordance below is a span, not
+      // a nested button. role/tabIndex rather than a real <button> because the
+      // message has to stay selectable — inside a button, dragging to copy it
+      // reads as a click instead.
+      {...(hint ? {
+        role: 'button',
+        tabIndex: 0,
+        'aria-expanded': showDetails,
+        onClick: handleClick,
+        onKeyDown: handleKeyDown,
+      } : {})}
       className={cn(
         'mt-4 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300',
+        hint && 'group cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         VARIANT_CLASSES[variant],
         className,
       )}
     >
-      Error: {message}
+      <div className="flex items-start gap-2">
+        {/* mt-px nudges the 14px glyph onto the 16px line box's optical center. */}
+        <Info className="mt-px h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 flex-1">{label}: {message}</span>
+        {hint && (
+          // Matches the billing banners' "Go to billing" affordance. Hover is
+          // driven off the container's `group` rather than the span's own
+          // :hover — the whole banner is the target, so the label has to
+          // respond wherever the pointer is.
+          <span className="inline-flex shrink-0 items-center gap-1 font-medium text-red-700/85 transition-colors group-hover:text-red-700 dark:text-red-300/85 dark:group-hover:text-red-300">
+            More details
+            <ChevronDown
+              className={cn('h-3 w-3 transition-transform', showDetails && 'rotate-180')}
+              aria-hidden="true"
+            />
+          </span>
+        )}
+      </div>
+      {/* Softened rather than muted-foreground: guidance belongs to the error,
+          so it stays inside the banner and in its palette, just under the
+          message in weight. */}
+      {hint && showDetails && (
+        <p className="mt-1 text-red-700/75 dark:text-red-300/75">{hint}</p>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/ui/provider-error-card.tsx
+++ b/src/renderer/components/ui/provider-error-card.tsx
@@ -1,4 +1,4 @@
-import { CloudOff } from 'lucide-react'
+import { RequestError } from '@renderer/components/messages/request-error'
 
 function extractReadableError(raw: string): string {
   const jsonMatch = raw.match(/\{"type":\s*"error".*?"message":\s*"([^"]+)"\s*\}/)
@@ -22,22 +22,22 @@ function getHint(message: string): string {
   return 'This error came from the external LLM provider API, not from this application. Check your provider configuration in Settings.'
 }
 
+/**
+ * A provider-side failure, in the app's one error treatment (RequestError — the
+ * same banner the setup wizard and the settings forms use). What makes it a
+ * PROVIDER error is the hint underneath, not a palette of its own.
+ */
 export function ProviderErrorCard({ message, 'data-testid': testId }: ProviderErrorCardProps) {
-  const displayMessage = extractReadableError(message)
-
   return (
-    <div
-      className="rounded-lg border border-amber-500/50 bg-amber-50 p-3 dark:bg-amber-950"
+    <RequestError
+      label="LLM Provider Error"
+      message={extractReadableError(message)}
+      hint={getHint(message)}
+      // Opaque in dark too: these sit in the overlay footer with the transcript
+      // scrolling behind them, where the shared banner's translucent dark fill
+      // would let the messages show through.
+      className="mt-0 dark:bg-red-950"
       data-testid={testId ?? 'provider-error-card'}
-    >
-      <div className="flex items-center gap-2">
-        <CloudOff className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-        <span className="text-sm font-medium text-amber-600 dark:text-amber-400">LLM Provider Error</span>
-      </div>
-      <p className="mt-1 text-sm text-amber-600/90 dark:text-amber-400/90">{displayMessage}</p>
-      <p className="mt-1.5 text-xs text-muted-foreground">
-        {getHint(message)}
-      </p>
-    </div>
+    />
   )
 }


### PR DESCRIPTION
**Stack 3 of 4** — base is `claude/activity-card-tracer` (#730). Next: `claude/low-balance-warning`.

Four surfaces in the same slot looked like four different products: the generic error was a red card with a title, a provider error was an amber one, insufficient balance was a bordered card with a filled button — and the setup wizard and settings forms used a fifth thing, `RequestError`, the shared red banner. That last one is the house treatment by usage, so everything else converges on it.

### RequestError grows what the other surfaces needed

- **`label`**, so a provider failure can still say so. Not decoration: `message-item` renders these inline in the transcript, where the label is what separates a provider error from the assistant's own text.
- **`hint`**, folded behind "More details" inside the banner, so guidance no longer trails outside it in muted grey. Clicking anywhere on the banner toggles it.
- A leading icon.

The disclosure is a `div` with `role="button"` rather than a real `<button>`: error text has to stay selectable, and inside a button, dragging to copy reads as a click. For the same reason the click handler bails when there's an active selection, so finishing a drag doesn't collapse the panel. **The banner stays completely inert when no hint is passed** — which is every other call site (~10 of them: the wizard's Docker step, settings form errors, the pending-request boundary).

### Opacity

Both cards override the shared banner's translucent dark fill to an opaque one. They sit in the overlay footer with the transcript scrolling behind them — the same problem #685 fixed for the input cards, whose regression guard those tests still carry, now pointed at the new class.

### Insufficient balance

Keeps its own component but adopts the banner's frame and metrics, with its CTA where the error banner puts "More details". It stays visually distinct from the other red banners by carrying an action at all — every other error here can only be retried.

### Testing

Typecheck, lint, and the full renderer suite (2413 tests) pass on this commit alone. Three tests were re-pointed from the old markup to the new; each still asserts the same user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)