### PR TITLE
Show and send inherited model and effort on chat, cron, and webhook (SUP-579)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -5961,6 +5961,7 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
       agentModel: 'global-agent-model',
       browserModel: 'browser-model',
       dashboardBuilderModel: 'dashboard-model',
+      agentEffort: 'medium',
     })
   })
 
@@ -5977,6 +5978,8 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
     const args = mockCreateSession.mock.calls[0][0]
     expect(args.model).toBe('haiku')
     expect(args.effort).toBe('high')
+    expect(args.prewarmDefaults.model).toBe('haiku')
+    expect(args.prewarmDefaults.effort).toBe('high')
   })
 
   it('reserves ownership before publishing global lifecycle state', async () => {
@@ -6006,16 +6009,20 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
     const args = mockCreateSession.mock.calls[0][0]
     expect(args.model).toBe('claude-opus-4')
     expect(args.effort).toBe('low')
+    expect(args.prewarmDefaults.model).toBe('haiku')
+    expect(args.prewarmDefaults.effort).toBe('high')
   })
 
-  it('uses the global default model when the agent has no preferences', async () => {
+  it('uses the global default model and effort when the agent has no preferences', async () => {
     const res = await postJson(app, SESSIONS_URL, { message: 'hello' })
 
     expect(res.status).toBe(201)
     expect(mockCreateSession).toHaveBeenCalledTimes(1)
     const args = mockCreateSession.mock.calls[0][0]
     expect(args.model).toBe('global-agent-model')
-    expect(args.effort).toBeUndefined()
+    expect(args.effort).toBe('medium')
+    expect(args.prewarmDefaults.model).toBe('global-agent-model')
+    expect(args.prewarmDefaults.effort).toBe('medium')
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -30,7 +30,7 @@ import {
   updateConnectedAccountsEnvironment,
   updateRemoteMcpEnvironment,
 } from '@shared/lib/container/connection-runtime-sync'
-import { parseRuntimeOptions } from '@shared/lib/container/runtime-options'
+import { parseRuntimeOptions, resolveRuntimeInherit } from '@shared/lib/container/runtime-options'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
 import { listWebhookTriggers, listActiveWebhookTriggers, listCancelledWebhookTriggers } from '@shared/lib/services/webhook-trigger-service'
 import { listChatIntegrations } from '@shared/lib/services/chat-integration-service'
@@ -1630,31 +1630,33 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
 
     // Model/effort/speed preference order: explicit per-session pick > agent default > global default.
     const agentPrefs = await readAgentPreferences(slug)
-    const sessionModel = runtimeOptions.model ?? agentPrefs.defaultModel ?? getEffectiveModels().agentModel
+    const models = getEffectiveModels()
+    const resolved = resolveRuntimeInherit(runtimeOptions, agentPrefs, models)
+    const prewarm = resolveRuntimeInherit({}, agentPrefs, models)
 
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: message.trim(),
       initialMessageUuid,
-      model: sessionModel,
-      browserModel: getEffectiveModels().browserModel,
-      dashboardBuilderModel: getEffectiveModels().dashboardBuilderModel,
+      model: resolved.model,
+      browserModel: models.browserModel,
+      dashboardBuilderModel: models.dashboardBuilderModel,
       maxOutputTokens: agentLimits.maxOutputTokens,
       maxThinkingTokens: agentLimits.maxThinkingTokens,
       maxTurns: agentLimits.maxTurns,
       maxBudgetUsd: agentLimits.maxBudgetUsd,
       customEnvVars: Object.keys(customEnvVars).length > 0 ? customEnvVars : undefined,
       maxBrowserTabs: getSettings().app?.maxBrowserTabs,
-      effort: runtimeOptions.effort ?? agentPrefs.defaultEffort,
-      speed: runtimeOptions.speed ?? agentPrefs.defaultSpeed,
+      effort: resolved.effort,
+      speed: resolved.speed,
       // Same preference chain MINUS the per-session pick: this is what the
       // composer will send next time (it only puts model/effort/speed on the
       // wire when the user explicitly chooses one), so it is what the
       // container should pre-warm for.
       prewarmDefaults: {
-        model: agentPrefs.defaultModel ?? getEffectiveModels().agentModel,
-        effort: agentPrefs.defaultEffort,
-        speed: agentPrefs.defaultSpeed,
+        model: prewarm.model,
+        effort: prewarm.effort,
+        speed: prewarm.speed,
       },
     })
     const sessionId = containerSession.id

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -206,6 +206,7 @@ describe('scheduled-tasks route', () => {
       agentModel: 'claude-agent',
       browserModel: 'claude-browser',
       summarizerModel: 'claude-haiku-4-5',
+      agentEffort: 'low',
     })
     mockReadAgentPreferences.mockResolvedValue({})
     mockValidateCronExpression.mockReturnValue({ valid: true })
@@ -246,6 +247,8 @@ describe('scheduled-tasks route', () => {
       initialMessage: 'Summarize yesterday',
       model: 'claude-agent',
       browserModel: 'claude-browser',
+      dashboardBuilderModel: undefined,
+      effort: 'low',
     })
     expect(mockRegisterSession).toHaveBeenCalledWith('agent-one', 'container-session-1', 'Daily report')
     expect(mockUpdateSessionMetadata).toHaveBeenCalledWith('agent-one', 'container-session-1', {
@@ -381,7 +384,7 @@ describe('scheduled-tasks route', () => {
     it('uses the global default when neither task nor agent set one', async () => {
       const args = await runNow()
       expect(args.model).toBe('claude-agent')
-      expect(args.effort).toBeUndefined()
+      expect(args.effort).toBe('low')
       expect(args.speed).toBeUndefined()
     })
 

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -34,8 +34,7 @@ import { messagePersister } from '@shared/lib/container/message-persister'
 import { getEffectiveModels } from '@shared/lib/config/settings'
 import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { validateCronExpression, getFrequencyWarning } from '@shared/lib/services/schedule-parser'
-import { RuntimeOptionsPatchSchema } from '@shared/lib/container/runtime-options'
-import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+import { RuntimeOptionsPatchSchema, resolveRuntimeInherit } from '@shared/lib/container/runtime-options'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { logAuditEvent } from '@shared/lib/services/audit-log-service'
 import { deliverSessionWake } from '@shared/lib/scheduler/wake-delivery'
@@ -310,17 +309,20 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
     // Model/effort/speed preference order: task override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(task.agentSlug)
-    const effort = task.effort ?? agentPrefs.defaultEffort
-    const speed = task.speed ?? agentPrefs.defaultSpeed
+    const resolved = resolveRuntimeInherit(
+      { model: task.model, effort: task.effort, speed: task.speed },
+      agentPrefs,
+      models,
+    )
 
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: task.prompt,
-      model: task.model || agentPrefs.defaultModel || models.agentModel,
+      model: resolved.model,
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
-      ...(effort ? { effort: effort as EffortLevel } : {}),
-      ...(speed ? { speed: speed as SpeedLevel } : {}),
+      effort: resolved.effort,
+      ...(resolved.speed ? { speed: resolved.speed } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -128,7 +128,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
 
 // Settings + secrets (only used by invoke for new sessions)
 vi.mock('@shared/lib/config/settings', () => ({
-  getEffectiveModels: () => ({ agentModel: 'sonnet', browserModel: 'sonnet' }),
+  getEffectiveModels: () => ({ agentModel: 'sonnet', browserModel: 'sonnet', agentEffort: 'medium' }),
   getEffectiveAgentLimits: () => ({}),
   getCustomEnvVars: () => ({}),
   getSettings: () => ({ app: {} }),
@@ -1045,8 +1045,8 @@ describe('/invoke', () => {
 // ============================================================================
 
 describe('/invoke model and effort resolution', () => {
-  // /invoke has no per-call model/effort override, so the order is just:
-  // target agent default (agent preferences) > global default.
+  // /invoke has no per-call model/effort override, so the order is:
+  // target agent default > app default. Same inherit helper as the other start paths.
   beforeEach(() => {
     mockGetAgent.mockResolvedValue({
       slug: TARGET_SLUG,
@@ -1058,22 +1058,27 @@ describe('/invoke model and effort resolution', () => {
   })
 
   it('uses the target agent default over the global default', async () => {
-    mockReadAgentPreferences.mockResolvedValue({ defaultModel: 'opus', defaultEffort: 'high' })
+    mockReadAgentPreferences.mockResolvedValue({
+      defaultModel: 'opus',
+      defaultEffort: 'high',
+      defaultSpeed: 'fast',
+    })
     const res = await authedFetch('/x-agent/invoke', { slug: TARGET_SLUG, prompt: 'hello' })
     expect(res.status).toBe(200)
     expect(mockReadAgentPreferences).toHaveBeenCalledWith(TARGET_SLUG)
     const args = mockCreateSession.mock.calls[0][0] as Record<string, unknown>
     expect(args.model).toBe('opus')
     expect(args.effort).toBe('high')
+    expect(args.speed).toBe('fast')
   })
 
-  it('falls back to the global default and omits effort when the agent sets none', async () => {
+  it('falls back to the global default model and effort when the agent sets none', async () => {
     const res = await authedFetch('/x-agent/invoke', { slug: TARGET_SLUG, prompt: 'hello' })
     expect(res.status).toBe(200)
     const args = mockCreateSession.mock.calls[0][0] as Record<string, unknown>
-    expect(args.model).toBe('sonnet') // the mocked getEffectiveModels().agentModel
-    // Effort must be omitted entirely, not sent as undefined.
-    expect('effort' in args).toBe(false)
+    expect(args.model).toBe('sonnet')
+    expect(args.effort).toBe('medium')
+    expect(args.speed).toBeUndefined()
   })
 })
 

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -44,6 +44,7 @@ import {
   type XAgentOperation,
 } from '@shared/lib/services/x-agent-policy-service'
 import { getEffectiveModels, getEffectiveAgentLimits, getCustomEnvVars, getSettings } from '@shared/lib/config/settings'
+import { resolveRuntimeInherit } from '@shared/lib/container/runtime-options'
 import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { captureException } from '@shared/lib/error-reporting'
@@ -704,6 +705,8 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       const agentLimits = getEffectiveAgentLimits()
       const customEnvVars = getCustomEnvVars()
       const targetPrefs = await readAgentPreferences(targetSlug)
+      const models = getEffectiveModels()
+      const resolved = resolveRuntimeInherit({}, targetPrefs, models)
       const callerName = await getAgentDisplayNameBestEffort(callerSlug)
       const initialMessageUuid = isAuthMode() && attributedUserId
         ? randomUUID()
@@ -714,11 +717,11 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
         initialMessage: prompt,
         ...(initialMessageUuid ? { initialMessageUuid } : {}),
-        model: targetPrefs.defaultModel ?? getEffectiveModels().agentModel,
-        browserModel: getEffectiveModels().browserModel,
-        dashboardBuilderModel: getEffectiveModels().dashboardBuilderModel,
-        ...(targetPrefs.defaultEffort ? { effort: targetPrefs.defaultEffort } : {}),
-        ...(targetPrefs.defaultSpeed ? { speed: targetPrefs.defaultSpeed } : {}),
+        model: resolved.model,
+        browserModel: models.browserModel,
+        dashboardBuilderModel: models.dashboardBuilderModel,
+        effort: resolved.effort,
+        speed: resolved.speed,
         maxOutputTokens: agentLimits.maxOutputTokens,
         maxThinkingTokens: agentLimits.maxThinkingTokens,
         maxTurns: agentLimits.maxTurns,

--- a/src/renderer/components/chat-integrations/integration-settings-controls.test.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@renderer/hooks/use-settings', () => {
         catalog: CATALOG,
         defaultModels: { agent: 'opus', summarizer: 'haiku', browser: 'sonnet' },
       }],
+      models: { agentModel: 'claude-opus-4-8', agentEffort: 'high' },
     },
   })
   return {
@@ -42,6 +43,10 @@ vi.mock('@renderer/hooks/use-settings', () => {
     useModelSettings: settings,
   }
 })
+
+vi.mock('@renderer/hooks/use-agent-preferences', () => ({
+  useAgentPreferences: () => ({ data: {} }),
+}))
 
 describe('IntegrationModelEffort', () => {
   beforeEach(() => {
@@ -53,9 +58,10 @@ describe('IntegrationModelEffort', () => {
     expect(screen.getByTestId('settings-model-trigger')).toBeInTheDocument()
   })
 
-  it('shows default effort (Medium) when integration has no effort set', () => {
+  it('shows the inherited app-default effort when integration has no effort set', () => {
     render(<IntegrationModelEffort integration={makeIntegration()} />)
-    expect(screen.getByTestId('settings-model-trigger')).toHaveTextContent('Medium')
+    expect(screen.getByTestId('settings-model-trigger')).toHaveTextContent('High')
+    expect(screen.getByTestId('settings-model-trigger')).not.toHaveTextContent('Medium')
   })
 
   it('shows the integration model (bare alias → latest) when set', () => {

--- a/src/renderer/components/chat-integrations/integration-settings-controls.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.tsx
@@ -20,7 +20,6 @@ import {
 } from '@shared/lib/container/runtime-options'
 import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
 import type { LlmProviderId } from '@shared/lib/config/settings'
-import type { SpeedLevel } from '@shared/lib/container/types'
 
 export function ToggleRow({ label, helperText, checked, onCheckedChange, disabled }: {
   label: string
@@ -160,7 +159,7 @@ export function IntegrationModelEffort({ integration }: { integration: ChatInteg
   const catalog = settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? []
   const catalogModel = findCatalogModel(resolved?.model, catalog)
   const displayEffort = clampEffortForDisplay(resolved?.effort, catalogModel?.supportedEfforts)
-  const displaySpeed = clampSpeedForDisplay(resolved?.speed, catalogModel?.supportedSpeeds as SpeedLevel[] | undefined)
+  const displaySpeed = clampSpeedForDisplay(resolved?.speed, catalogModel)
 
   if (!resolved?.model || !resolved.effort || !displayEffort) {
     return <span className="text-xs text-muted-foreground" data-testid="runtime-inherit-pending">—</span>

--- a/src/renderer/components/chat-integrations/integration-settings-controls.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.tsx
@@ -9,17 +9,9 @@ import {
   SelectValue,
 } from '@renderer/components/ui/select'
 import { useUpdateChatIntegration } from '@renderer/hooks/use-chat-integrations'
-import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
-import { useModelSettings } from '@renderer/hooks/use-settings'
+import { useInheritedRuntimeSelection } from '@renderer/hooks/use-inherited-runtime-selection'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
-import { findCatalogModel } from '@renderer/components/messages/model-family-list'
-import {
-  clampEffortForDisplay,
-  clampSpeedForDisplay,
-  resolveRuntimeInherit,
-} from '@shared/lib/container/runtime-options'
 import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
-import type { LlmProviderId } from '@shared/lib/config/settings'
 
 export function ToggleRow({ label, helperText, checked, onCheckedChange, disabled }: {
   label: string
@@ -143,38 +135,22 @@ export function SessionTimeoutSelect({ value, onCommit, disabled, id, descriptio
 
 export function IntegrationModelEffort({ integration }: { integration: ChatIntegration }) {
   const updateIntegration = useUpdateChatIntegration()
-  const { data: settings } = useModelSettings()
-  const { data: prefs } = useAgentPreferences(integration.agentSlug)
+  const { selection } = useInheritedRuntimeSelection(integration.agentSlug, integration)
 
-  const models = settings?.models
-  const resolved = models?.agentModel && models.agentEffort
-    ? resolveRuntimeInherit(
-        { model: integration.model, effort: integration.effort, speed: integration.speed },
-        prefs ?? {},
-        { agentModel: models.agentModel, agentEffort: models.agentEffort },
-      )
-    : null
-
-  const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
-  const catalog = settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? []
-  const catalogModel = findCatalogModel(resolved?.model, catalog)
-  const displayEffort = clampEffortForDisplay(resolved?.effort, catalogModel?.supportedEfforts)
-  const displaySpeed = clampSpeedForDisplay(resolved?.speed, catalogModel)
-
-  if (!resolved?.model || !resolved.effort || !displayEffort) {
+  if (!selection?.model || !selection.effort || !selection.displayEffort) {
     return <span className="text-xs text-muted-foreground" data-testid="runtime-inherit-pending">—</span>
   }
 
   // Drive display off the inherit ladder; writes stay on pick. Clamp is display-only.
   return (
     <SettingsModelSelect
-      model={resolved.model}
+      model={selection.model}
       onModelChange={(m) => updateIntegration.mutate({ id: integration.id, model: m })}
       includeEffort
-      effort={displayEffort}
+      effort={selection.displayEffort}
       onEffortChange={(e) => updateIntegration.mutate({ id: integration.id, effort: e })}
       includeSpeed
-      speed={displaySpeed ?? 'normal'}
+      speed={selection.displaySpeed ?? 'normal'}
       onSpeedChange={(s) => updateIntegration.mutate({ id: integration.id, speed: s })}
       // Left-aligned in its DetailCard, so the LEFT edge is the fixed one —
       // anchoring 'end' would slide the popover on every pick.

--- a/src/renderer/components/chat-integrations/integration-settings-controls.tsx
+++ b/src/renderer/components/chat-integrations/integration-settings-controls.tsx
@@ -9,9 +9,18 @@ import {
   SelectValue,
 } from '@renderer/components/ui/select'
 import { useUpdateChatIntegration } from '@renderer/hooks/use-chat-integrations'
+import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
+import { useModelSettings } from '@renderer/hooks/use-settings'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
-import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+import { findCatalogModel } from '@renderer/components/messages/model-family-list'
+import {
+  clampEffortForDisplay,
+  clampSpeedForDisplay,
+  resolveRuntimeInherit,
+} from '@shared/lib/container/runtime-options'
 import type { PublicChatIntegration as ChatIntegration } from '@shared/lib/chat-integrations/public'
+import type { LlmProviderId } from '@shared/lib/config/settings'
+import type { SpeedLevel } from '@shared/lib/container/types'
 
 export function ToggleRow({ label, helperText, checked, onCheckedChange, disabled }: {
   label: string
@@ -135,19 +144,38 @@ export function SessionTimeoutSelect({ value, onCommit, disabled, id, descriptio
 
 export function IntegrationModelEffort({ integration }: { integration: ChatIntegration }) {
   const updateIntegration = useUpdateChatIntegration()
+  const { data: settings } = useModelSettings()
+  const { data: prefs } = useAgentPreferences(integration.agentSlug)
 
-  // Drive directly off the integration; useUpdateChatIntegration invalidates the
-  // detail query, so an edit (or an integration switch) flows back through props -
-  // a local mirror would go stale when the same component renders another chat.
+  const models = settings?.models
+  const resolved = models?.agentModel && models.agentEffort
+    ? resolveRuntimeInherit(
+        { model: integration.model, effort: integration.effort, speed: integration.speed },
+        prefs ?? {},
+        { agentModel: models.agentModel, agentEffort: models.agentEffort },
+      )
+    : null
+
+  const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
+  const catalog = settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? []
+  const catalogModel = findCatalogModel(resolved?.model, catalog)
+  const displayEffort = clampEffortForDisplay(resolved?.effort, catalogModel?.supportedEfforts)
+  const displaySpeed = clampSpeedForDisplay(resolved?.speed, catalogModel?.supportedSpeeds as SpeedLevel[] | undefined)
+
+  if (!resolved?.model || !resolved.effort || !displayEffort) {
+    return <span className="text-xs text-muted-foreground" data-testid="runtime-inherit-pending">—</span>
+  }
+
+  // Drive display off the inherit ladder; writes stay on pick. Clamp is display-only.
   return (
     <SettingsModelSelect
-      model={integration.model ?? undefined}
+      model={resolved.model}
       onModelChange={(m) => updateIntegration.mutate({ id: integration.id, model: m })}
       includeEffort
-      effort={(integration.effort as EffortLevel) ?? 'medium'}
+      effort={displayEffort}
       onEffortChange={(e) => updateIntegration.mutate({ id: integration.id, effort: e })}
       includeSpeed
-      speed={(integration.speed as SpeedLevel) ?? 'normal'}
+      speed={displaySpeed ?? 'normal'}
       onSpeedChange={(s) => updateIntegration.mutate({ id: integration.id, speed: s })}
       // Left-aligned in its DetailCard, so the LEFT edge is the fixed one —
       // anchoring 'end' would slide the popover on every pick.

--- a/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
+++ b/src/renderer/components/scheduled-tasks/scheduled-task-view.tsx
@@ -462,6 +462,7 @@ export function ScheduledTaskView({ taskId, agentSlug }: ScheduledTaskViewProps)
           </DetailCard>
 
           <RuntimeOptionsCard
+            agentSlug={agentSlug}
             model={task.model}
             effort={task.effort}
             speed={task.speed}

--- a/src/renderer/components/triggers/override-inherit.test.tsx
+++ b/src/renderer/components/triggers/override-inherit.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+/**
+ * Override cards must show the same inherit the host sends:
+ * surface → agent default → app default.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IntegrationModelEffort } from '@renderer/components/chat-integrations/integration-settings-controls'
+import { makeChatIntegration } from '@renderer/components/chat-integrations/test-factories'
+import { RuntimeOptionsCard } from './runtime-options-card'
+import type { ModelDefinition } from '@shared/lib/llm-provider'
+import type { EffortLevel } from '@shared/lib/container/types'
+
+const STD: EffortLevel[] = ['low', 'medium', 'high']
+const CATALOG: ModelDefinition[] = [
+  { id: 'claude-opus-4-8', label: 'Opus 4.8', family: 'opus', isLatest: true, icon: 'anthropic', supportedEfforts: ['low', 'medium', 'high', 'xhigh', 'max'] },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', family: 'sonnet', isLatest: true, icon: 'anthropic', supportedEfforts: STD },
+]
+
+const useSettingsMock = vi.fn()
+const useAgentPreferencesMock = vi.fn()
+const mutateChat = vi.hoisted(() => vi.fn())
+
+vi.mock('@renderer/hooks/use-chat-integrations', () => ({
+  useUpdateChatIntegration: () => ({ mutate: mutateChat, isPending: false }),
+}))
+
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => useSettingsMock(),
+  useModelSettings: () => useSettingsMock(),
+}))
+
+vi.mock('@renderer/hooks/use-agent-preferences', () => ({
+  useAgentPreferences: (slug?: string) => useAgentPreferencesMock(slug),
+}))
+
+function settingsWith(models: { agentModel: string; agentEffort: EffortLevel }) {
+  return {
+    data: {
+      llmProvider: 'anthropic',
+      llmProviderStatus: [{
+        id: 'anthropic',
+        catalog: CATALOG,
+        defaultModels: { agent: 'opus', summarizer: 'haiku', browser: 'sonnet' },
+      }],
+      models,
+    },
+  }
+}
+
+function cronCard(onUpdate = vi.fn()) {
+  return (
+    <RuntimeOptionsCard
+      agentSlug="a"
+      model={null}
+      effort={null}
+      speed={null}
+      onUpdate={onUpdate}
+    />
+  )
+}
+
+beforeEach(() => {
+  mutateChat.mockReset()
+  useSettingsMock.mockReturnValue(settingsWith({
+    agentModel: 'claude-opus-4-8',
+    agentEffort: 'high',
+  }))
+  useAgentPreferencesMock.mockImplementation(() => ({ data: {} }))
+})
+
+describe('override-card inherit', () => {
+  it('chat card: unset shows inherited model and effort, not Select model · Medium', () => {
+    render(<IntegrationModelEffort integration={makeChatIntegration()} />)
+    const text = screen.getByTestId('settings-model-trigger').textContent ?? ''
+    expect(text).toContain('Opus 4.8')
+    expect(text).toContain('High')
+    expect(text).not.toMatch(/Select model/)
+    expect(text).not.toContain('Medium')
+  })
+
+  it('cron/webhook card: unset effort follows app default Low, not hardcoded High', () => {
+    useSettingsMock.mockReturnValue(settingsWith({
+      agentModel: 'claude-opus-4-8',
+      agentEffort: 'low',
+    }))
+    render(cronCard())
+    const text = screen.getByTestId('settings-model-trigger').textContent ?? ''
+    expect(text).toContain('Opus 4.8')
+    expect(text).toContain('Low')
+    expect(text).not.toContain('High')
+    expect(useAgentPreferencesMock).toHaveBeenCalledWith('a')
+  })
+
+  it('cron/webhook card: agent default effort beats the app default', () => {
+    useAgentPreferencesMock.mockImplementation(() => ({ data: { defaultEffort: 'low' } }))
+    render(cronCard())
+    const text = screen.getByTestId('settings-model-trigger').textContent ?? ''
+    expect(text).toContain('Low')
+    expect(text).not.toContain('Medium')
+    expect(text).not.toContain('High')
+  })
+
+  it('chat card: agent default effort beats the app default and loads prefs by slug', () => {
+    useAgentPreferencesMock.mockImplementation(() => ({ data: { defaultEffort: 'low' } }))
+    render(<IntegrationModelEffort integration={makeChatIntegration()} />)
+    const text = screen.getByTestId('settings-model-trigger').textContent ?? ''
+    expect(text).toContain('Low')
+    expect(text).not.toContain('High')
+    expect(useAgentPreferencesMock).toHaveBeenCalledWith('a')
+  })
+
+  it('both cards show a blank state while settings have not loaded', () => {
+    useSettingsMock.mockReturnValue({ data: undefined })
+    const cron = render(cronCard())
+    expect(screen.getByTestId('runtime-inherit-pending')).toBeInTheDocument()
+    expect(screen.queryByTestId('settings-model-trigger')).not.toBeInTheDocument()
+    cron.unmount()
+
+    render(<IntegrationModelEffort integration={makeChatIntegration()} />)
+    expect(screen.getByTestId('runtime-inherit-pending')).toBeInTheDocument()
+    expect(screen.queryByTestId('settings-model-trigger')).not.toBeInTheDocument()
+  })
+
+  it('opening does not persist a clamp on either card', async () => {
+    const onUpdate = vi.fn()
+    useSettingsMock.mockReturnValue(settingsWith({
+      agentModel: 'claude-sonnet-4-6',
+      agentEffort: 'max',
+    }))
+    const cron = render(cronCard(onUpdate))
+    await waitFor(() => expect(screen.getByTestId('settings-model-trigger')).toBeInTheDocument())
+    expect(onUpdate).not.toHaveBeenCalled()
+    cron.unmount()
+
+    render(<IntegrationModelEffort integration={makeChatIntegration()} />)
+    await waitFor(() => expect(screen.getByTestId('settings-model-trigger')).toBeInTheDocument())
+    expect(mutateChat).not.toHaveBeenCalled()
+  })
+
+  it('keeps a pick when prefs land after a click', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+    useAgentPreferencesMock.mockImplementation(() => ({ data: undefined }))
+    const { rerender } = render(cronCard(onUpdate))
+    await user.click(screen.getByTestId('settings-model-trigger'))
+    await user.click(await screen.findByTestId('effort-option-low'))
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledWith({ effort: 'low' })
+
+    useAgentPreferencesMock.mockImplementation(() => ({ data: { defaultEffort: 'high' } }))
+    rerender(cronCard(onUpdate))
+    expect(screen.getByTestId('settings-model-trigger').textContent).toContain('Low')
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides Reset for a stored override while settings are down', () => {
+    const onUpdate = vi.fn()
+    useSettingsMock.mockReturnValue({ data: undefined })
+    render(
+      <RuntimeOptionsCard
+        agentSlug="a"
+        model="claude-opus-4-8"
+        effort="high"
+        speed={null}
+        onUpdate={onUpdate}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument()
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/triggers/override-inherit.test.tsx
+++ b/src/renderer/components/triggers/override-inherit.test.tsx
@@ -129,6 +129,8 @@ describe('override-card inherit', () => {
       agentModel: 'claude-sonnet-4-6',
       agentEffort: 'max',
     }))
+    // Leftover Fast on a catalog model with no supportedSpeeds — the common case.
+    useAgentPreferencesMock.mockImplementation(() => ({ data: { defaultSpeed: 'fast' } }))
     const cron = render(cronCard(onUpdate))
     await waitFor(() => expect(screen.getByTestId('settings-model-trigger')).toBeInTheDocument())
     expect(onUpdate).not.toHaveBeenCalled()

--- a/src/renderer/components/triggers/runtime-options-card.tsx
+++ b/src/renderer/components/triggers/runtime-options-card.tsx
@@ -1,12 +1,21 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { RotateCcw } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
-import { useSettings } from '@renderer/hooks/use-settings'
+import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
+import { useModelSettings } from '@renderer/hooks/use-settings'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
+import { findCatalogModel } from '@renderer/components/messages/model-family-list'
+import {
+  clampEffortForDisplay,
+  clampSpeedForDisplay,
+  resolveRuntimeInherit,
+} from '@shared/lib/container/runtime-options'
 import { DetailCard } from './detail-card'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+import type { LlmProviderId } from '@shared/lib/config/settings'
 
 interface RuntimeOptionsCardProps {
+  agentSlug: string
   model: string | null
   effort: string | null
   speed: string | null
@@ -14,63 +23,85 @@ interface RuntimeOptionsCardProps {
   onUpdate: (options: { model?: string | null; effort?: string | null; speed?: string | null }) => void
 }
 
-export function RuntimeOptionsCard({ model, effort, speed, disabled, onUpdate }: RuntimeOptionsCardProps) {
-  const { data: settings } = useSettings()
-  // The override falls back to the user's default-model setting (a bare alias
-  // or pinned id) when no per-run model is set. The picker resolves it for display.
-  const fallbackModel = settings?.models?.agentModel
+export function RuntimeOptionsCard({ agentSlug, model, effort, speed, disabled, onUpdate }: RuntimeOptionsCardProps) {
+  const { data: settings } = useModelSettings()
+  const { data: prefs } = useAgentPreferences(agentSlug)
+  const picked = useRef(false)
 
-  const [localEffort, setLocalEffort] = useState<EffortLevel>((effort as EffortLevel) || 'high')
-  const [localSpeed, setLocalSpeed] = useState<SpeedLevel>((speed as SpeedLevel) || 'normal')
-  const [localModel, setLocalModel] = useState<string | undefined>(model || fallbackModel)
+  const models = settings?.models
+  const inheritModels = useMemo(
+    () => models?.agentModel && models.agentEffort
+      ? { agentModel: models.agentModel, agentEffort: models.agentEffort }
+      : null,
+    [models?.agentModel, models?.agentEffort],
+  )
+  const resolved = useMemo(
+    () => inheritModels
+      ? resolveRuntimeInherit(
+          { model: model || null, effort: effort || null, speed: speed || null },
+          prefs ?? {},
+          inheritModels,
+        )
+      : null,
+    [inheritModels, model, effort, speed, prefs],
+  )
+
+  const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
+  const catalog = settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? []
+  const catalogModel = findCatalogModel(resolved?.model, catalog)
+  const displayEffort = clampEffortForDisplay(resolved?.effort, catalogModel?.supportedEfforts)
+  const displaySpeed = clampSpeedForDisplay(resolved?.speed, catalogModel?.supportedSpeeds as SpeedLevel[] | undefined)
+
+  const [localEffort, setLocalEffort] = useState<EffortLevel | undefined>(displayEffort)
+  const [localSpeed, setLocalSpeed] = useState<SpeedLevel | undefined>(displaySpeed)
+  const [localModel, setLocalModel] = useState<string | undefined>(resolved?.model)
 
   useEffect(() => {
-    if (fallbackModel && !model) {
-      setLocalModel(fallbackModel)
-    }
-  }, [fallbackModel, model])
+    picked.current = false
+  }, [model, effort, speed])
 
   useEffect(() => {
-    setLocalEffort((effort as EffortLevel) || 'high')
-  }, [effort])
-
-  useEffect(() => {
-    setLocalSpeed((speed as SpeedLevel) || 'normal')
-  }, [speed])
-
-  useEffect(() => {
-    if (model) {
-      setLocalModel(model)
-    }
-  }, [model])
+    if (!resolved || picked.current) return
+    setLocalEffort(displayEffort)
+    setLocalSpeed(displaySpeed)
+    setLocalModel(resolved.model)
+  }, [resolved, displayEffort, displaySpeed])
 
   const handleSetEffort = useCallback((e: EffortLevel) => {
+    picked.current = true
     setLocalEffort(e)
     onUpdate({ effort: e })
   }, [onUpdate])
 
   const handleSetSpeed = useCallback((s: SpeedLevel) => {
+    picked.current = true
     setLocalSpeed(s)
     onUpdate({ speed: s })
   }, [onUpdate])
 
   const handleSetModel = useCallback((m: string) => {
+    picked.current = true
     setLocalModel(m)
     onUpdate({ model: m })
   }, [onUpdate])
 
   const handleReset = useCallback(() => {
-    setLocalEffort('high')
-    setLocalSpeed('normal')
-    setLocalModel(fallbackModel)
+    if (!inheritModels) return
+    picked.current = false
+    const cleared = resolveRuntimeInherit({ model: null, effort: null, speed: null }, prefs ?? {}, inheritModels)
+    const clearedModel = findCatalogModel(cleared.model, catalog)
+    setLocalEffort(clampEffortForDisplay(cleared.effort, clearedModel?.supportedEfforts))
+    setLocalSpeed(clampSpeedForDisplay(cleared.speed, clearedModel?.supportedSpeeds as SpeedLevel[] | undefined))
+    setLocalModel(cleared.model)
     onUpdate({ model: null, effort: null, speed: null })
-  }, [onUpdate, fallbackModel])
+  }, [onUpdate, inheritModels, prefs, catalog])
 
   const hasCustom = model !== null || effort !== null || speed !== null
+  const canReset = Boolean(hasCustom && !disabled && inheritModels)
 
   const headerActions = useMemo(
     () =>
-      hasCustom && !disabled ? (
+      canReset ? (
         <Button
           variant="ghost"
           size="sm"
@@ -81,27 +112,31 @@ export function RuntimeOptionsCard({ model, effort, speed, disabled, onUpdate }:
           Reset
         </Button>
       ) : undefined,
-    [hasCustom, disabled, handleReset],
+    [canReset, handleReset],
   )
 
   return (
     <DetailCard label="Model & Effort" headerActions={headerActions}>
       <div className="flex items-center gap-2">
-        <SettingsModelSelect
-          model={localModel}
-          onModelChange={handleSetModel}
-          includeEffort
-          effort={localEffort}
-          onEffortChange={handleSetEffort}
-          includeSpeed
-          speed={localSpeed}
-          onSpeedChange={handleSetSpeed}
-          disabled={disabled}
-          // This trigger is left-aligned in its card, so its LEFT edge is the
-          // stable anchor while picks rewrite the label width.
-          align="start"
-        />
-        {!hasCustom && <span className="text-xs text-muted-foreground">Using defaults</span>}
+        {resolved?.model && resolved.effort && localEffort ? (
+          <SettingsModelSelect
+            model={localModel}
+            onModelChange={handleSetModel}
+            includeEffort
+            effort={localEffort}
+            onEffortChange={handleSetEffort}
+            includeSpeed
+            speed={localSpeed ?? 'normal'}
+            onSpeedChange={handleSetSpeed}
+            disabled={disabled}
+            // This trigger is left-aligned in its card, so its LEFT edge is the
+            // stable anchor while picks rewrite the label width.
+            align="start"
+          />
+        ) : (
+          <span className="text-xs text-muted-foreground" data-testid="runtime-inherit-pending">—</span>
+        )}
+        {!hasCustom && inheritModels && <span className="text-xs text-muted-foreground">Using defaults</span>}
       </div>
     </DetailCard>
   )

--- a/src/renderer/components/triggers/runtime-options-card.tsx
+++ b/src/renderer/components/triggers/runtime-options-card.tsx
@@ -1,18 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { RotateCcw } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
-import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
-import { useModelSettings } from '@renderer/hooks/use-settings'
 import { SettingsModelSelect } from '@renderer/components/settings/settings-model-select'
-import { findCatalogModel } from '@renderer/components/messages/model-family-list'
-import {
-  clampEffortForDisplay,
-  clampSpeedForDisplay,
-  resolveRuntimeInherit,
-} from '@shared/lib/container/runtime-options'
+import { useInheritedRuntimeSelection } from '@renderer/hooks/use-inherited-runtime-selection'
 import { DetailCard } from './detail-card'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
-import type { LlmProviderId } from '@shared/lib/config/settings'
 
 interface RuntimeOptionsCardProps {
   agentSlug: string
@@ -24,51 +16,26 @@ interface RuntimeOptionsCardProps {
 }
 
 export function RuntimeOptionsCard({ agentSlug, model, effort, speed, disabled, onUpdate }: RuntimeOptionsCardProps) {
-  const { data: settings } = useModelSettings()
-  const { data: prefs } = useAgentPreferences(agentSlug)
   const picked = useRef(false)
+  const { ready, selection, resolveDisplay } = useInheritedRuntimeSelection(agentSlug, { model, effort, speed })
 
-  const models = settings?.models
-  const inheritModels = useMemo(
-    () => models?.agentModel && models.agentEffort
-      ? { agentModel: models.agentModel, agentEffort: models.agentEffort }
-      : null,
-    [models?.agentModel, models?.agentEffort],
-  )
-  const resolved = useMemo(
-    () => inheritModels
-      ? resolveRuntimeInherit(
-          { model: model || null, effort: effort || null, speed: speed || null },
-          prefs ?? {},
-          inheritModels,
-        )
-      : null,
-    [inheritModels, model, effort, speed, prefs],
-  )
-
-  const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
-  const catalog = useMemo(
-    () => settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? [],
-    [settings, activeProvider],
-  )
-  const catalogModel = findCatalogModel(resolved?.model, catalog)
-  const displayEffort = clampEffortForDisplay(resolved?.effort, catalogModel?.supportedEfforts)
-  const displaySpeed = clampSpeedForDisplay(resolved?.speed, catalogModel)
-
-  const [localEffort, setLocalEffort] = useState<EffortLevel | undefined>(displayEffort)
-  const [localSpeed, setLocalSpeed] = useState<SpeedLevel | undefined>(displaySpeed)
-  const [localModel, setLocalModel] = useState<string | undefined>(resolved?.model)
+  // Local mirror so a pick shows immediately; the parent's save round-trips
+  // through props, and the sync effect below re-adopts the inherit once it
+  // lands (or whenever the stored row changes underneath an untouched card).
+  const [localEffort, setLocalEffort] = useState<EffortLevel | undefined>(selection?.displayEffort)
+  const [localSpeed, setLocalSpeed] = useState<SpeedLevel | undefined>(selection?.displaySpeed)
+  const [localModel, setLocalModel] = useState<string | undefined>(selection?.model)
 
   useEffect(() => {
     picked.current = false
   }, [model, effort, speed])
 
   useEffect(() => {
-    if (!resolved || picked.current) return
-    setLocalEffort(displayEffort)
-    setLocalSpeed(displaySpeed)
-    setLocalModel(resolved.model)
-  }, [resolved, displayEffort, displaySpeed])
+    if (!selection || picked.current) return
+    setLocalEffort(selection.displayEffort)
+    setLocalSpeed(selection.displaySpeed)
+    setLocalModel(selection.model)
+  }, [selection])
 
   const handleSetEffort = useCallback((e: EffortLevel) => {
     picked.current = true
@@ -89,18 +56,17 @@ export function RuntimeOptionsCard({ agentSlug, model, effort, speed, disabled, 
   }, [onUpdate])
 
   const handleReset = useCallback(() => {
-    if (!inheritModels) return
+    const cleared = resolveDisplay({ model: null, effort: null, speed: null })
+    if (!cleared) return
     picked.current = false
-    const cleared = resolveRuntimeInherit({ model: null, effort: null, speed: null }, prefs ?? {}, inheritModels)
-    const clearedModel = findCatalogModel(cleared.model, catalog)
-    setLocalEffort(clampEffortForDisplay(cleared.effort, clearedModel?.supportedEfforts))
-    setLocalSpeed(clampSpeedForDisplay(cleared.speed, clearedModel))
+    setLocalEffort(cleared.displayEffort)
+    setLocalSpeed(cleared.displaySpeed)
     setLocalModel(cleared.model)
     onUpdate({ model: null, effort: null, speed: null })
-  }, [onUpdate, inheritModels, prefs, catalog])
+  }, [onUpdate, resolveDisplay])
 
   const hasCustom = model !== null || effort !== null || speed !== null
-  const canReset = Boolean(hasCustom && !disabled && inheritModels)
+  const canReset = Boolean(hasCustom && !disabled && ready)
 
   const headerActions = useMemo(
     () =>
@@ -121,7 +87,7 @@ export function RuntimeOptionsCard({ agentSlug, model, effort, speed, disabled, 
   return (
     <DetailCard label="Model & Effort" headerActions={headerActions}>
       <div className="flex items-center gap-2">
-        {resolved?.model && resolved.effort && localEffort ? (
+        {selection?.model && selection.effort && localEffort ? (
           <SettingsModelSelect
             model={localModel}
             onModelChange={handleSetModel}
@@ -139,7 +105,7 @@ export function RuntimeOptionsCard({ agentSlug, model, effort, speed, disabled, 
         ) : (
           <span className="text-xs text-muted-foreground" data-testid="runtime-inherit-pending">—</span>
         )}
-        {!hasCustom && inheritModels && <span className="text-xs text-muted-foreground">Using defaults</span>}
+        {!hasCustom && ready && <span className="text-xs text-muted-foreground">Using defaults</span>}
       </div>
     </DetailCard>
   )

--- a/src/renderer/components/triggers/runtime-options-card.tsx
+++ b/src/renderer/components/triggers/runtime-options-card.tsx
@@ -47,10 +47,13 @@ export function RuntimeOptionsCard({ agentSlug, model, effort, speed, disabled, 
   )
 
   const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
-  const catalog = settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? []
+  const catalog = useMemo(
+    () => settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? [],
+    [settings, activeProvider],
+  )
   const catalogModel = findCatalogModel(resolved?.model, catalog)
   const displayEffort = clampEffortForDisplay(resolved?.effort, catalogModel?.supportedEfforts)
-  const displaySpeed = clampSpeedForDisplay(resolved?.speed, catalogModel?.supportedSpeeds as SpeedLevel[] | undefined)
+  const displaySpeed = clampSpeedForDisplay(resolved?.speed, catalogModel)
 
   const [localEffort, setLocalEffort] = useState<EffortLevel | undefined>(displayEffort)
   const [localSpeed, setLocalSpeed] = useState<SpeedLevel | undefined>(displaySpeed)
@@ -91,7 +94,7 @@ export function RuntimeOptionsCard({ agentSlug, model, effort, speed, disabled, 
     const cleared = resolveRuntimeInherit({ model: null, effort: null, speed: null }, prefs ?? {}, inheritModels)
     const clearedModel = findCatalogModel(cleared.model, catalog)
     setLocalEffort(clampEffortForDisplay(cleared.effort, clearedModel?.supportedEfforts))
-    setLocalSpeed(clampSpeedForDisplay(cleared.speed, clearedModel?.supportedSpeeds as SpeedLevel[] | undefined))
+    setLocalSpeed(clampSpeedForDisplay(cleared.speed, clearedModel))
     setLocalModel(cleared.model)
     onUpdate({ model: null, effort: null, speed: null })
   }, [onUpdate, inheritModels, prefs, catalog])

--- a/src/renderer/components/webhook-triggers/webhook-trigger-view.tsx
+++ b/src/renderer/components/webhook-triggers/webhook-trigger-view.tsx
@@ -379,6 +379,7 @@ export function WebhookTriggerView({ triggerId, agentSlug }: WebhookTriggerViewP
           </DetailCard>
 
           <RuntimeOptionsCard
+            agentSlug={agentSlug}
             model={trigger.model ?? null}
             effort={trigger.effort ?? null}
             speed={trigger.speed ?? null}

--- a/src/renderer/hooks/use-inherited-runtime-selection.ts
+++ b/src/renderer/hooks/use-inherited-runtime-selection.ts
@@ -1,0 +1,93 @@
+import { useCallback, useMemo } from 'react'
+import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
+import { useModelSettings } from '@renderer/hooks/use-settings'
+import { findCatalogModel } from '@renderer/components/messages/model-family-list'
+import {
+  clampEffortForDisplay,
+  clampSpeedForDisplay,
+  resolveRuntimeInherit,
+} from '@shared/lib/container/runtime-options'
+import type { ModelDefinition } from '@shared/lib/llm-provider'
+import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+import type { LlmProviderId } from '@shared/lib/config/settings'
+
+/** A surface's stored override row; null, undefined, and '' all mean "unset". */
+export type RuntimeSurface = {
+  model?: string | null
+  effort?: string | null
+  speed?: string | null
+}
+
+export type InheritedRuntimeSelection = {
+  /** What the host will send: surface override → agent default → app default. */
+  model: string
+  effort?: EffortLevel
+  speed?: SpeedLevel
+  /** `effort`/`speed` snapped to what the catalog model allows — display only, never written back. */
+  displayEffort?: EffortLevel
+  displaySpeed?: SpeedLevel
+  catalogModel: ModelDefinition | undefined
+}
+
+/**
+ * The renderer half of the runtime-inherit contract: an override surface
+ * (chat integration, cron task, webhook trigger) must show exactly what the
+ * host will send for it — the same resolveRuntimeInherit ladder the four
+ * session-start paths use — with illegal values snapped for display only, so
+ * merely opening a card can never persist a clamp.
+ *
+ * Cards must derive their picker values from this hook rather than reading
+ * settings/preferences themselves; a surface that invents its own fallback
+ * chain reintroduces the display-vs-sent drift this exists to prevent.
+ */
+export function useInheritedRuntimeSelection(agentSlug: string, surface: RuntimeSurface): {
+  /** False until the app-default model settings have loaded; render a placeholder. */
+  ready: boolean
+  /** Ladder result for `surface`, or null while not ready. */
+  selection: InheritedRuntimeSelection | null
+  /** Re-run the ladder for another surface (e.g. the cleared row on Reset); null while not ready. */
+  resolveDisplay: (surface: RuntimeSurface) => InheritedRuntimeSelection | null
+} {
+  const { data: settings } = useModelSettings()
+  const { data: prefs } = useAgentPreferences(agentSlug)
+
+  const models = settings?.models
+  const inheritModels = useMemo(
+    () => models?.agentModel && models.agentEffort
+      ? { agentModel: models.agentModel, agentEffort: models.agentEffort }
+      : null,
+    [models?.agentModel, models?.agentEffort],
+  )
+
+  const activeProvider = (settings?.llmProvider ?? 'anthropic') as LlmProviderId
+  const catalog = useMemo(
+    () => settings?.llmProviderStatus?.find((p) => p.id === activeProvider)?.catalog ?? [],
+    [settings, activeProvider],
+  )
+
+  const resolveDisplay = useCallback(
+    (s: RuntimeSurface): InheritedRuntimeSelection | null => {
+      if (!inheritModels) return null
+      const resolved = resolveRuntimeInherit(
+        { model: s.model || null, effort: s.effort || null, speed: s.speed || null },
+        prefs ?? {},
+        inheritModels,
+      )
+      const catalogModel = findCatalogModel(resolved.model, catalog)
+      return {
+        ...resolved,
+        displayEffort: clampEffortForDisplay(resolved.effort, catalogModel?.supportedEfforts),
+        displaySpeed: clampSpeedForDisplay(resolved.speed, catalogModel),
+        catalogModel,
+      }
+    },
+    [inheritModels, prefs, catalog],
+  )
+
+  const selection = useMemo(
+    () => resolveDisplay({ model: surface.model, effort: surface.effort, speed: surface.speed }),
+    [resolveDisplay, surface.model, surface.effort, surface.speed],
+  )
+
+  return { ready: inheritModels !== null, selection, resolveDisplay }
+}

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -42,7 +42,8 @@ import {
 } from '@shared/lib/services/chat-integration-session-service'
 import { assertPathWithinDir, isPathWithinDir, sanitizeUploadFilename } from '@shared/lib/utils/path-safety'
 import { isHostOrSubdomain, tryParseUrl } from '@shared/lib/utils/url-safety'
-import type { EffortLevel, SpeedLevel, ContainerClient } from '@shared/lib/container/types'
+import type { ContainerClient } from '@shared/lib/container/types'
+import { resolveRuntimeInherit } from '@shared/lib/container/runtime-options'
 import type { ChatIntegration } from '@shared/lib/db/schema'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { runWithOptionalUser } from '@shared/lib/platform-attribution'
@@ -1179,17 +1180,20 @@ class ChatIntegrationManager {
     // Model/effort/speed preference order: integration override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(integration.agentSlug)
-    const effort = integration.effort ?? agentPrefs.defaultEffort
-    const speed = integration.speed ?? agentPrefs.defaultSpeed
+    const resolved = resolveRuntimeInherit(
+      { model: integration.model, effort: integration.effort, speed: integration.speed },
+      agentPrefs,
+      models,
+    )
 
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: messageText,
-      model: integration.model || agentPrefs.defaultModel || models.agentModel,
+      model: resolved.model,
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
-      ...(effort ? { effort: effort as EffortLevel } : {}),
-      ...(speed ? { speed: speed as SpeedLevel } : {}),
+      effort: resolved.effort,
+      ...(resolved.speed ? { speed: resolved.speed } : {}),
       ...(systemPrompt ? { systemPrompt } : {}),
     })
 

--- a/src/shared/lib/chat-integrations/chat-integration-model-resolution.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-model-resolution.test.ts
@@ -64,6 +64,7 @@ vi.mock('@shared/lib/config/settings', () => ({
   getEffectiveModels: () => ({
     agentModel: 'claude-sonnet-4-20250514',
     browserModel: 'claude-sonnet-4-20250514',
+    agentEffort: 'low',
   }),
   getSettings: () => ({}),
 }))
@@ -181,8 +182,7 @@ describe('chat integration model and effort resolution', () => {
   it('uses the global default when neither integration nor agent set one', async () => {
     const args = await startSession()
     expect(args.model).toBe('claude-sonnet-4-20250514')
-    // Effort/speed must be omitted entirely, not sent as undefined.
-    expect('effort' in args).toBe(false)
+    expect(args.effort).toBe('low')
     expect('speed' in args).toBe(false)
   })
 

--- a/src/shared/lib/container/runtime-options.test.ts
+++ b/src/shared/lib/container/runtime-options.test.ts
@@ -100,11 +100,8 @@ describe('resolveRuntimeInherit', () => {
     expect(resolveRuntimeInherit({ model: '' }, { defaultModel: 'sonnet' }, models).model).toBe('sonnet')
   })
 
-  it.each([
-    [{ effort: 'turbo' }, {}],
-    [{}, { defaultEffort: 'turbo' }],
-  ])('treats junk effort as unset and falls through to the app default (%j)', (surface, agent) => {
-    expect(resolveRuntimeInherit(surface, agent, models)).toEqual({
+  it('treats junk surface effort as unset and falls through to the app default', () => {
+    expect(resolveRuntimeInherit({ effort: 'turbo' }, {}, models)).toEqual({
       model: 'claude-opus-4-8',
       effort: 'medium',
     })
@@ -128,7 +125,16 @@ describe('clampEffortForDisplay', () => {
 })
 
 describe('clampSpeedForDisplay', () => {
-  it('snaps to normal when the model does not allow the inherited speed', () => {
-    expect(clampSpeedForDisplay('fast', ['slow'])).toBe('normal')
+  it('leaves the speed alone when the model is not in the catalog', () => {
+    expect(clampSpeedForDisplay('fast', undefined)).toBe('fast')
+  })
+
+  it('snaps to normal when the model is found and has no speed choice', () => {
+    expect(clampSpeedForDisplay('fast', {})).toBe('normal')
+  })
+
+  it('keeps an allowed speed and snaps an illegal listed one to normal', () => {
+    expect(clampSpeedForDisplay('fast', { supportedSpeeds: ['slow', 'normal', 'fast'] })).toBe('fast')
+    expect(clampSpeedForDisplay('fast', { supportedSpeeds: ['slow', 'normal'] })).toBe('normal')
   })
 })

--- a/src/shared/lib/container/runtime-options.test.ts
+++ b/src/shared/lib/container/runtime-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { RuntimeOptionsSchema, parseRuntimeOptions } from './runtime-options'
+import { RuntimeOptionsSchema, clampEffortForDisplay, clampSpeedForDisplay, parseRuntimeOptions, resolveRuntimeInherit } from './runtime-options'
 
 describe('RuntimeOptionsSchema', () => {
   it('accepts an empty object', () => {
@@ -60,5 +60,75 @@ describe('parseRuntimeOptions', () => {
     expect(parseRuntimeOptions(null)).toEqual({})
     expect(parseRuntimeOptions(undefined)).toEqual({})
     expect(parseRuntimeOptions('foo')).toEqual({})
+  })
+})
+
+describe('resolveRuntimeInherit', () => {
+  const models = { agentModel: 'claude-opus-4-8', agentEffort: 'medium' as const }
+
+  it('uses the app default when neither surface nor agent set one, and omits speed', () => {
+    const resolved = resolveRuntimeInherit({ model: null, effort: null, speed: null }, {}, models)
+    expect(resolved).toEqual({ model: 'claude-opus-4-8', effort: 'medium' })
+    expect('speed' in resolved).toBe(false)
+  })
+
+  it('prefers the agent default over the app default', () => {
+    expect(resolveRuntimeInherit({}, {
+      defaultModel: 'opus',
+      defaultEffort: 'high',
+      defaultSpeed: 'slow',
+    }, models)).toEqual({
+      model: 'opus',
+      effort: 'high',
+      speed: 'slow',
+    })
+  })
+
+  it('prefers the surface override over the agent default', () => {
+    expect(resolveRuntimeInherit(
+      { model: 'claude-haiku-4-5', effort: 'low', speed: 'fast' },
+      { defaultModel: 'opus', defaultEffort: 'high', defaultSpeed: 'slow' },
+      models,
+    )).toEqual({
+      model: 'claude-haiku-4-5',
+      effort: 'low',
+      speed: 'fast',
+    })
+  })
+
+  it('treats an empty surface model as unset', () => {
+    expect(resolveRuntimeInherit({ model: '' }, { defaultModel: 'sonnet' }, models).model).toBe('sonnet')
+  })
+
+  it.each([
+    [{ effort: 'turbo' }, {}],
+    [{}, { defaultEffort: 'turbo' }],
+  ])('treats junk effort as unset and falls through to the app default (%j)', (surface, agent) => {
+    expect(resolveRuntimeInherit(surface, agent, models)).toEqual({
+      model: 'claude-opus-4-8',
+      effort: 'medium',
+    })
+  })
+
+  it('omits effort when no rung has one, including junk app effort', () => {
+    expect(resolveRuntimeInherit({}, {}, { agentModel: 'claude-opus-4-8' })).toEqual({
+      model: 'claude-opus-4-8',
+    })
+    expect(resolveRuntimeInherit({}, {}, { agentModel: 'claude-opus-4-8', agentEffort: 'turbo' })).toEqual({
+      model: 'claude-opus-4-8',
+    })
+  })
+})
+
+describe('clampEffortForDisplay', () => {
+  it('keeps an allowed effort and snaps an illegal one to medium', () => {
+    expect(clampEffortForDisplay('high', ['low', 'medium', 'high'])).toBe('high')
+    expect(clampEffortForDisplay('max', ['low', 'medium', 'high'])).toBe('medium')
+  })
+})
+
+describe('clampSpeedForDisplay', () => {
+  it('snaps to normal when the model does not allow the inherited speed', () => {
+    expect(clampSpeedForDisplay('fast', ['slow'])).toBe('normal')
   })
 })

--- a/src/shared/lib/container/runtime-options.ts
+++ b/src/shared/lib/container/runtime-options.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import type { AgentPreferences } from '@shared/lib/types/agent-preferences'
 import { EFFORT_LEVELS, SPEED_LEVELS, type EffortLevel, type SpeedLevel } from './types'
 
 /**
@@ -93,22 +94,21 @@ export type RuntimeInherit = {
 
 /**
  * Surface override → agent default → app default.
- * Junk surface/agent values are treated as unset (do not throw).
+ * Junk surface values are treated as unset (do not throw).
  * Effort is omitted when no rung has one. Speed stays two-rung.
  */
 export function resolveRuntimeInherit(
   surface: unknown,
-  agent: unknown,
+  agent: Partial<AgentPreferences> | null | undefined,
   models: unknown,
 ): RuntimeInherit {
   const s = asRecord(surface) ?? {}
-  const a = asRecord(agent) ?? {}
   const raw = asRecord(models) ?? {}
   const m = inheritModelsSchema.parse({ agentModel: raw.agentModel })
 
-  const model = presentString(s.model) ?? presentString(a.defaultModel) ?? m.agentModel
-  const effort = optionalEffort(s.effort) ?? optionalEffort(a.defaultEffort) ?? optionalEffort(raw.agentEffort)
-  const speed = optionalSpeed(s.speed) ?? optionalSpeed(a.defaultSpeed)
+  const model = presentString(s.model) ?? presentString(agent?.defaultModel) ?? m.agentModel
+  const effort = optionalEffort(s.effort) ?? optionalEffort(agent?.defaultEffort) ?? optionalEffort(raw.agentEffort)
+  const speed = optionalSpeed(s.speed) ?? optionalSpeed(agent?.defaultSpeed)
 
   return {
     model,
@@ -127,12 +127,17 @@ export function clampEffortForDisplay(
   return supported.includes('medium') ? 'medium' : supported[0]
 }
 
-/** Snap a resolved speed for display only. Mirrors useSpeedClamp, which always snaps to 'normal'. */
+/**
+ * Snap a resolved speed for display only — mirrors useSpeedClamp. A found
+ * catalog model with no supportedSpeeds allows only 'normal'; an unknown
+ * model leaves the speed alone (useSpeedClamp is inert without a model).
+ */
 export function clampSpeedForDisplay(
   speed: SpeedLevel | undefined,
-  supported: SpeedLevel[] | undefined,
+  catalogModel: { supportedSpeeds?: readonly SpeedLevel[] } | undefined,
 ): SpeedLevel | undefined {
   if (!speed) return undefined
-  if (!supported || supported.length === 0 || supported.includes(speed)) return speed
-  return 'normal'
+  if (!catalogModel) return speed
+  const available = catalogModel.supportedSpeeds ?? ['normal']
+  return available.includes(speed) ? speed : 'normal'
 }

--- a/src/shared/lib/container/runtime-options.ts
+++ b/src/shared/lib/container/runtime-options.ts
@@ -60,3 +60,79 @@ export function parseRuntimeOptions(raw: unknown): RuntimeOptions {
 
   return result
 }
+
+const inheritModelsSchema = z.object({
+  agentModel: z.string().min(1),
+})
+
+function presentString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) return value
+  return undefined
+}
+
+function optionalEffort(value: unknown): EffortLevel | undefined {
+  const parsed = z.enum(EFFORT_LEVELS).safeParse(value)
+  return parsed.success ? parsed.data : undefined
+}
+
+function optionalSpeed(value: unknown): SpeedLevel | undefined {
+  const parsed = z.enum(SPEED_LEVELS).safeParse(value)
+  return parsed.success ? parsed.data : undefined
+}
+
+function asRecord(raw: unknown): Record<string, unknown> | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  return raw as Record<string, unknown>
+}
+
+export type RuntimeInherit = {
+  model: string
+  effort?: EffortLevel
+  speed?: SpeedLevel
+}
+
+/**
+ * Surface override → agent default → app default.
+ * Junk surface/agent values are treated as unset (do not throw).
+ * Effort is omitted when no rung has one. Speed stays two-rung.
+ */
+export function resolveRuntimeInherit(
+  surface: unknown,
+  agent: unknown,
+  models: unknown,
+): RuntimeInherit {
+  const s = asRecord(surface) ?? {}
+  const a = asRecord(agent) ?? {}
+  const raw = asRecord(models) ?? {}
+  const m = inheritModelsSchema.parse({ agentModel: raw.agentModel })
+
+  const model = presentString(s.model) ?? presentString(a.defaultModel) ?? m.agentModel
+  const effort = optionalEffort(s.effort) ?? optionalEffort(a.defaultEffort) ?? optionalEffort(raw.agentEffort)
+  const speed = optionalSpeed(s.speed) ?? optionalSpeed(a.defaultSpeed)
+
+  return {
+    model,
+    ...(effort ? { effort } : {}),
+    ...(speed ? { speed } : {}),
+  }
+}
+
+/** Snap a resolved effort to what the catalog model allows, for display only. */
+export function clampEffortForDisplay(
+  effort: EffortLevel | undefined,
+  supported: EffortLevel[] | undefined,
+): EffortLevel | undefined {
+  if (!effort) return undefined
+  if (!supported || supported.length === 0 || supported.includes(effort)) return effort
+  return supported.includes('medium') ? 'medium' : supported[0]
+}
+
+/** Snap a resolved speed for display only. Mirrors useSpeedClamp, which always snaps to 'normal'. */
+export function clampSpeedForDisplay(
+  speed: SpeedLevel | undefined,
+  supported: SpeedLevel[] | undefined,
+): SpeedLevel | undefined {
+  if (!speed) return undefined
+  if (!supported || supported.length === 0 || supported.includes(speed)) return speed
+  return 'normal'
+}

--- a/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.model-resolution.test.ts
@@ -28,6 +28,7 @@ vi.mock('@shared/lib/config/settings', () => ({
     agentModel: 'claude-sonnet-4-20250514',
     browserModel: 'claude-browser',
     dashboardBuilderModel: 'claude-dashboard',
+    agentEffort: 'low',
   }),
 }))
 
@@ -158,7 +159,7 @@ describe('TaskScheduler model, effort, and speed resolution', () => {
   it('uses the global default when neither task nor agent set one', async () => {
     const args = await executeTask()
     expect(args.model).toBe('claude-sonnet-4-20250514')
-    expect(args.effort).toBeUndefined()
+    expect(args.effort).toBe('low')
     expect(args.speed).toBeUndefined()
   })
 

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -18,7 +18,7 @@ import {
   updateNextExecution,
 } from '@shared/lib/services/scheduled-task-service'
 import type { ScheduledTask } from '@shared/lib/services/scheduled-task-service'
-import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+import { resolveRuntimeInherit } from '@shared/lib/container/runtime-options'
 import { getNextCronTime } from '@shared/lib/services/schedule-parser'
 import {
   getSessionForScheduledExecution,
@@ -222,18 +222,21 @@ class TaskScheduler {
     // Model/effort/speed preference order: task override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(task.agentSlug)
-    const effort = task.effort ?? agentPrefs.defaultEffort
-    const speed = task.speed ?? agentPrefs.defaultSpeed
+    const resolved = resolveRuntimeInherit(
+      { model: task.model, effort: task.effort, speed: task.speed },
+      agentPrefs,
+      models,
+    )
     const containerSession = await client.createSession({
       availableEnvVars:
         availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: task.prompt,
-      model: task.model || agentPrefs.defaultModel || models.agentModel,
+      model: resolved.model,
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
       metadata: { isAutomated: true },
-      ...(effort ? { effort: effort as EffortLevel } : {}),
-      ...(speed ? { speed: speed as SpeedLevel } : {}),
+      effort: resolved.effort,
+      ...(resolved.speed ? { speed: resolved.speed } : {}),
     })
 
     const sessionId = containerSession.id

--- a/src/shared/lib/scheduler/trigger-manager.test.ts
+++ b/src/shared/lib/scheduler/trigger-manager.test.ts
@@ -23,6 +23,7 @@ vi.mock('@shared/lib/config/settings', () => ({
   getEffectiveModels: () => ({
     agentModel: 'claude-sonnet-4-20250514',
     browserModel: 'claude-sonnet-4-20250514',
+    agentEffort: 'low',
   }),
 }))
 
@@ -384,7 +385,7 @@ describe('TriggerManager', () => {
     it('uses the global default when neither trigger nor agent set one', async () => {
       const args = await fireTrigger()
       expect(args.model).toBe('claude-sonnet-4-20250514')
-      expect(args.effort).toBeUndefined()
+      expect(args.effort).toBe('low')
       expect(args.speed).toBeUndefined()
     })
 

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -27,7 +27,7 @@ import {
   resolvePlatformMemberForCandidates,
 } from '@shared/lib/services/webhook-trigger-service'
 import type { WebhookTrigger } from '@shared/lib/services/webhook-trigger-service'
-import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
+import { resolveRuntimeInherit } from '@shared/lib/container/runtime-options'
 import { registerSession } from '@shared/lib/services/session-service'
 import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { agentExists } from '@shared/lib/services/agent-service'
@@ -359,17 +359,20 @@ class TriggerManager {
     // Model/effort/speed preference order: trigger override > agent default > global default.
     const models = getEffectiveModels()
     const agentPrefs = await readAgentPreferences(trigger.agentSlug)
-    const effort = trigger.effort ?? agentPrefs.defaultEffort
-    const speed = trigger.speed ?? agentPrefs.defaultSpeed
+    const resolved = resolveRuntimeInherit(
+      { model: trigger.model, effort: trigger.effort, speed: trigger.speed },
+      agentPrefs,
+      models,
+    )
     const containerSession = await client.createSession({
       availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
       initialMessage: prompt,
-      model: trigger.model || agentPrefs.defaultModel || models.agentModel,
+      model: resolved.model,
       browserModel: models.browserModel,
       dashboardBuilderModel: models.dashboardBuilderModel,
       metadata: { isAutomated: true },
-      ...(effort ? { effort: effort as EffortLevel } : {}),
-      ...(speed ? { speed: speed as SpeedLevel } : {}),
+      effort: resolved.effort,
+      ...(resolved.speed ? { speed: resolved.speed } : {}),
     })
 
     const sessionId = containerSession.id


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-579/chat-cron-and-webhook-show-and-send-the-wrong-inherited-effort

11 production files, +549 / −110 net.
9 test files.

Type: bug fix

After connect, the chat card said Select model and Medium.
Cron and webhook said High.
The missing model name was a label bug.
Unset effort was not.
The host sent no effort.
The session treated that as High.
Settings said Medium.

One inherit rule now feeds the card and every new session.
Override, else the agent default, else the app default.
A click still saves.
Opening does not.
Reset clears.

## The card, before and after

Before:

```
open the card
 └─ no override stored
     ├─ chat → show "Select model · Medium"
     └─ cron / webhook → show High
```

After:

```
open the card
 ├─ Settings not loaded → show a dash
 └─ Settings loaded
     → override, else agent default, else app default
     → snap the label if this model cannot do that effort or speed
     → do not write
```

## A new session, before and after

Before:

```
start a session
 → use override, else agent default
 → if neither has effort, send nothing
     └─ session treats nothing as High
```

After:

```
start a session
 → override, else agent default, else app default
 → send that effort
 └─ if no rung has one, omit it and still start
```

Chat, cron, webhook, run-now, composer, and cross-agent invoke all use this path.
Composer still omits an unpicked value on the wire.
The server fills it.
Cross-agent invoke has no per-call pick, so it is agent default, else Settings.

## Opening must not save

Showing the inherit hands the picker a real value.
If that value is illegal for the model, the picker would write a snap on first paint.

```
open, inherited effort the model cannot do
 ├─ before this PR: picker writes Medium
 └─ after: label snaps, stored row stays unset

open, leftover Fast on a model with no speed choice
 ├─ before: picker writes Normal
 └─ after: label snaps, stored row stays unset
```

## Worth reviewing

The inherit helper is the whole contract.
Cards and the six start paths must stay on it.
A future card that invents its own fallback will drift again.

Opening still must not write.
The snap is display-only.
The shared picker is unchanged.

A click holds the whole cron card still until the save lands.
If the save fails, the other knobs stay frozen until you leave the page.
That window is narrow.

## Why not just fix the labels

We could show High on the card to match omit.
That would make the label honest and leave unset sessions on High.
The product default is the Settings effort, not the old High guard.
The rejected path keeps every existing unset session on High forever.

## What this does not change

The shared picker.
Connect does not persist a model.
Speed is still two-rung: agent default, else omit.
The container still treats a missing effort as High.

Existing unset sessions move from High to the app default on the next session.
That is the fix.
That now includes composer chats and cross-agent invokes, not only automations.

## Try it

1. Open a chat with no override.
   The card should show the real inherited model and effort, not Select model or a lone Medium.
2. Reload without picking.
   Nothing should save.
3. Open a scheduled task with no override.
   Same inherit.
   Reset should be hidden.
4. Optional: pick Low, then Reset.
   It should return to inherit.
5. Start a composer chat with no pick.
   The new session should run at Settings' effort, not High.

## Validation

CI green on this head, including e2e after one unrelated flake rerun.
Focused unit: inherit helper, both cards, composer sessions, and cross-agent invoke.
`npm run typecheck` clean.
