### PR TITLE
Apply Slack mention-only to group DMs (SUP-575)

### DIFF
--- a/src/renderer/components/chat-integrations/chat-integration-setup-dialog.tsx
+++ b/src/renderer/components/chat-integrations/chat-integration-setup-dialog.tsx
@@ -195,7 +195,7 @@ function SetupForm({
   const [integrationName, setIntegrationName] = useState('')
   const [showToolCalls, setShowToolCalls] = useState(false)
   const [sessionTimeout, setSessionTimeout] = useState<number | null>(null)
-  const [onlyMentioned, setOnlyMentioned] = useState(false)
+  const [onlyMentioned, setOnlyMentioned] = useState(true)
   const [answerInThread, setAnswerInThread] = useState(false)
   const [newSessionPerThread, setNewSessionPerThread] = useState(false)
   const [testResult, setTestResult] = useState<{ valid: boolean; info?: string } | null>(null)

--- a/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
+++ b/src/shared/lib/chat-integrations/slack-channel-behavior.test.ts
@@ -54,11 +54,29 @@ describe('routeSlackMessage', () => {
       expect(result.shouldProcess).toBe(true)
     })
 
-    it('never filters group DMs regardless of onlyMentioned', () => {
+    it('filters group DMs without mention when onlyMentioned is on', () => {
       const result = routeSlackMessage(makeParams({
         rawText: 'hello',
         channelType: 'mpim',
         config: { onlyMentioned: true },
+      }))
+      expect(result.shouldProcess).toBe(false)
+    })
+
+    it('processes group DMs that mention the bot when onlyMentioned is on', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'hey <@U_BOT> help me',
+        channelType: 'mpim',
+        config: { onlyMentioned: true },
+      }))
+      expect(result.shouldProcess).toBe(true)
+    })
+
+    it('processes all group DM messages when onlyMentioned is off', () => {
+      const result = routeSlackMessage(makeParams({
+        rawText: 'hello',
+        channelType: 'mpim',
+        config: { onlyMentioned: false },
       }))
       expect(result.shouldProcess).toBe(true)
     })
@@ -188,6 +206,14 @@ describe('routeSlackMessage', () => {
     it('does not set thread context for DMs', () => {
       const result = routeSlackMessage(makeParams({
         channelType: 'im',
+        config: { answerInThread: true },
+      }))
+      expect(result.threadContext).toBeUndefined()
+    })
+
+    it('does not set thread context for group DMs', () => {
+      const result = routeSlackMessage(makeParams({
+        channelType: 'mpim',
         config: { answerInThread: true },
       }))
       expect(result.threadContext).toBeUndefined()

--- a/src/shared/lib/chat-integrations/slack-connector.ts
+++ b/src/shared/lib/chat-integrations/slack-connector.ts
@@ -204,8 +204,9 @@ export interface SlackMessageRoutingResult {
 export function routeSlackMessage(params: SlackMessageRoutingParams): SlackMessageRoutingResult {
   const { rawText, chatId, ts, channelType, threadTs, botUserId, config, activeThreads } = params
   const isChannel = channelType === 'channel' || channelType === 'group'
+  const mentionFilterApplies = isChannel || channelType === 'mpim'
 
-  if (isChannel && config.onlyMentioned) {
+  if (mentionFilterApplies && config.onlyMentioned) {
     const isMentioned = botUserId ? rawText.includes(`<@${botUserId}>`) : false
     if (!isMentioned) {
       if (!threadTs || !activeThreads.has(`${chatId}|${threadTs}`)) {


### PR DESCRIPTION
Closes https://linear.app/datawizz/issue/SUP-575/group-dms-with-2-agents-causes-runaway-converstion

Type: bug fix
2 production files, net +1.
1 test file, net +26.

Mention-only did not apply to Slack group DMs.
Two agents in one group DM answered every message, then each other.

The existing switch now covers group DMs too.
1:1 DMs still never need a mention.
New Slack setups start with the switch on.
Existing connections keep what they already stored.

## Worth reviewing

Existing setups that already had the switch on will stop answering unmentioned group DMs.
That is the fix.

## How to verify

1. Mention-only on. Unmentioned group DM stays quiet. @mention still answers.
2. 1:1 DM with the switch on still answers without a mention.
3. Switch off. Group DMs answer everything again.

## Validation

- `npx vitest run src/shared/lib/chat-integrations/slack-channel-behavior.test.ts` - 50 passed
- `npm run typecheck` - clean
- `npm run lint` - 0 errors
- Live Slack smoke: unmentioned group DM stayed quiet with the switch on. @mention and 1:1 still took the turn.
