### PR TITLE
Fix escaped browser preview tab titles

### DIFF
--- a/agent-container/src/chrome-target-title.test.ts
+++ b/agent-container/src/chrome-target-title.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { decodeChromeTargetTitle } from './chrome-target-title';
+
+describe('decodeChromeTargetTitle', () => {
+  it('decodes the entities escaped by Chrome target discovery', () => {
+    expect(decodeChromeTargetTitle('IAM &amp; Admin &lt;prod&gt; &quot;home&quot; &#39;one&#39;'))
+      .toBe('IAM & Admin <prod> "home" \'one\'');
+  });
+
+  it('decodes only one layer of escaping', () => {
+    expect(decodeChromeTargetTitle('Literal &amp;amp; text')).toBe('Literal &amp; text');
+  });
+
+  it('leaves unrelated entities and plain titles unchanged', () => {
+    expect(decodeChromeTargetTitle('Research & development &copy;')).toBe('Research & development &copy;');
+  });
+});

--- a/agent-container/src/chrome-target-title.ts
+++ b/agent-container/src/chrome-target-title.ts
@@ -1,0 +1,15 @@
+const CHROME_HTML_ENTITIES: Record<string, string> = {
+  '&lt;': '<',
+  '&gt;': '>',
+  '&amp;': '&',
+  '&quot;': '"',
+  '&#39;': "'",
+};
+
+/**
+ * Chrome HTML-escapes page titles returned by its `/json` discovery endpoint.
+ * Undo exactly that escaping before forwarding the title to the browser preview.
+ */
+export function decodeChromeTargetTitle(title: string): string {
+  return title.replace(/&(lt|gt|amp|quot|#39);/g, entity => CHROME_HTML_ENTITIES[entity]);
+}

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -44,6 +44,7 @@ import {
 import { getEditingCommands } from './cdp-editing-commands';
 import { CREDENTIAL_AUTOFILL_FUNCTION } from './credential-autofill-script';
 import { selectActivePageTarget } from './active-page-target';
+import { decodeChromeTargetTitle } from './chrome-target-title';
 
 // Global error handlers to prevent crashes from AbortError during interrupts
 // The SDK throws AbortError when queries are aborted, which can propagate uncaught
@@ -2217,7 +2218,7 @@ async function getAllPageTargets(): Promise<PageTarget[]> {
       return pages.map(p => ({
         id: p.id,
         url: p.url,
-        title: p.title || '',
+        title: decodeChromeTargetTitle(p.title || ''),
         wsUrl: p.webSocketDebuggerUrl,
         requiresSession: false,
       }));


### PR DESCRIPTION
## Summary

- decode Chrome's HTML-escaped target titles before forwarding them to the browser preview
- decode exactly one layer of the five entities emitted by Chrome, preserving intentionally literal entity text
- add regression coverage for escaped, double-escaped, unrelated, and plain titles

## Root cause

Chrome's `/json` target-discovery endpoint HTML-escapes page titles. The preview received that escaped value and React safely rendered it as literal text, so titles such as `IAM & Admin` appeared as `IAM &amp; Admin`.

## User impact

Browser preview tabs now display the same human-readable title as the underlying browser tab, including ampersands, quotes, apostrophes, and angle brackets.

## Validation

- `npm test -- src/chrome-target-title.test.ts`
- `npm run build`
