### PR TITLE
fix: stop messages OOM — strip inline tool images, propagate aborts, single-flight pages

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -304,6 +304,9 @@ vi.mock('@shared/lib/services/session-service', () => ({
   registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(),
   getSessionMessagesPage: vi.fn(),
+  getSessionMessagesPageShared: vi.fn(),
+  getToolResultImage: vi.fn(),
+  RequestAbortedError: class RequestAbortedError extends Error {},
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),
@@ -559,7 +562,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionMessagesPageShared, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3631,6 +3634,15 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
+  it('404s a registered session whose JSONL has not been written yet, including the paginated path the desktop client uses', async () => {
+    vi.mocked(sessionExists).mockResolvedValue(false)
+    vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
+
+    const res = await getReq(app, `${URL}?limit=300`)
+    expect(res.status).toBe(404)
+    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+  })
+
   it('does not query messageAuthor in non-auth mode', async () => {
     mockIsAuthMode.mockReturnValue(false)
     mockTransformMessages.mockReturnValue([
@@ -3742,7 +3754,7 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(body[0].id).toBe('m1')
     expect(body).not.toHaveProperty('nextCursor')
     expect(getSessionMessagesWithCompact).toHaveBeenCalledWith('test-agent', 'sess-1')
-    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+    expect(getSessionMessagesPageShared).not.toHaveBeenCalled()
   })
 
   it('does not page when MESSAGES_PAGE_LIMIT is set but the client sent no limit', async () => {
@@ -3756,11 +3768,11 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(Array.isArray(body)).toBe(true)
-    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+    expect(getSessionMessagesPageShared).not.toHaveBeenCalled()
   })
 
   it('returns a cursor envelope when limit is set', async () => {
-    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+    vi.mocked(getSessionMessagesPageShared).mockResolvedValue({
       messages: [
         { id: 'm1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
       ],
@@ -3773,58 +3785,65 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(body.messages).toHaveLength(1)
     expect(body.messages[0].id).toBe('m1')
     expect(body.nextCursor).toBe('m1')
-    expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', { limit: 2, cursor: undefined })
+    expect(getSessionMessagesPageShared).toHaveBeenCalledWith(
+      'test-agent',
+      'sess-1',
+      expect.objectContaining({ limit: 2, cursor: undefined, signal: expect.any(AbortSignal) })
+    )
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
   it('forwards cursor to the page reader', async () => {
-    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+    vi.mocked(getSessionMessagesPageShared).mockResolvedValue({
       messages: [],
       nextCursor: null,
     })
 
     const res = await getReq(app, `${URL}?limit=2&cursor=m1`)
     expect(res.status).toBe(200)
-    expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', {
-      limit: 2,
-      cursor: 'm1',
-    })
+    expect(getSessionMessagesPageShared).toHaveBeenCalledWith(
+      'test-agent',
+      'sess-1',
+      expect.objectContaining({ limit: 2, cursor: 'm1' })
+    )
   })
 
   it('rejects an invalid limit', async () => {
     const res = await getReq(app, `${URL}?limit=0`)
     expect(res.status).toBe(400)
-    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+    expect(getSessionMessagesPageShared).not.toHaveBeenCalled()
   })
 
   it('caps first-page limit to MESSAGES_PAGE_LIMIT', async () => {
     process.env.MESSAGES_PAGE_LIMIT = '100'
-    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+    vi.mocked(getSessionMessagesPageShared).mockResolvedValue({
       messages: [],
       nextCursor: null,
     })
 
     const res = await getReq(app, `${URL}?limit=300`)
     expect(res.status).toBe(200)
-    expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', {
-      limit: 100,
-      cursor: undefined,
-    })
+    expect(getSessionMessagesPageShared).toHaveBeenCalledWith(
+      'test-agent',
+      'sess-1',
+      expect.objectContaining({ limit: 100, cursor: undefined })
+    )
   })
 
   it('caps older-page limit to MESSAGES_PAGE_OLDER_LIMIT', async () => {
     process.env.MESSAGES_PAGE_OLDER_LIMIT = '80'
-    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+    vi.mocked(getSessionMessagesPageShared).mockResolvedValue({
       messages: [],
       nextCursor: null,
     })
 
     const res = await getReq(app, `${URL}?limit=200&cursor=m1`)
     expect(res.status).toBe(200)
-    expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', {
-      limit: 80,
-      cursor: 'm1',
-    })
+    expect(getSessionMessagesPageShared).toHaveBeenCalledWith(
+      'test-agent',
+      'sess-1',
+      expect.objectContaining({ limit: 80, cursor: 'm1' })
+    )
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -58,7 +58,9 @@ import {
   updateSessionName,
   registerSession,
   getSessionMessagesWithCompact,
-  getSessionMessagesPage,
+  getSessionMessagesPageShared,
+  getToolResultImage,
+  RequestAbortedError,
   getSession,
   getSessionMetadata,
   sessionExists,
@@ -1815,6 +1817,35 @@ async function annotateAndRecoverMessages(
   }
 }
 
+// GET /api/agents/:id/sessions/:sessionId/tool-images/:toolUseId/:imageIndex
+// Serves one inline image stripped from a tool result by stripInlineImages.
+// Tool results are immutable once persisted, so the response caches forever.
+agents.get('/:id/sessions/:sessionId/tool-images/:toolUseId/:imageIndex', AgentRead(), async (c) => {
+  try {
+    const agentSlug = getAgentId(c)
+    const sessionId = c.req.param('sessionId')
+    const toolUseId = c.req.param('toolUseId')
+    const imageIndex = Number(c.req.param('imageIndex'))
+    if (!/^[a-zA-Z0-9_-]{1,128}$/.test(toolUseId) || !Number.isInteger(imageIndex) || imageIndex < 0) {
+      return c.json({ error: 'Invalid image reference' }, 400)
+    }
+    if (!(await sessionBelongsToAgent(agentSlug, sessionId))) {
+      return c.json({ error: 'Session not found' }, 404)
+    }
+    const image = await getToolResultImage(agentSlug, sessionId, toolUseId, imageIndex)
+    if (!image) {
+      return c.json({ error: 'Image not found' }, 404)
+    }
+    return c.newResponse(new Uint8Array(image.data), 200, {
+      'Content-Type': image.mimeType,
+      'Cache-Control': 'private, max-age=31536000, immutable',
+    })
+  } catch (error) {
+    console.error('Failed to fetch tool result image:', error)
+    return c.json({ error: 'Failed to fetch tool result image' }, 500)
+  }
+})
+
 // Unpaginated path stays inlined so the stream-pipe PR can still land on `return c.json(transformed)`.
 // GET /api/agents/:id/sessions/:sessionId/messages - Get messages for a session
 agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
@@ -1842,10 +1873,16 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       if (!parsed.success) {
         return c.json({ error: 'Invalid pagination' }, 400)
       }
-      const page = await getSessionMessagesPage(agentSlug, sessionId, {
+      // Accessing .signal arms @hono/node-server's lazy AbortController, which
+      // aborts when the client socket closes — superseded refetches stop paying
+      // the parse cost instead of running to completion as zombies.
+      const signal = c.req.raw.signal
+      const page = await getSessionMessagesPageShared(agentSlug, sessionId, {
         limit: capMessagesPageLimit(parsed.data.limit, parsed.data.cursor),
         cursor: parsed.data.cursor,
+        signal,
       })
+      if (signal.aborted) return c.newResponse(null, 499 as never)
       await annotateAndRecoverMessages(page.messages, agentSlug, sessionId)
       return c.json({ messages: page.messages, nextCursor: page.nextCursor })
     }
@@ -1937,6 +1974,10 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       'Content-Type': 'application/json',
     })
   } catch (error) {
+    if (error instanceof RequestAbortedError) {
+      // Client is gone; 499 (client closed request) — nothing will read it.
+      return c.newResponse(null, 499 as never)
+    }
     console.error('Failed to fetch messages:', error)
     return c.json({ error: 'Failed to fetch messages' }, 500)
   }

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -514,7 +514,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                           isCompleted={completedSubagents?.has(toolCall.id) ?? false}
                         />
                       ) : (
-                        <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} isSessionActive={isSessionActive} />
+                        <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={isSessionActive} />
                       )}
                     </MessageErrorBoundary>
                   </div>

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -1646,7 +1646,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             } else {
               inner = (
                 <div className="max-w-[80%]">
-                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} isSessionActive={isActive} />
+                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={isActive} />
                 </div>
               )
             }

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -3,8 +3,9 @@ import { cn } from '@shared/lib/utils/cn'
 import { Check, X, Ban, ChevronDown, ChevronRight, Loader2, Search } from 'lucide-react'
 import { useState, useRef, useMemo, memo } from 'react'
 import { getToolRenderer } from './tool-renderers'
