### PR TITLE
Guard live-edge follow through clamp-producing transitions

### DIFF
--- a/e2e/specs/transcript-follow.spec.ts
+++ b/e2e/specs/transcript-follow.spec.ts
@@ -107,4 +107,41 @@ test.describe('Transcript live-edge follow', () => {
       .toBeLessThan(90)
     await expect(pill).toBeHidden()
   })
+
+  test('keeps the live edge pinned through vertical window resizes', async ({ page }) => {
+    await sessionPage.sendMessage(SAGA_PROMPT)
+    await sessionPage.waitForResponse(15000)
+    // Get past the new-turn reserve, whose spacer handles resizes on its own.
+    await expect(page.getByTestId('turn-anchor-spacer')).toBeHidden({ timeout: 20000 })
+    await expect
+      .poll(async () => (await scrollMetrics(page)).distanceFromBottom, { timeout: 15000 })
+      .toBeLessThan(90)
+
+    // Browsers anchor the top edge on a viewport shrink, which would slide
+    // the newest content behind the fold — the transcript must re-pin so
+    // content leaves from the top, not the bottom.
+    const viewport = page.viewportSize()!
+    await page.setViewportSize({ width: viewport.width, height: viewport.height - 250 })
+    await expect
+      .poll(async () => (await scrollMetrics(page)).distanceFromBottom, { timeout: 5000 })
+      .toBeLessThan(90)
+
+    // Growing back stays pinned too — the browser's own clamp scroll must
+    // not be misread as the reader escaping.
+    await page.setViewportSize({ width: viewport.width, height: viewport.height })
+    await expect
+      .poll(async () => (await scrollMetrics(page)).distanceFromBottom, { timeout: 5000 })
+      .toBeLessThan(90)
+
+    // Following survived both resizes: as the stream continues, the viewport
+    // keeps up and the escape affordance never appears.
+    const mark = (await scrollMetrics(page)).contentHeight
+    await expect
+      .poll(async () => (await scrollMetrics(page)).contentHeight, { timeout: 10000 })
+      .toBeGreaterThan(mark + 150)
+    await expect
+      .poll(async () => (await scrollMetrics(page)).distanceFromBottom, { timeout: 15000 })
+      .toBeLessThan(90)
+    await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
+  })
 })

--- a/e2e/specs/transcript-follow.spec.ts
+++ b/e2e/specs/transcript-follow.spec.ts
@@ -108,6 +108,33 @@ test.describe('Transcript live-edge follow', () => {
     await expect(pill).toBeHidden()
   })
 
