### PR TITLE
fix: pipe GET /messages and cursor-page large transcripts

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -56,12 +56,7 @@ vi.mock('fs', () => ({
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
 }))
 
-const mockToWeb = vi.fn(() => new ReadableStream())
-vi.mock('stream', () => ({
-  Readable: {
-    toWeb: (...args: unknown[]) => mockToWeb(...args),
-  },
-}))
+vi.mock('stream', async (importOriginal) => importOriginal<typeof import('stream')>())
 
 // child_process — the run-script route executes approved scripts via
 // promisify(exec)/promisify(execFile); the callback-style mocks below resolve
@@ -481,6 +476,23 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
   writeFile: vi.fn(),
   getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
   readJsonlFile: vi.fn(),
+  createJsonArrayStringifyTransform: () => {
+    const { Transform } = require('node:stream') as typeof import('node:stream')
+    let first = true
+    return new Transform({
+      writableObjectMode: true,
+      transform(obj, _enc, cb) {
+        const json = JSON.stringify(obj)
+        this.push(first ? `[${json}` : `,${json}`)
+        first = false
+        cb()
+      },
+      flush(cb) {
+        this.push(first ? '[]' : ']')
+        cb()
+      },
+    })
+  },
   createJsonlToJsonArrayTransform: vi.fn(() => ({})),
   getAgentWorkspaceDir: (slug: string) => mockGetAgentWorkspaceDir(slug),
   getAgentPreferencesPath: vi.fn((slug: string) => `/mock/workspace/${slug}/agent-preferences.json`),
@@ -543,7 +555,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3398,25 +3410,15 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
   })
 })
 
-describe('GET /:id/sessions/:sessionId/messages', () => {
+describe('message author attribution — GET /:id/sessions/:sessionId/messages', () => {
   let app: ReturnType<typeof createApp>
   const URL = '/api/agents/test-agent/sessions/sess-1/messages'
 
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
+    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
     vi.mocked(sessionExists).mockResolvedValue(true)
-    mockCreateReadStream.mockReturnValue({
-      pipe: vi.fn().mockReturnValue({}),
-    })
-    mockToWeb.mockReturnValue(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('[]'))
-          controller.close()
-        },
-      })
-    )
   })
 
   it('returns 404 when the session transcript is missing', async () => {
@@ -3424,20 +3426,79 @@ describe('GET /:id/sessions/:sessionId/messages', () => {
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(404)
-    expect(mockCreateReadStream).not.toHaveBeenCalled()
+    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
-  it('pipes the JSONL file into the HTTP body', async () => {
-    const piped = {}
-    const pipe = vi.fn().mockReturnValue(piped)
-    mockCreateReadStream.mockReturnValue({ pipe })
+  it('does not query messageAuthor in non-auth mode', async () => {
+    mockIsAuthMode.mockReturnValue(false)
+    mockTransformMessages.mockReturnValue([
+      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
+    ])
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
-    expect(mockCreateReadStream).toHaveBeenCalledWith('/mock/sessions/test-agent/sess-1.jsonl')
-    expect(pipe).toHaveBeenCalled()
-    expect(mockToWeb).toHaveBeenCalledWith(piped)
-    expect(await res.json()).toEqual([])
+
+    const body = await res.json()
+    expect(body[0].sender).toBeUndefined()
+    expect(mockDbSelectFrom).not.toHaveBeenCalled()
+  })
+
+  it('annotates user messages with sender info in auth mode', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
+      { id: 'msg-2', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    mockDbSelectFrom.mockReturnValue({
+      innerJoin: () => ({
+        where: () => Promise.resolve([
+          { messageId: 'msg-1', userId: 'user-1', userName: 'Alice', userEmail: 'alice@example.com' },
+        ]),
+      }),
+    })
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body[0].sender).toEqual({
+      id: 'user-1',
+      name: 'Alice',
+      email: 'alice@example.com',
+    })
+    expect(body[1].sender).toBeUndefined()
+  })
+
+  it('handles sessions with no author records gracefully', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'msg-old', type: 'user', content: { text: 'old message' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    mockDbSelectFrom.mockReturnValue({
+      innerJoin: () => ({
+        where: () => Promise.resolve([]),
+      }),
+    })
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body[0].sender).toBeUndefined()
+  })
+
+  it('skips author query when there are no user messages', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'msg-1', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+
+    expect(mockDbSelectFrom).not.toHaveBeenCalled()
   })
 })
 
@@ -4360,27 +4421,124 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
+    mockIsAuthMode.mockReturnValue(false)
     vi.mocked(sessionExists).mockResolvedValue(true)
-    mockCreateReadStream.mockReturnValue({
-      pipe: vi.fn().mockReturnValue({}),
-    })
-    mockToWeb.mockReturnValue(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('[]'))
-          controller.close()
-        },
-      })
-    )
+    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
   })
 
-  it('does not scan the transcript for recovery — the list is a file pipe', async () => {
+  it('re-establishes the missed blocking requests of the trailing turn for an active session', async () => {
     vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      { id: 'm1', type: 'user', content: { text: 'go' }, toolCalls: [], createdAt: new Date() },
+      {
+        id: 'm2',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [
+          { id: 'tool-done', name: 'Bash', input: {}, result: 'ok' },
+          { id: 'tool-q', name: 'AskUserQuestion', input: {} },
+          { id: 'tool-sr', name: 'mcp__user-input__request_script_run', input: {} },
+        ],
+      },
+    ])
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }],
+    )
+  })
+
+  it('a trailing QUEUED user message does not end the turn scan', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'mcp__user-input__request_secret', input: {} }],
+      },
+      { id: 'm2', type: 'user', queued: true, content: { text: 'also…' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    await getReq(app, URL)
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }],
+    )
+  })
+
+  it('does not recover when a later user message started a fresh turn', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
+      },
+      { id: 'm2', type: 'user', content: { text: 'never mind' }, toolCalls: [], createdAt: new Date() },
+    ])
+
+    await getReq(app, URL)
     expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
-    expect(messagePersister.getSettledInputRequests).not.toHaveBeenCalled()
+  })
+
+  it('a decision-settled request is stamped resolved and excluded from recovery', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
+      new Map([['tool-declined', 'declined']]),
+    )
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [
+          { id: 'tool-declined', name: 'mcp__user-input__request_secret', input: {} },
+          { id: 'tool-open', name: 'AskUserQuestion', input: {} },
+        ],
+      },
+    ])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Array<{
+      toolCalls?: Array<{ id: string; result?: string }>
+    }>
+    const toolCalls = body[0].toolCalls ?? []
+    expect(toolCalls.find((t) => t.id === 'tool-declined')?.result).toBe(
+      'User declined the request',
+    )
+    expect(toolCalls.find((t) => t.id === 'tool-open')?.result).toBeUndefined()
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
+      'sess-1',
+      'test-agent',
+      [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }],
+    )
+  })
+
+  it('does not recover for an inactive session', async () => {
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(false)
+    mockTransformMessages.mockReturnValue([
+      {
+        id: 'm1',
+        type: 'assistant',
+        content: { text: '' },
+        createdAt: new Date(),
+        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
+      },
+    ])
+
+    await getReq(app, URL)
+    expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -56,9 +56,10 @@ vi.mock('fs', () => ({
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
 }))
 
+const mockToWeb = vi.fn(() => new ReadableStream())
 vi.mock('stream', () => ({
   Readable: {
-    toWeb: () => new ReadableStream(),
+    toWeb: (...args: unknown[]) => mockToWeb(...args),
   },
 }))
 
@@ -480,6 +481,7 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
   writeFile: vi.fn(),
   getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
   readJsonlFile: vi.fn(),
+  createJsonlToJsonArrayTransform: vi.fn(() => ({})),
   getAgentWorkspaceDir: (slug: string) => mockGetAgentWorkspaceDir(slug),
   getAgentPreferencesPath: vi.fn((slug: string) => `/mock/workspace/${slug}/agent-preferences.json`),
   getTempUploadsDir: vi.fn(() => '/mock/tmp/uploads'),
@@ -541,7 +543,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3396,15 +3398,25 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
   })
 })
 
-describe('message author attribution — GET /:id/sessions/:sessionId/messages', () => {
+describe('GET /:id/sessions/:sessionId/messages', () => {
   let app: ReturnType<typeof createApp>
   const URL = '/api/agents/test-agent/sessions/sess-1/messages'
 
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
-    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
     vi.mocked(sessionExists).mockResolvedValue(true)
+    mockCreateReadStream.mockReturnValue({
+      pipe: vi.fn().mockReturnValue({}),
+    })
+    mockToWeb.mockReturnValue(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('[]'))
+          controller.close()
+        },
+      })
+    )
   })
 
   it('returns 404 when the session transcript is missing', async () => {
@@ -3412,88 +3424,20 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(404)
-    // Should not attempt to read messages for a missing transcript
-    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+    expect(mockCreateReadStream).not.toHaveBeenCalled()
   })
 
