### PR TITLE
APNs push channel: device registration, origin-device stamp, relay delivery

### DIFF
--- a/src/api/middleware/auth.test.ts
+++ b/src/api/middleware/auth.test.ts
@@ -66,6 +66,7 @@ import {
   Or,
   EntityAgentRole,
   getAuthorizedAgentRole,
+  getRequestDeviceId,
 } from './auth'
 
 // ---------------------------------------------------------------------------
@@ -186,6 +187,68 @@ describe('Auth Middleware', () => {
       const res = await request(app, '/')
       expect(res.status).toBe(200)
       expect(capturedUser).toEqual(adminUser)
+    })
+  })
+
+  // =========================================================================
+  // getRequestDeviceId()
+  // =========================================================================
+
+  describe('getRequestDeviceId()', () => {
+    function buildDeviceIdApp() {
+      let captured: string | null | undefined
+      const app = new Hono()
+      app.get('/', Authenticated(), (c) => {
+        captured = getRequestDeviceId(c)
+        return c.json({ ok: true })
+      })
+      return { app, getCaptured: () => captured }
+    }
+
+    it('returns the deviceId for a mobile session carrying one', async () => {
+      mockGetSession.mockResolvedValue({
+        user: { id: 'user-1', role: 'user' },
+        session: { id: 'sess-1', userId: 'user-1', deviceId: 'device-family-1' },
+      })
+      const { app, getCaptured } = buildDeviceIdApp()
+
+      const res = await request(app, '/')
+      expect(res.status).toBe(200)
+      expect(getCaptured()).toBe('device-family-1')
+    })
+
+    it('returns null for a browser/desktop session without a deviceId', async () => {
+      mockGetSession.mockResolvedValue({
+        user: { id: 'user-1', role: 'user' },
+        session: { id: 'sess-1', userId: 'user-1', deviceId: null },
+      })
+      const { app, getCaptured } = buildDeviceIdApp()
+
+      const res = await request(app, '/')
+      expect(res.status).toBe(200)
+      expect(getCaptured()).toBeNull()
+    })
+
+    it('returns null when the session object omits deviceId entirely', async () => {
+      mockGetSession.mockResolvedValue({
+        user: { id: 'user-1', role: 'user' },
+        session: { id: 'sess-1', userId: 'user-1' },
+      })
+      const { app, getCaptured } = buildDeviceIdApp()
+
+      const res = await request(app, '/')
+      expect(res.status).toBe(200)
+      expect(getCaptured()).toBeNull()
+    })
+
+    it('returns null in local (non-auth) mode where no session is stored', async () => {
+      mockIsAuthMode.mockReturnValue(false)
+      const { app, getCaptured } = buildDeviceIdApp()
+
+      const res = await request(app, '/')
+      expect(res.status).toBe(200)
+      expect(getCaptured()).toBeNull()
+      expect(mockGetSession).not.toHaveBeenCalled()
     })
   })
 

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -23,6 +23,29 @@ export { type AgentRole, ROLE_HIERARCHY, hasMinRole } from '@shared/lib/types/ag
 import { type AgentRole, hasMinRole } from '@shared/lib/types/agent'
 
 const AUTHORIZED_AGENT_ROLE_CONTEXT_KEY = 'authorizedAgentRole'
+const REQUEST_SESSION_CONTEXT_KEY = 'requestSession'
+
+/**
+ * The shape of the Better Auth session row we consume. `deviceId` is a
+ * session additionalField (mobile device family, set by
+ * mintInstalledClientSession) — persisted and returned by getSession but not
+ * part of the base inferred type, hence the widening here (same pattern as
+ * mobile-pairing.ts).
+ */
+interface RequestSessionInfo {
+  id: string
+  userId: string
+  deviceId?: string | null
+}
+
+/**
+ * Mobile device-family id of the calling session, or null (browser/desktop/
+ * local mode). Only meaningful after Authenticated() ran in auth mode.
+ */
+export function getRequestDeviceId(c: Context): string | null {
+  const session = c.get(REQUEST_SESSION_CONTEXT_KEY as never) as RequestSessionInfo | undefined
+  return session?.deviceId ?? null
+}
 
 function setAuthorizedAgentRole(c: Context, role: AgentRole): void {
   c.set(AUTHORIZED_AGENT_ROLE_CONTEXT_KEY as never, role as never)
@@ -53,6 +76,7 @@ export function Authenticated(): MiddlewareHandler {
     if (!session) return c.json({ error: 'Unauthorized' }, 401)
 
     c.set('user' as never, session.user as never)
+    c.set(REQUEST_SESSION_CONTEXT_KEY as never, session.session as never)
     return runWithRequestUser(session.user.id, () => next())
   }
 }

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -100,6 +100,9 @@ vi.mock('../credentials/credential-broker', () => ({
 
 // Auth middleware — passthrough (sets mock user on context for auth mode tests)
 const mockAuthUser = { id: 'test-user-id', name: 'Test User', email: 'test@example.com' }
+// Device identity of the calling session; tests set .value to simulate a
+// paired mobile device (null = browser/desktop/web).
+const mockRequestDevice = { value: null as string | null }
 const mockGlobalAdmin = vi.hoisted(() => ({ allowed: true }))
 let mockAuthorizedAgentRole: 'owner' | 'user' | 'viewer' = 'owner'
 // Display-slug -> canonical-id resolution applied by the ResolveAgent mock. Defaults
@@ -107,6 +110,7 @@ let mockAuthorizedAgentRole: 'owner' | 'user' | 'viewer' = 'owner'
 // routes where the URL display slug differs from the resolved id.
 let mockResolveSlug: (slug: string) => string = (slug) => slug
 vi.mock('../middleware/auth', () => ({
+  getRequestDeviceId: () => mockRequestDevice.value,
   Authenticated: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); return next() },
   AgentRead: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); c.set('authorizedAgentRole', mockAuthorizedAgentRole); return next() },
   AgentUser: () => async (c: any, next: () => Promise<void>) => { c.set('user', mockAuthUser); c.set('authorizedAgentRole', mockAuthorizedAgentRole); return next() },
@@ -555,7 +559,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3471,6 +3475,22 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
 
     // No DB insert for message author outside auth mode
     expect(mockDbInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('stamps the alert claim with the sender device, and clears it on deviceless sends', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+
+    // A paired mobile device speaks: it claims the session's visible alerts.
+    mockRequestDevice.value = 'device-family-9'
+    expect((await postJson(app, URL, { content: 'from phone' })).status).toBe(201)
+    expect(updateSessionMetadata).toHaveBeenCalledWith(
+      'test-agent', 'sess-1', { alertDeviceId: 'device-family-9' })
+
+    // A deviceless surface (web) speaks: the claim is explicitly cleared.
+    mockRequestDevice.value = null
+    expect((await postJson(app, URL, { content: 'from web' })).status).toBe(201)
+    expect(updateSessionMetadata).toHaveBeenLastCalledWith(
+      'test-agent', 'sess-1', { alertDeviceId: null })
   })
 
   it('generates UUID, inserts messageAuthor, passes it to sendMessage, and returns it in auth mode', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2184,8 +2184,22 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     if (runtimeOptions.effort) updates.effort = runtimeOptions.effort
     if (runtimeOptions.speed) updates.speed = runtimeOptions.speed
     if (runtimeOptions.model) updates.model = runtimeOptions.model
+    if (isAuthMode()) {
+      // Alert claim: the device that spoke last in a session is the one
+      // awaiting its outcome, so visible pushes follow it. A send with no
+      // device identity (web/desktop) CLEARS the claim — the user moved to a
+      // surface where a phone alert for this session would be noise (web push
+      // covers them there). Explicit null ≠ absent: absent falls back to the
+      // creation stamp in ApnsRelayChannel. Awaited via the metadata write
+      // below so a fast turn can't complete ahead of its own claim.
+      updates.alertDeviceId = getRequestDeviceId(c)
+    }
     if (Object.keys(updates).length > 0) {
-      updateSessionMetadata(agentSlug, sessionId, updates).catch(console.error)
+      try {
+        await updateSessionMetadata(agentSlug, sessionId, updates)
+      } catch (error) {
+        console.error(error)
+      }
     }
 
     return c.json({ success: true, uuid: messageUuid, queued: wasQueued }, 201)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -16,7 +16,7 @@ import {
 import { parsePagination } from '../pagination'
 import { MESSAGES_PAGE_MAX_LIMIT, capMessagesPageLimit } from '@shared/lib/messages-page'
 import { streamJsonArrayResponse } from '../stream-json-array'
-import { Authenticated, AgentRead, AgentUser, AgentAdmin, IsAdmin, ResolveAgent, getAgentId, getAuthorizedAgentRole } from '../middleware/auth'
+import { Authenticated, AgentRead, AgentUser, AgentAdmin, IsAdmin, ResolveAgent, getAgentId, getAuthorizedAgentRole, getRequestDeviceId } from '../middleware/auth'
 import {
   listAgentsWithStatus,
   createAgent,
@@ -1706,7 +1706,13 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     if (runtimeOptions.effort) initialMetadata.effort = runtimeOptions.effort
     if (runtimeOptions.speed) initialMetadata.speed = runtimeOptions.speed
     if (runtimeOptions.model) initialMetadata.model = runtimeOptions.model
-    if (isAuthMode()) initialMetadata.createdByUserId = getCurrentUserId(c)
+    if (isAuthMode()) {
+      initialMetadata.createdByUserId = getCurrentUserId(c)
+      // Origin-device stamp: which mobile device family (if any) started this
+      // session. ApnsRelayChannel routes visible alert pushes only to it.
+      const deviceId = getRequestDeviceId(c)
+      if (deviceId) initialMetadata.createdByDeviceId = deviceId
+    }
     if (Object.keys(initialMetadata).length > 0) {
       updateSessionMetadata(slug, sessionId, initialMetadata).catch(console.error)
     }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1669,6 +1669,25 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     // still wins the race with early container output.
     await reserveSessionOwnership(slug, sessionId)
 
+    // Persist only what the user explicitly chose. The server-side fallback is
+    // applied at session creation but should not masquerade as a user choice in
+    // metadata — otherwise a later change to the global default wouldn't be
+    // reflected when the composer reloads.
+    const initialMetadata: Parameters<typeof updateSessionMetadata>[2] = {}
+    if (runtimeOptions.effort) initialMetadata.effort = runtimeOptions.effort
+    if (runtimeOptions.speed) initialMetadata.speed = runtimeOptions.speed
+    if (runtimeOptions.model) initialMetadata.model = runtimeOptions.model
+    if (isAuthMode()) {
+      initialMetadata.createdByUserId = getCurrentUserId(c)
+      // Origin-device stamp: which mobile device family (if any) started this
+      // session. ApnsRelayChannel routes visible alert pushes only to it, so
+      // it must land in the INITIAL registration write — a fast completion
+      // would beat a fire-and-forget update and demote the origin's alert to
+      // a silent push.
+      const deviceId = getRequestDeviceId(c)
+      if (deviceId) initialMetadata.createdByDeviceId = deviceId
+    }
+
     // Attach lifecycle state and the stream before slower metadata/DB work. The
     // first turn can start emitting shortly after createSession returns, and a
     // blocking input emitted during that window must not be missed or reset.
@@ -1690,31 +1709,13 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
         })
       }
 
-      await registerSession(slug, sessionId, 'New Session')
+      await registerSession(slug, sessionId, 'New Session', initialMetadata)
       sessionRegistered = true
     } catch (error) {
       if (lifecycleStarted && !sessionRegistered) {
         messagePersister.unsubscribeFromSession(sessionId)
       }
       throw error
-    }
-    // Persist only what the user explicitly chose. The server-side fallback is
-    // applied at session creation but should not masquerade as a user choice in
-    // metadata — otherwise a later change to the global default wouldn't be
-    // reflected when the composer reloads.
-    const initialMetadata: Parameters<typeof updateSessionMetadata>[2] = {}
-    if (runtimeOptions.effort) initialMetadata.effort = runtimeOptions.effort
-    if (runtimeOptions.speed) initialMetadata.speed = runtimeOptions.speed
-    if (runtimeOptions.model) initialMetadata.model = runtimeOptions.model
-    if (isAuthMode()) {
-      initialMetadata.createdByUserId = getCurrentUserId(c)
-      // Origin-device stamp: which mobile device family (if any) started this
-      // session. ApnsRelayChannel routes visible alert pushes only to it.
-      const deviceId = getRequestDeviceId(c)
-      if (deviceId) initialMetadata.createdByDeviceId = deviceId
-    }
-    if (Object.keys(initialMetadata).length > 0) {
-      updateSessionMetadata(slug, sessionId, initialMetadata).catch(console.error)
     }
     // Store slash commands from container's init event (captured during session creation)
     if (containerSession.slashCommands && containerSession.slashCommands.length > 0) {

--- a/src/api/routes/push.ts
+++ b/src/api/routes/push.ts
@@ -17,7 +17,12 @@ import {
   pushSubscribeRequestSchema,
   pushUnsubscribeRequestSchema,
 } from '@shared/lib/notifications/push/push-subscription-schema'
-import { Authenticated } from '../middleware/auth'
+import {
+  upsertApnsDevice,
+  deleteApnsDeviceByToken,
+} from '@shared/lib/notifications/push/apns-device-service'
+import { apnsDeviceRegisterRequestSchema } from '@shared/lib/notifications/push/apns-device-schema'
+import { Authenticated, getRequestDeviceId } from '../middleware/auth'
 
 const pushRouter = new Hono()
 
@@ -83,6 +88,57 @@ pushRouter.delete('/subscriptions', async (c) => {
   )
   if (!deleted) {
     return c.json({ error: 'Subscription not found' }, 404)
+  }
+  return c.body(null, 204)
+})
+
+// POST /api/push/devices - register/refresh this native device's APNs token
+// (upsert by token; ApnsRelayChannel delivers to every stored row)
+pushRouter.post('/devices', async (c) => {
+  let body: unknown
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  const parsed = apnsDeviceRegisterRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid device payload' }, 400)
+  }
+
+  // Owner of the device row: user id in auth mode (Authenticated() guarantees
+  // the context user), null for the single local user. The mobile device
+  // family id ties the token to pairing so origin-device alert routing works;
+  // null for non-mobile sessions.
+  const ownerUserId = getViewerUserId(c)
+  const mobileDeviceId = getRequestDeviceId(c)
+
+  const { token, environment, platform, deviceName, workspaceTag } = parsed.data
+  const stored = upsertApnsDevice({
+    token: token.toLowerCase(),
+    environment,
+    userId: ownerUserId,
+    mobileDeviceId,
+    workspaceTag: workspaceTag ?? null,
+    deviceName: deviceName ?? null,
+    platform,
+  })
+  if (!stored) {
+    return c.json({ error: 'Too many registered devices for this account' }, 429)
+  }
+
+  return c.json({ success: true })
+})
+
+// DELETE /api/push/devices/:token - remove this device's registration (scoped to its owner)
+pushRouter.delete('/devices/:token', (c) => {
+  const deleted = deleteApnsDeviceByToken(
+    c.req.param('token').toLowerCase(),
+    getViewerUserId(c) ?? undefined
+  )
+  if (!deleted) {
+    return c.json({ error: 'Device not found' }, 404)
   }
   return c.body(null, 204)
 })