+  test('holds the reading line steady while the agent works', async ({ page }) => {
+    // The slow-work scenario streams a working indicator, then (~5s in) swaps
+    // it for its shorter persisted copy — a content shrink under the held
+    // reserve. The browser clamps scrollTop against the momentarily smaller
+    // scroll range; the transcript must restore the reading line in the same
+    // pass, not leave the held turn visibly sagging until content grows again.
+    await sessionPage.sendMessage('work slowly please')
+    await expect(page.getByTestId('turn-anchor-spacer')).toBeVisible({ timeout: 15000 })
+    await expect
+      .poll(async () => (await scrollMetrics(page)).distanceFromBottom, { timeout: 15000 })
+      .toBeLessThan(5)
+
+    // Ride through the swap: the persisted copy appearing means the clamp has
+    // already happened. The follow spring may trail transiently after content
+    // changes (by design), but the clamp's sag has no growth to recover it —
+    // only the same-pass restore can. So the discriminating assertion is that
+    // the viewport re-converges to the reading line and the reserve is still
+    // holding; without the restore the sag freezes ~40px deep and never comes
+    // back.
+    await expect(page.getByText('Finished the slow work.')).toBeVisible({ timeout: 20000 })
+    await expect(page.getByTestId('turn-anchor-spacer')).toBeVisible()
+    await expect
+      .poll(async () => (await scrollMetrics(page)).distanceFromBottom, { timeout: 3000 })
+      .toBeLessThan(5)
+    await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
+  })
+
   test('keeps the live edge pinned through vertical window resizes', async ({ page }) => {
     await sessionPage.sendMessage(SAGA_PROMPT)
     await sessionPage.waitForResponse(15000)

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2618,6 +2618,48 @@ describe('MessageList', () => {
       expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
     })
 
+    it('restores the reading line when a transient shrink clamps the held reserve', async () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(1099)
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+      fireEvent.scroll(el) // baseline at the reading line
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+
+      // A working indicator swapping forms (streamed block replaced by its
+      // shorter persisted copy) shrinks natural content while the reserve
+      // holds. The browser clamps scrollTop against the momentarily smaller
+      // scroll range and leaves it there — the spacer re-inflating afterwards
+      // restores the range but not the position. Model the sticky clamp.
+      geometry.setNaturalScrollHeight(1240)
+      geometry.setScrollTop(1040)
+      fireEvent.scroll(el)
+      mockStreamState.streamingMessage = 'A different working indicator'
+      mockStreamState.isStreaming = true
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+
+      // The reserve re-inflates AND the viewport returns to the reading line
+      // in the same pass — the held turn must not visibly sag.
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '460px' })
+      expect(geometry.scrollTop).toBe(1099)
+      // The clamp's scroll echo must not have latched an escape either.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+      expect(geometry.scrollTop).toBe(1099)
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+    })
+
     it('spends the reserved room before following streamed content at the live edge', async () => {
       installFakeResizeObserver()
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2441,6 +2441,7 @@ describe('MessageList', () => {
     function mockTurnGeometry(el: HTMLElement, { reducedMotion = true } = {}) {
       let naturalScrollHeight = 1300
       let scrollTop = 700
+      let clientHeight = 600
       const anchorDocumentTop = 1200
       const spacerHeight = () => Number.parseFloat(
         (el.querySelector('[data-testid="turn-anchor-spacer"]') as HTMLElement | null)?.style.height || '0',
@@ -2461,7 +2462,7 @@ describe('MessageList', () => {
         configurable: true,
         get: () => naturalScrollHeight + spacerHeight(),
       })
-      Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => 600 })
+      Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => clientHeight })
       Object.defineProperty(el, 'scrollTop', {
         configurable: true,
         // Browsers clamp scrollTop when removing the turn spacer lowers the
@@ -2469,7 +2470,7 @@ describe('MessageList', () => {
         // same observable effect as it does in the real transcript.
         get: () => Math.min(
           scrollTop,
-          Math.max(0, naturalScrollHeight + spacerHeight() - 600),
+          Math.max(0, naturalScrollHeight + spacerHeight() - clientHeight),
         ),
         set: (value: number) => { scrollTop = value },
       })
@@ -2497,6 +2498,7 @@ describe('MessageList', () => {
         get scrollTop() { return el.scrollTop },
         setScrollTop(value: number) { scrollTop = value },
         setNaturalScrollHeight(value: number) { naturalScrollHeight = value },
+        setClientHeight(value: number) { clientHeight = value },
       }
     }
 
@@ -2546,6 +2548,73 @@ describe('MessageList', () => {
       )
       expect(geometry.scrollTop).toBe(1099)
       expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+    })
+
+    it('does not read the send-time collapse clamp as an escape', async () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+
+      // The finished turn collapsing above the ghost (same commit as the
+      // send) shrinks content, and the browser clamps scrollTop — a
+      // browser-originated upward scroll event with no user gesture behind
+      // it. It must not latch an escape and surface the pill over the blank
+      // reading-line reserve.
+      geometry.setScrollTop(900)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+    })
+
+    it('does not read the idle-time turn collapse clamp as an escape', async () => {
+      installFakeResizeObserver()
+      // An active turn with collapsible work, reader at the live edge.
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Long question' } }),
+        createAssistantMessage({
+          content: { text: 'Final answer' },
+          toolCalls: [createToolCall({ name: 'Bash' })],
+        }),
+      ]
+      mockStreamState.isActive = true
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el) // baseline at the live edge
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+
+      // The turn completes: the work collapses into a summary row — a large
+      // one-commit shrink whose browser clamp fires an upward scroll event
+      // with no user gesture behind it.
+      mockStreamState.isActive = false
+      rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getByTestId('turn-summary')).toBeInTheDocument()
+      geometry.setNaturalScrollHeight(900)
+      geometry.setScrollTop(300)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+
+      // The final answer then renders below the summary and grows the
+      // content. Following must still be engaged: the reader is carried to
+      // the full response, with no stranded escape affordance.
+      geometry.setNaturalScrollHeight(1600)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1600)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(999))
       expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
     })
 
