### PR TITLE
fix(auth): never show deployment_unavailable, keep loading

### DIFF
--- a/src/renderer/components/auth/auth-page.test.tsx
+++ b/src/renderer/components/auth/auth-page.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { apiFetch } = vi.hoisted(() => ({
   apiFetch: vi.fn(),
@@ -36,6 +36,11 @@ describe('AuthPage', () => {
     })
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
   it('shows loading while fetching auth config', () => {
     apiFetch.mockReturnValue(new Promise(() => {}))
 
@@ -57,6 +62,64 @@ describe('AuthPage', () => {
     })
     expect(screen.queryByTestId('signin-submit')).not.toBeInTheDocument()
     expect(screen.queryByTestId('auth-provider-platform')).not.toBeInTheDocument()
+  })
+
+  it('keeps loading through deployment_unavailable and never shows the error code', async () => {
+    apiFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'deployment_unavailable', state: 'waking' }),
+    })
+
+    render(<AuthPage />)
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith('/api/auth-config')
+    })
+    expect(screen.getByTestId('auth-config-loading')).toBeInTheDocument()
+    expect(screen.queryByTestId('auth-config-error')).not.toBeInTheDocument()
+    expect(screen.queryByText('deployment_unavailable')).not.toBeInTheDocument()
+  })
+
+  it('retries auth config after deployment_unavailable and reloads once the origin answers', async () => {
+    vi.useFakeTimers()
+    const reload = vi.fn()
+    vi.stubGlobal('location', { ...window.location, reload })
+
+    apiFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'deployment_unavailable', state: 'waking' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          signupMode: 'open',
+          allowLocalAuth: true,
+          allowSocialAuth: false,
+          providers: [],
+          passwordMinLength: 8,
+          passwordRequireComplexity: false,
+          requireAdminApproval: false,
+          hasUsers: false,
+        }),
+      })
+
+    render(<AuthPage />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(apiFetch).toHaveBeenCalledTimes(1)
+    expect(reload).not.toHaveBeenCalled()
+    expect(screen.getByTestId('auth-config-loading')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+    expect(apiFetch).toHaveBeenCalledTimes(2)
+    expect(reload).toHaveBeenCalledOnce()
   })
 
   it('renders configured providers from auth config', async () => {

--- a/src/renderer/components/auth/auth-page.tsx
+++ b/src/renderer/components/auth/auth-page.tsx
@@ -37,6 +37,17 @@ const DEFAULT_AUTH_CONFIG: AuthConfig = {
   hasUsers: false,
 }
 
+const AUTH_CONFIG_RETRY_MS = 2500
+
+function isDeploymentUnavailable(body: unknown): boolean {
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    'error' in body &&
+    (body as { error: unknown }).error === 'deployment_unavailable'
+  )
+}
+
 function useAuthConfig() {
   const [config, setConfig] = useState<AuthConfig>(DEFAULT_AUTH_CONFIG)
   const [isLoading, setIsLoading] = useState(true)
@@ -44,28 +55,49 @@ function useAuthConfig() {
 
   useEffect(() => {
     let cancelled = false
-    apiFetch('/api/auth-config')
-      .then(async (res) => {
+    let retryTimer: ReturnType<typeof setTimeout> | undefined
+    let sawUnavailable = false
+
+    const load = async () => {
+      try {
+        const res = await apiFetch('/api/auth-config')
+        if (cancelled) return
         if (!res.ok) {
-          const data = await res.json().catch(() => ({}))
-          throw new Error(data.error || 'Failed to load authentication configuration')
+          const data: unknown = await res.json().catch(() => ({}))
+          // Edge 503 while the origin is still booting — keep the spinner.
+          if (isDeploymentUnavailable(data)) {
+            sawUnavailable = true
+            retryTimer = setTimeout(() => {
+              void load()
+            }, AUTH_CONFIG_RETRY_MS)
+            return
+          }
+          const message =
+            typeof data === 'object' && data !== null && 'error' in data && typeof data.error === 'string'
+              ? data.error
+              : 'Failed to load authentication configuration'
+          throw new Error(message)
         }
-        return res.json() as Promise<AuthConfig>
-      })
-      .then((data) => {
+        if (sawUnavailable) {
+          window.location.reload()
+          return
+        }
+        const data = (await res.json()) as AuthConfig
         if (cancelled) return
         setConfig(data)
         setError(null)
-      })
-      .catch((err) => {
+        setIsLoading(false)
+      } catch (err) {
         if (cancelled) return
         setError(err instanceof Error ? err.message : 'Failed to load authentication configuration')
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false)
-      })
+        setIsLoading(false)
+      }
+    }
+
+    void load()
     return () => {
       cancelled = true
+      if (retryTimer !== undefined) clearTimeout(retryTimer)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- The Cloudflare router returns `503 { error: "deployment_unavailable" }` while a host is sleeping, waking, or 502. AuthPage treated that as a fatal auth-config error and rendered the raw code in a red alert.
- Keep the loading spinner and retry every 2.5s. When the origin answers, reload once so the session check runs against a live host.
- Other auth-config failures still surface as errors.

Companion edge change (waking page never swaps to an error card): https://github.com/SkillfulAgents/gamut-infra/pull/175

## Test plan
- [x] `npx vitest run src/renderer/components/auth/auth-page.test.tsx`
- [ ] Load a vanity host while the task is waking or 502ing: AuthPage stays on "Loading authentication options...", never shows `deployment_unavailable`
- [ ] After the host comes up: page reloads and login or the app appears
- [ ] A real auth-config failure (not 503 `deployment_unavailable`) still shows the error alert


Made with [Cursor](https://cursor.com)