### PR TITLE
Fix host-app OOM on large session transcripts

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -287,6 +287,8 @@ vi.mock('@shared/lib/services/session-service', () => ({
   updateSessionName: vi.fn(),
   registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(),
+  getSessionToolResultImage: vi.fn(),
+  getSessionToolResult: vi.fn(),
   readDisplayTranscript: vi.fn().mockResolvedValue([]),
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
@@ -542,7 +544,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionToolResult, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3495,6 +3497,106 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
 
     // No DB query since there are no user messages to look up
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /:id/sessions/:sessionId/messages?strip-tools=1', () => {
+  let app: ReturnType<typeof createApp>
+  const URL = '/api/agents/test-agent/sessions/sess-1/messages?strip-tools=1'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    mockIsAuthMode.mockReturnValue(false)
+    vi.mocked(sessionExists).mockResolvedValue(true)
+    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
+  })
+
+  it('drops tool result payloads and sets hasResult after recovery', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
+      new Map([['tool-declined', 'declined']]),
+    )
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [
+          { id: 'tool-done', name: 'Bash', input: {}, result: 'ok' },
+          { id: 'tool-declined', name: 'mcp__user-input__request_secret', input: {} },
+          { id: 'tool-open', name: 'AskUserQuestion', input: {} },
+        ],
+      },
+    ])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Array<{
+      toolCalls?: Array<{ id: string; result?: string; hasResult?: boolean }>
+    }>
+    const toolCalls = body[0].toolCalls ?? []
+    expect(toolCalls.find((t) => t.id === 'tool-done')).toEqual(
+      expect.objectContaining({ hasResult: true }),
+    )
+    expect(toolCalls.find((t) => t.id === 'tool-done')).not.toHaveProperty('result')
+    expect(toolCalls.find((t) => t.id === 'tool-declined')).toEqual(
+      expect.objectContaining({ hasResult: true }),
+    )
+    expect(toolCalls.find((t) => t.id === 'tool-declined')).not.toHaveProperty('result')
+    expect(toolCalls.find((t) => t.id === 'tool-open')?.result).toBeUndefined()
+    expect(toolCalls.find((t) => t.id === 'tool-open')?.hasResult).toBeUndefined()
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }],
+    )
+  })
+
+  it('keeps tool results on the default list', async () => {
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-done', name: 'Bash', input: {}, result: 'ok' }],
+      },
+    ])
+
+    const res = await getReq(app, '/api/agents/test-agent/sessions/sess-1/messages')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Array<{
+      toolCalls?: Array<{ id: string; result?: string; hasResult?: boolean }>
+    }>
+    expect(body[0].toolCalls?.[0]).toEqual(expect.objectContaining({ id: 'tool-done', result: 'ok' }))
+    expect(body[0].toolCalls?.[0]?.hasResult).toBeUndefined()
+  })
+})
+
+describe('GET /:id/sessions/:sessionId/tool-results/:toolUseId', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+  })
+
+  it('returns the full tool result', async () => {
+    vi.mocked(getSessionToolResult).mockResolvedValue({ result: 'file list', isError: false })
+
+    const res = await getReq(app, '/api/agents/test-agent/sessions/sess-1/tool-results/toolu_ls')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ result: 'file list', isError: false })
+    expect(getSessionToolResult).toHaveBeenCalledWith('test-agent', 'sess-1', 'toolu_ls')
+  })
+
+  it('returns 404 when the tool result is missing', async () => {
+    vi.mocked(getSessionToolResult).mockResolvedValue(null)
+
+    const res = await getReq(app, '/api/agents/test-agent/sessions/sess-1/tool-results/missing')
+    expect(res.status).toBe(404)
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -287,6 +287,7 @@ vi.mock('@shared/lib/services/session-service', () => ({
   updateSessionName: vi.fn(),
   registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(),
+  readDisplayTranscript: vi.fn().mockResolvedValue([]),
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -55,6 +55,7 @@ import {
   updateSessionName,
   registerSession,
   getSessionMessagesWithCompact,
+  readDisplayTranscript,
   getSession,
   getSessionMetadata,
   sessionExists,
@@ -67,7 +68,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
@@ -1882,11 +1883,8 @@ agents.get('/:id/sessions/:sessionId/subagent/:agentId/messages', AgentRead(), a
     const sessionsDir = getAgentSessionsDir(agentSlug)
     const subagentJsonlPath = path.join(sessionsDir, sessionId, 'subagents', `agent-${subagentId}.jsonl`)
 
-    const entries = await readJsonlFile(subagentJsonlPath) as any[]
-    const messageEntries = entries.filter(
-      (e) => e.type === 'user' || e.type === 'assistant'
-    )
-    const transformed = transformMessages(messageEntries)
+    const entries = await readDisplayTranscript(subagentJsonlPath)
+    const transformed = transformMessages(entries)
     return c.json(transformed)
   } catch (error) {
     console.error('Failed to fetch subagent messages:', error)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -55,6 +55,8 @@ import {
   updateSessionName,
   registerSession,
   getSessionMessagesWithCompact,
+  getSessionToolResult,
+  getSessionToolResultImage,
   readDisplayTranscript,
   getSession,
   getSessionMetadata,
@@ -69,6 +71,12 @@ import {
   removeToolCall,
 } from '@shared/lib/services/session-service'
 import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
+import {
+  sessionToolResultSchema,
+  toolResultImageParamsSchema,
+  toolResultParamsSchema,
+  transcriptImageSchema,
+} from '@shared/lib/services/session-transcript-schema'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
@@ -495,6 +503,21 @@ function getUnresolvedBlockingInputRequests(
   }
 
   return unresolved
+}
+
+const messagesQuerySchema = z.object({
+  'strip-tools': z.enum(['1', 'true']).optional(),
+})
+
+function stripToolResults(items: TransformedItem[]): void {
+  for (const item of items) {
+    if (item.type !== 'assistant') continue
+    for (const toolCall of item.toolCalls) {
+      if (toolCall.result === undefined) continue
+      toolCall.hasResult = true
+      delete toolCall.result
+    }
+  }
 }
 
 /**
@@ -1758,6 +1781,7 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     const filtered = messages.filter((m) => !('isMeta' in m && m.isMeta))
     const transformed = transformMessages(filtered)
 
+
     // Discover subagent IDs for interrupted Task tool calls that have no result
     await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
 
@@ -1826,11 +1850,43 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       }
     }
 
+    const query = messagesQuerySchema.safeParse(c.req.query())
+    if (query.success && query.data['strip-tools']) {
+      stripToolResults(transformed)
+    }
+
     return c.json(transformed)
   } catch (error) {
     console.error('Failed to fetch messages:', error)
     return c.json({ error: 'Failed to fetch messages' }, 500)
   }
+})
+
+agents.get('/:id/sessions/:sessionId/tool-results/:toolUseId', AgentRead(), async (c) => {
+  const parsed = toolResultParamsSchema.safeParse({
+    toolUseId: c.req.param('toolUseId'),
+  })
+  if (!parsed.success) return c.json({ error: 'Invalid tool result request' }, 400)
+
+  const agentSlug = getAgentId(c)
+  const sessionId = c.req.param('sessionId')
+  const toolResult = await getSessionToolResult(agentSlug, sessionId, parsed.data.toolUseId)
+  if (!toolResult) return c.json({ error: 'Tool result not found' }, 404)
+  return c.json(sessionToolResultSchema.parse(toolResult))
+})
+
+agents.get('/:id/sessions/:sessionId/tool-results/:toolUseId/images/:index', AgentRead(), async (c) => {
+  const parsed = toolResultImageParamsSchema.safeParse({
+    toolUseId: c.req.param('toolUseId'),
+    index: c.req.param('index'),
+  })
+  if (!parsed.success) return c.json({ error: 'Invalid image request' }, 400)
+
+  const agentSlug = getAgentId(c)
+  const sessionId = c.req.param('sessionId')
+  const image = await getSessionToolResultImage(agentSlug, sessionId, parsed.data.toolUseId, parsed.data.index)
+  if (!image) return c.json({ error: 'Image not found' }, 404)
+  return c.json(transcriptImageSchema.parse(image))
 })
 
 // DELETE /api/agents/:id/sessions/:sessionId/messages/:messageId - Remove a message from history

--- a/src/api/routes/workflows.test.ts
+++ b/src/api/routes/workflows.test.ts
@@ -16,7 +16,7 @@ const SID = 'd63a9cbc-2f5e-44dd-8017-231ac99bef35'
 const RUN = 'wf_818f758a-c17'
 
 // Auth is a passthrough; getAgentSessionsDir points at the real fixture so the
-// routes read genuine on-disk workflow artifacts (readJsonlFile stays real).
+// routes read genuine on-disk workflow artifacts (streamed display reads stay real).
 const mockSessionsDir = { value: FIXTURE_ROOT }
 vi.mock('../middleware/auth', () => ({
   AgentRead: () => async (_c: unknown, next: () => Promise<void>) => next(),

--- a/src/api/routes/workflows.ts
+++ b/src/api/routes/workflows.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono'
 import * as path from 'path'
 import { AgentRead } from '../middleware/auth'
-import { getAgentSessionsDir, readJsonlFile } from '@shared/lib/utils/file-storage'
+import { getAgentSessionsDir } from '@shared/lib/utils/file-storage'
+import { readDisplayTranscript } from '@shared/lib/services/session-service'
 import { transformMessages } from '@shared/lib/utils/message-transform'
 import { buildWorkflowTree } from '@shared/lib/workflows/workflow-tree'
 
@@ -62,9 +63,8 @@ workflowRoutes.get(
         `agent-${workflowAgentId}.jsonl`
       )
 
-      const entries = (await readJsonlFile(jsonlPath)) as any[]
-      const messageEntries = entries.filter((e) => e.type === 'user' || e.type === 'assistant')
-      const transformed = transformMessages(messageEntries)
+      const entries = await readDisplayTranscript(jsonlPath)
+      const transformed = transformMessages(entries)
       return c.json(transformed)
     } catch (error) {
       console.error('Failed to fetch workflow agent messages:', error)

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -6,7 +6,7 @@ import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-request
 import { apiFetch } from '@renderer/lib/api'
 import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
 import { InsufficientBalanceCard, usePlatformBillingUrl } from './insufficient-balance-card'
-import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
+import { PROVIDER_ERROR_CODES, toolCallHasResult } from '@shared/lib/types/api'
 import { isTurnStartingUserMessage } from './pending-message'
 import { useCallback, useMemo, useState } from 'react'
 
@@ -131,7 +131,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
             agentId: tc.subagent?.agentId ?? null,
             name: input.subagent_type || tc.name,
             description: input.description || '',
-            completedFromResult: !isAsyncLaunched && tc.result != null,
+            completedFromResult: !isAsyncLaunched && toolCallHasResult(tc),
           }
           launchByToolId.set(tc.id, metadata)
           launches.push(metadata)

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -514,7 +514,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                           isCompleted={completedSubagents?.has(toolCall.id) ?? false}
                         />
                       ) : (
-                        <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} isSessionActive={isSessionActive} />
+                        <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={isSessionActive} />
                       )}
                     </MessageErrorBoundary>
                   </div>

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -1632,7 +1632,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             } else {
               inner = (
                 <div className="max-w-[80%]">
-                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} isSessionActive={isActive} />
+                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={isActive} />
                 </div>
               )
             }

--- a/src/renderer/components/messages/subagent-block.tsx
+++ b/src/renderer/components/messages/subagent-block.tsx
@@ -6,7 +6,7 @@ import { StreamingToolCallItem, StatusIndicator } from './tool-call-item'
 import { flattenAssistantMessages, TranscriptItems, TranscriptText, type FlatItem } from './agent-transcript'
 import { useSubagentMessages } from '@renderer/hooks/use-messages'
 import { parseToolResult } from '@renderer/lib/parse-tool-result'
-import type { ApiToolCall, ApiMessage } from '@shared/lib/types/api'
+import { toolCallHasResult, type ApiToolCall, type ApiMessage } from '@shared/lib/types/api'
 import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 
@@ -81,12 +81,12 @@ export function SubAgentBlock({
     isSessionActive &&
     activeSubagent &&
     !isCompleted &&
-    (isResumedRun || toolCall.result === null || toolCall.result === undefined)
+    (isResumedRun || !toolCallHasResult(toolCall))
   ) {
     // activeSubagent may be a later SendMessage run for the same stable agent.
     // Its live lifecycle takes precedence over the original Agent tool result.
     status = 'running'
-  } else if (toolCall.result !== null && toolCall.result !== undefined) {
+  } else if (toolCallHasResult(toolCall)) {
     // Background agents return an immediate "async_launched" result — don't treat as completed
     // unless we've received a subagent_completed SSE event (isCompleted) for this tool
     if (toolCall.subagent?.status === 'async_launched' && isSessionActive && !isCompleted) {

--- a/src/renderer/components/messages/tool-call-item.test.tsx
+++ b/src/renderer/components/messages/tool-call-item.test.tsx
@@ -6,10 +6,15 @@ import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
 import { formatToolName } from './tool-call-item'
 import { createToolCall } from '@renderer/test/factories'
 import { parseToolResult } from '@renderer/lib/parse-tool-result'
+import { apiFetch } from '@renderer/lib/api'
 
 // Mock getToolRenderer to return null (generic display)
 vi.mock('./tool-renderers', () => ({
   getToolRenderer: () => null,
+}))
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(),
 }))
 
 // Mock parseToolResult
@@ -95,6 +100,12 @@ describe('ToolCallItem', () => {
       // No elapsed timer for cancelled
       expect(screen.queryByText('5s')).not.toBeInTheDocument()
     })
+
+    it('renders success for a stripped result via hasResult', () => {
+      const tc = createToolCall({ result: undefined, hasResult: true })
+      render(<ToolCallItem toolCall={tc} isSessionActive />)
+      expect(screen.queryByText('5s')).not.toBeInTheDocument()
+    })
   })
 
   describe('tool name', () => {
@@ -159,6 +170,48 @@ describe('ToolCallItem', () => {
 
       await user.click(screen.getByTestId('tool-call-toggle-Bash'))
       expect(screen.getByTestId('omitted-screenshot')).toHaveTextContent('Screenshot omitted (2.1 MB)')
+    })
+
+    it('loads a stripped tool result on expand', async () => {
+      const user = userEvent.setup()
+      vi.mocked(apiFetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 'file list', isError: false }),
+      } as Response)
+      const tc = createToolCall({ id: 'toolu_ls', result: undefined, hasResult: true })
+      render(<ToolCallItem toolCall={tc} agentSlug="agent-1" sessionId="session-1" />)
+
+      await user.click(screen.getByTestId('tool-call-toggle-Bash'))
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/agents/agent-1/sessions/session-1/tool-results/toolu_ls'
+      )
+      expect(await screen.findByText('Output')).toBeInTheDocument()
+      expect(parseToolResult).toHaveBeenCalledWith('file list')
+    })
+
+    it('loads the omitted screenshot on click', async () => {
+      const user = userEvent.setup()
+      vi.mocked(parseToolResult).mockReturnValueOnce({
+        text: null,
+        images: [],
+        omittedImages: [{ mimeType: 'image/png', originalChars: 2_100_000 }],
+      })
+      vi.mocked(apiFetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ mimeType: 'image/png', data: 'abc123' }),
+      } as Response)
+      const tc = createToolCall({ id: 'toolu_shot', result: 'ignored' })
+      render(<ToolCallItem toolCall={tc} agentSlug="agent-1" sessionId="session-1" />)
+
+      await user.click(screen.getByTestId('tool-call-toggle-Bash'))
+      await user.click(screen.getByTestId('omitted-screenshot'))
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/agents/agent-1/sessions/session-1/tool-results/toolu_shot/images/0'
+      )
+      expect(await screen.findByAltText('Tool result')).toHaveAttribute(
+        'src',
+        'data:image/png;base64,abc123'
+      )
     })
   })
 

--- a/src/renderer/components/messages/tool-call-item.test.tsx
+++ b/src/renderer/components/messages/tool-call-item.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
 import { formatToolName } from './tool-call-item'
 import { createToolCall } from '@renderer/test/factories'
+import { parseToolResult } from '@renderer/lib/parse-tool-result'
 
 // Mock getToolRenderer to return null (generic display)
 vi.mock('./tool-renderers', () => ({
@@ -13,10 +14,11 @@ vi.mock('./tool-renderers', () => ({
 
 // Mock parseToolResult
 vi.mock('@renderer/lib/parse-tool-result', () => ({
-  parseToolResult: (result: unknown) => ({
+  parseToolResult: vi.fn((result: unknown) => ({
     text: result != null ? String(result) : null,
     images: [],
-  }),
+    omittedImages: [],
+  })),
 }))
 
 // Mock useElapsedTimer for deterministic values
@@ -143,6 +145,20 @@ describe('ToolCallItem', () => {
 
       await user.click(screen.getByTestId('tool-call-toggle-Bash'))
       expect(screen.queryByText('Input')).not.toBeInTheDocument()
+    })
+
+    it('shows a placeholder when the display transcript omitted a screenshot', async () => {
+      const user = userEvent.setup()
+      vi.mocked(parseToolResult).mockReturnValueOnce({
+        text: null,
+        images: [],
+        omittedImages: [{ mimeType: 'image/png', originalChars: 2_100_000 }],
+      })
+      const tc = createToolCall({ result: 'ignored' })
+      render(<ToolCallItem toolCall={tc} />)
+
+      await user.click(screen.getByTestId('tool-call-toggle-Bash'))
+      expect(screen.getByTestId('omitted-screenshot')).toHaveTextContent('Screenshot omitted (2.1 MB)')
     })
   })
 

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -1,12 +1,14 @@
 
 import { cn } from '@shared/lib/utils/cn'
 import { Check, X, Ban, ChevronDown, ChevronRight, Loader2, Search, ImageOff } from 'lucide-react'
-import { useState, useRef, useMemo, memo } from 'react'
+import { useState, useRef, useMemo, memo, useCallback, useEffect } from 'react'
 import { getToolRenderer } from './tool-renderers'
 import { parseToolResult } from '@renderer/lib/parse-tool-result'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
-import type { ApiToolCall } from '@shared/lib/types/api'
+import { toolCallHasResult, type ApiToolCall } from '@shared/lib/types/api'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
+import { apiFetch } from '@renderer/lib/api'
+import { sessionToolResultSchema, transcriptImageSchema } from '@shared/lib/services/session-transcript-schema'
 
 export { formatToolName } from '@shared/lib/tool-definitions/types'
 
@@ -14,6 +16,7 @@ interface ToolCallItemProps {
   toolCall: ApiToolCall
   messageCreatedAt?: Date | string
   agentSlug?: string
+  sessionId?: string
   isSessionActive?: boolean
 }
 
@@ -25,7 +28,7 @@ interface StreamingToolCallItemProps {
 type ToolCallStatus = 'running' | 'success' | 'error' | 'cancelled'
 
 function getStatus(toolCall: ApiToolCall, isSessionActive?: boolean): ToolCallStatus {
-  if (toolCall.result === null || toolCall.result === undefined) {
+  if (!toolCallHasResult(toolCall)) {
     // Only show "running" if the caller explicitly says this tool could still be active.
     // Otherwise it was interrupted/cancelled (or is from a historical interrupted turn).
     return isSessionActive ? 'running' : 'cancelled'
@@ -42,6 +45,65 @@ function formatOmittedSize(chars: number): string {
   if (chars >= 1_000_000) return `${(chars / 1_000_000).toFixed(1)} MB`
   if (chars >= 1_000) return `${Math.round(chars / 1_000)} KB`
   return `${chars} chars`
+}
+
+function OmittedScreenshot({
+  agentSlug,
+  sessionId,
+  toolUseId,
+  index,
+  originalChars,
+}: {
+  agentSlug?: string
+  sessionId?: string
+  toolUseId: string
+  index: number
+  originalChars: number
+}) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
+  const [src, setSrc] = useState<string | null>(null)
+  const canLoad = Boolean(agentSlug && sessionId && toolUseId)
+
+  const load = useCallback(async () => {
+    if (!agentSlug || !sessionId || !toolUseId || status === 'loading' || status === 'ready') return
+    setStatus('loading')
+    try {
+      const res = await apiFetch(
+        `/api/agents/${encodeURIComponent(agentSlug)}/sessions/${encodeURIComponent(sessionId)}/tool-results/${encodeURIComponent(toolUseId)}/images/${index}`
+      )
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const parsed = transcriptImageSchema.safeParse(await res.json())
+      if (!parsed.success) throw new Error('Invalid image payload')
+      setSrc(`data:${parsed.data.mimeType};base64,${parsed.data.data}`)
+      setStatus('ready')
+    } catch (error) {
+      console.warn('Failed to load omitted screenshot', error)
+      setStatus('error')
+    }
+  }, [agentSlug, sessionId, toolUseId, index, status])
+
+  if (status === 'ready' && src) {
+    return <img src={src} alt="Tool result" className="max-w-full rounded border" />
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="omitted-screenshot"
+      onClick={load}
+      disabled={!canLoad || status === 'loading'}
+      className="flex w-full items-center gap-2 rounded border border-dashed border-border px-2 py-2 text-left text-xs text-muted-foreground hover:bg-muted/50 disabled:hover:bg-transparent"
+    >
+      {status === 'loading' ? <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" /> : <ImageOff className="h-3.5 w-3.5 shrink-0" />}
+      {status === 'loading'
+        ? 'Loading screenshot…'
+        : status === 'error'
+          ? 'Failed to load screenshot'
+          : canLoad
+            ? `Screenshot omitted (${formatOmittedSize(originalChars)}) — click to load`
+            : `Screenshot omitted (${formatOmittedSize(originalChars)})`}
+    </button>
+  )
 }
 
 function ToolNameWithSummary({ name, summary, active = false }: { name: string; summary?: string | null; active?: boolean }) {
@@ -94,13 +156,42 @@ export function StatusIndicator({ status }: { status: string }) {
   )
 }
 
-function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessionActive }: ToolCallItemProps) {
+function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, sessionId, isSessionActive }: ToolCallItemProps) {
   const [expanded, setExpanded] = useState(false)
+  const [loaded, setLoaded] = useState<{ result: unknown; isError: boolean } | null>(null)
+  const [loadState, setLoadState] = useState<'idle' | 'loading' | 'error'>('idle')
   const status = getStatus(toolCall, isSessionActive)
   const renderer = getToolRenderer(toolCall.name)
   const isPendingUserInput = status === 'running' && isUserInputTool(toolCall.name)
   const elapsed = useElapsedTimer(status === 'running' && !isPendingUserInput ? (messageCreatedAt ?? null) : null)
   const ToolIcon = renderer?.icon || Search
+  const result = loaded?.result ?? toolCall.result
+  const isError = loaded?.isError ?? toolCall.isError
+
+  useEffect(() => {
+    if (!expanded || result != null || !toolCall.hasResult || !agentSlug || !sessionId) return
+    let cancelled = false
+    setLoadState('loading')
+    void apiFetch(
+      `/api/agents/${encodeURIComponent(agentSlug)}/sessions/${encodeURIComponent(sessionId)}/tool-results/${encodeURIComponent(toolCall.id)}`
+    )
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const parsed = sessionToolResultSchema.safeParse(await res.json())
+        if (!parsed.success) throw new Error('Invalid tool result')
+        if (!cancelled) {
+          setLoaded(parsed.data)
+          setLoadState('idle')
+        }
+      })
+      .catch((error) => {
+        console.warn('Failed to load tool result', error)
+        if (!cancelled) setLoadState('error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [expanded, result, toolCall.hasResult, toolCall.id, agentSlug, sessionId])
 
   // Get summary for collapsed view
   const summary = useMemo(() => renderer?.getSummary?.(toolCall.input), [renderer, toolCall.input])
@@ -112,7 +203,7 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
   )
 
   // Parse result into text + images
-  const parsed = useMemo(() => parseToolResult(toolCall.result), [toolCall.result])
+  const parsed = useMemo(() => parseToolResult(result), [result])
   const resultStr = parsed.text
   const resultImages = parsed.images
   const omittedImages = parsed.omittedImages
@@ -175,11 +266,20 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
 
       {expanded && (
         <div className="border-t border-border/70 bg-muted/50 px-3 py-3">
+          {loadState === 'loading' && (
+            <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading tool result…
+            </div>
+          )}
+          {loadState === 'error' && (
+            <div className="mb-2 text-xs text-muted-foreground">Failed to load tool result</div>
+          )}
           {CustomExpandedView ? (
             <CustomExpandedView
               input={toolCall.input}
               result={resultStr}
-              isError={toolCall.isError ?? false}
+              isError={isError ?? false}
               agentSlug={agentSlug}
             />
           ) : (
@@ -197,12 +297,12 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
               {resultStr && (
                 <div>
                   <div className="text-xs font-medium tracking-wider text-muted-foreground mb-1">
-                    {toolCall.isError ? 'Error' : 'Output'}
+                    {isError ? 'Error' : 'Output'}
                   </div>
                   <pre
                     className={cn(
                       'bg-background rounded p-2 text-xs overflow-x-auto max-h-40 overflow-y-auto',
-                      toolCall.isError && 'text-red-800 dark:text-red-200'
+                      isError && 'text-red-800 dark:text-red-200'
                     )}
                   >
                     {resultStr}
@@ -227,14 +327,14 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
           {omittedImages.length > 0 && (
             <div className="mt-2 space-y-2">
               {omittedImages.map((img, i) => (
-                <div
+                <OmittedScreenshot
                   key={i}
-                  data-testid="omitted-screenshot"
-                  className="flex items-center gap-2 rounded border border-dashed border-border px-2 py-2 text-xs text-muted-foreground"
-                >
-                  <ImageOff className="h-3.5 w-3.5 shrink-0" />
-                  Screenshot omitted ({formatOmittedSize(img.originalChars)})
-                </div>
+                  agentSlug={agentSlug}
+                  sessionId={sessionId}
+                  toolUseId={toolCall.id}
+                  index={i}
+                  originalChars={img.originalChars}
+                />
               ))}
             </div>
           )}

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -1,6 +1,6 @@
 
 import { cn } from '@shared/lib/utils/cn'
-import { Check, X, Ban, ChevronDown, ChevronRight, Loader2, Search } from 'lucide-react'
+import { Check, X, Ban, ChevronDown, ChevronRight, Loader2, Search, ImageOff } from 'lucide-react'
 import { useState, useRef, useMemo, memo } from 'react'
 import { getToolRenderer } from './tool-renderers'
 import { parseToolResult } from '@renderer/lib/parse-tool-result'
@@ -36,6 +36,12 @@ function getStatus(toolCall: ApiToolCall, isSessionActive?: boolean): ToolCallSt
 
 function isUserInputTool(name: string): boolean {
   return name === 'AskUserQuestion' || name.startsWith('mcp__user-input__')
+}
+
+function formatOmittedSize(chars: number): string {
+  if (chars >= 1_000_000) return `${(chars / 1_000_000).toFixed(1)} MB`
+  if (chars >= 1_000) return `${Math.round(chars / 1_000)} KB`
+  return `${chars} chars`
 }
 
 function ToolNameWithSummary({ name, summary, active = false }: { name: string; summary?: string | null; active?: boolean }) {
@@ -109,6 +115,7 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
   const parsed = useMemo(() => parseToolResult(toolCall.result), [toolCall.result])
   const resultStr = parsed.text
   const resultImages = parsed.images
+  const omittedImages = parsed.omittedImages
 
   // Get custom expanded view if available
   const CustomExpandedView = renderer?.ExpandedView
@@ -214,6 +221,20 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
                   alt="Tool result"
                   className="max-w-full rounded border"
                 />
+              ))}
+            </div>
+          )}
+          {omittedImages.length > 0 && (
+            <div className="mt-2 space-y-2">
+              {omittedImages.map((img, i) => (
+                <div
+                  key={i}
+                  data-testid="omitted-screenshot"
+                  className="flex items-center gap-2 rounded border border-dashed border-border px-2 py-2 text-xs text-muted-foreground"
+                >
+                  <ImageOff className="h-3.5 w-3.5 shrink-0" />
+                  Screenshot omitted ({formatOmittedSize(img.originalChars)})
+                </div>
               ))}
             </div>
           )}

--- a/src/renderer/components/messages/use-pending-requests.tsx
+++ b/src/renderer/components/messages/use-pending-requests.tsx
@@ -7,6 +7,7 @@ import { isTurnStartingUserMessage, type PendingMessage } from './pending-messag
 import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp } from '@shared/lib/computer-use/types'
 import { askUserQuestionDef } from '@shared/lib/tool-definitions/ask-user-question'
 import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
+import { toolCallHasResult } from '@shared/lib/types/api'
 
 interface UsePendingRequestsArgs {
   sessionId: string
@@ -632,7 +633,7 @@ export function usePendingRequests({
       if (hasSubsequentUserMessage) continue
 
       for (const toolCall of message.toolCalls) {
-        if (toolCall.result !== undefined) continue
+        if (toolCallHasResult(toolCall)) continue
         addPendingRequestFromToolCall(buckets, toolCall)
       }
     }

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -24,7 +24,7 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
   return useQuery<ApiMessageOrBoundary[]>({
     queryKey: ['messages', sessionId, agentSlug],
     queryFn: async () => {
-      const res = await apiFetch(`/api/agents/${agentSlug}/sessions/${sessionId}/messages`)
+      const res = await apiFetch(`/api/agents/${agentSlug}/sessions/${sessionId}/messages?strip-tools=1`)
       if (res.status === 404) throw new TranscriptNotFoundError()
       if (!res.ok) throw new Error('Failed to fetch messages')
       return res.json()

--- a/src/renderer/lib/parse-tool-result.test.ts
+++ b/src/renderer/lib/parse-tool-result.test.ts
@@ -5,24 +5,24 @@ describe('parseToolResult', () => {
   describe('null/undefined input', () => {
     it('returns null text and no images for null', () => {
       const result = parseToolResult(null)
-      expect(result).toEqual({ text: null, images: [] })
+      expect(result).toEqual({ text: null, images: [], omittedImages: [] })
     })
 
     it('returns null text and no images for undefined', () => {
       const result = parseToolResult(undefined)
-      expect(result).toEqual({ text: null, images: [] })
+      expect(result).toEqual({ text: null, images: [], omittedImages: [] })
     })
   })
 
   describe('plain string input', () => {
     it('returns the string as text', () => {
       const result = parseToolResult('hello world')
-      expect(result).toEqual({ text: 'hello world', images: [] })
+      expect(result).toEqual({ text: 'hello world', images: [], omittedImages: [] })
     })
 
     it('returns empty string as text', () => {
       const result = parseToolResult('')
-      expect(result).toEqual({ text: '', images: [] })
+      expect(result).toEqual({ text: '', images: [], omittedImages: [] })
     })
 
     it('handles strings with ANSI escape codes', () => {
@@ -44,7 +44,7 @@ describe('parseToolResult', () => {
     it('parses a JSON string containing text blocks', () => {
       const json = JSON.stringify([{ type: 'text', text: 'parsed text' }])
       const result = parseToolResult(json)
-      expect(result).toEqual({ text: 'parsed text', images: [] })
+      expect(result).toEqual({ text: 'parsed text', images: [], omittedImages: [] })
     })
 
     it('parses a JSON string containing image blocks (MCP format)', () => {
@@ -70,7 +70,7 @@ describe('parseToolResult', () => {
   describe('content block arrays (objects)', () => {
     it('extracts text from a single text block', () => {
       const result = parseToolResult([{ type: 'text', text: 'hello' }])
-      expect(result).toEqual({ text: 'hello', images: [] })
+      expect(result).toEqual({ text: 'hello', images: [], omittedImages: [] })
     })
 
     it('concatenates multiple text blocks with newlines', () => {
@@ -78,7 +78,7 @@ describe('parseToolResult', () => {
         { type: 'text', text: 'line 1' },
         { type: 'text', text: 'line 2' },
       ])
-      expect(result).toEqual({ text: 'line 1\nline 2', images: [] })
+      expect(result).toEqual({ text: 'line 1\nline 2', images: [], omittedImages: [] })
     })
 
     it('extracts images in Anthropic API format', () => {
@@ -140,14 +140,14 @@ describe('parseToolResult', () => {
 
     it('returns null text for empty arrays', () => {
       const result = parseToolResult([])
-      expect(result).toEqual({ text: null, images: [] })
+      expect(result).toEqual({ text: null, images: [], omittedImages: [] })
     })
   })
 
   describe('single content block objects', () => {
     it('extracts text from a single text block object', () => {
       const result = parseToolResult({ type: 'text', text: 'single block' })
-      expect(result).toEqual({ text: 'single block', images: [] })
+      expect(result).toEqual({ text: 'single block', images: [], omittedImages: [] })
     })
 
     it('extracts image from a single Anthropic format image block', () => {
@@ -183,6 +183,32 @@ describe('parseToolResult', () => {
       const result = parseToolResult(obj)
       expect(result.text).toBe(JSON.stringify(obj, null, 2))
       expect(result.images).toEqual([])
+    })
+  })
+
+  describe('omitted image payloads', () => {
+    it('collects omitted Anthropic image blocks without treating them as renderable', () => {
+      const result = parseToolResult([
+        {
+          type: 'image',
+          omitted: true,
+          originalChars: 99_000,
+          source: { type: 'base64', media_type: 'image/png' },
+        },
+      ])
+      expect(result.images).toEqual([])
+      expect(result.omittedImages).toEqual([{ mimeType: 'image/png', originalChars: 99_000 }])
+    })
+
+    it('collects omitted MCP image blocks', () => {
+      const result = parseToolResult({
+        type: 'image',
+        omitted: true,
+        originalChars: 50_000,
+        mimeType: 'image/jpeg',
+      })
+      expect(result.images).toEqual([])
+      expect(result.omittedImages).toEqual([{ mimeType: 'image/jpeg', originalChars: 50_000 }])
     })
   })
 })

--- a/src/renderer/lib/parse-tool-result.ts
+++ b/src/renderer/lib/parse-tool-result.ts
@@ -5,24 +5,42 @@ interface ContentBlock {
   // MCP image format
   data?: string
   mimeType?: string
+  omitted?: boolean
+  originalChars?: number
 }
 
 export interface ParsedToolResult {
   text: string | null
   images: Array<{ data: string; mimeType: string }>
+  omittedImages: Array<{ mimeType?: string; originalChars: number }>
 }
 
-/**
- * Extract displayable text and images from a tool result.
- * Results can be: a plain string, a JSON string of content blocks,
- * or an array of content block objects (from MCP).
- */
+function collectImage(
+  block: ContentBlock,
+  images: ParsedToolResult['images'],
+  omittedImages: ParsedToolResult['omittedImages']
+) {
+  if (block.omitted) {
+    omittedImages.push({
+      mimeType: block.source?.media_type ?? block.mimeType,
+      originalChars: typeof block.originalChars === 'number' ? block.originalChars : 0,
+    })
+    return
+  }
+  if (block.source?.data && block.source?.media_type) {
+    images.push({ data: block.source.data, mimeType: block.source.media_type })
+  } else if (block.data && block.mimeType) {
+    images.push({ data: block.data, mimeType: block.mimeType })
+  }
+}
+
+// Extract displayable text and images from a tool result (string, JSON blocks, or MCP array).
 export function parseToolResult(result: unknown): ParsedToolResult {
   const images: Array<{ data: string; mimeType: string }> = []
+  const omittedImages: ParsedToolResult['omittedImages'] = []
 
-  if (result == null) return { text: null, images }
+  if (result == null) return { text: null, images, omittedImages }
   if (typeof result === 'string') {
-    // Try parsing as JSON content blocks
     try {
       const parsed = JSON.parse(result)
       if (Array.isArray(parsed)) {
@@ -31,7 +49,7 @@ export function parseToolResult(result: unknown): ParsedToolResult {
     } catch {
       // Plain string
     }
-    return { text: result, images }
+    return { text: result, images, omittedImages }
   }
 
   if (Array.isArray(result)) {
@@ -40,33 +58,20 @@ export function parseToolResult(result: unknown): ParsedToolResult {
       if (block.type === 'text' && block.text) {
         textParts.push(block.text)
       } else if (block.type === 'image') {
-        // Anthropic API format: { type: "image", source: { type: "base64", media_type, data } }
-        if (block.source?.data && block.source?.media_type) {
-          images.push({ data: block.source.data, mimeType: block.source.media_type })
-        }
-        // MCP format: { type: "image", data, mimeType }
-        else if (block.data && block.mimeType) {
-          images.push({ data: block.data, mimeType: block.mimeType })
-        }
+        collectImage(block, images, omittedImages)
       }
     }
-    return { text: textParts.length > 0 ? textParts.join('\n') : null, images }
+    return { text: textParts.length > 0 ? textParts.join('\n') : null, images, omittedImages }
   }
 
-  // Single content block object
   const block = result as ContentBlock
   if (block.type === 'text' && block.text) {
-    return { text: block.text, images }
+    return { text: block.text, images, omittedImages }
   }
   if (block.type === 'image') {
-    if (block.source?.data && block.source?.media_type) {
-      images.push({ data: block.source.data, mimeType: block.source.media_type })
-    } else if (block.data && block.mimeType) {
-      images.push({ data: block.data, mimeType: block.mimeType })
-    }
-    return { text: null, images }
+    collectImage(block, images, omittedImages)
+    return { text: null, images, omittedImages }
   }
 
-  // Fallback: stringify
-  return { text: JSON.stringify(result, null, 2), images }
+  return { text: JSON.stringify(result, null, 2), images, omittedImages }
 }

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -15,6 +15,8 @@ import {
   getSession,
   getSessionMessages,
   getSessionMessagesWithCompact,
+  getSessionToolResult,
+  getSessionToolResultImage,
   readDisplayTranscript,
   DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS,
   deleteSession,
@@ -945,6 +947,87 @@ describe('session-service', () => {
         originalChars: huge.length,
       })
       expect(JSON.stringify(content[0])).not.toContain('[truncated')
+    })
+  })
+
+  describe('getSessionToolResultImage', () => {
+    it('returns the full image payload that display reads omit', async () => {
+      const huge = 'A'.repeat(DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS + 8000)
+      await createSessionFile('test-agent', 'image-fetch-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'toolu_shot',
+                content: [
+                  { type: 'text', text: 'viewport' },
+                  { type: 'image', source: { type: 'base64', media_type: 'image/png', data: huge } },
+                ],
+              },
+            ],
+          },
+        },
+      ])
+
+      const image = await getSessionToolResultImage('test-agent', 'image-fetch-session', 'toolu_shot', 0)
+      expect(image).toEqual({ mimeType: 'image/png', data: huge })
+    })
+
+    it('returns null for a missing tool or index', async () => {
+      await createSessionFile('test-agent', 'empty-image-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: { role: 'user', content: 'hello' },
+        },
+      ])
+      expect(await getSessionToolResultImage('test-agent', 'empty-image-session', 'missing', 0)).toBeNull()
+      expect(await getSessionToolResultImage('test-agent', 'missing-session', 'toolu_shot', 0)).toBeNull()
+    })
+  })
+
+  describe('getSessionToolResult', () => {
+    it('returns the full tool result that display reads cap', async () => {
+      const huge = 'A'.repeat(DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS + 8000)
+      await createSessionFile('test-agent', 'result-fetch-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'toolu_ls',
+                content: huge,
+              },
+            ],
+          },
+        },
+      ])
+
+      const found = await getSessionToolResult('test-agent', 'result-fetch-session', 'toolu_ls')
+      expect(found).toEqual({ result: huge, isError: false })
+    })
+
+    it('returns null for a missing tool or session', async () => {
+      await createSessionFile('test-agent', 'empty-result-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: { role: 'user', content: 'hello' },
+        },
+      ])
+      expect(await getSessionToolResult('test-agent', 'empty-result-session', 'missing')).toBeNull()
+      expect(await getSessionToolResult('test-agent', 'missing-session', 'toolu_ls')).toBeNull()
     })
   })
 

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -14,6 +14,9 @@ import {
   listSessionsByIds,
   getSession,
   getSessionMessages,
+  getSessionMessagesWithCompact,
+  readDisplayTranscript,
+  DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS,
   deleteSession,
   deleteSessionsBatch,
   readSessionMetadata,
@@ -737,6 +740,83 @@ describe('session-service', () => {
       expect(queued.uuid).toBe('queue-source-uuid')
       expect(queued.timestamp).toBe('2025-01-01T00:01:00.000Z')
       expect(queued.message.content).toEqual([{ type: 'text', text: 'Queued mid-turn message' }])
+    })
+  })
+
+  describe('getSessionMessagesWithCompact', () => {
+    it('returns empty array for a missing transcript', async () => {
+      await createSessionsDir('test-agent')
+      expect(await getSessionMessagesWithCompact('test-agent', 'missing')).toEqual([])
+      expect(await readDisplayTranscript('/no/such/file.jsonl')).toEqual([])
+    })
+
+    it('keeps compact_boundary system entries', async () => {
+      await createSessionFile('test-agent', 'compact-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: { role: 'user', content: 'hello' },
+        },
+        {
+          type: 'system',
+          uuid: 'c1',
+          timestamp: '2026-01-01T00:00:01.000Z',
+          subtype: 'compact_boundary',
+          compactMetadata: { trigger: 'auto', preTokens: 12 },
+        },
+        { type: 'file-history-snapshot', messageId: '123', snapshot: {} },
+      ])
+
+      const entries = await getSessionMessagesWithCompact('test-agent', 'compact-session')
+      expect(entries.map((e) => e.type)).toEqual(['user', 'system'])
+      expect(entries[1]).toMatchObject({ subtype: 'compact_boundary' })
+    })
+
+    it('caps oversized tool_result strings on display reads only', async () => {
+      const huge = 'x'.repeat(DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS + 4000)
+      await createSessionFile('test-agent', 'huge-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 't1', content: huge }],
+          },
+          toolUseResult: { stdout: huge, stderr: '', interrupted: false, isImage: false },
+        },
+      ])
+
+      const display = await getSessionMessagesWithCompact('test-agent', 'huge-session')
+      const displayMsg = display[0] as {
+        message: { content: Array<{ content: string }> }
+        toolUseResult?: { stdout: string }
+      }
+      expect(displayMsg.message.content[0].content.length).toBeLessThan(huge.length)
+      expect(displayMsg.message.content[0].content).toContain('[truncated')
+      expect(displayMsg.toolUseResult?.stdout.length).toBeLessThan(huge.length)
+      expect(displayMsg.toolUseResult?.stdout).toContain('[truncated')
+
+      const full = await getSessionMessages('test-agent', 'huge-session')
+      const fullContent = full[0].message.content as Array<{ content: string }>
+      expect(fullContent[0].content).toBe(huge)
+      expect(full[0].toolUseResult?.stdout).toBe(huge)
+    })
+
+    it('leaves strings at the cap unchanged', async () => {
+      const exact = 'y'.repeat(DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS)
+      await createSessionFile('test-agent', 'exact-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: { role: 'user', content: exact },
+        },
+      ])
+
+      const display = await getSessionMessagesWithCompact('test-agent', 'exact-session')
+      expect((display[0] as { message: { content: string } }).message.content).toBe(exact)
     })
   })
 

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -818,6 +818,134 @@ describe('session-service', () => {
       const display = await getSessionMessagesWithCompact('test-agent', 'exact-session')
       expect((display[0] as { message: { content: string } }).message.content).toBe(exact)
     })