-  it('does not query messageAuthor in non-auth mode', async () => {
-    mockIsAuthMode.mockReturnValue(false)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
-    ])
+  it('pipes the JSONL file into the HTTP body', async () => {
+    const piped = {}
+    const pipe = vi.fn().mockReturnValue(piped)
+    mockCreateReadStream.mockReturnValue({ pipe })
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
-
-    const body = await res.json()
-    // No sender field attached
-    expect(body[0].sender).toBeUndefined()
-    // DB select should not have been called for author lookup
-    expect(mockDbSelectFrom).not.toHaveBeenCalled()
-  })
-
-  it('annotates user messages with sender info in auth mode', async () => {
-    mockIsAuthMode.mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
-      { id: 'msg-2', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    // Mock the DB select chain for author lookup: db.select().from().innerJoin().where()
-    mockDbSelectFrom.mockReturnValue({
-      innerJoin: () => ({
-        where: () => Promise.resolve([
-          { messageId: 'msg-1', userId: 'user-1', userName: 'Alice', userEmail: 'alice@example.com' },
-        ]),
-      }),
-    })
-
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    // User message should have sender
-    expect(body[0].sender).toEqual({
-      id: 'user-1',
-      name: 'Alice',
-      email: 'alice@example.com',
-    })
-    // Assistant message should not have sender
-    expect(body[1].sender).toBeUndefined()
-  })
-
-  it('handles sessions with no author records gracefully', async () => {
-    mockIsAuthMode.mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-old', type: 'user', content: { text: 'old message' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    // DB returns no author records (messages from before feature was added)
-    mockDbSelectFrom.mockReturnValue({
-      innerJoin: () => ({
-        where: () => Promise.resolve([]),
-      }),
-    })
-
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    // Message returned without sender — no crash
-    expect(body[0].sender).toBeUndefined()
-  })
-
-  it('skips author query when there are no user messages', async () => {
-    mockIsAuthMode.mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-1', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
-
-    // No DB query since there are no user messages to look up
-    expect(mockDbSelectFrom).not.toHaveBeenCalled()
+    expect(mockCreateReadStream).toHaveBeenCalledWith('/mock/sessions/test-agent/sess-1.jsonl')
+    expect(pipe).toHaveBeenCalled()
+    expect(mockToWeb).toHaveBeenCalledWith(piped)
+    expect(await res.json()).toEqual([])
   })
 })
 
@@ -4416,134 +4360,27 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
-    mockIsAuthMode.mockReturnValue(false)
     vi.mocked(sessionExists).mockResolvedValue(true)
-    vi.mocked(getSessionMessagesWithCompact).mockResolvedValue([])
+    mockCreateReadStream.mockReturnValue({
+      pipe: vi.fn().mockReturnValue({}),
+    })
+    mockToWeb.mockReturnValue(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('[]'))
+          controller.close()
+        },
+      })
+    )
   })
 
-  it('re-establishes the missed blocking requests of the trailing turn for an active session', async () => {
+  it('does not scan the transcript for recovery — the list is a file pipe', async () => {
     vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'm1', type: 'user', content: { text: 'go' }, toolCalls: [], createdAt: new Date() },
-      {
-        id: 'm2',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [
-          // Resolved call: not recoverable.
-          { id: 'tool-done', name: 'Bash', input: {}, result: 'ok' },
-          // The missed blocking ask this fallback exists for.
-          { id: 'tool-q', name: 'AskUserQuestion', input: {} },
-          // script_run is excluded from isBlockingUserInputToolName (its
-          // handler decides blocking per-grant) — must not be recovered here.
-          { id: 'tool-sr', name: 'mcp__user-input__request_script_run', input: {} },
-        ],
-      },
-    ])
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }],
-    )
-  })
-
-  it('a trailing QUEUED user message does not end the turn scan', async () => {
-    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      {
-        id: 'm1',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [{ id: 'tool-q', name: 'mcp__user-input__request_secret', input: {} }],
-      },
-      // Queued mid-turn message: the turn is still the same one that parked.
-      { id: 'm2', type: 'user', queued: true, content: { text: 'also…' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    await getReq(app, URL)
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }],
-    )
-  })
-
-  it('does not recover when a later user message started a fresh turn', async () => {
-    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      {
-        id: 'm1',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
-      },
-      // A real (non-queued) user message supersedes the parked ask.
-      { id: 'm2', type: 'user', content: { text: 'never mind' }, toolCalls: [], createdAt: new Date() },
-    ])
-
-    await getReq(app, URL)
     expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
-  })
-
-  it('a decision-settled request is stamped resolved and excluded from recovery', async () => {
-    // Parallel tool calls hold every sibling's transcript result until the
-    // last one settles — the declined call still looks unresolved here.
-    // Without the stamp, a reload resurrects its card (history fallback) and
-    // recovery re-asserts awaiting for a request nothing can answer anymore.
-    vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
-    vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
-      new Map([['tool-declined', 'declined']]),
-    )
-    mockTransformMessages.mockReturnValue([
-      {
-        id: 'm1',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [
-          { id: 'tool-declined', name: 'mcp__user-input__request_secret', input: {} },
-          { id: 'tool-open', name: 'AskUserQuestion', input: {} },
-        ],
-      },
-    ])
-
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
-    const body = (await res.json()) as Array<{
-      toolCalls?: Array<{ id: string; result?: string }>
-    }>
-    const toolCalls = body[0].toolCalls ?? []
-    expect(toolCalls.find((t) => t.id === 'tool-declined')?.result).toBe(
-      'User declined the request',
-    )
-    expect(toolCalls.find((t) => t.id === 'tool-open')?.result).toBeUndefined()
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }],
-    )
-  })
-
-  it('does not recover for an inactive session', async () => {
-    vi.mocked(messagePersister.isSessionActive).mockReturnValue(false)
-    mockTransformMessages.mockReturnValue([
-      {
-        id: 'm1',
-        type: 'assistant',
-        content: { text: '' },
-        createdAt: new Date(),
-        toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
-      },
-    ])
-
-    await getReq(app, URL)
-    expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
+    expect(messagePersister.getSettledInputRequests).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -281,6 +281,7 @@ vi.mock('@shared/lib/services/session-service', () => ({
   updateSessionName: vi.fn(),
   registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(),
+  getSessionMessagesPage: vi.fn(),
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),
@@ -536,7 +537,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3489,6 +3490,56 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
 
     // No DB query since there are no user messages to look up
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /:id/sessions/:sessionId/messages pagination', () => {
+  let app: ReturnType<typeof createApp>
+  const URL = '/api/agents/test-agent/sessions/sess-1/messages'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    vi.mocked(sessionExists).mockResolvedValue(true)
+    vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
+  })
+
+  it('returns a cursor envelope when limit is set', async () => {
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+      messages: [
+        { id: 'm1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
+      ],
+      nextCursor: 'm1',
+    })
+
+    const res = await getReq(app, `${URL}?limit=2`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.messages).toHaveLength(1)
+    expect(body.messages[0].id).toBe('m1')
+    expect(body.nextCursor).toBe('m1')
+    expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', { limit: 2, cursor: undefined })
+    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+  })
+
+  it('forwards cursor to the page reader', async () => {
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+      messages: [],
+      nextCursor: null,
+    })
+
+    const res = await getReq(app, `${URL}?limit=2&cursor=m1`)
+    expect(res.status).toBe(200)
+    expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', {
+      limit: 2,
+      cursor: 'm1',
+    })
+  })
+
+  it('rejects an invalid limit', async () => {
+    const res = await getReq(app, `${URL}?limit=0`)
+    expect(res.status).toBe(400)
+    expect(getSessionMessagesPage).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -56,8 +56,6 @@ vi.mock('fs', () => ({
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
 }))
 
-vi.mock('stream', async (importOriginal) => importOriginal<typeof import('stream')>())
-
 // child_process — the run-script route executes approved scripts via
 // promisify(exec)/promisify(execFile); the callback-style mocks below resolve
 // through promisify. Also covers the fire-and-forget execFile in the
@@ -465,7 +463,8 @@ const mockGetAgentWorkspaceDir = vi.fn((_slug?: string) => '/mock/workspace')
 const mockGetSessionJsonlPath = vi.fn(
   (agentSlug: string, sessionId: string) => `/mock/sessions/${agentSlug}/${sessionId}.jsonl`,
 )
-vi.mock('@shared/lib/utils/file-storage', () => ({
+vi.mock('@shared/lib/utils/file-storage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shared/lib/utils/file-storage')>()),
   // ResolveAgent() resolves the :id param via resolveAgentId. Delegate to the
   // existing agentExists mock so the legacy 404-on-missing behavior is preserved:
   // returns the slug verbatim when it "exists", else null.
@@ -476,24 +475,6 @@ vi.mock('@shared/lib/utils/file-storage', () => ({
   writeFile: vi.fn(),
   getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
   readJsonlFile: vi.fn(),
-  createJsonArrayStringifyTransform: () => {
-    const { Transform } = require('node:stream') as typeof import('node:stream')
-    let first = true
-    return new Transform({
-      writableObjectMode: true,
-      transform(obj, _enc, cb) {
-        const json = JSON.stringify(obj)
-        this.push(first ? `[${json}` : `,${json}`)
-        first = false
-        cb()
-      },
-      flush(cb) {
-        this.push(first ? '[]' : ']')
-        cb()
-      },
-    })
-  },
-  createJsonlToJsonArrayTransform: vi.fn(() => ({})),
   getAgentWorkspaceDir: (slug: string) => mockGetAgentWorkspaceDir(slug),
   getAgentPreferencesPath: vi.fn((slug: string) => `/mock/workspace/${slug}/agent-preferences.json`),
   getTempUploadsDir: vi.fn(() => '/mock/tmp/uploads'),
@@ -3426,6 +3407,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(404)
+    // Should not attempt to read messages for a missing transcript
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
@@ -3439,7 +3421,9 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(res.status).toBe(200)
 
     const body = await res.json()
+    // No sender field attached
     expect(body[0].sender).toBeUndefined()
+    // DB select should not have been called for author lookup
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
   })
 
@@ -3450,6 +3434,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
       { id: 'msg-2', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
     ])
 
+    // Mock the DB select chain for author lookup: db.select().from().innerJoin().where()
     mockDbSelectFrom.mockReturnValue({
       innerJoin: () => ({
         where: () => Promise.resolve([
@@ -3462,11 +3447,13 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(res.status).toBe(200)
 
     const body = await res.json()
+    // User message should have sender
     expect(body[0].sender).toEqual({
       id: 'user-1',
       name: 'Alice',
       email: 'alice@example.com',
     })
+    // Assistant message should not have sender
     expect(body[1].sender).toBeUndefined()
   })
 
@@ -3476,6 +3463,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
       { id: 'msg-old', type: 'user', content: { text: 'old message' }, toolCalls: [], createdAt: new Date() },
     ])
 
+    // DB returns no author records (messages from before feature was added)
     mockDbSelectFrom.mockReturnValue({
       innerJoin: () => ({
         where: () => Promise.resolve([]),
@@ -3486,6 +3474,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(res.status).toBe(200)
 
     const body = await res.json()
+    // Message returned without sender — no crash
     expect(body[0].sender).toBeUndefined()
   })
 
@@ -3498,6 +3487,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
 
+    // No DB query since there are no user messages to look up
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
   })
 })
@@ -4436,8 +4426,12 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
         content: { text: '' },
         createdAt: new Date(),
         toolCalls: [
+          // Resolved call: not recoverable.
           { id: 'tool-done', name: 'Bash', input: {}, result: 'ok' },
+          // The missed blocking ask this fallback exists for.
           { id: 'tool-q', name: 'AskUserQuestion', input: {} },
+          // script_run is excluded from isBlockingUserInputToolName (its
+          // handler decides blocking per-grant) — must not be recovered here.
           { id: 'tool-sr', name: 'mcp__user-input__request_script_run', input: {} },
         ],
       },
@@ -4462,6 +4456,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
         createdAt: new Date(),
         toolCalls: [{ id: 'tool-q', name: 'mcp__user-input__request_secret', input: {} }],
       },
+      // Queued mid-turn message: the turn is still the same one that parked.
       { id: 'm2', type: 'user', queued: true, content: { text: 'also…' }, toolCalls: [], createdAt: new Date() },
     ])
 
