### PR TITLE
Fix subagent autoscroll snapping away from bottom

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2373,6 +2373,40 @@ describe('MessageList', () => {
       expect(geometry.scrollTop).toBe(800)
     })
 
+    it('retires a stale turn anchor when a scrollbar drag reaches the true bottom', () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+
+      geometry.setNaturalScrollHeight(1400)
+      // Dragging the scrollbar thumb produces pointerdown + scroll only — no
+      // wheel, touch, or key events — yet it is just as much an explicit trip
+      // to the live edge and must retire the reserve the same way.
+      fireEvent.pointerDown(el)
+      geometry.setScrollTop(1200)
+      fireEvent.scroll(el)
+
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '0px' })
+      expect(geometry.scrollTop).toBe(800)
+
+      mockStreamState.activeSubagents = [{
+        agentId: 'sub-1',
+        parentToolId: 'tool-1',
+        subagentType: 'Explore',
+        description: 'Explore workspace structure',
+      }]
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(800)
+    })
+
     it('follows within 80px of the bottom and resumes when the reader returns', () => {
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
       const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2168,7 +2168,9 @@ describe('MessageList', () => {
       let naturalScrollHeight = 1300
       let scrollTop = 700
       const anchorDocumentTop = 1200
-      const spacer = screen.getByTestId('turn-anchor-spacer')
+      const spacerHeight = () => Number.parseFloat(
+        (el.querySelector('[data-testid="turn-anchor-spacer"]') as HTMLElement | null)?.style.height || '0',
+      ) || 0
 
       vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
         matches: reducedMotion && query === '(prefers-reduced-motion: reduce)',
@@ -2183,12 +2185,18 @@ describe('MessageList', () => {
 
       Object.defineProperty(el, 'scrollHeight', {
         configurable: true,
-        get: () => naturalScrollHeight + (Number.parseFloat(spacer.style.height) || 0),
+        get: () => naturalScrollHeight + spacerHeight(),
       })
       Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => 600 })
       Object.defineProperty(el, 'scrollTop', {
         configurable: true,
-        get: () => scrollTop,
+        // Browsers clamp scrollTop when removing the turn spacer lowers the
+        // scrollable maximum. Model that here so retiring the reserve has the
+        // same observable effect as it does in the real transcript.
+        get: () => Math.min(
+          scrollTop,
+          Math.max(0, naturalScrollHeight + spacerHeight() - 600),
+        ),
         set: (value: number) => { scrollTop = value },
       })
 
@@ -2212,7 +2220,7 @@ describe('MessageList', () => {
       })
 
       return {
-        get scrollTop() { return scrollTop },
+        get scrollTop() { return el.scrollTop },
         setScrollTop(value: number) { scrollTop = value },
         setNaturalScrollHeight(value: number) { naturalScrollHeight = value },
       }
@@ -2325,6 +2333,44 @@ describe('MessageList', () => {
         <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
       )
       expect(geometry.scrollTop).toBe(releasedScrollTop)
+    })
+
+    it('retires a stale turn anchor when the reader manually reaches the true bottom', () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+
+      // A nested subagent card can grow before its ResizeObserver callback (or
+      // the next stream-state render) synchronizes the turn reserve. That makes
+      // a new, lower true bottom reachable while the old anchor is still live.
+      geometry.setNaturalScrollHeight(1400)
+      fireEvent.wheel(el, { deltaY: 200 })
+      geometry.setScrollTop(1200)
+      fireEvent.scroll(el)
+
+      // Reaching that true bottom is an explicit request to follow the live
+      // edge. The obsolete reading-line reserve must be retired immediately.
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '0px' })
+      expect(geometry.scrollTop).toBe(800)
+
+      // The next subagent update must stay bottom-pinned instead of restoring
+      // the old anchored scrollTop (the visible snap-up from the recording).
+      mockStreamState.activeSubagents = [{
+        agentId: 'sub-1',
+        parentToolId: 'tool-1',
+        subagentType: 'Explore',
+        description: 'Explore workspace structure',
+      }]
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(800)
     })
 
     it('follows within 80px of the bottom and resumes when the reader returns', () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -392,6 +392,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const bottomSpacerHeightRef = useRef(0)
   const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
   const programmaticScrollTopRef = useRef<number | null>(null)
+  const userScrollIntentRef = useRef(false)
   const lastScrollTopRef = useRef(0)
   const scrollAnimationFrameRef = useRef<number | null>(null)
   const animateNextTurnRef = useRef(false)
@@ -458,6 +459,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       Math.max(0, scrollTop),
       Math.max(0, el.scrollHeight - el.clientHeight),
     )
