### PR TITLE
Smooth the streaming auto-scroll

### DIFF
--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -60,14 +60,26 @@ const TURN_ANCHOR_TOP = 100
 const TURN_ANCHOR_ANIMATION_MS = 220
 // Following the live edge by assigning scrollTop teleports the viewport by the
 // full height of whatever just arrived — a paragraph, a tool card — so the
-// thread reads as a series of jumps. Instead the follow glides: each frame
-// closes a fraction of the remaining distance, turning every burst into a short
-// slide. The step ceiling keeps a tall card from whipping past, and past the
-// snap distance gliding would read as drift, so we jump instead.
-const FOLLOW_SMOOTHING = 0.22
-const FOLLOW_MAX_STEP_PX = 32
+// thread reads as a series of jumps. Instead the viewport chases the edge on a
+// critically damped spring: it carries velocity across retargets, so a chunk
+// landing mid-motion bends the existing curve instead of kicking the speed to a
+// new value. Critically damped means it converges without overshoot, which
+// matters here because overshoot past the live edge would bounce the text.
+//
+// Stiffness is in rad/s (higher = tighter tracking, closer to the old snap);
+// ~7 settles a burst in roughly two thirds of a second, letting the viewport
+// trail the text and drift up to it. The velocity ceiling stops a tall tool
+// card from whipping past, and past the snap distance any easing reads as
+// sluggish drift rather than float, so we jump instead.
+const FOLLOW_STIFFNESS = 7
+const FOLLOW_MAX_VELOCITY_PX_S = 2400
 const FOLLOW_SNAP_PX = 900
 const FOLLOW_SETTLE_PX = 0.5
+// A dropped frame or a backgrounded window must not integrate one huge step.
+const FOLLOW_MAX_FRAME_S = 1 / 15
+// Beyond this the viewport moved without us (user gesture, layout jump), so the
+// spring resyncs to reality rather than fighting toward a stale position.
+const FOLLOW_RESYNC_PX = 2
 const TURN_WORK_REVEAL_CLASS = 'animate-in fade-in-0 slide-in-from-top-2 duration-200 ease-out motion-reduce:animate-none'
 const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
 
@@ -406,6 +418,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const scrollAnimationFrameRef = useRef<number | null>(null)
   const followFrameRef = useRef<number | null>(null)
   const followTargetRef = useRef(0)
+  const followPositionRef = useRef(0)
+  const followVelocityRef = useRef(0)
+  const followLastFrameRef = useRef(0)
   const animateNextTurnRef = useRef(false)
   const isScrolledToBottomRef = useRef(true)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
@@ -482,15 +497,17 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   }, [])
 
   const cancelFollowAnimation = useCallback(() => {
+    followVelocityRef.current = 0
     if (followFrameRef.current == null) return
     cancelAnimationFrame(followFrameRef.current)
     followFrameRef.current = null
   }, [])
 
