### PR TITLE
Replace the agent settings dialog with a compact header popover

### DIFF
--- a/e2e/live/cloud-electron/run.mjs
+++ b/e2e/live/cloud-electron/run.mjs
@@ -435,8 +435,12 @@ try {
   })
 
   await check('D2 the agent directory action degrades to copy-the-path', async () => {
+    // The directory action lives in the agent header's settings popover
+    // (moved there from the sidebar context menu).
     const row = page.locator('[data-testid^="agent-item-"]', { hasText: CLOUD_AGENT }).first()
-    await row.click({ button: 'right' })
+    await row.click()
+    await page.waitForSelector('[data-testid="agent-settings-button"]', { timeout: 15_000 })
+    await page.click('[data-testid="agent-settings-button"]')
     await page.waitForSelector('[data-testid="open-agent-directory-item"]', { timeout: 15_000 })
     const label = await page.locator('[data-testid="open-agent-directory-item"]').innerText()
     expect(

--- a/e2e/pages/agent.page.ts
+++ b/e2e/pages/agent.page.ts
@@ -140,11 +140,11 @@ export class AgentPage {
   }
 
   /**
-   * Open the agent settings dialog
+   * Open the agent settings popover (the gear on the agent header)
    */
   async openSettings() {
     await this.page.locator('[data-testid="agent-settings-button"]').click()
-    await expect(this.page.locator('[data-testid="agent-settings-dialog"]')).toBeVisible()
+    await expect(this.page.locator('[data-testid="agent-settings-popover"]')).toBeVisible()
   }
 
   /**
@@ -159,8 +159,8 @@ export class AgentPage {
     // Confirm deletion - use a longer timeout since deletion may take time
     await this.page.locator('[data-testid="confirm-button"]').click()
 
-    // Wait for settings dialog to close (with longer timeout for deletion to complete)
-    await expect(this.page.locator('[data-testid="agent-settings-dialog"]')).not.toBeVisible({ timeout: 10000 })
+    // Wait for the confirm dialog to close (with longer timeout for deletion to complete)
+    await expect(this.page.locator('[data-testid="confirm-button"]')).not.toBeVisible({ timeout: 10000 })
   }
 
   /**

--- a/e2e/pages/agent.page.ts
+++ b/e2e/pages/agent.page.ts
@@ -157,10 +157,10 @@ export class AgentPage {
     await this.page.locator('[data-testid="delete-agent-button"]').click()
 
     // Confirm deletion - use a longer timeout since deletion may take time
-    await this.page.locator('[data-testid="confirm-button"]').click()
+    await this.page.locator('[data-testid="confirm-delete-agent-button"]').click()
 
     // Wait for the confirm dialog to close (with longer timeout for deletion to complete)
-    await expect(this.page.locator('[data-testid="confirm-button"]')).not.toBeVisible({ timeout: 10000 })
+    await expect(this.page.locator('[data-testid="confirm-delete-agent-button"]')).not.toBeVisible({ timeout: 10000 })
   }
 
   /**

--- a/e2e/specs/a11y-audit.spec.ts
+++ b/e2e/specs/a11y-audit.spec.ts
@@ -50,12 +50,12 @@ test.describe('Accessibility Audit', () => {
     expect(results.violations.filter(v => v.impact === 'critical')).toEqual([])
   })
 
-  test('agent settings dialog has no critical a11y violations', async ({ page }) => {
+  test('agent settings popover has no critical a11y violations', async ({ page }) => {
     const agentName = `A11y Settings Agent ${Date.now()}`
     await agentPage.createAgent(agentName)
 
     await page.locator('[data-testid="agent-settings-button"]').click()
-    await expect(page.locator('[data-testid="agent-settings-dialog"]')).toBeVisible()
+    await expect(page.locator('[data-testid="agent-settings-popover"]')).toBeVisible()
 
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])

--- a/e2e/specs/agent-rename.spec.ts
+++ b/e2e/specs/agent-rename.spec.ts
@@ -115,23 +115,25 @@ test.describe('Agent Rename', () => {
     await expect(page.locator('[data-testid^="agent-item-"]', { hasText: unsavedName })).toHaveCount(0)
   })
 
-  test('control: can type spaces in agent name input when settings opened via button without saving', async ({ page, request }, testInfo) => {
+  test('control: can type spaces in rename input when opened via settings popover without saving', async ({ page, request }, testInfo) => {
     const agent = await createAndOpenAgent(request, page, testInfo, 'Rename Button')
     const unsavedName = uniqueName(testInfo, 'Button Name With Spaces')
 
+    // Gear popover → "Rename agent" puts the inline title into edit mode
     await agentPage.openSettings()
+    await page.locator('[data-testid="rename-agent-button"]').click()
 
-    const dialog = page.locator('[data-testid="agent-settings-dialog"]')
-    const nameInput = page.locator('#agent-name')
+    const nameInput = page.locator('[data-testid="agent-name-input"]')
     await expect(nameInput).toBeVisible()
+    await expect(nameInput).toBeFocused()
 
     await nameInput.clear()
-    await nameInput.click()
     await nameInput.pressSequentially(unsavedName)
     await expect(nameInput).toHaveValue(unsavedName)
 
-    await dialog.getByRole('button', { name: /^Cancel$/ }).click()
-    await expect(dialog).not.toBeVisible()
+    // Escape cancels without saving
+    await nameInput.press('Escape')
+    await expect(nameInput).not.toBeVisible()
 
     await expect(page.locator('[data-testid="agent-breadcrumb"]')).toHaveText(agent.name)
     await expectAgentNamed(request, agent, agent.name)

--- a/e2e/specs/agent-secrets.spec.ts
+++ b/e2e/specs/agent-secrets.spec.ts
@@ -196,7 +196,7 @@ test.describe('Agent Secrets (reach the container & persist)', () => {
       await page.locator('[data-testid="agent-settings-dialog"] [data-testid="delete-agent-button"]').click()
 
       const alertDialog = page.getByRole('alertdialog')
-      const confirmButton = page.locator('[data-testid="confirm-button"]')
+      const confirmButton = page.locator('[data-testid="confirm-delete-agent-button"]')
       await expectContainedIn(confirmButton, alertDialog)
 
       // Reachable controls are not enough: the name itself must wrap rather than paint

--- a/e2e/specs/agent-secrets.spec.ts
+++ b/e2e/specs/agent-secrets.spec.ts
@@ -184,12 +184,16 @@ test.describe('Agent Secrets (reach the container & persist)', () => {
     })
 
     await test.step('AlertDialogContent: an overlong agent name leaves Confirm reachable and wraps', async () => {
-      await agentPage.openSettings()
-      await page.locator('[data-testid="agent-settings-nav-general"]').click()
+      // The header gear is a popover now; the full settings dialog (whose
+      // delete confirm quotes the LIVE name field, unsaved) opens via the
+      // sidebar context menu.
+      await page.locator('[data-testid^="agent-item-"]', { hasText: agentName }).click({ button: 'right' })
+      await page.locator('[data-testid="agent-settings-item"]').click()
+      await expect(page.locator('[data-testid="agent-settings-dialog"]')).toBeVisible()
       // The confirmation quotes the live value of this field, so the dialog inflates
       // without the rename ever being saved.
       await page.locator('#agent-name').fill(longToken)
-      await page.locator('[data-testid="delete-agent-button"]').click()
+      await page.locator('[data-testid="agent-settings-dialog"] [data-testid="delete-agent-button"]').click()
 
       const alertDialog = page.getByRole('alertdialog')
       const confirmButton = page.locator('[data-testid="confirm-button"]')

--- a/src/renderer/components/agents/agent-context-menu.test.tsx
+++ b/src/renderer/components/agents/agent-context-menu.test.tsx
@@ -109,50 +109,6 @@ afterEach(() => {
   _resetApiTargetForTest()
 })
 
-describe('the agent directory action', () => {
-  it('asks this computer to open the folder when it runs the agent', async () => {
-    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
-
-    expect(screen.getByText('Show Agent Directory')).toBeInTheDocument()
-    await userEvent.click(screen.getByTestId('open-agent-directory-item'))
-
-    await waitFor(() =>
-      expect(mockApiFetch).toHaveBeenCalledWith(
-        '/api/agents/sales/open-directory',
-        expect.objectContaining({ body: JSON.stringify({ open: true }) }),
-      ),
-    )
-  })
-
-  it('never asks a cloud workspace to launch a file manager on its own host', async () => {
-    drive('cloud')
-    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
-
-    await userEvent.click(screen.getByTestId('open-agent-directory-item'))
-
-    await waitFor(() =>
-      expect(mockApiFetch).toHaveBeenCalledWith(
-        '/api/agents/sales/open-directory',
-        expect.objectContaining({ body: JSON.stringify({ open: false }) }),
-      ),
-    )
-  })
-
-  it('offers the copy-the-path action remotely, which is the part that works', async () => {
-    drive('cloud')
-    const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
-
-    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
-
-    expect(screen.getByText('Copy Agent Directory Path')).toBeInTheDocument()
-    expect(screen.queryByText('Show Agent Directory')).not.toBeInTheDocument()
-
-    await userEvent.click(screen.getByTestId('open-agent-directory-item'))
-    await waitFor(() => expect(writeText).toHaveBeenCalledWith('/srv/agents/sales'))
-  })
-})
-
 describe('moving an agent into a left-nav folder', () => {
   const FOLDERS = [
     { id: 'f1', name: 'Work' },

--- a/src/renderer/components/agents/agent-context-menu.test.tsx
+++ b/src/renderer/components/agents/agent-context-menu.test.tsx
@@ -70,7 +70,7 @@ vi.mock('@renderer/components/ui/context-menu', async () => {
   }
 })
 
-import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
 import { AgentContextMenu } from './agent-context-menu'

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -23,10 +23,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
-import { useAgents, useDeleteAgent, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
+import { useAgents, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
 import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { AgentSettingsDialog } from './agent-settings-dialog'
+import { DeleteAgentConfirmDialog } from './delete-agent-confirm-dialog'
 import { apiFetch } from '@renderer/lib/api'
 import { Settings, Trash2, LogOut, Move, FolderInput } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
@@ -68,9 +69,7 @@ export function AgentContextMenu({
   const [showSettingsDialog, setShowSettingsDialog] = useState(false)
   const [showNewFolderDialog, setShowNewFolderDialog] = useState(false)
   const [newFolderName, setNewFolderName] = useState('')
-  const [isDeleting, setIsDeleting] = useState(false)
   const [isLeaving, setIsLeaving] = useState(false)
-  const deleteAgent = useDeleteAgent()
   const navigate = useNavigate()
   // undefined when the menu is opened off the agent route (e.g. from the sidebar
   // list), so the up-nav only fires when we're actually viewing the agent being
@@ -155,22 +154,6 @@ export function AgentContextMenu({
     setShowNewFolderDialog(false)
     setNewFolderName('')
   }, [agent.slug, buildSections, newFolderName, updateSettings])
-
-  const handleDelete = async () => {
-    setIsDeleting(true)
-    try {
-      await deleteAgent.mutateAsync(agent.slug)
-      setShowDeleteDialog(false)
-      if (routeAgentId === agent.slug) {
-        void navigate({ to: '/' })
-      }
-    } catch (error) {
-      console.error('Failed to delete agent:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to delete agent')
-    } finally {
-      setIsDeleting(false)
-    }
-  }
 
   const handleLeave = async () => {
     setIsLeaving(true)
@@ -292,28 +275,12 @@ export function AgentContextMenu({
         onOpenChange={setShowSettingsDialog}
       />
 
-      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <AlertDialogContent data-testid="confirm-delete-agent-dialog">
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Agent</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete &quot;{agent.name}&quot;? This will permanently
-              delete the agent and all its sessions. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              data-testid="confirm-delete-agent-button"
-            >
-              {isDeleting ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteAgentConfirmDialog
+        agentSlug={agent.slug}
+        agentName={agent.name}
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+      />
 
       <AlertDialog open={showLeaveDialog} onOpenChange={setShowLeaveDialog}>
         <AlertDialogContent data-testid="confirm-leave-agent-dialog">

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -28,8 +28,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { AgentSettingsDialog } from './agent-settings-dialog'
 import { apiFetch } from '@renderer/lib/api'
-import { canUseHostFeatures } from '@renderer/lib/host-features'
-import { Settings, FolderOpen, Copy, Trash2, LogOut, Move, FolderInput } from 'lucide-react'
+import { Settings, Trash2, LogOut, Move, FolderInput } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Input } from '@renderer/components/ui/input'
 import { useUserSettings, useUpdateUserSettings, type UserSettingsData } from '@renderer/hooks/use-user-settings'
@@ -67,10 +66,8 @@ export function AgentContextMenu({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showLeaveDialog, setShowLeaveDialog] = useState(false)
   const [showSettingsDialog, setShowSettingsDialog] = useState(false)
-  const [showPathDialog, setShowPathDialog] = useState(false)
   const [showNewFolderDialog, setShowNewFolderDialog] = useState(false)
   const [newFolderName, setNewFolderName] = useState('')
-  const [agentPath, setAgentPath] = useState('')
   const [isDeleting, setIsDeleting] = useState(false)
   const [isLeaving, setIsLeaving] = useState(false)
   const deleteAgent = useDeleteAgent()
@@ -158,30 +155,6 @@ export function AgentContextMenu({
     setShowNewFolderDialog(false)
     setNewFolderName('')
   }, [agent.slug, buildSections, newFolderName, updateSettings])
-
-  // `open: true` makes the API run the file manager on ITS OWN host. That is
-  // what you want when the API is this computer; against a cloud workspace it
-  // asks the deployment to launch `open`/`explorer`/`xdg-open` somewhere nobody
-  // is looking. Remotely this becomes the copy-the-path action the web build
-  // already uses, which is the part that still works.
-  const canShowDirectory = canUseHostFeatures()
-
-  const handleDirectoryAction = useCallback(async () => {
-    const res = await apiFetch(`/api/agents/${agent.slug}/open-directory`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ open: canShowDirectory }),
-    })
-    if (!canShowDirectory && res.ok) {
-      const { path } = await res.json()
-      try {
-        await navigator.clipboard.writeText(path)
-      } catch {
-        setAgentPath(path)
-        setShowPathDialog(true)
-      }
-    }
-  }, [agent.slug, canShowDirectory])
 
   const handleDelete = async () => {
     setIsDeleting(true)
@@ -287,24 +260,6 @@ export function AgentContextMenu({
             <Settings className="h-4 w-4 mr-2" />
             Settings
           </ContextMenuItem>
-          {isOwner && (
-            <ContextMenuItem
-              onClick={handleDirectoryAction}
-              data-testid="open-agent-directory-item"
-            >
-              {canShowDirectory ? (
-                <>
-                  <FolderOpen className="h-4 w-4 mr-2" />
-                  Show Agent Directory
-                </>
-              ) : (
-                <>
-                  <Copy className="h-4 w-4 mr-2" />
-                  Copy Agent Directory Path
-                </>
-              )}
-            </ContextMenuItem>
-          )}
           {isOwner && (
             <ContextMenuItem
               className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -416,20 +371,6 @@ export function AgentContextMenu({
             >
               Create &amp; Move
             </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      <AlertDialog open={showPathDialog} onOpenChange={setShowPathDialog}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Agent Directory Path</AlertDialogTitle>
-            <AlertDialogDescription className="break-all font-mono text-sm select-all">
-              {agentPath}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Close</AlertDialogCancel>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -38,6 +38,7 @@ const mockDeleteAgentMutate = vi.fn()
 vi.mock('@renderer/hooks/use-agents', () => ({
   useAgent: () => ({ data: { ...testAgent, mounts: [] } }),
   useAgents: () => ({ data: [testAgent] }),
+  useRouteAgentId: () => 'test-agent',
   useUpdateAgent: () => ({
     mutate: mockUpdateAgentMutate,
     mutateAsync: mockUpdateAgentMutateAsync,
@@ -118,11 +119,6 @@ vi.mock('@renderer/context/nav-transient-context', () => ({
   NavTransientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
-// The agent-scoped settings dialogs render inside AgentHome. Stub them
-// — their internals aren't under test here and would pull in extra hooks.
-vi.mock('@renderer/components/agents/agent-settings-dialog', () => ({
-  AgentSettingsDialog: () => null,
-}))
 vi.mock('@renderer/components/agents/agent-context-menu', () => ({
   AgentContextMenu: ({ agent, children }: { agent: ApiAgent; children: React.ReactNode }) => (
     <div data-testid="agent-title-context-menu" data-agent-slug={agent.slug}>{children}</div>

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -3,7 +3,7 @@ import { useState, useRef, useMemo, useCallback, useEffect } from 'react'
 import { cn } from '@shared/lib/utils/cn'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
-import { ArrowUp, Loader2, Eye, Settings2, Maximize2, Minimize2, Search } from 'lucide-react'
+import { ArrowUp, Loader2, Eye, Maximize2, Minimize2, Search } from 'lucide-react'
 import { useCreateSession, useSessions } from '@renderer/hooks/use-sessions'
 import { useScheduledTasks } from '@renderer/hooks/use-scheduled-tasks'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
@@ -14,7 +14,7 @@ import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { useNavTransient } from '@renderer/context/nav-transient-context'
 import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
-import { AgentSettingsDialog } from '@renderer/components/agents/agent-settings-dialog'
+import { AgentSettingsPopover } from '@renderer/components/agents/agent-settings-popover'
 import { AgentSharePopover } from '@renderer/components/agents/agent-share-popover'
 import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
 import { SystemPromptDialog } from '@renderer/components/agents/system-prompt-dialog'
@@ -28,7 +28,7 @@ import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box
 import { useIsMobile } from '@renderer/hooks/use-mobile'
 import { ComposerOptions, useComposerOptions } from '@renderer/components/messages/composer-options'
 import { AgentDefaultFooter } from '@renderer/components/messages/agent-default-footer'
-import { InlineEditableTitle } from '@renderer/components/ui/inline-editable-title'
+import { InlineEditableTitle, type InlineEditableTitleHandle } from '@renderer/components/ui/inline-editable-title'
 import { HomeTriggers } from './home-triggers'
 import { HomeSkills } from './home-skills'
 import { HomeExtras } from './home-extras'
@@ -125,19 +125,12 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   // Tracks whether a name has already been assigned (e.g. by the voice agent)
   // so the post-submit deriveAgentName fallback doesn't clobber it.
   const nameAssignedRef = useRef(false)
-  // Agent-scoped settings dialogs — opened from the settings button and
-  // HomeExtras (system prompt). Secrets now have a standalone route; these
-  // settings remain local dialog state rather than global /settings routes.
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const [settingsTab, setSettingsTab] = useState<string | undefined>(undefined)
+  // Agent-scoped dialogs opened from HomeExtras. Header settings are a
+  // popover on the gear now; the sidebar context menu keeps the full dialog.
   const [systemPromptOpen, setSystemPromptOpen] = useState(false)
+  const titleRef = useRef<InlineEditableTitleHandle>(null)
   const handleOpenSettings = useCallback((tab?: string) => {
-    if (tab === 'system-prompt') {
-      setSystemPromptOpen(true)
-      return
-    }
-    setSettingsTab(tab)
-    setSettingsOpen(true)
+    if (tab === 'system-prompt') setSystemPromptOpen(true)
   }, [])
   const sessions = useMemo(() => {
     if (!Array.isArray(sessionsData)) return []
@@ -322,6 +315,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
             <AgentContextMenu agent={agent}>
               <div className="flex-1 min-w-0 cursor-context-menu">
                 <InlineEditableTitle
+                  ref={titleRef}
                   value={agent.name}
                   canEdit={isOwner}
                   isSaving={updateAgent.isPending}
@@ -345,15 +339,18 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                 />
               </div>
             </AgentContextMenu>
-            {/* Share (ACL + publish + export) lives on the header, not in
-                settings. Owners only; outside auth mode everyone is an owner
-                and the popover shows just the Publish/Export tabs. */}
+            {/* Share (ACL + publish) lives on the header, not in settings. Owners
+                only; outside auth mode everyone is an owner and the popover
+                shows just the Publish pane. */}
             {isOwner && <AgentSharePopover agentSlug={agent.slug} agentName={agent.name} />}
-            {/* AgentHome owns the settings dialog (no onOpenSettings prop), so the
-                gear opens the local handler rather than a parent-supplied one. */}
-            <Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={() => handleOpenSettings()} aria-label="Agent settings" data-testid="agent-settings-button">
-              <Settings2 className="h-4 w-4" />
-            </Button>
+            {/* Gear = compact settings popover; Rename delegates to the
+                InlineEditableTitle above via its imperative handle. */}
+            {isOwner && (
+              <AgentSettingsPopover
+                agent={agent}
+                onRename={() => titleRef.current?.startEditing()}
+              />
+            )}
           </ScrollAwarePageTitle>
           {isViewOnly ? (
             <div className="flex items-center justify-center gap-2 text-sm font-medium text-muted-foreground border rounded-lg p-6" data-testid="view-only-banner">
@@ -601,12 +598,6 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
       </div>
     </div>
 
-      <AgentSettingsDialog
-        agent={agent}
-        open={settingsOpen}
-        onOpenChange={(open) => { setSettingsOpen(open); if (!open) setSettingsTab(undefined) }}
-        initialTab={settingsTab}
-      />
       <SystemPromptDialog
         agent={agent}
         open={systemPromptOpen}

--- a/src/renderer/components/agents/agent-settings-popover.test.tsx
+++ b/src/renderer/components/agents/agent-settings-popover.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockApiFetch } = vi.hoisted(() => ({ mockApiFetch: vi.fn() }))
+vi.mock('@renderer/lib/api', () => ({ apiFetch: mockApiFetch }))
+
+vi.mock('@renderer/hooks/use-agents', () => ({
+  useDeleteAgent: () => ({ mutateAsync: vi.fn() }),
+  useRouteAgentId: () => undefined,
+}))
+vi.mock('@renderer/hooks/use-agent-preferences', () => ({
+  useAgentPreferences: () => ({ data: undefined }),
+  useUpdateAgentPreferences: () => ({ mutate: vi.fn() }),
+}))
+vi.mock('@renderer/hooks/use-settings', () => ({ useSettings: () => ({ data: undefined }) }))
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// Radix popovers portal their content and need real pointer plumbing jsdom
+// lacks; render trigger and content inline so the items are reachable.
+vi.mock('@renderer/components/ui/popover', () => ({
+  Popover: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({
+    children,
+    align,
+    onCloseAutoFocus,
+    ...props
+  }: { align?: string; onCloseAutoFocus?: unknown } & React.HTMLAttributes<HTMLDivElement>) => {
+    void align
+    void onCloseAutoFocus
+    return <div {...props}>{children}</div>
+  },
+}))
+
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
+import { AgentSettingsPopover } from './agent-settings-popover'
+
+/**
+ * `open: true` makes the API run the file manager on ITS OWN host. Right when
+ * the API is this computer; against a cloud workspace it asks the deployment to
+ * launch `open`/`explorer`/`xdg-open` where nobody is looking.
+ *
+ * (Moved here from agent-context-menu.test.tsx when the directory action moved
+ * from the sidebar context menu to the header settings popover.)
+ */
+
+const AGENT = { slug: 'sales', name: 'Sales', status: 'running' } as never
+
+function drive(target: 'local' | 'cloud') {
+  _resetApiTargetForTest() // the global setup already settled it to 'local'
+  setActiveTarget(target, null)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockApiFetch.mockResolvedValue({ ok: true, json: async () => ({ path: '/srv/agents/sales' }) })
+  window.electronAPI = { platform: 'darwin' } as never
+  drive('local')
+})
+
+afterEach(() => {
+  cleanup()
+  delete (window as { electronAPI?: unknown }).electronAPI
+  _resetApiTargetForTest()
+})
+
+describe('the agent directory action', () => {
+  it('asks this computer to open the folder when it runs the agent', async () => {
+    render(<AgentSettingsPopover agent={AGENT} onRename={vi.fn()} />)
+
+    expect(screen.getByText('Show Agent Directory')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('open-agent-directory-item'))
+
+    await waitFor(() =>
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        '/api/agents/sales/open-directory',
+        expect.objectContaining({ body: JSON.stringify({ open: true }) }),
+      ),
+    )
+  })
+
+  it('never asks a cloud workspace to launch a file manager on its own host', async () => {
+    drive('cloud')
+    render(<AgentSettingsPopover agent={AGENT} onRename={vi.fn()} />)
+
+    await userEvent.click(screen.getByTestId('open-agent-directory-item'))
+
+    await waitFor(() =>
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        '/api/agents/sales/open-directory',
+        expect.objectContaining({ body: JSON.stringify({ open: false }) }),
+      ),
+    )
+  })
+
+  it('offers the copy-the-path action remotely, which is the part that works', async () => {
+    drive('cloud')
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+    render(<AgentSettingsPopover agent={AGENT} onRename={vi.fn()} />)
+
+    expect(screen.getByText('Copy Agent Directory Path')).toBeInTheDocument()
+    expect(screen.queryByText('Show Agent Directory')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('open-agent-directory-item'))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('/srv/agents/sales'))
+  })
+})

