### PR TITLE
Surface the agent menu as a hover 3-dot button in the sidebar

### DIFF
--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -83,7 +83,13 @@ interface AgentContextMenuProps {
    * home and the panel opens on arrival.
    */
   onOpenDirectory?: () => void
-  /** Reports the menu opening and closing (e.g. for a button's aria-expanded). */
+  /**
+   * Reports the menu opening and closing (e.g. for a button's aria-expanded).
+   * Call sites that reveal a trigger on hover (the sidebar's 3-dot button)
+   * also need this: once the menu is open Radix takes pointer events off the
+   * page, so `:hover` drops and a hover-only affordance would disappear out
+   * from under its own menu.
+   */
   onOpenChange?: (open: boolean) => void
   /** Homepage-only controls that should share the agent's single menu surface. */
   additionalOptions?: React.ReactNode

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -1,9 +1,9 @@
 
 import { useState, useRef, useMemo, useCallback, useEffect } from 'react'
 import { cn } from '@shared/lib/utils/cn'
-import { Button } from '@renderer/components/ui/button'
+import { Button, buttonVariants } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
-import { ArrowUp, Loader2, Eye, Maximize2, Minimize2, MoreVertical, Search } from 'lucide-react'
+import { ArrowUp, Loader2, Eye, Maximize2, Minimize2, Search } from 'lucide-react'
 import { useCreateSession, useSessions } from '@renderer/hooks/use-sessions'
 import { useScheduledTasks } from '@renderer/hooks/use-scheduled-tasks'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
@@ -20,6 +20,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { AgentSharePopover, type AgentSharePopoverHandle } from '@renderer/components/agents/agent-share-popover'
 import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
+import { AgentMenuButton } from '@renderer/components/agents/agent-menu-button'
 import { SystemPromptDialog } from '@renderer/components/agents/system-prompt-dialog'
 import { toast } from 'sonner'
 import { apiFetch } from '@renderer/lib/api'
@@ -402,32 +403,16 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                 shows just the Publish pane. */}
             {isOwner && <AgentSharePopover ref={shareRef} agentSlug={agent.slug} agentName={agent.name} />}
             {/* Three-dot = the same agent menu a right-click on the title (or
-                the sidebar row) opens, so the two never drift apart. A click
-                replays as a contextmenu event on the title's trigger, anchored
-                under this button; Rename hands off to the inline title above. */}
-            <Button
-              type="button"
-              size="icon"
-              variant="outline"
-              className="h-8 w-8 shrink-0"
-              aria-label="Agent menu"
-              aria-haspopup="menu"
-              aria-expanded={menuOpen}
+                the sidebar row) opens. The shared AgentMenuButton replays the
+                click as a contextmenu on the title's trigger, anchored under
+                this button; Rename hands off to the inline title above. */}
+            <AgentMenuButton
+              triggerRef={menuTriggerRef}
+              agentName={agent.name}
+              menuOpen={menuOpen}
               data-testid="agent-settings-button"
