### PR TITLE
fix: tear down notifications SSE stream on client disconnect

### DIFF
--- a/src/api/routes/notifications.stream.test.ts
+++ b/src/api/routes/notifications.stream.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import { serve } from '@hono/node-server'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+/**
+ * The notifications SSE stream over a real HTTP listener.
+ *
+ * `app.request()` never aborts: only a real socket teardown makes
+ * `@hono/node-server` fire the stream's abort signal, and that signal is the
+ * ONLY disconnect notification the handler ever gets — Hono's StreamingApi
+ * swallows write errors, so a failed ping can't surface a disconnect. These
+ * tests connect through a real socket, kill it, and assert the handler
+ * releases both resources it holds per connection: the global-notification
+ * client callback and the 30-second keep-alive interval.
+ */
+
+// Observable stand-in for the persister's global-client registry, with the
+// exact semantics of the real one (Set membership + unsubscribe deletes).
+const { globalClients } = vi.hoisted(() => ({
+  globalClients: new Set<(data: unknown) => void>(),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    addGlobalNotificationClient: (callback: (data: unknown) => void) => {
+      globalClients.add(callback)
+      return () => {
+        globalClients.delete(callback)
+      }
+    },
+  },
+}))
+
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => false }))
+
+// Auth middleware: no-op in tests
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  HasNotificationAccess: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+vi.mock('@shared/lib/services/notification-service', () => ({
+  listNotifications: vi.fn(),
+  countNotifications: vi.fn(),
+  getUnreadCount: vi.fn(),
+  markAsRead: vi.fn(),
+  markAllAsRead: vi.fn(),
+  markSessionNotificationsRead: vi.fn(),
+  deleteNotification: vi.fn(),
+  getAccessibleAgentSlugs: vi.fn().mockResolvedValue([]),
+}))
+
+import notificationsRouter from './notifications'
+
+// Track the handler's keep-alive intervals by their signature (30s delay) so
+// we can prove each one created is also cleared.
+const KEEP_ALIVE_MS = 30000
+const createdKeepAlives = new Set<unknown>()
+const clearedKeepAlives = new Set<unknown>()
+const realSetInterval = globalThis.setInterval
+const realClearInterval = globalThis.clearInterval
+
+let server: ReturnType<typeof serve>
+let port: number
+
+beforeAll(async () => {
+  vi.spyOn(globalThis, 'setInterval').mockImplementation(((
+    handler: () => void,
+    timeout?: number,
+    ...args: unknown[]
+  ) => {
+    const id = realSetInterval(handler, timeout, ...args)
+    if (timeout === KEEP_ALIVE_MS) createdKeepAlives.add(id)
+    return id
+  }) as typeof setInterval)
+  vi.spyOn(globalThis, 'clearInterval').mockImplementation(((id: unknown) => {
+    if (createdKeepAlives.has(id)) clearedKeepAlives.add(id)
+    return realClearInterval(id as Parameters<typeof clearInterval>[0])
+  }) as typeof clearInterval)
+
+  const app = new Hono()
+  app.route('/api/notifications', notificationsRouter)
+  await new Promise<void>((resolve) => {
+    server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info: AddressInfo) => {
+      port = info.port
+      resolve()
+    })
+  })
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  globalClients.clear()
+})
+
+/** Poll until `predicate` holds or `timeoutMs` elapses. */
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return predicate()
+}
+
+/** Open the SSE endpoint over a real socket; resolves once bytes can be read. */
+function connectSSE(): Promise<{
+  received: () => string
+  destroy: () => void
+  waitForData: (needle: string, timeoutMs?: number) => Promise<boolean>
+}> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(
+      { host: '127.0.0.1', port, path: '/api/notifications/stream', headers: { Accept: 'text/event-stream' } },
+      (res) => {
+        let buffer = ''
+        res.on('data', (chunk: Buffer) => {
+          buffer += chunk.toString()
+        })
+        res.on('error', () => {})
+        resolve({
+          received: () => buffer,
+          destroy: () => req.destroy(),
+          waitForData: (needle, timeoutMs) => waitFor(() => buffer.includes(needle), timeoutMs),
+        })
+      },
+    )
+    req.on('error', reject)
+  })
+}
+
+describe('GET /api/notifications/stream teardown', () => {
+  it('registers a client and keep-alive on connect, and releases both on disconnect', async () => {
+    const before = createdKeepAlives.size
+    const client = await connectSSE()
+
+    expect(await client.waitForData('"type":"connected"')).toBe(true)
+    expect(globalClients.size).toBe(1)
+    expect(createdKeepAlives.size).toBe(before + 1)
+
+    client.destroy()
+
+    expect(await waitFor(() => globalClients.size === 0)).toBe(true)
+    expect(await waitFor(() => clearedKeepAlives.size === createdKeepAlives.size)).toBe(true)
+  })
+
+  it('still delivers notifications while connected (no premature teardown)', async () => {
+    const client = await connectSSE()
+    expect(await client.waitForData('"type":"connected"')).toBe(true)
+
+    for (const callback of globalClients) {
+      callback({ type: 'os_notification', title: 'hello-still-connected' })
+    }
+
+    expect(await client.waitForData('hello-still-connected')).toBe(true)
+    expect(globalClients.size).toBe(1)
+
+    client.destroy()
+    expect(await waitFor(() => globalClients.size === 0)).toBe(true)
+  })
+
+  it('leaves no residue after repeated connect/disconnect cycles', async () => {
+    for (let i = 0; i < 5; i++) {
+      const client = await connectSSE()
+      expect(await client.waitForData('"type":"connected"')).toBe(true)
+      expect(globalClients.size).toBe(1)
+      client.destroy()
+      expect(await waitFor(() => globalClients.size === 0)).toBe(true)
+    }
+
+    expect(globalClients.size).toBe(0)
+    expect(await waitFor(() => clearedKeepAlives.size === createdKeepAlives.size)).toBe(true)
+  })
+})

