### PR TITLE
Throttle SSE-driven messages refetches and abort superseded fetches (SUP-593)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -51,11 +51,16 @@ import { authEnforcementMiddleware } from './middleware/auth-enforcement'
 import { getAuthSettings } from '@shared/lib/auth/auth-settings'
 import { getPublicAuthProviders } from '@shared/lib/auth/provider-config'
 import { LocalModeAuth, isContainerFacingPath } from './middleware/local-mode-auth'
+import { armAbortSignal } from './middleware/arm-abort-signal'
 
 const app = new Hono()
 
 // Background services start AFTER HTTP bind (web/server.ts, main/index.ts,
 // vite.config.ts) so cold-wake health is not gated on settings/DB/auth.
+
+// Must run before any middleware that awaits: a client hangup during those
+// awaits is otherwise invisible to every later signal check (see the module).
+app.use('*', armAbortSignal)
 
 // Enable CORS for all routes
 const trustedOrigins = process.env.TRUSTED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean)

--- a/src/api/middleware/arm-abort-signal.test.ts
+++ b/src/api/middleware/arm-abort-signal.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import net from 'net'
+import { serve } from '@hono/node-server'
+import type { ServerType } from '@hono/node-server'
+import { Hono } from 'hono'
+import { armAbortSignal } from './arm-abort-signal'
+
+// Real @hono/node-server + real socket disconnects: the adapter creates the
+// request AbortController lazily on first `.signal` access and its close
+// handler only aborts a controller that already exists, so these tests can't
+// run against Hono's in-process `app.request()` helper — the laziness under
+// test lives in the node adapter.
+
+interface Probe {
+  abortedSeenByHandler?: boolean
+}
+
+function buildApp(withArming: boolean): { app: Hono; probe: Probe } {
+  const app = new Hono()
+  if (withArming) app.use('*', armAbortSignal)
+  const probe: Probe = {}
+  app.get('/probe', async (c) => {
+    // Async pre-work before the route touches the signal — the window in which
+    // the real /messages route awaits auth and session-existence checks.
+    await new Promise((r) => setTimeout(r, 200))
+    const signal = c.req.raw.signal
+    // Give a late-created controller every chance to fire before we look.
+    await new Promise((r) => setTimeout(r, 100))
+    probe.abortedSeenByHandler = signal.aborted
+    return c.text('done')
+  })
+  return { app, probe }
+}
+
+let server: ServerType | undefined
+afterEach(() => {
+  server?.close()
+  server = undefined
+})
+
+function serveApp(app: Hono): Promise<number> {
+  return new Promise((resolve) => {
+    server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) =>
+      resolve(info.port)
+    )
+  })
+}
+
+// Connect, send the request, then destroy the socket while the handler is
+// still inside its pre-signal await.
+async function hitAndHangUp(port: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const sock = net.connect(port, '127.0.0.1', () => {
+      sock.write('GET /probe HTTP/1.1\r\nHost: t\r\n\r\n')
+      setTimeout(() => sock.destroy(), 50)
+    })
+    sock.on('error', () => {})
+    sock.on('close', () => resolve())
+  })
+  // Let the handler run to completion and record what it saw.
+  await new Promise((r) => setTimeout(r, 400))
+}
+
+describe('armAbortSignal', () => {
+  it('a hangup during pre-signal awaits is observed once the signal was armed up front', async () => {
+    const { app, probe } = buildApp(true)
+    const port = await serveApp(app)
+    await hitAndHangUp(port)
+    expect(probe.abortedSeenByHandler).toBe(true)
+  })
+
+  // Control: pins the adapter behavior that makes the middleware necessary.
+  // If an upgraded @hono/node-server starts observing pre-access hangups on
+  // its own, this fails — delete the middleware and this file together.
+  it('without arming, the same hangup is permanently missed', async () => {
+    const { app, probe } = buildApp(false)
+    const port = await serveApp(app)
+    await hitAndHangUp(port)
+    expect(probe.abortedSeenByHandler).toBe(false)
+  })
+})

--- a/src/api/middleware/arm-abort-signal.ts
+++ b/src/api/middleware/arm-abort-signal.ts
@@ -1,0 +1,18 @@
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Touch the request's AbortSignal before any asynchronous work runs.
+ *
+ * @hono/node-server materializes the request's AbortController lazily on the
+ * first `.signal` access, and its socket-close handler only aborts a controller
+ * that already exists at close time — a client hangup that lands before the
+ * first access is dropped, and the controller a later access creates never
+ * fires. Routes that check `c.req.raw.signal` mid-pipeline (the /messages
+ * transcript reads) would then run their full read/parse/serialize path for a
+ * client that is already gone. Arming the signal here, synchronously and ahead
+ * of every other middleware, guarantees downstream checks observe every hangup.
+ */
+export const armAbortSignal: MiddlewareHandler = (c, next) => {
+  void c.req.raw.signal
+  return next()
+}

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -3773,7 +3773,7 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(body.messages).toHaveLength(1)
     expect(body.messages[0].id).toBe('m1')
     expect(body.nextCursor).toBe('m1')
-    expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', { limit: 2, cursor: undefined })
+    expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', { limit: 2, cursor: undefined, signal: expect.any(AbortSignal) })
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
@@ -3788,6 +3788,7 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', {
       limit: 2,
       cursor: 'm1',
+      signal: expect.any(AbortSignal),
     })
   })
 
@@ -3809,6 +3810,7 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', {
       limit: 100,
       cursor: undefined,
+      signal: expect.any(AbortSignal),
     })
   })
 
@@ -3824,7 +3826,50 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(getSessionMessagesPage).toHaveBeenCalledWith('test-agent', 'sess-1', {
       limit: 80,
       cursor: 'm1',
+      signal: expect.any(AbortSignal),
     })
+  })
+
+  // The renderer aborts superseded refetches (SSE burst throttling); the route
+  // must honor that server-side. Without it every abandoned request still runs
+  // the full read/parse/serialize pipeline — orphaned jobs accumulate at the
+  // event rate and OOM memory-limited deployments over slow volumes.
+  it('propagates the request abort into the page reader and answers 499', async () => {
+    vi.mocked(getSessionMessagesPage).mockImplementation(async (_agent, _session, opts) => {
+      // Behave like the real reader: the tail loop throws when the signal fires.
+      opts.signal?.throwIfAborted()
+      return { messages: [], nextCursor: null }
+    })
+
+    const controller = new AbortController()
+    controller.abort()
+    const res = await app.request(`http://localhost${URL}?limit=2`, {
+      method: 'GET',
+      signal: controller.signal,
+    })
+    expect(res.status).toBe(499)
+  })
+
+  it('skips annotation and serialization when the client aborts after the read', async () => {
+    const controller = new AbortController()
+    vi.mocked(getSessionMessagesPage).mockImplementation(async () => {
+      // Abort lands while the read is completing — too late for the reader's
+      // own checks, so the route's post-read check must catch it.
+      controller.abort()
+      return {
+        messages: [
+          { id: 'm1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
+        ],
+        nextCursor: null,
+      }
+    })
+
+    const res = await app.request(`http://localhost${URL}?limit=2`, {
+      method: 'GET',
+      signal: controller.signal,
+    })
+    expect(res.status).toBe(499)
+    expect(res.body).toBeNull()
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1842,15 +1842,27 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       if (!parsed.success) {
         return c.json({ error: 'Invalid pagination' }, 400)
       }
+      // The renderer aborts superseded refetches; honor that server-side too.
+      // The signal threads down to the tail reader so an abandoned request
+      // stops paying for transcript reads (multi-second on network volumes)
+      // instead of running the full read/parse/serialize pipeline to
+      // completion for a client that hung up.
       const page = await getSessionMessagesPage(agentSlug, sessionId, {
         limit: capMessagesPageLimit(parsed.data.limit, parsed.data.cursor),
         cursor: parsed.data.cursor,
+        signal: c.req.raw.signal,
       })
+      c.req.raw.signal.throwIfAborted()
       await annotateAndRecoverMessages(page.messages, agentSlug, sessionId)
+      c.req.raw.signal.throwIfAborted()
       return c.json({ messages: page.messages, nextCursor: page.nextCursor })
     }
 
     const messages = await getSessionMessagesWithCompact(agentSlug, sessionId)
+    // The legacy full read above predates abort support (reworked wholesale by
+    // the streaming-page follow-up); at least skip transform + serialization
+    // when the client is already gone.
+    c.req.raw.signal.throwIfAborted()
     const filtered = messages.filter((m) => !('isMeta' in m && m.isMeta))
     const transformed = transformMessages(filtered)
 
@@ -1937,6 +1949,12 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       'Content-Type': 'application/json',
     })
   } catch (error) {
+    // Client hung up mid-request (the renderer aborts superseded refetches):
+    // the read path threw AbortError. Nothing receives this response — answer
+    // with the conventional 499 instead of logging a failure that isn't one.
+    if (c.req.raw.signal.aborted) {
+      return new Response(null, { status: 499 })
+    }
     console.error('Failed to fetch messages:', error)
     return c.json({ error: 'Failed to fetch messages' }, 500)
   }

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -586,26 +586,38 @@ describe('useMessageStream', () => {
     expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
   })
 
