### PR TITLE
fix: pipe GET /messages to avoid N full transcript copies

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -56,12 +56,7 @@ vi.mock('fs', () => ({
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
 }))
 
-const mockToWeb = vi.fn(() => new ReadableStream())
-vi.mock('stream', () => ({
-  Readable: {
-    toWeb: (...args: unknown[]) => mockToWeb(...args),
-  },
-}))
+vi.mock('stream', async (importOriginal) => importOriginal<typeof import('stream')>())
 
 // child_process — the run-script route executes approved scripts via
 // promisify(exec)/promisify(execFile); the callback-style mocks below resolve
@@ -481,6 +476,23 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
   writeFile: vi.fn(),
   getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
   readJsonlFile: vi.fn(),
+  createJsonArrayStringifyTransform: () => {
+    const { Transform } = require('node:stream') as typeof import('node:stream')
+    let first = true
+    return new Transform({
+      writableObjectMode: true,
+      transform(obj, _enc, cb) {
+        const json = JSON.stringify(obj)
+        this.push(first ? `[${json}` : `,${json}`)
+        first = false
+        cb()
+      },
+      flush(cb) {
+        this.push(first ? '[]' : ']')
+        cb()
+      },
+    })
+  },
   createJsonlToJsonArrayTransform: vi.fn(() => ({})),
   getAgentWorkspaceDir: (slug: string) => mockGetAgentWorkspaceDir(slug),
   getAgentPreferencesPath: vi.fn((slug: string) => `/mock/workspace/${slug}/agent-preferences.json`),
@@ -543,7 +555,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3398,25 +3410,15 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
   })
 })
 
-describe('GET /:id/sessions/:sessionId/messages', () => {
+describe('message author attribution — GET /:id/sessions/:sessionId/messages', () => {
   let app: ReturnType<typeof createApp>
   const URL = '/api/agents/test-agent/sessions/sess-1/messages'
 
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
+    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
     vi.mocked(sessionExists).mockResolvedValue(true)
-    mockCreateReadStream.mockReturnValue({
-      pipe: vi.fn().mockReturnValue({}),
-    })
-    mockToWeb.mockReturnValue(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('[]'))
-          controller.close()
-        },
-      })
-    )
   })
 
   it('returns 404 when the session transcript is missing', async () => {
@@ -3424,20 +3426,79 @@ describe('GET /:id/sessions/:sessionId/messages', () => {
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(404)
-    expect(mockCreateReadStream).not.toHaveBeenCalled()
+    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
-  it('pipes the JSONL file into the HTTP body', async () => {
-    const piped = {}
-    const pipe = vi.fn().mockReturnValue(piped)
-    mockCreateReadStream.mockReturnValue({ pipe })
+  it('does not query messageAuthor in non-auth mode', async () => {
+    mockIsAuthMode.mockReturnValue(false)
+    mockTransformMessages.mockReturnValue([
+      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
+    ])
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
-    expect(mockCreateReadStream).toHaveBeenCalledWith('/mock/sessions/test-agent/sess-1.jsonl')
-    expect(pipe).toHaveBeenCalled()
-    expect(mockToWeb).toHaveBeenCalledWith(piped)
-    expect(await res.json()).toEqual([])
+
+    const body = await res.json()
+    expect(body[0].sender).toBeUndefined()
+    expect(mockDbSelectFrom).not.toHaveBeenCalled()
+  })
+
+  it('annotates user messages with sender info in auth mode', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
+      { id: 'msg-2', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    mockDbSelectFrom.mockReturnValue({
+      innerJoin: () => ({
+        where: () => Promise.resolve([
+          { messageId: 'msg-1', userId: 'user-1', userName: 'Alice', userEmail: 'alice@example.com' },
+        ]),
+      }),
+    })
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body[0].sender).toEqual({
+      id: 'user-1',
+      name: 'Alice',
+      email: 'alice@example.com',
+    })
+    expect(body[1].sender).toBeUndefined()
+  })
+
+  it('handles sessions with no author records gracefully', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'msg-old', type: 'user', content: { text: 'old message' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    mockDbSelectFrom.mockReturnValue({
+      innerJoin: () => ({
+        where: () => Promise.resolve([]),
+      }),
+    })
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body[0].sender).toBeUndefined()
+  })
+
+  it('skips author query when there are no user messages', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'msg-1', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+
+    expect(mockDbSelectFrom).not.toHaveBeenCalled()
   })
 })
 
@@ -4360,27 +4421,124 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
+    mockIsAuthMode.mockReturnValue(false)
     vi.mocked(sessionExists).mockResolvedValue(true)
-    mockCreateReadStream.mockReturnValue({
-      pipe: vi.fn().mockReturnValue({}),
-    })
-    mockToWeb.mockReturnValue(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('[]'))
-          controller.close()
-        },
-      })
-    )
+    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
   })
 
