### PR TITLE
Fix Safari approval footer rendering

### DIFF
--- a/src/renderer/components/messages/request-item-actions.tsx
+++ b/src/renderer/components/messages/request-item-actions.tsx
@@ -16,14 +16,20 @@ export function RequestItemActions({ children, className, inline }: RequestItemA
 
   if (inline) {
     return (
-      <div className={cn('flex justify-end gap-2 pt-4', className)}>
+      <div
+        className={cn('flex justify-end gap-2 pt-4', className)}
+        data-request-item-actions="inline"
+      >
         {children}
       </div>
     )
   }
 
   return (
-    <div className="sticky bottom-0 z-10 -mx-4 -mb-4 mt-4 flex flex-col gap-2 border-t border-border bg-background px-4 pb-4 pt-4">
+    <div
+      className="shrink-0 flex flex-col gap-2 border-t border-border bg-background p-4"
+      data-request-item-actions="footer"
+    >
       <div className={cn('flex justify-end gap-2', className)}>{children}</div>
       {error ? <RequestError message={error} className="mt-0" /> : null}
     </div>

--- a/src/renderer/components/messages/request-item-shell.test.tsx
+++ b/src/renderer/components/messages/request-item-shell.test.tsx
@@ -100,6 +100,52 @@ describe('RequestItemShell', () => {
       expect(screen.queryByText(/Error:/)).not.toBeInTheDocument()
     })
 
+    it('keeps actions in a normal footer outside the scrollable card body', () => {
+      render(
+        <RequestItemShell
+          title="Tall request"
+          theme="orange"
+          data-testid="request-card"
+        >
+          <div data-testid="long-content">Long content</div>
+          <RequestItemActions>
+            <button type="button">Allow</button>
+          </RequestItemActions>
+        </RequestItemShell>
+      )
+
+      const card = screen.getByTestId('request-card')
+      const body = card.querySelector<HTMLElement>('[data-request-item-body]')
+      const actions = card.querySelector<HTMLElement>('[data-request-item-actions="footer"]')
+
+      expect(card).toHaveClass('flex', 'flex-col', 'overflow-hidden')
+      expect(card).not.toHaveClass('overflow-y-auto')
+      expect(body).toHaveClass('min-h-0', 'overflow-y-auto')
+      expect(body).toContainElement(screen.getByTestId('long-content'))
+      expect(body).not.toContainElement(actions)
+      expect(actions).not.toHaveClass('sticky')
+      expect(actions?.parentElement).toBe(card)
+    })
+
+    it('leaves explicitly inline actions inside the scrollable body', () => {
+      render(
+        <RequestItemShell title="Inline request" theme="blue" data-testid="request-card">
+          <div>
+            <RequestItemActions inline>
+              <button type="button">Connect</button>
+            </RequestItemActions>
+          </div>
+        </RequestItemShell>
+      )
+
+      const card = screen.getByTestId('request-card')
+      const body = card.querySelector<HTMLElement>('[data-request-item-body]')
+      const actions = card.querySelector<HTMLElement>('[data-request-item-actions="inline"]')
+
+      expect(body).toContainElement(actions)
+      expect(card.querySelector('[data-request-item-actions="footer"]')).toBeNull()
+    })
+
     it('renders headerRight content', () => {
       render(
         <RequestItemShell

--- a/src/renderer/components/messages/request-item-shell.tsx
+++ b/src/renderer/components/messages/request-item-shell.tsx
@@ -1,8 +1,8 @@
-import type { ReactNode } from 'react'
+import { Children, isValidElement, type ReactNode } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import { linkify } from '@renderer/lib/linkify'
-import { RequestItemErrorContext } from './request-item-actions'
+import { RequestItemActions, RequestItemErrorContext } from './request-item-actions'
 import { usePagination } from './pending-request-stack'
 import { StopSessionButton } from './stop-session-button'
 
@@ -165,12 +165,32 @@ export function RequestItemShell({
   const headerRightContent = paginationControls ?? headerRight
   const showStopButton = !!(sessionId && agentSlug)
 
+  // Action rows used to be sticky children of this scroll container. Safari
+  // can fail to paint that combination when the whole request card lives in
+  // the absolutely-positioned composer overlay. Split direct action rows into
+  // a real, non-scrolling footer instead. Inline action rows belong to their
+  // surrounding content and deliberately stay in the scrolling body.
+  const childNodes = Children.toArray(children)
+  const bodyChildren: ReactNode[] = []
+  const footerActions: ReactNode[] = []
+  for (const child of childNodes) {
+    if (
+      isValidElement<{ inline?: boolean }>(child) &&
+      child.type === RequestItemActions &&
+      !child.props.inline
+    ) {
+      footerActions.push(child)
+    } else {
+      bodyChildren.push(child)
+    }
+  }
+
   return (
     <div
-      className={cn('max-h-[50vh] overflow-y-auto', REQUEST_CARD_CLASS)}
+      className={cn('flex max-h-[50vh] flex-col overflow-hidden', REQUEST_CARD_CLASS)}
       {...dataAttrs}
     >
-      <div className="p-4">
+      <div className="min-h-0 overflow-y-auto p-4" data-request-item-body>
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-3">
             {titleNode}
@@ -190,10 +210,15 @@ export function RequestItemShell({
           </div>
           {subtitleNode}
           <RequestItemErrorContext.Provider value={error ?? null}>
-            {children}
+            {bodyChildren}
           </RequestItemErrorContext.Provider>
         </div>
       </div>
+      {footerActions.length > 0 && (
+        <RequestItemErrorContext.Provider value={error ?? null}>
+          {footerActions}
+        </RequestItemErrorContext.Provider>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What changed

- split pending-request cards into a scrollable content body and an in-flow action footer
- remove the nested `position: sticky` action row
- preserve specialized inline action layouts inside the scrollable body
- add regression coverage for footer placement, overflow ownership, and inline actions

## Why

Safari/WebKit could stop painting workflow approval buttons when a request card combined:

- an `overflow-y: auto` card capped with `50vh`
- a sticky action row
- the absolutely positioned composer overlay

Resizing the window forced a repaint and made the buttons reappear. The new layout removes that fragile sticky/overflow combination entirely.

## Impact

Approval actions remain visible at both tall and short window sizes. Long request content scrolls independently while the action footer stays reachable.

## Validation

- 167 shared request-card tests passed
- `npm run typecheck`
- ESLint on the changed files
- `git diff --check`
- browser validation at 1465×1033 and 1459×714
- tall → short → tall resize cycle confirmed both Run and Block remained visible and the footer stayed `position: static`