@@ -2750,6 +2819,42 @@ describe('MessageList', () => {
       })
       await waitFor(() => expect(geometry.scrollTop).toBe(999))
       expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+    })
+
+    it('keeps the live edge pinned when the viewport shrinks, but not while escaped', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      // The component's own observer watches the viewport (`el`); the follow
+      // library's watches only the content wrapper and never sees this.
+      const fireViewportResize = () => fireContentResize(el, 0)
+
+      // At the live edge, a vertical shrink keeps the newest content at the
+      // bottom (content leaves from the top, not the bottom): the pin writes
+      // scrollTop to the new target, 1300 - 1 - 450.
+      geometry.setClientHeight(450)
+      fireViewportResize()
+      expect(geometry.scrollTop).toBe(849)
+
+      // Let the resize's classification shield drain (one frame + a tick)
+      // before gesturing, mirroring a real pause between resize and scroll.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+
+      // Escaped readers keep their place instead: browsers anchor the top
+      // edge on resize, and the pin must not yank them to the bottom.
+      fireEvent.scroll(el)
+      geometry.setScrollTop(500)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+      geometry.setClientHeight(300)
+      fireViewportResize()
+      expect(geometry.scrollTop).toBe(500)
     })
   })
 

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2660,6 +2660,86 @@ describe('MessageList', () => {
       expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
     })
 
+    it('honors a keyboard escape whose scroll classification the collapse shield swallowed', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Long question' } }),
+        createAssistantMessage({
+          content: { text: 'Final answer' },
+          toolCalls: [createToolCall({ name: 'Bash' })],
+        }),
+      ]
+      mockStreamState.isActive = true
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el) // baseline at the live edge
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+
+      // The turn completes and collapses — the transition shield arms, and the
+      // browser clamp's echo is rightly discarded…
+      mockStreamState.isActive = false
+      rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      geometry.setNaturalScrollHeight(900)
+      geometry.setScrollTop(300)
+      fireEvent.scroll(el)
+
+      // …but inside the same window the reader pages up. The shield swallows
+      // that scroll's classification too (only wheel escapes bypass it), so
+      // the deferred verification must recognize the upward gesture and mark
+      // the escape itself.
+      fireEvent.keyDown(el, { key: 'PageUp' })
+      geometry.setScrollTop(100)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+
+      // Following stays disengaged: later growth must not pull the reader
+      // back down to the live edge.
+      geometry.setNaturalScrollHeight(1600)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1600)
+      })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+      expect(geometry.scrollTop).toBe(100)
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+    })
+
+    it('does not let the reserve restore preempt the send glide before its first frame', () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      // Real motion: the send scrolls via the animated glide, which the
+      // library only registers in its first animation frame.
+      const geometry = mockTurnGeometry(el, { reducedMotion: false })
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+      expect(geometry.scrollTop).toBe(700) // pre-glide position; the glide travels from here
+
+      // The POST response assigns the uuid before the glide's first frame —
+      // a commit in the gap where state.animation is still unset. The reserve
+      // restore must not fire here and snap the viewport to the reading line.
+      rerender(
+        <MessageList
+          sessionId="s-1"
+          agentSlug="agent-1"
+          pendingUserMessages={[{ ...pending, uuid: 'server-uuid-1' }]}
+        />,
+      )
+      expect(geometry.scrollTop).toBe(700)
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+    })
+
     it('spends the reserved room before following streamed content at the live edge', async () => {
       installFakeResizeObserver()
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -413,6 +413,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     scrollRef,
     contentRef,
     scrollToBottom: stickScrollToBottom,
+    stopScroll: stickStopScroll,
     isAtBottom,
     state: stickState,
   } = useStickToBottom({
@@ -425,7 +426,17 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
   const lastScrollTopRef = useRef(0)
   const lastGestureAtRef = useRef(0)
+  // Stamped when a gesture-attributed scroll event actually moved the reader
+  // upward — a stronger signal than lastGestureAtRef (which a downward wheel
+  // also stamps), used to honor escapes the transition shield swallowed.
+  const lastUpwardGestureAtRef = useRef(0)
   const pointerDownRef = useRef(false)
+  // True from a send until its scroll-to-reading-line settles. The library
+  // only assigns state.animation in its first animation frame, so this is the
+  // signal that covers the whole interval (a commit landing between the send
+  // effect and that first frame would otherwise let the reserve restore
+  // preempt the glide with an instant jump).
+  const sendScrollInFlightRef = useRef(false)
 
   // How many trailing (visible) messages to render. Grows on scroll-up and while
   // the user is scrolled up during streaming. Starts at BASE_WINDOW; the component
@@ -563,9 +574,25 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         pointerDownRef.current || lastGestureAtRef.current >= transitionAt
       if (!gestured && !stickState.isAtBottom) {
         void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
+        return
+      }
+      // The shield cuts both ways: while it holds, the library also discards
+      // the scroll classification of genuine keyboard, touch, and scrollbar
+      // escapes (wheel-up escapes through its own handler and is unaffected).
+      // If a gesture moved the reader upward during the window yet following
+      // still reads engaged and they are beyond the re-stick range, that
+      // escape was swallowed — honor it, or the next growth would yank them
+      // back down. Reserve eating is unaffected: it re-bases the reading line
+      // onto the reader, keeping them within the re-stick range.
+      if (
+        stickState.isAtBottom &&
+        lastUpwardGestureAtRef.current >= transitionAt &&
+        !stickState.isNearBottom
+      ) {
+        stickStopScroll()
       }
     }, 40)
-  }, [stickState, stickScrollToBottom])
+  }, [stickState, stickScrollToBottom, stickStopScroll])
 
   // Keep the newly-sent turn fixed at its reading line while the response uses
   // up the reserved room below it. The spacer inflates scrollHeight so that the
