### PR TITLE
fix(composer): refresh transcript before idle rescue restores a prompt (SUP-427)

### DIFF
--- a/e2e/specs/composer-failure-recovery.spec.ts
+++ b/e2e/specs/composer-failure-recovery.spec.ts
@@ -166,4 +166,41 @@ test.describe('Composer failure recovery', () => {
     // ~1.5s and was still present at this point)
     await expect(sessionPage.getMessageInput()).toHaveText('')
   })
+
+  test('a delayed transcript refetch does not restore an accepted short prompt', async ({ page }) => {
+    // Regression for the idle-rescue race: POST and SSE complete normally, but
+    // the messages GET is held past the 1.5s grace. The accepted prompt must
+    // not be written back into the composer just because the cached transcript
+    // has not caught up yet.
+    const text = 'short accepted prompt'
+    await page.route('**/sessions/*/messages', async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      await new Promise((r) => setTimeout(r, 4500))
+      return route.continue()
+    })
+
+    await sessionPage.typeMessage(text)
+    const sentAt = Date.now()
+    await sessionPage.getSendButton().click()
+    await expect(sessionPage.getMessageInput()).toHaveText('')
+
+    // The live reply can arrive while the transcript GET is still held.
+    await expect(
+      sessionPage.getAssistantMessages().filter({ hasText: 'This is a mock response from the E2E test container.' })
+    ).toHaveCount(2, { timeout: 15000 })
+
+    // Stay empty through the 1.5s idle-rescue window. If the prompt comes
+    // back, this poll surfaces the restored text instead of "empty-past-grace".
+    await expect.poll(async () => {
+      const composer = (await sessionPage.getMessageInput().textContent())?.trim() ?? ''
+      if (composer !== '') return composer
+      return Date.now() - sentAt >= 2000 ? 'empty-past-grace' : 'waiting'
+    }, { timeout: 8000 }).toBe('empty-past-grace')
+
+    await sessionPage.waitForUserMessageCount(2, 20000)
+    await sessionPage.expectUserMessage(text, 1)
+    await expect(sessionPage.getUserMessages().filter({ hasText: text })).toHaveCount(1)
+    await expect(sessionPage.getMessageInput()).toHaveText('')
+    await expect(sessionPage.getSendButton()).toBeDisabled()
+  })
 })

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -26,6 +26,7 @@ function successfulTranscriptRefetch(data?: ApiMessageOrBoundary[]) {
     data: data ?? mockMessagesData.data ?? [],
     error: null,
     isError: false,
+    dataUpdatedAt: Date.now(),
   }))
 }
 
@@ -1305,6 +1306,53 @@ describe('MessageList', () => {
     }
   })
 
