### PR TITLE
Speed up dashboard first-run startup

### DIFF
--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -200,6 +200,12 @@ describe('DashboardManager log stream lifecycle', () => {
     stopAll(): Promise<void>
     getDashboardUpstreamPathMode(slug: string): 'stripped' | 'mounted'
     captureScreenshot(slug: string): Promise<{ ok: true; path: string } | { ok: false; reason: string }>
+    listDashboards(): Array<{
+      slug: string
+      status: string
+      startupPhase?: string
+      firstRun?: boolean
+    }>
   }
   let procs: FakeChildProcess[]
   let slugCounter = 0
@@ -397,8 +403,41 @@ describe('DashboardManager log stream lifecycle', () => {
 
       const info = await manager.startDashboard(slug)
 
-      expect(spawns.map((s) => s.args)).toEqual([['install'], ['run', 'start']])
+      expect(spawns.map((s) => s.args)).toEqual([
+        ['install', '--network-concurrency=8'],
+        ['run', 'start'],
+      ])
       expect(info.status).toBe('running')
+    })
+
+    it('publishes a distinct first-run phase while dependencies install', async () => {
+      const slug = await scaffoldDashboard()
+      await fs.promises.rm(path.join(testDir, slug, 'node_modules'), { recursive: true })
+      let installProc: FakeChildProcess | undefined
+      spawnHolder.impl = (_command, args) => {
+        const proc = new FakeChildProcess()
+        procs.push(proc)
+        if (args[0] === 'install') installProc = proc
+        return proc
+      }
+
+      const start = manager.startDashboard(slug, { forceInstall: false })
+
+      await vi.waitFor(() => expect(installProc).toBeDefined())
+      expect(manager.listDashboards()).toContainEqual(expect.objectContaining({
+        slug,
+        status: 'starting',
+        startupPhase: 'installing-dependencies',
+        firstRun: true,
+      }))
+
+      installProc!.exit(0)
+      await start
+
+      const running = manager.listDashboards().find((dashboard) => dashboard.slug === slug)
+      expect(running).toEqual(expect.objectContaining({ status: 'running' }))
+      expect(running).not.toHaveProperty('startupPhase')
+      expect(running).not.toHaveProperty('firstRun')
     })
 
     it('passes dashboard mount metadata to the dashboard process', async () => {
@@ -450,8 +489,8 @@ describe('DashboardManager log stream lifecycle', () => {
       const info = await manager.startDashboard(slug, { forceInstall: false })
 
       expect(spawns.map((s) => s.args)).toEqual([
-        ['install', '--frozen-lockfile'],
-        ['install'],
+        ['install', '--network-concurrency=8', '--frozen-lockfile'],
+        ['install', '--network-concurrency=8'],
         ['run', 'start'],
       ])
       expect(info.status).toBe('running')

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -15,6 +15,10 @@ const RESTART_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
 // Boot screenshots spawn a Chromium per dashboard; deferring them keeps the
 // container's few CPUs free for dashboard/server startup while users wait.
 const BOOT_SCREENSHOT_DELAY_MS = 10_000
+// Bun defaults to 48 concurrent network requests. Under Lima's virtualized
+// network that causes small package downloads to stall in long waves; eight
+// keeps the pipeline full without overwhelming the VM's network path.
+export const BUN_INSTALL_NETWORK_CONCURRENCY = 8
 export const SLUG_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 
 // dashboard.log is append-only across every start/crash/restart; without a
@@ -92,6 +96,7 @@ export function getDashboardBasePath(
 }
 
 export type DashboardStatus = 'running' | 'stopped' | 'crashed' | 'starting'
+export type DashboardStartupPhase = 'installing-dependencies' | 'starting-server'
 export type DashboardUpstreamPathMode = 'stripped' | 'mounted'
 
 export function getDashboardValidationUrl(
@@ -111,6 +116,8 @@ interface DashboardInfo {
   upstreamPathMode: DashboardUpstreamPathMode
   port: number
   status: DashboardStatus
+  startupPhase: DashboardStartupPhase
+  firstRun: boolean
   process: ChildProcess | null
   restartCount: number
   restartTimestamps: number[]
@@ -251,6 +258,7 @@ class DashboardManager {
     const port = existing?.port ?? this.nextPort++
     const dashboardDir = path.join(ARTIFACTS_DIR, slug)
     const logPath = path.join(dashboardDir, 'dashboard.log')
+    const firstRun = !fs.existsSync(path.join(dashboardDir, 'node_modules'))
 
     const info: DashboardInfo = {
       slug,
@@ -259,6 +267,8 @@ class DashboardManager {
       upstreamPathMode,
       port,
       status: 'starting',
+      startupPhase: 'starting-server',
+      firstRun,
       process: null,
       restartCount: existing?.restartCount ?? 0,
       restartTimestamps: existing?.restartTimestamps ?? [],
@@ -281,9 +291,15 @@ class DashboardManager {
 
       // Run bun install: always when forced (deps may have changed), else
       // only if node_modules is missing or package.json is newer than it
-      await this.runBunInstallIfNeeded(dashboardDir, info.logStream, forceInstall)
+      await this.runBunInstallIfNeeded(
+        dashboardDir,
+        info.logStream,
+        forceInstall,
+        () => { info.startupPhase = 'installing-dependencies' },
+      )
 
       // Start the dashboard server
+      info.startupPhase = 'starting-server'
       const dashboardBasePath = getDashboardBasePath(slug)
       const proc = spawn('bun', ['run', 'start'], {
         cwd: dashboardDir,
@@ -361,7 +377,8 @@ class DashboardManager {
   private async runBunInstallIfNeeded(
     dir: string,
     logStream: fs.WriteStream | undefined,
-    force: boolean
+    force: boolean,
+    onInstallStart: () => void,
   ): Promise<void> {
     if (!force) {
       const nodeModules = path.join(dir, 'node_modules')
@@ -379,6 +396,7 @@ class DashboardManager {
       // Boot-path install with a lockfile present: try --frozen-lockfile first
       // so the install is resolution-free and deterministic. If the lockfile
       // is out of sync with package.json, fall back to a plain install.
+      onInstallStart()
       if (this.hasLockfile(dir)) {
         try {
           return await this.runBunInstall(dir, logStream, ['--frozen-lockfile'])
@@ -386,6 +404,8 @@ class DashboardManager {
           logStream?.write('[DashboardManager] frozen-lockfile install failed, retrying without\n')
         }
       }
+    } else {
+      onInstallStart()
     }
     // Forced (agent-initiated) or no/stale lockfile: plain install, which
     // resolves and updates the lockfile as needed.
@@ -405,10 +425,14 @@ class DashboardManager {
     extraArgs: string[] = []
   ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const proc = spawn('bun', ['install', ...extraArgs], {
-        cwd: dir,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
+      const proc = spawn(
+        'bun',
+        ['install', `--network-concurrency=${BUN_INSTALL_NETWORK_CONCURRENCY}`, ...extraArgs],
+        {
+          cwd: dir,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      )
 
       let stderr = ''
       proc.stdout?.on('data', (chunk) => {
@@ -488,6 +512,8 @@ class DashboardManager {
     description: string
     status: DashboardStatus
     port: number
+    startupPhase?: DashboardStartupPhase
+    firstRun?: boolean
   }> {
     const result: Array<{
       slug: string
@@ -495,6 +521,8 @@ class DashboardManager {
       description: string
       status: DashboardStatus
       port: number
+      startupPhase?: DashboardStartupPhase
+      firstRun?: boolean
     }> = []
 
     // Include tracked dashboards
@@ -505,6 +533,9 @@ class DashboardManager {
         description: info.description,
         status: info.status,
         port: info.port,
+        ...(info.status === 'starting'
+          ? { startupPhase: info.startupPhase, firstRun: info.firstRun }
+          : {}),
       })
     }
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -652,6 +652,53 @@ describe('GET /:id/artifacts/:artifactSlug/view', () => {
     expect(iframe.src).toBe('/api/agents/test-agent/artifacts/sales/')
     expect(iframe.sandbox).toContain('allow-downloads')
   })
+
+  it('shows the first-run dependency phase while the standalone view waits', async () => {
+    const res = await getReq(createApp(), '/api/agents/test-agent/artifacts/sales/view')
+    const html = await res.text()
+    const installing = {
+      slug: 'sales',
+      name: 'Sales',
+      status: 'starting',
+      startupPhase: 'installing-dependencies',
+      firstRun: true,
+    }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([installing]), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'running' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([installing]), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { slug: 'sales', name: 'Sales', status: 'running' },
+      ]), { status: 200 }))
+    const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+    const appendChild = vi.fn()
+    const iframe: Record<string, string> = {}
+    const statusElement = { textContent: '', classList: { add: vi.fn() } }
+    const loadingElement = { remove: vi.fn() }
+    const document = {
+      title: '',
+      getElementById: (id: string) => id === 'status' ? statusElement : loadingElement,
+      createElement: () => iframe,
+      body: { appendChild },
+    }
+
+    expect(script).toBeDefined()
+    runInNewContext(script!, {
+      document,
+      fetch: fetchMock,
+      setTimeout: (callback: () => void) => {
+        callback()
+        return 0
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(appendChild).toHaveBeenCalledWith(iframe)
+    })
+
+    expect(statusElement.textContent).toBe('Preparing dashboard for first use…')
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
 })
 
 // ============================================================================

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -5805,6 +5805,13 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
           if (!d) { throw new Error('Dashboard not found.'); }
           if (d.status === 'crashed') { throw new Error('Dashboard crashed.'); }
           if (d.status === 'running') { setTitle(d.name); return; }
+          if (d.status === 'starting' && d.startupPhase === 'installing-dependencies') {
+            statusEl.textContent = d.firstRun
+              ? 'Preparing dashboard for first use…'
+              : 'Installing dashboard dependencies…';
+          } else {
+            statusEl.textContent = 'Starting dashboard…';
+          }
         }
         await new Promise(r => setTimeout(r, 1000));
       }

--- a/src/renderer/components/dashboards/dashboard-view-state.test.ts
+++ b/src/renderer/components/dashboards/dashboard-view-state.test.ts
@@ -75,6 +75,56 @@ describe('resolveDashboardViewState', () => {
     })
   })
 
+  it('explains the one-time dependency install on first run', () => {
+    expect(resolveDashboardViewState(input({
+      dashboard: {
+        status: 'starting',
+        startupPhase: 'installing-dependencies',
+        firstRun: true,
+      },
+    }))).toEqual({
+      kind: 'installing',
+      message: 'Preparing dashboard for first use…',
+      detail: 'Installing dependencies. This only happens once.',
+      showSpinner: true,
+      slow: false,
+      pollFast: true,
+    })
+  })
+
+  it('uses a dependency update label outside first run', () => {
+    expect(resolveDashboardViewState(input({
+      dashboard: {
+        status: 'starting',
+        startupPhase: 'installing-dependencies',
+        firstRun: false,
+      },
+    }))).toEqual({
+      kind: 'installing',
+      message: 'Installing dashboard dependencies…',
+      showSpinner: true,
+      slow: false,
+      pollFast: true,
+    })
+  })
+
+  it('offers recovery when dependency installation exceeds the wait bound', () => {
+    expect(resolveDashboardViewState(input({
+      dashboard: {
+        status: 'starting',
+        startupPhase: 'installing-dependencies',
+        firstRun: true,
+      },
+      waitElapsedMs: DASHBOARD_WAIT_BOUND_MS,
+    }))).toEqual({
+      kind: 'installing',
+      message: 'Dependency installation is taking longer than expected.',
+      showSpinner: false,
+      slow: true,
+      pollFast: false,
+    })
+  })
+
   it('surfaces crashed as terminal with no spinner', () => {
     expect(resolveDashboardViewState(input({ dashboard: { status: 'crashed' } }))).toEqual({
       kind: 'crashed',
@@ -119,6 +169,20 @@ describe('resolveDashboardViewState', () => {
   })
 
   describe('agent not running', () => {
+    it('shows first-run preparation while the agent itself starts', () => {
+      expect(resolveDashboardViewState(input({
+        agentRunning: false,
+        dashboard: { status: 'stopped', firstRun: true },
+      }))).toEqual({
+        kind: 'installing',
+        message: 'Preparing dashboard for first use…',
+        detail: 'Installing dependencies. This only happens once.',
+        showSpinner: true,
+        slow: false,
+        pollFast: true,
+      })
+    })
+
     it('shows starting with a spinner when auto-start can proceed', () => {
       expect(
         resolveDashboardViewState(input({ agentRunning: false, dashboard: undefined })),

--- a/src/renderer/components/dashboards/dashboard-view-state.ts
+++ b/src/renderer/components/dashboards/dashboard-view-state.ts
@@ -13,6 +13,14 @@ export type DashboardViewState =
       slow: boolean
       pollFast: boolean
     }
+  | {
+      kind: 'installing'
+      message: string
+      detail?: string
+      showSpinner: boolean
+      slow: boolean
+      pollFast: boolean
+    }
   | { kind: 'crashed'; message: string }
   | { kind: 'missing'; message: string }
   | { kind: 'ready' }
@@ -20,7 +28,7 @@ export type DashboardViewState =
 export type DashboardViewStateInput = {
   agentRunning: boolean
   artifactsLoaded: boolean
-  dashboard: Pick<ArtifactInfo, 'status'> | undefined
+  dashboard: Pick<ArtifactInfo, 'status' | 'startupPhase' | 'firstRun'> | undefined
   canStart: boolean
   startFailed: boolean
   waitElapsedMs: number
@@ -61,6 +69,16 @@ export function resolveDashboardViewState(input: DashboardViewStateInput): Dashb
         message: 'Agent is not running. Ask an admin to start it.',
       }
     }
+    if (dashboard?.firstRun) {
+      return {
+        kind: 'installing',
+        message: 'Preparing dashboard for first use…',
+        detail: 'Installing dependencies. This only happens once.',
+        showSpinner: true,
+        slow: false,
+        pollFast: true,
+      }
+    }
     return {
       kind: 'agent-starting',
       message: 'Starting agent…',
@@ -84,6 +102,34 @@ export function resolveDashboardViewState(input: DashboardViewStateInput): Dashb
 
   if (dashboard.status === 'running') {
     return { kind: 'ready' }
+  }
+
+  if (
+    dashboard.status === 'starting'
+    && dashboard.startupPhase === 'installing-dependencies'
+  ) {
+    if (slow) {
+      return {
+        kind: 'installing',
+        message: 'Dependency installation is taking longer than expected.',
+        showSpinner: false,
+        slow: true,
+        pollFast: false,
+      }
+    }
+
+    return {
+      kind: 'installing',
+      message: dashboard.firstRun
+        ? 'Preparing dashboard for first use…'
+        : 'Installing dashboard dependencies…',
+      ...(dashboard.firstRun
+        ? { detail: 'Installing dependencies. This only happens once.' }
+        : {}),
+      showSpinner: true,
+      slow: false,
+      pollFast: true,
+    }
   }
 
   // `starting` and queued `stopped` are both transient from outside.

--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   agentSlug: 'agent',
   agentStatus: 'running',
   dashboardStatus: 'crashed',
+  dashboardStartupPhase: undefined as undefined | 'installing-dependencies' | 'starting-server',
+  dashboardFirstRun: undefined as boolean | undefined,
   start: {
     mutate: vi.fn(),
     mutateAsync: vi.fn(),
@@ -41,6 +43,8 @@ vi.mock('@renderer/hooks/use-artifacts', () => ({
       description: '',
       status: mocks.dashboardStatus,
       port: 0,
+      startupPhase: mocks.dashboardStartupPhase,
+      firstRun: mocks.dashboardFirstRun,
     }],
   }),
 }))
@@ -84,6 +88,8 @@ describe('DashboardView restart', () => {
     mocks.agentSlug = 'agent'
     mocks.agentStatus = 'running'
     mocks.dashboardStatus = 'crashed'
+    mocks.dashboardStartupPhase = undefined
+    mocks.dashboardFirstRun = undefined
     mocks.start.mutateAsync.mockResolvedValue({})
   })
 
@@ -112,6 +118,17 @@ describe('DashboardView restart', () => {
     expect(mocks.start.mutateAsync).toHaveBeenCalledOnce()
   })
 
+  it('renders the first-run dependency installation state', () => {
+    mocks.dashboardStatus = 'starting'
+    mocks.dashboardStartupPhase = 'installing-dependencies'
+    mocks.dashboardFirstRun = true
+
+    render(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+
+    expect(screen.getByText('Preparing dashboard for first use…')).toBeInTheDocument()
+    expect(screen.getByText('Installing dependencies. This only happens once.')).toBeInTheDocument()
+  })
+
   it('shows a running dashboard without waiting for the iframe load event', () => {
     mocks.dashboardStatus = 'running'
     const frame = () => document.querySelector('iframe')
@@ -135,6 +152,18 @@ describe('DashboardView restart', () => {
     expect(waiting()).toBeNull()
   })
 
+  it('shows the toolbar spinner until the first iframe document loads', () => {
+    mocks.dashboardStatus = 'running'
+    render(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    const frame = document.querySelector('iframe')!
+
+    expect(screen.getByRole('button', { name: 'Loading dashboard' })).toBeDisabled()
+
+    fireEvent.load(frame)
+
+    expect(screen.getByRole('button', { name: 'Refresh dashboard' })).not.toBeDisabled()
+  })
+
   it('uses the canonical agent id for the mounted dashboard URL', () => {
     mocks.agentSlug = 'abc1234567'
     mocks.dashboardStatus = 'running'
@@ -152,6 +181,7 @@ describe('DashboardView restart', () => {
     mocks.dashboardStatus = 'running'
     render(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
     const frame = document.querySelector('iframe')!
+    fireEvent.load(frame)
 
     await userEvent.click(screen.getByRole('button', { name: 'Refresh dashboard' }))
 

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -28,6 +28,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const [now, setNow] = useState(() => Date.now())
   const [restarting, setRestarting] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
+  const [frameLoading, setFrameLoading] = useState(true)
   const [restartError, setRestartError] = useState<string | null>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const waitStartedAtRef = useRef<number | null>(null)
@@ -77,7 +78,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     waitElapsedMs,
   })
 
-  const nextPollFast = viewState.kind === 'waiting' && viewState.pollFast
+  const nextPollFast = 'pollFast' in viewState && viewState.pollFast
   useEffect(() => {
     setPollFast((prev) => (prev === nextPollFast ? prev : nextPollFast))
   }, [nextPollFast])
@@ -92,6 +93,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const handleRefresh = useCallback(() => {
     if (iframeRef.current) {
       setRefreshing(true)
+      setFrameLoading(true)
       iframeRef.current.src = iframeSrc
     }
   }, [iframeSrc])
@@ -133,6 +135,10 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
 
   const showFrame = isAgentRunning && dashboard?.status === 'running'
   const actionPending = restarting || stopAgent.isPending || startAgent.isPending
+
+  useEffect(() => {
+    if (showFrame) setFrameLoading(true)
+  }, [iframeSrc, showFrame])
 
   if (!showFrame) {
     return (
@@ -180,11 +186,15 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
             variant="ghost"
             size="sm"
             onClick={handleRefresh}
-            disabled={refreshing}
-            title={refreshing ? 'Refreshing…' : 'Refresh'}
-            aria-label={refreshing ? 'Refreshing dashboard' : 'Refresh dashboard'}
+            disabled={frameLoading}
+            title={refreshing ? 'Refreshing…' : frameLoading ? 'Loading dashboard…' : 'Refresh'}
+            aria-label={refreshing
+              ? 'Refreshing dashboard'
+              : frameLoading
+                ? 'Loading dashboard'
+                : 'Refresh dashboard'}
           >
-            {refreshing
+            {frameLoading
               ? <Loader2 className="h-3 w-3 animate-spin" />
               : <RefreshCw className="h-3 w-3" />}
           </Button>
@@ -206,7 +216,10 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
           title={dashboard?.name || dashboardSlug}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
           allow="microphone; camera"
-          onLoad={() => setRefreshing(false)}
+          onLoad={() => {
+            setFrameLoading(false)
+            setRefreshing(false)
+          }}
         />
       </div>
     </div>
@@ -237,7 +250,7 @@ function DashboardStatusBody({
   const showSpinner = 'showSpinner' in viewState && viewState.showSpinner
   const showRetry = viewState.kind === 'agent-start-failed' && canStart
   const showRestart =
-    (viewState.kind === 'crashed' || (viewState.kind === 'waiting' && viewState.slow))
+    (viewState.kind === 'crashed' || ('slow' in viewState && viewState.slow))
     && canStart
 
   return (
@@ -246,6 +259,9 @@ function DashboardStatusBody({
         {showSpinner && <Loader2 className="h-4 w-4 animate-spin" />}
         <p className="text-base">{viewState.message}</p>
       </div>
+      {'detail' in viewState && viewState.detail && (
+        <p className="text-sm text-muted-foreground">{viewState.detail}</p>
+      )}
       {showRetry && (
         <Button onClick={onRetry} disabled={retryPending}>
           <Play className="mr-2 h-4 w-4" />

--- a/src/renderer/hooks/use-artifacts.ts
+++ b/src/renderer/hooks/use-artifacts.ts
@@ -7,6 +7,8 @@ export interface ArtifactInfo {
   description: string
   status: 'running' | 'stopped' | 'crashed' | 'starting'
   port: number
+  startupPhase?: 'installing-dependencies' | 'starting-server'
+  firstRun?: boolean
 }
 
 /**

--- a/src/shared/lib/services/artifact-service.test.ts
+++ b/src/shared/lib/services/artifact-service.test.ts
@@ -39,6 +39,7 @@ describe('artifact-service', () => {
       path.join(dir, 'package.json'),
       JSON.stringify(pkg)
     )
+    fs.mkdirSync(path.join(dir, 'node_modules'))
     return dir
   }
 
@@ -206,6 +207,23 @@ describe('artifact-service', () => {
         expect(artifact.status).toBe('stopped')
         expect(artifact.port).toBe(0)
       }
+    })
+
+    it('marks a dashboard as first run when node_modules is absent', async () => {
+      const dir = createArtifactDir('test-agent', 'cold-dash', { name: 'Cold' })
+      fs.rmdirSync(path.join(dir, 'node_modules'))
+
+      const result = await listArtifactsFromFilesystem('test-agent')
+
+      expect(result[0].firstRun).toBe(true)
+    })
+
+    it('omits firstRun after dependencies have been installed', async () => {
+      createArtifactDir('test-agent', 'warm-dash', { name: 'Warm' })
+
+      const result = await listArtifactsFromFilesystem('test-agent')
+
+      expect(result[0].firstRun).toBeUndefined()
     })
 
     it('omits hasScreenshot when screenshot.png is absent', async () => {

--- a/src/shared/lib/services/artifact-service.ts
+++ b/src/shared/lib/services/artifact-service.ts
@@ -12,6 +12,8 @@ export interface ArtifactInfo {
   status: 'running' | 'stopped' | 'crashed' | 'starting'
   port: number
   hasScreenshot?: boolean
+  startupPhase?: 'installing-dependencies' | 'starting-server'
+  firstRun?: boolean
 }
 
 /**
@@ -46,6 +48,7 @@ export async function listArtifactsFromFilesystem(
         ARTIFACT_SCREENSHOT_FILENAME
       )
       const hasScreenshot = await fileExists(screenshotPath)
+      const firstRun = !(await directoryExists(path.join(artifactsDir, entry.name, 'node_modules')))
       const info: ArtifactInfo = {
         slug: entry.name,
         name: pkg.name || entry.name,
@@ -56,6 +59,10 @@ export async function listArtifactsFromFilesystem(
       // Only include hasScreenshot when true — keeps the API shape minimal
       // and avoids spurious `hasScreenshot: false` fields in common responses.
       if (hasScreenshot) info.hasScreenshot = true
+      // The host can report this before the agent container is running. That
+      // lets the dashboard view explain first-run preparation during container
+      // startup instead of flashing the state only during a fast install.
+      if (firstRun) info.firstRun = true
       dashboards.push(info)
     } catch {
       // No valid package.json, skip
@@ -69,6 +76,14 @@ async function fileExists(p: string): Promise<boolean> {
   try {
     await fs.promises.access(p, fs.constants.R_OK)
     return true
+  } catch {
+    return false
+  }
+}
+
+async function directoryExists(p: string): Promise<boolean> {
+  try {
+    return (await fs.promises.stat(p)).isDirectory()
   } catch {
     return false
   }


### PR DESCRIPTION
## Summary

- cap Bun dashboard installs at a network concurrency of 8
- expose dependency-install and first-run phases through the artifacts API
- show a clear one-time dashboard preparation state in the app and standalone view
- animate the existing toolbar refresh control during the iframe's initial load
- add focused manager, API, state, component, and filesystem tests

## Root cause

Bun's default 48-request concurrency interacts poorly with the Lima network path. In a controlled cold install of OpenSlide's 376 packages, the default took 138.93 seconds while `--network-concurrency=8` took 2.44 seconds.

The install also blocked dashboard startup without exposing its phase, and the first iframe navigation could leave a blank content area while the toolbar still showed an inactive refresh icon.

## Impact

First launch is reduced from minutes to seconds in the affected environment. Users now see that first-use dependencies are being prepared, and the existing toolbar spinner remains active until the first dashboard document loads.

## Validation

- focused renderer, API, artifact-service, and dashboard-state Vitest suites
- dashboard manager Vitest suite (48 tests)
- `npm run typecheck`
- `npm --prefix agent-container run build`
- ESLint on changed files
- live cold-start validation in the Electron development app