@@ -4483,6 +4478,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
         createdAt: new Date(),
         toolCalls: [{ id: 'tool-q', name: 'AskUserQuestion', input: {} }],
       },
+      // A real (non-queued) user message supersedes the parked ask.
       { id: 'm2', type: 'user', content: { text: 'never mind' }, toolCalls: [], createdAt: new Date() },
     ])
 
@@ -4491,6 +4487,10 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
   })
 
   it('a decision-settled request is stamped resolved and excluded from recovery', async () => {
+    // Parallel tool calls hold every sibling's transcript result until the
+    // last one settles — the declined call still looks unresolved here.
+    // Without the stamp, a reload resurrects its card (history fallback) and
+    // recovery re-asserts awaiting for a request nothing can answer anymore.
     vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
     vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
       new Map([['tool-declined', 'declined']]),

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -54,6 +54,7 @@ import {
   readSessionMetadata,
   updateSessionName,
   registerSession,
+  getSessionMessagesWithCompact,
   getSession,
   getSessionMetadata,
   sessionExists,
@@ -66,7 +67,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonlToJsonArrayTransform } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonArrayStringifyTransform } from '@shared/lib/utils/file-storage'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
@@ -1752,8 +1753,79 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
-    const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
-    const stream = fs.createReadStream(jsonlPath).pipe(createJsonlToJsonArrayTransform())
+    const messages = await getSessionMessagesWithCompact(agentSlug, sessionId)
+    const filtered = messages.filter((m) => !('isMeta' in m && m.isMeta))
+    const transformed = transformMessages(filtered)
+
+    // Discover subagent IDs for interrupted Task tool calls that have no result
+    await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
+
+    // Parallel tool calls hold every sibling's transcript result until the
+    // LAST one resolves, so a request the user already decided still looks
+    // unresolved here. Stamp the settled outcome onto the transcript so every
+    // history consumer — the client's refresh fallback, the transcript card,
+    // and the recovery scan below — sees a completed call instead of
+    // resurrecting a decided one.
+    const settledRequests = messagePersister.getSettledInputRequests(sessionId)
+    if (settledRequests.size > 0) {
+      for (const item of transformed) {
+        if (item.type !== 'assistant') continue
+        for (const toolCall of item.toolCalls) {
+          if (toolCall.result !== undefined) continue
+          const outcome = settledRequests.get(toolCall.id)
+          if (outcome !== undefined) {
+            toolCall.result =
+              outcome === 'answered' ? 'User provided input' : 'User declined the request'
+          }
+        }
+      }
+    }
+
+    if (messagePersister.isSessionActive(sessionId)) {
+      const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
+      if (unresolvedRequests.length > 0) {
+        // If the request-specific stream event was missed, persisted messages are
+        // the fallback source of truth. A stale transcript can briefly re-assert
+        // awaiting input, but the next stream result/idle event clears it.
+        messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
+      }
+    }
+
+    // In auth mode, annotate user messages with sender info
+    if (isAuthMode()) {
+      const userMessageIds = transformed
+        .filter((m) => m.type === 'user')
+        .map((m) => m.id)
+
+      if (userMessageIds.length > 0) {
+        const authors = await db
+          .select({
+            messageId: messageAuthor.id,
+            userId: messageAuthor.userId,
+            userName: userTable.name,
+            userEmail: userTable.email,
+          })
+          .from(messageAuthor)
+          .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
+          .where(eq(messageAuthor.sessionId, sessionId))
+
+        const authorMap = new Map(authors.map((a) => [a.messageId, a]))
+
+        for (const msg of transformed) {
+          if (msg.type !== 'user') continue
+          const author = authorMap.get(msg.id)
+          if (author) {
+            msg.sender = {
+              id: author.userId,
+              name: author.userName,
+              email: author.userEmail,
+            }
+          }
+        }
+      }
+    }
+
+    const stream = Readable.from(transformed).pipe(createJsonArrayStringifyTransform())
     return c.body(Readable.toWeb(stream) as ReadableStream, 200, {
       'Content-Type': 'application/json',
     })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -13,6 +13,7 @@ import {
   injectDashboardRuntime,
 } from '../dashboard-runtime'
 import { parsePagination } from '../pagination'
+import { MESSAGES_PAGE_MAX_LIMIT, MESSAGES_PAGE_OLDER_LIMIT } from '@shared/lib/messages-page'
 import { Authenticated, AgentRead, AgentUser, AgentAdmin, IsAdmin, ResolveAgent, getAgentId, getAuthorizedAgentRole } from '../middleware/auth'
 import {
   listAgentsWithStatus,
@@ -55,6 +56,7 @@ import {
   updateSessionName,
   registerSession,
   getSessionMessagesWithCompact,
+  getSessionMessagesPage,
   getSession,
   getSessionMetadata,
   sessionExists,
@@ -1737,6 +1739,70 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
   }
 })
 
