### PR TITLE
Fix sticky session model routing

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -562,7 +562,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionMessagesDelta, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionMessagesDelta, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, updateSessionName, registerSession, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { listPendingScheduledTasks } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -3565,6 +3565,15 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
     const res = await postJson(app, URL, { content: 'hello', model: 'claude-haiku-4-5' })
     expect(res.status).toBe(201)
     expect(mockSendMessage).toHaveBeenCalledWith('sess-1', 'hello', expect.any(String), { model: 'claude-haiku-4-5' })
+    expect(updateSessionMetadata).toHaveBeenCalledWith('test-agent', 'sess-1', {
+      model: 'claude-haiku-4-5',
+    })
+    expect(messagePersister.broadcastSessionUpdate).toHaveBeenCalledWith('sess-1')
+    expect(messagePersister.broadcastGlobal).toHaveBeenCalledWith({
+      type: 'session_updated',
+      sessionId: 'sess-1',
+      agentSlug: 'test-agent',
+    })
   })
 
   it('forwards both effort and model when both are present', async () => {
@@ -3626,6 +3635,8 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
     const body = await res.json()
     expect(body.queued).toBe(true)
     expect(mockSendMessage).toHaveBeenCalledWith('sess-1', 'hello', expect.any(String), {})
+    expect(updateSessionMetadata).not.toHaveBeenCalled()
+    expect(messagePersister.broadcastSessionUpdate).not.toHaveBeenCalled()
   })
 })
 
@@ -6523,6 +6534,7 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
     vi.mocked(readJsonFileStrict).mockResolvedValue({
       defaultModel: 'haiku',
       defaultEffort: 'high',
+      defaultSpeed: 'fast',
     } as never)
 
     const res = await postJson(app, SESSIONS_URL, { message: 'hello' })
@@ -6532,8 +6544,15 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
     const args = mockCreateSession.mock.calls[0][0]
     expect(args.model).toBe('haiku')
     expect(args.effort).toBe('high')
+    expect(args.speed).toBe('fast')
     expect(args.prewarmDefaults.model).toBe('haiku')
     expect(args.prewarmDefaults.effort).toBe('high')
+    expect(registerSession).toHaveBeenCalledWith('test-agent', 'session-123', 'New Session', {
+      model: 'haiku',
+      effort: 'high',
+      speed: 'fast',
+    })
+    expect(await res.json()).toMatchObject({ model: 'haiku', effort: 'high', speed: 'fast' })
   })
 
   it('reserves ownership before publishing global lifecycle state', async () => {
@@ -6565,6 +6584,12 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
     expect(args.effort).toBe('low')
     expect(args.prewarmDefaults.model).toBe('haiku')
     expect(args.prewarmDefaults.effort).toBe('high')
+    expect(registerSession).toHaveBeenCalledWith(
+      'test-agent',
+      'session-123',
+      'New Session',
+      expect.objectContaining({ model: 'claude-opus-4', effort: 'low' }),
+    )
   })
 
   it('uses the global default model and effort when the agent has no preferences', async () => {
@@ -6577,6 +6602,12 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
     expect(args.effort).toBe('medium')
     expect(args.prewarmDefaults.model).toBe('global-agent-model')
     expect(args.prewarmDefaults.effort).toBe('medium')
+    expect(registerSession).toHaveBeenCalledWith(
+      'test-agent',
+      'session-123',
+      'New Session',
+      expect.objectContaining({ model: 'global-agent-model', effort: 'medium' }),
+    )
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -3576,6 +3576,43 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
     })
   })
 
