### PR TITLE
perf: enforce upload size server-side and stream single-shot uploads to disk

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
 import { runInNewContext } from 'node:vm'
+import { Writable } from 'node:stream'
+import { createHash } from 'node:crypto'
 
 // ============================================================================
 // Mocks — must be declared before import
@@ -16,6 +18,17 @@ const mockFsReaddir = vi.fn()
 const mockFsCp = vi.fn()
 const mockFsExistsSync = vi.fn()
 const mockCreateReadStream = vi.fn()
+
+// In-memory sink for the streaming upload write path; tests can inspect the
+// bytes written via mockCreateWriteStream.mock.results[n].value.chunks.
+class MemoryWriteStream extends Writable {
+  chunks: Buffer[] = []
+  override _write(chunk: Buffer, _enc: BufferEncoding, cb: (err?: Error | null) => void) {
+    this.chunks.push(Buffer.from(chunk))
+    cb()
+  }
+}
+const mockCreateWriteStream = vi.fn((..._args: unknown[]) => new MemoryWriteStream())
 const mockFsRealpath = vi.fn(async (value: unknown) => value)
 const mockFsRename = vi.fn()
 const mockFsUnlink = vi.fn()
@@ -38,6 +51,7 @@ vi.mock('fs', () => ({
     },
     existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
     createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
+    createWriteStream: (...args: unknown[]) => mockCreateWriteStream(...args),
   },
   promises: {
     stat: (...args: unknown[]) => mockFsStat(...args),
@@ -54,6 +68,7 @@ vi.mock('fs', () => ({
   },
   existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
+  createWriteStream: (...args: unknown[]) => mockCreateWriteStream(...args),
 }))
 
 // child_process — the run-script route executes approved scripts via
@@ -3076,8 +3091,84 @@ describe('file upload with relativePath — POST /:id/upload-file', () => {
       expect.stringContaining('myfolder/sub'),
       { recursive: true }
     )
-    // Verify writeFile was called
-    expect(mockFsWriteFile).toHaveBeenCalled()
+    // Verify the file was streamed to the destination path
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(
+      expect.stringContaining('myfolder/sub/test.txt'),
+    )
+  })
+
+  it('writes the uploaded bytes to disk unchanged (hash-identical)', async () => {
+    const content = Buffer.from(
+      Array.from({ length: 256 * 1024 }, (_, i) => i % 251),
+    )
+    const formData = new FormData()
+    formData.append('file', new File([content], 'data.bin', { type: 'application/octet-stream' }))
+
+    const res = await postFormData(app, '/api/agents/test-agent/upload-file', formData)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.size).toBe(content.byteLength)
+
+    const sink = mockCreateWriteStream.mock.results[0]!.value as InstanceType<typeof MemoryWriteStream>
+    const written = Buffer.concat(sink.chunks)
+    expect(written.byteLength).toBe(content.byteLength)
+    expect(createHash('sha256').update(written).digest('hex')).toBe(
+      createHash('sha256').update(content).digest('hex'),
+    )
+  })
+
+  it('uploads an empty file', async () => {
+    const formData = new FormData()
+    formData.append('file', new File([], 'empty.txt', { type: 'text/plain' }))
+
+    const res = await postFormData(app, '/api/agents/test-agent/upload-file', formData)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.size).toBe(0)
+    const sink = mockCreateWriteStream.mock.results[0]!.value as InstanceType<typeof MemoryWriteStream>
+    expect(Buffer.concat(sink.chunks).byteLength).toBe(0)
+  })
+
+  it('rejects a request whose Content-Length exceeds the per-request cap without reading the body', async () => {
+    const res = await app.request('http://localhost/api/agents/test-agent/upload-file', {
+      method: 'POST',
+      body: 'tiny',
+      headers: { 'content-length': String(65 * 1024 * 1024) },
+    })
+    expect(res.status).toBe(413)
+    const body = await res.json()
+    expect(body.error).toContain('use chunked upload')
+    expect(mockCreateWriteStream).not.toHaveBeenCalled()
+    expect(mockFsWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects an over-cap body without Content-Length (counted mid-stream) and leaves no partial file', async () => {
+    const formData = new FormData()
+    formData.append('file', new File([Buffer.alloc(65 * 1024 * 1024)], 'big.bin'))
+
+    const res = await postFormData(app, '/api/agents/test-agent/upload-file', formData)
+    expect(res.status).toBe(413)
+    const body = await res.json()
+    expect(body.error).toContain('use chunked upload')
+    expect(mockCreateWriteStream).not.toHaveBeenCalled()
+    expect(mockFsUnlink).not.toHaveBeenCalled()
+  })
+
+  it('removes the partial file when the disk write fails mid-stream', async () => {
+    mockCreateWriteStream.mockImplementationOnce(() => {
+      const failing = new MemoryWriteStream()
+      failing._write = (_chunk, _enc, cb) => cb(new Error('disk full'))
+      return failing
+    })
+    mockFsUnlink.mockResolvedValue(undefined)
+
+    const formData = new FormData()
+    formData.append('file', new File(['payload'], 'doomed.txt', { type: 'text/plain' }))
+
+    const res = await postFormData(app, '/api/agents/test-agent/upload-file', formData)
+    expect(res.status).toBe(500)
+    expect(mockFsUnlink).toHaveBeenCalledWith(expect.stringContaining('uploads'))
   })
 
   it('uploads file without relativePath uses timestamped name', async () => {
@@ -3135,6 +3226,7 @@ describe('file upload with relativePath — POST /:id/upload-file', () => {
     try {
       const res = await postFormData(app, '/api/agents/test-agent/upload-file', formData)
       expect(res.status).toBe(413)
+      expect(mockCreateWriteStream).not.toHaveBeenCalled()
       expect(mockFsWriteFile).not.toHaveBeenCalled()
     } finally {
       sizeSpy.mockRestore()

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1,4 +1,5 @@
 import { Hono, type Context } from 'hono'
+import { bodyLimit } from 'hono/body-limit'
 import { streamSSE } from 'hono/streaming'
 import { getConnInfo } from '@hono/node-server/conninfo'
 import type Anthropic from '@anthropic-ai/sdk'
@@ -181,6 +182,7 @@ import { loadSessionUsageTotals } from '@shared/lib/services/usage-service'
 import { captureException } from '@shared/lib/error-reporting'
 import * as fs from 'fs'
 import { Readable, pipeline } from 'stream'
+import { pipeline as streamPipeline } from 'stream/promises'
 import pLimit from 'p-limit'
 import * as path from 'path'
 import type { ApiAgent } from '@shared/lib/types/api'
@@ -4914,22 +4916,6 @@ function resolveUploadDestPath(agentSlug: string, filename: string, relativePath
   return { uploadPath, fullPath }
 }
 
-// Shared upload logic - writes a buffer to the agent workspace
-async function writeUploadedFile(agentSlug: string, filename: string, buffer: Buffer, relativePath?: string) {
-  const { uploadPath, fullPath } = resolveUploadDestPath(agentSlug, filename, relativePath)
-
-  // Write directly to host filesystem (volume-mounted into container)
-  await fs.promises.mkdir(path.dirname(fullPath), { recursive: true })
-  await fs.promises.writeFile(fullPath, buffer)
-
-  return {
-    success: true,
-    path: `/workspace/${uploadPath}`,
-    filename,
-    size: buffer.byteLength,
-  }
-}
-
 async function writeUploadedFileFromPath(agentSlug: string, filename: string, srcPath: string, relativePath?: string) {
   const { uploadPath, fullPath } = resolveUploadDestPath(agentSlug, filename, relativePath)
   const size = await moveUploadedFile(srcPath, fullPath)
@@ -4945,8 +4931,34 @@ async function handleFileUpload(agentSlug: string, file: File, relativePath?: st
   if (file.size > MAX_UPLOAD_TOTAL_SIZE) {
     throw new UploadTooLargeError(file.size, MAX_UPLOAD_TOTAL_SIZE)
   }
-  const buffer = Buffer.from(await file.arrayBuffer())
-  return writeUploadedFile(agentSlug, file.name, buffer, relativePath)
+  const { uploadPath, fullPath } = resolveUploadDestPath(agentSlug, file.name, relativePath)
+  await fs.promises.mkdir(path.dirname(fullPath), { recursive: true })
+
+  // Stream to disk instead of Buffer.from(await file.arrayBuffer()) — avoids a
+  // second full in-memory copy of the file on top of formData()'s buffering.
+  try {
+    await streamPipeline(
+      Readable.fromWeb(file.stream() as import('stream/web').ReadableStream),
+      fs.createWriteStream(fullPath),
+    )
+  } catch (err) {
+    // Don't leave a partial file behind (pipeline already closed the fd).
+    try {
+      await fs.promises.unlink(fullPath)
+    } catch (cleanupErr) {
+      if ((cleanupErr as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        console.warn('[agents] failed to remove partial upload:', cleanupErr)
+      }
+    }
+    throw err
+  }
+
+  return {
+    success: true,
+    path: `/workspace/${uploadPath}`,
+    filename: file.name,
+    size: file.size,
+  }
 }
 
 // Shared by both upload-file routes. When a `chunk` field is present, persist it
@@ -4955,7 +4967,7 @@ async function handleFileUpload(agentSlug: string, file: File, relativePath?: st
 // `chunk_received` ack) or `{ uploadResult }` once the file is fully assembled.
 type ChunkedFileUploadOutcome = {
   pending: Response | null
-  uploadResult?: Awaited<ReturnType<typeof writeUploadedFile>>
+  uploadResult?: Awaited<ReturnType<typeof writeUploadedFileFromPath>>
 }
 
 async function handleChunkedFileUpload(c: Context, agentSlug: string, formData: FormData, chunk: File): Promise<ChunkedFileUploadOutcome> {
@@ -5034,11 +5046,29 @@ async function respondUploadFile(c: Context) {
   }
 }
 
+// Per-request body cap for the upload-file routes. formData() buffers the whole
+// multipart body in memory, so without this any client (curl, proxies) could
+// POST a single multi-GB body and the server would hold it all in RAM. The web
+// client splits files above 50MB into chunks, so no legitimate request body
+// exceeds ~50MB plus multipart framing; 64MB leaves comfortable headroom.
+// Content-Length requests are rejected from the header alone; bodies without a
+// length (chunked transfer-encoding) are counted and cut off at the cap.
+const MAX_UPLOAD_REQUEST_SIZE = 64 * 1024 * 1024
+
+const uploadRequestBodyLimit = bodyLimit({
+  maxSize: MAX_UPLOAD_REQUEST_SIZE,
+  onError: (c) =>
+    c.json(
+      { error: `Request body too large (max ${MAX_UPLOAD_REQUEST_SIZE / 1024 / 1024}MB per request); use chunked upload for larger files` },
+      413,
+    ),
+})
+
 // POST /api/agents/:id/upload-file - Upload a file to the agent workspace (no session required)
-agents.post('/:id/upload-file', AgentUser(), respondUploadFile)
+agents.post('/:id/upload-file', AgentUser(), uploadRequestBodyLimit, respondUploadFile)
 
 // POST /api/agents/:id/sessions/:sessionId/upload-file - Upload a file to the agent workspace
-agents.post('/:id/sessions/:sessionId/upload-file', AgentUser(), respondUploadFile)
+agents.post('/:id/sessions/:sessionId/upload-file', AgentUser(), uploadRequestBodyLimit, respondUploadFile)
 
 async function handleFolderUpload(agentSlug: string, sourcePath: string) {
   const stat = await fs.promises.stat(sourcePath)


### PR DESCRIPTION
## Problem

The single-request path of the `upload-file` routes buffered whole files in memory with no server-side size limit:

- `src/api/routes/agents.ts:4948` (pre-change): `Buffer.from(await file.arrayBuffer())` materialized a second full in-memory copy of the file on top of `formData()`'s buffering, then wrote it to disk.
- `src/shared/lib/utils/chunked-upload.ts:8`: `MAX_UPLOAD_TOTAL_SIZE` (2GB) governs the chunked path's assembled total — the single-shot path enforced nothing per request.
- `src/renderer/lib/upload.ts:5`: the 50MB chunk split is renderer-side courtesy only; any client (curl, proxies, third-party) could POST a single 2GB body and the server would hold it all in RAM.

## Empirical findings (local probe, 300MB multipart POST to a minimal mounted copy of the route)

Hono/undici `formData()` **fully buffers the multipart body in memory** in this codebase's request path — a route that only calls `formData()` peaked at **+766–896MB RSS** for a 300MB upload (transient parsing copies push it well past 1× file size).

Peak RSS deltas per scenario (fresh server process each, Node 22):

| Scenario | 300MB upload | 50MB upload |
|---|---|---|
| `formData()` only | +766 to +896MB | +157 to +161MB |
| Old path (`arrayBuffer` → `Buffer` → `writeFile`) | +764 to +802MB | +256 to +259MB |
| Streaming write (`file.stream()` → `createWriteStream`) | +895 to +1010MB (GC-noise dominated) | +216 to +224MB |
| **New: size limit precheck → 413** | **+1MB** | n/a (passes, ≈ streaming row) |

Takeaways: the request cap is the fix that actually bounds memory (413 with ~flat RSS, body never read); at the capped size the streaming write reliably removes roughly one file-sized copy (~256MB → ~220MB for 50MB uploads). At uncapped sizes RSS is dominated by `formData()` buffering + GC timing, which is exactly why the cap comes first.

## Fix

1. **Per-request body cap (64MB) on both `upload-file` routes** via `hono/body-limit`: requests carrying a `Content-Length` are rejected from the header alone (413, body never read); bodies without a length (chunked transfer-encoding) are byte-counted and cut off at the cap, bounding worst-case buffering at 64MB. 413 responses keep the `{ error }` JSON shape.
2. **Streaming disk write** for the single-shot path: `pipeline(Readable.fromWeb(file.stream()), createWriteStream(...))` replaces `Buffer.from(await file.arrayBuffer())` + `writeFile`, removing the avoidable second full copy.
3. **Partial-file cleanup**: a mid-stream write failure unlinks the destination file (pipeline closes the fd) and surfaces the existing 500.

**Limit rationale (64MB):** the renderer splits anything above 50MB into chunks (`UPLOAD_CHUNK_SIZE`), so no legitimate request body exceeds ~50MB + multipart framing. I verified every producer: all four renderer call sites go through `uploadFileChunked` (files >50MB → chunked); the cloud proxy only forwards those same renderer requests; Slack/chat attachments are written server-side via `chat-integration-manager`, not this route; import flows use the separate `import-template` route (untouched). 64MB leaves comfortable headroom over 50MB + framing while staying under Cloudflare's 100MB edge limit that cloud deployments already live with.

Response shapes and status codes for all currently-valid requests are unchanged (single-shot success payload, chunk acks, existing 400/413/500 paths). The chunked-upload assembly path is untouched.

## Validation

- Baseline upload suites green before the change; after: `src/api/routes/agents.test.ts` (346) and `src/shared/lib/utils/chunked-upload.test.ts` (9) all pass, plus `security-repro`, `agents-owner-acl-rollback`, `agents.delete-ordering` (29).
- New tests: uploaded bytes on disk hash-identical (sha256) to source; empty file; oversize via `Content-Length` → 413 with no body read and no write attempted; oversize body without `Content-Length` → 413 counted mid-stream, no partial file; mid-stream disk-write failure → 500 and partial file unlinked; existing filename/traversal/chunked-assembly tests unchanged and green.
- E2E: `e2e/specs/file-upload.spec.ts` — 5/5 passed (mock mode).
- `npx tsc --noEmit` clean; eslint clean on touched files (repo-wide: 0 errors, 13 pre-existing warnings elsewhere).
- Renderer check: `src/renderer/lib/upload.ts` sends single-shot only when `file.size <= UPLOAD_CHUNK_SIZE` (50MB); anything larger goes through the chunked path, so no client-visible behavior changes.

## Follow-ups (out of scope here)

- `formData()` itself still buffers up to the cap per request; truly streaming multipart parsing (e.g. busboy) would remove that, and was explicitly out of scope for this change.
- The `import-template` single-shot path has the same `arrayBuffer` copy pattern (bounded by its own 500MB `MAX_COMPRESSED_SIZE` check but not by a pre-body-read cap); worth the same treatment separately.

Fixes SUP-584

https://claude.ai/code/session_01BiCd95jC6zB19Pxi9CQdGF