-  // Glide toward the live edge instead of snapping to it. Re-entrant by design:
-  // streaming calls this on every content change, and an in-flight glide simply
-  // retargets, so a burst mid-slide extends the same motion rather than
-  // restarting it (which is what makes fixed-duration animations stutter here).
+  // Chase the live edge instead of snapping to it. Re-entrant by design:
+  // streaming calls this on every content change, and an in-flight chase simply
+  // retargets. Because the spring carries its velocity, retargeting bends the
+  // curve rather than restarting it — restart-per-chunk is exactly what makes
+  // fixed-duration animations stutter under a stream.
   const followLiveEdge = useCallback((el: HTMLDivElement) => {
     const target = Math.max(0, el.scrollHeight - el.clientHeight)
     followTargetRef.current = target
@@ -500,28 +517,58 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // Settled, moving backwards, or so far out that easing would read as drift.
     if (reduceMotion || distance <= FOLLOW_SETTLE_PX || distance > FOLLOW_SNAP_PX) {
       cancelFollowAnimation()
+      followVelocityRef.current = 0
       setScrollTop(el, target)
       return
     }
 
     if (followFrameRef.current != null) return
 
-    const tick = () => {
+    // Integrate against our own float position. Reading scrollTop back each
+    // frame would re-quantize to the compositor's rounding, and at the low
+    // speeds this settles into that lost fraction is visible as judder.
+    followPositionRef.current = el.scrollTop
+    followLastFrameRef.current = performance.now()
+
+    const tick = (now: number) => {
       const viewport = scrollRef.current
       if (!viewport) {
         followFrameRef.current = null
         return
       }
 
-      const remaining = followTargetRef.current - viewport.scrollTop
+      const elapsed = Math.min((now - followLastFrameRef.current) / 1000, FOLLOW_MAX_FRAME_S)
+      followLastFrameRef.current = now
+
+      if (Math.abs(viewport.scrollTop - followPositionRef.current) > FOLLOW_RESYNC_PX) {
+        followPositionRef.current = viewport.scrollTop
+        followVelocityRef.current = 0
+      }
+
+      const goal = followTargetRef.current
+      const remaining = goal - followPositionRef.current
       if (remaining <= FOLLOW_SETTLE_PX || remaining > FOLLOW_SNAP_PX) {
         followFrameRef.current = null
-        setScrollTop(viewport, followTargetRef.current)
+        followVelocityRef.current = 0
+        setScrollTop(viewport, goal)
         return
       }
 
-      const step = Math.min(Math.max(remaining * FOLLOW_SMOOTHING, 1), FOLLOW_MAX_STEP_PX)
-      setScrollTop(viewport, viewport.scrollTop + step)
+      // Analytic step of a critically damped spring, so the motion is identical
+      // at 60Hz and 120Hz and a long frame cannot overshoot.
+      const offset = followPositionRef.current - goal
+      const detached = followVelocityRef.current + FOLLOW_STIFFNESS * offset
+      const decay = Math.exp(-FOLLOW_STIFFNESS * elapsed)
+      followPositionRef.current = goal + (offset + detached * elapsed) * decay
+      followVelocityRef.current = Math.max(
+        -FOLLOW_MAX_VELOCITY_PX_S,
+        Math.min(
+          FOLLOW_MAX_VELOCITY_PX_S,
+          (followVelocityRef.current - FOLLOW_STIFFNESS * detached * elapsed) * decay,
+        ),
+      )
+
+      setScrollTop(viewport, followPositionRef.current)
       followFrameRef.current = requestAnimationFrame(tick)
     }
     followFrameRef.current = requestAnimationFrame(tick)

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -58,6 +58,16 @@ const BASE_WINDOW = 300
 const LOAD_STEP = 200
 const TURN_ANCHOR_TOP = 100
 const TURN_ANCHOR_ANIMATION_MS = 220
+// Following the live edge by assigning scrollTop teleports the viewport by the
+// full height of whatever just arrived — a paragraph, a tool card — so the
+// thread reads as a series of jumps. Instead the follow glides: each frame
+// closes a fraction of the remaining distance, turning every burst into a short
+// slide. The step ceiling keeps a tall card from whipping past, and past the
+// snap distance gliding would read as drift, so we jump instead.
+const FOLLOW_SMOOTHING = 0.22
+const FOLLOW_MAX_STEP_PX = 32
+const FOLLOW_SNAP_PX = 900
+const FOLLOW_SETTLE_PX = 0.5
 const TURN_WORK_REVEAL_CLASS = 'animate-in fade-in-0 slide-in-from-top-2 duration-200 ease-out motion-reduce:animate-none'
 const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
 
@@ -394,6 +404,8 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const programmaticScrollTopRef = useRef<number | null>(null)
   const lastScrollTopRef = useRef(0)
   const scrollAnimationFrameRef = useRef<number | null>(null)
+  const followFrameRef = useRef<number | null>(null)
+  const followTargetRef = useRef(0)
   const animateNextTurnRef = useRef(false)
   const isScrolledToBottomRef = useRef(true)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
@@ -469,6 +481,52 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     scrollAnimationFrameRef.current = null
   }, [])
 
+  const cancelFollowAnimation = useCallback(() => {
+    if (followFrameRef.current == null) return
+    cancelAnimationFrame(followFrameRef.current)
+    followFrameRef.current = null
+  }, [])
+
+  // Glide toward the live edge instead of snapping to it. Re-entrant by design:
+  // streaming calls this on every content change, and an in-flight glide simply
+  // retargets, so a burst mid-slide extends the same motion rather than
+  // restarting it (which is what makes fixed-duration animations stutter here).
+  const followLiveEdge = useCallback((el: HTMLDivElement) => {
+    const target = Math.max(0, el.scrollHeight - el.clientHeight)
+    followTargetRef.current = target
+    const distance = target - el.scrollTop
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    // Settled, moving backwards, or so far out that easing would read as drift.
+    if (reduceMotion || distance <= FOLLOW_SETTLE_PX || distance > FOLLOW_SNAP_PX) {
+      cancelFollowAnimation()
+      setScrollTop(el, target)
+      return
+    }
+
+    if (followFrameRef.current != null) return
+
+    const tick = () => {
+      const viewport = scrollRef.current
+      if (!viewport) {
+        followFrameRef.current = null
+        return
+      }
+
+      const remaining = followTargetRef.current - viewport.scrollTop
+      if (remaining <= FOLLOW_SETTLE_PX || remaining > FOLLOW_SNAP_PX) {
+        followFrameRef.current = null
+        setScrollTop(viewport, followTargetRef.current)
+        return
+      }
+
+      const step = Math.min(Math.max(remaining * FOLLOW_SMOOTHING, 1), FOLLOW_MAX_STEP_PX)
+      setScrollTop(viewport, viewport.scrollTop + step)
+      followFrameRef.current = requestAnimationFrame(tick)
+    }
+    followFrameRef.current = requestAnimationFrame(tick)
+  }, [cancelFollowAnimation, setScrollTop])
+
   const animateScrollTop = useCallback((el: HTMLDivElement, targetScrollTop: number) => {
     cancelScrollAnimation()
     const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
@@ -499,6 +557,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   }, [cancelScrollAnimation, setScrollTop])
 
   useEffect(() => cancelScrollAnimation, [cancelScrollAnimation])
+  useEffect(() => cancelFollowAnimation, [cancelFollowAnimation])
 
   // Keep the newly-sent turn fixed at its reading line while the response uses
   // up the reserved room below it. Once that room reaches zero, following the
@@ -530,14 +589,17 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       }
 
       if (!isScrolledToBottomRef.current || scrollAnimationFrameRef.current != null) return
