### PR TITLE
Let owners use an agent-created child without reloading (SUP-425)

### DIFF
--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -111,6 +111,7 @@ const mockIsSessionAwaitingInput = vi.fn((_sessionId?: string): boolean => false
 const mockWaitForIdle = vi.fn(async (..._args: unknown[]) => {})
 const mockSubscribeToSession = vi.fn()
 const mockMarkSessionActive = vi.fn()
+const mockBroadcastGlobal = vi.fn()
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
     isSessionActive: (sessionId?: string) => mockIsSessionActive(sessionId),
@@ -121,6 +122,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     unsubscribeFromSession: vi.fn(),
     markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
     setSlashCommands: vi.fn(),
+    broadcastGlobal: (...args: unknown[]) => mockBroadcastGlobal(...args),
   },
 }))
 
@@ -387,6 +389,39 @@ describe('/create', () => {
     expect(newAgentAcl).toHaveLength(1)
     expect(newAgentAcl[0].userId).toBe(OWNER_USER_ID)
     expect(newAgentAcl[0].role).toBe('owner')
+  })
+
+  it('broadcasts agent_created only after inherited owner ACL is persisted', async () => {
+    authModeEnabled = true
+    reviewDecisions.push('allow')
+    // slug and displaySlug must DIFFER here: agentSlug is the ACL filter key the
+    // global stream matches against, and only the canonical slug is stored in the
+    // ACL. A fixture where both are equal cannot tell the two apart.
+    mockCreateAgent.mockResolvedValue({
+      slug: 'a1b2c3d4e5',
+      displaySlug: 'new-a1b2c3d4e5',
+      name: 'New',
+    })
+
+    let ownerAclAtBroadcast: Array<{ userId: string; role: string }> = []
+    mockBroadcastGlobal.mockImplementation(() => {
+      ownerAclAtBroadcast = testDb
+        .select()
+        .from(schema.agentAcl)
+        .all()
+        .filter((r) => r.agentSlug === 'a1b2c3d4e5' && r.role === 'owner')
+        .map((r) => ({ userId: r.userId, role: r.role }))
+    })
+
+    const res = await authedFetch('/x-agent/create', { name: 'New' })
+    expect(res.status).toBe(200)
+
+    expect(ownerAclAtBroadcast).toEqual([{ userId: OWNER_USER_ID, role: 'owner' }])
+    expect(mockBroadcastGlobal).toHaveBeenCalledTimes(1)
+    expect(mockBroadcastGlobal).toHaveBeenCalledWith({
+      type: 'agent_created',
+      agentSlug: 'a1b2c3d4e5',
+    })
   })
 })
 

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -327,6 +327,13 @@ xAgent.post('/create', zValidator('json', createBodySchema), async (c) => {
       })
     }
   }
