### PR TITLE
Stop leftover iMessage events from starting a session after connect

### DIFF
--- a/src/shared/lib/chat-integrations/imessage-connector-leftover-inbound.test.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector-leftover-inbound.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { IMessageConnector } from './imessage-connector'
+
+vi.mock('ws', () => {
+  const MockWebSocket = vi.fn() as any
+  MockWebSocket.OPEN = 1
+  return { default: MockWebSocket }
+})
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+}))
+
+const CONTACT_CAPTION = "Save me as a contact so I'm not just a number. Text me anytime."
+const USER_PHONE = '+15551234567'
+const OTHER_PHONE = '+10005551234'
+
+class MockWs {
+  readyState = 1
+  sent: string[] = []
+  send(data: string) { this.sent.push(data) }
+  close() {}
+  on() {}
+}
+
+function createConnector(): IMessageConnector {
+  return new IMessageConnector({
+    gatewayUrl: 'ws://localhost:3456',
+    phoneNumber: USER_PHONE,
+    token: 'test-token',
+  })
+}
+
+function wireUp(connector: IMessageConnector): MockWs {
+  const ws = new MockWs()
+  ;(connector as any).ws = ws
+  ;(connector as any)._connected = true
+  return ws
+}
+
+function inboundText(messageId: string, text: string, extra: Record<string, unknown> = {}) {
+  return {
+    messageId,
+    chatId: USER_PHONE,
+    from: OTHER_PHONE,
+    parts: [{ type: 'text', value: text }],
+    ...extra,
+  }
+}
+
+function emitLaterUserText(connector: IMessageConnector, handler: ReturnType<typeof vi.fn>, id = 'later-1') {
+  const before = handler.mock.calls.length
+  ;(connector as any).handleMessageReceived(inboundText(id, 'hello'))
+  expect(handler).toHaveBeenCalledTimes(before + 1)
+  expect(handler.mock.calls[before][0].text).toBe('hello')
+}
+
+describe('IMessageConnector leftover inbound', () => {
+  describe('handleMessageReceived — not a user turn', () => {
+    let connector: IMessageConnector
+
+    beforeEach(() => {
+      connector = createConnector()
+      wireUp(connector)
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('does not emit onMessage for fromMe: true (own-send echo)', () => {
+      const handler = vi.fn()
+      connector.onMessage(handler)
+
+      ;(connector as any).handleMessageReceived(inboundText('echo-1', CONTACT_CAPTION, { fromMe: true }))
+
+      expect(handler).not.toHaveBeenCalled()
+      emitLaterUserText(connector, handler)
+    })
+
+    it('does not emit onMessage for is_from_me: true', () => {
+      const handler = vi.fn()
+      connector.onMessage(handler)
+
+      ;(connector as any).handleMessageReceived(inboundText('echo-2', CONTACT_CAPTION, { is_from_me: true }))
+
+      expect(handler).not.toHaveBeenCalled()
+      emitLaterUserText(connector, handler)
+    })
+
+    it('does not emit onMessage for a message.sent id echo', () => {
+      const handler = vi.fn()
+      connector.onMessage(handler)
+
+      ;(connector as any).handleMessageSent({ messageId: 'out-1' })
+      ;(connector as any).handleMessageReceived(inboundText('out-1', CONTACT_CAPTION, { from: OTHER_PHONE }))
+
+      expect(handler).not.toHaveBeenCalled()
+      emitLaterUserText(connector, handler)
+    })
+
+    it('does not emit onMessage for the last sendFile caption while it is the last outbound', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+      const handler = vi.fn()
+      connector.onMessage(handler)
+
+      const pending = connector.sendFile(USER_PHONE, Buffer.from('BEGIN:VCARD'), 'Bobert.vcf', CONTACT_CAPTION)
+      ;(connector as any).handleUploadResponse({
+        attachmentId: 'att-1',
+        uploadUrl: 'https://example.com/upload',
+        downloadUrl: 'https://example.com/dl',
+        requiredHeaders: {},
+      })
+      await pending
+
+      ;(connector as any).handleMessageReceived({
+        messageId: 'card-1',
+        chatId: USER_PHONE,
+        from: OTHER_PHONE,
+        parts: [
+          {
+            type: 'media',
+            url: 'https://gateway.example/card.vcf',
+            filename: 'Bobert.vcf',
+            mimeType: 'text/vcard',
+          },
+          { type: 'text', value: CONTACT_CAPTION },
+        ],
+      })
+
+      expect(handler).not.toHaveBeenCalled()
+      emitLaterUserText(connector, handler)
+    })
+  })
+
+  describe('handshake flush', () => {
+    it('does not emit message.received before _connected', () => {
+      const connector = createConnector()
+      const handler = vi.fn()
+      connector.onMessage(handler)
+
+      ;(connector as any).handleServerEvent({
+        type: 'message.received',
+        data: inboundText('early-1', '/setup'),
+      })
+
+      expect(handler).not.toHaveBeenCalled()
+
+      ;(connector as any)._connected = true
+      ;(connector as any).handleServerEvent({
+        type: 'message.received',
+        data: inboundText('later-early', 'hello'),
+      })
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler.mock.calls[0][0].text).toBe('hello')
+    })
+
+    it('skips the next queuedCount receives after connected, then emits a later user text', () => {
+      const connector = createConnector()
+      wireUp(connector)
+      const handler = vi.fn()
+      connector.onMessage(handler)
+
+      ;(connector as any).handleServerEvent({ type: 'connected', data: { queuedCount: 3 } })
+      ;(connector as any).handleServerEvent({
+        type: 'message.received',
+        data: inboundText('q1', '/setup'),
+      })
+      ;(connector as any).handleServerEvent({
+        type: 'message.received',
+        data: inboundText('q2', CONTACT_CAPTION),
+      })
+      ;(connector as any).handleServerEvent({
+        type: 'message.received',
+        data: {
+          messageId: 'q3',
+          chatId: USER_PHONE,
+          from: OTHER_PHONE,
+          parts: [
+            {
+              type: 'media',
+              url: 'https://gateway.example/card.vcf',
+              filename: 'Bobert.vcf',
+            },
+          ],
+        },
+      })
+
+      expect(handler).not.toHaveBeenCalled()
+
+      ;(connector as any).handleServerEvent({
+        type: 'message.received',
+        data: inboundText('real-1', 'hello', { from: OTHER_PHONE }),
+      })
+
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler.mock.calls[0][0].text).toBe('hello')
+    })
+
+    it('emits the next user text when queuedCount is missing or zero', () => {
+      const connector = createConnector()
+      wireUp(connector)
+      const handler = vi.fn()
+      connector.onMessage(handler)
+
+      ;(connector as any).handleServerEvent({ type: 'connected', data: {} })
+      ;(connector as any).handleServerEvent({
+        type: 'message.received',
+        data: inboundText('real-2', 'hello', { from: OTHER_PHONE }),
+      })
+
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler.mock.calls[0][0].text).toBe('hello')
+    })
+  })
+})