+const messagesListQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(MESSAGES_PAGE_MAX_LIMIT).optional(),
+  cursor: z.string().min(1).max(200).optional(),
+})
+
+async function annotateAndRecoverMessages(
+  transformed: TransformedItem[],
+  agentSlug: string,
+  sessionId: string,
+): Promise<void> {
+  await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
+
+  const settledRequests = messagePersister.getSettledInputRequests(sessionId)
+  if (settledRequests.size > 0) {
+    for (const item of transformed) {
+      if (item.type !== 'assistant') continue
+      for (const toolCall of item.toolCalls) {
+        if (toolCall.result !== undefined) continue
+        const outcome = settledRequests.get(toolCall.id)
+        if (outcome !== undefined) {
+          toolCall.result =
+            outcome === 'answered' ? 'User provided input' : 'User declined the request'
+        }
+      }
+    }
+  }
+
+  if (messagePersister.isSessionActive(sessionId)) {
+    const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
+    if (unresolvedRequests.length > 0) {
+      messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
+    }
+  }
+
+  if (!isAuthMode()) return
+
+  const userMessageIds = transformed.filter((m) => m.type === 'user').map((m) => m.id)
+  if (userMessageIds.length === 0) return
+
+  const authors = await db
+    .select({
+      messageId: messageAuthor.id,
+      userId: messageAuthor.userId,
+      userName: userTable.name,
+      userEmail: userTable.email,
+    })
+    .from(messageAuthor)
+    .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
+    .where(eq(messageAuthor.sessionId, sessionId))
+
+  const authorMap = new Map(authors.map((a) => [a.messageId, a]))
+  for (const msg of transformed) {
+    if (msg.type !== 'user') continue
+    const author = authorMap.get(msg.id)
+    if (author) {
+      msg.sender = {
+        id: author.userId,
+        name: author.userName,
+        email: author.userEmail,
+      }
+    }
+  }
+}
+
 // GET /api/agents/:id/sessions/:sessionId/messages - Get messages for a session
 agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
   try {
@@ -1753,77 +1819,28 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
+    const rawLimit = c.req.query('limit')
+    const rawCursor = c.req.query('cursor')
+    if (rawLimit !== undefined || rawCursor !== undefined) {
+      const parsed = messagesListQuerySchema.safeParse({
+        ...(rawLimit !== undefined ? { limit: rawLimit } : {}),
+        ...(rawCursor !== undefined ? { cursor: rawCursor } : {}),
+      })
+      if (!parsed.success) {
+        return c.json({ error: 'Invalid pagination' }, 400)
+      }
+      const page = await getSessionMessagesPage(agentSlug, sessionId, {
+        limit: parsed.data.limit ?? MESSAGES_PAGE_OLDER_LIMIT,
+        cursor: parsed.data.cursor,
+      })
+      await annotateAndRecoverMessages(page.messages, agentSlug, sessionId)
+      return c.json({ messages: page.messages, nextCursor: page.nextCursor })
+    }
+
     const messages = await getSessionMessagesWithCompact(agentSlug, sessionId)
     const filtered = messages.filter((m) => !('isMeta' in m && m.isMeta))
     const transformed = transformMessages(filtered)
-
-    // Discover subagent IDs for interrupted Task tool calls that have no result
-    await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
-
-    // Parallel tool calls hold every sibling's transcript result until the
-    // LAST one resolves, so a request the user already decided still looks
-    // unresolved here. Stamp the settled outcome onto the transcript so every
-    // history consumer — the client's refresh fallback, the transcript card,
-    // and the recovery scan below — sees a completed call instead of
-    // resurrecting a decided one.
-    const settledRequests = messagePersister.getSettledInputRequests(sessionId)
-    if (settledRequests.size > 0) {
-      for (const item of transformed) {
-        if (item.type !== 'assistant') continue
-        for (const toolCall of item.toolCalls) {
-          if (toolCall.result !== undefined) continue
-          const outcome = settledRequests.get(toolCall.id)
-          if (outcome !== undefined) {
-            toolCall.result =
-              outcome === 'answered' ? 'User provided input' : 'User declined the request'
-          }
-        }
-      }
-    }
-
-    if (messagePersister.isSessionActive(sessionId)) {
-      const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
-      if (unresolvedRequests.length > 0) {
-        // If the request-specific stream event was missed, persisted messages are
-        // the fallback source of truth. A stale transcript can briefly re-assert
-        // awaiting input, but the next stream result/idle event clears it.
-        messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
-      }
-    }
-
-    // In auth mode, annotate user messages with sender info
-    if (isAuthMode()) {
-      const userMessageIds = transformed
-        .filter((m) => m.type === 'user')
-        .map((m) => m.id)
-
-      if (userMessageIds.length > 0) {
-        const authors = await db
-          .select({
-            messageId: messageAuthor.id,
-            userId: messageAuthor.userId,
-            userName: userTable.name,
-            userEmail: userTable.email,
-          })
-          .from(messageAuthor)
-          .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
-          .where(eq(messageAuthor.sessionId, sessionId))
-
-        const authorMap = new Map(authors.map((a) => [a.messageId, a]))
-
-        for (const msg of transformed) {
-          if (msg.type !== 'user') continue
-          const author = authorMap.get(msg.id)
-          if (author) {
-            msg.sender = {
-              id: author.userId,
-              name: author.userName,
-              email: author.userEmail,
-            }
-          }
-        }
-      }
-    }
+    await annotateAndRecoverMessages(transformed, agentSlug, sessionId)
 
     const source = Readable.from(transformed)
     const stringify = createJsonArrayStringifyTransform()

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -54,7 +54,6 @@ import {
   readSessionMetadata,
   updateSessionName,
   registerSession,
-  getSessionMessagesWithCompact,
   getSession,
   getSessionMetadata,
   sessionExists,
@@ -67,7 +66,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonlToJsonArrayTransform } from '@shared/lib/utils/file-storage'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
@@ -1753,79 +1752,11 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
-    const messages = await getSessionMessagesWithCompact(agentSlug, sessionId)
-    const filtered = messages.filter((m) => !('isMeta' in m && m.isMeta))
-    const transformed = transformMessages(filtered)
-
-    // Discover subagent IDs for interrupted Task tool calls that have no result
-    await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
-
-    // Parallel tool calls hold every sibling's transcript result until the
-    // LAST one resolves, so a request the user already decided still looks
-    // unresolved here. Stamp the settled outcome onto the transcript so every
-    // history consumer — the client's refresh fallback, the transcript card,
-    // and the recovery scan below — sees a completed call instead of
-    // resurrecting a decided one.
-    const settledRequests = messagePersister.getSettledInputRequests(sessionId)
-    if (settledRequests.size > 0) {
-      for (const item of transformed) {
-        if (item.type !== 'assistant') continue
-        for (const toolCall of item.toolCalls) {
-          if (toolCall.result !== undefined) continue
-          const outcome = settledRequests.get(toolCall.id)
-          if (outcome !== undefined) {
-            toolCall.result =
-              outcome === 'answered' ? 'User provided input' : 'User declined the request'
-          }
-        }
-      }
-    }
-
-    if (messagePersister.isSessionActive(sessionId)) {
-      const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
-      if (unresolvedRequests.length > 0) {
-        // If the request-specific stream event was missed, persisted messages are
-        // the fallback source of truth. A stale transcript can briefly re-assert
-        // awaiting input, but the next stream result/idle event clears it.
-        messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
-      }
-    }
-
-    // In auth mode, annotate user messages with sender info
-    if (isAuthMode()) {
-      const userMessageIds = transformed
-        .filter((m) => m.type === 'user')
-        .map((m) => m.id)
-
-      if (userMessageIds.length > 0) {
-        const authors = await db
-          .select({
-            messageId: messageAuthor.id,
-            userId: messageAuthor.userId,
-            userName: userTable.name,
-            userEmail: userTable.email,
-          })
-          .from(messageAuthor)
-          .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
-          .where(eq(messageAuthor.sessionId, sessionId))
-
-        const authorMap = new Map(authors.map((a) => [a.messageId, a]))
-
-        for (const msg of transformed) {
-          if (msg.type !== 'user') continue
-          const author = authorMap.get(msg.id)
-          if (author) {
-            msg.sender = {
-              id: author.userId,
-              name: author.userName,
-              email: author.userEmail,
-            }
-          }
-        }
-      }
-    }
-
-    return c.json(transformed)
+    const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+    const stream = fs.createReadStream(jsonlPath).pipe(createJsonlToJsonArrayTransform())
+    return c.body(Readable.toWeb(stream) as ReadableStream, 200, {
+      'Content-Type': 'application/json',
+    })
   } catch (error) {
     console.error('Failed to fetch messages:', error)
     return c.json({ error: 'Failed to fetch messages' }, 500)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1825,8 +1825,15 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       }
     }
 