--- a/src/api/routes/notifications.stream.test.ts
+++ b/src/api/routes/notifications.stream.test.ts
@@ -18,9 +18,32 @@ import type { AddressInfo } from 'node:net'
 
 // Observable stand-in for the persister's global-client registry, with the
 // exact semantics of the real one (Set membership + unsubscribe deletes).
-const { globalClients } = vi.hoisted(() => ({
+const { globalClients, abortBeforeHandler } = vi.hoisted(() => ({
   globalClients: new Set<(data: unknown) => void>(),
+  // When true, the streamSSE wrapper below aborts the stream BEFORE the
+  // route's handler body runs — deterministically reproducing a client that
+  // disconnected during handler setup, i.e. before onAbort is registered.
+  abortBeforeHandler: { value: false },
 }))
+
+// Transparent pass-through around streamSSE, except it can pre-abort the
+// stream to exercise the abort-raced-with-setup path. Hono's onAbort only
+// registers a listener (it never replays a past abort), so without the
+// handler's `stream.aborted` check this path would hang the wait forever.
+vi.mock('hono/streaming', async (importOriginal) => {
+  const real = await importOriginal<typeof import('hono/streaming')>()
+  return {
+    ...real,
+    streamSSE: (
+      c: Parameters<typeof real.streamSSE>[0],
+      cb: Parameters<typeof real.streamSSE>[1],
+    ) =>
+      real.streamSSE(c, async (stream) => {
+        if (abortBeforeHandler.value) stream.abort()
+        await cb(stream)
+      }),
+  }
+})
 
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
@@ -97,6 +120,7 @@ afterAll(async () => {
 
 afterEach(() => {
   globalClients.clear()
+  abortBeforeHandler.value = false
 })
 
 /** Poll until `predicate` holds or `timeoutMs` elapses. */
@@ -163,6 +187,28 @@ describe('GET /api/notifications/stream teardown', () => {
 
     client.destroy()
     expect(await waitFor(() => globalClients.size === 0)).toBe(true)
+  })
+
+  it('cleans up when the abort fires before the handler waits on it', async () => {
+    abortBeforeHandler.value = true
+
+    for (let i = 0; i < 3; i++) {
+      const created = createdKeepAlives.size
+      await new Promise<void>((resolve, reject) => {
+        const req = http.get({ host: '127.0.0.1', port, path: '/api/notifications/stream' }, (res) => {
+          res.resume()
+          res.on('close', () => resolve())
+        })
+        req.on('error', reject)
+      })
+
+      // The handler ran (it created its keep-alive) against a stream that was
+      // already aborted before onAbort could be registered — the `aborted`
+      // flag check is the only thing that lets the wait settle here.
+      expect(await waitFor(() => createdKeepAlives.size === created + 1)).toBe(true)
+      expect(await waitFor(() => globalClients.size === 0)).toBe(true)
+      expect(await waitFor(() => clearedKeepAlives.size === createdKeepAlives.size)).toBe(true)
+    }
   })
 
   it('leaves no residue after repeated connect/disconnect cycles', async () => {

--- a/src/api/routes/notifications.ts
+++ b/src/api/routes/notifications.ts
@@ -89,8 +89,12 @@ notificationsRouter.get('/stream', async (c) => {
         }
       }, 30000)
 
-      // Keep connection open
-      await new Promise(() => {})
+      // Wait for abort signal
+      await new Promise<void>((resolve) => {
+        stream.onAbort(() => {
+          resolve()
+        })
+      })
     } finally {
       if (pingInterval) clearInterval(pingInterval)
       if (unsubscribe) unsubscribe()

--- a/src/api/routes/notifications.ts
+++ b/src/api/routes/notifications.ts
@@ -89,11 +89,15 @@ notificationsRouter.get('/stream', async (c) => {
         }
       }, 30000)
 
-      // Wait for abort signal
+      // Wait for abort signal. onAbort only registers a listener — it does
+      // not replay an abort that already happened (abort() sets `aborted`
+      // before notifying), so check the flag after registering to cover a
+      // client that vanished during the setup writes above.
       await new Promise<void>((resolve) => {
         stream.onAbort(() => {
           resolve()
         })
+        if (stream.aborted) resolve()
       })
     } finally {
       if (pingInterval) clearInterval(pingInterval)


### PR DESCRIPTION
## Problem

`src/api/routes/notifications.ts:93` — the global notifications SSE handler (`GET /api/notifications/stream`, used by the Electron main process) held the connection open with `await new Promise(() => {})`, a promise that never settles. The `finally` block that unregisters the client callback and clears the 30-second keep-alive interval was therefore unreachable, and there was no `stream.onAbort` handler.

Client disconnects never surface any other way: Hono's `StreamingApi.write` swallows all write errors (bare try/catch in `hono/dist/utils/stream.js`), so the ping's try/catch cannot detect a closed socket. Result, per disconnect:

- one callback leaked forever in `globalNotificationClients` (`src/shared/lib/container/message-persister.ts:273`)
- one leaked 30s `setInterval`
- in auth mode, every subsequent broadcast runs a `getAccessibleAgentSlugs` DB query per leaked client, so cost compounds with every reconnect

## Fix

Replace the never-settling promise with the abort-wait pattern already used by the chat SSE route (`src/api/routes/agents.ts:2327`), plus an already-aborted guard:

```ts
await new Promise<void>((resolve) => {
  stream.onAbort(() => {
    resolve()
  })
  if (stream.aborted) resolve()
})
```

`@hono/node-server` fires the stream's abort when the client socket closes, so the `finally` now runs and releases both resources. Cleanup is idempotent: unsubscribe is a `Set.delete` and `clearInterval` is safe to repeat, so a double-fired abort (or a double resolve) is harmless.

**Why the `stream.aborted` check is needed:** in Hono's shipped `StreamingApi`, `onAbort(listener)` only pushes onto `abortSubscribers` — it does not replay an abort that already happened — while `abort()` sets `this.aborted = true` *before* notifying subscribers. The response readable is handed to the transport before the handler body finishes, so a client that vanishes during the handler's setup section (the initial `connected` write, interval setup) aborts the stream before the wait registers its listener. Without the flag check that connection's promise never settles and it leaks exactly like the original bug, just in a narrower window — and this endpoint is opened by every client on page load with reconnect churn, so the window would get hit. Since `abort()` sets the flag before notifying, checking the flag after registering fully closes the race.

**Known follow-up candidate (not touched here):** the reference chat SSE route at `src/api/routes/agents.ts:2327` uses the same `onAbort` wait *without* the already-aborted guard, so it has the same latent narrow-window race. Left out of this PR to keep the diff scoped.

## Why connected-client behavior is unchanged

The only edit is the awaited expression at the end of the handler. Subscription, the initial `connected` frame, notification forwarding, auth-mode filtering, and the 30s ping are untouched; the promise still blocks for the connection's whole lifetime and only settles on abort — i.e. after the client is already gone.

## Validation

**New tests** — `src/api/routes/notifications.stream.test.ts` (4 tests), integration-style over a **real** `@hono/node-server` listener and real sockets (in-process `app.request()` can never fire abort):

- `registers a client and keep-alive on connect, and releases both on disconnect`
- `still delivers notifications while connected (no premature teardown)`
- `cleans up when the abort fires before the handler waits on it` — deterministic: a transparent `streamSSE` wrapper pre-aborts the stream before the handler body runs, guaranteeing abort strictly precedes `onAbort` registration (looped 3×)
- `leaves no residue after repeated connect/disconnect cycles`

The first three teardown tests **fail on the unfixed code** (registry never drains; each times out waiting for size 0), and the early-abort test **fails with the onAbort wait alone** (guard line removed — verified by temporarily deleting it). All pass with the fix.

**Live repro** against the real transport (standalone script, run then deleted; faithful copy of the route handler in both pre-fix and post-fix form, mounted via `serve()` from `@hono/node-server`, real `http.get` sockets destroyed after the `connected` frame):

```
--- PRE-FIX handler (await new Promise(() => {})) ---
after 1 connect/disconnect:   clients=1 intervals=1
after 50 connect/disconnects: clients=50 intervals=50  <-- LEAK

--- POST-FIX handler (stream.onAbort) ---
after 1 connect/disconnect:   clients=0 intervals=0
after 50 connect/disconnects: clients=0 intervals=0

RESULT: PASS — fixed handler tears down; buggy handler leaks 1 client+interval per disconnect
```

**Suites & gates:**

- `npx vitest run src/shared/lib/container/message-persister.test.ts src/api/routes/notifications.stream.test.ts` — all passing (persister suite covers the real `addGlobalNotificationClient` registry semantics)
- `npx tsc --noEmit` — clean
- `npx eslint 'src/**/*.{ts,tsx}'` — 0 errors (13 pre-existing warnings, none in touched files)

Fixes SUP-586

https://claude.ai/code/session_01BiCd95jC6zB19Pxi9CQdGF