-      setScrollTop(el, targetScrollTop)
+      // While the reserve holds the turn at its reading line the position is
+      // static, so there is nothing to smooth — only the live-edge case glides.
+      if (requiredSpacer > 0) setScrollTop(el, targetScrollTop)
+      else followLiveEdge(el)
       return
     }
 
     animateNextTurnRef.current = false
     if (!isScrolledToBottomRef.current || scrollAnimationFrameRef.current != null) return
-    setScrollTop(el, el.scrollHeight)
-  }, [animateScrollTop, setBottomSpacerHeight, setScrollTop])
+    followLiveEdge(el)
+  }, [animateScrollTop, followLiveEdge, setBottomSpacerHeight, setScrollTop])
 
   const handleScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
     const el = event.currentTarget
@@ -546,6 +608,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     const programmaticTarget = programmaticScrollTopRef.current
     const isProgrammatic =
       scrollAnimationFrameRef.current != null ||
+      followFrameRef.current != null ||
       (programmaticTarget != null && Math.abs(el.scrollTop - programmaticTarget) <= 1)
     if (isProgrammatic) {
       programmaticScrollTopRef.current = null
@@ -568,9 +631,14 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // this threshold pauses following, and returning within it resumes.
     const threshold = 80
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-    isScrolledToBottomRef.current = distanceFromBottom < threshold
-    // Show "scroll to bottom" button when scrolled up more than 300px
-    setShowScrollToBottom(distanceFromBottom > 300)
+    // A glide trails the live edge on purpose, and that lag can exceed the
+    // threshold. Reading it as "the user scrolled away" would disengage
+    // auto-follow mid-response, so while we are driving, following stands.
+    if (followFrameRef.current == null) {
+      isScrolledToBottomRef.current = distanceFromBottom < threshold
+      // Show "scroll to bottom" button when scrolled up more than 300px
+      setShowScrollToBottom(distanceFromBottom > 300)
+    }
 
     // Near the top with older messages still hidden: reveal the next chunk.
     // prevScrollHeightRef doubles as a re-entrancy guard so we expand at most once
@@ -599,11 +667,12 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     const el = scrollRef.current
     if (!el) return
     cancelScrollAnimation()
+    cancelFollowAnimation()
     anchoredTurnRef.current = null
     animateNextTurnRef.current = false
     setBottomSpacerHeight(0)
     el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
-  }, [cancelScrollAnimation, setBottomSpacerHeight])
+  }, [cancelFollowAnimation, cancelScrollAnimation, setBottomSpacerHeight])
 
   // Safety net: if isCompacting is true but a NEW compact boundary appears in fetched
   // messages, compaction is done and the SSE compact_complete event was missed.