@@ -573,7 +600,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // the reader simply sits at the bottom, and content growth paired with an
   // equal spacer shrink is a net-zero resize — no motion. Once the reserve
   // reaches zero the anchor retires and real growth resumes normal following.
-  const syncTurnReserve = useCallback((options?: { skipRestore?: boolean }) => {
+  const syncTurnReserve = useCallback(() => {
     const el = scrollRef.current
     const anchoredTurn = anchoredTurnRef.current
     if (!el || !anchoredTurn) return
@@ -596,15 +623,16 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // it back until content grows again, so the held turn visibly sags. The
     // anchored reading line IS the scroll target while the reserve holds, so
     // put the viewport back on it. Skip while the reader is gesturing (their
-    // scroll owns the position — reserve eating re-bases the anchor) and
-    // while a scroll animation is in flight (the send glide starts below the
-    // target by construction).
+    // scroll owns the position — reserve eating re-bases the anchor), while a
+    // send's scroll to the reading line is pending or animating (it starts
+    // below the target by construction), and while any other scroll
+    // animation is in flight.
     const gestureDriven =
       pointerDownRef.current ||
       performance.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
     const target = Math.max(0, stickState.calculatedTargetScrollTop)
     if (
-      !options?.skipRestore &&
+      !sendScrollInFlightRef.current &&
       !gestureDriven &&
       stickState.isAtBottom &&
       !stickState.animation &&
@@ -648,6 +676,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     const anchoredTurn = anchoredTurnRef.current
     const upwardDelta = Math.max(0, previousScrollTop - el.scrollTop)
     const downwardDelta = Math.max(0, el.scrollTop - previousScrollTop)
+    if (gestureDriven && upwardDelta > 0) {
+      lastUpwardGestureAtRef.current = performance.now()
+    }
     if (gestureDriven && anchoredTurn && upwardDelta > 0 && bottomSpacerHeightRef.current > 0) {
       const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
       const remainingSpacer = bottomSpacerHeightRef.current - discard
@@ -1155,11 +1186,14 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         setBottomSpacerHeight(0)
       }
 
+      // The viewport intentionally sits below the new reading line until the
+      // scroll below travels there — hold the reserve restore off for the
+      // whole interval (state.animation alone starts too late: the library
+      // assigns it in its first animation frame, and a commit can land first).
+      sendScrollInFlightRef.current = true
       // Size the reserve before scrolling so the scroll target IS the new
       // turn's reading line (the spacer inflates scrollHeight to end there).
-      // Skip the reading-line restore: this call runs with the viewport still
-      // at the pre-send position on purpose — the glide below travels there.
-      syncTurnReserve({ skipRestore: true })
+      syncTurnReserve()
       // The collapse of the finished turn above (same commit as the ghost)
       // shrinks content and can clamp scrollTop — guard the transition so
       // that clamp echo cannot latch an escape under the send.
@@ -1170,7 +1204,11 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       if (prefersReducedMotion()) {
         stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
       }
-      void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
+      void Promise.resolve(
+        stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined),
+      ).finally(() => {
+        sendScrollInFlightRef.current = false
+      })
       // Programmatic writes fire their scroll event asynchronously (and not at
       // all in jsdom) — resync the gesture-delta baseline now so the write
       // isn't misread as a user delta.
@@ -1237,8 +1275,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       }
       lastContentHeight = contentHeight
       cancelAnimationFrame(frameId)
-      // Wrapped so the rAF timestamp doesn't arrive as the options argument.
-      frameId = requestAnimationFrame(() => syncTurnReserve())
+      frameId = requestAnimationFrame(syncTurnReserve)
     })
     observer.observe(content)
     observer.observe(viewport)

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -532,6 +532,41 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     spacer.hidden = nextHeight === 0
   }, [])
 