-  it('invalidates messages and sessions queries on session_idle', async () => {
-    const { useMessageStream } = await getHookModule()
-    const wrapper = createWrapper()
-    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
-    renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper }
-    )
+  it('invalidates messages (trailing-throttled) and sessions on session_idle', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      spy.mockClear()
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
-    })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
+      })
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+      // The sessions invalidation is not throttled.
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+      // The messages refetch collapses into the throttle's trailing edge —
+      // 'connected' consumed the leading edge moments earlier.
+      expect(spy).not.toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   // The session_idle SSE can arrive before the final assistant line is durably
@@ -650,20 +662,23 @@ describe('useMessageStream', () => {
       act(() => {
         MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
       })
-      // Immediate invalidate from the handler.
+      // The handler's invalidate is deferred to the throttle's trailing edge
+      // ('connected' consumed the leading edge), so nothing fires synchronously.
+      expect(countMessageInvalidations(spy)).toBe(0)
+
+      // Trailing edge: the idle invalidate and the reconcile loop's first retry
+      // collapse into one refetch.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800)
+      })
       expect(countMessageInvalidations(spy)).toBe(1)
 
-      // First backoff tick: still no match → an extra refetch fires.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(300)
-      })
-      expect(countMessageInvalidations(spy)).toBeGreaterThan(1)
-
-      // Drain well past the reconcile window — it must self-terminate (bounded:
-      // 1 immediate + at most 3 reconcile attempts).
+      // Drain well past the reconcile window — still no match, so the loop keeps
+      // retrying through the throttle, then must self-terminate (bounded).
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5000)
       })
+      expect(countMessageInvalidations(spy)).toBeGreaterThanOrEqual(2)
       expect(countMessageInvalidations(spy)).toBeLessThanOrEqual(4)
     } finally {
       vi.useRealTimers()
@@ -710,136 +725,300 @@ describe('useMessageStream', () => {
     }
   })
 
-  it('invalidates messages and sessions queries on session_error', async () => {
+  // ---- Messages refetch throttling (burst coalescing) ----
+  // Every SSE-driven ['messages', sessionId] invalidation funnels through a
+  // per-session leading-edge throttle: the first event in a window refetches
+  // immediately, the rest collapse into at most one trailing refetch. These
+  // tests pin the bound — an unthrottled event burst on a long session
+  // multiplies into concurrent multi-MB refetches and can OOM the server.
+
+  it('connected triggers an immediate messages refetch (late-join recovery)', async () => {
+    const { useMessageStream } = await getHookModule()
+    const wrapper = createWrapper()
+    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+    renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: false })
+    })
+
+    // Leading edge: the reconnect catch-up refetch fires immediately.
+    expect(countMessageInvalidations(spy)).toBe(1)
+  })
+
+  it('a burst of SSE events collapses into one leading + one trailing messages refetch', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+
+      // A busy tool loop: many refetch triggers inside one throttle window.
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'tool_call' })
+        MockEventSource.instances[0].simulateMessage({ type: 'tool_result' })
+        MockEventSource.instances[0].simulateMessage({ type: 'messages_updated' })
+        MockEventSource.instances[0].simulateMessage({ type: 'messages_updated' })
+        MockEventSource.instances[0].simulateMessage({ type: 'tool_call' })
+        MockEventSource.instances[0].simulateMessage({ type: 'tool_result' })
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+
+      // Trailing edge: the entire burst collapses into exactly one extra refetch.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(countMessageInvalidations(spy)).toBe(2)
+
+      // Quiet afterwards: no stray timers keep refetching.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS * 4)
+      })
+      expect(countMessageInvalidations(spy)).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('events in separate throttle windows each refetch on the leading edge', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS + 1)
+      })
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'messages_updated' })
+      })
+      // A fresh window: the event refetches immediately, not on a delay.
+      expect(countMessageInvalidations(spy)).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('throttles per session — a second session gets its own leading edge', async () => {
     const { useMessageStream } = await getHookModule()
     const wrapper = createWrapper()
     const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
     renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
+      () => {
+        useMessageStream('session-1', 'agent-1')
+        useMessageStream('session-2', 'agent-1')
+      },
       { wrapper }
     )
 
     act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    spy.mockClear()
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'session_error', error: 'boom' })
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: false })
+      MockEventSource.instances[1].simulateMessage({ type: 'connected', isActive: false })
     })
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+    const countFor = (sessionId: string) =>
+      spy.mock.calls.filter((call: unknown[]) => {
+        const key = (call[0] as { queryKey?: unknown[] } | undefined)?.queryKey
+        return Array.isArray(key) && key[0] === 'messages' && key[1] === sessionId
+      }).length
+    // One session's leading edge must not swallow the other's.
+    expect(countFor('session-1')).toBe(1)
+    expect(countFor('session-2')).toBe(1)
   })
 
-  it('invalidates messages on compact_complete', async () => {
-    const { useMessageStream } = await getHookModule()
-    const wrapper = createWrapper()
-    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
-    renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper }
-    )
+  it('invalidates messages (trailing-throttled) and sessions on session_error', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      spy.mockClear()
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'compact_complete' })
-    })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'session_error', error: 'boom' })
+      })
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it('invalidates messages on messages_updated event', async () => {
-    const { useMessageStream } = await getHookModule()
-    const wrapper = createWrapper()
-    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
-    renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper }
-    )
+  it('invalidates messages (trailing-throttled) on compact_complete', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      spy.mockClear()
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'messages_updated' })
-    })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'compact_complete' })
+      })
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it('invalidates messages on tool_call event and stops streaming', async () => {
-    const { useMessageStream } = await getHookModule()
-    const wrapper = createWrapper()
-    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper }
-    )
+  it('invalidates messages (trailing-throttled) on messages_updated event', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'stream_start' })
-    })
-    expect(result.current.isStreaming).toBe(true)
-    spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      spy.mockClear()
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'tool_call' })
-    })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'messages_updated' })
+      })
 
-    expect(result.current.isStreaming).toBe(false)
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it('invalidates messages on tool_result event', async () => {
-    const { useMessageStream } = await getHookModule()
-    const wrapper = createWrapper()
-    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
-    renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper }
-    )
+  it('invalidates messages (trailing-throttled) on tool_call event and stops streaming', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      const { result } = renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_start' })
+      })
+      expect(result.current.isStreaming).toBe(true)
+      spy.mockClear()
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'tool_result' })
-    })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'tool_call' })
+      })
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+      // Streaming state flips synchronously; only the refetch is throttled.
+      expect(result.current.isStreaming).toBe(false)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it('invalidates messages on error (EventSource onerror)', async () => {
-    const { useMessageStream } = await getHookModule()
-    const wrapper = createWrapper()
-    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
-    renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper }
-    )
+  it('invalidates messages (trailing-throttled) on tool_result event', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      spy.mockClear()
 
-    act(() => {
-      MockEventSource.instances[0].simulateError()
-    })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'tool_result' })
+      })
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('invalidates messages (trailing-throttled) on error (EventSource onerror)', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      spy.mockClear()
+
+      act(() => {
+        MockEventSource.instances[0].simulateError()
+      })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   // ---- Additional event types ----
@@ -1016,7 +1195,9 @@ describe('useMessageStream', () => {
   // ---- Subagent lifecycle ----
 
   it('handles subagent_completed — keeps streaming data and marks as completed', async () => {
-    const { useMessageStream } = await getHookModule()
+    vi.useFakeTimers()
+    try {
+    const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
     const wrapper = createWrapper()
     const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
     const { result } = renderHook(
@@ -1057,8 +1238,15 @@ describe('useMessageStream', () => {
     const sub = result.current.activeSubagents[0]
     expect(sub?.streamingMessage).toBe('summary text')
     expect(result.current.completedSubagents?.has('pt-1')).toBe(true)
+    // subagent-messages is not throttled; the messages refetch is.
     expect(spy).toHaveBeenCalledWith({ queryKey: ['subagent-messages', 'session-1'] })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+    })
     expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('handles subagent_updated — clears streaming state and invalidates subagent messages', async () => {
@@ -1258,36 +1446,45 @@ describe('useMessageStream', () => {
     expect(result.current.streamingToolUses).toEqual([])
   })
 
-  it('stream_start invalidates messages when previous streamingToolUses exist', async () => {
-    const { useMessageStream } = await getHookModule()
-    const wrapper = createWrapper()
-    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper }
-    )
+  it('stream_start invalidates messages (trailing-throttled) when previous streamingToolUses exist', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      const { result } = renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({
-        type: 'tool_use_start',
-        toolId: 'tc-1',
-        toolName: 'Bash',
-        partialInput: '',
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
       })
-    })
-    expect(result.current.streamingToolUses.length).toBeGreaterThan(0)
-    spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({
+          type: 'tool_use_start',
+          toolId: 'tc-1',
+          toolName: 'Bash',
+          partialInput: '',
+        })
+      })
+      expect(result.current.streamingToolUses.length).toBeGreaterThan(0)
+      spy.mockClear()
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'stream_start' })
-    })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_start' })
+      })
 
