### PR TITLE
fix(container): bounded recovery from a stale host-auth token (ELECTRON-DD)

### DIFF
--- a/agent-container/src/host-auth.test.ts
+++ b/agent-container/src/host-auth.test.ts
@@ -34,6 +34,26 @@ describe('host-auth', () => {
     expect(hostAuth.isValidHostToken(undefined)).toBe(false);
   });
 
+  // ELECTRON-DD: the host compares this id with the id of the token it is
+  // sending to tell a stale container (restart it) from a real 401.
+  it('exposes a one-way id of the token it was started with, never the token', async () => {
+    const hostAuth = await loadHostAuth('hostc_secret');
+    const id = hostAuth.hostTokenId();
+
+    expect(id).toHaveLength(16);
+    expect(id).toMatch(/^[0-9a-f]+$/);
+    expect(id).not.toContain('hostc');
+    expect('hostc_secret').not.toContain(id!);
+    // Stable for the same token, different for another.
+    expect(hostAuth.hostTokenId()).toBe(id);
+    expect((await loadHostAuth('hostc_other')).hostTokenId()).not.toBe(id);
+  });
+
+  it('reports no token id when host auth is disabled', async () => {
+    const hostAuth = await loadHostAuth(undefined);
+    expect(hostAuth.hostTokenId()).toBeUndefined();
+  });
+
   it('disables auth when no token was provided (older host)', async () => {
     const hostAuth = await loadHostAuth(undefined);
 

--- a/agent-container/src/host-auth.ts
+++ b/agent-container/src/host-auth.ts
@@ -33,6 +33,21 @@ export function hostAuthHeaders(): Record<string, string> {
   return HOST_API_TOKEN ? { [HOST_TOKEN_HEADER]: HOST_API_TOKEN } : {};
 }
 
+/**
+ * Non-secret, one-way id of the host token this container was started with
+ * ("key id"), or undefined when host auth is disabled.
+ *
+ * Served on the unauthenticated /health so the host can tell a stale-token 401
+ * (container still holding a token the host has since rotated — it must be
+ * restarted) apart from a genuinely unauthorized caller, without either side
+ * exchanging token material. A truncated SHA-256 of a 32-byte random secret is
+ * not reversible, and the agent can already read its own boot environment.
+ */
+export function hostTokenId(): string | undefined {
+  if (!HOST_API_TOKEN) return undefined;
+  return crypto.createHash('sha256').update(HOST_API_TOKEN).digest('hex').slice(0, 16);
+}
+
 export function isValidHostToken(presented: string | undefined): boolean {
   if (!HOST_API_TOKEN) return true;
   if (!presented) return false;

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
 // Captures SUPERAGENT_HOST_TOKEN and strips it from process.env — import early
 // so no later module can snapshot an environment that still contains it.
-import { HOST_TOKEN_HEADER, hostAuthEnabled, isValidHostToken } from './host-auth';
+import { HOST_TOKEN_HEADER, hostAuthEnabled, hostTokenId, isValidHostToken } from './host-auth';
 import { SessionManager } from './session-manager';
 import { CreateSessionRequest, SendMessageRequest } from './types';
 import { agentCapabilityPoliciesSchema, speedLevelSchema } from './capability-policies';
@@ -86,7 +86,15 @@ app.use('*', async (c, next) => {
 
 // Health check endpoint
 app.get('/health', (c) => {
-  return c.json({ status: 'ok', timestamp: new Date().toISOString() });
+  // hostTokenId is a one-way id (never the token) of the host token this
+  // container was started with. The host compares it with the id of the token
+  // it is sending to tell "this container is holding a rotated/stale token,
+  // restart it" apart from a genuinely unauthorized caller.
+  return c.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    ...(hostTokenId() ? { hostTokenId: hostTokenId() } : {}),
+  });
 });
 
 // Session endpoints

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -29,7 +29,7 @@ import { readAgentDisplayNameSync } from '@shared/lib/utils/file-storage'
 import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
 import { getActiveWebProvider } from '../web-provider'
 import { captureException, captureMessage, addErrorBreadcrumb } from '@shared/lib/error-reporting'
-import { getOrCreateHostToken } from './host-token-store'
+import { getOrCreateHostToken, hostTokenId } from './host-token-store'
 import { getSubagentModelCatalog } from './subagent-model-catalog'
 
 const execAsync = promisify(exec)
@@ -237,6 +237,22 @@ const BASE_PORT = (() => {
 // Max time for a single /health probe (isHealthy). Kept short because it gates
 // the request hot path via ensureRunning's stale-cache liveness check.
 const HEALTH_PROBE_TIMEOUT_MS = 2000
+
+/**
+ * The container rejected a host-authenticated request (HTTP 401).
+ *
+ * Typed so callers can distinguish "this container is holding a host token
+ * the host no longer has" (recoverable by a restart) from a generic
+ * request failure, and so a persistent 401 stays a single, classifiable
+ * error rather than an opaque string. [ELECTRON-DD]
+ */
+export class ContainerUnauthorizedError extends Error {
+  readonly status = 401
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'ContainerUnauthorizedError'
+  }
+}
 
 /**
  * Parse a memory value string (e.g., "231.2MiB", "1.5GiB", "512MB") to bytes.
@@ -1096,7 +1112,84 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     }
   }
 
+  /**
+   * Create a session, recovering once from a stale host-auth token.
+   *
+   * A container keeps requiring the host token it was *started* with. If the
+   * host's token store is lost or rewritten while that container keeps
+   * running (data-dir wipe, unreadable token file — see host-token-store's
+   * regenerate path), every policy-bearing request 401s forever and the agent
+   * is permanently wedged. Recovery is bounded and evidence-based: only when
+   * the container reports a *different* non-secret token id do we restart it
+   * once and retry once. [ELECTRON-DD]
+   */
   async createSession(options: CreateSessionOptions): Promise<ContainerSession> {
+    try {
+      return await this.createSessionRequest(options)
+    } catch (error) {
+      if (!(error instanceof ContainerUnauthorizedError)) throw error
+      if (!(await this.recoverStaleHostAuth())) throw error
+      // Exactly one retry: a second 401 propagates as the typed error.
+      return await this.createSessionRequest(options)
+    }
+  }
+
+  /**
+   * Restart the container iff it is provably holding a superseded host token.
+   * Returns whether a retry is worth attempting.
+   */
+  private async recoverStaleHostAuth(): Promise<boolean> {
+    if (!this.config.restartAgent) return false
+
+    // Re-read the token from disk: this client may have memoized a header
+    // built before the store was rewritten.
+    this.hostAuthHeadersCache = undefined
+    const expectedId = hostTokenId(getOrCreateHostToken(this.config.agentId))
+    const observedId = await this.probeHostTokenId()
+
+    if (!observedId || observedId === expectedId) {
+      // Unknown (older container image that doesn't report an id) or the same
+      // generation — a real authorization failure, not a stale container.
+      // Stay typed and do not restart, so a persistent 401 can't loop.
+      addErrorBreadcrumb({
+        category: 'container',
+        message: 'Host-auth 401 with current token generation; not restarting',
+        data: { agentId: this.config.agentId, expectedId, observedId: observedId ?? 'unknown' },
+      })
+      return false
+    }
+
+    addErrorBreadcrumb({
+      category: 'container',
+      message: 'Restarting container holding a superseded host token',
+      data: { agentId: this.config.agentId, expectedId, observedId },
+    })
+    await this.config.restartAgent()
+    this.hostAuthHeadersCache = undefined
+    return true
+  }
+
+  /**
+   * Read the running container's non-secret host-token id from /health (the
+   * one endpoint that does not require host auth). Never carries token
+   * material. Returns null when unavailable.
+   */
+  private async probeHostTokenId(): Promise<string | null> {
+    try {
+      const port = await this.getPortOrThrow()
+      const response = await fetch(`${this.getBaseUrl(port)}/health`, {
+        signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+      })
+      if (!response.ok) return null
+      const body = await response.json()
+      const id = (body as { hostTokenId?: unknown }).hostTokenId
+      return typeof id === 'string' && id.length > 0 ? id : null
+    } catch {
+      return null
+    }
+  }
+
+  private async createSessionRequest(options: CreateSessionOptions): Promise<ContainerSession> {
     const port = await this.getPortOrThrow()
     const timeoutMs = 60000 // 60 second timeout
 
@@ -1183,6 +1276,16 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           }
         } catch {
           errorDetail = response.statusText
+        }
+
+        // An explicit host-auth rejection is its own failure mode: the
+        // container is requiring a host token this host is not sending.
+        // Keep it typed so createSession can attempt bounded recovery and so
+        // it never degrades into an unclassifiable "Failed to create session".
+        if (response.status === 401) {
+          throw new ContainerUnauthorizedError(
+            'Failed to start session - the agent rejected this request as unauthorized. Restart the agent and try again.'
+          )
         }
 
         // Check for known error patterns and provide user-friendly messages

--- a/src/shared/lib/container/host-auth-stale-token.electron-dd.test.ts
+++ b/src/shared/lib/container/host-auth-stale-token.electron-dd.test.ts
@@ -1,0 +1,201 @@
+/**
+ * ELECTRON-DD — recurring 401 from a running local agent.
+ *
+ * A container keeps requiring the host token it was *started* with. When the
+ * host's token store is lost or rewritten while that container keeps running
+ * (data-dir wipe, unreadable token file — host-token-store regenerates in that
+ * case), every policy-bearing request 401s forever: the agent is wedged and
+ * `createSession` reported it as an opaque "Failed to create session".
+ *
+ * Recovery must be evidence-based and bounded: restart + retry exactly once,
+ * and only when the container proves it is holding a *different* token
+ * generation. A current-generation 401 stays a typed error so it cannot loop.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import http from 'http'
+import type { AddressInfo } from 'net'
+import { hostTokenId } from './host-token-store'
+
+let currentHostToken = 'hostc_current'
+vi.mock('./host-token-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./host-token-store')>()
+  return { ...actual, getOrCreateHostToken: () => currentHostToken }
+})
+
+const breadcrumbs: { message: string; data?: Record<string, unknown> }[] = []
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addErrorBreadcrumb: (crumb: { message: string; data?: Record<string, unknown> }) => {
+    breadcrumbs.push(crumb)
+  },
+}))
+
+vi.mock('@shared/lib/config/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shared/lib/config/settings')>()),
+  getSettings: () => ({ container: {}, enableToolSearch: true, llmProvider: 'anthropic' }),
+  getAgentCapabilitySettings: () => ({}),
+}))
+vi.mock('@shared/lib/llm-provider', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shared/lib/llm-provider')>()),
+  getActiveLlmProvider: () => ({ id: 'anthropic', getContainerEnvVars: () => ({}) }),
+}))
+
+const { BaseContainerClient, ContainerUnauthorizedError } = await import('./base-container-client')
+type ContainerInfo = import('./types').ContainerInfo
+type ContainerConfig = import('./types').ContainerConfig
+
+/** Stands in for the agent container: /health is open, /sessions needs the token. */
+class FakeContainer {
+  readonly server: http.Server
+  sessionAttempts = 0
+  constructor(public acceptedToken: string, public reportTokenId: boolean = true) {
+    this.server = http.createServer((req, res) => {
+      if (req.url === '/health') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({
+          status: 'ok',
+          ...(this.reportTokenId ? { hostTokenId: hostTokenId(this.acceptedToken) } : {}),
+        }))
+        return
+      }
+      if (req.url === '/sessions' && req.method === 'POST') {
+        this.sessionAttempts++
+        req.resume()
+        if (req.headers['x-superagent-host-token'] !== this.acceptedToken) {
+          res.writeHead(401, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ error: 'Unauthorized' }))
+          return
+        }
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ id: 'session-1', status: 'active' }))
+        return
+      }
+      res.writeHead(404)
+      res.end()
+    })
+  }
+  async listen(): Promise<number> {
+    await new Promise<void>((resolve) => this.server.listen(0, '127.0.0.1', resolve))
+    return (this.server.address() as AddressInfo).port
+  }
+  async close(): Promise<void> {
+    await new Promise<void>((resolve) => this.server.close(() => resolve()))
+  }
+}
+
+function makeClient(port: number, restartAgent?: () => Promise<void>) {
+  class TestClient extends BaseContainerClient {
+    protected getRunnerCommand(): string {
+      return 'docker'
+    }
+    async getInfoFromRuntime(): Promise<ContainerInfo> {
+      return { status: 'running', port }
+    }
+  }
+  return new TestClient({ agentId: 'agent-1', restartAgent } as ContainerConfig)
+}
+
+describe('createSession host-auth recovery (ELECTRON-DD)', () => {
+  let container: FakeContainer
+  let port: number
+
+  beforeEach(() => {
+    breadcrumbs.length = 0
+    currentHostToken = 'hostc_current'
+  })
+
+  afterEach(async () => {
+    await container?.close()
+  })
+
+  it('restarts the container once and retries once when it holds a superseded token', async () => {
+    // Container was started with the *old* token; the host store now holds a new one.
+    container = new FakeContainer('hostc_stale')
+    port = await container.listen()
+    const restartAgent = vi.fn(async () => {
+      // A real restart boots the container with the host's current token.
+      container.acceptedToken = currentHostToken
+    })
+
+    const session = await makeClient(port, restartAgent).createSession({ initialMessage: 'hi' })
+
+    expect(session).toMatchObject({ id: 'session-1' })
+    expect(restartAgent).toHaveBeenCalledTimes(1)
+    expect(container.sessionAttempts).toBe(2) // original + exactly one retry
+  })
+
+  it('keeps a current-generation 401 typed and does not restart', async () => {
+    // Same generation on both sides, yet the container refuses: a real
+    // authorization failure, not a stale container.
+    container = new FakeContainer(currentHostToken)
+    port = await container.listen()
+    container.acceptedToken = currentHostToken
+    const restartAgent = vi.fn(async () => {})
+    // Force a 401 while still reporting the *current* token id.
+    const client = makeClient(port, restartAgent)
+    container.acceptedToken = currentHostToken
+    vi.spyOn(client, 'getHostAuthHeaders').mockReturnValue({ 'x-superagent-host-token': 'wrong' })
+
+    await expect(client.createSession({ initialMessage: 'hi' }))
+      .rejects.toBeInstanceOf(ContainerUnauthorizedError)
+
+    expect(restartAgent).not.toHaveBeenCalled()
+    expect(container.sessionAttempts).toBe(1)
+  })
+
+  it('retries at most once — a second 401 propagates as the typed error', async () => {
+    container = new FakeContainer('hostc_stale')
+    port = await container.listen()
+    // A restart that does not fix the token (e.g. the store rotated again).
+    const restartAgent = vi.fn(async () => {
+      container.acceptedToken = 'hostc_still_stale'
+    })
+
+    await expect(makeClient(port, restartAgent).createSession({ initialMessage: 'hi' }))
+      .rejects.toBeInstanceOf(ContainerUnauthorizedError)
+
+    expect(restartAgent).toHaveBeenCalledTimes(1)
+    expect(container.sessionAttempts).toBe(2)
+  })
+
+  it('does not restart a container that cannot report its token id (older image)', async () => {
+    container = new FakeContainer('hostc_stale', /* reportTokenId */ false)
+    port = await container.listen()
+    const restartAgent = vi.fn(async () => {})
+
+    await expect(makeClient(port, restartAgent).createSession({ initialMessage: 'hi' }))
+      .rejects.toBeInstanceOf(ContainerUnauthorizedError)
+
+    expect(restartAgent).not.toHaveBeenCalled()
+    expect(container.sessionAttempts).toBe(1)
+  })
+
+  it('never records token material — only one-way ids', async () => {
+    container = new FakeContainer('hostc_stale')
+    port = await container.listen()
+    const restartAgent = vi.fn(async () => {
+      container.acceptedToken = currentHostToken
+    })
+
+    await makeClient(port, restartAgent).createSession({ initialMessage: 'hi' })
+
+    const authCrumbs = breadcrumbs.filter((c) => /host token/i.test(c.message))
+    expect(authCrumbs.length).toBeGreaterThan(0)
+    const serialized = JSON.stringify(authCrumbs)
+    expect(serialized).not.toContain('hostc_')
+    expect(serialized).toContain(hostTokenId('hostc_stale'))
+  })
+})
+
+describe('hostTokenId', () => {
+  it('is stable, short and reveals no token material', () => {
+    const token = 'hostc_0123456789abcdef'
+    const id = hostTokenId(token)
+    expect(id).toBe(hostTokenId(token))
+    expect(id).toHaveLength(16)
+    expect(id).toMatch(/^[0-9a-f]+$/)
+    expect(token).not.toContain(id)
+    expect(hostTokenId('hostc_other')).not.toBe(id)
+  })
+})

