### PR TITLE
perf: stream raw session log instead of buffering the whole file

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -17,6 +17,7 @@ const mockFsMkdir = vi.fn()
 const mockFsReaddir = vi.fn()
 const mockFsCp = vi.fn()
 const mockFsExistsSync = vi.fn()
+const mockFsOpen = vi.fn()
 const mockCreateReadStream = vi.fn()
 
 // In-memory sink for the streaming upload write path; tests can inspect the
@@ -48,6 +49,7 @@ vi.mock('fs', () => ({
       rename: (...args: unknown[]) => mockFsRename(...args),
       unlink: (...args: unknown[]) => mockFsUnlink(...args),
       rm: (...args: unknown[]) => mockFsRm(...args),
+      open: (...args: unknown[]) => mockFsOpen(...args),
     },
     existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
     createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
@@ -65,6 +67,7 @@ vi.mock('fs', () => ({
     rename: (...args: unknown[]) => mockFsRename(...args),
     unlink: (...args: unknown[]) => mockFsUnlink(...args),
     rm: (...args: unknown[]) => mockFsRm(...args),
+    open: (...args: unknown[]) => mockFsOpen(...args),
   },
   existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
   createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
@@ -562,7 +565,7 @@ import { containerManager } from '@shared/lib/container/container-manager'
 import { listUserSecrets, setSecret, updateSecret, getSecret, getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { keyToEnvVar } from '@shared/lib/utils/secrets'
 import { logAuditEventOrThrow } from '@shared/lib/services/audit-log-service'
-import { readJsonFileStrict, readJsonlFile, writeJsonFileAtomic } from '@shared/lib/utils/file-storage'
+import { readJsonFileStrict, readJsonlFile, writeJsonFileAtomic, readFileOrNull } from '@shared/lib/utils/file-storage'
 import { listChatIntegrations } from '@shared/lib/services/chat-integration-service'
 import { listWebhookTriggers } from '@shared/lib/services/webhook-trigger-service'
 
@@ -1024,6 +1027,110 @@ describe('session usage — GET /:id/sessions/:sessionId/usage', () => {
 
     expect(res.status).toBe(404)
     expect(mockLoadSessionUsageTotals).not.toHaveBeenCalled()
+  })
+})
+
+describe('session raw log — GET /:id/sessions/:sessionId/raw-log', () => {
+  let app: ReturnType<typeof createApp>
+  let realFs: typeof import('fs')
+  let realPath: typeof import('path')
+  let tmpDir: string
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    app = createApp()
+    realFs = await vi.importActual<typeof import('fs')>('fs')
+    realPath = await vi.importActual<typeof import('path')>('path')
+    const realOs = await vi.importActual<typeof import('os')>('os')
+    tmpDir = await realFs.promises.mkdtemp(realPath.join(realOs.tmpdir(), 'raw-log-route-'))
+
+    // Back the route with the real filesystem so the body assertions compare
+    // genuine bytes: point the transcript path at a temp file and delegate the
+    // fs helpers (both the readFileOrNull and open/createReadStream paths) to
+    // the real implementations.
+    mockGetSessionJsonlPath.mockImplementation(
+      (_agentSlug: string, sessionId: string) => realPath.join(tmpDir, `${sessionId}.jsonl`),
+    )
+    mockFsOpen.mockImplementation((...args: unknown[]) =>
+      (realFs.promises.open as (...a: unknown[]) => Promise<unknown>)(...args),
+    )
+    mockFsReadFile.mockImplementation((...args: unknown[]) =>
+      (realFs.promises.readFile as (...a: unknown[]) => Promise<unknown>)(...args),
+    )
+    vi.mocked(readFileOrNull).mockImplementation(async (filePath: string) => {
+      try {
+        return await realFs.promises.readFile(filePath, 'utf-8')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+        throw error
+      }
+    })
+  })
+
+  afterEach(async () => {
+    await realFs.promises.rm(tmpDir, { recursive: true, force: true })
+    // These implementations must not leak into other suites (vi.clearAllMocks
+    // clears calls, not implementations).
+    mockGetSessionJsonlPath.mockImplementation(
+      (agentSlug: string, sessionId: string) => `/mock/sessions/${agentSlug}/${sessionId}.jsonl`,
+    )
+    mockFsOpen.mockReset()
+    mockFsReadFile.mockReset()
+    vi.mocked(readFileOrNull).mockReset()
+  })
+
+  async function writeTranscript(sessionId: string, content: string | Buffer) {
+    await realFs.promises.writeFile(realPath.join(tmpDir, `${sessionId}.jsonl`), content)
+  }
+
+  it('returns the transcript byte-identical to the file with the plain-text content type', async () => {
+    const content =
+      '{"type":"user","message":{"content":"héllo — ünïcode"}}\n' +
+      '{"type":"assistant","message":{"content":"line two"}}\n'
+    await writeTranscript('session-1', content)
+
+    const res = await getReq(app, '/api/agents/test-agent/sessions/session-1/raw-log')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
+    const body = Buffer.from(await res.arrayBuffer())
+    const fileBytes = await realFs.promises.readFile(realPath.join(tmpDir, 'session-1.jsonl'))
+    expect(body.equals(fileBytes)).toBe(true)
+    expect(res.headers.get('content-length')).toBe(String(fileBytes.length))
+  })
+
+  it('returns 404 when the transcript file does not exist', async () => {
+    const res = await getReq(app, '/api/agents/test-agent/sessions/missing/raw-log')
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Session log not found' })
+  })
+
+  it('returns an empty 200 body for an empty transcript file', async () => {
+    await writeTranscript('empty-session', '')
+
+    const res = await getReq(app, '/api/agents/test-agent/sessions/empty-session/raw-log')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
+    expect(Buffer.from(await res.arrayBuffer()).length).toBe(0)
+    expect(res.headers.get('content-length')).toBe('0')
+  })
+
+  it('returns a multi-megabyte transcript byte-identical to the file', async () => {
+    const line = `{"type":"assistant","message":{"content":"${'x'.repeat(1024)}"}}\n`
+    const content = line.repeat(5 * 1024) // ~5.3 MB
+    await writeTranscript('big-session', content)
+
+    const res = await getReq(app, '/api/agents/test-agent/sessions/big-session/raw-log')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
+    const body = Buffer.from(await res.arrayBuffer())
+    const fileBytes = await realFs.promises.readFile(realPath.join(tmpDir, 'big-session.jsonl'))
+    expect(body.length).toBe(fileBytes.length)
+    expect(body.equals(fileBytes)).toBe(true)
+    expect(res.headers.get('content-length')).toBe(String(fileBytes.length))
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1941,8 +1941,18 @@ agents.get('/:id/sessions/:sessionId/raw-log', AgentRead(), async (c) => {
       await fileHandle.close().catch(() => {})
       throw error
     })
+    // An empty-at-open file must answer with an empty body even if the live
+    // transcript gains its first append before the read starts — an unbounded
+    // stream there would overrun the advertised Content-Length of 0.
+    if (size === 0) {
+      await fileHandle.close().catch(() => {})
+      return c.body('', 200, {
+        'Content-Type': 'text/plain; charset=UTF-8',
+        'Content-Length': '0',
+      })
+    }
     // autoClose (default) closes the handle on end/destroy.
-    const source = fileHandle.createReadStream(size > 0 ? { end: size - 1 } : undefined)
+    const source = fileHandle.createReadStream({ end: size - 1 })
     source.on('error', (err) => {
       // Client disconnects surface here as stream aborts and are routine on a
       // multi-MB endpoint; only report real read failures.

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -69,7 +69,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, readFileOrNull, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonArrayStringifyTransform } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonArrayStringifyTransform } from '@shared/lib/utils/file-storage'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
@@ -1923,13 +1923,39 @@ agents.get('/:id/sessions/:sessionId/raw-log', AgentRead(), async (c) => {
 
 
     const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
-    const content = await readFileOrNull(jsonlPath)
 
-    if (content === null) {
+    // Transcripts routinely reach tens of MB, so stream the file instead of
+    // buffering it whole. Open before committing to a 200 so a missing file
+    // still returns the 404 below (ENOENT → null, mirroring readFileOrNull).
+    const fileHandle = await fs.promises.open(jsonlPath, 'r').catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return null
+      throw error
+    })
+    if (fileHandle === null) {
       return c.json({ error: 'Session log not found' }, 404)
     }
 
-    return c.text(content)
+    // Bound the read to the size at open so the byte count always matches the
+    // Content-Length we advertise, even if the live transcript keeps growing.
+    const { size } = await fileHandle.stat().catch(async (error: unknown) => {
+      await fileHandle.close().catch(() => {})
+      throw error
+    })
+    // autoClose (default) closes the handle on end/destroy.
+    const source = fileHandle.createReadStream(size > 0 ? { end: size - 1 } : undefined)
+    source.on('error', (err) => {
+      // Client disconnects surface here as stream aborts and are routine on a
+      // multi-MB endpoint; only report real read failures.
+      const code = (err as NodeJS.ErrnoException)?.code
+      if (code === 'ABORT_ERR' || code === 'ERR_STREAM_PREMATURE_CLOSE') return
+      console.error('Failed to stream raw log:', err)
+      captureException(err, { tags: { component: 'agents', operation: 'stream-raw-log' } })
+    })
+    // Same headers the buffered c.text() response carried on the wire.
+    return c.body(Readable.toWeb(source) as ReadableStream, 200, {
+      'Content-Type': 'text/plain; charset=UTF-8',
+      'Content-Length': String(size),
+    })
   } catch (error) {
     console.error('Failed to fetch raw log:', error)
     return c.json({ error: 'Failed to fetch raw log' }, 500)


### PR DESCRIPTION
## Problem

`GET /api/agents/:id/sessions/:sessionId/raw-log` (`src/api/routes/agents.ts:1918` on main) did `readFileOrNull(jsonlPath)` and returned the entire transcript as one string via `c.text(content)` — the full file in host memory per request. Transcripts routinely reach 35MB and exceed 100MB when tool results carry base64 screenshots, so a few concurrent raw-log fetches could hold hundreds of MB.

## Fix

Stream the file: `fs.promises.open` → `fileHandle.createReadStream` → `Readable.toWeb` → `c.body(...)`.

- **Missing file keeps today's path**: the handle is opened *before* committing to a 200; ENOENT maps to the same `404 {"error":"Session log not found"}` (mirroring `readFileOrNull`'s ENOENT→null). Any other open/stat error still falls through to the same `500 {"error":"Failed to fetch raw log"}`.
- **Abort filter before Sentry**: `@hono/node-server` cancels the returned web stream when the client socket closes, which surfaces on the read stream as `ABORT_ERR` / `ERR_STREAM_PREMATURE_CLOSE`. The stream error handler filters those two codes before `captureException` (same pattern as the GET /messages stream from #752), so routine disconnects on a multi-MB endpoint don't flood Sentry.
- **Read bounded to size-at-open**: `createReadStream({ end: size - 1 })` guarantees the body byte count always equals the advertised `Content-Length`, even while a live session keeps appending to the transcript.
- **Empty file answered directly** (`ff524f71`, from review): a size-0 file was the one branch without an end bound, so a live transcript gaining its first append in the stat→read window could emit bytes against `Content-Length: 0` (a content-length mismatch the abort filter doesn't cover). The route now closes the handle and returns the empty body with identical headers; verified no fd leak (fd count flat over 50 iterations of the branch).

## Why the response is byte-identical

On the real wire, the old `c.text(content)` took Hono's bare `new Response(text)` shortcut and `@hono/node-server` stamped `Content-Type: text/plain; charset=UTF-8` plus `Content-Length`. The new response sets exactly those two headers (`Content-Length` from the size at open), so status, headers, and body bytes are unchanged — verified empirically below, including no `Transfer-Encoding: chunked`. (Note: in the vitest harness the *old* code's content-type appeared as undici's `text/plain;charset=UTF-8` — the space variant is what node-server actually serves, proven old-vs-new in the live harness.)

## Validation

**Pinned regression tests** (`src/api/routes/agents.test.ts`, new `session raw log` describe, backed by real temp files): existing file byte-identical to `fs.readFile`, missing file 404 + exact JSON body, empty file 200 with zero-byte body, ~5.3MB file byte-identical + correct `Content-Length`. The status/body/404 pins were written first and verified green against the old implementation (345/345) before the route change, then re-run green against the new one (345/345).

**Live repro against the real `@hono/node-server`** (standalone harness serving the old and new handlers side by side; deleted before commit): 18/18 checks —

```
PASS  happy: old status/new status both 200
PASS  happy: content-type identical  — old="text/plain; charset=UTF-8" new="text/plain; charset=UTF-8"
PASS  happy: content-length identical  — old=37212000 new=37212000
PASS  happy: transfer-encoding identical  — old=null new=null
PASS  happy: new body byte-identical to old body  — 37212000 vs 37212000 bytes
PASS  happy: new body byte-identical to file on disk
PASS  missing: status 404/404
PASS  missing: body identical  — {"error":"Session log not found"} vs {"error":"Session log not found"}
PASS  missing: content-type identical
PASS  empty: status 200/200
PASS  empty: both bodies zero bytes
PASS  empty: content-type identical  — "text/plain; charset=UTF-8"
PASS  empty: content-length identical  — old=0 new=0
PASS  disconnect: zero Sentry-equivalent captures  — captures=0
PASS  disconnect: abort actually reached the error handler and was filtered  — abortsFiltered=1
PASS  disconnect: no uncaught errors
PASS  delete-mid-stream: process survived, read handled  — read 37212000 bytes, error=none
PASS  delete-mid-stream: no uncaught errors
```

The disconnect check kills the client socket mid-body on a 35MB transfer: the cancellation demonstrably reached the stream error handler (`abortsFiltered=1`) and produced zero Sentry-equivalent captures and zero uncaught errors. Deleting the file mid-stream completed cleanly (open fd stays valid) with no crash.

**Gates**: `npx vitest run src/api/routes/agents.test.ts src/shared/lib/utils/file-storage.test.ts` → 441 passed; `npx tsc --noEmit` clean; `npx eslint` clean on touched files (0 errors repo-wide).

Fixes SUP-581

https://claude.ai/code/session_01BiCd95jC6zB19Pxi9CQdGF