-              onClick={(event) => {
-                const rect = event.currentTarget.getBoundingClientRect()
-                menuTriggerRef.current?.dispatchEvent(
-                  new MouseEvent('contextmenu', {
-                    bubbles: true,
-                    cancelable: true,
-                    clientX: rect.left,
-                    clientY: rect.bottom + 4,
-                  })
-                )
-              }}
-            >
-              <MoreVertical className="h-4 w-4" />
-            </Button>
+              className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-8 w-8 shrink-0')}
+            />
           </ScrollAwarePageTitle>
           {isViewOnly ? (
             <div className="flex items-center justify-center gap-2 text-sm font-medium text-muted-foreground border rounded-lg p-6" data-testid="view-only-banner">

--- a/src/renderer/components/agents/agent-menu-button.test.tsx
+++ b/src/renderer/components/agents/agent-menu-button.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AgentMenuButton } from './agent-menu-button'
+
+function renderButton(props: Partial<React.ComponentProps<typeof AgentMenuButton>> = {}) {
+  const triggerRef = createRef<HTMLAnchorElement>()
+  const onContextMenu = vi.fn((e: React.MouseEvent) => e.preventDefault())
+  const onTriggerClick = vi.fn()
+  // A link, like the sidebar row: the button's click must not navigate it.
+  render(
+    <a href="/agents/test-agent" ref={triggerRef} onContextMenu={onContextMenu} onClick={onTriggerClick}>
+      row
+      <AgentMenuButton triggerRef={triggerRef} agentName="Test Agent" menuOpen={false} {...props} />
+    </a>
+  )
+  return { onContextMenu, onTriggerClick }
+}
+
+describe('AgentMenuButton', () => {
+  it('replays a click as a contextmenu event on the menu trigger', async () => {
+    const { onContextMenu, onTriggerClick } = renderButton()
+    await userEvent.click(screen.getByRole('button', { name: 'Options for Test Agent' }))
+    expect(onContextMenu).toHaveBeenCalledTimes(1)
+    // The click itself must not leak to the row (which may be a link).
+    expect(onTriggerClick).not.toHaveBeenCalled()
+  })
+
+  it('anchors the menu under the button by default and beside it on request', async () => {
+    const rect = { left: 100, right: 120, top: 10, bottom: 30 } as DOMRect
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect)
+
+    const below = renderButton()
+    await userEvent.click(screen.getByRole('button', { name: 'Options for Test Agent' }))
+    expect(below.onContextMenu.mock.calls[0][0]).toMatchObject({ clientX: 100, clientY: 34 })
+
+    const beside = renderButton({ anchor: 'beside', agentName: 'Other' })
+    await userEvent.click(screen.getByRole('button', { name: 'Options for Other' }))
+    expect(beside.onContextMenu.mock.calls[0][0]).toMatchObject({ clientX: 120, clientY: 30 })
+
+    vi.restoreAllMocks()
+  })
+
+  it('reports the open menu through aria-expanded', () => {
+    renderButton({ menuOpen: true })
+    const button = screen.getByRole('button', { name: 'Options for Test Agent' })
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(button).toHaveAttribute('aria-haspopup', 'menu')
+  })
+})

--- a/src/renderer/components/agents/agent-menu-button.tsx
+++ b/src/renderer/components/agents/agent-menu-button.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import { MoreVertical } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+
+/**
+ * Where the menu lands relative to the button.
+ *
+ * - `below`: top-left corner hangs 4px under the button's left edge — a
+ *   dropdown, for a button sitting in a header row (the agent home).
+ * - `beside`: top-left corner sits at the button's bottom-right — the menu
+ *   spills out to the right, for a button at the edge of a narrow column (the
+ *   sidebar row), where a dropdown would cover the rows beneath it.
+ */
+export type AgentMenuAnchor = 'below' | 'beside'
+
+export interface AgentMenuButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'children' | 'aria-label' | 'aria-haspopup' | 'aria-expanded'> {
+  /**
+   * The element the surface's `AgentContextMenu` wraps. A click on this button
+   * replays as a `contextmenu` event on it, anchored under the button.
+   */
+  triggerRef: React.RefObject<HTMLElement | null>
+  agentName: string
+  /**
+   * Fed from the same `AgentContextMenu`'s `onOpenChange`. Drives
+   * `aria-expanded`, and lets a hover-revealed button stay visible while the
+   * menu it opened is up (Radix takes pointer events off the page, so `:hover`
+   * drops the moment the menu appears).
+   */
+  menuOpen: boolean
+  anchor?: AgentMenuAnchor
+  /** Sizing for the icon; the button's own box comes from `className`. */
+  iconClassName?: string
+}
+
+/**
+ * The 3-dot button that opens an agent's menu. Every surface that shows one
+ * (the sidebar row, the agent home title) renders this, so the way the menu is
+ * reached can't drift between them.
+ *
+ * It is deliberately not a menu trigger of its own: the surface already has an
+ * `AgentContextMenu` on right-click, and a second Radix menu next to it would
+ * be a second list to keep in sync. Instead the click synthesizes the
+ * `contextmenu` event the existing trigger listens for — the same trick
+ * `ui/context-menu.tsx` uses for its touch long-press — so right-click and the
+ * button open one and the same menu.
+ *
+ * Appearance belongs to the caller (a bare chip in the sidebar, an outline
+ * button on the agent home); behaviour and accessibility live here.
+ */
+export const AgentMenuButton = React.forwardRef<HTMLButtonElement, AgentMenuButtonProps>(
+  function AgentMenuButton(
+    { triggerRef, agentName, menuOpen, anchor = 'below', iconClassName, className, ...rest },
+    ref
+  ) {
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+      // The button may sit inside or beside a link (the sidebar row is an <a>);
+      // neither the navigation nor a row-level click handler should fire.
+      event.preventDefault()
+      event.stopPropagation()
+      const trigger = triggerRef.current
+      if (!trigger) return
+      const rect = event.currentTarget.getBoundingClientRect()
+      const point =
+        anchor === 'beside'
+          ? { clientX: rect.right, clientY: rect.bottom }
+          : { clientX: rect.left, clientY: rect.bottom + 4 }
+      trigger.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true, ...point })
+      )
+    }
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={handleClick}
+        aria-label={`Options for ${agentName}`}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        title="Agent options"
+        className={cn('inline-flex items-center justify-center', className)}
+        {...rest}
+      >
+        <MoreVertical className={cn('h-4 w-4', iconClassName)} />
+      </button>
+    )
+  }
+)

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -228,8 +228,27 @@ vi.mock('@renderer/components/agents/status-indicators', () => ({
   AwaitingDot: () => <span data-testid="awaiting-dot" />,
 }))
 
