### PR TITLE
Support PROMPT.md in agent templates (SUP-610)

### DIFF
--- a/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
+++ b/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
@@ -90,6 +90,7 @@ vi.mock('@shared/lib/services/agent-service', () => ({
 
 const mockImportAgentFromTemplate = vi.fn()
 const mockInstallAgentFromSkillset = vi.fn()
+const mockGetAgentTemplatePrompt = vi.fn().mockResolvedValue(undefined)
 vi.mock('@shared/lib/services/agent-template-service', () => ({
   exportAgentTemplate: vi.fn(), exportAgentFull: vi.fn(),
   importAgentFromTemplate: (...a: unknown[]) => mockImportAgentFromTemplate(...a),
@@ -99,6 +100,7 @@ vi.mock('@shared/lib/services/agent-template-service', () => ({
   refreshSkillsetCaches: vi.fn(), getAgentPRInfo: vi.fn(), createAgentPR: vi.fn(),
   getAgentPublishInfo: vi.fn(), publishAgentToSkillset: vi.fn(), refreshAgentTemplates: vi.fn(),
   hasOnboardingSkill: vi.fn().mockResolvedValue(false),
+  getAgentTemplatePrompt: (...a: unknown[]) => mockGetAgentTemplatePrompt(...a),
 }))
 
 // install-from-skillset resolves the skillset config from settings, then builds a
@@ -265,6 +267,8 @@ beforeEach(() => {
   mockDbInsertValues.mockResolvedValue(undefined)
   mockDeleteAgent.mockReset()
   mockDeleteAgent.mockResolvedValue(true)
+  mockGetAgentTemplatePrompt.mockReset()
+  mockGetAgentTemplatePrompt.mockResolvedValue(undefined)
 })
 
 describe('SUP-207: owner ACL insert failure rolls back the created workspace (AUTH_MODE)', () => {
@@ -382,6 +386,33 @@ describe('SUP-207: regression — successful creation does not roll back', () =>
 
     expect(res.status).toBe(201)
     expect(mockDbInsertValues).not.toHaveBeenCalled()
+    expect(mockDeleteAgent).not.toHaveBeenCalled()
+  })
+
+  it('POST /api/agents/install-from-skillset — returns the template prompt after a successful install', async () => {
+    mockInstallAgentFromSkillset.mockResolvedValue({
+      slug: 'installed-agent',
+      displaySlug: 'installed-agent',
+      name: 'Installed',
+      createdAt: new Date('2026-08-17T00:00:00.000Z'),
+      status: 'stopped',
+      containerPort: null,
+    })
+    mockGetAgentTemplatePrompt.mockResolvedValue('Summarize the latest research')
+
+    const res = await appWithAgents().request('http://localhost/api/agents/install-from-skillset', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ skillsetId: 'test-skillset', agentPath: 'agents/demo' }),
+    })
+
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toEqual(expect.objectContaining({
+      slug: 'installed-agent',
+      hasOnboarding: false,
+      templatePrompt: 'Summarize the latest research',
+    }))
+    expect(mockGetAgentTemplatePrompt).toHaveBeenCalledWith('installed-agent')
     expect(mockDeleteAgent).not.toHaveBeenCalled()
   })
 })

--- a/src/api/routes/agents.delete-ordering.sup208.test.ts
+++ b/src/api/routes/agents.delete-ordering.sup208.test.ts
@@ -220,6 +220,7 @@ vi.mock('@shared/lib/services/agent-template-service', () => ({
   getAgentTemplateStatus: vi.fn(), getDiscoverableAgents: vi.fn(), refreshSkillsetCaches: vi.fn(),
   getAgentPRInfo: vi.fn(), createAgentPR: vi.fn(), getAgentPublishInfo: vi.fn(),
   publishAgentToSkillset: vi.fn(), refreshAgentTemplates: vi.fn(), hasOnboardingSkill: vi.fn(),
+  getAgentTemplatePrompt: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@shared/lib/utils/retry', () => ({ withRetry: vi.fn((fn: () => unknown) => fn()) }))

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -426,6 +426,7 @@ vi.mock('@shared/lib/services/agent-template-service', () => ({
   publishAgentToSkillset: vi.fn(),
   refreshAgentTemplates: vi.fn(),
   hasOnboardingSkill: vi.fn(),
+  getAgentTemplatePrompt: vi.fn(),
 }))
 
 vi.mock('@shared/lib/utils/retry', () => ({
@@ -553,6 +554,7 @@ import { UploadTooLargeError } from '@shared/lib/utils/chunked-upload'
 import {
   importAgentFromTemplate,
   hasOnboardingSkill,
+  getAgentTemplatePrompt,
 } from '@shared/lib/services/agent-template-service'
 import {
   deleteSkill,
@@ -1278,6 +1280,7 @@ describe('POST /api/agents/import-template', () => {
       name: 'Imported Agent',
     } as any)
     vi.mocked(hasOnboardingSkill).mockResolvedValue(false)
+    vi.mocked(getAgentTemplatePrompt).mockResolvedValue(undefined)
   })
 
   function buildImportForm(mode?: 'template' | 'full') {
@@ -1300,6 +1303,19 @@ describe('POST /api/agents/import-template', () => {
     expect(res.status).toBe(201)
     expect(importAgentFromTemplate).toHaveBeenCalledWith(expect.any(Buffer), undefined, 'template')
   })
+
+  it('returns the optional template prompt for the post-install composer handoff', async () => {
+    vi.mocked(getAgentTemplatePrompt).mockResolvedValue('Summarize the latest customer interviews')
+
+    const res = await postFormData(app, '/api/agents/import-template', buildImportForm('template'))
+
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toEqual(expect.objectContaining({
+      slug: 'imported-agent',
+      templatePrompt: 'Summarize the latest customer interviews',
+    }))
+    expect(getAgentTemplatePrompt).toHaveBeenCalledWith('imported-agent')
+  })
 })
 
 // ============================================================================
@@ -1317,6 +1333,7 @@ describe('POST /api/agents/import-template (chunked)', () => {
       name: 'Imported Agent',
     } as any)
     vi.mocked(hasOnboardingSkill).mockResolvedValue(false)
+    vi.mocked(getAgentTemplatePrompt).mockResolvedValue(undefined)
   })
 
   function buildChunkForm(opts: {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -161,6 +161,7 @@ import {
   publishAgentToSkillset,
   refreshAgentTemplates,
   hasOnboardingSkill,
+  getAgentTemplatePrompt,
 } from '@shared/lib/services/agent-template-service'
 import { getSkillsetProvider } from '@shared/lib/skillset-provider'
 import type { SkillsetConfig } from '@shared/lib/types/skillset'
@@ -689,9 +690,12 @@ async function processImport(c: Context, zipBuffer: Buffer, formData: FormData) 
 
   const agent = await importAgentFromTemplate(zipBuffer, nameOverride || undefined, importMode)
   await createOwnerAclOrRollback(c, agent.slug)
-  const hasOnboarding = await hasOnboardingSkill(agent.slug)
+  const [hasOnboarding, templatePrompt] = await Promise.all([
+    hasOnboardingSkill(agent.slug),
+    getAgentTemplatePrompt(agent.slug),
+  ])
   logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: agent.slug, action: 'imported', details: { name: agent.name } })
-  return c.json({ ...agent, hasOnboarding }, 201)
+  return c.json({ ...agent, hasOnboarding, templatePrompt }, 201)
 }
 
 // GET /api/agents/discoverable-agents - List agents available from skillsets
@@ -735,9 +739,12 @@ agents.post('/install-from-skillset', async (c) => {
     )
 
     await createOwnerAclOrRollback(c, agent.slug)
-    const hasOnboarding = await hasOnboardingSkill(agent.slug)
+    const [hasOnboarding, templatePrompt] = await Promise.all([
+      hasOnboardingSkill(agent.slug),
+      getAgentTemplatePrompt(agent.slug),
+    ])
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: agent.slug, action: 'imported', details: { name: agent.name, skillsetId } })
-    return c.json({ ...agent, hasOnboarding }, 201)
+    return c.json({ ...agent, hasOnboarding, templatePrompt }, 201)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to install agent from skillset'
     console.error('Failed to install agent from skillset:', error)

--- a/src/api/routes/provide-connected-account.test.ts
+++ b/src/api/routes/provide-connected-account.test.ts
@@ -176,6 +176,7 @@ vi.mock('@shared/lib/services/agent-template-service', () => ({
   publishAgentToSkillset: vi.fn(),
   refreshAgentTemplates: vi.fn(),
   hasOnboardingSkill: vi.fn(),
+  getAgentTemplatePrompt: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@shared/lib/utils/retry', () => ({

--- a/src/api/routes/provide-remote-mcp.test.ts
+++ b/src/api/routes/provide-remote-mcp.test.ts
@@ -169,6 +169,7 @@ vi.mock('@shared/lib/services/agent-template-service', () => ({
   publishAgentToSkillset: vi.fn(),
   refreshAgentTemplates: vi.fn(),
   hasOnboardingSkill: vi.fn(),
+  getAgentTemplatePrompt: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@shared/lib/utils/retry', () => ({

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -303,6 +303,7 @@ vi.mock('@shared/lib/services/agent-template-service', () => ({
   getAgentTemplateStatus: vi.fn(), getDiscoverableAgents: vi.fn(), refreshSkillsetCaches: vi.fn(),
   getAgentPRInfo: vi.fn(), createAgentPR: vi.fn(), getAgentPublishInfo: vi.fn(),
   publishAgentToSkillset: vi.fn(), refreshAgentTemplates: vi.fn(), hasOnboardingSkill: vi.fn(),
+  getAgentTemplatePrompt: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@shared/lib/utils/retry', () => ({ withRetry: vi.fn((fn: () => unknown) => fn()) }))

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -19,11 +19,12 @@ import { useImportAgentTemplate, useDiscoverableAgents, type ImportProgress } fr
 import { AGENT_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
 import { useIsVoiceAgentConfigured } from '@renderer/hooks/use-voice-input'
 import type { VoiceAgentConfig } from '@renderer/lib/voice-agent'
-import type { ApiAgent } from '@shared/lib/types/api'
+import type { ApiAgent, ApiAgentTemplateInstallResult } from '@shared/lib/types/api'
 
 export interface ImportResult {
   agent: ApiAgent
-  hasOnboarding?: boolean
+  hasOnboarding?: ApiAgentTemplateInstallResult['hasOnboarding']
+  templatePrompt?: ApiAgentTemplateInstallResult['templatePrompt']
 }
 
 export interface AgentCreationAidsProps {
@@ -143,8 +144,12 @@ export function AgentCreationAids({
   }, [resetImport])
 
   const finishImport = useCallback(
-    async (agent: ApiAgent, hasOnboarding?: boolean) => {
-      await onImportComplete({ agent, hasOnboarding })
+    async (agent: ApiAgentTemplateInstallResult) => {
+      await onImportComplete({
+        agent,
+        hasOnboarding: agent.hasOnboarding,
+        templatePrompt: agent.templatePrompt,
+      })
     },
     [onImportComplete],
   )
@@ -165,7 +170,7 @@ export function AgentCreationAids({
 
         setShowImportDialog(false)
         resetImport()
-        await finishImport(result, result.hasOnboarding)
+        await finishImport(result)
       } catch (error) {
         setUploadProgress(null)
         console.error('Failed to import template:', error)

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -19,13 +19,9 @@ import { useImportAgentTemplate, useDiscoverableAgents, type ImportProgress } fr
 import { AGENT_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
 import { useIsVoiceAgentConfigured } from '@renderer/hooks/use-voice-input'
 import type { VoiceAgentConfig } from '@renderer/lib/voice-agent'
-import type { ApiAgent, ApiAgentTemplateInstallResult } from '@shared/lib/types/api'
+import type { ApiAgentTemplateInstallResult } from '@shared/lib/types/api'
 
-export interface ImportResult {
-  agent: ApiAgent
-  hasOnboarding?: ApiAgentTemplateInstallResult['hasOnboarding']
-  templatePrompt?: ApiAgentTemplateInstallResult['templatePrompt']
-}
+export type ImportResult = ApiAgentTemplateInstallResult
 
 export interface AgentCreationAidsProps {
   /** Called after the voice agent interview completes with its tool-call args. */
@@ -145,11 +141,7 @@ export function AgentCreationAids({
 
   const finishImport = useCallback(
     async (agent: ApiAgentTemplateInstallResult) => {
-      await onImportComplete({
-        agent,
-        hasOnboarding: agent.hasOnboarding,
-        templatePrompt: agent.templatePrompt,
-      })
+      await onImportComplete(agent)
     },
     [onImportComplete],
   )

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -53,7 +53,8 @@ import { useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { formatDistanceToNow } from 'date-fns'
 import { useNewSessionCarryover } from '@renderer/lib/new-session-carryover'
-import { seedAgentTemplatePrompt, useDraftsStore } from '@renderer/context/drafts-context'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import { completeAgentTemplateHandoff } from '@renderer/lib/agent-template-handoff'
 
 interface AgentHomeProps {
   agent: ApiAgent
@@ -203,7 +204,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   })
 
   const warmStartEnabled = useWarmStartOnTypeEnabled()
-  useWarmStartOnType({
+  const { noteProgrammaticChange } = useWarmStartOnType({
     agentSlug: agent.slug,
     message: composer.message,
     enabled: warmStartEnabled,
@@ -254,17 +255,23 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   )
 
   const handleImportComplete = useCallback(
-    async ({ agent: imported, hasOnboarding, templatePrompt }: ImportResult) => {
-      const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, imported.slug, templatePrompt)
-      void navigate({ to: '/agents/$slug', params: { slug: imported.slug } })
-      if (agent.name === UNTITLED_AGENT_NAME && sessions.length === 0 && agent.slug !== imported.slug) {
-        deleteAgent.mutate(agent.slug)
-      }
-      if (!hasTemplatePrompt && hasOnboarding) {
-        await startOnboardingSession(imported.slug)
-      }
+    async (imported: ImportResult) => {
+      await completeAgentTemplateHandoff({
+        draftsStore,
+        agentSlug: imported.slug,
+        hasOnboarding: imported.hasOnboarding,
+        templatePrompt: imported.templatePrompt,
+        noteProgrammaticChange,
+        openAgent: () => {
+          void navigate({ to: '/agents/$slug', params: { slug: imported.slug } })
+          if (agent.name === UNTITLED_AGENT_NAME && sessions.length === 0 && agent.slug !== imported.slug) {
+            deleteAgent.mutate(agent.slug)
+          }
+        },
+        startOnboardingSession,
+      })
     },
-    [draftsStore, navigate, agent.slug, agent.name, sessions.length, deleteAgent, startOnboardingSession],
+    [draftsStore, noteProgrammaticChange, navigate, agent.slug, agent.name, sessions.length, deleteAgent, startOnboardingSession],
   )
 
   const formatDate = useCallback(

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -53,6 +53,7 @@ import { useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { formatDistanceToNow } from 'date-fns'
 import { useNewSessionCarryover } from '@renderer/lib/new-session-carryover'
+import { seedAgentTemplatePrompt, useDraftsStore } from '@renderer/context/drafts-context'
 
 interface AgentHomeProps {
   agent: ApiAgent
@@ -85,6 +86,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
     if (introStagger) setJustCreatedSlug(null)
   }, [introStagger, setJustCreatedSlug])
   const startOnboardingSession = useStartOnboardingSession()
+  const draftsStore = useDraftsStore()
   const { canUseAgent, canAdminAgent } = useUser()
   const isViewOnly = !canUseAgent(agent.slug)
   const isOwner = canAdminAgent(agent.slug)
@@ -252,16 +254,17 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   )
 
   const handleImportComplete = useCallback(
-    async ({ agent: imported, hasOnboarding }: ImportResult) => {
+    async ({ agent: imported, hasOnboarding, templatePrompt }: ImportResult) => {
+      const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, imported.slug, templatePrompt)
       void navigate({ to: '/agents/$slug', params: { slug: imported.slug } })
       if (agent.name === UNTITLED_AGENT_NAME && sessions.length === 0 && agent.slug !== imported.slug) {
         deleteAgent.mutate(agent.slug)
       }
-      if (hasOnboarding) {
+      if (!hasTemplatePrompt && hasOnboarding) {
         await startOnboardingSession(imported.slug)
       }
     },
-    [navigate, agent.slug, agent.name, sessions.length, deleteAgent, startOnboardingSession],
+    [draftsStore, navigate, agent.slug, agent.name, sessions.length, deleteAgent, startOnboardingSession],
   )
 
   const formatDate = useCallback(

--- a/src/renderer/components/agents/agent-template-browse-dialog.tsx
+++ b/src/renderer/components/agents/agent-template-browse-dialog.tsx
@@ -14,6 +14,7 @@ import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useQueryClient } from '@tanstack/react-query'
 import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
+import { seedAgentTemplatePrompt, useDraftsStore } from '@renderer/context/drafts-context'
 
 interface AgentTemplateBrowseDialogProps {
   open: boolean
@@ -32,6 +33,7 @@ export function AgentTemplateBrowseDialog({
   const { track } = useAnalyticsTracking()
   const startOnboardingSession = useStartOnboardingSession()
   const queryClient = useQueryClient()
+  const draftsStore = useDraftsStore()
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
 
   useEffect(() => {
@@ -39,17 +41,18 @@ export function AgentTemplateBrowseDialog({
   }, [open])
 
   const handleInstalled = useCallback(
-    async (agent: ApiAgent, meta: { hasOnboarding?: boolean }) => {
+    async (agent: ApiAgent, meta: { hasOnboarding?: boolean; templatePrompt?: string }) => {
       track('agent_created', { source: 'skillset', num_skills_added_at_creation: 0 })
       await queryClient.refetchQueries({ queryKey: ['agents'] })
+      const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, agent.slug, meta.templatePrompt)
       void navigate({ to: '/agents/$slug', params: { slug: agent.slug } })
-      if (meta.hasOnboarding) {
+      if (!hasTemplatePrompt && meta.hasOnboarding) {
         await startOnboardingSession(agent.slug)
       }
       onOpenChange(false)
       await onInstalled?.()
     },
-    [track, queryClient, navigate, startOnboardingSession, onOpenChange, onInstalled],
+    [track, queryClient, draftsStore, navigate, startOnboardingSession, onOpenChange, onInstalled],
   )
 
   const hasTemplates = discoverableAgents && discoverableAgents.length > 0

--- a/src/renderer/components/agents/agent-template-browse-dialog.tsx
+++ b/src/renderer/components/agents/agent-template-browse-dialog.tsx
@@ -13,8 +13,9 @@ import { useNavigate } from '@tanstack/react-router'
 import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useQueryClient } from '@tanstack/react-query'
-import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
-import { seedAgentTemplatePrompt, useDraftsStore } from '@renderer/context/drafts-context'
+import type { ApiAgentTemplateInstallResult, ApiDiscoverableAgent } from '@shared/lib/types/api'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import { completeAgentTemplateHandoff } from '@renderer/lib/agent-template-handoff'
 
 interface AgentTemplateBrowseDialogProps {
   open: boolean
@@ -41,14 +42,17 @@ export function AgentTemplateBrowseDialog({
   }, [open])
 
   const handleInstalled = useCallback(
-    async (agent: ApiAgent, meta: { hasOnboarding?: boolean; templatePrompt?: string }) => {
+    async (agent: ApiAgentTemplateInstallResult) => {
       track('agent_created', { source: 'skillset', num_skills_added_at_creation: 0 })
       await queryClient.refetchQueries({ queryKey: ['agents'] })
-      const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, agent.slug, meta.templatePrompt)
-      void navigate({ to: '/agents/$slug', params: { slug: agent.slug } })
-      if (!hasTemplatePrompt && meta.hasOnboarding) {
-        await startOnboardingSession(agent.slug)
-      }
+      await completeAgentTemplateHandoff({
+        draftsStore,
+        agentSlug: agent.slug,
+        hasOnboarding: agent.hasOnboarding,
+        templatePrompt: agent.templatePrompt,
+        openAgent: () => { void navigate({ to: '/agents/$slug', params: { slug: agent.slug } }) },
+        startOnboardingSession,
+      })
       onOpenChange(false)
       await onInstalled?.()
     },

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -22,8 +22,9 @@ import {
 import { deriveAgentName } from '@renderer/lib/derive-agent-name'
 import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
 import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
-import { seedAgentTemplatePrompt, useDraftsStore } from '@renderer/context/drafts-context'
+import { useDraftsStore } from '@renderer/context/drafts-context'
 import { useModelSettings, useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
+import { completeAgentTemplateHandoff } from '@renderer/lib/agent-template-handoff'
 import {
   ComposerOptions,
   findCatalogModel,
@@ -32,7 +33,7 @@ import {
 import { captureRendererException } from '@renderer/lib/error-reporting'
 import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
-import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 /**
  * Ceiling, not a delay: the offer resolves the instant the discoverable list
@@ -171,18 +172,19 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
 
   const finishCreatedAgent = useCallback(
     async (
-      agent: ApiAgent,
-      source: 'new' | 'import' | 'skillset',
-      hasOnboarding?: boolean,
-      templatePrompt?: string,
+      agent: ImportResult,
+      source: 'import' | 'skillset',
     ) => {
       await discardWarmAgent()
       track('agent_created', { source, num_skills_added_at_creation: 0 })
-      const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, agent.slug, templatePrompt)
-      void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
-      if (!hasTemplatePrompt && hasOnboarding) {
-        await startOnboardingSession(agent.slug)
-      }
+      await completeAgentTemplateHandoff({
+        draftsStore,
+        agentSlug: agent.slug,
+        hasOnboarding: agent.hasOnboarding,
+        templatePrompt: agent.templatePrompt,
+        openAgent: () => { void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } }) },
+        startOnboardingSession,
+      })
       await onAgentCreated?.()
     },
     [discardWarmAgent, track, draftsStore, navigate, startOnboardingSession, onAgentCreated],
@@ -341,9 +343,7 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
   )
 
   const handleImportComplete = useCallback(
-    ({ agent, hasOnboarding, templatePrompt }: ImportResult) => (
-      finishCreatedAgent(agent, 'import', hasOnboarding, templatePrompt)
-    ),
+    (agent: ImportResult) => finishCreatedAgent(agent, 'import'),
     [finishCreatedAgent],
   )
 
@@ -432,9 +432,7 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
         template={templateToInstall}
         handoffOrigin
         onClose={() => setTemplateToInstall(null)}
-        onInstalled={(agent, { hasOnboarding, templatePrompt }) => (
-          finishCreatedAgent(agent, 'skillset', hasOnboarding, templatePrompt)
-        )}
+        onInstalled={(agent) => finishCreatedAgent(agent, 'skillset')}
       />
     </div>
   )

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -22,6 +22,7 @@ import {
 import { deriveAgentName } from '@renderer/lib/derive-agent-name'
 import { UNTITLED_AGENT_NAME } from '@renderer/hooks/use-create-untitled-agent'
 import { useWarmStartOnType } from '@renderer/hooks/use-warm-start-on-type'
+import { seedAgentTemplatePrompt, useDraftsStore } from '@renderer/context/drafts-context'
 import { useModelSettings, useWarmStartOnTypeEnabled } from '@renderer/hooks/use-settings'
 import {
   ComposerOptions,
@@ -80,6 +81,7 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
   const navigate = useNavigate()
   const { track } = useAnalyticsTracking()
   const startOnboardingSession = useStartOnboardingSession()
+  const draftsStore = useDraftsStore()
   const warmStartEnabled = useWarmStartOnTypeEnabled()
   const { signupHandoff, setSignupHandoff } = useNavTransient()
   const { data: modelSettings } = useModelSettings()
@@ -168,16 +170,22 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const finishCreatedAgent = useCallback(
-    async (agent: ApiAgent, source: 'new' | 'import' | 'skillset', hasOnboarding?: boolean) => {
+    async (
+      agent: ApiAgent,
+      source: 'new' | 'import' | 'skillset',
+      hasOnboarding?: boolean,
+      templatePrompt?: string,
+    ) => {
       await discardWarmAgent()
       track('agent_created', { source, num_skills_added_at_creation: 0 })
+      const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, agent.slug, templatePrompt)
       void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } })
-      if (hasOnboarding) {
+      if (!hasTemplatePrompt && hasOnboarding) {
         await startOnboardingSession(agent.slug)
       }
       await onAgentCreated?.()
     },
-    [discardWarmAgent, track, navigate, startOnboardingSession, onAgentCreated],
+    [discardWarmAgent, track, draftsStore, navigate, startOnboardingSession, onAgentCreated],
   )
 
   const composer = useMessageComposer({
@@ -333,7 +341,9 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
   )
 
   const handleImportComplete = useCallback(
-    ({ agent, hasOnboarding }: ImportResult) => finishCreatedAgent(agent, 'import', hasOnboarding),
+    ({ agent, hasOnboarding, templatePrompt }: ImportResult) => (
+      finishCreatedAgent(agent, 'import', hasOnboarding, templatePrompt)
+    ),
     [finishCreatedAgent],
   )
 
@@ -422,7 +432,9 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
         template={templateToInstall}
         handoffOrigin
         onClose={() => setTemplateToInstall(null)}
-        onInstalled={(agent, { hasOnboarding }) => finishCreatedAgent(agent, 'skillset', hasOnboarding)}
+        onInstalled={(agent, { hasOnboarding, templatePrompt }) => (
+          finishCreatedAgent(agent, 'skillset', hasOnboarding, templatePrompt)
+        )}
       />
     </div>
   )

--- a/src/renderer/components/agents/template-install-dialog.test.tsx
+++ b/src/renderer/components/agents/template-install-dialog.test.tsx
@@ -80,4 +80,28 @@ describe('TemplateInstallDialog handoffOrigin', () => {
     await user.click(screen.getByRole('button', { name: 'Install' }))
     await waitFor(() => expect(order).toEqual(['close', 'onInstalled']))
   })
+
+  it('passes the template prompt through to the navigation handoff', async () => {
+    const user = userEvent.setup()
+    const onInstalled = vi.fn()
+    mutateAsync.mockResolvedValue({
+      slug: 'research-bot',
+      displaySlug: 'research-bot',
+      templatePrompt: 'Investigate this company',
+    })
+
+    render(
+      <TemplateInstallDialog
+        template={template}
+        onClose={() => {}}
+        onInstalled={onInstalled}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Install' }))
+    await waitFor(() => expect(onInstalled).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'research-bot' }),
+      { hasOnboarding: undefined, templatePrompt: 'Investigate this company' },
+    ))
+  })
 })

--- a/src/renderer/components/agents/template-install-dialog.test.tsx
+++ b/src/renderer/components/agents/template-install-dialog.test.tsx
@@ -100,8 +100,10 @@ describe('TemplateInstallDialog handoffOrigin', () => {
 
     await user.click(screen.getByRole('button', { name: 'Install' }))
     await waitFor(() => expect(onInstalled).toHaveBeenCalledWith(
-      expect.objectContaining({ slug: 'research-bot' }),
-      { hasOnboarding: undefined, templatePrompt: 'Investigate this company' },
+      expect.objectContaining({
+        slug: 'research-bot',
+        templatePrompt: 'Investigate this company',
+      }),
     ))
   })
 })

--- a/src/renderer/components/agents/template-install-dialog.tsx
+++ b/src/renderer/components/agents/template-install-dialog.tsx
@@ -11,13 +11,13 @@ import {
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import { useInstallAgentFromSkillset } from '@renderer/hooks/use-agent-templates'
-import type { ApiAgent, ApiDiscoverableAgent } from '@shared/lib/types/api'
+import type { ApiAgent, ApiAgentTemplateInstallResult, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 interface TemplateInstallDialogProps {
   template: ApiDiscoverableAgent | null
   onClose: () => void
   /** Called after the agent is fully installed. */
-  onInstalled: (agent: ApiAgent, meta: { hasOnboarding?: boolean }) => void | Promise<void>
+  onInstalled: (agent: ApiAgent, meta: Pick<ApiAgentTemplateInstallResult, 'hasOnboarding' | 'templatePrompt'>) => void | Promise<void>
   /** Signup handoff: softer name-field focus (no autofocus steal). */
   handoffOrigin?: boolean
 }
@@ -55,7 +55,10 @@ export function TemplateInstallDialog({ template, onClose, onInstalled, handoffO
         // Close before onInstalled — that path may open the onboarding
         // "Setting up your agent..." dialog; stacking both looks broken.
         onClose()
-        await onInstalled(agent, { hasOnboarding: agent.hasOnboarding })
+        await onInstalled(agent, {
+          hasOnboarding: agent.hasOnboarding,
+          templatePrompt: agent.templatePrompt,
+        })
       } catch (error) {
         console.error('Failed to install agent from skillset:', error)
       }

--- a/src/renderer/components/agents/template-install-dialog.tsx
+++ b/src/renderer/components/agents/template-install-dialog.tsx
@@ -11,13 +11,13 @@ import {
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import { useInstallAgentFromSkillset } from '@renderer/hooks/use-agent-templates'
-import type { ApiAgent, ApiAgentTemplateInstallResult, ApiDiscoverableAgent } from '@shared/lib/types/api'
+import type { ApiAgentTemplateInstallResult, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 interface TemplateInstallDialogProps {
   template: ApiDiscoverableAgent | null
   onClose: () => void
   /** Called after the agent is fully installed. */
-  onInstalled: (agent: ApiAgent, meta: Pick<ApiAgentTemplateInstallResult, 'hasOnboarding' | 'templatePrompt'>) => void | Promise<void>
+  onInstalled: (agent: ApiAgentTemplateInstallResult) => void | Promise<void>
   /** Signup handoff: softer name-field focus (no autofocus steal). */
   handoffOrigin?: boolean
 }
@@ -55,10 +55,7 @@ export function TemplateInstallDialog({ template, onClose, onInstalled, handoffO
         // Close before onInstalled — that path may open the onboarding
         // "Setting up your agent..." dialog; stacking both looks broken.
         onClose()
-        await onInstalled(agent, {
-          hasOnboarding: agent.hasOnboarding,
-          templatePrompt: agent.templatePrompt,
-        })
+        await onInstalled(agent)
       } catch (error) {
         console.error('Failed to install agent from skillset:', error)
       }

--- a/src/renderer/components/package-import-handler.tsx
+++ b/src/renderer/components/package-import-handler.tsx
@@ -19,6 +19,7 @@ import type { ClassifiedImportPackage } from '@shared/lib/utils/package-extensio
 import { useImportAgentTemplate, type ImportProgress } from '@renderer/hooks/use-agent-templates'
 import { useImportSkillZip } from '@renderer/hooks/use-agent-skills'
 import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
+import { seedAgentTemplatePrompt, useDraftsStore } from '@renderer/context/drafts-context'
 
 /**
  * A .agent/.skill package the user opened with the app, already classified by
@@ -44,6 +45,7 @@ export function PackageImportHandler() {
   const importTemplate = useImportAgentTemplate()
   const importSkill = useImportSkillZip()
   const startOnboardingSession = useStartOnboardingSession()
+  const draftsStore = useDraftsStore()
 
   const [queue, setQueue] = useState<OpenedPackage[]>([])
   const [importFull, setImportFull] = useState(false)
@@ -125,8 +127,9 @@ export function PackageImportHandler() {
         })
         closeDialog()
         toast.success(`Imported agent "${result.name}"`)
+        const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, result.slug, result.templatePrompt)
         void navigate({ to: '/agents/$slug', params: { slug: result.displaySlug } })
-        if (result.hasOnboarding) {
+        if (!hasTemplatePrompt && result.hasOnboarding) {
           await startOnboardingSession(result.slug)
         }
       } catch {
@@ -137,7 +140,7 @@ export function PackageImportHandler() {
       importingRef.current = false
       setImporting(false)
     }
-  }, [current, readPackageFile, importFull, importTemplate, closeDialog, navigate, startOnboardingSession])
+  }, [current, readPackageFile, importFull, importTemplate, closeDialog, draftsStore, navigate, startOnboardingSession])
 
   const handleImportSkill = useCallback(async (agentSlug: string) => {
     if (!current || importingRef.current) return

--- a/src/renderer/context/drafts-context.test.tsx
+++ b/src/renderer/context/drafts-context.test.tsx
@@ -5,6 +5,7 @@ import { createElement, type ReactNode } from 'react'
 import {
   appendToSessionDraft,
   DraftsProvider,
+  seedAgentTemplatePrompt,
   useDraft,
   useDraftsStore,
 } from './drafts-context'
@@ -125,5 +126,27 @@ describe('appendToSessionDraft', () => {
     ))
 
     expect(result.current.draft[0]).toBe('Rescued message\n\nCurrent draft')
+  })
+})
+
+describe('seedAgentTemplatePrompt', () => {
+  it('stores the template prompt under the new agent home draft key', () => {
+    const { result } = renderHook(() => ({
+      draft: useDraft<string>('agent:new-agent'),
+      store: useDraftsStore(),
+    }), { wrapper })
+
+    act(() => {
+      expect(seedAgentTemplatePrompt(result.current.store, 'new-agent', 'Start with this task')).toBe(true)
+    })
+
+    expect(result.current.draft[0]).toBe('Start with this task')
+  })
+
+  it('does not seed or suppress onboarding when the prompt is absent', () => {
+    const { result } = renderHook(() => useDraftsStore(), { wrapper })
+
+    expect(seedAgentTemplatePrompt(result.current, 'new-agent', undefined)).toBe(false)
+    expect(result.current.get('agent:new-agent')).toBeUndefined()
   })
 })

--- a/src/renderer/context/drafts-context.tsx
+++ b/src/renderer/context/drafts-context.tsx
@@ -21,6 +21,17 @@ export function appendToSessionDraft(
   store.set(draftKey, parts.filter(Boolean).join('\n\n') || undefined)
 }
 
+/** Seed a newly installed agent's home composer from its template prompt. */
+export function seedAgentTemplatePrompt(
+  store: Pick<DraftsStore, 'set'>,
+  agentSlug: string,
+  content: string | undefined,
+): boolean {
+  if (!content) return false
+  store.set(`agent:${agentSlug}`, content)
+  return true
+}
+
 const DraftsContext = createContext<DraftsStore | null>(null)
 
 export function DraftsProvider({ children }: { children: ReactNode }) {

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -5,7 +5,7 @@ import { downloadBlob } from '@renderer/lib/download'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useSkillsets } from '@renderer/hooks/use-skillsets'
-import type { ApiAgent, ApiDiscoverableAgent, ApiItemStatus } from '@shared/lib/types/api'
+import type { ApiAgentTemplateInstallResult, ApiDiscoverableAgent, ApiItemStatus } from '@shared/lib/types/api'
 import { AGENT_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
 
 /** Normalize discoverable agent path `agents/<dir>/` → `<dir>` (website template_slug). */
@@ -106,13 +106,13 @@ export function useImportAgentTemplate() {
   const { track } = useAnalyticsTracking()
 
   return useMutation<
-    ApiAgent & { hasOnboarding?: boolean },
+    ApiAgentTemplateInstallResult,
     Error,
     { file: File; mode?: 'template' | 'full'; onProgress?: (p: ImportProgress) => void }
   >({
     meta: { skipGlobalErrorToast: true },
     mutationFn: async ({ file, mode, onProgress }) => {
-      return uploadFileChunked<ApiAgent & { hasOnboarding?: boolean }>({
+      return uploadFileChunked<ApiAgentTemplateInstallResult>({
         url: '/api/agents/import-template',
         file,
         fields: { mode: mode || 'template' },
@@ -132,7 +132,7 @@ export function useInstallAgentFromSkillset() {
   const { track } = useAnalyticsTracking()
 
   return useMutation<
-    ApiAgent & { hasOnboarding?: boolean },
+    ApiAgentTemplateInstallResult,
     Error,
     {
       skillsetId: string

--- a/src/renderer/lib/agent-template-handoff.test.ts
+++ b/src/renderer/lib/agent-template-handoff.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { DraftsStore } from '@renderer/context/drafts-context'
+import { completeAgentTemplateHandoff } from './agent-template-handoff'
+
+describe('completeAgentTemplateHandoff', () => {
+  it('seeds a template prompt and suppresses the auto-started onboarding session', async () => {
+    const order: string[] = []
+    const draftsStore: Pick<DraftsStore, 'set'> = {
+      set<T>(key: string, value: T | undefined): void {
+        order.push(`set:${key}:${String(value)}`)
+      },
+    }
+    const noteProgrammaticChange = vi.fn((prompt: string) => order.push(`baseline:${prompt}`))
+    const openAgent = vi.fn(() => { order.push('open') })
+    const startOnboardingSession = vi.fn()
+
+    await completeAgentTemplateHandoff({
+      draftsStore,
+      agentSlug: 'new-agent',
+      hasOnboarding: true,
+      templatePrompt: 'Start with this task',
+      noteProgrammaticChange,
+      openAgent,
+      startOnboardingSession,
+    })
+
+    expect(order).toEqual([
+      'baseline:Start with this task',
+      'set:agent:new-agent:Start with this task',
+      'open',
+    ])
+    expect(startOnboardingSession).not.toHaveBeenCalled()
+  })
+
+  it('starts onboarding after opening the agent when no template prompt exists', async () => {
+    const order: string[] = []
+    const startOnboardingSession = vi.fn(() => { order.push('onboarding') })
+
+    await completeAgentTemplateHandoff({
+      draftsStore: { set: vi.fn() as Pick<DraftsStore, 'set'>['set'] },
+      agentSlug: 'new-agent',
+      hasOnboarding: true,
+      openAgent: () => { order.push('open') },
+      startOnboardingSession,
+    })
+
+    expect(order).toEqual(['open', 'onboarding'])
+    expect(startOnboardingSession).toHaveBeenCalledWith('new-agent')
+  })
+})

--- a/src/renderer/lib/agent-template-handoff.ts
+++ b/src/renderer/lib/agent-template-handoff.ts
@@ -1,0 +1,34 @@
+import type { DraftsStore } from '@renderer/context/drafts-context'
+import { seedAgentTemplatePrompt } from '@renderer/context/drafts-context'
+
+interface CompleteAgentTemplateHandoffOptions {
+  draftsStore: Pick<DraftsStore, 'set'>
+  agentSlug: string
+  hasOnboarding?: boolean
+  templatePrompt?: string
+  /** Update a surviving composer's baseline before its draft changes. */
+  noteProgrammaticChange?: (prompt: string) => void
+  openAgent: () => void | Promise<void>
+  startOnboardingSession: (agentSlug: string) => void | Promise<void>
+}
+
+/**
+ * Hand a newly installed agent to the UI. A template prompt is authoritative:
+ * it seeds the composer and suppresses the auto-started onboarding session.
+ */
+export async function completeAgentTemplateHandoff({
+  draftsStore,
+  agentSlug,
+  hasOnboarding,
+  templatePrompt,
+  noteProgrammaticChange,
+  openAgent,
+  startOnboardingSession,
+}: CompleteAgentTemplateHandoffOptions): Promise<void> {
+  if (templatePrompt) noteProgrammaticChange?.(templatePrompt)
+  const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, agentSlug, templatePrompt)
+  await openAgent()
+  if (!hasTemplatePrompt && hasOnboarding) {
+    await startOnboardingSession(agentSlug)
+  }
+}

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -64,6 +64,7 @@ import {
   getInstalledAgentMetadata,
   hasOnboardingSkill,
   getAgentTemplatePrompt,
+  MAX_TEMPLATE_PROMPT_SIZE,
   getDiscoverableAgents,
 } from './agent-template-service'
 import { createAgentFromExistingWorkspace, getAgentWithStatus } from '@shared/lib/services/agent-service'
@@ -1725,6 +1726,21 @@ describe('getAgentTemplatePrompt', () => {
     const workspaceDir = path.join(testDir, 'agents', 'test-agent', 'workspace')
     fs.mkdirSync(workspaceDir, { recursive: true })
     fs.writeFileSync(path.join(workspaceDir, 'PROMPT.md'), '  \n')
+
+    await expect(getAgentTemplatePrompt('test-agent')).resolves.toBeUndefined()
+  })
+
+  it('skips a PROMPT.md directory without failing the completed install', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'test-agent', 'workspace')
+    fs.mkdirSync(path.join(workspaceDir, 'PROMPT.md'), { recursive: true })
+
+    await expect(getAgentTemplatePrompt('test-agent')).resolves.toBeUndefined()
+  })
+
+  it('skips prompt files larger than the composer handoff limit', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'test-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'PROMPT.md'), Buffer.alloc(MAX_TEMPLATE_PROMPT_SIZE + 1, 'a'))
 
     await expect(getAgentTemplatePrompt('test-agent')).resolves.toBeUndefined()
   })

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -63,6 +63,7 @@ import {
   getAgentTemplateStatus,
   getInstalledAgentMetadata,
   hasOnboardingSkill,
+  getAgentTemplatePrompt,
   getDiscoverableAgents,
 } from './agent-template-service'
 import { createAgentFromExistingWorkspace, getAgentWithStatus } from '@shared/lib/services/agent-service'
@@ -1682,6 +1683,50 @@ describe('hasOnboardingSkill', () => {
   it('returns false when workspace does not exist', async () => {
     const result = await hasOnboardingSkill('nonexistent-agent')
     expect(result).toBe(false)
+  })
+})
+
+// ============================================================================
+// getAgentTemplatePrompt
+// ============================================================================
+
+describe('getAgentTemplatePrompt', () => {
+  let testDir: string
+  let originalEnv: string | undefined
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-prompt-test-'))
+    originalEnv = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testDir
+  })
+
+  afterEach(async () => {
+    process.env.SUPERAGENT_DATA_DIR = originalEnv
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+  })
+
+  it('reads and trims a root PROMPT.md', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'test-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'PROMPT.md'), '\n  Research this market  \n')
+
+    await expect(getAgentTemplatePrompt('test-agent')).resolves.toBe('Research this market')
+  })
+
+  it('accepts the lowercase prompt.md spelling from existing templates', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'test-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'prompt.md'), 'Draft the launch plan')
+
+    await expect(getAgentTemplatePrompt('test-agent')).resolves.toBe('Draft the launch plan')
+  })
+
+  it('treats a missing or blank prompt as absent', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'test-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'PROMPT.md'), '  \n')
+
+    await expect(getAgentTemplatePrompt('test-agent')).resolves.toBeUndefined()
   })
 })
 

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -62,6 +62,7 @@ import { pruneInstalledTemplateIfInvalid } from './skillset-reconcile'
 const MAX_UNCOMPRESSED_SIZE = 500 * 1024 * 1024 // 500MB
 export const MAX_COMPRESSED_SIZE = 500 * 1024 * 1024 // 500MB
 const MAX_FILE_COUNT = 2000
+export const MAX_TEMPLATE_PROMPT_SIZE = 16 * 1024 // 16KB
 
 /** Canonical prompt handoff file, plus a lowercase compatibility spelling. */
 const TEMPLATE_PROMPT_FILE_NAMES = ['PROMPT.md', 'prompt.md'] as const
@@ -710,14 +711,35 @@ export async function hasOnboardingSkill(agentSlug: string): Promise<boolean> {
 
 /**
  * Read the optional prompt handoff supplied by an installed template.
- * Empty prompt files are treated as absent so they do not suppress onboarding.
+ * Empty, oversized, non-file, and unreadable candidates are treated as absent
+ * so this best-effort probe can never fail an otherwise successful install.
  */
 export async function getAgentTemplatePrompt(agentSlug: string): Promise<string | undefined> {
   const workspaceDir = getAgentWorkspaceDir(agentSlug)
   for (const fileName of TEMPLATE_PROMPT_FILE_NAMES) {
-    const content = await readFileOrNull(path.join(workspaceDir, fileName))
-    const prompt = content?.trim()
-    if (prompt) return prompt
+    let handle: Awaited<ReturnType<typeof fs.promises.open>> | undefined
+    try {
+      handle = await fs.promises.open(path.join(workspaceDir, fileName), 'r')
+      const stats = await handle.stat()
+      if (!stats.isFile() || stats.size === 0 || stats.size > MAX_TEMPLATE_PROMPT_SIZE) continue
+
+      // Allocate only after the size check and keep the read bounded even if
+      // the file grows between stat() and read().
+      const buffer = Buffer.alloc(stats.size)
+      let bytesRead = 0
+      while (bytesRead < buffer.length) {
+        const result = await handle.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead)
+        if (result.bytesRead === 0) break
+        bytesRead += result.bytesRead
+      }
+      const prompt = buffer.subarray(0, bytesRead).toString('utf8').trim()
+      if (prompt) return prompt
+    } catch {
+      // PROMPT.md is an optional handoff. Filesystem errors must not strand an
+      // agent after its workspace and owner ACL have already been created.
+    } finally {
+      await handle?.close().catch(() => undefined)
+    }
   }
   return undefined
 }

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -63,6 +63,9 @@ const MAX_UNCOMPRESSED_SIZE = 500 * 1024 * 1024 // 500MB
 export const MAX_COMPRESSED_SIZE = 500 * 1024 * 1024 // 500MB
 const MAX_FILE_COUNT = 2000
 
+/** Canonical prompt handoff file, plus a lowercase compatibility spelling. */
+const TEMPLATE_PROMPT_FILE_NAMES = ['PROMPT.md', 'prompt.md'] as const
+
 /** Files/dirs excluded from templates (matched by name at any level) */
 const TEMPLATE_EXCLUDE = new Set([
   '.env',
@@ -703,6 +706,20 @@ export async function hasOnboardingSkill(agentSlug: string): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+/**
+ * Read the optional prompt handoff supplied by an installed template.
+ * Empty prompt files are treated as absent so they do not suppress onboarding.
+ */
+export async function getAgentTemplatePrompt(agentSlug: string): Promise<string | undefined> {
+  const workspaceDir = getAgentWorkspaceDir(agentSlug)
+  for (const fileName of TEMPLATE_PROMPT_FILE_NAMES) {
+    const content = await readFileOrNull(path.join(workspaceDir, fileName))
+    const prompt = content?.trim()
+    if (prompt) return prompt
+  }
+  return undefined
 }
 
 /**

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -37,6 +37,13 @@ export interface ApiAgent {
   dashboards?: ApiAgentDashboard[]
 }
 
+/** Response returned when an agent template has been installed or imported. */
+export interface ApiAgentTemplateInstallResult extends ApiAgent {
+  hasOnboarding?: boolean
+  /** Optional root PROMPT.md contents to prefill on the new agent's home page. */
+  templatePrompt?: string
+}
+
 export interface ApiAgentDashboard {
   slug: string
   name: string


### PR DESCRIPTION
## Summary

- read optional root `PROMPT.md` files from imported and marketplace agent templates, with lowercase `prompt.md` compatibility
- carry the template prompt through the install API and seed the new agent's home-composer draft before navigation
- keep prompted templates on agent home instead of automatically starting the onboarding session
- treat prompt discovery as a best-effort probe: ignore filesystem errors/non-files and skip files larger than 16 KiB
- centralize and test the prompt-vs-onboarding handoff across import and marketplace entry paths
- mark AgentHome template prefills as programmatic so they do not trigger a warm start before user input

## Why

Agent templates can now provide a ready-to-run starter prompt so users arrive at the newly created agent with the intended task prefilled and editable. Invalid or oversized optional prompt files cannot fail an otherwise completed install or strand an agent after ownership has been committed.

Linear: [SUP-610](https://linear.app/datawizz/issue/SUP-610/support-promptmd-in-agent-templates)

## Validation

- `npm run typecheck`
- ESLint on all changed files
- focused API/service/UI suites: 626 tests passed
- full Vitest suite: 9,628 tests passed, 45 skipped, 1 todo
