### PR TITLE
fix(db): serialize SQLite startup across processes + narrow journal repair (ELECTRON-9T, HW, H9, HS, KV)

### DIFF
--- a/src/shared/lib/db/filesystem-class.ts
+++ b/src/shared/lib/db/filesystem-class.ts
@@ -1,0 +1,61 @@
+import crypto from 'crypto'
+
+/**
+ * Where the database file lives, coarsely — enough to diagnose "SQLite cannot
+ * lock this file" without ever recording a user path.
+ *
+ * SQLite's locking is unreliable on SMB/NFS shares (advisory locks are not
+ * honoured across clients), which shows up as unexplained SQLITE_BUSY /
+ * SQLITE_IOERR / SQLITE_PROTOCOL at startup. Users hit this by pointing
+ * SUPERAGENT_DB_PATH at a network drive or by syncing their data dir.
+ */
+export type DatabaseFilesystemClass = 'local' | 'network-share' | 'unknown'
+
+/** UNC (\\server\share, //server/share) is definitively a network share. */
+export function classifyDatabaseFilesystem(dbPath: string): DatabaseFilesystemClass {
+  if (/^(\\\\|\/\/)[^\\/]/.test(dbPath)) return 'network-share'
+  return 'local'
+}
+
+/** Opaque, stable identity for a database file — never the path itself. */
+export function databaseIdentity(dbPath: string): string {
+  return crypto.createHash('sha256').update(dbPath).digest('hex').slice(0, 12)
+}
+
+const LOCKING_ERROR_CODES = [
+  'SQLITE_BUSY',
+  'SQLITE_LOCKED',
+  'SQLITE_IOERR',
+  'SQLITE_PROTOCOL',
+  'SQLITE_READONLY',
+]
+
+/** SQLite's own error code, when the driver provides one. */
+export function sqliteErrorCode(error: unknown): string | null {
+  const code = (error as { code?: unknown } | null)?.code
+  return typeof code === 'string' && code.startsWith('SQLITE') ? code : null
+}
+
+export function isLockingError(error: unknown): boolean {
+  const code = sqliteErrorCode(error)
+  if (code && LOCKING_ERROR_CODES.some((c) => code.startsWith(c))) return true
+  return /database is locked|database table is locked/i.test(
+    error instanceof Error ? error.message : String(error)
+  )
+}
+
+/**
+ * Turn an unexplained locking failure on a network share into an actionable
+ * message instead of a bare SQLITE_BUSY. Returns null when the failure is not
+ * attributable to the filesystem.
+ */
+export function describeUnsupportedFilesystem(
+  filesystem: DatabaseFilesystemClass,
+  error: unknown
+): string | null {
+  if (filesystem !== 'network-share' || !isLockingError(error)) return null
+  return (
+    'The database is stored on a network share, where SQLite cannot lock the file reliably. ' +
+    'Move the data directory to a local disk (or set SUPERAGENT_DB_PATH to a local path) and restart.'
+  )
+}

--- a/src/shared/lib/db/index.ts
+++ b/src/shared/lib/db/index.ts
@@ -5,7 +5,27 @@ import * as schema from './schema'
 import fs from 'fs'
 import path from 'path'
 import { getDatabasePath, getDataDir } from '@shared/lib/config/data-dir'
-import { captureException } from '@shared/lib/error-reporting'
+import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
+import { withMigrationLock, MigrationLockTimeoutError } from './migration-lock'
+import { isDuplicateColumnError, repairJournalForAppliedMigration } from './migration-repair'
+import {
+  classifyDatabaseFilesystem,
+  databaseIdentity,
+  describeUnsupportedFilesystem,
+  sqliteErrorCode,
+} from './filesystem-class'
+
+/**
+ * How long a writer waits for another connection's write lock before giving
+ * up. Without this, better-sqlite3 fails an unlucky concurrent write
+ * immediately with SQLITE_BUSY — the app runs several writers (scheduler,
+ * renderer requests, container callbacks) plus, briefly, a second process
+ * during start/restart overlap.
+ */
+export const SQLITE_BUSY_TIMEOUT_MS = 10_000
+
+/** Upper bound on journal reconciliations in one startup — never a spin loop. */
+const MAX_JOURNAL_REPAIRS = 50
 
 // Run migrations on startup
 // This is safe to run on every start - it only applies pending migrations