--- a/src/shared/lib/chat-integrations/imessage-connector.ts
+++ b/src/shared/lib/chat-integrations/imessage-connector.ts
@@ -117,6 +117,9 @@ export class IMessageConnector extends ChatClientConnector {
 
   private lastReceivedMessageId: string | null = null
   private lastChatId: string | null = null
+  private recentOutboundIds: string[] = []
+  private lastSendFileCaption: string | null = null
+  private handshakeSkipRemaining = 0
   // Chats currently showing the typing bubble. The manager's tick calls startWorking
   // every ~1s for keep-alive; iMessage's bubble self-expires, so we send start_typing
   // once per working segment (on the not-shown→shown edge) instead of on every tick.
@@ -272,6 +275,7 @@ export class IMessageConnector extends ChatClientConnector {
       return `reaction-only-${Date.now()}`
     }
 
+    this.lastSendFileCaption = null
     this.send({
       type: 'send_message',
       data: { chatId: targetChatId, parts: [{ type: 'text', value: cleanText }] },
@@ -350,12 +354,14 @@ export class IMessageConnector extends ChatClientConnector {
         parts.push({ type: 'text', value: caption })
       }
 
+      this.lastSendFileCaption = caption ?? null
       this.send({ type: 'send_message', data: { chatId: targetChatId, parts } })
       return `file-${Date.now()}`
     } catch (err) {
       console.error('[IMessageConnector] Failed to send file:', err)
       captureException(err, { tags: { component: 'chat-integration', operation: 'imessage-send-file' } })
       // Fall back to a text message about the file
+      this.lastSendFileCaption = caption ?? null
       this.send({
         type: 'send_message',
         data: { chatId: targetChatId, parts: [{ type: 'text', value: `[File: ${filename}]${caption ? ` — ${caption}` : ''}` }] },
@@ -468,11 +474,18 @@ export class IMessageConnector extends ChatClientConnector {
 
   private handleServerEvent(event: { type: string; data?: any }): void {
     switch (event.type) {
-      case 'connected':
-        // Already handled in doConnect
+      case 'connected': {
+        const queued = event.data?.queuedCount
+        this.handshakeSkipRemaining = typeof queued === 'number' && queued > 0 ? queued : 0
         break
+      }
 
       case 'message.received':
+        if (!this._connected) return
+        if (this.handshakeSkipRemaining > 0) {
+          this.handshakeSkipRemaining--
+          return
+        }
         this.handleMessageReceived(event.data)
         break
 
@@ -510,21 +523,17 @@ export class IMessageConnector extends ChatClientConnector {
 
   private handleMessageReceived(data: any): void {
     if (!data) return
+    if (data.fromMe === true || data.is_from_me === true) return
 
     const messageId = data.messageId as string
+    if (messageId && this.recentOutboundIds.includes(messageId)) return
+
     const chatId = data.chatId as string || this.config.phoneNumber
     const chatName = data.chatName as string | undefined
     const from = data.from as string
     const parts = data.parts as Array<{ type: string; value?: string; url?: string; mimeType?: string; filename?: string; sizeBytes?: number }> || []
     const sentAt = data.sentAt ? new Date(data.sentAt) : new Date()
 
-    this.lastReceivedMessageId = messageId
-    this.lastChatId = chatId
-
-    // Send read receipt immediately
-    this.send({ type: 'mark_read', data: { chatId } })
-
-    // Extract text and files from parts
     let text = ''
     const files: Array<{ name: string; url: string; mimeType?: string }> = []
 
@@ -539,6 +548,14 @@ export class IMessageConnector extends ChatClientConnector {
         })
       }
     }
+
+    if (this.lastSendFileCaption && text === this.lastSendFileCaption) return
+
+    this.lastReceivedMessageId = messageId
+    this.lastChatId = chatId
+
+    // Send read receipt immediately
+    this.send({ type: 'mark_read', data: { chatId } })
 
     // Check if there's a pending question — resolve it with this message
     if (this.pendingQuestions.size > 0) {
@@ -595,6 +612,10 @@ export class IMessageConnector extends ChatClientConnector {
   private handleMessageSent(data: any): void {
     if (!data) return
     const messageId = data.messageId as string
+    if (messageId) {
+      this.recentOutboundIds.push(messageId)
+      if (this.recentOutboundIds.length > 16) this.recentOutboundIds.shift()
+    }
     // Resolve any pending send confirmations
     for (const [key, resolver] of this.sentMessageResolvers) {
       resolver(messageId)
@@ -697,6 +718,7 @@ export class IMessageConnector extends ChatClientConnector {
   }
 
   private sendTextAndReturn(text: string, targetChatId?: string): string {
+    this.lastSendFileCaption = null
     this.send({
       type: 'send_message',
       data: { chatId: targetChatId, parts: [{ type: 'text', value: text }] },


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-587/stop-leftover-imessage-events-from-starting-a-session-after-connect

1 production file, +31 / −9.
New leftover-inbound unit file.

## The bug

After iMessage connects, leftover setup traffic is treated as if you typed it.

You finish setup. We send the contact card. That is intended.

The gateway then dumps leftovers back at us: your `/setup`, our own send, the card caption, the contact file.
Each leftover is treated as a new user text.
Each one tries to start a conversation.

```
connect + send contact card
  → leftovers come back as "user" texts
  → each leftover starts a conversation
       ├─ start fails → "Failed to start a new session" on the phone
       └─ start partly works → agent is already running
            → it asks for GitHub
            → you never asked for that
```

That is why the phone gets a burst of the same error, then later talks about a GitHub request you never made.

## What should happen

```
connect + send contact card
  → leftovers dropped
  → quiet
  → you text something real
  → one conversation starts
  → agent replies
```

## Before

```
finish iMessage setup / reconnect
  → we send the contact card
  → gateway flushes leftovers (/setup, our own send, card caption, vcf)
  → each leftover counts as a user text
  → each one starts a session
  → phone: "Failed to start a new session"
  → agent may already be running (GitHub was that side effect)
```

## After

```
finish iMessage setup / reconnect
  → we still send the contact card
  → leftovers are dropped
  → no session
  → you text Hello
  → one session starts from that text
  → agent replies
```

## What changed

The iMessage connector drops leftover inbound before emit.

- Own sends (`fromMe` / `is_from_me`)
- Echoes of what we just sent (`message.sent` ids, last contact-card caption)
- Handshake flush (nothing before `_connected`, then skip the next `queuedCount` receives)

A later real text still emits.

## Unchanged

Contact card after setup still sends.
Slack, Telegram, and session-save order stay as they are.

## Why not a manager-wide filter

Slack already drops bot-authored inbound.
Telegram never echoes the bot's own sends.
The missing filter is local to iMessage.
A manager caption-string skip would also drop a real user text that matches the card.

## Worth reviewing

- Handshake skip is by `queuedCount` after `connected`, including reconnect.
  The live gateway payload shape is still unproven.
- Caption match lasts until the next outbound.
  A user who types the exact card caption in that window is dropped.
- Own-send detection trusts `fromMe` / `is_from_me` on the gateway payload.

## Known leftovers

This does not add an `IncomingMessage` provenance field on every connector.
That is a larger interface change than this defect.

Reconnect with a non-zero queued flush was not hit in live smoke.
This boot and reconnect both reported `0 queued events`.
The unit file covers the non-zero flush.

## Validation

- [x] Red then green on leftover-inbound cases, plus existing connector tests
- [x] Typecheck
- [x] Live smoke: reconnect stayed quiet, `Hello` started one session, reply landed on the phone
