### PR TITLE
Fix iMessage contact card using the agent name instead of Bot Name

### DIFF
--- a/src/shared/lib/chat-integrations/chat-integration-manager-contact-card.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-contact-card.test.ts
@@ -42,8 +42,8 @@ function registerConnector(): void {
   mgr.connections.set(INT, { connector: { sendFile } })
 }
 
-function mockIntegration(provider: string): void {
-  vi.mocked(getChatIntegration).mockReturnValue({ provider, agentSlug: 'ada' } as never)
+function mockIntegration(provider: string, name?: string | null): void {
+  vi.mocked(getChatIntegration).mockReturnValue({ provider, agentSlug: 'ada', name: name ?? null } as never)
 }
 
 function mockAgent(): void {
@@ -105,6 +105,21 @@ describe('sendContactCard', () => {
     expect((data as Buffer).toString('utf8')).toContain('BEGIN:VCARD')
     expect(filename).toBe('Ada.vcf')
     expect(caption).toBeTruthy()
+  })
+
+  it('uses the Bot Name on the card when setup stored one, not the agent name', async () => {
+    mockIntegration('imessage', 'Phone Ada')
+    registerConnector()
+    mockAgent()
+
+    await chatIntegrationManager.sendContactCard(INT)
+
+    const [, data, filename] = sendFile.mock.calls[0]
+    const vcf = (data as Buffer).toString('utf8')
+    expect(vcf).toContain('FN:Phone Ada')
+    expect(vcf).toContain('N:Phone Ada;;;;')
+    expect(filename).toBe('Phone_Ada.vcf')
+    expect(vcf).not.toMatch(/^FN:Ada\r?$/m)
   })
 
   it('strips path characters out of the agent name before it becomes a filename', async () => {

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -456,11 +456,13 @@ class ChatIntegrationManager {
       const agent = await getAgent(integration.agentSlug)
       if (!agent) return
 
+      const cardName = integration.name?.trim() || agent.frontmatter.name
+
       const card = buildAgentContactCard({
         // UID stays the minted id: renaming the agent must not mint a second
         // contact on the phone. Only the link carries the prettier display slug.
         slug: integration.agentSlug,
-        name: agent.frontmatter.name,
+        name: cardName,
         description: agent.frontmatter.description,
         appUrl: resolveAgentWebUrl(displaySlug(agent.frontmatter.name, integration.agentSlug)),
       })
@@ -474,7 +476,7 @@ class ChatIntegrationManager {
       await connector.sendFile(
         '',
         card,
-        `${sanitizeUploadFilename(agent.frontmatter.name)}.vcf`,
+        `${sanitizeUploadFilename(cardName)}.vcf`,
         `Save me as a contact so I'm not just a number. Text me anytime.`,
       )
     } catch (err) {


### PR DESCRIPTION
## Summary

- After iMessage setup, the contact card on the phone used the original agent name.
- The card now uses the Bot Name from setup when one is set.
- If Bot Name is blank, the card still uses the agent name.
- Telegram and Slack are unchanged. Those apps already have a name from BotFather or the Slack app.

## Test plan

- [ ] Unit: Bot Name `Phone Ada` and agent name `Ada` → card `FN`/`N` and filename use Phone Ada
- [ ] Unit: no Bot Name → card still uses the agent name
- [ ] App link on the card still points at the agent, not the Bot Name
