### PR TITLE
fix(web): let Platform SSO launcher bypass the PWA service worker

### DIFF
--- a/e2e/specs/pwa-precache.spec.ts
+++ b/e2e/specs/pwa-precache.spec.ts
@@ -173,6 +173,17 @@ test.describe('PWA precaching service worker', () => {
     }
   })
 
+  test('SSO launcher navigations are not answered by navigateFallback', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('[data-testid="settings-button"]')).toBeVisible()
+    await waitForActiveServiceWorker(page)
+
+    const response = await page.goto('/auth/platform/start?return_to=%2F')
+    expect(response, 'launcher must reach the network, not the SW').not.toBeNull()
+    expect(response!.fromServiceWorker()).toBe(false)
+    await expect(page.getByTestId('route-not-found')).toHaveCount(0)
+  })
+
   test('API responses are never served from SW caches', async ({ page }) => {
     await page.goto('/')
     await expect(page.locator('[data-testid="settings-button"]')).toBeVisible()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,10 +48,9 @@ export default defineConfig({
         clientsClaim: true,
         // Everything the UI is made of; hdr-*.mp4 stay network-only (decorative).
         globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest,woff2}'],
-        // Offline/PWA document loads (deep links included) get the app shell.
-        // API routes must never fall back to HTML.
+        // Offline deep links get the app shell; /api and /auth (SSO launcher) must hit the network.
         navigateFallback: 'index.html',
-        navigateFallbackDenylist: [/^\/api\//],
+        navigateFallbackDenylist: [/^\/api\//, /^\/auth\//],
         // Vendor chunk exceeds workbox's 2MB default before compression.
         maximumFileSizeToCacheInBytes: 8 * 1024 * 1024,
         inlineWorkboxRuntime: true, // single sw.js file, nothing extra at the dist root


### PR DESCRIPTION
## Summary
- Returning visitors clicking **Open Cloud Agents** land on SuperAgent's SPA **Page not found** at `/auth/platform/start` instead of the Platform OIDC 302.
- Cause: [#693](https://github.com/SkillfulAgents/SuperAgent/pull/693) `navigateFallback` only denylisted `/api/`. The SSO launcher (`GET /auth/platform/start`, SUP-466) is a document navigation, so the SW serves cached `index.html` and TanStack Router 404s.
- Fresh / incognito users are unaffected (no SW yet). Curl to the same URL still 302s. This PR adds `/auth/` to `navigateFallbackDenylist` so the launcher hits the network.

## Test plan
- [x] `npm run test:e2e:pwa` — new case asserts `/auth/platform/start` is not answered by the SW (`fromServiceWorker() === false`, no `route-not-found`)
- [x] Returning browser (SW already installed): after this web build is deployed and `sw.js` activates, Open Cloud Agents 302s to `auth.gamutagents.com/authorize?...`
- [x] Incognito / first visit still 302s (unchanged)
- [x] Platform Open Cloud Agents href does **not** need to change


Made with [Cursor](https://cursor.com)