--- a/src/renderer/components/agents/agent-settings-popover.tsx
+++ b/src/renderer/components/agents/agent-settings-popover.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { useNavigate } from '@tanstack/react-router'
-import { Copy, FolderOpen, Loader2, MoreVertical, Pencil, Timer, Trash2 } from 'lucide-react'
+import { Copy, FolderOpen, MoreVertical, Pencil, Timer, Trash2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -15,7 +13,8 @@ import {
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
 import { AgentAutoDeleteSelect } from '@renderer/components/settings/auto-delete-select'
-import { useDeleteAgent, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
+import { DeleteAgentConfirmDialog } from '@renderer/components/agents/delete-agent-confirm-dialog'
+import { type ApiAgent } from '@renderer/hooks/use-agents'
 import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { apiFetch } from '@renderer/lib/api'
@@ -35,16 +34,12 @@ interface AgentSettingsPopoverProps {
 export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverProps) {
   const [open, setOpen] = useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
-  const [isDeleting, setIsDeleting] = useState(false)
   // Set when Rename is clicked: the popover must not restore focus to the
   // gear on close, or it would steal it from the title input.
   const skipRestoreFocusRef = useRef(false)
-  const deleteAgent = useDeleteAgent()
   const { data: agentPrefs } = useAgentPreferences(agent.slug)
   const updatePrefs = useUpdateAgentPreferences(agent.slug)
   const { data: settings } = useSettings()
-  const navigate = useNavigate()
-  const routeAgentId = useRouteAgentId()
   const [showPathDialog, setShowPathDialog] = useState(false)
   const [agentPath, setAgentPath] = useState('')
 
@@ -71,20 +66,6 @@ export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverPr
       }
     }
   }, [agent.slug, canShowDirectory])