+  it('does not restore when a successful refetch returns a stale cache', async () => {
+    // A cancelled in-flight refetch can resolve as success with the previous
+    // cache: isError false, data present, dataUpdatedAt from before the ask.
+    // Treat that as missing evidence, same as a failed refresh.
+    vi.useFakeTimers()
+    try {
+      const onAppeared = vi.fn()
+      const staleUpdatedAt = Date.now()
+      mockMessagesData.data = []
+      mockMessagesData.refetch = vi.fn(async () => ({
+        data: [],
+        error: null,
+        isError: false,
+        dataUpdatedAt: staleUpdatedAt,
+      }))
+      mockStreamState.isActive = false
+
+      const DraftProbe = () => {
+        const [draft] = useDraft<string>('session:s-1')
+        return <div data-testid="draft-probe">{draft ?? ''}</div>
+      }
+
+      renderWithProviders(
+        <>
+          <MessageList
+            sessionId="s-1"
+            agentSlug="agent-1"
+            pendingUserMessages={[{ localId: 'l1', uuid: 'server-uuid', text: 'accepted prompt', sentAt: Date.now() }]}
+            onPendingMessageAppeared={onAppeared}
+          />
+          <DraftProbe />
+        </>
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500)
+      })
+
+      expect(mockMessagesData.refetch).toHaveBeenCalled()
+      expect(onAppeared).not.toHaveBeenCalled()
+      expect(screen.getByTestId('draft-probe').textContent).toBe('')
+      expect(screen.getByTestId('pending-user-message')).toHaveTextContent('accepted prompt')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('clears peer ghosts at idle without restarting the local transcript refresh', async () => {
     vi.useFakeTimers()
     try {
@@ -1313,6 +1361,7 @@ describe('MessageList', () => {
         data: ApiMessageOrBoundary[]
         error: Error | null
         isError: boolean
+        dataUpdatedAt: number
       }) => void = () => {}
       mockMessagesData.data = []
       mockMessagesData.refetch = vi.fn(
@@ -1382,6 +1431,7 @@ describe('MessageList', () => {
           ],
           error: null,
           isError: false,
+          dataUpdatedAt: Date.now(),
         })
       })
 

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -1296,10 +1296,99 @@ describe('MessageList', () => {
         await vi.advanceTimersByTimeAsync(1500)
       })
 
+      expect(mockMessagesData.refetch).toHaveBeenCalled()
       expect(onAppeared).not.toHaveBeenCalled()
       expect(screen.getByTestId('draft-probe').textContent).toBe('')
       expect(screen.getByTestId('pending-user-message')).toHaveTextContent('still pending')
     } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears peer ghosts at idle without restarting the local transcript refresh', async () => {
+    vi.useFakeTimers()
+    try {
+      const onAppeared = vi.fn()
+      let resolveRefetch: (value: {
+        data: ApiMessageOrBoundary[]
+        error: Error | null
+        isError: boolean
+      }) => void = () => {}
+      mockMessagesData.data = []
+      mockMessagesData.refetch = vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveRefetch = resolve
+          }),
+      )
+      mockStreamState.isActive = false
+      mockStreamState.peerUserMessages = [
+        { uuid: 'peer-1', receivedAt: Date.now(), content: 'Hello from peer', sender: { id: 'other-user', name: 'Alice' } },
+      ]
+      mockClearPeerUserMessages.mockImplementation(() => {
+        mockStreamState.peerUserMessages = []
+      })
+
+      const pending = [{ localId: 'l1', uuid: 'server-uuid', text: 'accepted prompt', sentAt: Date.now() }]
+      const DraftProbe = () => {
+        const [draft] = useDraft<string>('session:s-1')
+        return <div data-testid="draft-probe">{draft ?? ''}</div>
+      }
+      const { rerender } = renderWithProviders(
+        <>
+          <MessageList
+            sessionId="s-1"
+            agentSlug="agent-1"
+            pendingUserMessages={pending}
+            onPendingMessageAppeared={onAppeared}
+          />
+          <DraftProbe />
+        </>
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500)
+      })
+
+      expect(mockClearPeerUserMessages).toHaveBeenCalledWith('s-1')
+      expect(mockMessagesData.refetch).toHaveBeenCalledTimes(1)
+
+      rerender(
+        <>
+          <MessageList
+            sessionId="s-1"
+            agentSlug="agent-1"
+            pendingUserMessages={pending}
+            onPendingMessageAppeared={onAppeared}
+          />
+          <DraftProbe />
+        </>
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500)
+      })
+
+      expect(mockMessagesData.refetch).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        resolveRefetch({
+          data: [
+            createUserMessage({
+              id: 'server-uuid',
+              content: { text: 'accepted prompt' },
+              createdAt: new Date(),
+            }),
+          ],
+          error: null,
+          isError: false,
+        })
+      })
+
+      expect(onAppeared).toHaveBeenCalledWith('l1')
+      expect(screen.getByTestId('draft-probe').textContent).toBe('')
+    } finally {
+      mockClearPeerUserMessages.mockReset()
       vi.useRealTimers()
     }
   })

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -9,10 +9,24 @@ import { createUserMessage, createAssistantMessage, createToolCall, createCompac
 import type { ApiMessageOrBoundary } from '@shared/lib/types/api'
 
 // Mock useMessages
-const mockMessagesData: { data: ApiMessageOrBoundary[] | undefined; isLoading: boolean; error: Error | null } = {
+const mockMessagesData: {
+  data: ApiMessageOrBoundary[] | undefined
+  isLoading: boolean
+  error: Error | null
+  refetch: ReturnType<typeof vi.fn>
+} = {
   data: undefined,
   isLoading: false,
   error: null,
+  refetch: vi.fn(),
+}
+
+function successfulTranscriptRefetch(data?: ApiMessageOrBoundary[]) {
+  return vi.fn(async () => ({
+    data: data ?? mockMessagesData.data ?? [],
+    error: null,
+    isError: false,
+  }))
 }
 
 const mockDeleteMessage = vi.fn()
@@ -145,6 +159,7 @@ describe('MessageList', () => {
     vi.clearAllMocks()
     mockMessagesData.data = undefined
     mockMessagesData.isLoading = false
+    mockMessagesData.refetch = successfulTranscriptRefetch()
     mockIsOnline = true
     mockCurrentUser = null
     mockCancelResult = { cancelled: true }
@@ -810,7 +825,7 @@ describe('MessageList', () => {
       rerender(<CompactRaceHarness />)
 
       await act(async () => {
-        vi.advanceTimersByTime(1500)
+        await vi.advanceTimersByTimeAsync(1500)
       })
 
       expect(screen.getByTestId('draft-probe')).toHaveTextContent('the next message')
@@ -1043,10 +1058,13 @@ describe('MessageList', () => {
       expect(onAppeared).not.toHaveBeenCalled()
       expect(screen.getByTestId('draft-probe')).toHaveTextContent('')
 
-      // After the post-idle grace, the un-picked-up text returns to the composer
+      // After the post-idle grace, a successful fresh transcript still lacks
+      // the queued prompt, so the un-picked-up text returns to the composer
       // draft and the ghost is removed.
+      mockMessagesData.refetch = successfulTranscriptRefetch([])
+
       await act(async () => {
-        vi.advanceTimersByTime(1500)
+        await vi.advanceTimersByTimeAsync(1500)
       })
 
       expect(onAppeared).toHaveBeenCalledWith('l1')
@@ -1142,7 +1160,7 @@ describe('MessageList', () => {
       )
 
       await act(async () => {
-        vi.advanceTimersByTime(1500)
+        await vi.advanceTimersByTimeAsync(1500)
       })
 
       expect(onAppeared).not.toHaveBeenCalled()
@@ -1153,13 +1171,14 @@ describe('MessageList', () => {
   })
 
   it('still restores a non-queued pending that was accepted (uuid) but never materialized', async () => {
-    // The POST succeeded but the message never showed up in the transcript by
-    // idle (e.g. an interrupt raced the CLI before it persisted the entry) —
-    // this is genuinely lost work, so the restore must still fire.
+    // The POST succeeded but a successful fresh transcript still lacks the
+    // message by idle (e.g. an interrupt raced the CLI before it persisted
+    // the entry) — this is genuinely lost work, so the restore must still fire.
     vi.useFakeTimers()
     try {
       const onAppeared = vi.fn()
       mockMessagesData.data = []
+      mockMessagesData.refetch = successfulTranscriptRefetch([])
       mockStreamState.isActive = false
 
       const DraftProbe = () => {
@@ -1180,11 +1199,106 @@ describe('MessageList', () => {
       )
 
       await act(async () => {
-        vi.advanceTimersByTime(1500)
+        await vi.advanceTimersByTimeAsync(1500)
       })
 
       expect(onAppeared).toHaveBeenCalledWith('l1')
       expect(screen.getByTestId('draft-probe')).toHaveTextContent('accepted then dropped')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not restore an accepted pending whose fresh transcript already contains it', async () => {
+    // Cached transcript is still empty after idle, but a fresh read already
+    // has the accepted uuid. Restoring would put a delivered prompt back in
+    // the composer and enable a duplicate send.
+    vi.useFakeTimers()
+    try {
+      const onAppeared = vi.fn()
+      mockMessagesData.data = []
+      mockMessagesData.refetch = successfulTranscriptRefetch([
+        createUserMessage({
+          id: 'server-uuid',
+          content: { text: 'accepted prompt' },
+          createdAt: new Date(),
+        }),
+      ])
+      mockStreamState.isActive = false
+
+      const DraftProbe = () => {
+        const [draft] = useDraft<string>('session:s-1')
+        return <div data-testid="draft-probe">{draft ?? ''}</div>
+      }
+
+      renderWithProviders(
+        <>
+          <MessageList
+            sessionId="s-1"
+            agentSlug="agent-1"
+            pendingUserMessages={[{ localId: 'l1', uuid: 'server-uuid', text: 'accepted prompt', sentAt: Date.now() }]}
+            onPendingMessageAppeared={onAppeared}
+          />
+          <DraftProbe />
+        </>
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500)
+      })
+
+      expect(screen.getByTestId('draft-probe').textContent).toBe('')
+      expect(onAppeared).toHaveBeenCalledWith('l1')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not restore or drop a pending when the idle transcript refresh fails', async () => {
+    // A failed fresh read is missing evidence, not proof of delivery or loss.
+    // Leftover data on the error result must not be treated as a successful
+    // transcript — keep the optimistic copy and leave the composer alone.
+    vi.useFakeTimers()
+    try {
+      const onAppeared = vi.fn()
+      mockMessagesData.data = []
+      mockMessagesData.refetch = vi.fn(async () => ({
+        data: [
+          createUserMessage({
+            id: 'server-uuid',
+            content: { text: 'still pending' },
+            createdAt: new Date(),
+          }),
+        ],
+        error: new Error('Failed to fetch messages'),
+        isError: true,
+      }))
+      mockStreamState.isActive = false
+
+      const DraftProbe = () => {
+        const [draft] = useDraft<string>('session:s-1')
+        return <div data-testid="draft-probe">{draft ?? ''}</div>
+      }
+
+      renderWithProviders(
+        <>
+          <MessageList
+            sessionId="s-1"
+            agentSlug="agent-1"
+            pendingUserMessages={[{ localId: 'l1', uuid: 'server-uuid', text: 'still pending', sentAt: Date.now() }]}
+            onPendingMessageAppeared={onAppeared}
+          />
+          <DraftProbe />
+        </>
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500)
+      })
+
+      expect(onAppeared).not.toHaveBeenCalled()
+      expect(screen.getByTestId('draft-probe').textContent).toBe('')
+      expect(screen.getByTestId('pending-user-message')).toHaveTextContent('still pending')
     } finally {
       vi.useRealTimers()
     }

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -397,12 +397,25 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     }
   }, [discardedCommandUuids, pendingUserMessages, peerUserMessages, sessionId, draftsStore, onPendingMessageAppeared])
 
-  // Once the session goes idle, pending copies a successful fresh transcript
-  // still lacks are treated as undelivered. Restore their text so the user can
-  // resend, and remove the ghosts; drop peer ghosts (we can't restore another
-  // user's text — their own client restores it). The cached query can lag a
+  // Peer ghosts need no transcript evidence — we cannot restore another
+  // user's text. Drop them on the same idle grace, on their own timer, so
+  // clearing them cannot cancel the local rescue below.
+  useEffect(() => {
+    if (isActive || peerUserMessages.length === 0) return
+    const timerId = setTimeout(() => {
+      clearPeerUserMessages(sessionId)
+    }, 1500)
+    return () => clearTimeout(timerId)
+  }, [peerUserMessages, isActive, sessionId])
+
+  // Once the session goes idle, pending copies that a successful fresh
+  // transcript still lacks are treated as undelivered. Restore their text so
+  // the user can resend, and remove the ghosts. The cached query can lag a
   // successful POST, so absence there is not proof of loss. A failed refresh
   // is missing evidence: leave the optimistic copy and do not restore.
+  // Messages that were delivered still clear via the materialize effect above
+  // as the post-idle refetch lands. While the agent is active, queued ghosts
+  // may wait minutes.
   //
   // EXCEPT: a non-queued pending without a uuid has its POST still in flight
   // — commonly a send into a session whose container is waking, where the
@@ -413,39 +426,37 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // is actually mid-delivery — it then lands in the transcript AND sits in
   // the composer, baiting a duplicate resend. Leave those pending.
   useEffect(() => {
-    if (isActive || ((pendingUserMessages?.length ?? 0) === 0 && peerUserMessages.length === 0)) return
+    if (isActive) return
     const undelivered = (pendingUserMessages ?? []).filter((p) => p.queued || p.uuid)
+    if (undelivered.length === 0) return
     let cancelled = false
     const timerId = setTimeout(() => {
       void (async () => {
-        if (undelivered.length > 0) {
-          const result = await refetch()
-          if (cancelled) return
-          if (!result.isError && !result.error && result.data != null) {
-            const claimed = claimedMessageIdsRef.current
-            const stillMissing: PendingMessage[] = []
-            for (const pending of undelivered) {
-              if (matchPendingMessage(pending, result.data, claimed)) {
-                onPendingMessageAppeared?.(pending.localId)
-              } else {
-                stillMissing.push(pending)
-              }
-            }
-            if (stillMissing.length > 0) {
-              const restored = stillMissing.map((p) => p.text.trim()).filter(Boolean)
-              appendToSessionDraft(draftsStore, sessionId, restored.join('\n\n'), { prepend: true })
-              for (const pending of stillMissing) onPendingMessageAppeared?.(pending.localId)
+        const result = await refetch()
+        if (cancelled) return
+        if (!result.isError && !result.error && result.data != null) {
+          const claimed = claimedMessageIdsRef.current
+          const stillMissing: PendingMessage[] = []
+          for (const pending of undelivered) {
+            if (matchPendingMessage(pending, result.data, claimed)) {
+              onPendingMessageAppeared?.(pending.localId)
+            } else {
+              stillMissing.push(pending)
             }
           }
+          if (stillMissing.length > 0) {
+            const restored = stillMissing.map((p) => p.text.trim()).filter(Boolean)
+            appendToSessionDraft(draftsStore, sessionId, restored.join('\n\n'), { prepend: true })
+            for (const pending of stillMissing) onPendingMessageAppeared?.(pending.localId)
+          }
         }
-        if (!cancelled) clearPeerUserMessages(sessionId)
       })()
     }, 1500)
     return () => {
       cancelled = true
       clearTimeout(timerId)
     }
-  }, [pendingUserMessages, peerUserMessages, isActive, onPendingMessageAppeared, sessionId, draftsStore, refetch])
+  }, [pendingUserMessages, isActive, onPendingMessageAppeared, sessionId, draftsStore, refetch])
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const contentBodyRef = useRef<HTMLDivElement>(null)

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -40,7 +40,7 @@ import {
   type UIEvent as ReactUIEvent,
 } from 'react'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
-import type { ApiMessage, ApiCompactBoundary, ApiMemoryRecall, ApiInformational } from '@shared/lib/types/api'
+import type { ApiMessage, ApiMessageOrBoundary, ApiCompactBoundary, ApiMemoryRecall, ApiInformational } from '@shared/lib/types/api'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 
 // Prefix for system-injected user messages that should be hidden in the UI.
@@ -160,6 +160,40 @@ function DeliveredFiles({ files, agentSlug }: { files: { filePath: string }[]; a
   )
 }
 
+function matchPendingMessage(
+  pending: PendingMessage,
+  messages: ApiMessageOrBoundary[],
+  claimed: Set<string>,
+): ApiMessageOrBoundary | undefined {
+  const findTextMatch = (text: string, notBefore: number) => {
+    const trimmed = text.trim()
+    return messages.find(
+      (m) =>
+        m.type === 'user' &&
+        !claimed.has(m.id) &&
+        (m.content as { text?: string }).text?.trim() === trimmed &&
+        new Date(m.createdAt).getTime() >= notBefore
+    )
+  }
+  let match = pending.uuid ? messages.find((m) => m.id === pending.uuid) : undefined
+  // Text fallback only where the uuid can't work: queued messages (CLI
+  // re-ids them) and sends still awaiting their POST response.
+  if (!match && (pending.queued || !pending.uuid)) {
+    match = findTextMatch(pending.text, pending.sentAt - 5000)
+    if (match) claimed.add(match.id)
+  }
+  if (!match && /^\/compact(?:\s|$)/.test(pending.text.trim())) {
+    match = messages.find(
+      (m) =>
+        m.type === 'compact_boundary' &&
+        !claimed.has(m.id) &&
+        new Date(m.createdAt).getTime() >= pending.sentAt - 5000
+    )
+    if (match) claimed.add(match.id)
+  }
+  return match
+}
+
 interface MessageListProps {
   sessionId: string
   agentSlug: string
@@ -178,7 +212,7 @@ interface MessageListProps {
 
 export function MessageList({ sessionId, agentSlug, pendingUserMessages, pendingRequestCount = 0, onPendingMessageAppeared, readOnly, suppressScrollToBottom = false, bottomInset = 0 }: MessageListProps) {
   useRenderTracker('MessageList')
-  const { data: messages, isLoading, error } = useMessages(sessionId, agentSlug)
+  const { data: messages, isLoading, error, refetch } = useMessages(sessionId, agentSlug)
   const deleteMessage = useDeleteMessage()
   const deleteToolCall = useDeleteToolCall()
   const cancelQueuedMessage = useCancelQueuedMessage()
@@ -312,22 +346,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       )
     }
     for (const pending of pendingUserMessages ?? []) {
-      let match = pending.uuid ? messages.find((m) => m.id === pending.uuid) : undefined
-      // Text fallback only where the uuid can't work: queued messages (CLI
-      // re-ids them) and sends still awaiting their POST response.
-      if (!match && (pending.queued || !pending.uuid)) {
-        match = findTextMatch(pending.text, pending.sentAt - 5000)
-        if (match) claimed.add(match.id)
-      }
-      if (!match && /^\/compact(?:\s|$)/.test(pending.text.trim())) {
-        match = messages.find(
-          (m) =>
-            m.type === 'compact_boundary' &&
-            !claimed.has(m.id) &&
-            new Date(m.createdAt).getTime() >= pending.sentAt - 5000
-        )
-        if (match) claimed.add(match.id)
-      }
+      const match = matchPendingMessage(pending, messages, claimed)
       if (match) {
         onPendingMessageAppeared?.(pending.localId)
       }
@@ -378,16 +397,12 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     }
   }, [discardedCommandUuids, pendingUserMessages, peerUserMessages, sessionId, draftsStore, onPendingMessageAppeared])
 
-  // Once the session goes idle, our messages still showing as pending are
-  // treated as undelivered — the agent was interrupted before picking them
-  // up, or the turn ended without consuming them. Restore their text to the
-  // composer so the user can edit/resend, and remove the ghosts; drop peer
-  // ghosts (we can't restore another user's text into our composer — their
-  // own client restores it for them). Messages that WERE delivered clear via
-  // the materialize effect above, which prunes them from this list as the
-  // post-idle refetch lands. The short grace below gives that refetch a beat
-  // to settle so a just-answered message isn't yanked back into the composer.
-  // While the agent is active, queued ghosts may wait minutes.
+  // Once the session goes idle, pending copies a successful fresh transcript
+  // still lacks are treated as undelivered. Restore their text so the user can
+  // resend, and remove the ghosts; drop peer ghosts (we can't restore another
+  // user's text — their own client restores it). The cached query can lag a
+  // successful POST, so absence there is not proof of loss. A failed refresh
+  // is missing evidence: leave the optimistic copy and do not restore.
   //
   // EXCEPT: a non-queued pending without a uuid has its POST still in flight
   // — commonly a send into a session whose container is waking, where the
@@ -400,16 +415,37 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   useEffect(() => {
     if (isActive || ((pendingUserMessages?.length ?? 0) === 0 && peerUserMessages.length === 0)) return
     const undelivered = (pendingUserMessages ?? []).filter((p) => p.queued || p.uuid)
+    let cancelled = false
     const timerId = setTimeout(() => {
-      if (undelivered.length > 0) {
-        const restored = undelivered.map((p) => p.text.trim()).filter(Boolean)
-        appendToSessionDraft(draftsStore, sessionId, restored.join('\n\n'), { prepend: true })
-        for (const pending of undelivered) onPendingMessageAppeared?.(pending.localId)
-      }
-      clearPeerUserMessages(sessionId)
+      void (async () => {
+        if (undelivered.length > 0) {
+          const result = await refetch()
+          if (cancelled) return
+          if (!result.isError && !result.error && result.data != null) {
+            const claimed = claimedMessageIdsRef.current
+            const stillMissing: PendingMessage[] = []
+            for (const pending of undelivered) {
+              if (matchPendingMessage(pending, result.data, claimed)) {
+                onPendingMessageAppeared?.(pending.localId)
+              } else {
+                stillMissing.push(pending)
+              }
+            }
+            if (stillMissing.length > 0) {
+              const restored = stillMissing.map((p) => p.text.trim()).filter(Boolean)
+              appendToSessionDraft(draftsStore, sessionId, restored.join('\n\n'), { prepend: true })
+              for (const pending of stillMissing) onPendingMessageAppeared?.(pending.localId)
+            }
+          }
+        }
+        if (!cancelled) clearPeerUserMessages(sessionId)
+      })()
     }, 1500)
-    return () => clearTimeout(timerId)
-  }, [pendingUserMessages, peerUserMessages, isActive, onPendingMessageAppeared, sessionId, draftsStore])
+    return () => {
+      cancelled = true
+      clearTimeout(timerId)
+    }
+  }, [pendingUserMessages, peerUserMessages, isActive, onPendingMessageAppeared, sessionId, draftsStore, refetch])
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const contentBodyRef = useRef<HTMLDivElement>(null)

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -413,6 +413,8 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // the user can resend, and remove the ghosts. The cached query can lag a
   // successful POST, so absence there is not proof of loss. A failed refresh
   // is missing evidence: leave the optimistic copy and do not restore.
+  // A cancelled refetch can resolve as success with the previous cache, so
+  // dataUpdatedAt must be at or after the request, not merely non-error.
   // Messages that were delivered still clear via the materialize effect above
   // as the post-idle refetch lands. While the agent is active, queued ghosts
   // may wait minutes.
@@ -432,9 +434,15 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     let cancelled = false
     const timerId = setTimeout(() => {
       void (async () => {
+        const fetchedAfter = Date.now()
         const result = await refetch()
         if (cancelled) return
-        if (!result.isError && !result.error && result.data != null) {
+        if (
+          !result.isError &&
+          !result.error &&
+          result.data != null &&
+          result.dataUpdatedAt >= fetchedAfter
+        ) {
           const claimed = claimedMessageIdsRef.current
           const stillMissing: PendingMessage[] = []
           for (const pending of undelivered) {


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-427/sent-message-text-sometimes-stays-in-the-composer-after-a-successful

Production: 1 file, +55 net (`message-list.tsx`).
Tests: 2 files, +290 net.

Type: bug fix

A successful send can put the text back in the composer and turn Send on.
The agent may already be working, or have already replied.

```
before
  you send
    → the server accepts
    → the composer clears
    → a local copy stays in memory
  the session goes idle
    → wait 1.5s
    → if that copy is still there, put the text back
    → do not read a fresh transcript

after
  you send
    → the server accepts
    → the composer clears
    → a local copy stays in memory
  the session goes idle
    → wait 1.5s
    → fetch a fresh transcript
         ├─ fetch failed → leave the copy, leave the composer empty
         ├─ fetch came back with an older cache → same
         ├─ the prompt is in the transcript → drop the copy, leave the composer empty
         └─ the prompt is still missing → put the text back so you can resend
```

A send still in flight with no server id is left alone.
Failed send restore and Stop restore are unchanged.

Other people's leftover copies drop on their own 1.5s timer.
Clearing them in the same wait cancelled the fresh read and restarted the clock.

## Worth reviewing

The 1.5s wait is still a beat, not proof the transcript has the prompt.
If the source of truth itself is empty at that fetch, we still restore.

A cancelled fetch can look like success with yesterday's list.
We refuse that the same way we refuse a failed fetch.

Peer copies sit on a second timer so they cannot cancel the local read.
One shared timer would leave their copies up until the fetch returns.

## Why not a longer wait

A longer wait still treats a stale list as loss.
The E2E that holds the transcript read for 4.5s can also pass if recovery is deleted.
The unit case (cache empty, fresh read has the id) is what pins this shape.

## What this does not fix

Lost HTTP acknowledgement.
The server accepted.
This window never sees that.
Composer restore runs as a failed send.
That needs request correlation.
Separate design.

A hung transcript fetch that never finishes can leave rescue unresolved.
The messages query does not abort.

## How to verify

1. From this worktree, run `gamut-test electron`.
2. Open `test-agent`. Type a short prompt. Send.
3. Wait 3 seconds.
4. Composer stays empty. Send stays off. One transcript copy. Mock reply can arrive.

Smoke screenshot (drop into the PR): `/tmp/stuck-prompt-electron-smoke.png`

## Validation

- `npx vitest run src/renderer/components/messages/message-list.test.tsx src/renderer/components/messages/message-input.test.tsx` - 160 passed
- `E2E_MOCK=true E2E_PORT=3017 PORT=3017 npx playwright test e2e/specs/composer-failure-recovery.spec.ts --project=web-chromium` - 4 passed
- `npm run typecheck` - pass
- eslint on the touched files - pass
- Electron mock smoke: three accepted short prompts, composer empty at idle
