### PR TITLE
Two-pass streaming messages page with byte budget (SUP-595)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1824,6 +1824,19 @@ async function annotateAndRecoverMessages(
   }
 }
 
+// Buffers, not strings: Readable.toWeb hands chunks straight to the web
+// ReadableStream, whose byte consumers reject non-Uint8Array chunks.
+function* messagesPageJsonChunks(page: {
+  messages: TransformedItem[]
+  nextCursor: string | null
+}): Generator<Buffer> {
+  yield Buffer.from('{"messages":[')
+  for (let i = 0; i < page.messages.length; i++) {
+    yield Buffer.from((i === 0 ? '' : ',') + JSON.stringify(page.messages[i]))
+  }
+  yield Buffer.from(`],"nextCursor":${JSON.stringify(page.nextCursor)}}`)
+}
+
 // Unpaginated path stays inlined so the stream-pipe PR can still land on `return c.json(transformed)`.
 // GET /api/agents/:id/sessions/:sessionId/messages - Get messages for a session
 agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
@@ -1884,7 +1897,14 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       c.req.raw.signal.throwIfAborted()
       await annotateAndRecoverMessages(page.messages, agentSlug, sessionId)
       c.req.raw.signal.throwIfAborted()
-      return c.json({ messages: page.messages, nextCursor: page.nextCursor })
+      // Serialize item-by-item instead of one JSON.stringify of the whole
+      // envelope: pages hold multi-MB tool results, and a monolithic response
+      // string was one of the transients that made concurrent page fetches
+      // OOM the process. Readable.from pulls lazily, so writes see real
+      // backpressure from the socket.
+      return c.body(Readable.toWeb(Readable.from(messagesPageJsonChunks(page))) as ReadableStream, 200, {
+        'Content-Type': 'application/json',
+      })
     }
 
     const messages = await getSessionMessagesWithCompact(agentSlug, sessionId)

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -1148,9 +1148,9 @@ describe('session-service', () => {
     it('hard cap bounds a huge non-display gap and still serves the trailing item', async () => {
       // Tool-result-only rows are not display items, so the two-item budget
       // floor alone would scan through an arbitrarily large run of them. The
-      // hard cap stops the scan unconditionally; the trailing item (complete,
-      // single-entry) must still be served rather than sacrificed, and the
-      // walk must terminate rather than error on the unreachable gap.
+      // hard cap stops the scan once its one-servable-item floor is met; the
+      // trailing item (complete, single-entry) must be served rather than
+      // sacrificed, and cursor paging must cross the gap to older history.
       const ts = (s: number) => new Date(Date.UTC(2026, 0, 8, 0, 0, s)).toISOString()
       const rows: object[] = [
         ...makeThread(2),
@@ -1182,6 +1182,93 @@ describe('session-service', () => {
       }
       expect(cursor).toBeNull()
       expect(hops).toBeLessThanOrEqual(2)
+    })
+
+    it('serves the visible history behind a capped trailing tool-result run', async () => {
+      // A turn that just wrote its tool results leaves only non-display rows
+      // at EOF. The hard cap must not settle before at least one servable
+      // item is in the window — an empty terminal page here would blank the
+      // whole session in the client.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 9, 0, 0, s)).toISOString()
+      const rows: object[] = [
+        { type: 'user', uuid: 'u-0', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'q0' } },
+        { type: 'assistant', uuid: 'A-use', timestamp: ts(1), sessionId: 's', parentUuid: null, message: { id: 'msg-A', role: 'assistant', content: [{ type: 'tool_use', id: 'tg', name: 'Bash', input: {} }] } },
+      ]
+      for (let i = 0; i < 10; i++) {
+        rows.push({ type: 'user', uuid: `rg-${i}`, timestamp: ts(2 + i), sessionId: 's', parentUuid: 'A-use', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tg', content: 'y'.repeat(1024) }] } })
+      }
+      await createSessionFile('test-agent', 'page-session', rows)
+
+      // budget 512 -> hard cap 1024, far below the trailing 10KB result run.
+      const page = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 5,
+        byteBudget: 512,
+      })
+      expect(page.messages.map((m) => m.id)).toEqual(['u-0', 'A-use'])
+      const use = page.messages[1]
+      expect(use!.type === 'assistant' && use!.toolCalls[0]?.result).toBeDefined()
+    })
+
+    it('never cuts a merge group split by an interleaved queued message', async () => {
+      // old -> A0(id=M) -> queued Q -> A1(id=M) -> N: the group's older entry
+      // lies below the queued row. A window boundary between Q and A0 would
+      // serve a partial item under A1's non-canonical id, which then vanishes
+      // from the next window and terminates pagination.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 10, 0, 0, s)).toISOString()
+      await createSessionFile('test-agent', 'page-session', [
+        { type: 'user', uuid: 'old', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'earlier' } },
+        { type: 'assistant', uuid: 'A0', timestamp: ts(1), sessionId: 's', parentUuid: null, message: { id: 'M', role: 'assistant', content: [{ type: 'text', text: 'part one ' }] } },
+        { type: 'attachment', uuid: 'q-raw', timestamp: ts(2), parentUuid: null, attachment: { type: 'queued_command', commandMode: 'prompt', prompt: 'steer', source_uuid: 'Q' } },
+        { type: 'assistant', uuid: 'A1', timestamp: ts(3), sessionId: 's', parentUuid: null, message: { id: 'M', role: 'assistant', content: [{ type: 'text', text: 'part two' }] } },
+        { type: 'user', uuid: 'N', timestamp: ts(4), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'newest' } },
+      ])
+
+      const first = await getSessionMessagesPage('test-agent', 'page-session', { limit: 2 })
+      expect(first.messages.map((m) => m.id)).toEqual(['Q', 'N'])
+
+      const older = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 2,
+        cursor: first.nextCursor!,
+      })
+      expect(older.messages.map((m) => m.id)).toEqual(['old', 'A0'])
+      expect(older.messages[1]).toMatchObject({ content: { text: 'part one part two' } })
+      expect(older.nextCursor).toBeNull()
+    })
+
+    it('walks system runs split by meta rows without losing items', async () => {
+      // A meta row between system entries is filtered out before the
+      // transform runs, so the entries on either side are adjacent in
+      // transform semantics and reorder as one run — the scan boundary must
+      // treat them the same way.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 11, 0, 0, s)).toISOString()
+      const sys = (uuid: string, subtype: string, s: number, extra: object = {}) => ({
+        type: 'system', uuid, subtype, content: '', isMeta: false, timestamp: ts(s), ...extra,
+      })
+      await createSessionFile('test-agent', 'page-session', [
+        { type: 'user', uuid: 'u-0', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'q0' } },
+        sys('info1', 'informational', 1, { content: 'note one' }),
+        { type: 'user', uuid: 'meta-x', timestamp: ts(2), sessionId: 's', parentUuid: null, isMeta: true, message: { role: 'user', content: 'meta' } },
+        sys('mr', 'memory_recall', 3, { memory_paths: ['M.md'] }),
+        sys('cb', 'compact_boundary', 4, { compactMetadata: { trigger: 'manual', preTokens: 1 } }),
+        sys('info2', 'informational', 5, { content: 'note two' }),
+      ])
+
+      const full = await getSessionMessagesPage('test-agent', 'page-session', { limit: 100 })
+      const first = await getSessionMessagesPage('test-agent', 'page-session', { limit: 1 })
+      const collected = [...first.messages.map((m) => m.id)]
+      let cursor = first.nextCursor
+      for (let i = 0; i < 10 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 1,
+          cursor,
+        })
+        collected.unshift(...page.messages.map((m) => m.id))
+        cursor = page.nextCursor
+      }
+
+      expect(cursor).toBeNull()
+      expect(collected).toEqual(full.messages.map((m) => m.id))
+      expect(collected).toContain('info1')
     })
 
     it('attaches a tool result recorded past the cursor line', async () => {

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -1064,6 +1064,126 @@ describe('session-service', () => {
       expect(queued).toMatchObject({ type: 'user', queued: true, content: { text: 'steer' } })
     })
 
+    it('terminates and returns each item once when history is replayed verbatim', async () => {
+      // Session resume can re-append prior history to the transcript with the
+      // SAME uuids. The transform canonicalizes duplicates to their oldest
+      // occurrence; cursor resolution must do the same, or paging anchors on
+      // the newest copy and cycles over the same pages forever.
+      const six = makeThread(3)
+      await createSessionFile('test-agent', 'page-session', [...six, ...six])
+
+      const first = await getSessionMessagesPage('test-agent', 'page-session', { limit: 3 })
+      const collected = [...first.messages.map((m) => m.id)]
+      let cursor = first.nextCursor
+      for (let i = 0; i < 10 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 3,
+          cursor,
+        })
+        collected.unshift(...page.messages.map((m) => m.id))
+        cursor = page.nextCursor
+      }
+
+      expect(cursor).toBeNull()
+      expect(collected).toEqual(['u-0', 'a-0', 'u-1', 'a-1', 'u-2', 'a-2'])
+    })
+
+    it('returns every trailing system item across pages despite display reordering', async () => {
+      // The transform orders adjacent system items by type (recalls, then
+      // boundaries, then informationals) regardless of file order. A window
+      // boundary landing inside such a run must not make pagination skip the
+      // reordered items.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 6, 0, 0, s)).toISOString()
+      await createSessionFile('test-agent', 'page-session', [
+        { type: 'user', uuid: 'u-0', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'q0' } },
+        { type: 'system', uuid: 'info1', subtype: 'informational', content: 'note one', isMeta: false, timestamp: ts(1) },
+        { type: 'system', uuid: 'mr', subtype: 'memory_recall', content: '', isMeta: false, timestamp: ts(2), memory_paths: ['M.md'] },
+        { type: 'system', uuid: 'cb', subtype: 'compact_boundary', content: '', isMeta: false, timestamp: ts(3), compactMetadata: { trigger: 'manual', preTokens: 1 } },
+        { type: 'system', uuid: 'info2', subtype: 'informational', content: 'note two', isMeta: false, timestamp: ts(4) },
+      ])
+
+      const full = await getSessionMessagesPage('test-agent', 'page-session', { limit: 100 })
+      expect(full.messages.map((m) => m.id)).toEqual(['u-0', 'mr', 'cb', 'info1', 'info2'])
+
+      const first = await getSessionMessagesPage('test-agent', 'page-session', { limit: 1 })
+      const collected = [...first.messages.map((m) => m.id)]
+      let cursor = first.nextCursor
+      for (let i = 0; i < 10 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 1,
+          cursor,
+        })
+        collected.unshift(...page.messages.map((m) => m.id))
+        cursor = page.nextCursor
+      }
+
+      expect(cursor).toBeNull()
+      expect(collected).toEqual(['u-0', 'mr', 'cb', 'info1', 'info2'])
+    })
+
+    it('attaches an oversized tool result that starts inside the grace region', async () => {
+      // The window past the cursor must end on a LINE boundary: a fixed byte
+      // end would cut this 600KB result row mid-line and drop it as
+      // malformed, leaving the historical call permanently unresolved.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 7, 0, 0, s)).toISOString()
+      const big = 'X'.repeat(600 * 1024)
+      await createSessionFile('test-agent', 'page-session', [
+        ...makeThread(2),
+        { type: 'user', uuid: 'u-ask', timestamp: ts(10), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'run it' } },
+        { type: 'assistant', uuid: 'X-use', timestamp: ts(11), sessionId: 's', parentUuid: 'u-ask', message: { id: 'msg-X', role: 'assistant', content: [{ type: 'tool_use', id: 't9', name: 'Bash', input: {} }] } },
+        { type: 'attachment', uuid: 'qc-raw', timestamp: ts(12), parentUuid: null, attachment: { type: 'queued_command', commandMode: 'prompt', prompt: 'steer', source_uuid: 'qc-2' } },
+        { type: 'user', uuid: 'r-9', timestamp: ts(13), sessionId: 's', parentUuid: 'X-use', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't9', content: big }] } },
+        { type: 'assistant', uuid: 'a-done', timestamp: ts(14), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] } },
+      ])
+
+      const page = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 2,
+        cursor: 'qc-2',
+      })
+      expect(page.messages.map((m) => m.id)).toEqual(['u-ask', 'X-use'])
+      const use = page.messages[1]
+      expect(use!.type === 'assistant' && use!.toolCalls[0]?.result?.length).toBe(big.length)
+    })
+
+    it('hard cap bounds a huge non-display gap and still serves the trailing item', async () => {
+      // Tool-result-only rows are not display items, so the two-item budget
+      // floor alone would scan through an arbitrarily large run of them. The
+      // hard cap stops the scan unconditionally; the trailing item (complete,
+      // single-entry) must still be served rather than sacrificed, and the
+      // walk must terminate rather than error on the unreachable gap.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 8, 0, 0, s)).toISOString()
+      const rows: object[] = [
+        ...makeThread(2),
+        { type: 'assistant', uuid: 'A-use', timestamp: ts(10), sessionId: 's', parentUuid: null, message: { id: 'msg-A', role: 'assistant', content: [{ type: 'tool_use', id: 'tg', name: 'Bash', input: {} }] } },
+      ]
+      for (let i = 0; i < 20; i++) {
+        rows.push({ type: 'user', uuid: `rg-${i}`, timestamp: ts(11 + i), sessionId: 's', parentUuid: 'A-use', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tg', content: 'y'.repeat(1024) }] } })
+      }
+      rows.push({ type: 'assistant', uuid: 'a-done', timestamp: ts(40), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] } })
+      await createSessionFile('test-agent', 'page-session', rows)
+
+      // budget 1024 → hard cap 2048, far below the ~20KB result gap.
+      const first = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 5,
+        byteBudget: 1024,
+      })
+      expect(first.messages.map((m) => m.id)).toEqual(['a-done'])
+
+      let cursor = first.nextCursor
+      let hops = 0
+      for (let i = 0; i < 5 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 5,
+          cursor,
+          byteBudget: 1024,
+        })
+        hops++
+        cursor = page.nextCursor
+      }
+      expect(cursor).toBeNull()
+      expect(hops).toBeLessThanOrEqual(2)
+    })
+
     it('attaches a tool result recorded past the cursor line', async () => {
       // A queued user message lands between a tool_use and its result, and
       // becomes the page cursor: the result then sits ABOVE the cursor line,

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -1271,6 +1271,118 @@ describe('session-service', () => {
       expect(collected).toContain('info1')
     })
 
+    it('pages across a capped gap when the cursor sits in a reordered system run', async () => {
+      // The system run after the gap reorders (recalls before boundaries
+      // before informationals), so the raw rows below a system cursor can
+      // transform to display-AFTER it. If they satisfied the item count, the
+      // page would come out empty and terminate paging while older visible
+      // history exists behind the gap.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 12, 0, 0, s)).toISOString()
+      const rows: object[] = [
+        { type: 'user', uuid: 'old-u', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'older q' } },
+        { type: 'assistant', uuid: 'old-a', timestamp: ts(1), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'older r' }] } },
+        { type: 'assistant', uuid: 'A-use', timestamp: ts(2), sessionId: 's', parentUuid: null, message: { id: 'msg-A', role: 'assistant', content: [{ type: 'tool_use', id: 'tg', name: 'Bash', input: {} }] } },
+      ]
+      for (let i = 0; i < 10; i++) {
+        rows.push({ type: 'user', uuid: `rg-${i}`, timestamp: ts(3 + i), sessionId: 's', parentUuid: 'A-use', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tg', content: 'y'.repeat(1024) }] } })
+      }
+      rows.push(
+        { type: 'system', uuid: 'cb', subtype: 'compact_boundary', content: '', isMeta: false, timestamp: ts(20), compactMetadata: { trigger: 'auto', preTokens: 1 } },
+        { type: 'system', uuid: 'mr', subtype: 'memory_recall', content: '', isMeta: false, timestamp: ts(21), memory_paths: ['M.md'] },
+        { type: 'system', uuid: 'info', subtype: 'informational', content: 'note', isMeta: false, timestamp: ts(22) },
+        { type: 'user', uuid: 'new-u', timestamp: ts(23), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'new q' } },
+        { type: 'assistant', uuid: 'new-a', timestamp: ts(24), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'new r' }] } },
+      )
+      await createSessionFile('test-agent', 'page-session', rows)
+
+      const full = await getSessionMessagesPage('test-agent', 'page-session', { limit: 100 })
+      const first = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 5,
+        byteBudget: 512,
+      })
+      expect(first.messages.map((m) => m.id)).toEqual(['mr', 'cb', 'info', 'new-u', 'new-a'])
+      const collected = [...first.messages.map((m) => m.id)]
+      let cursor = first.nextCursor
+      for (let i = 0; i < 10 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 5,
+          cursor,
+          byteBudget: 512,
+        })
+        collected.unshift(...page.messages.map((m) => m.id))
+        cursor = page.nextCursor
+      }
+      expect(cursor).toBeNull()
+      expect(collected).toEqual(full.messages.map((m) => m.id))
+    })
+
+    it('keeps a heterogeneous system run whole under a small hard cap', async () => {
+      // Every row is individually below the cap, but the run collectively
+      // exceeds it: run completion is cap-exempt, so no window boundary may
+      // land inside the reorderable group.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 13, 0, 0, s)).toISOString()
+      const pad = 'p'.repeat(300)
+      await createSessionFile('test-agent', 'page-session', [
+        { type: 'user', uuid: 'older-u', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'older' } },
+        { type: 'assistant', uuid: 'older-a', timestamp: ts(1), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'older r' }] } },
+        { type: 'system', uuid: 'recall', subtype: 'memory_recall', content: pad, isMeta: false, timestamp: ts(2), memory_paths: ['M.md'] },
+        { type: 'system', uuid: 'boundary', subtype: 'compact_boundary', content: pad, isMeta: false, timestamp: ts(3), compactMetadata: { trigger: 'auto', preTokens: 1 } },
+        { type: 'system', uuid: 'info1', subtype: 'informational', content: `note one ${pad}`, isMeta: false, timestamp: ts(4) },
+        { type: 'system', uuid: 'info2', subtype: 'informational', content: `note two ${pad}`, isMeta: false, timestamp: ts(5) },
+        { type: 'user', uuid: 'newer-u', timestamp: ts(6), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'newer' } },
+        { type: 'assistant', uuid: 'newer-a', timestamp: ts(7), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'newer r' }] } },
+      ])
+
+      const full = await getSessionMessagesPage('test-agent', 'page-session', { limit: 100 })
+      for (const [limit, byteBudget] of [[2, 400], [3, 700], [1, 400]] as const) {
+        const first = await getSessionMessagesPage('test-agent', 'page-session', { limit, byteBudget })
+        const collected = [...first.messages.map((m) => m.id)]
+        let cursor = first.nextCursor
+        for (let i = 0; i < 15 && cursor; i++) {
+          const page = await getSessionMessagesPage('test-agent', 'page-session', {
+            limit,
+            cursor,
+            byteBudget,
+          })
+          collected.unshift(...page.messages.map((m) => m.id))
+          cursor = page.nextCursor
+        }
+        expect(cursor).toBeNull()
+        expect(collected).toEqual(full.messages.map((m) => m.id))
+      }
+    })
+
+    it('collapses repeated compact boundaries like the transform does', async () => {
+      // Boundary/summary pairs with no message between them all share one
+      // anchor; the transform keeps only the newest. Counting each would
+      // satisfy the page target with items that never display, and the
+      // system-cursor page below the surviving boundary must reach the real
+      // older messages.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 14, 0, 0, s)).toISOString()
+      const rows: object[] = [
+        { type: 'user', uuid: 'U', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'q' } },
+        { type: 'assistant', uuid: 'A', timestamp: ts(1), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'r' }] } },
+      ]
+      for (let i = 1; i <= 4; i++) {
+        rows.push({ type: 'system', uuid: `c${i}`, subtype: 'compact_boundary', content: '', isMeta: false, timestamp: ts(1 + i), compactMetadata: { trigger: 'auto', preTokens: i } })
+        rows.push({ type: 'user', uuid: `s${i}`, timestamp: ts(6 + i), sessionId: 's', parentUuid: null, isCompactSummary: true, message: { role: 'user', content: `summary ${i}` } })
+      }
+      rows.push({ type: 'user', uuid: 'N', timestamp: ts(20), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'after' } })
+      await createSessionFile('test-agent', 'page-session', rows)
+
+      const full = await getSessionMessagesPage('test-agent', 'page-session', { limit: 100 })
+      expect(full.messages.map((m) => m.id)).toEqual(['U', 'A', 'c4', 'N'])
+
+      const first = await getSessionMessagesPage('test-agent', 'page-session', { limit: 2 })
+      expect(first.messages.map((m) => m.id)).toEqual(['c4', 'N'])
+      const older = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 2,
+        cursor: first.nextCursor!,
+      })
+      expect(older.messages.map((m) => m.id)).toEqual(['U', 'A'])
+      expect(older.nextCursor).toBeNull()
+    })
+
     it('attaches a tool result recorded past the cursor line', async () => {
       // A queued user message lands between a tool_use and its result, and
       // becomes the page cursor: the result then sits ABOVE the cursor line,

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -940,6 +940,156 @@ describe('session-service', () => {
       expect(page.messages.map((m) => m.id)).toEqual(['a-7', 'u-8', 'a-8', 'u-9', 'a-9'])
       expect(page.nextCursor).toBe('a-7')
     })
+
+    it('byte budget truncates a page short and cursor paging walks the remainder', async () => {
+      await createSessionFile('test-agent', 'page-session', makeThread(30))
+
+      // ~1KB budget against ~180-byte rows: each window holds a handful of
+      // items, far fewer than the requested limit.
+      const first = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 20,
+        byteBudget: 1024,
+      })
+      expect(first.messages.length).toBeGreaterThan(0)
+      expect(first.messages.length).toBeLessThan(20)
+      expect(first.nextCursor).toBe(first.messages[0]!.id)
+
+      const collected = [...first.messages.map((m) => m.id)]
+      let cursor = first.nextCursor
+      for (let i = 0; i < 100 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 20,
+          cursor,
+          byteBudget: 1024,
+        })
+        collected.unshift(...page.messages.map((m) => m.id))
+        cursor = page.nextCursor
+      }
+
+      const expected: string[] = []
+      for (let i = 0; i < 30; i++) expected.push(`u-${i}`, `a-${i}`)
+      expect(collected).toEqual(expected)
+    })
+
+    it('serves a single item larger than the whole byte budget', async () => {
+      const giant = {
+        type: 'assistant',
+        uuid: 'a-giant',
+        timestamp: '2026-01-01T00:10:00.000Z',
+        sessionId: 'page-session',
+        parentUuid: null,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'G'.repeat(64 * 1024) }],
+        },
+      }
+      await createSessionFile('test-agent', 'page-session', [...makeThread(5), giant])
+
+      const page = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 5,
+        byteBudget: 1024,
+      })
+      // The budget floor guarantees at least one servable item beyond the
+      // sacrificial head — the giant trailing item must not become an empty page.
+      expect(page.messages.map((m) => m.id)).toEqual(['a-giant'])
+      expect(page.nextCursor).toBe('a-giant')
+
+      const older = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 5,
+        cursor: 'a-giant',
+        byteBudget: 1024,
+      })
+      expect(older.messages.length).toBeGreaterThan(0)
+    })
+
+    it('paged walk over a mixed transcript matches the full transform', async () => {
+      // Every classification the backward index scan replicates: meta rows,
+      // split assistant merges with tool results, queued_command attachments,
+      // task notifications, informational banners with their synthetic user
+      // copy, memory recalls, compact boundaries with summaries.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 2, 0, 0, s)).toISOString()
+      const entries: object[] = [
+        { type: 'user', uuid: 'u-0', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'q0' } },
+        { type: 'assistant', uuid: 'a-0', timestamp: ts(1), sessionId: 's', parentUuid: 'u-0', message: { role: 'assistant', content: [{ type: 'text', text: 'r0' }] } },
+        { type: 'user', uuid: 'meta-0', timestamp: ts(2), sessionId: 's', parentUuid: null, isMeta: true, message: { role: 'user', content: 'meta' } },
+        { type: 'user', uuid: 'u-1', timestamp: ts(3), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'q1' } },
+        { type: 'assistant', uuid: 'A1a', timestamp: ts(4), sessionId: 's', parentUuid: 'u-1', message: { id: 'msg-1', role: 'assistant', content: [{ type: 'text', text: 'part1 ' }] } },
+        { type: 'assistant', uuid: 'A1b', timestamp: ts(5), sessionId: 's', parentUuid: 'u-1', message: { id: 'msg-1', role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }] } },
+        { type: 'user', uuid: 'r-1', timestamp: ts(6), sessionId: 's', parentUuid: 'A1b', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } },
+        { type: 'user', uuid: 'task-note', timestamp: ts(7), sessionId: 's', parentUuid: null, origin: { kind: 'task-notification' }, message: { role: 'user', content: 'subagent done' } },
+        { type: 'attachment', uuid: 'qc-raw', timestamp: ts(8), parentUuid: null, attachment: { type: 'queued_command', commandMode: 'prompt', prompt: 'steer', source_uuid: 'qc-u' } },
+        { type: 'assistant', uuid: 'a-2', timestamp: ts(9), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'r2' }] } },
+        { type: 'user', uuid: 'stop-user', timestamp: ts(10), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'Operation stopped by hook: X' } },
+        { type: 'system', uuid: 'info-1', subtype: 'informational', content: 'Operation stopped by hook: X', isMeta: false, timestamp: ts(11) },
+        { type: 'system', uuid: 'mr-1', subtype: 'memory_recall', content: '', isMeta: false, timestamp: ts(12), memory_paths: ['MEMORY.md'] },
+        { type: 'system', uuid: 'cb-1', subtype: 'compact_boundary', content: '', isMeta: false, timestamp: ts(13), compactMetadata: { trigger: 'manual', preTokens: 5 } },
+        { type: 'user', uuid: 'cs-1', timestamp: ts(14), sessionId: 's', parentUuid: null, isCompactSummary: true, message: { role: 'user', content: 'summary' } },
+        { type: 'user', uuid: 'u-3', timestamp: ts(15), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'q3' } },
+        { type: 'assistant', uuid: 'a-3', timestamp: ts(16), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'r3' }] } },
+      ]
+      await createSessionFile('test-agent', 'page-session', entries)
+
+      // Reference: one page big enough to hold everything.
+      const full = await getSessionMessagesPage('test-agent', 'page-session', { limit: 100 })
+      expect(full.messages.map((m) => m.id)).toEqual([
+        'u-0', 'a-0', 'u-1', 'A1a', 'qc-u', 'a-2', 'mr-1', 'cb-1', 'info-1', 'u-3', 'a-3',
+      ])
+
+      // Small pages + small budget: the same items must come back, in order,
+      // with the split assistant still merged and its tool result attached.
+      const first = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 3,
+        byteBudget: 600,
+      })
+      const collected = [...first.messages]
+      let cursor = first.nextCursor
+      for (let i = 0; i < 50 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 3,
+          cursor,
+          byteBudget: 600,
+        })
+        collected.unshift(...page.messages)
+        cursor = page.nextCursor
+      }
+
+      expect(collected.map((m) => m.id)).toEqual(full.messages.map((m) => m.id))
+      const merged = collected.find((m) => m.id === 'A1a')
+      expect(merged).toMatchObject({ type: 'assistant', content: { text: 'part1 ' } })
+      expect(merged!.type === 'assistant' && merged!.toolCalls[0]).toMatchObject({
+        id: 't1',
+        result: 'ok',
+      })
+      const queued = collected.find((m) => m.id === 'qc-u')
+      expect(queued).toMatchObject({ type: 'user', queued: true, content: { text: 'steer' } })
+    })
+
+    it('attaches a tool result recorded past the cursor line', async () => {
+      // A queued user message lands between a tool_use and its result, and
+      // becomes the page cursor: the result then sits ABOVE the cursor line,
+      // inside the window's forward grace region.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 3, 0, 0, s)).toISOString()
+      const entries: object[] = [
+        ...makeThread(2),
+        { type: 'user', uuid: 'u-ask', timestamp: ts(10), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'run it' } },
+        { type: 'assistant', uuid: 'X-use', timestamp: ts(11), sessionId: 's', parentUuid: 'u-ask', message: { id: 'msg-X', role: 'assistant', content: [{ type: 'tool_use', id: 't9', name: 'Bash', input: { command: 'sleep' } }] } },
+        { type: 'attachment', uuid: 'qc2-raw', timestamp: ts(12), parentUuid: null, attachment: { type: 'queued_command', commandMode: 'prompt', prompt: 'steer2', source_uuid: 'qc-2' } },
+        { type: 'user', uuid: 'r-9', timestamp: ts(13), sessionId: 's', parentUuid: 'X-use', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't9', content: 'late-ok' }] } },
+        { type: 'assistant', uuid: 'a-done', timestamp: ts(14), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] } },
+      ]
+      await createSessionFile('test-agent', 'page-session', entries)
+
+      const page = await getSessionMessagesPage('test-agent', 'page-session', {
+        limit: 2,
+        cursor: 'qc-2',
+      })
+      expect(page.messages.map((m) => m.id)).toEqual(['u-ask', 'X-use'])
+      const use = page.messages[1]
+      expect(use!.type === 'assistant' && use!.toolCalls[0]).toMatchObject({
+        id: 't9',
+        result: 'late-ok',
+      })
+    })
   })
 
   describe('getSessionMessagesDelta', () => {

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -1383,6 +1383,46 @@ describe('session-service', () => {
       expect(older.nextCursor).toBeNull()
     })
 
+    it('replayed duplicate anchors do not reopen a collapsed boundary span', async () => {
+      // Byte-identical replayed rows share their original's uuid, and the
+      // transform keys boundary collapse BY uuid — so boundaries separated
+      // only by duplicates of one anchor all collapse to the newest. If each
+      // duplicate reset the span, the collapsed boundaries would satisfy the
+      // page target and the cursor page below the survivor would come out
+      // empty, hiding the real older messages.
+      const ts = (s: number) => new Date(Date.UTC(2026, 0, 15, 0, 0, s)).toISOString()
+      const boundary = (uuid: string, s: number) => ({
+        type: 'system', uuid, subtype: 'compact_boundary', content: '', isMeta: false,
+        timestamp: ts(s), compactMetadata: { trigger: 'auto', preTokens: 1 },
+      })
+      const X = { type: 'user', uuid: 'X', timestamp: ts(10), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'anchor msg' } }
+      await createSessionFile('test-agent', 'page-session', [
+        { type: 'user', uuid: 'U', timestamp: ts(0), sessionId: 's', parentUuid: null, message: { role: 'user', content: 'q' } },
+        { type: 'assistant', uuid: 'A', timestamp: ts(1), sessionId: 's', parentUuid: null, message: { role: 'assistant', content: [{ type: 'text', text: 'r' }] } },
+        boundary('c1', 2), X,
+        boundary('c2', 3), X,
+        boundary('c3', 4), X,
+        boundary('c4', 5), X,
+      ])
+
+      const full = await getSessionMessagesPage('test-agent', 'page-session', { limit: 100 })
+      expect(full.messages.map((m) => m.id)).toEqual(['U', 'A', 'c4', 'X'])
+
+      const first = await getSessionMessagesPage('test-agent', 'page-session', { limit: 2 })
+      const collected = [...first.messages.map((m) => m.id)]
+      let cursor = first.nextCursor
+      for (let i = 0; i < 10 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 2,
+          cursor,
+        })
+        collected.unshift(...page.messages.map((m) => m.id))
+        cursor = page.nextCursor
+      }
+      expect(cursor).toBeNull()
+      expect(collected).toEqual(['U', 'A', 'c4', 'X'])
+    })
+
     it('attaches a tool result recorded past the cursor line', async () => {
       // A queued user message lands between a tool_use and its result, and
       // becomes the page cursor: the result then sits ABOVE the cursor line,

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -1200,6 +1200,18 @@ async function scanMessagesPageWindow(
   // message.id of an assistant merge group whose span may extend below the
   // current line — set while walking its (possibly interleaved) turn.
   let openGroupId: string | null = null
+  // While the cursor is a system item, rows below it may belong to the same
+  // contiguous system run and reorder display-AFTER the cursor (recalls sort
+  // before boundaries before informationals regardless of file order). Such
+  // rows must not satisfy the item count: a page counted from them can
+  // transform to empty and terminate paging while older history exists.
+  // Suppression lifts at the first anchor row below the cursor's run; every
+  // item counted after that is provably display-before the cursor.
+  let suppressUntilAnchorRow = false
+  // The transform keeps only the NEWEST compact boundary before each anchor
+  // (a single-slot map keyed by the next message), so deeper boundaries in
+  // the same span collapse away and must not count as display items.
+  let boundaryCountedSinceAnchor = false
 
   for await (const { line, offset } of iterateJsonlLinesBackward(jsonlPath, signal)) {
     linesScanned++
@@ -1227,6 +1239,8 @@ async function scanMessagesPageWindow(
         windowBytes = 0
         deepestCountedIsGroup = true
         openGroupId = null
+        suppressUntilAnchorRow = normalized.type === 'system'
+        boundaryCountedSinceAnchor = false
         startOffset = offset
         endOffset = graceEndOffset(lineOffsets!, offset + line.length + 1)
         continue
@@ -1242,7 +1256,11 @@ async function scanMessagesPageWindow(
 
     if (mode === 'extending') {
       const kind = classifyExtensionRow(normalized, state)
-      if (kind !== 'settle' && windowBytes + line.length + 1 < hardCap) {
+      if (kind !== 'settle') {
+        // Cap-exempt: the transform reorders an entire contiguous system run
+        // as one unit, so a cap-placed boundary inside it loses items exactly
+        // like a cut merge group would. Bounded by the run's span — system
+        // and filtered rows are small.
         windowBytes += line.length + 1
         startOffset = offset
         if (kind === 'system') deepestCountedIsGroup = false
@@ -1260,9 +1278,37 @@ async function scanMessagesPageWindow(
       normalized !== undefined && (normalized.type === 'user' || normalized.type === 'assistant')
         ? (normalized as JsonlMessageEntry)
         : undefined
-    if (normalized !== undefined && countsAsDisplayStart(normalized, state)) {
-      displayCount++
-      deepestCountedIsGroup = msgEntry?.type === 'assistant' && !!msgEntry.message.id
+    const pendingInfoBefore = state.pendingInformationalContent
+    const counted = normalized !== undefined && countsAsDisplayStart(normalized, state)
+    // An anchor row is one the transform attaches system items to — a real
+    // message entry, not a filtered/skipped one (meta rows, compact
+    // summaries, an informational's synthetic user copy).
+    const isAnchorRow =
+      msgEntry !== undefined &&
+      !('isMeta' in msgEntry && msgEntry.isMeta) &&
+      !msgEntry.isCompactSummary &&
+      !(
+        pendingInfoBefore !== null &&
+        msgEntry.type === 'user' &&
+        typeof msgEntry.message.content === 'string' &&
+        msgEntry.message.content === pendingInfoBefore
+      )
+    if (isAnchorRow) {
+      suppressUntilAnchorRow = false
+      boundaryCountedSinceAnchor = false
+    }
+    if (counted && !suppressUntilAnchorRow) {
+      const isBoundary =
+        normalized!.type === 'system' &&
+        (normalized as JsonlSystemEntry).subtype === 'compact_boundary'
+      if (isBoundary && boundaryCountedSinceAnchor) {
+        // Collapsed by the transform — the newest boundary in this span,
+        // already counted, is the only one that displays.
+      } else {
+        if (isBoundary) boundaryCountedSinceAnchor = true
+        displayCount++
+        deepestCountedIsGroup = msgEntry?.type === 'assistant' && !!msgEntry.message.id
+      }
     }
     // Merge-group span tracking. An assistant group's older entries can lie
     // below queued/system/filtered rows interleaved inside its turn, so a
@@ -1287,19 +1333,18 @@ async function scanMessagesPageWindow(
       // least one servable item, so a single display item larger than the
       // budget is still delivered instead of an empty page.
       mode = 'extending'
-    }
-    // The hard cap has its own floor: at least one servable item (two when
-    // the deepest item is a merge group the head-drop would sacrifice), so a
-    // run of non-display rows at EOF — a turn's freshly written tool results
-    // — cannot produce an empty terminal page while visible history exists.
-    if (
-      mode === 'counting' &&
+    } else if (
       windowBytes >= hardCap &&
       !groupOpen &&
       displayCount >= (deepestCountedIsGroup ? 2 : 1)
     ) {
-      mode = 'settled'
-      if (!cursorNeedle) break
+      // The hard cap has its own floor: at least one servable item (two when
+      // the deepest item is a merge group the head-drop would sacrifice), so
+      // a run of non-display rows at EOF — a turn's freshly written tool
+      // results — cannot produce an empty terminal page while visible
+      // history exists. Routed through extension rather than settling
+      // directly, so a cap landing on a system run still completes the run.
+      mode = 'extending'
     }
   }
 

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -1279,12 +1279,22 @@ async function scanMessagesPageWindow(
         ? (normalized as JsonlMessageEntry)
         : undefined
     const pendingInfoBefore = state.pendingInformationalContent
+    // Checked BEFORE the classifier registers this row's uuid: a
+    // byte-identical replayed row shares its original's uuid, and the
+    // transform keys system-item anchors BY uuid — a duplicate row is the
+    // same anchor, not a new one. Treating it as new would reset the
+    // boundary-collapse span and lift system-cursor suppression, letting the
+    // page target be satisfied by items that never display.
+    const isDuplicateRow =
+      msgEntry !== undefined && !!msgEntry.uuid && state.seenUuids.has(msgEntry.uuid)
     const counted = normalized !== undefined && countsAsDisplayStart(normalized, state)
     // An anchor row is one the transform attaches system items to — a real
     // message entry, not a filtered/skipped one (meta rows, compact
-    // summaries, an informational's synthetic user copy).
+    // summaries, an informational's synthetic user copy) and not a replayed
+    // duplicate of an anchor already seen.
     const isAnchorRow =
       msgEntry !== undefined &&
+      !isDuplicateRow &&
       !('isMeta' in msgEntry && msgEntry.isMeta) &&
       !msgEntry.isCompactSummary &&
       !(

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -922,24 +922,31 @@ export interface SessionMessagesPage {
 // EOF, so history beyond this many raw JSONL lines is unreachable (walk is
 // O(depth²)). Lifting it needs an offset-carrying cursor that seeks instead.
 const MAX_TAIL_LINES = 50_000
-// Hard cap on the raw bytes a single page window may materialize. A window
+// Soft cap on the raw bytes a single page window may materialize. A window
 // that hits it is served short with a nextCursor, and the client's existing
 // scroll-up paging fetches the rest — this is what makes the endpoint's
 // per-request memory bounded regardless of transcript geometry (a single turn
-// with huge tool results used to pull the whole file into one window).
+// with huge tool results used to pull the whole file into one window). Soft:
+// the scan runs past it until the window holds at least two display items
+// (one sacrificial head plus one servable), so a single item larger than the
+// budget still serves instead of yielding an empty page.
 const MESSAGES_PAGE_BYTE_BUDGET = 4 * 1024 * 1024
-// A cursor page's window extends this far past the cursor line so tool_use
-// blocks near the page's newest edge still meet their tool_result entries
-// (results land within the same turn, typically adjacent lines). The old
-// implementation read from the cursor to EOF; results further out than this
-// are not attached — bounded staleness on a historical page, never on the
+// Unconditional ceiling on the window — the structural memory bound. The
+// two-item floor above does not apply here: a run of non-display rows (tool
+// results between two visible items) larger than this makes the history
+// behind it unreachable through paging, which is the accepted trade-off for
+// never letting one request materialize an unbounded window.
+const MESSAGES_PAGE_HARD_CAP_FACTOR = 2
+// A cursor page's window extends at least this far past the cursor line so
+// tool_use blocks near the page's newest edge still meet their tool_result
+// entries (results land within the same turn, typically adjacent lines). The
+// boundary is then rounded UP to the next line start, so any row that BEGINS
+// inside the grace region is included whole — a fixed byte end would cut a
+// large result row mid-line and drop it as malformed. The old implementation
+// read from the cursor to EOF; results starting beyond the grace region are
+// not attached — bounded staleness on a historical page, never on the
 // trailing page (whose window always ends at EOF).
 const CURSOR_WINDOW_GRACE_BYTES = 512 * 1024
-
-function dropPartialHead<T>(items: T[], reachedStart: boolean): T[] {
-  if (reachedStart || items.length === 0) return items
-  return items.slice(1)
-}
 
 function pageCursor(messages: TransformedItem[], hasOlder: boolean): string | null {
   return hasOlder && messages[0] ? messages[0].id : null
@@ -1010,17 +1017,16 @@ interface DisplayCountState {
   pendingInformationalContent: string | null
 }
 
-/** Whether this raw line starts a new display item, by the same rules
- * transformMessages applies (uuid dedup, assistant merge by message.id,
- * meta/tool-result-only/task-notification/compact-summary skips). Lines are
- * visited NEWEST-FIRST, so "first occurrence" checks invert: the newest copy
- * of a duplicate uuid / merged message.id is the one counted. That can place
- * a count on a different line than the forward transform keeps, which shifts
- * the window boundary by at most the affected item — absorbed by the
- * sacrificial head item the page slicing already drops. */
-function countsAsDisplayStart(raw: JsonlEntry | undefined, state: DisplayCountState): boolean {
-  if (!raw) return false
-  const entry = normalizeQueuedCommandEntry(raw)
+/** Whether this (already normalized) entry starts a new display item, by the
+ * same rules transformMessages applies (uuid dedup, assistant merge by
+ * message.id, meta/tool-result-only/task-notification/compact-summary skips).
+ * Entries are visited NEWEST-FIRST, so "first occurrence" checks invert: the
+ * newest copy of a duplicate uuid / merged message.id is the one counted.
+ * That can place a count on a different line than the forward transform
+ * keeps, which shifts the window boundary by at most the affected item —
+ * absorbed by the sacrificial head item the page slicing drops when the
+ * window's deepest item may be partial. */
+function countsAsDisplayStart(entry: JsonlEntry, state: DisplayCountState): boolean {
   if (!isMessageOrSystemDisplayEntry(entry)) return false
   if ('isMeta' in entry && entry.isMeta) return false
 
@@ -1073,92 +1079,171 @@ interface PageWindowScan {
   endOffset: number | undefined
   /** Window start coincides with the file start. */
   reachedStart: boolean
+  /** The window's deepest display item may be partially merged (an assistant
+   * group whose older entries lie below the window start) — page slicing must
+   * sacrifice it. False when the deepest item is single-entry (user, system,
+   * id-less assistant): those are complete wherever the window starts, and
+   * dropping them would lose data (an empty page behind a huge tool-result
+   * run, a trailing system item swallowed by display reordering). */
+  dropHead: boolean
+}
+
+/** Smallest recorded line-start offset at or past the grace distance, so the
+ * window end lands on a line boundary: any row BEGINNING inside the grace
+ * region is included whole. undefined = grace reaches past the newest scanned
+ * line, read to EOF. `lineOffsets` is newest-first (descending). */
+function graceEndOffset(lineOffsets: number[], cursorLineEnd: number): number | undefined {
+  const target = cursorLineEnd + CURSOR_WINDOW_GRACE_BYTES
+  for (let i = lineOffsets.length - 1; i >= 0; i--) {
+    if (lineOffsets[i]! >= target) return lineOffsets[i]
+  }
+  return undefined
 }
 
 /** Pass 1 of the paged read: walk backward from EOF, parsing each line
  * transiently to count display-item starts (and locate the cursor), retaining
- * only offsets and id sets. Stops at `limit + 1` items (the head item is
- * sacrificial — see dropPartialHead), the byte budget, MAX_TAIL_LINES, or the
- * file start. Never materializes entries, so scan depth costs CPU, not memory.
+ * only offsets and id sets. Counting stops at `limit + 1` items, the byte
+ * budget (two-item floor), or unconditionally at the hard cap; the whole scan
+ * is bounded by MAX_TAIL_LINES and the file start. Never materializes
+ * entries, so scan depth costs CPU, not memory.
  *
- * While searching for the cursor, lines are only JSON-parsed when their raw
- * bytes contain the quoted cursor id — a deep cursor scan is a byte search,
- * not a parse of everything above the cursor. */
+ * Cursor resolution is canonical: the forward transform deduplicates uuids to
+ * their OLDEST occurrence, so the scan keeps byte-searching below the first
+ * match and re-anchors on every deeper verified occurrence (a resume-replayed
+ * transcript otherwise paginates in a cycle, serving the same pages forever).
+ * Between matches, lines are only JSON-parsed when their raw bytes contain
+ * the quoted cursor id — the search is memchr, not a parse of the transcript.
+ *
+ * When counting stops on a system entry, the scan extends through the rest of
+ * the contiguous system run: the transform reorders adjacent system items
+ * (recalls, then boundaries, then informationals) regardless of file order,
+ * and a window boundary inside the run makes pagination skip the reordered
+ * items entirely. */
 async function scanMessagesPageWindow(
   jsonlPath: string,
   opts: { limit: number; cursor?: string; byteBudget: number; signal?: AbortSignal }
 ): Promise<PageWindowScan> {
   const { limit, cursor, byteBudget, signal } = opts
+  const hardCap = byteBudget * MESSAGES_PAGE_HARD_CAP_FACTOR
   const cursorNeedle = cursor !== undefined ? Buffer.from(JSON.stringify(cursor)) : null
+  // Items needed below the cursor (or below EOF): the page plus the head
+  // item that slicing sacrifices when the window start may cut it.
+  const targetItems = limit + 1
+  // Line-start offsets of every scanned line, for grace-boundary placement on
+  // (re-)anchor. Bounded by MAX_TAIL_LINES numbers. Cursor pages only.
+  const lineOffsets: number[] | null = cursorNeedle ? [] : null
 
-  const state: DisplayCountState = {
+  let mode: 'searching' | 'counting' | 'extending' | 'settled' =
+    cursorNeedle ? 'searching' : 'counting'
+  let anchored = cursorNeedle === null
+  let state: DisplayCountState = {
     seenUuids: new Set(),
     seenAssistantMessageIds: new Set(),
     pendingInformationalContent: null,
   }
-  // Items needed below the cursor (or below EOF): the page plus the
-  // sacrificial head item that page slicing drops when the window start is
-  // not the file start.
-  const targetItems = limit + 1
-  let searching = cursorNeedle !== null
   let endOffset: number | undefined
   let linesScanned = 0
   let displayCount = 0
   let windowBytes = 0
   let startOffset = 0
-  let reachedStart = true
+  let hitLineCap = false
+  // Conservative default: with nothing counted, treat the head as partial.
+  let deepestCountedIsGroup = true
 
   for await (const { line, offset } of iterateJsonlLinesBackward(jsonlPath, signal)) {
     linesScanned++
     if (linesScanned > MAX_TAIL_LINES) {
       // Same reachability contract as the old tail reader: history deeper
       // than MAX_TAIL_LINES raw lines from EOF cannot be paged to.
-      reachedStart = false
-      return searching
-        ? { found: false, startOffset: 0, endOffset: undefined, reachedStart }
-        : { found: true, startOffset, endOffset, reachedStart }
+      hitLineCap = true
+      break
+    }
+    lineOffsets?.push(offset)
+
+    if (cursorNeedle && line.includes(cursorNeedle)) {
+      const parsed = parseJsonlLine<JsonlEntry>(line)
+      const normalized = parsed !== undefined ? normalizeQueuedCommandEntry(parsed) : undefined
+      if (normalized !== undefined && (normalized as { uuid?: string }).uuid === cursor) {
+        // (Re-)anchor at this occurrence — the deepest seen so far wins.
+        mode = 'counting'
+        anchored = true
+        state = {
+          seenUuids: new Set(),
+          seenAssistantMessageIds: new Set(),
+          pendingInformationalContent: null,
+        }
+        displayCount = 0
+        windowBytes = 0
+        deepestCountedIsGroup = true
+        startOffset = offset
+        endOffset = graceEndOffset(lineOffsets!, offset + line.length + 1)
+        continue
+      }
+      // A quoted-id byte match inside content or parentUuid parses to a
+      // different uuid — not an occurrence.
     }
 
-    if (searching) {
-      if (cursorNeedle && line.includes(cursorNeedle)) {
-        const parsed = parseJsonlLine<JsonlEntry>(line)
-        const normalized = parsed !== undefined ? normalizeQueuedCommandEntry(parsed) : undefined
-        if (normalized !== undefined && (normalized as { uuid?: string }).uuid === cursor) {
-          searching = false
-          // Window extends past the cursor line so the cursor item's own
-          // merged blocks and the surrounding turn's tool results are in view.
-          endOffset = offset + line.length + 1 + CURSOR_WINDOW_GRACE_BYTES
-          startOffset = offset
-        }
-        // A quoted-id byte match inside content or parentUuid parses to a
-        // different uuid — keep searching.
+    if (mode === 'searching' || mode === 'settled') continue
+
+    const parsed = parseJsonlLine<JsonlEntry>(line)
+    const normalized = parsed !== undefined ? normalizeQueuedCommandEntry(parsed) : undefined
+
+    if (mode === 'extending') {
+      const isSystemDisplay =
+        normalized !== undefined &&
+        normalized.type === 'system' &&
+        isMessageOrSystemDisplayEntry(normalized) &&
+        !normalized.isMeta
+      if (isSystemDisplay && windowBytes + line.length + 1 < hardCap) {
+        windowBytes += line.length + 1
+        startOffset = offset
+        deepestCountedIsGroup = false
+        continue
       }
+      mode = 'settled'
+      if (!cursorNeedle) break
       continue
     }
 
+    // counting
     windowBytes += line.length + 1
     startOffset = offset
-    if (countsAsDisplayStart(parseJsonlLine<JsonlEntry>(line), state)) {
+    if (normalized !== undefined && countsAsDisplayStart(normalized, state)) {
       displayCount++
-      if (displayCount >= targetItems) {
-        reachedStart = false
-        break
-      }
+      deepestCountedIsGroup =
+        normalized.type === 'assistant' &&
+        !!(normalized as JsonlMessageEntry).message.id
+      if (displayCount >= targetItems) mode = 'extending'
     }
-    // The budget is a hard cap, but never below two items: one sacrificial
-    // head plus at least one servable item, so a single display item larger
-    // than the whole budget is still delivered instead of an empty page.
-    if (windowBytes >= byteBudget && displayCount >= 2) {
-      reachedStart = false
-      break
+    // The budget stop waits for two items: one sacrificial head plus at least
+    // one servable item, so a single display item larger than the budget is
+    // still delivered instead of an empty page.
+    if (mode === 'counting' && windowBytes >= byteBudget && displayCount >= 2) {
+      mode = 'extending'
+    }
+    if (windowBytes >= hardCap) {
+      mode = 'settled'
+      if (!cursorNeedle) break
     }
   }
 
-  if (searching) {
-    // Cursor never found and the scan covered the whole file: vanished id.
-    return { found: false, startOffset: 0, endOffset: undefined, reachedStart: true }
+  if (!anchored) {
+    // Cursor never found: vanished id, or deeper than the line cap.
+    return {
+      found: false,
+      startOffset: 0,
+      endOffset: undefined,
+      reachedStart: !hitLineCap,
+      dropHead: true,
+    }
   }
-  return { found: true, startOffset, endOffset, reachedStart }
+  return {
+    found: true,
+    startOffset,
+    endOffset,
+    reachedStart: startOffset === 0,
+    dropHead: deepestCountedIsGroup,
+  }
 }
 
 /** Pass 2 of the paged read: parse + normalize + filter the entries of a byte
@@ -1171,8 +1256,13 @@ async function readEntriesRange(
   signal?: AbortSignal
 ): Promise<(JsonlMessageEntry | JsonlSystemEntry)[]> {
   const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
-  for await (const line of streamFileLines(jsonlPath, { start: startOffset, end: endOffset })) {
-    signal?.throwIfAborted()
+  // The signal is threaded into the reader itself (checked per chunk): a
+  // multi-MB row spans many chunks before it ever surfaces as a line here.
+  for await (const line of streamFileLines(
+    jsonlPath,
+    { start: startOffset, end: endOffset },
+    signal
+  )) {
     const parsed = parseJsonlLine<JsonlEntry>(line)
     if (!parsed) continue
     const normalized = normalizeQueuedCommandEntry(parsed)
@@ -1228,6 +1318,7 @@ export async function getSessionMessagesPage(
   signal?.throwIfAborted()
   const transformed = transformMessages(entries)
   const reachedStart = scan.reachedStart
+  const dropHead = scan.dropHead && !reachedStart
 
   if (cursor) {
     const idx = transformed.findIndex((item) => item.id === cursor)
@@ -1242,22 +1333,28 @@ export async function getSessionMessagesPage(
       )
       return { messages: [], nextCursor: null }
     }
-    const start = reachedStart ? Math.max(0, idx - limit) : Math.max(1, idx - limit)
+    const start = Math.max(dropHead ? 1 : 0, idx - limit)
     const messages = transformed.slice(start, idx)
     const hasOlder = messages.length > 0 && (!reachedStart || start > 0)
-    // Sequential walks end here when the cap truncates the page to empty.
+    // Sequential walks end here when a cap truncates the page to empty.
     if (messages.length === 0 && !reachedStart) {
       console.warn(
-        `getSessionMessagesPage: pagination for session ${sessionId} hit the ` +
-        `${MAX_TAIL_LINES}-line depth cap; deeper history is unreachable`
+        `getSessionMessagesPage: pagination for session ${sessionId} hit a ` +
+        `scan cap below cursor ${cursor}; deeper history is unreachable`
       )
     }
     return { messages, nextCursor: pageCursor(messages, hasOlder) }
   }
 
-  const usable = dropPartialHead(transformed, reachedStart)
+  const usable = dropHead ? transformed.slice(1) : transformed
   const messages = usable.slice(-limit)
   const hasOlder = messages.length > 0 && (!reachedStart || usable.length > messages.length)
+  if (messages.length === 0 && !reachedStart) {
+    console.warn(
+      `getSessionMessagesPage: window for session ${sessionId} hit the byte ` +
+      `hard cap before a complete display item; serving an empty page`
+    )
+  }
   return { messages, nextCursor: pageCursor(messages, hasOlder) }
 }
 

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -931,11 +931,17 @@ const MAX_TAIL_LINES = 50_000
 // (one sacrificial head plus one servable), so a single item larger than the
 // budget still serves instead of yielding an empty page.
 const MESSAGES_PAGE_BYTE_BUDGET = 4 * 1024 * 1024
-// Unconditional ceiling on the window — the structural memory bound. The
-// two-item floor above does not apply here: a run of non-display rows (tool
-// results between two visible items) larger than this makes the history
-// behind it unreachable through paging, which is the accepted trade-off for
-// never letting one request materialize an unbounded window.
+// Ceiling on the window — the structural memory bound. The true per-request
+// bound is O(hardCap + one turn's span + largest single row): the cap yields
+// only to three exceptions, each bounded by content that must be materialized
+// to serve anything at all — (a) at least one complete servable display item
+// (a session whose newest turn just wrote a huge tool-result run must still
+// render), (b) closing an assistant merge group whose entries straddle the
+// boundary (a cut group's item id vanishes on the next window and terminates
+// pagination), and (c) a single JSONL row, which has to be assembled whole
+// even to classify it. Multi-MB embedded content stops hitting this path
+// entirely when large payloads move behind references (the media-ref
+// follow-up ticket).
 const MESSAGES_PAGE_HARD_CAP_FACTOR = 2
 // A cursor page's window extends at least this far past the cursor line so
 // tool_use blocks near the page's newest edge still meet their tool_result
@@ -1100,6 +1106,48 @@ function graceEndOffset(lineOffsets: number[], cursorLineEnd: number): number | 
   return undefined
 }
 
+/** How a row behaves at the extension boundary after a counting stop.
+ *
+ * 'system': a system display item — the run continues, and the row becomes
+ * the window's deepest COMPLETE item. 'filtered': removed by readEntriesRange
+ * or skipped by the transform before ordering (meta rows, non-display entry
+ * types, malformed lines, compact summaries, an informational's synthetic
+ * user copy) — invisible to transform adjacency, so it cannot split a logical
+ * system run and the extension walks through it. 'settle': acts as an anchor
+ * in the transform (a real user/assistant row, including tool-result-only
+ * ones, which genuinely split the system-attachment grouping) — the run ends
+ * just above it. */
+function classifyExtensionRow(
+  normalized: JsonlEntry | undefined,
+  state: DisplayCountState
+): 'system' | 'filtered' | 'settle' {
+  if (normalized === undefined) return 'filtered'
+  if (!isMessageOrSystemDisplayEntry(normalized)) return 'filtered'
+  if ('isMeta' in normalized && normalized.isMeta) return 'filtered'
+  if (normalized.type === 'system') {
+    const sys = normalized as JsonlSystemEntry
+    // Mirror countsAsDisplayStart's synthetic-copy tracking so the copy of an
+    // informational consumed here is recognized on the next (older) line.
+    state.pendingInformationalContent =
+      sys.subtype === 'informational' ? (sys.content ?? '') : null
+    return 'system'
+  }
+  const msg = normalized as JsonlMessageEntry
+  const pendingInfo = state.pendingInformationalContent
+  state.pendingInformationalContent = null
+  if (msg.type === 'user') {
+    if (
+      pendingInfo !== null &&
+      typeof msg.message.content === 'string' &&
+      msg.message.content === pendingInfo
+    ) {
+      return 'filtered'
+    }
+    if (msg.isCompactSummary) return 'filtered'
+  }
+  return 'settle'
+}
+
 /** Pass 1 of the paged read: walk backward from EOF, parsing each line
  * transiently to count display-item starts (and locate the cursor), retaining
  * only offsets and id sets. Counting stops at `limit + 1` items, the byte
@@ -1149,6 +1197,9 @@ async function scanMessagesPageWindow(
   let hitLineCap = false
   // Conservative default: with nothing counted, treat the head as partial.
   let deepestCountedIsGroup = true
+  // message.id of an assistant merge group whose span may extend below the
+  // current line — set while walking its (possibly interleaved) turn.
+  let openGroupId: string | null = null
 
   for await (const { line, offset } of iterateJsonlLinesBackward(jsonlPath, signal)) {
     linesScanned++
@@ -1175,6 +1226,7 @@ async function scanMessagesPageWindow(
         displayCount = 0
         windowBytes = 0
         deepestCountedIsGroup = true
+        openGroupId = null
         startOffset = offset
         endOffset = graceEndOffset(lineOffsets!, offset + line.length + 1)
         continue
@@ -1189,15 +1241,11 @@ async function scanMessagesPageWindow(
     const normalized = parsed !== undefined ? normalizeQueuedCommandEntry(parsed) : undefined
 
     if (mode === 'extending') {
-      const isSystemDisplay =
-        normalized !== undefined &&
-        normalized.type === 'system' &&
-        isMessageOrSystemDisplayEntry(normalized) &&
-        !normalized.isMeta
-      if (isSystemDisplay && windowBytes + line.length + 1 < hardCap) {
+      const kind = classifyExtensionRow(normalized, state)
+      if (kind !== 'settle' && windowBytes + line.length + 1 < hardCap) {
         windowBytes += line.length + 1
         startOffset = offset
-        deepestCountedIsGroup = false
+        if (kind === 'system') deepestCountedIsGroup = false
         continue
       }
       mode = 'settled'
@@ -1208,20 +1256,48 @@ async function scanMessagesPageWindow(
     // counting
     windowBytes += line.length + 1
     startOffset = offset
+    const msgEntry =
+      normalized !== undefined && (normalized.type === 'user' || normalized.type === 'assistant')
+        ? (normalized as JsonlMessageEntry)
+        : undefined
     if (normalized !== undefined && countsAsDisplayStart(normalized, state)) {
       displayCount++
-      deepestCountedIsGroup =
-        normalized.type === 'assistant' &&
-        !!(normalized as JsonlMessageEntry).message.id
-      if (displayCount >= targetItems) mode = 'extending'
+      deepestCountedIsGroup = msgEntry?.type === 'assistant' && !!msgEntry.message.id
     }
-    // The budget stop waits for two items: one sacrificial head plus at least
-    // one servable item, so a single display item larger than the budget is
-    // still delivered instead of an empty page.
-    if (mode === 'counting' && windowBytes >= byteBudget && displayCount >= 2) {
+    // Merge-group span tracking. An assistant group's older entries can lie
+    // below queued/system/filtered rows interleaved inside its turn, so a
+    // window boundary placed while a group is "open" would cut it — the cut
+    // item gets a non-canonical id that vanishes from the next (deeper)
+    // window, terminating the client's pagination. No stop condition may fire
+    // while a group is open; a group closes at the first row that proves the
+    // turn boundary (a different assistant response, or a non-queued user
+    // row), which bounds the overshoot by one turn's span.
+    if (msgEntry !== undefined) {
+      if (msgEntry.type === 'assistant') {
+        openGroupId = msgEntry.message.id ?? null
+      } else if (!msgEntry.isQueuedCommand && !('isMeta' in msgEntry && msgEntry.isMeta)) {
+        openGroupId = null
+      }
+    }
+    const groupOpen = openGroupId !== null
+    if (displayCount >= targetItems && !groupOpen) {
+      mode = 'extending'
+    } else if (windowBytes >= byteBudget && displayCount >= 2 && !groupOpen) {
+      // The budget stop waits for two items: one sacrificial head plus at
+      // least one servable item, so a single display item larger than the
+      // budget is still delivered instead of an empty page.
       mode = 'extending'
     }
-    if (windowBytes >= hardCap) {
+    // The hard cap has its own floor: at least one servable item (two when
+    // the deepest item is a merge group the head-drop would sacrifice), so a
+    // run of non-display rows at EOF — a turn's freshly written tool results
+    // — cannot produce an empty terminal page while visible history exists.
+    if (
+      mode === 'counting' &&
+      windowBytes >= hardCap &&
+      !groupOpen &&
+      displayCount >= (deepestCountedIsGroup ? 2 : 1)
+    ) {
       mode = 'settled'
       if (!cursorNeedle) break
     }

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -24,13 +24,19 @@ import {
   readJsonlFile,
   streamJsonlFile,
   readJsonlTailLines,
+  iterateJsonlLinesBackward,
   parseJsonl,
   streamFileLines,
   parseJsonlLine,
   writeFileAtomicStream,
   ensureDirectory,
 } from '@shared/lib/utils/file-storage'
-import { transformMessages, type TransformedItem } from '@shared/lib/utils/message-transform'
+import {
+  transformMessages,
+  isToolResultOnlyMessage,
+  isTaskNotificationMessage,
+  type TransformedItem,
+} from '@shared/lib/utils/message-transform'
 import { findDeltaWindowStart } from '@shared/lib/messages-delta'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
 import { isHiddenAutomatedSession } from './session-visibility'
@@ -912,11 +918,23 @@ export interface SessionMessagesPage {
   nextCursor: string | null
 }
 
-const INITIAL_TAIL_FACTOR = 4
 // Hard bound on how deep paging can reach: every cursor request re-scans from
 // EOF, so history beyond this many raw JSONL lines is unreachable (walk is
 // O(depth²)). Lifting it needs an offset-carrying cursor that seeks instead.
 const MAX_TAIL_LINES = 50_000
+// Hard cap on the raw bytes a single page window may materialize. A window
+// that hits it is served short with a nextCursor, and the client's existing
+// scroll-up paging fetches the rest — this is what makes the endpoint's
+// per-request memory bounded regardless of transcript geometry (a single turn
+// with huge tool results used to pull the whole file into one window).
+const MESSAGES_PAGE_BYTE_BUDGET = 4 * 1024 * 1024
+// A cursor page's window extends this far past the cursor line so tool_use
+// blocks near the page's newest edge still meet their tool_result entries
+// (results land within the same turn, typically adjacent lines). The old
+// implementation read from the cursor to EOF; results further out than this
+// are not attached — bounded staleness on a historical page, never on the
+// trailing page (whose window always ends at EOF).
+const CURSOR_WINDOW_GRACE_BYTES = 512 * 1024
 
 function dropPartialHead<T>(items: T[], reachedStart: boolean): T[] {
   if (reachedStart || items.length === 0) return items
@@ -981,11 +999,207 @@ function toolResultIdsAfterEntry(
   return ids
 }
 
-/** Trailing (or `cursor`-before) display page. Parses only a tail of the JSONL. */
+/** Bookkeeping for the backward display-item count. Mirrors the parts of
+ * transformMessages that decide whether an entry STARTS a new display item;
+ * only counters, uuids, and message ids are retained — never entry content. */
+interface DisplayCountState {
+  seenUuids: Set<string>
+  seenAssistantMessageIds: Set<string>
+  /** Content of an informational banner whose synthetic user copy (the
+   * adjacent older entry with identical string content) must not count. */
+  pendingInformationalContent: string | null
+}
+
+/** Whether this raw line starts a new display item, by the same rules
+ * transformMessages applies (uuid dedup, assistant merge by message.id,
+ * meta/tool-result-only/task-notification/compact-summary skips). Lines are
+ * visited NEWEST-FIRST, so "first occurrence" checks invert: the newest copy
+ * of a duplicate uuid / merged message.id is the one counted. That can place
+ * a count on a different line than the forward transform keeps, which shifts
+ * the window boundary by at most the affected item — absorbed by the
+ * sacrificial head item the page slicing already drops. */
+function countsAsDisplayStart(raw: JsonlEntry | undefined, state: DisplayCountState): boolean {
+  if (!raw) return false
+  const entry = normalizeQueuedCommandEntry(raw)
+  if (!isMessageOrSystemDisplayEntry(entry)) return false
+  if ('isMeta' in entry && entry.isMeta) return false
+
+  if (entry.type === 'system') {
+    const sys = entry as JsonlSystemEntry
+    if (state.seenUuids.has(sys.uuid)) return false
+    state.seenUuids.add(sys.uuid)
+    state.pendingInformationalContent =
+      sys.subtype === 'informational' ? (sys.content ?? '') : null
+    return true
+  }
+
+  const msg = entry as JsonlMessageEntry
+  const pendingInfo = state.pendingInformationalContent
+  state.pendingInformationalContent = null
+  if (
+    pendingInfo !== null &&
+    msg.type === 'user' &&
+    typeof msg.message.content === 'string' &&
+    msg.message.content === pendingInfo
+  ) {
+    // The CLI's synthetic stop-text copy directly before an informational
+    // banner — hidden by the transform, the banner is the visible surface.
+    return false
+  }
+  if (msg.uuid) {
+    if (state.seenUuids.has(msg.uuid)) return false
+    state.seenUuids.add(msg.uuid)
+  }
+  if (msg.type === 'user') {
+    if (msg.isCompactSummary) return false
+    if (isToolResultOnlyMessage(msg)) return false
+    if (isTaskNotificationMessage(msg)) return false
+    return true
+  }
+  const messageId = msg.message.id
+  if (messageId) {
+    if (state.seenAssistantMessageIds.has(messageId)) return false
+    state.seenAssistantMessageIds.add(messageId)
+  }
+  return true
+}
+
+interface PageWindowScan {
+  /** Cursor located (always true for the no-cursor trailing page). */
+  found: boolean
+  /** Byte offset of the window's first line. */
+  startOffset: number
+  /** Exclusive end of the window; undefined = read to EOF (trailing page). */
+  endOffset: number | undefined
+  /** Window start coincides with the file start. */
+  reachedStart: boolean
+}
+
+/** Pass 1 of the paged read: walk backward from EOF, parsing each line
+ * transiently to count display-item starts (and locate the cursor), retaining
+ * only offsets and id sets. Stops at `limit + 1` items (the head item is
+ * sacrificial — see dropPartialHead), the byte budget, MAX_TAIL_LINES, or the
+ * file start. Never materializes entries, so scan depth costs CPU, not memory.
+ *
+ * While searching for the cursor, lines are only JSON-parsed when their raw
+ * bytes contain the quoted cursor id — a deep cursor scan is a byte search,
+ * not a parse of everything above the cursor. */
+async function scanMessagesPageWindow(
+  jsonlPath: string,
+  opts: { limit: number; cursor?: string; byteBudget: number; signal?: AbortSignal }
+): Promise<PageWindowScan> {
+  const { limit, cursor, byteBudget, signal } = opts
+  const cursorNeedle = cursor !== undefined ? Buffer.from(JSON.stringify(cursor)) : null
+
+  const state: DisplayCountState = {
+    seenUuids: new Set(),
+    seenAssistantMessageIds: new Set(),
+    pendingInformationalContent: null,
+  }
+  // Items needed below the cursor (or below EOF): the page plus the
+  // sacrificial head item that page slicing drops when the window start is
+  // not the file start.
+  const targetItems = limit + 1
+  let searching = cursorNeedle !== null
+  let endOffset: number | undefined
+  let linesScanned = 0
+  let displayCount = 0
+  let windowBytes = 0
+  let startOffset = 0
+  let reachedStart = true
+
+  for await (const { line, offset } of iterateJsonlLinesBackward(jsonlPath, signal)) {
+    linesScanned++
+    if (linesScanned > MAX_TAIL_LINES) {
+      // Same reachability contract as the old tail reader: history deeper
+      // than MAX_TAIL_LINES raw lines from EOF cannot be paged to.
+      reachedStart = false
+      return searching
+        ? { found: false, startOffset: 0, endOffset: undefined, reachedStart }
+        : { found: true, startOffset, endOffset, reachedStart }
+    }
+
+    if (searching) {
+      if (cursorNeedle && line.includes(cursorNeedle)) {
+        const parsed = parseJsonlLine<JsonlEntry>(line)
+        const normalized = parsed !== undefined ? normalizeQueuedCommandEntry(parsed) : undefined
+        if (normalized !== undefined && (normalized as { uuid?: string }).uuid === cursor) {
+          searching = false
+          // Window extends past the cursor line so the cursor item's own
+          // merged blocks and the surrounding turn's tool results are in view.
+          endOffset = offset + line.length + 1 + CURSOR_WINDOW_GRACE_BYTES
+          startOffset = offset
+        }
+        // A quoted-id byte match inside content or parentUuid parses to a
+        // different uuid — keep searching.
+      }
+      continue
+    }
+
+    windowBytes += line.length + 1
+    startOffset = offset
+    if (countsAsDisplayStart(parseJsonlLine<JsonlEntry>(line), state)) {
+      displayCount++
+      if (displayCount >= targetItems) {
+        reachedStart = false
+        break
+      }
+    }
+    // The budget is a hard cap, but never below two items: one sacrificial
+    // head plus at least one servable item, so a single display item larger
+    // than the whole budget is still delivered instead of an empty page.
+    if (windowBytes >= byteBudget && displayCount >= 2) {
+      reachedStart = false
+      break
+    }
+  }
+
+  if (searching) {
+    // Cursor never found and the scan covered the whole file: vanished id.
+    return { found: false, startOffset: 0, endOffset: undefined, reachedStart: true }
+  }
+  return { found: true, startOffset, endOffset, reachedStart }
+}
+
+/** Pass 2 of the paged read: parse + normalize + filter the entries of a byte
+ * range chosen by pass 1. Identical filtering to readTransformedTail; memory
+ * is bounded by the range, which pass 1 bounded by the byte budget. */
+async function readEntriesRange(
+  jsonlPath: string,
+  startOffset: number,
+  endOffset: number | undefined,
+  signal?: AbortSignal
+): Promise<(JsonlMessageEntry | JsonlSystemEntry)[]> {
+  const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
+  for await (const line of streamFileLines(jsonlPath, { start: startOffset, end: endOffset })) {
+    signal?.throwIfAborted()
+    const parsed = parseJsonlLine<JsonlEntry>(line)
+    if (!parsed) continue
+    const normalized = normalizeQueuedCommandEntry(parsed)
+    if (
+      isMessageOrSystemDisplayEntry(normalized) &&
+      !('isMeta' in normalized && normalized.isMeta)
+    ) {
+      entries.push(normalized)
+    }
+  }
+  return entries
+}
+
+/** Trailing (or `cursor`-before) display page.
+ *
+ * Two passes, O(window) memory: a backward index scan picks the window's byte
+ * range without materializing anything (see scanMessagesPageWindow), then a
+ * forward read parses only that range and hands it to the same
+ * transformMessages the whole-file path uses — so page content matches the
+ * old grow-and-re-read implementation, while a transcript's size no longer
+ * sets the request's memory footprint. Pages truncated by the byte budget are
+ * valid short pages: nextCursor points at their first item and the client's
+ * scroll-up paging walks the rest. */
 export async function getSessionMessagesPage(
   agentSlug: string,
   sessionId: string,
-  opts: { limit: number; cursor?: string; signal?: AbortSignal }
+  opts: { limit: number; cursor?: string; signal?: AbortSignal; byteBudget?: number }
 ): Promise<SessionMessagesPage> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   if (!(await fileExists(jsonlPath))) {
@@ -993,58 +1207,58 @@ export async function getSessionMessagesPage(
   }
 
   const { limit, cursor, signal } = opts
-  let maxLines = Math.min(MAX_TAIL_LINES, Math.max(limit * INITIAL_TAIL_FACTOR, 32))
+  const byteBudget = opts.byteBudget ?? MESSAGES_PAGE_BYTE_BUDGET
 
-  for (let attempt = 0; attempt < 32; attempt++) {
-    const { transformed, reachedStart } = await readTransformedTail(jsonlPath, maxLines, signal)
-
-    if (cursor) {
-      const idx = transformed.findIndex((item) => item.id === cursor)
-      if (idx === -1) {
-        // Deep cursors from sequential scroll-up paging are legitimate — keep growing.
-        if (!reachedStart && maxLines < MAX_TAIL_LINES) {
-          maxLines = Math.min(MAX_TAIL_LINES, maxLines * 2)
-          continue
-        }
-        // Vanished id (or cursor deeper than MAX_TAIL_LINES): terminate paging.
-        // Never point the client at a newer message — it would loop on
-        // already-loaded pages.
-        if (!reachedStart) {
-          console.warn(
-            `getSessionMessagesPage: cursor ${cursor} not found within ` +
-            `${MAX_TAIL_LINES} tail lines of session ${sessionId}; ending pagination`
-          )
-        }
-        return { messages: [], nextCursor: null }
-      }
-      if (!reachedStart && idx <= limit && maxLines < MAX_TAIL_LINES) {
-        maxLines = Math.min(MAX_TAIL_LINES, maxLines * 2)
-        continue
-      }
-      const start = reachedStart ? Math.max(0, idx - limit) : Math.max(1, idx - limit)
-      const messages = transformed.slice(start, idx)
-      const hasOlder = messages.length > 0 && (!reachedStart || start > 0)
-      // Sequential walks end here when the cap truncates the page to empty.
-      if (messages.length === 0 && !reachedStart) {
-        console.warn(
-          `getSessionMessagesPage: pagination for session ${sessionId} hit the ` +
-          `${MAX_TAIL_LINES}-line depth cap; deeper history is unreachable`
-        )
-      }
-      return { messages, nextCursor: pageCursor(messages, hasOlder) }
+  const scan = await scanMessagesPageWindow(jsonlPath, { limit, cursor, byteBudget, signal })
+  signal?.throwIfAborted()
+  if (!scan.found) {
+    // Vanished id (or cursor deeper than MAX_TAIL_LINES): terminate paging.
+    // Never point the client at a newer message — it would loop on
+    // already-loaded pages.
+    if (!scan.reachedStart) {
+      console.warn(
+        `getSessionMessagesPage: cursor ${cursor} not found within ` +
+        `${MAX_TAIL_LINES} tail lines of session ${sessionId}; ending pagination`
+      )
     }
+    return { messages: [], nextCursor: null }
+  }
 
-    if (!reachedStart && transformed.length <= limit && maxLines < MAX_TAIL_LINES) {
-      maxLines = Math.min(MAX_TAIL_LINES, maxLines * 2)
-      continue
+  const entries = await readEntriesRange(jsonlPath, scan.startOffset, scan.endOffset, signal)
+  signal?.throwIfAborted()
+  const transformed = transformMessages(entries)
+  const reachedStart = scan.reachedStart
+
+  if (cursor) {
+    const idx = transformed.findIndex((item) => item.id === cursor)
+    if (idx === -1) {
+      // The index scan located the cursor's line but the transform of the
+      // materialized window disagrees — a concurrent rewrite between the two
+      // passes, or a replayed duplicate id. Terminate like a vanished cursor
+      // rather than serving a mislabeled page.
+      console.warn(
+        `getSessionMessagesPage: cursor ${cursor} vanished between scan and ` +
+        `read for session ${sessionId}; ending pagination`
+      )
+      return { messages: [], nextCursor: null }
     }
-    const usable = dropPartialHead(transformed, reachedStart)
-    const messages = usable.slice(-limit)
-    const hasOlder = messages.length > 0 && (!reachedStart || usable.length > messages.length)
+    const start = reachedStart ? Math.max(0, idx - limit) : Math.max(1, idx - limit)
+    const messages = transformed.slice(start, idx)
+    const hasOlder = messages.length > 0 && (!reachedStart || start > 0)
+    // Sequential walks end here when the cap truncates the page to empty.
+    if (messages.length === 0 && !reachedStart) {
+      console.warn(
+        `getSessionMessagesPage: pagination for session ${sessionId} hit the ` +
+        `${MAX_TAIL_LINES}-line depth cap; deeper history is unreachable`
+      )
+    }
     return { messages, nextCursor: pageCursor(messages, hasOlder) }
   }
 
-  throw new Error('getSessionMessagesPage exceeded tail growth attempts')
+  const usable = dropPartialHead(transformed, reachedStart)
+  const messages = usable.slice(-limit)
+  const hasOlder = messages.length > 0 && (!reachedStart || usable.length > messages.length)
+  return { messages, nextCursor: pageCursor(messages, hasOlder) }
 }
 
 export interface SessionMessagesDelta {

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -1140,6 +1140,50 @@ describe('iterateJsonlLinesBackward', () => {
     }
   })
 
+  it('an abort during short-read refills stops before the next physical read', async () => {
+    // One logical chunk can take many physical reads on filesystems that
+    // short-read; each is RPC-priced, so the refill loop must observe the
+    // signal per read rather than only at chunk boundaries.
+    const filePath = path.join(testDir, 'backward-refill-abort.jsonl')
+    await fs.promises.writeFile(filePath, 'alpha\nbeta\ngamma\n')
+
+    const controller = new AbortController()
+    let reads = 0
+    const realOpen = fs.promises.open.bind(fs.promises)
+    const openSpy = vi.spyOn(fs.promises, 'open').mockImplementation(async (...args) => {
+      const handle = await realOpen(...(args as Parameters<typeof fs.promises.open>))
+      const realRead = handle.read.bind(handle) as (
+        buf: Buffer, off: number, len: number, pos: number
+      ) => Promise<{ bytesRead: number }>
+      return new Proxy(handle, {
+        get(target, prop, receiver) {
+          if (prop === 'read') {
+            return (buf: Buffer, off: number, len: number, pos: number) => {
+              reads++
+              controller.abort() // lands while the first short read is in flight
+              return realRead(buf, off, Math.min(3, len), pos)
+            }
+          }
+          const value = Reflect.get(target, prop, receiver)
+          return typeof value === 'function' ? value.bind(target) : value
+        },
+      }) as Awaited<ReturnType<typeof fs.promises.open>>
+    })
+
+    try {
+      await expect(
+        (async () => {
+          for await (const item of iterateJsonlLinesBackward(filePath, controller.signal)) {
+            void item
+          }
+        })()
+      ).rejects.toMatchObject({ name: 'AbortError' })
+      expect(reads).toBe(1)
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
   it('stops with AbortError before the next chunk read after an abort', async () => {
     // Multi-chunk file (>64KB) so the walk needs several reads: abort after
     // the first yielded line and the iterator must stop at the next chunk

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -1100,6 +1100,46 @@ describe('iterateJsonlLinesBackward', () => {
     expect(await collect(emptyPath)).toEqual([])
   })
 
+  it('survives legal short reads without skipping bytes', async () => {
+    // Network filesystems may return fewer bytes than requested mid-file.
+    // Cap every positional read at 3 bytes: the walk must loop until each
+    // chunk range is filled instead of leaving unread gaps that splice lines.
+    const filePath = path.join(testDir, 'backward-short-reads.jsonl')
+    await fs.promises.writeFile(filePath, 'alpha\nbeta\ngamma\n')
+
+    const realOpen = fs.promises.open.bind(fs.promises)
+    const openSpy = vi.spyOn(fs.promises, 'open').mockImplementation(async (...args) => {
+      const handle = await realOpen(...(args as Parameters<typeof fs.promises.open>))
+      const realRead = handle.read.bind(handle) as (
+        buf: Buffer, off: number, len: number, pos: number
+      ) => Promise<{ bytesRead: number }>
+      return new Proxy(handle, {
+        get(target, prop, receiver) {
+          if (prop === 'read') {
+            return (buf: Buffer, off: number, len: number, pos: number) =>
+              realRead(buf, off, Math.min(3, len), pos)
+          }
+          const value = Reflect.get(target, prop, receiver)
+          return typeof value === 'function' ? value.bind(target) : value
+        },
+      }) as Awaited<ReturnType<typeof fs.promises.open>>
+    })
+
+    try {
+      const out: string[] = []
+      for await (const { line } of iterateJsonlLinesBackward(filePath)) {
+        out.push(line.toString('utf-8'))
+      }
+      expect(out).toEqual(['gamma', 'beta', 'alpha'])
+
+      const { lines, reachedStart } = await readJsonlTailLines(filePath, 10)
+      expect(lines.map((l) => l.toString('utf-8'))).toEqual(['alpha', 'beta', 'gamma'])
+      expect(reachedStart).toBe(true)
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
   it('stops with AbortError before the next chunk read after an abort', async () => {
     // Multi-chunk file (>64KB) so the walk needs several reads: abort after
     // the first yielded line and the iterator must stop at the next chunk
@@ -1161,5 +1201,28 @@ describe('streamFileLines with a byte range', () => {
       out.push(line.toString('utf-8'))
     }
     expect(out).toEqual([])
+  })
+
+  it('aborts between chunks instead of reading the rest of the file', async () => {
+    // Chunk-level abort granularity: a consumer-level per-line check is not
+    // enough because a multi-MB row spans many chunks before it yields. Abort
+    // after the first line: iteration must stop within one chunk's worth of
+    // lines, not drain the remaining chunks.
+    const filePath = path.join(testDir, 'stream-abort.jsonl')
+    const row = `${'x'.repeat(1023)}\n`
+    await fs.promises.writeFile(filePath, row.repeat(300)) // ~300KB, ~5 chunks
+
+    const controller = new AbortController()
+    const received: number[] = []
+    await expect(
+      (async () => {
+        for await (const line of streamFileLines(filePath, undefined, controller.signal)) {
+          received.push(line.length)
+          controller.abort()
+        }
+      })()
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(received.length).toBeGreaterThan(0)
+    expect(received.length).toBeLessThanOrEqual(65)
   })
 })

--- a/src/shared/lib/utils/file-storage.test.ts
+++ b/src/shared/lib/utils/file-storage.test.ts
@@ -21,6 +21,8 @@ import {
   parseJsonl,
   readJsonlFile,
   readJsonlTailLines,
+  iterateJsonlLinesBackward,
+  streamFileLines,
   streamJsonlFile,
   createJsonArrayStringifyTransform,
   getAgentsDir,
@@ -1043,5 +1045,121 @@ describe('path helpers', () => {
   it('getSessionJsonlPath rejects session ids that escape the sessions directory', () => {
     expect(() => getSessionJsonlPath('my-agent', '../outside')).toThrow('Invalid session ID')
     expect(() => getSessionJsonlPath('my-agent', '/tmp/outside')).toThrow('Invalid session ID')
+  })
+})
+
+describe('iterateJsonlLinesBackward', () => {
+  async function collect(filePath: string, signal?: AbortSignal) {
+    const out: Array<{ text: string; offset: number }> = []
+    for await (const { line, offset } of iterateJsonlLinesBackward(filePath, signal)) {
+      // Copy: yielded buffers may alias the iterator's internal chunk.
+      out.push({ text: line.toString('utf-8'), offset })
+    }
+    return out
+  }
+
+  it('yields lines newest-first with their byte offsets', async () => {
+    const filePath = path.join(testDir, 'backward.jsonl')
+    const content = 'alpha\nbeta\ngamma\n'
+    await fs.promises.writeFile(filePath, content)
+
+    const lines = await collect(filePath)
+    expect(lines.map((l) => l.text)).toEqual(['gamma', 'beta', 'alpha'])
+    for (const { text, offset } of lines) {
+      expect(content.slice(offset, offset + text.length)).toBe(text)
+    }
+  })
+
+  it('handles a file without a trailing newline', async () => {
+    const filePath = path.join(testDir, 'backward-no-eol.jsonl')
+    await fs.promises.writeFile(filePath, 'a\nb\nlast')
+
+    const lines = await collect(filePath)
+    expect(lines.map((l) => l.text)).toEqual(['last', 'b', 'a'])
+    expect(lines[0].offset).toBe(4)
+  })
+
+  it('reassembles a line larger than the read chunk', async () => {
+    const filePath = path.join(testDir, 'backward-huge.jsonl')
+    // One row far larger than the 64KB chunk, so its bytes span several
+    // backward reads and must be stitched through the carry buffer.
+    const huge = 'H'.repeat(200 * 1024)
+    const content = `first\n${huge}\nlast\n`
+    await fs.promises.writeFile(filePath, content)
+
+    const lines = await collect(filePath)
+    expect(lines.map((l) => l.text.length)).toEqual([4, huge.length, 5])
+    expect(lines[1].text).toBe(huge)
+    expect(lines[1].offset).toBe('first\n'.length)
+  })
+
+  it('yields nothing for a missing or empty file', async () => {
+    expect(await collect(path.join(testDir, 'nope.jsonl'))).toEqual([])
+    const emptyPath = path.join(testDir, 'empty.jsonl')
+    await fs.promises.writeFile(emptyPath, '')
+    expect(await collect(emptyPath)).toEqual([])
+  })
+
+  it('stops with AbortError before the next chunk read after an abort', async () => {
+    // Multi-chunk file (>64KB) so the walk needs several reads: abort after
+    // the first yielded line and the iterator must stop at the next chunk
+    // boundary instead of paying for the rest of the file.
+    const filePath = path.join(testDir, 'backward-abort.jsonl')
+    const row = `${'x'.repeat(1023)}\n`
+    await fs.promises.writeFile(filePath, row.repeat(300)) // ~300KB, ~5 chunks
+
+    const controller = new AbortController()
+    const iterated: string[] = []
+    await expect(
+      (async () => {
+        for await (const { line } of iterateJsonlLinesBackward(filePath, controller.signal)) {
+          iterated.push(line.toString('utf-8'))
+          controller.abort()
+        }
+      })()
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    // Only the lines of the first chunk (64 rows of 1KB) can have been
+    // yielded — the abort stops the walk before the second chunk read.
+    expect(iterated.length).toBeGreaterThan(0)
+    expect(iterated.length).toBeLessThanOrEqual(65)
+  })
+})
+
+describe('streamFileLines with a byte range', () => {
+  it('reads only lines inside [start, end)', async () => {
+    const filePath = path.join(testDir, 'range.jsonl')
+    const rows = ['zero', 'one', 'two', 'three']
+    const content = rows.map((r) => `${r}\n`).join('')
+    await fs.promises.writeFile(filePath, content)
+
+    const start = 'zero\n'.length
+    const end = 'zero\none\ntwo\n'.length
+    const out: string[] = []
+    for await (const line of streamFileLines(filePath, { start, end })) {
+      out.push(line.toString('utf-8'))
+    }
+    expect(out).toEqual(['one', 'two'])
+  })
+
+  it('a range ending mid-line yields the truncated head of that line', async () => {
+    const filePath = path.join(testDir, 'range-cut.jsonl')
+    await fs.promises.writeFile(filePath, 'aaa\nbbbbbb\n')
+
+    const out: string[] = []
+    for await (const line of streamFileLines(filePath, { start: 0, end: 7 })) {
+      out.push(line.toString('utf-8'))
+    }
+    // 'bbb' is the cut tail — JSONL consumers drop it as malformed.
+    expect(out).toEqual(['aaa', 'bbb'])
+  })
+
+  it('an empty or inverted range yields nothing', async () => {
+    const filePath = path.join(testDir, 'range-empty.jsonl')
+    await fs.promises.writeFile(filePath, 'aaa\nbbb\n')
+    const out: string[] = []
+    for await (const line of streamFileLines(filePath, { start: 4, end: 4 })) {
+      out.push(line.toString('utf-8'))
+    }
+    expect(out).toEqual([])
   })
 })

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -368,14 +368,19 @@ const TAIL_READ_CHUNK = 64 * 1024
 /** Fill `buf` from an absolute file position, looping over legal short reads
  * (network filesystems may return fewer bytes than requested mid-file).
  * Returns the bytes actually filled — less than `buf.length` only when the
- * file ended early, i.e. it was truncated concurrently with the walk. */
+ * file ended early, i.e. it was truncated concurrently with the walk.
+ *
+ * `signal` is observed before every physical read: one logical chunk can take
+ * many RPC-priced reads on the filesystems where short reads happen at all. */
 async function readFileRangeFully(
   fileHandle: fs.promises.FileHandle,
   buf: Buffer,
-  position: number
+  position: number,
+  signal?: AbortSignal
 ): Promise<number> {
   let filled = 0
   while (filled < buf.length) {
+    signal?.throwIfAborted()
     const { bytesRead } = await fileHandle.read(buf, filled, buf.length - filled, position + filled)
     if (bytesRead === 0) break
     filled += bytesRead
@@ -426,7 +431,7 @@ export async function readJsonlTailLines(
       const size = Math.min(TAIL_READ_CHUNK, pos)
       pos -= size
       const buf = Buffer.allocUnsafe(size)
-      const filled = await readFileRangeFully(fileHandle, buf, pos)
+      const filled = await readFileRangeFully(fileHandle, buf, pos, signal)
       signal?.throwIfAborted()
       if (filled < size) {
         // The file shrank while we walked it (rewrite race). Splicing a short
@@ -511,7 +516,7 @@ export async function* iterateJsonlLinesBackward(
       const size = Math.min(TAIL_READ_CHUNK, pos)
       pos -= size
       const buf = Buffer.allocUnsafe(size)
-      const filled = await readFileRangeFully(fileHandle, buf, pos)
+      const filled = await readFileRangeFully(fileHandle, buf, pos, signal)
       signal?.throwIfAborted()
       if (filled < size) {
         // File shrank while we walked it (rewrite race): the bytes above were
@@ -542,7 +547,14 @@ export async function* iterateJsonlLinesBackward(
     }
 
     if (carryBytes > 0) {
-      yield { line: Buffer.concat(carryParts), offset: 0 }
+      // Release the source fragments BEFORE yielding: the yield suspends the
+      // generator, and holding both the fragments and their concatenation
+      // would double the resident memory of exactly the oversized rows this
+      // reader is sized for (same pattern as streamFileLines' pending).
+      const firstLine = Buffer.concat(carryParts)
+      carryParts = []
+      carryBytes = 0
+      yield { line: firstLine, offset: 0 }
     }
   } finally {
     await fileHandle.close()
@@ -623,6 +635,10 @@ export async function* streamFileLines(
       if (start < chunk.length) pending.push(chunk.subarray(start))
     }
 
+    // An abort can arrive together with the stream's end event, after the
+    // last per-chunk check — observe it before paying for the concatenation
+    // of an unterminated trailing row.
+    signal?.throwIfAborted()
     // Process any remaining content (file not terminated by a newline)
     if (pending.length > 0) {
       // Same as above: drop the source chunks before suspending on yield

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -365,6 +365,24 @@ export async function readJsonlFile<T = unknown>(filePath: string): Promise<T[]>
 const NEWLINE_BYTE = 0x0a
 const TAIL_READ_CHUNK = 64 * 1024
 
+/** Fill `buf` from an absolute file position, looping over legal short reads
+ * (network filesystems may return fewer bytes than requested mid-file).
+ * Returns the bytes actually filled — less than `buf.length` only when the
+ * file ended early, i.e. it was truncated concurrently with the walk. */
+async function readFileRangeFully(
+  fileHandle: fs.promises.FileHandle,
+  buf: Buffer,
+  position: number
+): Promise<number> {
+  let filled = 0
+  while (filled < buf.length) {
+    const { bytesRead } = await fileHandle.read(buf, filled, buf.length - filled, position + filled)
+    if (bytesRead === 0) break
+    filled += bytesRead
+  }
+  return filled
+}
+
 /** Last `maxLines` JSONL rows from disk. Older rows are never read into a line buffer.
  *
  * `signal` (optional) aborts the backward walk between chunk reads: transcripts
@@ -396,6 +414,7 @@ export async function readJsonlTailLines(
     let pos = stat.size
     const parts: Buffer[] = []
     let newlineCount = 0
+    let truncated = false
 
     while (pos > 0 && newlineCount <= maxLines) {
       // Check BEFORE each read (an abort landing during open/stat or a prior
@@ -407,12 +426,18 @@ export async function readJsonlTailLines(
       const size = Math.min(TAIL_READ_CHUNK, pos)
       pos -= size
       const buf = Buffer.allocUnsafe(size)
-      const { bytesRead } = await fileHandle.read(buf, 0, size, pos)
+      const filled = await readFileRangeFully(fileHandle, buf, pos)
       signal?.throwIfAborted()
-      const chunk = bytesRead === size ? buf : buf.subarray(0, bytesRead)
-      parts.unshift(chunk)
-      for (let i = 0; i < chunk.length; i++) {
-        if (chunk[i] === NEWLINE_BYTE) newlineCount++
+      if (filled < size) {
+        // The file shrank while we walked it (rewrite race). Splicing a short
+        // chunk against already-collected higher chunks would garble line
+        // boundaries — stop here and serve only what was read cleanly.
+        truncated = true
+        break
+      }
+      parts.unshift(buf)
+      for (let i = 0; i < buf.length; i++) {
+        if (buf[i] === NEWLINE_BYTE) newlineCount++
       }
     }
 
@@ -427,7 +452,7 @@ export async function readJsonlTailLines(
     }
     if (start < combined.length) lines.push(combined.subarray(start))
 
-    const reachedStart = pos === 0
+    const reachedStart = pos === 0 && !truncated
     if (!reachedStart && lines.length > 0) lines.shift()
     if (lines.length > 0 && lines[lines.length - 1]!.length === 0) lines.pop()
 
@@ -469,9 +494,12 @@ export async function* iterateJsonlLinesBackward(
   try {
     const stat = await fileHandle.stat()
     let pos = stat.size
-    // Bytes below the lowest newline processed so far — the tail fragment of
-    // the line whose start lies in a chunk not yet read.
-    let carry = Buffer.alloc(0)
+    // Fragments (in file order) of the line whose start lies in a chunk not
+    // yet read — the bytes below the lowest newline processed so far. Kept as
+    // an array and concatenated ONCE at the line boundary: re-concatenating
+    // per chunk would make a multi-chunk row cost O(rowBytes²) in copying.
+    let carryParts: Buffer[] = []
+    let carryBytes = 0
     // The first candidate is the region between the last newline and EOF —
     // empty when the file ends with a newline. Skip only that empty
     // pseudo-line; interior empty lines are yielded (parseJsonlLine treats
@@ -483,32 +511,38 @@ export async function* iterateJsonlLinesBackward(
       const size = Math.min(TAIL_READ_CHUNK, pos)
       pos -= size
       const buf = Buffer.allocUnsafe(size)
-      const { bytesRead } = await fileHandle.read(buf, 0, size, pos)
+      const filled = await readFileRangeFully(fileHandle, buf, pos)
       signal?.throwIfAborted()
-      const chunk = bytesRead === size ? buf : buf.subarray(0, bytesRead)
+      if (filled < size) {
+        // File shrank while we walked it (rewrite race): the bytes above were
+        // read from the old layout, so stop instead of splicing garbage.
+        return
+      }
 
       // Unprocessed region of this chunk, scanned high-to-low.
-      let high = chunk.length
-      let idx = high > 0 ? chunk.lastIndexOf(NEWLINE_BYTE, high - 1) : -1
+      let high = buf.length
+      let idx = high > 0 ? buf.lastIndexOf(NEWLINE_BYTE, high - 1) : -1
       while (idx !== -1) {
-        const segment = chunk.subarray(idx + 1, high)
-        const line = carry.length > 0 ? Buffer.concat([segment, carry]) : segment
-        carry = Buffer.alloc(0)
+        const segment = buf.subarray(idx + 1, high)
+        const line =
+          carryParts.length > 0 ? Buffer.concat([segment, ...carryParts]) : segment
+        carryParts = []
+        carryBytes = 0
         if (line.length > 0 || !first) {
           yield { line, offset: pos + idx + 1 }
         }
         first = false
         high = idx
-        idx = high > 0 ? chunk.lastIndexOf(NEWLINE_BYTE, high - 1) : -1
+        idx = high > 0 ? buf.lastIndexOf(NEWLINE_BYTE, high - 1) : -1
       }
-      carry =
-        carry.length > 0
-          ? Buffer.concat([chunk.subarray(0, high), carry])
-          : Buffer.from(chunk.subarray(0, high))
+      if (high > 0) {
+        carryParts.unshift(buf.subarray(0, high))
+        carryBytes += high
+      }
     }
 
-    if (carry.length > 0) {
-      yield { line: carry, offset: 0 }
+    if (carryBytes > 0) {
+      yield { line: Buffer.concat(carryParts), offset: 0 }
     }
   } finally {
     await fileHandle.close()
@@ -543,11 +577,17 @@ export async function* streamJsonlFile<T = unknown>(
  * `range` restricts the read to `[start, end)` byte offsets. `start` must be a
  * line boundary; a range ending mid-line yields the truncated head of that
  * line, which JSONL consumers drop as malformed.
+ *
+ * `signal` aborts between chunk reads (throws the abort reason) — a per-line
+ * check in the consumer is not enough, because a multi-MB row spans many
+ * chunks before it ever yields.
  */
 export async function* streamFileLines(
   filePath: string,
-  range?: { start?: number; end?: number }
+  range?: { start?: number; end?: number },
+  signal?: AbortSignal
 ): AsyncIterable<Buffer> {
+  signal?.throwIfAborted()
   if (range?.end !== undefined && range.end <= (range.start ?? 0)) return
   const fileHandle = await fs.promises.open(filePath, 'r')
   try {
@@ -561,6 +601,7 @@ export async function* streamFileLines(
     let pending: Buffer[] = []
 
     for await (const chunk of stream) {
+      signal?.throwIfAborted()
       let start = 0
       let idx = chunk.indexOf(NEWLINE_BYTE)
       while (idx !== -1) {

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -441,6 +441,81 @@ export async function readJsonlTailLines(
 }
 
 /**
+ * Iterate a file's raw lines BACKWARD from EOF without retaining the file.
+ * Yields `{ line, offset }` per line — `offset` is the byte position of the
+ * line's first byte; the newline is excluded from `line`. Memory held between
+ * iterations is one read chunk plus the partial head of the line currently
+ * being assembled, so walking an arbitrarily deep tail is O(chunk) — the
+ * property the paged messages reader's index scan relies on. Yielded buffers
+ * may alias an internal read chunk: consume them within the iteration, don't
+ * retain them.
+ *
+ * Missing file yields nothing. `signal` aborts between chunk reads (throws the
+ * abort reason), same contract as readJsonlTailLines.
+ */
+export async function* iterateJsonlLinesBackward(
+  filePath: string,
+  signal?: AbortSignal
+): AsyncGenerator<{ line: Buffer; offset: number }> {
+  signal?.throwIfAborted()
+  let fileHandle: fs.promises.FileHandle
+  try {
+    fileHandle = await fs.promises.open(filePath, 'r')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
+  }
+
+  try {
+    const stat = await fileHandle.stat()
+    let pos = stat.size
+    // Bytes below the lowest newline processed so far — the tail fragment of
+    // the line whose start lies in a chunk not yet read.
+    let carry = Buffer.alloc(0)
+    // The first candidate is the region between the last newline and EOF —
+    // empty when the file ends with a newline. Skip only that empty
+    // pseudo-line; interior empty lines are yielded (parseJsonlLine treats
+    // them as blanks), matching readJsonlTailLines.
+    let first = true
+
+    while (pos > 0) {
+      signal?.throwIfAborted()
+      const size = Math.min(TAIL_READ_CHUNK, pos)
+      pos -= size
+      const buf = Buffer.allocUnsafe(size)
+      const { bytesRead } = await fileHandle.read(buf, 0, size, pos)
+      signal?.throwIfAborted()
+      const chunk = bytesRead === size ? buf : buf.subarray(0, bytesRead)
+
+      // Unprocessed region of this chunk, scanned high-to-low.
+      let high = chunk.length
+      let idx = high > 0 ? chunk.lastIndexOf(NEWLINE_BYTE, high - 1) : -1
+      while (idx !== -1) {
+        const segment = chunk.subarray(idx + 1, high)
+        const line = carry.length > 0 ? Buffer.concat([segment, carry]) : segment
+        carry = Buffer.alloc(0)
+        if (line.length > 0 || !first) {
+          yield { line, offset: pos + idx + 1 }
+        }
+        first = false
+        high = idx
+        idx = high > 0 ? chunk.lastIndexOf(NEWLINE_BYTE, high - 1) : -1
+      }
+      carry =
+        carry.length > 0
+          ? Buffer.concat([chunk.subarray(0, high), carry])
+          : Buffer.from(chunk.subarray(0, high))
+    }
+
+    if (carry.length > 0) {
+      yield { line: carry, offset: 0 }
+    }
+  } finally {
+    await fileHandle.close()
+  }
+}
+
+/**
  * Stream-read JSONL file line by line (for large files)
  * Yields parsed objects one at a time
  *
@@ -464,11 +539,23 @@ export async function* streamJsonlFile<T = unknown>(
  * excluded; a `\r` from a CRLF line is kept). Lines are never decoded or
  * re-encoded, so a consumer that copies them back out preserves the original
  * bytes exactly — the property the transcript rewriters rely on.
+ *
+ * `range` restricts the read to `[start, end)` byte offsets. `start` must be a
+ * line boundary; a range ending mid-line yields the truncated head of that
+ * line, which JSONL consumers drop as malformed.
  */
-export async function* streamFileLines(filePath: string): AsyncIterable<Buffer> {
+export async function* streamFileLines(
+  filePath: string,
+  range?: { start?: number; end?: number }
+): AsyncIterable<Buffer> {
+  if (range?.end !== undefined && range.end <= (range.start ?? 0)) return
   const fileHandle = await fs.promises.open(filePath, 'r')
   try {
-    const stream = fileHandle.createReadStream()
+    const stream = fileHandle.createReadStream({
+      ...(range?.start !== undefined ? { start: range.start } : {}),
+      // createReadStream's `end` is inclusive; the range contract is exclusive.
+      ...(range?.end !== undefined ? { end: range.end - 1 } : {}),
+    })
     // Chunks holding the trailing, not-yet-terminated line. Concatenated only
     // once its newline arrives, so a row spanning many chunks is joined once.
     let pending: Buffer[] = []


### PR DESCRIPTION
Implements SUP-595 (parent SUP-592): makes `GET /messages` pagination structurally un-OOM-able server-side. Same JSON shape, chunked transfer — invisible to clients. Follows #771 (SUP-593) and #772 (SUP-594).

## Why the old reader blew up

`getSessionMessagesPage` sized its tail window in lines with a message-count goal, but the raw-line→display-item ratio (~0.18 on real transcripts) made the `maxLines *= 2` loop escalate until it re-read the **whole file from EOF, repeatedly**, materializing every chunk, parsed entry, and transformed item — then serialized the response as one multi-MB `c.json` string. Measured: ~50–150MB transient per in-flight request; OOM-killed at 14–15 concurrent requests in a 1GB cgroup.

## Design

**Pass 1 — backward index scan** (`scanMessagesPageWindow` + new `iterateJsonlLinesBackward`). Walks backward from EOF one line at a time, parsing each transiently to count display-item starts, retaining only offsets and id sets. The classifier (`countsAsDisplayStart`) mirrors every rule `transformMessages` uses to decide an entry starts a new item: uuid dedup, assistant merge by `message.id`, meta / tool-result-only / task-notification / compact-summary skips, queued-command attachments, the informational banner's synthetic user copy. The scan stops at `limit+1` items (one sacrificial head item, same `dropPartialHead` contract as before), the **byte budget**, `MAX_TAIL_LINES`, or file start. The doubling loop is gone — one scan, extended incrementally, never re-read.

Cursor pages locate the cursor by **raw byte search** for the quoted id (no JSON parse above the cursor; candidates are verified by parsing, which also catches queued-command cursors whose id lives in `source_uuid`). A cursor 17k raw lines deep resolves in 63ms.

**Pass 2 — bounded materialization.** One deliberate deviation from the ticket's sketch: instead of rewriting the transform as a streaming operator, the byte budget bounds the window and the **unchanged `transformMessages`** runs over just that window. Page semantics are preserved by construction — all nine pre-existing pagination tests passed untouched on first run. Slicing logic is byte-for-byte the old code.

**Byte budget** (`MESSAGES_PAGE_BYTE_BUDGET`, 4MB): a hard cap on raw bytes a window may materialize, with a ≥2-item floor so a single item larger than the budget still serves rather than producing an empty page. Truncated pages are valid short pages: `nextCursor` points at their first item and the client's existing scroll-up paging walks the rest.

**Streamed envelope**: the route emits `{"messages":[…],"nextCursor":…}` item-by-item through `Readable.from` with real backpressure instead of one monolithic JSON string. (Chunks must be Buffers — `Readable.toWeb`'s byte consumers reject strings; a route test caught this immediately.)

**Untouched**: the `?after=` delta path (already bounded, SUP-594) and the legacy unpaginated branch (per ticket).

## Documented deviations from the old reader

- A cursor page's window extends 512KB (`CURSOR_WINDOW_GRACE_BYTES`) past the cursor line so tool_use blocks at the page's newest edge still meet their results (results land within the same turn, typically adjacent). The old code read from the cursor to EOF; a result further out than the grace region is not attached — bounded cosmetic staleness on a historical page, never on the trailing page (whose window always ends at EOF). Pinned by test: a result recorded past the cursor line (queued message interleaved between use and result) still attaches.
- Backward-order counting can place an item boundary on a different line than the forward transform for replayed/duplicated ids; the shift lands on the sacrificial head item that page slicing already drops. The mixed-transcript parity test walks tiny budget-truncated pages across every classifier rule and reconstructs the full transform's output exactly.

## Acceptance

**Memory** — 37MB transcript, 16 concurrent `limit=300` requests:
- In-process probe: peak **+10MB heap / +10MB external for all 16 combined**, 50ms wall (baseline: 50–150MB *per request*, OOM at 14–15 concurrent).
- Live dev server burst: peak RSS 274MB from a 111MB baseline ≈ **~10MB transient per in-flight request** (target was ≤~15MB).

**Content parity** — full unit suite **9,599 passed / 0 failed**, including all pre-existing pagination tests unmodified. 31 new tests: backward iterator (offsets, chunk-spanning lines, abort), ranged `streamFileLines`, budget truncation + full cursor-walk reconstruction, giant-item floor, mixed-transcript parity walk, grace-region result attachment, depth-cap/vanished-cursor termination.

**Byte-budget paging** — `byteBudget: 1024` against a 60-item thread: every truncated page returns a valid `nextCursor`, and the walk reconstructs the exact full item sequence.

**Browser** (mock server, real Chromium): initial 300-item page renders from the streamed endpoint (603KB, 32ms); scroll-up prepends cursor pages (200-item cap via `capMessagesPageLimit`, contiguous, no gaps); a live turn still runs entirely on SUP-594 deltas (~4KB each) with the final text rendered. 13 chat/messages E2E specs green.

⚠ Base is `main`, so CI runs the full suite on this PR.

https://claude.ai/code/session_01Xvya59kGnQTwWRHTUbtZ3B
