### PR TITLE
Teach Replicate list then schema then create

### DIFF
--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -42,6 +42,9 @@ describe('generateSystemPrompt rendering', () => {
     expect(out.includes('## Built-in media generation')).toBe(webhook)
     expect(out.includes('v1/replicate')).toBe(webhook)
     expect(out.includes('ANTHROPIC_AUTH_TOKEN')).toBe(webhook)
+    expect(out.includes('GET .../models')).toBe(webhook)
+    expect(out.includes('?kind=image|video|audio|3d|talking_head')).toBe(webhook)
+    expect(out.includes('Available models')).toBe(false)
   })
 
   // The pause/resume guidance must always render: without it agents reach for

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -43,8 +43,10 @@ describe('generateSystemPrompt rendering', () => {
     expect(out.includes('v1/replicate')).toBe(webhook)
     expect(out.includes('ANTHROPIC_AUTH_TOKEN')).toBe(webhook)
     expect(out.includes('GET .../models')).toBe(webhook)
-    expect(out.includes('?kind=image|video|audio|3d|talking_head')).toBe(webhook)
+    expect(out.includes('?kind=image|video|audio|talking_head|3d|document')).toBe(webhook)
+    expect(out.includes('cost from the list row')).toBe(webhook)
     expect(out.includes('Available models')).toBe(false)
+    expect(out.includes('models/_/_')).toBe(false)
   })
 
   // The pause/resume guidance must always render: without it agents reach for

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -596,12 +596,17 @@ Triggers and webhooks are platform-dependent and are not available without a con
 <%#platformServices%>
 ## Built-in media generation
 
-Generate images, video, or audio through the platform — no Replicate signup or API key.
+Generate or edit images, video, speech, music, 3D, or a talking-head clip through the platform. No Replicate signup or API key.
+Confirm with the user before video, music, 3D, talking-head, or voice cloning.
 
 Call `$ANTHROPIC_BASE_URL/v1/replicate/...` with `Authorization: Bearer $ANTHROPIC_AUTH_TOKEN`.
-Create: `POST .../models/{owner}/{name}/predictions` (optional `Prefer: wait`). Poll: `GET .../predictions/{id}`.
-List currently allowed models with `GET .../models/_/_` — if refused, the error message includes `Available models`. Pick only from that list; do not invent model slugs. Confirm with the user before video or music.
-Download output URLs into `/workspace` immediately (they expire in about an hour). Wrong paths return a platform error — do not invent alternate endpoints.
+
+1. List: `GET .../models` (optional `?kind=image|video|audio|3d|talking_head`). This is the allowlist. Each row has id, kind, description, and the fields that change the bill.
+2. Schema: `GET .../models/{owner}/{name}` for the input fields. Only slugs from that list work.
+3. Create: `POST .../models/{owner}/{name}/predictions` (optional `Prefer: wait`). Poll: `GET .../predictions/{id}`.
+
+Do not invent slugs. Do not probe `.../models/_/_`. A 403 means the slug is not on the platform.
+Download output URLs into `/workspace` immediately (they expire in about an hour). Wrong paths return a platform error. Do not invent alternate endpoints.
 <%/platformServices%>
 
 ## Cross-Agent Work

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -596,17 +596,25 @@ Triggers and webhooks are platform-dependent and are not available without a con
 <%#platformServices%>
 ## Built-in media generation
 
-Generate or edit images, video, speech, music, 3D, or a talking-head clip through the platform. No Replicate signup or API key.
-Confirm with the user before video, music, 3D, talking-head, or voice cloning.
+Generate or edit images, video, speech, music, 3D, or a talking-head clip through the platform.
+No Replicate signup or API key.
 
 Call `$ANTHROPIC_BASE_URL/v1/replicate/...` with `Authorization: Bearer $ANTHROPIC_AUTH_TOKEN`.
 
-1. List: `GET .../models` (optional `?kind=image|video|audio|3d|talking_head`). This is the allowlist. Each row has id, kind, description, and the fields that change the bill.
-2. Schema: `GET .../models/{owner}/{name}` for the input fields. Only slugs from that list work.
-3. Create: `POST .../models/{owner}/{name}/predictions` (optional `Prefer: wait`). Poll: `GET .../predictions/{id}`.
+1. List: `GET .../models?kind=image|video|audio|talking_head|3d|document`. Always filter.
+   This is the allowlist. Each row has the slug, the kind, and what it costs.
+2. Schema: `GET .../models/{owner}/{name}` for the input fields.
+   Only slugs from that list work.
+3. Create: `POST .../models/{owner}/{name}/predictions` with `{"input": {...}}`.
+   Poll: `GET .../predictions/{id}`.
+   `Prefer: wait` is for images and speech. Omit it for video or anything long.
 
-Do not invent slugs. Do not probe `.../models/_/_`. A 403 means the slug is not on the platform.
-Download output URLs into `/workspace` immediately (they expire in about an hour). Wrong paths return a platform error. Do not invent alternate endpoints.
+Before video, music, 3D, talking-head, or voice cloning, tell the user the cost from the list row and get an OK.
+If the row needs a media file, send a reachable http(s) file URL, not text or a page.
+
+Do not invent slugs.
+A 403 means go back to the list.
+Download output URLs into `/workspace` immediately. They expire in about an hour.
 <%/platformServices%>
 
 ## Cross-Agent Work


### PR DESCRIPTION
Depends on SkillfulAgents/platform#288. That PR is on `main`.
File-duration models are out of the platform table until after-run billing exists.
Refresh staging from `main` before you test this there. Staging may still list those rows.

Type: prompt change.
Production: 1 file.
Tests: 1 file.

Teach list → schema → create for platform Replicate.
Drop the old catalog scrape.
Confirm before video, music, 3D, talking-head, or voice cloning.
Those confirms include the cost from the list row.
No hardcoded slugs. The platform table stays the menu.

```
list GET /v1/replicate/models?kind=
schema GET /v1/replicate/models/{owner}/{name}
create POST /v1/replicate/models/{owner}/{name}/predictions
 └ unknown slug → 403
```

## What this does not do

- No SuperAgent allowlist of its own
- Does not add lip-sync or source-file talking-head. Those wait on platform after-run billing.

## How to check

1. Connect a platform account so the media section renders.
2. Ask the agent to generate an image. It should `GET /v1/replicate/models?kind=image` first.
3. Ask for video. It should confirm with a cost from the list row.
4. Lip-sync or talking-head from a source file should stay off the list.

## Validation

- `npm --prefix agent-container test -- src/system-prompt-vars.test.ts` - 40 passed