+// Stands in for the real Radix context menu: like the real asChild trigger it
+// adds no DOM of its own (the file-drop tests reach the row's wrapper via
+// parentElement), and it reports "opened" when a contextmenu event reaches the
+// row — which is exactly how the row's 3-dot button opens the menu it shares
+// with right-click.
 vi.mock('@renderer/components/agents/agent-context-menu', () => ({
-  AgentContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  AgentContextMenu: ({
+    children,
+    onOpenChange,
+  }: {
+    children: React.ReactNode
+    onOpenChange?: (open: boolean) => void
+  }) =>
+    isValidElement(children)
+      ? cloneElement(children as ReactElement<{ onContextMenu?: (e: React.MouseEvent) => void }>, {
+          onContextMenu: (e: React.MouseEvent) => {
+            e.preventDefault()
+            onOpenChange?.(true)
+          },
+        })
+      : <>{children}</>,
 }))
 
 vi.mock('@renderer/components/sessions/session-context-menu', () => ({
@@ -875,6 +894,35 @@ describe('AppSidebar — agent row indicator', () => {
     const status = screen.getByTestId('agent-status-running')
     expect(status).toHaveAttribute('data-awaiting', 'true')
     expect(screen.queryByLabelText('unread notifications')).not.toBeInTheDocument()
+  })
+})
+
+// ============================================================================
+// Agent row 3-dot menu button
+// ----------------------------------------------------------------------------
+// Right-click was the only way into the agent menu and nobody found it. The
+// button takes over the status slot on hover and opens that same menu, so the
+// two gestures can never drift apart.
+// ============================================================================
+describe('AppSidebar — agent row menu button', () => {
+  it('opens the agent context menu, hiding the status indicator behind it', async () => {
+    renderWithProviders(<AppSidebar />)
+    // Status owns the slot until the menu opens.
+    expect(screen.getByTestId('agent-status-running').parentElement).not.toHaveClass('opacity-0')
+
+    await userEvent.click(screen.getByTestId('agent-menu-button-test-agent'))
+
+    expect(screen.getByTestId('agent-status-running').parentElement).toHaveClass('opacity-0')
+  })
+
+  it('keeps the button a sibling of the row link, never nested inside it', () => {
+    renderWithProviders(<AppSidebar />)
+    const row = screen.getByTestId('agent-item-test-agent')
+    const button = screen.getByTestId('agent-menu-button-test-agent')
+    // A <button> inside the row's <a> would be invalid markup and its click
+    // would navigate; the row must stay a single interactive element.
+    expect(row.contains(button)).toBe(false)
+    expect(button).toHaveAccessibleName('Options for Test Agent')
   })
 })
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Bell, ChevronDown, ChevronLeft, ChevronRight, Cloud, Laptop, MoreVertical, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
+import { Bell, ChevronDown, ChevronLeft, ChevronRight, Cloud, Laptop, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { toast } from 'sonner'
 import { cn } from '@shared/lib/utils/cn'
@@ -61,6 +61,7 @@ import { AgentStatus } from '@renderer/components/agents/agent-status'
 import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-indicators'
 import { SIDEBAR_TREE_CONNECTORS } from '@renderer/components/ui/tree-connectors'
 import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
+import { AgentMenuButton } from '@renderer/components/agents/agent-menu-button'
 import { SessionContextMenu } from '@renderer/components/sessions/session-context-menu'
 import { DashboardContextMenu } from '@renderer/components/dashboards/dashboard-context-menu'
 import { useQueryClient } from '@tanstack/react-query'
@@ -552,10 +553,8 @@ const AgentMenuItemInner = React.forwardRef<
   })
 
   // Right-click on the row was the only way to reach the agent menu, which