+  // A programmatic follow transition — the send-anchor scroll (where the
+  // previous turn collapses to a summary row and content shrinks above), or a
+  // viewport re-pin — can coincide with a browser clamp whose scroll event
+  // reads as the reader scrolling up. Two defenses: shield the library's
+  // deferred classification across the transition (it skips scroll events
+  // while a resize is in flight), and verify shortly after — an escape with
+  // no user gesture inside the window can only be such an echo, so reverse
+  // it. Real gestures (wheel, touch, held pointer, scroll keys) suppress the
+  // reversal, so a reader who actually leaves during the window stays left.
+  const verifyFollowTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  useEffect(() => () => clearTimeout(verifyFollowTimerRef.current), [])
+  const protectFollowTransition = useCallback(() => {
+    if (stickState.resizeDifference === 0) {
+      stickState.resizeDifference = 1
+      // Mirror the library's own reset: the clamp's deferred classification
+      // (a tick after its scroll event) must land inside the shield, so drop
+      // it a frame + a tick later. The guard keeps a concurrent real content
+      // resize's value intact.
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          if (stickState.resizeDifference === 1) stickState.resizeDifference = 0
+        }, 1)
+      })
+    }
+    const transitionAt = performance.now()
+    clearTimeout(verifyFollowTimerRef.current)
+    verifyFollowTimerRef.current = setTimeout(() => {
+      const gestured =
+        pointerDownRef.current || lastGestureAtRef.current >= transitionAt
+      if (!gestured && !stickState.isAtBottom) {
+        void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
+      }
+    }, 40)
+  }, [stickState, stickScrollToBottom])
+
   // Keep the newly-sent turn fixed at its reading line while the response uses
   // up the reserved room below it. The spacer inflates scrollHeight so that the
   // reading line IS the scroll target: from the follow library's perspective
@@ -1010,6 +1045,18 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     hasTurnStartingPendingMessage,
   ])
 
+  // A turn completing collapses its whole work phase into a summary row — a
+  // massive one-commit shrink whose browser clamp reads as the reader
+  // scrolling up, stranding the viewport above the final answer. Guard the
+  // transition from the same commit (this runs before the clamp's scroll
+  // event can dispatch, so the shield is race-free here).
+  const prevCompletedTurnCountRef = useRef(completedTurns.length)
+  useLayoutEffect(() => {
+    const grew = completedTurns.length > prevCompletedTurnCountRef.current
+    prevCompletedTurnCountRef.current = completedTurns.length
+    if (grew && stickState.isAtBottom) protectFollowTransition()
+  }, [completedTurns, stickState, protectFollowTransition])
+
   // Drop expansion state for turns that no longer exist after edits/refetches.
   useEffect(() => {
     const validIds = new Set(completedTurns.map((turn) => turn.id))
@@ -1083,6 +1130,10 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       // Size the reserve before scrolling so the scroll target IS the new
       // turn's reading line (the spacer inflates scrollHeight to end there).
       syncTurnReserve()
+      // The collapse of the finished turn above (same commit as the ghost)
+      // shrinks content and can clamp scrollTop — guard the transition so
+      // that clamp echo cannot latch an escape under the send.
+      protectFollowTransition()
       // A send always returns the reader to the thread: re-engage following
       // and glide to the reading line (or the live edge for queued sends).
       // Under reduced motion, position synchronously instead of gliding.
@@ -1112,6 +1163,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     scrollRef,
     stickState,
     stickScrollToBottom,
+    protectFollowTransition,
     bottomInset,
   ])
 