-    // Should invalidate messages to fetch persisted tool call before clearing streaming state
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
-    expect(result.current.streamingToolUses).toEqual([])
+      // Streaming state clears synchronously; the refetch that fetches the
+      // persisted tool call rides the throttle's trailing edge.
+      expect(result.current.streamingToolUses).toEqual([])
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('ping does not change state when server agrees session is active', async () => {
@@ -1457,29 +1654,37 @@ describe('useMessageStream', () => {
     expect(result.current.completedSubagents?.has('pt-2')).toBe(true)
   })
 
-  it('ping invalidates messages and sessions when correcting active state', async () => {
-    const { useMessageStream } = await getHookModule()
-    const wrapper = createWrapper()
-    const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
-    renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper }
-    )
+  it('ping invalidates messages (trailing-throttled) and sessions when correcting active state', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      renderHook(
+        () => useMessageStream('session-1', 'agent-1'),
+        { wrapper }
+      )
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'session_active' })
-    })
-    spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'session_active' })
+      })
+      spy.mockClear()
 
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'ping', isActive: false })
-    })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'ping', isActive: false })
+      })
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
-    expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+      })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['messages', 'session-1'] })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   describe('auto-approved suppress-sets (from user_request_created)', () => {
@@ -1812,30 +2017,46 @@ describe('useMessageStream', () => {
     })
 
     it('refetches at queued-command pickup and again when its model response starts', async () => {
-      const { es, queryClient } = await setupHook('cmd-s4')
-      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+      vi.useFakeTimers()
+      try {
+        const { es, queryClient, mod } = await setupHook('cmd-s4')
+        const { MESSAGES_REFETCH_THROTTLE_MS } = mod
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
-      act(() => {
-        es.simulateMessage({ type: 'command_lifecycle', commandUuid: 'u1', state: 'started' })
-      })
+        act(() => {
+          es.simulateMessage({ type: 'command_lifecycle', commandUuid: 'u1', state: 'started' })
+        })
 
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['messages', 'cmd-s4'] })
+        // Deferred to the throttle's trailing edge ('connected' took the leading edge).
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+        })
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['messages', 'cmd-s4'] })
 
-      // The pickup refetch can race the CLI's queued_command transcript write.
-      // A model response proves the command has been incorporated, so it must
-      // trigger one bounded reconciliation retry.
-      invalidateSpy.mockClear()
-      act(() => {
-        es.simulateMessage({ type: 'stream_start' })
-      })
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['messages', 'cmd-s4'] })
+        // The pickup refetch can race the CLI's queued_command transcript write.
+        // A model response proves the command has been incorporated, so it must
+        // trigger one bounded reconciliation retry.
+        invalidateSpy.mockClear()
+        act(() => {
+          es.simulateMessage({ type: 'stream_start' })
+        })
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS)
+        })
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['messages', 'cmd-s4'] })
 
-      // The marker is consumed: later model iterations do not keep polling.
-      invalidateSpy.mockClear()
-      act(() => {
-        es.simulateMessage({ type: 'stream_start' })
-      })
-      expect(invalidateSpy).not.toHaveBeenCalled()
+        // The marker is consumed: later model iterations do not keep polling.
+        invalidateSpy.mockClear()
+        act(() => {
+          es.simulateMessage({ type: 'stream_start' })
+        })
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS * 2)
+        })
+        expect(invalidateSpy).not.toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('does not retry after the picked-up command completes before another response starts', async () => {

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -852,6 +852,69 @@ describe('useMessageStream', () => {
     }
   })
 
+  // The idle reconcile loop sleeps between retries, so it can wake after the
+  // last subscriber unmounted. A stale wake must not invalidate: it would
+  // recreate the throttle entry the unmount cleanup just removed and its
+  // fresh window stamp would push a rapid remount's leading-edge refetch onto
+  // the trailing edge.
+  it('a stale idle reconcile stops after unmount and does not throttle the remount', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream } = await getHookModule()
+      const wrapper = createWrapper()
+      const qc = wrapper.queryClient
+      const spy = vi.spyOn(qc, 'invalidateQueries')
+      const { unmount } = renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_start' })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_delta', text: 'Final answer' })
+      })
+      // Persisted transcript lags the streamed text, so session_idle arms the
+      // reconcile loop.
+      qc.setQueryData(['messages', 'session-1', 'agent-1'], {
+        messages: [
+          { id: 'u1', type: 'user', content: { text: 'hi' }, createdAt: '2026-01-01T00:00:00Z' },
+        ],
+        nextCursor: null,
+      })
+      spy.mockClear()
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
+      })
+      expect(countMessageInvalidations(spy)).toBe(0)
+
+      // Unmount while the loop sleeps toward its first 250ms retry.
+      unmount()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      expect(countMessageInvalidations(spy)).toBe(0)
+
+      // A rapid remount right after the stale loop's would-be retry gets its
+      // fresh leading edge immediately — nothing restamped the window.
+      renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+      act(() => {
+        MockEventSource.instances[1].simulateMessage({ type: 'connected', isActive: true })
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+
+      // The old loop's remaining wakes see a different stream generation and
+      // bail — no fourth-hand invalidations trickle in later.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('throttles per session — a second session gets its own leading edge', async () => {
     const { useMessageStream } = await getHookModule()
     const wrapper = createWrapper()

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -666,20 +666,22 @@ describe('useMessageStream', () => {
       // ('connected' consumed the leading edge), so nothing fires synchronously.
       expect(countMessageInvalidations(spy)).toBe(0)
 
-      // Trailing edge: the idle invalidate and the reconcile loop's first retry
-      // collapse into one refetch.
+      // The reconcile loop bypasses the throttle: its first retry fires at
+      // ~250ms and FOLDS the pending trailing (scheduled for 750ms) into
+      // itself, so persistence lag is recovered on the pre-throttle schedule
+      // (250 / 750 / 1500), not a window later.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(800)
+        await vi.advanceTimersByTimeAsync(300)
       })
       expect(countMessageInvalidations(spy)).toBe(1)
 
-      // Drain well past the reconcile window — still no match, so the loop keeps
-      // retrying through the throttle, then must self-terminate (bounded).
+      // Drain well past the reconcile window: retries at 750 and 1500, then
+      // self-terminates. Exactly three refetches — the folded trailing timer
+      // must not fire a fourth.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5000)
       })
-      expect(countMessageInvalidations(spy)).toBeGreaterThanOrEqual(2)
-      expect(countMessageInvalidations(spy)).toBeLessThanOrEqual(4)
+      expect(countMessageInvalidations(spy)).toBe(3)
     } finally {
       vi.useRealTimers()
     }
@@ -807,6 +809,43 @@ describe('useMessageStream', () => {
         MockEventSource.instances[0].simulateMessage({ type: 'messages_updated' })
       })
       // A fresh window: the event refetches immediately, not on a delay.
+      expect(countMessageInvalidations(spy)).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears pending throttle state when the last subscriber unmounts', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream, MESSAGES_REFETCH_THROTTLE_MS } = await getHookModule()
+      const wrapper = createWrapper()
+      const spy = vi.spyOn(wrapper.queryClient, 'invalidateQueries')
+      const { unmount } = renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+
+      // Schedule a trailing refetch, then unmount before it fires.
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'messages_updated' })
+      })
+      unmount()
+
+      // The cancelled trailing timer must not refetch after unmount…
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MESSAGES_REFETCH_THROTTLE_MS * 3)
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+
+      // …and a remount starts on a fresh leading edge instead of joining
+      // stale pending work from the previous mount.
+      renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+      act(() => {
+        MockEventSource.instances[1].simulateMessage({ type: 'connected', isActive: true })
+      })
       expect(countMessageInvalidations(spy)).toBe(2)
     } finally {
       vi.useRealTimers()

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -915,6 +915,75 @@ describe('useMessageStream', () => {
     }
   })
 