-  // nobody discovers. A 3-dot button now takes over the status slot on hover
-  // and opens that same menu — one menu surface, not two: the button
-  // synthesizes the `contextmenu` event the row's trigger already listens for
-  // (same trick as the touch long-press in ui/context-menu.tsx).
+  // nobody discovers. The shared AgentMenuButton takes over the status slot on
+  // hover and opens that same menu by replaying a contextmenu on the row.
   const [menuOpen, setMenuOpen] = useState(false)
   const rowRef = React.useRef<HTMLAnchorElement | null>(null)
   const setRowRef = useCallback(
@@ -565,21 +564,6 @@ const AgentMenuItemInner = React.forwardRef<
     },
     [hintRef]
   )
-  const handleMenuButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault()
-    e.stopPropagation()
-    const row = rowRef.current
-    if (!row) return
-    const rect = e.currentTarget.getBoundingClientRect()
-    row.dispatchEvent(
-      new MouseEvent('contextmenu', {
-        bubbles: true,
-        cancelable: true,
-        clientX: rect.right,
-        clientY: rect.bottom,
-      })
-    )
-  }
 
   return (
     <Collapsible asChild open={isOpen && !isDragActive} onOpenChange={setIsOpen}>
@@ -637,17 +621,18 @@ const AgentMenuItemInner = React.forwardRef<
             while the cmd-hint overlay owns that slot.
           */}
           {hint === null && (
-            <button
-              type="button"
-              onClick={handleMenuButtonClick}
-              aria-label={`Options for ${agent.name}`}
-              aria-haspopup="menu"
-              title="Agent options"
+            <AgentMenuButton
+              triggerRef={rowRef}
+              agentName={agent.name}
+              menuOpen={menuOpen}
+              // Spill to the right: a dropdown here would cover the rows below.
+              anchor="beside"
               data-testid={`agent-menu-button-${agent.slug}`}
+              iconClassName="h-3.5 w-3.5"
               className={cn(
                 // right-1.5 + w-5 centers the icon exactly where the w-4
                 // indicator slot sits, so the swap doesn't shift the row.
-                'absolute right-1.5 top-1/2 -translate-y-1/2 flex h-5 w-5 items-center justify-center rounded-md',
+                'absolute right-1.5 top-1/2 -translate-y-1/2 h-5 w-5 rounded-md',
                 'text-muted-foreground/60 opacity-0 transition-[opacity,background-color,color]',
                 // One step darker than the row's #f4f4f5 wash it sits on
                 // (composites to ~#e2e2e4). Translucent rather than a fixed
@@ -661,9 +646,7 @@ const AgentMenuItemInner = React.forwardRef<
                 'focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none',
                 menuOpen && 'opacity-100 text-sidebar-foreground'
               )}
-            >
-              <MoreVertical className="h-3.5 w-3.5" />
-            </button>
+            />
           )}
           {/*
             Sibling chevron button overlays its slot in the row so the row stays a

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Bell, ChevronDown, ChevronLeft, ChevronRight, Cloud, Laptop, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
+import { Bell, ChevronDown, ChevronLeft, ChevronRight, Cloud, Laptop, MoreVertical, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { toast } from 'sonner'
 import { cn } from '@shared/lib/utils/cn'
@@ -551,6 +551,36 @@ const AgentMenuItemInner = React.forwardRef<
     displaySlug: agent.displaySlug,
   })
 
+  // Right-click on the row was the only way to reach the agent menu, which
+  // nobody discovers. A 3-dot button now takes over the status slot on hover
+  // and opens that same menu — one menu surface, not two: the button
+  // synthesizes the `contextmenu` event the row's trigger already listens for
+  // (same trick as the touch long-press in ui/context-menu.tsx).
+  const [menuOpen, setMenuOpen] = useState(false)
+  const rowRef = React.useRef<HTMLAnchorElement | null>(null)
+  const setRowRef = useCallback(
+    (element: HTMLAnchorElement | null) => {
+      rowRef.current = element
+      hintRef(element)
+    },
+    [hintRef]
+  )
+  const handleMenuButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const row = rowRef.current
+    if (!row) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    row.dispatchEvent(
+      new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        clientX: rect.right,
+        clientY: rect.bottom,
+      })
+    )
+  }
+
   return (
     <Collapsible asChild open={isOpen && !isDragActive} onOpenChange={setIsOpen}>
       <SidebarMenuItem ref={ref} style={style} {...rest} onMouseEnter={handleMouseEnter}>
@@ -560,17 +590,25 @@ const AgentMenuItemInner = React.forwardRef<
           item that also contains CollapsibleContent below.
         */}
         <div
