### PR TITLE
feat(analytics): tag agent_created with has_template_prompt

### DIFF
--- a/src/renderer/components/agents/agent-template-browse-dialog.tsx
+++ b/src/renderer/components/agents/agent-template-browse-dialog.tsx
@@ -43,7 +43,11 @@ export function AgentTemplateBrowseDialog({
 
   const handleInstalled = useCallback(
     async (agent: ApiAgentTemplateInstallResult) => {
-      track('agent_created', { source: 'skillset', num_skills_added_at_creation: 0 })
+      track('agent_created', {
+        source: 'skillset',
+        num_skills_added_at_creation: 0,
+        has_template_prompt: Boolean(agent.templatePrompt),
+      })
       await queryClient.refetchQueries({ queryKey: ['agents'] })
       await completeAgentTemplateHandoff({
         draftsStore,

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -176,7 +176,11 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
       source: 'import' | 'skillset',
     ) => {
       await discardWarmAgent()
-      track('agent_created', { source, num_skills_added_at_creation: 0 })
+      track('agent_created', {
+        source,
+        num_skills_added_at_creation: 0,
+        has_template_prompt: Boolean(agent.templatePrompt),
+      })
       await completeAgentTemplateHandoff({
         draftsStore,
         agentSlug: agent.slug,

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -119,8 +119,11 @@ export function useImportAgentTemplate() {
         onProgress,
       })
     },
-    onSuccess: () => {
-      track('agent_created', { source: 'file_import' })
+    onSuccess: (result) => {
+      track('agent_created', {
+        source: 'file_import',
+        has_template_prompt: Boolean(result.templatePrompt),
+      })
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
     },
@@ -154,8 +157,11 @@ export function useInstallAgentFromSkillset() {
       }
       return res.json()
     },
-    onSuccess: () => {
-      track('agent_created', { source: 'skillset' })
+    onSuccess: (result) => {
+      track('agent_created', {
+        source: 'skillset',
+        has_template_prompt: Boolean(result.templatePrompt),
+      })
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['discoverable-agents'] })
       queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })


### PR DESCRIPTION
## What

Adds a `has_template_prompt` boolean to `agent_created` at the four template-install call sites (create-agent form import/skillset, browse dialog, file-import and skillset-install mutations).

## Why

Since #788 (SUP-610, shipped in 0.5.8), templates carrying a root PROMPT.md skip the onboarding auto-session — `completeAgentTemplateHandoff` seeds the composer instead of calling `startOnboardingSession`, so `session_created`/`message_sent` only fire if the user actually sends. That makes a per-install dip in `session_created` expected, but today nothing marks which installs took the PROMPT.md path, so:
- SUP-610 adoption is unmeasurable, and
- the new "prompt seeded but never sent" drop-off is invisible.

`has_template_prompt` mirrors `completeAgentTemplateHandoff`'s own decision input (`agent.templatePrompt`). Untitled-agent and blank-form creation sites are untouched (no template involved).

Note: the pre-existing reserved-prop `source` usage and the skillset dialog/mutation double-emit at these sites are known open items and deliberately out of scope here.

## Tests

- `tsc --noEmit` clean.
- `create-agent-form.test.tsx`, `create-agent-form.handoff.test.tsx`, `use-agent-templates.slug.test.ts`, `template-install-dialog.test.tsx`: 37/37 pass.

Catalog CSV row for `agent_created` updated alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
