### PR TITLE
Fix provider error e2e and subagent input flake

### DIFF
--- a/e2e/specs/api-error-display.spec.ts
+++ b/e2e/specs/api-error-display.spec.ts
@@ -30,6 +30,9 @@ test.describe('API Error Display', () => {
     await expect(errorCard.first()).toBeVisible({ timeout: 15000 })
     await expect(errorCard.first()).toContainText('LLM Provider Error')
     await expect(errorCard.first()).toContainText('Invalid API key')
+    await expect(errorCard.first()).toHaveAttribute('aria-expanded', 'false')
+    await errorCard.first().getByText('More details', { exact: true }).click()
+    await expect(errorCard.first()).toHaveAttribute('aria-expanded', 'true')
     await expect(errorCard.first()).toContainText('external LLM provider API')
   })
 

--- a/e2e/specs/subagent-browser-input-status.spec.ts
+++ b/e2e/specs/subagent-browser-input-status.spec.ts
@@ -28,6 +28,15 @@ test.describe('Subagent Browser Input Status', () => {
 
     agent = await createAgent(request, uniqueName(testInfo, 'Subagent Browser Agent'))
     await gotoAgentHome(page, agent)
+
+    // Establish the session route and its event stream before issuing a
+    // short-lived request. Otherwise the create-session navigation can miss
+    // request events while the chat is still mounting.
+    await sessionPage.sendMessage(`slow response establish subagent session ${uniqueSuffix(testInfo)}`)
+    await sessionPage.waitForResponse(15000)
+    await page.reload()
+    await expect(sessionPage.getMessageList()).toBeVisible({ timeout: 15000 })
+    await agentPage.waitForStatus('idle', 15000)
   })
 
   test('browser input requested by a subagent shows the card and flips status to awaiting_input', async ({ page }, testInfo) => {

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -963,6 +963,8 @@ export class DeadSubagentInputScenario implements MockScenario {
   execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
     const parentToolId = `agent_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
     const subToolId = `subtool_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
+    const subagentDeathDelayMs = 5_000
+    const mainTurnCompletionDelayMs = subagentDeathDelayMs + 2_500
 
     client.writeJsonlEntry(sessionId, {
       type: 'user',
@@ -1001,9 +1003,8 @@ export class DeadSubagentInputScenario implements MockScenario {
       })
     }, 60)
 
-    // The subagent dies ~2.5s later: its terminal sidechain 'result' frame
-    // arrives while the browser_input has no tool_result. Long enough for a
-    // spec to assert the card + awaiting window first.
+    // Keep the parked phase observable under a loaded, multi-worker browser
+    // run before the terminal sidechain 'result' invalidates the request.
     setTimeout(() => {
       client.emitStreamMessage(sessionId, {
         type: 'result',
@@ -1013,7 +1014,7 @@ export class DeadSubagentInputScenario implements MockScenario {
           subtype: 'success',
         },
       })
-    }, 2500)
+    }, subagentDeathDelayMs)
 
     // The main turn continues briefly, then settles on its own — the parked
     // ask must NOT be what ends it.
@@ -1029,7 +1030,7 @@ export class DeadSubagentInputScenario implements MockScenario {
         type: 'result',
         content: { type: 'result', subtype: 'success' },
       })
-    }, 5000)
+    }, mainTurnCompletionDelayMs)
   }
 }
 


### PR DESCRIPTION
## Summary

- update provider-error e2e coverage for the collapsed **More details** disclosure
- establish and rehydrate a settled session before the subagent input lifecycle assertions
- keep the dead-subagent request observable for 5 seconds before invalidation

## Root cause

There are two test regressions in scope:

1. PR #731 intentionally moved provider guidance behind a disclosure and updated renderer coverage, but the existing e2e assertion still expected the hidden guidance to be immediately visible.
2. The subagent input suite issued a one-shot sidechain request while the first-session navigation and browser event stream were still mounting. The dead-subagent mock invalidated that request about 2.5 seconds later, so loaded CI runs could miss both the card's creation and its invalidation.

Both are test-infrastructure regressions; production behavior remains unchanged.

## Fix

- exercise the provider disclosure through the intended user flow
- warm the subagent suite with the existing slow-response fixture, reload the settled session, and only then trigger the lifecycle transition under test
- extend the dead-subagent parked phase from 2.5 seconds to 5 seconds while preserving the 2.5-second working-before-idle window

## Validation

- pre-fix reproduction: 0/20 passes at 6 workers
- post-fix stress: 20/20 passes at 6 workers
- focused PR suite: 7/7 passes (`api-error-display` + `subagent-browser-input-status`)
- `npx eslint e2e/specs/subagent-browser-input-status.spec.ts src/shared/lib/container/mock-container-client.ts`
- `npm run typecheck`