-          className={cn('relative rounded-md', SIDEBAR_FILE_DROP_CUE)}
+          className={cn('relative rounded-md group/agent-row', SIDEBAR_FILE_DROP_CUE)}
           {...dragHandlers}
         >
-          <AgentContextMenu agent={agent}>
+          <AgentContextMenu agent={agent} onOpenChange={setMenuOpen}>
             <SidebarMenuButton
               asChild
               isActive={isSelected}
-              className="justify-between pl-7"
+              className={cn(
+                'justify-between pl-7',
+                // The row's own `hover:` can't hold the highlight: the 3-dot
+                // button and the chevron are siblings painted over it, so
+                // pointing at either makes the row itself un-hovered and the
+                // background drops out. Drive it from the wrapper instead —
+                // anywhere in the row, including its controls, keeps the wash.
+                'group-hover/agent-row:bg-sidebar-accent group-hover/agent-row:text-sidebar-accent-foreground'
+              )}
               data-testid={`agent-item-${agent.slug}`}
             >
-              <AppLink ref={hintRef} to="/agents/$slug" params={{ slug: agent.displaySlug }}>
+              <AppLink ref={setRowRef} to="/agents/$slug" params={{ slug: agent.displaySlug }}>
                 <span className="flex items-center gap-1.5 min-w-0">
                   <span className="truncate text-[13px] font-normal text-sidebar-foreground">{agent.name}</span>
                   {isShared && <Users className="h-3 w-3 shrink-0 text-muted-foreground" />}
@@ -578,11 +616,55 @@ const AgentMenuItemInner = React.forwardRef<
                 {hint !== null ? (
                   <CmdHintBadge hint={hint} />
                 ) : (
-                  <AgentRowIndicator agent={agent} sessions={sessions} isOpen={isOpen} />
+                  // Yields the slot to the 3-dot button on hover (and for as
+                  // long as the menu it opened stays open).
+                  <span
+                    className={cn(
+                      'flex items-center transition-opacity group-hover/agent-row:opacity-0',
+                      menuOpen && 'opacity-0'
+                    )}
+                  >
+                    <AgentRowIndicator agent={agent} sessions={sessions} isOpen={isOpen} />
+                  </span>
                 )}
               </AppLink>
             </SidebarMenuButton>
           </AgentContextMenu>