+  // A newer turn's idle must SUPERSEDE a sleeping reconcile loop, not be
+  // dropped by it. With a plain one-loop-at-a-time guard, a remount plus a
+  // quick turn — both finishing before the stale loop's first 250ms wake —
+  // left the new final text with no reconciler at all (the stale loop exits on
+  // its generation check without invalidating), so it waited on the 15s poll.
+  it('a newer idle supersedes a sleeping reconcile from before the remount', async () => {
+    vi.useFakeTimers()
+    try {
+      const { useMessageStream } = await getHookModule()
+      const wrapper = createWrapper()
+      const qc = wrapper.queryClient
+      const spy = vi.spyOn(qc, 'invalidateQueries')
+      const { unmount } = renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_start' })
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'stream_delta', text: 'First answer' })
+      })
+      // Neither turn's final text is persisted, so both idles arm reconciles.
+      qc.setQueryData(['messages', 'session-1', 'agent-1'], {
+        messages: [
+          { id: 'u1', type: 'user', content: { text: 'hi' }, createdAt: '2026-01-01T00:00:00Z' },
+        ],
+        nextCursor: null,
+      })
+      act(() => {
+        MockEventSource.instances[0].simulateMessage({ type: 'session_idle' })
+      })
+
+      // Remount and complete a second turn BEFORE the first loop's 250ms wake.
+      unmount()
+      renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+      act(() => {
+        MockEventSource.instances[1].simulateMessage({ type: 'connected', isActive: true })
+      })
+      act(() => {
+        MockEventSource.instances[1].simulateMessage({ type: 'stream_start' })
+      })
+      act(() => {
+        MockEventSource.instances[1].simulateMessage({ type: 'stream_delta', text: 'Second answer' })
+      })
+      spy.mockClear()
+      act(() => {
+        MockEventSource.instances[1].simulateMessage({ type: 'session_idle' })
+      })
+
+      // The new loop owns the session: its first retry fires at ~250ms (and
+      // folds the idle's pending trailing refetch into itself).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      expect(countMessageInvalidations(spy)).toBe(1)
+
+      // Full drain: the new loop's three retries, nothing more — the
+      // superseded pre-remount loop must contribute zero.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+      expect(countMessageInvalidations(spy)).toBe(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('throttles per session — a second session gets its own leading edge', async () => {
     const { useMessageStream } = await getHookModule()
     const wrapper = createWrapper()

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -228,7 +228,13 @@ export const MESSAGES_REFETCH_THROTTLE_MS = 750
 interface MessagesInvalidateThrottle {
   lastInvalidatedAt: number
   /** Pending trailing refetch; further calls in the window join its promise. */
-  trailing: { timer: ReturnType<typeof setTimeout>; promise: Promise<void> } | null
+  trailing: {
+    timer: ReturnType<typeof setTimeout>
+    promise: Promise<void>
+    /** Resolves the joined promise — called by the timer, by a fold-in
+     * refetch that supersedes the timer, or by unmount cleanup. */
+    settle: () => void
+  } | null
 }
 const messagesInvalidateThrottles = new Map<string, MessagesInvalidateThrottle>()
 
@@ -257,8 +263,35 @@ function invalidateMessagesThrottled(
     throttle.lastInvalidatedAt = Date.now()
     queryClient.invalidateQueries({ queryKey: ['messages', sessionId] }).then(settle, settle)
   }, wait)
-  throttle.trailing = { timer, promise }
+  throttle.trailing = { timer, promise, settle }
   return promise
+}
+
+// Immediate variant for the post-idle reconcile loop. Its whole job is beating
+// the transcript write/read race, so deferring its retries to the trailing edge
+// would push finalization a window later exactly when persistence lags. The
+// loop is already rate-limited — single-flight per session with its own bounded
+// backoff — so exempting it cannot reopen the refetch storm. The refetch FOLDS
+// into the throttle rather than stacking on top of it: a pending trailing timer
+// is cancelled (its waiters settle with this refetch) and the window restarts
+// from now, so surrounding events coalesce onto this fetch instead of adding
+// another.
+function invalidateMessagesNow(
+  queryClient: QueryClient,
+  sessionId: string
+): Promise<void> {
+  let entry = messagesInvalidateThrottles.get(sessionId)
+  if (!entry) {
+    entry = { lastInvalidatedAt: 0, trailing: null }
+    messagesInvalidateThrottles.set(sessionId, entry)
+  }
+  const pending = entry.trailing
+  entry.trailing = null
+  if (pending) clearTimeout(pending.timer)
+  entry.lastInvalidatedAt = Date.now()
+  const refetch = queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+  if (pending) refetch.then(pending.settle, pending.settle)
+  return refetch
 }
 
 // Does the last persisted assistant message in the messages cache match the