-import { parseToolResult } from '@renderer/lib/parse-tool-result'
+import { parseToolResult, type ParsedToolResultImage } from '@renderer/lib/parse-tool-result'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
+import { getApiBaseUrl } from '@renderer/lib/env'
 import type { ApiToolCall } from '@shared/lib/types/api'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
 
@@ -14,7 +15,21 @@ interface ToolCallItemProps {
   toolCall: ApiToolCall
   messageCreatedAt?: Date | string
   agentSlug?: string
+  sessionId?: string
   isSessionActive?: boolean
+}
+
+/** data: URL for inline images; tool-images route URL for server-stripped refs (null without session context). */
+function toolImageSrc(
+  img: ParsedToolResultImage,
+  agentSlug?: string,
+  sessionId?: string
+): string | null {
+  if (img.data) return `data:${img.mimeType};base64,${img.data}`
+  if (img.ref && agentSlug && sessionId) {
+    return `${getApiBaseUrl()}/api/agents/${agentSlug}/sessions/${sessionId}/tool-images/${encodeURIComponent(img.ref.toolUseId)}/${img.ref.index}`
+  }
+  return null
 }
 
 interface StreamingToolCallItemProps {
@@ -88,7 +103,7 @@ export function StatusIndicator({ status }: { status: string }) {
   )
 }
 
