### PR TITLE
Forward-delta cursor on GET /messages (?after=) with upsert-by-id merge (SUP-594)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -304,6 +304,7 @@ vi.mock('@shared/lib/services/session-service', () => ({
   registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(),
   getSessionMessagesPage: vi.fn(),
+  getSessionMessagesDelta: vi.fn(),
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),
@@ -559,7 +560,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionMessagesDelta, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3870,6 +3871,100 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     })
     expect(res.status).toBe(499)
     expect(res.body).toBeNull()
+  })
+})
+
+describe('GET /:id/sessions/:sessionId/messages forward delta (?after=)', () => {
+  let app: ReturnType<typeof createApp>
+  const URL = '/api/agents/test-agent/sessions/sess-1/messages'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    vi.mocked(sessionExists).mockResolvedValue(true)
+    vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
+  })
+
+  it('answers a delta envelope and forwards after + abort signal to the reader', async () => {
+    vi.mocked(getSessionMessagesDelta).mockResolvedValue({
+      messages: [
+        { id: 'm5', type: 'user', content: { text: 'anchor' }, toolCalls: [], createdAt: new Date() },
+        { id: 'm6', type: 'assistant', content: { text: 'new' }, toolCalls: [], createdAt: new Date() },
+      ],
+      anchor: 'm5',
+    })
+
+    const res = await getReq(app, `${URL}?after=m5&limit=300`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.messages.map((m: { id: string }) => m.id)).toEqual(['m5', 'm6'])
+    expect(body.anchor).toBe('m5')
+    expect(body).not.toHaveProperty('resync')
+    expect(body).not.toHaveProperty('nextCursor')
+    expect(getSessionMessagesDelta).toHaveBeenCalledWith('test-agent', 'sess-1', {
+      after: 'm5',
+      signal: expect.any(AbortSignal),
+    })
+    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+  })
+
+  it('passes resync through so the client falls back to a full fetch', async () => {
+    vi.mocked(getSessionMessagesDelta).mockResolvedValue({
+      messages: [],
+      anchor: null,
+      resync: true,
+    })
+
+    const res = await getReq(app, `${URL}?after=vanished`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ messages: [], anchor: null, resync: true })
+  })
+
+  it('rejects a request mixing after with cursor', async () => {
+    const res = await getReq(app, `${URL}?after=m5&cursor=m1`)
+    expect(res.status).toBe(400)
+    expect(getSessionMessagesDelta).not.toHaveBeenCalled()
+    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+  })
+
+  it('propagates the request abort into the delta reader and answers 499', async () => {
+    vi.mocked(getSessionMessagesDelta).mockImplementation(async (_agent, _session, opts) => {
+      opts.signal?.throwIfAborted()
+      return { messages: [], anchor: null }
+    })
+
+    const controller = new AbortController()
+    controller.abort()
+    const res = await app.request(`http://localhost${URL}?after=m5`, {
+      method: 'GET',
+      signal: controller.signal,
+    })
+    expect(res.status).toBe(499)
+  })
+
+  it('stamps settled input-request outcomes onto open tool calls in the delta window', async () => {
+    vi.mocked(getSessionMessagesDelta).mockResolvedValue({
+      messages: [
+        {
+          id: 'm5',
+          type: 'assistant',
+          content: { text: '' },
+          toolCalls: [{ id: 'tool-1', name: 'AskUserQuestion', input: {}, result: undefined }],
+          createdAt: new Date(),
+        },
+      ],
+      anchor: 'm4',
+    })
+    vi.mocked(messagePersister.getSettledInputRequests).mockReturnValue(
+      new Map([['tool-1', 'answered']])
+    )
+
+    const res = await getReq(app, `${URL}?after=m4`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.messages[0].toolCalls[0].result).toBe('User provided input')
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1796,6 +1796,9 @@ async function annotateAndRecoverMessages(
   const userMessageIds = transformed.filter((m) => m.type === 'user').map((m) => m.id)
   if (userMessageIds.length === 0) return
 
+  // Scope the lookup to the ids actually in this response — a delta window is
+  // a handful of items, and loading the whole session's author history per
+  // refetch would erase the bounded-memory benefit on auth deployments.
   const authors = await db
     .select({
       messageId: messageAuthor.id,
@@ -1805,7 +1808,7 @@ async function annotateAndRecoverMessages(
     })
     .from(messageAuthor)
     .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
-    .where(eq(messageAuthor.sessionId, sessionId))
+    .where(and(eq(messageAuthor.sessionId, sessionId), inArray(messageAuthor.id, userMessageIds)))
 
   const authorMap = new Map(authors.map((a) => [a.messageId, a]))
   for (const msg of transformed) {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -59,6 +59,7 @@ import {
   registerSession,
   getSessionMessagesWithCompact,
   getSessionMessagesPage,
+  getSessionMessagesDelta,
   getSession,
   getSessionMetadata,
   sessionExists,
@@ -1751,10 +1752,15 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
   }
 })
 
-const messagesListQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(MESSAGES_PAGE_MAX_LIMIT).optional(),
-  cursor: z.string().min(1).max(200).optional(),
-})
+const messagesListQuerySchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(MESSAGES_PAGE_MAX_LIMIT).optional(),
+    cursor: z.string().min(1).max(200).optional(),
+    after: z.string().min(1).max(200).optional(),
+  })
+  // Backward paging and the forward delta are different protocols; a request
+  // mixing them has no coherent meaning.
+  .refine((q) => !(q.cursor && q.after), { message: 'cursor and after are mutually exclusive' })
 
 async function annotateAndRecoverMessages(
   transformed: TransformedItem[],
@@ -1834,10 +1840,12 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
 
     const rawLimit = c.req.query('limit')
     const rawCursor = c.req.query('cursor')
-    if (rawLimit !== undefined || rawCursor !== undefined) {
+    const rawAfter = c.req.query('after')
+    if (rawLimit !== undefined || rawCursor !== undefined || rawAfter !== undefined) {
       const parsed = messagesListQuerySchema.safeParse({
         ...(rawLimit !== undefined ? { limit: rawLimit } : {}),
         ...(rawCursor !== undefined ? { cursor: rawCursor } : {}),
+        ...(rawAfter !== undefined ? { after: rawAfter } : {}),
       })
       if (!parsed.success) {
         return c.json({ error: 'Invalid pagination' }, 400)
@@ -1847,6 +1855,24 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       // stops paying for transcript reads (multi-second on network volumes)
       // instead of running the full read/parse/serialize pipeline to
       // completion for a client that hung up.
+      if (parsed.data.after !== undefined) {
+        // Forward delta: upserted items at-or-after the anchor (a live-session
+        // refetch only cares about lines appended since the last read). The
+        // window is bounded by the active turn near EOF, so this stays a few
+        // KB while the full trailing page is multi-MB on long sessions.
+        const delta = await getSessionMessagesDelta(agentSlug, sessionId, {
+          after: parsed.data.after,
+          signal: c.req.raw.signal,
+        })
+        c.req.raw.signal.throwIfAborted()
+        await annotateAndRecoverMessages(delta.messages, agentSlug, sessionId)
+        c.req.raw.signal.throwIfAborted()
+        return c.json({
+          messages: delta.messages,
+          anchor: delta.anchor,
+          ...(delta.resync ? { resync: true as const } : {}),
+        })
+      }
       const page = await getSessionMessagesPage(agentSlug, sessionId, {
         limit: capMessagesPageLimit(parsed.data.limit, parsed.data.cursor),
         cursor: parsed.data.cursor,

--- a/src/renderer/hooks/poll-cadence.test.ts
+++ b/src/renderer/hooks/poll-cadence.test.ts
@@ -19,8 +19,15 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
   }
 })
 
+import { createElement } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useMessages } from './use-messages'
 import { useChatIntegrationSessions } from './use-chat-integrations'
+
+// useMessages reads the query cache via useQueryClient (delta anchoring), so a
+// real provider is needed even with useQuery itself mocked out.
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  createElement(QueryClientProvider, { client: new QueryClient() }, children)
 
 describe('polling cadence (reviewed interval constants)', () => {
   beforeEach(() => {
@@ -28,7 +35,7 @@ describe('polling cadence (reviewed interval constants)', () => {
   })
 
   it('useMessages polls every 15s as the SSE safety net', () => {
-    renderHook(() => useMessages('session-1', 'agent-1'))
+    renderHook(() => useMessages('session-1', 'agent-1'), { wrapper })
     const messagesQuery = capturedOptions.find((opts) => {
       const key = opts.queryKey as unknown[] | undefined
       return Array.isArray(key) && key[0] === 'messages'

--- a/src/renderer/hooks/use-messages.test.ts
+++ b/src/renderer/hooks/use-messages.test.ts
@@ -322,18 +322,70 @@ describe('useMessages forward delta', () => {
     await waitFor(() => expect(inflight).toHaveLength(3))
     inflight[2].resolve({ messages: [], anchor: null, resync: true })
     await waitFor(() => expect(inflight).toHaveLength(4))
-    inflight[3].resolve({ messages: [user('u9')], nextCursor: null })
+    inflight[3].resolve({ messages: [user('u9')], nextCursor: 'c2' })
     await waitFor(() => expect(result.current.data?.map((m) => m.id)).toEqual(['u9']))
 
-    // The pre-resync older page finally lands — stale history from the old
-    // transcript generation must not commit.
-    inflight[1].resolve({ messages: [user('u0-stale')], nextCursor: null })
+    // The reset aborts the stale request outright — fencing alone would let a
+    // hung request hold isFetchingOlder and block all fresh paging.
+    expect(inflight[1].init?.signal?.aborted).toBe(true)
     await act(async () => {
       expect(await olderDone).toBe(false)
     })
     expect(result.current.data?.map((m) => m.id)).toEqual(['u9'])
-    // Nor may the stale page's terminal cursor latch older-history loading off.
-    expect(result.current.hasOlder).toBe(false)
+    expect(result.current.isFetchingOlder).toBe(false)
+
+    // Fresh paging starts immediately against the post-resync cursor.
+    act(() => {
+      void result.current.fetchOlder()
+    })
+    await waitFor(() => expect(inflight).toHaveLength(5))
+    expect(inflight[4].url).toContain('cursor=c2')
+  })
+
+  it('drops an item deleted remotely from within the covered range on a periodic full fetch', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    try {
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+      await settleInitialPage(wrapper, result, [user('u1'), assistant('a1'), user('u2'), assistant('a2')])
+
+      vi.setSystemTime(Date.now() + MESSAGES_FULL_REFETCH_INTERVAL_MS + 1000)
+      act(() => {
+        void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+      })
+      await waitFor(() => expect(inflight).toHaveLength(2))
+      // Another client deleted a1; the page still starts at u1, so a1's
+      // absence is a rewrite, not turnover — it must not survive in `older`.
+      inflight[1].resolve({ messages: [user('u1'), user('u2'), assistant('a2')], nextCursor: null })
+      await waitFor(() => expect(result.current.data?.map((m) => m.id)).toEqual(['u1', 'u2', 'a2']))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('items before the new page start still slide into older history', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    try {
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+      await settleInitialPage(wrapper, result, [user('u1'), assistant('a1'), user('u2'), assistant('a2')])
+
+      vi.setSystemTime(Date.now() + MESSAGES_FULL_REFETCH_INTERVAL_MS + 1000)
+      act(() => {
+        void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+      })
+      await waitFor(() => expect(inflight).toHaveLength(2))
+      // The page advanced: u1/a1 fell off its start — genuine turnover.
+      inflight[1].resolve({
+        messages: [user('u2'), assistant('a2'), user('u3'), assistant('a3')],
+        nextCursor: 'u2',
+      })
+      await waitFor(() =>
+        expect(result.current.data?.map((m) => m.id)).toEqual(['u1', 'a1', 'u2', 'a2', 'u3', 'a3'])
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('falls back to a full fetch when the delta window predates the cache', async () => {

--- a/src/renderer/hooks/use-messages.test.ts
+++ b/src/renderer/hooks/use-messages.test.ts
@@ -293,6 +293,47 @@ describe('useMessages forward delta', () => {
 
     await waitFor(() => expect(inflight).toHaveLength(3))
     expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+
+    // The refetch omits the rewritten-away assistant. That omission is
+    // authoritative — the item must vanish, not slide into the older-history
+    // buffer and resurface elsewhere in the transcript.
+    inflight[2].resolve({ messages: [user('u1')], nextCursor: null })
+    await waitFor(() => expect(result.current.messages.data?.map((m) => m.id)).toEqual(['u1']))
+  })
+
+  it('discards an older-history page that resolves after a resync', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+    await settleInitialPage(wrapper, result, [user('u1'), assistant('a1')])
+
+    // Start paging older history; leave the request in flight.
+    let olderDone: Promise<boolean>
+    act(() => {
+      olderDone = result.current.fetchOlder()
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    expect(inflight[1].url).toContain('cursor=older-cursor')
+
+    // Meanwhile the transcript is rewritten: delta answers resync, the full
+    // fetch replaces the page.
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(3))
+    inflight[2].resolve({ messages: [], anchor: null, resync: true })
+    await waitFor(() => expect(inflight).toHaveLength(4))
+    inflight[3].resolve({ messages: [user('u9')], nextCursor: null })
+    await waitFor(() => expect(result.current.data?.map((m) => m.id)).toEqual(['u9']))
+
+    // The pre-resync older page finally lands — stale history from the old
+    // transcript generation must not commit.
+    inflight[1].resolve({ messages: [user('u0-stale')], nextCursor: null })
+    await act(async () => {
+      expect(await olderDone).toBe(false)
+    })
+    expect(result.current.data?.map((m) => m.id)).toEqual(['u9'])
+    // Nor may the stale page's terminal cursor latch older-history loading off.
+    expect(result.current.hasOlder).toBe(false)
   })
 
   it('falls back to a full fetch when the delta window predates the cache', async () => {

--- a/src/renderer/hooks/use-messages.test.ts
+++ b/src/renderer/hooks/use-messages.test.ts
@@ -22,6 +22,7 @@ import {
   useSubagentMessages,
   useWorkflowTree,
   useWorkflowAgentMessages,
+  MESSAGES_FULL_REFETCH_INTERVAL_MS,
 } from './use-messages'
 
 interface InflightRequest {
@@ -132,6 +133,148 @@ describe('useMessages abort wiring', () => {
     await waitFor(() => expect(result.current.data).toHaveLength(1))
     expect(result.current.data?.[0].id).toBe('m1')
     expect(result.current.isError).toBe(false)
+  })
+})
+
+describe('useMessages forward delta', () => {
+  const user = (id: string, text = 'q') => ({
+    id,
+    type: 'user' as const,
+    content: { text },
+    toolCalls: [],
+    createdAt: '2026-01-01T00:00:00Z',
+  })
+  const assistant = (id: string, text = 'a') => ({
+    id,
+    type: 'assistant' as const,
+    content: { text },
+    toolCalls: [],
+    createdAt: '2026-01-01T00:00:01Z',
+  })
+
+  async function settleInitialPage(
+    wrapper: ReturnType<typeof createWrapper>,
+    result: { current: { isFetching: boolean } },
+    messages: unknown[]
+  ) {
+    await waitFor(() => expect(inflight).toHaveLength(1))
+    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    inflight[0].resolve({ messages, nextCursor: 'older-cursor' })
+    await waitFor(() => expect(result.current.isFetching).toBe(false))
+  }
+
+  it('refetches as a forward delta anchored on the last settled item and merges the upserts', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+    // The trailing assistant may still merge streamed blocks → anchor is u1.
+    await settleInitialPage(wrapper, result, [user('u1'), assistant('a1', 'stale')])
+
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&after=u1')
+
+    inflight[1].resolve({
+      messages: [user('u1'), assistant('a1', 'fresh'), assistant('a2', 'new')],
+      anchor: 'a1',
+    })
+    await waitFor(() => expect(result.current.data).toHaveLength(3))
+    expect(result.current.data?.map((m) => m.id)).toEqual(['u1', 'a1', 'a2'])
+    expect((result.current.data?.[1] as { content: { text: string } }).content.text).toBe('fresh')
+    // Older-history paging state survives delta merges.
+    expect(result.current.hasOlder).toBe(true)
+  })
+
+  it('falls back to a full fetch in the same refetch when the server answers resync', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+    await settleInitialPage(wrapper, result, [user('u1'), assistant('a1')])
+
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    inflight[1].resolve({ messages: [], anchor: null, resync: true })
+
+    await waitFor(() => expect(inflight).toHaveLength(3))
+    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    inflight[2].resolve({ messages: [user('u9')], nextCursor: null })
+    // u1/a1 slide into the older-history buffer (standard latest-page turnover).
+    await waitFor(() => expect(result.current.data?.map((m) => m.id)).toEqual(['u1', 'a1', 'u9']))
+  })
+
+  it('treats a plain page response (pre-delta server) as the full fetch', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+    await settleInitialPage(wrapper, result, [user('u1'), assistant('a1')])
+
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    // An old server ignores `after` and answers the trailing page envelope.
+    inflight[1].resolve({ messages: [user('u1'), assistant('a1', 'full')], nextCursor: null })
+
+    await waitFor(() =>
+      expect((result.current.data?.[1] as { content: { text: string } }).content.text).toBe('full')
+    )
+    expect(inflight).toHaveLength(2)
+  })
+
+  it('does a full refetch when the periodic drift repair is due, then returns to deltas', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    try {
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+      await settleInitialPage(wrapper, result, [user('u1'), assistant('a1')])
+
+      vi.setSystemTime(Date.now() + MESSAGES_FULL_REFETCH_INTERVAL_MS + 1000)
+      act(() => {
+        void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+      })
+      await waitFor(() => expect(inflight).toHaveLength(2))
+      expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+      inflight[1].resolve({ messages: [user('u1'), assistant('a1')], nextCursor: null })
+      await waitFor(() => expect(result.current.isFetching).toBe(false))
+
+      // The full fetch restamped the cadence — the next refetch is a delta again.
+      act(() => {
+        void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+      })
+      await waitFor(() => expect(inflight).toHaveLength(3))
+      expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&after=u1')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fetches the full page while nothing is safely settled (lone streaming assistant)', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+    await settleInitialPage(wrapper, result, [assistant('a1')])
+
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+  })
+
+  it('falls back to a full fetch when the delta window predates the cache', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+    await settleInitialPage(wrapper, result, [user('u1'), assistant('a1')])
+
+    act(() => {
+      void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    // Server widened past everything the client holds — splice point unknown.
+    inflight[1].resolve({ messages: [user('u0'), user('u1'), assistant('a1')], anchor: 'u1' })
+
+    await waitFor(() => expect(inflight).toHaveLength(3))
+    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
   })
 })
 

--- a/src/renderer/hooks/use-messages.test.ts
+++ b/src/renderer/hooks/use-messages.test.ts
@@ -19,6 +19,7 @@ vi.mock('@renderer/lib/upload', () => ({
 
 import {
   useMessages,
+  useDeleteToolCall,
   useSubagentMessages,
   useWorkflowTree,
   useWorkflowAgentMessages,
@@ -200,8 +201,9 @@ describe('useMessages forward delta', () => {
     await waitFor(() => expect(inflight).toHaveLength(3))
     expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
     inflight[2].resolve({ messages: [user('u9')], nextCursor: null })
-    // u1/a1 slide into the older-history buffer (standard latest-page turnover).
-    await waitFor(() => expect(result.current.data?.map((m) => m.id)).toEqual(['u1', 'a1', 'u9']))
+    // Resync means the transcript was rewritten: u1/a1 may no longer exist, so
+    // they must NOT survive in the older-history buffer.
+    await waitFor(() => expect(result.current.data?.map((m) => m.id)).toEqual(['u9']))
   })
 
   it('treats a plain page response (pre-delta server) as the full fetch', async () => {
@@ -259,6 +261,38 @@ describe('useMessages forward delta', () => {
     })
     await waitFor(() => expect(inflight).toHaveLength(2))
     expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+  })
+
+  it('a tool-call deletion forces the next refetch to be a full page', async () => {
+    // The rewrite can edit an assistant item BEFORE the delta anchor, which
+    // deltas never re-serve — without expiring the full-fetch stamp the
+    // deleted call would stay rendered until the periodic full repair.
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({ messages: useMessages('s1', 'agent-1'), del: useDeleteToolCall() }),
+      { wrapper }
+    )
+    await waitFor(() => expect(inflight).toHaveLength(1))
+    inflight[0].resolve({ messages: [user('u1'), assistant('a1')], nextCursor: null })
+    await waitFor(() => expect(result.current.messages.isFetching).toBe(false))
+
+    let deletion: Promise<unknown>
+    act(() => {
+      deletion = result.current.del.mutateAsync({
+        sessionId: 's1',
+        agentSlug: 'agent-1',
+        toolCallId: 't1',
+      })
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/tool-calls/t1')
+    inflight[1].resolve({})
+    await act(async () => {
+      await deletion
+    })
+
+    await waitFor(() => expect(inflight).toHaveLength(3))
+    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
   })
 
   it('falls back to a full fetch when the delta window predates the cache', async () => {

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -177,10 +177,15 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
   // Bumped whenever older-history state is reset (session switch, resync).
   // An in-flight fetchOlder from a previous generation must not commit — it
   // could repopulate rewritten-away history or latch a stale terminal cursor.
+  // The request is also aborted outright: fencing alone leaves a hung request
+  // holding isFetchingOlder, which blocks every fresh fetchOlder call.
   const olderGenRef = useRef(0)
+  const olderAbortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     olderGenRef.current++
+    olderAbortRef.current?.abort()
+    olderAbortRef.current = null
     setOlder([])
     setOlderCursor(undefined)
     prevLatestRef.current = EMPTY_MESSAGES
@@ -198,6 +203,8 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
     if (resyncedAt === undefined || resyncedAt === lastResyncRef.current) return
     lastResyncRef.current = resyncedAt
     olderGenRef.current++
+    olderAbortRef.current?.abort()
+    olderAbortRef.current = null
     prevLatestRef.current = EMPTY_MESSAGES
     setOlder([])
     setOlderCursor(undefined)
@@ -208,7 +215,16 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
     prevLatestRef.current = latestMessages
     if (prev.length === 0) return
     const nextIds = new Set(latestMessages.map((m) => m.id))
-    const slidOff = prev.filter((m) => !nextIds.has(m.id) && !deleted.has(m.id))
+    // Only items that sat BEFORE the new page's first item can have slid off
+    // the trailing window. An item missing from within the still-covered
+    // range was rewritten away (e.g. deleted by another client) — retaining
+    // it as scrolled-off history would resurrect it indefinitely. When the
+    // new first item isn't in prev (the page advanced wholesale between
+    // fetches), fall back to treating everything missing as turnover.
+    const firstId = latestMessages[0]?.id
+    const boundary = firstId !== undefined ? prev.findIndex((m) => m.id === firstId) : -1
+    const candidates = boundary >= 0 ? prev.slice(0, boundary) : prev
+    const slidOff = candidates.filter((m) => !nextIds.has(m.id) && !deleted.has(m.id))
     if (slidOff.length === 0) return
     setOlder((cur) => {
       const seen = new Set(cur.map((m) => m.id))
@@ -231,11 +247,14 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
       olderCursor ?? latest.data?.nextCursor ?? older[0]?.id ?? latestMessages[0]?.id
     if (!cursor) return false
     const gen = olderGenRef.current
+    const controller = new AbortController()
+    olderAbortRef.current = controller
     setIsFetchingOlder(true)
     try {
       const page = await fetchMessagesPage(agentSlug, sessionId, {
         limit: MESSAGES_PAGE_OLDER_LIMIT,
         cursor,
+        signal: controller.signal,
       })
       // Older-history state was reset while this page was in flight (resync
       // or session switch): the response belongs to the previous transcript
@@ -251,12 +270,15 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
       setOlderCursor(page.nextCursor)
       return prepended.length > 0
     } catch (error) {
+      // Rejection caused by our own generation reset (abort) — not an error.
+      if (gen !== olderGenRef.current) return false
       console.warn('Failed to fetch older messages:', error)
       if (!(error instanceof TranscriptNotFoundError)) {
         captureRendererException(error, { tags: { area: 'messages', op: 'fetch-older' } })
       }
       return false
     } finally {
+      if (olderAbortRef.current === controller) olderAbortRef.current = null
       setIsFetchingOlder(false)
     }
   }, [sessionId, agentSlug, isFetchingOlder, hasOlder, older, olderCursor, latest.data?.nextCursor, latestMessages, deleted])

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -118,7 +118,13 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
         cached && cached.messages.length > 0 ? pickDeltaAnchor(cached.messages) : null
       const fullIsFresh =
         Date.now() - (cached?.fetchedFullAt ?? 0) < MESSAGES_FULL_REFETCH_INTERVAL_MS
-      let sawResync = false
+      // fetchedFullAt === 0 is the rewrite-mutation marker (see
+      // forceNextMessagesRefetchFull): the transcript changed shape, so this
+      // full fetch is authoritative the same way a resync one is — items it
+      // omits were rewritten away, not paged out, and must not slide into the
+      // older-history buffer.
+      const forcedFull = cached?.fetchedFullAt === 0
+      let sawResync = forcedFull
       if (cached && anchor && fullIsFresh) {
         const body = await fetchMessagesDelta(agentSlug, sessionId, { after: anchor, signal })
         if (!isDeltaResponse(body)) {
@@ -168,8 +174,13 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
   const [isFetchingOlder, setIsFetchingOlder] = useState(false)
   const prevLatestRef = useRef<ApiMessageOrBoundary[]>(EMPTY_MESSAGES)
   const lastResyncRef = useRef<number | undefined>(undefined)
+  // Bumped whenever older-history state is reset (session switch, resync).
+  // An in-flight fetchOlder from a previous generation must not commit — it
+  // could repopulate rewritten-away history or latch a stale terminal cursor.
+  const olderGenRef = useRef(0)
 
   useEffect(() => {
+    olderGenRef.current++
     setOlder([])
     setOlderCursor(undefined)
     prevLatestRef.current = EMPTY_MESSAGES
@@ -186,6 +197,7 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
   useLayoutEffect(() => {
     if (resyncedAt === undefined || resyncedAt === lastResyncRef.current) return
     lastResyncRef.current = resyncedAt
+    olderGenRef.current++
     prevLatestRef.current = EMPTY_MESSAGES
     setOlder([])
     setOlderCursor(undefined)
@@ -218,12 +230,17 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
     const cursor =
       olderCursor ?? latest.data?.nextCursor ?? older[0]?.id ?? latestMessages[0]?.id
     if (!cursor) return false
+    const gen = olderGenRef.current
     setIsFetchingOlder(true)
     try {
       const page = await fetchMessagesPage(agentSlug, sessionId, {
         limit: MESSAGES_PAGE_OLDER_LIMIT,
         cursor,
       })
+      // Older-history state was reset while this page was in flight (resync
+      // or session switch): the response belongs to the previous transcript
+      // generation and must not commit.
+      if (gen !== olderGenRef.current) return false
       const existing = new Set(older.map((m) => m.id))
       const prepended = page.messages.filter((m) => !existing.has(m.id) && !deleted.has(m.id))
       if (prepended.length > 0) onBeforePrepend?.()

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -31,6 +31,11 @@ interface MessagesPage {
    * page fetch (delta merges carry it forward). Drives the periodic full
    * refetch that repairs drift and re-bounds the delta-grown page. */
   fetchedFullAt?: number
+  /** Client-only: set when this full page was fetched because the server
+   * answered resync (the transcript was rewritten and the delta anchor
+   * vanished). Tells the hook to drop its older-history buffer, which may
+   * hold items that no longer exist. */
+  resyncedAt?: number
 }
 
 interface MessagesDelta {
@@ -113,13 +118,16 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
         cached && cached.messages.length > 0 ? pickDeltaAnchor(cached.messages) : null
       const fullIsFresh =
         Date.now() - (cached?.fetchedFullAt ?? 0) < MESSAGES_FULL_REFETCH_INTERVAL_MS
+      let sawResync = false
       if (cached && anchor && fullIsFresh) {
         const body = await fetchMessagesDelta(agentSlug, sessionId, { after: anchor, signal })
         if (!isDeltaResponse(body)) {
           // Pre-delta server answered with a plain trailing page — a full fetch.
           return { ...body, fetchedFullAt: Date.now() }
         }
-        if (!body.resync) {
+        if (body.resync) {
+          sawResync = true
+        } else {
           const merged = mergeDeltaMessages(cached.messages, body.messages)
           if (merged) {
             return {
@@ -134,7 +142,11 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
         limit: MESSAGES_PAGE_LIMIT,
         signal,
       })
-      return { ...page, fetchedFullAt: Date.now() }
+      return {
+        ...page,
+        fetchedFullAt: Date.now(),
+        ...(sawResync ? { resyncedAt: Date.now() } : {}),
+      }
     },
     enabled: !!sessionId && !!agentSlug,
     retry: (failureCount, error) =>
@@ -155,14 +167,29 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
   const [olderCursor, setOlderCursor] = useState<string | null | undefined>(undefined)
   const [isFetchingOlder, setIsFetchingOlder] = useState(false)
   const prevLatestRef = useRef<ApiMessageOrBoundary[]>(EMPTY_MESSAGES)
+  const lastResyncRef = useRef<number | undefined>(undefined)
 
   useEffect(() => {
     setOlder([])
     setOlderCursor(undefined)
     prevLatestRef.current = EMPTY_MESSAGES
+    lastResyncRef.current = undefined
   }, [sessionId, agentSlug])
 
   const latestMessages = latest.data?.messages ?? EMPTY_MESSAGES
+  const resyncedAt = latest.data?.resyncedAt
+
+  // A resync full fetch means the transcript was rewritten server-side: items
+  // held in the older-history buffer may no longer exist. Drop the buffer and
+  // reset the slide-off baseline BEFORE the effect below runs, so the vanished
+  // items aren't captured as "slid off" and re-rendered forever.
+  useLayoutEffect(() => {
+    if (resyncedAt === undefined || resyncedAt === lastResyncRef.current) return
+    lastResyncRef.current = resyncedAt
+    prevLatestRef.current = EMPTY_MESSAGES
+    setOlder([])
+    setOlderCursor(undefined)
+  }, [resyncedAt])
 
   useLayoutEffect(() => {
     const prev = prevLatestRef.current
@@ -306,9 +333,24 @@ export function useDeleteMessage() {
       queryClient.setQueryData<string[]>(deletedMessagesKey(sessionId), (cur = []) =>
         cur.includes(messageId) ? cur : [...cur, messageId]
       )
+      forceNextMessagesRefetchFull(queryClient, sessionId, agentSlug)
       queryClient.invalidateQueries({ queryKey: ['messages', sessionId, agentSlug] })
     },
   })
+}
+
+// Rewrite mutations edit the transcript ANYWHERE, including items before the
+// delta anchor, which deltas by design never re-serve. Expire the cached
+// full-fetch stamp so the invalidation's refetch is authoritative instead of
+// leaving the rewritten item stale until the periodic full repair.
+function forceNextMessagesRefetchFull(
+  queryClient: ReturnType<typeof useQueryClient>,
+  sessionId: string,
+  agentSlug: string
+) {
+  queryClient.setQueryData<MessagesPage>(['messages', sessionId, agentSlug], (cur) =>
+    cur ? { ...cur, fetchedFullAt: 0 } : cur
+  )
 }
 
 export function useDeleteToolCall() {
@@ -322,6 +364,7 @@ export function useDeleteToolCall() {
       if (!res.ok) throw new Error('Failed to delete tool call')
     },
     onSuccess: (_, { sessionId, agentSlug }) => {
+      forceNextMessagesRefetchFull(queryClient, sessionId, agentSlug)
       queryClient.invalidateQueries({ queryKey: ['messages', sessionId, agentSlug] })
     },
   })

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -7,6 +7,7 @@ import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { WorkflowTree } from '@shared/lib/workflows/workflow-schemas'
 import { MESSAGES_PAGE_LIMIT, MESSAGES_PAGE_OLDER_LIMIT } from '@shared/lib/messages-page'
+import { pickDeltaAnchor, mergeDeltaMessages } from '@shared/lib/messages-delta'
 
 // Re-export for convenience
 export type { ApiMessage, ApiMessageOrBoundary }
@@ -26,7 +27,23 @@ export class TranscriptNotFoundError extends Error {
 interface MessagesPage {
   messages: ApiMessageOrBoundary[]
   nextCursor: string | null
+  /** Client-only bookkeeping: when this cache entry was last built from a full
+   * page fetch (delta merges carry it forward). Drives the periodic full
+   * refetch that repairs drift and re-bounds the delta-grown page. */
+  fetchedFullAt?: number
 }
+
+interface MessagesDelta {
+  messages: ApiMessageOrBoundary[]
+  anchor: string | null
+  resync?: true
+}
+
+/** Full-page cadence while deltas are in use: periodic drift repair (deletions
+ * from other clients, missed rewrites) and the bound on how far past
+ * MESSAGES_PAGE_LIMIT the delta-merged page can grow before it resets to the
+ * trailing page (overflow slides into the `older` buffer). */
+export const MESSAGES_FULL_REFETCH_INTERVAL_MS = 60_000
 
 const EMPTY_MESSAGES: ApiMessageOrBoundary[] = []
 const EMPTY_IDS: string[] = []
@@ -51,8 +68,31 @@ async function fetchMessagesPage(
   return res.json() as Promise<MessagesPage>
 }
 
+// `limit` rides along so a server that predates the delta protocol (rolling
+// deploy) answers with a plain trailing page instead of the legacy unpaginated
+// array; the caller detects which one it got by the `anchor` field.
+async function fetchMessagesDelta(
+  agentSlug: string,
+  sessionId: string,
+  opts: { after: string; signal?: AbortSignal }
+): Promise<MessagesDelta | MessagesPage> {
+  const params = new URLSearchParams({ limit: String(MESSAGES_PAGE_LIMIT), after: opts.after })
+  const res = await apiFetch(
+    `/api/agents/${agentSlug}/sessions/${sessionId}/messages?${params.toString()}`,
+    { signal: opts.signal }
+  )
+  if (res.status === 404) throw new TranscriptNotFoundError()
+  if (!res.ok) throw new Error('Failed to fetch messages')
+  return res.json() as Promise<MessagesDelta | MessagesPage>
+}
+
+function isDeltaResponse(body: MessagesDelta | MessagesPage): body is MessagesDelta {
+  return 'anchor' in body || (body as { resync?: boolean }).resync === true
+}
+
 // Trailing page only unless the caller uses fetchOlder (MessageList). Other hook instances see ~MESSAGES_PAGE_LIMIT.
 export function useMessages(sessionId: string | null, agentSlug: string | null) {
+  const queryClient = useQueryClient()
   const latest = useQuery<MessagesPage>({
     queryKey: ['messages', sessionId, agentSlug],
     // Take React Query's per-fetch signal so a superseding invalidation aborts
@@ -61,7 +101,40 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
     // produced and buffered server-side while the client has already moved on.
     queryFn: async ({ signal }) => {
       if (!sessionId || !agentSlug) throw new Error('Missing session')
-      return fetchMessagesPage(agentSlug, sessionId, { limit: MESSAGES_PAGE_LIMIT, signal })
+      // Forward delta when possible: SSE-driven refetches only care about
+      // lines appended since the last read, so ask for upserts at-or-after the
+      // last settled item instead of re-reading the whole trailing page
+      // (multi-MB on long sessions). Fall back to the full page when nothing
+      // is cached, no item is safely settled yet, the anchor vanished
+      // server-side (resync), the server predates the delta protocol, or the
+      // periodic full-refetch drift repair is due.
+      const cached = queryClient.getQueryData<MessagesPage>(['messages', sessionId, agentSlug])
+      const anchor =
+        cached && cached.messages.length > 0 ? pickDeltaAnchor(cached.messages) : null
+      const fullIsFresh =
+        Date.now() - (cached?.fetchedFullAt ?? 0) < MESSAGES_FULL_REFETCH_INTERVAL_MS
+      if (cached && anchor && fullIsFresh) {
+        const body = await fetchMessagesDelta(agentSlug, sessionId, { after: anchor, signal })
+        if (!isDeltaResponse(body)) {
+          // Pre-delta server answered with a plain trailing page — a full fetch.
+          return { ...body, fetchedFullAt: Date.now() }
+        }
+        if (!body.resync) {
+          const merged = mergeDeltaMessages(cached.messages, body.messages)
+          if (merged) {
+            return {
+              messages: merged,
+              nextCursor: cached.nextCursor,
+              fetchedFullAt: cached.fetchedFullAt,
+            }
+          }
+        }
+      }
+      const page = await fetchMessagesPage(agentSlug, sessionId, {
+        limit: MESSAGES_PAGE_LIMIT,
+        signal,
+      })
+      return { ...page, fetchedFullAt: Date.now() }
     },
     enabled: !!sessionId && !!agentSlug,
     retry: (failureCount, error) =>

--- a/src/shared/lib/messages-delta.test.ts
+++ b/src/shared/lib/messages-delta.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  findDeltaWindowStart,
+  pickDeltaAnchor,
+  mergeDeltaMessages,
+  type DeltaWindowItem,
+} from './messages-delta'
+
+function user(id: string, queued = false): DeltaWindowItem {
+  return { id, type: 'user', ...(queued ? { queued: true } : {}) }
+}
+
+function assistant(id: string, opts?: { open?: number; closed?: number }): DeltaWindowItem {
+  const toolCalls: Array<{ result?: unknown }> = []
+  for (let i = 0; i < (opts?.closed ?? 0); i++) toolCalls.push({ result: 'ok' })
+  for (let i = 0; i < (opts?.open ?? 0); i++) toolCalls.push({})
+  return { id, type: 'assistant', toolCalls }
+}
+
+function informational(id: string): DeltaWindowItem {
+  return { id, type: 'informational' }
+}
+
+describe('findDeltaWindowStart / pickDeltaAnchor', () => {
+  it('marks the trailing assistant message volatile even with no tool calls (it may still merge streamed blocks)', () => {
+    const items = [user('u1'), assistant('a1'), user('u2'), assistant('a2')]
+    expect(findDeltaWindowStart(items)).toBe(3)
+    expect(pickDeltaAnchor(items)).toBe('u2')
+  })
+
+  it('anchors on the last user message when it is the last item (turn just started)', () => {
+    const items = [user('u1'), assistant('a1'), user('u2')]
+    expect(findDeltaWindowStart(items)).toBe(3)
+    expect(pickDeltaAnchor(items)).toBe('u2')
+  })
+
+  it('starts the window at the first open tool call of the live turn', () => {
+    const items = [
+      user('u1'),
+      assistant('a1', { open: 1 }),
+      assistant('a2'),
+      assistant('a3', { closed: 1 }),
+    ]
+    expect(findDeltaWindowStart(items)).toBe(1)
+    expect(pickDeltaAnchor(items)).toBe('u1')
+  })
+
+  it('ignores open tool calls from finished turns (a non-queued user message ends the turn)', () => {
+    // a1's call was interrupted — its result can never arrive once u2 started a
+    // new turn — so it must not drag the anchor back forever.
+    const items = [
+      user('u1'),
+      assistant('a1', { open: 1 }),
+      user('u2'),
+      assistant('a2', { closed: 2 }),
+      user('u3'),
+      assistant('a3'),
+    ]
+    expect(findDeltaWindowStart(items)).toBe(5)
+    expect(pickDeltaAnchor(items)).toBe('u3')
+  })
+
+  it('a queued user message does not end the turn: open calls before it stay volatile', () => {
+    const items = [user('u1'), assistant('a1', { open: 1 }), user('uq', true)]
+    expect(findDeltaWindowStart(items)).toBe(1)
+    expect(pickDeltaAnchor(items)).toBe('u1')
+  })
+
+  it('trailing system items do not shield the still-merging assistant before them', () => {
+    const items = [user('u1'), assistant('a1'), informational('i1')]
+    expect(findDeltaWindowStart(items)).toBe(1)
+    expect(pickDeltaAnchor(items)).toBe('u1')
+  })
+
+  it('returns null when nothing is safely settled yet', () => {
+    expect(pickDeltaAnchor([assistant('a1', { open: 1 })])).toBeNull()
+    expect(pickDeltaAnchor([assistant('a1')])).toBeNull()
+    expect(pickDeltaAnchor([])).toBeNull()
+  })
+
+  it('settled assistant items with all results present are only volatile when trailing', () => {
+    const items = [user('u1'), assistant('a1', { closed: 2 }), user('u2'), assistant('a2', { closed: 1 })]
+    // a2 is trailing (may still merge); a1 is settled history.
+    expect(findDeltaWindowStart(items)).toBe(3)
+    expect(pickDeltaAnchor(items)).toBe('u2')
+  })
+})
+
+describe('mergeDeltaMessages', () => {
+  const m = (id: string, text = '') => ({ id, text })
+
+  it('appends new items after the anchor', () => {
+    const merged = mergeDeltaMessages([m('a'), m('b')], [m('b'), m('c'), m('d')])
+    expect(merged?.map((x) => x.id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('upserts: the delta version of an item the client already holds wins', () => {
+    const merged = mergeDeltaMessages(
+      [m('a'), m('b', 'stale'), m('c', 'stale')],
+      [m('b', 'fresh'), m('c', 'fresh')]
+    )
+    expect(merged).toEqual([m('a'), m('b', 'fresh'), m('c', 'fresh')])
+  })
+
+  it('drops cached suffix items the window no longer contains (rewritten away)', () => {
+    const merged = mergeDeltaMessages([m('a'), m('b'), m('gone'), m('c')], [m('b'), m('c')])
+    expect(merged?.map((x) => x.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns null when the window start is unknown to the cache (caller must full-fetch)', () => {
+    expect(mergeDeltaMessages([m('a'), m('b')], [m('x'), m('y')])).toBeNull()
+  })
+
+  it('an empty delta leaves the cache unchanged', () => {
+    expect(mergeDeltaMessages([m('a')], [])).toEqual([m('a')])
+  })
+})

--- a/src/shared/lib/messages-delta.test.ts
+++ b/src/shared/lib/messages-delta.test.ts
@@ -130,15 +130,17 @@ describe('mergeDeltaMessages', () => {
     expect(mergeDeltaMessages([m('a')], [])).toEqual([m('a')])
   })
 
-  it('dedupes the kept prefix against replayed window items', () => {
+  it('replayed window items upsert in place, preserving chronology', () => {
     // Resume replay re-appends old history verbatim; when the originals sit
     // beyond the server's bounded tail, the window carries copies of ids the
-    // prefix already holds. The window's copy wins at its replayed position.
+    // prefix already holds. The client still has the originals in order, so
+    // the copies must upsert in place — splicing them at their replayed
+    // positions would move old turns after newer ones.
     const merged = mergeDeltaMessages(
       [m('u1'), m('a1'), m('u2', 'anchor')],
       [m('u2', 'anchor'), m('u1', 'replayed'), m('a1', 'replayed'), m('a2', 'new')]
     )
-    expect(merged?.map((x) => x.id)).toEqual(['u2', 'u1', 'a1', 'a2'])
+    expect(merged?.map((x) => x.id)).toEqual(['u1', 'a1', 'u2', 'a2'])
     expect(new Set(merged?.map((x) => x.id)).size).toBe(merged?.length)
     expect(merged?.find((x) => x.id === 'a1')?.text).toBe('replayed')
   })

--- a/src/shared/lib/messages-delta.test.ts
+++ b/src/shared/lib/messages-delta.test.ts
@@ -66,6 +66,21 @@ describe('findDeltaWindowStart / pickDeltaAnchor', () => {
     expect(pickDeltaAnchor(items)).toBe('u1')
   })
 
+  it('a queued user message does not shield the still-streaming assistant before it', () => {
+    // Steering input lands mid-turn: block entries for a1 can still follow the
+    // queued message in the transcript. Anchoring on the queued message would
+    // leave the client's copy of a1 frozen at its partial text.
+    const items = [user('u1'), assistant('a1'), user('uq', true)]
+    expect(findDeltaWindowStart(items)).toBe(1)
+    expect(pickDeltaAnchor(items)).toBe('u1')
+  })
+
+  it('a trailing queued user message with no assistant behind it is a valid anchor', () => {
+    const items = [user('u1'), user('uq', true)]
+    expect(findDeltaWindowStart(items)).toBe(2)
+    expect(pickDeltaAnchor(items)).toBe('uq')
+  })
+
   it('trailing system items do not shield the still-merging assistant before them', () => {
     const items = [user('u1'), assistant('a1'), informational('i1')]
     expect(findDeltaWindowStart(items)).toBe(1)
@@ -113,5 +128,18 @@ describe('mergeDeltaMessages', () => {
 
   it('an empty delta leaves the cache unchanged', () => {
     expect(mergeDeltaMessages([m('a')], [])).toEqual([m('a')])
+  })
+
+  it('dedupes the kept prefix against replayed window items', () => {
+    // Resume replay re-appends old history verbatim; when the originals sit
+    // beyond the server's bounded tail, the window carries copies of ids the
+    // prefix already holds. The window's copy wins at its replayed position.
+    const merged = mergeDeltaMessages(
+      [m('u1'), m('a1'), m('u2', 'anchor')],
+      [m('u2', 'anchor'), m('u1', 'replayed'), m('a1', 'replayed'), m('a2', 'new')]
+    )
+    expect(merged?.map((x) => x.id)).toEqual(['u2', 'u1', 'a1', 'a2'])
+    expect(new Set(merged?.map((x) => x.id)).size).toBe(merged?.length)
+    expect(merged?.find((x) => x.id === 'a1')?.text).toBe('replayed')
   })
 })

--- a/src/shared/lib/messages-delta.ts
+++ b/src/shared/lib/messages-delta.ts
@@ -89,11 +89,13 @@ export function pickDeltaAnchor(items: readonly DeltaWindowItem[]): string | nul
  * widened past the cached head or the anchor drifted — and the caller must
  * fall back to a full fetch.
  *
- * The kept prefix is deduped against the window: a resumed CLI can re-append
- * old history verbatim, and when the originals sit beyond the server's bounded
- * tail the replayed copies arrive as window items with ids the prefix already
- * holds. Keeping the window's copy (at its replayed position) matches what a
- * full fetch of the tail would show.
+ * Window ids that already exist in the kept prefix are replay copies: a
+ * resumed CLI can re-append old history verbatim, and when the originals sit
+ * beyond the server's bounded tail the copies arrive as window items. The
+ * client knows more than the server here — it still holds the originals in
+ * chronological position — so those are upserted IN PLACE (content from the
+ * window's copy) and only genuinely new ids are appended. Splicing the copies
+ * at their replayed positions would move old turns after newer ones.
  */
 export function mergeDeltaMessages<T extends { id: string }>(
   cached: readonly T[],
@@ -102,9 +104,11 @@ export function mergeDeltaMessages<T extends { id: string }>(
   if (delta.length === 0) return [...cached]
   const spliceIdx = cached.findIndex((item) => item.id === delta[0].id)
   if (spliceIdx === -1) return null
-  const deltaIds = new Set(delta.map((item) => item.id))
+  const prefix = cached.slice(0, spliceIdx)
+  const prefixIds = new Set(prefix.map((item) => item.id))
+  const windowById = new Map(delta.map((item) => [item.id, item]))
   return [
-    ...cached.slice(0, spliceIdx).filter((item) => !deltaIds.has(item.id)),
-    ...delta,
+    ...prefix.map((item) => windowById.get(item.id) ?? item),
+    ...delta.filter((item) => !prefixIds.has(item.id)),
   ]
 }

--- a/src/shared/lib/messages-delta.ts
+++ b/src/shared/lib/messages-delta.ts
@@ -1,0 +1,97 @@
+/**
+ * Forward-delta anchoring and merging for the messages list.
+ *
+ * A live-session refetch only cares about transcript lines appended since the
+ * last read, but new JSONL lines can also MUTATE display items the client
+ * already holds: a tool_result attaches to a tool_use inside an earlier
+ * assistant item, and a streaming assistant message keeps merging content
+ * blocks (text, thinking, usage) into the same display item across lines. The
+ * delta contract therefore works in upserted windows, not appends:
+ *
+ * - the client picks an ANCHOR — the last display item that can no longer
+ *   change — and asks the server for everything at-or-after it (`?after=`);
+ * - the server re-transforms the transcript tail and returns the full current
+ *   version of every item in that window;
+ * - the client splices the window over its cached suffix.
+ *
+ * Shared between the server route (defensive window widening, response anchor)
+ * and the renderer (anchor selection over the query cache, merge) so both
+ * sides agree on what "can no longer change" means.
+ */
+
+/** Structural subset of TransformedItem / ApiMessageOrBoundary the anchor logic needs. */
+export interface DeltaWindowItem {
+  id: string
+  type: string
+  /** User message delivered mid-turn (queued/steering) — does not end the turn it appears in. */
+  queued?: boolean
+  toolCalls?: Array<{ result?: unknown }>
+}
+
+/**
+ * Index of the first display item that may still change as the transcript
+ * grows (`items.length` when every item is settled). Items before it are
+ * immutable going forward:
+ *
+ * - An unresolved tool call can only receive its result while its turn is
+ *   alive, and a non-queued user message ends the turn — so open calls before
+ *   the last one belong to finished/interrupted turns and never resolve.
+ * - The trailing assistant message may still merge streamed content blocks
+ *   (same message.id across JSONL lines) even when it has no tool calls yet.
+ *   Trailing system items (boundaries, banners) after it don't shield it.
+ */
+export function findDeltaWindowStart(items: readonly DeltaWindowItem[]): number {
+  let turnStart = 0
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i]
+    if (item.type === 'user' && !item.queued) {
+      turnStart = i + 1
+      break
+    }
+  }
+
+  let start = items.length
+  for (let i = turnStart; i < items.length; i++) {
+    const item = items[i]
+    if (item.type === 'assistant' && item.toolCalls?.some((tc) => tc.result === undefined)) {
+      start = i
+      break
+    }
+  }
+
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i]
+    if (item.type !== 'user' && item.type !== 'assistant') continue
+    if (item.type === 'assistant') start = Math.min(start, i)
+    break
+  }
+
+  return start
+}
+
+/**
+ * The id to send as `?after=` — the last settled item — or null when nothing
+ * is safely settled yet (caller falls back to a full page fetch).
+ */
+export function pickDeltaAnchor(items: readonly DeltaWindowItem[]): string | null {
+  const start = findDeltaWindowStart(items)
+  return start > 0 ? items[start - 1].id : null
+}
+
+/**
+ * Splice a delta window over the cached list. The window is authoritative from
+ * its first item to the end of the transcript: cached items in that range the
+ * server no longer returns were rewritten away (deletion, interrupt cleanup).
+ * Returns null when the window's first item isn't in the cache — the server
+ * widened past the cached head or the anchor drifted — and the caller must
+ * fall back to a full fetch.
+ */
+export function mergeDeltaMessages<T extends { id: string }>(
+  cached: readonly T[],
+  delta: readonly T[]
+): T[] | null {
+  if (delta.length === 0) return [...cached]
+  const spliceIdx = cached.findIndex((item) => item.id === delta[0].id)
+  if (spliceIdx === -1) return null
+  return [...cached.slice(0, spliceIdx), ...delta]
+}

--- a/src/shared/lib/messages-delta.ts
+++ b/src/shared/lib/messages-delta.ts
@@ -38,7 +38,9 @@ export interface DeltaWindowItem {
  *   the last one belong to finished/interrupted turns and never resolve.
  * - The trailing assistant message may still merge streamed content blocks
  *   (same message.id across JSONL lines) even when it has no tool calls yet.
- *   Trailing system items (boundaries, banners) after it don't shield it.
+ *   Trailing system items (boundaries, banners) after it don't shield it, and
+ *   neither do queued user messages — steering input lands mid-turn, so block
+ *   entries for the assistant before it can still follow in the transcript.
  */
 export function findDeltaWindowStart(items: readonly DeltaWindowItem[]): number {
   let turnStart = 0
@@ -62,6 +64,7 @@ export function findDeltaWindowStart(items: readonly DeltaWindowItem[]): number 
   for (let i = items.length - 1; i >= 0; i--) {
     const item = items[i]
     if (item.type !== 'user' && item.type !== 'assistant') continue
+    if (item.type === 'user' && item.queued) continue
     if (item.type === 'assistant') start = Math.min(start, i)
     break
   }
@@ -85,6 +88,12 @@ export function pickDeltaAnchor(items: readonly DeltaWindowItem[]): string | nul
  * Returns null when the window's first item isn't in the cache — the server
  * widened past the cached head or the anchor drifted — and the caller must
  * fall back to a full fetch.
+ *
+ * The kept prefix is deduped against the window: a resumed CLI can re-append
+ * old history verbatim, and when the originals sit beyond the server's bounded
+ * tail the replayed copies arrive as window items with ids the prefix already
+ * holds. Keeping the window's copy (at its replayed position) matches what a
+ * full fetch of the tail would show.
  */
 export function mergeDeltaMessages<T extends { id: string }>(
   cached: readonly T[],
@@ -93,5 +102,9 @@ export function mergeDeltaMessages<T extends { id: string }>(
   if (delta.length === 0) return [...cached]
   const spliceIdx = cached.findIndex((item) => item.id === delta[0].id)
   if (spliceIdx === -1) return null
-  return [...cached.slice(0, spliceIdx), ...delta]
+  const deltaIds = new Set(delta.map((item) => item.id))
+  return [
+    ...cached.slice(0, spliceIdx).filter((item) => !deltaIds.has(item.id)),
+    ...delta,
+  ]
 }

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -1229,6 +1229,33 @@ describe('session-service', () => {
       })
     })
 
+    it('a trailing orphan tool_result on a transcript beyond the tail cap does not resync-loop', async () => {
+      // The parent (if any) lies deeper than the bounded tail can reach; a
+      // resync here would repeat on EVERY poll — full fetch, new delta, same
+      // orphan — recreating the refetch cascade. Serve the delta without the
+      // unreachable parent instead.
+      await createSessionFile('test-agent', 'delta-session', [
+        ...makeThread(5100),
+        {
+          type: 'user',
+          uuid: 'tr-beyond-cap',
+          timestamp: '2026-01-01T06:00:00.000Z',
+          sessionId: 'delta-session',
+          parentUuid: null,
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'unreachable-t1', content: 'late' }],
+          },
+        },
+      ])
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'u-5099',
+      })
+      expect(delta.resync).toBeUndefined()
+      expect(delta.messages[0]?.id).toBe('u-5099')
+    })
+
     it('an orphaned tool_result (parent rewritten away) does not force resync', async () => {
       await createSessionFile('test-agent', 'delta-session', [
         ...makeThread(3),

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -1121,6 +1121,137 @@ describe('session-service', () => {
       ).rejects.toMatchObject({ name: 'AbortError' })
     })
 
+    it('re-serves the still-streaming assistant when the anchor is a queued message after it', async () => {
+      // Steering input lands mid-turn; more blocks for the assistant before it
+      // can still arrive. Anchoring on the queued message must not freeze the
+      // assistant's partial text on the client.
+      await createSessionFile('test-agent', 'delta-session', [
+        ...makeThread(2),
+        {
+          type: 'assistant',
+          uuid: 'S-0',
+          timestamp: '2026-01-01T00:01:00.000Z',
+          sessionId: 'delta-session',
+          parentUuid: 'a-1',
+          message: {
+            id: 'msg-S',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'streaming ' }],
+          },
+        },
+        {
+          type: 'attachment',
+          uuid: 'q-attachment',
+          timestamp: '2026-01-01T00:01:05.000Z',
+          sessionId: 'delta-session',
+          attachment: {
+            type: 'queued_command',
+            prompt: [{ type: 'text', text: 'steering note' }],
+            source_uuid: 'q-1',
+            commandMode: 'prompt',
+          },
+        },
+        {
+          type: 'assistant',
+          uuid: 'S-1',
+          timestamp: '2026-01-01T00:01:10.000Z',
+          sessionId: 'delta-session',
+          parentUuid: 'q-attachment',
+          message: {
+            id: 'msg-S',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'continued' }],
+          },
+        },
+      ])
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'q-1',
+      })
+      expect(delta.messages.map((m) => m.id)).toEqual(['S-0', 'q-1'])
+      expect(delta.messages[0]).toMatchObject({ content: { text: 'streaming continued' } })
+    })
+
+    it('grows the window until a late tool_result finds its parent assistant item', async () => {
+      // The parent call sits well past the initial 128-line window; its result
+      // lands after the anchor. Without growth the parent's upsert would be
+      // silently skipped and the client's copy stay unresolved forever.
+      const parent = {
+        type: 'assistant',
+        uuid: 'P',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        sessionId: 'delta-session',
+        parentUuid: null,
+        message: {
+          id: 'msg-P',
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'deep-t1', name: 'AskUserQuestion', input: {} }],
+        },
+      }
+      const filler = makeThread(100).map((e, i) => ({
+        ...e,
+        uuid: `f-${i}`,
+        timestamp: new Date(Date.UTC(2026, 0, 1, 1, 0, i)).toISOString(),
+      }))
+      const anchorMsg = {
+        type: 'user',
+        uuid: 'anchor-u',
+        timestamp: '2026-01-01T02:00:00.000Z',
+        sessionId: 'delta-session',
+        parentUuid: null,
+        message: { role: 'user', content: 'latest question' },
+      }
+      const lateResult = {
+        type: 'user',
+        uuid: 'tr-deep',
+        timestamp: '2026-01-01T02:00:10.000Z',
+        sessionId: 'delta-session',
+        parentUuid: 'P',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'deep-t1', content: 'answered' }],
+        },
+      }
+      await createSessionFile('test-agent', 'delta-session', [
+        parent,
+        ...filler,
+        anchorMsg,
+        lateResult,
+      ])
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'anchor-u',
+      })
+      expect(delta.resync).toBeUndefined()
+      expect(delta.messages[0]?.id).toBe('P')
+      expect(delta.messages[0]).toMatchObject({
+        toolCalls: [{ id: 'deep-t1', result: 'answered' }],
+      })
+    })
+
+    it('an orphaned tool_result (parent rewritten away) does not force resync', async () => {
+      await createSessionFile('test-agent', 'delta-session', [
+        ...makeThread(3),
+        {
+          type: 'user',
+          uuid: 'tr-orphan',
+          timestamp: '2026-01-01T00:05:00.000Z',
+          sessionId: 'delta-session',
+          parentUuid: null,
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'gone-t1', content: 'orphan' }],
+          },
+        },
+      ])
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'u-2',
+      })
+      expect(delta.resync).toBeUndefined()
+      expect(delta.messages[0]?.id).toBe('u-2')
+    })
+
     it('merges a block-split assistant message into one upsert item', async () => {
       await createSessionFile('test-agent', 'delta-session', [
         ...makeThread(2),

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -15,6 +15,7 @@ import {
   getSession,
   getSessionMessages,
   getSessionMessagesPage,
+  getSessionMessagesDelta,
   deleteSession,
   deleteSessionsBatch,
   readSessionMetadata,
@@ -938,6 +939,222 @@ describe('session-service', () => {
       })
       expect(page.messages.map((m) => m.id)).toEqual(['a-7', 'u-8', 'a-8', 'u-9', 'a-9'])
       expect(page.nextCursor).toBe('a-7')
+    })
+  })
+
+  describe('getSessionMessagesDelta', () => {
+    function makeThread(n: number, sessionId = 'delta-session') {
+      const entries: object[] = []
+      for (let i = 0; i < n; i++) {
+        entries.push({
+          type: 'user',
+          uuid: `u-${i}`,
+          timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i * 2)).toISOString(),
+          sessionId,
+          parentUuid: null,
+          message: { role: 'user', content: `q${i}` },
+        })
+        entries.push({
+          type: 'assistant',
+          uuid: `a-${i}`,
+          timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i * 2 + 1)).toISOString(),
+          sessionId,
+          parentUuid: `u-${i}`,
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: `a${i}` }],
+          },
+        })
+      }
+      return entries
+    }
+
+    it('returns upserts at-or-after the anchor plus items appended since', async () => {
+      await createSessionFile('test-agent', 'delta-session', makeThread(10))
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'u-8',
+      })
+      expect(delta.resync).toBeUndefined()
+      expect(delta.messages.map((m) => m.id)).toEqual(['u-8', 'a-8', 'u-9', 'a-9'])
+      // The trailing assistant may still merge streamed blocks, so the settled
+      // anchor is the user message before it.
+      expect(delta.anchor).toBe('u-9')
+    })
+
+    it('a tool_result landing after the anchor updates the already-served assistant item', async () => {
+      // Assistant X calls a tool; a queued (mid-turn) user message follows, so a
+      // client could legitimately anchor past X while X's call is still open.
+      const base = [
+        ...makeThread(3),
+        {
+          type: 'assistant',
+          uuid: 'X',
+          timestamp: '2026-01-01T00:01:00.000Z',
+          sessionId: 'delta-session',
+          parentUuid: 'a-2',
+          message: {
+            id: 'msg-X',
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }],
+          },
+        },
+        {
+          type: 'attachment',
+          uuid: 'q-attachment',
+          timestamp: '2026-01-01T00:01:05.000Z',
+          sessionId: 'delta-session',
+          attachment: {
+            type: 'queued_command',
+            prompt: [{ type: 'text', text: 'steering note' }],
+            source_uuid: 'q-1',
+            commandMode: 'prompt',
+          },
+        },
+      ]
+      await createSessionFile('test-agent', 'delta-session', base)
+
+      const before = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'q-1',
+      })
+      // Defensive widening: the open tool call before the anchor is re-emitted.
+      expect(before.messages.map((m) => m.id)).toEqual(['X', 'q-1'])
+      const openCall = before.messages.find((m) => m.id === 'X')
+      expect(openCall).toMatchObject({ toolCalls: [{ id: 't1', result: undefined }] })
+
+      await createSessionFile('test-agent', 'delta-session', [
+        ...base,
+        {
+          type: 'user',
+          uuid: 'tr-1',
+          timestamp: '2026-01-01T00:01:10.000Z',
+          sessionId: 'delta-session',
+          parentUuid: 'X',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 't1', content: 'file1\nfile2' }],
+          },
+        },
+      ])
+
+      const after = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'q-1',
+      })
+      expect(after.messages.map((m) => m.id)).toEqual(['X', 'q-1'])
+      const resolvedCall = after.messages.find((m) => m.id === 'X')
+      expect(resolvedCall).toMatchObject({ toolCalls: [{ id: 't1', result: 'file1\nfile2' }] })
+    })
+
+    it('widens the window to the trailing assistant when the anchor sits after it', async () => {
+      // e.g. the client anchored on a trailing informational banner while the
+      // assistant message before it can still merge streamed blocks.
+      await createSessionFile('test-agent', 'delta-session', [
+        ...makeThread(3),
+        {
+          type: 'system',
+          subtype: 'informational',
+          uuid: 'info-1',
+          timestamp: '2026-01-01T00:02:00.000Z',
+          sessionId: 'delta-session',
+          content: 'a hook blocked something',
+        },
+      ])
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'info-1',
+      })
+      expect(delta.messages.map((m) => m.id)).toEqual(['a-2', 'info-1'])
+      expect(delta.anchor).toBe('u-2')
+    })
+
+    it('grows the tail window until a deep anchor resolves', async () => {
+      // 200 pairs = 400 raw lines, past the initial 128-line window.
+      await createSessionFile('test-agent', 'delta-session', makeThread(200))
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'u-30',
+      })
+      expect(delta.resync).toBeUndefined()
+      expect(delta.messages[0]?.id).toBe('u-30')
+      expect(delta.messages.at(-1)?.id).toBe('a-199')
+      expect(delta.messages).toHaveLength(340)
+    })
+
+    it('answers resync when the anchor id is not in the transcript', async () => {
+      await createSessionFile('test-agent', 'delta-session', makeThread(10))
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'vanished-id',
+      })
+      expect(delta).toEqual({ messages: [], anchor: null, resync: true })
+    })
+
+    it('answers resync when the transcript file is gone', async () => {
+      await createSessionsDir('test-agent')
+
+      const delta = await getSessionMessagesDelta('test-agent', 'nonexistent', {
+        after: 'u-1',
+      })
+      expect(delta).toEqual({ messages: [], anchor: null, resync: true })
+    })
+
+    it('answers resync instead of scanning past the bounded tail', async () => {
+      // 5100 pairs = 10200 raw lines; u-0 sits beyond the 10k-line delta cap.
+      await createSessionFile('test-agent', 'delta-session', makeThread(5100))
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'u-0',
+      })
+      expect(delta).toEqual({ messages: [], anchor: null, resync: true })
+    })
+
+    it('rejects with AbortError when the signal is already aborted', async () => {
+      await createSessionFile('test-agent', 'delta-session', makeThread(10))
+
+      const controller = new AbortController()
+      controller.abort()
+      await expect(
+        getSessionMessagesDelta('test-agent', 'delta-session', {
+          after: 'u-8',
+          signal: controller.signal,
+        })
+      ).rejects.toMatchObject({ name: 'AbortError' })
+    })
+
+    it('merges a block-split assistant message into one upsert item', async () => {
+      await createSessionFile('test-agent', 'delta-session', [
+        ...makeThread(2),
+        {
+          type: 'assistant',
+          uuid: 'X-0',
+          timestamp: '2026-01-01T00:01:00.000Z',
+          sessionId: 'delta-session',
+          parentUuid: 'a-1',
+          message: {
+            id: 'msg-X',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'leading ' }],
+          },
+        },
+        {
+          type: 'assistant',
+          uuid: 'X-1',
+          timestamp: '2026-01-01T00:01:01.000Z',
+          sessionId: 'delta-session',
+          parentUuid: 'X-0',
+          message: {
+            id: 'msg-X',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'trailing' }],
+          },
+        },
+      ])
+
+      const delta = await getSessionMessagesDelta('test-agent', 'delta-session', {
+        after: 'u-1',
+      })
+      expect(delta.messages.map((m) => m.id)).toEqual(['u-1', 'a-1', 'X-0'])
+      expect(delta.messages.at(-1)).toMatchObject({ content: { text: 'leading trailing' } })
     })
   })
 

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -1107,11 +1107,31 @@ export async function getSessionMessagesDelta(
     let start = Math.min(idx, windowStart)
     // Every tool_result recorded after the anchor must have its parent
     // assistant item in the response: the result may have closed a call the
-    // client still holds open (e.g. it anchored past a queued mid-turn user
-    // message while the call was pending), and only the parent item's upsert
-    // carries the resolution.
+    // client still holds open (e.g. it anchored past a call that annotation
+    // stamped as settled while the raw transcript still had it open), and
+    // only the parent item's upsert carries the resolution.
     const lateResultIds = toolResultIdsAfterEntry(entries, after)
     if (lateResultIds.size > 0) {
+      // A parent deeper than the current window would be silently skipped by
+      // the scan below — grow until every late result's parent is in view.
+      // Once the window covers the whole file, a still-unmatched id is a
+      // genuine orphan (its tool_use was rewritten away) and carries nothing
+      // to upsert.
+      if (!reachedStart) {
+        const windowToolIds = new Set<string>()
+        for (const item of transformed) {
+          if (item.type !== 'assistant') continue
+          for (const toolCall of item.toolCalls) windowToolIds.add(toolCall.id)
+        }
+        const hasUnmatched = [...lateResultIds].some((id) => !windowToolIds.has(id))
+        if (hasUnmatched) {
+          if (canGrow) {
+            maxLines = Math.min(DELTA_MAX_TAIL_LINES, maxLines * 2)
+            continue
+          }
+          return { messages: [], anchor: null, resync: true }
+        }
+      }
       for (let i = 0; i < start; i++) {
         const item = transformed[i]
         if (item.type === 'assistant' && item.toolCalls.some((tc) => lateResultIds.has(tc.id))) {

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -1114,22 +1114,22 @@ export async function getSessionMessagesDelta(
     if (lateResultIds.size > 0) {
       // A parent deeper than the current window would be silently skipped by
       // the scan below — grow until every late result's parent is in view.
-      // Once the window covers the whole file, a still-unmatched id is a
-      // genuine orphan (its tool_use was rewritten away) and carries nothing
-      // to upsert.
-      if (!reachedStart) {
+      // When growth is exhausted, proceed WITHOUT the parent's upsert instead
+      // of resyncing: with the file fully read the id is a genuine orphan
+      // (its tool_use was rewritten away), and at the bounded-tail cap the
+      // parent sits deeper than any anchor the client could still hold open —
+      // a permanent orphan there would otherwise turn every poll into a
+      // resync + full-fetch cycle, recreating the cascade this delta exists
+      // to prevent.
+      if (!reachedStart && canGrow) {
         const windowToolIds = new Set<string>()
         for (const item of transformed) {
           if (item.type !== 'assistant') continue
           for (const toolCall of item.toolCalls) windowToolIds.add(toolCall.id)
         }
-        const hasUnmatched = [...lateResultIds].some((id) => !windowToolIds.has(id))
-        if (hasUnmatched) {
-          if (canGrow) {
-            maxLines = Math.min(DELTA_MAX_TAIL_LINES, maxLines * 2)
-            continue
-          }
-          return { messages: [], anchor: null, resync: true }
+        if ([...lateResultIds].some((id) => !windowToolIds.has(id))) {
+          maxLines = Math.min(DELTA_MAX_TAIL_LINES, maxLines * 2)
+          continue
         }
       }
       for (let i = 0; i < start; i++) {

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -31,6 +31,7 @@ import {
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
 import { transformMessages, type TransformedItem } from '@shared/lib/utils/message-transform'
+import { findDeltaWindowStart } from '@shared/lib/messages-delta'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
 import { isHiddenAutomatedSession } from './session-visibility'
 import {
@@ -926,11 +927,61 @@ function pageCursor(messages: TransformedItem[], hasOlder: boolean): string | nu
   return hasOlder && messages[0] ? messages[0].id : null
 }
 
-/** Trailing (or `cursor`-before) display page. Parses only a tail of the JSONL.
+/** Tail-window read + parse + transform shared by the page and delta readers.
  *
- * `opts.signal` aborts the read/parse work mid-flight (throws AbortError): the
- * caller is an HTTP route whose client cancels superseded refetches, and without
+ * `signal` aborts the read/parse work mid-flight (throws AbortError): the
+ * callers are HTTP routes whose clients cancel superseded refetches, and without
  * the signal every abandoned request still pays full transcript reads server-side. */
+async function readTransformedTail(
+  jsonlPath: string,
+  maxLines: number,
+  signal?: AbortSignal
+): Promise<{
+  transformed: TransformedItem[]
+  entries: (JsonlMessageEntry | JsonlSystemEntry)[]
+  reachedStart: boolean
+}> {
+  const { lines, reachedStart } = await readJsonlTailLines(jsonlPath, maxLines, signal)
+  // An abort landing on the last chunk read still saves the parse/transform
+  // below — on large transcripts that is seconds of synchronous work.
+  signal?.throwIfAborted()
+  const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
+  for (const line of lines) {
+    const parsed = parseJsonlLine<JsonlEntry>(line)
+    if (!parsed) continue
+    const normalized = normalizeQueuedCommandEntry(parsed)
+    if (
+      isMessageOrSystemDisplayEntry(normalized) &&
+      !('isMeta' in normalized && normalized.isMeta)
+    ) {
+      entries.push(normalized)
+    }
+  }
+  return { transformed: transformMessages(entries), entries, reachedStart }
+}
+
+/** tool_use ids of tool_result blocks recorded after the anchor entry — new
+ * lines the client hasn't seen, whose parent assistant items (possibly before
+ * the anchor) they mutate. */
+function toolResultIdsAfterEntry(
+  entries: (JsonlMessageEntry | JsonlSystemEntry)[],
+  anchorUuid: string
+): Set<string> {
+  const ids = new Set<string>()
+  const anchorIdx = entries.findIndex((e) => e.uuid === anchorUuid)
+  for (let i = anchorIdx + 1; i < entries.length; i++) {
+    const entry = entries[i]
+    if (entry.type !== 'user') continue
+    const content = (entry as JsonlMessageEntry).message.content
+    if (!Array.isArray(content)) continue
+    for (const block of content as ContentBlock[]) {
+      if (block.type === 'tool_result') ids.add(block.tool_use_id)
+    }
+  }
+  return ids
+}
+
+/** Trailing (or `cursor`-before) display page. Parses only a tail of the JSONL. */
 export async function getSessionMessagesPage(
   agentSlug: string,
   sessionId: string,
@@ -945,23 +996,7 @@ export async function getSessionMessagesPage(
   let maxLines = Math.min(MAX_TAIL_LINES, Math.max(limit * INITIAL_TAIL_FACTOR, 32))
 
   for (let attempt = 0; attempt < 32; attempt++) {
-    const { lines, reachedStart } = await readJsonlTailLines(jsonlPath, maxLines, signal)
-    // An abort landing on the last chunk read still saves the parse/transform
-    // below — on large transcripts that is seconds of synchronous work.
-    signal?.throwIfAborted()
-    const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
-    for (const line of lines) {
-      const parsed = parseJsonlLine<JsonlEntry>(line)
-      if (!parsed) continue
-      const normalized = normalizeQueuedCommandEntry(parsed)
-      if (
-        isMessageOrSystemDisplayEntry(normalized) &&
-        !('isMeta' in normalized && normalized.isMeta)
-      ) {
-        entries.push(normalized)
-      }
-    }
-    const transformed = transformMessages(entries)
+    const { transformed, reachedStart } = await readTransformedTail(jsonlPath, maxLines, signal)
 
     if (cursor) {
       const idx = transformed.findIndex((item) => item.id === cursor)
@@ -1010,6 +1045,99 @@ export async function getSessionMessagesPage(
   }
 
   throw new Error('getSessionMessagesPage exceeded tail growth attempts')
+}
+
+export interface SessionMessagesDelta {
+  messages: TransformedItem[]
+  /** Last settled item in the server's current view — the client's next `after`. */
+  anchor: string | null
+  /** Anchor not found within a bounded tail (file rewritten by deletion or
+   * retention cleanup, or the anchor is deeper than a live tail can be):
+   * the client must fall back to a full page fetch. */
+  resync?: true
+}
+
+const DELTA_INITIAL_TAIL_LINES = 128
+// The anchor is by definition near EOF (the last settled item of a page the
+// client already holds); a miss deeper than this is drift, answered with
+// resync rather than an unbounded scan.
+const DELTA_MAX_TAIL_LINES = 10_000
+
+/** Forward delta: transformed display items at-or-after the `after` anchor, as
+ * upserts (full current versions — new lines can mutate items the client
+ * already holds, e.g. a tool_result attaching to an earlier assistant item).
+ *
+ * The window widens backward past the anchor to the first still-mutable item
+ * (open tool call in the live turn, trailing assistant message still merging
+ * streamed blocks) so a stale anchor still yields every pending upsert. A
+ * tail window that cuts an assistant message mid-merge gives the partial item
+ * a different id, so an anchor inside a cut group misses and forces growth —
+ * anchors always resolve against complete items. */
+export async function getSessionMessagesDelta(
+  agentSlug: string,
+  sessionId: string,
+  opts: { after: string; signal?: AbortSignal }
+): Promise<SessionMessagesDelta> {
+  const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
+  if (!(await fileExists(jsonlPath))) {
+    return { messages: [], anchor: null, resync: true }
+  }
+
+  const { after, signal } = opts
+  let maxLines = DELTA_INITIAL_TAIL_LINES
+
+  for (let attempt = 0; attempt < 32; attempt++) {
+    const { transformed, entries, reachedStart } = await readTransformedTail(
+      jsonlPath,
+      maxLines,
+      signal
+    )
+    const canGrow = !reachedStart && maxLines < DELTA_MAX_TAIL_LINES
+
+    const idx = transformed.findIndex((item) => item.id === after)
+    if (idx === -1) {
+      if (canGrow) {
+        maxLines = Math.min(DELTA_MAX_TAIL_LINES, maxLines * 2)
+        continue
+      }
+      return { messages: [], anchor: null, resync: true }
+    }
+
+    const windowStart = findDeltaWindowStart(transformed)
+    let start = Math.min(idx, windowStart)
+    // Every tool_result recorded after the anchor must have its parent
+    // assistant item in the response: the result may have closed a call the
+    // client still holds open (e.g. it anchored past a queued mid-turn user
+    // message while the call was pending), and only the parent item's upsert
+    // carries the resolution.
+    const lateResultIds = toolResultIdsAfterEntry(entries, after)
+    if (lateResultIds.size > 0) {
+      for (let i = 0; i < start; i++) {
+        const item = transformed[i]
+        if (item.type === 'assistant' && item.toolCalls.some((tc) => lateResultIds.has(tc.id))) {
+          start = i
+          break
+        }
+      }
+    }
+    // Item 0 of a window that didn't reach the file start may be a partially
+    // merged assistant message (its leading block entries cut off) — never
+    // serve it; grow until the window has context before the response.
+    if (start === 0 && !reachedStart) {
+      if (canGrow) {
+        maxLines = Math.min(DELTA_MAX_TAIL_LINES, maxLines * 2)
+        continue
+      }
+      return { messages: [], anchor: null, resync: true }
+    }
+
+    return {
+      messages: transformed.slice(start),
+      anchor: windowStart > 0 ? transformed[windowStart - 1].id : null,
+    }
+  }
+
+  throw new Error('getSessionMessagesDelta exceeded tail growth attempts')
 }
 
 // Tail-window sizing for findLastSessionEntry: start small (covers the last


### PR DESCRIPTION
Implements SUP-594 (child of SUP-592 session-OOM): a forward-delta cursor on `GET /messages` so live-session refetches stop re-reading and re-transferring the whole trailing page. Stacked on #771 (SUP-593) — review only the last commit; the base branch carries the throttle/abort work.

## Why upserts, not appends

New JSONL lines can **mutate** display items the client already holds: a `tool_result` attaches to a `tool_use` inside an earlier assistant item, and a streaming assistant message keeps merging content blocks (text, thinking, usage) into the same display item across lines. So the protocol returns an upserted **window**: everything at-or-after an anchor, as full current versions, spliced over the client's cached suffix by id.

## Design

**Shared definition of "settled"** (`src/shared/lib/messages-delta.ts`, used by both server and renderer):
- An unresolved tool call can only receive its result while its turn is alive; a non-queued user message ends the turn, so open calls before the last one (interrupted turns) are dead forever and never drag the anchor back.
- The trailing assistant message is always still-mutable (it may merge more streamed blocks), even behind trailing system items.
- `pickDeltaAnchor` = the item before the first still-mutable one; `mergeDeltaMessages` splices the window over the cache, returning null (→ full fetch) when the splice point is unknown.

**Server** (`getSessionMessagesDelta`): growing tail read (128 → 10,000-line cap). Anchor resolution has a free safety property: a tail window that cuts an assistant message mid-merge gives the partial item a *different* uuid, so anchors can only ever resolve against complete items — a miss forces growth. The response window widens backward defensively past still-mutable items **and** past parents of any `tool_result` recorded after the anchor entry (covers a client that anchored past a queued mid-turn message while a call was open and the result has since closed it). Anchor miss / exhausted growth ⇒ `{ messages: [], anchor: null, resync: true }` — which doubles as drift protection for file rewrites (message deletion, retention cleanup).

**Route**: `?after=` on the existing endpoint, 400 when mixed with `cursor`, reuses `annotateAndRecoverMessages` (settled input requests, subagent resolution, auth-mode senders), and answers 499 on client abort exactly like the page branch.

**Client** (`useMessages` queryFn): refetches as a delta when the cache has a pickable anchor and the last full fetch is under 60s old (`MESSAGES_FULL_REFETCH_INTERVAL_MS`; the stamp lives inside the cache entry so it's GC'd with it). `resync`, merge misses, and pre-delta servers all fall back to a full page **in the same call** — `limit` rides along with `after` so an old server answers a detectable page envelope (missing `anchor` field) instead of the legacy unpaginated array. The periodic full refetch repairs cross-client drift and re-bounds the delta-grown page; overflow slides into the existing older-history buffer. Old clients never send `after` → byte-identical behavior (all pre-existing route/page tests untouched and green).

## Validation

**Unit**: full suite 9,553 passed / 0 failed. New coverage: 13 anchor/merge tests, 9 service delta tests (late-tool-result widening, block-split merge, bounded-tail resync on a 10k+-line file, abort), 5 route tests, 6 client hook tests (delta URL, upsert merge, resync fallback, 60s cadence, old-server downgrade, splice-miss fallback). One existing test fixed: `poll-cadence.test.ts` mocks `useQuery` while `useMessages` now also calls `useQueryClient` — needed a provider wrapper.

**E2E**: 63 message-flow tests green (chat-flow, tool-rendering, message-queueing, persistence, cross-session, session-delete, thinking-display, typing-indicator, user-input-requests, awaiting-input-status).

**Browser (real Chromium against the E2E mock server)**, per SUP-594 acceptance:
- Turn refetches are all deltas: leading edge +0.10s, throttle trailing +0.85s, and the 15s poll rides the delta too with a correctly advanced anchor. Zero resyncs.
- On a 5.4MB grown transcript: the one full page load transfers 603KB (300 items) and reads ~15MB server-side (the known pagination degeneracy — SUP-595's scope); per-event deltas transfer **4.1KB / 4.6KB / 0.5KB (~150× less)** and read a **262–327KB bounded tail** regardless of file size — zero full-file reads (verified with fs-level telemetry).
- Streaming UX unchanged: streamed text visible at 340ms, final persisted line reconciled 148ms after idle; transcript, tool card, and final text render correctly.

Typecheck and lint clean. ⚠ Stacked-PR note: CI on a non-main base runs no tests — the results above are from local runs at this head.

https://claude.ai/code/session_01Xvya59kGnQTwWRHTUbtZ3B