+  it('does not broadcast when the accepted selection matches the stored metadata', async () => {
+    mockIsAuthMode.mockReturnValue(false)
+    // Seeded composers re-send their whole selection on every fresh turn; a
+    // value the metadata already records must not fan out list/detail
+    // refetches to every open window.
+    vi.mocked(updateSessionMetadata).mockResolvedValueOnce({ model: 'claude-haiku-4-5' } as never)
+
+    const res = await postJson(app, URL, { content: 'hello again', model: 'claude-haiku-4-5' })
+    expect(res.status).toBe(201)
+    expect(updateSessionMetadata).toHaveBeenCalledWith('test-agent', 'sess-1', {
+      model: 'claude-haiku-4-5',
+    })
+    expect(messagePersister.broadcastSessionUpdate).not.toHaveBeenCalled()
+    expect(messagePersister.broadcastGlobal).not.toHaveBeenCalled()
+  })
+
+  it('broadcasts when any one option differs from the stored metadata', async () => {
+    mockIsAuthMode.mockReturnValue(false)
+    vi.mocked(updateSessionMetadata).mockResolvedValueOnce({
+      model: 'claude-haiku-4-5',
+      effort: 'medium',
+    } as never)
+
+    const res = await postJson(app, URL, {
+      content: 'hello',
+      model: 'claude-haiku-4-5',
+      effort: 'high',
+    })
+    expect(res.status).toBe(201)
+    expect(messagePersister.broadcastSessionUpdate).toHaveBeenCalledWith('sess-1')
+    expect(messagePersister.broadcastGlobal).toHaveBeenCalledWith({
+      type: 'session_updated',
+      sessionId: 'sess-1',
+      agentSlug: 'test-agent',
+    })
+  })
+
   it('forwards both effort and model when both are present', async () => {
     mockIsAuthMode.mockReturnValue(false)
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1679,14 +1679,15 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     // still wins the race with early container output.
     await reserveSessionOwnership(slug, sessionId)
 
-    // Persist only what the user explicitly chose. The server-side fallback is
-    // applied at session creation but should not masquerade as a user choice in
-    // metadata — otherwise a later change to the global default wouldn't be
-    // reflected when the composer reloads.
-    const initialMetadata: Parameters<typeof updateSessionMetadata>[2] = {}
-    if (runtimeOptions.effort) initialMetadata.effort = runtimeOptions.effort
-    if (runtimeOptions.speed) initialMetadata.speed = runtimeOptions.speed
-    if (runtimeOptions.model) initialMetadata.model = runtimeOptions.model
+    // Runtime choices are SESSION state once the first turn starts, including
+    // inherited defaults. Persist the effective values, not merely explicit
+    // overrides, so changing an agent/app default later cannot silently change
+    // an existing conversation's next turn or make the composer claim it will.
+    const initialMetadata: Parameters<typeof updateSessionMetadata>[2] = {
+      model: resolved.model,
+      ...(resolved.effort ? { effort: resolved.effort } : {}),
+      ...(resolved.speed ? { speed: resolved.speed } : {}),
+    }
     if (isAuthMode()) {
       initialMetadata.createdByUserId = getCurrentUserId(c)
       // Origin-device stamp: which mobile device family (if any) started this
@@ -1749,6 +1750,9 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
         lastActivityAt: new Date(),
         messageCount: 0,
         isActive: true,
+        model: resolved.model,
+        ...(resolved.effort ? { effort: resolved.effort } : {}),
+        ...(resolved.speed ? { speed: resolved.speed } : {}),
         initialMessageUuid,
       },
       201
@@ -2276,6 +2280,17 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
       } catch (error) {
         console.error(error)
       }
+    }
+    const runtimeSelectionChanged =
+      runtimeOptions.effort !== undefined ||
+      runtimeOptions.speed !== undefined ||
+      runtimeOptions.model !== undefined
+    if (runtimeSelectionChanged) {
+      // Other windows/devices may already have seeded their composer from the
+      // previous session metadata. Tell both the local session stream and the
+      // global event stream to refresh before their next send.
+      messagePersister.broadcastSessionUpdate(sessionId)
+      messagePersister.broadcastGlobal({ type: 'session_updated', sessionId, agentSlug })
     }
 
     return c.json({ success: true, uuid: messageUuid, queued: wasQueued }, 201)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2276,21 +2276,27 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     }
     if (Object.keys(updates).length > 0) {
       try {
-        await updateSessionMetadata(agentSlug, sessionId, updates)
+        const previous = await updateSessionMetadata(agentSlug, sessionId, updates)
+        // The composer re-sends its whole selection on every fresh turn, so
+        // option presence alone doesn't mean anything changed. Compare against
+        // the previous metadata (captured under the update's lock) — otherwise
+        // every send would make every open window refetch the session list and
+        // detail for a no-op. A failed metadata write skips the broadcast too:
+        // peers would only refetch the stale values.
+        const runtimeSelectionChanged =
+          (updates.effort !== undefined && previous?.effort !== updates.effort) ||
+          (updates.speed !== undefined && previous?.speed !== updates.speed) ||
+          (updates.model !== undefined && previous?.model !== updates.model)
+        if (runtimeSelectionChanged) {
+          // Other windows/devices may already have seeded their composer from
+          // the previous session metadata. Tell both the local session stream
+          // and the global event stream to refresh before their next send.
+          messagePersister.broadcastSessionUpdate(sessionId)
+          messagePersister.broadcastGlobal({ type: 'session_updated', sessionId, agentSlug })
+        }
       } catch (error) {
         console.error(error)
       }
-    }
-    const runtimeSelectionChanged =
-      runtimeOptions.effort !== undefined ||
-      runtimeOptions.speed !== undefined ||
-      runtimeOptions.model !== undefined
-    if (runtimeSelectionChanged) {
-      // Other windows/devices may already have seeded their composer from the
-      // previous session metadata. Tell both the local session stream and the
-      // global event stream to refresh before their next send.
-      messagePersister.broadcastSessionUpdate(sessionId)
-      messagePersister.broadcastGlobal({ type: 'session_updated', sessionId, agentSlug })
     }
 
     return c.json({ success: true, uuid: messageUuid, queued: wasQueued }, 201)

