### PR TITLE
perf: read transcript tail instead of full parse in x-agent reply retry loop

### DIFF
--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -83,6 +83,18 @@ const mockReserveSessionOwnership = vi.fn(async (..._args: unknown[]) => {})
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: (...args: unknown[]) => mockListSessions(...args),
   getSessionMessagesWithCompact: (...args: unknown[]) => mockGetTranscript(...args),
+  // Backed by the same transcript fixture so tests control both read paths.
+  findLastSessionEntry: async (
+    slug: unknown,
+    sessionId: unknown,
+    predicate: (entry: unknown) => boolean,
+  ) => {
+    const entries = ((await mockGetTranscript(slug, sessionId)) ?? []) as unknown[]
+    for (let i = entries.length - 1; i >= 0; i--) {
+      if (predicate(entries[i])) return entries[i]
+    }
+    return null
+  },
   registerSession: (...args: unknown[]) => mockRegisterSession(...args),
   reserveSessionOwnership: (...args: unknown[]) => mockReserveSessionOwnership(...args),
   updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
@@ -990,6 +1002,43 @@ describe('/invoke', () => {
     const body = await res.json()
     expect(body.status).toBe('completed')
     expect(body.lastMessage).toBeUndefined()
+  })
+
+  it('exhausts the full retry budget when no assistant entry ever appears', async () => {
+    reviewDecisions.push('allow')
+    mockGetTranscript.mockResolvedValue([
+      { type: 'user', message: { role: 'user', content: 'still just the prompt' } },
+    ])
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'still just the prompt',
+      sync: true,
+    })
+    const body = await res.json()
+    expect(body.status).toBe('completed')
+    expect(body.lastMessage).toBeUndefined()
+    // One transcript read per attempt (X_AGENT_READ_RETRY_ATTEMPTS=4 above).
+    expect(mockGetTranscript).toHaveBeenCalledTimes(4)
+  })
+
+  it('stops polling as soon as an assistant entry appears', async () => {
+    reviewDecisions.push('allow')
+    mockGetTranscript
+      .mockResolvedValueOnce([{ type: 'user', message: { role: 'user', content: 'q' } }])
+      .mockResolvedValueOnce([{ type: 'user', message: { role: 'user', content: 'q' } }])
+      .mockResolvedValue([
+        { type: 'user', message: { role: 'user', content: 'q' } },
+        { type: 'assistant', message: { role: 'assistant', content: 'late answer' } },
+      ])
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'q',
+      sync: true,
+    })
+    const body = await res.json()
+    expect(body.status).toBe('completed')
+    expect(body.lastMessage).toBe('late answer')
+    expect(mockGetTranscript).toHaveBeenCalledTimes(3)
   })
 
   it('rejects when continuing an already-running session', async () => {

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -30,6 +30,7 @@ import { resolveAgentId, displaySlug } from '@shared/lib/utils/file-storage'
 import {
   listSessions,
   getSessionMessagesWithCompact,
+  findLastSessionEntry,
   getSessionMetadata,
   registerSession,
   reserveSessionOwnership,
@@ -481,12 +482,16 @@ async function readLastAssistantMessage(
   intervalMs = READ_RETRY_INTERVAL_MS,
 ): Promise<{ role: string; content: string; toolName?: string } | null> {
   for (let i = 0; i < attempts; i++) {
-    const entries = await getSessionMessagesWithCompact(targetSlug, sessionId)
-    // Walk backwards to find the most recent assistant entry.
-    for (let j = entries.length - 1; j >= 0; j--) {
-      const e = entries[j]
-      if (e.type !== 'assistant') continue
-      const compact = compactMessage(e)
+    // Only the most recent assistant entry matters, so read the transcript
+    // from the tail instead of full-parsing it (transcripts reach 100MB+, and
+    // this runs up to `attempts` times per invoke).
+    const entry = await findLastSessionEntry(
+      targetSlug,
+      sessionId,
+      (e) => e.type === 'assistant' && compactMessage(e) !== null,
+    )
+    if (entry) {
+      const compact = compactMessage(entry)
       if (compact) return compact
     }
     if (i < attempts - 1) {

--- a/src/shared/lib/services/session-service.tail-read.test.ts
+++ b/src/shared/lib/services/session-service.tail-read.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Differential tests for findLastSessionEntry.
+ *
+ * findLastSessionEntry reads the transcript tail instead of full-parsing the
+ * file. Its contract is exact equivalence with the pre-existing path: a full
+ * getSessionMessagesWithCompact parse walked backwards to the newest entry
+ * matching the predicate. Every test here runs BOTH paths on the same fixture
+ * and asserts identical results (the full parse is the oracle).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+import {
+  findLastSessionEntry,
+  getSessionMessagesWithCompact,
+} from './session-service'
+import type { JsonlMessageEntry, JsonlSystemEntry } from '@shared/lib/types/agent'
+
+type Entry = JsonlMessageEntry | JsonlSystemEntry
+type Predicate = (entry: Entry) => boolean
+
+const AGENT = 'tail-agent'
+const SESSION = 'tail-session'
+
+const isAssistant: Predicate = (e) => e.type === 'assistant'
+
+const KB = 1024
+const INITIAL_WINDOW = 256 * KB
+const MAX_WINDOW = 4 * 1024 * KB
+
+describe('findLastSessionEntry', () => {
+  let testDir: string
+  let originalEnv: string | undefined
+  let sessionsDir: string
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'tail-read-test-'))
+    originalEnv = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testDir
+    sessionsDir = path.join(
+      testDir,
+      'agents',
+      AGENT,
+      'workspace',
+      '.claude',
+      'projects',
+      '-workspace'
+    )
+    await fs.promises.mkdir(sessionsDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    if (originalEnv) {
+      process.env.SUPERAGENT_DATA_DIR = originalEnv
+    } else {
+      delete process.env.SUPERAGENT_DATA_DIR
+    }
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  function jsonlPath(): string {
+    return path.join(sessionsDir, `${SESSION}.jsonl`)
+  }
+
+  async function writeTranscript(raw: string): Promise<void> {
+    await fs.promises.writeFile(jsonlPath(), raw)
+  }
+
+  function userEntry(id: number, content: string): object {
+    return {
+      type: 'user',
+      parentUuid: null,
+      sessionId: SESSION,
+      uuid: `user-${id}`,
+      timestamp: '2026-01-24T01:00:00.000Z',
+      message: { role: 'user', content },
+    }
+  }
+
+  function assistantEntry(id: number, text: string): object {
+    return {
+      type: 'assistant',
+      parentUuid: null,
+      sessionId: SESSION,
+      uuid: `assistant-${id}`,
+      timestamp: '2026-01-24T01:00:01.000Z',
+      message: { role: 'assistant', content: [{ type: 'text', text }] },
+    }
+  }
+
+  function toolResultEntry(id: number, payload: string): object {
+    return {
+      type: 'user',
+      parentUuid: null,
+      sessionId: SESSION,
+      uuid: `tool-result-${id}`,
+      timestamp: '2026-01-24T01:00:02.000Z',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: `t-${id}`, content: payload }],
+      },
+    }
+  }
+
+  function compactBoundaryEntry(id: number): object {
+    return {
+      type: 'system',
+      subtype: 'compact_boundary',
+      uuid: `compact-${id}`,
+      timestamp: '2026-01-24T01:00:03.000Z',
+    }
+  }
+
+  /** A user entry padded with base64-ish payload so its JSONL line is ~`bytes` long. */
+  function bigLine(id: number, bytes: number): object {
+    const overhead = JSON.stringify(toolResultEntry(id, '')).length
+    return toolResultEntry(id, 'A'.repeat(Math.max(0, bytes - overhead)))
+  }
+
+  function toJsonl(entries: object[]): string {
+    return entries.map((e) => JSON.stringify(e)).join('\n') + '\n'
+  }
+
+  /** The pre-existing code path, run directly as the oracle. */
+  async function fullParseOracle(predicate: Predicate): Promise<Entry | null> {
+    const entries = await getSessionMessagesWithCompact(AGENT, SESSION)
+    for (let i = entries.length - 1; i >= 0; i--) {
+      if (predicate(entries[i])) return entries[i]
+    }
+    return null
+  }
+
+  async function expectSameAsFullParse(predicate: Predicate): Promise<Entry | null> {
+    const expected = await fullParseOracle(predicate)
+    const actual = await findLastSessionEntry(AGENT, SESSION, predicate)
+    expect(actual).toEqual(expected)
+    return actual
+  }
+
+  it('normal multi-turn transcript: picks the newest assistant entry', async () => {
+    await writeTranscript(
+      toJsonl([
+        userEntry(1, 'first question'),
+        assistantEntry(1, 'first answer'),
+        userEntry(2, 'second question'),
+        assistantEntry(2, 'second answer'),
+      ])
+    )
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-2' })
+  })
+
+  it('trailing tool_result/user frames after the last assistant entry', async () => {
+    await writeTranscript(
+      toJsonl([
+        userEntry(1, 'do a thing'),
+        assistantEntry(1, 'final answer'),
+        toolResultEntry(1, 'result data'),
+        userEntry(2, 'stray trailing user frame'),
+      ])
+    )
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-1' })
+  })
+
+  it('transcript with compaction markers: last assistant after the boundary', async () => {
+    await writeTranscript(
+      toJsonl([
+        userEntry(1, 'old turn'),
+        assistantEntry(1, 'pre-compact answer'),
+        compactBoundaryEntry(1),
+        userEntry(2, 'post-compact turn'),
+        assistantEntry(2, 'post-compact answer'),
+        toolResultEntry(2, 'trailing'),
+      ])
+    )
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-2' })
+
+    // Compact boundaries are themselves selectable entries.
+    const boundary = await expectSameAsFullParse(
+      (e) => e.type === 'system' && e.subtype === 'compact_boundary'
+    )
+    expect(boundary).toMatchObject({ uuid: 'compact-1' })
+  })
+
+  it('compaction marker AFTER the last assistant entry (compact just happened)', async () => {
+    await writeTranscript(
+      toJsonl([
+        userEntry(1, 'turn'),
+        assistantEntry(1, 'answer'),
+        compactBoundaryEntry(1),
+      ])
+    )
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-1' })
+  })
+
+  it('huge base64-heavy trailing lines push the assistant beyond the first window (escalation)', async () => {
+    // ~600KB of trailing tool results: not in the 256KB window, found at 1MB.
+    await writeTranscript(
+      toJsonl([
+        userEntry(1, 'screenshot please'),
+        assistantEntry(1, 'took the screenshots'),
+        bigLine(1, 200 * KB),
+        bigLine(2, 200 * KB),
+        bigLine(3, 200 * KB),
+      ])
+    )
+    const openSpy = vi.spyOn(fs.promises, 'open')
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-1' })
+    // Escalated exactly once (256KB miss → 1MB hit); the oracle's own full
+    // parse accounts for the third open.
+    expect(openSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it('huge single line larger than the initial window (no complete line in window)', async () => {
+    await writeTranscript(
+      toJsonl([
+        userEntry(1, 'big output'),
+        assistantEntry(1, 'summarized'),
+        bigLine(1, 300 * KB),
+      ])
+    )
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-1' })
+  })
+
+  it('assistant only at the very start of a >4MB file: escalates to cap, then full-parse fallback', async () => {
+    const filler: object[] = []
+    for (let i = 0; i < 6; i++) filler.push(bigLine(i, 900 * KB)) // ~5.4MB
+    await writeTranscript(toJsonl([assistantEntry(1, 'only answer'), ...filler]))
+
+    const openSpy = vi.spyOn(fs.promises, 'open')
+    const result = await findLastSessionEntry(AGENT, SESSION, isAssistant)
+    // 3 tail windows (256KB, 1MB, 4MB — all miss) + 1 full-parse fallback.
+    expect(openSpy).toHaveBeenCalledTimes(4)
+    expect(result).toMatchObject({ uuid: 'assistant-1' })
+    expect(result).toEqual(await fullParseOracle(isAssistant))
+  })
+
+  it('match misses capped windows but file smaller than cap: found without fallback', async () => {
+    const filler: object[] = []
+    for (let i = 0; i < 2; i++) filler.push(bigLine(i, 900 * KB)) // ~1.8MB, < 4MB cap
+    await writeTranscript(toJsonl([assistantEntry(1, 'early answer'), ...filler]))
+
+    const openSpy = vi.spyOn(fs.promises, 'open')
+    const result = await findLastSessionEntry(AGENT, SESSION, isAssistant)
+    // 256KB miss → 1MB miss → 4MB window covers the whole file and hits.
+    expect(openSpy).toHaveBeenCalledTimes(3)
+    expect(result).toMatchObject({ uuid: 'assistant-1' })
+    expect(result).toEqual(await fullParseOracle(isAssistant))
+  })
+
+  it('no assistant entry at all: null, decided from a whole-file window without fallback', async () => {
+    await writeTranscript(toJsonl([userEntry(1, 'hello?'), toolResultEntry(1, 'noise')]))
+    const openSpy = vi.spyOn(fs.promises, 'open')
+    const result = await findLastSessionEntry(AGENT, SESSION, isAssistant)
+    expect(result).toBeNull()
+    // Small file: first window covers it entirely — one read, no fallback.
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    expect(await fullParseOracle(isAssistant)).toBeNull()
+  })
+
+  it('no assistant entry in a large file: null equals the oracle', async () => {
+    const filler: object[] = []
+    for (let i = 0; i < 6; i++) filler.push(bigLine(i, 900 * KB))
+    await writeTranscript(toJsonl(filler))
+    await expectSameAsFullParse(isAssistant)
+  })
+
+  it('empty file: null', async () => {
+    await writeTranscript('')
+    expect(await expectSameAsFullParse(isAssistant)).toBeNull()
+  })
+
+  it('missing file: null', async () => {
+    expect(await expectSameAsFullParse(isAssistant)).toBeNull()
+  })
+
+  it('file ending without a trailing newline: last line still parsed', async () => {
+    const raw = toJsonl([userEntry(1, 'q'), assistantEntry(1, 'a')]).slice(0, -1)
+    expect(raw.endsWith('\n')).toBe(false)
+    await writeTranscript(raw)
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-1' })
+  })
+
+  it('partial (mid-write) last line: skipped by both paths', async () => {
+    const raw =
+      toJsonl([userEntry(1, 'q'), assistantEntry(1, 'complete answer')]) +
+      '{"type":"assistant","mess'
+    await writeTranscript(raw)
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-1' })
+  })
+
+  it('queued_command attachment entries are normalized in the tail path too', async () => {
+    await writeTranscript(
+      toJsonl([
+        userEntry(1, 'start'),
+        assistantEntry(1, 'working'),
+        {
+          type: 'attachment',
+          uuid: 'attach-1',
+          parentUuid: 'assistant-1',
+          sessionId: SESSION,
+          timestamp: '2026-01-24T01:00:04.000Z',
+          attachment: {
+            type: 'queued_command',
+            commandMode: 'prompt',
+            prompt: 'queued follow-up',
+            source_uuid: 'queued-1',
+          },
+        },
+      ])
+    )
+    const isUser: Predicate = (e) => e.type === 'user'
+    const result = await expectSameAsFullParse(isUser)
+    expect(result).toMatchObject({
+      type: 'user',
+      uuid: 'queued-1',
+      isQueuedCommand: true,
+    })
+    // And the assistant walk still skips over the attachment-derived entry.
+    await expectSameAsFullParse(isAssistant)
+  })
+
+  it('window offset landing exactly on a line boundary still equals the oracle', async () => {
+    // Build a suffix whose byte length is exactly the initial window, so the
+    // tail read starts precisely at a line start and discards one complete
+    // line. The discarded line is a filler user entry; the assistant target
+    // sits later in the window.
+    const tailEntries = [
+      userEntry(2, 'second turn'),
+      assistantEntry(2, 'target answer'),
+      toolResultEntry(2, 'trailing'),
+    ]
+    const tailFixed = toJsonl(tailEntries)
+    const boundaryLineTarget = INITIAL_WINDOW - tailFixed.length - 1 // -1 for its own '\n'
+    const boundaryLine = JSON.stringify(bigLine(99, boundaryLineTarget)) + '\n'
+    // bigLine pads to an exact byte length; verify the arithmetic held.
+    const suffix = boundaryLine + tailFixed
+    expect(Buffer.byteLength(suffix)).toBe(INITIAL_WINDOW)
+
+    const prefix = toJsonl([userEntry(1, 'first turn'), assistantEntry(1, 'decoy answer')])
+    await writeTranscript(prefix + suffix)
+
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-2' })
+  })
+
+  it('assistant entry exactly at the discarded first line of the window: escalation recovers it', async () => {
+    // The newest assistant line IS the first line of the initial window: the
+    // first attempt discards it (complete-line discard case) and finds only
+    // trailing noise, so escalation must recover the same entry the full
+    // parse selects.
+    const assistantLine = JSON.stringify(assistantEntry(7, 'boundary answer')) + '\n'
+    const noiseLine =
+      JSON.stringify(bigLine(98, INITIAL_WINDOW - assistantLine.length - 1)) + '\n'
+    const suffix = assistantLine + noiseLine
+    expect(Buffer.byteLength(suffix)).toBe(INITIAL_WINDOW)
+
+    const prefix = toJsonl([userEntry(1, 'first turn')])
+    await writeTranscript(prefix + suffix)
+    // Sanity: the initial window starts exactly at the assistant line.
+    const size = (await fs.promises.stat(jsonlPath())).size
+    expect(size - INITIAL_WINDOW).toBe(Buffer.byteLength(prefix))
+
+    const result = await expectSameAsFullParse(isAssistant)
+    expect(result).toMatchObject({ uuid: 'assistant-7' })
+  })
+
+  it('window sizes: escalation stays within the documented cap', () => {
+    // Guard the constants this suite's fixtures are built around.
+    expect(INITIAL_WINDOW * 4 * 4).toBe(MAX_WINDOW)
+  })
+})

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -24,6 +24,7 @@ import {
   CorruptFileError,
   readJsonlFile,
   streamJsonlFile,
+  parseJsonl,
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
@@ -899,6 +900,120 @@ export async function getSessionMessagesWithCompact(
 
   const entries = await readJsonlFile<JsonlEntry>(jsonlPath)
   return entries.map(normalizeQueuedCommandEntry).filter(isMessageOrSystemDisplayEntry)
+}
+
+// Tail-window sizing for findLastSessionEntry: start small (covers the last
+// few turns of a typical transcript), escalate when the window has no match,
+// and cap before falling back to a full parse.
+const TAIL_WINDOW_INITIAL_BYTES = 256 * 1024
+const TAIL_WINDOW_GROWTH_FACTOR = 4
+const TAIL_WINDOW_MAX_BYTES = 4 * 1024 * 1024
+
+/**
+ * Read the last `windowBytes` of a session transcript and return the entries
+ * parsed from the complete lines inside that window (same normalization and
+ * filtering as getSessionMessagesWithCompact). Returns null when the file does
+ * not exist.
+ *
+ * When the window starts mid-file, everything up to and including the first
+ * newline is discarded: that prefix is (almost always) the tail of a line
+ * whose start lies outside the window. If the window happens to start exactly
+ * on a line boundary this discards one complete line — harmless, because
+ * callers never conclude "absent" from a partial window (see
+ * findLastSessionEntry). Discarding to a newline also guarantees the decoded
+ * text never starts inside a multi-byte UTF-8 sequence.
+ */
+async function readSessionEntriesFromTail(
+  jsonlPath: string,
+  windowBytes: number
+): Promise<{
+  entries: (JsonlMessageEntry | JsonlSystemEntry)[]
+  coveredWholeFile: boolean
+} | null> {
+  let fileHandle: fs.promises.FileHandle
+  try {
+    fileHandle = await fs.promises.open(jsonlPath, 'r')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+  try {
+    const { size } = await fileHandle.stat()
+    const offset = Math.max(0, size - windowBytes)
+    const length = size - offset
+    const buffer = Buffer.alloc(length)
+    let bytesReadTotal = 0
+    while (bytesReadTotal < length) {
+      const { bytesRead } = await fileHandle.read(
+        buffer,
+        bytesReadTotal,
+        length - bytesReadTotal,
+        offset + bytesReadTotal
+      )
+      if (bytesRead === 0) break // file shrank under us; parse what we got
+      bytesReadTotal += bytesRead
+    }
+    let window = buffer.subarray(0, bytesReadTotal)
+    if (offset > 0) {
+      const firstNewline = window.indexOf(0x0a) // '\n'
+      if (firstNewline === -1) {
+        // One line larger than the whole window — no complete line to parse.
+        return { entries: [], coveredWholeFile: false }
+      }
+      window = window.subarray(firstNewline + 1)
+    }
+    const entries = parseJsonl<JsonlEntry>(window.toString('utf-8'))
+      .map(normalizeQueuedCommandEntry)
+      .filter(isMessageOrSystemDisplayEntry)
+    return { entries, coveredWholeFile: offset === 0 }
+  } finally {
+    await fileHandle.close()
+  }
+}
+
+/**
+ * Find the newest transcript entry matching `predicate`, over the same entry
+ * set getSessionMessagesWithCompact produces, without parsing the whole file.
+ * Transcripts routinely reach 100MB+, so callers that only need the most
+ * recent entry (e.g. the reply of a just-finished turn) should not pay a full
+ * parse — especially inside retry loops.
+ *
+ * Equivalence with the full parse: every transcript entry is line-local (one
+ * JSONL line maps to at most one entry; normalization and filtering never
+ * merge or reorder lines, and compact boundaries are ordinary standalone
+ * lines), so the newest matching entry within a complete-line tail window is
+ * exactly the entry a full parse would select. A window with no match is only
+ * trusted when it covered the whole file; otherwise the window escalates and
+ * finally falls back to one full parse, so the result always equals the
+ * full-parse result — it is just cheaper in the common case.
+ */
+export async function findLastSessionEntry(
+  agentSlug: string,
+  sessionId: string,
+  predicate: (entry: JsonlMessageEntry | JsonlSystemEntry) => boolean
+): Promise<JsonlMessageEntry | JsonlSystemEntry | null> {
+  const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+
+  for (
+    let windowBytes = TAIL_WINDOW_INITIAL_BYTES;
+    windowBytes <= TAIL_WINDOW_MAX_BYTES;
+    windowBytes *= TAIL_WINDOW_GROWTH_FACTOR
+  ) {
+    const tail = await readSessionEntriesFromTail(jsonlPath, windowBytes)
+    if (tail === null) return null // no transcript file
+    for (let i = tail.entries.length - 1; i >= 0; i--) {
+      if (predicate(tail.entries[i])) return tail.entries[i]
+    }
+    if (tail.coveredWholeFile) return null
+  }
+
+  // The match (if any) starts earlier than the capped window: parse the whole
+  // file once so behavior is never worse than the pre-tail-read path.
+  const entries = await getSessionMessagesWithCompact(agentSlug, sessionId)
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (predicate(entries[i])) return entries[i]
+  }
+  return null
 }
 
 /**


### PR DESCRIPTION
## Problem

`readLastAssistantMessage` (`src/api/routes/x-agent.ts:484` on main) called `getSessionMessagesWithCompact` — a full parse of the session transcript — inside its retry loop (`READ_RETRY_ATTEMPTS = 10` at 500ms). Transcripts routinely reach 35MB, and 100MB+ with base64 screenshots, and the parsed heap cost is a multiple of file size. Worst case: 10 full parses of a 100MB file to answer one sync invoke, when all the caller needs is the newest assistant entry.

## Fix

New `findLastSessionEntry(agentSlug, sessionId, predicate)` in `session-service.ts`:

- Reads the last 256KB of the JSONL file, discards everything up to the first newline when the window starts mid-file (so only complete lines are parsed, and UTF-8 sequences are never split), and runs the lines through the **same** pipeline as `getSessionMessagesWithCompact` (`parseJsonl` → `normalizeQueuedCommandEntry` → `isMessageOrSystemDisplayEntry`), then walks newest-first for the predicate match.
- No match: escalates the window ×4 (256KB → 1MB → 4MB). A "not found" is only trusted when the window covered the whole file; past the cap it falls back to **one** full parse, so behavior is never worse than before — only cheaper in the common case.
- `readLastAssistantMessage` now calls it with the exact selection criterion the old backwards walk used (`type === 'assistant'` with non-null `compactMessage`). Retry attempt count, interval, found-criterion, and returned content are unchanged.

## Why a tail scan is equivalent

Every transcript entry is line-local: one JSONL line maps to at most one entry, and nothing in the pipeline merges, reorders, or drops-by-context lines — `normalizeQueuedCommandEntry` rewrites a single attachment line in place, and compaction boundaries are ordinary standalone `system` lines (the entries after a compact boundary are the live conversation, so "newest assistant entry in the file" is well-defined regardless of compaction). Therefore the newest matching entry within a complete-line tail window is exactly the entry a full parse selects; windows without a match never conclude "absent" unless they covered the whole file.

## Validation

- **Differential tests** (`session-service.tail-read.test.ts`, 18 tests): every fixture runs the old code path directly as the oracle (`getSessionMessagesWithCompact` + backwards walk) and asserts the tail read returns an identical result. Fixtures: normal multi-turn; compaction markers before/after the last assistant; trailing tool-result/user frames; ~200KB base64 lines forcing window escalation; single line larger than the initial window; assistant only at the start of a >4MB file (asserts 3 tail windows + exactly one full-parse fallback via an `fs.promises.open` spy); large file smaller than the cap (found at the 4MB window, no fallback); no assistant at all (small + large); empty file; missing file; no trailing newline; partial mid-write last line; queued_command attachment normalization; window offset landing exactly on a line boundary; assistant line exactly at the discarded window start (escalation recovers it).
- **Retry loop**: new x-agent tests pin the loop's semantics — exhausts the configured attempt budget (one transcript read per attempt) when no assistant appears, and stops polling the moment one does.
- Full `x-agent.test.ts` (62), `session-service*` suites, `npx tsc --noEmit`, eslint: all green. (Two file-lock stress tests in `session-service.metadata/ownership` timed out once under a 10-suite parallel run on a loaded machine; both pass in isolation and are untouched by this change.)

## Perf evidence

Synthetic 52.7MB transcript (800 × 64KB base64 tool-result lines, assistant near the end — the common shape), measured with `/usr/bin/time -l`, node + tsx:

| | time per read | peak RSS |
|---|---|---|
| old (full parse) | 66.4 ms | 309 MB |
| new (tail read) | 1.0 ms | 172 MB (≈ node+tsx baseline) |

Under the retry loop that's up to 10× per invoke; the old path also re-materialized the ~300MB parsed heap on every attempt.

## Out of scope / follow-up

`POST /get-transcript` (`x-agent.ts` ~line 544) still full-parses the transcript — legitimately, since it returns all messages — but could stream or page; left as a follow-up per the audit.

Fixes SUP-582

https://claude.ai/code/session_01BiCd95jC6zB19Pxi9CQdGF