### PR TITLE
Warn before the balance runs out

### DIFF
--- a/src/renderer/components/messages/insufficient-balance-card.tsx
+++ b/src/renderer/components/messages/insufficient-balance-card.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Info } from 'lucide-react'
+import { ArrowUpRight, Info, X } from 'lucide-react'
 
 import { cn } from '@shared/lib/utils'
 
@@ -40,7 +40,8 @@ export function usePlatformBillingUrl(message: string): string | null {
  * RequestError): a leading glyph, one line of copy, and the billing link where
  * the error banner puts "More details".
  *
- * Red, like the other error banners. What sets this one apart is that it
+ * Red for the hard stop, blue for the warning — the split is severity, not
+ * source. What sets the hard stop apart from the other red banners is that it
  * carries an action; every other error can only be retried.
  *
  * Tinted fills stay opaque in dark for the same reason as the red banner — the
@@ -51,6 +52,10 @@ const BANNER_TONES = {
     container: 'bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300',
     action: 'text-red-700/85 hover:text-red-700 dark:text-red-300/85 dark:hover:text-red-300',
   },
+  warn: {
+    container: 'bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300',
+    action: 'text-blue-700/85 hover:text-blue-700 dark:text-blue-300/85 dark:hover:text-blue-300',
+  },
 } as const
 
 function BillingBanner({
@@ -58,11 +63,14 @@ function BillingBanner({
   billingUrl,
   tone,
   testId,
+  onDismiss,
 }: {
   message: string
   billingUrl: string
   tone: keyof typeof BANNER_TONES
   testId: string
+  /** Warnings can be waved away; the hard stop has nothing to dismiss to. */
+  onDismiss?: () => void
 }) {
   async function handleGoToBilling() {
     if (window.electronAPI?.openExternal) {
@@ -91,6 +99,19 @@ function BillingBanner({
           Go to billing
           <ArrowUpRight className="h-3 w-3" />
         </button>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className={cn(
+              'shrink-0 cursor-pointer rounded p-0.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              BANNER_TONES[tone].action,
+            )}
+            aria-label="Dismiss balance warning"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
       </div>
     </div>
   )
@@ -110,6 +131,33 @@ export function InsufficientBalanceCard({
       billingUrl={billingUrl}
       tone="stop"
       testId={testId ?? 'insufficient-balance-card'}
+    />
+  )
+}
+
+/**
+ * The warning before the wall — credits are low but agents still run, so this is
+ * the one billing message a user can act on BEFORE losing a turn.
+ *
+ * Copy is a statement plus the concrete thing to do, not a number: "18%
+ * remaining" reads as data to interpret, where "add more credits" is the action.
+ */
+export function LowBalanceCard({
+  billingUrl,
+  onDismiss,
+  'data-testid': testId,
+}: {
+  billingUrl: string
+  onDismiss?: () => void
+  'data-testid'?: string
+}) {
+  return (
+    <BillingBanner
+      message="Balance running low. Add more credits to avoid interrupting your agents."
+      billingUrl={billingUrl}
+      tone="warn"
+      testId={testId ?? 'low-balance-card'}
+      onDismiss={onDismiss}
     />
   )
 }

--- a/src/renderer/components/messages/low-balance-notice.test.tsx
+++ b/src/renderer/components/messages/low-balance-notice.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { LowBalanceNotice } from './low-balance-notice'
+
+/**
+ * The banner itself is trivial; what needs holding still is WHEN it appears.
+ * It asks a workspace to top up, so every gate below is the difference between
+ * a useful nudge and telling someone with no platform balance to pay for one.
+ */
+
+const platformAuth = {
+  connected: true as boolean,
+  platformBaseUrl: 'https://platform.example.com' as string | null,
+  orgId: 'org_123' as string | null,
+}
+const settings = { llmProvider: 'platform' as string | null }
+let billing: unknown = {
+  connected: true,
+  billing: {
+    configured: true,
+    subscription: { status: 'active', paymentStatus: null, currentPeriodEnd: null },
+    seat: { balanceCents: 300, startingBalanceCents: 2000 },
+    orgPool: { poolBalanceCents: 0 },
+  },
+}
+let billingEnabled: boolean | undefined
+
+vi.mock('@renderer/hooks/use-platform-auth', () => ({
+  usePlatformAuthStatus: () => ({ data: platformAuth }),
+}))
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => ({ data: settings }),
+}))
+vi.mock('@renderer/hooks/use-billing-info', () => ({
+  useBillingInfo: (enabled: boolean) => {
+    billingEnabled = enabled
+    return { data: enabled ? billing : undefined }
+  },
+}))
+vi.mock('@renderer/lib/api-target', () => ({ getActiveTarget: () => 'local' }))
+
+/** balanceCents for a given percent of a 2000-cent seat. */
+const atPercent = (pct: number) => ({ balanceCents: (pct / 100) * 2000, startingBalanceCents: 2000 })
+
+function setSeat(seat: { balanceCents: number; startingBalanceCents: number } | null) {
+  billing = {
+    connected: true,
+    billing: {
+      configured: true,
+      subscription: { status: 'active', paymentStatus: null, currentPeriodEnd: null },
+      seat,
+      orgPool: { poolBalanceCents: 0 },
+    },
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  platformAuth.connected = true
+  platformAuth.platformBaseUrl = 'https://platform.example.com'
+  platformAuth.orgId = 'org_123'
+  settings.llmProvider = 'platform'
+  billingEnabled = undefined
+  setSeat(atPercent(15))
+})
+
+const visible = () => screen.queryByTestId('low-balance-card') !== null
+
+describe('LowBalanceNotice', () => {
+  it('warns once the seat drops to the same point the Settings meter turns amber', () => {
+    setSeat(atPercent(15))
+    render(<LowBalanceNotice />)
+    expect(visible()).toBe(true)
+  })
+
+  it('stays quiet while there is plenty left', () => {
+    setSeat(atPercent(60))
+    render(<LowBalanceNotice />)
+    expect(visible()).toBe(false)
+  })
+
+  it('stays quiet at zero — the hard 402 is the accurate message there', () => {
+    setSeat(atPercent(0))
+    render(<LowBalanceNotice />)
+    expect(visible()).toBe(false)
+  })
+
+  describe('does not ask for a top-up when there is no platform balance to top up', () => {
+    it('BYOK provider', () => {
+      settings.llmProvider = 'anthropic'
+      render(<LowBalanceNotice />)
+      expect(visible()).toBe(false)
+      expect(billingEnabled).toBe(false)
+    })
+
+    it('platform account not connected', () => {
+      platformAuth.connected = false
+      render(<LowBalanceNotice />)
+      expect(visible()).toBe(false)
+      expect(billingEnabled).toBe(false)
+    })
+
+    it('org unknown', () => {
+      platformAuth.orgId = null
+      render(<LowBalanceNotice />)
+      expect(visible()).toBe(false)
+      expect(billingEnabled).toBe(false)
+    })
+
+    it('org has no seat', () => {
+      setSeat(null)
+      render(<LowBalanceNotice />)
+      expect(visible()).toBe(false)
+    })
+  })
+
+  it('links to the org billing page', () => {
+    render(<LowBalanceNotice />)
+    expect(screen.getByRole('button', { name: /go to billing/i })).toBeInTheDocument()
+  })
+
+  describe('dismissal', () => {
+    it('stays gone for the band it was dismissed in', () => {
+      const { unmount } = render(<LowBalanceNotice />)
+      fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+      expect(visible()).toBe(false)
+
+      unmount()
+      render(<LowBalanceNotice />)
+      expect(visible()).toBe(false)
+    })
+
+    it('comes back when the balance falls into the next band', () => {
+      const { unmount } = render(<LowBalanceNotice />)
+      fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+      unmount()
+
+      // 15% was waved away; 3% is a more urgent statement, not the same one.
+      setSeat(atPercent(3))
+      render(<LowBalanceNotice />)
+      expect(visible()).toBe(true)
+    })
+
+    it('does not re-warn about the milder band after the urgent one was dismissed', () => {
+      setSeat(atPercent(3))
+      const { unmount } = render(<LowBalanceNotice />)
+      fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+      unmount()
+
+      // A top-up that only reaches 15% should not re-raise what was just silenced.
+      setSeat(atPercent(15))
+      render(<LowBalanceNotice />)
+      expect(visible()).toBe(false)
+    })
+  })
+})

--- a/src/renderer/components/messages/low-balance-notice.tsx
+++ b/src/renderer/components/messages/low-balance-notice.tsx
@@ -1,0 +1,87 @@
+import { useCallback, useState } from 'react'
+
+import { PROGRESS_THRESHOLDS } from '@renderer/components/ui/progress'
+import { useBillingInfo } from '@renderer/hooks/use-billing-info'
+import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
+import { useSettings } from '@renderer/hooks/use-settings'
+import { getActiveTarget } from '@renderer/lib/api-target'
+import { LowBalanceCard } from './insufficient-balance-card'
+
+/**
+ * The warning before the wall: credits are low but agents still run.
+ *
+ * Renders nothing unless the workspace is actually spending platform credits —
+ * a BYOK provider, a disconnected account, or an org with no seat has no balance
+ * this could be about, and must never be asked to top one up.
+ */
+
+/**
+ * Which side of the meter the balance is on, or null when there is nothing to
+ * warn about. Bands rather than a raw percent because the dismissal is keyed to
+ * them: dismissing "running low" should not also silence "nearly out".
+ */
+type Band = 'warning' | 'critical'
+
+function bandFor(percentRemaining: number): Band | null {
+  // At zero the hard 402 is already the accurate message; warning about a
+  // balance that has run out would only duplicate it.
+  if (percentRemaining <= 0) return null
+  if (percentRemaining <= PROGRESS_THRESHOLDS.critical) return 'critical'
+  if (percentRemaining <= PROGRESS_THRESHOLDS.warning) return 'warning'
+  return null
+}
+
+/**
+ * Remembers the band a user dismissed, per workspace, so the notice stays gone
+ * for that band but returns when the balance drops into the next one. A warning
+ * that cannot come back is not much of a warning; one that cannot be silenced,
+ * on every session, for as long as the balance is low, is worse than none.
+ */
+function useDismissedBand(): [Band | null, (band: Band) => void] {
+  const key = `low-balance-dismissed.${getActiveTarget()}`
+  const [dismissed, setDismissed] = useState<Band | null>(
+    () => (localStorage.getItem(key) as Band | null) ?? null,
+  )
+  const dismiss = useCallback((band: Band) => {
+    localStorage.setItem(key, band)
+    setDismissed(band)
+  }, [key])
+  return [dismissed, dismiss]
+}
+
+export function LowBalanceNotice() {
+  const { data: platformAuth } = usePlatformAuthStatus()
+  const { data: settings } = useSettings()
+  const [dismissedBand, dismiss] = useDismissedBand()
+
+  const platformBaseUrl = platformAuth?.platformBaseUrl
+  const orgId = platformAuth?.orgId
+  // Gate the query itself, not just the render: a workspace that cannot have a
+  // platform balance should never fetch one.
+  const spendsPlatformCredits =
+    settings?.llmProvider === 'platform' &&
+    !!platformAuth?.connected &&
+    !!platformBaseUrl &&
+    !!orgId
+  const { data } = useBillingInfo(spendsPlatformCredits)
+
+  const seat = data?.billing?.configured ? data.billing.seat : null
+  if (!spendsPlatformCredits || !seat || seat.startingBalanceCents <= 0) return null
+
+  const percentRemaining = (seat.balanceCents / seat.startingBalanceCents) * 100
+  const band = bandFor(percentRemaining)
+  // Dropping from warning into critical un-dismisses: the second band is a
+  // different, more urgent statement than the one that was waved away.
+  if (!band || band === dismissedBand || (band === 'warning' && dismissedBand === 'critical')) {
+    return null
+  }
+
+  return (
+    <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
+      <LowBalanceCard
+        billingUrl={`${platformBaseUrl}/dashboard/organizations/${orgId}?tab=billing`}
+        onDismiss={() => dismiss(band)}
+      />
+    </div>
+  )
+}

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { cn } from '@shared/lib/utils'
 import { MessageList } from '@renderer/components/messages/message-list'
 import { AgentActivityIndicator } from '@renderer/components/messages/agent-activity-indicator'
+import { LowBalanceNotice } from '@renderer/components/messages/low-balance-notice'
 import { TrayManager } from '@renderer/components/tray/tray-manager'
 import type { PendingMessage } from '@renderer/components/messages/pending-message'
 
@@ -109,6 +110,10 @@ export function SessionThread({
           data-composer-footer
           data-overlay-footer={overlayFooter || undefined}
         >
+          {/* Above the activity card, so a warning about running out sits next
+              to the thing spending it — and in the same slot the hard 402
+              lands in, which is where a user already looks for billing. */}
+          <LowBalanceNotice />
           <AgentActivityIndicator sessionId={sessionId} agentSlug={agentSlug} />
           {footer}
         </div>

--- a/src/renderer/components/ui/progress.tsx
+++ b/src/renderer/components/ui/progress.tsx
@@ -1,18 +1,21 @@
 import { cn } from '@shared/lib/utils'
 
+/**
+ * Colour thresholds on the REMAINING percent, mirroring the platform web app's
+ * seat-quota bar. Exported so the low-balance warning fires at exactly the point
+ * this bar turns amber — one story between Settings and the session view.
+ */
+export const PROGRESS_THRESHOLDS = { warning: 20, critical: 5 } as const
+
 interface ProgressProps {
   /** Fill percentage, 0–100 (clamped). */
   percent: number
-  /**
-   * Color thresholds on the REMAINING percent: at/below `critical` → red,
-   * at/below `warning` → amber, otherwise primary. Mirrors the platform web
-   * app's seat-quota bar.
-   */
+  /** Override the shared PROGRESS_THRESHOLDS for this bar. */
   thresholds?: { warning: number; critical: number }
   className?: string
 }
 
-export function Progress({ percent, thresholds = { warning: 20, critical: 5 }, className }: ProgressProps) {
+export function Progress({ percent, thresholds = PROGRESS_THRESHOLDS, className }: ProgressProps) {
   const pct = Math.max(0, Math.min(100, percent))
   const color =
     pct <= thresholds.critical


### PR DESCRIPTION
**Stack 4 of 4** — base is `claude/unify-error-banners` (#731).

The first signal a user got about credits was a hard 402 mid-turn, with the run already dead. The seat meter in Settings goes amber at 20% remaining and red at 5%, but nothing surfaced that anywhere they'd see it.

This is the state before the wall: blue rather than red, because agents are still running and it's still fixable. It shares `InsufficientBalanceCard`'s shell so the two read as one family split by severity, and it sits in the same footer slot the hard 402 lands in — where a user already looks for billing, next to the thing spending the credits.

Copy is a statement plus the action, with no number: "18% remaining" is data to interpret, where "add more credits" is the thing to do.

### The four decisions

**Threshold** — comes from `PROGRESS_THRESHOLDS`, now exported from the Progress bar rather than duplicated, so the warning fires at exactly the point the Settings meter turns amber. One story in both places.

**Data** — `useBillingInfo`, but the gates run *before* the query is enabled, so a workspace that can't have a platform balance never fetches one. Reuses the existing `['platform-billing']` key and its 30s staleTime, so a session view and an open Settings tab share one fetch.

**Placement** — the footer above the composer. The sidebar banner stack was the alternative and is the established home for app-level warnings, but this design was approved as a composer-slot banner, and putting both billing messages in one place leaves severity as the only thing that varies.

**Dismissal** — banded, not boolean. Waving away "running low" at 15% shouldn't also silence the more urgent statement at 3%, so the dismissal remembers which band it applied to and the notice returns when the balance falls into the next one. Stored per workspace, since two Superagents have different billing.

### Not asking the wrong person to pay

Every gate is about that. A BYOK provider, a disconnected account, an org with no seat, or a balance already at zero all render nothing. At zero the 402 is already the accurate message; duplicating it would only add noise.

### Testing

11 new tests in `low-balance-notice.test.tsx` cover each way it must stay silent, that the query stays disabled in those cases, and all three dismissal transitions. That's where the risk is — this asks someone to spend money, so showing it to a BYOK user would be a real bug.

Typecheck, lint, and the full renderer suite (2424 tests) pass on this commit alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)