### PR TITLE
fix: convert mount/skillset filesystem calls to async

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -501,6 +501,9 @@ vi.mock('@shared/lib/utils/file-storage', async (importOriginal) => ({
   getAgentSessionsDir: vi.fn(() => '/mock/sessions'),
   readJsonlFile: vi.fn(),
   getAgentWorkspaceDir: (slug: string) => mockGetAgentWorkspaceDir(slug),
+  // The skills-files route checks the skill dir via directoryExists; delegate
+  // to the same mock the tests already use for fs.existsSync.
+  directoryExists: async (p: string) => mockFsExistsSync(p),
   getAgentPreferencesPath: vi.fn((slug: string) => `/mock/workspace/${slug}/agent-preferences.json`),
   getTempUploadsDir: vi.fn(() => '/mock/tmp/uploads'),
   ensureDirectory: vi.fn(),

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -72,7 +72,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
-import { getSessionJsonlPath, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonArrayStringifyTransform } from '@shared/lib/utils/file-storage'
+import { getSessionJsonlPath, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonArrayStringifyTransform, directoryExists } from '@shared/lib/utils/file-storage'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
   UploadTooLargeError,
@@ -4972,7 +4972,7 @@ agents.get('/:id/skills/:dir/files', AgentAdmin(), async (c) => {
 
     const skillDir = path.join(getAgentWorkspaceDir(agentSlug), '.claude', 'skills', dir)
 
-    if (!fs.existsSync(skillDir)) {
+    if (!(await directoryExists(skillDir))) {
       return c.json({ error: 'Skill directory not found' }, 404)
     }
 
@@ -5357,7 +5357,7 @@ agents.post('/:id/sessions/:sessionId/upload-folder', AgentUser(), async (c) => 
 agents.get('/:id/mounts', AgentRead(), async (c) => {
   try {
     const agentSlug = getAgentId(c)
-    const mounts = getMountsWithHealth(agentSlug)
+    const mounts = await getMountsWithHealth(agentSlug)
     return c.json(mounts)
   } catch (error) {
     console.error('Failed to list mounts:', error)
@@ -5374,7 +5374,7 @@ agents.post('/:id/mounts', AgentUser(), async (c) => {
 
     let mount
     try {
-      mount = addMount(agentSlug, hostPath)
+      mount = await addMount(agentSlug, hostPath)
     } catch (err: any) {
       return c.json({ error: err.message || 'Invalid path' }, 400)
     }
@@ -5401,7 +5401,7 @@ agents.delete('/:id/mounts/:mountId', AgentUser(), async (c) => {
     const mountId = c.req.param('mountId')
     const restart = c.req.query('restart') === 'true'
 
-    removeMount(agentSlug, mountId)
+    await removeMount(agentSlug, mountId)
 
     if (restart) {
       const cachedInfo = containerManager.getCachedInfo(agentSlug)

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -651,7 +651,7 @@ class ContainerManager {
       envVars['CLAUDE_CODE_ATTRIBUTION_HEADER'] = '0'
 
       // Load mounts and build volume flags for healthy ones
-      const mountsWithHealth = getMountsWithHealth(agentId)
+      const mountsWithHealth = await getMountsWithHealth(agentId)
       const healthyMounts = mountsWithHealth.filter((m) => m.health === 'ok')
       const missingMounts = mountsWithHealth.filter((m) => m.health === 'missing')
 

--- a/src/shared/lib/services/mount-service.atomic.test.ts
+++ b/src/shared/lib/services/mount-service.atomic.test.ts
@@ -41,7 +41,7 @@ describe('mounts.json reads — tolerant display, fail-closed writes', () => {
   it('absent file → [] (legitimate "no mounts yet")', async () => {
     const { getMounts } = await importService()
     makeAgentDir('agent')
-    expect(getMounts('agent')).toEqual([])
+    expect(await getMounts('agent')).toEqual([])
   })
 
   it('corrupt file → getMounts degrades to [] (tolerant) and does NOT overwrite', async () => {
@@ -52,7 +52,7 @@ describe('mounts.json reads — tolerant display, fail-closed writes', () => {
     makeAgentDir('agent')
     const corrupt = '[ { "id": "a", '
     fs.writeFileSync(mountsPath('agent'), corrupt)
-    expect(getMounts('agent')).toEqual([])
+    expect(await getMounts('agent')).toEqual([])
     expect(fs.readFileSync(mountsPath('agent'), 'utf-8')).toBe(corrupt) // not clobbered
   })
 
@@ -60,8 +60,7 @@ describe('mounts.json reads — tolerant display, fail-closed writes', () => {
     const { getMountsWithHealth } = await importService()
     makeAgentDir('agent')
     fs.writeFileSync(mountsPath('agent'), '[ { "id": "a", ')
-    expect(() => getMountsWithHealth('agent')).not.toThrow()
-    expect(getMountsWithHealth('agent')).toEqual([])
+    await expect(getMountsWithHealth('agent')).resolves.toEqual([])
   })
 
   it('addMount on a corrupt file THROWS and does NOT overwrite (prior mounts preserved)', async () => {
@@ -70,7 +69,7 @@ describe('mounts.json reads — tolerant display, fail-closed writes', () => {
     const corrupt = '[ { "id": "old-mount", "hostPath": "/x"'
     fs.writeFileSync(mountsPath('agent'), corrupt)
 
-    expect(() => addMount('agent', makeHostDir('newfolder'))).toThrow(CorruptFileError)
+    await expect(addMount('agent', makeHostDir('newfolder'))).rejects.toThrow(CorruptFileError)
     // The unreadable file is left intact — NOT clobbered with just the new mount.
     expect(fs.readFileSync(mountsPath('agent'), 'utf-8')).toBe(corrupt)
   })
@@ -80,21 +79,23 @@ describe('atomic mounts.json writes', () => {
   it('addMount writes atomically (no temp file left behind) and round-trips', async () => {
     const { addMount, getMounts } = await importService()
     makeAgentDir('agent')
-    addMount('agent', makeHostDir('a'))
-    addMount('agent', makeHostDir('b'))
+    await addMount('agent', makeHostDir('a'))
+    await addMount('agent', makeHostDir('b'))
 
     const dir = path.dirname(mountsPath('agent'))
     expect(fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'))).toEqual([])
-    expect(getMounts('agent')).toHaveLength(2)
+    expect(await getMounts('agent')).toHaveLength(2)
     // File is valid JSON.
     expect(() => JSON.parse(fs.readFileSync(mountsPath('agent'), 'utf-8'))).not.toThrow()
   })
 
-  it('a batch of addMount calls all survive (no lost update)', async () => {
+  it('CONCURRENT addMount calls all survive (withFileLock prevents lost updates)', async () => {
+    // The old sync implementation couldn't interleave by construction; the async
+    // version relies on withFileLock to serialize the read-modify-write.
     const { addMount, getMounts } = await importService()
     makeAgentDir('agent')
     const names = ['m0', 'm1', 'm2', 'm3', 'm4']
-    for (const n of names) addMount('agent', makeHostDir(n))
-    expect(getMounts('agent').map((m) => m.folderName).sort()).toEqual([...names].sort())
+    await Promise.all(names.map((n) => addMount('agent', makeHostDir(n))))
+    expect((await getMounts('agent')).map((m) => m.folderName).sort()).toEqual([...names].sort())
   })
 })

--- a/src/shared/lib/services/mount-service.test.ts
+++ b/src/shared/lib/services/mount-service.test.ts
@@ -33,7 +33,7 @@ describe('mount-service', () => {
   describe('getMounts', () => {
     it('returns empty array when no mounts.json exists', async () => {
       const { getMounts } = await importService()
-      expect(getMounts('test-agent')).toEqual([])
+      expect(await getMounts('test-agent')).toEqual([])
     })
   })
 
@@ -41,7 +41,7 @@ describe('mount-service', () => {
     it('creates mounts.json and returns mount with correct fields', async () => {
       const { addMount } = await importService()
       const hostPath = makeHostDir('myapp')
-      const mount = addMount('test-agent', hostPath)
+      const mount = await addMount('test-agent', hostPath)
 
       expect(mount.id).toBeDefined()
       expect(mount.hostPath).toBe(hostPath)
@@ -54,7 +54,7 @@ describe('mount-service', () => {
     it('picks /mounts/{basename} as containerPath', async () => {
       const { addMount } = await importService()
       const hostPath = makeHostDir('src')
-      const mount = addMount('test-agent', hostPath)
+      const mount = await addMount('test-agent', hostPath)
       expect(mount.containerPath).toBe('/mounts/src')
     })
 
@@ -63,9 +63,9 @@ describe('mount-service', () => {
       const dir1 = makeHostDir('a/project')
       const dir2 = makeHostDir('b/project')
       const dir3 = makeHostDir('c/project')
-      const m1 = addMount('test-agent', dir1)
-      const m2 = addMount('test-agent', dir2)
-      const m3 = addMount('test-agent', dir3)
+      const m1 = await addMount('test-agent', dir1)
+      const m2 = await addMount('test-agent', dir2)
+      const m3 = await addMount('test-agent', dir3)
 
       expect(m1.containerPath).toBe('/mounts/project')
       expect(m2.containerPath).toBe('/mounts/project-2')
@@ -74,10 +74,10 @@ describe('mount-service', () => {
 
     it('persists mounts to disk', async () => {
       const { addMount, getMounts } = await importService()
-      addMount('test-agent', makeHostDir('folder-a'))
-      addMount('test-agent', makeHostDir('folder-b'))
+      await addMount('test-agent', makeHostDir('folder-a'))
+      await addMount('test-agent', makeHostDir('folder-b'))
 
-      const mounts = getMounts('test-agent')
+      const mounts = await getMounts('test-agent')
       expect(mounts).toHaveLength(2)
       expect(mounts[0].folderName).toBe('folder-a')
       expect(mounts[1].folderName).toBe('folder-b')
@@ -85,19 +85,19 @@ describe('mount-service', () => {
 
     it('rejects relative paths', async () => {
       const { addMount } = await importService()
-      expect(() => addMount('test-agent', 'relative/path')).toThrow('absolute path')
+      await expect(addMount('test-agent', 'relative/path')).rejects.toThrow('absolute path')
     })
 
     it('rejects non-existent paths', async () => {
       const { addMount } = await importService()
-      expect(() => addMount('test-agent', '/non/existent/path/xyz')).toThrow()
+      await expect(addMount('test-agent', '/non/existent/path/xyz')).rejects.toThrow()
     })
 
     it('rejects files (non-directories)', async () => {
       const { addMount } = await importService()
       const filePath = path.join(tmpDir, 'a-file.txt')
       fs.writeFileSync(filePath, 'content')
-      expect(() => addMount('test-agent', filePath)).toThrow('directory')
+      await expect(addMount('test-agent', filePath)).rejects.toThrow('directory')
     })
 
     it('resolves symlinks', async () => {
@@ -106,7 +106,7 @@ describe('mount-service', () => {
       const linkPath = path.join(tmpDir, 'host-dirs', 'link-dir')
       fs.symlinkSync(realDir, linkPath)
 
-      const mount = addMount('test-agent', linkPath)
+      const mount = await addMount('test-agent', linkPath)
       // hostPath should be the resolved real path (use realpathSync for comparison
       // since macOS /tmp -> /private/var/... resolution)
       expect(mount.hostPath).toBe(fs.realpathSync(realDir))
@@ -116,13 +116,13 @@ describe('mount-service', () => {
       const { addMount } = await importService()
       const cloudDir = path.join(os.homedir(), 'Library', 'Mobile Documents', 'com~apple~CloudDocs', 'proj')
       // Path need not exist — the prefix check fires before any fs access.
-      expect(() => addMount('test-agent', cloudDir)).toThrow(/cloud-synced|iCloud/i)
+      await expect(addMount('test-agent', cloudDir)).rejects.toThrow(/cloud-synced|iCloud/i)
     })
 
     it.runIf(process.platform === 'darwin')('rejects File Provider (CloudStorage) paths like Dropbox', async () => {
       const { addMount } = await importService()
       const cloudDir = path.join(os.homedir(), 'Library', 'CloudStorage', 'Dropbox', 'work')
-      expect(() => addMount('test-agent', cloudDir)).toThrow(/cloud-synced|iCloud/i)
+      await expect(addMount('test-agent', cloudDir)).rejects.toThrow(/cloud-synced|iCloud/i)
     })
   })
 
@@ -138,32 +138,32 @@ describe('mount-service', () => {
   describe('removeMount', () => {
     it('removes entry by id, preserving others', async () => {
       const { addMount, removeMount, getMounts } = await importService()
-      const m1 = addMount('test-agent', makeHostDir('keep'))
-      const m2 = addMount('test-agent', makeHostDir('remove'))
+      const m1 = await addMount('test-agent', makeHostDir('keep'))
+      const m2 = await addMount('test-agent', makeHostDir('remove'))
 
-      removeMount('test-agent', m2.id)
+      await removeMount('test-agent', m2.id)
 
-      const mounts = getMounts('test-agent')
+      const mounts = await getMounts('test-agent')
       expect(mounts).toHaveLength(1)
       expect(mounts[0].id).toBe(m1.id)
     })
 
     it('is a no-op for non-existent mount id', async () => {
       const { addMount, removeMount, getMounts } = await importService()
-      addMount('test-agent', makeHostDir('keep'))
+      await addMount('test-agent', makeHostDir('keep'))
 
-      removeMount('test-agent', 'non-existent-id')
+      await removeMount('test-agent', 'non-existent-id')
 
-      expect(getMounts('test-agent')).toHaveLength(1)
+      expect(await getMounts('test-agent')).toHaveLength(1)
     })
   })
 
   describe('getMountsWithHealth', () => {
     it('returns ok for existing host paths', async () => {
       const { addMount, getMountsWithHealth } = await importService()
-      addMount('test-agent', makeHostDir('exists'))
+      await addMount('test-agent', makeHostDir('exists'))
 
-      const mounts = getMountsWithHealth('test-agent')
+      const mounts = await getMountsWithHealth('test-agent')
       expect(mounts).toHaveLength(1)
       expect(mounts[0].health).toBe('ok')
     })
@@ -171,12 +171,12 @@ describe('mount-service', () => {
     it('returns missing when host path is later deleted', async () => {
       const { addMount, getMountsWithHealth } = await importService()
       const dir = makeHostDir('will-delete')
-      addMount('test-agent', dir)
+      await addMount('test-agent', dir)
 
       // Delete the directory after adding mount
       fs.rmSync(dir, { recursive: true })
 
-      const mounts = getMountsWithHealth('test-agent')
+      const mounts = await getMountsWithHealth('test-agent')
       expect(mounts).toHaveLength(1)
       expect(mounts[0].health).toBe('missing')
     })
@@ -185,19 +185,19 @@ describe('mount-service', () => {
   describe('CRUD roundtrip', () => {
     it('add/remove cycles produce consistent state', async () => {
       const { addMount, removeMount, getMounts } = await importService()
-      const m1 = addMount('test-agent', makeHostDir('a'))
-      const m2 = addMount('test-agent', makeHostDir('b'))
-      const m3 = addMount('test-agent', makeHostDir('c'))
+      const m1 = await addMount('test-agent', makeHostDir('a'))
+      const m2 = await addMount('test-agent', makeHostDir('b'))
+      const m3 = await addMount('test-agent', makeHostDir('c'))
 
-      removeMount('test-agent', m2.id)
-      expect(getMounts('test-agent')).toHaveLength(2)
+      await removeMount('test-agent', m2.id)
+      expect(await getMounts('test-agent')).toHaveLength(2)
 
-      removeMount('test-agent', m1.id)
-      expect(getMounts('test-agent')).toHaveLength(1)
-      expect(getMounts('test-agent')[0].id).toBe(m3.id)
+      await removeMount('test-agent', m1.id)
+      expect(await getMounts('test-agent')).toHaveLength(1)
+      expect((await getMounts('test-agent'))[0].id).toBe(m3.id)
 
-      removeMount('test-agent', m3.id)
-      expect(getMounts('test-agent')).toHaveLength(0)
+      await removeMount('test-agent', m3.id)
+      expect(await getMounts('test-agent')).toHaveLength(0)
     })
   })
 })

--- a/src/shared/lib/services/mount-service.ts
+++ b/src/shared/lib/services/mount-service.ts
@@ -4,8 +4,10 @@ import fs from 'fs'
 import crypto from 'crypto'
 import {
   getAgentDir,
-  readJsonFileStrictSync,
-  writeJsonFileAtomicSync,
+  readJsonFileStrict,
+  writeJsonFileAtomic,
+  withFileLock,
+  directoryExists,
   CorruptFileError,
 } from '@shared/lib/utils/file-storage'
 import { isPathWithinDir } from '@shared/lib/utils/path-safety'
@@ -24,8 +26,8 @@ function getMountsFilePath(slug: string): string {
  * previous catch-all swallowed bad reads, so the next write dropped every prior
  * mount). Do NOT use this on read-only display paths — use {@link getMounts}.
  */
-function readMountsStrict(slug: string): AgentMount[] {
-  return readJsonFileStrictSync(getMountsFilePath(slug), agentMountsSchema, [])
+function readMountsStrict(slug: string): Promise<AgentMount[]> {
+  return readJsonFileStrict(getMountsFilePath(slug), agentMountsSchema, [])
 }
 
 /**
@@ -37,9 +39,9 @@ function readMountsStrict(slug: string): AgentMount[] {
  * writes go through addMount/removeMount, which use the strict read and abort on
  * corruption instead of overwriting.
  */
-export function getMounts(slug: string): AgentMount[] {
+export async function getMounts(slug: string): Promise<AgentMount[]> {
   try {
-    return readMountsStrict(slug)
+    return await readMountsStrict(slug)
   } catch (error) {
     if (error instanceof CorruptFileError) {
       console.error(`Corrupt mounts.json for agent ${slug}; treating as no mounts (NOT overwriting)`, error)
@@ -85,15 +87,15 @@ export const CLOUD_MOUNT_MESSAGE =
   'which can’t be shared into the agent sandbox. Please copy it to a regular local folder ' +
   '(e.g. somewhere under your home directory) and mount that instead.'
 
-function writeMounts(slug: string, mounts: AgentMount[]): void {
+async function writeMounts(slug: string, mounts: AgentMount[]): Promise<void> {
   const filePath = getMountsFilePath(slug)
-  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
   // Atomic temp-file + rename: an interrupted write can never truncate
   // mounts.json into the half-state the old reader would have swallowed.
-  writeJsonFileAtomicSync(filePath, agentMountsSchema.parse(mounts))
+  await writeJsonFileAtomic(filePath, agentMountsSchema.parse(mounts))
 }
 
-export function addMount(slug: string, hostPath: string): AgentMount {
+export async function addMount(slug: string, hostPath: string): Promise<AgentMount> {
   if (!path.isAbsolute(hostPath)) {
     throw new Error('hostPath must be an absolute path')
   }
@@ -104,48 +106,56 @@ export function addMount(slug: string, hostPath: string): AgentMount {
   if (isCloudStoragePath(hostPath)) {
     throw new Error(CLOUD_MOUNT_MESSAGE)
   }
-  const resolved = fs.realpathSync(hostPath)
+  const resolved = await fs.promises.realpath(hostPath)
   if (isCloudStoragePath(resolved)) {
     throw new Error(CLOUD_MOUNT_MESSAGE)
   }
-  if (!fs.statSync(resolved).isDirectory()) {
+  if (!(await fs.promises.stat(resolved)).isDirectory()) {
     throw new Error('hostPath must be a directory')
   }
 
-  const mounts = readMountsStrict(slug)
-  const baseName = path.basename(resolved)
+  // The read-modify-write must not interleave with a concurrent add/remove for
+  // the same agent (the old sync code got this for free by never yielding).
+  return withFileLock(getMountsFilePath(slug), async () => {
+    const mounts = await readMountsStrict(slug)
+    const baseName = path.basename(resolved)
 
-  // Pick container path, append -2, -3, etc. on collision
-  let containerName = baseName
-  let suffix = 2
-  while (mounts.some((m) => m.containerPath === `/mounts/${containerName}`)) {
-    containerName = `${baseName}-${suffix}`
-    suffix++
-  }
+    // Pick container path, append -2, -3, etc. on collision
+    let containerName = baseName
+    let suffix = 2
+    while (mounts.some((m) => m.containerPath === `/mounts/${containerName}`)) {
+      containerName = `${baseName}-${suffix}`
+      suffix++
+    }
 
-  const mount: AgentMount = {
-    id: crypto.randomUUID(),
-    hostPath: resolved,
-    containerPath: `/mounts/${containerName}`,
-    folderName: baseName,
-    addedAt: new Date().toISOString(),
-  }
+    const mount: AgentMount = {
+      id: crypto.randomUUID(),
+      hostPath: resolved,
+      containerPath: `/mounts/${containerName}`,
+      folderName: baseName,
+      addedAt: new Date().toISOString(),
+    }
 
-  mounts.push(mount)
-  writeMounts(slug, mounts)
-  return mount
+    mounts.push(mount)
+    await writeMounts(slug, mounts)
+    return mount
+  })
 }
 
-export function removeMount(slug: string, mountId: string): void {
-  const mounts = readMountsStrict(slug)
-  const filtered = mounts.filter((m) => m.id !== mountId)
-  writeMounts(slug, filtered)
+export function removeMount(slug: string, mountId: string): Promise<void> {
+  return withFileLock(getMountsFilePath(slug), async () => {
+    const mounts = await readMountsStrict(slug)
+    const filtered = mounts.filter((m) => m.id !== mountId)
+    await writeMounts(slug, filtered)
+  })
 }
 
-export function getMountsWithHealth(slug: string): AgentMountWithHealth[] {
-  const mounts = getMounts(slug)
-  return mounts.map((m) => ({
-    ...m,
-    health: fs.existsSync(m.hostPath) ? 'ok' : 'missing',
-  }))
+export async function getMountsWithHealth(slug: string): Promise<AgentMountWithHealth[]> {
+  const mounts = await getMounts(slug)
+  return Promise.all(
+    mounts.map(async (m) => ({
+      ...m,
+      health: (await directoryExists(m.hostPath)) ? ('ok' as const) : ('missing' as const),
+    }))
+  )
 }

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -22,6 +22,7 @@ import {
   readFileOrNull,
   ensureDirectory,
   directoryExists,
+  fileExists,
   removeDirectory,
 } from '@shared/lib/utils/file-storage'
 import type {
@@ -823,7 +824,7 @@ async function recloneSkillsetCache(ref: SkillsetRef, repoDir: string, cause: st
   console.warn(`[refreshSkillset] Re-cloning corrupt skillset cache at ${repoDir}: ${cause}`)
   await fs.promises.rm(repoDir, { recursive: true, force: true })
   await ensureSkillsetCached(ref)
-  if (!fs.existsSync(path.join(repoDir, 'index.json'))) {
+  if (!(await fileExists(path.join(repoDir, 'index.json')))) {
     throw new Error(
       `Skillset repository has no index.json at its root (re-cloned ${repoDir} after: ${cause})`,
     )
@@ -865,7 +866,7 @@ async function refreshSkillsetCache(
       return readIndexJson(repoDir)
     }
 
-    if (!fs.existsSync(path.join(repoDir, 'index.json'))) {
+    if (!(await fileExists(path.join(repoDir, 'index.json')))) {
       if (pullResult === 'skipped-offline') {
         // The cache is incomplete but we can't re-clone right now. Don't nuke
         // it while offline — retry on the next refresh instead.
@@ -877,7 +878,7 @@ async function refreshSkillsetCache(
     }
   } else {
     await ensureSkillsetCached(ref)
-    if (!fs.existsSync(path.join(repoDir, 'index.json'))) {
+    if (!(await fileExists(path.join(repoDir, 'index.json')))) {
       throw new Error(
         `Skillset repository has no index.json at its root (fresh clone at ${repoDir})`,
       )
@@ -1079,7 +1080,7 @@ export async function getAgentSkillsWithStatus(
 ): Promise<SkillWithStatus[]> {
   const skillsDir = getAgentSkillsDir(agentSlug)
 
-  if (!fs.existsSync(skillsDir)) {
+  if (!(await directoryExists(skillsDir))) {
     return []
   }
 
@@ -1246,7 +1247,7 @@ export async function refreshAgentSkills(
   }
 
   const skillsDir = getAgentSkillsDir(agentSlug)
-  if (!fs.existsSync(skillsDir)) return
+  if (!(await directoryExists(skillsDir))) return
 
   const entries = await fs.promises.readdir(skillsDir, { withFileTypes: true })
 
@@ -1382,7 +1383,7 @@ export async function getDiscoverableSkills(
   const skillsDir = getAgentSkillsDir(agentSlug)
   const installedDirs = new Set<string>()
 
-  if (fs.existsSync(skillsDir)) {
+  if (await directoryExists(skillsDir)) {
     const entries = await fs.promises.readdir(skillsDir, { withFileTypes: true })
     for (const entry of entries) {
       if (entry.isDirectory()) installedDirs.add(entry.name)


### PR DESCRIPTION
## Why

On cloud, `/data` is an S3 Files mount. A synchronous `existsSync` / `readFileSync` against that mount can hang for several seconds and freeze the entire host-app event loop. Every in-flight request waits — including cheap SQLite reads and unauthenticated 401s — then they all return in the same ~10 ms.

Measured on `datawizz.ongamut.so` 2026-08-17 11:59 PDT: 30 requests started up to 3 s apart and released together. Worker CPU was 0–4 ms; host CPU 19–25%. The first freeze started within 0.4 s of `GET /api/agents/:id/mounts` and `GET /api/agents/:id/discoverable-skills` (the only two request paths that did sync FS on `/data`). The same sync `getMountsWithHealth` also runs on every container start.

This PR does not make S3 Files faster. It stops a slow filesystem call from blocking every other request.

## What changed

- `mount-service`: reads (`getMounts`, `getMountsWithHealth`) and writes (`addMount`, `removeMount`) are async. Writes keep the old no-interleave guarantee via `withFileLock`.
- `skillset-service`: all six `existsSync` calls → `fileExists` / `directoryExists`.
- Callers: mount CRUD routes, skills-files 404 check, `container-manager` start path.
- Tests updated; the atomic suite now fires concurrent `addMount`s to exercise the lock.