@@ -1075,7 +1144,10 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const handleUserScrollIntent = useCallback(() => {
     programmaticScrollTopRef.current = null
     cancelScrollAnimation()
-  }, [cancelScrollAnimation])
+    // Hand the viewport back immediately — a glide that keeps running under a
+    // wheel gesture feels like the thread is fighting the reader.
+    cancelFollowAnimation()
+  }, [cancelFollowAnimation, cancelScrollAnimation])
 
   const handleScrollKey = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (SCROLL_KEYS.has(event.key)) handleUserScrollIntent()

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -67,18 +67,21 @@ const TURN_ANCHOR_ANIMATION_MS = 220
 // matters here because overshoot past the live edge would bounce the text.
 //
 // Stiffness is in rad/s (higher = tighter tracking, closer to the old snap);
-// ~7 settles a burst in roughly two thirds of a second, letting the viewport
-// trail the text and drift up to it. The velocity ceiling stops a tall tool
-// card from whipping past, and past the snap distance any easing reads as
-// sluggish drift rather than float, so we jump instead.
+// ~7 closes most of a burst inside the first half second and fully settles in
+// about a second, letting the viewport trail the text and drift up to it. The
+// velocity ceiling stops a tall tool card from whipping past, and past the
+// snap distance any easing reads as sluggish drift rather than float, so we
+// jump instead.
 const FOLLOW_STIFFNESS = 7
 const FOLLOW_MAX_VELOCITY_PX_S = 2400
 const FOLLOW_SNAP_PX = 900
 const FOLLOW_SETTLE_PX = 0.5
 // A dropped frame or a backgrounded window must not integrate one huge step.
 const FOLLOW_MAX_FRAME_S = 1 / 15
-// Beyond this the viewport moved without us (user gesture, layout jump), so the
-// spring resyncs to reality rather than fighting toward a stale position.
+// Beyond this the viewport moved without us. The scroll handler releases the
+// glide when an event deviates from the spring's position; this covers the
+// same-frame window before that event dispatches, resyncing to reality rather
+// than fighting toward a stale position for a frame.
 const FOLLOW_RESYNC_PX = 2
 const TURN_WORK_REVEAL_CLASS = 'animate-in fade-in-0 slide-in-from-top-2 duration-200 ease-out motion-reduce:animate-none'
 const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
@@ -517,7 +520,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // Settled, moving backwards, or so far out that easing would read as drift.
     if (reduceMotion || distance <= FOLLOW_SETTLE_PX || distance > FOLLOW_SNAP_PX) {
       cancelFollowAnimation()
-      followVelocityRef.current = 0
       setScrollTop(el, target)
       return
     }
@@ -576,6 +578,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
   const animateScrollTop = useCallback((el: HTMLDivElement, targetScrollTop: number) => {
     cancelScrollAnimation()
+    // A follow glide still in flight would keep writing scrollTop toward a
+    // stale live edge underneath this animation — two drivers, one viewport.
+    cancelFollowAnimation()
     const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
     const target = Math.min(Math.max(0, targetScrollTop), maxScrollTop)
     const start = el.scrollTop
@@ -601,7 +606,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       setScrollTop(el, anchoredTurn ? anchoredTurn.scrollTop : el.scrollHeight)
     }
     scrollAnimationFrameRef.current = requestAnimationFrame(tick)
-  }, [cancelScrollAnimation, setScrollTop])
+  }, [cancelFollowAnimation, cancelScrollAnimation, setScrollTop])
 
   useEffect(() => cancelScrollAnimation, [cancelScrollAnimation])
   useEffect(() => cancelFollowAnimation, [cancelFollowAnimation])
@@ -652,10 +657,26 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     const el = event.currentTarget
     const previousScrollTop = lastScrollTopRef.current
     lastScrollTopRef.current = el.scrollTop
+
+    // A glide writes scrollTop every frame, so its scroll events echo the
+    // spring's own position (give or take compositor quantization). An event
+    // that deviates means the viewport moved without us — a scrollbar drag,
+    // which unlike wheel/touch/keys fires no intent event, or a layout clamp.
+    // Hand the viewport back and read the event as the user's; if it was
+    // really a layout shift near the edge, the distance check below keeps
+    // following engaged and the next content change resumes the chase.
+    const followDriven =
+      followFrameRef.current != null &&
+      Math.abs(el.scrollTop - followPositionRef.current) <= 1
+    if (followFrameRef.current != null && !followDriven) {
+      cancelFollowAnimation()
+      programmaticScrollTopRef.current = null
+    }
+
     const programmaticTarget = programmaticScrollTopRef.current
     const isProgrammatic =
       scrollAnimationFrameRef.current != null ||