@@ -1124,7 +1176,36 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     const viewport = scrollRef.current
     if (!content || !viewport || typeof ResizeObserver === 'undefined') return
     let frameId = 0
+    let lastViewportHeight = viewport.clientHeight
+    let lastContentHeight = content.offsetHeight
     const observer = new ResizeObserver(() => {
+      // A vertical viewport resize is invisible to the follow library (it
+      // observes only the content element), and browsers anchor the TOP edge
+      // on resize — so a window shrink would slide the live edge behind the
+      // fold. Re-pin immediately while following, guarded against the grow
+      // clamp's scroll echo being read as an escape (a viewport GROW lowers
+      // the scroll range, and the browser's clamp fires a scroll event that
+      // classifies as the reader scrolling up). During the turn reserve the
+      // spacer math already keeps the reading line valid, so no pin there.
+      const viewportHeight = viewport.clientHeight
+      if (viewportHeight !== lastViewportHeight) {
+        lastViewportHeight = viewportHeight
+        if (stickState.isAtBottom && !anchoredTurnRef.current) {
+          protectFollowTransition()
+          stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
+          lastScrollTopRef.current = viewport.scrollTop
+        }
+      }
+      // Catch-all for content shrinks at the live edge (a thinking card
+      // collapsing, a streamed block swapped for its shorter persisted form):
+      // each one clamps scrollTop and can latch a spurious escape the same
+      // way. The commit-hooked guards cover the big known transitions
+      // race-free; this covers the rest via the deferred verification.
+      const contentHeight = content.offsetHeight
+      if (contentHeight < lastContentHeight && stickState.isAtBottom) {
+        protectFollowTransition()
+      }
+      lastContentHeight = contentHeight
       cancelAnimationFrame(frameId)
       frameId = requestAnimationFrame(syncTurnReserve)
     })
@@ -1134,7 +1215,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       cancelAnimationFrame(frameId)
       observer.disconnect()
     }
-  }, [syncTurnReserve, scrollRef, isLoading, error])
+  }, [syncTurnReserve, scrollRef, stickState, protectFollowTransition, isLoading, error])
 
   // Escape from following is owned by the stick-to-bottom library (wheel
   // direction, scroll direction, selection). These stamps exist only so the

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -573,7 +573,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // the reader simply sits at the bottom, and content growth paired with an
   // equal spacer shrink is a net-zero resize — no motion. Once the reserve
   // reaches zero the anchor retires and real growth resumes normal following.
-  const syncTurnReserve = useCallback(() => {
+  const syncTurnReserve = useCallback((options?: { skipRestore?: boolean }) => {
     const el = scrollRef.current
     const anchoredTurn = anchoredTurnRef.current
     if (!el || !anchoredTurn) return
@@ -585,8 +585,36 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     setBottomSpacerHeight(requiredSpacer)
     // The response now fills the viewport. Retire the special turn state so
     // long-thread windowing can return to its bounded trailing slice.
-    if (requiredSpacer === 0) anchoredTurnRef.current = null
-  }, [scrollRef, setBottomSpacerHeight])
+    if (requiredSpacer === 0) {
+      anchoredTurnRef.current = null
+      return
+    }
+    // A transient content shrink during the reserve hold (a working indicator
+    // swapping forms, a streamed block replaced by its shorter persisted copy)
+    // clamps scrollTop below the reading line for the instant before the
+    // spacer write above re-inflates the scroll range — and nothing else moves
+    // it back until content grows again, so the held turn visibly sags. The
+    // anchored reading line IS the scroll target while the reserve holds, so
+    // put the viewport back on it. Skip while the reader is gesturing (their
+    // scroll owns the position — reserve eating re-bases the anchor) and
+    // while a scroll animation is in flight (the send glide starts below the
+    // target by construction).
+    const gestureDriven =
+      pointerDownRef.current ||
+      performance.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
+    const target = Math.max(0, stickState.calculatedTargetScrollTop)
+    if (
+      !options?.skipRestore &&
+      !gestureDriven &&
+      stickState.isAtBottom &&
+      !stickState.animation &&
+      el.scrollTop < target
+    ) {
+      protectFollowTransition()
+      stickState.scrollTop = target
+      lastScrollTopRef.current = el.scrollTop
+    }
+  }, [scrollRef, setBottomSpacerHeight, stickState, protectFollowTransition])
 
   // Pin the viewport to the live edge before first paint. The library's own
   // initial scroll runs from its ResizeObserver callback, which lands after
