### PR TITLE
Consolidate dashboard chrome and breadcrumb overflow

### DIFF
--- a/src/renderer/components/dashboards/dashboard-header-actions.tsx
+++ b/src/renderer/components/dashboards/dashboard-header-actions.tsx
@@ -1,0 +1,73 @@
+import { Dock, ExternalLink, Loader2, RefreshCw } from 'lucide-react'
+import { useDashboardHeader } from '@renderer/context/dashboard-header-context'
+import { Button } from '@renderer/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
+
+export function DashboardHeaderActions({
+  agentSlug,
+  dashboardSlug,
+}: {
+  agentSlug: string
+  dashboardSlug: string | null
+}) {
+  const dashboardHeader = useDashboardHeader(agentSlug, dashboardSlug)
+  const actions = dashboardHeader?.actions
+  if (!actions) return null
+
+  const refreshLabel = actions.refreshState === 'refreshing'
+    ? 'Refreshing dashboard'
+    : actions.refreshState === 'loading'
+      ? 'Loading dashboard'
+      : 'Refresh dashboard'
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <div className="flex items-center gap-0" data-testid="dashboard-header-actions">
+        {actions.onAddToDock && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={actions.onAddToDock}
+                aria-label="Add dashboard to Dock"
+              >
+                <Dock className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent><p>Add to Dock</p></TooltipContent>
+          </Tooltip>
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={actions.onOpenExternal}
+              aria-label="Open dashboard in new window"
+            >
+              <ExternalLink className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent><p>Open in new window</p></TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={actions.onRefresh}
+              disabled={actions.refreshState !== 'idle'}
+              aria-label={refreshLabel}
+            >
+              {actions.refreshState !== 'idle'
+                ? <Loader2 className="h-4 w-4 animate-spin" />
+                : <RefreshCw className="h-4 w-4" />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent><p>{refreshLabel}</p></TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -2,12 +2,15 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DashboardHeaderProvider } from '@renderer/context/dashboard-header-context'
+import { DashboardHeaderActions } from './dashboard-header-actions'
 import { DashboardView } from './dashboard-view'
 
 const mocks = vi.hoisted(() => ({
   agentSlug: 'agent',
   agentStatus: 'running',
   dashboardStatus: 'crashed',
+  dashboardDescription: '',
   dashboardStartupPhase: undefined as undefined | 'installing-dependencies' | 'starting-server',
   dashboardFirstRun: undefined as boolean | undefined,
   start: {
@@ -40,7 +43,7 @@ vi.mock('@renderer/hooks/use-artifacts', () => ({
     data: [{
       slug: 'dashboard',
       name: 'Dashboard',
-      description: '',
+      description: mocks.dashboardDescription,
       status: mocks.dashboardStatus,
       port: 0,
       startupPhase: mocks.dashboardStartupPhase,
@@ -82,12 +85,26 @@ vi.mock('@renderer/lib/perf', () => ({
   useRenderTracker: vi.fn(),
 }))
 
+function DashboardHarness({ agentSlug = 'agent' }: { agentSlug?: string }) {
+  return (
+    <DashboardHeaderProvider>
+      <DashboardHeaderActions agentSlug={agentSlug} dashboardSlug="dashboard" />
+      <DashboardView agentSlug={agentSlug} dashboardSlug="dashboard" />
+    </DashboardHeaderProvider>
+  )
+}
+
+function renderDashboard(agentSlug = 'agent') {
+  return render(<DashboardHarness agentSlug={agentSlug} />)
+}
+
 describe('DashboardView restart', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.agentSlug = 'agent'
     mocks.agentStatus = 'running'
     mocks.dashboardStatus = 'crashed'
+    mocks.dashboardDescription = ''
     mocks.dashboardStartupPhase = undefined
     mocks.dashboardFirstRun = undefined
     mocks.start.mutateAsync.mockResolvedValue({})
@@ -101,15 +118,13 @@ describe('DashboardView restart', () => {
       }),
     )
 
-    const view = render(
-      <DashboardView agentSlug="agent" dashboardSlug="dashboard" />,
-    )
+    const view = renderDashboard()
     await userEvent.click(screen.getByRole('button', { name: 'Restart agent' }))
 
     expect(mocks.stop.mutateAsync).toHaveBeenCalledOnce()
 
     mocks.agentStatus = 'stopped'
-    view.rerender(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    view.rerender(<DashboardHarness />)
 
     expect(mocks.start.mutate).not.toHaveBeenCalled()
 
@@ -123,7 +138,7 @@ describe('DashboardView restart', () => {
     mocks.dashboardStartupPhase = 'installing-dependencies'
     mocks.dashboardFirstRun = true
 
-    render(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    renderDashboard()
 
     expect(screen.getByText('Preparing dashboard for first use…')).toBeInTheDocument()
     expect(screen.getByText('Installing dependencies. This only happens once.')).toBeInTheDocument()
@@ -134,19 +149,17 @@ describe('DashboardView restart', () => {
     const frame = () => document.querySelector('iframe')
     const waiting = () => screen.queryByText('Waiting for dashboard…')
 
-    const view = render(
-      <DashboardView agentSlug="agent" dashboardSlug="dashboard" />,
-    )
+    const view = renderDashboard()
     expect(frame()).not.toBeNull()
     expect(waiting()).toBeNull()
 
     // The agent leaves running through a control outside this view.
     mocks.agentStatus = 'stopped'
-    view.rerender(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    view.rerender(<DashboardHarness />)
     expect(frame()).toBeNull()
 
     mocks.agentStatus = 'running'
-    view.rerender(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    view.rerender(<DashboardHarness />)
 
     expect(frame()).not.toBeNull()
     expect(waiting()).toBeNull()
@@ -154,7 +167,7 @@ describe('DashboardView restart', () => {
 
   it('shows the toolbar spinner until the first iframe document loads', () => {
     mocks.dashboardStatus = 'running'
-    render(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    renderDashboard()
     const frame = document.querySelector('iframe')!
 
     expect(screen.getByRole('button', { name: 'Loading dashboard' })).toBeDisabled()
@@ -168,9 +181,7 @@ describe('DashboardView restart', () => {
     mocks.agentSlug = 'abc1234567'
     mocks.dashboardStatus = 'running'
 
-    render(
-      <DashboardView agentSlug="My Agent-abc1234567" dashboardSlug="dashboard" />,
-    )
+    renderDashboard('My Agent-abc1234567')
 
     expect(document.querySelector('iframe')?.getAttribute('src')).toBe(
       '/api/agents/abc1234567/artifacts/dashboard/',
@@ -179,7 +190,7 @@ describe('DashboardView restart', () => {
 
   it('shows refresh progress until the new iframe document loads', async () => {
     mocks.dashboardStatus = 'running'
-    render(<DashboardView agentSlug="agent" dashboardSlug="dashboard" />)
+    renderDashboard()
     const frame = document.querySelector('iframe')!
     fireEvent.load(frame)
 
@@ -190,5 +201,17 @@ describe('DashboardView restart', () => {
     fireEvent.load(frame)
 
     expect(screen.getByRole('button', { name: 'Refresh dashboard' })).not.toBeDisabled()
+  })
+
+  it('moves dashboard actions into the shared header and omits the description chrome', async () => {
+    mocks.dashboardStatus = 'running'
+    mocks.dashboardDescription = 'Day-by-day calorie and macro tracking'
+    renderDashboard()
+
+    expect(screen.getByTestId('dashboard-header-actions')).toBeInTheDocument()
+    expect(screen.queryByText(mocks.dashboardDescription)).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open dashboard in new window' }))
+    expect(mocks.openDashboardExternal).toHaveBeenCalledWith('agent', 'dashboard', 'Dashboard')
   })
 })

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { Button } from '@renderer/components/ui/button'
-import { Play, RefreshCw, SquareMousePointer, ExternalLink, Dock, Loader2 } from 'lucide-react'
+import { Play, RefreshCw, Loader2 } from 'lucide-react'
 import { useAgent, useStartAgent, useStopAgent } from '@renderer/hooks/use-agents'
 import { useKeepAlive } from '@renderer/hooks/use-keep-alive'
 import { useArtifacts } from '@renderer/hooks/use-artifacts'
@@ -10,6 +10,7 @@ import { buildDashboardArtifactPath } from '@shared/lib/dashboard-url'
 import { AddToDockDialog } from './add-to-dock-dialog'
 import { PendingAgentReviews } from './pending-agent-reviews'
 import { useRenderTracker } from '@renderer/lib/perf'
+import { useRegisterDashboardHeader } from '@renderer/context/dashboard-header-context'
 import {
   DASHBOARD_WAIT_BOUND_MS,
   resolveDashboardViewState,
@@ -102,6 +103,10 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     openDashboardExternal(dashboardAgentSlug, dashboardSlug, dashboard?.name)
   }, [dashboardAgentSlug, dashboardSlug, dashboard?.name])
 
+  const handleAddToDock = useCallback(() => {
+    setDockDialogOpen(true)
+  }, [])
+
   const handleStartAgent = useCallback(() => {
     startAgent.mutate(agentSlug)
   }, [startAgent, agentSlug])
@@ -136,6 +141,31 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const showFrame = isAgentRunning && dashboard?.status === 'running'
   const actionPending = restarting || stopAgent.isPending || startAgent.isPending
 
+  const dashboardHeader = useMemo(() => ({
+    agentSlug,
+    dashboardSlug,
+    dashboardName: dashboard?.name || dashboardSlug,
+    actions: showFrame
+      ? {
+          onOpenExternal: handlePopOut,
+          onRefresh: handleRefresh,
+          ...(isElectron() && getPlatform() === 'darwin' ? { onAddToDock: handleAddToDock } : {}),
+          refreshState: refreshing ? 'refreshing' as const : frameLoading ? 'loading' as const : 'idle' as const,
+        }
+      : null,
+  }), [
+    agentSlug,
+    dashboardSlug,
+    dashboard?.name,
+    showFrame,
+    handlePopOut,
+    handleRefresh,
+    handleAddToDock,
+    refreshing,
+    frameLoading,
+  ])
+  useRegisterDashboardHeader(dashboardHeader)
+
   useEffect(() => {
     if (showFrame) setFrameLoading(true)
   }, [iframeSrc, showFrame])
@@ -164,42 +194,6 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
-      <div className="shrink-0 flex items-center gap-2 pl-4 pr-2 py-2 border-b bg-muted/30">
-        <SquareMousePointer className="h-4 w-4 text-muted-foreground shrink-0" />
-        <span className="text-sm font-medium">{dashboard?.name || dashboardSlug}</span>
-        {dashboard?.description && (
-          <span className="text-xs text-muted-foreground truncate">
-            — {dashboard.description}
-          </span>
-        )}
-        <div className="ml-auto flex items-center gap-1">
-          {/* TODO: Add Windows support — create .lnk shortcut and pin to taskbar */}
-          {isElectron() && getPlatform() === 'darwin' && (
-            <Button variant="ghost" size="sm" onClick={() => setDockDialogOpen(true)} title="Add to Dock">
-              <Dock className="h-3 w-3" />
-            </Button>
-          )}
-          <Button variant="ghost" size="sm" onClick={handlePopOut} title="Open in new window">
-            <ExternalLink className="h-3 w-3" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleRefresh}
-            disabled={frameLoading}
-            title={refreshing ? 'Refreshing…' : frameLoading ? 'Loading dashboard…' : 'Refresh'}
-            aria-label={refreshing
-              ? 'Refreshing dashboard'
-              : frameLoading
-                ? 'Loading dashboard'
-                : 'Refresh dashboard'}
-          >
-            {frameLoading
-              ? <Loader2 className="h-3 w-3 animate-spin" />
-              : <RefreshCw className="h-3 w-3" />}
-          </Button>
-        </div>
-      </div>
       <PendingAgentReviews agentSlug={agentSlug} onReviewResolved={handleRefresh} />
       <AddToDockDialog
         open={dockDialogOpen}

--- a/src/renderer/components/layout/agent-header.test.tsx
+++ b/src/renderer/components/layout/agent-header.test.tsx
@@ -1,9 +1,23 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { AgentHeader } from './agent-header'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
+import { HOVER_SCROLL_DELAY_MS } from '@renderer/components/ui/hover-scroll-text'
+import {
+  DashboardHeaderProvider,
+  useRegisterDashboardHeader,
+  type DashboardHeaderRegistration,
+} from '@renderer/context/dashboard-header-context'
+
+const mocks = vi.hoisted(() => ({
+  routeView: { kind: 'session', id: 'session-1' } as {
+    kind: string
+    id?: string
+    slug?: string
+  },
+}))
 
 const agent: ApiAgent = {
   slug: 'test-agent',
@@ -16,7 +30,7 @@ const agent: ApiAgent = {
 }
 
 vi.mock('@renderer/router/use-route-location', () => ({
-  useRouteLocation: () => ({ view: { kind: 'session', id: 'session-1' } }),
+  useRouteLocation: () => ({ view: mocks.routeView }),
 }))
 
 vi.mock('@renderer/hooks/use-agents', () => ({
@@ -66,7 +80,7 @@ vi.mock('@renderer/components/ui/app-link', () => ({
 
 vi.mock('@renderer/components/agents/agent-context-menu', () => ({
   AgentContextMenu: ({ agent, children }: { agent: ApiAgent; children: ReactNode }) => (
-    <div data-testid="agent-breadcrumb-context-menu" data-agent-slug={agent.slug}>{children}</div>
+    <span data-testid="agent-breadcrumb-context-menu" data-agent-slug={agent.slug}>{children}</span>
   ),
 }))
 
@@ -82,18 +96,43 @@ vi.mock('@renderer/components/sessions/session-context-menu', () => ({
     agentSlug: string
     children: ReactNode
   }) => (
-    <div
+    <span
       data-testid="session-breadcrumb-context-menu"
       data-session-id={sessionId}
       data-session-name={sessionName}
       data-agent-slug={agentSlug}
     >
       {children}
-    </div>
+    </span>
   ),
 }))
 
+const dashboardRegistration: DashboardHeaderRegistration = {
+  agentSlug: 'test-agent',
+  dashboardSlug: 'nutrition',
+  dashboardName: 'Nutrition Dashboard',
+  actions: {
+    onOpenExternal: vi.fn(),
+    onRefresh: vi.fn(),
+    refreshState: 'idle',
+  },
+}
+
+function RegisterDashboardHeader() {
+  useRegisterDashboardHeader(dashboardRegistration)
+  return null
+}
+
 describe('AgentHeader breadcrumbs', () => {
+  beforeEach(() => {
+    mocks.routeView = { kind: 'session', id: 'session-1' }
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('reuses the agent and session context menus on their breadcrumbs', () => {
     const mutation = { mutate: vi.fn(), isPending: false }
     render(
@@ -114,5 +153,64 @@ describe('AgentHeader breadcrumbs', () => {
     expect(sessionMenu).toHaveAttribute('data-session-name', 'Test Session')
     expect(sessionMenu).toHaveAttribute('data-agent-slug', 'test-agent')
     expect(sessionMenu).toContainElement(screen.getByTestId('session-breadcrumb'))
+  })
+
+  it('clips and hover-scrolls the complete breadcrumb trail as one unit', () => {
+    vi.useFakeTimers()
+    const mutation = { mutate: vi.fn(), isPending: false }
+    const { container } = render(
+      <AgentHeader
+        slug="test-agent"
+        isViewOnly={false}
+        startAgent={mutation as never}
+        stopAgent={mutation as never}
+      />,
+    )
+
+    const trail = screen.getByTestId('breadcrumb-trail')
+    const content = trail.firstElementChild as HTMLElement
+    const agentCrumb = screen.getByTestId('agent-breadcrumb')
+    const sessionCrumb = screen.getByTestId('session-breadcrumb')
+
+    expect(trail).toHaveClass('hover-scroll-text')
+    expect(container.querySelectorAll('.hover-scroll-text')).toHaveLength(1)
+    expect(content).toHaveClass('hover-scroll-text-content', 'truncate')
+    expect(content).toContainElement(agentCrumb)
+    expect(content).toContainElement(sessionCrumb)
+    expect(agentCrumb).not.toHaveClass('truncate')
+    expect(sessionCrumb).not.toHaveClass('truncate')
+
+    Object.defineProperty(trail, 'clientWidth', { configurable: true, value: 120 })
+    Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 300 })
+    fireEvent.mouseEnter(trail)
+    act(() => vi.advanceTimersByTime(HOVER_SCROLL_DELAY_MS))
+
+    expect(trail).toHaveAttribute('data-scrolling', 'true')
+    expect(trail).toHaveStyle({ '--hover-scroll-distance': '180px' })
+  })
+
+  it('renders the dashboard name as a breadcrumb and its actions in the shared toolbar', () => {
+    mocks.routeView = { kind: 'dashboard', slug: 'nutrition' }
+    const mutation = { mutate: vi.fn(), isPending: false }
+
+    const { container } = render(
+      <DashboardHeaderProvider>
+        <AgentHeader
+          slug="test-agent"
+          isViewOnly={false}
+          startAgent={mutation as never}
+          stopAgent={mutation as never}
+        />
+        <RegisterDashboardHeader />
+      </DashboardHeaderProvider>,
+    )
+
+    expect(screen.getByTestId('dashboard-breadcrumb')).toHaveTextContent('Nutrition Dashboard')
+    expect(screen.getByTestId('dashboard-header-actions')).toBeInTheDocument()
+
+    const separators = container.querySelectorAll('[data-orientation="vertical"]')
+    expect(separators).toHaveLength(2)
+    expect(separators[0].className).toBe(separators[1].className)
+    expect(separators[0]).not.toHaveClass('ml-2')
   })
 })

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -15,6 +15,9 @@ import { Separator } from '@renderer/components/ui/separator'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverTrigger, PopoverContent } from '@renderer/components/ui/popover'
+import { HoverScrollText } from '@renderer/components/ui/hover-scroll-text'
+import { useDashboardHeader } from '@renderer/context/dashboard-header-context'
+import { DashboardHeaderActions } from '@renderer/components/dashboards/dashboard-header-actions'
 import type { ContainerStatus } from '@shared/lib/container/types'
 
 interface AgentHeaderProps {
@@ -22,6 +25,14 @@ interface AgentHeaderProps {
   isViewOnly: boolean
   startAgent: ReturnType<typeof useStartAgent>
   stopAgent: ReturnType<typeof useStopAgent>
+}
+
+function BreadcrumbSeparator() {
+  return (
+    <span aria-hidden="true" className="mx-1.5 text-sm font-light text-muted-foreground">
+      /
+    </span>
+  )
 }
 
 /**
@@ -41,6 +52,8 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
   const secretsOpen = view.kind === 'secrets'
   const xAgentPermissionsOpen = view.kind === 'xAgentPermissions'
   const connectionsOpen = view.kind === 'connections'
+  const dashboardSlug = view.kind === 'dashboard' ? view.slug : null
+  const dashboardHeader = useDashboardHeader(slug, dashboardSlug)
 
   const { data: agent } = useAgent(slug)
   const { data: sessions } = useSessions(slug)
@@ -57,48 +70,49 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
 
   return (
     <>
-      <div className="flex flex-col md:flex-row md:items-center gap-0 md:gap-1.5 min-w-0 flex-1">
-        <div className="flex items-center gap-2 min-w-0">
-          {agent ? (
-            <AgentContextMenu agent={agent}>
-              <AppLink
-                to="/agents/$slug"
-                params={{ slug }}
-                activeOptions={{ exact: true }}
-                noDrag
-                // Route-derived leaf styling: foreground only when this link is the
-                // exact active route (`data-status=active`), muted/clickable otherwise.
-                className="text-sm font-light truncate transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground cursor-context-menu"
-                data-testid="agent-breadcrumb"
-              >
-                {agent.name}
-              </AppLink>
-            </AgentContextMenu>
-          ) : (
+      <HoverScrollText
+        className="min-w-0 flex-1 app-no-drag"
+        data-testid="breadcrumb-trail"
+      >
+        {agent ? (
+          <AgentContextMenu agent={agent}>
             <AppLink
               to="/agents/$slug"
               params={{ slug }}
               activeOptions={{ exact: true }}
               noDrag
-              className="text-sm font-light truncate transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground"
+              // Route-derived leaf styling: foreground only when this link is the
+              // exact active route (`data-status=active`), muted/clickable otherwise.
+              className="text-sm font-light transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground cursor-context-menu"
               data-testid="agent-breadcrumb"
             >
-              Loading...
+              {agent.name}
             </AppLink>
-          )}
-        </div>
+          </AgentContextMenu>
+        ) : (
+          <AppLink
+            to="/agents/$slug"
+            params={{ slug }}
+            activeOptions={{ exact: true }}
+            noDrag
+            className="text-sm font-light transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground"
+            data-testid="agent-breadcrumb"
+          >
+            Loading...
+          </AppLink>
+        )}
         {(() => {
           const taskCrumbId = scheduledTaskId ?? (sessionId ? session?.scheduledTaskId ?? null : null)
           const taskCrumbName = scheduledTask?.name ?? (sessionId ? session?.scheduledTaskName : null)
           if (!taskCrumbId) return null
           const isLeaf = !!scheduledTaskId
           return (
-            <div className="flex items-center gap-1.5 min-w-0">
-              <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
+            <>
+              <BreadcrumbSeparator />
               {isLeaf ? (
-                <span className="flex items-center gap-1 text-muted-foreground app-no-drag">
-                  <Clock className="h-4 w-4" />
-                  <span className="truncate text-sm font-light text-foreground">
+                <span className="inline-flex items-center gap-1 align-middle text-muted-foreground app-no-drag">
+                  <Clock className="h-4 w-4 shrink-0" />
+                  <span className="text-sm font-light text-foreground">
                     {taskCrumbName || 'Scheduled Task'}
                   </span>
                 </span>
@@ -107,15 +121,15 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
                   to="/agents/$slug/tasks/$taskId"
                   params={{ slug, taskId: taskCrumbId }}
                   noDrag
-                  className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+                  className="inline-flex items-center gap-1 align-middle text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  <Clock className="h-4 w-4" />
-                  <span className="truncate text-sm font-light">
+                  <Clock className="h-4 w-4 shrink-0" />
+                  <span className="text-sm font-light">
                     {taskCrumbName || 'Scheduled Task'}
                   </span>
                 </AppLink>
               )}
-            </div>
+            </>
           )
         })()}
         {(() => {
@@ -124,12 +138,12 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
           if (!webhookCrumbId) return null
           const isLeaf = !!webhookTriggerId
           return (
-            <div className="flex items-center gap-1.5 min-w-0">
-              <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
+            <>
+              <BreadcrumbSeparator />
               {isLeaf ? (
-                <span className="flex items-center gap-1 text-muted-foreground app-no-drag">
-                  <Zap className="h-4 w-4" />
-                  <span className="truncate text-sm font-light text-foreground">
+                <span className="inline-flex items-center gap-1 align-middle text-muted-foreground app-no-drag">
+                  <Zap className="h-4 w-4 shrink-0" />
+                  <span className="text-sm font-light text-foreground">
                     {webhookCrumbName || 'Webhook Trigger'}
                   </span>
                 </span>
@@ -138,51 +152,62 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
                   to="/agents/$slug/webhooks/$webhookId"
                   params={{ slug, webhookId: webhookCrumbId }}
                   noDrag
-                  className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+                  className="inline-flex items-center gap-1 align-middle text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  <Zap className="h-4 w-4" />
-                  <span className="truncate text-sm font-light">
+                  <Zap className="h-4 w-4 shrink-0" />
+                  <span className="text-sm font-light">
                     {webhookCrumbName || 'Webhook Trigger'}
                   </span>
                 </AppLink>
               )}
-            </div>
+            </>
           )
         })()}
         {sessionId && session?.agentSlug === agent?.slug && (
-          <div className="flex items-center gap-1.5 min-w-0">
-            <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
+          <>
+            <BreadcrumbSeparator />
             <SessionContextMenu
               sessionId={sessionId}
               sessionName={session?.name || 'Session'}
               agentSlug={slug}
             >
               <span
-                className="text-sm font-light text-foreground truncate cursor-context-menu app-no-drag"
+                className="text-sm font-light text-foreground cursor-context-menu app-no-drag"
                 data-testid="session-breadcrumb"
               >
                 {session?.name || 'Loading...'}
               </span>
             </SessionContextMenu>
-          </div>
+          </>
+        )}
+        {dashboardSlug && (
+          <>
+            <BreadcrumbSeparator />
+            <span
+              className="text-sm font-light text-foreground app-no-drag"
+              data-testid="dashboard-breadcrumb"
+            >
+              {dashboardHeader?.dashboardName || dashboardSlug}
+            </span>
+          </>
         )}
         {apiLogsOpen && (
-          <div className="flex items-center gap-1.5 min-w-0">
-            <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
-            <span className="truncate text-sm font-light text-foreground">API Logs</span>
-          </div>
+          <>
+            <BreadcrumbSeparator />
+            <span className="text-sm font-light text-foreground">API Logs</span>
+          </>
         )}
         {secretsOpen && (
-          <div className="flex items-center gap-1.5 min-w-0">
-            <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
-            <span className="truncate text-sm font-light text-foreground">Secrets</span>
-          </div>
+          <>
+            <BreadcrumbSeparator />
+            <span className="text-sm font-light text-foreground">Secrets</span>
+          </>
         )}
         {xAgentPermissionsOpen && (
-          <div className="flex items-center gap-1.5 min-w-0">
-            <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
-            <span className="truncate text-sm font-light text-foreground">Agent-to-agent Connections</span>
-          </div>
+          <>
+            <BreadcrumbSeparator />
+            <span className="text-sm font-light text-foreground">Agent-to-agent Connections</span>
+          </>
         )}
         {connectionsOpen && (
           <ConnectionsCrumbs
@@ -190,8 +215,12 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
             detail={view.kind === 'connections' ? view.detail ?? null : null}
           />
         )}
-      </div>
+      </HoverScrollText>
       <div className="flex items-center gap-0 md:gap-2 shrink-0 app-no-drag">
+        <DashboardHeaderActions agentSlug={slug} dashboardSlug={dashboardSlug} />
+        {dashboardHeader?.actions && (
+          <Separator orientation="vertical" className="hidden h-5 md:block" />
+        )}
         {agent && (
           <AgentStatus
             status={agent.status}
@@ -204,7 +233,7 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
         )}
         {!isViewOnly && (
           <>
-            <Separator orientation="vertical" className="h-5 hidden md:block ml-2" />
+            <Separator orientation="vertical" className="hidden h-5 md:block" />
             <div className="hidden md:flex items-center gap-2" data-testid="agent-power-controls">
               {agent?.status === 'running' ? (
                 <TooltipProvider delayDuration={0}>
@@ -391,16 +420,12 @@ function ConnectionsCrumbs({
   const { data: accountsData } = useConnectedAccounts()
   const { data: mcpsData } = useRemoteMcps()
 
-  const separator = (
-    <span aria-hidden="true" className="text-sm font-light text-muted-foreground shrink-0 hidden md:block">/</span>
-  )
-
   if (!detail) {
     return (
-      <div className="flex items-center gap-1.5 min-w-0">
-        {separator}
-        <span className="truncate text-sm font-light text-foreground">Connections</span>
-      </div>
+      <>
+        <BreadcrumbSeparator />
+        <span className="text-sm font-light text-foreground">Connections</span>
+      </>
     )
   }
 
@@ -414,41 +439,39 @@ function ConnectionsCrumbs({
   return (
     <>
       {detail.source === 'list' && (
-        <div className="flex items-center gap-1.5 min-w-0">
-          {separator}
+        <>
+          <BreadcrumbSeparator />
           <AppLink
             to="/agents/$slug/connections"
             params={{ slug }}
             // No `search` → drops `?detail`/`?source`, returning to the list.
             noDrag
-            className="truncate text-sm font-light text-muted-foreground hover:text-foreground transition-colors"
+            className="text-sm font-light text-muted-foreground hover:text-foreground transition-colors"
             data-testid="connections-breadcrumb"
           >
             Connections
           </AppLink>
-        </div>
+        </>
       )}
-      <div className="flex items-center gap-1.5 min-w-0">
-        {separator}
-        {detail.view === 'logs' ? (
-          <AppLink
-            to="/agents/$slug/connections"
-            params={{ slug }}
-            search={{ detail: detail.rowKey, source: detail.source }}
-            noDrag
-            className="truncate text-sm font-light text-muted-foreground hover:text-foreground transition-colors"
-          >
-            {connectionName}
-          </AppLink>
-        ) : (
-          <span className="truncate text-sm font-light text-foreground">{connectionName}</span>
-        )}
-      </div>
+      <BreadcrumbSeparator />
+      {detail.view === 'logs' ? (
+        <AppLink
+          to="/agents/$slug/connections"
+          params={{ slug }}
+          search={{ detail: detail.rowKey, source: detail.source }}
+          noDrag
+          className="text-sm font-light text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {connectionName}
+        </AppLink>
+      ) : (
+        <span className="text-sm font-light text-foreground">{connectionName}</span>
+      )}
       {detail.view === 'logs' && (
-        <div className="flex items-center gap-1.5 min-w-0">
-          {separator}
-          <span className="truncate text-sm font-light text-foreground">Logs</span>
-        </div>
+        <>
+          <BreadcrumbSeparator />
+          <span className="text-sm font-light text-foreground">Logs</span>
+        </>
       )}
     </>
   )

--- a/src/renderer/components/layout/agent-shell.tsx
+++ b/src/renderer/components/layout/agent-shell.tsx
@@ -9,6 +9,7 @@ import { isElectron, getPlatform } from '@renderer/lib/env'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { PendingMessagesProvider, type PendingMessagesContextValue } from '@renderer/context/pending-messages-context'
 import { clearPendingSessionSeed, peekPendingSessionSeed } from '@renderer/context/pending-session-seed'
+import { DashboardHeaderProvider } from '@renderer/context/dashboard-header-context'
 import type { PendingMessage } from '@renderer/components/messages/pending-message'
 import { ContentShell } from './content-shell'
 import { AgentHeader } from './agent-header'
@@ -184,19 +185,21 @@ export function AgentShell() {
 
   return (
     <PendingMessagesProvider value={value}>
-      <ContentShell
-        needsTrafficLightPadding={needsTrafficLightPadding}
-        headerContent={
-          slug ? (
-            <AgentHeader slug={slug} isViewOnly={isViewOnly} startAgent={startAgent} stopAgent={stopAgent} />
-          ) : null
-        }
-      >
-        {slug && <AgentBanners slug={slug} startAgent={startAgent} />}
-        <ErrorBoundary>
-          <Outlet />
-        </ErrorBoundary>
-      </ContentShell>
+      <DashboardHeaderProvider>
+        <ContentShell
+          needsTrafficLightPadding={needsTrafficLightPadding}
+          headerContent={
+            slug ? (
+              <AgentHeader slug={slug} isViewOnly={isViewOnly} startAgent={startAgent} stopAgent={stopAgent} />
+            ) : null
+          }
+        >
+          {slug && <AgentBanners slug={slug} startAgent={startAgent} />}
+          <ErrorBoundary>
+            <Outlet />
+          </ErrorBoundary>
+        </ContentShell>
+      </DashboardHeaderProvider>
     </PendingMessagesProvider>
   )
 }

--- a/src/renderer/context/dashboard-header-context.tsx
+++ b/src/renderer/context/dashboard-header-context.tsx
@@ -1,0 +1,81 @@
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export interface DashboardHeaderRegistration {
+  agentSlug: string
+  dashboardSlug: string
+  dashboardName: string
+  actions: {
+    onOpenExternal: () => void
+    onRefresh: () => void
+    onAddToDock?: () => void
+    refreshState: 'idle' | 'loading' | 'refreshing'
+  } | null
+}
+
+interface DashboardHeaderContextValue {
+  registration: DashboardHeaderRegistration | null
+  setRegistration: React.Dispatch<React.SetStateAction<DashboardHeaderRegistration | null>>
+}
+
+const DashboardHeaderContext = createContext<DashboardHeaderContextValue | null>(null)
+
+/**
+ * Bridges dashboard-owned state (notably the iframe refresh lifecycle) into the
+ * persistent AgentShell header without making the shared layout own the iframe.
+ */
+export function DashboardHeaderProvider({ children }: { children: ReactNode }) {
+  const [registration, setRegistration] = useState<DashboardHeaderRegistration | null>(null)
+  const value = useMemo(
+    () => ({ registration, setRegistration }),
+    [registration],
+  )
+
+  return (
+    <DashboardHeaderContext.Provider value={value}>
+      {children}
+    </DashboardHeaderContext.Provider>
+  )
+}
+
+/** Registers the active dashboard's breadcrumb label and optional toolbar actions. */
+export function useRegisterDashboardHeader(registration: DashboardHeaderRegistration) {
+  const setRegistration = useContext(DashboardHeaderContext)?.setRegistration
+  const registrationKey = `${registration.agentSlug}/${registration.dashboardSlug}`
+
+  useLayoutEffect(() => {
+    setRegistration?.(registration)
+  }, [registration, setRegistration])
+
+  useLayoutEffect(() => {
+    return () => {
+      setRegistration?.((current) => {
+        if (!current) return null
+        const currentKey = `${current.agentSlug}/${current.dashboardSlug}`
+        return currentKey === registrationKey ? null : current
+      })
+    }
+  }, [registrationKey, setRegistration])
+}
+
+/** Returns chrome only when it belongs to the currently rendered dashboard route. */
+export function useDashboardHeader(
+  agentSlug: string,
+  dashboardSlug: string | null,
+): DashboardHeaderRegistration | null {
+  const registration = useContext(DashboardHeaderContext)?.registration ?? null
+  if (
+    !dashboardSlug
+    || registration?.agentSlug !== agentSlug
+    || registration.dashboardSlug !== dashboardSlug
+  ) {
+    return null
+  }
+  return registration
+}


### PR DESCRIPTION
## Summary

- move the dashboard name into the shared agent breadcrumb and move dashboard actions into the main app toolbar
- remove the redundant dashboard subheader and description row
- normalize the separators and spacing around agent status controls
- reuse the sidebar's hover-scroll treatment for the complete breadcrumb trail, with one trailing ellipsis instead of per-crumb truncation

## Why

Dashboard pages duplicated the app header with a second strip of chrome, while each breadcrumb segment truncated independently. This created the visual “double chin,” inconsistent toolbar spacing, and multiple ellipses for long breadcrumb paths.

The dashboard view now registers its route-specific label and actions with the persistent agent header. The full breadcrumb trail is treated as one overflow region, so hover reveals the complete path together.

## Impact

Dashboard content gains vertical space, toolbar controls remain available in the standard location, and long agent/session/dashboard paths stay readable without fragmenting the breadcrumb hierarchy.

## Validation

- `npm run test:run -- src/renderer/components/layout/agent-header.test.tsx src/renderer/components/ui/hover-scroll-text.test.tsx`
- `npm run typecheck`
- `./node_modules/.bin/eslint src/renderer/components/layout/agent-header.tsx src/renderer/components/layout/agent-header.test.tsx`
- live Electron development build with HMR