-      followFrameRef.current != null ||
+      followDriven ||
       (programmaticTarget != null && Math.abs(el.scrollTop - programmaticTarget) <= 1)
     if (isProgrammatic) {
       programmaticScrollTopRef.current = null
@@ -681,7 +702,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // A glide trails the live edge on purpose, and that lag can exceed the
     // threshold. Reading it as "the user scrolled away" would disengage
     // auto-follow mid-response, so while we are driving, following stands.
-    if (followFrameRef.current == null) {
+    if (!followDriven) {
       isScrolledToBottomRef.current = distanceFromBottom < threshold
       // Show "scroll to bottom" button when scrolled up more than 300px
       setShowScrollToBottom(distanceFromBottom > 300)
@@ -698,7 +719,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       isScrolledToBottomRef.current = false
       setWindowSize((n) => n + LOAD_STEP)
     }
-  }, [hiddenCount, setBottomSpacerHeight])
+  }, [cancelFollowAnimation, hiddenCount, setBottomSpacerHeight])
 
   // After a scroll-up expansion adds older messages above the viewport, restore the
   // scroll position so the content the user was reading stays put (no jump).


### PR DESCRIPTION
## Summary

Stacked on #720 — base is `codex/streaming-word-blur`, so this diff is only the scroll work. Merge #720 first (GitHub will retarget this to `main` automatically).

- chase the live edge on a critically damped spring instead of assigning `scrollTop` directly
- keep auto-follow engaged while the spring deliberately trails the edge
- hand the viewport back instantly on any wheel / touch / arrow-key gesture
- drop `will-change` from the per-word streaming spans

## Why

Auto-follow degraded to `setScrollTop(el, el.scrollHeight)` once a turn's reserved space ran out. That is a teleport, fired on every stream update and every ResizeObserver frame, so the viewport jumped by the exact height of whatever just arrived — ~24px for a line of prose, ~80-100px for a tool-call box. On long responses, which is when reading matters most, the thread jumped continuously.

The first attempt closed a fixed fraction of the remaining distance per frame. That was still rough for three reasons:

- **Display dependent.** A per-frame fraction converges twice as fast at 120Hz as at 60Hz, and every dropped frame changes the distance covered, so the motion was never twice the same.
- **Velocity kick per chunk.** Speed was a pure function of remaining distance, so each arriving chunk moved the target and changed the speed discontinuously — one hitch per chunk, which under a stream is constant.
- **Sub-pixel judder.** Reading `scrollTop` back each frame re-quantized to the compositor's rounding, most visible at the low speeds it settles into.

## Approach

The analytic step of a critically damped spring, integrated against elapsed time and its own float position. Velocity carries across retargets, so a chunk landing mid-motion bends the curve rather than restarting it — restart-per-chunk is what makes fixed-duration animations stutter here. 60Hz and 120Hz produce identical motion.

Critically damped rather than merely damped is deliberate: overshooting the live edge would bounce the text back, which reads worse than the jump this replaces. Guards: a velocity ceiling so a tall tool card cannot whip past, a snap distance past which easing would read as drift, resync if the viewport moves without us, and `prefers-reduced-motion` falls back to the old instant assignment.

Two integration details that would otherwise break it:

- The spring trails the live edge on purpose, and that lag exceeds the 80px "user scrolled away" threshold. Reading it as intent to leave would disengage auto-follow mid-response, so following stands while we are the one driving.
- Any user gesture cancels the chase immediately, so it never fights the reader for the viewport.

`FOLLOW_STIFFNESS` is the feel knob — currently 7 rad/s (floaty, settles in ~2/3s). Higher tracks tighter.

## Note on the `will-change` removal

#720 sets `will-change: filter, opacity` on every word span. The growing tail holds hundreds, so it asks the compositor for hundreds of layers at once, and the frames that costs surface as judder in the scroll chasing that same text. Removed — the animation is short and self-limiting, so the hint buys little. Flagging explicitly since it is @iddogino's code and the cost is device-dependent.

## Also fixed

Three `message-list` tests broken by #720: word-level spans mean streaming prose can no longer be matched by an exact `getByText`. They now match the innermost element whose combined text is the phrase. (Verified against `main` that these passed before #720.)

## Validation

- `npx tsc --noEmit`
- `npx vitest run src/renderer/components/messages/` — 773 passed
- ESLint on the changed files
- exercised by hand in the Electron dev app against a live streaming session

Scroll feel is subjective — worth a second pair of eyes on the stiffness value.