### PR TITLE
Put a subagent's description on its own row's line

### DIFF
--- a/src/renderer/components/messages/activity-card.tsx
+++ b/src/renderer/components/messages/activity-card.tsx
@@ -6,6 +6,7 @@ import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
 import { RequestError } from './request-error'
 import { ACTIVITY_TREE_CONNECTORS, ACTIVITY_TREE_TRACER } from '@renderer/components/ui/tree-connectors'
 import { HoverScrollText } from '@renderer/components/ui/hover-scroll-text'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import type { Todo } from '@shared/lib/utils/derive-task-list'
 import { ActivityOrb, type ActivityOrbState } from './activity-orb'
 
@@ -190,25 +191,7 @@ export function ActivityCard({
                   <RowMark>
                     {item.status === 'completed' ? <span>✓</span> : null}
                   </RowMark>
-                  {/* Name, description and live progress all ride ONE line: a
-                      wrapped second line breaks the tree's row rhythm, and the
-                      elbows are pinned to a single 16px line box. Overflow is
-                      handled the way long names are in the sidebar — truncate,
-                      then pan on hover. */}
-                  <HoverScrollText className="flex-1" hoverTarget="parent">
-                    <span className="font-mono">{item.name}</span>
-                    {item.description && (
-                      <span className="text-muted-foreground">{' '}{item.description}</span>
-                    )}
-                    {item.progressSummary && item.status === 'running' && (
-                      <>
-                        {/* Spaces live in the text, not in margins, so the row
-                            reads (and copies) as one sentence. */}
-                        <span className="text-muted-foreground" aria-hidden="true">{' · '}</span>
-                        <span className="italic text-muted-foreground">{item.progressSummary}</span>
-                      </>
-                    )}
-                  </HoverScrollText>
+                  <SubagentActivityLabel item={item} />
                 </div>
               </li>
             ))}
@@ -257,6 +240,57 @@ export function ActivityErrorCard({ message }: { message: string }) {
 function formatActivityCount(count: number, singular: string, plural: string): string {
   if (count === 0) return ''
   return `${count} ${count === 1 ? singular : plural}`
+}
+
+function SubagentActivityLabel({ item }: { item: ActivitySubagentItem }) {
+  const progressSummary = item.status === 'running' ? item.progressSummary : null
+  const fullActivityText = [
+    item.name,
+    item.description,
+    progressSummary ? `· ${progressSummary}` : '',
+  ].filter(Boolean).join(' ')
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="min-w-0 flex-1 cursor-help rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`Show full activity: ${fullActivityText}`}
+          title={fullActivityText}
+        >
+          {/* Name, description and live progress all ride ONE line: a wrapped
+              second line breaks the tree's row rhythm, and the elbows are
+              pinned to a single 16px line box. Hover pans the label; the
+              button's popover supplies a static keyboard, touch and
+              reduced-motion path to the complete text. */}
+          <HoverScrollText hoverTarget="parent">
+            <span className="font-mono">{item.name}</span>
+            {item.description && (
+              <span className="text-muted-foreground">{' '}{item.description}</span>
+            )}
+            {progressSummary && (
+              <>
+                {/* Spaces live in the text, not in margins, so the row reads
+                    (and copies) as one sentence. */}
+                <span className="text-muted-foreground" aria-hidden="true">{' · '}</span>
+                <span className="italic text-muted-foreground">{progressSummary}</span>
+              </>
+            )}
+          </HoverScrollText>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        aria-label="Full activity details"
+        className="w-auto max-w-[min(24rem,calc(100vw-2rem))] break-words px-3 py-2 text-xs motion-reduce:!animate-none"
+        data-testid="subagent-activity-full-text"
+      >
+        {fullActivityText}
+      </PopoverContent>
+    </Popover>
+  )
 }
 
 type ActivitySummaryTickerStyle = CSSProperties & {

--- a/src/renderer/components/messages/activity-card.tsx
+++ b/src/renderer/components/messages/activity-card.tsx
@@ -5,6 +5,7 @@ import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type 
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
 import { RequestError } from './request-error'
 import { ACTIVITY_TREE_CONNECTORS, ACTIVITY_TREE_TRACER } from '@renderer/components/ui/tree-connectors'
+import { HoverScrollText } from '@renderer/components/ui/hover-scroll-text'
 import type { Todo } from '@shared/lib/utils/derive-task-list'
 import { ActivityOrb, type ActivityOrbState } from './activity-orb'
 
@@ -180,30 +181,34 @@ export function ActivityCard({
                 style={tracerRowStyle(computerUseRows + index)}
                 data-tracer-live={item.status === 'running' ? 'true' : undefined}
               >
-                <div className="flex flex-col gap-0.5">
-                  {/* A finished row recedes as a whole — the mark inherits the
-                      muting with its label rather than carrying its own color. */}
-                  <div className={cn(
-                    'flex items-center gap-1.5',
-                    item.status === 'completed' && 'text-muted-foreground',
-                  )}>
-                    <RowMark>
-                      {item.status === 'completed' ? <span>✓</span> : null}
-                    </RowMark>
-                    <span className="font-mono">
-                      {item.name}
-                    </span>
+                {/* A finished row recedes as a whole — the mark inherits the
+                    muting with its label rather than carrying its own color. */}
+                <div className={cn(
+                  'flex items-center gap-1.5',
+                  item.status === 'completed' && 'text-muted-foreground',
+                )}>
+                  <RowMark>
+                    {item.status === 'completed' ? <span>✓</span> : null}
+                  </RowMark>
+                  {/* Name, description and live progress all ride ONE line: a
+                      wrapped second line breaks the tree's row rhythm, and the
+                      elbows are pinned to a single 16px line box. Overflow is
+                      handled the way long names are in the sidebar — truncate,
+                      then pan on hover. */}
+                  <HoverScrollText className="flex-1" hoverTarget="parent">
+                    <span className="font-mono">{item.name}</span>
                     {item.description && (
-                      <span className="truncate text-muted-foreground">
-                        {item.description}
-                      </span>
+                      <span className="text-muted-foreground">{' '}{item.description}</span>
                     )}
-                  </div>
-                  {item.progressSummary && item.status === 'running' && (
-                    <span className="ml-5 italic text-muted-foreground">
-                      {item.progressSummary}
-                    </span>
-                  )}
+                    {item.progressSummary && item.status === 'running' && (
+                      <>
+                        {/* Spaces live in the text, not in margins, so the row
+                            reads (and copies) as one sentence. */}
+                        <span className="text-muted-foreground" aria-hidden="true">{' · '}</span>
+                        <span className="italic text-muted-foreground">{item.progressSummary}</span>
+                      </>
+                    )}
+                  </HoverScrollText>
                 </div>
               </li>
             ))}

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -931,6 +931,40 @@ describe('AgentActivityIndicator', () => {
       expect(screen.getByText('✓')).toBeInTheDocument()
     })
 
