### PR TITLE
Cap markdown font weights at 500 and scale down heading sizes

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -97,6 +97,51 @@ const config: Config = {
 			'8xl': ['88px', { lineHeight: '5.875rem' }],
 			'9xl': ['120px', { lineHeight: '7.75rem' }],
 		},
+		// Inter is never rendered heavier than Medium (500) anywhere in the app,
+		// but @tailwindcss/typography's defaults reach 600-900 (h1 800, h2 700,
+		// h3/h4 600, strong 600 and up to 900 inside a heading, code/th/dt 600).
+		// Cap them here - one lever for every `prose` block (session markdown,
+		// thinking blocks, file previews, tool result cards) instead of a
+		// `prose-*:font-medium` per call site. These merge in AFTER the plugin's
+		// own rules at the same specificity, so a call site that wants something
+		// lighter (e.g. `prose-code:font-normal`) still overrides them.
+		typography: {
+			DEFAULT: {
+				css: {
+					strong: { fontWeight: '500' },
+					dt: { fontWeight: '500' },
+					code: { fontWeight: '500' },
+					'thead th': { fontWeight: '500' },
+					h1: { fontWeight: '500' },
+					h2: { fontWeight: '500' },
+					h3: { fontWeight: '500' },
+					h4: { fontWeight: '500' },
+					'h1 strong': { fontWeight: '500' },
+					'h2 strong': { fontWeight: '500' },
+					'h3 strong': { fontWeight: '500' },
+					'h4 strong': { fontWeight: '500' },
+					// A plain 2px rule. The plugin's 0.25rem (4px) bar reads as a slab
+					// next to 14px text, and stacks badly on nested quotes.
+					blockquote: { borderInlineStartWidth: '2px' },
+				},
+			},
+			// Heading scale for `prose-sm`, the size every markdown surface uses. The
+			// plugin's own sm scale is built for article layouts - a 30px h1 against
+			// 14px body - which is far too top-heavy inside a message bubble. Pulled
+			// down to 24/18/16/14 so a reply with headings reads as one block of text
+			// rather than as a document. These MUST live under `sm`, not DEFAULT:
+			// `.prose-sm` rules are emitted after `.prose` at equal specificity, so a
+			// font-size set on DEFAULT would be silently overridden by the modifier.
+			// (The weight cap above stays on DEFAULT - `sm` sets no font-weight.)
+			sm: {
+				css: {
+					h1: { fontSize: '1.7143em', marginTop: '0', marginBottom: '0.5em', lineHeight: '1.3333' },
+					h2: { fontSize: '1.2857em', marginTop: '1.3333em', marginBottom: '0.5556em', lineHeight: '1.4444' },
+					h3: { fontSize: '1.1429em', marginTop: '1.25em', marginBottom: '0.5em', lineHeight: '1.5' },
+					h4: { fontSize: '1em', marginTop: '1.2857em', marginBottom: '0.4286em', lineHeight: '1.4286' },
+				},
+			},
+		},
 		keyframes: {
 			'cobalt-glow': {
 				'0%, 100%': {


### PR DESCRIPTION
## What

Markdown in sessions renders through Tailwind's `prose` classes, whose typography defaults reach 600–900. Only `strong` was pulled back (via `prose-strong:font-medium` at one call site), so every heading in an agent reply rendered bold — and since Inter loads 600 and 700, these were real bold, not a synthesized fallback.

| | before | after |
|---|---|---|
| h1 | 30px / 800 | 24px / 500 |
| h2 | 20px / 700 | 18px / 500 |
| h3 | 18px / 600 | 16px / 500 |
| h4 | 14px / 600 | 14px / 500 |
| `strong` / `code` / `th` / `dt` | 600 | 500 |
| blockquote border | 4px | 2px |

The heading scale also comes down. The plugin's `sm` scale is built for article layouts — a 30px h1 against 14px body reads as a document, not a message. Margins come down with it so spacing stays proportional.

## Why the theme, not the call sites

The weight cap goes in `theme.extend.typography` rather than adding `prose-*:font-medium` to each of the ~7 call sites. The plugin's `DEFAULT.css` is an array, so these merge in last at equal specificity — covering session messages, thinking blocks, agent transcripts, workflow cards, web-search/fetch results and file previews at once, while a call site that wants something *lighter* (e.g. thinking-block's `prose-code:font-normal`) still overrides them.

## One non-obvious constraint

The sizes must live under `sm`, not `DEFAULT`. `.prose-sm` rules are emitted *after* `.prose` at identical specificity, so a `font-size` set on `DEFAULT` is silently overridden by the modifier and nothing changes. The weight cap stays on `DEFAULT` because `sm` sets no `font-weight` — the two don't collide. Both are commented at the call site.

## Verification

- Compiled the app's real `globals.css` against this config and confirmed every `prose` rule is now ≤ 500; the only 600/700 left in the output are the `.font-bold` / `.font-semibold` utility classes themselves.
- Rendered a markdown element showcase through the compiled stylesheet and checked computed values: h1 24px/500, h2 18px/500, h3 16px/500, h4 14px/500, blockquote border 2px.
- Ran in the Electron app.
- `npx vitest run src/renderer/components/messages` — 49 files, 768 tests pass. Typecheck and lint clean.

## Not included

Three heavy weights remain outside markdown, left alone deliberately:

- `bash.tsx` `font-bold` ×2 — terminal output styling, flagged for review previously and still open.
- `usage-tab.tsx` `font-semibold` — from the analytics redesign in 7c997622.
- `index.html` still requests Inter `600;700`. Trimming to `300;400;500` would enforce the rule at the source, but until the two above change it would give them synthesized faux-bold, which looks worse than real 600.

Also unchanged: `h5`/`h6` get no `prose` rule at all, so they render at 14px/400 — identical to body text. Distinguishing them needs color or letter-spacing, since size and weight are both used up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)