-
-  const handleDelete = async () => {
-    setIsDeleting(true)
-    try {
-      await deleteAgent.mutateAsync(agent.slug)
-      setDeleteConfirmOpen(false)
-      if (routeAgentId === agent.slug) void navigate({ to: '/' })
-    } catch (error) {
-      console.error('Failed to delete agent:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to delete agent')
-    } finally {
-      setIsDeleting(false)
-    }
-  }
 
   return (
     <>
@@ -179,35 +160,12 @@ export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverPr
       </Popover>
 
       {/* Outside the popover so it survives the popover closing */}
-      <AlertDialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Agent</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete &quot;{agent.name}&quot;? This will permanently delete
-              the agent and all its sessions, messages, and data. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              data-testid="confirm-button"
-            >
-              {isDeleting ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Deleting...
-                </>
-              ) : (
-                'Delete'
-              )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteAgentConfirmDialog
+        agentSlug={agent.slug}
+        agentName={agent.name}
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+      />
 
       {/* Clipboard-write fallback: surface the path for manual copying */}
       <AlertDialog open={showPathDialog} onOpenChange={setShowPathDialog}>

--- a/src/renderer/components/agents/agent-settings-popover.tsx
+++ b/src/renderer/components/agents/agent-settings-popover.tsx
@@ -103,7 +103,7 @@ export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverPr
         </PopoverTrigger>
         <PopoverContent
           align="end"
-          className="w-96 p-1.5"
+          className="w-96 p-1"
           onCloseAutoFocus={(e) => {
             if (skipRestoreFocusRef.current) {
               e.preventDefault()
@@ -161,7 +161,7 @@ export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverPr
             />
           </div>
 
-          <div className="my-1 border-t" />
+          <div className="-mx-1 my-1 border-t" />
 
           <button
             type="button"

--- a/src/renderer/components/agents/agent-settings-popover.tsx
+++ b/src/renderer/components/agents/agent-settings-popover.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { useNavigate } from '@tanstack/react-router'
+import { Copy, FolderOpen, Loader2, MoreVertical, Pencil, Timer, Trash2 } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import { AgentAutoDeleteSelect } from '@renderer/components/settings/auto-delete-select'
+import { useDeleteAgent, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
+import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
+import { useSettings } from '@renderer/hooks/use-settings'
+import { apiFetch } from '@renderer/lib/api'
+import { canUseHostFeatures } from '@renderer/lib/host-features'
+
+interface AgentSettingsPopoverProps {
+  agent: ApiAgent
+  /** Put the header's InlineEditableTitle into edit mode. */
+  onRename: () => void
+}
+
+/**
+ * Compact agent settings, popover-form: rename (delegates to the inline
+ * title), session auto-delete, and delete. Replaced the settings dialog on
+ * the agent header; the sidebar context menu still opens the full dialog.
+ */
+export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  // Set when Rename is clicked: the popover must not restore focus to the
+  // gear on close, or it would steal it from the title input.
+  const skipRestoreFocusRef = useRef(false)
+  const deleteAgent = useDeleteAgent()
+  const { data: agentPrefs } = useAgentPreferences(agent.slug)
+  const updatePrefs = useUpdateAgentPreferences(agent.slug)
+  const { data: settings } = useSettings()
+  const navigate = useNavigate()
+  const routeAgentId = useRouteAgentId()
+  const [showPathDialog, setShowPathDialog] = useState(false)
+  const [agentPath, setAgentPath] = useState('')
+
+  // `open: true` makes the API run the file manager on ITS OWN host — right
+  // when the API is this computer, wrong against a remote deployment, where
+  // this becomes the copy-the-path action instead (same logic as the sidebar
+  // context menu had before this moved here).
+  const canShowDirectory = canUseHostFeatures()
+
+  const handleDirectoryAction = useCallback(async () => {
+    const res = await apiFetch(`/api/agents/${agent.slug}/open-directory`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ open: canShowDirectory }),
+    })
+    if (!canShowDirectory && res.ok) {
+      const { path } = await res.json()
+      try {
+        await navigator.clipboard.writeText(path)
+        toast.success('Agent directory path copied')
+      } catch {
+        setAgentPath(path)
+        setShowPathDialog(true)
+      }
+    }
+  }, [agent.slug, canShowDirectory])
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    try {
+      await deleteAgent.mutateAsync(agent.slug)
+      setDeleteConfirmOpen(false)
+      if (routeAgentId === agent.slug) void navigate({ to: '/' })
+    } catch (error) {
+      console.error('Failed to delete agent:', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to delete agent')
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            size="icon"
+            variant="outline"
+            className="h-8 w-8 shrink-0"
+            aria-label="Agent settings"
+            data-testid="agent-settings-button"
+          >
+            <MoreVertical className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          className="w-96 p-1.5"
+          onCloseAutoFocus={(e) => {
+            if (skipRestoreFocusRef.current) {
+              e.preventDefault()
+              skipRestoreFocusRef.current = false
+            }
+          }}
+          data-testid="agent-settings-popover"
+        >
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent"
+            onClick={() => {
+              skipRestoreFocusRef.current = true
+              setOpen(false)
+              onRename()
+            }}
+            data-testid="rename-agent-button"
+          >
+            <Pencil className="h-4 w-4 shrink-0" />
+            Rename agent
+          </button>
+
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent"
+            onClick={() => {
+              setOpen(false)
+              void handleDirectoryAction()
+            }}
+            data-testid="open-agent-directory-item"
+          >
+            {canShowDirectory ? (
+              <>
+                <FolderOpen className="h-4 w-4 shrink-0" />
+                Show Agent Directory
+              </>
+            ) : (
+              <>
+                <Copy className="h-4 w-4 shrink-0" />
+                Copy Agent Directory Path
+              </>
+            )}
+          </button>
+
+          <div className="flex items-center gap-2 px-2 py-1.5">
+            <Timer className="h-4 w-4 shrink-0" />
+            <p className="min-w-0 flex-1 text-sm">Session Auto-Delete</p>
+            <AgentAutoDeleteSelect
+              value={agentPrefs?.autoDeleteInactiveDays}
+              appDefault={settings?.app?.autoDeleteInactiveDays}
+              onChange={(days) => {
+                updatePrefs.mutate({ autoDeleteInactiveDays: days })
+              }}
+              triggerClassName="h-8 w-auto shrink-0 gap-1 border-none bg-transparent px-1.5 text-sm text-muted-foreground shadow-none hover:text-foreground focus:ring-0 focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          </div>
+
+          <div className="my-1 border-t" />
+
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-destructive hover:bg-accent"
+            onClick={() => {
+              setOpen(false)
+              setDeleteConfirmOpen(true)
+            }}
+            data-testid="delete-agent-button"
+          >
+            <Trash2 className="h-4 w-4 shrink-0" />
+            Delete Agent
+          </button>
+        </PopoverContent>
+      </Popover>
+
+      {/* Outside the popover so it survives the popover closing */}
+      <AlertDialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Agent</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete &quot;{agent.name}&quot;? This will permanently delete
+              the agent and all its sessions, messages, and data. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid="confirm-button"
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Clipboard-write fallback: surface the path for manual copying */}
+      <AlertDialog open={showPathDialog} onOpenChange={setShowPathDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Agent Directory Path</AlertDialogTitle>
+            <AlertDialogDescription className="break-all font-mono text-sm select-all">
+              {agentPath}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Close</AlertDialogCancel>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/src/renderer/components/agents/agent-settings-popover.tsx
+++ b/src/renderer/components/agents/agent-settings-popover.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { Copy, FolderOpen, MoreVertical, Pencil, Timer, Trash2 } from 'lucide-react'
+import { Copy, FileClock, FolderOpen, MoreVertical, Pencil, Timer, Trash2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import {
@@ -13,6 +13,7 @@ import {
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
 import { AgentAutoDeleteSelect } from '@renderer/components/settings/auto-delete-select'
+import { AgentApiLogAutoDeleteSelect } from '@renderer/components/settings/api-log-auto-delete-select'
 import { DeleteAgentConfirmDialog } from '@renderer/components/agents/delete-agent-confirm-dialog'
 import { type ApiAgent } from '@renderer/hooks/use-agents'
 import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
@@ -137,6 +138,20 @@ export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverPr
               appDefault={settings?.app?.autoDeleteInactiveDays}
               onChange={(days) => {
                 updatePrefs.mutate({ autoDeleteInactiveDays: days })
+              }}
+              triggerClassName="h-8 w-auto shrink-0 gap-1 border-none bg-transparent px-1.5 text-sm text-muted-foreground shadow-none hover:text-foreground focus:ring-0 focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          </div>
+
+          {/* Per-agent override for API and MCP request log retention */}
+          <div className="flex items-center gap-2 px-2 py-1.5">
+            <FileClock className="h-4 w-4 shrink-0" />
+            <p className="min-w-0 flex-1 text-sm">API Log Auto-Delete</p>
+            <AgentApiLogAutoDeleteSelect
+              value={agentPrefs?.apiLogAutoDeleteDays}
+              appDefault={settings?.app?.apiLogAutoDeleteDays}
+              onChange={(days) => {
+                updatePrefs.mutate({ apiLogAutoDeleteDays: days })
               }}
               triggerClassName="h-8 w-auto shrink-0 gap-1 border-none bg-transparent px-1.5 text-sm text-muted-foreground shadow-none hover:text-foreground focus:ring-0 focus-visible:ring-1 focus-visible:ring-ring"
             />

--- a/src/renderer/components/agents/agent-settings-popover.tsx
+++ b/src/renderer/components/agents/agent-settings-popover.tsx
@@ -130,7 +130,9 @@ export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverPr
             )}
           </button>
 
-          <div className="flex items-center gap-2 px-2 py-1.5">
+          {/* No vertical padding: the h-8 trigger already makes these rows the
+              same 32px as the py-1.5 text rows, keeping the spacing even. */}
+          <div className="flex items-center gap-2 px-2">
             <Timer className="h-4 w-4 shrink-0" />
             <p className="min-w-0 flex-1 text-sm">Session Auto-Delete</p>
             <AgentAutoDeleteSelect
@@ -144,7 +146,7 @@ export function AgentSettingsPopover({ agent, onRename }: AgentSettingsPopoverPr
           </div>
 
           {/* Per-agent override for API and MCP request log retention */}
-          <div className="flex items-center gap-2 px-2 py-1.5">
+          <div className="flex items-center gap-2 px-2">
             <FileClock className="h-4 w-4 shrink-0" />
             <p className="min-w-0 flex-1 text-sm">API Log Auto-Delete</p>
             <AgentApiLogAutoDeleteSelect

--- a/src/renderer/components/agents/delete-agent-confirm-dialog.tsx
+++ b/src/renderer/components/agents/delete-agent-confirm-dialog.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { useNavigate } from '@tanstack/react-router'
+import { Loader2 } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
+import { useDeleteAgent, useRouteAgentId } from '@renderer/hooks/use-agents'
+
+interface DeleteAgentConfirmDialogProps {
+  agentSlug: string
+  agentName: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Runs after a successful delete (e.g. close the parent settings dialog). */
+  onDeleted?: () => void
+}
+
+/**
+ * The one delete-agent confirmation, shared by the header settings popover,
+ * the sidebar context menu, and the settings dialog's Danger Zone. Owns the
+ * mutation, the navigate-away-when-viewing-the-agent behavior, and the copy.
+ */
+export function DeleteAgentConfirmDialog({
+  agentSlug,
+  agentName,
+  open,
+  onOpenChange,
+  onDeleted,
+}: DeleteAgentConfirmDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false)
+  const deleteAgent = useDeleteAgent()
+  const navigate = useNavigate()
+  const routeAgentId = useRouteAgentId()
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    try {
+      await deleteAgent.mutateAsync(agentSlug)
+      onOpenChange(false)
+      onDeleted?.()
+      if (routeAgentId === agentSlug) void navigate({ to: '/' })
+    } catch (error) {
+      console.error('Failed to delete agent:', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to delete agent')
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent data-testid="confirm-delete-agent-dialog">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Agent</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete &quot;{agentName}&quot;? This will permanently delete
+            the agent and all its sessions, messages, and data. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            data-testid="confirm-delete-agent-button"
+          >
+            {isDeleting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              'Delete'
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/components/agents/settings/general-tab.tsx
+++ b/src/renderer/components/agents/settings/general-tab.tsx
@@ -1,6 +1,5 @@
 
 import { useState } from 'react'
-import { toast } from 'sonner'
 import { Input } from '@renderer/components/ui/input'
 import { Label } from '@renderer/components/ui/label'
 import { Button } from '@renderer/components/ui/button'
@@ -15,12 +14,10 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from '@renderer/components/ui/alert-dialog'
-import { useDeleteAgent, useRouteAgentId } from '@renderer/hooks/use-agents'
+import { DeleteAgentConfirmDialog } from '@renderer/components/agents/delete-agent-confirm-dialog'
 import { useAgentPreferences, useUpdateAgentPreferences } from '@renderer/hooks/use-agent-preferences'
 import { useSettings } from '@renderer/hooks/use-settings'
-import { useNavigate } from '@tanstack/react-router'
 import {
   useForceSyncAgentTemplate,
   useAgentTemplateStatus,
@@ -41,15 +38,12 @@ interface GeneralTabProps {
 }
 
 export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: GeneralTabProps) {
-  const [isDeleting, setIsDeleting] = useState(false)
   const [prDialogOpen, setPrDialogOpen] = useState(false)
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [forceSyncDialogOpen, setForceSyncDialogOpen] = useState(false)
-  const deleteAgent = useDeleteAgent()
   const { data: agentPrefs } = useAgentPreferences(agentSlug)
   const updatePrefs = useUpdateAgentPreferences(agentSlug)
   const { data: settings } = useSettings()
-  const navigate = useNavigate()
-  const routeAgentId = useRouteAgentId()
   const { data: templateStatus } = useAgentTemplateStatus(agentSlug)
   const refreshTemplateStatus = useRefreshAgentTemplateStatus()
   const forceSyncTemplate = useForceSyncAgentTemplate()
@@ -58,20 +52,6 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
   const publishMode = useSkillsetPublishMode(templateStatus?.skillsetId)
   const isPR = isPullRequestPublishMode(publishMode)
   const SubmitIcon = isPR ? GitPullRequest : Send
-
-  const handleDelete = async () => {
-    setIsDeleting(true)
-    try {
-      await deleteAgent.mutateAsync(agentSlug)
-      onDialogClose()
-      if (routeAgentId === agentSlug) void navigate({ to: '/' })
-    } catch (error) {
-      console.error('Failed to delete agent:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to delete agent')
-    } finally {
-      setIsDeleting(false)
-    }
-  }
 
   return (
     <div className="space-y-6">
@@ -197,34 +177,22 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
           <p className="text-sm text-muted-foreground">
             Permanently delete this agent and all its sessions, messages, and data.
           </p>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="destructive" size="sm" data-testid="delete-agent-button">
-                <Trash2 className="h-4 w-4 mr-2" />
-                Delete Agent
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete Agent</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Are you sure you want to delete &quot;{name}&quot;? This will permanently delete
-                  the agent and all its sessions, messages, and data. This action cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={handleDelete}
-                  disabled={isDeleting}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  data-testid="confirm-button"
-                >
-                  {isDeleting ? 'Deleting...' : 'Delete'}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setDeleteConfirmOpen(true)}
+            data-testid="delete-agent-button"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete Agent
+          </Button>
+          <DeleteAgentConfirmDialog
+            agentSlug={agentSlug}
+            agentName={name}
+            open={deleteConfirmOpen}
+            onOpenChange={setDeleteConfirmOpen}
+            onDeleted={onDialogClose}
+          />
         </div>
       </div>
 

--- a/src/renderer/components/settings/api-log-auto-delete-select.tsx
+++ b/src/renderer/components/settings/api-log-auto-delete-select.tsx
@@ -9,11 +9,18 @@ import {
   API_LOG_AUTO_DELETE_DAY_OPTIONS,
   DEFAULT_API_LOG_AUTO_DELETE_DAYS,
 } from '@shared/lib/config/api-log-auto-delete'
+import { cn } from '@shared/lib/utils/cn'
 
 export function formatApiLogAutoDeleteLabel(days: number | undefined): string {
   if (days === 0) return 'never'
   if (days && days > 0) return `${days} days`
   return `${DEFAULT_API_LOG_AUTO_DELETE_DAYS} days`
+}
+
+/** "Never (app default)" — the inherited value first, its provenance in parens. */
+function formatAppDefaultLabel(days: number | undefined): string {
+  const label = formatApiLogAutoDeleteLabel(days)
+  return `${label.charAt(0).toUpperCase()}${label.slice(1)} (app default)`
 }
 
 // Custom values (e.g. written by the agent via the preferences file hook) are
@@ -61,12 +68,15 @@ interface AgentApiLogAutoDeleteSelectProps {
   value: number | undefined
   appDefault: number | undefined
   onChange: (days: number | null) => void
+  /** Override trigger sizing (e.g. compact width inside a popover row). */
+  triggerClassName?: string
 }
 
 export function AgentApiLogAutoDeleteSelect({
   value,
   appDefault,
   onChange,
+  triggerClassName,
 }: AgentApiLogAutoDeleteSelectProps) {
   return (
     <Select
@@ -75,12 +85,12 @@ export function AgentApiLogAutoDeleteSelect({
         onChange(val === 'default' ? null : parseInt(val, 10))
       }}
     >
-      <SelectTrigger className="w-48" aria-label="API log auto-delete">
+      <SelectTrigger className={cn('w-48', triggerClassName)} aria-label="API log auto-delete">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="default">
-          App default ({formatApiLogAutoDeleteLabel(appDefault)})
+          {formatAppDefaultLabel(appDefault)}
         </SelectItem>
         <SelectItem value="0">Never</SelectItem>
         {API_LOG_AUTO_DELETE_DAY_OPTIONS.map((days) => (

--- a/src/renderer/components/settings/auto-delete-select.tsx
+++ b/src/renderer/components/settings/auto-delete-select.tsx
@@ -5,6 +5,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@renderer/components/ui/select'
+import { cn } from '@shared/lib/utils/cn'
 
 const AUTO_DELETE_OPTIONS = [
   { value: '30', label: '30 days' },
@@ -17,6 +18,12 @@ export function formatAutoDeleteLabel(days: number | undefined): string {
   if (option) return option.label
   if (days && days > 0) return `${days} days`
   return 'never'
+}
+
+/** "Never (app default)" — the inherited value first, its provenance in parens. */
+function formatAppDefaultLabel(days: number | undefined): string {
+  const label = formatAutoDeleteLabel(days)
+  return `${label.charAt(0).toUpperCase()}${label.slice(1)} (app default)`
 }
 
 interface AutoDeleteSelectProps {
@@ -51,12 +58,15 @@ interface AgentAutoDeleteSelectProps {
   value: number | undefined
   appDefault: number | undefined
   onChange: (days: number | null) => void
+  /** Override trigger sizing (e.g. compact width inside a popover row). */
+  triggerClassName?: string
 }
 
 export function AgentAutoDeleteSelect({
   value,
   appDefault,
   onChange,
+  triggerClassName,
 }: AgentAutoDeleteSelectProps) {
   return (
     <Select
@@ -65,12 +75,12 @@ export function AgentAutoDeleteSelect({
         onChange(val === 'default' ? null : parseInt(val, 10))
       }}
     >
-      <SelectTrigger className="w-48" aria-label="Session auto-delete">
+      <SelectTrigger className={cn('w-48', triggerClassName)} aria-label="Session auto-delete">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="default">
-          App default ({formatAutoDeleteLabel(appDefault)})
+          {formatAppDefaultLabel(appDefault)}
         </SelectItem>
         {AUTO_DELETE_OPTIONS.map((opt) => (
           <SelectItem key={opt.value} value={opt.value}>

--- a/src/renderer/components/ui/inline-editable-title.tsx
+++ b/src/renderer/components/ui/inline-editable-title.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
 import { Check, Loader2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
@@ -24,7 +24,13 @@ interface InlineEditableTitleProps {
   saveButtonTestId?: string
 }
 
-export function InlineEditableTitle({
+/** Imperative surface: lets a parent (e.g. a settings popover's "Rename"
+ *  action) enter edit mode without simulating a click on the title. */
+export interface InlineEditableTitleHandle {
+  startEditing: () => void
+}
+
+export const InlineEditableTitle = forwardRef<InlineEditableTitleHandle, InlineEditableTitleProps>(function InlineEditableTitle({
   value,
   canEdit,
   isSaving,
@@ -40,9 +46,15 @@ export function InlineEditableTitle({
   displayTestId,
   inputTestId,
   saveButtonTestId,
-}: InlineEditableTitleProps) {
+}: InlineEditableTitleProps, ref) {
   const [isEditing, setIsEditing] = useState(false)
   const [draft, setDraft] = useState(value)
+
+  useImperativeHandle(ref, () => ({
+    startEditing: () => {
+      if (canEdit) setIsEditing(true)
+    },
+  }), [canEdit])
 
   useEffect(() => {
     if (!isEditing) setDraft(value)
@@ -135,4 +147,4 @@ export function InlineEditableTitle({
       {value}
     </h1>
   )
-}
+})


### PR DESCRIPTION
Part 3 of 3, stacked on #776 (merge bottom-up).

The gear on the agent header (now a vertical three-dot, outline-styled to match Share) opens a **popover** instead of the settings dialog:

- **Rename agent** — delegates to the inline title via a new imperative handle on `InlineEditableTitle`; focus is not stolen back by the closing popover
- **Show/Copy Agent Directory** — moved from the sidebar context menu, same `canUseHostFeatures()` gating, plus a copied toast
- **Session Auto-Delete** — single row with a quiet borderless select; default option reads "Never (app default)"
- **Delete Agent** — existing confirm dialog

The sidebar context menu keeps the full settings dialog (still the home of Template Status) and loses its directory item. Directory-action unit tests moved to `agent-settings-popover.test.tsx` (3/3).

E2E: agent page object drives the popover for settings/delete; rename control test goes popover → Rename → focused inline input; the overlong-name AlertDialog overflow test opens settings via the context menu, preserving its unsaved-live-value premise. Mock specs 12/12, auth 37/37 at this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)