### PR TITLE
fix(microvm): multiplex ingress over HTTP/2

### DIFF
--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -9,12 +9,7 @@ const responses: Record<string, unknown> = {}
 
 // Upstream transports are mocked so the proxy's real loopback server can be
 // driven by real http/net clients while we capture what it forwards upstream.
-const httpsRequestMock = vi.fn()
 const tlsConnectMock = vi.fn()
-vi.mock('https', () => ({
-  default: { request: (...a: unknown[]) => httpsRequestMock(...a) },
-  request: (...a: unknown[]) => httpsRequestMock(...a),
-}))
 vi.mock('tls', () => ({
   default: { connect: (...a: unknown[]) => tlsConnectMock(...a) },
   connect: (...a: unknown[]) => tlsConnectMock(...a),
@@ -81,7 +76,6 @@ beforeEach(() => {
   for (const k in responses) delete responses[k]
   autoSleepTimeoutMinutes.mockReturnValue(30)
   sendMock.mockReset()
-  httpsRequestMock.mockReset()
   tlsConnectMock.mockReset()
   sendMock.mockImplementation(async (cmd: { type: string }) => {
     if (cmd.type === 'Run') return { microvmId: 'mvm-1', endpoint: 'ep.lambda-microvm.aws' }
@@ -1009,19 +1003,67 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
 })
 
 describe('LocalAuthForwardProxy', () => {
-  let capturedRequest: { host?: string; path?: string; headers?: Record<string, string> }
+  let capturedRequest: { host?: string; path?: string; headers?: Record<string, string>; timeout?: number }
   const proxies: LocalAuthForwardProxy[] = []
+
+  type H2Stream = PassThrough & { setTimeout: (ms: number) => void }
+  type H2Handler = (headers: Record<string, string>, stream: H2Stream) => void
+
+  function h2Respond(stream: H2Stream, status: number, body: string) {
+    if (body) stream.push(Buffer.from(body))
+    process.nextTick(() => {
+      stream.emit('response', { ':status': status })
+      stream.push(null)
+    })
+  }
+
+  function mockH2Session(handler: H2Handler) {
+    return {
+      closed: false,
+      destroyed: false,
+      request(headers: Record<string, string>) {
+        const stream = new PassThrough() as H2Stream
+        stream.setTimeout = (ms: number) => {
+          capturedRequest = { ...capturedRequest, timeout: ms }
+        }
+        handler(headers, stream)
+        return stream
+      },
+      destroy() {
+        this.destroyed = true
+        this.closed = true
+      },
+      close() {
+        this.closed = true
+      },
+      on() { return this },
+      once(ev: string, cb: () => void) {
+        if (ev === 'connect') cb()
+        return this
+      },
+    }
+  }
+
+  let http2ConnectImpl: ((...args: unknown[]) => ReturnType<typeof mockH2Session>) | undefined
+  let http2ConnectCalls = 0
+
+  function installH2(handler: H2Handler) {
+    http2ConnectCalls = 0
+    http2ConnectImpl = () => {
+      http2ConnectCalls++
+      return mockH2Session(handler)
+    }
+  }
 
   beforeEach(() => {
     capturedRequest = {}
-    httpsRequestMock.mockImplementation((options: typeof capturedRequest, cb: (res: PassThrough) => void) => {
-      capturedRequest = options
-      const upstreamRes = new PassThrough() as PassThrough & { statusCode: number; headers: Record<string, string> }
-      upstreamRes.statusCode = 200
-      upstreamRes.headers = {}
-      cb(upstreamRes)
-      upstreamRes.end('UPSTREAM_OK')
-      return new PassThrough() // stands in for the upstream client request (req.pipe target)
+    installH2((headers, stream) => {
+      capturedRequest = {
+        host: String(headers[':authority'] ?? ''),
+        path: String(headers[':path'] ?? ''),
+        headers: { ...headers, host: String(headers[':authority'] ?? '') },
+      }
+      h2Respond(stream, 200, 'UPSTREAM_OK')
     })
   })
 
@@ -1030,7 +1072,12 @@ describe('LocalAuthForwardProxy', () => {
   })
 
   function makeProxy(mintToken: () => Promise<Record<string, string>>) {
-    const proxy = new LocalAuthForwardProxy({ endpoint: 'mvm.lambda-microvm.aws', agentPort: 3000, mintToken })
+    const proxy = new LocalAuthForwardProxy({
+      endpoint: 'mvm.lambda-microvm.aws',
+      agentPort: 3000,
+      mintToken,
+      http2Connect: http2ConnectImpl as ConstructorParameters<typeof LocalAuthForwardProxy>[0]['http2Connect'],
+    })
     proxies.push(proxy)
     return proxy
   }
@@ -1059,6 +1106,7 @@ describe('LocalAuthForwardProxy', () => {
     expect(capturedRequest.headers!.host).toBe('mvm.lambda-microvm.aws')
     expect(capturedRequest.headers!['x-custom']).toBe('v')
     expect(capturedRequest.headers!.connection).toBeUndefined()
+    expect(capturedRequest.headers!['x-aws-proxy-force-h2']).toBeUndefined()
   })
 
   it('caches the auth token across requests (mints once)', async () => {
@@ -1125,14 +1173,9 @@ describe('LocalAuthForwardProxy', () => {
 
   it('wakes a suspended VM (retries /health past a 502) before piping a WS upgrade', async () => {
     let healthCalls = 0
-    httpsRequestMock.mockImplementation((_opts: unknown, cb: (res: PassThrough) => void) => {
+    installH2((_headers, stream) => {
       healthCalls++
-      const res = new PassThrough() as PassThrough & { statusCode: number; headers: Record<string, string> }
-      res.statusCode = healthCalls === 1 ? 502 : 200 // first probe: still resuming
-      res.headers = {}
-      cb(res)
-      res.end('')
-      return new PassThrough()
+      h2Respond(stream, healthCalls === 1 ? 502 : 200, '')
     })
     let tlsCalled = false
     const tlsReady = new Promise<void>((resolve) => {
@@ -1152,6 +1195,49 @@ describe('LocalAuthForwardProxy', () => {
     client.destroy()
     expect(healthCalls).toBeGreaterThanOrEqual(2) // retried past the 502
     expect(tlsCalled).toBe(true) // only piped once the VM was awake
+  })
+
+  it('retries an ingress 429 then returns the successful body', async () => {
+    let calls = 0
+    installH2((_headers, stream) => {
+      calls++
+      h2Respond(stream, calls === 1 ? 429 : 200, calls === 1 ? 'Rate limit exceeded' : 'UPSTREAM_OK')
+    })
+    const port = await makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok' })).start()
+    const res = await httpGet(port, '/artifacts/open-slide-studio/')
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('UPSTREAM_OK')
+    expect(calls).toBe(2)
+  })
+
+  it('multiplexes HTTP requests on one HTTP/2 session', async () => {
+    const port = await makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok' })).start()
+    const [first, second] = await Promise.all([httpGet(port, '/a'), httpGet(port, '/b')])
+    expect(first.body).toBe('UPSTREAM_OK')
+    expect(second.body).toBe('UPSTREAM_OK')
+    expect(http2ConnectCalls).toBe(1)
+  })
+
+  it('keeps HTTP/2 streams flowing while a WebSocket is open', async () => {
+    const tlsReady = new Promise<void>((resolve) => {
+      tlsConnectMock.mockImplementation((_opts: unknown, cb: () => void) => {
+        const sock = new PassThrough()
+        process.nextTick(() => {
+          cb()
+          resolve()
+        })
+        return sock
+      })
+    })
+    const port = await makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok' })).start()
+    const wsClient = net.connect(port, '127.0.0.1', () => {
+      wsClient.write('GET /sessions/s1/stream HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: k\r\nSec-WebSocket-Version: 13\r\n\r\n')
+    })
+    await tlsReady
+    const [first, second] = await Promise.all([httpGet(port, '/a'), httpGet(port, '/b')])
+    expect(first.body).toBe('UPSTREAM_OK')
+    expect(second.body).toBe('UPSTREAM_OK')
+    wsClient.destroy()
   })
 
   it('destroys the client socket if the WS upstream connect never completes', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -42,6 +42,7 @@ vi.mock('@shared/lib/config/settings', () => ({
   getSettings: () => ({ app: { autoSleepTimeoutMinutes: autoSleepTimeoutMinutes() }, enableToolSearch: true }),
 }))
 
+import { captureException } from '@shared/lib/error-reporting'
 import {
   LambdaMicroVmRuntimeClient,
   LocalAuthForwardProxy,
@@ -1098,7 +1099,7 @@ describe('LocalAuthForwardProxy', () => {
   it('injects auth + proxy-port headers, sets upstream host, and drops hop-by-hop headers', async () => {
     const proxy = makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok1' }))
     const port = await proxy.start()
-    const res = await httpGet(port, '/sessions', { connection: 'keep-alive', 'x-custom': 'v' })
+    const res = await httpGet(port, '/sessions', { connection: 'keep-alive', te: 'trailers', 'x-custom': 'v' })
     expect(res.body).toBe('UPSTREAM_OK')
     expect(capturedRequest.host).toBe('mvm.lambda-microvm.aws')
     expect(capturedRequest.path).toBe('/sessions')
@@ -1107,6 +1108,7 @@ describe('LocalAuthForwardProxy', () => {
     expect(capturedRequest.headers!.host).toBe('mvm.lambda-microvm.aws')
     expect(capturedRequest.headers!['x-custom']).toBe('v')
     expect(capturedRequest.headers!.connection).toBeUndefined()
+    expect(capturedRequest.headers!.te).toBeUndefined()
     expect(capturedRequest.headers!['x-aws-proxy-force-h2']).toBeUndefined()
     expect(capturedRequest.timeout).toBe(30_000)
   })
@@ -1268,6 +1270,69 @@ describe('LocalAuthForwardProxy', () => {
     expect(first.body).toBe('UPSTREAM_OK')
     expect(second.body).toBe('UPSTREAM_OK')
     wsClient.destroy()
+  })
+
+  it('does not report a client abort to Sentry', async () => {
+    vi.mocked(captureException).mockClear()
+    http2ConnectImpl = () => mockH2Session((_headers, stream) => {
+      stream.end = ((() => stream) as unknown as typeof stream.end)
+      stream.push(Buffer.from('partial'))
+      process.nextTick(() => stream.emit('response', { ':status': 200 }))
+    })
+    const port = await makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok' })).start()
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request({ host: '127.0.0.1', port, path: '/asset.js' }, (res) => {
+        res.resume()
+        req.destroy()
+        resolve()
+      })
+      req.on('error', () => {})
+      req.setTimeout(2000, () => reject(new Error('client got no response')))
+      req.end()
+    })
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  it('reports a non-abort pipeline error to Sentry', async () => {
+    vi.mocked(captureException).mockClear()
+    installH2((_headers, stream) => {
+      process.nextTick(() => {
+        stream.emit('response', { ':status': 200 })
+        stream.destroy(new Error('upstream exploded'))
+      })
+    })
+    const port = await makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok' })).start()
+    await httpGet(port, '/asset.js').catch(() => {})
+    await vi.waitFor(() => expect(captureException).toHaveBeenCalled())
+    expect(vi.mocked(captureException).mock.calls[0][0]).toMatchObject({ message: 'upstream exploded' })
+  })
+
+  it('closes a session that connects after stop()', async () => {
+    let connectCb: (() => void) | undefined
+    const session = {
+      closed: false,
+      destroyed: false,
+      request() { throw new Error('should not request') },
+      destroy() { this.destroyed = true; this.closed = true },
+      close() { this.closed = true },
+      on() { return this },
+      off() { return this },
+      once(ev: string, cb: () => void) {
+        if (ev === 'connect') connectCb = cb
+        return this
+      },
+    }
+    http2ConnectImpl = () => session
+    const proxy = makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok' }))
+    const port = await proxy.start()
+    const pending = httpGet(port, '/health').catch(() => {})
+    await vi.waitFor(() => { if (!connectCb) throw new Error('connect not armed') })
+    proxy.stop()
+    connectCb!()
+    expect(session.closed).toBe(true)
+    await pending
   })
 
   it('destroys the client socket if the WS upstream connect never completes', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -1006,7 +1006,7 @@ describe('LocalAuthForwardProxy', () => {
   let capturedRequest: { host?: string; path?: string; headers?: Record<string, string>; timeout?: number }
   const proxies: LocalAuthForwardProxy[] = []
 
-  type H2Stream = PassThrough & { setTimeout: (ms: number) => void }
+  type H2Stream = PassThrough & { setTimeout: (ms: number, cb?: () => void) => void }
   type H2Handler = (headers: Record<string, string>, stream: H2Stream) => void
 
   function h2Respond(stream: H2Stream, status: number, body: string) {
@@ -1037,6 +1037,7 @@ describe('LocalAuthForwardProxy', () => {
         this.closed = true
       },
       on() { return this },
+      off() { return this },
       once(ev: string, cb: () => void) {
         if (ev === 'connect') cb()
         return this
@@ -1107,6 +1108,7 @@ describe('LocalAuthForwardProxy', () => {
     expect(capturedRequest.headers!['x-custom']).toBe('v')
     expect(capturedRequest.headers!.connection).toBeUndefined()
     expect(capturedRequest.headers!['x-aws-proxy-force-h2']).toBeUndefined()
+    expect(capturedRequest.timeout).toBe(30_000)
   })
 
   it('caches the auth token across requests (mints once)', async () => {
@@ -1195,6 +1197,34 @@ describe('LocalAuthForwardProxy', () => {
     client.destroy()
     expect(healthCalls).toBeGreaterThanOrEqual(2) // retried past the 502
     expect(tlsCalled).toBe(true) // only piped once the VM was awake
+  })
+
+  it('retries after an HTTP/2 connect error then returns the body', async () => {
+    let connects = 0
+    http2ConnectImpl = () => {
+      connects++
+      if (connects === 1) {
+        return {
+          closed: false,
+          destroyed: false,
+          request() { throw new Error('should not request') },
+          destroy() { this.destroyed = true; this.closed = true },
+          close() { this.closed = true },
+          on() { return this },
+          off() { return this },
+          once(ev: string, cb: (err?: Error) => void) {
+            if (ev === 'error') process.nextTick(() => cb(new Error('alpn rejected')))
+            return this
+          },
+        }
+      }
+      return mockH2Session((_headers, stream) => h2Respond(stream, 200, 'UPSTREAM_OK'))
+    }
+    const port = await makeProxy(async () => ({ 'X-aws-proxy-auth': 'tok' })).start()
+    const res = await httpGet(port, '/health')
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('UPSTREAM_OK')
+    expect(connects).toBe(2)
   })
 
   it('retries an ingress 429 then returns the successful body', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -229,12 +229,20 @@ export interface ProxyOptions {
 
 const INGRESS_RATE_LIMIT_RETRY_DELAY_MS = 150
 const INGRESS_RATE_LIMIT_RETRY_BUDGET_MS = 8_000
+const INGRESS_RATE_LIMIT_RETRY_MAX_DELAY_MS = 2_000
 const H2_FORBIDDEN_HEADERS = new Set([
-  'host', 'connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade',
+  'host', 'connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade', 'te',
 ])
 
-function pipeUntilSettled(src: http.IncomingMessage, dest: http.ServerResponse): Promise<void> {
-  return pipeline(src, dest)
+function isRoutineClientAbort(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code
+  return code === 'ABORT_ERR' || code === 'ERR_STREAM_PREMATURE_CLOSE'
+}
+
+// Equal-jitter exponential backoff so a sustained 429 does not stampede.
+function ingressRateLimitDelayMs(attempt: number): number {
+  const exp = Math.min(INGRESS_RATE_LIMIT_RETRY_DELAY_MS * 2 ** attempt, INGRESS_RATE_LIMIT_RETRY_MAX_DELAY_MS)
+  return exp / 2 + Math.random() * (exp / 2)
 }
 
 export class LocalAuthForwardProxy {
@@ -349,9 +357,14 @@ export class LocalAuthForwardProxy {
       session.once('connect', () => {
         session.off('error', onConnectError)
         clearTimeout(timer)
+        if (!this.server) {
+          session.close()
+          finishErr(new Error('microvm http2 connect aborted: proxy stopped'))
+          return
+        }
         this.h2 = session
         session.once('close', () => { if (this.h2 === session) this.h2 = null })
-        session.once('error', (error) => {
+        session.on('error', (error) => {
           if (this.h2 === session) this.h2 = null
           captureException(error, { tags: { area: 'container', op: 'microvm.proxy.http2.session' }, extra: { endpoint: this.options.endpoint } })
         })
@@ -411,6 +424,7 @@ export class LocalAuthForwardProxy {
   private async waitForUpstreamReady(): Promise<boolean> {
     const deadline = Date.now() + RESUME_KICK_TIMEOUT_MS
     for (;;) {
+      if (!this.server) return false
       let auth: Record<string, string>
       try {
         auth = await this.authHeaders()
@@ -443,7 +457,9 @@ export class LocalAuthForwardProxy {
     try {
       await this.forwardRequest(req, res, body)
     } catch (error) {
-      captureException(error, { tags: { area: 'container', op: 'microvm.proxy.request' }, extra: { endpoint: this.options.endpoint, path: req.url } })
+      if (!isRoutineClientAbort(error)) {
+        captureException(error, { tags: { area: 'container', op: 'microvm.proxy.request' }, extra: { endpoint: this.options.endpoint, path: req.url } })
+      }
       if (!res.headersSent) res.writeHead(502)
       res.end()
     }
@@ -456,7 +472,13 @@ export class LocalAuthForwardProxy {
   ): Promise<void> {
     const deadline = Date.now() + RESUME_KICK_TIMEOUT_MS
     const rateLimitDeadline = Date.now() + INGRESS_RATE_LIMIT_RETRY_BUDGET_MS
+    let rateLimitAttempts = 0
     for (;;) {
+      if (!this.server) {
+        if (!res.headersSent) res.writeHead(502)
+        res.end()
+        return
+      }
       let auth: Record<string, string>
       try {
         auth = await this.authHeaders()
@@ -471,6 +493,11 @@ export class LocalAuthForwardProxy {
       try {
         upstreamRes = await this.forwardOnce(req.method ?? 'GET', req.url ?? '/', headers, body)
       } catch (error) {
+        if (!this.server) {
+          if (!res.headersSent) res.writeHead(502)
+          res.end()
+          return
+        }
         // Connection error = VM still waking; retry within the resume budget.
         if (Date.now() < deadline) {
           await new Promise((r) => setTimeout(r, RESUME_RETRY_DELAY_MS))
@@ -489,11 +516,12 @@ export class LocalAuthForwardProxy {
       }
       if (upstreamRes.statusCode === 429 && Date.now() < rateLimitDeadline) {
         upstreamRes.resume()
-        await new Promise((r) => setTimeout(r, INGRESS_RATE_LIMIT_RETRY_DELAY_MS))
+        await new Promise((r) => setTimeout(r, ingressRateLimitDelayMs(rateLimitAttempts)))
+        rateLimitAttempts++
         continue
       }
       res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers)
-      await pipeUntilSettled(upstreamRes, res)
+      await pipeline(upstreamRes, res)
       return
     }
   }

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -243,7 +243,7 @@ export class LocalAuthForwardProxy {
   private tokenCache: { token: MicrovmAuthToken; expiresAt: number } | null = null
   private refreshing: Promise<MicrovmAuthToken> | null = null
   private h2: http2.ClientHttp2Session | null = null
-  private h2connecting: Promise<http2.ClientHttp2Session | null> | null = null
+  private h2connecting: Promise<http2.ClientHttp2Session> | null = null
 
   constructor(private readonly options: ProxyOptions) {}
 
@@ -310,7 +310,7 @@ export class LocalAuthForwardProxy {
 
   // One HTTP/2 session = one AWS ingress connection. Agent is plaintext HTTP/1.1
   // inside the VM — do not send x-aws-proxy-force-h2; AWS translates streams.
-  private async ensureHttp2(): Promise<http2.ClientHttp2Session | null> {
+  private async ensureHttp2(): Promise<http2.ClientHttp2Session> {
     if (this.h2 && !this.h2.closed && !this.h2.destroyed) return this.h2
     if (this.h2connecting) return this.h2connecting
     this.h2connecting = this.connectHttp2().finally(() => {
@@ -319,32 +319,43 @@ export class LocalAuthForwardProxy {
     return this.h2connecting
   }
 
-  private connectHttp2(): Promise<http2.ClientHttp2Session | null> {
-    return new Promise((resolve) => {
+  private connectHttp2(): Promise<http2.ClientHttp2Session> {
+    return new Promise((resolve, reject) => {
       let settled = false
-      const finish = (session: http2.ClientHttp2Session | null) => {
+      const finishOk = (session: http2.ClientHttp2Session) => {
         if (settled) return
         settled = true
         resolve(session)
+      }
+      const finishErr = (error: Error) => {
+        if (settled) return
+        settled = true
+        reject(error)
       }
       const connect = this.options.http2Connect ?? http2.connect
       const session = connect(`https://${this.options.endpoint}`, {
         servername: this.options.endpoint,
       })
       const timer = setTimeout(() => {
-        session.destroy()
-        finish(null)
+        const error = new Error('microvm http2 connect timed out')
+        session.destroy(error)
+        finishErr(error)
       }, UPSTREAM_IDLE_TIMEOUT_MS)
+      const onConnectError = (error: Error) => {
+        clearTimeout(timer)
+        finishErr(error)
+      }
+      session.once('error', onConnectError)
       session.once('connect', () => {
+        session.off('error', onConnectError)
         clearTimeout(timer)
         this.h2 = session
         session.once('close', () => { if (this.h2 === session) this.h2 = null })
-        session.once('error', () => { if (this.h2 === session) this.h2 = null })
-        finish(session)
-      })
-      session.once('error', () => {
-        clearTimeout(timer)
-        finish(null)
+        session.once('error', (error) => {
+          if (this.h2 === session) this.h2 = null
+          captureException(error, { tags: { area: 'container', op: 'microvm.proxy.http2.session' }, extra: { endpoint: this.options.endpoint } })
+        })
+        finishOk(session)
       })
     })
   }
@@ -368,12 +379,11 @@ export class LocalAuthForwardProxy {
         h2headers[key] = value
       }
       const stream = session.request(h2headers)
-      const timer = setTimeout(() => {
+      // Idle timeout (resets on data), including after response headers.
+      stream.setTimeout(UPSTREAM_IDLE_TIMEOUT_MS, () => {
         stream.destroy(new Error('microvm upstream request timed out'))
-      }, UPSTREAM_IDLE_TIMEOUT_MS)
-      stream.setTimeout?.(UPSTREAM_IDLE_TIMEOUT_MS)
+      })
       stream.once('response', (resHeaders) => {
-        clearTimeout(timer)
         const incoming = stream as unknown as http.IncomingMessage
         incoming.statusCode = Number(resHeaders[':status'] ?? 502)
         const out: http.IncomingHttpHeaders = {}
@@ -384,10 +394,7 @@ export class LocalAuthForwardProxy {
         incoming.headers = out
         resolve(incoming)
       })
-      stream.once('error', (error) => {
-        clearTimeout(timer)
-        reject(error)
-      })
+      stream.once('error', reject)
       if (body.length) stream.write(body)
       stream.end()
     })
@@ -395,7 +402,6 @@ export class LocalAuthForwardProxy {
 
   private async forwardOnce(method: string, path: string, headers: Record<string, string>, body: Buffer): Promise<http.IncomingMessage> {
     const session = await this.ensureHttp2()
-    if (!session) throw new Error('microvm http2 unavailable')
     return this.forwardOnceH2(session, method, path, headers, body)
   }
 

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -1,7 +1,8 @@
 import http from 'http'
-import https from 'https'
+import http2 from 'http2'
 import tls from 'tls'
 import net, { AddressInfo } from 'net'
+import { pipeline } from 'stream/promises'
 import { randomBytes, randomUUID } from 'crypto'
 import { z } from 'zod'
 import {
@@ -222,6 +223,18 @@ export interface ProxyOptions {
   agentPort: number
   /** Mints a fresh auth-token map ({ "X-aws-proxy-auth": "<jwe>", ... }). */
   mintToken: () => Promise<MicrovmAuthToken>
+  /** Override HTTP/2 connect (tests). */
+  http2Connect?: typeof http2.connect
+}
+
+const INGRESS_RATE_LIMIT_RETRY_DELAY_MS = 150
+const INGRESS_RATE_LIMIT_RETRY_BUDGET_MS = 8_000
+const H2_FORBIDDEN_HEADERS = new Set([
+  'host', 'connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade',
+])
+
+function pipeUntilSettled(src: http.IncomingMessage, dest: http.ServerResponse): Promise<void> {
+  return pipeline(src, dest)
 }
 
 export class LocalAuthForwardProxy {
@@ -229,6 +242,8 @@ export class LocalAuthForwardProxy {
   private port: number | null = null
   private tokenCache: { token: MicrovmAuthToken; expiresAt: number } | null = null
   private refreshing: Promise<MicrovmAuthToken> | null = null
+  private h2: http2.ClientHttp2Session | null = null
+  private h2connecting: Promise<http2.ClientHttp2Session | null> | null = null
 
   constructor(private readonly options: ProxyOptions) {}
 
@@ -250,6 +265,9 @@ export class LocalAuthForwardProxy {
     this.server = null
     this.port = null
     this.tokenCache = null
+    this.h2?.close()
+    this.h2 = null
+    this.h2connecting = null
   }
 
   // Single-flight token refresh so a burst of requests can't trigger a token storm.
@@ -290,19 +308,95 @@ export class LocalAuthForwardProxy {
     })
   }
 
-  private forwardOnce(method: string, path: string, headers: Record<string, string>, body: Buffer): Promise<http.IncomingMessage> {
-    return new Promise((resolve, reject) => {
-      const upstream = https.request(
-        { host: this.options.endpoint, port: 443, method, path, servername: this.options.endpoint, headers, timeout: UPSTREAM_IDLE_TIMEOUT_MS },
-        resolve,
-      )
-      upstream.on('error', reject)
-      // A hung socket fires 'timeout' (not 'error'); destroy so the caller's
-      // retry loop sees a real error instead of blocking on it indefinitely.
-      upstream.on('timeout', () => upstream.destroy(new Error('microvm upstream request timed out')))
-      if (body.length) upstream.write(body)
-      upstream.end()
+  // One HTTP/2 session = one AWS ingress connection. Agent is plaintext HTTP/1.1
+  // inside the VM — do not send x-aws-proxy-force-h2; AWS translates streams.
+  private async ensureHttp2(): Promise<http2.ClientHttp2Session | null> {
+    if (this.h2 && !this.h2.closed && !this.h2.destroyed) return this.h2
+    if (this.h2connecting) return this.h2connecting
+    this.h2connecting = this.connectHttp2().finally(() => {
+      this.h2connecting = null
     })
+    return this.h2connecting
+  }
+
+  private connectHttp2(): Promise<http2.ClientHttp2Session | null> {
+    return new Promise((resolve) => {
+      let settled = false
+      const finish = (session: http2.ClientHttp2Session | null) => {
+        if (settled) return
+        settled = true
+        resolve(session)
+      }
+      const connect = this.options.http2Connect ?? http2.connect
+      const session = connect(`https://${this.options.endpoint}`, {
+        servername: this.options.endpoint,
+      })
+      const timer = setTimeout(() => {
+        session.destroy()
+        finish(null)
+      }, UPSTREAM_IDLE_TIMEOUT_MS)
+      session.once('connect', () => {
+        clearTimeout(timer)
+        this.h2 = session
+        session.once('close', () => { if (this.h2 === session) this.h2 = null })
+        session.once('error', () => { if (this.h2 === session) this.h2 = null })
+        finish(session)
+      })
+      session.once('error', () => {
+        clearTimeout(timer)
+        finish(null)
+      })
+    })
+  }
+
+  private forwardOnceH2(
+    session: http2.ClientHttp2Session,
+    method: string,
+    path: string,
+    headers: Record<string, string>,
+    body: Buffer,
+  ): Promise<http.IncomingMessage> {
+    return new Promise((resolve, reject) => {
+      const h2headers: http2.OutgoingHttpHeaders = {
+        ':method': method,
+        ':path': path,
+        ':scheme': 'https',
+        ':authority': this.options.endpoint,
+      }
+      for (const [key, value] of Object.entries(headers)) {
+        if (H2_FORBIDDEN_HEADERS.has(key.toLowerCase())) continue
+        h2headers[key] = value
+      }
+      const stream = session.request(h2headers)
+      const timer = setTimeout(() => {
+        stream.destroy(new Error('microvm upstream request timed out'))
+      }, UPSTREAM_IDLE_TIMEOUT_MS)
+      stream.setTimeout?.(UPSTREAM_IDLE_TIMEOUT_MS)
+      stream.once('response', (resHeaders) => {
+        clearTimeout(timer)
+        const incoming = stream as unknown as http.IncomingMessage
+        incoming.statusCode = Number(resHeaders[':status'] ?? 502)
+        const out: http.IncomingHttpHeaders = {}
+        for (const [key, value] of Object.entries(resHeaders)) {
+          if (key.startsWith(':') || value === undefined) continue
+          out[key] = value
+        }
+        incoming.headers = out
+        resolve(incoming)
+      })
+      stream.once('error', (error) => {
+        clearTimeout(timer)
+        reject(error)
+      })
+      if (body.length) stream.write(body)
+      stream.end()
+    })
+  }
+
+  private async forwardOnce(method: string, path: string, headers: Record<string, string>, body: Buffer): Promise<http.IncomingMessage> {
+    const session = await this.ensureHttp2()
+    if (!session) throw new Error('microvm http2 unavailable')
+    return this.forwardOnceH2(session, method, path, headers, body)
   }
 
   // Confirm the MicroVM agent serves before we start an unreplayable WS pipe.
@@ -321,7 +415,7 @@ export class LocalAuthForwardProxy {
       try {
         const res = await this.forwardOnce('GET', '/health', { host: this.options.endpoint, ...auth }, Buffer.alloc(0))
         res.resume()
-        if (res.statusCode !== 502) return true
+        if (res.statusCode !== 502 && res.statusCode !== 429) return true
       } catch {
         // Connection refused/reset/timeout = VM still waking; retry below.
       }
@@ -340,7 +434,22 @@ export class LocalAuthForwardProxy {
       res.end()
       return
     }
+    try {
+      await this.forwardRequest(req, res, body)
+    } catch (error) {
+      captureException(error, { tags: { area: 'container', op: 'microvm.proxy.request' }, extra: { endpoint: this.options.endpoint, path: req.url } })
+      if (!res.headersSent) res.writeHead(502)
+      res.end()
+    }
+  }
+
+  private async forwardRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    body: Buffer,
+  ): Promise<void> {
     const deadline = Date.now() + RESUME_KICK_TIMEOUT_MS
+    const rateLimitDeadline = Date.now() + INGRESS_RATE_LIMIT_RETRY_BUDGET_MS
     for (;;) {
       let auth: Record<string, string>
       try {
@@ -372,8 +481,13 @@ export class LocalAuthForwardProxy {
         await new Promise((r) => setTimeout(r, RESUME_RETRY_DELAY_MS))
         continue
       }
+      if (upstreamRes.statusCode === 429 && Date.now() < rateLimitDeadline) {
+        upstreamRes.resume()
+        await new Promise((r) => setTimeout(r, INGRESS_RATE_LIMIT_RETRY_DELAY_MS))
+        continue
+      }
       res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers)
-      upstreamRes.pipe(res)
+      await pipeUntilSettled(upstreamRes, res)
       return
     }
   }


### PR DESCRIPTION
## Summary
- Hosted Vite `dev` dashboards (e.g. Open Slide Studio) issue hundreds of native ESM GETs. Host-app → MicroVM ingress was HTTP/1.1 (`https.request`), one TCP connection per file.
- AWS MicroVM ingress caps **8 concurrent connections** on 1 vCPU. Session WebSocket + Vite HMR consume slots, so the rest 429 (`Rate limit exceeded`) and the iframe goes blank.
- The proxy now opens **one HTTP/2 session** and multiplexes HTTP as streams. WebSocket upgrades stay HTTP/1.1. No HTTP/1.1 fallback and no connection-slot limiter.

## Repro (before)
1. Open a hosted dashboard whose `start` is Vite `dev` (Open Slide Studio on yitian-superagent).
2. The iframe stays blank or shows `Rate limit exceeded`.
3. Host-app / ingress logs show many concurrent HTTP/1.1 connections and 429s.

## Test plan
- [x] `npx vitest run src/shared/lib/container/lambda-microvm-runtime.test.ts` (65 passed)
- [x] Canary: rebuild host-app with this commit and roll yitian-superagent only (`0.5.6-pr751-auth`, task def `:55`)
- [x] Open Open Slide Studio: no 429, no `ERR_HTTP2`, dashboard assets load
- [x] Session WebSocket + Vite HMR still connect

Canary boxes were left unchecked by mistake. Deployed on https://yitian-superagent.ongamutstaging.com — all canary checks green. Staging ALPN also negotiated `h2` (`http2.connect` + `GET /health` 200). No HTTP/1.1 fallback.

Review follow-ups on this PR (1, 3, 4, 5):
- Filter `ABORT_ERR` / `ERR_STREAM_PREMATURE_CLOSE` before `captureException`
- Close an HTTP/2 session that connects after `stop()`
- Use `session.on('error')` instead of `once`
- Jittered 429 backoff; inline `pipeline`; forbid `te` on h2