@@ -1129,7 +1157,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
 
       // Size the reserve before scrolling so the scroll target IS the new
       // turn's reading line (the spacer inflates scrollHeight to end there).
-      syncTurnReserve()
+      // Skip the reading-line restore: this call runs with the viewport still
+      // at the pre-send position on purpose — the glide below travels there.
+      syncTurnReserve({ skipRestore: true })
       // The collapse of the finished turn above (same commit as the ghost)
       // shrinks content and can clamp scrollTop — guard the transition so
       // that clamp echo cannot latch an escape under the send.
@@ -1207,7 +1237,8 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       }
       lastContentHeight = contentHeight
       cancelAnimationFrame(frameId)
-      frameId = requestAnimationFrame(syncTurnReserve)
+      // Wrapped so the rAF timestamp doesn't arrive as the options argument.
+      frameId = requestAnimationFrame(() => syncTurnReserve())
     })
     observer.observe(content)
     observer.observe(viewport)


### PR DESCRIPTION
Follow-up to #784. Fixes three regressions from the `use-stick-to-bottom` migration, all instances of one bug family: **clamp-echo escapes**. When the scroll range shrinks while pinned to the live edge, the browser clamps `scrollTop`; the clamp's scroll event is byte-identical to a user scrolling up, so the library classified it as the reader escaping — silently killing follow and/or showing a stale "Scroll to bottom" pill.

## The three transitions

1. **Vertical viewport shrink** — the library's ResizeObserver watches only the content element, so window resizes never re-pinned; browsers anchor the top edge, sliding the newest content behind the fold. Growing the window back also produced a grow-clamp misread as an escape.
2. **Send-time turn collapse** — the finished turn collapsing (same commit as the optimistic message) shrank content → clamp → spurious escape → pill shown over the blank new-turn reserve, and the reserve→follow handoff started disengaged.
3. **Idle-time turn collapse** — the "Worked for Nm" summary swallowing the turn's tool cards clamped `scrollTop` and stranded the reader above the final answer.

## The fix

A shared `protectFollowTransition()` guard with two layers, called from the send effect, the viewport-resize pin, and a `completedTurns`-growth layout effect:

- **Shield**: extend the library's own `resizeDifference` window across the transition so the clamp echo is discarded by its scroll classification (commit-hooked where possible, so it's race-free).
- **Verification backstop**: 40ms later, if follow reads escaped-at-bottom and no user gesture (wheel/touch/keys/held pointer) happened since the transition, reverse the escape via `scrollToBottom`. A real gesture suppresses the reversal, so user intent always wins. This covers the ~1-in-8 case where ResizeObserver delivery slips a frame behind the clamp event.

Plus the viewport RO now re-pins on viewport height changes (`state.scrollTop` write, marked as the library's own) and a catch-all guards any content shrink at the bottom — thinking-card collapses, streamed→persisted swaps, and future shrink sources.

## Verification

- Every guard is negative-tested: disabling it makes a specific test fail deterministically (the resize shield: 2/2 E2E failures without it; the idle-collapse guard: unit test red with the guard short-circuited).
- New E2E: `keeps the live edge pinned through vertical window resizes` — shrink 250px → still pinned, grow back → still pinned, stream continues → still following, no pill. 10/10 serial passes.
- New unit tests for all three transitions (viewport shrink pin + escaped-stays-put, send-collapse clamp → no pill, idle-collapse clamp → growth still followed to bottom + no pill), via a controllable FakeResizeObserver harness.
- Full suite: transcript-follow E2E 9/9 across 3 serial repeats; messages-dir unit tests 796/796 (51 files); typecheck + lint clean (including `e2e/`).

https://claude.ai/code/session_01GGDfc6bd4NeNio2DwmBT39