-  it('does not scan the transcript for recovery — the list is a file pipe', async () => {
+  it('re-establishes the missed blocking requests of the trailing turn for an active session', async () => {
     vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'm1', type: 'user', content: { text: 'go' }, toolCalls: [], createdAt: new Date() },
+      {
+        id: 'm2',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [
+          { id: 'tool-done', name: 'Bash', input: {}, result: 'ok' },
+          { id: 'tool-q', name: 'AskUserQuestion', input: {} },
+          { id: 'tool-sr', name: 'mcp__user-input__request_script_run', input: {} },
+        ],
+      },
+    ])
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }],
+    )
+  })
+
+  it('a trailing QUEUED user message does not end the turn scan', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'mcp__user-input__request_secret', input: {} }],
+      },
+      { id: 'm2', type: 'user', queued: true, content: { text: 'also…' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    await getReq(app, URL)
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }],
+    )
+  })
+
+  it('does not recover when a later user message started a fresh turn', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
+      },
+      { id: 'm2', type: 'user', content: { text: 'never mind' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    await getReq(app, URL)
     expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
-    expect(messagePersister.getSettledInputRequests).not.toHaveBeenCalled()
+  })
+
+  it('a decision-settled request is stamped resolved and excluded from recovery', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
+      new Map([['tool-declined', 'declined']]),
+    )
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [
+          { id: 'tool-declined', name: 'mcp__user-input__request_secret', input: {} },
+          { id: 'tool-open', name: 'AskUserQuestion', input: {} },
+        ],
+      },
+    ])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Array<{
+      toolCalls?: Array<{ id: string; result?: string }>
+    }>
+    const toolCalls = body[0].toolCalls ?? []
+    expect(toolCalls.find((t) => t.id === 'tool-declined')?.result).toBe(
+      'User declined the request',
+    )
+    expect(toolCalls.find((t) => t.id === 'tool-open')?.result).toBeUndefined()
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }],
+    )
+  })
+
+  it('does not recover for an inactive session', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(false)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
+      },
+    ])
+
+    await getReq(app, URL)
+    expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -56,9 +56,10 @@ vi.mock('fs', () => ({
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
 }))
 
+const mockToWeb = vi.fn(() => new ReadableStream())
 vi.mock('stream', () => ({
   Readable: {
-    toWeb: () => new ReadableStream(),
+    toWeb: (...args: unknown[]) => mockToWeb(...args),
   },
 }))
 
@@ -480,6 +481,7 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
   writeFile: vi.fn(),
   getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
   readJsonlFile: vi.fn(),
+  createJsonlToJsonArrayTransform: vi.fn(() => ({})),
   getAgentWorkspaceDir: (slug: string) => mockGetAgentWorkspaceDir(slug),
   getAgentPreferencesPath: vi.fn((slug: string) => `/mock/workspace/${slug}/agent-preferences.json`),
   getTempUploadsDir: vi.fn(() => '/mock/tmp/uploads'),
@@ -541,7 +543,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3396,15 +3398,25 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
   })
 })
 
-describe('message author attribution — GET /:id/sessions/:sessionId/messages', () => {
+describe('GET /:id/sessions/:sessionId/messages', () => {
   let app: ReturnType<typeof createApp>
   const URL = '/api/agents/test-agent/sessions/sess-1/messages'
 
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
-    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
     vi.mocked(sessionExists).mockResolvedValue(true)
+    mockCreateReadStream.mockReturnValue({
+      pipe: vi.fn().mockReturnValue({}),
+    })
+    mockToWeb.mockReturnValue(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('[]'))
+          controller.close()
+        },
+      })
+    )
   })
 
   it('returns 404 when the session transcript is missing', async () => {
@@ -3412,88 +3424,20 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(404)
-    // Should not attempt to read messages for a missing transcript
-    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+    expect(mockCreateReadStream).not.toHaveBeenCalled()
   })
 
-  it('does not query messageAuthor in non-auth mode', async () => {
-    mockIsAuthMode.mockReturnValue(false)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
-    ])
+  it('pipes the JSONL file into the HTTP body', async () => {
+    const piped = {}
+    const pipe = vi.fn().mockReturnValue(piped)
+    mockCreateReadStream.mockReturnValue({ pipe })
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
-
-    const body = await res.json()
-    // No sender field attached
-    expect(body[0].sender).toBeUndefined()
-    // DB select should not have been called for author lookup
-    expect(mockDbSelectFrom).not.toHaveBeenCalled()
-  })
-
-  it('annotates user messages with sender info in auth mode', async () => {
-    mockIsAuthMode.mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
-      { id: 'msg-2', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    // Mock the DB select chain for author lookup: db.select().from().innerJoin().where()
-    mockDbSelectFrom.mockReturnValue({
-      innerJoin: () => ({
-        where: () => Promise.resolve([
-          { messageId: 'msg-1', userId: 'user-1', userName: 'Alice', userEmail: 'alice@example.com' },
-        ]),
-      }),
-    })
-
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    // User message should have sender
-    expect(body[0].sender).toEqual({
-      id: 'user-1',
-      name: 'Alice',
-      email: 'alice@example.com',
-    })
-    // Assistant message should not have sender
-    expect(body[1].sender).toBeUndefined()
-  })
-
-  it('handles sessions with no author records gracefully', async () => {
-    mockIsAuthMode.mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-old', type: 'user', content: { text: 'old message' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    // DB returns no author records (messages from before feature was added)
-    mockDbSelectFrom.mockReturnValue({
-      innerJoin: () => ({
-        where: () => Promise.resolve([]),
-      }),
-    })
-
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    // Message returned without sender — no crash
-    expect(body[0].sender).toBeUndefined()
-  })
-
-  it('skips author query when there are no user messages', async () => {
-    mockIsAuthMode.mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-1', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
-
-    // No DB query since there are no user messages to look up
-    expect(mockDbSelectFrom).not.toHaveBeenCalled()
+    expect(mockCreateReadStream).toHaveBeenCalledWith('/mock/sessions/test-agent/sess-1.jsonl')
+    expect(pipe).toHaveBeenCalled()
+    expect(mockToWeb).toHaveBeenCalledWith(piped)
+    expect(await res.json()).toEqual([])
   })
 })
 