+
+  // Announce only after ACL inheritance so live stream filters admit owners.
+  messagePersister.broadcastGlobal({
+    type: 'agent_created',
+    agentSlug: agent.slug,
+  })
+
   return c.json({ slug: agent.displaySlug, name: agent.name })
 })
 

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 class MockEventSource {
   static instances: MockEventSource[] = []
   onmessage: ((event: { data: string }) => void) | null = null
+  onopen: (() => void) | null = null
   onerror: (() => void) | null = null
   url: string
   constructor(url: string) {
@@ -549,5 +550,45 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
         { slug: 'support', name: 'Support' },
       ])
     expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('agent_created invalidates visible agents and personal roles together', () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    // Producer contract: x-agent create broadcasts this exact shape after ACL writes.
+    simulateSSEMessage(getLatestEventSource(), {
+      type: 'agent_created',
+      agentSlug: 'new-helper',
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+  })
+
+  it('SSE open invalidates agents and roles, including the first connect', () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    const es = getLatestEventSource()
+    es.onopen?.()
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+
+    invalidateSpy.mockClear()
+    es.onerror?.()
+    es.onopen?.()
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
   })
 })

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -403,6 +403,13 @@ export function GlobalNotificationHandler() {
             queryClient.invalidateQueries({ queryKey: ['agents'] })
             break
 
+          case 'agent_created':
+            // Agent-created child creation lands outside the human create mutation,
+            // so refresh both caches the direct-create path invalidates together.
+            queryClient.invalidateQueries({ queryKey: ['agents'] })
+            queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
+            break
+
           case 'scheduled_task_created':
           case 'scheduled_task_cancelled':
           case 'scheduled_task_updated': {
@@ -463,8 +470,15 @@ export function GlobalNotificationHandler() {
       }
     }
 
+    // Catch up anything missed while the stream was down, including the
+    // window before the first successful connect.
+    es.onopen = () => {
+      queryClient.invalidateQueries({ queryKey: ['agents'] })
+      queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
+    }
+
     es.onerror = () => {
-      // EventSource will auto-reconnect
+      // EventSource will auto-reconnect; onopen above catches up.
     }
 
     return () => {


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-425/agent-created-agents-leave-their-human-owner-view-only-with-no-way-to

When an agent creates a child, the server already copies the parent's owners onto the child.
The owner's app never heard about it, so the child showed up view-only until a reload.
This tells open apps after those owner records exist.
They refresh the agent list and this user's roles together.
If that ping is missed, the same refresh runs when the live stream connects, including the first successful connect.

Type: bug fix
Footprint: 2 production files, +22 / -1. 2 test files, +76.

## What happens now

```
parent asks to create a child
  human denies  → nothing is created, nothing is announced
  human approves
    → child files written
    → copy every parent owner onto the child
    → only then announce "a new agent exists" with the child's permanent id
         connected owner  → refresh list + roles together → child usable, no reload
         anyone else      → live filter drops the event
         missed announce  → same refresh when the live stream connects
```

The announce uses the permanent id, not the display name.
The live filter keys off the same id the owner records use.
Announcing the display name would drop the event for every owner.

## Worth reviewing

1. **Announce after the owner records, not before.** The live filter asks whether this user has access to this agent. If the announce goes out first, the answer is no, and the people who need the event never get it.
2. **Both refreshes, not just the list.** The list already polls every minute, so the child can appear on its own. Roles did not. Refreshing only the list recreates the original screen: child visible, no composer.
3. **Refresh on every successful connect.** Skipping the first connect saved one fetch and missed children created before the stream was up. One extra fetch per page load is the cost.

## Why not the obvious alternatives

- **Refresh roles when the approval card resolves.** Approval finishes before the child exists and before owner records are written. The refresh would cache the same empty result.
- **Treat any visible agent as owned.** The list recovering first is what made the bug look like missing access. Trusting visibility would hide a real missing owner record.
- **Poll roles every minute.** The agent list already does this. A timer refreshes while the wire is fine. Connect is the miss.
- **Skip the first connect.** That is the window before the stream is up. Refreshing then is the catch-up.
- **A child-creation e2e.** The ping and the connect refresh are unit-tested. A live auth e2e would add a server and not cover reconnect. Out of scope.
- **A generic event for every permission change.** Invitations, role changes, revokes, leaves, and deletions still go stale. That is a different design, tracked on SUP-573.

## What this does not fix

- **Who inherits the child in a shared workspace** ([SUP-573](https://linear.app/datawizz/issue/SUP-573)). Owners of the parent still become owners of the child. A collaborator who can chat but does not own the parent still gets nothing. A parent with no owners still produces an unowned child. Not a regression. Same rule as before, now visible without a reload.
- **Invitations, role changes, revokes, leaves, deletions.** Those surfaces were already stale. Out of scope.

## How to verify

Auth-mode workspace, you own the parent.

1. Ask the parent to create a child. Approve. The child appears with chat and owner settings. No reload.
2. Repeat and deny. Nothing new in the list.

Local single-user has no roles, so this bug cannot reproduce there.

## Validation

- `npx vitest run src/api/routes/x-agent.test.ts src/renderer/components/notifications/global-notification-handler.test.tsx` - pass
- `npm run typecheck` - pass
- `npm run lint` - 0 errors (pre-existing warnings elsewhere)
- Auth-mode real surface: approve create, child usable without reload
