### PR TITLE
Expose Platform workspace icon in deployment auth API (SUP-625)

### DIFF
--- a/src/api/routes/platform-auth.test.ts
+++ b/src/api/routes/platform-auth.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+
+const mocks = vi.hoisted(() => ({
+  getEnrichedPlatformAuthStatus: vi.fn(),
+  getPlatformAuthStatus: vi.fn(),
+}))
+
+vi.mock('../middleware/auth', () => ({
+  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+vi.mock('@shared/lib/auth/config', () => ({
+  getCurrentUserId: () => 'ba-user',
+}))
+
+vi.mock('@shared/lib/auth/mode', () => ({
+  isAuthMode: () => true,
+}))
+
+vi.mock('@shared/lib/auth/auth-settings', () => ({
+  isPlatformControlledAuth: () => true,
+}))
+
+vi.mock('@shared/lib/platform-auth/config', () => ({
+  buildPlatformLoginUrl: () => 'https://platform.example/login',
+  getPlatformBaseUrl: () => 'https://platform.example',
+}))
+
+vi.mock('@shared/lib/services/platform-device-service', () => ({
+  getOrCreatePlatformClientInstanceId: () => 'client-instance',
+  getPlatformDeviceName: () => 'Test Device',
+}))
+
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getEnrichedPlatformAuthStatus: (...args: unknown[]) =>
+    mocks.getEnrichedPlatformAuthStatus(...args),
+  getPlatformAuthStatus: (...args: unknown[]) => mocks.getPlatformAuthStatus(...args),
+  savePlatformAuth: vi.fn(),
+  revokePlatformToken: vi.fn(),
+}))
+
+vi.mock('@shared/lib/services/download-nonce-service', () => ({
+  dismissDownloadNonceOffer: vi.fn(),
+  getDownloadNonceOffer: vi.fn(),
+  redeemDownloadNonce: vi.fn(),
+  DownloadNonceUnavailableError: class DownloadNonceUnavailableError extends Error {},
+}))
+
+vi.mock('@shared/lib/services/platform-service', () => ({
+  platformService: {
+    refreshBilling: vi.fn(),
+    getCachedBilling: vi.fn(),
+    getLastRefreshedAt: vi.fn(),
+  },
+}))
+
+vi.mock('@shared/lib/services/cloud-workspace-service', () => ({
+  getCloudWorkspace: vi.fn(),
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  setErrorReportingUser: vi.fn(),
+}))
+
+import platformAuth from './platform-auth'
+
+const CONNECTED_STATUS = {
+  connected: true,
+  tokenPreview: 'plat_s...cdef',
+  email: 'owner@example.com',
+  label: 'Managed by organization',
+  orgId: 'org_acme',
+  orgName: 'Acme Inc',
+  role: 'owner',
+  userId: 'user_1',
+  memberId: 'sub_1',
+  createdAt: null,
+  updatedAt: null,
+  source: 'env',
+}
+
+const DISCONNECTED_STATUS = {
+  connected: false,
+  tokenPreview: null,
+  email: null,
+  label: null,
+  orgId: null,
+  orgName: null,
+  role: null,
+  userId: null,
+  memberId: null,
+  createdAt: null,
+  updatedAt: null,
+  source: null,
+}
+
+function makeApp() {
+  const app = new Hono()
+  app.route('/api/platform-auth', platformAuth)
+  return app
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.getPlatformAuthStatus.mockReturnValue(CONNECTED_STATUS)
+})
+
+describe('GET /api/platform-auth workspace icon contract (SUP-625)', () => {
+  it('returns the configured Platform workspace icon with existing fields intact', async () => {
+    mocks.getEnrichedPlatformAuthStatus.mockResolvedValue({
+      ...CONNECTED_STATUS,
+      orgIconUrl: 'https://cdn.example.com/workspaces/acme.png',
+    })
+
+    const response = await makeApp().request('/api/platform-auth')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ...CONNECTED_STATUS,
+      orgIconUrl: 'https://cdn.example.com/workspaces/acme.png',
+      platformBaseUrl: 'https://platform.example',
+      platformControlled: true,
+    })
+    expect(mocks.getEnrichedPlatformAuthStatus).toHaveBeenCalledWith('ba-user')
+  })
+
+  it('returns null when the connected organization has no icon', async () => {
+    mocks.getEnrichedPlatformAuthStatus.mockResolvedValue({
+      ...CONNECTED_STATUS,
+      orgIconUrl: null,
+    })
+
+    const response = await makeApp().request('/api/platform-auth')
+
+    expect(await response.json()).toMatchObject({
+      connected: true,
+      orgName: 'Acme Inc',
+      orgIconUrl: null,
+    })
+  })
+
+  it('does not add the field to the disconnected response', async () => {
+    mocks.getEnrichedPlatformAuthStatus.mockResolvedValue(DISCONNECTED_STATUS)
+
+    const response = await makeApp().request('/api/platform-auth')
+    const body = await response.json()
+
+    expect(body.connected).toBe(false)
+    expect(body).not.toHaveProperty('orgIconUrl')
+  })
+
+  it('does not add the field to a settings-backed self-hosted response', async () => {
+    mocks.getEnrichedPlatformAuthStatus.mockResolvedValue({
+      ...CONNECTED_STATUS,
+      source: 'settings',
+    })
+
+    const response = await makeApp().request('/api/platform-auth')
+    const body = await response.json()
+
+    expect(body).toMatchObject({ connected: true, source: 'settings' })
+    expect(body).not.toHaveProperty('orgIconUrl')
+  })
+})

