### PR TITLE
APNs: origin device gets the background push alongside its alert

### DIFF
--- a/src/shared/lib/notifications/channels/apns-relay-channel.test.ts
+++ b/src/shared/lib/notifications/channels/apns-relay-channel.test.ts
@@ -152,7 +152,7 @@ describe('kill switch / disabled config', () => {
 })
 
 describe('origin-device alert routing', () => {
-  it('origin device gets a visible alert; all others get background pushes', async () => {
+  it('origin device gets a visible alert PLUS a background push; others background only', async () => {
     mocks.listDeliverableApnsDevices.mockReturnValue([
       makeDevice(),
       makeDevice({ id: 'dev-row-2', token: TOKEN_B, mobileDeviceId: 'family-2' }),
@@ -162,10 +162,14 @@ describe('origin-device alert routing', () => {
     await channel.deliver(makeEvent())
 
     const pushes = sentPushes()
-    expect(pushes).toHaveLength(2)
-    const alert = pushes.find((p) => p.deviceToken === TOKEN_A)!
-    const background = pushes.find((p) => p.deviceToken === TOKEN_B)!
-    expect(alert.kind).toBe('alert')
+    expect(pushes).toHaveLength(3)
+    const originPushes = pushes.filter((p) => p.deviceToken === TOKEN_A)
+    const otherPushes = pushes.filter((p) => p.deviceToken === TOKEN_B)
+    // The alert draws the banner; the paired silent push is what wakes the
+    // app to refresh the origin device's widget snapshots (an alert alone
+    // runs no app code on iOS).
+    expect(originPushes.map((p) => p.kind).sort()).toEqual(['alert', 'background'])
+    const alert = originPushes.find((p) => p.kind === 'alert')!
     expect(alert.alert).toEqual({
       title: 'Session Complete',
       body: 'Demo Agent has finished running',
@@ -178,8 +182,9 @@ describe('origin-device alert routing', () => {
       navigatePath: '/agents/agent-x/sessions/sess-1',
       workspaceId: 'ws-1',
     })
-    expect(background.kind).toBe('background')
-    expect(background.alert).toBeUndefined()
+    expect(otherPushes).toHaveLength(1)
+    expect(otherPushes[0].kind).toBe('background')
+    expect(otherPushes[0].alert).toBeUndefined()
   })
 
   it('an alertDeviceId claim overrides the creation stamp', async () => {
@@ -196,8 +201,15 @@ describe('origin-device alert routing', () => {
     await channel.deliver(makeEvent())
 
     const pushes = sentPushes()
-    expect(pushes.find((p) => p.deviceToken === TOKEN_A)!.kind).toBe('background')
-    expect(pushes.find((p) => p.deviceToken === TOKEN_B)!.kind).toBe('alert')
+    expect(pushes.filter((p) => p.deviceToken === TOKEN_A).map((p) => p.kind)).toEqual([
+      'background',
+    ])
+    expect(
+      pushes
+        .filter((p) => p.deviceToken === TOKEN_B)
+        .map((p) => p.kind)
+        .sort()
+    ).toEqual(['alert', 'background'])
   })
 
   it('a null alertDeviceId (web spoke last) silences everyone despite a creation stamp', async () => {

--- a/src/shared/lib/notifications/channels/apns-relay-channel.ts
+++ b/src/shared/lib/notifications/channels/apns-relay-channel.ts
@@ -69,7 +69,11 @@ interface RelayResult {
  *
  * Alert routing: only the device whose mobile-device family started the
  * session (session metadata `createdByDeviceId`) gets a visible alert; every
- * other eligible device gets a silent background push. Sessions with no origin
+ * other eligible device gets a silent background push. The origin device gets
+ * the background push AS WELL as its alert: an alert alone runs no app code
+ * on iOS (no content-available → no background wake), so without the paired
+ * silent push the one phone the user is actually holding would keep stale
+ * widget snapshots until the app next opened. Sessions with no origin
  * (web/cron/webhook) are silent to everyone. An origin device whose owner
  * disabled the type degrades to a background push — never to nothing, so the
  * widget still refreshes.
@@ -108,8 +112,8 @@ export class ApnsRelayChannel implements NotificationChannel {
 
     const batch: Array<{ device: ApnsDeviceRow; push: ApnsRelayPush }> = []
     for (const device of devices) {
-      const push = await this.buildPushForDevice(event, device, originDeviceId, accessCache)
-      if (push) {
+      const pushes = await this.buildPushesForDevice(event, device, originDeviceId, accessCache)
+      for (const push of pushes) {
         batch.push({ device, push })
       }
     }
@@ -141,18 +145,18 @@ export class ApnsRelayChannel implements NotificationChannel {
     }
   }
 
-  /** Per-device gating + payload choice; null = skip this device entirely. */
-  private async buildPushForDevice(
+  /** Per-device gating + payload choice; empty = skip this device entirely. */
+  private async buildPushesForDevice(
     event: NotificationEvent,
     device: ApnsDeviceRow,
     originDeviceId: string | null,
     accessCache: Map<string, Promise<string[]>>
-  ): Promise<ApnsRelayPush | null> {
+  ): Promise<ApnsRelayPush[]> {
     if (isAuthMode()) {
       // An ownerless row in auth mode (e.g. registered before auth was
       // enabled) has no user to gate on — never deliver to it.
       if (!device.userId) {
-        return null
+        return []
       }
       let access = accessCache.get(device.userId)
       if (!access) {
@@ -162,7 +166,7 @@ export class ApnsRelayChannel implements NotificationChannel {
       // No access to the agent means no push at all — a silent push still
       // leaks that the agent ran.
       if (!(await access).includes(event.agentSlug)) {
-        return null
+        return []
       }
     }
 
@@ -174,11 +178,14 @@ export class ApnsRelayChannel implements NotificationChannel {
       const ownerId = isAuthMode() ? (device.userId as string) : 'local'
       const settings = getUserSettings(ownerId)
       if (isNotificationTypeEnabled(settings.notifications, event.type)) {
-        return buildApnsAlertPush(event, device)
+        // Alert AND background: the alert draws the banner but wakes no app
+        // code on iOS, so the paired silent push is what refreshes the
+        // origin device's widget snapshots.
+        return [buildApnsAlertPush(event, device), buildApnsBackgroundPush(event, device)]
       }
       // Prefs disabled: degrade to background so the widget still refreshes.
     }
-    return buildApnsBackgroundPush(event, device)
+    return [buildApnsBackgroundPush(event, device)]
   }
 
   private async sendChunk(


### PR DESCRIPTION
## Problem

Field report from the iOS app: trigger a session from the phone, get the visible "Session Complete" push, but the fleet widget keeps showing the agent as **Working** for minutes afterwards.

Root cause: `ApnsRelayChannel` sends each device *either* an alert *or* a background push. The origin device wins the alert — but an iOS alert without `content-available` runs **no app code**; it only draws the banner. The silent background push is what wakes the app's `SilentPushHandler` to refresh the App-Group widget snapshots and call `WidgetCenter.reloadTimelines`. So every device *except* the one the user is actually holding refreshed its widgets; the origin phone stayed stale until the app next opened (or the widget's ~45-min timeline floor).

The prefs-disabled branch already carried the intent ("degrade to background so the widget still refreshes") — the happy alert path just missed the same guarantee.

## Fix

`buildPushForDevice` → `buildPushesForDevice` returning a list. The origin + visible-type + prefs-enabled case now returns the alert **plus** the same background push every non-origin device gets. All other cases unchanged (gated → none, everyone else → background only). No relay or iOS changes needed — the client already handles the silent push correctly.

## Tests

- Updated: origin now expects `['alert', 'background']` (3 pushes total for 2 devices); the alertDeviceId-claim test likewise.
- All other expectations unchanged and passing: 28/28 in `apns-relay-channel.test.ts`; typecheck clean.

https://claude.ai/code/session_01EGq2u76eJdTcuP4e2tb5QE