### PR TITLE
fix: point desktop download links at updates.gamutagents.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SuperAgent is a super app for building and running personal agents. You can crea
 
 | Windows | Mac |
 |:-------:|:---:|
-| [Download for Windows](https://github.com/SkillfulAgents/SuperAgent/releases/latest/download/Superagent-Setup.exe) | [Download for Mac](https://github.com/SkillfulAgents/SuperAgent/releases/latest/download/Superagent-arm64.dmg) |
+| [Download for Windows](https://updates.gamutagents.com/download/win) | [Download for Mac](https://updates.gamutagents.com/download/mac) |
 
 **Features:**
 


### PR DESCRIPTION
The README's "Download for Windows" and "Download for Mac" buttons request `Superagent-Setup.exe` and `Superagent-arm64.dmg`. Release assets were renamed to `Gamut-*` at v0.4.0, so GitHub resolves `latest` to the newest tag and then 404s on the asset name. Both links have been dead for every release since. A customer hit this trying to download 0.5.8:

```
README "Download for Mac"
  -> /releases/latest/download/Superagent-arm64.dmg
  -> 302 -> /releases/download/v0.5.8/Superagent-arm64.dmg
  -> 404
```

This points both at the branded release host, which resolves to the current installer and survives future renames. Same URLs the dashboard already uses (`apps/web/src/getting-started.tsx`).

The "releases page" link on line 42 is unchanged - that page still works.

The published landing page at skillfulagents.github.io has the same two dead links; fixed in a companion PR.

https://claude.ai/code/session_016WJ1p5npPztQovA8YD6H8f
