### PR TITLE
fix(composer): re-enable Inter arrow ligatures in the editor

### DIFF
--- a/e2e/specs/composer-markdown.spec.ts
+++ b/e2e/specs/composer-markdown.spec.ts
@@ -79,6 +79,22 @@ test.describe('composer Markdown blocks', () => {
     await expect.poll(() => input.evaluate((element) => element.scrollTop)).toBeGreaterThan(0)
   })
 
+  test('keeps contextual ligatures enabled in the editor', async ({ page }) => {
+    const input = page.locator('[data-testid="home-message-input"]')
+    // prosemirror-view's stylesheet disables ligatures on .ProseMirror, which
+    // would also kill Inter's -> / => arrow substitutions; globals.css must win.
+    await expect(input).toHaveClass(/ProseMirror/)
+    const styles = await input.evaluate((element) => {
+      const computed = window.getComputedStyle(element)
+      return {
+        ligatures: computed.fontVariantLigatures,
+        features: computed.fontFeatureSettings,
+      }
+    })
+    expect(styles.ligatures).toBe('normal')
+    expect(styles.features).toBe('normal')
+  })
+
   test('creates a code block before session Enter-to-send', async ({ page }) => {
     const agentPage = new AgentPage(page)
     const sessionPage = new SessionPage(page)

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -154,6 +154,15 @@ html[data-keyboard-open] [data-composer-footer] {
 .markdown-composer-editor {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+/* prosemirror-view's own stylesheet sets `font-variant-ligatures: none` on
+   .ProseMirror, which also disables Inter's contextual alternates — the calt
+   substitutions that draw ->, --> and => as arrows. That stylesheet is imported
+   by the editor component, so it lands after this file in the bundle and a
+   same-specificity override loses the cascade. Double the class so this rule
+   wins regardless of import order. */
+.markdown-composer-editor.markdown-composer-editor {
   -webkit-font-variant-ligatures: normal;
   font-variant-ligatures: normal;
   font-feature-settings: normal;


### PR DESCRIPTION
## Problem

Typing `->`, `-->` or `=>` in the composer used to render as arrows (→, ⟶, ⇒); it stopped when the live Markdown composer (#497) replaced the plain textarea. The font never changed — the arrows are Inter's **contextual alternates** (`calt`), and `prosemirror-view/style/prosemirror.css` disables them via `.ProseMirror { font-variant-ligatures: none; font-feature-settings: "liga" 0 }` (per CSS Fonts, `none` also turns off `calt`).

globals.css already had a re-enable on `.markdown-composer-editor`, but it loses the cascade: same specificity as `.ProseMirror`, and prosemirror.css is imported by the editor component, so it lands **later** in the bundle. The override was dead code.

## Fix

Double the class on the override (`.markdown-composer-editor.markdown-composer-editor`) so it out-ranks `.ProseMirror` regardless of import order. The block-spacing declarations stay on the single-class selector — only the ligature settings needed the bump.

Verified the mechanism in Chromium against the exact Google-Fonts Inter build the app loads: default Inter shows the arrows, the ProseMirror rules kill them, and the doubled-specificity override restores them.

Known tradeoff (same as the pre-#497 textarea): the caret sits after a rendered `→` whose underlying text is `->`, so one backspace turns it back into `-`. ProseMirror disables ligatures to sidestep exactly this; it matches how the old composer behaved.

## Validation

- `npx tsc --noEmit` and eslint clean
- `E2E_MOCK=true npx playwright test e2e/specs/composer-markdown.spec.ts` — 5/5 pass
- New E2E test asserts the editor's computed `font-variant-ligatures` / `font-feature-settings` stay `normal`; confirmed it **fails** with the fix reverted, so it guards against future import-order/selector regressions

https://claude.ai/code/session_01QKCKd6u42KouiWu5zD6oYt