### PR TITLE
Modernize context menus

### DIFF
--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -30,6 +30,8 @@ import { useQueryClient } from '@tanstack/react-query'
 interface AgentContextMenuProps {
   agent: ApiAgent
   children: React.ReactNode
+  /** Stabilizes the glass over nearly-white chrome without flattening it elsewhere. */
+  surfaceTone?: 'glass' | 'over-light'
   /** Homepage-only controls that should share the agent's single menu surface. */
   additionalOptions?: React.ReactNode
   /** Enables the homepage grid's explicit arrange mode from any agent card. */
@@ -41,6 +43,7 @@ interface AgentContextMenuProps {
 export function AgentContextMenu({
   agent,
   children,
+  surfaceTone = 'glass',
   additionalOptions,
   onArrange,
   disableTouchLongPress,
@@ -130,7 +133,7 @@ export function AgentContextMenu({
         <ContextMenuTrigger asChild disableTouchLongPress={disableTouchLongPress}>
           {children}
         </ContextMenuTrigger>
-        <ContextMenuContent>
+        <ContextMenuContent data-context-menu-tone={surfaceTone}>
           {onArrange && (
             <ContextMenuItem
               onClick={() => {

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -60,7 +60,7 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
       <div className="flex flex-col md:flex-row md:items-center gap-0 md:gap-1.5 min-w-0 flex-1">
         <div className="flex items-center gap-2 min-w-0">
           {agent ? (
-            <AgentContextMenu agent={agent}>
+            <AgentContextMenu agent={agent} surfaceTone="over-light">
               <AppLink
                 to="/agents/$slug"
                 params={{ slug }}

--- a/src/renderer/components/ui/context-menu.test.tsx
+++ b/src/renderer/components/ui/context-menu.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
-import { createEvent, fireEvent, screen } from '@testing-library/react'
+import { createEvent, fireEvent, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import {
   ContextMenu,
   ContextMenuContent,
+  ContextMenuItem,
   ContextMenuSwitchItem,
   ContextMenuTrigger,
 } from './context-menu'
@@ -55,5 +56,56 @@ describe('ContextMenu touch and switch options', () => {
 
     fireEvent.click(option)
     expect(onCheckedChange).toHaveBeenCalledWith(false)
+  })
+
+  it('moves one selection surface between highlighted rows', async () => {
+    renderWithProviders(
+      <ContextMenu>
+        <ContextMenuTrigger>
+          <div>Agent card</div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem>Settings</ContextMenuItem>
+          <ContextMenuItem className="text-destructive">Delete Agent</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByText('Agent card'))
+    const settings = screen.getByRole('menuitem', { name: 'Settings' })
+    const deleteAgent = screen.getByRole('menuitem', { name: 'Delete Agent' })
+    const surface = settings.closest('[data-context-menu-surface]') as HTMLElement
+    const indicator = surface.querySelector(
+      '[data-context-menu-selection-indicator]'
+    ) as HTMLElement
+
+    surface.getBoundingClientRect = vi.fn(() =>
+      DOMRect.fromRect({ x: 20, y: 30, width: 200, height: 100 })
+    )
+    settings.getBoundingClientRect = vi.fn(() =>
+      DOMRect.fromRect({ x: 24, y: 34, width: 192, height: 26 })
+    )
+    deleteAgent.getBoundingClientRect = vi.fn(() =>
+      DOMRect.fromRect({ x: 24, y: 64, width: 192, height: 26 })
+    )
+
+    settings.setAttribute('data-highlighted', '')
+    fireEvent.pointerMove(settings)
+    await waitFor(() => {
+      expect(indicator).toHaveAttribute('data-visible')
+      expect(indicator).toHaveStyle({
+        width: '192px',
+        height: '26px',
+        transform: 'translate3d(4px, 4px, 0)',
+      })
+    })
+
+    settings.removeAttribute('data-highlighted')
+    deleteAgent.setAttribute('data-highlighted', '')
+    fireEvent.pointerMove(deleteAgent)
+    await waitFor(() => {
+      expect(indicator).toHaveStyle({ transform: 'translate3d(4px, 34px, 0)' })
+      expect(indicator).toHaveAttribute('data-destructive')
+    })
   })
 })

--- a/src/renderer/components/ui/context-menu.tsx
+++ b/src/renderer/components/ui/context-menu.tsx
@@ -153,6 +153,7 @@ const ContextMenuSubTrigger = React.forwardRef<
 >(({ className, inset, children, ...props }, ref) => (
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
+    data-context-menu-item=""
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       inset && "pl-8",
@@ -166,34 +167,111 @@ const ContextMenuSubTrigger = React.forwardRef<
 ))
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
 
+/** One shared selection surface that glides between Radix-highlighted rows. */
+function ContextMenuSelectionIndicator() {
+  const indicatorRef = React.useRef<HTMLDivElement>(null)
+
+  React.useLayoutEffect(() => {
+    const indicator = indicatorRef.current
+    const surface = indicator?.parentElement
+    if (!indicator || !surface) return
+
+    let updateFrame = 0
+    const update = () => {
+      updateFrame = 0
+      const item = surface.querySelector<HTMLElement>(
+        '[data-context-menu-item][data-highlighted]',
+      )
+      if (!item) {
+        indicator.removeAttribute('data-visible')
+        return
+      }
+
+      const surfaceRect = surface.getBoundingClientRect()
+      const itemRect = item.getBoundingClientRect()
+      const scaleX = surface.offsetWidth ? surfaceRect.width / surface.offsetWidth : 1
+      const scaleY = surface.offsetHeight ? surfaceRect.height / surface.offsetHeight : 1
+      const x = (itemRect.left - surfaceRect.left) / scaleX + surface.scrollLeft
+      const y = (itemRect.top - surfaceRect.top) / scaleY + surface.scrollTop
+
+      indicator.style.width = `${itemRect.width / scaleX}px`
+      indicator.style.height = `${itemRect.height / scaleY}px`
+      indicator.style.transform = `translate3d(${x}px, ${y}px, 0)`
+      indicator.toggleAttribute(
+        'data-destructive',
+        item.classList.contains('text-destructive'),
+      )
+      indicator.setAttribute('data-visible', '')
+    }
+
+    const scheduleUpdate = () => {
+      if (updateFrame) return
+      updateFrame = window.requestAnimationFrame(update)
+    }
+
+    const events = [
+      'pointermove',
+      'pointerleave',
+      'keydown',
+      'focusin',
+      'focusout',
+      'scroll',
+      'animationend',
+    ] as const
+    events.forEach((event) => surface.addEventListener(event, scheduleUpdate))
+    scheduleUpdate()
+
+    return () => {
+      window.cancelAnimationFrame(updateFrame)
+      events.forEach((event) => surface.removeEventListener(event, scheduleUpdate))
+    }
+  }, [])
+
+  return (
+    <div
+      ref={indicatorRef}
+      data-context-menu-selection-indicator=""
+      aria-hidden="true"
+    />
+  )
+}
+
 const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <ContextMenuPrimitive.SubContent
     ref={ref}
+    data-context-menu-surface=""
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
       className
     )}
     {...props}
-  />
+  >
+    <ContextMenuSelectionIndicator />
+    {children}
+  </ContextMenuPrimitive.SubContent>
 ))
 ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
 
 const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <ContextMenuPrimitive.Portal>
     <ContextMenuPrimitive.Content
       ref={ref}
+      data-context-menu-surface=""
       className={cn(
         "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
         className
       )}
       {...props}
-    />
+    >
+      <ContextMenuSelectionIndicator />
+      {children}
+    </ContextMenuPrimitive.Content>
   </ContextMenuPrimitive.Portal>
 ))
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName
@@ -206,6 +284,7 @@ const ContextMenuItem = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <ContextMenuPrimitive.Item
     ref={ref}
+    data-context-menu-item=""
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
@@ -222,6 +301,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
 >(({ className, children, checked, ...props }, ref) => (
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
+    data-context-menu-item=""
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
@@ -246,8 +326,9 @@ const ContextMenuSwitchItem = React.forwardRef<
 >(({ className, children, checked, ...props }, ref) => (
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
+    data-context-menu-item=""
     className={cn(
-      "relative flex cursor-default select-none items-center justify-between gap-3 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center justify-between gap-3 rounded-sm py-1.5 pl-[1.6875rem] pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -278,6 +359,7 @@ const ContextMenuRadioItem = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <ContextMenuPrimitive.RadioItem
     ref={ref}
+    data-context-menu-item=""
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
@@ -302,6 +384,7 @@ const ContextMenuLabel = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <ContextMenuPrimitive.Label
     ref={ref}
+    data-context-menu-label=""
     className={cn(
       "px-2 py-1.5 text-sm font-medium text-foreground",
       inset && "pl-8",
@@ -318,6 +401,7 @@ const ContextMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ContextMenuPrimitive.Separator
     ref={ref}
+    data-context-menu-separator=""
     className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
@@ -330,6 +414,7 @@ const ContextMenuShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
+      data-context-menu-shortcut=""
       className={cn(
         "ml-auto text-xs tracking-widest text-muted-foreground",
         className

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -148,6 +148,143 @@ html[data-keyboard-open] [data-composer-footer] {
   }
 }
 
+/* Compact frosted context menus. The nearly borderless, milky material mirrors
+   the connection-detail cards while the tighter rows keep secondary actions
+   appropriately quiet. Applied at the shared primitive so submenus, switches,
+   and every existing menu use one consistent treatment. */
+[data-context-menu-surface] {
+  position: relative;
+  isolation: isolate;
+  border-color: rgb(255 255 255 / .62);
+  border-radius: .75rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgb(255 255 255 / .4) 0%,
+      rgb(255 255 255 / .1) 52%,
+      rgb(255 255 255 / .22) 100%
+    ),
+    rgb(255 255 255 / .52);
+  padding: .25rem;
+  box-shadow:
+    0 24px 55px -28px rgb(15 23 42 / .34),
+    0 8px 22px -14px rgb(15 23 42 / .2),
+    inset 0 1px 0 rgb(255 255 255 / .78),
+    inset 0 0 0 1px rgb(255 255 255 / .08);
+  backdrop-filter: blur(4px) saturate(1.12) brightness(1.01);
+  -webkit-backdrop-filter: blur(4px) saturate(1.12) brightness(1.01);
+}
+
+.dark [data-context-menu-surface] {
+  border-color: rgb(255 255 255 / .14);
+  background:
+    linear-gradient(
+      145deg,
+      rgb(255 255 255 / .11) 0%,
+      rgb(255 255 255 / .025) 52%,
+      rgb(255 255 255 / .065) 100%
+    ),
+    rgb(25 25 27 / .54);
+  box-shadow:
+    0 24px 55px -26px rgb(0 0 0 / .72),
+    0 8px 22px -14px rgb(0 0 0 / .62),
+    inset 0 1px 0 rgb(255 255 255 / .16),
+    inset 0 0 0 1px rgb(255 255 255 / .025);
+}
+
+[data-context-menu-surface][data-context-menu-tone="over-light"] {
+  border-color: rgb(255 255 255 / .72);
+  background:
+    linear-gradient(
+      145deg,
+      rgb(255 255 255 / .24) 0%,
+      rgb(255 255 255 / .06) 52%,
+      rgb(255 255 255 / .14) 100%
+    ),
+    rgb(248 248 248 / .7);
+  backdrop-filter: blur(4px) saturate(1.12) brightness(1.01);
+  -webkit-backdrop-filter: blur(4px) saturate(1.12) brightness(1.01);
+}
+
+.dark [data-context-menu-surface][data-context-menu-tone="over-light"] {
+  border-color: rgb(255 255 255 / .14);
+  background:
+    linear-gradient(
+      145deg,
+      rgb(255 255 255 / .08) 0%,
+      rgb(255 255 255 / .02) 52%,
+      rgb(255 255 255 / .045) 100%
+    ),
+    rgb(25 25 27 / .7);
+}
+
+[data-context-menu-selection-indicator] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  border-radius: .375rem;
+  background: hsl(var(--foreground) / .06);
+  opacity: 0;
+  pointer-events: none;
+  will-change: width, height, transform, opacity;
+  transition:
+    width 110ms cubic-bezier(.2, .8, .2, 1),
+    height 110ms cubic-bezier(.2, .8, .2, 1),
+    transform 110ms cubic-bezier(.2, .8, .2, 1),
+    background-color 90ms ease,
+    opacity 70ms ease;
+}
+
+[data-context-menu-selection-indicator][data-visible] {
+  opacity: 1;
+}
+
+[data-context-menu-selection-indicator][data-destructive] {
+  background: hsl(var(--destructive) / .08);
+}
+
+[data-context-menu-surface] > :not([data-context-menu-selection-indicator]) {
+  position: relative;
+  z-index: 1;
+}
+
+[data-context-menu-item] {
+  min-height: 1.625rem;
+  border-radius: .375rem;
+  padding-top: .1875rem;
+  padding-bottom: .1875rem;
+  font-size: .75rem;
+}
+
+[data-context-menu-item]:focus,
+[data-context-menu-item][data-highlighted] {
+  background: transparent;
+}
+
+[data-context-menu-item] > svg {
+  width: .8125rem;
+  height: .8125rem;
+  margin-right: .375rem;
+}
+
+[data-context-menu-label] {
+  padding-top: .3125rem;
+  padding-bottom: .1875rem;
+  font-size: .625rem;
+  color: hsl(var(--muted-foreground));
+}
+
+[data-context-menu-separator] {
+  margin: .1875rem .375rem;
+  background: hsl(var(--foreground) / .075);
+}
+
+[data-context-menu-shortcut] {
+  font-size: .625rem;
+  letter-spacing: .06em;
+}
+
 /* The composer uses a ProseMirror document model but its controlled value is
    always serialized Markdown. Keep block spacing compact enough for chat while
    still making each Markdown construct immediately legible as it is typed. */


### PR DESCRIPTION
## What changed

- restyles shared context menus as compact, subtly frosted surfaces with a consistent 4px CSS backdrop blur
- aligns the switch row with the other menu labels and supports a lighter header-surface tone
- adds one shared selection pill that smoothly follows pointer and keyboard-highlighted rows
- keeps destructive-row feedback while avoiding per-row background flashes

## Why

The existing menus felt oversized and visually disconnected from the rest of the app. The new shared treatment modernizes them without maintaining separate menu implementations for the sidebar, header, and homepage.

The sidebar uses native Electron vibrancy, which cannot be sampled reliably by Chromium backdrop filters. This draft intentionally keeps the implementation simple and uses the same CSS glass surface everywhere rather than cloning sidebar DOM to simulate blur.

## Impact

All existing context-menu consumers inherit the compact styling and moving highlight. Menu semantics and actions are unchanged.

## Validation

- `npx vitest run src/renderer/components/ui/context-menu.test.tsx src/renderer/components/agents/agent-context-menu.test.tsx src/renderer/components/layout/agent-header.test.tsx src/renderer/components/layout/app-sidebar.test.tsx` — 42 tests passed
- `npx tsc --noEmit`
- targeted ESLint for modified context-menu files
- live verification in Electron for sidebar and homepage menus, including cursor-follow interpolation