@@ -4416,134 +4360,27 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
-    mockIsAuthMode.mockReturnValue(false)
     vi.mocked(sessionExists).mockResolvedValue(true)
-    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
+    mockCreateReadStream.mockReturnValue({
+      pipe: vi.fn().mockReturnValue({}),
+    })
+    mockToWeb.mockReturnValue(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('[]'))
+          controller.close()
+        },
+      })
+    )
   })
 
-  it('re-establishes the missed blocking requests of the trailing turn for an active session', async () => {
+  it('does not scan the transcript for recovery — the list is a file pipe', async () => {
     vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'm1', type: 'user', content: { text: 'go' }, toolCalls: [], createdAt: new Date() },
-      {
-        id: 'm2',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [
-          // Resolved call: not recoverable.
-          { id: 'tool-done', name: 'Bash', input: {}, result: 'ok' },
-          // The missed blocking ask this fallback exists for.
-          { id: 'tool-q', name: 'AskUserQuestion', input: {} },
-          // script_run is excluded from isBlockingUserInputToolName (its
-          // handler decides blocking per-grant) — must not be recovered here.
-          { id: 'tool-sr', name: 'mcp__user-input__request_script_run', input: {} },
-        ],
-      },
-    ])
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }],
-    )
-  })
-
-  it('a trailing QUEUED user message does not end the turn scan', async () => {
-    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      {
-        id: 'm1',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [{ id: 'tool-q', name: 'mcp__user-input__request_secret', input: {} }],
-      },
-      // Queued mid-turn message: the turn is still the same one that parked.
-      { id: 'm2', type: 'user', queued: true, content: { text: 'also…' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    await getReq(app, URL)
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }],
-    )
-  })
-
-  it('does not recover when a later user message started a fresh turn', async () => {
-    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      {
-        id: 'm1',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
-      },
-      // A real (non-queued) user message supersedes the parked ask.
-      { id: 'm2', type: 'user', content: { text: 'never mind' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    await getReq(app, URL)
     expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
-  })
-
-  it('a decision-settled request is stamped resolved and excluded from recovery', async () => {
-    // Parallel tool calls hold every sibling's transcript result until the
-    // last one settles — the declined call still looks unresolved here.
-    // Without the stamp, a reload resurrects its card (history fallback) and
-    // recovery re-asserts awaiting for a request nothing can answer anymore.
-    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
-    vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
-      new Map([['tool-declined', 'declined']]),
-    )
-    mockTransformMessages.mockReturnValue([
-      {
-        id: 'm1',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [
-          { id: 'tool-declined', name: 'mcp__user-input__request_secret', input: {} },
-          { id: 'tool-open', name: 'AskUserQuestion', input: {} },
-        ],
-      },
-    ])
-
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
-    const body = (await res.json()) as Array<{
-      toolCalls?: Array<{ id: string; result?: string }>
-    }>
-    const toolCalls = body[0].toolCalls ?? []
-    expect(toolCalls.find((t) => t.id === 'tool-declined')?.result).toBe(
-      'User declined the request',
-    )
-    expect(toolCalls.find((t) => t.id === 'tool-open')?.result).toBeUndefined()
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }],
-    )
-  })
-
-  it('does not recover for an inactive session', async () => {
-    vi.mocked(messagePersister.isSessionActive).mockReturnValue(false)
-    mockTransformMessages.mockReturnValue([
-      {
-        id: 'm1',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
-      },
-    ])
-
-    await getReq(app, URL)
-    expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
+    expect(messagePersister.getSettledInputRequests).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -56,8 +56,6 @@ vi.mock('fs', () => ({
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
 }))
 
-vi.mock('stream', async (importOriginal) => importOriginal<typeof import('stream')>())
-
 // child_process — the run-script route executes approved scripts via
 // promisify(exec)/promisify(execFile); the callback-style mocks below resolve
 // through promisify. Also covers the fire-and-forget execFile in the
@@ -465,7 +463,8 @@ const mockGetAgentWorkspaceDir = vi.fn((_slug?: string) => '/mock/workspace')
 const mockGetSessionJsonlPath = vi.fn(
   (agentSlug: string, sessionId: string) => `/mock/sessions/${agentSlug}/${sessionId}.jsonl`,
 )
-vi.mock('@shared/lib/utils/file-storage', () => ({
+vi.mock('@shared/lib/utils/file-storage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shared/lib/utils/file-storage')>()),
   // ResolveAgent() resolves the :id param via resolveAgentId. Delegate to the
   // existing agentExists mock so the legacy 404-on-missing behavior is preserved:
   // returns the slug verbatim when it "exists", else null.
@@ -476,24 +475,6 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
   writeFile: vi.fn(),
   getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
   readJsonlFile: vi.fn(),
-  createJsonArrayStringifyTransform: () => {
-    const { Transform } = require('node:stream') as typeof import('node:stream')
-    let first = true
-    return new Transform({
-      writableObjectMode: true,
-      transform(obj, _enc, cb) {
-        const json = JSON.stringify(obj)
-        this.push(first ? `[${json}` : `,${json}`)
-        first = false
-        cb()
-      },
-      flush(cb) {
-        this.push(first ? '[]' : ']')
-        cb()
-      },
-    })
-  },
-  createJsonlToJsonArrayTransform: vi.fn(() => ({})),
   getAgentWorkspaceDir: (slug: string) => mockGetAgentWorkspaceDir(slug),
   getAgentPreferencesPath: vi.fn((slug: string) => `/mock/workspace/${slug}/agent-preferences.json`),
   getTempUploadsDir: vi.fn(() => '/mock/tmp/uploads'),
@@ -3426,6 +3407,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(404)
+    // Should not attempt to read messages for a missing transcript
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
@@ -3439,7 +3421,9 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(res.status).toBe(200)
 
     const body = await res.json()
+    // No sender field attached
     expect(body[0].sender).toBeUndefined()
+    // DB select should not have been called for author lookup
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
   })
 
@@ -3450,6 +3434,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
       { id: 'msg-2', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
     ])
 
+    // Mock the DB select chain for author lookup: db.select().from().innerJoin().where()
     mockDbSelectFrom.mockReturnValue({
       innerJoin: () => ({
         where: () => Promise.resolve([
@@ -3462,11 +3447,13 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(res.status).toBe(200)
 
     const body = await res.json()
+    // User message should have sender
     expect(body[0].sender).toEqual({
       id: 'user-1',
       name: 'Alice',
       email: 'alice@example.com',
     })
+    // Assistant message should not have sender
     expect(body[1].sender).toBeUndefined()
   })
 
@@ -3476,6 +3463,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
       { id: 'msg-old', type: 'user', content: { text: 'old message' }, toolCalls: [], createdAt: new Date() },
     ])
 
+    // DB returns no author records (messages from before feature was added)
     mockDbSelectFrom.mockReturnValue({
       innerJoin: () => ({
         where: () => Promise.resolve([]),
@@ -3486,6 +3474,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(res.status).toBe(200)
 
     const body = await res.json()
+    // Message returned without sender — no crash
     expect(body[0].sender).toBeUndefined()
   })
 
@@ -3498,6 +3487,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
 
+    // No DB query since there are no user messages to look up
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
   })
 })
@@ -4436,8 +4426,12 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
         content: { text: '' },
         createdAt: new Date(),
         toolCalls: [
+          // Resolved call: not recoverable.
           { id: 'tool-done', name: 'Bash', input: {}, result: 'ok' },
+          // The missed blocking ask this fallback exists for.
           { id: 'tool-q', name: 'AskUserQuestion', input: {} },
+          // script_run is excluded from isBlockingUserInputToolName (its
+          // handler decides blocking per-grant) — must not be recovered here.
           { id: 'tool-sr', name: 'mcp__user-input__request_script_run', input: {} },
         ],
       },