@@ -24,11 +44,70 @@ function getMigrationsFolder(): string {
 let _sqlite: InstanceType<typeof Database> | null = null
 let _db: BetterSQLite3Database<typeof schema> | null = null
 
+/**
+ * Apply pending migrations under an inter-process lock.
+ *
+ * Exported for tests. The lock exists because drizzle's migrator reads "last
+ * applied migration" outside its transaction: two processes starting together
+ * both decide to apply the same files, and the loser either fails with
+ * "database is locked" or (once a busy timeout makes it wait) replays applied
+ * DDL and fails with "duplicate column name".
+ */
+export function runMigrations(
+  sqlite: InstanceType<typeof Database>,
+  db: BetterSQLite3Database<typeof schema>,
+  dbPath: string,
+  migrationsFolder: string
+): void {
+  withMigrationLock(dbPath, ({ stoleStaleLock, waitedMs }) => {
+    if (stoleStaleLock || waitedMs > 0) {
+      addErrorBreadcrumb({
+        category: 'database',
+        message: 'Acquired migration lock',
+        data: { waitedMs, stoleStaleLock, dbId: databaseIdentity(dbPath) },
+      })
+    }
+
+    // Each pass either applies the pending migrations or reconciles ONE
+    // already-applied migration into the journal. Bounded so a repair that
+    // stops making progress can never spin.
+    for (let repairs = 0; ; repairs++) {
+      try {
+        migrate(db, { migrationsFolder })
+        return
+      } catch (error) {
+        if (!isDuplicateColumnError(error) || repairs >= MAX_JOURNAL_REPAIRS) throw error
+
+        // The schema may simply be ahead of the journal (a racing starter
+        // applied it first). Repair the journal ONLY when every column the
+        // migration declares already exists with the exact declared shape.
+        const outcome = repairJournalForAppliedMigration(sqlite, migrationsFolder, error)
+        if (!outcome.repaired) {
+          addErrorBreadcrumb({
+            category: 'database',
+            message: 'Migration journal repair declined',
+            data: { reason: outcome.reason, tag: outcome.tag, dbId: databaseIdentity(dbPath) },
+          })
+          throw error
+        }
+
+        addErrorBreadcrumb({
+          category: 'database',
+          message: 'Recorded already-applied migration in the journal',
+          data: { tag: outcome.tag, columns: outcome.columns.length, dbId: databaseIdentity(dbPath) },
+        })
+      }
+    }
+  })
+}
+
 function initDb() {
   if (_db) return
 
   const dbPath = getDatabasePath()
   const dataDir = getDataDir()
+  const filesystem = classifyDatabaseFilesystem(dbPath)
+  const dbId = databaseIdentity(dbPath)
 
   // Data dir (settings/agents) and DB parent may differ when SUPERAGENT_DB_PATH is set.
   if (!fs.existsSync(dataDir)) {
@@ -41,27 +120,45 @@ function initDb() {
 
   try {
     _sqlite = new Database(dbPath)
+    // Set the busy timeout FIRST: every statement below (including the WAL
+    // switch, which needs an exclusive lock) can contend with another process.
+    _sqlite.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`)
     _sqlite.pragma('journal_mode = WAL')
     _sqlite.pragma('foreign_keys = ON')
   } catch (err) {
     captureException(err, {
-      tags: { component: 'database', operation: 'open' },
-      extra: { dbPath, dataDir },
+      tags: {
+        component: 'database',
+        operation: 'open',
+        filesystem,
+        sqliteCode: sqliteErrorCode(err) ?? 'none',
+      },
+      extra: { dbId },
       level: 'fatal',
     })
+    const diagnosis = describeUnsupportedFilesystem(filesystem, err)
+    if (diagnosis) throw new Error(diagnosis, { cause: err })
     throw err
   }
 
   _db = drizzle(_sqlite, { schema })
 
   try {
-    migrate(_db, { migrationsFolder: getMigrationsFolder() })
+    runMigrations(_sqlite, _db, dbPath, getMigrationsFolder())
   } catch (err) {
     captureException(err, {
-      tags: { component: 'database', operation: 'migrate' },
-      extra: { dbPath, migrationsFolder: getMigrationsFolder() },
+      tags: {
+        component: 'database',
+        operation: 'migrate',
+        filesystem,
+        sqliteCode: sqliteErrorCode(err) ?? 'none',
+        phase: err instanceof MigrationLockTimeoutError ? 'lock' : 'apply',
+      },
+      extra: { dbId },
       level: 'fatal',
     })
+    const diagnosis = describeUnsupportedFilesystem(filesystem, err)
+    if (diagnosis) throw new Error(diagnosis, { cause: err })
     throw err
   }
 }

--- a/src/shared/lib/db/migration-coordination.test.ts
+++ b/src/shared/lib/db/migration-coordination.test.ts
@@ -1,0 +1,387 @@
+/**
+ * ELECTRON-H9 / ELECTRON-HS / ELECTRON-9T / ELECTRON-HW / ELECTRON-KV —
+ * SQLite startup contention.
+ *
+ * drizzle's better-sqlite3 migrator reads "last applied migration" BEFORE it
+ * opens its transaction, then applies every newer migration inside it. Two
+ * processes starting together therefore both decide to apply the same files:
+ *
+ *   - with no busy timeout the loser dies immediately on "database is locked"
+ *     (H9/HS/9T/HW);
+ *   - with a busy timeout it waits, wakes after the winner commits, and
+ *     replays applied DDL → "duplicate column name: creation_method" (KV,
+ *     migration 0033).
+ *
+ * So the busy timeout alone just trades one failure for the other. These
+ * tests pin down all three parts of the fix: bounded lock waiting, an
+ * inter-process migration lock with stale recovery, and a NARROW journal
+ * repair that never blanket-ignores a duplicate column.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawn } from 'child_process'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import { withMigrationLock, MigrationLockTimeoutError } from './migration-lock'
+import {
+  columnMatches,
+  extractDuplicateColumn,
+  isDuplicateColumnError,
+  parseAddColumnMigration,
+  repairJournalForAppliedMigration,
+} from './migration-repair'
+import { runMigrations, SQLITE_BUSY_TIMEOUT_MS } from './index'
+import { classifyDatabaseFilesystem, describeUnsupportedFilesystem } from './filesystem-class'
+
+const MIGRATIONS_FOLDER = path.resolve(__dirname, 'migrations')
+const REPO_NODE_MODULES = path.resolve(__dirname, '../../../../node_modules')
+
+let tmpDir: string
+let dbPath: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-db-test-'))
+  dbPath = path.join(tmpDir, 'superagent.db')
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/** Runs `source` in a real second process; resolves with its exit code. */
+function runChild(source: string): { done: Promise<number> } {
+  const scriptPath = path.join(tmpDir, `child-${Math.random().toString(36).slice(2)}.cjs`)
+  fs.writeFileSync(scriptPath, source)
+  const child = spawn(process.execPath, [scriptPath], { stdio: ['ignore', 'pipe', 'pipe'] })
+  let stderr = ''
+  child.stderr.on('data', (chunk) => { stderr += String(chunk) })
+  const done = new Promise<number>((resolve, reject) => {
+    child.on('error', reject)
+    child.on('exit', (code) => (code === 0 ? resolve(0) : reject(new Error(`child exited ${code}: ${stderr}`))))
+  })
+  return { done }
+}
+
+// ---------------------------------------------------------------------------
+// Bounded lock waiting (busy_timeout)
+// ---------------------------------------------------------------------------
+
+describe('SQLite busy timeout', () => {
+  it('lets a second connection wait out another process\'s write transaction', async () => {
+    // A first process holds a write transaction for 400ms.
+    const holder = runChild(`
+      const Database = require(${JSON.stringify(path.join(REPO_NODE_MODULES, 'better-sqlite3'))});
+      const db = new Database(${JSON.stringify(dbPath)});
+      db.pragma('journal_mode = WAL');
+      db.exec('CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, v TEXT)');
+      db.exec('BEGIN IMMEDIATE');
+      db.prepare('INSERT INTO t (v) VALUES (?)').run('from-holder');
+      setTimeout(() => { db.exec('COMMIT'); db.close(); }, 400);
+    `)
+    // Wait for the child to actually hold the lock.
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    const patient = new Database(dbPath)
+    patient.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`)
+    // Blocks until the holder commits, then succeeds.
+    patient.prepare('INSERT INTO t (v) VALUES (?)').run('from-patient')
+    const rows = patient.prepare('SELECT v FROM t ORDER BY id').all() as { v: string }[]
+    patient.close()
+
+    expect(rows.map((r) => r.v)).toEqual(['from-holder', 'from-patient'])
+    await holder.done
+  })
+
+  it('fails immediately without a busy timeout (the pre-fix behaviour)', async () => {
+    const holder = runChild(`
+      const Database = require(${JSON.stringify(path.join(REPO_NODE_MODULES, 'better-sqlite3'))});
+      const db = new Database(${JSON.stringify(dbPath)});
+      db.pragma('journal_mode = WAL');
+      db.exec('CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, v TEXT)');
+      db.exec('BEGIN IMMEDIATE');
+      db.prepare('INSERT INTO t (v) VALUES (?)').run('from-holder');
+      setTimeout(() => { db.exec('COMMIT'); db.close(); }, 400);
+    `)
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    const impatient = new Database(dbPath)
+    impatient.pragma('busy_timeout = 0')
+    expect(() => impatient.prepare('INSERT INTO t (v) VALUES (?)').run('nope')).toThrow(/locked/i)
+    impatient.close()
+
+    await holder.done
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Inter-process migration lock
+// ---------------------------------------------------------------------------
+
+describe('withMigrationLock', () => {
+  it('serialises against another process holding the lock file', async () => {
+    const lockPath = `${dbPath}.migrate.lock`
+    const releasedAtPath = path.join(tmpDir, 'released-at')
+    const holder = runChild(`
+      const fs = require('fs');
+      const fd = fs.openSync(${JSON.stringify(lockPath)}, 'wx');
+      fs.writeFileSync(fd, 'child.owner');
+      fs.closeSync(fd);
+      setTimeout(() => {
+        fs.writeFileSync(${JSON.stringify(releasedAtPath)}, String(Date.now()));
+        fs.rmSync(${JSON.stringify(lockPath)}, { force: true });
+      }, 400);
+    `)
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    expect(fs.existsSync(lockPath)).toBe(true)
+
+    // Blocks (synchronously) until the other process releases.
+    const acquiredAt = withMigrationLock(dbPath, () => Date.now())
+    const releasedAt = Number(fs.readFileSync(releasedAtPath, 'utf-8'))
+
+    expect(acquiredAt).toBeGreaterThanOrEqual(releasedAt)
+    expect(fs.existsSync(lockPath)).toBe(false) // released again
+    await holder.done
+  })
+
+  it('times out instead of blocking forever on a live lock', () => {
+    fs.writeFileSync(`${dbPath}.migrate.lock`, 'someone.else')
+    expect(() => withMigrationLock(dbPath, () => 'never', { timeoutMs: 150, retryIntervalMs: 10 }))
+      .toThrow(MigrationLockTimeoutError)
+  })
+
+  it('steals a stale lock left behind by a crashed process', () => {
+    const lockPath = `${dbPath}.migrate.lock`
+    fs.writeFileSync(lockPath, 'dead.process')
+    const old = Date.now() / 1000 - 3600
+    fs.utimesSync(lockPath, old, old)
+
+    const outcome = withMigrationLock(dbPath, (o) => o, { timeoutMs: 500, staleMs: 60_000 })
+
+    expect(outcome.stoleStaleLock).toBe(true)
+    expect(fs.existsSync(lockPath)).toBe(false)
+  })
+
+  it('does not delete a lock that was stolen from us mid-run', () => {
+    const lockPath = `${dbPath}.migrate.lock`
+    withMigrationLock(dbPath, () => {
+      // Someone decided our lock was stale and took it over.
+      fs.writeFileSync(lockPath, 'later.owner')
+    })
+    expect(fs.readFileSync(lockPath, 'utf-8')).toBe('later.owner')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Two-process migration
+// ---------------------------------------------------------------------------
+
+describe('two-process migration', () => {
+  it('does not duplicate DDL or journal rows when two processes migrate at once', async () => {
+    // A real second process migrating the same file, taking the same lock.
+    const other = runChild(`
+      const fs = require('fs');
+      const Database = require(${JSON.stringify(path.join(REPO_NODE_MODULES, 'better-sqlite3'))});
+      const { drizzle } = require(${JSON.stringify(path.join(REPO_NODE_MODULES, 'drizzle-orm/better-sqlite3'))});
+      const { migrate } = require(${JSON.stringify(path.join(REPO_NODE_MODULES, 'drizzle-orm/better-sqlite3/migrator'))});
+      const lockPath = ${JSON.stringify(`${dbPath}.migrate.lock`)};
+      // Same O_EXCL protocol as withMigrationLock.
+      for (;;) {
+        try { const fd = fs.openSync(lockPath, 'wx'); fs.writeFileSync(fd, 'child'); fs.closeSync(fd); break; }
+        catch (e) { if (e.code !== 'EEXIST') throw e; Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25); }
+      }
+      try {
+        const sqlite = new Database(${JSON.stringify(dbPath)});
+        sqlite.pragma('busy_timeout = 10000');
+        sqlite.pragma('journal_mode = WAL');
+        migrate(drizzle(sqlite), { migrationsFolder: ${JSON.stringify(MIGRATIONS_FOLDER)} });
+        sqlite.close();
+      } finally {
+        if (fs.readFileSync(lockPath, 'utf-8') === 'child') fs.rmSync(lockPath, { force: true });
+      }
+    `)
+
+    const sqlite = new Database(dbPath)
+    sqlite.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`)
+    sqlite.pragma('journal_mode = WAL')
+    // Whichever process gets there second must not blow up.
+    expect(() => runMigrations(sqlite, drizzle(sqlite), dbPath, MIGRATIONS_FOLDER)).not.toThrow()
+    await other.done
+
+    const journal = sqlite
+      .prepare('SELECT hash, COUNT(*) AS n FROM __drizzle_migrations GROUP BY hash HAVING n > 1')
+      .all()
+    expect(journal).toEqual([]) // no migration recorded twice
+    const columns = sqlite.prepare('PRAGMA table_info(`session`)').all() as { name: string }[]
+    expect(columns.filter((c) => c.name === 'creation_method')).toHaveLength(1)
+    sqlite.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Partial migration: column present, journal row missing (ELECTRON-KV)
+// ---------------------------------------------------------------------------
+
+/**
+ * A miniature migrations folder shaped like the real one at the time of
+ * ELECTRON-KV: a table, then `ALTER TABLE session ADD creation_method text`
+ * (the repo's 0033_normal_whiplash.sql). Synthetic so the test pins the
+ * behaviour rather than whichever migration happens to be last today.
+ */
+function writeSyntheticMigrations(extraColumnMigration = false): string {
+  const folder = path.join(tmpDir, 'migrations')
+  fs.mkdirSync(path.join(folder, 'meta'), { recursive: true })
+  const entries = [
+    { tag: '0000_init', sql: 'CREATE TABLE `session` (\n\t`id` text PRIMARY KEY NOT NULL\n);\n', when: 1000 },
+    { tag: '0001_creation_method', sql: 'ALTER TABLE `session` ADD `creation_method` text;', when: 2000 },
+  ]
+  if (extraColumnMigration) {
+    entries.push({ tag: '0002_source', sql: 'ALTER TABLE `session` ADD `source` text;', when: 3000 })
+  }
+  for (const entry of entries) fs.writeFileSync(path.join(folder, `${entry.tag}.sql`), entry.sql)
+  fs.writeFileSync(
+    path.join(folder, 'meta', '_journal.json'),
+    JSON.stringify({
+      version: '7',
+      dialect: 'sqlite',
+      entries: entries.map((entry, idx) => ({
+        idx, version: '6', when: entry.when, tag: entry.tag, breakpoints: true,
+      })),
+    })
+  )
+  return folder
+}
+
+/** Migrate fully, then roll the journal watermark back to leave schema > journal. */
+function makeSchemaAheadOfJournal(folder: string, rollBackTo = 1): InstanceType<typeof Database> {
+  const sqlite = new Database(dbPath)
+  sqlite.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`)
+  migrate(drizzle(sqlite), { migrationsFolder: folder })
+  sqlite
+    .prepare('DELETE FROM __drizzle_migrations WHERE created_at > ?')
+    .run(rollBackTo * 1000)
+  return sqlite
+}
+
+describe('partial migration repair', () => {
+  it('records the already-applied migration instead of failing on duplicate column', () => {
+    const folder = writeSyntheticMigrations()
+    const sqlite = makeSchemaAheadOfJournal(folder)
+    const before = sqlite.prepare('SELECT COUNT(*) AS n FROM __drizzle_migrations').get() as { n: number }
+
+    // Baseline: plain drizzle fails on this database — the KV crash. drizzle
+    // wraps the driver error, so the SQLite text is on the cause chain.
+    let baselineError: unknown
+    try {
+      migrate(drizzle(sqlite), { migrationsFolder: folder })
+    } catch (error) {
+      baselineError = error
+    }
+    expect(baselineError).toBeInstanceOf(Error)
+    expect(isDuplicateColumnError(baselineError)).toBe(true)
+    expect(extractDuplicateColumn(baselineError)).toBe('creation_method')
+
+    // Our coordinated path repairs the journal and completes.
+    expect(() => runMigrations(sqlite, drizzle(sqlite), dbPath, folder)).not.toThrow()
+
+    const after = sqlite.prepare('SELECT COUNT(*) AS n FROM __drizzle_migrations').get() as { n: number }
+    expect(after.n).toBe(before.n + 1)
+    sqlite.close()
+  })
+
+  it('reconciles several already-applied column migrations without looping', () => {
+    const folder = writeSyntheticMigrations(true)
+    const sqlite = makeSchemaAheadOfJournal(folder) // both column migrations pending again
+
+    expect(() => runMigrations(sqlite, drizzle(sqlite), dbPath, folder)).not.toThrow()
+
+    const rows = sqlite.prepare('SELECT COUNT(*) AS n FROM __drizzle_migrations').get() as { n: number }
+    expect(rows.n).toBe(3)
+    sqlite.close()
+  })
+
+  it('stays fatal for a replayed non-column migration (never blanket-ignored)', () => {
+    const folder = writeSyntheticMigrations()
+    // Watermark rolled all the way back: CREATE TABLE replays. That is not a
+    // duplicate-column error and must not be swallowed.
+    const sqlite = makeSchemaAheadOfJournal(folder, 0)
+
+    expect(() => runMigrations(sqlite, drizzle(sqlite), dbPath, folder)).toThrow(/CREATE TABLE|already exists/i)
+    sqlite.close()
+  })
+
+  it('stays fatal when the existing column has a different shape', () => {
+    const folder = writeSyntheticMigrations()
+    const sqlite = makeSchemaAheadOfJournal(folder)
+    // Rebuild the column with an incompatible declaration.
+    sqlite.exec('ALTER TABLE `session` DROP COLUMN `creation_method`')
+    sqlite.exec('ALTER TABLE `session` ADD `creation_method` integer NOT NULL DEFAULT 0')
+
+    let error: unknown
+    try {
+      runMigrations(sqlite, drizzle(sqlite), dbPath, folder)
+    } catch (err) {
+      error = err
+    }
+    expect(isDuplicateColumnError(error)).toBe(true) // stays fatal, unrepaired
+    sqlite.close()
+  })
+
+  it('declines to repair when the column is genuinely missing', () => {
+    const folder = writeSyntheticMigrations()
+    const sqlite = makeSchemaAheadOfJournal(folder)
+    sqlite.exec('ALTER TABLE `session` DROP COLUMN `creation_method`')
+
+    const outcome = repairJournalForAppliedMigration(sqlite, folder, new Error('duplicate column name: creation_method'))
+
+    expect(outcome).toMatchObject({ repaired: false, reason: 'column-missing' })
+    sqlite.close()
+  })
+
+  it('never repairs a migration that does more than add columns', () => {
+    const statements = ['CREATE TABLE `x` (`id` text)', 'ALTER TABLE `x` ADD `y` text']
+    expect(parseAddColumnMigration(statements)).toBeNull()
+  })
+
+  it('classifies duplicate-column errors only, through the cause chain', () => {
+    expect(isDuplicateColumnError(new Error('duplicate column name: creation_method'))).toBe(true)
+    expect(isDuplicateColumnError(new Error('database is locked'))).toBe(false)
+    // drizzle's wrapper shape.
+    const wrapped = new Error("Failed to run the query 'ALTER TABLE ...'", {
+      cause: new Error('duplicate column name: creation_method'),
+    })
+    expect(isDuplicateColumnError(wrapped)).toBe(true)
+    expect(extractDuplicateColumn(wrapped)).toBe('creation_method')
+  })
+
+  it('compares the full declared shape, not just the name', () => {
+    const [declared] = parseAddColumnMigration(['ALTER TABLE `session` ADD `creation_method` text'])!
+    expect(columnMatches(declared, { name: 'creation_method', type: 'text', notnull: 0, dflt_value: null })).toBe(true)
+    expect(columnMatches(declared, { name: 'creation_method', type: 'integer', notnull: 0, dflt_value: null })).toBe(false)
+    expect(columnMatches(declared, { name: 'creation_method', type: 'text', notnull: 1, dflt_value: null })).toBe(false)
+    expect(columnMatches(declared, { name: 'creation_method', type: 'text', notnull: 0, dflt_value: "'x'" })).toBe(false)
+    expect(columnMatches(declared, undefined)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unsupported filesystems
+// ---------------------------------------------------------------------------
+
+describe('filesystem diagnosis', () => {
+  it('recognises UNC network shares', () => {
+    expect(classifyDatabaseFilesystem('\\\\nas\\share\\superagent.db')).toBe('network-share')
+    expect(classifyDatabaseFilesystem('//nas/share/superagent.db')).toBe('network-share')
+    expect(classifyDatabaseFilesystem('/Users/me/.superagent/superagent.db')).toBe('local')
+    expect(classifyDatabaseFilesystem('C:\\Users\\me\\superagent.db')).toBe('local')
+  })
+
+  it('explains a locking failure on a network share and stays quiet otherwise', () => {
+    const busy = Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' })
+    expect(describeUnsupportedFilesystem('network-share', busy)).toMatch(/network share/i)
+    expect(describeUnsupportedFilesystem('local', busy)).toBeNull()
+    expect(describeUnsupportedFilesystem('network-share', new Error('syntax error'))).toBeNull()
+  })
+})

--- a/src/shared/lib/db/migration-lock.ts
+++ b/src/shared/lib/db/migration-lock.ts
@@ -1,0 +1,136 @@
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+
+/**
+ * Synchronous inter-process lock for database startup (open + migrate).
+ *
+ * Why sync: the database is initialised lazily and synchronously (see
+ * `db/index.ts` — the exported `db`/`sqlite` proxies call `initDb()` on first
+ * property access), so the lock has to hold across a sync critical section.
+ * The async `withCrossProcessFileLock` in `utils/file-storage.ts` cannot be
+ * used here. Blocking is correct at this point: nothing in the process can do
+ * useful work until the schema exists.
+ *
+ * Why a lock at all: drizzle's better-sqlite3 migrator reads "last applied
+ * migration" BEFORE opening its transaction, then applies every newer
+ * migration inside it. Two processes starting together therefore both decide
+ * to apply the same migrations; the loser either fails outright with
+ * "database is locked" (no busy timeout) or — once a busy timeout makes it
+ * wait — wakes up after the winner commits and replays already-applied DDL,
+ * producing "duplicate column name". A busy timeout alone converts one
+ * failure into the other; serialising the whole read-decide-apply sequence is
+ * what actually fixes it.
+ */
+
+export interface MigrationLockOptions {
+  /** Max time to wait for the lock before throwing (ms). */
+  timeoutMs?: number
+  /** Poll interval while another process holds the lock (ms). */
+  retryIntervalMs?: number
+  /** A lock file older than this is treated as abandoned and stolen (ms). */
+  staleMs?: number
+}
+
+export const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 30_000
+const DEFAULT_RETRY_INTERVAL_MS = 50
+const DEFAULT_STALE_MS = 60_000
+
+/** Blocking sleep — safe here, and the only option in a sync critical section. */
+function sleepSync(ms: number): void {
+  const shared = new Int32Array(new SharedArrayBuffer(4))
+  Atomics.wait(shared, 0, 0, ms)
+}
+
+export class MigrationLockTimeoutError extends Error {
+  constructor(public readonly waitedMs: number) {
+    super(`Timed out after ${waitedMs}ms waiting for the database migration lock`)
+    this.name = 'MigrationLockTimeoutError'
+  }
+}
+
+export interface MigrationLockOutcome {
+  /** Whether an abandoned lock from a dead process had to be stolen. */
+  stoleStaleLock: boolean
+  /** How long acquisition blocked, for telemetry. */
+  waitedMs: number
+}
+
+/**
+ * Run `fn` while holding `<dbPath>.migrate.lock`.
+ *
+ * The lock file is created with O_EXCL and carries an owner token, so release
+ * only removes a lock we still own. A lock whose file is older than `staleMs`
+ * is assumed to belong to a process that died mid-migration and is stolen —
+ * otherwise one crash would wedge every future start.
+ */
+export function withMigrationLock<T>(
+  dbPath: string,
+  fn: (outcome: MigrationLockOutcome) => T,
+  options?: MigrationLockOptions
+): T {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS
+  const retryIntervalMs = options?.retryIntervalMs ?? DEFAULT_RETRY_INTERVAL_MS
+  const staleMs = options?.staleMs ?? DEFAULT_STALE_MS
+  const lockPath = `${dbPath}.migrate.lock`
+  const ownerToken = `${process.pid}.${crypto.randomBytes(8).toString('hex')}`
+
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true })
+
+  const startedAt = Date.now()
+  const deadline = startedAt + timeoutMs
+  let stoleStaleLock = false
+  let acquiredAt = 0
+
+  for (;;) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx')
+      try {
+        fs.writeFileSync(fd, ownerToken)
+      } finally {
+        fs.closeSync(fd)
+      }
+      acquiredAt = Date.now()
+      break
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'EEXIST') throw err
+      try {
+        const stat = fs.statSync(lockPath)
+        if (Date.now() - stat.mtimeMs > staleMs) {
+          // The holder died mid-migration (or the machine lost power). Steal
+          // rather than let one crash wedge every future start.
+          fs.rmSync(lockPath, { force: true })
+          stoleStaleLock = true
+          continue
+        }
+      } catch {
+        continue // vanished between open and stat — try again immediately
+      }
+      if (Date.now() >= deadline) {
+        throw new MigrationLockTimeoutError(Date.now() - startedAt)
+      }
+      sleepSync(retryIntervalMs)
+    }
+  }
+
+  try {
+    return fn({ stoleStaleLock, waitedMs: acquiredAt - startedAt })
+  } finally {
+    // Release only if the file still holds OUR token: a later starter may have
+    // stolen it as stale while we ran, and deleting theirs would let a third
+    // process in while they are mid-migration.
+    let current: string | null = null
+    try {
+      current = fs.readFileSync(lockPath, 'utf-8')
+    } catch {
+      current = null
+    }
+    if (current === ownerToken || (current === null && Date.now() - acquiredAt < staleMs)) {
+      try {
+        fs.rmSync(lockPath, { force: true })
+      } catch {
+        // Best effort: a leaked lock ages into staleness and is stolen.
+      }
+    }
+  }
+}

--- a/src/shared/lib/db/migration-repair.ts
+++ b/src/shared/lib/db/migration-repair.ts
@@ -1,0 +1,202 @@
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+
+/**
+ * Narrow repair for a database whose SCHEMA is ahead of its migration journal.
+ *
+ * How that state is reached: drizzle's better-sqlite3 migrator reads "last
+ * applied migration" before it opens its transaction, so two processes racing
+ * a start can both decide to apply the same file. Once the loser stops failing
+ * with "database is locked" (busy timeout) it replays already-applied DDL and
+ * dies with `duplicate column name: <col>` — and any tool that applies
+ * migrations outside the app (drizzle-kit) can leave the same divergence.
+ *
+ * The repair is deliberately narrow. A duplicate-column error is NEVER
+ * blanket-ignored: the migration in question must consist solely of ADD COLUMN
+ * statements, and every one of those columns must already exist with the exact
+ * declared shape (name, type, NOT NULL, DEFAULT). Only then is the journal row
+ * recorded so the migrator can move on. Anything else — a missing column, a
+ * column whose type/nullability/default differs, a migration that also creates
+ * tables or indexes — stays fatal, because the schema is genuinely not what
+ * the migration describes.
+ */
+
+export interface JournalMigration {
+  tag: string
+  /** `when` from meta/_journal.json — drizzle's `created_at`/folderMillis. */
+  when: number
+  /** sha256 of the raw file, exactly as drizzle computes it. */
+  hash: string
+  statements: string[]
+}
+
+export interface AddColumnStatement {
+  table: string
+  column: string
+  type: string
+  notNull: boolean
+  defaultValue: string | null
+}
+
+export type RepairOutcome =
+  | { repaired: true; tag: string; columns: string[] }
+  | { repaired: false; reason: string; tag?: string }
+
+const MIGRATIONS_TABLE = '__drizzle_migrations'
+
+/**
+ * Flatten an error and its `cause` chain: drizzle wraps driver failures in
+ * `Failed to run the query '<sql>'`, so the SQLite text we need to classify
+ * ("duplicate column name: x") only appears on the cause.
+ */
+function messageChain(error: unknown, depth = 0): string {
+  if (depth > 5 || error === null || error === undefined) return ''
+  const message = error instanceof Error ? error.message : String(error)
+  const cause = (error as { cause?: unknown })?.cause
+  return cause === undefined ? message : `${message}\n${messageChain(cause, depth + 1)}`
+}
+
+export function isDuplicateColumnError(error: unknown): boolean {
+  return /duplicate column name/i.test(messageChain(error))
+}
+
+export function extractDuplicateColumn(error: unknown): string | null {
+  return messageChain(error).match(/duplicate column name:\s*"?([A-Za-z0-9_]+)"?/i)?.[1] ?? null
+}
+
+/** Read the journal exactly the way drizzle's migrator does. */
+export function readJournalMigrations(migrationsFolder: string): JournalMigration[] {
+  const journalPath = path.join(migrationsFolder, 'meta', '_journal.json')
+  const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8')) as {
+    entries: { when: number; tag: string }[]
+  }
+  return journal.entries.map((entry) => {
+    const raw = fs.readFileSync(path.join(migrationsFolder, `${entry.tag}.sql`), 'utf-8')
+    return {
+      tag: entry.tag,
+      when: entry.when,
+      hash: crypto.createHash('sha256').update(raw).digest('hex'),
+      statements: raw
+        .split('--> statement-breakpoint')
+        .map((s) => s.trim().replace(/;\s*$/, '').trim())
+        .filter(Boolean),
+    }
+  })
+}
+
+const ADD_COLUMN_RE =
+  /^ALTER\s+TABLE\s+`?([A-Za-z0-9_]+)`?\s+ADD\s+(?:COLUMN\s+)?`?([A-Za-z0-9_]+)`?\s*(.*)$/is
+
+/**
+ * Parse a migration as a pure ADD COLUMN migration.
+ * Returns null if ANY statement is something else — such a migration is never
+ * repaired here.
+ */
+export function parseAddColumnMigration(statements: string[]): AddColumnStatement[] | null {
+  const parsed: AddColumnStatement[] = []
+  for (const statement of statements) {
+    const match = statement.match(ADD_COLUMN_RE)
+    if (!match) return null
+    const [, table, column, rest] = match
+    const declaration = rest.trim()
+    const notNull = /\bNOT\s+NULL\b/i.test(declaration)
+    const defaultMatch = declaration.match(/\bDEFAULT\s+(.+?)(?:\s+NOT\s+NULL\b|$)/i)
+    const type = declaration.replace(/\bNOT\s+NULL\b/i, '').replace(/\bDEFAULT\s+.*$/i, '').trim()
+    parsed.push({
+      table,
+      column,
+      type,
+      notNull,
+      defaultValue: defaultMatch ? defaultMatch[1].trim() : null,
+    })
+  }
+  return parsed
+}
+
+interface TableColumn {
+  name: string
+  type: string
+  notnull: number
+  dflt_value: string | null
+}
+
+/** Minimal surface of better-sqlite3 used here, so tests can drive it directly. */
+export interface SqliteLike {
+  prepare(sql: string): {
+    all(...params: unknown[]): unknown[]
+    get(...params: unknown[]): unknown
+    run(...params: unknown[]): unknown
+  }
+}
+
+function normalize(value: string | null): string | null {
+  return value === null ? null : value.trim().toLowerCase()
+}
+
+/** Whether the live column matches the migration's declaration exactly. */
+export function columnMatches(declared: AddColumnStatement, live: TableColumn | undefined): boolean {
+  if (!live) return false
+  if (normalize(live.type) !== normalize(declared.type)) return false
+  if ((live.notnull === 1) !== declared.notNull) return false
+  return normalize(live.dflt_value) === normalize(declared.defaultValue)
+}
+
+/**
+ * Record a fully-applied migration in the journal, or explain why we won't.
+ * Never mutates schema — the only write is the journal row.
+ */
+export function repairJournalForAppliedMigration(
+  sqlite: SqliteLike,
+  migrationsFolder: string,
+  error: unknown
+): RepairOutcome {
+  const duplicateColumn = extractDuplicateColumn(error)
+  if (!duplicateColumn) return { repaired: false, reason: 'not-a-duplicate-column-error' }
+
+  let migrations: JournalMigration[]
+  try {
+    migrations = readJournalMigrations(migrationsFolder)
+  } catch {
+    return { repaired: false, reason: 'journal-unreadable' }
+  }
+
+  // drizzle applies every migration newer than the newest recorded one.
+  const lastApplied = sqlite
+    .prepare(`SELECT created_at FROM ${MIGRATIONS_TABLE} ORDER BY created_at DESC LIMIT 1`)
+    .get() as { created_at?: number } | undefined
+  const lastAppliedAt = Number(lastApplied?.created_at ?? -1)
+
+  const candidate = migrations.find((migration) => {
+    if (migration.when <= lastAppliedAt) return false
+    const columns = parseAddColumnMigration(migration.statements)
+    return columns?.some((c) => c.column === duplicateColumn) ?? false
+  })
+  if (!candidate) return { repaired: false, reason: 'no-pending-add-column-migration-for-column' }
+
+  const declared = parseAddColumnMigration(candidate.statements)
+  if (!declared) {
+    return { repaired: false, reason: 'migration-is-not-pure-add-column', tag: candidate.tag }
+  }
+
+  for (const column of declared) {
+    const live = (
+      sqlite.prepare(`PRAGMA table_info(\`${column.table}\`)`).all() as TableColumn[]
+    ).find((c) => c.name === column.column)
+    if (!columnMatches(column, live)) {
+      // Either the migration is genuinely unapplied, or the live column has a
+      // different shape than the migration declares. Both must stay fatal.
+      return {
+        repaired: false,
+        reason: live ? 'column-shape-mismatch' : 'column-missing',
+        tag: candidate.tag,
+      }
+    }
+  }
+
+  sqlite
+    .prepare(`INSERT INTO ${MIGRATIONS_TABLE} ("hash", "created_at") VALUES (?, ?)`)
+    .run(candidate.hash, candidate.when)
+
+  return { repaired: true, tag: candidate.tag, columns: declared.map((c) => c.column) }
+}


### PR DESCRIPTION
## Sentry issues covered

- **ELECTRON-9T** (103 events) — SQLite lock failures on startup
- **ELECTRON-HW** (262 events) — SQLite lock failures on startup
- **ELECTRON-H9** — migration lock failure
- **ELECTRON-HS** — migration lock failure
- **ELECTRON-KV** — `duplicate column name: creation_method` (0.5.2)

## Evidence

These five are one bug, and the two symptoms are causally linked.

`drizzle-orm/sqlite-core` (`SQLiteDialect.migrate`, `dialect.cjs:662`) reads the watermark **outside** the transaction, then applies everything newer **inside** it:

```js
const dbMigrations = session.values(sql`SELECT id, hash, created_at FROM __drizzle_migrations ORDER BY created_at DESC LIMIT 1`);
const lastDbMigration = dbMigrations[0] ?? void 0;
session.run(sql`BEGIN`);                       // deferred — write lock taken at the first DDL
for (const migration of migrations) {
  if (!lastDbMigration || Number(lastDbMigration[2]) < migration.folderMillis) { … }
}
```

Two processes starting together (app + restart overlap, second window, scheduler wake) both read the same watermark and both decide to apply the same files.

- `src/shared/lib/db/index.ts` opened the database with **no `busy_timeout`**, so the loser's first DDL failed instantly → `database is locked` (**9T / HW / H9 / HS**).
- Add only a busy timeout and the loser *waits*, wakes after the winner commits, and — because its watermark decision was made before the wait — replays the DDL the winner just applied → `duplicate column name: creation_method`, which is `src/shared/lib/db/migrations/0033_normal_whiplash.sql`: `ALTER TABLE \`session\` ADD \`creation_method\` text;` (**KV**).

So the busy timeout alone would have converted one crash into the other. Serialising the whole read-decide-apply sequence is what actually fixes it. Both baselines are pinned as tests (see below).

## Fix

1. **`busy_timeout` immediately after open** (10s), *before* `journal_mode = WAL` — the WAL switch itself needs an exclusive lock and was contending too.
2. **Inter-process migration lock** — new `src/shared/lib/db/migration-lock.ts`: `<dbPath>.migrate.lock` via O_EXCL with an owner token, bounded wait (30s default), and **stale-lock stealing** (60s) so a process killed mid-migration can't wedge every future start. Release only removes a lock we still own, so a lock stolen from us is never deleted out from under its new holder.
   *Why a new sync primitive rather than the existing `withCrossProcessFileLock`:* the database is initialised lazily and **synchronously** (the exported `db`/`sqlite` proxies call `initDb()` on first property access), so the async helper cannot span this critical section. Blocking is correct here — nothing in the process can proceed without a schema.
3. **Narrow journal repair** — new `src/shared/lib/db/migration-repair.ts`. On `duplicate column name`, the journal is reconciled **only** when the offending pending migration consists *solely* of `ADD COLUMN` statements **and** every declared column already exists with the exact declared **type, NOT NULL and DEFAULT** (`PRAGMA table_info`). Then, and only then, its journal row is recorded so the migrator can move on. Everything else stays fatal:
   - column genuinely missing → `column-missing`
   - column present with a different shape → `column-shape-mismatch`
   - migration also creates a table/index → `migration-is-not-pure-add-column`
   Repairs are counted and capped, so they can never spin. Error classification walks the `cause` chain, because drizzle wraps driver errors as `Failed to run the query '…'` — the SQLite text is only on the cause.
4. **Unsupported filesystems** — new `src/shared/lib/db/filesystem-class.ts` classifies UNC/`//server/share` paths as `network-share`; a locking failure there now raises an actionable message ("SQLite cannot lock the file reliably… set `SUPERAGENT_DB_PATH` to a local path") instead of a bare `SQLITE_BUSY`.

### Privacy

Startup telemetry changed from `extra: { dbPath, dataDir }` (full user paths) to an **opaque `dbId`** (truncated SHA-256 of the path) plus tags for `phase` (`lock` vs `apply`), SQLite code, filesystem class, and lock timing / stale-steal. No rows, no SQL parameter values, no paths.

### Deliberately not done

The bundle also lists "retry only idempotent SQLITE_BUSY/LOCKED operations". A blanket write-retry wrapper would need per-call-site idempotency analysis and can silently double-apply non-idempotent writes. Bounded lock *waiting* (`busy_timeout`) is the mechanism SQLite provides for exactly this and covers the reported traces; a retry wrapper should be a separate, evidence-driven change.

## Tests

New: `src/shared/lib/db/migration-coordination.test.ts` — **17 tests, all green.** They use real second OS processes (`spawn`) against a real SQLite file, not mocks.

| Area | Tests |
| --- | --- |
| Bounded waiting | second connection waits out another **process's** write transaction and succeeds; **the pre-fix baseline** (`busy_timeout = 0`) fails with `database is locked` |
| Inter-process lock | serialises against a real second process holding the lock file (acquire timestamp ≥ the other process's release); times out instead of blocking forever; steals a stale lock; does not delete a lock stolen from us mid-run |
| Two-process migration | a real second process migrating the same DB under the same lock — no duplicate journal rows, exactly one `creation_method` column, no throw |
| Partial migration | column-present/journal-missing is repaired (**with the un-fixed drizzle path asserted to fail first**); several consecutive column migrations reconcile without looping; incompatible column shape stays fatal; genuinely missing column declines with `column-missing`; a replayed `CREATE TABLE` stays fatal; cause-chain classification |
| Filesystem | UNC/`//` recognised as `network-share`; locking failure there is explained; unrelated errors and local paths stay quiet |

Wider runs: `vitest run src/shared/lib/db/ src/shared/lib/services/` → **1310 passed / 17 skipped**. `tsc --noEmit` → clean.

> Note: `npx eslint` cannot run in this environment (`Cannot find module 'ajv'`); unrelated to this change.

Sentry issues are intentionally **not** resolved by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
