### PR TITLE
Cache CLAUDE.md and session metadata by file mtime on GET /api/agents

### DIFF
--- a/src/shared/lib/services/agent-service.test.ts
+++ b/src/shared/lib/services/agent-service.test.ts
@@ -48,6 +48,7 @@ import {
   agentExists,
   getAgentClaudeMdContent,
   setAgentClaudeMdContent,
+  _resetAgentClaudeMdMtimeCacheForTest,
 } from './agent-service'
 
 describe('agent-service', () => {
@@ -66,9 +67,11 @@ describe('agent-service', () => {
 
     // Reset mocks
     vi.clearAllMocks()
+    _resetAgentClaudeMdMtimeCacheForTest()
   })
 
   afterEach(async () => {
+    _resetAgentClaudeMdMtimeCacheForTest()
     // Restore env
     if (originalEnv) {
       process.env.SUPERAGENT_DATA_DIR = originalEnv
@@ -455,6 +458,67 @@ Instructions`
 
       const content = await getAgentClaudeMdContent('test-agent')
       expect(content).toBe(newContent)
+    })
+  })
+
+  describe('CLAUDE.md mtime cache', () => {
+    function claudeMdPath(slug: string): string {
+      return path.join(testDir, 'agents', slug, 'workspace', 'CLAUDE.md')
+    }
+
+    function claudeReads(spy: ReturnType<typeof vi.spyOn>, slug: string): number {
+      return spy.mock.calls.filter((call: unknown[]) => String(call[0]) === claudeMdPath(slug)).length
+    }
+
+    it('skips readFile on a warm get when mtime is unchanged', async () => {
+      await createTestAgent('test-agent', SAMPLE_CLAUDE_MD)
+      await getAgent('test-agent')
+      const spy = vi.spyOn(fs.promises, 'readFile')
+
+      const agent = await getAgent('test-agent')
+
+      expect(agent?.frontmatter.name).toBe('Github Agent')
+      expect(claudeReads(spy, 'test-agent')).toBe(0)
+      spy.mockRestore()
+    })
+
+    it('re-reads after a container-style write so updateAgent does not clobber it', async () => {
+      await createTestAgent('test-agent', SAMPLE_CLAUDE_MD)
+      await getAgent('test-agent')
+      await fs.promises.writeFile(
+        claudeMdPath('test-agent'),
+        '---\nname: Container Rename\ncreatedAt: "2026-01-01T00:00:00.000Z"\n---\n# Container edit\n',
+      )
+
+      const updated = await updateAgent('test-agent', { description: 'from host' })
+
+      expect(updated?.name).toBe('Container Rename')
+      expect(updated?.description).toBe('from host')
+      expect((await getAgent('test-agent'))?.frontmatter.name).toBe('Container Rename')
+    })
+
+    it('overlapping gets share one CLAUDE.md read', async () => {
+      await createTestAgent('test-agent', SAMPLE_CLAUDE_MD)
+      const target = claudeMdPath('test-agent')
+      let release!: () => void
+      const held = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const actual = fs.promises.readFile.bind(fs.promises)
+      const spy = vi.spyOn(fs.promises, 'readFile').mockImplementation((async (file, opts) => {
+        if (String(file) === target) await held
+        return actual(file, opts as never)
+      }) as typeof fs.promises.readFile)
+
+      const first = getAgent('test-agent')
+      const second = getAgent('test-agent')
+      release()
+      const [a, b] = await Promise.all([first, second])
+
+      expect(a?.frontmatter.name).toBe('Github Agent')
+      expect(b?.frontmatter.name).toBe('Github Agent')
+      expect(claudeReads(spy, 'test-agent')).toBe(1)
+      spy.mockRestore()
     })
   })
 })

--- a/src/shared/lib/services/agent-service.ts
+++ b/src/shared/lib/services/agent-service.ts
@@ -34,6 +34,13 @@ import { containerManager } from '@shared/lib/container/container-manager'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
 import { getSessionSummary } from './session-service'
+import { MtimeFileCache } from '@shared/lib/utils/mtime-file-cache'
+
+const claudeMdCache = new MtimeFileCache<AgentConfig>(structuredClone)
+
+export function _resetAgentClaudeMdMtimeCacheForTest(): void {
+  claudeMdCache.clear()
+}
 
 // ============================================================================
 // Internal to API Type Conversion
@@ -65,20 +72,9 @@ function toApiAgent(
 // Read Operations
 // ============================================================================
 
-/**
- * Parse CLAUDE.md file into AgentConfig
- */
-async function parseAgentClaudeMd(slug: string): Promise<AgentConfig | null> {
-  const claudeMdPath = getAgentClaudeMdPath(slug)
-  const content = await readFileOrNull(claudeMdPath)
-
-  if (content === null) {
-    return null
-  }
-
+function parseAgentClaudeMdContent(slug: string, content: string): AgentConfig {
   const { frontmatter, body } = parseMarkdownWithFrontmatter<AgentFrontmatter>(content)
 
-  // Validate required fields
   if (!frontmatter.name) {
     console.warn(`Agent ${slug} has invalid CLAUDE.md: missing name`)
     frontmatter.name = slug
@@ -86,7 +82,6 @@ async function parseAgentClaudeMd(slug: string): Promise<AgentConfig | null> {
   frontmatter.name = String(frontmatter.name)
 
   if (!frontmatter.createdAt) {
-    // Use directory creation time as fallback
     frontmatter.createdAt = new Date().toISOString()
   }
 
@@ -95,6 +90,16 @@ async function parseAgentClaudeMd(slug: string): Promise<AgentConfig | null> {
     frontmatter,
     instructions: body,
   }
+}
+
+async function parseAgentClaudeMd(slug: string): Promise<AgentConfig | null> {
+  const claudeMdPath = getAgentClaudeMdPath(slug)
+  const parsed = await claudeMdCache.get(claudeMdPath, async () => {
+    const content = await readFileOrNull(claudeMdPath)
+    if (content === null) return undefined
+    return parseAgentClaudeMdContent(slug, content)
+  })
+  return parsed ?? null
 }
 
 /**

--- a/src/shared/lib/services/artifact-service.test.ts
+++ b/src/shared/lib/services/artifact-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -255,6 +255,42 @@ describe('artifact-service', () => {
       // Current implementation only checks access(R_OK), which succeeds for a
       // directory. Document that explicitly.
       expect(result[0].hasScreenshot).toBe(true)
+    })
+
+    it('overlapping lists share one artifacts walk', async () => {
+      createArtifactDir('test-agent', 'sales', { name: 'Sales' })
+      const artifactsDir = path.join(testDir, 'agents', 'test-agent', 'workspace', 'artifacts')
+      let release!: () => void
+      const held = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const actual = fs.promises.readdir.bind(fs.promises)
+      const spy = vi.spyOn(fs.promises, 'readdir').mockImplementation((async (dir, opts) => {
+        if (String(dir) === artifactsDir) await held
+        return actual(dir, opts as never)
+      }) as typeof fs.promises.readdir)
+
+      const first = listArtifactsFromFilesystem('test-agent')
+      const second = listArtifactsFromFilesystem('test-agent')
+      release()
+      const [a, b] = await Promise.all([first, second])
+
+      expect(a.map((d) => d.slug)).toEqual(['sales'])
+      expect(b.map((d) => d.slug)).toEqual(['sales'])
+      expect(spy.mock.calls.filter((call) => String(call[0]) === artifactsDir)).toHaveLength(1)
+      spy.mockRestore()
+    })
+
+    it('a later list walks disk again', async () => {
+      createArtifactDir('test-agent', 'sales', { name: 'Sales' })
+      const artifactsDir = path.join(testDir, 'agents', 'test-agent', 'workspace', 'artifacts')
+      const spy = vi.spyOn(fs.promises, 'readdir')
+
+      await listArtifactsFromFilesystem('test-agent')
+      await listArtifactsFromFilesystem('test-agent')
+
+      expect(spy.mock.calls.filter((call) => String(call[0]) === artifactsDir)).toHaveLength(2)
+      spy.mockRestore()
     })
   })
 })

--- a/src/shared/lib/services/artifact-service.ts
+++ b/src/shared/lib/services/artifact-service.ts
@@ -16,11 +16,28 @@ export interface ArtifactInfo {
   firstRun?: boolean
 }
 
+// Overlapping list polls share one walk. The result is not kept — the next
+// call after this walk finishes reads disk again.
+const artifactListInflight = new Map<string, Promise<ArtifactInfo[]>>()
+
 /**
  * List dashboard artifacts for an agent by reading the host filesystem.
  * Used when the container is not running (all dashboards reported as 'stopped').
  */
 export async function listArtifactsFromFilesystem(
+  agentSlug: string
+): Promise<ArtifactInfo[]> {
+  const key = getAgentWorkspaceDir(agentSlug)
+  const existing = artifactListInflight.get(key)
+  if (existing) return existing
+  const pending = walkArtifactsFromFilesystem(agentSlug).finally(() => {
+    if (artifactListInflight.get(key) === pending) artifactListInflight.delete(key)
+  })
+  artifactListInflight.set(key, pending)
+  return pending
+}
+
+async function walkArtifactsFromFilesystem(
   agentSlug: string
 ): Promise<ArtifactInfo[]> {
   const workspaceDir = getAgentWorkspaceDir(agentSlug)

--- a/src/shared/lib/services/session-service.metadata.test.ts
+++ b/src/shared/lib/services/session-service.metadata.test.ts
@@ -30,7 +30,9 @@ beforeEach(() => {
   process.env.SUPERAGENT_DATA_DIR = tmpDir
 })
 
-afterEach(() => {
+afterEach(async () => {
+  const { _resetSessionMetadataMtimeCacheForTest } = await import('./session-service')
+  _resetSessionMetadataMtimeCacheForTest()
   fs.rmSync(tmpDir, { recursive: true, force: true })
   delete process.env.SUPERAGENT_DATA_DIR
   vi.restoreAllMocks()
@@ -243,5 +245,41 @@ describe('finalizeAutomationStatus guards', () => {
 
     await expect(finalizeAutomationStatus('agent', 's0', 'succeeded')).rejects.toThrow()
     expect(fs.readFileSync(metadataPath('agent'), 'utf-8')).toBe(corrupt)
+  })
+})
+
+describe('readSessionMetadata mtime cache', () => {
+  function metadataReads(spy: ReturnType<typeof vi.spyOn>, slug: string): number {
+    return spy.mock.calls.filter((call: unknown[]) => String(call[0]) === metadataPath(slug)).length
+  }
+
+  it('skips readFile on a warm read when mtime is unchanged', async () => {
+    const { registerSession, readSessionMetadata } = await importService()
+    makeAgent('agent')
+    await registerSession('agent', 's1', 'First')
+    const spy = vi.spyOn(fs.promises, 'readFile')
+
+    expect((await readSessionMetadata('agent'))['s1']?.name).toBe('First')
+    expect((await readSessionMetadata('agent'))['s1']?.name).toBe('First')
+    expect(metadataReads(spy, 'agent')).toBe(1)
+  })
+
+  it('does not cache a miss, so registerSession is visible on the next read', async () => {
+    const { registerSession, readSessionMetadata } = await importService()
+    makeAgent('agent')
+    expect(await readSessionMetadata('agent')).toEqual({})
+    await registerSession('agent', 's1', 'First')
+    expect((await readSessionMetadata('agent'))['s1']?.name).toBe('First')
+  })
+
+  it('re-reads after a write so a new session name is visible', async () => {
+    const { registerSession, readSessionMetadata } = await importService()
+    makeAgent('agent')
+    await registerSession('agent', 's1', 'First')
+    await readSessionMetadata('agent')
+    await registerSession('agent', 's2', 'Second')
+    const meta = await readSessionMetadata('agent')
+    expect(meta['s1']?.name).toBe('First')
+    expect(meta['s2']?.name).toBe('Second')
   })
 })

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -53,6 +53,13 @@ import {
   SESSION_SUMMARY_CACHE_TTL_MS,
   type SessionSummaryCacheValue,
 } from './session-summary-cache'
+import { MtimeFileCache } from '@shared/lib/utils/mtime-file-cache'
+
+const sessionMetadataReadCache = new MtimeFileCache<SessionMetadataMap>(structuredClone)
+
+export function _resetSessionMetadataMtimeCacheForTest(): void {
+  sessionMetadataReadCache.clear()
+}
 
 // Session transcripts and metadata live inside the agent workspace, which is
 // bind-mounted read/write into its container. They are therefore evidence that
@@ -250,8 +257,12 @@ async function readSessionMetadataStrict(agentSlug: string): Promise<SessionMeta
  * error still propagates (matches the original `readFileOrNull` behaviour).
  */
 export async function readSessionMetadata(agentSlug: string): Promise<SessionMetadataMap> {
+  const metadataPath = getAgentSessionMetadataPath(agentSlug)
   try {
-    return await readSessionMetadataStrict(agentSlug)
+    const cached = await sessionMetadataReadCache.get(metadataPath, () =>
+      readSessionMetadataStrict(agentSlug),
+    )
+    return cached ?? {}
   } catch (error) {
     if (error instanceof CorruptFileError) {
       console.error(

--- a/src/shared/lib/utils/mtime-file-cache.test.ts
+++ b/src/shared/lib/utils/mtime-file-cache.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import { MtimeFileCache } from './mtime-file-cache'
+
+describe('MtimeFileCache', () => {
+  let dir: string
+  let filePath: string
+  let cache: MtimeFileCache<string>
+  let loads: number
+
+  beforeEach(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mtime-file-cache-'))
+    filePath = path.join(dir, 'note.txt')
+    cache = new MtimeFileCache((value) => value)
+    loads = 0
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.promises.rm(dir, { recursive: true, force: true })
+  })
+
+  async function load(): Promise<string | undefined> {
+    loads += 1
+    try {
+      return await fs.promises.readFile(filePath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+      throw error
+    }
+  }
+
+  it('skips load when mtime and size are unchanged', async () => {
+    await fs.promises.writeFile(filePath, 'hello')
+    expect(await cache.get(filePath, load)).toBe('hello')
+    expect(await cache.get(filePath, load)).toBe('hello')
+    expect(loads).toBe(1)
+  })
+
+  it('reloads after the file is written', async () => {
+    await fs.promises.writeFile(filePath, 'hello')
+    await cache.get(filePath, load)
+    await fs.promises.writeFile(filePath, 'world')
+    expect(await cache.get(filePath, load)).toBe('world')
+    expect(loads).toBe(2)
+  })
+
+  it('reloads when size changes even if mtime is copied back', async () => {
+    await fs.promises.writeFile(filePath, 'aa')
+    const { mtimeMs } = await fs.promises.stat(filePath)
+    await cache.get(filePath, load)
+    await fs.promises.writeFile(filePath, 'bbb')
+    await fs.promises.utimes(filePath, new Date(mtimeMs), new Date(mtimeMs))
+    expect(await cache.get(filePath, load)).toBe('bbb')
+    expect(loads).toBe(2)
+  })
+
+  it('does not cache a miss, so a later create is visible', async () => {
+    expect(await cache.get(filePath, load)).toBeUndefined()
+    expect(loads).toBe(0)
+    await fs.promises.writeFile(filePath, 'created')
+    expect(await cache.get(filePath, load)).toBe('created')
+    expect(loads).toBe(1)
+  })
+
+  it('overlapping gets share one load', async () => {
+    await fs.promises.writeFile(filePath, 'shared')
+    let release!: () => void
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const blockedLoad = async () => {
+      await held
+      return load()
+    }
+
+    const first = cache.get(filePath, blockedLoad)
+    const second = cache.get(filePath, blockedLoad)
+    release()
+    expect(await first).toBe('shared')
+    expect(await second).toBe('shared')
+    expect(loads).toBe(1)
+  })
+
+  it('does not cache when mtimeMs is 0', async () => {
+    await fs.promises.writeFile(filePath, 'epoch')
+    await fs.promises.utimes(filePath, new Date(0), new Date(0))
+    expect((await fs.promises.stat(filePath)).mtimeMs).toBe(0)
+    expect(await cache.get(filePath, load)).toBe('epoch')
+    expect(await cache.get(filePath, load)).toBe('epoch')
+    expect(loads).toBe(2)
+  })
+
+  it('returns a clone so callers cannot mutate the stored value', async () => {
+    const objectCache = new MtimeFileCache((value: { name: string }) => ({ ...value }))
+    await fs.promises.writeFile(filePath, '{"name":"A"}')
+    const first = await objectCache.get(filePath, async () =>
+      JSON.parse(await fs.promises.readFile(filePath, 'utf-8')),
+    )
+    first!.name = 'mutated'
+    const second = await objectCache.get(filePath, async () => {
+      throw new Error('should not reload')
+    })
+    expect(second).toEqual({ name: 'A' })
+  })
+})

--- a/src/shared/lib/utils/mtime-file-cache.ts
+++ b/src/shared/lib/utils/mtime-file-cache.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+type Slot<T> = {
+  mtimeMs: number
+  size: number
+  value: T
+}
+
+function isEnoent(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException)?.code === 'ENOENT'
+}
+
+// Serve a parsed file when stat mtime+size still match. No TTL.
+// Missing files are not stored, so a later create is visible on the next stat.
+export class MtimeFileCache<T> {
+  private readonly slots = new Map<string, Slot<T>>()
+  private readonly inflight = new Map<string, Promise<T | undefined>>()
+
+  constructor(private readonly clone: (value: T) => T) {}
+
+  async get(filePath: string, load: () => Promise<T | undefined>): Promise<T | undefined> {
+    const key = path.resolve(filePath)
+    const existing = this.inflight.get(key)
+    if (existing) {
+      const value = await existing
+      return value === undefined ? undefined : this.clone(value)
+    }
+
+    const pending = this.load(key, load).finally(() => {
+      if (this.inflight.get(key) === pending) this.inflight.delete(key)
+    })
+    this.inflight.set(key, pending)
+    const value = await pending
+    return value === undefined ? undefined : this.clone(value)
+  }
+
+  clear(): void {
+    this.slots.clear()
+    this.inflight.clear()
+  }
+
+  private async load(key: string, load: () => Promise<T | undefined>): Promise<T | undefined> {
+    let st: fs.Stats
+    try {
+      st = await fs.promises.stat(key)
+    } catch (error) {
+      if (isEnoent(error)) return undefined
+      throw error
+    }
+
+    // mtimeMs === 0 is unusable as a generation (S3 Files birthtime is epoch;
+    // skip caching rather than treat 0 as a stable key).
+    if (st.mtimeMs !== 0) {
+      const hit = this.slots.get(key)
+      if (hit && hit.mtimeMs === st.mtimeMs && hit.size === st.size) {
+        return hit.value
+      }
+    }
+
+    const value = await load()
+    if (value !== undefined && st.mtimeMs !== 0) {
+      this.slots.set(key, { mtimeMs: st.mtimeMs, size: st.size, value })
+    }
+    return value
+  }
+}


### PR DESCRIPTION
## Why

`GET /api/agents` re-reads each agent's `CLAUDE.md` and `session-metadata.json` on every tray/UI poll. Local SSD hides that. Cloud `/data` is S3 Files, so those reads are network RTTs stacked on one Node process.

The correct cache for a single file is the one `getSessionSummary` already uses: **stat, then serve the parsed result only when mtime (and size) still match.** No TTL. A write — host or container — changes mtime, so the next list re-reads.

## What changed

- `CLAUDE.md` and `session-metadata.json`: in-process cache keyed by resolved path + `mtimeMs` + size. Overlapping lists share one load. Missing files are not stored, so a create is visible on the next stat.
- `updateAgent` goes through the same `stat` path, so a host rename cannot merge into a stale parse after a container edit.
- `readSessionMetadata` (read-only) is cached. `readSessionMetadataStrict` (the write path) still hits disk.
- `artifacts/`: still **single-flight only**. Directory mtime is not a correct generation — editing `package.json`, adding `screenshot.png`, or creating `node_modules` often does not bump the parent dir. The walk result is dropped when the walk finishes.

No event invalidation. No 20s TTL.

## Staging check (S3 Files `/data`)

One-off Fargate task on `yitian-superagent` (org `e72242c1-…`), same access point as the host-app, write + `stat` on `/data/.mtime-probe`:

| check | result |
|---|---|
| `mtime` after create | non-zero, current time |
| restat with no write | same `mtimeMs` |
| append after 1.1s | `mtime` changed (`deltaMs` 1114 / 1126) |
| `birthtime` | epoch 0 (already known) |
| existing `CLAUDE.md` | real `mtime` (`2026-07-07`), not epoch |

Same-client write → `stat` is usable. Cross-client NFS attribute cache (MicroVM write, host-app `stat`) can lag a few seconds — the same caveat `getSessionSummary` already lives with. Not a TTL.

## Test plan

- [x] Warm `getAgent` / `readSessionMetadata` does not `readFile` when mtime is unchanged
- [x] Write then read re-reads (including `updateAgent` after a container-style `CLAUDE.md` write)
- [x] Overlapping reads share one load
- [x] A miss is not cached; a later create is visible
- [x] `mtimeMs === 0` is not used as a cache key
- [x] Two overlapping artifact lists share one walk; a later list walks disk again
- [ ] After deploy: warm `/api/agents` polls stop re-reading unchanged `CLAUDE.md` / `session-metadata.json`