--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -182,6 +182,7 @@ vi.mock('@shared/lib/db/schema', () => ({
   tokenExchangeJti: {},
   mobilePairingToken: {},
   mobileDevice: {},
+  apnsDevices: {},
   pushSubscriptions: {},
   pushVapidKeys: {},
 }))

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -77,6 +77,7 @@ import {
   tokenExchangeJti,
   mobilePairingToken,
   mobileDevice,
+  apnsDevices,
   pushSubscriptions,
   pushVapidKeys,
 } from '@shared/lib/db/schema'
@@ -200,6 +201,9 @@ const FACTORY_RESET_TABLES: SQLiteTable[] = [
   tokenExchangeJti,
   // transient single-use mobile pairing tokens
   mobilePairingToken,
+  // APNs registrations before mobile devices: the cascade covers paired rows,
+  // but nullable mobile_device_id rows would survive it
+  apnsDevices,
   // stable mobile devices; deleting them cascades their access sessions
   mobileDevice,
   // web push device subscriptions + the VAPID keypair they were minted against

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -242,6 +242,20 @@ export interface CloudWorkspaceSettings {
   tokenFingerprint: string | null
 }
 
+/**
+ * Server-side push delivery via the APNs relay (native iOS companion app).
+ * The relay holds the APNs credentials; this deployment only POSTs push
+ * batches to it (see ApnsRelayChannel).
+ */
+export interface PushSettings {
+  /** Relay base URL. Defaults to DEFAULT_APNS_RELAY_URL; empty string disables. */
+  apnsRelayUrl?: string
+  /** Master kill switch for APNs delivery, default true. */
+  apnsEnabled?: boolean
+}
+
+export const DEFAULT_APNS_RELAY_URL = 'https://gamut-apns-relay.datawizz.workers.dev'
+
 export interface AppSettings {
   container: ContainerSettings
   apiKeys?: ApiKeySettings
@@ -276,6 +290,8 @@ export interface AppSettings {
    * — the inbox reads live from the platform.
    */
   platformNotifications?: PlatformNotificationsSettings
+  /** APNs relay push delivery for the native iOS companion app. */
+  push?: PushSettings
   /** Anthropic SDK tool search — defaults on; passed as `ENABLE_TOOL_SEARCH` to the container. */
   enableToolSearch?: boolean
   /** Launch policies for subagents (Task/Agent) and workflows (Workflow tool). */
@@ -561,6 +577,7 @@ function mergeLoadedSettings(loaded: Record<string, any>): AppSettings {
     shareErrorReports: loaded.shareErrorReports,
     platformAuth: loaded.platformAuth,
     cloudWorkspace: loaded.cloudWorkspace,
+    push: loaded.push,
     // Narrowed on read: an unrecognized value (hand-edited file, a future
     // version's target) must resolve to local rather than to something that
     // routes work off this machine.
@@ -910,6 +927,18 @@ export function getCustomEnvVars(): Record<string, string> {
 export function getVoiceSettings(): VoiceSettings {
   const settings = getSettings()
   return settings.voice ?? {}
+}
+
+/**
+ * Resolved APNs relay config: `url` is null when delivery is disabled (kill
+ * switch off, or relay URL explicitly set to the empty string).
+ */
+export function getApnsRelayConfig(): { url: string | null; enabled: boolean } {
+  const settings = getSettings()
+  const enabled = settings.push?.apnsEnabled !== false
+  const rawUrl = settings.push?.apnsRelayUrl ?? DEFAULT_APNS_RELAY_URL
+  const url = enabled && rawUrl !== '' ? rawUrl.replace(/\/+$/, '') : null
+  return { url, enabled }
 }
 
 /** Resolved launch policies for subagents/workflows (defaults applied). */

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -254,7 +254,7 @@ export interface PushSettings {
   apnsEnabled?: boolean
 }
 
-export const DEFAULT_APNS_RELAY_URL = 'https://gamut-apns-relay.datawizz.workers.dev'
+export const DEFAULT_APNS_RELAY_URL = 'https://apn-relay.gamutagents.com'
 
 export interface AppSettings {
   container: ContainerSettings

--- a/src/shared/lib/db/migrations/0036_special_victor_mancha.sql
+++ b/src/shared/lib/db/migrations/0036_special_victor_mancha.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `apns_devices` (
+	`id` text PRIMARY KEY NOT NULL,
+	`token` text NOT NULL,
+	`environment` text DEFAULT 'production' NOT NULL,
+	`user_id` text,
+	`mobile_device_id` text,
+	`workspace_tag` text,
+	`device_name` text,
+	`platform` text DEFAULT 'ios' NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`mobile_device_id`) REFERENCES `mobile_device`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `apns_devices_token_unique` ON `apns_devices` (`token`);--> statement-breakpoint
+CREATE INDEX `apns_devices_user_id_idx` ON `apns_devices` (`user_id`);--> statement-breakpoint
+CREATE INDEX `apns_devices_mobile_device_id_idx` ON `apns_devices` (`mobile_device_id`);

--- a/src/shared/lib/db/migrations/meta/0036_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0036_snapshot.json
@@ -1,0 +1,2916 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4b98a85f-7a32-4af9-bd5e-d37628875f43",
+  "prevId": "9d295210-608d-444b-a837-0048b67bbf41",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apns_devices": {
+      "name": "apns_devices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'production'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_device_id": {
+          "name": "mobile_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_tag": {
+          "name": "workspace_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ios'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apns_devices_token_unique": {
+          "name": "apns_devices_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "apns_devices_user_id_idx": {
+          "name": "apns_devices_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "apns_devices_mobile_device_id_idx": {
+          "name": "apns_devices_mobile_device_id_idx",
+          "columns": [
+            "mobile_device_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apns_devices_mobile_device_id_mobile_device_id_fk": {
+          "name": "apns_devices_mobile_device_id_mobile_device_id_fk",
+          "tableFrom": "apns_devices",
+          "tableTo": "mobile_device",
+          "columnsFrom": [
+            "mobile_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creation_method": {
+          "name": "creation_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_device_id_idx": {
+          "name": "session_device_id_idx",
+          "columns": [
+            "device_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_device_id_mobile_device_id_fk": {
+          "name": "session_device_id_mobile_device_id_fk",
+          "tableFrom": "session",
+          "tableTo": "mobile_device",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_audit_log_agent_slug_created_at_idx": {
+          "name": "mcp_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_remote_mcp_id_created_at_idx": {
+          "name": "mcp_audit_log_remote_mcp_id_created_at_idx",
+          "columns": [
+            "remote_mcp_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_mcp_agent_idx": {
+          "name": "mcp_audit_log_mcp_agent_idx",
+          "columns": [
+            "remote_mcp_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mobile_device": {
+      "name": "mobile_device",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mobile_device_refresh_token_hash_unique": {
+          "name": "mobile_device_refresh_token_hash_unique",
+          "columns": [
+            "refresh_token_hash"
+          ],
+          "isUnique": true
+        },
+        "mobile_device_user_id_idx": {
+          "name": "mobile_device_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "mobile_device_expires_at_idx": {
+          "name": "mobile_device_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mobile_device_user_id_user_id_fk": {
+          "name": "mobile_device_user_id_user_id_fk",
+          "tableFrom": "mobile_device",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mobile_pairing_token": {
+      "name": "mobile_pairing_token",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mobile_pairing_token_expires_at_idx": {
+          "name": "mobile_pairing_token_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mobile_pairing_token_user_id_user_id_fk": {
+          "name": "mobile_pairing_token_user_id_user_id_fk",
+          "tableFrom": "mobile_pairing_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_audit_log_agent_slug_created_at_idx": {
+          "name": "proxy_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_id_created_at_idx": {
+          "name": "proxy_audit_log_account_id_created_at_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_agent_idx": {
+          "name": "proxy_audit_log_account_agent_idx",
+          "columns": [
+            "account_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keys_p256dh": {
+          "name": "keys_p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keys_auth": {
+          "name": "keys_auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        },
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_vapid_keys": {
+      "name": "push_vapid_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resume_session_id": {
+          "name": "resume_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_tasks_pending_wake_unique": {
+          "name": "scheduled_tasks_pending_wake_unique",
+          "columns": [
+            "resume_session_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending' AND resume_session_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "token_exchange_jti": {
+      "name": "token_exchange_jti",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "token_exchange_jti_expires_at_idx": {
+          "name": "token_exchange_jti_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1786055590568,
       "tag": "0035_push_subscriptions",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1786728485469,
+      "tag": "0036_special_victor_mancha",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -304,6 +304,34 @@ export const pushSubscriptions = sqliteTable('push_subscriptions', {
   userIdIdx: index('push_subscriptions_user_id_idx').on(table.userId),
 }))
 
+/**
+ * APNs device registrations — one row per native iOS app install that
+ * registered its device token (POST /api/push/devices). Like
+ * `push_subscriptions`, rows are per-user in auth mode (`user_id` gates
+ * settings and agent access; plain text, no FK, because local mode has no user
+ * rows). `mobile_device_id` ties the token to the stable mobile-device family
+ * so origin-device alert routing can match a session's `createdByDeviceId`;
+ * cascade delete means unpairing the device also silences its pushes.
+ * `workspace_tag` is an opaque client-supplied id echoed back in every push
+ * payload as `workspaceId` so the app can route the push to the right paired
+ * deployment.
+ */
+export const apnsDevices = sqliteTable('apns_devices', {
+  id: text('id').primaryKey(),
+  token: text('token').notNull().unique(),
+  environment: text('environment').notNull().default('production'), // 'sandbox' | 'production'
+  userId: text('user_id'),
+  mobileDeviceId: text('mobile_device_id').references(() => mobileDevice.id, { onDelete: 'cascade' }),
+  workspaceTag: text('workspace_tag'),
+  deviceName: text('device_name'),
+  platform: text('platform').notNull().default('ios'),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+}, (table) => ({
+  userIdIdx: index('apns_devices_user_id_idx').on(table.userId),
+  mobileDeviceIdIdx: index('apns_devices_mobile_device_id_idx').on(table.mobileDeviceId),
+}))
+
 // Single-row VAPID keypair identifying this install to push services.
 // Must stay stable: browsers bind subscriptions to the public key, so a
 // regenerated pair invalidates every existing push_subscriptions row

--- a/src/shared/lib/notifications/channels/apns-relay-channel.test.ts
+++ b/src/shared/lib/notifications/channels/apns-relay-channel.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   fetch: vi.fn(),
-  listApnsDevices: vi.fn((): unknown[] => []),
+  listDeliverableApnsDevices: vi.fn((): unknown[] => []),
   deleteApnsDeviceById: vi.fn(),
   getApnsRelayConfig: vi.fn(
     (): { url: string | null; enabled: boolean } => ({
@@ -26,7 +26,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('../push/apns-device-service', () => ({
-  listApnsDevices: mocks.listApnsDevices,
+  listDeliverableApnsDevices: mocks.listDeliverableApnsDevices,
   deleteApnsDeviceById: mocks.deleteApnsDeviceById,
 }))
 vi.mock('@shared/lib/config/settings', () => ({
@@ -103,7 +103,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   mocks.isAuthMode.mockReturnValue(false)
   mocks.getApnsRelayConfig.mockReturnValue({ url: 'https://relay.example', enabled: true })
-  mocks.listApnsDevices.mockReturnValue([makeDevice()])
+  mocks.listDeliverableApnsDevices.mockReturnValue([makeDevice()])
   mocks.getSessionMetadata.mockResolvedValue(null)
   mocks.getAccessibleAgentSlugs.mockResolvedValue([])
   mocks.getUserSettings.mockReturnValue({
@@ -133,7 +133,7 @@ describe('type gating', () => {
   it('never touches the relay for types outside the silent set', async () => {
     await channel.deliver(makeEvent({ type: 'session_chat_integration' }))
     expect(mocks.fetch).not.toHaveBeenCalled()
-    expect(mocks.listApnsDevices).not.toHaveBeenCalled()
+    expect(mocks.listDeliverableApnsDevices).not.toHaveBeenCalled()
   })
 })
 
@@ -145,7 +145,7 @@ describe('kill switch / disabled config', () => {
   })
 
   it('does nothing when no devices are registered', async () => {
-    mocks.listApnsDevices.mockReturnValue([])
+    mocks.listDeliverableApnsDevices.mockReturnValue([])
     await channel.deliver(makeEvent())
     expect(mocks.fetch).not.toHaveBeenCalled()
   })
@@ -153,7 +153,7 @@ describe('kill switch / disabled config', () => {
 
 describe('origin-device alert routing', () => {
   it('origin device gets a visible alert; all others get background pushes', async () => {
-    mocks.listApnsDevices.mockReturnValue([
+    mocks.listDeliverableApnsDevices.mockReturnValue([
       makeDevice(),
       makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
     ])
@@ -183,7 +183,7 @@ describe('origin-device alert routing', () => {
   })
 
   it('a session with no origin (web/cron/webhook) is silent to everyone', async () => {
-    mocks.listApnsDevices.mockReturnValue([
+    mocks.listDeliverableApnsDevices.mockReturnValue([
       makeDevice(),
       makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
     ])
@@ -197,7 +197,7 @@ describe('origin-device alert routing', () => {
   })
 
   it('a device row with no mobileDeviceId can never be the origin', async () => {
-    mocks.listApnsDevices.mockReturnValue([makeDevice({ mobileDeviceId: null })])
+    mocks.listDeliverableApnsDevices.mockReturnValue([makeDevice({ mobileDeviceId: null })])
     // A null metadata stamp must not match a null mobileDeviceId.
     mocks.getSessionMetadata.mockResolvedValue({ createdByDeviceId: undefined })
 
@@ -252,7 +252,7 @@ describe('owner settings gate', () => {
 
     mocks.isAuthMode.mockReturnValue(true)
     mocks.getAccessibleAgentSlugs.mockResolvedValue(['agent-x'])
-    mocks.listApnsDevices.mockReturnValue([makeDevice({ userId: 'user-a' })])
+    mocks.listDeliverableApnsDevices.mockReturnValue([makeDevice({ userId: 'user-a' })])
     await channel.deliver(makeEvent())
     expect(mocks.getUserSettings).toHaveBeenCalledWith('user-a')
   })
@@ -264,7 +264,7 @@ describe('auth-mode agent access gate', () => {
   })
 
   it('skips owners without access to the event agent — silent pushes too', async () => {
-    mocks.listApnsDevices.mockReturnValue([
+    mocks.listDeliverableApnsDevices.mockReturnValue([
       makeDevice({ userId: 'user-a' }),
       makeDevice({ id: 'dev-row-2', token: TOKEN_B, userId: 'user-b', mobileDeviceId: 'family-2' }),
     ])
@@ -280,7 +280,7 @@ describe('auth-mode agent access gate', () => {
   })
 
   it('never delivers to ownerless device rows in auth mode', async () => {
-    mocks.listApnsDevices.mockReturnValue([makeDevice({ userId: null })])
+    mocks.listDeliverableApnsDevices.mockReturnValue([makeDevice({ userId: null })])
 
     await channel.deliver(makeEvent())
 
@@ -305,7 +305,7 @@ describe('relay result handling', () => {
   })
 
   it('does NOT prune on RelayRateLimited (429) or RelayFetchFailed (0)', async () => {
-    mocks.listApnsDevices.mockReturnValue([
+    mocks.listDeliverableApnsDevices.mockReturnValue([
       makeDevice(),
       makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
     ])
@@ -322,7 +322,7 @@ describe('relay result handling', () => {
   })
 
   it('one dead token does not affect the others', async () => {
-    mocks.listApnsDevices.mockReturnValue([
+    mocks.listDeliverableApnsDevices.mockReturnValue([
       makeDevice(),
       makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
     ])
@@ -363,7 +363,7 @@ describe('batching', () => {
         mobileDeviceId: `family-${i}`,
       })
     )
-    mocks.listApnsDevices.mockReturnValue(devices)
+    mocks.listDeliverableApnsDevices.mockReturnValue(devices)
     mocks.fetch.mockImplementation(async (_url: unknown, init: unknown) => {
       const pushes = JSON.parse((init as { body: string }).body).pushes as Array<{
         deviceToken: string

--- a/src/shared/lib/notifications/channels/apns-relay-channel.test.ts
+++ b/src/shared/lib/notifications/channels/apns-relay-channel.test.ts
@@ -182,6 +182,36 @@ describe('origin-device alert routing', () => {
     expect(background.alert).toBeUndefined()
   })
 
+  it('an alertDeviceId claim overrides the creation stamp', async () => {
+    mocks.listDeliverableApnsDevices.mockReturnValue([
+      makeDevice(),
+      makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
+    ])
+    // Created on family-1, but family-2 spoke last — the alert follows it.
+    mocks.getSessionMetadata.mockResolvedValue({
+      createdByDeviceId: 'family-1',
+      alertDeviceId: 'family-2',
+    })
+
+    await channel.deliver(makeEvent())
+
+    const pushes = sentPushes()
+    expect(pushes.find((p) => p.deviceToken === TOKEN_A)!.kind).toBe('background')
+    expect(pushes.find((p) => p.deviceToken === TOKEN_B)!.kind).toBe('alert')
+  })
+
+  it('a null alertDeviceId (web spoke last) silences everyone despite a creation stamp', async () => {
+    mocks.listDeliverableApnsDevices.mockReturnValue([makeDevice()])
+    mocks.getSessionMetadata.mockResolvedValue({
+      createdByDeviceId: 'family-1',
+      alertDeviceId: null,
+    })
+
+    await channel.deliver(makeEvent())
+
+    expect(sentPushes()[0].kind).toBe('background')
+  })
+
   it('a session with no origin (web/cron/webhook) is silent to everyone', async () => {
     mocks.listDeliverableApnsDevices.mockReturnValue([
       makeDevice(),

--- a/src/shared/lib/notifications/channels/apns-relay-channel.test.ts
+++ b/src/shared/lib/notifications/channels/apns-relay-channel.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  listApnsDevices: vi.fn((): unknown[] => []),
+  deleteApnsDeviceById: vi.fn(),
+  getApnsRelayConfig: vi.fn(
+    (): { url: string | null; enabled: boolean } => ({
+      url: 'https://relay.example',
+      enabled: true,
+    })
+  ),
+  isAuthMode: vi.fn(() => false),
+  getUserSettings: vi.fn(() => ({
+    notifications: {
+      enabled: true,
+      sessionComplete: true,
+      sessionWaiting: true,
+      sessionScheduled: true,
+      platformNotification: true,
+      notifyWhenUnfocused: false,
+    },
+  })),
+  getAccessibleAgentSlugs: vi.fn(async (_userId: string): Promise<string[]> => []),
+  getSessionMetadata: vi.fn(async (): Promise<Record<string, unknown> | null> => null),
+}))
+
+vi.mock('../push/apns-device-service', () => ({
+  listApnsDevices: mocks.listApnsDevices,
+  deleteApnsDeviceById: mocks.deleteApnsDeviceById,
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getApnsRelayConfig: mocks.getApnsRelayConfig,
+}))
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: mocks.isAuthMode,
+}))
+vi.mock('@shared/lib/services/user-settings-service', () => ({
+  getUserSettings: mocks.getUserSettings,
+}))
+vi.mock('@shared/lib/services/notification-service', () => ({
+  getAccessibleAgentSlugs: mocks.getAccessibleAgentSlugs,
+}))
+vi.mock('@shared/lib/services/session-service', () => ({
+  getSessionMetadata: mocks.getSessionMetadata,
+}))
+
+vi.stubGlobal('fetch', mocks.fetch)
+
+import { ApnsRelayChannel } from './apns-relay-channel'
+import type { NotificationEvent } from '../notification-event'
+
+const TOKEN_A = 'a'.repeat(64)
+const TOKEN_B = 'b'.repeat(64)
+
+function makeEvent(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
+  return {
+    notificationId: 'notif-1',
+    type: 'session_complete',
+    sessionId: 'sess-1',
+    agentSlug: 'agent-x',
+    title: 'Session Complete',
+    body: 'Demo Agent has finished running',
+    navigatePath: '/agents/agent-x/sessions/sess-1',
+    ...overrides,
+  }
+}
+
+function makeDevice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'dev-row-1',
+    token: TOKEN_A,
+    environment: 'production',
+    userId: null,
+    mobileDeviceId: 'family-1',
+    workspaceTag: 'ws-1',
+    deviceName: 'iPhone',
+    platform: 'ios',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  }
+}
+
+function relayOk(results: Array<{ deviceToken: string; status: number; reason?: string }>) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ results }),
+  }
+}
+
+/** Every push sent across all fetch calls, in order. */
+function sentPushes(): Array<Record<string, unknown>> {
+  return mocks.fetch.mock.calls.flatMap(
+    (call) => JSON.parse((call[1] as { body: string }).body).pushes
+  )
+}
+
+const channel = new ApnsRelayChannel()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.isAuthMode.mockReturnValue(false)
+  mocks.getApnsRelayConfig.mockReturnValue({ url: 'https://relay.example', enabled: true })
+  mocks.listApnsDevices.mockReturnValue([makeDevice()])
+  mocks.getSessionMetadata.mockResolvedValue(null)
+  mocks.getAccessibleAgentSlugs.mockResolvedValue([])
+  mocks.getUserSettings.mockReturnValue({
+    notifications: {
+      enabled: true,
+      sessionComplete: true,
+      sessionWaiting: true,
+      sessionScheduled: true,
+      platformNotification: true,
+      notifyWhenUnfocused: false,
+    },
+  })
+  mocks.fetch.mockResolvedValue(
+    relayOk([{ deviceToken: TOKEN_A, status: 200 }]) as never
+  )
+})
+
+describe('type gating', () => {
+  it.each(['session_complete', 'session_waiting', 'session_scheduled', 'session_webhook'] as const)(
+    'delivers %s (at least silently)',
+    async (type) => {
+      await channel.deliver(makeEvent({ type }))
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('never touches the relay for types outside the silent set', async () => {
+    await channel.deliver(makeEvent({ type: 'session_chat_integration' }))
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(mocks.listApnsDevices).not.toHaveBeenCalled()
+  })
+})
+
+describe('kill switch / disabled config', () => {
+  it('does nothing when the relay is disabled (null url)', async () => {
+    mocks.getApnsRelayConfig.mockReturnValue({ url: null, enabled: false })
+    await channel.deliver(makeEvent())
+    expect(mocks.fetch).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when no devices are registered', async () => {
+    mocks.listApnsDevices.mockReturnValue([])
+    await channel.deliver(makeEvent())
+    expect(mocks.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('origin-device alert routing', () => {
+  it('origin device gets a visible alert; all others get background pushes', async () => {
+    mocks.listApnsDevices.mockReturnValue([
+      makeDevice(),
+      makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
+    ])
+    mocks.getSessionMetadata.mockResolvedValue({ createdByDeviceId: 'family-1' })
+
+    await channel.deliver(makeEvent())
+
+    const pushes = sentPushes()
+    expect(pushes).toHaveLength(2)
+    const alert = pushes.find((p) => p.deviceToken === TOKEN_A)!
+    const background = pushes.find((p) => p.deviceToken === TOKEN_B)!
+    expect(alert.kind).toBe('alert')
+    expect(alert.alert).toEqual({
+      title: 'Session Complete',
+      body: 'Demo Agent has finished running',
+    })
+    expect(alert.data).toMatchObject({
+      type: 'session_complete',
+      notificationId: 'notif-1',
+      sessionId: 'sess-1',
+      agentSlug: 'agent-x',
+      navigatePath: '/agents/agent-x/sessions/sess-1',
+      workspaceId: 'ws-1',
+    })
+    expect(background.kind).toBe('background')
+    expect(background.alert).toBeUndefined()
+  })
+
+  it('a session with no origin (web/cron/webhook) is silent to everyone', async () => {
+    mocks.listApnsDevices.mockReturnValue([
+      makeDevice(),
+      makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
+    ])
+    mocks.getSessionMetadata.mockResolvedValue({})
+
+    await channel.deliver(makeEvent())
+
+    const pushes = sentPushes()
+    expect(pushes).toHaveLength(2)
+    expect(pushes.every((p) => p.kind === 'background')).toBe(true)
+  })
+
+  it('a device row with no mobileDeviceId can never be the origin', async () => {
+    mocks.listApnsDevices.mockReturnValue([makeDevice({ mobileDeviceId: null })])
+    // A null metadata stamp must not match a null mobileDeviceId.
+    mocks.getSessionMetadata.mockResolvedValue({ createdByDeviceId: undefined })
+
+    await channel.deliver(makeEvent())
+
+    expect(sentPushes()[0].kind).toBe('background')
+  })
+
+  it('silent-only types are background even on the origin device', async () => {
+    mocks.getSessionMetadata.mockResolvedValue({ createdByDeviceId: 'family-1' })
+
+    await channel.deliver(makeEvent({ type: 'session_scheduled' }))
+
+    expect(sentPushes()[0].kind).toBe('background')
+  })
+
+  it('metadata read failure degrades to no-origin (all background), not to no delivery', async () => {
+    mocks.getSessionMetadata.mockRejectedValue(new Error('corrupt metadata'))
+
+    await channel.deliver(makeEvent())
+
+    expect(sentPushes()[0].kind).toBe('background')
+  })
+})
+
+describe('owner settings gate', () => {
+  it('prefs-disabled type degrades the origin device to background — never to nothing', async () => {
+    mocks.getSessionMetadata.mockResolvedValue({ createdByDeviceId: 'family-1' })
+    mocks.getUserSettings.mockReturnValue({
+      notifications: {
+        enabled: true,
+        sessionComplete: false,
+        sessionWaiting: true,
+        sessionScheduled: true,
+        platformNotification: true,
+        notifyWhenUnfocused: false,
+      },
+    })
+
+    await channel.deliver(makeEvent({ type: 'session_complete' }))
+
+    const pushes = sentPushes()
+    expect(pushes).toHaveLength(1)
+    expect(pushes[0].kind).toBe('background')
+  })
+
+  it('resolves settings per owner — local sentinel in local mode, user id in auth mode', async () => {
+    mocks.getSessionMetadata.mockResolvedValue({ createdByDeviceId: 'family-1' })
+
+    await channel.deliver(makeEvent())
+    expect(mocks.getUserSettings).toHaveBeenCalledWith('local')
+
+    mocks.isAuthMode.mockReturnValue(true)
+    mocks.getAccessibleAgentSlugs.mockResolvedValue(['agent-x'])
+    mocks.listApnsDevices.mockReturnValue([makeDevice({ userId: 'user-a' })])
+    await channel.deliver(makeEvent())
+    expect(mocks.getUserSettings).toHaveBeenCalledWith('user-a')
+  })
+})
+
+describe('auth-mode agent access gate', () => {
+  beforeEach(() => {
+    mocks.isAuthMode.mockReturnValue(true)
+  })
+
+  it('skips owners without access to the event agent — silent pushes too', async () => {
+    mocks.listApnsDevices.mockReturnValue([
+      makeDevice({ userId: 'user-a' }),
+      makeDevice({ id: 'dev-row-2', token: TOKEN_B, userId: 'user-b', mobileDeviceId: 'family-2' }),
+    ])
+    mocks.getAccessibleAgentSlugs.mockImplementation(async (userId: string) =>
+      userId === 'user-a' ? ['agent-x'] : ['agent-other']
+    )
+
+    await channel.deliver(makeEvent())
+
+    const pushes = sentPushes()
+    expect(pushes).toHaveLength(1)
+    expect(pushes[0].deviceToken).toBe(TOKEN_A)
+  })
+
+  it('never delivers to ownerless device rows in auth mode', async () => {
+    mocks.listApnsDevices.mockReturnValue([makeDevice({ userId: null })])
+
+    await channel.deliver(makeEvent())
+
+    expect(mocks.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('relay result handling', () => {
+  it.each([
+    { status: 410, reason: 'Unregistered' },
+    { status: 410, reason: undefined },
+    { status: 400, reason: 'BadDeviceToken' },
+    { status: 400, reason: 'DeviceTokenNotForTopic' },
+  ])('prunes the device on $status/$reason', async ({ status, reason }) => {
+    mocks.fetch.mockResolvedValue(
+      relayOk([{ deviceToken: TOKEN_A, status, reason }]) as never
+    )
+
+    await channel.deliver(makeEvent())
+
+    expect(mocks.deleteApnsDeviceById).toHaveBeenCalledWith('dev-row-1')
+  })
+
+  it('does NOT prune on RelayRateLimited (429) or RelayFetchFailed (0)', async () => {
+    mocks.listApnsDevices.mockReturnValue([
+      makeDevice(),
+      makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
+    ])
+    mocks.fetch.mockResolvedValue(
+      relayOk([
+        { deviceToken: TOKEN_A, status: 429, reason: 'RelayRateLimited' },
+        { deviceToken: TOKEN_B, status: 0, reason: 'RelayFetchFailed' },
+      ]) as never
+    )
+
+    await channel.deliver(makeEvent())
+
+    expect(mocks.deleteApnsDeviceById).not.toHaveBeenCalled()
+  })
+
+  it('one dead token does not affect the others', async () => {
+    mocks.listApnsDevices.mockReturnValue([
+      makeDevice(),
+      makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
+    ])
+    mocks.fetch.mockResolvedValue(
+      relayOk([
+        { deviceToken: TOKEN_A, status: 410, reason: 'Unregistered' },
+        { deviceToken: TOKEN_B, status: 200 },
+      ]) as never
+    )
+
+    await channel.deliver(makeEvent())
+
+    expect(mocks.deleteApnsDeviceById).toHaveBeenCalledTimes(1)
+    expect(mocks.deleteApnsDeviceById).toHaveBeenCalledWith('dev-row-1')
+  })
+
+  it('a network failure is swallowed and prunes nothing', async () => {
+    mocks.fetch.mockRejectedValue(new Error('connect ETIMEDOUT'))
+
+    await expect(channel.deliver(makeEvent())).resolves.toBeUndefined()
+    expect(mocks.deleteApnsDeviceById).not.toHaveBeenCalled()
+  })
+
+  it('a non-200 relay response is swallowed and prunes nothing', async () => {
+    mocks.fetch.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as never)
+
+    await expect(channel.deliver(makeEvent())).resolves.toBeUndefined()
+    expect(mocks.deleteApnsDeviceById).not.toHaveBeenCalled()
+  })
+})
+
+describe('batching', () => {
+  it('splits more than 50 pushes across multiple relay requests', async () => {
+    const devices = Array.from({ length: 60 }, (_, i) =>
+      makeDevice({
+        id: `dev-row-${i}`,
+        token: i.toString(16).padStart(64, '0'),
+        mobileDeviceId: `family-${i}`,
+      })
+    )
+    mocks.listApnsDevices.mockReturnValue(devices)
+    mocks.fetch.mockImplementation(async (_url: unknown, init: unknown) => {
+      const pushes = JSON.parse((init as { body: string }).body).pushes as Array<{
+        deviceToken: string
+      }>
+      return relayOk(pushes.map((p) => ({ deviceToken: p.deviceToken, status: 200 })))
+    })
+
+    await channel.deliver(makeEvent())
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(2)
+    const sizes = mocks.fetch.mock.calls.map(
+      (call) => JSON.parse((call[1] as { body: string }).body).pushes.length
+    )
+    expect(sizes).toEqual([50, 10])
+  })
+
+  it('posts to {url}/push with a bounded timeout', async () => {
+    await channel.deliver(makeEvent())
+
+    const [url, init] = mocks.fetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://relay.example/push')
+    expect(init.method).toBe('POST')
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+})

--- a/src/shared/lib/notifications/channels/apns-relay-channel.ts
+++ b/src/shared/lib/notifications/channels/apns-relay-channel.ts
@@ -1,0 +1,222 @@
+import { isAuthMode } from '@shared/lib/auth/mode'
+import { getApnsRelayConfig } from '@shared/lib/config/settings'
+import { getUserSettings } from '@shared/lib/services/user-settings-service'
+import { getAccessibleAgentSlugs } from '@shared/lib/services/notification-service'
+import { getSessionMetadata } from '@shared/lib/services/session-service'
+import {
+  listApnsDevices,
+  deleteApnsDeviceById,
+  type ApnsDeviceRow,
+} from '../push/apns-device-service'
+import {
+  buildApnsAlertPush,
+  buildApnsBackgroundPush,
+  type ApnsRelayPush,
+} from '../push/apns-payload'
+import { isNotificationTypeEnabled } from '../notification-preferences'
+import type { NotificationType } from '@shared/lib/services/notification-service'
+import type { NotificationChannel } from './types'
+import type { NotificationEvent } from '../notification-event'
+
+/**
+ * Only the "phone me" types may show a visible alert — and only on the device
+ * that started the session. Everything else the channel carries is a silent
+ * content-available push (widget/snapshot invalidation), so the silent set is
+ * wider: automation runs change agent state the widget shows, but must never
+ * buzz a phone.
+ * Typed against the union so a renamed or mistyped member fails typecheck
+ * instead of silently never pushing.
+ */
+const VISIBLE_TYPES = new Set<NotificationType>(['session_complete', 'session_waiting'])
+const SILENT_TYPES = new Set<NotificationType>([
+  'session_complete',
+  'session_waiting',
+  'session_scheduled',
+  'session_webhook',
+])
+
+/** Relay wire contract: 1..50 pushes per request. */
+const MAX_PUSHES_PER_REQUEST = 50
+const SEND_TIMEOUT_MS = 10_000
+
+/**
+ * Relay result statuses/reasons that mean the token is permanently dead
+ * (uninstalled app, rotated token, token from a different app/topic) — the
+ * device row is pruned. Everything else (RelayRateLimited 429, RelayFetchFailed
+ * status 0, 5xx) is transient: log and keep the row.
+ */
+function isTokenDead(status: number, reason: string | undefined): boolean {
+  return (
+    status === 410 ||
+    reason === 'Unregistered' ||
+    reason === 'BadDeviceToken' ||
+    reason === 'DeviceTokenNotForTopic'
+  )
+}
+
+interface RelayResult {
+  deviceToken: string
+  status: number
+  reason?: string
+}
+
+/**
+ * Delivers over APNs (via the deployed Cloudflare Worker relay, which holds
+ * the APNs credentials) to native iOS app installs with a registered device
+ * token. Like WebPushChannel there is no live client to defer policy to, so
+ * gating happens here per device: the type allowlists, the owner's
+ * notification settings, and (in auth mode) the owner's agent access.
+ *
+ * Alert routing: only the device whose mobile-device family started the
+ * session (session metadata `createdByDeviceId`) gets a visible alert; every
+ * other eligible device gets a silent background push. Sessions with no origin
+ * (web/cron/webhook) are silent to everyone. An origin device whose owner
+ * disabled the type degrades to a background push — never to nothing, so the
+ * widget still refreshes.
+ */
+export class ApnsRelayChannel implements NotificationChannel {
+  readonly id = 'apns_relay'
+
+  async deliver(event: NotificationEvent): Promise<void> {
+    try {
+      await this.deliverInner(event)
+    } catch (error) {
+      // Fire-and-forget: a relay/config failure must never affect other channels.
+      console.error('[ApnsRelayChannel] delivery failed:', error)
+    }
+  }
+
+  private async deliverInner(event: NotificationEvent): Promise<void> {
+    if (!SILENT_TYPES.has(event.type)) {
+      return
+    }
+
+    const { url } = getApnsRelayConfig()
+    if (!url) {
+      return
+    }
+
+    const devices = listApnsDevices()
+    if (devices.length === 0) {
+      return
+    }
+
+    const originDeviceId = await this.getOriginDeviceId(event)
+
+    // Several devices can share an owner — resolve agent access once per user.
+    const accessCache = new Map<string, Promise<string[]>>()
+
+    const batch: Array<{ device: ApnsDeviceRow; push: ApnsRelayPush }> = []
+    for (const device of devices) {
+      const push = await this.buildPushForDevice(event, device, originDeviceId, accessCache)
+      if (push) {
+        batch.push({ device, push })
+      }
+    }
+    if (batch.length === 0) {
+      return
+    }
+
+    for (let i = 0; i < batch.length; i += MAX_PUSHES_PER_REQUEST) {
+      await this.sendChunk(url, batch.slice(i, i + MAX_PUSHES_PER_REQUEST))
+    }
+  }
+
+  /** Origin mobile-device family of the session, or null (web/cron/webhook). */
+  private async getOriginDeviceId(event: NotificationEvent): Promise<string | null> {
+    try {
+      const meta = await getSessionMetadata(event.agentSlug, event.sessionId)
+      return meta?.createdByDeviceId ?? null
+    } catch (error) {
+      console.error('[ApnsRelayChannel] failed to read session metadata:', error)
+      return null
+    }
+  }
+
+  /** Per-device gating + payload choice; null = skip this device entirely. */
+  private async buildPushForDevice(
+    event: NotificationEvent,
+    device: ApnsDeviceRow,
+    originDeviceId: string | null,
+    accessCache: Map<string, Promise<string[]>>
+  ): Promise<ApnsRelayPush | null> {
+    if (isAuthMode()) {
+      // An ownerless row in auth mode (e.g. registered before auth was
+      // enabled) has no user to gate on — never deliver to it.
+      if (!device.userId) {
+        return null
+      }
+      let access = accessCache.get(device.userId)
+      if (!access) {
+        access = getAccessibleAgentSlugs(device.userId)
+        accessCache.set(device.userId, access)
+      }
+      // No access to the agent means no push at all — a silent push still
+      // leaks that the agent ran.
+      if (!(await access).includes(event.agentSlug)) {
+        return null
+      }
+    }
+
+    const isOrigin = device.mobileDeviceId != null && device.mobileDeviceId === originDeviceId
+    if (isOrigin && VISIBLE_TYPES.has(event.type)) {
+      // In local mode the single local user's settings govern every device —
+      // including rows that retain a userId from a previous auth-mode life of
+      // this database (that user's old per-user settings row is stale there).
+      const ownerId = isAuthMode() ? (device.userId as string) : 'local'
+      const settings = getUserSettings(ownerId)
+      if (isNotificationTypeEnabled(settings.notifications, event.type)) {
+        return buildApnsAlertPush(event, device)
+      }
+      // Prefs disabled: degrade to background so the widget still refreshes.
+    }
+    return buildApnsBackgroundPush(event, device)
+  }
+
+  private async sendChunk(
+    url: string,
+    chunk: Array<{ device: ApnsDeviceRow; push: ApnsRelayPush }>
+  ): Promise<void> {
+    let results: RelayResult[]
+    try {
+      const response = await fetch(`${url}/push`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pushes: chunk.map((entry) => entry.push) }),
+        signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+      })
+      if (!response.ok) {
+        console.error(`[ApnsRelayChannel] relay returned HTTP ${response.status}; keeping devices`)
+        return
+      }
+      const body = (await response.json()) as { results?: RelayResult[] }
+      if (!Array.isArray(body.results)) {
+        console.error('[ApnsRelayChannel] relay response missing results array')
+        return
+      }
+      results = body.results
+    } catch (error) {
+      // Network failure/timeout is transient — never prune on it.
+      console.error('[ApnsRelayChannel] relay request failed:', error)
+      return
+    }
+
+    // Results come back in input order, one per push.
+    results.forEach((result, index) => {
+      const entry = chunk[index]
+      if (!entry) {
+        return
+      }
+      if (isTokenDead(result.status, result.reason)) {
+        deleteApnsDeviceById(entry.device.id)
+        return
+      }
+      if (result.status < 200 || result.status >= 300) {
+        // Transient (RelayRateLimited 429, RelayFetchFailed 0, 5xx): log, keep.
+        console.error(
+          `[ApnsRelayChannel] push failed (${result.status}${result.reason ? ` ${result.reason}` : ''}) for device ${entry.device.id}`
+        )
+      }
+    })
+  }
+}

--- a/src/shared/lib/notifications/channels/apns-relay-channel.ts
+++ b/src/shared/lib/notifications/channels/apns-relay-channel.ts
@@ -122,11 +122,19 @@ export class ApnsRelayChannel implements NotificationChannel {
     }
   }
 
-  /** Origin mobile-device family of the session, or null (web/cron/webhook). */
+  /**
+   * Which mobile-device family gets the VISIBLE push for this session.
+   * "Last speaker claims the alert": alertDeviceId is re-stamped on every
+   * device-authenticated message send and explicitly null when a deviceless
+   * surface (web) spoke last; absent means the session was never re-claimed,
+   * so the creation stamp decides. Null result = silent for everyone.
+   */
   private async getOriginDeviceId(event: NotificationEvent): Promise<string | null> {
     try {
       const meta = await getSessionMetadata(event.agentSlug, event.sessionId)
-      return meta?.createdByDeviceId ?? null
+      if (!meta) return null
+      if (meta.alertDeviceId !== undefined) return meta.alertDeviceId
+      return meta.createdByDeviceId ?? null
     } catch (error) {
       console.error('[ApnsRelayChannel] failed to read session metadata:', error)
       return null

--- a/src/shared/lib/notifications/channels/apns-relay-channel.ts
+++ b/src/shared/lib/notifications/channels/apns-relay-channel.ts
@@ -4,7 +4,7 @@ import { getUserSettings } from '@shared/lib/services/user-settings-service'
 import { getAccessibleAgentSlugs } from '@shared/lib/services/notification-service'
 import { getSessionMetadata } from '@shared/lib/services/session-service'
 import {
-  listApnsDevices,
+  listDeliverableApnsDevices,
   deleteApnsDeviceById,
   type ApnsDeviceRow,
 } from '../push/apns-device-service'
@@ -96,7 +96,7 @@ export class ApnsRelayChannel implements NotificationChannel {
       return
     }
 
-    const devices = listApnsDevices()
+    const devices = listDeliverableApnsDevices()
     if (devices.length === 0) {
       return
     }

--- a/src/shared/lib/notifications/channels/index.ts
+++ b/src/shared/lib/notifications/channels/index.ts
@@ -1,17 +1,18 @@
 import { ClientBroadcastChannel } from './client-broadcast-channel'
 import { WebPushChannel } from './web-push-channel'
+import { ApnsRelayChannel } from './apns-relay-channel'
 import type { NotificationChannel } from './types'
 
 let channels: NotificationChannel[] | null = null
 
 /**
- * Every registered delivery backend. Adding a platform (APNs for the native
- * companion app, a platform relay, …) means implementing NotificationChannel
- * and appending it here — trigger sites and the event shape don't change.
+ * Every registered delivery backend. Adding a platform (a platform relay, …)
+ * means implementing NotificationChannel and appending it here — trigger
+ * sites and the event shape don't change.
  */
 export function getNotificationChannels(): NotificationChannel[] {
   if (!channels) {
-    channels = [new ClientBroadcastChannel(), new WebPushChannel()]
+    channels = [new ClientBroadcastChannel(), new WebPushChannel(), new ApnsRelayChannel()]
   }
   return channels
 }

--- a/src/shared/lib/notifications/push/apns-device-schema.ts
+++ b/src/shared/lib/notifications/push/apns-device-schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+/**
+ * Wire shape of the native app's device registration call
+ * (POST /api/push/devices). Validated at the API boundary before anything is
+ * stored. The token is the raw APNs device token in hex — Apple documents no
+ * fixed length (currently 32 bytes / 64 hex chars, historically promised to
+ * grow), so accept a bounded hex range rather than exactly 64.
+ */
+export const apnsDeviceRegisterRequestSchema = z.object({
+  token: z.string().regex(/^[0-9a-f]{64,200}$/i, 'Token must be 64-200 hex characters'),
+  /** Which APNs environment issued the token (Xcode/dev builds → sandbox). */
+  environment: z.enum(['sandbox', 'production']).default('production'),
+  platform: z.string().max(64).default('ios'),
+  deviceName: z.string().max(120).optional(),
+  /**
+   * Opaque client-chosen workspace id, echoed back in every push payload as
+   * `workspaceId` so the app can route the push to the right paired deployment.
+   */
+  workspaceTag: z.string().max(128).optional(),
+})
+
+export type ApnsDeviceRegisterRequest = z.infer<typeof apnsDeviceRegisterRequestSchema>

--- a/src/shared/lib/notifications/push/apns-device-service.test.ts
+++ b/src/shared/lib/notifications/push/apns-device-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as path from 'path'
+import { eq } from 'drizzle-orm'
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
@@ -20,6 +21,7 @@ vi.mock('../../db', () => ({
 import {
   upsertApnsDevice,
   listApnsDevices,
+  listDeliverableApnsDevices,
   deleteApnsDeviceById,
   deleteApnsDeviceByToken,
   MAX_APNS_DEVICES_PER_OWNER,
@@ -155,6 +157,32 @@ describe('apns-device-service', () => {
       upsertApnsDevice({ ...BASE_DEVICE, token: TOKEN_B, userId: 'user-a' })
 
       expect(listApnsDevices()).toHaveLength(2)
+    })
+
+    it('delivery excludes registrations whose paired device has expired', () => {
+      seedMobileDevices('dev-live', 'dev-expired')
+      testDb
+        .update(schema.mobileDevice)
+        .set({ expiresAt: new Date(Date.now() - 1000) })
+        .where(eq(schema.mobileDevice.id, 'dev-expired'))
+        .run()
+
+      upsertApnsDevice({ ...BASE_DEVICE, userId: 'user-a', mobileDeviceId: 'dev-live' })
+      upsertApnsDevice({
+        ...BASE_DEVICE,
+        token: TOKEN_B,
+        userId: 'user-a',
+        mobileDeviceId: 'dev-expired',
+      })
+      // Defensive local-mode-parity row with no device link stays deliverable.
+      upsertApnsDevice({ ...BASE_DEVICE, token: 'c'.repeat(64) })
+
+      expect(listApnsDevices()).toHaveLength(3)
+      const deliverable = listDeliverableApnsDevices()
+      expect(deliverable).toHaveLength(2)
+      expect(deliverable.map((d) => d.mobileDeviceId)).toEqual(
+        expect.arrayContaining(['dev-live', null])
+      )
     })
   })
 

--- a/src/shared/lib/notifications/push/apns-device-service.test.ts
+++ b/src/shared/lib/notifications/push/apns-device-service.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as path from 'path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../../db/schema'
+
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+
+vi.mock('../../db', () => ({
+  get db() {
+    return testDb
+  },
+  get sqlite() {
+    return testSqlite
+  },
+}))
+
+import {
+  upsertApnsDevice,
+  listApnsDevices,
+  deleteApnsDeviceById,
+  deleteApnsDeviceByToken,
+  MAX_APNS_DEVICES_PER_OWNER,
+} from './apns-device-service'
+
+const TOKEN_A = 'a'.repeat(64)
+const TOKEN_B = 'b'.repeat(64)
+
+const BASE_DEVICE = {
+  token: TOKEN_A,
+  environment: 'production',
+  userId: null,
+  mobileDeviceId: null,
+}
+
+function tokenFor(i: number): string {
+  return i.toString(16).padStart(64, '0')
+}
+
+describe('apns-device-service', () => {
+  beforeEach(() => {
+    testSqlite = new Database(':memory:')
+    testDb = drizzle(testSqlite, { schema })
+    const migrationsFolder = path.join(process.cwd(), 'src/shared/lib/db/migrations')
+    migrate(testDb, { migrationsFolder })
+  })
+
+  afterEach(() => {
+    testSqlite?.close()
+  })
+
+  it('inserts a new device with defaults applied', () => {
+    upsertApnsDevice({ ...BASE_DEVICE, deviceName: 'iPhone 17', workspaceTag: 'ws-1' })
+
+    const rows = listApnsDevices()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      token: TOKEN_A,
+      environment: 'production',
+      userId: null,
+      mobileDeviceId: null,
+      workspaceTag: 'ws-1',
+      deviceName: 'iPhone 17',
+      platform: 'ios',
+    })
+  })
+
+  it('upserts by token — re-registering refreshes metadata instead of duplicating', () => {
+    upsertApnsDevice(BASE_DEVICE)
+    upsertApnsDevice({
+      ...BASE_DEVICE,
+      environment: 'sandbox',
+      deviceName: 'Renamed Phone',
+      workspaceTag: 'ws-2',
+    })
+
+    const rows = listApnsDevices()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].environment).toBe('sandbox')
+    expect(rows[0].deviceName).toBe('Renamed Phone')
+    expect(rows[0].workspaceTag).toBe('ws-2')
+  })
+
+  it('deletes by id', () => {
+    upsertApnsDevice(BASE_DEVICE)
+    const [row] = listApnsDevices()
+
+    deleteApnsDeviceById(row.id)
+
+    expect(listApnsDevices()).toHaveLength(0)
+  })
+
+  describe('mobileDeviceId token-rotation eviction', () => {
+    function seedMobileDevices(...ids: string[]) {
+      const now = new Date()
+      testDb
+        .insert(schema.user)
+        .values({
+          id: 'user-a',
+          name: 'User A',
+          email: 'a@example.com',
+          emailVerified: true,
+          createdAt: now,
+          updatedAt: now,
+        } as never)
+        .run()
+      for (const id of ids) {
+        testDb
+          .insert(schema.mobileDevice)
+          .values({
+            id,
+            userId: 'user-a',
+            refreshTokenHash: `hash-${id}`,
+            createdAt: now,
+            updatedAt: now,
+            expiresAt: new Date(now.getTime() + 86_400_000),
+          })
+          .run()
+      }
+    }
+
+    it('a new token for the same physical device evicts the rotated-away one', () => {
+      seedMobileDevices('dev-1')
+      upsertApnsDevice({ ...BASE_DEVICE, userId: 'user-a', mobileDeviceId: 'dev-1' })
+      upsertApnsDevice({
+        ...BASE_DEVICE,
+        token: TOKEN_B,
+        userId: 'user-a',
+        mobileDeviceId: 'dev-1',
+      })
+
+      const rows = listApnsDevices()
+      expect(rows).toHaveLength(1)
+      expect(rows[0].token).toBe(TOKEN_B)
+    })
+
+    it('does not evict rows belonging to a different physical device', () => {
+      seedMobileDevices('dev-1', 'dev-2')
+      upsertApnsDevice({ ...BASE_DEVICE, userId: 'user-a', mobileDeviceId: 'dev-1' })
+      upsertApnsDevice({
+        ...BASE_DEVICE,
+        token: TOKEN_B,
+        userId: 'user-a',
+        mobileDeviceId: 'dev-2',
+      })
+
+      expect(listApnsDevices()).toHaveLength(2)
+    })
+
+    it('a null mobileDeviceId never evicts anything', () => {
+      seedMobileDevices('dev-1')
+      upsertApnsDevice({ ...BASE_DEVICE, userId: 'user-a', mobileDeviceId: 'dev-1' })
+      upsertApnsDevice({ ...BASE_DEVICE, token: TOKEN_B, userId: 'user-a' })
+
+      expect(listApnsDevices()).toHaveLength(2)
+    })
+  })
+
+  describe('per-owner device cap', () => {
+    it('rejects a new token once the owner is at the cap; refreshing an existing one still works', () => {
+      for (let i = 0; i < MAX_APNS_DEVICES_PER_OWNER; i++) {
+        expect(upsertApnsDevice({ ...BASE_DEVICE, token: tokenFor(i) })).toBe(true)
+      }
+
+      expect(upsertApnsDevice({ ...BASE_DEVICE, token: 'f'.repeat(64) })).toBe(false)
+      expect(listApnsDevices()).toHaveLength(MAX_APNS_DEVICES_PER_OWNER)
+
+      // Re-upserting a token that already exists is a refresh, not growth.
+      expect(
+        upsertApnsDevice({ ...BASE_DEVICE, token: tokenFor(0), deviceName: 'refreshed' })
+      ).toBe(true)
+    })
+
+    it('the cap is per owner, not global', () => {
+      for (let i = 0; i < MAX_APNS_DEVICES_PER_OWNER; i++) {
+        upsertApnsDevice({ ...BASE_DEVICE, token: tokenFor(i), userId: 'user-a' })
+      }
+      expect(
+        upsertApnsDevice({ ...BASE_DEVICE, token: 'f'.repeat(64), userId: 'user-b' })
+      ).toBe(true)
+    })
+  })
+
+  describe('deleteApnsDeviceByToken owner scoping', () => {
+    it('an auth-mode user cannot delete another user’s device by token', () => {
+      upsertApnsDevice({ ...BASE_DEVICE, userId: 'user-a' })
+
+      expect(deleteApnsDeviceByToken(TOKEN_A, 'user-b')).toBe(false)
+      expect(listApnsDevices()).toHaveLength(1)
+
+      expect(deleteApnsDeviceByToken(TOKEN_A, 'user-a')).toBe(true)
+      expect(listApnsDevices()).toHaveLength(0)
+    })
+
+    it('local mode (no owner) deletes by token alone — including rows from a previous auth-mode life', () => {
+      upsertApnsDevice({ ...BASE_DEVICE, userId: 'user-a' })
+
+      expect(deleteApnsDeviceByToken(TOKEN_A)).toBe(true)
+      expect(listApnsDevices()).toHaveLength(0)
+    })
+
+    it('returns false when nothing matches (route surfaces this as 404)', () => {
+      expect(deleteApnsDeviceByToken('0'.repeat(64))).toBe(false)
+    })
+  })
+})

--- a/src/shared/lib/notifications/push/apns-device-service.ts
+++ b/src/shared/lib/notifications/push/apns-device-service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
-import { and, eq, isNull, ne, count } from 'drizzle-orm'
+import { and, eq, gt, isNull, ne, or, count, getTableColumns } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
-import { apnsDevices } from '@shared/lib/db/schema'
+import { apnsDevices, mobileDevice } from '@shared/lib/db/schema'
 
 export type ApnsDeviceRow = typeof apnsDevices.$inferSelect
 
@@ -103,6 +103,22 @@ export function upsertApnsDevice(params: {
 
 export function listApnsDevices(): ApnsDeviceRow[] {
   return db.select().from(apnsDevices).all()
+}
+
+/**
+ * Devices eligible for push DELIVERY: registrations whose paired mobile
+ * device is still live. An expired pairing is hidden from the user's device
+ * management UI — it must not keep receiving session metadata just because
+ * APNs still accepts its token. Rows with no device link (defensive local-mode
+ * parity with push_subscriptions) stay deliverable.
+ */
+export function listDeliverableApnsDevices(now: Date = new Date()): ApnsDeviceRow[] {
+  return db
+    .select(getTableColumns(apnsDevices))
+    .from(apnsDevices)
+    .leftJoin(mobileDevice, eq(apnsDevices.mobileDeviceId, mobileDevice.id))
+    .where(or(isNull(apnsDevices.mobileDeviceId), gt(mobileDevice.expiresAt, now)))
+    .all()
 }
 
 export function deleteApnsDeviceById(id: string): void {

--- a/src/shared/lib/notifications/push/apns-device-service.ts
+++ b/src/shared/lib/notifications/push/apns-device-service.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from 'crypto'
+import { and, eq, isNull, ne, count } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { apnsDevices } from '@shared/lib/db/schema'
+
+export type ApnsDeviceRow = typeof apnsDevices.$inferSelect
+
+/**
+ * Ceiling on stored devices per owner. Real users have a handful of devices;
+ * the cap exists so an authenticated caller can't grow the table (and the
+ * per-notification send fan-out) without bound. Refreshing an existing token
+ * never counts against it.
+ */
+export const MAX_APNS_DEVICES_PER_OWNER = 10
+
+/**
+ * Insert or refresh a device's APNs registration, keyed by the device token.
+ * The app re-registers on every launch (APNs asks apps to treat the token as
+ * ephemeral), so this doubles as the keep-alive that repairs a lost row.
+ *
+ * When the registration carries a `mobileDeviceId`, any other row for the same
+ * physical device but a DIFFERENT token is deleted in the same transaction —
+ * APNs rotates tokens across reinstalls/restores and the stale token would
+ * otherwise linger until a send finally reports it Unregistered.
+ *
+ * Returns false when the owner is at MAX_APNS_DEVICES_PER_OWNER and the token
+ * is new (the route surfaces this as 429).
+ */
+export function upsertApnsDevice(params: {
+  token: string
+  environment: string
+  userId: string | null
+  mobileDeviceId: string | null
+  workspaceTag?: string | null
+  deviceName?: string | null
+  platform?: string
+}): boolean {
+  const now = new Date()
+  return db.transaction((tx) => {
+    if (params.mobileDeviceId !== null) {
+      // One live token per physical device: drop rotated-away tokens.
+      tx.delete(apnsDevices)
+        .where(
+          and(
+            eq(apnsDevices.mobileDeviceId, params.mobileDeviceId),
+            ne(apnsDevices.token, params.token)
+          )
+        )
+        .run()
+    }
+
+    const exists = tx
+      .select({ id: apnsDevices.id })
+      .from(apnsDevices)
+      .where(eq(apnsDevices.token, params.token))
+      .limit(1)
+      .all()
+
+    if (exists.length === 0) {
+      const ownerFilter =
+        params.userId === null
+          ? isNull(apnsDevices.userId)
+          : eq(apnsDevices.userId, params.userId)
+      const [{ ownerCount }] = tx
+        .select({ ownerCount: count() })
+        .from(apnsDevices)
+        .where(ownerFilter)
+        .all()
+      if (ownerCount >= MAX_APNS_DEVICES_PER_OWNER) {
+        return false
+      }
+    }
+
+    tx.insert(apnsDevices)
+      .values({
+        id: randomUUID(),
+        token: params.token,
+        environment: params.environment,
+        userId: params.userId,
+        mobileDeviceId: params.mobileDeviceId,
+        workspaceTag: params.workspaceTag ?? null,
+        deviceName: params.deviceName ?? null,
+        platform: params.platform ?? 'ios',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: apnsDevices.token,
+        set: {
+          environment: params.environment,
+          userId: params.userId,
+          mobileDeviceId: params.mobileDeviceId,
+          workspaceTag: params.workspaceTag ?? null,
+          deviceName: params.deviceName ?? null,
+          platform: params.platform ?? 'ios',
+          updatedAt: now,
+        },
+      })
+      .run()
+    return true
+  })
+}
+
+export function listApnsDevices(): ApnsDeviceRow[] {
+  return db.select().from(apnsDevices).all()
+}
+
+export function deleteApnsDeviceById(id: string): void {
+  db.delete(apnsDevices).where(eq(apnsDevices.id, id)).run()
+}
+
+/**
+ * Remove a device's registration. In auth mode the delete is scoped to the
+ * owner (`ownerUserId`) so one user can't unregister another user's device by
+ * guessing its token. Local mode (undefined) deletes by token alone: the
+ * single local user owns every device, including rows created under a
+ * previous auth-mode life of the same database — those must stay deletable.
+ */
+export function deleteApnsDeviceByToken(token: string, ownerUserId?: string): boolean {
+  const ownerFilter =
+    ownerUserId === undefined ? undefined : eq(apnsDevices.userId, ownerUserId)
+  const result = db
+    .delete(apnsDevices)
+    .where(and(eq(apnsDevices.token, token), ownerFilter))
+    .run()
+  return result.changes > 0
+}

--- a/src/shared/lib/notifications/push/apns-payload.test.ts
+++ b/src/shared/lib/notifications/push/apns-payload.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { buildApnsAlertPush, buildApnsBackgroundPush } from './apns-payload'
+import type { ApnsDeviceRow } from './apns-device-service'
+import type { NotificationEvent } from '../notification-event'
+
+const NOW_MS = 1_755_200_000_000
+
+function makeEvent(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
+  return {
+    notificationId: 'notif-1',
+    type: 'session_complete',
+    sessionId: 'sess-1',
+    agentSlug: 'agent-x',
+    title: 'Session Complete',
+    body: 'Demo Agent has finished running',
+    navigatePath: '/agents/agent-x/sessions/sess-1',
+    ...overrides,
+  }
+}
+
+function makeDevice(overrides: Partial<ApnsDeviceRow> = {}): ApnsDeviceRow {
+  return {
+    id: 'dev-row-1',
+    token: 'a'.repeat(64),
+    environment: 'production',
+    userId: null,
+    mobileDeviceId: 'family-1',
+    workspaceTag: 'ws-1',
+    deviceName: 'iPhone',
+    platform: 'ios',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  }
+}
+
+describe('buildApnsAlertPush', () => {
+  it('builds the full alert push shape', () => {
+    const push = buildApnsAlertPush(makeEvent(), makeDevice(), NOW_MS)
+
+    expect(push).toEqual({
+      deviceToken: 'a'.repeat(64),
+      environment: 'production',
+      kind: 'alert',
+      alert: { title: 'Session Complete', body: 'Demo Agent has finished running' },
+      data: {
+        type: 'session_complete',
+        notificationId: 'notif-1',
+        sessionId: 'sess-1',
+        agentSlug: 'agent-x',
+        navigatePath: '/agents/agent-x/sessions/sess-1',
+        workspaceId: 'ws-1',
+      },
+      collapseId: 'sess-1',
+      expiration: NOW_MS / 1000 + 60 * 60,
+    })
+  })
+
+  it('echoes the device workspaceTag as workspaceId; a null tag becomes undefined', () => {
+    const push = buildApnsAlertPush(makeEvent(), makeDevice({ workspaceTag: null }), NOW_MS)
+    expect(push.data.workspaceId).toBeUndefined()
+  })
+
+  it('carries the sandbox environment through for dev-build tokens', () => {
+    const push = buildApnsAlertPush(makeEvent(), makeDevice({ environment: 'sandbox' }), NOW_MS)
+    expect(push.environment).toBe('sandbox')
+  })
+
+  it('sanitizes the collapse id — strips non [A-Za-z0-9_-] and caps at 64 chars', () => {
+    const push = buildApnsAlertPush(
+      makeEvent({ sessionId: 'sess/1:evil?' + 'x'.repeat(100) }),
+      makeDevice(),
+      NOW_MS
+    )
+    expect(push.collapseId).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(push.collapseId!.length).toBeLessThanOrEqual(64)
+    expect(push.collapseId!.startsWith('sess1evil')).toBe(true)
+  })
+
+  it('actionable session_waiting pushes carry a short TTL — stale prompts expire', () => {
+    const push = buildApnsAlertPush(makeEvent({ type: 'session_waiting' }), makeDevice(), NOW_MS)
+    expect(push.expiration).toBe(NOW_MS / 1000 + 10 * 60)
+  })
+})
+
+describe('buildApnsBackgroundPush', () => {
+  it('builds a silent push: no alert, no collapse id, minimal data', () => {
+    const push = buildApnsBackgroundPush(
+      makeEvent({ type: 'session_scheduled' }),
+      makeDevice(),
+      NOW_MS
+    )
+
+    expect(push).toEqual({
+      deviceToken: 'a'.repeat(64),
+      environment: 'production',
+      kind: 'background',
+      data: {
+        type: 'session_scheduled',
+        sessionId: 'sess-1',
+        agentSlug: 'agent-x',
+        workspaceId: 'ws-1',
+      },
+      expiration: NOW_MS / 1000 + 60 * 60,
+    })
+    expect(push.alert).toBeUndefined()
+    expect(push.collapseId).toBeUndefined()
+  })
+
+  it('uses the default TTL for types without a specific one', () => {
+    const push = buildApnsBackgroundPush(
+      makeEvent({ type: 'session_webhook' }),
+      makeDevice(),
+      NOW_MS
+    )
+    expect(push.expiration).toBe(NOW_MS / 1000 + 60 * 60)
+  })
+})

--- a/src/shared/lib/notifications/push/apns-payload.ts
+++ b/src/shared/lib/notifications/push/apns-payload.ts
@@ -1,0 +1,95 @@
+import type { NotificationEvent } from '../notification-event'
+import type { ApnsDeviceRow } from './apns-device-service'
+
+/**
+ * One push object in the APNs relay's wire contract (POST {relayUrl}/push).
+ * The relay spreads `data` at the top level of the APNs payload (stripping any
+ * `aps` key) and, for alerts, adds sound=default and thread-id=agentSlug
+ * itself — so this builder only supplies content, addressing, and lifetime.
+ */
+export interface ApnsRelayPush {
+  deviceToken: string
+  environment: string
+  kind: 'alert' | 'background'
+  alert?: { title: string; body: string }
+  data: Record<string, unknown>
+  collapseId?: string
+  expiration?: number
+}
+
+/**
+ * How long APNs may hold an undelivered push for an offline device. Mirrors
+ * WebPushChannel's TTLs: an "Action Required" prompt is pointless once the
+ * review window has passed; a completion is stale after an hour.
+ */
+const PUSH_TTL_SECONDS: Record<string, number> = {
+  session_waiting: 10 * 60,
+  session_complete: 60 * 60,
+}
+const DEFAULT_PUSH_TTL_SECONDS = 60 * 60
+
+function expirationFor(type: string, nowMs: number): number {
+  return Math.floor(nowMs / 1000) + (PUSH_TTL_SECONDS[type] ?? DEFAULT_PUSH_TTL_SECONDS)
+}
+
+/**
+ * APNs collapse id (≤64 chars, header-safe): one id per session, so while the
+ * device is offline a newer push for the same session replaces an undelivered
+ * older one (a stale "Action Required") instead of stacking behind it.
+ */
+function collapseIdForSession(sessionId: string): string {
+  return sessionId.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 64)
+}
+
+/**
+ * Visible alert push — only for the device that started the session (origin).
+ * `data` keys land at the top level of the APNs payload for the app's
+ * notification tap handler; `workspaceId` echoes the device's registration
+ * workspaceTag so the app can route to the right paired deployment.
+ */
+export function buildApnsAlertPush(
+  event: NotificationEvent,
+  device: ApnsDeviceRow,
+  nowMs: number = Date.now()
+): ApnsRelayPush {
+  return {
+    deviceToken: device.token,
+    environment: device.environment,
+    kind: 'alert',
+    alert: { title: event.title, body: event.body },
+    data: {
+      type: event.type,
+      notificationId: event.notificationId,
+      sessionId: event.sessionId,
+      agentSlug: event.agentSlug,
+      navigatePath: event.navigatePath,
+      workspaceId: device.workspaceTag ?? undefined,
+    },
+    collapseId: collapseIdForSession(event.sessionId),
+    expiration: expirationFor(event.type, nowMs),
+  }
+}
+
+/**
+ * Silent content-available push — widget/snapshot invalidation for every
+ * registered device that is not the session's origin. No alert content and no
+ * collapse id (background pushes don't stack in Notification Center).
+ */
+export function buildApnsBackgroundPush(
+  event: NotificationEvent,
+  device: ApnsDeviceRow,
+  nowMs: number = Date.now()
+): ApnsRelayPush {
+  return {
+    deviceToken: device.token,
+    environment: device.environment,
+    kind: 'background',
+    data: {
+      type: event.type,
+      sessionId: event.sessionId,
+      agentSlug: event.agentSlug,
+      workspaceId: device.workspaceTag ?? undefined,
+    },
+    expiration: expirationFor(event.type, nowMs),
+  }
+}

--- a/src/shared/lib/services/session-metadata-schema.ts
+++ b/src/shared/lib/services/session-metadata-schema.ts
@@ -39,6 +39,7 @@ export const sessionMetadataSchema = z
     starred: z.boolean().optional(),
     createdAt: z.string().optional(),
     createdByUserId: z.string().optional(),
+    createdByDeviceId: z.string().optional(),
     isScheduledExecution: z.boolean().optional(),
     scheduledTaskId: z.string().optional(),
     scheduledTaskName: z.string().optional(),

--- a/src/shared/lib/services/session-metadata-schema.ts
+++ b/src/shared/lib/services/session-metadata-schema.ts
@@ -40,6 +40,11 @@ export const sessionMetadataSchema = z
     createdAt: z.string().optional(),
     createdByUserId: z.string().optional(),
     createdByDeviceId: z.string().optional(),
+    // Which device's user gets VISIBLE pushes for this session: re-stamped on
+    // every device-authenticated message send ("last speaker claims the
+    // alert"), explicitly null when a deviceless surface (web) spoke last.
+    // Absent = never re-claimed → fall back to createdByDeviceId.
+    alertDeviceId: z.string().nullable().optional(),
     isScheduledExecution: z.boolean().optional(),
     scheduledTaskId: z.string().optional(),
     scheduledTaskName: z.string().optional(),

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -82,8 +82,13 @@ export interface SessionMetadata {
   createdByUserId?: string
   // Mobile device family that started the session (session deviceId
   // additionalField). Absent for browser/desktop/web/cron/webhook starts.
-  // Origin-device routing: only this device gets visible alert pushes.
+  // Origin-device routing: the alert target falls back to this when no
+  // alertDeviceId claim exists.
   createdByDeviceId?: string
+  // "Last speaker claims the alert": re-stamped on every device-authenticated
+  // message send; null when a deviceless surface (web) spoke last; absent =
+  // never re-claimed (fall back to createdByDeviceId).
+  alertDeviceId?: string | null
   // Scheduled task fields - present when session was created from a scheduled task
   isScheduledExecution?: boolean
   scheduledTaskId?: string

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -80,6 +80,10 @@ export interface SessionMetadata {
   starred?: boolean
   createdAt?: string // ISO date string - set when session is first created
   createdByUserId?: string
+  // Mobile device family that started the session (session deviceId
+  // additionalField). Absent for browser/desktop/web/cron/webhook starts.
+  // Origin-device routing: only this device gets visible alert pushes.
+  createdByDeviceId?: string
   // Scheduled task fields - present when session was created from a scheduled task
   isScheduledExecution?: boolean
   scheduledTaskId?: string


### PR DESCRIPTION
Server side of the iOS push refactor (SkillfulAgents/iOS-App#1). Extends the existing declarative notification-channel architecture with APNs delivery through the Cloudflare relay at `apn-relay.gamutagents.com` — the deployment never touches APNs credentials.

## Commits

1. **Device registration + storage** — `apns_devices` table (migration `0036_special_victor_mancha.sql`, cascade FK to `mobile_device` so revoking a pairing kills its pushes), `apns-device-service` (upsert by token, 10/owner cap, one-live-token-per-device eviction for APNs token rotation), `POST /api/push/devices` + `DELETE /api/push/devices/:token` in the existing push router.
2. **Origin-device stamp** — `Authenticated()` now exposes `getRequestDeviceId()` (Better Auth session `deviceId`); session creation stamps `createdByDeviceId` in metadata. Attribution captured in passing — no lifecycle state.
3. **`ApnsRelayChannel`** — registered beside `WebPushChannel`. The origin device gets visible alerts for `session_complete`/`session_waiting`; all other registered devices get silent `content-available` pushes (widget invalidation), as do all devices for web/cron/webhook-started sessions. Per-user prefs gate alerts only (degrade to silent, never to nothing); agent-ACL gating mirrors web push; devices prune on `410`/`Unregistered`/`BadDeviceToken`. Settings: `push.apnsRelayUrl` (defaults to the hosted relay) + `push.apnsEnabled` kill switch.
4. **Default relay URL** → the `apn-relay.gamutagents.com` custom domain.

## Testing

788 tests across the touched suites, all green — including 48 new ones (device service, payload builders, channel origin/silent/prefs/prune matrix, `getRequestDeviceId`). Typecheck + eslint clean.

## Deliberate v1 gaps (commented in code)

- Hidden automated sessions return from `triggerSessionComplete` before channels run — background-automation completions don't ping widgets yet.
- Expired `mobile_device` rows leave their APNs row until a 410 or re-registration evicts it.

https://claude.ai/code/session_01EGq2u76eJdTcuP4e2tb5QE