-    const stream = Readable.from(transformed).pipe(createJsonArrayStringifyTransform())
-    return c.body(Readable.toWeb(stream) as ReadableStream, 200, {
+    const source = Readable.from(transformed)
+    const stringify = createJsonArrayStringifyTransform()
+    const reportStreamError = (err: unknown) => {
+      console.error('Failed to stream messages:', err)
+      captureException(err, { tags: { component: 'agents', operation: 'stream-messages' } })
+    }
+    source.on('error', reportStreamError)
+    stringify.on('error', reportStreamError)
+    return c.body(Readable.toWeb(source.pipe(stringify)) as ReadableStream, 200, {
       'Content-Type': 'application/json',
     })
   } catch (error) {

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -9,10 +9,21 @@ import { createUserMessage, createAssistantMessage, createToolCall, createCompac
 import type { ApiMessageOrBoundary } from '@shared/lib/types/api'
 
 // Mock useMessages
-const mockMessagesData: { data: ApiMessageOrBoundary[] | undefined; isLoading: boolean; error: Error | null } = {
+const mockFetchOlder = vi.fn()
+const mockMessagesData: {
+  data: ApiMessageOrBoundary[] | undefined
+  isLoading: boolean
+  error: Error | null
+  fetchOlder: typeof mockFetchOlder
+  hasOlder: boolean
+  isFetchingOlder: boolean
+} = {
   data: undefined,
   isLoading: false,
   error: null,
+  fetchOlder: mockFetchOlder,
+  hasOlder: false,
+  isFetchingOlder: false,
 }
 
 const mockDeleteMessage = vi.fn()
@@ -145,6 +156,9 @@ describe('MessageList', () => {
     vi.clearAllMocks()
     mockMessagesData.data = undefined
     mockMessagesData.isLoading = false
+    mockMessagesData.error = null
+    mockMessagesData.hasOlder = false
+    mockMessagesData.isFetchingOlder = false
     mockIsOnline = true
     mockCurrentUser = null
     mockCancelResult = { cancelled: true }
@@ -2128,6 +2142,16 @@ describe('MessageList', () => {
       // windowSize grew by LOAD_STEP (200) → 305 < 500, so the whole thread renders.
       expect(screen.getByText('m0')).toBeInTheDocument()
       expect(screen.queryByText(/earlier messages? hidden/)).not.toBeInTheDocument()
+    })
+
+    it('fetches the next API page when scrolled to the top of a fully-rendered page', () => {
+      mockMessagesData.data = manyMessages(50)
+      mockMessagesData.hasOlder = true
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      mockScrollGeometry(el, { scrollHeight: 10000, clientHeight: 500, scrollTop: 50 })
+      fireEvent.scroll(el)
+      expect(mockFetchOlder).toHaveBeenCalledOnce()
     })
 
     it('keeps the top of the window stable when a message arrives while scrolled up', () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -178,7 +178,7 @@ interface MessageListProps {
 
 export function MessageList({ sessionId, agentSlug, pendingUserMessages, pendingRequestCount = 0, onPendingMessageAppeared, readOnly, suppressScrollToBottom = false, bottomInset = 0 }: MessageListProps) {
   useRenderTracker('MessageList')
-  const { data: messages, isLoading, error } = useMessages(sessionId, agentSlug)
+  const { data: messages, isLoading, error, fetchOlder, hasOlder, isFetchingOlder } = useMessages(sessionId, agentSlug)
   const deleteMessage = useDeleteMessage()
   const deleteToolCall = useDeleteToolCall()
   const cancelQueuedMessage = useCancelQueuedMessage()
@@ -732,18 +732,21 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       setShowScrollToBottom(distanceFromBottom > 300)
     }
 
-    // Near the top with older messages still hidden: reveal the next chunk.
+    // Near the top: reveal the next local chunk, or fetch the next API page.
     // prevScrollHeightRef doubles as a re-entrancy guard so we expand at most once
     // per scroll gesture; the layout effect clears it after re-anchoring.
-    if (el.scrollTop < 200 && prevScrollHeightRef.current == null && hiddenCount > 0) {
-      prevScrollHeightRef.current = el.scrollHeight
-      // The user is reading older content — make sure nothing auto-pins to the
-      // bottom during the expand (the distance heuristic can misfire when the
-      // rendered slice barely overflows the viewport).
-      isScrolledToBottomRef.current = false
-      setWindowSize((n) => n + LOAD_STEP)
+    if (el.scrollTop < 200 && prevScrollHeightRef.current == null) {
+      if (hiddenCount > 0) {
+        prevScrollHeightRef.current = el.scrollHeight
+        isScrolledToBottomRef.current = false
+        setWindowSize((n) => n + LOAD_STEP)
+      } else if (hasOlder && !isFetchingOlder && fetchOlder) {
+        prevScrollHeightRef.current = el.scrollHeight
+        isScrolledToBottomRef.current = false
+        void fetchOlder()
+      }
     }
-  }, [cancelFollowAnimation, hiddenCount, setBottomSpacerHeight])
+  }, [cancelFollowAnimation, hiddenCount, hasOlder, isFetchingOlder, fetchOlder, setBottomSpacerHeight])
 
   // After a scroll-up expansion adds older messages above the viewport, restore the
   // scroll position so the content the user was reading stays put (no jump).

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -1,9 +1,11 @@
 import { apiFetch } from '@renderer/lib/api'
 import { uploadFileChunked } from '@renderer/lib/upload'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { WorkflowTree } from '@shared/lib/workflows/workflow-schemas'
+import { MESSAGES_PAGE_LIMIT, MESSAGES_PAGE_OLDER_LIMIT } from '@shared/lib/messages-page'
 
 // Re-export for convenience
 export type { ApiMessage, ApiMessageOrBoundary }
@@ -20,27 +22,105 @@ export class TranscriptNotFoundError extends Error {
   }
 }
 
+interface MessagesPage {
+  messages: ApiMessageOrBoundary[]
+  nextCursor: string | null
+}
+
+const EMPTY_MESSAGES: ApiMessageOrBoundary[] = []
+
+async function fetchMessagesPage(
+  agentSlug: string,
+  sessionId: string,
+  opts: { limit: number; cursor?: string }
+): Promise<MessagesPage> {
+  const params = new URLSearchParams({ limit: String(opts.limit) })
+  if (opts.cursor) params.set('cursor', opts.cursor)
+  const res = await apiFetch(
+    `/api/agents/${agentSlug}/sessions/${sessionId}/messages?${params.toString()}`
+  )
+  if (res.status === 404) throw new TranscriptNotFoundError()
+  if (!res.ok) throw new Error('Failed to fetch messages')
+  return res.json() as Promise<MessagesPage>
+}
+
 export function useMessages(sessionId: string | null, agentSlug: string | null) {
-  return useQuery<ApiMessageOrBoundary[]>({
+  const latest = useQuery<MessagesPage>({
     queryKey: ['messages', sessionId, agentSlug],
     queryFn: async () => {
-      const res = await apiFetch(`/api/agents/${agentSlug}/sessions/${sessionId}/messages`)
-      if (res.status === 404) throw new TranscriptNotFoundError()
-      if (!res.ok) throw new Error('Failed to fetch messages')
-      return res.json()
+      if (!sessionId || !agentSlug) throw new Error('Missing session')
+      return fetchMessagesPage(agentSlug, sessionId, { limit: MESSAGES_PAGE_LIMIT })
     },
     enabled: !!sessionId && !!agentSlug,
-    // A missing transcript won't reappear — don't hammer it with retries.
     retry: (failureCount, error) =>
       !(error instanceof TranscriptNotFoundError) && failureCount < 3,
-    // Safety-net poll for any messages the SSE stream missed. The stream
-    // (use-message-stream) is the primary, near-instant path; this only
-    // backstops out-of-band edits / a silently-stalled SSE.
-    // TODO: conservative first step down from the original 5s. Once we've
-    // confirmed nothing relies on tight polling, this can be raised further
-    // (e.g. 30s) or gated on SSE-connection health.
     refetchInterval: 15000,
   })
+
+  const [older, setOlder] = useState<ApiMessageOrBoundary[]>([])
+  const [olderCursor, setOlderCursor] = useState<string | null | undefined>(undefined)
+  const [isFetchingOlder, setIsFetchingOlder] = useState(false)
+  const prevLatestRef = useRef<ApiMessageOrBoundary[]>(EMPTY_MESSAGES)
+
+  useEffect(() => {
+    setOlder([])
+    setOlderCursor(undefined)
+    prevLatestRef.current = EMPTY_MESSAGES
+  }, [sessionId, agentSlug])
+
+  const latestMessages = latest.data?.messages ?? EMPTY_MESSAGES
+
+  useEffect(() => {
+    const prev = prevLatestRef.current
+    prevLatestRef.current = latestMessages
+    if (prev.length === 0) return
+    const nextIds = new Set(latestMessages.map((m) => m.id))
+    const slidOff = prev.filter((m) => !nextIds.has(m.id))
+    if (slidOff.length === 0) return
+    setOlder((cur) => {
+      const seen = new Set(cur.map((m) => m.id))
+      return [...cur, ...slidOff.filter((m) => !seen.has(m.id))]
+    })
+  }, [latestMessages])
+
+  const data = useMemo(() => {
+    if (!latest.data && older.length === 0) return undefined
+    const latestIds = new Set(latestMessages.map((m) => m.id))
+    return [...older.filter((m) => !latestIds.has(m.id)), ...latestMessages]
+  }, [latest.data, older, latestMessages])
+
+  const hasOlder =
+    olderCursor !== undefined ? olderCursor !== null : latest.data?.nextCursor != null
+
+  const fetchOlder = useCallback(async () => {
+    if (!sessionId || !agentSlug || isFetchingOlder || !hasOlder) return
+    const cursor = older[0]?.id ?? latestMessages[0]?.id
+    if (!cursor) return
+    setIsFetchingOlder(true)
+    try {
+      const page = await fetchMessagesPage(agentSlug, sessionId, {
+        limit: MESSAGES_PAGE_OLDER_LIMIT,
+        cursor,
+      })
+      setOlder((cur) => {
+        const seen = new Set(cur.map((m) => m.id))
+        return [...page.messages.filter((m) => !seen.has(m.id)), ...cur]
+      })
+      setOlderCursor(page.nextCursor)
+    } catch (error) {
+      console.warn('Failed to fetch older messages:', error)
+    } finally {
+      setIsFetchingOlder(false)
+    }
+  }, [sessionId, agentSlug, isFetchingOlder, hasOlder, older, latestMessages])
+
+  return {
+    ...latest,
+    data,
+    fetchOlder,
+    hasOlder,
+    isFetchingOlder,
+  }
 }
 
 export function useSendMessage() {

--- a/src/shared/lib/messages-page.ts
+++ b/src/shared/lib/messages-page.ts
@@ -1,0 +1,5 @@
+/** First chat-list page: trailing display items. Matches the renderer window. */
+export const MESSAGES_PAGE_LIMIT = 300
+/** Older page loaded on scroll-up. Matches the renderer load step. */
+export const MESSAGES_PAGE_OLDER_LIMIT = 200
+export const MESSAGES_PAGE_MAX_LIMIT = 500

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -14,6 +14,7 @@ import {
   listSessionsByIds,
   getSession,
   getSessionMessages,
+  getSessionMessagesPage,
   deleteSession,
   deleteSessionsBatch,
   readSessionMetadata,
@@ -737,6 +738,78 @@ describe('session-service', () => {
       expect(queued.uuid).toBe('queue-source-uuid')
       expect(queued.timestamp).toBe('2025-01-01T00:01:00.000Z')
       expect(queued.message.content).toEqual([{ type: 'text', text: 'Queued mid-turn message' }])
+    })
+  })
+
+  describe('getSessionMessagesPage', () => {
+    function makeThread(n: number) {
+      const entries: object[] = []
+      for (let i = 0; i < n; i++) {
+        entries.push({
+          type: 'user',
+          uuid: `u-${i}`,
+          timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i * 2)).toISOString(),
+          sessionId: 'page-session',
+          parentUuid: null,
+          message: { role: 'user', content: `q${i}` },
+        })
+        entries.push({
+          type: 'assistant',
+          uuid: `a-${i}`,
+          timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i * 2 + 1)).toISOString(),
+          sessionId: 'page-session',
+          parentUuid: `u-${i}`,
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: `a${i}` }],
+          },
+        })
+      }
+      return entries
+    }
+
+    it('returns the trailing page and a cursor when more remain', async () => {
+      await createSessionFile('test-agent', 'page-session', makeThread(10))
+
+      const page = await getSessionMessagesPage('test-agent', 'page-session', { limit: 5 })
+      expect(page.messages.map((m) => m.id)).toEqual(['a-7', 'u-8', 'a-8', 'u-9', 'a-9'])
+      expect(page.nextCursor).toBe('a-7')
+    })
+
+    it('returns the page before a cursor', async () => {
+      await createSessionFile('test-agent', 'page-session', makeThread(10))
+
+      const page = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 5,
+        cursor: 'a-7',
+      })
+      expect(page.messages.map((m) => m.id)).toEqual(['u-5', 'a-5', 'u-6', 'a-6', 'u-7'])
+      expect(page.nextCursor).toBe('u-5')
+    })
+
+    it('returns no cursor on the oldest page', async () => {
+      await createSessionFile('test-agent', 'page-session', makeThread(3))
+
+      const page = await getSessionMessagesPage('test-agent', 'page-session', { limit: 20 })
+      expect(page.messages).toHaveLength(6)
+      expect(page.nextCursor).toBeNull()
+    })
+
+    it('does not include a huge prefix row in the trailing page', async () => {
+      const prefix = {
+        type: 'user',
+        uuid: 'huge-prefix',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        sessionId: 'page-session',
+        parentUuid: null,
+        message: { role: 'user', content: 'x'.repeat(80 * 1024) },
+      }
+      await createSessionFile('test-agent', 'page-session', [prefix, ...makeThread(20)])
+
+      const page = await getSessionMessagesPage('test-agent', 'page-session', { limit: 4 })
+      expect(page.messages.map((m) => m.id)).toEqual(['u-18', 'a-18', 'u-19', 'a-19'])
+      expect(page.messages.some((m) => m.id === 'huge-prefix')).toBe(false)
+      expect(page.nextCursor).toBe('u-18')
     })
   })
 

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -24,8 +24,11 @@ import {
   CorruptFileError,
   readJsonlFile,
   streamJsonlFile,
+  readJsonlTailLines,
+  parseJsonlLine,
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
+import { transformMessages, type TransformedItem } from '@shared/lib/utils/message-transform'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
 import { isHiddenAutomatedSession } from './session-visibility'
 import {
@@ -899,6 +902,79 @@ export async function getSessionMessagesWithCompact(
 
   const entries = await readJsonlFile<JsonlEntry>(jsonlPath)
   return entries.map(normalizeQueuedCommandEntry).filter(isMessageOrSystemDisplayEntry)
+}
+
+export interface SessionMessagesPage {
+  messages: TransformedItem[]
+  nextCursor: string | null
+}
+
+const INITIAL_TAIL_FACTOR = 4
+const MAX_TAIL_LINES = 50_000
+
+/** Trailing (or `cursor`-before) display page. Parses only a tail of the JSONL. */
+export async function getSessionMessagesPage(
+  agentSlug: string,
+  sessionId: string,
+  opts: { limit: number; cursor?: string }
+): Promise<SessionMessagesPage> {
+  const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+  if (!(await fileExists(jsonlPath))) {
+    return { messages: [], nextCursor: null }
+  }
+
+  const { limit, cursor } = opts
+  let maxLines = Math.min(MAX_TAIL_LINES, Math.max(limit * INITIAL_TAIL_FACTOR, 32))
+
+  while (true) {
+    const { lines, reachedStart } = await readJsonlTailLines(jsonlPath, maxLines)
+    const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
+    for (const line of lines) {
+      const parsed = parseJsonlLine<JsonlEntry>(line)
+      if (!parsed) continue
+      const normalized = normalizeQueuedCommandEntry(parsed)
+      if (
+        isMessageOrSystemDisplayEntry(normalized) &&
+        !('isMeta' in normalized && normalized.isMeta)
+      ) {
+        entries.push(normalized)
+      }
+    }
+    const transformed = transformMessages(entries)
+
+    if (cursor) {
+      const idx = transformed.findIndex((item) => item.id === cursor)
+      if (idx === -1 && !reachedStart && maxLines < MAX_TAIL_LINES) {
+        maxLines = Math.min(MAX_TAIL_LINES, maxLines * 2)
+        continue
+      }
+      const end = idx === -1 ? 0 : idx
+      if (idx !== -1 && end < limit && !reachedStart && maxLines < MAX_TAIL_LINES) {
+        maxLines = Math.min(MAX_TAIL_LINES, maxLines * 2)
+        continue
+      }
+      const start = Math.max(0, end - limit)
+      const messages = transformed.slice(start, end)
+      const hasOlder = messages.length > 0 && (!reachedStart || start > 0)
+      return {
+        messages,
+        nextCursor: hasOlder && messages[0] ? messages[0].id : null,
+      }
+    }
+
+    if (transformed.length < limit && !reachedStart && maxLines < MAX_TAIL_LINES) {
+      maxLines = Math.min(MAX_TAIL_LINES, maxLines * 2)
+      continue
+    }
+    const messages = transformed.slice(-limit)
+    const hasOlder =
+      messages.length > 0 &&
+      (transformed.length > limit || (!reachedStart && messages.length === limit))
+    return {
+      messages,
+      nextCursor: hasOlder && messages[0] ? messages[0].id : null,
+    }
+  }
 }
 
 /**

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -22,6 +22,7 @@ import {
   readJsonlFile,
   streamJsonlFile,
   createJsonlToJsonArrayTransform,
+  createJsonArrayStringifyTransform,
   getAgentsDir,
   getAgentDir,
   getAgentWorkspaceDir,
@@ -655,6 +656,19 @@ describe('readJsonlFile', () => {
   it('returns empty array for non-existent file', async () => {
     const result = await readJsonlFile(path.join(testDir, 'nonexistent.jsonl'))
     expect(result).toEqual([])
+  })
+
+  it('pipes objects into a JSON array', async () => {
+    const { Readable } = await import('stream')
+    const chunks: Buffer[] = []
+    await new Promise<void>((resolve, reject) => {
+      Readable.from([{ id: 1 }, { id: 2 }])
+        .pipe(createJsonArrayStringifyTransform())
+        .on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+        .on('end', resolve)
+        .on('error', reject)
+    })
+    expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
   })
 
   it('pipes JSONL into a JSON array', async () => {

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -21,6 +21,7 @@ import {
   parseJsonl,
   readJsonlFile,
   streamJsonlFile,
+  readJsonlTailLines,
   createJsonArrayStringifyTransform,
   getAgentsDir,
   getAgentDir,
@@ -694,6 +695,35 @@ describe('readJsonlFile', () => {
     const result = await readJsonlFile<{ id: number; padding?: string }>(filePath)
     expect(result.map((r) => r.id)).toEqual([1, 2])
     expect(result[0].padding).toHaveLength(padding.length)
+  })
+})
+
+describe('readJsonlTailLines', () => {
+  it('returns the last N lines without the earlier rows', async () => {
+    const filePath = path.join(testDir, 'tail.jsonl')
+    await fs.promises.writeFile(filePath, 'a\nb\nc\nd\ne\n')
+
+    const { lines, reachedStart } = await readJsonlTailLines(filePath, 2)
+    expect(lines.map((l) => l.toString('utf-8'))).toEqual(['d', 'e'])
+    expect(reachedStart).toBe(false)
+  })
+
+  it('marks reachedStart when the tail is the whole file', async () => {
+    const filePath = path.join(testDir, 'short-tail.jsonl')
+    await fs.promises.writeFile(filePath, 'a\nb\n')
+
+    const { lines, reachedStart } = await readJsonlTailLines(filePath, 10)
+    expect(lines.map((l) => l.toString('utf-8'))).toEqual(['a', 'b'])
+    expect(reachedStart).toBe(true)
+  })
+
+  it('returns empty for a missing file', async () => {
+    const { lines, reachedStart } = await readJsonlTailLines(
+      path.join(testDir, 'missing.jsonl'),
+      5
+    )
+    expect(lines).toEqual([])
+    expect(reachedStart).toBe(true)
   })
 })
 

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -21,6 +21,7 @@ import {
   parseJsonl,
   readJsonlFile,
   streamJsonlFile,
+  createJsonlToJsonArrayTransform,
   getAgentsDir,
   getAgentDir,
   getAgentWorkspaceDir,
@@ -654,6 +655,35 @@ describe('readJsonlFile', () => {
   it('returns empty array for non-existent file', async () => {
     const result = await readJsonlFile(path.join(testDir, 'nonexistent.jsonl'))
     expect(result).toEqual([])
+  })
+
+  it('pipes JSONL into a JSON array', async () => {
+    const filePath = path.join(testDir, 'pipe.jsonl')
+    await fs.promises.writeFile(filePath, '{"id": 1}\n{"id": 2}\n')
+
+    const chunks: Buffer[] = []
+    await new Promise<void>((resolve, reject) => {
+      fs.createReadStream(filePath)
+        .pipe(createJsonlToJsonArrayTransform())
+        .on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+        .on('end', resolve)
+        .on('error', reject)
+    })
+
+    expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('parses rows wider than a read chunk without a whole-file string', async () => {
+    const filePath = path.join(testDir, 'wide-read.jsonl')
+    const padding = 'x'.repeat(64 * 1024 + 137)
+    await fs.promises.writeFile(
+      filePath,
+      `${JSON.stringify({ id: 1, padding })}\n${JSON.stringify({ id: 2 })}\n`
+    )
+
+    const result = await readJsonlFile<{ id: number; padding?: string }>(filePath)
+    expect(result.map((r) => r.id)).toEqual([1, 2])
+    expect(result[0].padding).toHaveLength(padding.length)
   })
 })
 

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -21,7 +21,6 @@ import {
   parseJsonl,
   readJsonlFile,
   streamJsonlFile,
-  createJsonlToJsonArrayTransform,
   createJsonArrayStringifyTransform,
   getAgentsDir,
   getAgentDir,
@@ -671,20 +670,17 @@ describe('readJsonlFile', () => {
     expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
   })
 
-  it('pipes JSONL into a JSON array', async () => {
-    const filePath = path.join(testDir, 'pipe.jsonl')
-    await fs.promises.writeFile(filePath, '{"id": 1}\n{"id": 2}\n')
-
+  it('pipes an empty iterable into []', async () => {
+    const { Readable } = await import('stream')
     const chunks: Buffer[] = []
     await new Promise<void>((resolve, reject) => {
-      fs.createReadStream(filePath)
-        .pipe(createJsonlToJsonArrayTransform())
+      Readable.from([])
+        .pipe(createJsonArrayStringifyTransform())
         .on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
         .on('end', resolve)
         .on('error', reject)
     })
-
-    expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual([{ id: 1 }, { id: 2 }])
+    expect(Buffer.concat(chunks).toString('utf-8')).toBe('[]')
   })
 
   it('parses rows wider than a read chunk without a whole-file string', async () => {

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -11,6 +11,7 @@
 
 import * as fs from 'fs'
 import * as path from 'path'
+import { Transform } from 'stream'
 import type { ZodType } from 'zod'
 import { getDataDir } from '@shared/lib/config/data-dir'
 import { assertPathWithinDir } from '@shared/lib/utils/path-safety'
@@ -343,15 +344,22 @@ export function parseJsonl<T = unknown>(content: string): T[] {
 }
 
 /**
- * Read and parse a JSONL file
- * Returns empty array if file doesn't exist
+ * Read and parse a JSONL file. Streams line-by-line so a large transcript is
+ * never one `readFile` string. Returns [] if the file does not exist.
  */
 export async function readJsonlFile<T = unknown>(filePath: string): Promise<T[]> {
-  const content = await readFileOrNull(filePath)
-  if (content === null) {
-    return []
+  const results: T[] = []
+  try {
+    for await (const item of streamJsonlFile<T>(filePath)) {
+      results.push(item)
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
   }
-  return parseJsonl<T>(content)
+  return results
 }
 
 const NEWLINE_BYTE = 0x0a
@@ -420,6 +428,54 @@ function parseJsonlLine<T>(line: Buffer): T | undefined {
   } catch {
     return undefined
   }
+}
+
+/** JSONL bytes in → JSON array bytes out. Used as `createReadStream(path).pipe(this)`. */
+export function createJsonlToJsonArrayTransform(): Transform {
+  let pending: Buffer[] = []
+  let first = true
+  let opened = false
+
+  const emit = (transform: Transform, line: Buffer) => {
+    const parsed = parseJsonlLine(line)
+    if (parsed === undefined) return
+    const json = JSON.stringify(parsed)
+    transform.push(first ? json : `,${json}`)
+    first = false
+  }
+
+  return new Transform({
+    transform(chunk, _enc, cb) {
+      if (!opened) {
+        this.push('[')
+        opened = true
+      }
+      const buf = chunk as Buffer
+      let start = 0
+      let idx = buf.indexOf(NEWLINE_BYTE)
+      while (idx !== -1) {
+        let line: Buffer
+        if (pending.length > 0) {
+          pending.push(buf.subarray(start, idx))
+          line = Buffer.concat(pending)
+          pending = []
+        } else {
+          line = buf.subarray(start, idx)
+        }
+        emit(this, line)
+        start = idx + 1
+        idx = buf.indexOf(NEWLINE_BYTE, start)
+      }
+      if (start < buf.length) pending.push(buf.subarray(start))
+      cb()
+    },
+    flush(cb) {
+      if (!opened) this.push('[')
+      if (pending.length > 0) emit(this, Buffer.concat(pending))
+      this.push(']')
+      cb()
+    },
+  })
 }
 
 // ============================================================================

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -452,54 +452,6 @@ export function createJsonArrayStringifyTransform(): Transform {
   })
 }
 
-/** JSONL bytes in → JSON array bytes out. Used as `createReadStream(path).pipe(this)`. */
-export function createJsonlToJsonArrayTransform(): Transform {
-  let pending: Buffer[] = []
-  let first = true
-  let opened = false
-
-  const emit = (transform: Transform, line: Buffer) => {
-    const parsed = parseJsonlLine(line)
-    if (parsed === undefined) return
-    const json = JSON.stringify(parsed)
-    transform.push(first ? json : `,${json}`)
-    first = false
-  }
-
-  return new Transform({
-    transform(chunk, _enc, cb) {
-      if (!opened) {
-        this.push('[')
-        opened = true
-      }
-      const buf = chunk as Buffer
-      let start = 0
-      let idx = buf.indexOf(NEWLINE_BYTE)
-      while (idx !== -1) {
-        let line: Buffer
-        if (pending.length > 0) {
-          pending.push(buf.subarray(start, idx))
-          line = Buffer.concat(pending)
-          pending = []
-        } else {
-          line = buf.subarray(start, idx)
-        }
-        emit(this, line)
-        start = idx + 1
-        idx = buf.indexOf(NEWLINE_BYTE, start)
-      }
-      if (start < buf.length) pending.push(buf.subarray(start))
-      cb()
-    },
-    flush(cb) {
-      if (!opened) this.push('[')
-      if (pending.length > 0) emit(this, Buffer.concat(pending))
-      this.push(']')
-      cb()
-    },
-  })
-}
-
 // ============================================================================
 // Temp Upload Helpers
 // ============================================================================

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -430,6 +430,28 @@ function parseJsonlLine<T>(line: Buffer): T | undefined {
   }
 }
 