+    userScrollIntentRef.current = false
     programmaticScrollTopRef.current = nextScrollTop
     lastScrollTopRef.current = nextScrollTop
     el.scrollTop = nextScrollTop
@@ -471,6 +473,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
   const animateScrollTop = useCallback((el: HTMLDivElement, targetScrollTop: number) => {
     cancelScrollAnimation()
+    userScrollIntentRef.current = false
     const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
     const target = Math.min(Math.max(0, targetScrollTop), maxScrollTop)
     const start = el.scrollTop
@@ -556,12 +559,33 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // reserve's live edge, so that discarded blank area cannot be revisited.
     const anchoredTurn = anchoredTurnRef.current
     const upwardDelta = Math.max(0, previousScrollTop - el.scrollTop)
+    const downwardDelta = Math.max(0, el.scrollTop - previousScrollTop)
     if (!isProgrammatic && anchoredTurn && upwardDelta > 0 && bottomSpacerHeightRef.current > 0) {
       const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
       const remainingSpacer = bottomSpacerHeightRef.current - discard
       anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
       setBottomSpacerHeight(remainingSpacer)
       if (remainingSpacer === 0) anchoredTurnRef.current = null
+    }
+
+    // Reaching the actual live edge through a user scroll transfers ownership
+    // back to bottom-following. Keeping the turn anchor alive here lets the next
+    // subagent/layout update restore its old reading-line scrollTop, which is
+    // the visible snap-up even after the reader manually scrolled all the way
+    // down. Drop the reserve first; the browser clamps scrollTop to the new
+    // natural maximum synchronously.
+    const distanceFromBottomBeforeRelease = el.scrollHeight - el.scrollTop - el.clientHeight
+    if (
+      !isProgrammatic &&
+      userScrollIntentRef.current &&
+      downwardDelta > 0 &&
+      anchoredTurnRef.current &&
+      distanceFromBottomBeforeRelease <= 1
+    ) {
+      anchoredTurnRef.current = null
+      animateNextTurnRef.current = false
+      setBottomSpacerHeight(0)
+      lastScrollTopRef.current = el.scrollTop
     }
 
     // Proximity to the live edge is the auto-follow contract: moving beyond
@@ -599,6 +623,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     const el = scrollRef.current
     if (!el) return
     cancelScrollAnimation()
+    userScrollIntentRef.current = false
     anchoredTurnRef.current = null
     animateNextTurnRef.current = false
     setBottomSpacerHeight(0)
@@ -1005,6 +1030,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
     if (hasNewSend) {
       cancelScrollAnimation()
+      userScrollIntentRef.current = false
       isScrolledToBottomRef.current = true
       setShowScrollToBottom(false)
 
@@ -1073,6 +1099,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   }, [syncFollowPosition])
 
   const handleUserScrollIntent = useCallback(() => {
+    userScrollIntentRef.current = true
     programmaticScrollTopRef.current = null
     cancelScrollAnimation()
   }, [cancelScrollAnimation])

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -1273,6 +1273,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         onScroll={handleScroll}
         onWheel={handleUserScrollIntent}
         onTouchMove={handleUserScrollIntent}
+        // Scrollbar drags emit no wheel/touch/key events, only pointerdown +
+        // scroll — without this they would never register as user intent.
+        onPointerDown={handleUserScrollIntent}
         onKeyDown={handleScrollKey}
         role="region"
         aria-label="Messages"


### PR DESCRIPTION
## Summary

- retire a stale turn anchor when a user manually reaches the transcript's true live edge
- distinguish user scroll intent from programmatic scroll updates
- add a regression case for a growing subagent card invalidating the old turn reserve

## Root cause

The turn-anchor spacer could remain active after the reader manually scrolled to the actual bottom. When the variable-height subagent/working section changed again, the next synchronization restored the anchor's older `scrollTop`, producing the recorded snap upward and pushing live content beneath the working indicator.

## Impact

Once the reader returns to the true bottom, bottom-following now owns the scroll position again. Subsequent subagent and layout updates remain pinned to the live edge instead of reviving an obsolete reading-line anchor.

## Validation

- `npm run test:run -- src/renderer/components/messages/message-list.test.tsx` — 100 tests passed
- visually reproduced the supplied subagent/working-indicator sequence before the fix and confirmed the transcript remains bottom-pinned after the fix
