### PR TITLE
Restyle the activity card's planned-tasks section

### DIFF
--- a/src/renderer/components/messages/activity-card.tsx
+++ b/src/renderer/components/messages/activity-card.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@shared/lib/utils'
-import { ChevronDown, Circle, CircleCheckBig, Ellipsis, Monitor, X } from 'lucide-react'
+import { ChevronDown, Circle, CircleCheckBig, Loader2, Monitor, X } from 'lucide-react'
 import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from 'react'
 
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
@@ -222,6 +222,7 @@ export function ActivityCard({
             todos={todos}
             showAllTodos={showAllTodos}
             setShowAllTodos={setShowAllTodos}
+            followsTree={hasTreeRows}
           />
         )}
       </div>
@@ -470,7 +471,7 @@ function BackgroundTasksRow({ tasks, tracerRow }: {
 
 /**
  * The task list, under the tree rather than on it: the tree is live work, and
- * the plan is intent. A small "Plan" header owns the section, with the
+ * the plan is intent. A small "Planned Tasks" label owns the section, with the
  * truncation toggle beside it instead of spending a row on it. Items run
  * pending/in-progress first, then finished ones newest first.
  */
@@ -478,10 +479,13 @@ function TodoPlan({
   todos,
   showAllTodos,
   setShowAllTodos,
+  followsTree,
 }: {
   todos: Todo[]
   showAllTodos: boolean
   setShowAllTodos: (show: boolean) => void
+  /** Whether the live-work tree renders above this section. */
+  followsTree: boolean
 }) {
   const MAX_VISIBLE = 5
   const needsTruncation = todos.length > MAX_VISIBLE && !showAllTodos
@@ -504,33 +508,63 @@ function TodoPlan({
     hiddenTodos = todos.filter(t => !visibleSet.has(t))
   }
 
-  const hiddenPending = hiddenTodos.filter(t => t.status !== 'completed').length
-  const hiddenDone = hiddenTodos.filter(t => t.status === 'completed').length
+  // Shown expanded, the list hides nothing — so the toggle has to survive on
+  // the list being longer than the cap, or "Show less" would vanish the moment
+  // it did its job and strand the user in the long list.
+  const canToggleTruncation = hiddenTodos.length > 0 || todos.length > MAX_VISIBLE
 
   return (
-    <div className="mt-2 pl-6 text-xs" data-testid="activity-plan">
-      {/* Indented to the tree rows' own left edge so the two sections read as
-          one column, plan marks under tree marks. */}
-      <div className="flex items-center gap-2">
-        <span className="font-medium text-muted-foreground">Plan</span>
-        {hiddenTodos.length > 0 && (
+    // pl-3 puts the section on the tree's trunk (the rail's 12px x-offset, one
+    // notch left of the pl-6 branch rows), so the plan hangs off the same line
+    // the branches do rather than starting inside them.
+    //
+    // w-fit: the section is exactly as wide as its widest line, so the header
+    // and its rule stop at the longest task instead of running out past the
+    // list. max-w-md is the cap that keeps a long task from stretching the rule
+    // across the card — and it's what makes the rows' `truncate` reachable,
+    // since shrink-to-fit alone would just size to the full text.
+    //
+    // Following the tree, the section needs a real break: the tree's last row
+    // sits only space-y-1 off its neighbours, so at the header's own mt-2 the
+    // plan looked like one more branch. With no tree it hangs straight off the
+    // header row and that gap would just be a hole.
+    <div
+      className={cn('w-fit max-w-md pl-3 text-xs', followsTree ? 'mt-4' : 'mt-2')}
+      data-testid="activity-plan"
+    >
+      {/* Hairline under the header. Lighter than the tree rail's /25: the rail
+          is structure the eye follows, this rule only has to separate, and at
+          the rail's weight it competed with the rows above it. It starts at the
+          trunk (the section's pl-3) and ends at the section's own width cap,
+          which is what makes the plan read as its own section under the tree. */}
+      <div className="flex items-center gap-2 border-b border-muted-foreground/15 pb-1">
+        {/* A label, not a heading: it names the section for anyone scanning
+            past it and otherwise stays out of the way, so the task rows are
+            the darkest thing in their own section. */}
+        <span className="text-muted-foreground/70">Planned Tasks</span>
+        {/* One toggle rather than two labels: the two states are mutually
+            exclusive (nothing is hidden once everything is shown), and a single
+            control that stays put is easier to hit twice than a label that
+            moves. ml-auto parks it at the rule's right end, and the chevron
+            flips like the card's own disclosure so both read as the same
+            gesture. */}
+        {canToggleTruncation && (
           <button
-            onClick={() => setShowAllTodos(true)}
-            className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            type="button"
+            onClick={() => setShowAllTodos(!showAllTodos)}
+            // Same weight and color as the "Planned Tasks" label — the two ends
+            // of the header row are one line of chrome, not a label and a
+            // control competing. Only hover picks it out as clickable.
+            className="ml-auto flex shrink-0 cursor-pointer items-center gap-0.5 text-muted-foreground/70 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-expanded={showAllTodos}
           >
-            {hiddenTodos.length} more{': '}
-            {[
-              hiddenPending > 0 && `${hiddenPending} pending`,
-              hiddenDone > 0 && `${hiddenDone} done`,
-            ].filter(Boolean).join(', ')}
-          </button>
-        )}
-        {showAllTodos && todos.length > MAX_VISIBLE && (
-          <button
-            onClick={() => setShowAllTodos(false)}
-            className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-          >
-            Show fewer
+            {showAllTodos ? 'Show less' : 'Show more'}
+            {/* 12px to match the task marks, so the toggle keeps the header on
+                the same 16px line box as every other row. */}
+            <ChevronDown
+              className={cn('h-3 w-3 transition-transform', showAllTodos && 'rotate-180')}
+              aria-hidden="true"
+            />
           </button>
         )}
       </div>
@@ -540,11 +574,13 @@ function TodoPlan({
             <div
               className={cn(
                 'flex items-center gap-1.5',
-                // Only the task being worked on carries full weight. Pending
-                // used to sit at plain foreground, which made the row NOT being
-                // worked on the darkest thing in the list.
+                // The task being worked on steps up in color only — weight too
+                // made it the loudest thing on the card, louder than the
+                // header it sits under. One step of contrast is enough to find
+                // it. (Pending used to sit at plain foreground, which made the
+                // row NOT being worked on the darkest thing in the list.)
                 todo.status === 'in_progress'
-                  ? 'font-medium text-foreground'
+                  ? 'text-foreground'
                   : 'text-muted-foreground'
               )}
             >
@@ -557,7 +593,10 @@ function TodoPlan({
                   // thing in a finished row.
                   <CircleCheckBig className="h-3 w-3" aria-hidden data-testid="todo-status-completed" />
                 ) : todo.status === 'in_progress' ? (
-                  <Ellipsis className="h-3 w-3" aria-hidden data-testid="todo-status-in-progress" />
+                  // The app's one spinner (Loader2 + animate-spin), at the same
+                  // 12px box as the pending circle and the completed check — a
+                  // task's mark must not resize as it moves through the list.
+                  <Loader2 className="h-3 w-3 animate-spin" aria-hidden data-testid="todo-status-in-progress" />
                 ) : (
                   // Same 12px box and stroke as the check, so a task's mark
                   // doesn't change size when it completes.

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -598,8 +598,8 @@ describe('AgentActivityIndicator', () => {
     // The other 2 completed tasks are hidden
     expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
     expect(screen.queryByText('Task 2')).not.toBeInTheDocument()
-    // Shows the overflow indicator
-    expect(screen.getByText(/2 more.*2 done/)).toBeInTheDocument()
+    // Shows the overflow toggle
+    expect(screen.getByText('Show more')).toBeInTheDocument()
   })
 
   it('shows all tasks when toggle is clicked', async () => {
@@ -624,16 +624,21 @@ describe('AgentActivityIndicator', () => {
 
     // 1 task hidden
     expect(screen.queryByText('Task 6')).not.toBeInTheDocument()
-    expect(screen.getByText(/1 more.*1 pending/)).toBeInTheDocument()
+    expect(screen.getByText('Show more')).toBeInTheDocument()
 
     // Click toggle
-    act(() => { screen.getByText(/1 more/).click() })
+    act(() => { screen.getByText('Show more').click() })
 
     // All tasks now visible
     expect(screen.getByText('Task 6')).toBeInTheDocument()
-    expect(screen.queryByText(/1 more/)).not.toBeInTheDocument()
-    // "Show fewer" button appears
-    expect(screen.getByText('Show fewer')).toBeInTheDocument()
+    expect(screen.queryByText('Show more')).not.toBeInTheDocument()
+    // The toggle flips to its collapse label
+    expect(screen.getByText('Show less')).toBeInTheDocument()
+
+    // ...and back: the toggle survives being expanded rather than vanishing
+    act(() => { screen.getByText('Show less').click() })
+    expect(screen.queryByText('Task 6')).not.toBeInTheDocument()
+    expect(screen.getByText('Show more')).toBeInTheDocument()
   })
 
   it('prefers TaskCreate/TaskUpdate over TodoWrite when both exist', () => {


### PR DESCRIPTION
The planned-tasks section of the activity card sat at the branch rows' indent with a bold `Plan` header, a verbose truncation label, and an in-progress row heavy enough to be the loudest thing on the card — so it read as one more branch of the tree above it rather than its own section.

## Changes

**Position and width.** Moved onto the tree's trunk (`pl-6` → `pl-3`, the rail's own 12px x-offset) and switched to `w-fit` so the section hugs its widest line. `max-w-md` stays as the cap — it stops a long task from stretching the rule across the card, and it's what keeps the rows' `truncate` reachable, since shrink-to-fit alone would just size to the full text.

**A hairline under the header**, at `muted-foreground/15` — lighter than the tree rail's `/25`. The rail is structure the eye follows down the tree; this rule only has to separate, and at the rail's weight it competed with the branches above it.

**"Plan" → "Planned Tasks"**, dropped from `font-medium text-muted-foreground` to `text-muted-foreground/70`. It's a label, not a heading — the task rows should be the darkest thing in their own section.

**One truncation toggle instead of two labels.** `N more: X pending, Y done` / `Show fewer` collapse into `Show more` / `Show less` with a chevron that flips like the card's own disclosure. It's parked at the rule's right end via `ml-auto` and styled identically to the label, so the header reads as one line of chrome rather than a label and a control competing. The toggle now survives being expanded (it keys off `todos.length > MAX_VISIBLE`, not off there being hidden items) — otherwise "Show less" vanished the moment it did its job and stranded you in the long list.

**In-progress rows step up in color only** — dropping `font-medium` — and take the app's standard `Loader2 + animate-spin` in place of the `Ellipsis` glyph, at the same 12px box as the pending circle and the completed check, so a task's mark doesn't resize as it moves through the list.

**Top margin is conditional**: `mt-4` when the tree renders above the section, `mt-2` when it doesn't. With a tree, the last branch sits only `space-y-1` off its neighbours and 8px made the plan look like one more branch; with no tree the section hangs straight off the header row and 16px would just be a hole.

## Testing

`npm run typecheck` and `npm run lint` are clean (42 pre-existing warnings in unrelated files, 0 errors). The 49 tests in `agent-activity-indicator.test.tsx` pass — two were updated for the new toggle labels, and the toggle test now clicks back the other way, covering the survives-when-expanded behavior that nothing tested before.

Verified visually in the Electron dev app across a live turn with a subagent tree, truncated and expanded lists, and an in-progress task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)