### PR TITLE
perf: stream subagent and workflow transcript responses

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -547,7 +547,7 @@ import { containerManager } from '@shared/lib/container/container-manager'
 import { listUserSecrets, setSecret, updateSecret, getSecret, getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { keyToEnvVar } from '@shared/lib/utils/secrets'
 import { logAuditEventOrThrow } from '@shared/lib/services/audit-log-service'
-import { readJsonFileStrict, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
+import { readJsonFileStrict, readJsonlFile, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
 import { listChatIntegrations } from '@shared/lib/services/chat-integration-service'
 import { listWebhookTriggers } from '@shared/lib/services/webhook-trigger-service'
 
@@ -3489,6 +3489,72 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
 
     // No DB query since there are no user messages to look up
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /:id/sessions/:sessionId/subagent/:agentId/messages', () => {
+  let app: ReturnType<typeof createApp>
+  const URL = '/api/agents/test-agent/sessions/sess-1/subagent/sub-1/messages'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    vi.mocked(readJsonlFile).mockResolvedValue([])
+  })
+
+  it('returns the transformed transcript as a parseable JSON array', async () => {
+    vi.mocked(readJsonlFile).mockResolvedValue([
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+      { type: 'assistant', message: { role: 'assistant', content: [] } },
+    ])
+    const transformed = [
+      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'msg-2', type: 'assistant', content: { text: 'hello "quoted"\n' }, toolCalls: [], createdAt: '2026-01-01T00:00:01.000Z' },
+    ]
+    mockTransformMessages.mockReturnValue(transformed)
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(await res.json()).toEqual(transformed)
+  })
+
+  it('returns [] when the subagent transcript is empty or missing', async () => {
+    mockTransformMessages.mockReturnValue([])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('[]')
+  })
+
+  it('serializes undefined transformed elements as null, matching JSON.stringify', async () => {
+    mockTransformMessages.mockReturnValue([undefined, { id: 'msg-1', type: 'user' }])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('[null,{"id":"msg-1","type":"user"}]')
+  })
+
+  it('returns a large transcript parse-identically', async () => {
+    const transformed = Array.from({ length: 2000 }, (_, i) => ({
+      id: `msg-${i}`,
+      type: 'assistant',
+      content: { text: 'z'.repeat(400) },
+      toolCalls: [],
+    }))
+    mockTransformMessages.mockReturnValue(transformed)
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(transformed)
+  })
+
+  it('returns 500 when reading the transcript fails', async () => {
+    vi.mocked(readJsonlFile).mockRejectedValue(new Error('disk error'))
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Failed to fetch subagent messages' })
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -13,6 +13,7 @@ import {
   injectDashboardRuntime,
 } from '../dashboard-runtime'
 import { parsePagination } from '../pagination'
+import { streamJsonArrayResponse } from '../stream-json-array'
 import { Authenticated, AgentRead, AgentUser, AgentAdmin, IsAdmin, ResolveAgent, getAgentId, getAuthorizedAgentRole } from '../middleware/auth'
 import {
   listAgentsWithStatus,
@@ -1900,7 +1901,12 @@ agents.get('/:id/sessions/:sessionId/subagent/:agentId/messages', AgentRead(), a
       (e) => e.type === 'user' || e.type === 'assistant'
     )
     const transformed = transformMessages(messageEntries)
-    return c.json(transformed)
+    // Fanned out in parallel across all subagent ids by the activity log, so
+    // stream the serialization instead of building one JSON string per request.
+    return streamJsonArrayResponse(c, transformed, {
+      logLabel: 'subagent messages',
+      tags: { component: 'agents', operation: 'stream-subagent-messages' },
+    })
   } catch (error) {
     console.error('Failed to fetch subagent messages:', error)
     return c.json({ error: 'Failed to fetch subagent messages' }, 500)

--- a/src/api/routes/workflows.test.ts
+++ b/src/api/routes/workflows.test.ts
@@ -70,10 +70,47 @@ describe('workflow agent-messages route', () => {
       `/api/agents/my-agent/sessions/${SID}/workflows/${RUN}/agents/ae6ffae379942dd19/messages`
     )
     expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/json')
     const body = await res.json()
     expect(Array.isArray(body)).toBe(true)
     expect(body.length).toBeGreaterThanOrEqual(1)
     expect(JSON.stringify(body)).toContain('alpha')
+  })
+
+  it('returns a large transcript parse-identically', async () => {
+    const os = await import('os')
+    const fs = await import('fs')
+    const tmpRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wf-large-'))
+    const runDir = path.join(tmpRoot, SID, 'subagents', 'workflows', RUN)
+    await fs.promises.mkdir(runDir, { recursive: true })
+    const lines = Array.from({ length: 800 }, (_, i) =>
+      JSON.stringify({
+        parentUuid: null,
+        isSidechain: true,
+        agentId: 'bigagent',
+        type: 'user',
+        message: { role: 'user', content: `entry ${i} ${'x'.repeat(200)}` },
+        uuid: `uuid-${i}`,
+        timestamp: '2026-06-23T20:00:23.404Z',
+      })
+    )
+    await fs.promises.writeFile(path.join(runDir, 'agent-bigagent.jsonl'), lines.join('\n'))
+
+    const previousDir = mockSessionsDir.value
+    mockSessionsDir.value = tmpRoot
+    try {
+      const res = await get(
+        `/api/agents/my-agent/sessions/${SID}/workflows/${RUN}/agents/bigagent/messages`
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body).toHaveLength(800)
+      expect(body[0].content.text).toContain('entry 0')
+      expect(body[799].content.text).toContain('entry 799')
+    } finally {
+      mockSessionsDir.value = previousDir
+      await fs.promises.rm(tmpRoot, { recursive: true, force: true })
+    }
   })
 
   it('returns [] for a valid-but-missing agent id (no 500)', async () => {

--- a/src/api/routes/workflows.ts
+++ b/src/api/routes/workflows.ts
@@ -4,6 +4,7 @@ import { AgentRead } from '../middleware/auth'
 import { getAgentSessionsDir, readJsonlFile } from '@shared/lib/utils/file-storage'
 import { transformMessages } from '@shared/lib/utils/message-transform'
 import { buildWorkflowTree } from '@shared/lib/workflows/workflow-tree'
+import { streamJsonArrayResponse } from '../stream-json-array'
 
 /**
  * Read-only routes backing the per-agent workflow drawer (SUP-308). A dynamic
@@ -65,7 +66,12 @@ workflowRoutes.get(
       const entries = (await readJsonlFile(jsonlPath)) as any[]
       const messageEntries = entries.filter((e) => e.type === 'user' || e.type === 'assistant')
       const transformed = transformMessages(messageEntries)
-      return c.json(transformed)
+      // Polled while the workflow drawer is open, so stream the serialization
+      // instead of building one JSON string per poll.
+      return streamJsonArrayResponse(c, transformed, {
+        logLabel: 'workflow agent messages',
+        tags: { component: 'workflows', operation: 'stream-workflow-agent-messages' },
+      })
     } catch (error) {
       console.error('Failed to fetch workflow agent messages:', error)
       return c.json({ error: 'Failed to fetch workflow agent messages' }, 500)

--- a/src/api/stream-json-array.test.ts
+++ b/src/api/stream-json-array.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+const mockCaptureException = vi.fn()
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+import { streamJsonArrayResponse } from './stream-json-array'
+
+const TAGS = { component: 'test', operation: 'stream-test' }
+
+function appFor(items: unknown[]) {
+  const app = new Hono()
+  app.get('/items', (c) => streamJsonArrayResponse(c, items, { logLabel: 'test items', tags: TAGS }))
+  return app
+}
+
+const get = (items: unknown[]) => appFor(items).request('http://localhost/items')
+
+async function settle() {
+  // Let the Node-side pipeline callback run.
+  await new Promise((resolve) => setTimeout(resolve, 20))
+}
+
+describe('streamJsonArrayResponse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('streams a body that parses to the same value c.json produced', async () => {
+    const items = [
+      { id: 'a', nested: { deep: [1, 2, 3] }, text: 'héllo "quoted" \n newline' },
+      { id: 'b', value: null },
+    ]
+    const res = await get(items)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(await res.json()).toEqual(JSON.parse(JSON.stringify(items)))
+  })
+
+  it('serializes an empty array as []', async () => {
+    const res = await get([])
+    expect(await res.text()).toBe('[]')
+  })
+
+  it('serializes undefined elements as null, matching JSON.stringify of the array', async () => {
+    const res = await get([undefined, { id: 1 }, undefined])
+    expect(await res.text()).toBe('[null,{"id":1},null]')
+  })
+
+  it('streams a large array parse-identically', async () => {
+    const items = Array.from({ length: 5000 }, (_, i) => ({
+      id: `msg-${i}`,
+      content: { text: 'x'.repeat(500) },
+      toolCalls: [],
+    }))
+    const res = await get(items)
+    const body = await res.json()
+    expect(body).toEqual(items)
+  })
+
+  it('does not report when the client cancels the stream mid-body', async () => {
+    const items = Array.from({ length: 10000 }, (_, i) => ({ id: i, pad: 'y'.repeat(1000) }))
+    const res = await get(items)
+    const reader = res.body!.getReader()
+    await reader.read()
+    await reader.cancel()
+    await settle()
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it('reports non-abort serialization failures with the given tags', async () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    const res = await get([{ ok: true }, circular])
+    // The body errors mid-stream; consume defensively.
+    await res.text().catch(() => {})
+    await settle()
+    expect(mockCaptureException).toHaveBeenCalledTimes(1)
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.anything(), { tags: TAGS })
+  })
+})

--- a/src/api/stream-json-array.ts
+++ b/src/api/stream-json-array.ts
@@ -1,0 +1,31 @@
+import type { Context } from 'hono'
+import { Readable, pipeline } from 'stream'
+import { createJsonArrayStringifyTransform } from '@shared/lib/utils/file-storage'
+import { captureException } from '@shared/lib/error-reporting'
+
+/**
+ * Respond with `items` serialized as a JSON array, streamed element by element
+ * instead of materialized as one `JSON.stringify` string (the transform matches
+ * `c.json` semantics exactly, including `undefined` elements becoming `null`).
+ *
+ * A client that disconnects mid-body cancels the returned web stream, which
+ * surfaces Node-side as ABORT_ERR / ERR_STREAM_PREMATURE_CLOSE — routine
+ * connection churn, filtered out before reporting.
+ */
+export function streamJsonArrayResponse(
+  c: Context,
+  items: unknown[],
+  options: { logLabel: string; tags: { component: string; operation: string } }
+): Response {
+  const stringify = createJsonArrayStringifyTransform()
+  pipeline(Readable.from(items), stringify, (err) => {
+    if (!err) return
+    const code = (err as NodeJS.ErrnoException)?.code
+    if (code === 'ABORT_ERR' || code === 'ERR_STREAM_PREMATURE_CLOSE') return
+    console.error(`Failed to stream ${options.logLabel}:`, err)
+    captureException(err, { tags: options.tags })
+  })
+  return c.body(Readable.toWeb(stringify) as ReadableStream, 200, {
+    'Content-Type': 'application/json',
+  })
+}


### PR DESCRIPTION
## Problem

Two transcript routes still buffered their entire transformed transcript as one `JSON.stringify` string on top of the parsed array, per request:

- `src/api/routes/agents.ts:1896-1903` — `GET /:id/sessions/:sessionId/subagent/:agentId/messages` (fanned out in parallel across **all** subagent ids at once by `browser-activity-log.tsx`)
- `src/api/routes/workflows.ts:65-68` — `GET .../workflows/:runId/agents/:agentId/messages` (polled every 1.5s while the workflow drawer is open)

The main `GET /messages` route was already converted to a streamed serialization in #752; these two were left behind, so concurrent-request memory and clean abort handling (React Query cancels on unmount) both still mattered here.

## Fix

Only the serialization changes — parse + transform stays materialized exactly as before (paging that is a separate follow-up riding #753). The `c.json(transformed)` call is replaced with the #752 pipeline pattern, extracted once as `streamJsonArrayResponse` (`src/api/stream-json-array.ts`): `pipeline(Readable.from(items), createJsonArrayStringifyTransform(), cb)` returned via `Readable.toWeb`, with `ABORT_ERR` / `ERR_STREAM_PREMATURE_CLOSE` filtered before `captureException` and per-route Sentry tags. The already-merged main messages route is intentionally left untouched.

## Wire-shape proof

Both routes returned a **bare JSON array**, so the array stringify transform alone preserves the shape:
- `createJsonArrayStringifyTransform` serializes `undefined` elements as `null`, matching `JSON.stringify`/`c.json` exactly (unit-asserted byte-for-byte: `[null,{"id":"msg-1","type":"user"}]`).
- Missing file → `readJsonlFile` returns `[]` → transform flush emits `[]`, identical to before (route test asserts exact `[]` body).
- Live repro compared streamed vs `c.json` bodies **byte-identical** for normal (43,881 bytes), empty, and missing transcripts against the real `@hono/node-server`.
- Renderer consumers (`browser-activity-log.tsx`, `use-messages.ts`) parse `res.json()` as an array — unchanged.

## Validation

- **Old-behavior capture first**: all new route tests were written and run green against the pre-change buffered code (`agents.test.ts` 346 passed, `workflows.test.ts` + `file-storage.test.ts` 104 passed), then re-run green after the change — 456 tests across the 4 touched suites, including the main messages route suite unmodified.
- **New tests**: subagent route (normal / empty / undefined-element / 2000-row large / read-failure 500), workflow route (content-type + 800-row large synthetic through the real `transformMessages`), and `stream-json-array.test.ts` (parse-identical, `[]`, `null` semantics, 5000-row large, client-cancel → no capture, circular-ref serialization failure → capture with tags).
- **Live repro** (standalone script against the real `@hono/node-server`, deleted before commit):

```
PASS  happy path (normal): byte-identical to c.json — 43881 bytes
PASS  happy path (normal): parses
PASS  happy path (empty): byte-identical to c.json — 2 bytes
PASS  happy path (empty): parses
PASS  happy path (missing): byte-identical to c.json — 2 bytes
PASS  happy path (missing): parses
PASS  happy path (big): parses with all rows — 8000 rows
PASS  mid-body disconnect: zero reported stream errors — 0 reports
PASS  mid-body disconnect: no uncaught errors
PASS  abort loop x100: zero reported stream errors — 0 reports
PASS  abort loop x100: no uncaught errors
PASS  abort loop x100: steady handle count — before=5 after=3
INFO  rss after loop: 52 MB

ALL CHECKS PASSED
```

- `npx tsc --noEmit` clean; `npx eslint 'src/**/*.{ts,tsx}'` 0 errors (13 pre-existing warnings, none in touched files).
- No Playwright spec covers these routes directly, so no E2E run.

Fixes SUP-580

https://claude.ai/code/session_01BiCd95jC6zB19Pxi9CQdGF