+/** Object-mode items in → JSON array bytes out. Used as `Readable.from(items).pipe(this)`. */
+export function createJsonArrayStringifyTransform(): Transform {
+  let first = true
+  return new Transform({
+    writableObjectMode: true,
+    transform(obj, _enc, cb) {
+      try {
+        const json = JSON.stringify(obj)
+        this.push(first ? `[${json}` : `,${json}`)
+        first = false
+        cb()
+      } catch (err) {
+        cb(err as Error)
+      }
+    },
+    flush(cb) {
+      this.push(first ? '[]' : ']')
+      cb()
+    },
+  })
+}
+
 /** JSONL bytes in → JSON array bytes out. Used as `createReadStream(path).pipe(this)`. */
 export function createJsonlToJsonArrayTransform(): Transform {
   let pending: Buffer[] = []

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -363,25 +363,13 @@ export async function readJsonlFile<T = unknown>(filePath: string): Promise<T[]>
 }
 
 const NEWLINE_BYTE = 0x0a
+const TAIL_READ_CHUNK = 64 * 1024
 
-/**
- * Stream-read JSONL file line by line (for large files)
- * Yields parsed objects one at a time
- *
- * Lines are split in the raw bytes rather than through a string decoder: agent
- * transcripts are dominated by very large tool-result rows, and materializing a
- * whole file (or even a whole chunk-spanning row twice) costs several times the
- * file size in peak memory. Only ASCII whitespace is trimmed at the byte level,
- * and every such byte is < 0x80, so a multi-byte UTF-8 sequence is never split.
- */
-export async function* streamJsonlFile<T = unknown>(
-  filePath: string
-): AsyncIterable<T> {
+/** Yield raw JSONL line buffers. Split in bytes so a multi-MB row is joined once. */
+export async function* streamJsonlRawLines(filePath: string): AsyncIterable<Buffer> {
   const fileHandle = await fs.promises.open(filePath, 'r')
   try {
     const stream = fileHandle.createReadStream()
-    // Chunks holding the trailing, not-yet-terminated line. Concatenated only
-    // once its newline arrives, so a row spanning many chunks is joined once.
     let pending: Buffer[] = []
 
     for await (const chunk of stream) {
@@ -396,31 +384,93 @@ export async function* streamJsonlFile<T = unknown>(
         } else {
           line = chunk.subarray(start, idx)
         }
-        const parsed = parseJsonlLine<T>(line)
-        if (parsed !== undefined) yield parsed
+        yield line
         start = idx + 1
         idx = chunk.indexOf(NEWLINE_BYTE, start)
       }
       if (start < chunk.length) pending.push(chunk.subarray(start))
     }
 
-    // Process any remaining content (file not terminated by a newline)
     if (pending.length > 0) {
-      const parsed = parseJsonlLine<T>(Buffer.concat(pending))
-      if (parsed !== undefined) yield parsed
+      yield Buffer.concat(pending)
     }
   } finally {
-    // Runs on early `break` from the consumer's for-await too, which the
-    // previous trailing close() silently skipped — leaking the descriptor.
     await fileHandle.close()
   }
 }
 