--- a/src/renderer/components/messages/composer-options.test.tsx
+++ b/src/renderer/components/messages/composer-options.test.tsx
@@ -178,6 +178,109 @@ describe('useComposerOptions default adoption', () => {
     expect(result.current.model).toBe('claude-opus-4-6')
     expect(result.current.effort).toBe('xhigh')
   })
+
+  it('adopts a newer authoritative session model after mounting from stale cached detail', () => {
+    const { result, rerender } = render({
+      initialModel: 'claude-opus-4-6',
+      agentKey: 'a',
+      agentDefaultModel: 'haiku',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('claude-opus-4-6')
+
+    // React Query can render cached session detail first, then deliver the
+    // refetched last-used model. The refreshed session value must replace the
+    // stale seed and be the value sent on the next turn.
+    rerender({
+      initialModel: 'claude-sonnet-4-6',
+      agentKey: 'a',
+      agentDefaultModel: 'haiku',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('claude-sonnet-4-6')
+    expect(result.current.toRuntimeOptions()).toEqual({ model: 'claude-sonnet-4-6' })
+  })
+
+  it('protects an unsent model pick, then follows session updates after submit succeeds', () => {
+    const { result, rerender } = render({
+      initialModel: 'claude-opus-4-6',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+    act(() => result.current.setModel('claude-sonnet-4-6'))
+
+    // A peer update/refetch must not erase a local choice that has not reached
+    // the server yet.
+    rerender({
+      initialModel: 'claude-haiku-4-5',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('claude-sonnet-4-6')
+
+    act(() => result.current.markSubmitted({ model: 'claude-sonnet-4-6' }))
+    rerender({
+      initialModel: 'claude-sonnet-4-6',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+
+    // Once acknowledged, a later peer's accepted model is authoritative.
+    rerender({
+      initialModel: 'claude-opus-4-8',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.model).toBe('claude-opus-4-8')
+    expect(result.current.toRuntimeOptions()).toEqual({ model: 'claude-opus-4-8' })
+  })
+
+  it('applies the same authoritative refresh and unsent-edit protection to effort and speed', () => {
+    const { result, rerender } = render({
+      initialEffort: 'medium',
+      initialSpeed: 'normal',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+
+    rerender({
+      initialEffort: 'high',
+      initialSpeed: 'fast',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.effort).toBe('high')
+    expect(result.current.speed).toBe('fast')
+
+    act(() => {
+      result.current.setEffort('low')
+      result.current.setSpeed('slow')
+    })
+    rerender({
+      initialEffort: 'xhigh',
+      initialSpeed: 'normal',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.effort).toBe('low')
+    expect(result.current.speed).toBe('slow')
+
+    act(() => result.current.markSubmitted({ effort: 'low', speed: 'slow' }))
+    rerender({
+      initialEffort: 'low',
+      initialSpeed: 'slow',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+    rerender({
+      initialEffort: 'high',
+      initialSpeed: 'fast',
+      agentKey: 'a',
+      agentDefaultsReady: true,
+    })
+    expect(result.current.effort).toBe('high')
+    expect(result.current.speed).toBe('fast')
+  })
 })
 
 describe('useComposerOptions web provider', () => {

--- a/src/renderer/components/messages/composer-options.tsx
+++ b/src/renderer/components/messages/composer-options.tsx
@@ -11,8 +11,7 @@ import type { LlmProviderId } from '@shared/lib/config/settings'
  * same per-message runtime knobs (effort, model) and the same seeding rules,
  * so we centralize:
  *   - reading the active provider's model catalog from settings
- *   - one-time seeding from `initialEffort` / `initialModel` (so late-loading
- *     session data doesn't clobber later user edits)
+ *   - adopting authoritative session state without clobbering unsent user edits
  *   - falling back to the user's "Default Model" setting when no initial
  *     model is supplied
  *   - rendering the two selector buttons as one toolbar block
@@ -47,6 +46,17 @@ export interface ComposerOptionsState {
   toRuntimeOptions(): { effort?: EffortLevel; speed?: SpeedLevel; model?: string }
 }
 
+/** Submit lifecycle used by composer hosts; presentation-only consumers only need the state above. */
+export interface ComposerOptionsController extends ComposerOptionsState {
+  /**
+   * Acknowledge runtime options the server accepted for a fresh turn. Until
+   * this is called, a user-picked runtime option is an unsent local edit and
+   * must not be overwritten by a session-detail refetch. Afterwards, newer
+   * initial values are authoritative (another window may have spoken).
+   */
+  markSubmitted(options: { effort?: EffortLevel; speed?: SpeedLevel; model?: string }): void
+}
+
 /**
  * Resolve a stored selection to its catalog entry for display: an exact
  * concrete-id match first, then a bare family alias → that family's latest.
@@ -64,11 +74,11 @@ export function findCatalogModel(
 }
 
 export interface UseComposerOptionsArgs {
-  /** Effort last used on this session, seeds the selector once if provided. */
+  /** Effort last used on this session, seeds the selector if provided. */
   initialEffort?: EffortLevel
-  /** Speed last used on this session, seeds the selector once if provided. */
+  /** Speed last used on this session, seeds the selector if provided. */
   initialSpeed?: SpeedLevel
-  /** Model last used on this session, seeds the selector once if provided. */
+  /** Authoritative model last used on this session. */
   initialModel?: string
   /** The agent's own default model, if set. Slots between a session's initial model and the app-wide default. */
   agentDefaultModel?: string
@@ -99,7 +109,7 @@ export interface UseComposerOptionsArgs {
   followDefaults?: boolean
 }
 
-export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerOptionsState {
+export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerOptionsController {
   const {
     initialEffort,
     initialSpeed,
@@ -119,31 +129,41 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
   // ---- Effort ----
   const [effort, setEffortState] = useState<EffortLevel>(initialEffort ?? DEFAULT_EFFORT)
   const effortSeededRef = useRef(initialEffort !== undefined)
+  const lastInitialEffortRef = useRef(initialEffort)
+  const effortDirtyRef = useRef(false)
   useEffect(() => {
-    if (!effortSeededRef.current && initialEffort !== undefined) {
+    if (lastInitialEffortRef.current === initialEffort) return
+    lastInitialEffortRef.current = initialEffort
+    if (!effortDirtyRef.current && initialEffort !== undefined) {
       setEffortState(initialEffort)
       effortSeededRef.current = true
     }
   }, [initialEffort])
-  // Wrap the setter so an explicit user pick locks out the late-arriving
-  // initial-seed effect — otherwise a slow `useSession` resolution can clobber
-  // the user's choice if they pick before session data lands.
+  // Wrap the setter so an explicit user pick locks out authoritative refreshes
+  // until it is submitted — otherwise a slow `useSession` resolution can
+  // clobber the user's choice if they pick before session data lands.
   const setEffort = useCallback((e: EffortLevel) => {
     effortSeededRef.current = true
+    effortDirtyRef.current = true
     setEffortState(e)
   }, [])
 
   // ---- Speed ---- (same seeding/locking shape as effort)
   const [speed, setSpeedState] = useState<SpeedLevel>(initialSpeed ?? DEFAULT_SPEED)
   const speedSeededRef = useRef(initialSpeed !== undefined)
+  const lastInitialSpeedRef = useRef(initialSpeed)
+  const speedDirtyRef = useRef(false)
   useEffect(() => {
-    if (!speedSeededRef.current && initialSpeed !== undefined) {
+    if (lastInitialSpeedRef.current === initialSpeed) return
+    lastInitialSpeedRef.current = initialSpeed
+    if (!speedDirtyRef.current && initialSpeed !== undefined) {
       setSpeedState(initialSpeed)
       speedSeededRef.current = true
     }
   }, [initialSpeed])
   const setSpeed = useCallback((sp: SpeedLevel) => {
     speedSeededRef.current = true
+    speedDirtyRef.current = true
     setSpeedState(sp)
   }, [])
 
@@ -169,17 +189,44 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
   // ---- Model ----
   const [model, setModelState] = useState<string | undefined>(initialModel ?? fallbackModel)
   const modelSeededRef = useRef(initialModel !== undefined)
-  // Seed once when session data loads after mount.
+  // `initialModel` is authoritative session state, but the first render may
+  // contain a stale React Query cache entry while a background refetch is in
+  // flight. Track every distinct value rather than treating the first one as
+  // final. The only thing allowed to beat a newer session value is an explicit
+  // user pick that has not been accepted by the server yet.
+  const lastInitialModelRef = useRef(initialModel)
+  const modelDirtyRef = useRef(false)
   useEffect(() => {
-    if (!modelSeededRef.current && initialModel !== undefined) {
+    if (lastInitialModelRef.current === initialModel) return
+    lastInitialModelRef.current = initialModel
+    if (!modelDirtyRef.current && initialModel !== undefined) {
       setModelState(initialModel)
       modelSeededRef.current = true
     }
   }, [initialModel])
   const setModel = useCallback((m: string) => {
     modelSeededRef.current = true
+    modelDirtyRef.current = true
     setModelState(m)
   }, [])
+
+  const markSubmitted = useCallback(
+    (options: { effort?: EffortLevel; speed?: SpeedLevel; model?: string }) => {
+      // Do not clear a newer selection if a request somehow completed after
+      // the picker changed again. MessageInput disables the picker in flight,
+      // but the equality check keeps this helper correct for other callers.
+      if (options.effort !== undefined && options.effort === effort) {
+        effortDirtyRef.current = false
+      }
+      if (options.speed !== undefined && options.speed === speed) {
+        speedDirtyRef.current = false
+      }
+      if (options.model !== undefined && options.model === model) {
+        modelDirtyRef.current = false
+      }
+    },
+    [effort, speed, model],
+  )
 
   // ---- Default adoption ----
   // An untouched knob follows the effective default (agent default → user
@@ -261,8 +308,9 @@ export function useComposerOptions(args: UseComposerOptionsArgs = {}): ComposerO
       defaultModel: fallbackModel,
       webProvider: settings?.webProvider,
       toRuntimeOptions,
+      markSubmitted,
     }),
-    [effort, setEffort, speed, setSpeed, model, setModel, catalog, fallbackModel, settings, toRuntimeOptions],
+    [effort, setEffort, speed, setSpeed, model, setModel, catalog, fallbackModel, settings, toRuntimeOptions, markSubmitted],
   )
 }
 

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -909,6 +909,46 @@ describe('MessageInput', () => {
     })
   })
 
+  it('keeps a model pick unsent when the server authoritatively queues the message', async () => {
+    // Simulate stale SSE state: this window thinks the session is idle, but a
+    // peer already has a turn in flight. The server strips runtime options and
+    // reports the message as queued.
+    mockSendMessage.mutateAsync.mockResolvedValueOnce({
+      success: true,
+      uuid: 'server-uuid-queued',
+      queued: true,
+    })
+    const user = userEvent.setup()
+    const onMessageUuidAssigned = vi.fn()
+    const { rerender } = renderWithProviders(
+      <MessageInput
+        sessionId="s-1"
+        agentSlug="agent-1"
+        initialModel="opus"
+        onMessageUuidAssigned={onMessageUuidAssigned}
+      />
+    )
+
+    await user.click(screen.getByTestId('composer-options-trigger'))
+    await user.click(await screen.findByTestId('model-pinned-claude-haiku-4-5'))
+    await user.type(screen.getByTestId('message-input'), 'Queue this')
+    await user.keyboard('{Enter}')
+    await waitFor(() => {
+      expect(onMessageUuidAssigned).toHaveBeenCalledWith(
+        expect.any(String),
+        'server-uuid-queued',
+        true,
+      )
+    })
+
+    // A peer/cache refresh must not erase Haiku: the queued message did not
+    // apply that choice to the live session, so it remains a local unsent edit.
+    rerender(
+      <MessageInput sessionId="s-1" agentSlug="agent-1" initialModel="sonnet" />
+    )
+    expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('Haiku')
+  })
+
   it('sends both effort and model on submit', async () => {
     const user = userEvent.setup()
     renderWithProviders(

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -98,14 +98,19 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
       // a parameter change would interrupt/restart the in-flight query.
       // (The server also strips them when it sees the session is active.)
       const queued = isActive && !isWaitingBackground
+      const runtimeOptions = queued ? {} : composerOptions.toRuntimeOptions()
       onMessageSent?.(content, localId, queued)
       try {
         const result = await sendMessage.mutateAsync({
           sessionId,
           agentSlug,
           content,
-          ...(queued ? {} : composerOptions.toRuntimeOptions()),
+          ...runtimeOptions,
         })
+        // Only a fresh turn accepts runtime-option changes. The server's
+        // queued decision is authoritative and may differ from our SSE-based
+        // guess, so keep a user pick dirty when the server stripped it.
+        if (!result.queued) composerOptions.markSubmitted(runtimeOptions)
         // Reconcile against the server's authoritative decision: our local
         // `queued` guess is derived from SSE state that can be stale (reconnect,
         // a peer's turn, background-task flag), and a mismatch otherwise strands

--- a/src/renderer/hooks/use-messages.test.ts
+++ b/src/renderer/hooks/use-messages.test.ts
@@ -19,6 +19,7 @@ vi.mock('@renderer/lib/upload', () => ({
 
 import {
   useMessages,
+  useSendMessage,
   useDeleteToolCall,
   useSubagentMessages,
   useWorkflowTree,
@@ -134,6 +135,68 @@ describe('useMessages abort wiring', () => {
     await waitFor(() => expect(result.current.data).toHaveLength(1))
     expect(result.current.data?.[0].id).toBe('m1')
     expect(result.current.isError).toBe(false)
+  })
+})
+
+describe('useSendMessage session runtime cache', () => {
+  const session = {
+    id: 's1',
+    agentSlug: 'agent-1',
+    name: 'Session',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    lastActivityAt: new Date('2026-01-01T00:00:00Z'),
+    messageCount: 2,
+    model: 'claude-opus-4-6',
+    effort: 'medium' as const,
+  }
+
+  it('patches all cached session-detail spellings with accepted runtime options', async () => {
+    const wrapper = createWrapper()
+    wrapper.queryClient.setQueryData(['session', 's1', 'agent-1'], session)
+    wrapper.queryClient.setQueryData(['session', 's1', 'display-agent-1'], session)
+    apiFetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, uuid: 'u1', queued: false }),
+    })
+    const { result } = renderHook(() => useSendMessage(), { wrapper })
+
+    await act(() => result.current.mutateAsync({
+      sessionId: 's1',
+      agentSlug: 'agent-1',
+      content: 'use sonnet',
+      model: 'claude-sonnet-4-6',
+      effort: 'high',
+    }))
+
+    expect(wrapper.queryClient.getQueryData(['session', 's1', 'agent-1'])).toMatchObject({
+      model: 'claude-sonnet-4-6',
+      effort: 'high',
+    })
+    expect(wrapper.queryClient.getQueryData(['session', 's1', 'display-agent-1'])).toMatchObject({
+      model: 'claude-sonnet-4-6',
+      effort: 'high',
+    })
+  })
+
+  it('does not claim a queued message changed the session model', async () => {
+    const wrapper = createWrapper()
+    wrapper.queryClient.setQueryData(['session', 's1', 'agent-1'], session)
+    apiFetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, uuid: 'u1', queued: true }),
+    })
+    const { result } = renderHook(() => useSendMessage(), { wrapper })
+
+    await act(() => result.current.mutateAsync({
+      sessionId: 's1',
+      agentSlug: 'agent-1',
+      content: 'queued',
+      model: 'claude-sonnet-4-6',
+    }))
+
+    expect(wrapper.queryClient.getQueryData(['session', 's1', 'agent-1'])).toMatchObject({
+      model: 'claude-opus-4-6',
+    })
   })
 })
 

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -3,7 +3,7 @@ import { captureRendererException } from '@renderer/lib/error-reporting'
 import { uploadFileChunked } from '@renderer/lib/upload'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
+import type { ApiMessage, ApiMessageOrBoundary, ApiSession } from '@shared/lib/types/api'
 import type { EffortLevel, SpeedLevel } from '@shared/lib/container/types'
 import type { WorkflowTree } from '@shared/lib/workflows/workflow-schemas'
 import { MESSAGES_PAGE_LIMIT, MESSAGES_PAGE_OLDER_LIMIT } from '@shared/lib/messages-page'
@@ -293,6 +293,7 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
 }
 
 export function useSendMessage() {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (data: { sessionId: string; agentSlug: string; content: string; effort?: EffortLevel; speed?: SpeedLevel; model?: string }) => {
       const res = await apiFetch(`/api/agents/${data.agentSlug}/sessions/${data.sessionId}/messages`, {
@@ -310,7 +311,26 @@ export function useSendMessage() {
       // optimistic pending copy by exact id match.
       return res.json() as Promise<{ success: boolean; uuid: string; queued: boolean }>
     },
-    // No onSuccess - we'll handle the pending message via props
+    onSuccess: (result, variables) => {
+      // Keep every cached spelling of this session detail (canonical agent id
+      // or a pre-resolution display slug) aligned with the runtime options the
+      // server accepted. Without this, leaving and returning to the session
+      // remounts the composer from the old model and the next request can
+      // switch the live session back. Queued messages intentionally carry no
+      // runtime changes; trust the server's decision rather than the client's
+      // possibly stale activity snapshot.
+      if (result.queued) return
+      const patch = {
+        ...(variables.effort !== undefined ? { effort: variables.effort } : {}),
+        ...(variables.speed !== undefined ? { speed: variables.speed } : {}),
+        ...(variables.model !== undefined ? { model: variables.model } : {}),
+      }
+      if (Object.keys(patch).length === 0) return
+      queryClient.setQueriesData<ApiSession>(
+        { queryKey: ['session', variables.sessionId] },
+        (session) => (session ? { ...session, ...patch } : session),
+      )
+    },
   })
 }
 

--- a/src/shared/lib/services/session-service.metadata.test.ts
+++ b/src/shared/lib/services/session-service.metadata.test.ts
@@ -96,6 +96,20 @@ describe('lost-update protection (serialized read-modify-write)', () => {
     const meta = await getSessionMetadata('agent', 's1')
     expect(meta).toMatchObject({ name: 'Original', starred: true, effort: 'high', model: 'opus' })
   })
+
+  it('updateSessionMetadata returns the pre-update entry so callers can detect real changes', async () => {
+    const { registerSession, updateSessionMetadata } = await importService()
+    makeAgent('agent')
+
+    // No entry yet → undefined (the caller treats every value as a change).
+    const beforeRegister = await updateSessionMetadata('agent', 'fresh', { model: 'opus' })
+    expect(beforeRegister).toBeUndefined()
+
+    await registerSession('agent', 's1', 'Original')
+    await updateSessionMetadata('agent', 's1', { model: 'opus', effort: 'high' })
+    const previous = await updateSessionMetadata('agent', 's1', { model: 'haiku' })
+    expect(previous).toMatchObject({ name: 'Original', model: 'opus', effort: 'high' })
+  })
 })
 
 describe('atomic writes', () => {

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -298,19 +298,25 @@ async function mutateSessionMetadata(
 }
 
 /**
- * Update metadata for a single session
+ * Update metadata for a single session. Returns the session's previous
+ * metadata entry (undefined when it had none), captured under the same lock
+ * as the write, so callers can tell whether an update actually changed a
+ * value without racing a concurrent update.
  */
 export async function updateSessionMetadata(
   agentSlug: string,
   sessionId: string,
   updates: Partial<SessionMetadata>
-): Promise<void> {
+): Promise<SessionMetadata | undefined> {
+  let previous: SessionMetadata | undefined
   await mutateSessionMetadata(agentSlug, (metadata) => {
+    previous = metadata[sessionId]
     metadata[sessionId] = {
       ...metadata[sessionId],
       ...updates,
     }
   })
+  return previous
 }
 
 export type AutomationStatusResult = 'updated' | 'not-automation' | 'already-final'


### PR DESCRIPTION
## Summary

- persist the effective model, effort, and speed as session state when an interactive session starts
- refresh peer windows and patch every cached session-detail key after an accepted runtime selection
- let refreshed session state replace stale cached composer values while preserving unsent local picks
- trust the server's queued decision so a stripped runtime selection is not falsely committed

## Root cause

The session composer treated its first `initialModel` as permanent. After a model change, the send path persisted server metadata but left renderer session-detail caches stale. Navigating away and back could therefore seed the composer from an old cached model; the background refetch was ignored, and the next send could route back to that stale value. Inherited defaults were also not recorded as initial session runtime state.

## Impact

Existing sessions keep routing subsequent fresh turns with the last accepted runtime selection across navigation, background refetches, and peer-window updates. Mid-turn queued messages continue to carry no runtime changes, and an unsent picker choice remains available locally.

## Validation

- `npm test -- --run src/api/routes/agents.test.ts src/renderer/components/messages/composer-options.test.tsx src/renderer/components/messages/message-input.test.tsx src/renderer/hooks/use-messages.test.ts` — 458 tests passed
- targeted ESLint on all changed files — passed
- `git diff --check` — passed

## Typecheck note

The checkout's existing dependency install is missing `use-stick-to-bottom`, so the normal project typecheck stops at that unresolved module. Supplying its locked package types reaches an unrelated existing error at `src/shared/lib/server-bind.ts:49`; no change-related TypeScript errors remain.
