### PR TITLE
fix(sidebar): stop the local/cloud toggle moving under the cursor

### DIFF
--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -833,13 +833,10 @@ export function AppSidebar() {
         animates shut.
       */}
       <SidebarHeader
-        className="app-drag-region h-12 shrink-0 p-0 overflow-hidden transition-[padding-left] duration-200 ease-out"
+        className="app-drag-region h-12 shrink-0 p-0 transition-[padding-left] duration-200 ease-out"
         style={{ paddingLeft: needsTrafficLightPadding ? '80px' : undefined }}
       >
-        {/* `overflow-hidden`: nothing in this fixed-height row may spill into the
-            content below it — anything too wide for the row is clipped at its
-            edge rather than squeezing its neighbours. */}
-        <div className="flex items-center h-12 px-2 gap-1 overflow-hidden">
+        <div className="flex items-center h-12 px-2 gap-1">
           {__WEB__ && (
             <span className="shrink-0 select-none text-base font-medium">Gamut</span>
           )}

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -836,9 +836,9 @@ export function AppSidebar() {
         className="app-drag-region h-12 shrink-0 p-0 overflow-hidden transition-[padding-left] duration-200 ease-out"
         style={{ paddingLeft: needsTrafficLightPadding ? '80px' : undefined }}
       >
-        {/* `overflow-hidden` is load-bearing: hovering the target switcher
-            expands it in place, which pushes the buttons after it past the right
-            edge rather than squeezing them. */}
+        {/* `overflow-hidden`: nothing in this fixed-height row may spill into the
+            content below it — anything too wide for the row is clipped at its
+            edge rather than squeezing its neighbours. */}
         <div className="flex items-center h-12 px-2 gap-1 overflow-hidden">
           {__WEB__ && (
             <span className="shrink-0 select-none text-base font-medium">Gamut</span>

--- a/src/renderer/components/layout/target-switcher.test.tsx
+++ b/src/renderer/components/layout/target-switcher.test.tsx
@@ -52,6 +52,32 @@ describe('TargetSwitcher', () => {
     expect(screen.getByTestId('target-option-local')).toHaveAttribute('aria-pressed', 'false')
   })
 
+  // The options are named by tooltip, not by button text: text inside the
+  // button would have to appear on hover, moving the option next to it out from
+  // under a cursor already travelling toward it.
+  it('names the options without rendering text inside the buttons', () => {
+    state()
+    render(<TargetSwitcher />)
+
+    expect(screen.getByRole('button', { name: 'Local Agents (This computer)' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cloud Agents' })).toBeInTheDocument()
+    expect(screen.getByTestId('target-option-local')).toHaveTextContent('')
+    expect(screen.getByTestId('target-option-cloud')).toHaveTextContent('')
+  })
+
+  // The name does not change with state — `aria-pressed` carries that, and a
+  // name that moved with it would be announced twice over.
+  it('names each option the same whichever one is current', async () => {
+    state({ current: 'cloud' })
+    render(<TargetSwitcher />)
+
+    await userEvent.hover(screen.getByTestId('target-option-cloud'))
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Cloud Agents')
+
+    await userEvent.hover(screen.getByTestId('target-option-local'))
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Local Agents (This computer)')
+  })
+
   it('switches on click', async () => {
     state({ current: 'local' })
     render(<TargetSwitcher />)
@@ -61,12 +87,26 @@ describe('TargetSwitcher', () => {
     expect(switchTo).toHaveBeenCalledWith('cloud')
   })
 
-  it('is disabled while a switch is in flight', async () => {
+  // Marked disabled rather than `disabled`, so the button still emits the
+  // pointer events its tooltip needs — see the comment on the button.
+  it('reports itself disabled while a switch is in flight, and still explains itself', async () => {
     state({ switching: true })
     render(<TargetSwitcher />)
 
-    expect(screen.getByTestId('target-option-cloud')).toBeDisabled()
-    await userEvent.click(screen.getByTestId('target-option-cloud'))
-    expect(switchTo).not.toHaveBeenCalled()
+    const cloud = screen.getByTestId('target-option-cloud')
+    expect(cloud).toHaveAttribute('aria-disabled', 'true')
+
+    await userEvent.hover(cloud)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Switching…')
+  })
+
+  it('offers a reason to pick each option', async () => {
+    state({ current: 'local' })
+    render(<TargetSwitcher />)
+
+    await userEvent.hover(screen.getByTestId('target-option-cloud'))
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Run 24/7. Access anywhere. Share and collaborate with your team',
+    )
   })
 })

--- a/src/renderer/components/layout/target-switcher.test.tsx
+++ b/src/renderer/components/layout/target-switcher.test.tsx
@@ -52,9 +52,8 @@ describe('TargetSwitcher', () => {
     expect(screen.getByTestId('target-option-local')).toHaveAttribute('aria-pressed', 'false')
   })
 
-  // The options are named by tooltip, not by button text: text inside the
-  // button would have to appear on hover, moving the option next to it out from
-  // under a cursor already travelling toward it.
+  // Keep labels out of the buttons so hover never changes either option's
+  // width; aria-label provides the name without adding visible text.
   it('names the options without rendering text inside the buttons', () => {
     state()
     render(<TargetSwitcher />)
@@ -65,17 +64,30 @@ describe('TargetSwitcher', () => {
     expect(screen.getByTestId('target-option-cloud')).toHaveTextContent('')
   })
 
-  // The name does not change with state — `aria-pressed` carries that, and a
-  // name that moved with it would be announced twice over.
-  it('names each option the same whichever one is current', async () => {
+  it('keeps each option name stable when the current target changes', () => {
     state({ current: 'cloud' })
-    render(<TargetSwitcher />)
+    const { rerender } = render(<TargetSwitcher />)
 
-    await userEvent.hover(screen.getByTestId('target-option-cloud'))
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Cloud Agents')
+    expect(screen.getByRole('button', { name: 'Local Agents (This computer)' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+    expect(screen.getByRole('button', { name: 'Cloud Agents' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
 
-    await userEvent.hover(screen.getByTestId('target-option-local'))
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Local Agents (This computer)')
+    state({ current: 'local' })
+    rerender(<TargetSwitcher />)
+
+    expect(screen.getByRole('button', { name: 'Local Agents (This computer)' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: 'Cloud Agents' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
   })
 
   it('switches on click', async () => {
@@ -98,15 +110,23 @@ describe('TargetSwitcher', () => {
 
     await userEvent.hover(cloud)
     expect(await screen.findByRole('tooltip')).toHaveTextContent('Switching…')
+    expect(cloud).toHaveAccessibleDescription('Switching…')
+
+    await userEvent.click(cloud)
+    expect(switchTo).not.toHaveBeenCalled()
   })
 
   it('offers a reason to pick each option', async () => {
     state({ current: 'local' })
     render(<TargetSwitcher />)
 
-    await userEvent.hover(screen.getByTestId('target-option-cloud'))
+    const cloud = screen.getByTestId('target-option-cloud')
+    await userEvent.hover(cloud)
     expect(await screen.findByRole('tooltip')).toHaveTextContent(
-      'Run 24/7. Access anywhere. Share and collaborate with your team',
+      'Run 24/7. Access anywhere. Share and collaborate with your team.',
+    )
+    expect(cloud).toHaveAccessibleDescription(
+      'Run 24/7. Access anywhere. Share and collaborate with your team.',
     )
   })
 })

--- a/src/renderer/components/layout/target-switcher.tsx
+++ b/src/renderer/components/layout/target-switcher.tsx
@@ -44,7 +44,7 @@ const options: {
     value: 'cloud',
     icon: Cloud,
     label: 'Cloud Agents',
-    hint: 'Run 24/7. Access anywhere. Share and collaborate with your team',
+    hint: 'Run 24/7. Access anywhere. Share and collaborate with your team.',
   },
 ]
 
@@ -96,11 +96,13 @@ export function TargetSwitcher() {
                   // `aria-disabled`, not `disabled`: a disabled button emits no
                   // pointer events, so it cannot open a tooltip — and mid-switch
                   // is exactly when the user wants to be told what is happening.
-                  // Clicks stay safe because `switchTo` ignores them while a
-                  // switch is in flight.
+                  // Keep activation inert here as well as in `switchTo`, so the
+                  // button owns the disabled contract it exposes.
                   aria-disabled={switching}
                   data-testid={`target-option-${value}`}
-                  onClick={() => void switchTo(value)}
+                  onClick={() => {
+                    if (!switching) void switchTo(value)
+                  }}
                   className={cn(
                     // Fixed at every state, so neither option shifts under a
                     // pointer travelling toward the other. Slightly wider than
@@ -126,7 +128,14 @@ export function TargetSwitcher() {
                   widen only because hoverable content is off — with it on, a
                   bigger gap is a bigger polygon to get stuck in. */}
               {!isMobile && (
-                <TooltipContent side="bottom" sideOffset={8} className="max-w-52">
+                <TooltipContent
+                  side="bottom"
+                  sideOffset={8}
+                  className="max-w-52"
+                  // Radix exposes this as the trigger's description. Leave the
+                  // repeated visual heading out of what a screen reader hears.
+                  aria-label={switching ? 'Switching…' : hint}
+                >
                   <span className="block">{switching ? 'Switching…' : label}</span>
                   {/* Why you would pick this one. Dropped mid-switch, where the
                       only useful thing to say is that the switch is under way. */}

--- a/src/renderer/components/layout/target-switcher.tsx
+++ b/src/renderer/components/layout/target-switcher.tsx
@@ -1,5 +1,7 @@
 import { Cloud, Laptop } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
+import { useIsMobile } from '@renderer/hooks/use-mobile'
 import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
 import type { ApiTarget } from '@renderer/lib/api-target'
 
@@ -11,29 +13,44 @@ import type { ApiTarget } from '@renderer/lib/api-target'
  * single-machine user never sees a control with one option.
  *
  * Sits in the sidebar's title-bar row, which is a fixed 48px shared with the
- * traffic lights and the history/search buttons — so it shows icons only and
- * reveals its labels on hover, rather than permanently spending the width two
- * words need. The labels stay in the DOM at every size (they are the accessible
- * names); only their box collapses.
+ * traffic lights and the history/search buttons — so it shows icons only, and
+ * names them in a tooltip rather than in the button. The buttons are a fixed
+ * size at every state: an earlier version expanded its labels in place on
+ * hover, which moved the *other* option out from under a cursor already on its
+ * way to it — you cannot grow the control the pointer is aiming through.
  */
 
-const options: { value: ApiTarget; icon: typeof Laptop; label: string; title: string }[] = [
+/**
+ * `label` names the option and is also its accessible name. It stays the same at
+ * every state: `aria-pressed` is what tells a screen reader which one is on, so
+ * a name that changed with state would be announced twice over.
+ *
+ * `hint` is why you would pick this one — the part neither the icon nor the
+ * pressed state can carry.
+ */
+const options: {
+  value: ApiTarget
+  icon: typeof Laptop
+  label: string
+  hint: string
+}[] = [
   {
     value: 'local',
     icon: Laptop,
-    label: 'This computer',
-    title: 'Run agents on this computer',
+    label: 'Local Agents (This computer)',
+    hint: 'Most private and secure. Best browser use capabilities.',
   },
   {
     value: 'cloud',
     icon: Cloud,
-    label: 'Cloud',
-    title: "Run agents on your organization's cloud workspace",
+    label: 'Cloud Agents',
+    hint: 'Run 24/7. Access anywhere. Share and collaborate with your team',
   },
 ]
 
 export function TargetSwitcher() {
   const { current, available, switching, switchTo } = useTargetSwitch()
+  const isMobile = useIsMobile()
 
   if (!available) return null
 
@@ -41,58 +58,85 @@ export function TargetSwitcher() {
     // `app-no-drag`: this lives in the window's drag region, where a plain
     // button would move the window instead of being pressed.
     <div
-      className="group/target app-no-drag flex shrink-0 items-center gap-0.5 rounded-md bg-muted/60 p-0.5"
+      className="app-no-drag flex shrink-0 items-center gap-0.5 rounded-md bg-muted/60 p-0.5"
       role="group"
       aria-label="Where agents run"
       data-testid="target-switcher"
     >
-      {options.map(({ value, icon: Icon, label, title }) => {
-        const active = value === current
-        return (
-          <button
-            key={value}
-            type="button"
-            title={title}
-            aria-pressed={active}
-            disabled={switching}
-            data-testid={`target-option-${value}`}
-            onClick={() => void switchTo(value)}
-            className={cn(
-              // Expanded, this control has to fit the narrowest sidebar (288)
-              // less the inset, the traffic-light reservation, and the row's
-              // left padding — 184px of visible room, against ~177 for the two
-              // options and their labels. There is about 7px of slack, so a
-              // wider label or more padding here clips the pill at the default
-              // width, where nobody can drag it narrower to reproduce.
-              'flex items-center justify-center rounded px-1.5 py-1 text-xs transition-colors',
-              active
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-              switching && 'cursor-wait opacity-60',
-            )}
-          >
-            <Icon className="size-3.5 shrink-0" />
-            {/* A single-column grid animated between 0fr and 1fr: the label's own
-                width is the target, so nothing here has to guess how wide two
-                translated words are. `overflow-hidden` on the clipping span is
-                what lets the column actually reach zero (a grid item's automatic
-                minimum size is its content unless it clips). Focus-within opens
-                it too — a keyboard user never hovers, and would otherwise meet
-                two unlabelled icons.
+      {/* Its own provider: this renders outside the one wrapping the header's
+          history/search buttons.
 
-                The gap between icon and label is padding on the *inner* span,
-                inside the clip. Put it on the clipping span instead and it
-                survives the collapse — box-sizing cannot shrink a box below its
-                own padding — leaving 6px of dead space that shoves every icon
-                off the centre of its button. */}
-            <span className="grid grid-cols-[0fr] transition-[grid-template-columns] duration-200 ease-out group-hover/target:grid-cols-[1fr] group-focus-within/target:grid-cols-[1fr]">
-              <span className="overflow-hidden">
-                <span className="block whitespace-nowrap pl-1.5">{label}</span>
-              </span>
-            </span>
-          </button>
-        )
-      })}
+          `disableHoverableContent` is what makes moving between the two options
+          work. Hoverable content — the default — lets you travel from a trigger
+          into its tooltip without it closing, and Radix implements that by
+          drawing a grace polygon from the exit point around the content rect and
+          suppressing *every* trigger in the provider while the pointer is inside
+          it. Our content is far wider than the button it hangs under, so that
+          polygon covers the other option: hovering A then B left B silently dead
+          until the pointer wandered out of the hull. Nothing in these tooltips is
+          worth hovering into, so the grace area is pure cost.
+
+          `skipDelayDuration={0}` is what makes the delay hold on the *second*
+          hover. Radix's default 300ms skip window opens any further tooltip in
+          the provider instantly once one has been shown, so moving between the
+          two options fired with no delay at all while the first hover waited —
+          two different behaviours for the same gesture. Zero means both wait. */}
+      <TooltipProvider delayDuration={400} skipDelayDuration={0} disableHoverableContent>
+        {options.map(({ value, icon: Icon, label, hint }) => {
+          const active = value === current
+          return (
+            <Tooltip key={value}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  // The label is the accessible name — the button has no text of
+                  // its own, and a tooltip is not a substitute for one.
+                  aria-label={label}
+                  aria-pressed={active}
+                  // `aria-disabled`, not `disabled`: a disabled button emits no
+                  // pointer events, so it cannot open a tooltip — and mid-switch
+                  // is exactly when the user wants to be told what is happening.
+                  // Clicks stay safe because `switchTo` ignores them while a
+                  // switch is in flight.
+                  aria-disabled={switching}
+                  data-testid={`target-option-${value}`}
+                  onClick={() => void switchTo(value)}
+                  className={cn(
+                    // Fixed at every state, so neither option shifts under a
+                    // pointer travelling toward the other. Slightly wider than
+                    // tall: the extra width is aim room on the axis the cursor
+                    // actually approaches from, and it leaves the row's 48px
+                    // height alone.
+                    'flex h-6 w-8 items-center justify-center rounded transition-colors',
+                    active
+                      ? 'bg-background text-foreground shadow-sm cursor-default'
+                      : 'text-muted-foreground hover:text-foreground',
+                    switching && 'cursor-wait opacity-60',
+                  )}
+                >
+                  <Icon className="size-3.5 shrink-0" />
+                </button>
+              </TooltipTrigger>
+              {/* Suppressed on mobile for the same reason as the header's other
+                  tooltips: no hover to dismiss, and the Sheet's focus-trap would
+                  open one on the first focusable control with no way out.
+
+                  `sideOffset` is 8 rather than the 4px default, so the panel reads
+                  as its own surface instead of hanging off the button. Safe to
+                  widen only because hoverable content is off — with it on, a
+                  bigger gap is a bigger polygon to get stuck in. */}
+              {!isMobile && (
+                <TooltipContent side="bottom" sideOffset={8} className="max-w-52">
+                  <span className="block">{switching ? 'Switching…' : label}</span>
+                  {/* Why you would pick this one. Dropped mid-switch, where the
+                      only useful thing to say is that the switch is under way. */}
+                  {!switching && <span className="mt-0.5 block opacity-70">{hint}</span>}
+                </TooltipContent>
+              )}
+            </Tooltip>
+          )
+        })}
+      </TooltipProvider>
     </div>
   )
 }


### PR DESCRIPTION
## The bug

Each option in the sidebar's Local/Cloud switcher expanded its label in place on hover, which pushed the option after it to the right. Aiming for **Cloud** moved Cloud out from under the cursor, so you had to stop and re-aim. You cannot grow the control the pointer is travelling through — so the labels come out of the buttons entirely and move into tooltips.

## What changed

`src/renderer/components/layout/target-switcher.tsx`

- **Fixed-size icon buttons** (`h-6 w-8`) at every state. The `0fr → 1fr` grid that animated the label open is gone, along with the `group/target` hover hook it needed.
- **Named by tooltip.** One `label` per option is both the tooltip heading and the `aria-label`. It does not change with state — `aria-pressed` already carries which option is current, and a state-dependent name would be announced twice and contradict itself on the inactive option ("switch to cloud agents, *not pressed*").
- **A hint line per option** — why you would pick that one, which neither the icon nor the pressed state can express.
- **`aria-disabled` instead of `disabled`** while a switch is in flight. A disabled button emits no pointer events, so it could not open a tooltip at the one moment the user most wants to know what is happening; it now says "Switching…". Clicks stay safe on the existing guard in `switchTo` (`if (target === current || switching) return`).
- **`disableHoverableContent`** on the provider. This one is subtle: Radix's hoverable-content feature draws a grace polygon from the exit point around the *content rect* and suppresses **every** trigger in the provider while the pointer is inside it (its `onPointerMove` handler bails on `isPointerInTransitRef`). Our content is far wider than the button it hangs under, so that polygon covered the *other* option and left it silently dead on hover until the pointer wandered out of the hull. Nothing in these tooltips is worth hovering into.
- **`skipDelayDuration={0}`** with a 400ms `delayDuration`, so the delay holds on the second hover. Radix's default 300ms skip window opens any further tooltip in the provider instantly once one has been shown, which made the same gesture behave two different ways.
- Minor: `sideOffset={8}`, and `cursor-default` on the active option, whose click is a no-op.

`src/renderer/components/layout/app-sidebar.tsx` — updated the comment that justified `overflow-hidden` by the hover expansion that no longer exists.

## Reviewer notes

- **Copy is product-facing** and was iterated on in the app: "Local Agents (This computer)" / "Cloud Agents", with hints "Most private and secure. Best browser use capabilities." and "Run 24/7. Access anywhere. Share and collaborate with your team". The two hints are punctuated inconsistently (one ends in a period) — easy to settle either way.
- **Verified by hand in the Electron app**, which needed a throwaway local patch forcing `available: true` in `use-target-switch.ts`, since the control only renders with a connected platform account and a valid cloud-workspace token. That patch is **not** part of this branch — the hook is untouched.
- **The same Radix grace-area trap applies to the header's other `TooltipProvider`** (`app-sidebar.tsx`, around back/forward/search). Left alone here to keep the diff scoped; back/forward sit 2px apart and are plausible candidates for the same dead-hover.
- Tests: 43 pass across `target-switcher.test.tsx` (+3 new: names without button text, name stable across state, "Switching…" while in flight) and `app-sidebar.test.tsx`. Typecheck and lint clean. The `disableHoverableContent` fix is geometry-dependent and cannot be reproduced in jsdom — it was confirmed by hover in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