-function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessionActive }: ToolCallItemProps) {
+function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, sessionId, isSessionActive }: ToolCallItemProps) {
   const [expanded, setExpanded] = useState(false)
   const status = getStatus(toolCall, isSessionActive)
   const renderer = getToolRenderer(toolCall.name)
@@ -207,14 +222,18 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
           {/* Render images from tool results */}
           {resultImages.length > 0 && (
             <div className="mt-2 space-y-2">
-              {resultImages.map((img, i) => (
-                <img
-                  key={i}
-                  src={`data:${img.mimeType};base64,${img.data}`}
-                  alt="Tool result"
-                  className="max-w-full rounded border"
-                />
-              ))}
+              {resultImages.map((img, i) => {
+                const src = toolImageSrc(img, agentSlug, sessionId)
+                if (!src) return null
+                return (
+                  <img
+                    key={i}
+                    src={src}
+                    alt="Tool result"
+                    className="max-w-full rounded border"
+                  />
+                )
+              })}
             </div>
           )}
         </div>

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -38,12 +38,16 @@ function deletedMessagesKey(sessionId: string) {
 async function fetchMessagesPage(
   agentSlug: string,
   sessionId: string,
-  opts: { limit: number; cursor?: string }
+  opts: { limit: number; cursor?: string },
+  signal?: AbortSignal
 ): Promise<MessagesPage> {
   const params = new URLSearchParams({ limit: String(opts.limit) })
   if (opts.cursor) params.set('cursor', opts.cursor)
+  // Without the signal, TanStack's cancelRefetch is client-side only and the
+  // server keeps computing superseded pages (measured: ~350 MB RSS each).
   const res = await apiFetch(
-    `/api/agents/${agentSlug}/sessions/${sessionId}/messages?${params.toString()}`
+    `/api/agents/${agentSlug}/sessions/${sessionId}/messages?${params.toString()}`,
+    signal ? { signal } : undefined
   )
   if (res.status === 404) throw new TranscriptNotFoundError()
   if (!res.ok) throw new Error('Failed to fetch messages')
@@ -54,9 +58,9 @@ async function fetchMessagesPage(
 export function useMessages(sessionId: string | null, agentSlug: string | null) {
   const latest = useQuery<MessagesPage>({
     queryKey: ['messages', sessionId, agentSlug],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       if (!sessionId || !agentSlug) throw new Error('Missing session')
-      return fetchMessagesPage(agentSlug, sessionId, { limit: MESSAGES_PAGE_LIMIT })
+      return fetchMessagesPage(agentSlug, sessionId, { limit: MESSAGES_PAGE_LIMIT }, signal)
     },
     enabled: !!sessionId && !!agentSlug,
     retry: (failureCount, error) =>

--- a/src/renderer/lib/parse-tool-result.ts
+++ b/src/renderer/lib/parse-tool-result.ts
@@ -5,11 +5,22 @@ interface ContentBlock {
   // MCP image format
   data?: string
   mimeType?: string
+  // image_ref format (server-stripped inline image; fetched via tool-images route)
+  toolUseId?: string
+  index?: number
+}
+
+export interface ParsedToolResultImage {
+  mimeType: string
+  /** Inline base64 payload (legacy / small images). */
+  data?: string
+  /** Server-side ref; the caller builds the tool-images URL from it. */
+  ref?: { toolUseId: string; index: number }
 }
 
 export interface ParsedToolResult {
   text: string | null
-  images: Array<{ data: string; mimeType: string }>
+  images: ParsedToolResultImage[]
 }
 
 /**
@@ -18,7 +29,7 @@ export interface ParsedToolResult {
  * or an array of content block objects (from MCP).
  */
 export function parseToolResult(result: unknown): ParsedToolResult {
-  const images: Array<{ data: string; mimeType: string }> = []
+  const images: ParsedToolResultImage[] = []
 
   if (result == null) return { text: null, images }
   if (typeof result === 'string') {
@@ -34,20 +45,32 @@ export function parseToolResult(result: unknown): ParsedToolResult {
     return { text: result, images }
   }
 
+  const pushImage = (block: ContentBlock) => {
+    // Anthropic API format: { type: "image", source: { type: "base64", media_type, data } }
+    if (block.source?.data && block.source?.media_type) {
+      images.push({ data: block.source.data, mimeType: block.source.media_type })
+    }
+    // MCP format: { type: "image", data, mimeType }
+    else if (block.data && block.mimeType) {
+      images.push({ data: block.data, mimeType: block.mimeType })
+    }
+  }
+
+  const pushImageRef = (block: ContentBlock) => {
+    if (block.toolUseId && block.index !== undefined && block.mimeType) {
+      images.push({ mimeType: block.mimeType, ref: { toolUseId: block.toolUseId, index: block.index } })
+    }
+  }
+
   if (Array.isArray(result)) {
     const textParts: string[] = []
     for (const block of result as ContentBlock[]) {
       if (block.type === 'text' && block.text) {
         textParts.push(block.text)
       } else if (block.type === 'image') {
-        // Anthropic API format: { type: "image", source: { type: "base64", media_type, data } }
-        if (block.source?.data && block.source?.media_type) {
-          images.push({ data: block.source.data, mimeType: block.source.media_type })
-        }
-        // MCP format: { type: "image", data, mimeType }
-        else if (block.data && block.mimeType) {
-          images.push({ data: block.data, mimeType: block.mimeType })
-        }
+        pushImage(block)
+      } else if (block.type === 'image_ref') {
+        pushImageRef(block)
       }
     }
     return { text: textParts.length > 0 ? textParts.join('\n') : null, images }
@@ -59,11 +82,11 @@ export function parseToolResult(result: unknown): ParsedToolResult {
     return { text: block.text, images }
   }
   if (block.type === 'image') {
-    if (block.source?.data && block.source?.media_type) {
-      images.push({ data: block.source.data, mimeType: block.source.media_type })
-    } else if (block.data && block.mimeType) {
-      images.push({ data: block.data, mimeType: block.mimeType })
-    }
+    pushImage(block)
+    return { text: null, images }
+  }
+  if (block.type === 'image_ref') {
+    pushImageRef(block)
     return { text: null, images }
   }
 

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -30,7 +30,7 @@ import {
   writeFileAtomicStream,
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
-import { transformMessages, type TransformedItem } from '@shared/lib/utils/message-transform'
+import { transformMessages, stripEntryInlineImages, type TransformedItem } from '@shared/lib/utils/message-transform'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
 import { isHiddenAutomatedSession } from './session-visibility'
 import {
@@ -926,34 +926,114 @@ function pageCursor(messages: TransformedItem[], hasOlder: boolean): string | nu
   return hasOlder && messages[0] ? messages[0].id : null
 }
 
+/** Thrown when the requesting client disconnected mid-computation; callers translate to an empty non-response. */
+export class RequestAbortedError extends Error {
+  constructor() {
+    super('Request aborted by client')
+    this.name = 'RequestAbortedError'
+  }
+}
+
+interface InflightPage {
+  promise: Promise<SessionMessagesPage>
+  waiters: number
+  controller: AbortController
+}
+
+const inflightPages = new Map<string, InflightPage>()
+
+/**
+ * Single-flight wrapper for getSessionMessagesPage: identical concurrent
+ * requests (poll + SSE-invalidation storms) share one computation instead of
+ * each paying the full transcript parse (measured ~350 MB RSS per request on a
+ * 49 MB transcript). The shared computation aborts only when every waiter's
+ * signal has fired.
+ */
+export async function getSessionMessagesPageShared(
+  agentSlug: string,
+  sessionId: string,
+  opts: { limit: number; cursor?: string; signal?: AbortSignal }
+): Promise<SessionMessagesPage> {
+  const { signal, ...pageOpts } = opts
+  if (signal?.aborted) throw new RequestAbortedError()
+
+  const key = [agentSlug, sessionId, opts.limit, opts.cursor ?? ''].join('\u0000')
+  let entry = inflightPages.get(key)
+  if (!entry) {
+    const controller = new AbortController()
+    const created: InflightPage = {
+      controller,
+      waiters: 0,
+      promise: getSessionMessagesPage(agentSlug, sessionId, {
+        ...pageOpts,
+        signal: controller.signal,
+      }).finally(() => {
+        inflightPages.delete(key)
+      }),
+    }
+    entry = created
+    inflightPages.set(key, created)
+  }
+
+  entry.waiters++
+  const onAbort = () => {
+    entry.waiters--
+    if (entry.waiters <= 0) entry.controller.abort()
+  }
+  signal?.addEventListener('abort', onAbort, { once: true })
+  try {
+    const page = await entry.promise
+    if (signal?.aborted) throw new RequestAbortedError()
+    return page
+  } finally {
+    signal?.removeEventListener('abort', onAbort)
+  }
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new RequestAbortedError()
+}
+
 /** Trailing (or `cursor`-before) display page. Parses only a tail of the JSONL. */
 export async function getSessionMessagesPage(
   agentSlug: string,
   sessionId: string,
-  opts: { limit: number; cursor?: string }
+  opts: { limit: number; cursor?: string; signal?: AbortSignal }
 ): Promise<SessionMessagesPage> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   if (!(await fileExists(jsonlPath))) {
     return { messages: [], nextCursor: null }
   }
 
-  const { limit, cursor } = opts
+  const { limit, cursor, signal } = opts
   let maxLines = Math.min(MAX_TAIL_LINES, Math.max(limit * INITIAL_TAIL_FACTOR, 32))
 
   for (let attempt = 0; attempt < 32; attempt++) {
+    // Checked between the expensive phases (tail read, parse, transform): a
+    // disconnected client's request stops consuming memory instead of running
+    // to completion as a zombie.
+    throwIfAborted(signal)
     const { lines, reachedStart } = await readJsonlTailLines(jsonlPath, maxLines)
+    throwIfAborted(signal)
     const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
-    for (const line of lines) {
-      const parsed = parseJsonlLine<JsonlEntry>(line)
+    for (let i = 0; i < lines.length; i++) {
+      const parsed = parseJsonlLine<JsonlEntry>(lines[i])
+      // Free each raw line buffer as soon as it's parsed; keeping the whole
+      // tail's buffers alive doubles peak memory on image-heavy transcripts.
+      ;(lines as Array<Buffer | undefined>)[i] = undefined
       if (!parsed) continue
       const normalized = normalizeQueuedCommandEntry(parsed)
       if (
         isMessageOrSystemDisplayEntry(normalized) &&
         !('isMeta' in normalized && normalized.isMeta)
       ) {
+        if (normalized.type === 'user') {
+          stripEntryInlineImages(normalized as JsonlMessageEntry)
+        }
         entries.push(normalized)
       }
     }
+    throwIfAborted(signal)
     const transformed = transformMessages(entries)
 
     if (cursor) {
@@ -1117,6 +1197,85 @@ export async function findLastSessionEntry(
     if (predicate(entries[i])) return entries[i]
   }
   return null
+}
+
+/**
+ * Extract one inline image from a persisted tool_result, addressed by the
+ * `image_ref` emitted by stripInlineImages (index counts image blocks only).
+ * Byte-scans the transcript and JSON-parses only lines containing the
+ * toolUseId, so a 50 MB transcript costs one stream pass, not a full parse.
+ */
+export async function getToolResultImage(
+  agentSlug: string,
+  sessionId: string,
+  toolUseId: string,
+  imageIndex: number
+): Promise<{ data: Buffer; mimeType: string } | null> {
+  const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+  if (!(await fileExists(jsonlPath))) return null
+
+  const needle = Buffer.from(toolUseId)
+  const NEWLINE = 0x0a
+  const fileHandle = await fs.promises.open(jsonlPath, 'r')
+  try {
+    const stream = fileHandle.createReadStream()
+    let pending: Buffer[] = []
+
+    const tryLine = (line: Buffer): { data: Buffer; mimeType: string } | null => {
+      if (!line.includes(needle)) return null
+      const entry = parseJsonlLine<JsonlMessageEntry>(line)
+      if (!entry || entry.type !== 'user') return null
+      const content = entry.message?.content
+      if (!Array.isArray(content)) return null
+      for (const block of content) {
+        if (block.type !== 'tool_result' || block.tool_use_id !== toolUseId) continue
+        const inner = block.content
+        if (!Array.isArray(inner)) continue
+        let idx = 0
+        for (const b of inner as Array<{
+          type?: string
+          source?: { media_type?: string; data?: string }
+          data?: string
+          mimeType?: string
+        }>) {
+          if (b?.type !== 'image') continue
+          if (idx++ !== imageIndex) continue
+          const mimeType = b.source?.media_type ?? b.mimeType
+          const data = b.source?.data ?? b.data
+          if (typeof data !== 'string' || !mimeType) return null
+          return { data: Buffer.from(data, 'base64'), mimeType }
+        }
+      }
+      return null
+    }
+
+    for await (const chunk of stream) {
+      let start = 0
+      let idx = chunk.indexOf(NEWLINE)
+      while (idx !== -1) {
+        let line: Buffer
+        if (pending.length > 0) {
+          pending.push(chunk.subarray(start, idx))
+          line = Buffer.concat(pending)
+          pending = []
+        } else {
+          line = chunk.subarray(start, idx)
+        }
+        const found = tryLine(line)
+        if (found) return found
+        start = idx + 1
+        idx = chunk.indexOf(NEWLINE, start)
+      }
+      if (start < chunk.length) pending.push(chunk.subarray(start))
+    }
+    if (pending.length > 0) {
+      const found = tryLine(Buffer.concat(pending))
+      if (found) return found
+    }
+    return null
+  } finally {
+    await fileHandle.close()
+  }
 }
 
 /**

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -90,6 +90,68 @@ export interface TransformedInformational {
 
 export type TransformedItem = TransformedMessage | TransformedCompactBoundary | TransformedMemoryRecall | TransformedInformational
 
+/** Placeholder for an inline base64 image stripped from a tool result; the client fetches it via the tool-images route. */
+export interface ImageRefBlock {
+  type: 'image_ref'
+  toolUseId: string
+  index: number
+  mimeType: string
+}
+
+/** Untyped view of an image content block (Anthropic `source.data` or MCP `data`/`mimeType` shape). */
+interface ImageLikeBlock {
+  type?: string
+  source?: { media_type?: string; data?: string }
+  data?: string
+  mimeType?: string
+}
+
+/**
+ * Parse-side strip for the paged read path: replaces inline images with refs on
+ * a just-parsed entry so megabyte base64 strings become garbage immediately
+ * instead of accumulating across the whole tail (measured ~350 MB RSS/request).
+ * Also drops toolUseResult.file.base64 — a duplicate copy the API never reads.
+ */
+export function stripEntryInlineImages(entry: JsonlMessageEntry): void {
+  if (entry.type !== 'user') return
+  const content = entry.message?.content
+  if (Array.isArray(content)) {
+    for (const block of content as ContentBlock[]) {
+      if (block.type === 'tool_result' && Array.isArray(block.content)) {
+        ;(block as { content: unknown }).content = stripInlineImages(block.content, block.tool_use_id)
+      }
+    }
+  }
+  const file = (entry.toolUseResult as { file?: { base64?: unknown } } | undefined)?.file
+  if (file && typeof file.base64 === 'string') {
+    delete file.base64
+  }
+}
+
+// Inline base64 images made a 300-message page ~20 MB (94.8% base64) and drove
+// host RSS spikes; replace them with refs resolvable on demand. Index counts
+// image blocks only, mirroring getToolResultImage's extraction walk.
+export function stripInlineImages(result: unknown, toolUseId: string): unknown {
+  if (!Array.isArray(result)) return result
+  let imageIndex = 0
+  let changed = false
+  const out = result.map((block) => {
+    const b = block as ImageLikeBlock
+    if (b && typeof b === 'object' && b.type === 'image') {
+      const mimeType = b.source?.media_type ?? b.mimeType
+      const data = b.source?.data ?? b.data
+      const index = imageIndex++
+      if (typeof data === 'string' && mimeType) {
+        changed = true
+        const ref: ImageRefBlock = { type: 'image_ref', toolUseId, index, mimeType }
+        return ref
+      }
+    }
+    return block
+  })
+  return changed ? out : result
+}
+
 /**
  * Parse a user message that may contain SDK-injected slash command XML tags.
  *
@@ -553,8 +615,10 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
           const toolResult = toolResults.get(block.id)
           // Use toolUseResult.stdout if available, otherwise use content
           // Use ?? instead of || to preserve empty string as valid result (e.g., mkdir has no output)
-          const resultContent =
-            toolResult?.toolUseResult?.stdout ?? toolResult?.content ?? undefined
+          const resultContent = stripInlineImages(
+            toolResult?.toolUseResult?.stdout ?? toolResult?.content ?? undefined,
+            block.id
+          ) as string | undefined
 
           const subagent = ((block.name === 'Task' || block.name === 'Agent') && toolResult?.toolUseResult?.agentId)
             ? {


### PR DESCRIPTION
## What was broken

A production host-app (1,024 MB ECS task serving 9 agents) was OOM-killed twice (exit 137) while one image-heavy session was open. Root cause was three defects multiplying:

1. **Inline base64 images end-to-end.** Browser-tool screenshots are persisted as base64 inside `tool_result` blocks — 91.2% of the 49 MB transcript, with each image stored twice per line (`message.content[].source.data` + `toolUseResult.file.base64`). `GET /messages?limit=300` returned 19–20 MB (94.8% base64) and cost ~350 MB RSS per request.
2. **Broken cancellation.** The renderer refetches messages on a 15 s poll plus ~10 SSE invalidation paths. TanStack's `cancelRefetch` aborted client-side only: the `queryFn` discarded its `AbortSignal`, and the server never checked for disconnects — superseded requests ran to completion as zombies.
3. **No concurrency guard.** Identical concurrent requests each paid the full transcript parse. Measured: 3 concurrent ≈ +900 MB RSS → over the 1 GB task limit.

## Repro

Copy an image-heavy session transcript (~49 MB, 2,068 lines) into a local agent, then:
- `curl 'GET /api/agents/:slug/sessions/:id/messages?limit=300'` → ~20 MB response, ~350 MB RSS spike
- 3 concurrent curls → ~+800 MB RSS
- 3 curls killed after 50 ms (`--max-time 0.05`) → ~+645 MB RSS (server keeps computing for dead clients)

## What changed

- **`message-transform.ts`**: `stripInlineImages` replaces inline image blocks in tool results with `image_ref { toolUseId, index, mimeType }`; `stripEntryInlineImages` applies it at parse time on the paged path (and drops the unused duplicate `toolUseResult.file.base64`) so megabyte base64 strings never accumulate across the tail.
- **New route `GET /:id/sessions/:sessionId/tool-images/:toolUseId/:imageIndex`**: serves one image on demand via a byte-scan that JSON-parses only lines containing the toolUseId; `Cache-Control: immutable` (tool results never change).
- **Renderer**: `parseToolResult` understands `image_ref`; `ToolCallItem` (expanded view only) loads refs lazily from the new route; `sessionId` threaded to the two call sites.
- **Abort propagation**: `useMessages`' `queryFn` now passes its `AbortSignal` through `apiFetch`; `getSessionMessagesPage` checks the signal between tail-read / parse / transform phases and the route returns 499 for disconnected clients.
- **Single-flight**: `getSessionMessagesPageShared` dedupes identical concurrent page computations; the shared computation aborts only when every waiter's signal has fired.

## Ablation measurements (same 49 MB transcript, dev Electron host)

| Metric | Before | +strip response | +abort | +single-flight | Full stack |
|---|---|---|---|---|---|
| Response size (limit=300) | 20.10 MB | **1.05 MB** | 1.05 MB | 1.05 MB | 1.05 MB |
| RSS, 1 request | +348 MB | +361 MB | — | — | **+300 MB** |
| RSS, 3 concurrent | +797 MB | +680 MB | +444 MB | **+41 MB** | +227 MB |
| RSS, 3 aborted clients | +645 MB | +637 MB | **+178 MB** | **+0 MB** | +57 MB |

Worst case drops from unbounded N × ~350 MB to a structural ~1 × ~300 MB (one computation per page at a time, aborted when all clients disconnect).

## Test plan

- [x] 912 tests pass across `agents.test.ts` (349), transform/service/renderer suites
- [x] `src/` typecheck clean
- [x] Concurrent responses byte-identical under single-flight
- [x] `tool-images` endpoint returns valid JPEG (13 ms, correct content-type)
- [x] Sanity: normal request unchanged (HTTP 200, same message shape, 79 `image_ref` blocks for 79 images)
- [ ] UI walkthrough on the image-heavy session (images load on expand)
- [ ] Subagent transcript images (stripped but no ref context in drawer yet — renders nothing; follow-up if needed)

## Not in scope

- Single-request parse cost (~300 MB) — needs streaming parse / byte-budget; follow-up.
- Transcript storage format (base64 duplication at write time) — SDK-owned resume history; needs SDK contract support for external image refs.

Made with [Cursor](https://cursor.com)