@@ -4462,6 +4456,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
         createdAt: new Date(),
         toolCalls: [{ id: 'tool-q', name: 'mcp__user-input__request_secret', input: {} }],
       },
+      // Queued mid-turn message: the turn is still the same one that parked.
       { id: 'm2', type: 'user', queued: true, content: { text: 'also…' }, toolCalls: [], createdAt: new Date() },
     ])
 
@@ -4483,6 +4478,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
         createdAt: new Date(),
         toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
       },
+      // A real (non-queued) user message supersedes the parked ask.
       { id: 'm2', type: 'user', content: { text: 'never mind' }, toolCalls: [], createdAt: new Date() },
     ])
 
@@ -4491,6 +4487,10 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
   })
 
   it('a decision-settled request is stamped resolved and excluded from recovery', async () => {
+    // Parallel tool calls hold every sibling's transcript result until the
+    // last one settles — the declined call still looks unresolved here.
+    // Without the stamp, a reload resurrects its card (history fallback) and
+    // recovery re-asserts awaiting for a request nothing can answer anymore.
     vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
     vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
       new Map([['tool-declined', 'declined']]),

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -180,7 +180,7 @@ import { logAuditEvent, logAuditEventOrThrow } from '@shared/lib/services/audit-
 import { loadSessionUsageTotals } from '@shared/lib/services/usage-service'
 import { captureException } from '@shared/lib/error-reporting'
 import * as fs from 'fs'
-import { Readable } from 'stream'
+import { Readable, pipeline } from 'stream'
 import pLimit from 'p-limit'
 import * as path from 'path'
 import type { ApiAgent } from '@shared/lib/types/api'
@@ -1828,12 +1828,15 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     const source = Readable.from(transformed)
     const stringify = createJsonArrayStringifyTransform()
     const reportStreamError = (err: unknown) => {
+      const code = (err as NodeJS.ErrnoException)?.code
+      if (code === 'ABORT_ERR' || code === 'ERR_STREAM_PREMATURE_CLOSE') return
       console.error('Failed to stream messages:', err)
       captureException(err, { tags: { component: 'agents', operation: 'stream-messages' } })
     }
-    source.on('error', reportStreamError)
-    stringify.on('error', reportStreamError)
-    return c.body(Readable.toWeb(source.pipe(stringify)) as ReadableStream, 200, {
+    pipeline(source, stringify, (err) => {
+      if (err) reportStreamError(err)
+    })
+    return c.body(Readable.toWeb(stringify) as ReadableStream, 200, {
       'Content-Type': 'application/json',
     })
   } catch (error) {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -54,6 +54,7 @@ import {
   readSessionMetadata,
   updateSessionName,
   registerSession,
+  getSessionMessagesWithCompact,
   getSession,
   getSessionMetadata,
   sessionExists,
@@ -66,7 +67,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonlToJsonArrayTransform } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonArrayStringifyTransform } from '@shared/lib/utils/file-storage'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
@@ -1752,8 +1753,79 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
-    const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
-    const stream = fs.createReadStream(jsonlPath).pipe(createJsonlToJsonArrayTransform())
+    const messages = await getSessionMessagesWithCompact(agentSlug, sessionId)
+    const filtered = messages.filter((m) => !('isMeta' in m && m.isMeta))
+    const transformed = transformMessages(filtered)
+
+    // Discover subagent IDs for interrupted Task tool calls that have no result
+    await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
+
+    // Parallel tool calls hold every sibling's transcript result until the
+    // LAST one resolves, so a request the user already decided still looks
+    // unresolved here. Stamp the settled outcome onto the transcript so every
+    // history consumer — the client's refresh fallback, the transcript card,
+    // and the recovery scan below — sees a completed call instead of
+    // resurrecting a decided one.
+    const settledRequests = messagePersister.getSettledInputRequests(sessionId)
+    if (settledRequests.size > 0) {
+      for (const item of transformed) {
+        if (item.type !== 'assistant') continue
+        for (const toolCall of item.toolCalls) {
+          if (toolCall.result !== undefined) continue
+          const outcome = settledRequests.get(toolCall.id)
+          if (outcome !== undefined) {
+            toolCall.result =
+              outcome === 'answered' ? 'User provided input' : 'User declined the request'
+          }
+        }
+      }
+    }
+
+    if (messagePersister.isSessionActive(sessionId)) {
+      const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
+      if (unresolvedRequests.length > 0) {
+        // If the request-specific stream event was missed, persisted messages are
+        // the fallback source of truth. A stale transcript can briefly re-assert
+        // awaiting input, but the next stream result/idle event clears it.
+        messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
+      }
+    }
+
+    // In auth mode, annotate user messages with sender info
+    if (isAuthMode()) {
+      const userMessageIds = transformed
+        .filter((m) => m.type === 'user')
+        .map((m) => m.id)
+
+      if (userMessageIds.length > 0) {
+        const authors = await db
+          .select({
+            messageId: messageAuthor.id,
+            userId: messageAuthor.userId,
+            userName: userTable.name,
+            userEmail: userTable.email,
+          })
+          .from(messageAuthor)
+          .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
+          .where(eq(messageAuthor.sessionId, sessionId))
+
+        const authorMap = new Map(authors.map((a) => [a.messageId, a]))
+
+        for (const msg of transformed) {
+          if (msg.type !== 'user') continue
+          const author = authorMap.get(msg.id)
+          if (author) {
+            msg.sender = {
+              id: author.userId,
+              name: author.userName,
+              email: author.userEmail,
+            }
+          }
+        }
+      }
+    }
+
+    const stream = Readable.from(transformed).pipe(createJsonArrayStringifyTransform())
     return c.body(Readable.toWeb(stream) as ReadableStream, 200, {
       'Content-Type': 'application/json',
     })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -54,7 +54,6 @@ import {
   readSessionMetadata,
   updateSessionName,
   registerSession,
-  getSessionMessagesWithCompact,
   getSession,
   getSessionMetadata,
   sessionExists,
@@ -67,7 +66,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonlToJsonArrayTransform } from '@shared/lib/utils/file-storage'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
@@ -1753,79 +1752,11 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
-    const messages = await getSessionMessagesWithCompact(agentSlug, sessionId)
-    const filtered = messages.filter((m) => !('isMeta' in m && m.isMeta))
-    const transformed = transformMessages(filtered)
-
-    // Discover subagent IDs for interrupted Task tool calls that have no result
-    await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
-
-    // Parallel tool calls hold every sibling's transcript result until the
-    // LAST one resolves, so a request the user already decided still looks
-    // unresolved here. Stamp the settled outcome onto the transcript so every
-    // history consumer — the client's refresh fallback, the transcript card,
-    // and the recovery scan below — sees a completed call instead of
-    // resurrecting a decided one.
-    const settledRequests = messagePersister.getSettledInputRequests(sessionId)
-    if (settledRequests.size > 0) {
-      for (const item of transformed) {
-        if (item.type !== 'assistant') continue
-        for (const toolCall of item.toolCalls) {
-          if (toolCall.result !== undefined) continue
-          const outcome = settledRequests.get(toolCall.id)
-          if (outcome !== undefined) {
-            toolCall.result =
-              outcome === 'answered' ? 'User provided input' : 'User declined the request'
-          }
-        }
-      }
-    }
-
-    if (messagePersister.isSessionActive(sessionId)) {
-      const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
-      if (unresolvedRequests.length > 0) {
-        // If the request-specific stream event was missed, persisted messages are
-        // the fallback source of truth. A stale transcript can briefly re-assert
-        // awaiting input, but the next stream result/idle event clears it.
-        messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
-      }
-    }
-
-    // In auth mode, annotate user messages with sender info
-    if (isAuthMode()) {
-      const userMessageIds = transformed
-        .filter((m) => m.type === 'user')
-        .map((m) => m.id)
-
-      if (userMessageIds.length > 0) {
-        const authors = await db
-          .select({
-            messageId: messageAuthor.id,
-            userId: messageAuthor.userId,
-            userName: userTable.name,
-            userEmail: userTable.email,
-          })
-          .from(messageAuthor)
-          .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
-          .where(eq(messageAuthor.sessionId, sessionId))
-
-        const authorMap = new Map(authors.map((a) => [a.messageId, a]))
-
-        for (const msg of transformed) {
-          if (msg.type !== 'user') continue
-          const author = authorMap.get(msg.id)
-          if (author) {
-            msg.sender = {
-              id: author.userId,
-              name: author.userName,
-              email: author.userEmail,
-            }
-          }
-        }
-      }
-    }
-
-    return c.json(transformed)
+    const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+    const stream = fs.createReadStream(jsonlPath).pipe(createJsonlToJsonArrayTransform())
+    return c.body(Readable.toWeb(stream) as ReadableStream, 200, {
+      'Content-Type': 'application/json',
+    })
   } catch (error) {
     console.error('Failed to fetch messages:', error)
     return c.json({ error: 'Failed to fetch messages' }, 500)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1825,8 +1825,15 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       }
     }
 
-    const stream = Readable.from(transformed).pipe(createJsonArrayStringifyTransform())
-    return c.body(Readable.toWeb(stream) as ReadableStream, 200, {
+    const source = Readable.from(transformed)
+    const stringify = createJsonArrayStringifyTransform()
+    const reportStreamError = (err: unknown) => {
+      console.error('Failed to stream messages:', err)
+      captureException(err, { tags: { component: 'agents', operation: 'stream-messages' } })
+    }
+    source.on('error', reportStreamError)
+    stringify.on('error', reportStreamError)
+    return c.body(Readable.toWeb(source.pipe(stringify)) as ReadableStream, 200, {
       'Content-Type': 'application/json',
     })
   } catch (error) {

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -22,6 +22,7 @@ import {
   readJsonlFile,
   streamJsonlFile,
   createJsonlToJsonArrayTransform,
+  createJsonArrayStringifyTransform,
   getAgentsDir,
   getAgentDir,
   getAgentWorkspaceDir,
@@ -655,6 +656,19 @@ describe('readJsonlFile', () => {
   it('returns empty array for non-existent file', async () => {
     const result = await readJsonlFile(path.join(testDir, 'nonexistent.jsonl'))
     expect(result).toEqual([])
+  })
+
+  it('pipes objects into a JSON array', async () => {
+    const { Readable } = await import('stream')
+    const chunks: Buffer[] = []
+    await new Promise<void>((resolve, reject) => {
+      Readable.from([{ id: 1 }, { id: 2 }])
+        .pipe(createJsonArrayStringifyTransform())
+        .on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+        .on('end', resolve)
+        .on('error', reject)
+    })
+    expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
   })
 
   it('pipes JSONL into a JSON array', async () => {

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -657,30 +657,30 @@ describe('readJsonlFile', () => {
     expect(result).toEqual([])
   })
 
-  it('pipes objects into a JSON array', async () => {
-    const { Readable } = await import('stream')
+  async function stringifyJsonArray(items: unknown[]): Promise<string> {
+    const { Readable, pipeline } = await import('stream')
     const chunks: Buffer[] = []
+    const stringify = createJsonArrayStringifyTransform()
+    stringify.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
     await new Promise<void>((resolve, reject) => {
-      Readable.from([{ id: 1 }, { id: 2 }])
-        .pipe(createJsonArrayStringifyTransform())
-        .on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
-        .on('end', resolve)
-        .on('error', reject)
+      pipeline(Readable.from(items), stringify, (err) => {
+        if (err) reject(err)
+        else resolve()
+      })
     })
-    expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
+    return Buffer.concat(chunks).toString('utf-8')
+  }
+
+  it('pipes objects into a JSON array', async () => {
+    expect(JSON.parse(await stringifyJsonArray([{ id: 1 }, { id: 2 }]))).toEqual([{ id: 1 }, { id: 2 }])
   })
 
   it('pipes an empty iterable into []', async () => {
-    const { Readable } = await import('stream')
-    const chunks: Buffer[] = []
-    await new Promise<void>((resolve, reject) => {
-      Readable.from([])
-        .pipe(createJsonArrayStringifyTransform())
-        .on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
-        .on('end', resolve)
-        .on('error', reject)
-    })
-    expect(Buffer.concat(chunks).toString('utf-8')).toBe('[]')
+    expect(await stringifyJsonArray([])).toBe('[]')
+  })
+
+  it('serializes undefined elements as null', async () => {
+    expect(JSON.parse(await stringifyJsonArray([undefined, 1]))).toEqual([null, 1])
   })
 
   it('parses rows wider than a read chunk without a whole-file string', async () => {

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -21,6 +21,7 @@ import {
   parseJsonl,
   readJsonlFile,
   streamJsonlFile,
+  createJsonlToJsonArrayTransform,
   getAgentsDir,
   getAgentDir,
   getAgentWorkspaceDir,
@@ -654,6 +655,35 @@ describe('readJsonlFile', () => {
   it('returns empty array for non-existent file', async () => {
     const result = await readJsonlFile(path.join(testDir, 'nonexistent.jsonl'))
     expect(result).toEqual([])
+  })
+
+  it('pipes JSONL into a JSON array', async () => {
+    const filePath = path.join(testDir, 'pipe.jsonl')
+    await fs.promises.writeFile(filePath, '{"id": 1}\n{"id": 2}\n')
+
+    const chunks: Buffer[] = []
+    await new Promise<void>((resolve, reject) => {
+      fs.createReadStream(filePath)
+        .pipe(createJsonlToJsonArrayTransform())
+        .on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+        .on('end', resolve)
+        .on('error', reject)
+    })
+
+    expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('parses rows wider than a read chunk without a whole-file string', async () => {
+    const filePath = path.join(testDir, 'wide-read.jsonl')
+    const padding = 'x'.repeat(64 * 1024 + 137)
+    await fs.promises.writeFile(
+      filePath,
+      `${JSON.stringify({ id: 1, padding })}\n${JSON.stringify({ id: 2 })}\n`
+    )
+
+    const result = await readJsonlFile<{ id: number; padding?: string }>(filePath)
+    expect(result.map((r) => r.id)).toEqual([1, 2])
+    expect(result[0].padding).toHaveLength(padding.length)
   })
 })
 

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -21,7 +21,6 @@ import {
   parseJsonl,
   readJsonlFile,
   streamJsonlFile,
-  createJsonlToJsonArrayTransform,
   createJsonArrayStringifyTransform,
   getAgentsDir,
   getAgentDir,
@@ -671,20 +670,17 @@ describe('readJsonlFile', () => {
     expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
   })
 
-  it('pipes JSONL into a JSON array', async () => {
-    const filePath = path.join(testDir, 'pipe.jsonl')
-    await fs.promises.writeFile(filePath, '{"id": 1}\n{"id": 2}\n')
-
+  it('pipes an empty iterable into []', async () => {
+    const { Readable } = await import('stream')
     const chunks: Buffer[] = []
     await new Promise<void>((resolve, reject) => {
-      fs.createReadStream(filePath)
-        .pipe(createJsonlToJsonArrayTransform())
+      Readable.from([])
+        .pipe(createJsonArrayStringifyTransform())
         .on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
         .on('end', resolve)
         .on('error', reject)
     })
-
-    expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
+    expect(Buffer.concat(chunks).toString('utf-8')).toBe('[]')
   })
 
   it('parses rows wider than a read chunk without a whole-file string', async () => {

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -11,6 +11,7 @@
 
 import * as fs from 'fs'
 import * as path from 'path'
+import { Transform } from 'stream'
 import type { ZodType } from 'zod'
 import { getDataDir } from '@shared/lib/config/data-dir'
 import { assertPathWithinDir } from '@shared/lib/utils/path-safety'
@@ -343,15 +344,22 @@ export function parseJsonl<T = unknown>(content: string): T[] {
 }
 
 /**
- * Read and parse a JSONL file
- * Returns empty array if file doesn't exist
+ * Read and parse a JSONL file. Streams line-by-line so a large transcript is
+ * never one `readFile` string. Returns [] if the file does not exist.
  */
 export async function readJsonlFile<T = unknown>(filePath: string): Promise<T[]> {
-  const content = await readFileOrNull(filePath)
-  if (content === null) {
-    return []
+  const results: T[] = []
+  try {
+    for await (const item of streamJsonlFile<T>(filePath)) {
+      results.push(item)
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
   }
-  return parseJsonl<T>(content)
+  return results
 }
 
 const NEWLINE_BYTE = 0x0a
@@ -420,6 +428,54 @@ function parseJsonlLine<T>(line: Buffer): T | undefined {
   } catch {
     return undefined
   }
+}
+
+/** JSONL bytes in → JSON array bytes out. Used as `createReadStream(path).pipe(this)`. */
+export function createJsonlToJsonArrayTransform(): Transform {
+  let pending: Buffer[] = []
+  let first = true
+  let opened = false
+
+  const emit = (transform: Transform, line: Buffer) => {
+    const parsed = parseJsonlLine(line)
+    if (parsed === undefined) return
+    const json = JSON.stringify(parsed)
+    transform.push(first ? json : `,${json}`)
+    first = false
+  }
+
+  return new Transform({
+    transform(chunk, _enc, cb) {
+      if (!opened) {
+        this.push('[')
+        opened = true
+      }
+      const buf = chunk as Buffer
+      let start = 0
+      let idx = buf.indexOf(NEWLINE_BYTE)
+      while (idx !== -1) {
+        let line: Buffer
+        if (pending.length > 0) {
+          pending.push(buf.subarray(start, idx))
+          line = Buffer.concat(pending)
+          pending = []
+        } else {
+          line = buf.subarray(start, idx)
+        }
+        emit(this, line)
+        start = idx + 1
+        idx = buf.indexOf(NEWLINE_BYTE, start)
+      }
+      if (start < buf.length) pending.push(buf.subarray(start))
+      cb()
+    },
+    flush(cb) {
+      if (!opened) this.push('[')
+      if (pending.length > 0) emit(this, Buffer.concat(pending))
+      this.push(']')
+      cb()
+    },
+  })
 }
 
 // ============================================================================

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -452,54 +452,6 @@ export function createJsonArrayStringifyTransform(): Transform {
   })
 }
 
-/** JSONL bytes in → JSON array bytes out. Used as `createReadStream(path).pipe(this)`. */
-export function createJsonlToJsonArrayTransform(): Transform {
-  let pending: Buffer[] = []
-  let first = true
-  let opened = false
-
-  const emit = (transform: Transform, line: Buffer) => {
-    const parsed = parseJsonlLine(line)
-    if (parsed === undefined) return
-    const json = JSON.stringify(parsed)
-    transform.push(first ? json : `,${json}`)
-    first = false
-  }
-
-  return new Transform({
-    transform(chunk, _enc, cb) {
-      if (!opened) {
-        this.push('[')
-        opened = true
-      }
-      const buf = chunk as Buffer
-      let start = 0
-      let idx = buf.indexOf(NEWLINE_BYTE)
-      while (idx !== -1) {
-        let line: Buffer
-        if (pending.length > 0) {
-          pending.push(buf.subarray(start, idx))
-          line = Buffer.concat(pending)
-          pending = []
-        } else {
-          line = buf.subarray(start, idx)
-        }
-        emit(this, line)
-        start = idx + 1
-        idx = buf.indexOf(NEWLINE_BYTE, start)
-      }
-      if (start < buf.length) pending.push(buf.subarray(start))
-      cb()
-    },
-    flush(cb) {
-      if (!opened) this.push('[')
-      if (pending.length > 0) emit(this, Buffer.concat(pending))
-      this.push(']')
-      cb()
-    },
-  })
-}
-
 // ============================================================================
 // Temp Upload Helpers
 // ============================================================================

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -430,14 +430,14 @@ function parseJsonlLine<T>(line: Buffer): T | undefined {
   }
 }
 
-/** Object-mode items in → JSON array bytes out. Used as `Readable.from(items).pipe(this)`. */
+/** Object-mode items in → JSON array bytes out. Pair with `pipeline(Readable.from(items), this)`. */
 export function createJsonArrayStringifyTransform(): Transform {
   let first = true
   return new Transform({
     writableObjectMode: true,
     transform(obj, _enc, cb) {
       try {
-        const json = JSON.stringify(obj)
+        const json = JSON.stringify(obj) ?? 'null'
         this.push(first ? `[${json}` : `,${json}`)
         first = false
         cb()

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -430,6 +430,28 @@ function parseJsonlLine<T>(line: Buffer): T | undefined {
   }
 }
 
+/** Object-mode items in → JSON array bytes out. Used as `Readable.from(items).pipe(this)`. */
+export function createJsonArrayStringifyTransform(): Transform {
+  let first = true
+  return new Transform({
+    writableObjectMode: true,
+    transform(obj, _enc, cb) {
+      try {
+        const json = JSON.stringify(obj)
+        this.push(first ? `[${json}` : `,${json}`)
+        first = false
+        cb()
+      } catch (err) {
+        cb(err as Error)
+      }
+    },
+    flush(cb) {
+      this.push(first ? '[]' : ']')
+      cb()
+    },
+  })
+}
+
 /** JSONL bytes in → JSON array bytes out. Used as `createReadStream(path).pipe(this)`. */
 export function createJsonlToJsonArrayTransform(): Transform {
   let pending: Buffer[] = []


### PR DESCRIPTION
## Summary
- Host-app OOM on `GET /messages`: overlapping list refetches each `readFile` + parse + `c.json()` the whole Claude JSONL (screenshots included). A 1 GB Fargate task already at 400–500 MB dies (exit 137).
- Response shape is unchanged: `transformMessages`, author annotation, interrupted-subagent resolution, and awaiting-input recovery still run.
- Two cuts on that path:
  1. `readJsonlFile` streams line-by-line instead of one `readFile` string.
  2. The transformed array is piped through `createJsonArrayStringifyTransform`, so the host does not also hold the full `JSON.stringify` response string.
- Peak per request is still the parsed + transformed array. Concurrent refetches still hold N of those. This PR drops the extra whole-file string and the extra response string.

## RSS (re-measured on this branch)

Incident file `/tmp/iddo-9b2c4d80.jsonl` (35.7 MB), includes `transformMessages`, separate processes, `--expose-gc`:

- Old path (`readFile` + parse + `JSON.stringify`) 3 concurrent: **91 → 556 MB** RSS
- This PR 3 concurrent: **91 → 278 MB** RSS
- This PR 10 concurrent: **570 MB** RSS (N transformed arrays still retained)

The 924 → 183 MB numbers from the first commit were for a raw JSONL pipe with no transform. They do not apply to HEAD.

## What this does not do
- Image base64 is still parsed and sent (~17 MB transformed body).
- Client refetch stacking is unchanged.
- Follow-up: page / stream the transform so the host does not accumulate the full array per request.

## Test plan
- [x] `npx vitest run src/shared/lib/utils/file-storage.test.ts src/api/routes/agents.test.ts`
- [ ] Open a session with a large illustrated transcript and confirm `GET /messages` returns 200 with `content.text` / `toolCalls`
- [ ] Confirm host RSS during a tool-result burst does not jump by ~file-size × in-flight × 3