### PR TITLE
perf: stream transcript rewrites and bound the append dedup scan

### DIFF
--- a/src/shared/lib/services/session-service.transcript-rewrite.test.ts
+++ b/src/shared/lib/services/session-service.transcript-rewrite.test.ts
@@ -1,0 +1,534 @@
+/**
+ * Differential tests for the streaming transcript rewrite in removeMessage /
+ * removeToolCall.
+ *
+ * The previous implementation parsed the whole transcript, filtered it, and
+ * rewrote every line via JSON.stringify — costing 3-4x the file size in peak
+ * memory and re-serializing (i.e. potentially re-formatting) every byte of the
+ * file. The streaming implementation must make the SAME keep/drop/modify
+ * decisions, while copying every untouched line through byte-for-byte.
+ *
+ * Each test runs the OLD implementation as an in-test oracle over the same
+ * input and asserts the new on-disk result is semantically identical, plus
+ * byte-fidelity properties the old implementation did not have.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+import { removeMessage, removeToolCall } from './session-service'
+
+// ---------------------------------------------------------------------------
+// Oracle: the previous implementation, verbatim logic, operating on a raw
+// transcript string. Returns the rewritten content, or null for "not found"
+// (in which case the old code left the file untouched).
+// ---------------------------------------------------------------------------
+
+type AnyEntry = Record<string, any>
+
+function oracleParseJsonl(content: string): AnyEntry[] {
+  const results: AnyEntry[] = []
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      results.push(JSON.parse(trimmed))
+    } catch {
+      // old behavior: skip malformed lines
+    }
+  }
+  return results
+}
+
+function oracleRemoveMessage(content: string, messageUuid: string): string | null {
+  const entries = oracleParseJsonl(content)
+
+  const matchesTargetId = (e: AnyEntry): boolean =>
+    ('uuid' in e && e.uuid === messageUuid) ||
+    (e.type === 'attachment' && e.attachment?.source_uuid === messageUuid)
+
+  const target = entries.find(matchesTargetId)
+  if (!target) return null
+
+  const messageIdsToRemove = new Set<string>()
+  const toolUseIdsToRemove = new Set<string>()
+
+  if (target.type === 'assistant' && target.message.id) {
+    messageIdsToRemove.add(target.message.id)
+    for (const entry of entries) {
+      if (!('message' in entry)) continue
+      if (entry.type === 'assistant' && entry.message.id === target.message.id) {
+        const blocks = entry.message.content
+        if (Array.isArray(blocks)) {
+          for (const block of blocks) {
+            if (block.type === 'tool_use') toolUseIdsToRemove.add(block.id)
+          }
+        }
+      }
+    }
+  }
+
+  const filtered = entries.filter((entry) => {
+    if (matchesTargetId(entry)) return false
+    if (!('uuid' in entry)) return true
+    if (entry.type === 'assistant' && entry.message.id && messageIdsToRemove.has(entry.message.id))
+      return false
+    if (entry.type === 'user' && toolUseIdsToRemove.size > 0) {
+      const blocks = entry.message.content
+      if (Array.isArray(blocks)) {
+        if (
+          blocks.every(
+            (b: AnyEntry) => b.type === 'tool_result' && toolUseIdsToRemove.has(b.tool_use_id)
+          )
+        ) {
+          return false
+        }
+      }
+    }
+    return true
+  })
+
+  return filtered.map((e) => JSON.stringify(e)).join('\n') + (filtered.length > 0 ? '\n' : '')
+}
+
+function oracleRemoveToolCall(content: string, toolCallId: string): string | null {
+  const entries = oracleParseJsonl(content)
+  let found = false
+  const filtered: AnyEntry[] = []
+
+  for (const entry of entries) {
+    if (!('message' in entry)) {
+      filtered.push(entry)
+      continue
+    }
+    if (entry.type === 'user' && Array.isArray(entry.message.content)) {
+      const blocks = entry.message.content
+      const remaining = blocks.filter(
+        (b: AnyEntry) => !(b.type === 'tool_result' && b.tool_use_id === toolCallId)
+      )
+      if (remaining.length < blocks.length) {
+        found = true
+        if (remaining.length === 0) continue
+        filtered.push({ ...entry, message: { ...entry.message, content: remaining } })
+        continue
+      }
+    }
+    if (entry.type === 'assistant' && Array.isArray(entry.message.content)) {
+      const blocks = entry.message.content
+      const remaining = blocks.filter(
+        (b: AnyEntry) => !(b.type === 'tool_use' && b.id === toolCallId)
+      )
+      if (remaining.length < blocks.length) {
+        found = true
+        if (remaining.length === 0) continue
+        filtered.push({ ...entry, message: { ...entry.message, content: remaining } })
+        continue
+      }
+    }
+    filtered.push(entry)
+  }
+
+  if (!found) return null
+  return filtered.map((e) => JSON.stringify(e)).join('\n') + (filtered.length > 0 ? '\n' : '')
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function userEntry(uuid: string, text: string): AnyEntry {
+  return {
+    type: 'user',
+    uuid,
+    parentUuid: null,
+    sessionId: 'sess-1',
+    timestamp: '2026-01-24T01:00:00.000Z',
+    message: { role: 'user', content: text },
+  }
+}
+
+function assistantEntry(uuid: string, messageId: string, blocks: AnyEntry[]): AnyEntry {
+  return {
+    type: 'assistant',
+    uuid,
+    parentUuid: null,
+    sessionId: 'sess-1',
+    timestamp: '2026-01-24T01:00:01.000Z',
+    message: { role: 'assistant', content: blocks, id: messageId },
+  }
+}
+
+function toolResultEntry(uuid: string, toolUseId: string, result: string): AnyEntry {
+  return {
+    type: 'user',
+    uuid,
+    parentUuid: null,
+    sessionId: 'sess-1',
+    timestamp: '2026-01-24T01:00:02.000Z',
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: toolUseId, content: result }],
+    },
+  }
+}
+
+/** Lines exercising bytes that a parse-and-restringify pass would NOT
+ *  round-trip: non-canonical spacing, unicode escapes, float formatting. */
+const NON_CANONICAL_LINES = [
+  '{"type": "user",  "uuid": "spaced-1", "message": {"role": "user", "content": "caf\\u00e9"}, "sortWeight": 1.0}',
+  '{"type":"user","uuid":"unicode-1","message":{"role":"user","content":"héllo 🌍 日本語 \\"quoted\\" back\\\\slash"}}',
+]
+
+/** A tool-free filler transcript body of roughly `bytes` bytes. */
+function fillerLines(bytes: number, prefix: string): string[] {
+  const lines: string[] = []
+  const text = 'x'.repeat(2048)
+  let total = 0
+  let i = 0
+  while (total < bytes) {
+    const line = JSON.stringify(userEntry(`${prefix}-${i++}`, text))
+    lines.push(line)
+    total += line.length + 1
+  }
+  return lines
+}
+
+const longBase64Line = JSON.stringify(
+  userEntry('base64-1', Buffer.from('binary'.repeat(400000)).toString('base64'))
+)
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+describe('transcript rewrite (streaming) vs previous implementation', () => {
+  let testDir: string
+  let originalEnv: string | undefined
+  let sessionsDir: string
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'transcript-rewrite-test-'))
+    originalEnv = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testDir
+    sessionsDir = path.join(testDir, 'agents', 'test-agent', 'workspace', '.claude', 'projects', '-workspace')
+    await fs.promises.mkdir(sessionsDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    if (originalEnv) {
+      process.env.SUPERAGENT_DATA_DIR = originalEnv
+    } else {
+      delete process.env.SUPERAGENT_DATA_DIR
+    }
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  function jsonlPath(sessionId: string): string {
+    return path.join(sessionsDir, `${sessionId}.jsonl`)
+  }
+
+  async function writeTranscript(sessionId: string, raw: string): Promise<void> {
+    await fs.promises.writeFile(jsonlPath(sessionId), raw)
+  }
+
+  async function readTranscript(sessionId: string): Promise<string> {
+    return fs.promises.readFile(jsonlPath(sessionId), 'utf-8')
+  }
+
+  async function listTempFiles(): Promise<string[]> {
+    const names = await fs.promises.readdir(sessionsDir)
+    return names.filter((n) => n.endsWith('.tmp'))
+  }
+
+  /**
+   * Core differential assertion:
+   *  - the new on-disk result parses to the same entries as the oracle output
+   *  - every output line that is not an expected modification appears
+   *    byte-identically in the input (untouched lines are never re-serialized)
+   */
+  function assertDifferential(
+    inputRaw: string,
+    actualRaw: string,
+    oracleRaw: string,
+    opts: { allowModifiedLine?: (line: string) => boolean } = {}
+  ): void {
+    expect(oracleParseJsonl(actualRaw)).toEqual(oracleParseJsonl(oracleRaw))
+    const inputLines = new Set(inputRaw.split('\n'))
+    for (const line of actualRaw.split('\n')) {
+      if (line === '') continue
+      if (inputLines.has(line)) continue
+      if (opts.allowModifiedLine?.(line)) continue
+      throw new Error(`output line was re-serialized (not byte-identical to input): ${line.slice(0, 120)}`)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // removeMessage
+  // -------------------------------------------------------------------------
+
+  describe('removeMessage', () => {
+    function buildTranscript(targetPosition: 'start' | 'middle' | 'end'): string {
+      const target = JSON.stringify(userEntry('target-uuid', 'delete me'))
+      const front = fillerLines(1_500_000, 'front')
+      const back = fillerLines(1_500_000, 'back')
+      const middle = [...NON_CANONICAL_LINES, longBase64Line]
+      const lines =
+        targetPosition === 'start'
+          ? [target, ...front, ...middle, ...back]
+          : targetPosition === 'end'
+            ? [...front, ...middle, ...back, target]
+            : [...front, ...middle, target, ...back]
+      return lines.join('\n') + '\n'
+    }
+
+    for (const position of ['start', 'middle', 'end'] as const) {
+      it(`matches the old implementation on a multi-MB transcript (target at ${position})`, async () => {
+        const input = buildTranscript(position)
+        await writeTranscript('sess-1', input)
+
+        const oracle = oracleRemoveMessage(input, 'target-uuid')
+        expect(oracle).not.toBeNull()
+
+        const result = await removeMessage('test-agent', 'sess-1', 'target-uuid')
+        expect(result).toBe(true)
+
+        const actual = await readTranscript('sess-1')
+        assertDifferential(input, actual, oracle!)
+        // The non-canonical lines were untouched, so their exact original
+        // bytes must survive (the old implementation would have normalized
+        // them — proving the rewrite no longer re-serializes kept lines).
+        for (const line of NON_CANONICAL_LINES) {
+          expect(actual.includes(line)).toBe(true)
+        }
+        expect(await listTempFiles()).toEqual([])
+      })
+    }
+
+    it('removes an assistant message spanning multiple entries plus its tool_results, like the old implementation', async () => {
+      const lines = [
+        JSON.stringify(userEntry('user-1', 'hi')),
+        // Streamed assistant turn: two entries share message.id, each with a tool_use
+        JSON.stringify(
+          assistantEntry('asst-1-part-1', 'msg-1', [
+            { type: 'text', text: 'part one' },
+            { type: 'tool_use', id: 'tc-1', name: 'Bash', input: { command: 'ls' } },
+          ])
+        ),
+        JSON.stringify(
+          assistantEntry('asst-1-part-2', 'msg-1', [
+            { type: 'tool_use', id: 'tc-2', name: 'Read', input: { file: 'a.txt' } },
+          ])
+        ),
+        JSON.stringify(toolResultEntry('tr-1', 'tc-1', 'out-1')),
+        JSON.stringify(toolResultEntry('tr-2', 'tc-2', 'out-2')),
+        JSON.stringify(assistantEntry('asst-2', 'msg-2', [{ type: 'text', text: 'done' }])),
+        ...NON_CANONICAL_LINES,
+      ]
+      const input = lines.join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const oracle = oracleRemoveMessage(input, 'asst-1-part-1')
+      const result = await removeMessage('test-agent', 'sess-1', 'asst-1-part-1')
+      expect(result).toBe(true)
+
+      const actual = await readTranscript('sess-1')
+      assertDifferential(input, actual, oracle!)
+      const remainingUuids = oracleParseJsonl(actual).map((e) => e.uuid)
+      expect(remainingUuids).toEqual(['user-1', 'asst-2', 'spaced-1', 'unicode-1'])
+    })
+
+    it('removes a queued message by attachment source_uuid, like the old implementation', async () => {
+      const attachment = {
+        type: 'attachment',
+        uuid: 'attachment-entry-uuid',
+        parentUuid: 'user-1',
+        sessionId: 'sess-1',
+        timestamp: '2026-01-24T01:00:05.000Z',
+        attachment: {
+          type: 'queued_command',
+          prompt: [{ type: 'text', text: 'Queued steer' }],
+          source_uuid: 'queue-source-uuid',
+          commandMode: 'prompt',
+        },
+      }
+      const lines = [JSON.stringify(userEntry('user-1', 'start')), JSON.stringify(attachment)]
+      const input = lines.join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const oracle = oracleRemoveMessage(input, 'queue-source-uuid')
+      const result = await removeMessage('test-agent', 'sess-1', 'queue-source-uuid')
+      expect(result).toBe(true)
+      assertDifferential(input, await readTranscript('sess-1'), oracle!)
+    })
+
+    it('handles a file without a trailing newline (adds one, same as the old implementation)', async () => {
+      const lines = [
+        JSON.stringify(userEntry('user-1', 'first')),
+        JSON.stringify(userEntry('target-uuid', 'delete me')),
+        JSON.stringify(userEntry('user-3', 'last')),
+      ]
+      const input = lines.join('\n') // no trailing newline
+      await writeTranscript('sess-1', input)
+
+      const oracle = oracleRemoveMessage(input, 'target-uuid')
+      const result = await removeMessage('test-agent', 'sess-1', 'target-uuid')
+      expect(result).toBe(true)
+
+      const actual = await readTranscript('sess-1')
+      expect(actual).toBe(oracle) // identical here: kept lines were canonical
+      expect(actual.endsWith('\n')).toBe(true)
+    })
+
+    it('returns false and leaves the file byte-identical when the uuid is not found', async () => {
+      const input = [...NON_CANONICAL_LINES, JSON.stringify(userEntry('user-1', 'hi'))].join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const result = await removeMessage('test-agent', 'sess-1', 'nonexistent-uuid')
+      expect(result).toBe(false)
+      expect(await readTranscript('sess-1')).toBe(input)
+      expect(await listTempFiles()).toEqual([])
+    })
+
+    it('preserves blank and malformed (mid-write) lines byte-for-byte', async () => {
+      // Deliberate difference from the old implementation, which silently
+      // DROPPED blank/malformed lines on every rewrite. Malformed lines are
+      // usually a concurrent SDK write in progress; discarding them was a
+      // destructive side effect, not a feature. The streaming rewrite copies
+      // them through untouched.
+      const malformed = '{"type":"user","uuid":"truncated-'
+      const input = [
+        JSON.stringify(userEntry('user-1', 'keep me')),
+        '',
+        malformed,
+        JSON.stringify(userEntry('target-uuid', 'delete me')),
+      ].join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const result = await removeMessage('test-agent', 'sess-1', 'target-uuid')
+      expect(result).toBe(true)
+
+      const actual = await readTranscript('sess-1')
+      expect(actual.split('\n')).toContain(malformed)
+      expect(actual.split('\n')).toContain('')
+      expect(oracleParseJsonl(actual).map((e) => e.uuid)).toEqual(['user-1'])
+    })
+
+    it('cleans up the temp file and leaves the original untouched when the rewrite fails', async () => {
+      const input = [
+        JSON.stringify(userEntry('user-1', 'hi')),
+        JSON.stringify(userEntry('target-uuid', 'delete me')),
+      ].join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const err = Object.assign(new Error('injected rename failure'), { code: 'EIO' })
+      const renameSpy = vi.spyOn(fs.promises, 'rename').mockRejectedValue(err)
+      try {
+        await expect(removeMessage('test-agent', 'sess-1', 'target-uuid')).rejects.toThrow(
+          'injected rename failure'
+        )
+      } finally {
+        renameSpy.mockRestore()
+      }
+
+      expect(await readTranscript('sess-1')).toBe(input)
+      expect(await listTempFiles()).toEqual([])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // removeToolCall
+  // -------------------------------------------------------------------------
+
+  describe('removeToolCall', () => {
+    it('strips the tool_use block and drops the tool_result entry, matching the old implementation', async () => {
+      const lines = [
+        JSON.stringify(userEntry('user-1', 'hi')),
+        JSON.stringify(
+          assistantEntry('asst-1', 'msg-1', [
+            { type: 'text', text: 'running a tool' },
+            { type: 'tool_use', id: 'tc-1', name: 'Bash', input: { command: 'ls' } },
+          ])
+        ),
+        JSON.stringify(toolResultEntry('tr-1', 'tc-1', 'out')),
+        ...NON_CANONICAL_LINES,
+        longBase64Line,
+      ]
+      const input = lines.join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const oracle = oracleRemoveToolCall(input, 'tc-1')
+      const result = await removeToolCall('test-agent', 'sess-1', 'tc-1')
+      expect(result).toBe(true)
+
+      const actual = await readTranscript('sess-1')
+      // The assistant line is legitimately modified (tool_use stripped);
+      // everything else must be byte-identical to the input.
+      assertDifferential(input, actual, oracle!, {
+        allowModifiedLine: (line) => JSON.parse(line).uuid === 'asst-1',
+      })
+      for (const line of NON_CANONICAL_LINES) {
+        expect(actual.includes(line)).toBe(true)
+      }
+      expect(actual.includes(longBase64Line)).toBe(true)
+      expect(await listTempFiles()).toEqual([])
+    })
+
+    it('drops entries whose content becomes empty, matching the old implementation', async () => {
+      const lines = [
+        JSON.stringify(userEntry('user-1', 'hi')),
+        JSON.stringify(
+          assistantEntry('asst-1', 'msg-1', [
+            { type: 'tool_use', id: 'tc-1', name: 'Bash', input: { command: 'ls' } },
+          ])
+        ),
+        JSON.stringify(toolResultEntry('tr-1', 'tc-1', 'out')),
+      ]
+      const input = lines.join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const oracle = oracleRemoveToolCall(input, 'tc-1')
+      const result = await removeToolCall('test-agent', 'sess-1', 'tc-1')
+      expect(result).toBe(true)
+
+      const actual = await readTranscript('sess-1')
+      assertDifferential(input, actual, oracle!)
+      expect(oracleParseJsonl(actual).map((e) => e.uuid)).toEqual(['user-1'])
+    })
+
+    it('returns false and leaves the file byte-identical when the tool call is not found', async () => {
+      const input = [...NON_CANONICAL_LINES, JSON.stringify(userEntry('user-1', 'hi'))].join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const result = await removeToolCall('test-agent', 'sess-1', 'nonexistent-tc')
+      expect(result).toBe(false)
+      expect(await readTranscript('sess-1')).toBe(input)
+      expect(await listTempFiles()).toEqual([])
+    })
+
+    it('matches the old implementation on a multi-MB transcript', async () => {
+      const lines = [
+        ...fillerLines(2_000_000, 'front'),
+        JSON.stringify(
+          assistantEntry('asst-1', 'msg-1', [
+            { type: 'text', text: 'keep this text' },
+            { type: 'tool_use', id: 'tc-1', name: 'Bash', input: { command: 'ls' } },
+          ])
+        ),
+        JSON.stringify(toolResultEntry('tr-1', 'tc-1', 'out')),
+        ...fillerLines(2_000_000, 'back'),
+      ]
+      const input = lines.join('\n') + '\n'
+      await writeTranscript('sess-1', input)
+
+      const oracle = oracleRemoveToolCall(input, 'tc-1')
+      const result = await removeToolCall('test-agent', 'sess-1', 'tc-1')
+      expect(result).toBe(true)
+
+      assertDifferential(input, await readTranscript('sess-1'), oracle!, {
+        allowModifiedLine: (line) => JSON.parse(line).uuid === 'asst-1',
+      })
+    })
+  })
+})

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -17,7 +17,6 @@ import {
   listDirectories,
   directoryExists,
   fileExists,
-  writeFile,
   writeJsonFileAtomic,
   readJsonFileStrict,
   withFileLock,
@@ -25,6 +24,9 @@ import {
   readJsonlFile,
   streamJsonlFile,
   parseJsonl,
+  streamFileLines,
+  parseJsonlLine,
+  writeFileAtomicStream,
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
@@ -1231,8 +1233,6 @@ export async function removeMessage(
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   if (!(await fileExists(jsonlPath))) return false
 
-  const entries = await readJsonlFile<JsonlEntry>(jsonlPath)
-
   // Find the target entry by id. Regular messages match by top-level uuid;
   // queued (mid-turn) messages surface in the UI with id = the queued_command
   // attachment's source_uuid (see normalizeQueuedCommandEntry), so match the
@@ -1241,7 +1241,23 @@ export async function removeMessage(
     ('uuid' in e && e.uuid === messageUuid) ||
     (e.type === 'attachment' && (e as JsonlAttachmentEntry).attachment?.source_uuid === messageUuid)
 
-  const target = entries.find(matchesTargetId)
+  // Transcripts run to tens (sometimes hundreds) of MB, so never materialize
+  // the whole file: stream once to find the target, once more to collect the
+  // associated tool_use ids if needed, then stream-rewrite.
+  let target: JsonlEntry | undefined
+  try {
+    for await (const entry of streamJsonlFile<JsonlEntry>(jsonlPath)) {
+      if (matchesTargetId(entry)) {
+        target = entry
+        break
+      }
+    }
+  } catch (error) {
+    // Transcript deleted between the existence check and the read: the old
+    // full-read implementation treated this as "not found".
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
   if (!target) return false
 
   // Collect message IDs and tool_use IDs to remove
@@ -1253,7 +1269,7 @@ export async function removeMessage(
     messageIdsToRemove.add(target.message.id)
 
     // Collect tool_use IDs from all entries with this message.id
-    for (const entry of entries) {
+    for await (const entry of streamJsonlFile<JsonlEntry>(jsonlPath)) {
       if (!('message' in entry)) continue
       const e = entry as JsonlMessageEntry
       if (e.type === 'assistant' && e.message.id === target.message.id) {
@@ -1269,13 +1285,12 @@ export async function removeMessage(
     }
   }
 
-  // Filter entries
-  const filtered = entries.filter((entry) => {
+  await rewriteTranscript(jsonlPath, (entry) => {
     // Remove the target entry (user message or queued_command attachment)
-    if (matchesTargetId(entry)) return false
-    if (!('uuid' in entry)) return true // keep non-message entries
+    if (matchesTargetId(entry)) return 'drop'
+    if (!('uuid' in entry)) return 'keep' // keep non-message entries
     const e = entry as JsonlMessageEntry
-    if (e.type === 'assistant' && e.message.id && messageIdsToRemove.has(e.message.id)) return false
+    if (e.type === 'assistant' && e.message.id && messageIdsToRemove.has(e.message.id)) return 'drop'
 
     // Remove tool_result user entries referencing removed tool calls
     if (e.type === 'user' && toolUseIdsToRemove.size > 0) {
@@ -1283,19 +1298,55 @@ export async function removeMessage(
       if (Array.isArray(content)) {
         const blocks = content as ContentBlock[]
         if (blocks.every((b) => b.type === 'tool_result' && toolUseIdsToRemove.has(b.tool_use_id))) {
-          return false
+          return 'drop'
         }
       }
     }
 
-    return true
+    return 'keep'
   })
-
-  // Write back
-  const jsonl = filtered.map((e) => JSON.stringify(e)).join('\n') + (filtered.length > 0 ? '\n' : '')
-  await writeFile(jsonlPath, jsonl)
   recordSessionActivity(agentSlug, sessionId)
   return true
+}
+
+/**
+ * Stream-rewrite a transcript, deciding per entry whether to keep, drop, or
+ * replace its line. Kept lines are copied through byte-for-byte from the
+ * original file (never parse-and-restringified, which could alter number
+ * formatting or unicode escapes); blank/malformed lines are copied through
+ * untouched. Output goes to a sibling temp file that atomically replaces the
+ * original (see writeFileAtomicStream), so a failure mid-rewrite leaves the
+ * transcript exactly as it was.
+ *
+ * Like the read-modify-write it replaces, this takes no lock against
+ * concurrent transcript appends — callers rely on the same exclusivity
+ * assumption as before.
+ */
+async function rewriteTranscript(
+  jsonlPath: string,
+  mapEntry: (entry: JsonlEntry) => JsonlEntry | 'keep' | 'drop'
+): Promise<void> {
+  const newline = Buffer.from('\n')
+  async function* lines(): AsyncGenerator<Buffer | string> {
+    for await (const raw of streamFileLines(jsonlPath)) {
+      const entry = parseJsonlLine<JsonlEntry>(raw)
+      if (entry === undefined) {
+        // Blank or malformed line (mid-write artifact): copy through untouched
+        yield raw
+        yield newline
+        continue
+      }
+      const result = mapEntry(entry)
+      if (result === 'drop') continue
+      if (result === 'keep') {
+        yield raw
+        yield newline
+        continue
+      }
+      yield JSON.stringify(result) + '\n'
+    }
+  }
+  await writeFileAtomicStream(jsonlPath, lines())
 }
 
 /**
@@ -1313,17 +1364,11 @@ export async function removeToolCall(
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   if (!(await fileExists(jsonlPath))) return false
 
-  const entries = await readJsonlFile<JsonlEntry>(jsonlPath)
-  let found = false
-
-  // Process entries: remove the tool_use block and tool_result entries
-  const filtered: JsonlEntry[] = []
-
-  for (const entry of entries) {
-    if (!('message' in entry)) {
-      filtered.push(entry)
-      continue
-    }
+  // Decide what to do with one entry: remove the tool_use block from assistant
+  // entries and the tool_result block from user entries, dropping an entry
+  // whose content would become empty. Untouched entries are kept verbatim.
+  const mapEntry = (entry: JsonlEntry): JsonlEntry | 'keep' | 'drop' => {
+    if (!('message' in entry)) return 'keep'
     const e = entry as JsonlMessageEntry
 
     // Remove tool_result user entries for this tool call
@@ -1333,10 +1378,8 @@ export async function removeToolCall(
         (b) => !(b.type === 'tool_result' && b.tool_use_id === toolCallId)
       )
       if (remaining.length < blocks.length) {
-        found = true
-        if (remaining.length === 0) continue // drop entire entry
-        filtered.push({ ...e, message: { ...e.message, content: remaining } })
-        continue
+        if (remaining.length === 0) return 'drop' // drop entire entry
+        return { ...e, message: { ...e.message, content: remaining } }
       }
     }
 
@@ -1347,20 +1390,34 @@ export async function removeToolCall(
         (b) => !(b.type === 'tool_use' && b.id === toolCallId)
       )
       if (remaining.length < blocks.length) {
-        found = true
-        if (remaining.length === 0) continue // drop entire entry
-        filtered.push({ ...e, message: { ...e.message, content: remaining } })
-        continue
+        if (remaining.length === 0) return 'drop' // drop entire entry
+        return { ...e, message: { ...e.message, content: remaining } }
       }
     }
 
-    filtered.push(entry)
+    return 'keep'
   }
 
+  // First streaming pass: bail out (and leave the file untouched) unless some
+  // entry actually references this tool call — matches the old behavior of
+  // only writing when `found`.
+  let found = false
+  try {
+    for await (const entry of streamJsonlFile<JsonlEntry>(jsonlPath)) {
+      if (mapEntry(entry) !== 'keep') {
+        found = true
+        break
+      }
+    }
+  } catch (error) {
+    // Transcript deleted between the existence check and the read: the old
+    // full-read implementation treated this as "not found".
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
   if (!found) return false
 
-  const jsonl = filtered.map((e) => JSON.stringify(e)).join('\n') + (filtered.length > 0 ? '\n' : '')
-  await writeFile(jsonlPath, jsonl)
+  await rewriteTranscript(jsonlPath, mapEntry)
   recordSessionActivity(agentSlug, sessionId)
   return true
 }

--- a/src/shared/lib/services/session-transcript-append.test.ts
+++ b/src/shared/lib/services/session-transcript-append.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+import { appendInformationalEntry } from './session-transcript-append'
+
+describe('appendInformationalEntry', () => {
+  let testDir: string
+  let originalEnv: string | undefined
+  let sessionsDir: string
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'transcript-append-test-'))
+    originalEnv = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testDir
+    sessionsDir = path.join(testDir, 'agents', 'test-agent', 'workspace', '.claude', 'projects', '-workspace')
+  })
+
+  afterEach(async () => {
+    if (originalEnv) {
+      process.env.SUPERAGENT_DATA_DIR = originalEnv
+    } else {
+      delete process.env.SUPERAGENT_DATA_DIR
+    }
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+  })
+
+  function jsonlPath(sessionId: string): string {
+    return path.join(sessionsDir, `${sessionId}.jsonl`)
+  }
+
+  async function readLines(sessionId: string): Promise<string[]> {
+    const content = await fs.promises.readFile(jsonlPath(sessionId), 'utf-8')
+    return content.split('\n').filter((l) => l.trim())
+  }
+
+  function transcriptLine(uuid: string, padding = 0): string {
+    return JSON.stringify({
+      type: 'user',
+      uuid,
+      message: { role: 'user', content: padding > 0 ? 'x'.repeat(padding) : 'hello' },
+    })
+  }
+
+  it('creates the file (and parent dirs) when the transcript does not exist yet', async () => {
+    await appendInformationalEntry('test-agent', 'sess-1', {
+      uuid: 'info-1',
+      content: 'prompt blocked',
+      level: 'warning',
+    })
+
+    const lines = await readLines('sess-1')
+    expect(lines.length).toBe(1)
+    const entry = JSON.parse(lines[0])
+    expect(entry).toMatchObject({
+      uuid: 'info-1',
+      type: 'system',
+      subtype: 'informational',
+      content: 'prompt blocked',
+      level: 'warning',
+      isMeta: false,
+    })
+  })
+
+  it('appends to an empty existing file', async () => {
+    await fs.promises.mkdir(sessionsDir, { recursive: true })
+    await fs.promises.writeFile(jsonlPath('sess-1'), '')
+
+    await appendInformationalEntry('test-agent', 'sess-1', { uuid: 'info-1', content: 'note' })
+    expect((await readLines('sess-1')).length).toBe(1)
+  })
+
+  it('appends when the uuid is absent from the transcript', async () => {
+    await fs.promises.mkdir(sessionsDir, { recursive: true })
+    await fs.promises.writeFile(jsonlPath('sess-1'), transcriptLine('other-uuid') + '\n')
+
+    await appendInformationalEntry('test-agent', 'sess-1', { uuid: 'info-1', content: 'note' })
+
+    const lines = await readLines('sess-1')
+    expect(lines.length).toBe(2)
+    expect(JSON.parse(lines[1]).uuid).toBe('info-1')
+  })
+
+  it('skips a duplicate uuid in a file smaller than the scan window', async () => {
+    await fs.promises.mkdir(sessionsDir, { recursive: true })
+    const original = transcriptLine('info-1') + '\n'
+    await fs.promises.writeFile(jsonlPath('sess-1'), original)
+
+    await appendInformationalEntry('test-agent', 'sess-1', { uuid: 'info-1', content: 'dupe' })
+
+    expect(await fs.promises.readFile(jsonlPath('sess-1'), 'utf-8')).toBe(original)
+  })
+
+  it('skips a duplicate uuid found within the tail window of a large file', async () => {
+    await fs.promises.mkdir(sessionsDir, { recursive: true })
+    // > 1MB of padding first, duplicate uuid near the end (inside the window)
+    const content =
+      transcriptLine('old-entry', 1_200_000) + '\n' + transcriptLine('info-1') + '\n'
+    await fs.promises.writeFile(jsonlPath('sess-1'), content)
+
+    await appendInformationalEntry('test-agent', 'sess-1', { uuid: 'info-1', content: 'dupe' })
+
+    expect((await readLines('sess-1')).length).toBe(2)
+  })
+
+  it('re-appends a duplicate uuid that lies entirely outside the tail scan window (deliberate trade)', async () => {
+    // The dedup exists for near-in-time double-delivery (hook replay,
+    // late-join replay), which always lands within the tail window. Bounding
+    // the scan means a duplicate OLDER than the window is no longer detected —
+    // this test pins that accepted behavior change (previously the whole file
+    // was read and this would have been skipped).
+    await fs.promises.mkdir(sessionsDir, { recursive: true })
+    const content =
+      transcriptLine('info-1') + '\n' + transcriptLine('padding-entry', 1_500_000) + '\n'
+    await fs.promises.writeFile(jsonlPath('sess-1'), content)
+
+    await appendInformationalEntry('test-agent', 'sess-1', { uuid: 'info-1', content: 'dupe' })
+
+    const lines = await readLines('sess-1')
+    expect(lines.length).toBe(3)
+    expect(JSON.parse(lines[2]).uuid).toBe('info-1')
+  })
+})

--- a/src/shared/lib/services/session-transcript-append.ts
+++ b/src/shared/lib/services/session-transcript-append.ts
@@ -5,6 +5,46 @@ import type { JsonlSystemEntry } from '@shared/lib/types/agent'
 import { recordSessionActivity } from './session-summary-cache'
 
 /**
+ * How far back (in bytes) the duplicate-uuid check scans from the end of the
+ * transcript. Duplicates only arise near-in-time — a hook double-delivery or a
+ * late-join replay lands within moments of the original append — so a generous
+ * tail window preserves the dedup in practice while keeping the check O(window)
+ * instead of re-reading a transcript that routinely runs to tens of MB. A
+ * duplicate uuid older than the window would be re-appended; that trade is
+ * deliberate.
+ */
+const DEDUP_SCAN_WINDOW_BYTES = 1024 * 1024
+
+/**
+ * Read up to the last `maxBytes` bytes of a file as UTF-8. Returns null when
+ * the file is missing or unreadable (mirrors the readFile().catch(null) it
+ * replaces). A window boundary can split a multi-byte character, but the scan
+ * only searches for an ASCII-quoted uuid, so that never affects the match.
+ */
+async function readFileTail(filePath: string, maxBytes: number): Promise<string | null> {
+  try {
+    const handle = await fs.promises.open(filePath, 'r')
+    try {
+      const { size } = await handle.stat()
+      const start = Math.max(0, size - maxBytes)
+      const length = size - start
+      const buf = Buffer.alloc(length)
+      let offset = 0
+      while (offset < length) {
+        const { bytesRead } = await handle.read(buf, offset, length - offset, start + offset)
+        if (bytesRead === 0) break
+        offset += bytesRead
+      }
+      return buf.subarray(0, offset).toString('utf-8')
+    } finally {
+      await handle.close()
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
  * Append a host-authored `system`/`informational` entry to a session's JSONL
  * transcript. The CLI writes nothing to the transcript when a UserPromptSubmit
  * hook blocks a prompt — the warning exists only on the live SDK stream — so
@@ -24,7 +64,8 @@ export async function appendInformationalEntry(
   // Idempotent by uuid: some hook shapes (continue:false) make the CLI persist
   // the banner itself with the streamed uuid, and the container's late-join
   // replay can deliver the same frame twice — never write a duplicate line.
-  const existing = await fs.promises.readFile(jsonlPath, 'utf-8').catch(() => null)
+  // Duplicates land near-in-time, so scanning the tail window is sufficient.
+  const existing = await readFileTail(jsonlPath, DEDUP_SCAN_WINDOW_BYTES)
   if (existing?.includes(`"${entry.uuid}"`)) return
   const jsonlEntry: JsonlSystemEntry = {
     uuid: entry.uuid,

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -403,8 +403,13 @@ export async function* streamFileLines(filePath: string): AsyncIterable<Buffer> 
       while (idx !== -1) {
         if (pending.length > 0) {
           pending.push(chunk.subarray(start, idx))
-          yield Buffer.concat(pending)
+          // Concat and release the source chunks BEFORE yielding: yield
+          // suspends the generator, so anything still referenced here stays
+          // reachable while the consumer holds the line — clearing `pending`
+          // after the yield would retain a chunk-spanning row twice.
+          const line = Buffer.concat(pending)
           pending = []
+          yield line
         } else {
           yield chunk.subarray(start, idx)
         }
@@ -416,7 +421,10 @@ export async function* streamFileLines(filePath: string): AsyncIterable<Buffer> 
 
     // Process any remaining content (file not terminated by a newline)
     if (pending.length > 0) {
-      yield Buffer.concat(pending)
+      // Same as above: drop the source chunks before suspending on yield
+      const line = Buffer.concat(pending)
+      pending = []
+      yield line
     }
   } finally {
     // Runs on early `break` from the consumer's for-await too, which the

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -377,6 +377,19 @@ const NEWLINE_BYTE = 0x0a
 export async function* streamJsonlFile<T = unknown>(
   filePath: string
 ): AsyncIterable<T> {
+  for await (const line of streamFileLines(filePath)) {
+    const parsed = parseJsonlLine<T>(line)
+    if (parsed !== undefined) yield parsed
+  }
+}
+
+/**
+ * Stream a file's RAW lines as byte buffers, split on `\n` (the newline byte is
+ * excluded; a `\r` from a CRLF line is kept). Lines are never decoded or
+ * re-encoded, so a consumer that copies them back out preserves the original
+ * bytes exactly — the property the transcript rewriters rely on.
+ */
+export async function* streamFileLines(filePath: string): AsyncIterable<Buffer> {
   const fileHandle = await fs.promises.open(filePath, 'r')
   try {
     const stream = fileHandle.createReadStream()
@@ -388,16 +401,13 @@ export async function* streamJsonlFile<T = unknown>(
       let start = 0
       let idx = chunk.indexOf(NEWLINE_BYTE)
       while (idx !== -1) {
-        let line: Buffer
         if (pending.length > 0) {
           pending.push(chunk.subarray(start, idx))
-          line = Buffer.concat(pending)
+          yield Buffer.concat(pending)
           pending = []
         } else {
-          line = chunk.subarray(start, idx)
+          yield chunk.subarray(start, idx)
         }
-        const parsed = parseJsonlLine<T>(line)
-        if (parsed !== undefined) yield parsed
         start = idx + 1
         idx = chunk.indexOf(NEWLINE_BYTE, start)
       }
@@ -406,8 +416,7 @@ export async function* streamJsonlFile<T = unknown>(
 
     // Process any remaining content (file not terminated by a newline)
     if (pending.length > 0) {
-      const parsed = parseJsonlLine<T>(Buffer.concat(pending))
-      if (parsed !== undefined) yield parsed
+      yield Buffer.concat(pending)
     }
   } finally {
     // Runs on early `break` from the consumer's for-await too, which the
@@ -420,7 +429,7 @@ export async function* streamJsonlFile<T = unknown>(
  * Decode and parse one JSONL line. Returns undefined for blank and malformed
  * lines (common while the SDK is mid-write), which callers skip.
  */
-function parseJsonlLine<T>(line: Buffer): T | undefined {
+export function parseJsonlLine<T>(line: Buffer): T | undefined {
   const trimmed = line.toString('utf-8').trim()
   if (!trimmed) return undefined
   try {
@@ -764,6 +773,60 @@ export async function writeFileAtomic(
   content: string,
   options?: { mode?: number; forceMode?: boolean }
 ): Promise<void> {
+  await writeFileAtomicWith(filePath, (handle) => handle.writeFile(content, 'utf-8'), options)
+}
+
+/**
+ * Streaming variant of {@link writeFileAtomic}: the content is produced by an
+ * iterable of chunks (written verbatim, in order) instead of one string, so a
+ * large file can be rewritten without ever materializing it in memory. Same
+ * temp-file + fsync + rename guarantees; if the producer throws, the temp file
+ * is removed and the target is untouched.
+ */
+export async function writeFileAtomicStream(
+  filePath: string,
+  chunks: AsyncIterable<Buffer | string> | Iterable<Buffer | string>,
+  options?: { mode?: number; forceMode?: boolean }
+): Promise<void> {
+  // Batch small chunks (transcript lines) into ~1MB writes so a many-line file
+  // doesn't pay one syscall per line.
+  const FLUSH_BYTES = 1 << 20
+  await writeFileAtomicWith(
+    filePath,
+    async (handle) => {
+      let batch: Buffer[] = []
+      let batchSize = 0
+      const flush = async () => {
+        if (batchSize === 0) return
+        const buf = batch.length === 1 ? batch[0] : Buffer.concat(batch)
+        batch = []
+        batchSize = 0
+        let offset = 0
+        while (offset < buf.length) {
+          const { bytesWritten } = await handle.write(buf, offset, buf.length - offset)
+          offset += bytesWritten
+        }
+      }
+      for await (const chunk of chunks) {
+        const buf = typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : chunk
+        if (buf.length === 0) continue
+        batch.push(buf)
+        batchSize += buf.length
+        if (batchSize >= FLUSH_BYTES) await flush()
+      }
+      await flush()
+    },
+    options
+  )
+}
+
+/** Shared temp-write/fsync/rename core of {@link writeFileAtomic} and
+ *  {@link writeFileAtomicStream}; `writeContent` fills the open temp file. */
+async function writeFileAtomicWith(
+  filePath: string,
+  writeContent: (handle: fs.promises.FileHandle) => Promise<void>,
+  options?: { mode?: number; forceMode?: boolean }
+): Promise<void> {
   const dir = path.dirname(filePath)
   const tmpPath = tempPathFor(filePath)
   // Match fs.writeFile(mode) semantics: `mode` applies only when CREATING the
@@ -794,7 +857,7 @@ export async function writeFileAtomic(
     // 'wx' = O_EXCL: never reuse a stray temp file. Unique name makes this safe.
     const handle = await fs.promises.open(tmpPath, 'wx', options?.mode ?? 0o666)
     try {
-      await handle.writeFile(content, 'utf-8')
+      await writeContent(handle)
       // Best-effort: object-storage / perms-less mounts (e.g. an S3 FUSE driver)
       // may reject chown/chmod — a metadata tweak must never fail the data write.
       // chown before chmod: chown can clear mode bits on some platforms.


### PR DESCRIPTION
## Problem

Two full-file memory hot spots on session transcripts (routinely 35MB, 100MB+ possible):

1. **`src/shared/lib/services/session-service.ts` — `removeMessage` (~L1111) / `removeToolCall` (~L1193):** parsed the entire transcript into memory (`readJsonlFile`), filtered it, then re-serialized every entry with `.map(JSON.stringify).join('\n')` and rewrote the file with a plain truncating write. Measured peak RSS was ~7x the file size above process baseline (see numbers below). As a side effect, every rewrite re-serialized every line (normalizing number formatting, unicode escapes, key spacing) and a crash mid-write could leave a truncated transcript.
2. **`src/shared/lib/services/session-transcript-append.ts` (~L27):** the duplicate-uuid dedup check read the ENTIRE transcript into a string for an `includes()` scan on every hook-blocked prompt append.

## Fix

**Part 1 — streaming rewrite with byte fidelity** (`file-storage.ts` + `session-service.ts`):
- New `streamFileLines()` yields a file's raw lines as byte buffers; `streamJsonlFile()` is now a thin parsing layer over it (same behavior as before). `parseJsonlLine()` is exported so the rewrite parses lines through the exact same helper the read path uses.
- New `writeFileAtomicStream()` writes an iterable of chunks (batched into ~1MB writes) through the same temp-file → fsync → atomic-rename core as the existing `writeFileAtomic` (now shared as `writeFileAtomicWith`). On any failure the temp file is removed and the original transcript is untouched.
- `removeMessage`/`removeToolCall` now stream: one pass to find the target (early-exit), one pass to collect associated `tool_use` ids when removing an assistant message, then a rewrite pass that makes exactly the same keep/drop/modify decisions as before. **Untouched lines are copied through byte-for-byte** — only entries actually modified by `removeToolCall` are re-serialized.

**Review fix — yield-suspension retention in `streamFileLines`:** the first version of the generator cleared its `pending` chunk list only *after* `yield`, but `yield` suspends the generator — so while the consumer processed a chunk-spanning line, both the concatenated line and all its source chunks stayed reachable, retaining the row twice (a 64MiB row held 128MiB). Both the mid-file and EOF branches now concat to a local, clear `pending`, and only then yield. Measured with a single 64MiB line (`process.memoryUsage().arrayBuffers` under `--expose-gc`, fresh process per variant, sampled while the consumer holds the yielded line): **128.1 MiB alive pre-fix → 64.1 MiB fixed**.

**Part 2 — bounded tail scan** (`session-transcript-append.ts`):
- The dedup check now reads only the last `DEDUP_SCAN_WINDOW_BYTES` (1MB) of the transcript. Duplicates only arise near-in-time (hook double-delivery, container late-join replay), so a generous tail window preserves the dedup in practice. Files smaller than the window are scanned whole (identical to before); a missing file behaves as before.

## Deliberate behavior notes (each pinned by a test)

- **Dedup window trade:** a duplicate informational-entry uuid older than the 1MB tail window would now be re-appended. Accepted: the duplicate sources are near-in-time replays that land well within the window.
- **Blank/malformed lines** (typically a concurrent SDK write in progress) are now preserved byte-for-byte; the old implementation silently dropped them on every rewrite. Semantically identical to readers (both are skipped on parse), and strictly less destructive.
- **Concurrency:** like the read-modify-write it replaces, the rewrite takes no lock against concurrent transcript appends — the code keeps the same exclusivity assumption it always had. The atomic rename is strictly safer than the old truncate+write: readers can never observe a half-written transcript.
- A rewrite still leaves the file newline-terminated (same as before), including when the input lacked a trailing newline.

## Validation

**Differential tests** (`session-service.transcript-rewrite.test.ts`, new): the OLD implementation is embedded verbatim as an in-test oracle and run against the same inputs. Fixtures: multi-MB transcripts with the target at start/middle/end; multi-entry assistant turns sharing `message.id` with `tool_use`/`tool_result` pairs; queued-command attachment `source_uuid` match; unicode, escaped quotes, a >3MB base64 line; non-canonical JSON formatting (extra spaces, `é`, `1.0` — bytes the oracle would normalize, proving the new path never re-serializes kept lines); file without trailing newline; not-found no-ops leave the file byte-identical. Atomicity: no temp file left after success, and on an injected `rename` failure the operation rejects, the original file is byte-identical, and the temp file is cleaned up.

**Append tests** (`session-transcript-append.test.ts`, new): missing file (creates dirs + file), empty file, absent uuid appends, duplicate uuid skipped in small files and within the tail window of a >1MB file, duplicate outside the window re-appends (pins the accepted trade).

**Peak RSS** — 50.0MB synthetic transcript (12,572 entries), `removeMessage` of a mid-file message, measured with `/usr/bin/time -l`, both variants run under the identical tsx import graph (baseline run: 149MB RSS doing no work):

| run | peak RSS | attributable to the operation |
|---|---|---|
| old (full parse + rewrite) | 492 MB | ~343 MB (~6.9x file size) |
| new (streaming rewrite) | 194 MB | ~46 MB (~0.9x file size) |

(The local bench script was not committed.)

**Gates:** `npx tsc --noEmit` clean; `npx eslint 'src/**/*.{ts,tsx}'` clean; all existing suites for touched files green — session-service (149), file-storage (52), summary-cache, session-visibility, and both message-persister suites (409 tests; two unrelated metadata/ownership timeouts under parallel-tsc CPU load re-ran green in isolation).

Fixes SUP-585

https://claude.ai/code/session_01BiCd95jC6zB19Pxi9CQdGF
