### PR TITLE
Rename Cloud Workspace to Cloud Agents, lead Account with workspace

### DIFF
--- a/src/renderer/components/settings/platform-tab.tsx
+++ b/src/renderer/components/settings/platform-tab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { ArrowUpRight, BadgeX, Loader2, RefreshCw } from 'lucide-react'
+import { ArrowUpRight, BadgeX, ChevronsUpDown, Loader2, RefreshCw } from 'lucide-react'
 
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { Button } from '@renderer/components/ui/button'
@@ -196,7 +196,7 @@ function CloudWorkspaceCard({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between px-1">
-        <h3 className="text-xs font-medium text-muted-foreground">Cloud Workspace</h3>
+        <h3 className="text-xs font-medium text-muted-foreground">Cloud Agents</h3>
         <Button
           size="sm"
           variant="ghost"
@@ -213,11 +213,11 @@ function CloudWorkspaceCard({
         {isLoading ? (
           <div className="flex items-center gap-2 py-6 px-4 text-xs text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
-            Loading cloud workspace…
+            Loading cloud agents…
           </div>
         ) : data?.found && data.deploymentUrl ? (
           <SettingRow
-            name="Cloud workspace"
+            name="Cloud agents"
             subtitle={data.deploymentUrl}
             right={
               <Button
@@ -235,8 +235,8 @@ function CloudWorkspaceCard({
           // exists. Offer a retry — claiming "none yet" here would push the user
           // to create a second one.
           <SettingRow
-            name="Cloud workspace"
-            subtitle="Couldn't check for a cloud workspace right now"
+            name="Cloud agents"
+            subtitle="Couldn't check for cloud agents right now"
             right={
               <Button
                 size="sm"
@@ -252,8 +252,8 @@ function CloudWorkspaceCard({
           // Discovery succeeded and listed none — CTA to create one on the web
           // dashboard.
           <SettingRow
-            name="Cloud workspace"
-            subtitle="No cloud workspace yet for this organization"
+            name="Cloud agents"
+            subtitle="No cloud agents yet for this organization"
             right={
               <Button
                 size="sm"
@@ -267,7 +267,7 @@ function CloudWorkspaceCard({
                 }}
                 disabled={!platformBaseUrl || !orgId}
               >
-                Create workspace
+                Set up cloud agents
                 <HoverArrow />
               </Button>
             }
@@ -487,12 +487,26 @@ export function PlatformTab({ readOnly = false }: PlatformTabProps) {
       {isConnected && (
         <div className={CARD_CLASS}>
           <SettingRow
-            name="Email"
-            right={<span className={valueClass}>{data?.email ?? '—'}</span>}
+            name="Workspace"
+            right={
+              // Switching workspaces means re-authenticating, so this opens the
+              // same platform login the Reconnect button below launches.
+              <button
+                type="button"
+                onClick={() => {
+                  void handleConnect()
+                }}
+                disabled={readOnly || isLaunching}
+                className="flex items-center gap-1 max-w-[260px] rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+              >
+                <span className="truncate">{data?.orgName ?? '—'}</span>
+                <ChevronsUpDown className="h-3 w-3 shrink-0 text-foreground" aria-hidden />
+              </button>
+            }
           />
           <SettingRow
-            name="Organization"
-            right={<span className={valueClass}>{data?.orgName ?? '—'}</span>}
+            name="Email"
+            right={<span className={valueClass}>{data?.email ?? '—'}</span>}
           />
           <SettingRow
             name="Role"

--- a/src/renderer/components/settings/platform-tab.tsx
+++ b/src/renderer/components/settings/platform-tab.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRight, BadgeX, ChevronsUpDown, Loader2, RefreshCw } from 'lucide
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Progress } from '@renderer/components/ui/progress'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { RequestError } from '@renderer/components/messages/request-error'
@@ -306,6 +307,47 @@ function HoverArrow() {
   )
 }
 
+interface WorkspaceSwitcherProps {
+  orgName: string
+  /** Re-auth is rejected in auth mode and pointless mid-launch — see ReconnectRow. */
+  switchDisabled: boolean
+  onSwitch: () => void
+}
+
+function WorkspaceSwitcher({ orgName, switchDisabled, onSwitch }: WorkspaceSwitcherProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-expanded={open}
+          className="flex items-center gap-1 max-w-[260px] rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <span className="truncate">{orgName}</span>
+          <ChevronsUpDown className="h-3 w-3 shrink-0 text-foreground" aria-hidden />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-auto p-1">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="w-full justify-between gap-6 text-xs font-normal"
+          disabled={switchDisabled}
+          onClick={() => {
+            setOpen(false)
+            onSwitch()
+          }}
+        >
+          Switch workspace
+          <ArrowUpRight className="h-3.5 w-3.5 shrink-0" />
+        </Button>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 function AccessKeyInput({ onClose }: { onClose: () => void }) {
   const [key, setKey] = useState('')
   const saveKey = useSavePlatformAccessKey()
@@ -489,19 +531,13 @@ export function PlatformTab({ readOnly = false }: PlatformTabProps) {
           <SettingRow
             name="Workspace"
             right={
-              // Switching workspaces means re-authenticating, so this opens the
-              // same platform login the Reconnect button below launches.
-              <button
-                type="button"
-                onClick={() => {
-                  void handleConnect()
-                }}
-                disabled={readOnly || isLaunching}
-                className="flex items-center gap-1 max-w-[260px] rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
-              >
-                <span className="truncate">{data?.orgName ?? '—'}</span>
-                <ChevronsUpDown className="h-3 w-3 shrink-0 text-foreground" aria-hidden />
-              </button>
+              // Switching workspaces means re-authenticating, so the popover's
+              // action opens the same platform login Reconnect below launches.
+              <WorkspaceSwitcher
+                orgName={data?.orgName ?? '—'}
+                switchDisabled={readOnly || isLaunching}
+                onSwitch={handleConnect}
+              />
             }
           />
           <SettingRow


### PR DESCRIPTION
## What

Settings → Account, two changes to the same screen.

**Cloud Workspace → Cloud Agents.** The deployment card's user-facing copy is renamed: section heading, all three row states (found / discovery-failed / empty), the loading line, and the empty-state CTA ("Create workspace" → "Set up cloud agents"). Internal names — `CloudWorkspaceCard`, `useCloudWorkspace`, the `cloud-workspace-*` modules and `docs/cloud-workspace.md` — are untouched. This is terminology, not a refactor.

**The account card now leads with the workspace.** The org row moves above Email, is relabelled "Workspace", and its value becomes a popover trigger:

- The trigger shows the workspace name with `ChevronsUpDown`, the picker affordance already used in `timezone-picker.tsx` and `users-tab.tsx`.
- The popover holds one action — **Switch workspace** with a trailing `ArrowUpRight` — which opens the same platform login the Reconnect button below launches (`handleConnect`), since switching workspaces means re-authenticating.
- Gating sits on that action, not the trigger: opening the popover is harmless, while the button keeps the `readOnly || isLaunching` conditions copied from `ReconnectRow`. In auth mode the API rejects this flow (`rejectMutationInAuthMode`), so offering it there would only produce a failure.

## Note

`handleConnect` revokes the existing token before reopening login, so switching drops the current session on the way to re-auth. That is inherent to reusing the Reconnect path rather than new behavior here — the popover exists so that step is deliberate rather than one stray click on something that reads as a label.

## Testing

- `npm run typecheck` and `eslint` clean
- `vitest run src/renderer/components/settings` — 20 files, 131 tests passing
- Ran the Electron dev app against staging (`PLATFORM_BASE_URL=https://platform.gamutstaging.com` + proxy/issuer). `/api/platform-auth` confirmed the staging base URL and a live connected session (`orgName: "Skew Dog"`), so the card rendered its connected state. Screen access for a screenshot was declined, so the rendering was not visually verified from my side.

## Out of scope

Two other user-facing "Cloud workspace" strings remain — the quick-dispatch cloud banner and the dashboard window title (asserted in `dashboard-window.cloud.test.ts`). Say the word and I'll fold them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)