@@ -322,7 +355,7 @@ async function reconcileMessagesAfterIdle(
       await new Promise((resolve) => setTimeout(resolve, delay))
       // refetchType defaults to 'active': refetches the mounted messages query
       // (the session being viewed) and resolves once the cache is updated.
-      await invalidateMessagesThrottled(queryClient, sessionId)
+      await invalidateMessagesNow(queryClient, sessionId)
     }
   } finally {
     reconcilingIdleSessions.delete(sessionId)
@@ -1266,6 +1299,19 @@ function releaseEventSource(sessionId: string): void {
       eventSources.delete(key)
     }
     refCounts.delete(key)
+    // Symmetric cleanup for the refetch throttle: cancel a pending trailing
+    // timer (nothing is mounted to refetch), settle its waiters so nothing can
+    // ever hang on the joined promise, and drop the entry so the map stays
+    // bounded by open sessions and a remount starts on a fresh leading edge.
+    const throttle = messagesInvalidateThrottles.get(key)
+    if (throttle) {
+      if (throttle.trailing) {
+        clearTimeout(throttle.trailing.timer)
+        throttle.trailing.settle()
+        throttle.trailing = null
+      }
+      messagesInvalidateThrottles.delete(key)
+    }
   }
 }
 

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -347,12 +347,20 @@ async function reconcileMessagesAfterIdle(
   if (!expected) return
   if (reconcilingIdleSessions.has(sessionId)) return
   reconcilingIdleSessions.add(sessionId)
+  // The stream generation this loop belongs to. The sleeps below can straddle
+  // the last subscriber's unmount (which closes the EventSource and clears the
+  // throttle state) or a rapid remount (which creates a NEW EventSource);
+  // invalidating from a stale loop would recreate the throttle entry the
+  // unmount cleanup just removed and push the remount's fresh leading-edge
+  // refetch onto the trailing edge.
+  const generation = eventSources.get(sessionId)
   try {
     // ~1.5s total across 3 tries — long enough to beat the write/read race,
     // short enough that a genuine mismatch falls through to the poll quickly.
     for (const delay of [250, 500, 750]) {
       if (lastPersistedAssistantMatches(queryClient, sessionId, expected)) return
       await new Promise((resolve) => setTimeout(resolve, delay))
+      if (eventSources.get(sessionId) !== generation) return
       // refetchType defaults to 'active': refetches the mounted messages query
       // (the session being viewed) and resolves once the cache is updated.
       await invalidateMessagesNow(queryClient, sessionId)

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -208,9 +208,13 @@ const sessionAutoApprovedComputerUseIds = new Map<string, Set<string>>()
 const eventSources = new Map<string, EventSource>()
 const refCounts = new Map<string, number>()
 
-// Sessions with an in-flight post-idle reconcile loop, so overlapping
-// session_idle events don't spawn duplicate loops for the same session.
-const reconcilingIdleSessions = new Set<string>()
+// Owner token of the in-flight post-idle reconcile loop per session. A newer
+// session_idle SUPERSEDES a sleeping loop by overwriting the token: only the
+// current owner invalidates, and a superseded loop exits at its next wake. A
+// plain "one loop at a time" guard would DROP the newer turn's reconciliation
+// instead — a second short turn (or a rapid remount) idling while the previous
+// loop sleeps would then wait on the 15s poll for its final text.
+const idleReconcileOwners = new Map<string, symbol>()
 
 // Every SSE-driven ['messages', sessionId] invalidation funnels through one
 // per-session leading-edge throttle: the first event refetches immediately,
@@ -345,8 +349,8 @@ async function reconcileMessagesAfterIdle(
   // Nothing streamed (e.g. a tool-only or interrupted turn) — no text to match
   // against, so the handler's immediate invalidate is all we can do.
   if (!expected) return
-  if (reconcilingIdleSessions.has(sessionId)) return
-  reconcilingIdleSessions.add(sessionId)
+  const token = Symbol(sessionId)
+  idleReconcileOwners.set(sessionId, token)
   // The stream generation this loop belongs to. The sleeps below can straddle
   // the last subscriber's unmount (which closes the EventSource and clears the
   // throttle state) or a rapid remount (which creates a NEW EventSource);
@@ -360,13 +364,16 @@ async function reconcileMessagesAfterIdle(
     for (const delay of [250, 500, 750]) {
       if (lastPersistedAssistantMatches(queryClient, sessionId, expected)) return
       await new Promise((resolve) => setTimeout(resolve, delay))
+      if (idleReconcileOwners.get(sessionId) !== token) return
       if (eventSources.get(sessionId) !== generation) return
       // refetchType defaults to 'active': refetches the mounted messages query
       // (the session being viewed) and resolves once the cache is updated.
       await invalidateMessagesNow(queryClient, sessionId)
     }
   } finally {
-    reconcilingIdleSessions.delete(sessionId)
+    if (idleReconcileOwners.get(sessionId) === token) {
+      idleReconcileOwners.delete(sessionId)
+    }
   }
 }
 

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -212,6 +212,55 @@ const refCounts = new Map<string, number>()
 // session_idle events don't spawn duplicate loops for the same session.
 const reconcilingIdleSessions = new Set<string>()
 
+// Every SSE-driven ['messages', sessionId] invalidation funnels through one
+// per-session leading-edge throttle: the first event refetches immediately,
+// further events within the window collapse into at most one trailing refetch.
+// A busy turn emits many refetch triggers in quick succession (tool_call,
+// tool_result, messages_updated, turn_output_complete, session_idle …); each
+// refetch of a long session is a multi-MB response the server assembles from a
+// full transcript read, so an unthrottled burst multiplies into concurrent
+// requests that can OOM a memory-limited deployment. Live deltas render from
+// stream state, not from these refetches, so collapsing them does not affect
+// streaming UX. User-initiated invalidations (delete message/tool call,
+// interrupt in use-messages.ts) intentionally do NOT go through this throttle.
+export const MESSAGES_REFETCH_THROTTLE_MS = 750
+
+interface MessagesInvalidateThrottle {
+  lastInvalidatedAt: number
+  /** Pending trailing refetch; further calls in the window join its promise. */
+  trailing: { timer: ReturnType<typeof setTimeout>; promise: Promise<void> } | null
+}
+const messagesInvalidateThrottles = new Map<string, MessagesInvalidateThrottle>()
+
+// Resolves once the (possibly deferred) invalidate's refetch has settled, so
+// callers that need the refreshed cache (the idle reconcile loop) can await it.
+function invalidateMessagesThrottled(
+  queryClient: QueryClient,
+  sessionId: string
+): Promise<void> {
+  let entry = messagesInvalidateThrottles.get(sessionId)
+  if (!entry) {
+    entry = { lastInvalidatedAt: 0, trailing: null }
+    messagesInvalidateThrottles.set(sessionId, entry)
+  }
+  if (entry.trailing) return entry.trailing.promise
+  const wait = MESSAGES_REFETCH_THROTTLE_MS - (Date.now() - entry.lastInvalidatedAt)
+  if (wait <= 0) {
+    entry.lastInvalidatedAt = Date.now()
+    return queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+  }
+  const throttle = entry
+  let settle!: () => void
+  const promise = new Promise<void>((resolve) => { settle = resolve })
+  const timer = setTimeout(() => {
+    throttle.trailing = null
+    throttle.lastInvalidatedAt = Date.now()
+    queryClient.invalidateQueries({ queryKey: ['messages', sessionId] }).then(settle, settle)
+  }, wait)
+  throttle.trailing = { timer, promise }
+  return promise
+}
+
 // Does the last persisted assistant message in the messages cache match the
 // just-streamed text? Mirrors MessageList's `isStreamingMessagePersisted` so we
 // stop reconciling at exactly the point the UI considers the turn finalized.
@@ -273,7 +322,7 @@ async function reconcileMessagesAfterIdle(
       await new Promise((resolve) => setTimeout(resolve, delay))
       // refetchType defaults to 'active': refetches the mounted messages query
       // (the session being viewed) and resolves once the cache is updated.
-      await queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+      await invalidateMessagesThrottled(queryClient, sessionId)
     }
   } finally {
     reconcilingIdleSessions.delete(sessionId)
@@ -357,7 +406,7 @@ function getOrCreateEventSource(
         // input requests from them), so force a refetch now instead of waiting for the
         // safety-net poll. Without this, a late join only recovers on the next poll
         // tick, which races the assertion timeout in tests and shows a stale UI in prod.
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
         // Resync the unified pending-request store too: its create/resolve
         // events are one-shot, so anything settled or opened while this
         // stream was down must be recovered from the snapshot endpoint.
@@ -446,7 +495,7 @@ function getOrCreateEventSource(
           isWaitingBackground: false,
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
         // The immediate invalidate above can refetch before the final assistant
         // line is durably readable in the JSONL transcript. Beat that race with a
@@ -486,7 +535,7 @@ function getOrCreateEventSource(
           isWaitingBackground: false,
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
       }
       // Per-command lifecycle (runtime >= CLI 2.1.206). A started command
@@ -501,7 +550,7 @@ function getOrCreateEventSource(
           // Fast path: in the common case the transcript attachment is already
           // readable. stream_start below provides the bounded read-after-write
           // retry when this invalidate lands a moment too early.
-          queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+          invalidateMessagesThrottled(queryClient, sessionId)
         } else if (
           commandUuid &&
           (data.state === 'completed' || data.state === 'discarded' || data.state === 'cancelled')
@@ -616,7 +665,7 @@ function getOrCreateEventSource(
       else if (data.type === 'stream_start') {
         if (startedCommandsAwaitingTranscript.size > 0) {
           startedCommandsAwaitingTranscript.clear()
-          queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+          invalidateMessagesThrottled(queryClient, sessionId)
         }
         // Capture slash commands from init event (piggybacked on stream_start)
         if (Array.isArray(data.slashCommands)) {
@@ -625,7 +674,7 @@ function getOrCreateEventSource(
         // If there were streaming tool uses, trigger a refetch so the persisted
         // versions are available before we clear the streaming state.
         if (current?.streamingToolUses?.length) {
-          queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+          invalidateMessagesThrottled(queryClient, sessionId)
         }
         streamStates.set(sessionId, {
           isActive: current?.isActive ?? false,
@@ -769,7 +818,7 @@ function getOrCreateEventSource(
           })
         }
         // Refetch to pick up the persisted message shortly
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
       }
       else if (data.type === 'user_typing') {
         // Another user is typing in this shared session
@@ -786,7 +835,7 @@ function getOrCreateEventSource(
         }
       }
       else if (data.type === 'messages_updated') {
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
       }
       else if (data.type === 'turn_output_complete') {
         // A turn's output finished (the session may or may not settle — e.g.
@@ -796,7 +845,7 @@ function getOrCreateEventSource(
         // bubble before the persisted copy is fetched and the final message
         // disappears briefly. The reconcile helper is idempotent, so the
         // session_idle handler's own reconcile coexists harmlessly.
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
         void reconcileMessagesAfterIdle(sessionId, queryClient, current?.streamingMessage ?? null)
       }
       else if (data.type === 'tool_call' || data.type === 'tool_result') {
@@ -811,7 +860,7 @@ function getOrCreateEventSource(
         // card cleanup here: the registry resolution that accompanies it emits
         // user_request_resolved, and the branch above invalidates the store
         // every tab renders from.
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
       }
       else if (data.type === 'context_usage') {
         // Context window usage update from backend
@@ -933,11 +982,11 @@ function getOrCreateEventSource(
             isCompacting: false,
           })
         }
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
       }
       else if (data.type === 'memory_recall') {
         // Agent recalled memory files — refetch messages so the persisted entry appears
-        queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+        invalidateMessagesThrottled(queryClient, sessionId)
       }
       else if (data.type === 'api_retry') {
         // API is retrying a transient error — show retry state in activity indicator
@@ -1065,7 +1114,7 @@ function getOrCreateEventSource(
             completedSubagents: newCompleted,
           })
           queryClient.invalidateQueries({ queryKey: ['subagent-messages', sessionId] })
-          queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+          invalidateMessagesThrottled(queryClient, sessionId)
         }
       }
       // Subagent streaming events
@@ -1170,7 +1219,7 @@ function getOrCreateEventSource(
             apiErrorCode: null,
             activeStartTime: null,
           })
-          queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+          invalidateMessagesThrottled(queryClient, sessionId)
           queryClient.invalidateQueries({ queryKey: ['sessions'] })
         }
       }
@@ -1199,7 +1248,7 @@ function getOrCreateEventSource(
     }
     streamListeners.get(sessionId)?.forEach((listener) => listener())
     // Refetch messages to ensure we have latest data
-    queryClient.invalidateQueries({ queryKey: ['messages', sessionId] })
+    invalidateMessagesThrottled(queryClient, sessionId)
   }
 
   return es

--- a/src/renderer/hooks/use-messages.test.ts
+++ b/src/renderer/hooks/use-messages.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// The hooks under test only need apiFetch; stub the siblings so the module
+// import stays inert (upload/error-reporting pull in heavier dependencies).
+const apiFetchMock = vi.fn()
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+vi.mock('@renderer/lib/error-reporting', () => ({
+  captureRendererException: vi.fn(),
+}))
+vi.mock('@renderer/lib/upload', () => ({
+  uploadFileChunked: vi.fn(),
+}))
+
+import {
+  useMessages,
+  useSubagentMessages,
+  useWorkflowTree,
+  useWorkflowAgentMessages,
+} from './use-messages'
+
+interface InflightRequest {
+  url: string
+  init?: RequestInit
+  resolve: (body: unknown) => void
+}
+
+// apiFetch stub with real abort semantics: each call parks until the test
+// resolves it, and rejects with an AbortError when its signal fires — the
+// same observable behavior as fetch() in a browser.
+let inflight: InflightRequest[] = []
+function installHangingFetch() {
+  inflight = []
+  apiFetchMock.mockImplementation(
+    (url: string, init?: RequestInit) =>
+      new Promise((resolve, reject) => {
+        inflight.push({
+          url,
+          init,
+          resolve: (body: unknown) => resolve({ ok: true, status: 200, json: async () => body }),
+        })
+        init?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('The operation was aborted.', 'AbortError'))
+        )
+      })
+  )
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+  return Object.assign(wrapper, { queryClient })
+}
+
+beforeEach(() => {
+  apiFetchMock.mockReset()
+  installHangingFetch()
+})
+
+describe('useMessages abort wiring', () => {
+  it('passes React Query’s per-fetch AbortSignal through to apiFetch', async () => {
+    const wrapper = createWrapper()
+    renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+
+    await waitFor(() => expect(inflight).toHaveLength(1))
+    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    expect(inflight[0].init?.signal).toBeInstanceOf(AbortSignal)
+    expect(inflight[0].init?.signal?.aborted).toBe(false)
+  })
+
+  // The core of the OOM fix: a superseding invalidation must ABORT the
+  // in-flight refetch (React Query v5's default cancelRefetch), not orphan it.
+  // Before the signal was wired, superseded multi-MB /messages responses kept
+  // being produced and buffered server-side while the client had moved on.
+  // Note RQ only cancels once the cache holds data — an INITIAL fetch is
+  // reused, not cancelled — which is exactly the incident's steady state
+  // (session open, SSE-driven refetch storm).
+  it('aborts the in-flight refetch when a new invalidation supersedes it', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+
+    // Initial load settles — the cache now has data.
+    await waitFor(() => expect(inflight).toHaveLength(1))
+    inflight[0].resolve({ messages: [], nextCursor: null })
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+
+    // First invalidation starts a refetch… (same shape the SSE-driven
+    // throttle uses: prefix key, refetch active)
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+
+    // …and a second invalidation while it is still in flight aborts it.
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(3))
+    expect(inflight[1].init?.signal?.aborted).toBe(true)
+    expect(inflight[2].init?.signal?.aborted).toBe(false)
+  })
+
+  it('the superseding refetch still delivers data after the aborted one', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+
+    await waitFor(() => expect(inflight).toHaveLength(1))
+    inflight[0].resolve({ messages: [], nextCursor: null })
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(3))
+
+    inflight[2].resolve({
+      messages: [{ id: 'm1', type: 'user', content: { text: 'hi' }, createdAt: '2026-01-01T00:00:00Z' }],
+      nextCursor: null,
+    })
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1))
+    expect(result.current.data?.[0].id).toBe('m1')
+    expect(result.current.isError).toBe(false)
+  })
+})
+
+describe('sibling queryFns abort wiring', () => {
+  it('useSubagentMessages passes the per-fetch AbortSignal', async () => {
+    const wrapper = createWrapper()
+    renderHook(() => useSubagentMessages('s1', 'agent-1', 'sub-1'), { wrapper })
+
+    await waitFor(() => expect(inflight).toHaveLength(1))
+    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/subagent/sub-1/messages')
+    expect(inflight[0].init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('useWorkflowTree passes the per-fetch AbortSignal', async () => {
+    const wrapper = createWrapper()
+    renderHook(() => useWorkflowTree('s1', 'agent-1', 'run-1'), { wrapper })
+
+    await waitFor(() => expect(inflight).toHaveLength(1))
+    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/workflows/run-1/tree')
+    expect(inflight[0].init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('useWorkflowAgentMessages passes the per-fetch AbortSignal', async () => {
+    const wrapper = createWrapper()
+    renderHook(() => useWorkflowAgentMessages('s1', 'agent-1', 'run-1', 'agent-3'), { wrapper })
+
+    await waitFor(() => expect(inflight).toHaveLength(1))
+    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/workflows/run-1/agents/agent-3/messages')
+    expect(inflight[0].init?.signal).toBeInstanceOf(AbortSignal)
+  })
+})

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -38,12 +38,13 @@ function deletedMessagesKey(sessionId: string) {
 async function fetchMessagesPage(
   agentSlug: string,
   sessionId: string,
-  opts: { limit: number; cursor?: string }
+  opts: { limit: number; cursor?: string; signal?: AbortSignal }
 ): Promise<MessagesPage> {
   const params = new URLSearchParams({ limit: String(opts.limit) })
   if (opts.cursor) params.set('cursor', opts.cursor)
   const res = await apiFetch(
-    `/api/agents/${agentSlug}/sessions/${sessionId}/messages?${params.toString()}`
+    `/api/agents/${agentSlug}/sessions/${sessionId}/messages?${params.toString()}`,
+    { signal: opts.signal }
   )
   if (res.status === 404) throw new TranscriptNotFoundError()
   if (!res.ok) throw new Error('Failed to fetch messages')
@@ -54,9 +55,13 @@ async function fetchMessagesPage(
 export function useMessages(sessionId: string | null, agentSlug: string | null) {
   const latest = useQuery<MessagesPage>({
     queryKey: ['messages', sessionId, agentSlug],
-    queryFn: async () => {
+    // Take React Query's per-fetch signal so a superseding invalidation aborts
+    // the in-flight HTTP request instead of orphaning it — without the signal,
+    // superseded /messages responses (multi-MB on long sessions) keep being
+    // produced and buffered server-side while the client has already moved on.
+    queryFn: async ({ signal }) => {
       if (!sessionId || !agentSlug) throw new Error('Missing session')
-      return fetchMessagesPage(agentSlug, sessionId, { limit: MESSAGES_PAGE_LIMIT })
+      return fetchMessagesPage(agentSlug, sessionId, { limit: MESSAGES_PAGE_LIMIT, signal })
     },
     enabled: !!sessionId && !!agentSlug,
     retry: (failureCount, error) =>
@@ -256,9 +261,10 @@ export function useSubagentMessages(
 ) {
   return useQuery<ApiMessageOrBoundary[]>({
     queryKey: ['subagent-messages', sessionId, agentSlug, subagentId],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const res = await apiFetch(
-        `/api/agents/${agentSlug}/sessions/${sessionId}/subagent/${subagentId}/messages`
+        `/api/agents/${agentSlug}/sessions/${sessionId}/subagent/${subagentId}/messages`,
+        { signal }
       )
       if (!res.ok) throw new Error('Failed to fetch subagent messages')
       return res.json()
@@ -282,9 +288,10 @@ export function useWorkflowTree(
 ) {
   return useQuery<WorkflowTree>({
     queryKey: ['workflow-tree', sessionId, agentSlug, runId],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const res = await apiFetch(
-        `/api/agents/${agentSlug}/sessions/${sessionId}/workflows/${runId}/tree`
+        `/api/agents/${agentSlug}/sessions/${sessionId}/workflows/${runId}/tree`,
+        { signal }
       )
       if (!res.ok) throw new Error('Failed to fetch workflow tree')
       return res.json()
@@ -312,9 +319,10 @@ export function useWorkflowAgentMessages(
 ) {
   return useQuery<ApiMessageOrBoundary[]>({
     queryKey: ['workflow-agent-messages', sessionId, agentSlug, runId, agentId],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const res = await apiFetch(
-        `/api/agents/${agentSlug}/sessions/${sessionId}/workflows/${runId}/agents/${agentId}/messages`
+        `/api/agents/${agentSlug}/sessions/${sessionId}/workflows/${runId}/agents/${agentId}/messages`,
+        { signal }
       )
       if (!res.ok) throw new Error('Failed to fetch workflow agent messages')
       return res.json()

--- a/src/renderer/lib/api.test.ts
+++ b/src/renderer/lib/api.test.ts
@@ -266,3 +266,26 @@ describe('apiFetch 401 against a cloud workspace', () => {
     unsubscribe()
   })
 })
+
+describe('apiFetch (init passthrough)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // The messages queryFns hand React Query's per-fetch AbortSignal to apiFetch;
+  // if the wrapper ever stops forwarding init, superseded /messages requests
+  // (multi-MB on long sessions) silently go back to running to completion
+  // server-side. Pin the pass-through.
+  it('forwards an AbortSignal to fetch so superseded requests can actually abort', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const controller = new AbortController()
+    await apiFetch('/api/x', { signal: controller.signal })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/x',
+      expect.objectContaining({ signal: controller.signal })
+    )
+  })
+})

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -911,6 +911,34 @@ describe('session-service', () => {
       expect(cursor).toBeNull()
       expect(loaded.size).toBe(600)
     })
+
+    // The signal lets the /messages route stop paying for transcript reads when
+    // the HTTP client has already aborted (superseded refetch). Rejection must
+    // be the standard AbortError so the route can map it to 499.
+    it('rejects with AbortError when the signal is already aborted', async () => {
+      await createSessionFile('test-agent', 'page-session', makeThread(10))
+
+      const controller = new AbortController()
+      controller.abort()
+      await expect(
+        getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 5,
+          signal: controller.signal,
+        })
+      ).rejects.toMatchObject({ name: 'AbortError' })
+    })
+
+    it('a never-aborted signal changes nothing', async () => {
+      await createSessionFile('test-agent', 'page-session', makeThread(10))
+
+      const controller = new AbortController()
+      const page = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 5,
+        signal: controller.signal,
+      })
+      expect(page.messages.map((m) => m.id)).toEqual(['a-7', 'u-8', 'a-8', 'u-9', 'a-9'])
+      expect(page.nextCursor).toBe('a-7')
+    })
   })
 
   describe('deleteSession', () => {

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -926,22 +926,29 @@ function pageCursor(messages: TransformedItem[], hasOlder: boolean): string | nu
   return hasOlder && messages[0] ? messages[0].id : null
 }
 
-/** Trailing (or `cursor`-before) display page. Parses only a tail of the JSONL. */
+/** Trailing (or `cursor`-before) display page. Parses only a tail of the JSONL.
+ *
+ * `opts.signal` aborts the read/parse work mid-flight (throws AbortError): the
+ * caller is an HTTP route whose client cancels superseded refetches, and without
+ * the signal every abandoned request still pays full transcript reads server-side. */
 export async function getSessionMessagesPage(
   agentSlug: string,
   sessionId: string,
-  opts: { limit: number; cursor?: string }
+  opts: { limit: number; cursor?: string; signal?: AbortSignal }
 ): Promise<SessionMessagesPage> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   if (!(await fileExists(jsonlPath))) {
     return { messages: [], nextCursor: null }
   }
 
-  const { limit, cursor } = opts
+  const { limit, cursor, signal } = opts
   let maxLines = Math.min(MAX_TAIL_LINES, Math.max(limit * INITIAL_TAIL_FACTOR, 32))
 
   for (let attempt = 0; attempt < 32; attempt++) {
-    const { lines, reachedStart } = await readJsonlTailLines(jsonlPath, maxLines)
+    const { lines, reachedStart } = await readJsonlTailLines(jsonlPath, maxLines, signal)
+    // An abort landing on the last chunk read still saves the parse/transform
+    // below — on large transcripts that is seconds of synchronous work.
+    signal?.throwIfAborted()
     const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
     for (const line of lines) {
       const parsed = parseJsonlLine<JsonlEntry>(line)

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -725,6 +725,69 @@ describe('readJsonlTailLines', () => {
     expect(lines).toEqual([])
     expect(reachedStart).toBe(true)
   })
+
+  // The abort signal exists so an HTTP caller whose client hung up stops
+  // paying for the rest of a large transcript (reads are multi-second on
+  // network volumes). Pin both halves: a pre-aborted signal never opens the
+  // file, and an abort mid-walk stops before the next chunk read.
+  it('rejects without opening the file when the signal is already aborted', async () => {
+    const filePath = path.join(testDir, 'abort-pre.jsonl')
+    await fs.promises.writeFile(filePath, 'a\nb\n')
+    const openSpy = vi.spyOn(fs.promises, 'open')
+
+    const controller = new AbortController()
+    controller.abort()
+    await expect(readJsonlTailLines(filePath, 5, controller.signal)).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+    expect(openSpy).not.toHaveBeenCalled()
+    openSpy.mockRestore()
+  })
+
+  it('stops the backward walk when the signal aborts between chunk reads', async () => {
+    // >4 chunks of 64KB so an unaborted read would take several iterations.
+    const filePath = path.join(testDir, 'abort-mid.jsonl')
+    const row = `${'x'.repeat(1023)}\n`
+    await fs.promises.writeFile(filePath, row.repeat(300)) // ~300KB, ~5 chunks
+
+    const controller = new AbortController()
+    let reads = 0
+    const realOpen = fs.promises.open.bind(fs.promises)
+    const openSpy = vi.spyOn(fs.promises, 'open').mockImplementation(async (...args) => {
+      const handle = await realOpen(...(args as Parameters<typeof fs.promises.open>))
+      const realRead = handle.read.bind(handle) as (...a: unknown[]) => unknown
+      return new Proxy(handle, {
+        get(target, prop, receiver) {
+          if (prop === 'read') {
+            return (...readArgs: unknown[]) => {
+              reads++
+              controller.abort() // abort lands while the first read is in flight
+              return realRead(...readArgs)
+            }
+          }
+          const value = Reflect.get(target, prop, receiver)
+          return typeof value === 'function' ? value.bind(target) : value
+        },
+      }) as Awaited<ReturnType<typeof fs.promises.open>>
+    })
+
+    // Ask for every line so only the abort can stop the walk early.
+    await expect(readJsonlTailLines(filePath, 100_000, controller.signal)).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+    expect(reads).toBe(1)
+    openSpy.mockRestore()
+  })
+
+  it('ignores a never-aborted signal', async () => {
+    const filePath = path.join(testDir, 'abort-none.jsonl')
+    await fs.promises.writeFile(filePath, 'a\nb\nc\n')
+
+    const controller = new AbortController()
+    const { lines, reachedStart } = await readJsonlTailLines(filePath, 10, controller.signal)
+    expect(lines.map((l) => l.toString('utf-8'))).toEqual(['a', 'b', 'c'])
+    expect(reachedStart).toBe(true)
+  })
 })
 
 describe('streamJsonlFile', () => {

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -779,6 +779,38 @@ describe('readJsonlTailLines', () => {
     openSpy.mockRestore()
   })
 
+  it('rejects when the abort lands during the final chunk read', async () => {
+    // Single-chunk file: this read IS the final one, so there is no next loop
+    // iteration to observe the abort — only a post-read check catches it
+    // before the tail buffer is materialized and line-scanned.
+    const filePath = path.join(testDir, 'abort-final.jsonl')
+    await fs.promises.writeFile(filePath, 'a\nb\nc\n')
+
+    const controller = new AbortController()
+    const realOpen = fs.promises.open.bind(fs.promises)
+    const openSpy = vi.spyOn(fs.promises, 'open').mockImplementation(async (...args) => {
+      const handle = await realOpen(...(args as Parameters<typeof fs.promises.open>))
+      const realRead = handle.read.bind(handle) as (...a: unknown[]) => unknown
+      return new Proxy(handle, {
+        get(target, prop, receiver) {
+          if (prop === 'read') {
+            return (...readArgs: unknown[]) => {
+              controller.abort() // abort lands while the only read is in flight
+              return realRead(...readArgs)
+            }
+          }
+          const value = Reflect.get(target, prop, receiver)
+          return typeof value === 'function' ? value.bind(target) : value
+        },
+      }) as Awaited<ReturnType<typeof fs.promises.open>>
+    })
+
+    await expect(readJsonlTailLines(filePath, 10, controller.signal)).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+    openSpy.mockRestore()
+  })
+
   it('ignores a never-aborted signal', async () => {
     const filePath = path.join(testDir, 'abort-none.jsonl')
     await fs.promises.writeFile(filePath, 'a\nb\nc\n')

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -779,6 +779,46 @@ describe('readJsonlTailLines', () => {
     openSpy.mockRestore()
   })
 
+  it('rejects without reading a chunk when the abort lands during open/stat', async () => {
+    // The entry check runs before open(), but open and stat are themselves
+    // awaited RPCs on network volumes — an abort landing inside them must be
+    // observed before the first (also RPC-priced) chunk read starts.
+    const filePath = path.join(testDir, 'abort-stat.jsonl')
+    await fs.promises.writeFile(filePath, 'a\nb\nc\n')
+
+    const controller = new AbortController()
+    let reads = 0
+    const realOpen = fs.promises.open.bind(fs.promises)
+    const openSpy = vi.spyOn(fs.promises, 'open').mockImplementation(async (...args) => {
+      const handle = await realOpen(...(args as Parameters<typeof fs.promises.open>))
+      const realStat = handle.stat.bind(handle) as (...a: unknown[]) => unknown
+      return new Proxy(handle, {
+        get(target, prop, receiver) {
+          if (prop === 'stat') {
+            return (...statArgs: unknown[]) => {
+              controller.abort() // abort lands while stat is in flight
+              return realStat(...statArgs)
+            }
+          }
+          if (prop === 'read') {
+            return () => {
+              reads++
+              throw new Error('read must not start after the abort')
+            }
+          }
+          const value = Reflect.get(target, prop, receiver)
+          return typeof value === 'function' ? value.bind(target) : value
+        },
+      }) as Awaited<ReturnType<typeof fs.promises.open>>
+    })
+
+    await expect(readJsonlTailLines(filePath, 10, controller.signal)).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+    expect(reads).toBe(0)
+    openSpy.mockRestore()
+  })
+
   it('rejects when the abort lands during the final chunk read', async () => {
     // Single-chunk file: this read IS the final one, so there is no next loop
     // iteration to observe the abort — only a post-read check catches it

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -365,11 +365,18 @@ export async function readJsonlFile<T = unknown>(filePath: string): Promise<T[]>
 const NEWLINE_BYTE = 0x0a
 const TAIL_READ_CHUNK = 64 * 1024
 
-/** Last `maxLines` JSONL rows from disk. Older rows are never read into a line buffer. */
+/** Last `maxLines` JSONL rows from disk. Older rows are never read into a line buffer.
+ *
+ * `signal` (optional) aborts the backward walk between chunk reads: transcripts
+ * run to tens of MB and network filesystems make each read slow, so a caller
+ * whose HTTP client already hung up must be able to stop paying for the rest
+ * of the file. Throws the signal's abort reason (AbortError). */
 export async function readJsonlTailLines(
   filePath: string,
-  maxLines: number
+  maxLines: number,
+  signal?: AbortSignal
 ): Promise<{ lines: Buffer[]; reachedStart: boolean }> {
+  signal?.throwIfAborted()
   if (maxLines <= 0) return { lines: [], reachedStart: true }
 
   let fileHandle: fs.promises.FileHandle
@@ -391,6 +398,7 @@ export async function readJsonlTailLines(
     let newlineCount = 0
 
     while (pos > 0 && newlineCount <= maxLines) {
+      signal?.throwIfAborted()
       const size = Math.min(TAIL_READ_CHUNK, pos)
       pos -= size
       const buf = Buffer.allocUnsafe(size)

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -398,11 +398,14 @@ export async function readJsonlTailLines(
     let newlineCount = 0
 
     while (pos > 0 && newlineCount <= maxLines) {
-      signal?.throwIfAborted()
       const size = Math.min(TAIL_READ_CHUNK, pos)
       pos -= size
       const buf = Buffer.allocUnsafe(size)
       const { bytesRead } = await fileHandle.read(buf, 0, size, pos)
+      // Check AFTER the awaited read: an abort landing while the FINAL chunk
+      // is in flight has no next iteration to observe it, and would otherwise
+      // still pay for concatenating and line-scanning the whole tail window.
+      signal?.throwIfAborted()
       const chunk = bytesRead === size ? buf : buf.subarray(0, bytesRead)
       parts.unshift(chunk)
       for (let i = 0; i < chunk.length; i++) {

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -398,13 +398,16 @@ export async function readJsonlTailLines(
     let newlineCount = 0
 
     while (pos > 0 && newlineCount <= maxLines) {
+      // Check BEFORE each read (an abort landing during open/stat or a prior
+      // iteration must not start another RPC-priced read) and AFTER it (an
+      // abort landing while the FINAL chunk is in flight has no next iteration
+      // to observe it, and would otherwise still pay for concatenating and
+      // line-scanning the whole tail window).
+      signal?.throwIfAborted()
       const size = Math.min(TAIL_READ_CHUNK, pos)
       pos -= size
       const buf = Buffer.allocUnsafe(size)
       const { bytesRead } = await fileHandle.read(buf, 0, size, pos)
-      // Check AFTER the awaited read: an abort landing while the FINAL chunk
-      // is in flight has no next iteration to observe it, and would otherwise
-      // still pay for concatenating and line-scanning the whole tail window.
       signal?.throwIfAborted()
       const chunk = bytesRead === size ? buf : buf.subarray(0, bytesRead)
       parts.unshift(chunk)


### PR DESCRIPTION
Client half of the session-OOM fix (SUP-592), plus the server-side abort handling added during review — the /messages read path now honors client cancellation end to end. Fixes [SUP-593](https://linear.app/datawizz/issue/SUP-593).

## Problem

On a long session, every SSE event that touches the transcript (`tool_call`, `tool_result`, `messages_updated`, `session_idle`, …) fired its own `invalidateQueries(['messages', sessionId])`, and the queryFns never passed React Query's AbortSignal — so superseded refetches ran to completion server-side. Each refetch of the incident session is a 17.8 MB response built from two full 37 MB transcript reads; under NFS-grade latency, in-flight concurrency grows as event rate × latency. This is the proven mechanism behind the 1 GB cloud app-container OOM on session resume (repro: OOMKilled in 25 s at 4 req/s fast disk, ~45 s at 1 req/s over real NFS).

## Changes

**Throttle (`use-message-stream.ts`)** — all ~17 SSE-driven `['messages', sessionId]` invalidation sites now funnel through `invalidateMessagesThrottled`, a per-session leading-edge throttle (750 ms): the first event refetches immediately, the rest of the burst collapses into at most one trailing refetch. Collapsed callers share a promise that resolves when the trailing refetch settles, so the post-idle reconcile loop keeps its bounded-retry semantics. Not throttled: `['sessions']` / `['pending-user-requests']` / `['subagent-messages']` invalidations, and all user-initiated ones (delete message/tool call, interrupt).

**Abort (`use-messages.ts`)** — `useMessages` and the sibling queryFns (`useSubagentMessages`, `useWorkflowTree`, `useWorkflowAgentMessages`) now take React Query's per-fetch `{ signal }` and pass it through `apiFetch`, so TanStack v5's default `cancelRefetch` genuinely aborts a superseded HTTP request instead of orphaning it. Nuance (documented in tests): RQ only cancels once the cache has data — initial fetches are reused, never aborted — which is exactly the incident's steady state.

Why not a native TanStack mechanism: `staleTime` is ignored by `invalidateQueries` (it force-marks stale); `cancelRefetch: false` collapses only while a fetch is in flight (window scales with latency, not event rate) and can strand the UI on data fetched *before* the last event, with nothing refetching after; `notifyManager.batch` batches renders, not fetches. The trailing edge guarantees one refetch strictly after the last event of a burst.

## Server-side changes (added during review)

**Server honors aborts (`c3a3590f`)** — the client abort now propagates: route → `getSessionMessagesPage` → `readJsonlTailLines`, checked per 64 KB chunk of the backward tail walk. An aborted request answers 499 (no error log) and stops paying for transcript reads — probed on a real node server with a 20 ms/read fs shim: abort at 150 ms cost 7 reads / 0.46 MB vs 38 reads / 2.49 MB for the control (−82 %), zero reads after.

**Arm the signal before async work (`b27580de`)** — `@hono/node-server` creates the request `AbortController` lazily on first `.signal` access, and its close handler only aborts a controller that already exists — a hangup landing before first access (during auth/session-existence awaits) was permanently missed. An `armAbortSignal` middleware now runs first in `src/api/index.ts`; a real socket-disconnect test pins both the fix and the adapter behavior that requires it. Also: the tail reader observes aborts landing during the final chunk read, and the idle reconcile loop is generation-scoped to its EventSource so a stale wake can't undo the unmount cleanup.

**Review round 4 (`c7314d35`)** — a newer `session_idle` supersedes a sleeping reconcile loop (ownership token) instead of being dropped, so a second short turn or rapid remount doesn't wait on the 15 s poll for its final text; the tail reader checks the signal both before and after each chunk read, so an abort landing during `open()`/`stat()` no longer starts one unnecessary read.

Known residual (deliberate): the paginated response is still eagerly serialized via `c.json`, so an abort arriving mid-stringify is only observed afterward — that's the two-pass-streaming scope of SUP-595.

## Validation

- Unit suite green: 9 526 tests. ~12 existing sync-invalidation tests adapted to fake-timer trailing-edge assertions.
- New tests pin the contract: burst-coalescing bound (6-event burst → exactly leading + 1 trailing; separate windows refetch immediately; per-session independence; `connected` still refetches immediately as the late-join recovery path), real abort semantics in the new `use-messages.test.ts` (superseding invalidation flips `signal.aborted`, superseding refetch still delivers), an `apiFetch` signal pass-through pin in `api.test.ts`, route 499 + signal-forwarding tests, tail-reader abort tests (pre-open / during stat / mid-walk / final read), a real node-server socket-disconnect pair for the arming middleware, and reconcile lifecycle tests (unmount cleanup, stale-loop generation bail, newer-idle supersession). Each regression test was verified to fail against the unfixed code.
- E2E: 20/20 passed across chat-flow, message-queueing, cross-session-messages, concurrent-tabs-request-sync, persistence.
- Manual validation in a real Chromium renderer against a mock-mode server: **3 GET `/messages` per 22 s tool-using turn, down from the measured baseline of 7** (leading +0.07 s, trailing +0.82 s, 15 s safety poll), **zero same-moment duplicates**, a real `net::ERR_ABORTED` captured on a superseded `?limit=300` fetch. Streaming UX intact: live delta rendered 224 ms after turn start; final persisted text ~70 ms after idle.

## Acceptance (from SUP-593)

- [x] One tool-using turn produces ≤ 2–3 messages refetches, zero same-moment duplicates
- [x] Superseded requests actually cancelled client-side
- [x] Streaming UX unchanged; final state reconciles promptly after idle
- [x] `connected` still triggers an immediate refetch (late-join/drift recovery)
- [x] No regression in interrupt flow, queued messages, pending-input recovery (E2E green)

https://claude.ai/code/session_01Xvya59kGnQTwWRHTUbtZ3B