+
+    it('omits oversized image payloads instead of slicing the base64', async () => {
+      const huge = 'A'.repeat(DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS + 8000)
+      await createSessionFile('test-agent', 'image-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 't1',
+                content: [
+                  { type: 'text', text: 'screenshot below' },
+                  {
+                    type: 'image',
+                    source: { type: 'base64', media_type: 'image/png', data: huge },
+                  },
+                  { type: 'image', data: huge, mimeType: 'image/jpeg' },
+                ],
+              },
+            ],
+          },
+        },
+      ])
+
+      const display = await getSessionMessagesWithCompact('test-agent', 'image-session')
+      const blocks = (
+        display[0] as {
+          message: {
+            content: Array<{
+              content: Array<Record<string, unknown>>
+            }>
+          }
+        }
+      ).message.content[0].content
+
+      const anthropic = blocks[1]
+      const mcp = blocks[2]
+      expect(anthropic).toMatchObject({
+        type: 'image',
+        omitted: true,
+        originalChars: huge.length,
+        source: { type: 'base64', media_type: 'image/png' },
+      })
+      expect(anthropic.source).not.toHaveProperty('data')
+      expect(JSON.stringify(anthropic)).not.toContain('[truncated')
+      expect(mcp).toMatchObject({
+        type: 'image',
+        omitted: true,
+        originalChars: huge.length,
+        mimeType: 'image/jpeg',
+      })
+      expect(mcp).not.toHaveProperty('data')
+
+      const full = await getSessionMessages('test-agent', 'image-session')
+      const fullBlocks = (full[0].message.content as Array<{ content: Array<{ source?: { data?: string }; data?: string }> }>)[0]
+        .content
+      expect(fullBlocks[1].source?.data).toBe(huge)
+      expect(fullBlocks[2].data).toBe(huge)
+    })
+
+    it('keeps image payloads at the cap', async () => {
+      const exact = 'B'.repeat(DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS)
+      await createSessionFile('test-agent', 'small-image-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 't1',
+                content: [
+                  {
+                    type: 'image',
+                    source: { type: 'base64', media_type: 'image/png', data: exact },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ])
+
+      const display = await getSessionMessagesWithCompact('test-agent', 'small-image-session')
+      const block = (
+        display[0] as {
+          message: { content: Array<{ content: Array<{ source?: { data?: string }; omitted?: boolean }> }> }
+        }
+      ).message.content[0].content[0]
+      expect(block.source?.data).toBe(exact)
+      expect(block.omitted).toBeUndefined()
+    })
+
+    it('caps JSON-encoded image arrays without slicing the payload string', async () => {
+      const huge = 'C'.repeat(DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS + 8000)
+      const encoded = JSON.stringify([
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: huge } },
+      ])
+      await createSessionFile('test-agent', 'json-image-session', [
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 't1', content: encoded }],
+          },
+        },
+      ])
+
+      const display = await getSessionMessagesWithCompact('test-agent', 'json-image-session')
+      const content = (
+        display[0] as { message: { content: Array<{ content: Array<Record<string, unknown>> }> } }
+      ).message.content[0].content
+      expect(Array.isArray(content)).toBe(true)
+      expect(content[0]).toMatchObject({
+        type: 'image',
+        omitted: true,
+        originalChars: huge.length,
+      })
+      expect(JSON.stringify(content[0])).not.toContain('[truncated')
+    })
   })
 
   describe('deleteSession', () => {

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -398,6 +398,70 @@ function isMessageEntry(entry: JsonlEntry): entry is JsonlMessageEntry {
   return entry.type === 'user' || entry.type === 'assistant'
 }
 
+function isMessageOrSystemDisplayEntry(
+  entry: JsonlEntry
+): entry is JsonlMessageEntry | JsonlSystemEntry {
+  if (entry.type === 'user' || entry.type === 'assistant') return true
+  if (entry.type === 'system') {
+    const subtype = (entry as JsonlSystemEntry).subtype
+    return subtype === 'compact_boundary' || subtype === 'memory_recall' || subtype === 'informational'
+  }
+  return false
+}
+
+/** Per-field cap for display reads. Oversized tool_result rows are the OOM vector. */
+export const DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS = 32_768
+
+function capDisplayString(value: string): string {
+  if (value.length <= DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS) return value
+  return `${value.slice(0, DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS)}\n…[truncated ${value.length - DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS} chars]`
+}
+
+function capDisplayValue(value: unknown, depth = 0): unknown {
+  if (depth > 8 || value == null) return value
+  if (typeof value === 'string') return capDisplayString(value)
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = capDisplayValue(value[i], depth + 1)
+    }
+    return value
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    for (const key of Object.keys(obj)) {
+      obj[key] = capDisplayValue(obj[key], depth + 1)
+    }
+    return obj
+  }
+  return value
+}
+
+async function forEachTranscriptEntry(
+  jsonlPath: string,
+  visit: (entry: JsonlEntry) => void
+): Promise<void> {
+  try {
+    for await (const raw of streamJsonlFile<JsonlEntry>(jsonlPath)) {
+      visit(normalizeQueuedCommandEntry(raw))
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
+  }
+}
+
+/** Stream a transcript for UI/API display, capping oversized string fields. */
+export async function readDisplayTranscript(
+  jsonlPath: string
+): Promise<(JsonlMessageEntry | JsonlSystemEntry)[]> {
+  const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
+  await forEachTranscriptEntry(jsonlPath, (entry) => {
+    if (!isMessageOrSystemDisplayEntry(entry)) return
+    entries.push(capDisplayValue(entry) as JsonlMessageEntry | JsonlSystemEntry)
+  })
+  return entries
+}
+
 /**
  * Convert a `queued_command` attachment entry into a synthetic user message
  * entry. The CLI records user messages that arrive mid-turn (queued/steering
@@ -861,27 +925,11 @@ export async function getSessionMessages(
   sessionId: string
 ): Promise<JsonlMessageEntry[]> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
-
-  if (!(await fileExists(jsonlPath))) {
-    return []
-  }
-
-  const entries = await readJsonlFile<JsonlEntry>(jsonlPath)
-  return entries.map(normalizeQueuedCommandEntry).filter(isMessageEntry)
-}
-
-/**
- * Check if a JSONL entry is a message or compact boundary (for display)
- */
-function isMessageOrSystemDisplayEntry(
-  entry: JsonlEntry
-): entry is JsonlMessageEntry | JsonlSystemEntry {
-  if (entry.type === 'user' || entry.type === 'assistant') return true
-  if (entry.type === 'system') {
-    const subtype = (entry as JsonlSystemEntry).subtype
-    return subtype === 'compact_boundary' || subtype === 'memory_recall' || subtype === 'informational'
-  }
-  return false
+  const messages: JsonlMessageEntry[] = []
+  await forEachTranscriptEntry(jsonlPath, (entry) => {
+    if (isMessageEntry(entry)) messages.push(entry)
+  })
+  return messages
 }
 
 /**
@@ -891,14 +939,7 @@ export async function getSessionMessagesWithCompact(
   agentSlug: string,
   sessionId: string
 ): Promise<(JsonlMessageEntry | JsonlSystemEntry)[]> {
-  const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
-
-  if (!(await fileExists(jsonlPath))) {
-    return []
-  }
-
-  const entries = await readJsonlFile<JsonlEntry>(jsonlPath)
-  return entries.map(normalizeQueuedCommandEntry).filter(isMessageOrSystemDisplayEntry)
+  return readDisplayTranscript(getSessionJsonlPath(agentSlug, sessionId))
 }
 
 /**

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -417,9 +417,40 @@ function capDisplayString(value: string): string {
   return `${value.slice(0, DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS)}\n…[truncated ${value.length - DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS} chars]`
 }
 
+function omitOversizedImagePayload(block: Record<string, unknown>): void {
+  let originalChars: number | undefined
+  const source = block.source
+  if (source && typeof source === 'object') {
+    const src = source as Record<string, unknown>
+    if (typeof src.data === 'string' && src.data.length > DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS) {
+      originalChars = src.data.length
+      delete src.data
+    }
+  }
+  if (typeof block.data === 'string' && block.data.length > DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS) {
+    originalChars = block.data.length
+    delete block.data
+  }
+  if (originalChars != null) {
+    block.omitted = true
+    block.originalChars = originalChars
+  }
+}
+
 function capDisplayValue(value: unknown, depth = 0): unknown {
   if (depth > 8 || value == null) return value
-  if (typeof value === 'string') return capDisplayString(value)
+  if (typeof value === 'string') {
+    if (value.length <= DISPLAY_TRANSCRIPT_FIELD_MAX_CHARS) return value
+    const trimmed = value.trimStart()
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        return capDisplayValue(JSON.parse(value), depth)
+      } catch {
+        // Not JSON — fall through to a text cap.
+      }
+    }
+    return capDisplayString(value)
+  }
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; i++) {
       value[i] = capDisplayValue(value[i], depth + 1)
@@ -428,6 +459,10 @@ function capDisplayValue(value: unknown, depth = 0): unknown {
   }
   if (typeof value === 'object') {
     const obj = value as Record<string, unknown>
+    if (obj.type === 'image') {
+      omitOversizedImagePayload(obj)
+      return obj
+    }
     for (const key of Object.keys(obj)) {
       obj[key] = capDisplayValue(obj[key], depth + 1)
     }

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -27,6 +27,7 @@ import {
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
+import type { SessionToolResult, TranscriptImage } from './session-transcript-schema'
 import { isHiddenAutomatedSession } from './session-visibility'
 import {
   SessionInfo,
@@ -483,6 +484,129 @@ async function forEachTranscriptEntry(
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
     throw error
   }
+}
+
+function pushImageBlock(block: Record<string, unknown>, out: TranscriptImage[]): void {
+  const source = block.source
+  if (source && typeof source === 'object') {
+    const src = source as Record<string, unknown>
+    if (typeof src.data === 'string' && typeof src.media_type === 'string') {
+      out.push({ mimeType: src.media_type, data: src.data })
+      return
+    }
+  }
+  if (typeof block.data === 'string' && typeof block.mimeType === 'string') {
+    out.push({ mimeType: block.mimeType, data: block.data })
+  }
+}
+
+function collectImages(value: unknown, out: TranscriptImage[]): void {
+  if (value == null) return
+  if (typeof value === 'string') {
+    const trimmed = value.trimStart()
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        collectImages(JSON.parse(value), out)
+      } catch {
+        return
+      }
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectImages(item, out)
+    return
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    if (obj.type === 'image') {
+      pushImageBlock(obj, out)
+      return
+    }
+    for (const nested of Object.values(obj)) {
+      if (nested && typeof nested === 'object') collectImages(nested, out)
+    }
+  }
+}
+
+function toolResultForUse(
+  entry: JsonlMessageEntry,
+  toolUseId: string
+): { content: unknown; isError: boolean } | null {
+  const content = entry.message.content
+  if (!Array.isArray(content)) return null
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue
+    const result = block as { type?: string; tool_use_id?: string; content?: unknown; is_error?: boolean }
+    if (result.type !== 'tool_result' || result.tool_use_id !== toolUseId) continue
+    return {
+      content: entry.toolUseResult?.stdout ?? result.content ?? '',
+      isError: result.is_error === true,
+    }
+  }
+  return null
+}
+
+function imagesForToolUse(entry: JsonlMessageEntry, toolUseId: string): TranscriptImage[] | null {
+  const content = entry.message.content
+  if (!Array.isArray(content)) return null
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue
+    const result = block as { type?: string; tool_use_id?: string; content?: unknown }
+    if (result.type !== 'tool_result' || result.tool_use_id !== toolUseId) continue
+    const images: TranscriptImage[] = []
+    collectImages(result.content, images)
+    if (images.length === 0) collectImages(entry.toolUseResult, images)
+    return images
+  }
+  return null
+}
+
+/** Full-fidelity tool result from disk. Display list reads may omit this payload. */
+export async function getSessionToolResult(
+  agentSlug: string,
+  sessionId: string,
+  toolUseId: string
+): Promise<SessionToolResult | null> {
+  if (!toolUseId) return null
+  const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+  try {
+    for await (const raw of streamJsonlFile<JsonlEntry>(jsonlPath)) {
+      const entry = normalizeQueuedCommandEntry(raw)
+      if (!isMessageEntry(entry)) continue
+      const found = toolResultForUse(entry, toolUseId)
+      if (!found) continue
+      return { result: found.content, isError: found.isError }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+  return null
+}
+
+/** Full-fidelity image from disk. Display reads omit these; this is the on-demand path. */
+export async function getSessionToolResultImage(
+  agentSlug: string,
+  sessionId: string,
+  toolUseId: string,
+  index: number
+): Promise<TranscriptImage | null> {
+  if (index < 0 || !toolUseId) return null
+  const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+  try {
+    for await (const raw of streamJsonlFile<JsonlEntry>(jsonlPath)) {
+      const entry = normalizeQueuedCommandEntry(raw)
+      if (!isMessageEntry(entry)) continue
+      const images = imagesForToolUse(entry, toolUseId)
+      if (!images) continue
+      return images[index] ?? null
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+  return null
 }
 
 /** Stream a transcript for UI/API display, capping oversized string fields. */

--- a/src/shared/lib/services/session-transcript-schema.ts
+++ b/src/shared/lib/services/session-transcript-schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+export const transcriptImageSchema = z.object({
+  mimeType: z.string().min(1),
+  data: z.string().min(1),
+})
+
+export type TranscriptImage = z.infer<typeof transcriptImageSchema>
+
+export const toolUseIdParamSchema = z.string().regex(/^[\w.-]{1,128}$/)
+
+export const toolResultParamsSchema = z.object({
+  toolUseId: toolUseIdParamSchema,
+})
+
+export const toolResultImageParamsSchema = toolResultParamsSchema.extend({
+  index: z.coerce.number().int().min(0).max(50),
+})
+
+export const sessionToolResultSchema = z.object({
+  result: z.unknown(),
+  isError: z.boolean(),
+})
+
+export type SessionToolResult = z.infer<typeof sessionToolResultSchema>

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -119,6 +119,8 @@ export interface ApiToolCall {
   name: string
   input: Record<string, unknown>
   result?: unknown
+  /** True when a result exists but was omitted from this payload (`strip-tools`). */
+  hasResult?: boolean
   isError?: boolean
   subagent?: {
     agentId: string
@@ -127,6 +129,10 @@ export interface ApiToolCall {
     totalTokens?: number
     totalToolUseCount?: number
   }
+}
+
+export function toolCallHasResult(toolCall: Pick<ApiToolCall, 'result' | 'hasResult'>): boolean {
+  return toolCall.hasResult === true || (toolCall.result !== undefined && toolCall.result !== null)
 }
 
 /**

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -655,6 +655,17 @@ describe('readJsonlFile', () => {
     const result = await readJsonlFile(path.join(testDir, 'nonexistent.jsonl'))
     expect(result).toEqual([])
   })
+
+  it('parses a large file without requiring a full-string split', async () => {
+    const filePath = path.join(testDir, 'many.jsonl')
+    const lines = Array.from({ length: 2000 }, (_, i) => JSON.stringify({ id: i }))
+    await fs.promises.writeFile(filePath, lines.join('\n'))
+
+    const result = await readJsonlFile<{ id: number }>(filePath)
+    expect(result).toHaveLength(2000)
+    expect(result[0]).toEqual({ id: 0 })
+    expect(result[1999]).toEqual({ id: 1999 })
+  })
 })
 
 describe('streamJsonlFile', () => {

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -342,16 +342,18 @@ export function parseJsonl<T = unknown>(content: string): T[] {
   return results
 }
 
-/**
- * Read and parse a JSONL file
- * Returns empty array if file doesn't exist
- */
+/** Stream-parse JSONL. Missing file → []. Peak cost is one row plus the result array. */
 export async function readJsonlFile<T = unknown>(filePath: string): Promise<T[]> {
-  const content = await readFileOrNull(filePath)
-  if (content === null) {
-    return []
+  const results: T[] = []
+  try {
+    for await (const item of streamJsonlFile<T>(filePath)) {
+      results.push(item)
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
   }
-  return parseJsonl<T>(content)
+  return results
 }
 
 const NEWLINE_BYTE = 0x0a

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -24,6 +24,7 @@ export interface TransformedMessage {
     name: string
     input: Record<string, unknown>
     result?: string
+    hasResult?: boolean
     isError?: boolean
     subagent?: {
       agentId: string


### PR DESCRIPTION
## Bug

Opening a large session kills the host-app with `OutOfMemoryError: container killed due to memory usage` (exit 137). Clients retry `GET /messages`, the replacement task dies again, and the org crash-loops.

Repro: a session whose JSONL is tens of MB (typical cause: large `tool_result` / browser / fetch rows). `GET /api/agents/:id/sessions/:sessionId/messages` reads the entire file into memory on every request (`readFile` → split → `JSON.parse` every line → transform → JSON response), with no size cap. Concurrent reconnects multiply that.

Observed on a cloud org: memory sat at 400–500 MB, then spiked to ~1 GB and the ECS task was OOM-killed. Replacements lasted 12 / 6 / 4 minutes.

## Supporting evidence (prod, 2026-08-13)

From CloudWatch / ECS / Sentry for one affected cloud org (one agent, one oversized session):

- **OOM kills** — three consecutive host-app tasks stopped with `OutOfMemoryError: container killed due to memory usage`. Lifetimes after the first death: ~12 min, ~6 min, ~4 min.
- **Memory spike** — ContainerInsights `MemoryUtilized` (1-min max) sat at 310–340 MB, climbed through 400–500 MB, then **max 1017 MB** in the minute the 12-min task died. Post-crash minutes read 46–85 MB (fresh containers booting).
- **Trigger file size** — the session JSONL is **~21.7 MB**.
- **Retry loop** — each replacement task accepted a WebSocket for the same session within 1–4 minutes of starting, then died. The client kept reopening the oversized session against every fresh task.
- **Route** — Sentry `read ECONNRESET` / `socket hang up` on `GET /api/agents/:id/sessions/:sessionId/messages` (hundreds of occurrences in the crash window), matching the router's 502 / `socket hang up` storm seconds before the first task death.

## What changed

- Stream JSONL line-by-line in `readJsonlFile` so we never hold a second copy of the whole file as a string.
- Display reads (`getSessionMessagesWithCompact`, subagent transcripts, workflow agent transcripts) cap oversized string fields at 32 KB. Rewrite paths (`getSessionMessages`, delete message/tool-call) keep full fidelity.
- Oversized `image` blocks (Anthropic `source.data` / MCP `data`) are dropped, not sliced. The block keeps `omitted: true` + `originalChars`; the UI shows a "Screenshot omitted" placeholder instead of a broken `data:` URI. JSON-encoded image arrays are parsed then capped the same way.
- Response shape is unchanged (still a JSON array), so existing clients keep working. Huge tool outputs show a `[truncated N chars]` suffix in the UI.

## Test plan

- [x] `session-service` tests: missing file, compact_boundary kept, oversized tool_result capped on display only, strings at the cap unchanged, oversized screenshots omitted (not sliced), JSON-encoded image arrays parsed then omitted
- [x] `parse-tool-result` / `ToolCallItem`: omitted image blocks become a screenshot placeholder, not a broken `<img>`
- [x] `file-storage` tests: ENOENT → `[]`, large JSONL stream-parse
- [x] workflow agent-messages route still returns the fixture transcript
- [x] agents route tests
- [x] lint on changed files
- [x] local: 15 MB screenshot-heavy transcript → `GET /messages` is ~516 KB; 5 concurrent reads stay well under 1 GB RSS