+    it('keeps name, description and progress on one hover-scrolling line', () => {
+      // A wrapped second line breaks the tree's row rhythm — the elbows are
+      // pinned to a single line box — so the progress summary joins the row
+      // behind a dot instead of stacking under it.
+      mockStreamState.isActive = true
+      mockStreamState.activeStartTime = Date.now()
+      mockStreamState.activeSubagents = [{
+        parentToolId: 'tc-sub',
+        agentId: 'a1',
+        subagentType: 'web-browser',
+        description: 'Gather UniFi WiFi events',
+        progressSummary: 'Scrolling Lobby AP detail panel',
+      }]
+      mockStreamState.completedSubagents = new Set()
+      mockMessages.push({
+        id: 'msg-1',
+        type: 'assistant',
+        content: { text: '' },
+        toolCalls: [{
+          id: 'tc-sub',
+          name: 'Agent',
+          input: { subagent_type: 'web-browser', description: 'Gather UniFi WiFi events' },
+          subagent: { agentId: 'a1', status: 'async_launched' },
+        }],
+        createdAt: new Date(),
+      })
+
+      render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+
+      const line = screen.getByText('web-browser').closest('.hover-scroll-text')
+      expect(line).not.toBeNull()
+      expect(line).toHaveTextContent('web-browser Gather UniFi WiFi events · Scrolling Lobby AP detail panel')
+    })
+
     it('reopens the original subagent row while a SendMessage resume is running', () => {
       mockStreamState.isActive = true
       mockStreamState.activeStartTime = Date.now()

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { AgentActivityIndicator } from './agent-activity-indicator'
 
 // Mock useMessageStream
@@ -931,10 +932,30 @@ describe('AgentActivityIndicator', () => {
       expect(screen.getByText('✓')).toBeInTheDocument()
     })
 
-    it('keeps name, description and progress on one hover-scrolling line', () => {
+    it('keeps activity on one line and provides a static keyboard and touch disclosure', async () => {
       // A wrapped second line breaks the tree's row rhythm — the elbows are
       // pinned to a single line box — so the progress summary joins the row
-      // behind a dot instead of stacking under it.
+      // behind a dot instead of stacking under it. The popover is the complete,
+      // non-moving fallback when that line is clipped.
+      const user = userEvent.setup()
+      const fullActivityText = 'web-browser Gather UniFi WiFi events · Scrolling Lobby AP detail panel'
+      const matchMedia = vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+      const clientWidth = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement) {
+        return this.classList.contains('hover-scroll-text') ? 100 : 0
+      })
+      const scrollWidth = vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockImplementation(function (this: HTMLElement) {
+        return this.classList.contains('hover-scroll-text-content') ? 320 : 0
+      })
+
       mockStreamState.isActive = true
       mockStreamState.activeStartTime = Date.now()
       mockStreamState.activeSubagents = [{
@@ -960,9 +981,31 @@ describe('AgentActivityIndicator', () => {
 
       render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
 
-      const line = screen.getByText('web-browser').closest('.hover-scroll-text')
+      const line = screen.getByText('web-browser').closest('.hover-scroll-text') as HTMLElement | null
       expect(line).not.toBeNull()
-      expect(line).toHaveTextContent('web-browser Gather UniFi WiFi events · Scrolling Lobby AP detail panel')
+      expect(line).toHaveTextContent(fullActivityText)
+      expect(line).toHaveAttribute('data-overflowing', 'true')
+      expect(line).toHaveAttribute('data-scrolling', 'false')
+
+      const disclosure = screen.getByRole('button', { name: `Show full activity: ${fullActivityText}` })
+      expect(disclosure).toContainElement(line)
+      expect(disclosure).toHaveAttribute('title', fullActivityText)
+
+      disclosure.focus()
+      await user.keyboard('{Enter}')
+      expect(screen.getByTestId('subagent-activity-full-text')).toHaveTextContent(fullActivityText)
+      expect(screen.getByTestId('subagent-activity-full-text')).toHaveClass('motion-reduce:!animate-none')
+
+      await user.keyboard('{Escape}')
+      expect(screen.queryByTestId('subagent-activity-full-text')).not.toBeInTheDocument()
+
+      // A click is the same activation path used by a touch tap.
+      await user.click(disclosure)
+      expect(screen.getByTestId('subagent-activity-full-text')).toHaveTextContent(fullActivityText)
+
+      matchMedia.mockRestore()
+      clientWidth.mockRestore()
+      scrollWidth.mockRestore()
     })
 
     it('reopens the original subagent row while a SendMessage resume is running', () => {

--- a/src/renderer/components/ui/hover-scroll-text.test.tsx
+++ b/src/renderer/components/ui/hover-scroll-text.test.tsx
@@ -95,8 +95,13 @@ describe('HoverScrollText', () => {
     // New words under the pointer: the old measurement is stale, so it restarts
     // from the dwell rather than either stalling or panning the wrong distance.
     rerender(<HoverScrollText data-testid="label">A different long session name</HoverScrollText>)
+    expect(viewport).toHaveAttribute('data-scrolling', 'false')
     setTextWidths(viewport, content, 100, 200)
-    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS))
+
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS - 1))
+    expect(viewport).toHaveAttribute('data-scrolling', 'false')
+
+    act(() => vi.advanceTimersByTime(1))
     expect(viewport).toHaveAttribute('data-scrolling', 'true')
     expect(viewport).toHaveStyle({ '--hover-scroll-distance': '100px' })
   })

--- a/src/renderer/components/ui/hover-scroll-text.test.tsx
+++ b/src/renderer/components/ui/hover-scroll-text.test.tsx
@@ -51,6 +51,56 @@ describe('HoverScrollText', () => {
     expect(viewport).toHaveAttribute('data-scrolling', 'false')
   })
 
+  it('keeps panning when a re-render hands it the same words in a new element', () => {
+    // The activity card re-renders every second for its elapsed clock, so its
+    // rows arrive as a fresh element with identical text. Treating that as new
+    // content cancelled the pan mid-flight and snapped the row back to the
+    // start — the sidebar never saw it because its child is a plain string.
+    const row = (
+      <>
+        <span>web-browser</span>
+        <span> Gather UniFi WiFi events</span>
+      </>
+    )
+    const { rerender } = render(<HoverScrollText data-testid="label">{row}</HoverScrollText>)
+    const viewport = screen.getByTestId('label')
+    const content = viewport.firstElementChild as HTMLElement
+    setTextWidths(viewport, content, 100, 145)
+
+    fireEvent.mouseEnter(viewport)
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS))
+    expect(viewport).toHaveAttribute('data-scrolling', 'true')
+
+    rerender(
+      <HoverScrollText data-testid="label">
+        <>
+          <span>web-browser</span>
+          <span> Gather UniFi WiFi events</span>
+        </>
+      </HoverScrollText>
+    )
+    expect(viewport).toHaveAttribute('data-scrolling', 'true')
+  })
+
+  it('re-arms the pan when the text itself changes mid-hover', () => {
+    const { rerender } = render(<HoverScrollText data-testid="label">A long session name</HoverScrollText>)
+    const viewport = screen.getByTestId('label')
+    const content = viewport.firstElementChild as HTMLElement
+    setTextWidths(viewport, content, 100, 145)
+
+    fireEvent.mouseEnter(viewport)
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS))
+    expect(viewport).toHaveAttribute('data-scrolling', 'true')
+
+    // New words under the pointer: the old measurement is stale, so it restarts
+    // from the dwell rather than either stalling or panning the wrong distance.
+    rerender(<HoverScrollText data-testid="label">A different long session name</HoverScrollText>)
+    setTextWidths(viewport, content, 100, 200)
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS))
+    expect(viewport).toHaveAttribute('data-scrolling', 'true')
+    expect(viewport).toHaveStyle({ '--hover-scroll-distance': '100px' })
+  })
+
   it('does not animate text that fits', () => {
     render(<HoverScrollText data-testid="label">Short name</HoverScrollText>)
     const viewport = screen.getByTestId('label')

--- a/src/renderer/components/ui/hover-scroll-text.tsx
+++ b/src/renderer/components/ui/hover-scroll-text.tsx
@@ -36,6 +36,7 @@ export function HoverScrollText({
   const contentRef = useRef<HTMLSpanElement>(null)
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isHoveredRef = useRef(false)
+  const lastTextRef = useRef<string | null>(null)
   const [scrollDistance, setScrollDistance] = useState(0)
   const [isScrolling, setIsScrolling] = useState(false)
   const [motionAllowed, setMotionAllowed] = useState(() =>
@@ -86,10 +87,26 @@ export function HoverScrollText({
     }, HOVER_SCROLL_DELAY_MS)
   }, [clearHoverTimer, measureOverflow, motionAllowed])
 
+  // Reset on the rendered TEXT changing, not on `children` changing identity.
+  // A caller that re-renders on a timer (the activity card re-renders every
+  // second for its elapsed clock) hands us a brand-new element each time with
+  // the same words in it — keying off that identity cancelled the pan
+  // mid-flight and parked the row back at the start, which the sidebar never
+  // hit because its child is a plain string. Reading the committed text is
+  // what both callers actually mean by "new content".
   useLayoutEffect(() => {
+    const text = contentRef.current?.textContent ?? ''
+    if (lastTextRef.current === text) return
+    lastTextRef.current = text
+    // Content changed under the pointer: re-measure and re-arm rather than
+    // stall, so a label that updates mid-hover keeps panning.
+    if (isHoveredRef.current) {
+      startScrolling()
+      return
+    }
     stopScrolling()
     measureOverflow()
-  }, [children, measureOverflow, stopScrolling])
+  })
 
   useEffect(() => {
     const viewport = viewportRef.current

--- a/src/renderer/components/ui/hover-scroll-text.tsx
+++ b/src/renderer/components/ui/hover-scroll-text.tsx
@@ -75,6 +75,10 @@ export function HoverScrollText({
   const startScrolling = useCallback(() => {
     isHoveredRef.current = true
     clearHoverTimer()
+    // Remove the animation before re-arming it. When rendered text changes
+    // during an active pan, leaving this true would keep the old CSS animation
+    // attached and make the delayed set-to-true below a no-op.
+    setIsScrolling(false)
 
     const distance = measureOverflow()
     if (!motionAllowed || distance === 0) return


### PR DESCRIPTION
A subagent row in the activity tree stacked its live progress summary under the name and description. That second line breaks the tree: the elbows are pinned to half of one 16px line box, so a two-line row leaves its connector floating against the top of the label instead of centered on it, and the rows below lose their rhythm.

**Before**

```
├─ web-browser  Gather UniFi WiFi events
   Scrolling Lobby AP detail panel
```

**After**

```
├─ web-browser  Gather UniFi WiFi events · Scrolling Lobby AP detail panel
```

Name, description and progress now ride one line, the summary joined on behind a dot. Overflow is handled the way long session names are in the sidebar — truncate, then pan on hover — via the same `HoverScrollText`.

### The reuse surfaced a bug in `HoverScrollText`

Its reset effect keyed off `children` identity, and the activity card re-renders every second for its elapsed clock, handing the component a fresh element with the same words in it. Each of those re-renders called `stopScrolling()`: the pan died mid-flight, the row snapped back to the start, and the cleared hover flag meant it never re-armed under a still pointer. The sidebar never hit this because its child is a plain string, so identity only changes on a real rename.

It now compares the **committed text** instead:

- same words in a new element → no-op, so the pan runs to the end and holds there (the animation already used `forwards`)
- text that genuinely changes mid-hover → re-measures and re-arms from the dwell, instead of stalling on a stale distance

### Testing

- New case in `agent-activity-indicator.test.tsx` pinning name + description + summary to one `.hover-scroll-text` line.
- Two new cases in `hover-scroll-text.test.tsx` covering both paths above; both fail on the old effect.
- `vitest run src/renderer/components/{messages,ui,layout}` — 936 passed, incl. the sidebar suite. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)