### PR TITLE
fix(x-agent): cap sync waits at 120s and promote to async on timeout

### DIFF
--- a/agent-container/src/tools/agents/get-session-transcript.ts
+++ b/agent-container/src/tools/agents/get-session-transcript.ts
@@ -17,7 +17,7 @@ export const getSessionTranscriptTool = tool(
   'get_agent_session_transcript',
   `Read the message transcript of a session belonging to another agent. Returns a status line ('running' | 'idle' | 'awaiting_input') followed by the messages.
 
-If sync=true and the session is currently running, the tool waits until the target agent's turn is complete before returning. Otherwise it returns the current transcript immediately.
+If sync=true and the session is currently running, the tool waits up to ~2 minutes for the target agent's turn to complete before returning. If the turn is still in progress after that, it returns the transcript so far with status 'running' — call again with sync=true to keep waiting. Otherwise it returns the current transcript immediately.
 
 Tool calls in the transcript are summarized — the raw tool input/output is omitted to keep the result compact.`,
   {

--- a/agent-container/src/tools/agents/invoke-agent.ts
+++ b/agent-container/src/tools/agents/invoke-agent.ts
@@ -14,9 +14,9 @@ export function makeInvokeAgentTool(getCallerSessionId: () => string) {
     'invoke_agent',
     `Send a message to another agent in this workspace.
 
-If session_id is omitted, a new session is started on the target agent. If session_id is provided, the message is appended to that existing session — the session must exist and not currently be running (use get_session_transcript with sync to wait).
+If session_id is omitted, a new session is started on the target agent. If session_id is provided, the message is appended to that existing session — the session must exist and not currently be running (use get_agent_session_transcript with sync to wait).
 
-If sync=true, the tool waits for the target agent's turn to finish and returns its last message. If sync=false (default), the tool returns immediately with status 'running' and you can later read the transcript with get_session_transcript.
+If sync=true, the tool waits up to ~2 minutes for the target agent's turn to finish and returns its last message. If the target is still working after that, the call returns status 'running' with the session_id — the invocation was delivered and is in progress; do NOT re-invoke (that would start a duplicate run), poll get_agent_session_transcript instead. If sync=false (default), the tool returns immediately with status 'running' and you can later read the transcript with get_agent_session_transcript.
 
 Use list_agents first to discover available slugs.
 

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -126,6 +126,21 @@ function waitForIdleTimeoutError(): Error {
     name: 'WaitForIdleTimeoutError',
   })
 }
+
+// Sync waits pass the REMAINING end-to-end budget (deadline stamped at handler
+// entry minus pre-wait work), so the exact timeoutMs varies — assert the shape
+// and that it stays within (0, 120s]. requireActiveFirst is off because sync
+// callers mark/observe the session active before waiting, so "inactive" means
+// the turn already finished.
+function expectBoundedSyncWait(sessionId: string): void {
+  expect(mockWaitForIdle).toHaveBeenCalledWith(sessionId, {
+    timeoutMs: expect.any(Number),
+    requireActiveFirst: false,
+  })
+  const opts = mockWaitForIdle.mock.calls.at(-1)?.[1] as { timeoutMs: number }
+  expect(opts.timeoutMs).toBeGreaterThan(0)
+  expect(opts.timeoutMs).toBeLessThanOrEqual(120_000)
+}
 const mockIsSessionActive = vi.fn((_sessionId?: string): boolean => false)
 const mockIsSessionAwaitingInput = vi.fn((_sessionId?: string): boolean => false)
 const mockWaitForIdle = vi.fn(async (..._args: unknown[]) => {})
@@ -184,7 +199,7 @@ vi.mock('@shared/lib/error-reporting', () => ({
 // Imports (after mocks)
 // ----------------------------------------------------------------------------
 
-import xAgentRoute from './x-agent'
+import xAgentRoute, { resolveSyncWaitTimeoutMs } from './x-agent'
 
 // ----------------------------------------------------------------------------
 // Test app + helpers
@@ -916,7 +931,8 @@ describe('/invoke', () => {
     expect(body.error).toMatch(/get_agent_session_transcript/)
     // The sync wait must be capped below the container fetch's 300s header
     // timeout — an uncapped wait surfaces as "fetch failed" on the caller.
-    expect(mockWaitForIdle).toHaveBeenCalledWith('new-sess-id', { timeoutMs: 120_000 })
+    // The budget is end-to-end, so pre-wait work shrinks the passed timeout.
+    expectBoundedSyncWait('new-sess-id')
     // No transcript read should have been attempted since waitForIdle failed
     expect(mockGetTranscript).not.toHaveBeenCalled()
   })
@@ -936,7 +952,39 @@ describe('/invoke', () => {
     expect(body.sessionId).toBe('existing-sess')
     expect(body.status).toBe('running')
     expect(body.error).toMatch(/do not re-invoke/i)
-    expect(mockWaitForIdle).toHaveBeenCalledWith('existing-sess', { timeoutMs: 120_000 })
+    expectBoundedSyncWait('existing-sess')
+  })
+
+  it('promotes to async without waiting when pre-delivery work exhausts the sync budget', async () => {
+    // Policy review and container startup run before the prompt is delivered
+    // and count against the same end-to-end budget — otherwise slow delivery
+    // plus a full wait could still cross the container fetch's 300s header
+    // timeout and resurface as "fetch failed".
+    reviewDecisions.push('allow')
+    const realNow = Date.now.bind(Date)
+    let clockOffsetMs = 0
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow() + clockOffsetMs)
+    try {
+      mockSendMessage.mockImplementationOnce(async () => {
+        clockOffsetMs = 150_000
+      })
+      const res = await authedFetch('/x-agent/invoke', {
+        slug: TARGET_SLUG,
+        prompt: 'slow to deliver',
+        sessionId: 'existing-sess',
+        sync: true,
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.sessionId).toBe('existing-sess')
+      expect(body.status).toBe('running')
+      expect(body.error).toMatch(/do not re-invoke/i)
+      // The prompt WAS delivered; only the wait was skipped.
+      expect(mockSendMessage).toHaveBeenCalled()
+      expect(mockWaitForIdle).not.toHaveBeenCalled()
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('returns running + error (200) when sync=true on existing session and waitForIdle rejects', async () => {
@@ -995,7 +1043,7 @@ describe('/invoke', () => {
       sync: true,
     })
     const body = await res.json()
-    expect(mockWaitForIdle).toHaveBeenCalledWith('new-sess-id', { timeoutMs: 120_000 })
+    expectBoundedSyncWait('new-sess-id')
     expect(body.status).toBe('completed')
     expect(body.lastMessage).toBe('hi back')
   })
@@ -1347,7 +1395,7 @@ describe('/get-transcript', () => {
     })
     // Capped below the container fetch's 300s header timeout: sync reads are a
     // bounded long-poll, not an unbounded wait.
-    expect(mockWaitForIdle).toHaveBeenCalledWith('sess-1', { timeoutMs: 120_000 })
+    expectBoundedSyncWait('sess-1')
     const body = await res.json()
     expect(body.status).toBe('idle')
   })
@@ -1384,6 +1432,32 @@ describe('/get-transcript', () => {
     expect(res.status).toBe(504)
     expect((await res.json()).error).toMatch(/did not idle.*aborted/)
     expect(mockGetTranscript).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveSyncWaitTimeoutMs', () => {
+  it('defaults to 120s when unset or unparseable', () => {
+    expect(resolveSyncWaitTimeoutMs(undefined)).toBe(120_000)
+    expect(resolveSyncWaitTimeoutMs('')).toBe(120_000)
+    expect(resolveSyncWaitTimeoutMs('not-a-number')).toBe(120_000)
+  })
+
+  it('rejects non-positive and non-finite overrides', () => {
+    // A zero/negative budget would promote every sync call immediately, and
+    // Infinity would restore the unbounded wait behind the transport cliff.
+    expect(resolveSyncWaitTimeoutMs('0')).toBe(120_000)
+    expect(resolveSyncWaitTimeoutMs('-5000')).toBe(120_000)
+    expect(resolveSyncWaitTimeoutMs('Infinity')).toBe(120_000)
+    expect(resolveSyncWaitTimeoutMs('NaN')).toBe(120_000)
+  })
+
+  it('accepts overrides but clamps them under the transport deadline', () => {
+    expect(resolveSyncWaitTimeoutMs('30000')).toBe(30_000)
+    expect(resolveSyncWaitTimeoutMs('240000')).toBe(240_000)
+    // Values at/past undici's 300s header timeout would resurrect the
+    // "fetch failed" retry-storm failure this timeout exists to prevent.
+    expect(resolveSyncWaitTimeoutMs('300000')).toBe(240_000)
+    expect(resolveSyncWaitTimeoutMs('600000')).toBe(240_000)
   })
 })
 

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -965,6 +965,9 @@ describe('/invoke', () => {
     let clockOffsetMs = 0
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow() + clockOffsetMs)
     try {
+      // Mirror the real persister: marking active flips the activity flag, so
+      // the exhausted-budget check sees a genuinely still-running turn.
+      mockMarkSessionActive.mockImplementation(() => mockIsSessionActive.mockReturnValue(true))
       mockSendMessage.mockImplementationOnce(async () => {
         clockOffsetMs = 150_000
       })
@@ -982,6 +985,130 @@ describe('/invoke', () => {
       // The prompt WAS delivered; only the wait was skipped.
       expect(mockSendMessage).toHaveBeenCalled()
       expect(mockWaitForIdle).not.toHaveBeenCalled()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('returns completed with the reply when the turn finishes during budget-exhausting delivery', async () => {
+    // Exhausted budget + inactive session = the turn finished while we were
+    // delivering. That's a completion, not a 'running' the caller must poll.
+    reviewDecisions.push('allow')
+    const realNow = Date.now.bind(Date)
+    let clockOffsetMs = 0
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow() + clockOffsetMs)
+    try {
+      const oldEntry = { type: 'assistant', uuid: 'a-old', message: { role: 'assistant', content: 'old answer' } }
+      const newEntry = { type: 'assistant', uuid: 'a-new', message: { role: 'assistant', content: 'fresh answer' } }
+      let transcript = [oldEntry]
+      mockGetTranscript.mockImplementation(async () => transcript)
+      mockMarkSessionActive.mockImplementation(() => mockIsSessionActive.mockReturnValue(true))
+      mockSendMessage.mockImplementationOnce(async () => {
+        clockOffsetMs = 150_000
+        mockIsSessionActive.mockReturnValue(false) // result arrived during delivery
+        transcript = [oldEntry, newEntry]
+      })
+      const res = await authedFetch('/x-agent/invoke', {
+        slug: TARGET_SLUG,
+        prompt: 'quick question',
+        sessionId: 'existing-sess',
+        sync: true,
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.status).toBe('completed')
+      expect(body.lastMessage).toBe('fresh answer')
+      expect(mockWaitForIdle).not.toHaveBeenCalled()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it("returns THIS turn's reply on an existing session, not the previous turn's", async () => {
+    // The turn's 'result' event clears isActive before the new assistant entry
+    // is flushed to the JSONL file. Without the pre-delivery boundary, the
+    // reader would grab the previous turn's answer and present it as this one's.
+    reviewDecisions.push('allow')
+    const oldEntry = { type: 'assistant', uuid: 'a-old', message: { role: 'assistant', content: 'old answer' } }
+    const newEntry = { type: 'assistant', uuid: 'a-new', message: { role: 'assistant', content: 'fresh answer' } }
+    let transcript = [oldEntry]
+    let reads = 0
+    mockGetTranscript.mockImplementation(async () => {
+      reads++
+      // Read 1 is the boundary capture, read 2 the first post-wait attempt —
+      // both see only the previous turn. The new reply flushes by read 3.
+      if (reads >= 3) transcript = [oldEntry, newEntry]
+      return transcript
+    })
+    mockMarkSessionActive.mockImplementation(() => mockIsSessionActive.mockReturnValue(true))
+    mockWaitForIdle.mockImplementation(async () => {
+      mockIsSessionActive.mockReturnValue(false)
+    })
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'follow-up',
+      sessionId: 'existing-sess',
+      sync: true,
+    })
+    const body = await res.json()
+    expect(body.status).toBe('completed')
+    expect(body.lastMessage).toBe('fresh answer')
+  })
+
+  it('refuses to deliver when startup exceeds the delivery cutoff (existing session)', async () => {
+    // Past ~240s the caller's fetch is already dead (undici 300s); delivering
+    // anyway creates a ghost run that the caller's retry then duplicates.
+    reviewDecisions.push('allow')
+    const realNow = Date.now.bind(Date)
+    let clockOffsetMs = 0
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow() + clockOffsetMs)
+    try {
+      mockEnsureRunning.mockImplementationOnce(async () => {
+        clockOffsetMs = 250_000
+        return {
+          createSession: mockCreateSession,
+          sendMessage: mockSendMessage,
+          deleteSession: mockDeleteSession,
+        } as never
+      })
+      const res = await authedFetch('/x-agent/invoke', {
+        slug: TARGET_SLUG,
+        prompt: 'too late',
+        sessionId: 'existing-sess',
+        sync: true,
+      })
+      expect(res.status).toBe(504)
+      expect((await res.json()).error).toMatch(/not delivered/i)
+      expect(mockSendMessage).not.toHaveBeenCalled()
+      expect(mockMarkSessionActive).not.toHaveBeenCalled()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('refuses to create a session past the delivery cutoff, even for async invokes', async () => {
+    // Async invokes also respond only after delivery, so the same ghost-run
+    // hazard applies without sync.
+    reviewDecisions.push('allow')
+    const realNow = Date.now.bind(Date)
+    let clockOffsetMs = 0
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow() + clockOffsetMs)
+    try {
+      mockEnsureRunning.mockImplementationOnce(async () => {
+        clockOffsetMs = 250_000
+        return {
+          createSession: mockCreateSession,
+          sendMessage: mockSendMessage,
+          deleteSession: mockDeleteSession,
+        } as never
+      })
+      const res = await authedFetch('/x-agent/invoke', {
+        slug: TARGET_SLUG,
+        prompt: 'too late',
+      })
+      expect(res.status).toBe(504)
+      expect((await res.json()).error).toMatch(/not delivered/i)
+      expect(mockCreateSession).not.toHaveBeenCalled()
     } finally {
       nowSpy.mockRestore()
     }
@@ -1420,6 +1547,36 @@ describe('/get-transcript', () => {
     expect(body.messages).toHaveLength(1)
   })
 
+  it('reconciles after a sync wait so idle responses include the awaited reply', async () => {
+    // 'result' clears isActive before the final assistant entry is flushed —
+    // without reconciling against the pre-wait boundary, the handler returns
+    // status idle with a transcript missing the very reply it waited for.
+    reviewDecisions.push('allow')
+    const oldEntry = { type: 'assistant', uuid: 'a-old', message: { role: 'assistant', content: 'old answer' } }
+    const newEntry = { type: 'assistant', uuid: 'a-new', message: { role: 'assistant', content: 'fresh answer' } }
+    let transcript = [oldEntry]
+    let reads = 0
+    mockGetTranscript.mockImplementation(async () => {
+      reads++
+      // Read 1 = boundary capture, read 2 = first reconcile attempt (stale),
+      // read 3 onward sees the flushed reply.
+      if (reads >= 3) transcript = [oldEntry, newEntry]
+      return transcript
+    })
+    mockIsSessionActive.mockReturnValue(true)
+    mockWaitForIdle.mockImplementation(async () => {
+      mockIsSessionActive.mockReturnValue(false)
+    })
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'sess-1',
+      sync: true,
+    })
+    const body = await res.json()
+    expect(body.status).toBe('idle')
+    expect(body.messages.map((m: { content: string }) => m.content)).toContain('fresh answer')
+  })
+
   it('still 504s when the sync wait fails for a non-timeout reason', async () => {
     reviewDecisions.push('allow')
     mockIsSessionActive.mockReturnValue(true)
@@ -1431,7 +1588,9 @@ describe('/get-transcript', () => {
     })
     expect(res.status).toBe(504)
     expect((await res.json()).error).toMatch(/did not idle.*aborted/)
-    expect(mockGetTranscript).not.toHaveBeenCalled()
+    // Only the pre-wait boundary capture read the transcript — the failure
+    // must short-circuit before the response transcript is assembled.
+    expect(mockGetTranscript).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -1451,13 +1610,13 @@ describe('resolveSyncWaitTimeoutMs', () => {
     expect(resolveSyncWaitTimeoutMs('NaN')).toBe(120_000)
   })
 
-  it('accepts overrides but clamps them under the transport deadline', () => {
+  it('lets overrides shorten the wait but never extend it', () => {
     expect(resolveSyncWaitTimeoutMs('30000')).toBe(30_000)
-    expect(resolveSyncWaitTimeoutMs('240000')).toBe(240_000)
-    // Values at/past undici's 300s header timeout would resurrect the
-    // "fetch failed" retry-storm failure this timeout exists to prevent.
-    expect(resolveSyncWaitTimeoutMs('300000')).toBe(240_000)
-    expect(resolveSyncWaitTimeoutMs('600000')).toBe(240_000)
+    expect(resolveSyncWaitTimeoutMs('120000')).toBe(120_000)
+    // The tool docs promise "up to ~2 minutes" and the transport dies at 300s
+    // — a longer override would break the former and threaten the latter.
+    expect(resolveSyncWaitTimeoutMs('240000')).toBe(120_000)
+    expect(resolveSyncWaitTimeoutMs('600000')).toBe(120_000)
   })
 })
 

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -118,6 +118,14 @@ vi.mock('@shared/lib/container/container-manager', () => ({
 }))
 
 // Message persister
+// Built by name, not by importing the class from the (wholesale-mocked) module:
+// the routes match timeout errors on error.name, and this mirrors that contract.
+// message-persister.test.ts pins the real class to this name.
+function waitForIdleTimeoutError(): Error {
+  return Object.assign(new Error('waitForIdle timeout after 120000ms'), {
+    name: 'WaitForIdleTimeoutError',
+  })
+}
 const mockIsSessionActive = vi.fn((_sessionId?: string): boolean => false)
 const mockIsSessionAwaitingInput = vi.fn((_sessionId?: string): boolean => false)
 const mockWaitForIdle = vi.fn(async (..._args: unknown[]) => {})
@@ -885,13 +893,13 @@ describe('/invoke', () => {
     )
   })
 
-  it('returns running + error (200, not 500) when sync=true and waitForIdle rejects', async () => {
-    // Sync invoke degrades gracefully when the target never idles: caller still
-    // gets the sessionId so they can poll/follow up via get-transcript later,
-    // plus an error string for visibility. This is intentionally NOT a 500 —
-    // the session was successfully created, it just didn't finish in time.
+  it('promotes sync=true to async (running + guidance note) when the wait times out', async () => {
+    // A slow target turn is not a failure: the caller gets the async contract
+    // (sessionId + status running) plus explicit guidance to poll the transcript
+    // rather than re-invoke. Left as a plain network error, callers retried the
+    // invoke and spawned duplicate runs (retry storm).
     reviewDecisions.push('allow')
-    mockWaitForIdle.mockRejectedValueOnce(new Error('waitForIdle timeout after 600000ms'))
+    mockWaitForIdle.mockRejectedValueOnce(waitForIdleTimeoutError())
     const res = await authedFetch('/x-agent/invoke', {
       slug: TARGET_SLUG,
       prompt: 'long-running task',
@@ -902,10 +910,33 @@ describe('/invoke', () => {
     expect(body).toEqual({
       sessionId: 'new-sess-id',
       status: 'running',
-      error: expect.stringMatching(/timeout/i),
+      error: expect.stringMatching(/still working/i),
     })
+    expect(body.error).toMatch(/do not re-invoke/i)
+    expect(body.error).toMatch(/get_agent_session_transcript/)
+    // The sync wait must be capped below the container fetch's 300s header
+    // timeout — an uncapped wait surfaces as "fetch failed" on the caller.
+    expect(mockWaitForIdle).toHaveBeenCalledWith('new-sess-id', { timeoutMs: 120_000 })
     // No transcript read should have been attempted since waitForIdle failed
     expect(mockGetTranscript).not.toHaveBeenCalled()
+  })
+
+  it('promotes sync=true on an existing session to async when the wait times out', async () => {
+    reviewDecisions.push('allow')
+    mockIsSessionActive.mockReturnValue(false)
+    mockWaitForIdle.mockRejectedValueOnce(waitForIdleTimeoutError())
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'follow-up',
+      sessionId: 'existing-sess',
+      sync: true,
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.sessionId).toBe('existing-sess')
+    expect(body.status).toBe('running')
+    expect(body.error).toMatch(/do not re-invoke/i)
+    expect(mockWaitForIdle).toHaveBeenCalledWith('existing-sess', { timeoutMs: 120_000 })
   })
 
   it('returns running + error (200) when sync=true on existing session and waitForIdle rejects', async () => {
@@ -964,7 +995,7 @@ describe('/invoke', () => {
       sync: true,
     })
     const body = await res.json()
-    expect(mockWaitForIdle).toHaveBeenCalledWith('new-sess-id')
+    expect(mockWaitForIdle).toHaveBeenCalledWith('new-sess-id', { timeoutMs: 120_000 })
     expect(body.status).toBe('completed')
     expect(body.lastMessage).toBe('hi back')
   })
@@ -1314,9 +1345,45 @@ describe('/get-transcript', () => {
       sessionId: 'sess-1',
       sync: true,
     })
-    expect(mockWaitForIdle).toHaveBeenCalledWith('sess-1')
+    // Capped below the container fetch's 300s header timeout: sync reads are a
+    // bounded long-poll, not an unbounded wait.
+    expect(mockWaitForIdle).toHaveBeenCalledWith('sess-1', { timeoutMs: 120_000 })
     const body = await res.json()
     expect(body.status).toBe('idle')
+  })
+
+  it('returns transcript-so-far with status running (200) when the sync wait times out', async () => {
+    // Timeout is the long-poll expiring, not a failure: the caller gets the
+    // current transcript and can call again with sync=true to keep waiting.
+    reviewDecisions.push('allow')
+    mockIsSessionActive.mockReturnValue(true)
+    mockWaitForIdle.mockRejectedValueOnce(waitForIdleTimeoutError())
+    mockGetTranscript.mockResolvedValue([
+      { type: 'user', message: { role: 'user', content: 'hello' } },
+    ])
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'sess-1',
+      sync: true,
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe('running')
+    expect(body.messages).toHaveLength(1)
+  })
+
+  it('still 504s when the sync wait fails for a non-timeout reason', async () => {
+    reviewDecisions.push('allow')
+    mockIsSessionActive.mockReturnValue(true)
+    mockWaitForIdle.mockRejectedValueOnce(new Error('waitForIdle aborted'))
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'sess-1',
+      sync: true,
+    })
+    expect(res.status).toBe(504)
+    expect((await res.json()).error).toMatch(/did not idle.*aborted/)
+    expect(mockGetTranscript).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -23,6 +23,7 @@ import * as schema from '@shared/lib/db/schema'
 vi.hoisted(() => {
   process.env.X_AGENT_READ_RETRY_ATTEMPTS = '4'
   process.env.X_AGENT_READ_RETRY_INTERVAL_MS = '50'
+  process.env.X_AGENT_SUBSCRIBE_TIMEOUT_MS = '150'
 })
 
 // ----------------------------------------------------------------------------
@@ -1086,6 +1087,101 @@ describe('/invoke', () => {
     }
   })
 
+  it('refuses to deliver when the stream attach eats the cutoff (existing session)', async () => {
+    // The cutoff is checked AFTER subscribe — a check before it could pass,
+    // then the unbounded pre-send awaits could carry delivery past the
+    // caller's 300s fetch timeout anyway.
+    reviewDecisions.push('allow')
+    const realNow = Date.now.bind(Date)
+    let clockOffsetMs = 0
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow() + clockOffsetMs)
+    try {
+      mockSubscribeToSession.mockImplementationOnce(async () => {
+        clockOffsetMs = 250_000
+      })
+      const res = await authedFetch('/x-agent/invoke', {
+        slug: TARGET_SLUG,
+        prompt: 'too late',
+        sessionId: 'existing-sess',
+        sync: true,
+      })
+      expect(res.status).toBe(504)
+      expect((await res.json()).error).toMatch(/not delivered/i)
+      expect(mockSendMessage).not.toHaveBeenCalled()
+      expect(mockMarkSessionActive).not.toHaveBeenCalled()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('fails fast instead of hanging when the stream attach stalls (existing session)', async () => {
+    // The persister's WebSocket ready promise has no timeout of its own; a
+    // wedged container must surface as an error before the prompt goes out,
+    // not hold the caller's fetch open indefinitely.
+    reviewDecisions.push('allow')
+    mockSubscribeToSession.mockImplementationOnce(() => new Promise(() => {}))
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'hello',
+      sessionId: 'existing-sess',
+      sync: true,
+    })
+    expect(res.status).toBe(500)
+    expect((await res.json()).error).toMatch(/attaching to session stream/i)
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  it('revokes a session created after the delivery cutoff', async () => {
+    // createSession cannot be cancelled mid-flight; when it lands after the
+    // caller's fetch is already dead, the session must be deleted the moment
+    // it materializes — otherwise the caller's retry duplicates the run.
+    reviewDecisions.push('allow')
+    const realNow = Date.now.bind(Date)
+    let clockOffsetMs = 0
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realNow() + clockOffsetMs)
+    try {
+      // Enter createSession with ~50ms left to the cutoff; the create resolves
+      // 120ms later — past the deadline.
+      mockEnsureRunning.mockImplementationOnce(async () => {
+        clockOffsetMs = 239_950
+        return {
+          createSession: mockCreateSession,
+          sendMessage: mockSendMessage,
+          deleteSession: mockDeleteSession,
+        } as never
+      })
+      mockCreateSession.mockImplementationOnce(
+        () => new Promise((resolve) => setTimeout(() => resolve({ id: 'late-sess' }), 120)),
+      )
+      const res = await authedFetch('/x-agent/invoke', {
+        slug: TARGET_SLUG,
+        prompt: 'slow create',
+        sync: true,
+      })
+      expect(res.status).toBe(504)
+      expect((await res.json()).error).toMatch(/safe to retry/i)
+      expect(mockRegisterSession).not.toHaveBeenCalled()
+      await vi.waitFor(() => expect(mockDeleteSession).toHaveBeenCalledWith('late-sess'))
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('revokes the new session when the stream attach stalls, instead of leaving a ghost run', async () => {
+    // Post-delivery, an unsubscribed session would run with nothing persisting
+    // its transcript — delete it like a failed registration.
+    reviewDecisions.push('allow')
+    mockSubscribeToSession.mockImplementationOnce(() => new Promise(() => {}))
+    const res = await authedFetch('/x-agent/invoke', {
+      slug: TARGET_SLUG,
+      prompt: 'hello',
+      sync: true,
+    })
+    expect(res.status).toBe(500)
+    expect((await res.json()).error).toMatch(/attach/i)
+    expect(mockDeleteSession).toHaveBeenCalledWith('new-sess-id')
+  })
+
   it('refuses to create a session past the delivery cutoff, even for async invokes', async () => {
     // Async invokes also respond only after delivery, so the same ghost-run
     // hazard applies without sync.
@@ -1566,6 +1662,35 @@ describe('/get-transcript', () => {
     mockIsSessionActive.mockReturnValue(true)
     mockWaitForIdle.mockImplementation(async () => {
       mockIsSessionActive.mockReturnValue(false)
+    })
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'sess-1',
+      sync: true,
+    })
+    const body = await res.json()
+    expect(body.status).toBe('idle')
+    expect(body.messages.map((m: { content: string }) => m.content)).toContain('fresh answer')
+  })
+
+  it('reconciles when the turn ends between the wait timing out and the status read', async () => {
+    // A timeout followed by the turn finishing in the gap is the same flush
+    // race as a completion: without reconciling, the response reports idle
+    // with a transcript missing the reply it waited for.
+    reviewDecisions.push('allow')
+    const oldEntry = { type: 'assistant', uuid: 'a-old', message: { role: 'assistant', content: 'old answer' } }
+    const newEntry = { type: 'assistant', uuid: 'a-new', message: { role: 'assistant', content: 'fresh answer' } }
+    let transcript = [oldEntry]
+    let reads = 0
+    mockGetTranscript.mockImplementation(async () => {
+      reads++
+      if (reads >= 3) transcript = [oldEntry, newEntry]
+      return transcript
+    })
+    mockIsSessionActive.mockReturnValue(true)
+    mockWaitForIdle.mockImplementationOnce(async () => {
+      mockIsSessionActive.mockReturnValue(false) // turn ended...
+      throw waitForIdleTimeoutError() // ...but the wait had already timed out
     })
     const res = await authedFetch('/x-agent/get-transcript', {
       slug: TARGET_SLUG,

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -488,18 +488,33 @@ const READ_RETRY_INTERVAL_MS = Number(process.env.X_AGENT_READ_RETRY_INTERVAL_MS
 // and a wait that ignored them could still push the total response time past
 // the transport cliff.
 const SYNC_WAIT_TIMEOUT_DEFAULT_MS = 120_000
-// Ceiling for the env override — at or past the 300s transport cliff the
-// override would restore the exact failure this timeout exists to prevent.
-const SYNC_WAIT_TIMEOUT_MAX_MS = 240_000
 
-// Exported for unit tests.
+// Exported for unit tests. The env override can only SHORTEN the wait (its
+// purpose is keeping tests snappy): the container tool docs promise "up to
+// ~2 minutes", and a longer wait would both break that promise and erode the
+// margin to the 300s transport cliff.
 export function resolveSyncWaitTimeoutMs(raw: string | undefined): number {
   const parsed = Number(raw)
   if (!Number.isFinite(parsed) || parsed <= 0) return SYNC_WAIT_TIMEOUT_DEFAULT_MS
-  return Math.min(parsed, SYNC_WAIT_TIMEOUT_MAX_MS)
+  return Math.min(parsed, SYNC_WAIT_TIMEOUT_DEFAULT_MS)
 }
 
 const SYNC_WAIT_TIMEOUT_MS = resolveSyncWaitTimeoutMs(process.env.X_AGENT_SYNC_WAIT_TIMEOUT_MS)
+
+// Hard stop for delivering the prompt at all. Past this point the caller's
+// fetch has been dead-or-dying for a while (undici gives up at 300s), so
+// delivering anyway creates exactly the ghost run the caller's inevitable
+// retry then duplicates. Applies to async invokes too — they also respond
+// only after delivery, so a slow container start can strand them the same way.
+// The 60s margin leaves room for the delivery call itself plus the response.
+const DELIVERY_CUTOFF_MS = 240_000
+
+function deliveryCutoffError(): string {
+  return (
+    `Target agent took too long to become ready (over ${Math.round(DELIVERY_CUTOFF_MS / 1000)}s), ` +
+    'so the prompt was NOT delivered. It is safe to retry; prefer sync=false.'
+  )
+}
 
 // Matched by name rather than instanceof: the persister module is wholesale-
 // mocked in many test suites, and an instanceof against a possibly-undefined
@@ -524,7 +539,12 @@ async function waitForTurnWithinBudget(
   deadline: number,
 ): Promise<'completed' | 'timeout'> {
   const remainingMs = deadline - Date.now()
-  if (remainingMs <= 0) return 'timeout'
+  if (remainingMs <= 0) {
+    // Pre-wait work can eat the whole budget; if the turn already finished
+    // during it, that's a completion — reporting 'timeout' here would label a
+    // finished turn 'running' and make the caller poll for a result it has.
+    return messagePersister.isSessionActive(sessionId) ? 'timeout' : 'completed'
+  }
   try {
     await messagePersister.waitForIdle(sessionId, {
       timeoutMs: remainingMs,
@@ -545,27 +565,34 @@ function syncWaitPromotedNote(timeoutMs: number): string {
   )
 }
 
+function isReturnableAssistantEntry(e: JsonlMessageEntry | JsonlSystemEntry): boolean {
+  return e.type === 'assistant' && compactMessage(e) !== null
+}
+
+/**
+ * `boundaryUuid` is the uuid of the last assistant entry persisted BEFORE the
+ * current turn's prompt was delivered (undefined when the session is new or
+ * had none). Seeing that entry still last means this turn's reply hasn't
+ * flushed yet — keep polling rather than returning the previous turn's answer
+ * as if it were this one's.
+ */
 async function readLastAssistantMessage(
   targetSlug: string,
   sessionId: string,
-  attempts = READ_RETRY_ATTEMPTS,
-  intervalMs = READ_RETRY_INTERVAL_MS,
+  boundaryUuid?: string,
 ): Promise<{ role: string; content: string; toolName?: string } | null> {
-  for (let i = 0; i < attempts; i++) {
+  for (let i = 0; i < READ_RETRY_ATTEMPTS; i++) {
     // Only the most recent assistant entry matters, so read the transcript
     // from the tail instead of full-parsing it (transcripts reach 100MB+, and
-    // this runs up to `attempts` times per invoke).
-    const entry = await findLastSessionEntry(
-      targetSlug,
-      sessionId,
-      (e) => e.type === 'assistant' && compactMessage(e) !== null,
-    )
-    if (entry) {
+    // this runs up to READ_RETRY_ATTEMPTS times per invoke).
+    const entry = await findLastSessionEntry(targetSlug, sessionId, isReturnableAssistantEntry)
+    const isStaleBoundary = boundaryUuid !== undefined && entry?.uuid === boundaryUuid
+    if (entry && !isStaleBoundary) {
       const compact = compactMessage(entry)
       if (compact) return compact
     }
-    if (i < attempts - 1) {
-      await new Promise((r) => setTimeout(r, intervalMs))
+    if (i < READ_RETRY_ATTEMPTS - 1) {
+      await new Promise((r) => setTimeout(r, READ_RETRY_INTERVAL_MS))
     }
   }
   return null
@@ -602,13 +629,23 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
   }
 
   if (sync && messagePersister.isSessionActive(sessionId)) {
+    // Last reply flushed before we started waiting — used below to detect that
+    // the turn we waited out has actually reached the transcript file.
+    const boundaryEntry = await findLastSessionEntry(targetSlug, sessionId, isReturnableAssistantEntry)
     try {
       // 'timeout' falls through: return the transcript so far with status
       // 'running'. Sync get-transcript is a bounded long-poll the caller can
       // repeat, not an unbounded wait — an unbounded wait would outlive the
       // container's 300s fetch header timeout and surface as a retry-inducing
       // network error. Other failures stay hard errors.
-      await waitForTurnWithinBudget(sessionId, syncDeadline)
+      const outcome = await waitForTurnWithinBudget(sessionId, syncDeadline)
+      if (outcome === 'completed') {
+        // The turn's 'result' event clears isActive before its final assistant
+        // entry hits the JSONL file. Reconcile (bounded, ~5s) until an entry
+        // newer than the pre-wait boundary appears, so an "idle" response
+        // doesn't ship a transcript missing the reply it waited for.
+        await readLastAssistantMessage(targetSlug, sessionId, boundaryEntry?.uuid)
+      }
     } catch (error) {
       return c.json({
         error: `Session did not idle: ${error instanceof Error ? error.message : String(error)}`,
@@ -648,10 +685,13 @@ const invokeBodySchema = z.object({
 })
 
 xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
-  // Stamp the sync budget before any slow pre-work (policy review, container
-  // startup, session creation) so the total response time stays under the
-  // container fetch's 300s header timeout even when delivery itself was slow.
+  // Stamp both clocks before any slow pre-work (policy review, container
+  // startup, session creation): the sync budget governs how long we wait for
+  // the turn, the delivery cutoff governs whether we deliver the prompt at all
+  // — so the total response time stays under the container fetch's 300s header
+  // timeout, and no prompt is delivered to a caller that already gave up.
   const syncDeadline = Date.now() + SYNC_WAIT_TIMEOUT_MS
+  const deliveryCutoff = Date.now() + DELIVERY_CUTOFF_MS
   const callerSlug = getCallerSlug(c)
   const { slug: rawTargetSlug, prompt, sessionId: existingSessionId, sync, _callerSessionId } = c.req.valid('json')
 
@@ -736,6 +776,20 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         }
         stage = 'ensure_running'
         const client = await containerManager.ensureRunning(targetSlug)
+        if (Date.now() > deliveryCutoff) {
+          console.warn('[x-agent] delivery cutoff exceeded before send; prompt not delivered', {
+            callerSlug,
+            targetSlug,
+            sessionId: existingSessionId,
+          })
+          return c.json({ error: deliveryCutoffError() }, 504)
+        }
+        // Last reply flushed before THIS prompt goes out — used to make sure a
+        // fast turn's answer isn't confused with the previous turn's while the
+        // new entry is still being written to the JSONL file.
+        const replyBoundary = sync
+          ? await findLastSessionEntry(targetSlug, existingSessionId, isReturnableAssistantEntry)
+          : null
         stage = 'subscribe'
         if (!messagePersister.isSubscribed(existingSessionId)) {
           await messagePersister.subscribeToSession(existingSessionId, client, existingSessionId, targetSlug)
@@ -787,7 +841,11 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
               error: syncWaitPromotedNote(SYNC_WAIT_TIMEOUT_MS),
             })
           }
-          const lastMessage = await readLastAssistantMessage(targetSlug, existingSessionId)
+          const lastMessage = await readLastAssistantMessage(
+            targetSlug,
+            existingSessionId,
+            replyBoundary?.uuid,
+          )
           return c.json({
             sessionId: existingSessionId,
             status: 'completed',
@@ -810,6 +868,15 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         ? randomUUID()
         : undefined
 
+      // createSession delivers the prompt (initialMessage) — same cutoff rule
+      // as sendMessage above.
+      if (Date.now() > deliveryCutoff) {
+        console.warn('[x-agent] delivery cutoff exceeded before create; prompt not delivered', {
+          callerSlug,
+          targetSlug,
+        })
+        return c.json({ error: deliveryCutoffError() }, 504)
+      }
       stage = 'create_session'
       const containerSession = await client.createSession({
         availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -516,6 +516,50 @@ function deliveryCutoffError(): string {
   )
 }
 
+function lateDeliveryRevokedError(): string {
+  return (
+    `Target agent took too long to start the session (over ${Math.round(DELIVERY_CUTOFF_MS / 1000)}s total). ` +
+    'The invocation was cancelled and any late-created session is revoked, so nothing is running — ' +
+    'it is safe to retry; prefer sync=false.'
+  )
+}
+
+const DEADLINE = Symbol('deadline')
+
+// Race a promise against an absolute deadline. The losing promise keeps
+// running — callers that receive DEADLINE must decide what to do when (or if)
+// it eventually settles, and must attach their own rejection handler to it.
+async function raceDeadline<T>(promise: Promise<T>, deadline: number): Promise<T | typeof DEADLINE> {
+  const remainingMs = deadline - Date.now()
+  if (remainingMs <= 0) return DEADLINE
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof DEADLINE>((resolve) => {
+        timer = setTimeout(() => resolve(DEADLINE), remainingMs)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+// Bounds the persister's stream attach — its WebSocket `ready` promise has no
+// timeout of its own, so a wedged container would otherwise hold the caller's
+// fetch open past its 300s header timeout.
+const SUBSCRIBE_TIMEOUT_MS = Number(process.env.X_AGENT_SUBSCRIBE_TIMEOUT_MS) || 30_000
+
+async function subscribeWithTimeout(subscribe: Promise<void>): Promise<void> {
+  const result = await raceDeadline(subscribe, Date.now() + SUBSCRIBE_TIMEOUT_MS)
+  if (result === DEADLINE) {
+    // The stalled attach may still settle later; swallow its rejection so a
+    // late failure doesn't become an unhandled rejection.
+    subscribe.catch(() => {})
+    throw new Error(`Timed out attaching to session stream after ${SUBSCRIBE_TIMEOUT_MS}ms`)
+  }
+}
+
 // Matched by name rather than instanceof: the persister module is wholesale-
 // mocked in many test suites, and an instanceof against a possibly-undefined
 // mock export throws instead of returning false.
@@ -639,11 +683,20 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
       // container's 300s fetch header timeout and surface as a retry-inducing
       // network error. Other failures stay hard errors.
       const outcome = await waitForTurnWithinBudget(sessionId, syncDeadline)
-      if (outcome === 'completed') {
-        // The turn's 'result' event clears isActive before its final assistant
-        // entry hits the JSONL file. Reconcile (bounded, ~5s) until an entry
-        // newer than the pre-wait boundary appears, so an "idle" response
-        // doesn't ship a transcript missing the reply it waited for.
+      // The turn's 'result' event clears isActive before its final assistant
+      // entry hits the JSONL file. When the turn we observed running has ended
+      // — the wait said so, or it timed out and the turn ended in the gap
+      // before the status read below — reconcile (bounded, ~5s) until an entry
+      // newer than the pre-wait boundary appears, so an "idle" response
+      // doesn't ship a transcript missing the reply it waited for.
+      //
+      // Deliberately gated on activity observed IN THIS REQUEST: the JSONL is
+      // written by the container process, so the host has no write queue to
+      // barrier on, and reconciling on every idle response would burn the full
+      // poll budget on sessions that are simply idle. A session that went idle
+      // just before the isSessionActive check above keeps plain read-what's-
+      // flushed semantics.
+      if (outcome === 'completed' || !messagePersister.isSessionActive(sessionId)) {
         await readLastAssistantMessage(targetSlug, sessionId, boundaryEntry?.uuid)
       }
     } catch (error) {
@@ -776,14 +829,6 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         }
         stage = 'ensure_running'
         const client = await containerManager.ensureRunning(targetSlug)
-        if (Date.now() > deliveryCutoff) {
-          console.warn('[x-agent] delivery cutoff exceeded before send; prompt not delivered', {
-            callerSlug,
-            targetSlug,
-            sessionId: existingSessionId,
-          })
-          return c.json({ error: deliveryCutoffError() }, 504)
-        }
         // Last reply flushed before THIS prompt goes out — used to make sure a
         // fast turn's answer isn't confused with the previous turn's while the
         // new entry is still being written to the JSONL file.
@@ -792,7 +837,21 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
           : null
         stage = 'subscribe'
         if (!messagePersister.isSubscribed(existingSessionId)) {
-          await messagePersister.subscribeToSession(existingSessionId, client, existingSessionId, targetSlug)
+          await subscribeWithTimeout(
+            messagePersister.subscribeToSession(existingSessionId, client, existingSessionId, targetSlug),
+          )
+        }
+        // Checked AFTER every unbounded pre-send await (container startup and
+        // the stream attach above) so only fast local writes remain between
+        // here and sendMessage — a check followed by a slow await could still
+        // deliver to a caller whose fetch died at the 300s header timeout.
+        if (Date.now() > deliveryCutoff) {
+          console.warn('[x-agent] delivery cutoff exceeded before send; prompt not delivered', {
+            callerSlug,
+            targetSlug,
+            sessionId: existingSessionId,
+          })
+          return c.json({ error: deliveryCutoffError() }, 504)
         }
         messagePersister.markSessionActive(existingSessionId, targetSlug)
         stage = 'send_message'
@@ -878,7 +937,12 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         return c.json({ error: deliveryCutoffError() }, 504)
       }
       stage = 'create_session'
-      const containerSession = await client.createSession({
+      // createSession IS the delivery (initialMessage carries the prompt) and
+      // cannot be cancelled mid-flight, so race it against the cutoff: if it
+      // lands after the caller's fetch is already dead, revoke the session the
+      // moment it materializes instead of leaving a ghost run for the caller's
+      // retry to duplicate.
+      const createPromise = client.createSession({
         availableEnvVars: availableEnvVars.length > 0 ? availableEnvVars : undefined,
         initialMessage: prompt,
         ...(initialMessageUuid ? { initialMessageUuid } : {}),
@@ -894,6 +958,25 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         customEnvVars: Object.keys(customEnvVars).length > 0 ? customEnvVars : undefined,
         maxBrowserTabs: getSettings().app?.maxBrowserTabs,
       })
+      const created = await raceDeadline(createPromise, deliveryCutoff)
+      if (created === DEADLINE) {
+        console.warn('[x-agent] delivery cutoff exceeded during create; late session will be revoked', {
+          callerSlug,
+          targetSlug,
+        })
+        void createPromise.then(
+          (lateSession) =>
+            client.deleteSession(lateSession.id).catch((cleanupErr) => {
+              console.error('[x-agent] failed to revoke late-created session', {
+                sessionId: lateSession.id,
+                error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+              })
+            }),
+          () => {}, // create itself failed — nothing to revoke
+        )
+        return c.json({ error: lateDeliveryRevokedError() }, 504)
+      }
+      const containerSession = created
       const newSessionId = containerSession.id
       await reserveSessionOwnership(targetSlug, newSessionId)
       // Mark active before any await so waitForIdle sees state if result arrives early.
@@ -952,7 +1035,38 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       }
 
       stage = 'subscribe'
-      await messagePersister.subscribeToSession(newSessionId, client, newSessionId, targetSlug)
+      try {
+        await subscribeWithTimeout(
+          messagePersister.subscribeToSession(newSessionId, client, newSessionId, targetSlug),
+        )
+      } catch (subscribeErr) {
+        const message = subscribeErr instanceof Error ? subscribeErr.message : String(subscribeErr)
+        console.error('[x-agent] invoke failed', {
+          callerSlug,
+          targetSlug,
+          sessionId: newSessionId,
+          stage,
+          error: message,
+        })
+        captureException(subscribeErr, {
+          tags: { ...X_AGENT_SENTRY, stage },
+          extra: { callerSlug, targetSlug, sessionId: newSessionId },
+        })
+        // Without the stream attach nothing would persist this session's
+        // transcript — it would run as an invisible ghost. Revoke it, same
+        // remediation as a failed registration above.
+        await client.deleteSession(newSessionId).catch((cleanupErr) => {
+          console.error('[x-agent] failed to clean up orphaned container session', {
+            sessionId: newSessionId,
+            error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          })
+        })
+        if (authorRecorded && initialMessageUuid) {
+          await deleteMessageAuthorBestEffort(initialMessageUuid)
+        }
+        messagePersister.unsubscribeFromSession(newSessionId)
+        return c.json({ error: `Failed to attach to invoked session: ${message}` }, 500)
+      }
       if (containerSession.slashCommands && containerSession.slashCommands.length > 0) {
         messagePersister.setSlashCommands(newSessionId, containerSession.slashCommands)
       }

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -476,6 +476,29 @@ function compactMessage(entry: JsonlMessageEntry | JsonlSystemEntry): {
 const READ_RETRY_ATTEMPTS = Number(process.env.X_AGENT_READ_RETRY_ATTEMPTS) || 10
 const READ_RETRY_INTERVAL_MS = Number(process.env.X_AGENT_READ_RETRY_INTERVAL_MS) || 500
 
+// Sync x-agent calls hold the HTTP response open with zero bytes written until
+// the target turn completes, and the container's fetch (undici) aborts any
+// request whose response headers don't arrive within 300s ("fetch failed").
+// Cap the sync wait well under that cliff: sync is meant for fast turns, so a
+// slow turn promotes to the async contract (status 'running' + session id)
+// instead of dying as a network error that invites the caller to retry.
+const SYNC_WAIT_TIMEOUT_MS = Number(process.env.X_AGENT_SYNC_WAIT_TIMEOUT_MS) || 120_000
+
+// Matched by name rather than instanceof: the persister module is wholesale-
+// mocked in many test suites, and an instanceof against a possibly-undefined
+// mock export throws instead of returning false.
+function isWaitForIdleTimeout(error: unknown): boolean {
+  return error instanceof Error && error.name === 'WaitForIdleTimeoutError'
+}
+
+function syncWaitPromotedNote(timeoutMs: number): string {
+  return (
+    `Sync wait timed out after ${Math.round(timeoutMs / 1000)}s, but the target agent is still ` +
+    'working on this prompt. Do NOT re-invoke — that would start a duplicate run. ' +
+    'Poll get_agent_session_transcript with this session_id to retrieve the result.'
+  )
+}
+
 async function readLastAssistantMessage(
   targetSlug: string,
   sessionId: string,
@@ -531,11 +554,18 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
 
   if (sync && messagePersister.isSessionActive(sessionId)) {
     try {
-      await messagePersister.waitForIdle(sessionId)
+      await messagePersister.waitForIdle(sessionId, { timeoutMs: SYNC_WAIT_TIMEOUT_MS })
     } catch (error) {
-      return c.json({
-        error: `Session did not idle: ${error instanceof Error ? error.message : String(error)}`,
-      }, 504)
+      // Still running past the sync cap: fall through and return the transcript
+      // so far with status 'running'. Sync get-transcript is a bounded long-poll
+      // the caller can repeat, not an unbounded wait — an unbounded wait would
+      // outlive the container's 300s fetch header timeout and surface as a
+      // retry-inducing network error. Other failures stay hard errors.
+      if (!isWaitForIdleTimeout(error)) {
+        return c.json({
+          error: `Session did not idle: ${error instanceof Error ? error.message : String(error)}`,
+        }, 504)
+      }
     }
   }
 
@@ -686,12 +716,17 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         if (sync) {
           try {
             stage = 'wait_for_idle'
-            await messagePersister.waitForIdle(existingSessionId)
+            await messagePersister.waitForIdle(existingSessionId, { timeoutMs: SYNC_WAIT_TIMEOUT_MS })
           } catch (error) {
+            // Timeout means the target is simply still working — promote to the
+            // async contract with explicit guidance so the caller polls instead
+            // of re-invoking (a re-invoke duplicates the whole run).
             return c.json({
               sessionId: existingSessionId,
               status: 'running',
-              error: error instanceof Error ? error.message : String(error),
+              error: isWaitForIdleTimeout(error)
+                ? syncWaitPromotedNote(SYNC_WAIT_TIMEOUT_MS)
+                : error instanceof Error ? error.message : String(error),
             })
           }
           const lastMessage = await readLastAssistantMessage(targetSlug, existingSessionId)
@@ -800,12 +835,17 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       if (sync) {
         try {
           stage = 'wait_for_idle'
-          await messagePersister.waitForIdle(newSessionId)
+          await messagePersister.waitForIdle(newSessionId, { timeoutMs: SYNC_WAIT_TIMEOUT_MS })
         } catch (error) {
+          // Timeout means the target is simply still working — promote to the
+          // async contract with explicit guidance so the caller polls instead
+          // of re-invoking (a re-invoke duplicates the whole run).
           return c.json({
             sessionId: newSessionId,
             status: 'running',
-            error: error instanceof Error ? error.message : String(error),
+            error: isWaitForIdleTimeout(error)
+              ? syncWaitPromotedNote(SYNC_WAIT_TIMEOUT_MS)
+              : error instanceof Error ? error.message : String(error),
           })
         }
         const lastMessage = await readLastAssistantMessage(targetSlug, newSessionId)

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -482,13 +482,59 @@ const READ_RETRY_INTERVAL_MS = Number(process.env.X_AGENT_READ_RETRY_INTERVAL_MS
 // Cap the sync wait well under that cliff: sync is meant for fast turns, so a
 // slow turn promotes to the async contract (status 'running' + session id)
 // instead of dying as a network error that invites the caller to retry.
-const SYNC_WAIT_TIMEOUT_MS = Number(process.env.X_AGENT_SYNC_WAIT_TIMEOUT_MS) || 120_000
+//
+// The budget is end-to-end from handler entry, not from when waitForIdle
+// starts: policy review and container startup happen first and can be slow,
+// and a wait that ignored them could still push the total response time past
+// the transport cliff.
+const SYNC_WAIT_TIMEOUT_DEFAULT_MS = 120_000
+// Ceiling for the env override — at or past the 300s transport cliff the
+// override would restore the exact failure this timeout exists to prevent.
+const SYNC_WAIT_TIMEOUT_MAX_MS = 240_000
+
+// Exported for unit tests.
+export function resolveSyncWaitTimeoutMs(raw: string | undefined): number {
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return SYNC_WAIT_TIMEOUT_DEFAULT_MS
+  return Math.min(parsed, SYNC_WAIT_TIMEOUT_MAX_MS)
+}
+
+const SYNC_WAIT_TIMEOUT_MS = resolveSyncWaitTimeoutMs(process.env.X_AGENT_SYNC_WAIT_TIMEOUT_MS)
 
 // Matched by name rather than instanceof: the persister module is wholesale-
 // mocked in many test suites, and an instanceof against a possibly-undefined
 // mock export throws instead of returning false.
 function isWaitForIdleTimeout(error: unknown): boolean {
   return error instanceof Error && error.name === 'WaitForIdleTimeoutError'
+}
+
+/**
+ * Wait for the target turn to finish within what's left of the caller's sync
+ * budget (deadline is stamped at handler entry). Returns 'timeout' when the
+ * budget is exhausted — before or during the wait — and rethrows any other
+ * waitForIdle failure.
+ *
+ * requireActiveFirst is off: every sync caller marks the session active before
+ * the prompt is delivered (invoke) or checks isSessionActive just before
+ * waiting (get-transcript), so an inactive session here means the turn already
+ * finished — resolving immediately is correct, not a startup race.
+ */
+async function waitForTurnWithinBudget(
+  sessionId: string,
+  deadline: number,
+): Promise<'completed' | 'timeout'> {
+  const remainingMs = deadline - Date.now()
+  if (remainingMs <= 0) return 'timeout'
+  try {
+    await messagePersister.waitForIdle(sessionId, {
+      timeoutMs: remainingMs,
+      requireActiveFirst: false,
+    })
+    return 'completed'
+  } catch (error) {
+    if (isWaitForIdleTimeout(error)) return 'timeout'
+    throw error
+  }
 }
 
 function syncWaitPromotedNote(timeoutMs: number): string {
@@ -526,6 +572,9 @@ async function readLastAssistantMessage(
 }
 
 xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), async (c) => {
+  // Stamp the sync budget before any slow pre-work (policy review can block on
+  // a human decision) so the total response time stays under the transport cap.
+  const syncDeadline = Date.now() + SYNC_WAIT_TIMEOUT_MS
   const callerSlug = getCallerSlug(c)
   const { slug: rawTargetSlug, sessionId, sync } = c.req.valid('json')
 
@@ -554,18 +603,16 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
 
   if (sync && messagePersister.isSessionActive(sessionId)) {
     try {
-      await messagePersister.waitForIdle(sessionId, { timeoutMs: SYNC_WAIT_TIMEOUT_MS })
+      // 'timeout' falls through: return the transcript so far with status
+      // 'running'. Sync get-transcript is a bounded long-poll the caller can
+      // repeat, not an unbounded wait — an unbounded wait would outlive the
+      // container's 300s fetch header timeout and surface as a retry-inducing
+      // network error. Other failures stay hard errors.
+      await waitForTurnWithinBudget(sessionId, syncDeadline)
     } catch (error) {
-      // Still running past the sync cap: fall through and return the transcript
-      // so far with status 'running'. Sync get-transcript is a bounded long-poll
-      // the caller can repeat, not an unbounded wait — an unbounded wait would
-      // outlive the container's 300s fetch header timeout and surface as a
-      // retry-inducing network error. Other failures stay hard errors.
-      if (!isWaitForIdleTimeout(error)) {
-        return c.json({
-          error: `Session did not idle: ${error instanceof Error ? error.message : String(error)}`,
-        }, 504)
-      }
+      return c.json({
+        error: `Session did not idle: ${error instanceof Error ? error.message : String(error)}`,
+      }, 504)
     }
   }
 
@@ -601,6 +648,10 @@ const invokeBodySchema = z.object({
 })
 
 xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
+  // Stamp the sync budget before any slow pre-work (policy review, container
+  // startup, session creation) so the total response time stays under the
+  // container fetch's 300s header timeout even when delivery itself was slow.
+  const syncDeadline = Date.now() + SYNC_WAIT_TIMEOUT_MS
   const callerSlug = getCallerSlug(c)
   const { slug: rawTargetSlug, prompt, sessionId: existingSessionId, sync, _callerSessionId } = c.req.valid('json')
 
@@ -714,19 +765,26 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         }
 
         if (sync) {
+          stage = 'wait_for_idle'
+          let outcome: 'completed' | 'timeout'
           try {
-            stage = 'wait_for_idle'
-            await messagePersister.waitForIdle(existingSessionId, { timeoutMs: SYNC_WAIT_TIMEOUT_MS })
+            outcome = await waitForTurnWithinBudget(existingSessionId, syncDeadline)
           } catch (error) {
-            // Timeout means the target is simply still working — promote to the
-            // async contract with explicit guidance so the caller polls instead
-            // of re-invoking (a re-invoke duplicates the whole run).
             return c.json({
               sessionId: existingSessionId,
               status: 'running',
-              error: isWaitForIdleTimeout(error)
-                ? syncWaitPromotedNote(SYNC_WAIT_TIMEOUT_MS)
-                : error instanceof Error ? error.message : String(error),
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+          if (outcome === 'timeout') {
+            // Budget exhausted (whether before or during the wait) means the
+            // target is simply still working — promote to the async contract
+            // with explicit guidance so the caller polls instead of re-invoking
+            // (a re-invoke duplicates the whole run).
+            return c.json({
+              sessionId: existingSessionId,
+              status: 'running',
+              error: syncWaitPromotedNote(SYNC_WAIT_TIMEOUT_MS),
             })
           }
           const lastMessage = await readLastAssistantMessage(targetSlug, existingSessionId)
@@ -833,19 +891,26 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       }
 
       if (sync) {
+        stage = 'wait_for_idle'
+        let outcome: 'completed' | 'timeout'
         try {
-          stage = 'wait_for_idle'
-          await messagePersister.waitForIdle(newSessionId, { timeoutMs: SYNC_WAIT_TIMEOUT_MS })
+          outcome = await waitForTurnWithinBudget(newSessionId, syncDeadline)
         } catch (error) {
-          // Timeout means the target is simply still working — promote to the
-          // async contract with explicit guidance so the caller polls instead
-          // of re-invoking (a re-invoke duplicates the whole run).
           return c.json({
             sessionId: newSessionId,
             status: 'running',
-            error: isWaitForIdleTimeout(error)
-              ? syncWaitPromotedNote(SYNC_WAIT_TIMEOUT_MS)
-              : error instanceof Error ? error.message : String(error),
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+        if (outcome === 'timeout') {
+          // Budget exhausted (whether before or during the wait) means the
+          // target is simply still working — promote to the async contract
+          // with explicit guidance so the caller polls instead of re-invoking
+          // (a re-invoke duplicates the whole run).
+          return c.json({
+            sessionId: newSessionId,
+            status: 'running',
+            error: syncWaitPromotedNote(SYNC_WAIT_TIMEOUT_MS),
           })
         }
         const lastMessage = await readLastAssistantMessage(targetSlug, newSessionId)

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -173,7 +173,7 @@ vi.mock('./container-manager', () => ({
 }))
 
 // Import after mocks are set up
-import { messagePersister, redactStreamedToolInput } from './message-persister'
+import { messagePersister, redactStreamedToolInput, WaitForIdleTimeoutError } from './message-persister'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { finalizeAutomationStatus, getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 
@@ -5804,9 +5804,15 @@ describe('MessagePersister', () => {
       // Once the session is active, observeMs no longer applies — timeoutMs is
       // the stop-gap. Verifies the timeout branch (not the never-active branch).
       messagePersister.markSessionActive(WAIT_SESSION, AGENT_SLUG)
-      await expect(
-        messagePersister.waitForIdle(WAIT_SESSION, { timeoutMs: 200 }),
-      ).rejects.toThrow(/timeout after 200ms/)
+      const err: unknown = await messagePersister
+        .waitForIdle(WAIT_SESSION, { timeoutMs: 200 })
+        .then(() => null, (e: unknown) => e)
+      expect(err).toBeInstanceOf(WaitForIdleTimeoutError)
+      // The x-agent routes distinguish timeout from other failures by error
+      // NAME (their tests mock this module wholesale, so instanceof is out).
+      // If this name changes, sync invoke stops promoting to async on timeout.
+      expect((err as Error).name).toBe('WaitForIdleTimeoutError')
+      expect((err as Error).message).toMatch(/timeout after 200ms/)
     })
 
     it('resolves once an active session goes idle (and preserves isActive across subscribe)', async () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -257,6 +257,16 @@ export function redactStreamedToolInput(toolName: string | undefined, partialInp
   return partialInput.replace(/("secret"\s*:\s*")(?:\\.|[^"\\])*/g, '$1***')
 }
 
+// Thrown by waitForIdle when the session is still active past timeoutMs.
+// Callers use this to tell "target is still working" (recoverable — poll later)
+// apart from genuine failures like "session never became active".
+export class WaitForIdleTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`waitForIdle timeout after ${timeoutMs}ms`)
+    this.name = 'WaitForIdleTimeoutError'
+  }
+}
+
 // TODO this file is too big, this class is HUGE. Needs breaking up
 class MessagePersister {
   private streamingStates: Map<string, StreamingState> = new Map()
@@ -619,7 +629,7 @@ class MessagePersister {
         }
         if (Date.now() - startedAt > timeoutMs) {
           cleanup()
-          reject(new Error(`waitForIdle timeout after ${timeoutMs}ms`))
+          reject(new WaitForIdleTimeoutError(timeoutMs))
           return
         }
         timer = setTimeout(tick, 250)


### PR DESCRIPTION
## Problem

A sync `invoke_agent` call against a slow target failed after exactly ~5 minutes with `Network error calling x-agent invoke: fetch failed`, even though the invoked session was running fine. The calling agent then re-invoked, spawning a duplicate run — a retry storm in the making.

Root cause: the sync paths in `/api/x-agent/invoke` and `/api/x-agent/get-transcript` hold the HTTP response open with **zero bytes written** until `waitForIdle` resolves (default 10 min), while the container's bare `fetch` (Node ≥22 / undici) aborts any request whose response headers don't arrive within **300 s**. Any target turn longer than 5 minutes was guaranteed to surface as a retry-inducing network error, and since the host never sees the disconnect, the original run kept going — so every retry duplicated the whole job.

## Fix

Sync is meant for fast turns, so a slow turn now promotes to the async contract instead of erroring:

- `waitForIdle` rejects its timeout branch with a typed `WaitForIdleTimeoutError` so callers can tell "target still working" apart from real failures.
- Both `/invoke` sync branches cap the wait at **120 s** (`SYNC_WAIT_TIMEOUT_MS`, env-overridable) — safely under the 300 s undici cliff. On timeout they return `{sessionId, status: 'running'}` with explicit guidance in the existing `error` field: *do NOT re-invoke, poll `get_agent_session_transcript`*. Reusing the `error` field keeps already-deployed containers compatible (they render it as `note:`).
- `/get-transcript` sync becomes a bounded long-poll: same 120 s cap; on timeout it returns the transcript-so-far with `status: 'running'` (200) so the caller can call again, instead of a 504. Non-timeout failures still 504.
- The route matches the timeout by `error.name` rather than `instanceof`: many test suites mock the persister module wholesale, and `instanceof` against a missing mock export throws. The persister's own test pins the class name so the contract can't drift silently.
- Container tool descriptions (`invoke_agent`, `get_agent_session_transcript`) now document the ~2-minute cap, the promotion behavior, and the poll-don't-re-invoke rule; also fixed a stale `get_session_transcript` tool-name reference.

The host-side cap alone already eliminates the "fetch failed" mode for containers built before this change, since no sync response can outlive 300 s anymore.

## Testing

- `x-agent.test.ts` 65/65: new tests for both invoke promotion paths (guidance text + `timeoutMs: 120_000` cap asserted), get-transcript timeout long-poll (200 + transcript-so-far), and the non-timeout 504 path. Timeout errors in tests are built by name, not imported, so they exercise the wire contract independent of the fix.
- `message-persister.test.ts` 272/272: timeout rejection now asserted to carry the `WaitForIdleTimeoutError` class and name.
- `npx tsc --noEmit` and eslint clean on touched files.

https://claude.ai/code/session_015mcU8vDZ7D6BkixhPnDNpr