-/**
- * Decode and parse one JSONL line. Returns undefined for blank and malformed
- * lines (common while the SDK is mid-write), which callers skip.
- */
-function parseJsonlLine<T>(line: Buffer): T | undefined {
+export async function* streamJsonlFile<T = unknown>(
+  filePath: string
+): AsyncIterable<T> {
+  for await (const line of streamJsonlRawLines(filePath)) {
+    const parsed = parseJsonlLine<T>(line)
+    if (parsed !== undefined) yield parsed
+  }
+}
+
+/** Last `maxLines` JSONL rows from disk. Older rows are never read into a line buffer. */
+export async function readJsonlTailLines(
+  filePath: string,
+  maxLines: number
+): Promise<{ lines: Buffer[]; reachedStart: boolean }> {
+  if (maxLines <= 0) return { lines: [], reachedStart: true }
+
+  let fileHandle: fs.promises.FileHandle
+  try {
+    fileHandle = await fs.promises.open(filePath, 'r')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { lines: [], reachedStart: true }
+    }
+    throw error
+  }
+
+  try {
+    const stat = await fileHandle.stat()
+    if (stat.size === 0) return { lines: [], reachedStart: true }
+
+    let pos = stat.size
+    const parts: Buffer[] = []
+    let newlineCount = 0
+
+    while (pos > 0 && newlineCount <= maxLines) {
+      const size = Math.min(TAIL_READ_CHUNK, pos)
+      pos -= size
+      const buf = Buffer.allocUnsafe(size)
+      const { bytesRead } = await fileHandle.read(buf, 0, size, pos)
+      const chunk = bytesRead === size ? buf : buf.subarray(0, bytesRead)
+      parts.unshift(chunk)
+      for (let i = 0; i < chunk.length; i++) {
+        if (chunk[i] === NEWLINE_BYTE) newlineCount++
+      }
+    }
+
+    const combined = parts.length === 1 ? parts[0]! : Buffer.concat(parts)
+    const lines: Buffer[] = []
+    let start = 0
+    for (let i = 0; i < combined.length; i++) {
+      if (combined[i] === NEWLINE_BYTE) {
+        lines.push(combined.subarray(start, i))
+        start = i + 1
+      }
+    }
+    if (start < combined.length) lines.push(combined.subarray(start))
+
+    const reachedStart = pos === 0
+    if (!reachedStart && lines.length > 0) lines.shift()
+    if (lines.length > 0 && lines[lines.length - 1]!.length === 0) lines.pop()
+
+    if (lines.length > maxLines) {
+      return { lines: lines.slice(-maxLines), reachedStart: false }
+    }
+    return { lines, reachedStart }
+  } finally {
+    await fileHandle.close()
+  }
+}
+
+/** Decode and parse one JSONL line. Blank / malformed lines return undefined. */
+export function parseJsonlLine<T>(line: Buffer): T | undefined {
   const trimmed = line.toString('utf-8').trim()
   if (!trimmed) return undefined
   try {


### PR DESCRIPTION
## Summary
Combines #752 and #753 onto one branch targeting `main`. #753 was based on an older #752 commit and conflicted after the #752 review follow-up; this rebases the cursor-page commit onto latest `fix/transcript-read-pipe`.

- **#752**: stream `readJsonlFile` and pipe `JSON.stringify` of the transformed array so overlapping `GET /messages` refetches do not each hold a whole-file string plus a full response string.
- **#753**: `?limit=` / `?cursor=` reads a JSONL tail (older screenshot rows are not `JSON.parse`d), returns `{ messages, nextCursor }`, and the chat fetches the next older page on scroll-up. No query params keeps the existing full-array streamed response.

## Test plan
- [x] `npx vitest run src/shared/lib/utils/file-storage.test.ts src/api/routes/agents.test.ts src/shared/lib/services/session-service.test.ts src/renderer/components/messages/message-list.test.tsx`
- [ ] Open a session with a large illustrated transcript; `GET /messages` (no query) returns 200 with `content.text` / `toolCalls`
- [ ] Long session (300+ visible messages): first load is the trailing page; scroll to the top loads older messages
- [ ] SSE / new messages while scrolled up do not drop the older page or jump the viewport
- [ ] Small sessions (under 300) still render in full; `nextCursor` is null

Made with [Cursor](https://cursor.com)