+          {/*
+            Sibling of the row (not a child) for the same reason as the chevron
+            below: the row is a single <a>, and nesting a button inside it is
+            invalid. Sits over the indicator slot the row just faded out. Hidden
+            while the cmd-hint overlay owns that slot.
+          */}
+          {hint === null && (
+            <button
+              type="button"
+              onClick={handleMenuButtonClick}
+              aria-label={`Options for ${agent.name}`}
+              aria-haspopup="menu"
+              title="Agent options"
+              data-testid={`agent-menu-button-${agent.slug}`}
+              className={cn(
+                // right-1.5 + w-5 centers the icon exactly where the w-4
+                // indicator slot sits, so the swap doesn't shift the row.
+                'absolute right-1.5 top-1/2 -translate-y-1/2 flex h-5 w-5 items-center justify-center rounded-md',
+                'text-muted-foreground/60 opacity-0 transition-[opacity,background-color,color]',
+                // One step darker than the row's #f4f4f5 wash it sits on
+                // (composites to ~#e2e2e4). Translucent rather than a fixed
+                // token so dark mode gets the same one-step contrast — there it
+                // reads as a lighter chip on the #303030 row, not a darker one.
+                'hover:bg-sidebar-foreground/10 hover:text-sidebar-foreground',
+                // Scoped to the row, not the menu item: an expanded agent's
+                // session sub-rows live in the same <li>, and hovering one of
+                // them must not swap the parent row's indicator.
+                'group-hover/agent-row:opacity-100 focus-visible:opacity-100',
+                'focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none',
+                menuOpen && 'opacity-100 text-sidebar-foreground'
+              )}
+            >
+              <MoreVertical className="h-3.5 w-3.5" />
+            </button>
+          )}
           {/*
             Sibling chevron button overlays its slot in the row so the row stays a
             single <button> (no nested interactive controls). Only rendered when
@@ -595,11 +677,21 @@ const AgentMenuItemInner = React.forwardRef<
               onClick={handleChevronClick}
               aria-label={isOpen ? 'Collapse' : 'Expand'}
               aria-expanded={isOpen}
-              className="absolute left-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none"
+              className={cn(
+                // Same chip as the 3-dot button at the other end of the row.
+                'absolute left-1.5 top-1/2 -translate-y-1/2 flex h-5 w-5 items-center justify-center rounded-md',
+                'text-muted-foreground/60 transition-[background-color,color]',
+                // Brightening with the row is pre-existing behaviour; scoped to
+                // the row rather than the menu item so an expanded agent's
+                // session sub-rows no longer brighten their parent's chevron.
+                'group-hover/agent-row:text-sidebar-foreground',
+                'hover:bg-sidebar-foreground/10 hover:text-sidebar-foreground',
+                'focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none'
+              )}
             >
               <ChevronRight
                 className={cn(
-                  'h-3.5 w-3.5 text-muted-foreground/60 transition-[color,transform] group-hover/menu-item:text-sidebar-foreground',
+                  'h-3.5 w-3.5 transition-transform',
                   isOpen && !isDragActive && 'rotate-90'
                 )}
               />

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -398,7 +398,13 @@ html[data-keyboard-open] [data-composer-footer] {
   background: rgba(0, 0, 0, 0.4) !important;
 }
 
-/* Semi-transparent hover/active states so vibrancy remains visible */
+/* Semi-transparent hover/active states so vibrancy remains visible.
+   The agent row's ⋮ and chevron are siblings painted over the row, so pointing
+   at either un-hovers the button itself. Without the `.group/agent-row:hover`
+   selectors below, this tint would drop out and the opaque Tailwind fallback
+   (bg-sidebar-accent, near-white) would paint instead — the row would flash
+   lighter the moment you reached for its menu. */
+.electron-vibrancy [data-sidebar="sidebar"] .group\/agent-row:hover [data-sidebar="menu-button"],
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-button"]:hover,
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-button"]:active,
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-button"][data-active="true"],
@@ -409,6 +415,7 @@ html[data-keyboard-open] [data-composer-footer] {
   background: rgba(0, 0, 0, 0.06) !important;
 }
 
+.electron-vibrancy.dark [data-sidebar="sidebar"] .group\/agent-row:hover [data-sidebar="menu-button"],
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-button"]:hover,
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-button"]:active,
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-button"][data-active="true"],

--- a/src/renderer/test/setup.ts
+++ b/src/renderer/test/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { beforeEach, vi } from 'vitest'
-import { createElement } from 'react'
+import { createElement, forwardRef } from 'react'
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
 
 // Auth mode is now derived from the resolved API target, and reading it before
@@ -98,24 +98,34 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 // have neither, so stub it as a plain anchor that forwards the props tests
 // inspect (onClick, className, data-testid). A file-level vi.mock overrides this
 // where a test needs the real link.
-vi.mock('@renderer/components/ui/app-link', () => ({
+vi.mock('@renderer/components/ui/app-link', () => {
   // Strip the link-specific props so they don't land as DOM attributes; forward
-  // the rest (onClick/className/data-testid) to a plain anchor.
-  AppLink: ({ children, to, params, search, activeClassName: _ac, activeOptions: _ao, noDrag: _nd, ...props }: Record<string, unknown> & { children?: unknown }) =>
-    createElement(
-      'a',
-      {
-        href: '#',
-        // Expose the route target so tests can assert navigation (the real
-        // <a href> isn't built in jsdom; data-* attrs avoid React DOM warnings).
-        'data-to': to,
-        'data-params': params ? JSON.stringify(params) : undefined,
-        'data-search': search ? JSON.stringify(search) : undefined,
-        ...props,
-      },
-      children as never,
-    ),
-}))
+  // the rest (onClick/className/data-testid) to a plain anchor. forwardRef like
+  // the real AppLink: callers ref the anchor (the sidebar's cmd-hint targets and
+  // its agent-menu button both reach the row that way).
+  const AppLink = forwardRef(
+    (
+      { children, to, params, search, activeClassName: _ac, activeOptions: _ao, noDrag: _nd, ...props }: Record<string, unknown> & { children?: unknown },
+      ref,
+    ) =>
+      createElement(
+        'a',
+        {
+          ref,
+          href: '#',
+          // Expose the route target so tests can assert navigation (the real
+          // <a href> isn't built in jsdom; data-* attrs avoid React DOM warnings).
+          'data-to': to,
+          'data-params': params ? JSON.stringify(params) : undefined,
+          'data-search': search ? JSON.stringify(search) : undefined,
+          ...props,
+        },
+        children as never,
+      ),
+  )
+  AppLink.displayName = 'AppLink'
+  return { AppLink }
+})
 
 // DialogContext drives global settings via the router. Renderer unit
 // tests have no RouterProvider, so stub it — DialogProvider passes children


### PR DESCRIPTION
Right-click on a sidebar agent row was the only way into the agent menu, and nobody finds it. A 3-dot button now fades in on hover and takes over the status-indicator slot, opening that same menu.

## How it works

**One menu surface, not two.** The button synthesizes the `contextmenu` event the row's Radix trigger already listens for — the same trick `ui/context-menu.tsx` uses for its touch long-press. Right-click and the button therefore can't drift apart in contents or behavior. `AgentContextMenu`'s `onOpenChange` keeps the button visible while the menu is up: once open, Radix takes pointer events off the page, so a hover-only trigger would otherwise vanish out from under its own menu.

**One button component, not two.** The agent home already had a 3-dot button doing the same replay. Both surfaces now render a shared `AgentMenuButton` (`src/renderer/components/agents/agent-menu-button.tsx`), which owns the replay, the aria wiring, and the icon. Each caller keeps its own look through `className` (a bare hover chip in the sidebar, an outline button on the agent home). The one real difference between them — where the menu lands — is an explicit `anchor` prop: `below` for a header-row button, `beside` for the sidebar, where a dropdown would cover the rows underneath. The agent home's label becomes "Options for {name}", matching the sidebar; its `agent-settings-button` test id is unchanged.

**The row keeps its background.** Both the 3-dot and the expand chevron are siblings painted over the row (it must stay a single `<a>` — no nested interactive controls), so pointing at either one un-hovers the row itself and its background drops out. Fixed in two places:

- Web build: the wash is driven from the row wrapper (`group/agent-row`) instead of the link's own `:hover`.
- Desktop: the macOS vibrancy override in `globals.css` is keyed on `[data-sidebar="menu-button"]:hover`, so the row was flashing from its `rgba(0,0,0,0.06)` tint to the opaque near-white Tailwind fallback the instant you reached for the menu. That block now matches on the wrapper too.

Both controls carry the same 20×20 `rounded-md` hover chip, one step darker than the row wash.

**Hover scoping** is the row wrapper rather than `group/menu-item` throughout, so an expanded agent's session sub-rows no longer drive their parent row's indicator swap or chevron brightening.

## Incidental

The shared `AppLink` test stub is now a `forwardRef` like the real component — it was silently swallowing refs, including the pre-existing cmd-hint target ref.

## Test plan

- `agent-menu-button.test.tsx`: the click replays as a contextmenu on the trigger and does not leak to the row link; both anchor points; `aria-expanded` follows the menu.
- 2 cases in `app-sidebar.test.tsx`: the button opens the menu and the indicator yields its slot; the button is never nested inside the row link.
- Full unit suite green; typecheck + lint clean.
- Row hover, chevron hover, and 3-dot hover verified by hand in the Electron dev app (vibrancy override) on the original commit; the shared-button refactor verified on the web target — captures below.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Sidebar row hover (light)](https://github.com/user-attachments/assets/d12aca31-33d3-4910-806a-d3114b21c23e) | ![Sidebar row hover (dark)](https://github.com/user-attachments/assets/7e676785-3fbc-4aea-b707-b7d5b4e6d01d) |
| ![Sidebar 3-dot menu (light)](https://github.com/user-attachments/assets/0178c589-ac15-4b00-adf0-a1558809f36c) | ![Sidebar 3-dot menu (dark)](https://github.com/user-attachments/assets/ab682e7f-3d8e-4dcf-b34d-e13449f5b301) |
| ![Agent home 3-dot menu (light)](https://github.com/user-attachments/assets/e3a59a18-3f89-48b1-8b24-7999dcebd852) | ![Agent home 3-dot menu (dark)](https://github.com/user-attachments/assets/c103f828-a7bf-41f7-a4d9-2047f02f5816) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