--- a/src/shared/lib/container/host-token-store.ts
+++ b/src/shared/lib/container/host-token-store.ts
@@ -37,6 +37,18 @@ function readTokens(): HostTokens {
   }
 }
 
+/**
+ * Non-secret, one-way identifier for a host token ("key id").
+ *
+ * Used to tell whether a *running* container was started with the token the
+ * host is currently sending, without either side ever exchanging token
+ * material. A truncated SHA-256 of a 32-byte random secret is not reversible
+ * and is safe to log and to serve on the container's unauthenticated /health.
+ */
+export function hostTokenId(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex').slice(0, 16)
+}
+
 export function getOrCreateHostToken(agentSlug: string): string {
   const tokens = readTokens()
   const existing = tokens[agentSlug]


### PR DESCRIPTION
## Sentry issues covered

- **ELECTRON-DD** — recurring `Failed to create session: Unauthorized` from a running local agent (2 events, latest 0.5.4; a recurring Lima task returns 401)

## Evidence

`getOrCreateHostToken()` in `src/shared/lib/container/host-token-store.ts` regenerates silently whenever the store cannot be read:

```ts
} catch (error) {
  if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
    console.warn('[host-token-store] Unreadable token file; regenerating tokens:', error)
  }
  return {}                      // → getOrCreateHostToken mints a NEW token
}
```

But the container captures `SUPERAGENT_HOST_TOKEN` **at boot** (`agent-container/src/host-auth.ts`) and validates against that value for its entire life. So a container that is still running when the host store is lost or rewritten (data-dir wipe, unreadable/partially-written token file, a second data dir) will reject every host request forever — exactly the recurring-task 401 in this issue. `BaseContainerClient` additionally memoizes the header (`hostAuthHeadersCache`), so a client can also keep sending a token the store no longer holds.

`createSession()` then flattened that into an unclassifiable string error:

```ts
throw new Error(`Failed to create session: ${errorDetail || response.statusText}`)
```

— no 401 branch, no typing, and no recovery. The agent stays wedged until a human restarts it.

## Fix

**Compare non-secret generations, then recover exactly once.**

1. `agent-container` serves `hostTokenId` on `/health` (the one endpoint that is deliberately unauthenticated): a truncated SHA-256 "key id" of the token it booted with. Never the token, never a preview; omitted entirely when host auth is disabled.
2. Host side gains `hostTokenId(token)` in `host-token-store.ts` (same one-way construction).
3. An explicit `401` from the container now throws a typed `ContainerUnauthorizedError` instead of a generic `Error`.
4. `createSession()` wraps the request: on `ContainerUnauthorizedError` it drops the memoized auth header, re-reads the token from disk, probes `/health` and compares ids.
   - **ids differ** → the running container provably holds a superseded token → breadcrumb, `restartAgent()` (the manager-owned single-flight restart already used by the MicroVM dead-generation path), then **exactly one** retry.
   - **ids match**, `/health` unreachable, no `hostTokenId` (older container image), or no `restartAgent` hook → no restart, the typed error propagates. A persistent 401 therefore cannot loop.
   - a second 401 after the retry propagates as the typed error — there is no second recovery attempt.

Behaviour is unchanged for every non-401 path.

### Privacy

Breadcrumbs carry only `agentId` and the two 16-hex-char one-way ids (`expectedId` / `observedId`, or the literal `unknown`). No token values, no previews. A truncated SHA-256 of a 32-byte random secret is not reversible; the agent can already read its own boot environment (documented in `host-auth.ts`), so serving the id on `/health` adds no exposure.

## Tests

New: `src/shared/lib/container/host-auth-stale-token.electron-dd.test.ts` — drives the real `createSession` against an HTTP fake of the container (open `/health`, token-checked `POST /sessions`).

| Test | Covers |
| --- | --- |
| `restarts the container once and retries once when it holds a superseded token` | Stale generation recovers; `restartAgent` called 1×; exactly 2 session attempts |
| `keeps a current-generation 401 typed and does not restart` | Current generation stays unauthorized, no restart |
| `retries at most once — a second 401 propagates as the typed error` | Bounded retry, no loop |
| `does not restart a container that cannot report its token id (older image)` | Safe degradation |
| `never records token material — only one-way ids` | Breadcrumbs contain the id, never `hostc_…` |
| `hostTokenId` | Stable, 16 hex chars, non-reversible, distinct per token |

Extended: `agent-container/src/host-auth.test.ts` — id is one-way/stable/distinct, and `undefined` when host auth is disabled.

Results:
- `vitest run src/shared/lib/container/` → **967 passed / 5 skipped** (whole container suite, no regressions)
- `agent-container`: `vitest run src/host-auth.test.ts` → **5 passed**; `tsc --noEmit` clean
- root `tsc --noEmit` → clean
- Recovery verified as load-bearing: stubbing `recoverStaleHostAuth()` to return `false` turns the 3 recovery tests red (`3 failed | 3 passed`).

> Note: `npx eslint` cannot run in this environment (`Cannot find module 'ajv'`); unrelated to this change.

Sentry issues are intentionally **not** resolved by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