--- a/src/shared/lib/services/platform-auth-service.test.ts
+++ b/src/shared/lib/services/platform-auth-service.test.ts
@@ -139,6 +139,13 @@ describe('platform-auth-service', () => {
     expect(getPlatformAccessToken('local')).toBeNull()
   })
 
+  it('leaves the disconnected status contract unchanged', () => {
+    const status = getPlatformAuthStatus('local')
+
+    expect(status.connected).toBe(false)
+    expect(status).not.toHaveProperty('orgIconUrl')
+  })
+
   it('returns env-managed status with verified orgId after init', async () => {
     process.env.AUTH_MODE = 'true'
     process.env.PLATFORM_TOKEN = await signTestOrgToken('org_env')
@@ -516,7 +523,7 @@ describe('platform-auth-service', () => {
   // Env-managed (org-JWT) account enrichment via /v1/account introspection
   // ---------------------------------------------------------------------------
 
-  it('enriches env-managed status with email/orgName/role from /v1/account', async () => {
+  it('enriches env-managed status with the safe workspace icon from /v1/account', async () => {
     process.env.AUTH_MODE = 'true'
     process.env.PLATFORM_TOKEN = await signTestOrgToken('org_env')
     process.env.PLATFORM_PROXY_URL = 'http://proxy.test'
@@ -528,6 +535,7 @@ describe('platform-auth-service', () => {
           memberId: 'sub_member_1',
           orgId: 'org_env',
           orgName: 'Acme Inc',
+          orgIconUrl: 'https://cdn.example.com/workspaces/acme.png?token=do-not-forward#avatar',
           role: 'owner',
           userId: 'user_1',
           email: 'owner@example.com',
@@ -543,10 +551,74 @@ describe('platform-auth-service', () => {
       source: 'env',
       email: 'owner@example.com',
       orgName: 'Acme Inc',
+      orgIconUrl: 'https://cdn.example.com/workspaces/acme.png',
       role: 'owner',
     })
     // env-managed connections have no "last changed" anchor; updatedAt stays null.
     expect(status.updatedAt).toBeNull()
+  })
+
+  it('returns a null workspace icon when /v1/account has no icon field', async () => {
+    process.env.AUTH_MODE = 'true'
+    process.env.PLATFORM_TOKEN = await signTestOrgToken('org_env')
+    process.env.PLATFORM_PROXY_URL = 'http://proxy.test'
+    await initEnvManagedPlatformStatus()
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          memberId: 'sub_member_1',
+          orgId: 'org_env',
+          orgName: 'Acme Inc',
+          role: 'owner',
+          userId: 'user_1',
+          email: 'owner@example.com',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const status = await getEnrichedPlatformAuthStatus('ba-user')
+
+    expect(status).toMatchObject({
+      connected: true,
+      source: 'env',
+      orgName: 'Acme Inc',
+      orgIconUrl: null,
+    })
+  })
+
+  it.each([
+    '/private/workspace/icon.png',
+    'file:///private/workspace/icon.png',
+    'data:image/png;base64,c2VjcmV0',
+    'https://user:secret@cdn.example.com/icon.png',
+    'https://localhost/icon.png',
+    'https://127.0.0.1/icon.png',
+  ])('does not forward an unsafe workspace icon value: %s', async (orgIconUrl) => {
+    process.env.AUTH_MODE = 'true'
+    process.env.PLATFORM_TOKEN = await signTestOrgToken('org_env')
+    process.env.PLATFORM_PROXY_URL = 'http://proxy.test'
+    await initEnvManagedPlatformStatus()
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          memberId: 'sub_member_1',
+          orgId: 'org_env',
+          orgName: 'Acme Inc',
+          orgIconUrl,
+          role: 'owner',
+          userId: 'user_1',
+          email: 'owner@example.com',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const status = await getEnrichedPlatformAuthStatus('ba-user')
+
+    expect(status.orgIconUrl).toBeNull()
   })
 
   it('falls back to the base env-managed status when introspection fails', async () => {
@@ -628,6 +700,7 @@ describe('platform-auth-service', () => {
 
     expect(fetchSpy).not.toHaveBeenCalled()
     expect(status).toMatchObject({ source: 'settings', orgName: 'Stored Org', email: 'stored@example.com' })
+    expect(status).not.toHaveProperty('orgIconUrl')
   })
 
   // Helpers for the org-switch / lifecycle tests below.

--- a/src/shared/lib/services/platform-auth-service.ts
+++ b/src/shared/lib/services/platform-auth-service.ts
@@ -13,6 +13,7 @@ import { db } from '@shared/lib/db'
 import { authAccount } from '@shared/lib/db/schema'
 import { runWithRequestUser } from '@shared/lib/platform-attribution/request-context'
 import { clearCloudWorkspaceRecord } from '@shared/lib/platform-auth/cloud-workspace-record'
+import { isPrivateHost, tryParseUrl } from '@shared/lib/utils/url-safety'
 
 export type PlatformAuthRecord = PlatformAuthSettings
 
@@ -74,6 +75,12 @@ export interface PlatformAuthStatus {
   label: string | null
   orgId: string | null
   orgName: string | null
+  /**
+   * Public HTTPS workspace icon returned for Platform-managed deployments.
+   * Absent for disconnected and settings-backed/self-hosted connections; null
+   * means the connected organization has no safe icon configured.
+   */
+  orgIconUrl?: string | null
   role: string | null
   /** Global platform user identity (Supabase auth UUID) — used for analytics. */
   userId: string | null
@@ -358,7 +365,30 @@ export function getPlatformAuthStatus(userId?: string): PlatformAuthStatus {
 interface EnrichedEnvAccount {
   email: string | null
   orgName: string | null
+  orgIconUrl: string | null
   role: string | null
+}
+
+/**
+ * Defense in depth for an upstream display URL. Platform stores workspace
+ * icons in a public bucket, so URL credentials, private hosts, query strings,
+ * and fragments are neither needed nor safe to forward to native clients.
+ */
+function normalizeOrgIconUrl(value: string | null): string | null {
+  if (!value) return null
+  const url = tryParseUrl(value.trim())
+  if (
+    !url ||
+    url.protocol !== 'https:' ||
+    url.username.length > 0 ||
+    url.password.length > 0 ||
+    isPrivateHost(url.hostname)
+  ) {
+    return null
+  }
+  url.search = ''
+  url.hash = ''
+  return url.toString()
 }
 
 // Introspection is memoized per user: the Account screen re-fetches the status
@@ -384,7 +414,12 @@ async function introspectEnvManagedAccount(userId: string): Promise<EnrichedEnvA
         mapStatusError: (status) => ({ message: 'Account introspection failed', status }),
       }),
     )
-    return { email: account.email, orgName: account.orgName, role: account.role }
+    return {
+      email: account.email,
+      orgName: account.orgName,
+      orgIconUrl: normalizeOrgIconUrl(account.orgIconUrl),
+      role: account.role,
+    }
   } catch (error) {
     captureException(error, { tags: { area: 'platform-auth', op: 'introspect-env-account' } })
     return null
@@ -416,6 +451,7 @@ export async function getEnrichedPlatformAuthStatus(userId?: string): Promise<Pl
     ...base,
     email: account.email,
     orgName: account.orgName,
+    orgIconUrl: account.orgIconUrl,
     role: account.role,
   }
 }

--- a/src/shared/lib/types/skillset-schema.ts
+++ b/src/shared/lib/types/skillset-schema.ts
@@ -106,6 +106,9 @@ export const PlatformAccountInfoSchema = z.object({
   memberId: z.string(),
   orgId: z.string(),
   orgName: z.string().nullish().transform((v) => v ?? null),
+  // Added by newer Platform proxies. Nullish keeps deployments compatible
+  // during a rolling rollout where the upstream field may not exist yet.
+  orgIconUrl: z.string().nullish().transform((v) => v ?? null),
   role: z.string().nullish().transform((v) => v ?? null),
   userId: z.string(),
   email: z.string().nullish().transform((v) => v ?? null),


### PR DESCRIPTION
## Summary

- Extend authenticated `GET /api/platform-auth` with nullable `orgIconUrl` for env-managed Platform deployments.
- Consume the additive Platform `/v1/account` field while remaining compatible with older proxies that omit it.
- Validate the upstream value as a public HTTPS URL and strip credentials, query strings, and fragments before returning it to native clients.
- Keep disconnected and settings-backed/self-hosted response shapes unchanged.
- Document the optional field on the shared deployment response type and add route/service contract coverage.

## Dependency and rollout

Depends on [SkillfulAgents/platform#298](https://github.com/SkillfulAgents/platform/pull/298), which adds the producer field sourced from `organization.configurations.icon_url`. Deploy the Platform producer first; this consumer safely returns `null` while talking to an older proxy.

## Validation

- `npm run test:run -- src/shared/lib/services/platform-auth-service.test.ts src/api/routes/platform-auth.test.ts` — 45 tests passed
- `npm run typecheck`
- `npx eslint src/shared/lib/services/platform-auth-service.ts src/shared/lib/services/platform-auth-service.test.ts src/shared/lib/types/skillset-schema.ts src/api/routes/platform-auth.test.ts`

Linear: https://linear.app/datawizz/issue/SUP-625/expose-platform-workspace-icon-in-deployment-platform-auth-api
