### PR TITLE
Full-page agent template marketplace at /explore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@hono/node-server": "^1.13.7",
         "@hono/zod-validator": "^0.8.0",
-        "@outpacelabs/avatars": "^0.4.1",
         "@sentry/node": "^10.48.0",
         "@skillful-agents/agent-computer": "^0.0.11",
         "@slack/bolt": "^4.7.0",
@@ -6459,15 +6458,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@outpacelabs/avatars": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@outpacelabs/avatars/-/avatars-0.4.1.tgz",
-      "integrity": "sha512-22vZeWZBaZWM9eKUU1BRVjhIomevCJG707pnqhggHANFAyOcb6f9pz4zYkliZcS1ZURMcZFOUYs3ywShoy7kEw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -18233,6 +18223,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -18719,6 +18710,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -21592,6 +21584,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@hono/node-server": "^1.13.7",
         "@hono/zod-validator": "^0.8.0",
+        "@outpacelabs/avatars": "^0.4.1",
         "@sentry/node": "^10.48.0",
         "@skillful-agents/agent-computer": "^0.0.11",
         "@slack/bolt": "^4.7.0",
@@ -6458,6 +6459,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@outpacelabs/avatars": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@outpacelabs/avatars/-/avatars-0.4.1.tgz",
+      "integrity": "sha512-22vZeWZBaZWM9eKUU1BRVjhIomevCJG707pnqhggHANFAyOcb6f9pz4zYkliZcS1ZURMcZFOUYs3ywShoy7kEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -18223,7 +18233,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -18710,7 +18719,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -21584,7 +21592,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@aws-sdk/client-lambda-microvms": "^3.1075.0",
     "@hono/node-server": "^1.13.7",
     "@hono/zod-validator": "^0.8.0",
-    "@outpacelabs/avatars": "^0.4.1",
     "@sentry/node": "^10.48.0",
     "@skillful-agents/agent-computer": "^0.0.11",
     "@slack/bolt": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@aws-sdk/client-lambda-microvms": "^3.1075.0",
     "@hono/node-server": "^1.13.7",
     "@hono/zod-validator": "^0.8.0",
+    "@outpacelabs/avatars": "^0.4.1",
     "@sentry/node": "^10.48.0",
     "@skillful-agents/agent-computer": "^0.0.11",
     "@slack/bolt": "^4.7.0",

--- a/src/renderer/components/agents/agent-template-browse-dialog.tsx
+++ b/src/renderer/components/agents/agent-template-browse-dialog.tsx
@@ -9,13 +9,8 @@ import {
 import { AgentTemplateBrowseContent } from './agent-template-browse-content'
 import { TemplateInstallDialog } from './template-install-dialog'
 import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
-import { useNavigate } from '@tanstack/react-router'
-import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
-import { useAnalyticsTracking } from '@renderer/context/analytics-context'
-import { useQueryClient } from '@tanstack/react-query'
+import { useCompleteTemplateInstall } from '@renderer/hooks/use-complete-template-install'
 import type { ApiAgentTemplateInstallResult, ApiDiscoverableAgent } from '@shared/lib/types/api'
-import { useDraftsStore } from '@renderer/context/drafts-context'
-import { completeAgentTemplateHandoff } from '@renderer/lib/agent-template-handoff'
 
 interface AgentTemplateBrowseDialogProps {
   open: boolean
@@ -30,11 +25,7 @@ export function AgentTemplateBrowseDialog({
   onInstalled,
 }: AgentTemplateBrowseDialogProps) {
   const { data: discoverableAgents } = useDiscoverableAgents()
-  const navigate = useNavigate()
-  const { track } = useAnalyticsTracking()
-  const startOnboardingSession = useStartOnboardingSession()
-  const queryClient = useQueryClient()
-  const draftsStore = useDraftsStore()
+  const completeInstall = useCompleteTemplateInstall()
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
 
   useEffect(() => {
@@ -43,24 +34,11 @@ export function AgentTemplateBrowseDialog({
 
   const handleInstalled = useCallback(
     async (agent: ApiAgentTemplateInstallResult) => {
-      track('agent_created', {
-        source: 'skillset',
-        num_skills_added_at_creation: 0,
-        has_template_prompt: Boolean(agent.templatePrompt),
-      })
-      await queryClient.refetchQueries({ queryKey: ['agents'] })
-      await completeAgentTemplateHandoff({
-        draftsStore,
-        agentSlug: agent.slug,
-        hasOnboarding: agent.hasOnboarding,
-        templatePrompt: agent.templatePrompt,
-        openAgent: () => { void navigate({ to: '/agents/$slug', params: { slug: agent.slug } }) },
-        startOnboardingSession,
-      })
+      await completeInstall(agent)
       onOpenChange(false)
       await onInstalled?.()
     },
-    [track, queryClient, draftsStore, navigate, startOnboardingSession, onOpenChange, onInstalled],
+    [completeInstall, onOpenChange, onInstalled],
   )
 
   const hasTemplates = discoverableAgents && discoverableAgents.length > 0

--- a/src/renderer/components/explore/category-view.test.tsx
+++ b/src/renderer/components/explore/category-view.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigate = vi.fn()
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => navigate }))
+
+const openSettings = vi.fn()
+vi.mock('@renderer/context/dialog-context', () => ({ useDialogs: () => ({ openSettings }) }))
+
+let skillsets: { id: string }[] | undefined = []
+let discoverable: ApiDiscoverableAgent[] | undefined
+let isLoading = false
+vi.mock('@renderer/hooks/use-skillsets', () => ({ useSkillsets: () => ({ data: skillsets }) }))
+vi.mock('@renderer/hooks/use-agent-templates', () => ({
+  useDiscoverableAgents: () => ({ data: discoverable, isLoading }),
+  slugFromAgentPath: (path: string) => path.replace(/^agents\//, '').replace(/\/$/, ''),
+}))
+
+import { CategoryView } from './category-view'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+const marketing: ApiDiscoverableAgent = {
+  skillsetId: 'skillset-1',
+  skillsetName: 'Public',
+  name: 'Campaign Writer',
+  description: 'Writes campaigns',
+  version: '1.0.0',
+  path: 'agents/campaign-writer/',
+  category: 'Marketing',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  skillsets = [{ id: 'skillset-1' }]
+  discoverable = [marketing]
+  isLoading = false
+})
+
+describe('CategoryView', () => {
+  it('lists the templates in the category', () => {
+    render(<CategoryView category="Marketing" />)
+    expect(screen.getAllByTestId('explore-template-card')).toHaveLength(1)
+  })
+
+  it('treats Featured as a category, keyed off the developer', () => {
+    discoverable = [
+      marketing,
+      { ...marketing, name: 'First Party', developer: { name: 'SkillfulAgents' } },
+    ]
+    render(<CategoryView category="Featured" />)
+    const cards = screen.getAllByTestId('explore-template-card')
+    expect(cards).toHaveLength(1)
+    expect(cards[0].textContent).toContain('First Party')
+  })
+
+  // `useDiscoverableAgents` is `enabled: hasSkillsets`, so with none configured
+  // its data never arrives — a page branching on the data alone renders a
+  // skeleton forever.
+  it('shows the empty state rather than a skeleton that never resolves', () => {
+    skillsets = []
+    discoverable = undefined
+    render(<CategoryView category="Marketing" />)
+    expect(screen.getByTestId('explore-empty')).toBeTruthy()
+  })
+
+  it('distinguishes an empty category from having no skillsets at all', () => {
+    render(<CategoryView category="Recruiting" />)
+    expect(screen.queryByTestId('explore-empty')).toBeNull()
+    expect(screen.getByText('No templates in Recruiting.')).toBeTruthy()
+  })
+
+  it('shows a skeleton while the skillset list is still loading', () => {
+    skillsets = undefined
+    discoverable = undefined
+    const { container } = render(<CategoryView category="Marketing" />)
+    expect(screen.queryByTestId('explore-empty')).toBeNull()
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+})

--- a/src/renderer/components/explore/category-view.tsx
+++ b/src/renderer/components/explore/category-view.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { Button } from '@renderer/components/ui/button'
+import { Skeleton } from '@renderer/components/ui/skeleton'
+import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
+import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
+import { ExploreTemplateCard } from './explore-template-card'
+import { FEATURED_SECTION_LABEL, isFeaturedTemplate, templateCategory } from './template-meta'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+/**
+ * `/explore/category/$category` — every template in one category, reached from
+ * a section's "Show N more" tile. `Featured` is a category here too, even
+ * though it comes from the developer field rather than the category one.
+ */
+export function CategoryView({ category }: { category: string }) {
+  const navigate = useNavigate()
+  const { data: discoverableAgents, isLoading } = useDiscoverableAgents()
+
+  const templates = useMemo(() => {
+    const all = discoverableAgents ?? []
+    return category === FEATURED_SECTION_LABEL
+      ? all.filter(isFeaturedTemplate)
+      : all.filter((t) => templateCategory(t) === category)
+  }, [discoverableAgents, category])
+
+  const openTemplate = (template: ApiDiscoverableAgent) => {
+    void navigate({
+      to: '/explore/$skillsetId/$templateSlug',
+      params: { skillsetId: template.skillsetId, templateSlug: slugFromAgentPath(template.path) },
+    })
+  }
+
+  return (
+    <SettingsPageContainer fullScreen className="px-[88px] pb-16 pt-12">
+      <PageTitle
+        title={
+          <div className="flex items-baseline gap-2">
+            <h2 className="text-xl font-medium">{category}</h2>
+            {templates.length > 0 && (
+              <span className="text-sm text-muted-foreground">{templates.length}</span>
+            )}
+          </div>
+        }
+        back={{ onClick: () => void navigate({ to: '/explore' }), label: 'Discover New Agents' }}
+      />
+
+      <div data-testid="explore-category-view">
+        {isLoading || discoverableAgents === undefined ? (
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-[180px] rounded-3xl" />
+            ))}
+          </div>
+        ) : templates.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-16 text-center">
+            <p className="text-sm text-muted-foreground">No templates in {category}.</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void navigate({ to: '/explore' })}
+            >
+              Back to all agents
+            </Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {templates.map((template) => (
+              <ExploreTemplateCard
+                key={`${template.skillsetId}/${template.path}`}
+                template={template}
+                onOpen={openTemplate}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </SettingsPageContainer>
+  )
+}

--- a/src/renderer/components/explore/category-view.tsx
+++ b/src/renderer/components/explore/category-view.tsx
@@ -3,8 +3,9 @@ import { useNavigate } from '@tanstack/react-router'
 import { Button } from '@renderer/components/ui/button'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
-import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
+import { slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { ExploreTemplateCard } from './explore-template-card'
+import { NoTemplatesEmptyState, useExploreTemplates } from './explore-templates'
 import { FEATURED_SECTION_LABEL, isFeaturedTemplate, templateCategory } from './template-meta'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
@@ -15,14 +16,15 @@ import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
  */
 export function CategoryView({ category }: { category: string }) {
   const navigate = useNavigate()
-  const { data: discoverableAgents, isLoading } = useDiscoverableAgents()
+  const { templates: all, hasSkillsets, isLoading } = useExploreTemplates()
 
-  const templates = useMemo(() => {
-    const all = discoverableAgents ?? []
-    return category === FEATURED_SECTION_LABEL
-      ? all.filter(isFeaturedTemplate)
-      : all.filter((t) => templateCategory(t) === category)
-  }, [discoverableAgents, category])
+  const templates = useMemo(
+    () =>
+      category === FEATURED_SECTION_LABEL
+        ? all.filter(isFeaturedTemplate)
+        : all.filter((t) => templateCategory(t) === category),
+    [all, category],
+  )
 
   const openTemplate = (template: ApiDiscoverableAgent) => {
     void navigate({
@@ -46,12 +48,14 @@ export function CategoryView({ category }: { category: string }) {
       />
 
       <div data-testid="explore-category-view">
-        {isLoading || discoverableAgents === undefined ? (
+        {isLoading ? (
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             {Array.from({ length: 6 }).map((_, i) => (
               <Skeleton key={i} className="h-[180px] rounded-3xl" />
             ))}
           </div>
+        ) : !hasSkillsets ? (
+          <NoTemplatesEmptyState />
         ) : templates.length === 0 ? (
           <div className="flex flex-col items-center gap-3 py-16 text-center">
             <p className="text-sm text-muted-foreground">No templates in {category}.</p>

--- a/src/renderer/components/explore/explore-template-card.tsx
+++ b/src/renderer/components/explore/explore-template-card.tsx
@@ -1,26 +1,20 @@
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
-import {
-  connectionIconSlug,
-  connectionLabel,
-  getTemplateAccent,
-  getTemplateIcon,
-} from './template-meta'
+import { connectionLabel, getTemplateAccent, getTemplateIcon } from './template-meta'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 /**
- * Named chips for the services a template connects to. Only connections with a
- * real logo are shown — a chip bearing the generic fallback glyph carries no
- * information, and a row of identical fallbacks reads as broken.
+ * Named chips for the services a template connects to. Every declared
+ * connection is listed, logo or not: the chip carries the service's name, so
+ * one falling back to a generic glyph still says what it connects to — and a
+ * card that hides connections misrepresents what the template needs.
  */
 function ToolStack({ template }: { template: ApiDiscoverableAgent }) {
-  const withLogos = (template.worksWith ?? [])
-    .map((c) => ({ ...c, iconSlug: connectionIconSlug(c.slug) }))
-    .filter((c) => c.iconSlug)
-  if (withLogos.length === 0) return null
+  const connections = template.worksWith ?? []
+  if (connections.length === 0) return null
   // Named chips are far wider than the bare coins were, so only the first few
   // fit on one line — the rest collapse into a count.
-  const shown = withLogos.slice(0, MAX_NAMED_CONNECTIONS)
-  const overflow = withLogos.length - shown.length
+  const shown = connections.slice(0, MAX_NAMED_CONNECTIONS)
+  const overflow = connections.length - shown.length
   return (
     <span className="flex items-center gap-0.5">
       {shown.map((connection) => (
@@ -28,13 +22,17 @@ function ToolStack({ template }: { template: ApiDiscoverableAgent }) {
           key={`${connection.type}-${connection.slug}`}
           className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-1.5 text-[11px] text-muted-foreground"
         >
-          <ServiceIcon slug={connection.iconSlug} className="size-[15px]" />
+          <ServiceIcon
+            slug={connection.slug}
+            fallback={connection.type === 'mcp' ? 'mcp' : 'oauth'}
+            className="size-[15px] shrink-0"
+          />
           {connectionLabel(connection.slug)}
         </span>
       ))}
       {overflow > 0 && (
         <span
-          title={withLogos.slice(MAX_NAMED_CONNECTIONS).map((c) => connectionLabel(c.slug)).join(', ')}
+          title={connections.slice(MAX_NAMED_CONNECTIONS).map((c) => connectionLabel(c.slug)).join(', ')}
           className="inline-flex h-7 shrink-0 items-center rounded-lg px-1.5 text-[11px] text-muted-foreground"
         >
           +{overflow}
@@ -94,17 +92,22 @@ export function ExploreTemplateCard({
     // not it fills them, and the 28px chip row. That sums to exactly 179px of
     // content + 32px padding, so the height is fixed at 180 with no leftover
     // slack — no `mt-auto`, which is what made the gaps uneven before.
-    <div
+    //
+    // The card IS the button rather than carrying an `absolute inset-0` overlay
+    // one: a positioned overlay paints above the static content beneath it, so
+    // the chip row's `title` never surfaced. Everything inside is a span, so it
+    // nests legally.
+    <button
+      type="button"
       data-testid="explore-template-card"
-      className="relative flex h-[180px] flex-col items-start gap-5 rounded-3xl border border-black/[0.06] bg-card p-4 text-left shadow-none transition-[box-shadow,transform] duration-500 ease-out hover:-translate-y-0.5 hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.16)] dark:border-white/[0.06] dark:hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)]"
+      onClick={() => onOpen(template)}
+      aria-label={`${template.name} — details`}
+      // 200ms: hover is feedback, not an animation. The lift is 2px, so a
+      // longer curve spends its tail finishing a sub-pixel move that already
+      // looks arrived — which reads as lag. Matches the renderer's dominant
+      // duration and the see-more tile beside it.
+      className="flex h-[180px] w-full flex-col items-start gap-5 rounded-3xl border border-black/[0.06] bg-card p-4 text-left shadow-none transition-[box-shadow,transform] duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/[0.06] dark:hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)]"
     >
-      <button
-        type="button"
-        onClick={() => onOpen(template)}
-        aria-label={`${template.name} — details`}
-        className="absolute inset-0 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      />
-
       <span className="flex w-full items-center gap-2">
         {/* The glyph is debossed — it drops a 1px light highlight beneath its
             strokes, the bevel your eye reads as "carved in". Dark mode flips
@@ -130,6 +133,6 @@ export function ExploreTemplateCard({
       <span className="flex w-full items-center gap-2 overflow-hidden">
         <ToolStack template={template} />
       </span>
-    </div>
+    </button>
   )
 }

--- a/src/renderer/components/explore/explore-template-card.tsx
+++ b/src/renderer/components/explore/explore-template-card.tsx
@@ -22,11 +22,11 @@ function ToolStack({ template }: { template: ApiDiscoverableAgent }) {
   const shown = withLogos.slice(0, MAX_NAMED_CONNECTIONS)
   const overflow = withLogos.length - shown.length
   return (
-    <span className="flex items-center gap-1.5">
+    <span className="flex items-center gap-0.5">
       {shown.map((connection) => (
         <span
           key={`${connection.type}-${connection.slug}`}
-          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg bg-card px-2 text-[11px] text-muted-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.07)]"
+          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-1.5 text-[11px] text-muted-foreground"
         >
           <ServiceIcon slug={connection.iconSlug} className="size-[15px]" />
           {connectionLabel(connection.slug)}
@@ -35,7 +35,7 @@ function ToolStack({ template }: { template: ApiDiscoverableAgent }) {
       {overflow > 0 && (
         <span
           title={withLogos.slice(MAX_NAMED_CONNECTIONS).map((c) => connectionLabel(c.slug)).join(', ')}
-          className="inline-flex h-7 shrink-0 items-center rounded-lg bg-card px-2 text-[11px] text-muted-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.07)]"
+          className="inline-flex h-7 shrink-0 items-center rounded-lg px-1.5 text-[11px] text-muted-foreground"
         >
           +{overflow}
         </span>
@@ -68,7 +68,7 @@ export function TemplateAvatar({
   const { tile, glyph } = AVATAR_SIZES[size]
   return (
     <span
-      className={`grid shrink-0 place-items-center bg-muted/50 shadow-[0_1px_2px_0_rgba(0,0,0,0.06)] ${tile}`}
+      className={`grid shrink-0 place-items-center bg-muted/50 shadow-[0_2px_6px_0_rgba(0,0,0,0.14)] ${tile}`}
     >
       <Icon className={`${accent} ${glyph}`} aria-hidden />
     </span>
@@ -89,14 +89,14 @@ export function ExploreTemplateCard({
 }) {
   const Icon = getTemplateIcon(template)
   return (
-    // Fixed 188px. A full two-line card needs ~175px (32px outer padding +
-    // 40px title row + 12px gap + 8px description lead-in + 39px of
-    // description + 8px gap + 36px chip row), so this leaves a little slack
-    // rather than pinning the chips against the text. Every field is bounded —
-    // the title truncates and the description clamps — so nothing outgrows it.
+    // Three evenly spaced blocks, one 20px gap between each: the 40px title
+    // row, a description that always reserves its two lines (39px) whether or
+    // not it fills them, and the 28px chip row. That sums to exactly 179px of
+    // content + 32px padding, so the height is fixed at 180 with no leftover
+    // slack — no `mt-auto`, which is what made the gaps uneven before.
     <div
       data-testid="explore-template-card"
-      className="relative flex h-[188px] flex-col items-start gap-3 rounded-3xl border border-black/[0.06] bg-card p-4 text-left transition-colors hover:border-black/15 dark:border-white/[0.06] dark:hover:border-white/15 hover:bg-accent/30"
+      className="relative flex h-[180px] flex-col items-start gap-5 rounded-3xl border border-black/[0.06] bg-card p-4 text-left shadow-none transition-[box-shadow,transform] duration-500 ease-out hover:-translate-y-0.5 hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.16)] dark:border-white/[0.06] dark:hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)]"
     >
       <button
         type="button"
@@ -106,23 +106,29 @@ export function ExploreTemplateCard({
       />
 
       <span className="flex w-full items-center gap-2">
+        {/* The glyph is debossed — it drops a 1px light highlight beneath its
+            strokes, the bevel your eye reads as "carved in". Dark mode flips
+            the highlight to a shadow, since white would read as embossed. */}
         <span className="grid size-10 shrink-0 place-items-center rounded-xl bg-muted/50 shadow-[0_2px_6px_0_rgba(0,0,0,0.14)]">
-          <Icon className={`size-6 ${getTemplateAccent(template.name)}`} aria-hidden />
+          <Icon
+            className={`size-5 ${getTemplateAccent(template.name)} [filter:drop-shadow(0_1px_0_rgba(255,255,255,0.9))] dark:[filter:drop-shadow(0_1px_0_rgba(0,0,0,0.6))]`}
+            aria-hidden
+          />
         </span>
         <span className="min-w-0 flex-1 truncate pl-1 text-[13px] font-medium text-foreground">
           {template.name}
         </span>
       </span>
 
-      <span className="flex min-w-0 w-full flex-1 flex-col gap-2">
-        {/* No `block` here — it would override line-clamp's `-webkit-box`
-            display and the clamp would silently never apply. */}
-        <span className="line-clamp-2 pt-2 text-[13px] leading-normal text-muted-foreground/70">
-          {template.description}
-        </span>
-        <span className="mt-auto flex items-center gap-2 overflow-hidden pt-2">
-          <ToolStack template={template} />
-        </span>
+      {/* `h-[39px]` reserves both lines even for a one-line blurb, so the chip
+          row lands at the same height on every card. No `block` on the clamp —
+          it would override `-webkit-box` and the clamp would never apply. */}
+      <span className="line-clamp-2 h-[39px] w-full text-[13px] leading-normal text-muted-foreground/70">
+        {template.description}
+      </span>
+
+      <span className="flex w-full items-center gap-2 overflow-hidden">
+        <ToolStack template={template} />
       </span>
     </div>
   )

--- a/src/renderer/components/explore/explore-template-card.tsx
+++ b/src/renderer/components/explore/explore-template-card.tsx
@@ -1,0 +1,129 @@
+import { ServiceIcon } from '@renderer/components/ui/service-icon'
+import {
+  connectionIconSlug,
+  connectionLabel,
+  getTemplateAccent,
+  getTemplateIcon,
+} from './template-meta'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+/**
+ * Named chips for the services a template connects to. Only connections with a
+ * real logo are shown — a chip bearing the generic fallback glyph carries no
+ * information, and a row of identical fallbacks reads as broken.
+ */
+function ToolStack({ template }: { template: ApiDiscoverableAgent }) {
+  const withLogos = (template.worksWith ?? [])
+    .map((c) => ({ ...c, iconSlug: connectionIconSlug(c.slug) }))
+    .filter((c) => c.iconSlug)
+  if (withLogos.length === 0) return null
+  // Named chips are far wider than the bare coins were, so only the first few
+  // fit on one line — the rest collapse into a count.
+  const shown = withLogos.slice(0, MAX_NAMED_CONNECTIONS)
+  const overflow = withLogos.length - shown.length
+  return (
+    <span className="flex items-center gap-1.5">
+      {shown.map((connection) => (
+        <span
+          key={`${connection.type}-${connection.slug}`}
+          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg bg-card px-2 text-[11px] text-muted-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.07)]"
+        >
+          <ServiceIcon slug={connection.iconSlug} className="size-[15px]" />
+          {connectionLabel(connection.slug)}
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span
+          title={withLogos.slice(MAX_NAMED_CONNECTIONS).map((c) => connectionLabel(c.slug)).join(', ')}
+          className="inline-flex h-7 shrink-0 items-center rounded-lg bg-card px-2 text-[11px] text-muted-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.07)]"
+        >
+          +{overflow}
+        </span>
+      )}
+    </span>
+  )
+}
+
+const MAX_NAMED_CONNECTIONS = 3
+
+const AVATAR_SIZES = {
+  md: { tile: 'size-14 rounded-[14px]', glyph: 'size-6' },
+  lg: { tile: 'size-16 rounded-2xl', glyph: 'size-7' },
+} as const
+
+/** Template icon tile: the icon named by the skillset index, colored from the
+ *  palette by template name, on a neutral grey square. The grey is `muted` at
+ *  half strength — the extra headroom lifts every accent above the 3:1
+ *  graphics threshold. The cards render the bare glyph instead; this tiled
+ *  form heads the details page. */
+export function TemplateAvatar({
+  template,
+  size = 'md',
+}: {
+  template: ApiDiscoverableAgent
+  size?: keyof typeof AVATAR_SIZES
+}) {
+  const Icon = getTemplateIcon(template)
+  const accent = getTemplateAccent(template.name)
+  const { tile, glyph } = AVATAR_SIZES[size]
+  return (
+    <span
+      className={`grid shrink-0 place-items-center bg-muted/50 shadow-[0_1px_2px_0_rgba(0,0,0,0.06)] ${tile}`}
+    >
+      <Icon className={`${accent} ${glyph}`} aria-hidden />
+    </span>
+  )
+}
+
+/**
+ * Marketplace card for one agent template: the icon stacked above the name,
+ * blurb, and the services it connects to. The whole card opens the details
+ * page, which is where installing happens.
+ */
+export function ExploreTemplateCard({
+  template,
+  onOpen,
+}: {
+  template: ApiDiscoverableAgent
+  onOpen: (template: ApiDiscoverableAgent) => void
+}) {
+  const Icon = getTemplateIcon(template)
+  return (
+    // Fixed 188px. A full two-line card needs ~175px (32px outer padding +
+    // 40px title row + 12px gap + 8px description lead-in + 39px of
+    // description + 8px gap + 36px chip row), so this leaves a little slack
+    // rather than pinning the chips against the text. Every field is bounded —
+    // the title truncates and the description clamps — so nothing outgrows it.
+    <div
+      data-testid="explore-template-card"
+      className="relative flex h-[188px] flex-col items-start gap-3 rounded-3xl border border-black/[0.06] bg-card p-4 text-left transition-colors hover:border-black/15 dark:border-white/[0.06] dark:hover:border-white/15 hover:bg-accent/30"
+    >
+      <button
+        type="button"
+        onClick={() => onOpen(template)}
+        aria-label={`${template.name} — details`}
+        className="absolute inset-0 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+
+      <span className="flex w-full items-center gap-2">
+        <span className="grid size-10 shrink-0 place-items-center rounded-xl bg-muted/50 shadow-[0_2px_6px_0_rgba(0,0,0,0.14)]">
+          <Icon className={`size-6 ${getTemplateAccent(template.name)}`} aria-hidden />
+        </span>
+        <span className="min-w-0 flex-1 truncate pl-1 text-[13px] font-medium text-foreground">
+          {template.name}
+        </span>
+      </span>
+
+      <span className="flex min-w-0 w-full flex-1 flex-col gap-2">
+        {/* No `block` here — it would override line-clamp's `-webkit-box`
+            display and the clamp would silently never apply. */}
+        <span className="line-clamp-2 pt-2 text-[13px] leading-normal text-muted-foreground/70">
+          {template.description}
+        </span>
+        <span className="mt-auto flex items-center gap-2 overflow-hidden pt-2">
+          <ToolStack template={template} />
+        </span>
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/components/explore/explore-templates.tsx
+++ b/src/renderer/components/explore/explore-templates.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from 'react'
+import { Button } from '@renderer/components/ui/button'
+import { useSkillsets } from '@renderer/hooks/use-skillsets'
+import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
+import { useDialogs } from '@renderer/context/dialog-context'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+/**
+ * The template roster for every Explore surface, with the one gate they all
+ * need.
+ *
+ * `useDiscoverableAgents` is `enabled: hasSkillsets`, so with no skillset
+ * configured it never runs: `isLoading` is false, `data` stays `undefined`
+ * forever, and a page that branches on `data === undefined` renders a skeleton
+ * that never resolves. Branch on `hasSkillsets` FIRST — that state is an empty
+ * state, not a loading one.
+ *
+ * While the skillset list itself is still loading the answer is unknown, so
+ * `hasSkillsets` optimistically reads true and `isLoading` covers the wait —
+ * flashing "connect a skillset" at someone who has one is worse than a beat of
+ * skeleton.
+ */
+export function useExploreTemplates(): {
+  templates: ApiDiscoverableAgent[]
+  hasSkillsets: boolean
+  isLoading: boolean
+} {
+  const { data: skillsets } = useSkillsets()
+  const { data: discoverableAgents, isLoading } = useDiscoverableAgents()
+
+  const hasSkillsets = skillsets === undefined || skillsets.length > 0
+  return {
+    templates: useMemo(() => discoverableAgents ?? [], [discoverableAgents]),
+    hasSkillsets,
+    isLoading:
+      skillsets === undefined || (hasSkillsets && (isLoading || discoverableAgents === undefined)),
+  }
+}
+
+/** Shown wherever the roster is empty because nothing supplies templates. */
+export function NoTemplatesEmptyState() {
+  const { openSettings } = useDialogs()
+  return (
+    <div className="flex flex-col items-center gap-3 py-16 text-center" data-testid="explore-empty">
+      <p className="text-sm text-muted-foreground">
+        No agent templates available. Connect a skillset with agent templates to get started.
+      </p>
+      <Button type="button" variant="outline" size="sm" onClick={() => openSettings('skillsets')}>
+        Manage skillsets
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/components/explore/explore-view.test.tsx
+++ b/src/renderer/components/explore/explore-view.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigate = vi.fn()
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => navigate }))
+
+const openSettings = vi.fn()
+vi.mock('@renderer/context/dialog-context', () => ({ useDialogs: () => ({ openSettings }) }))
+
+let skillsets: { id: string; name: string }[] | undefined = []
+let discoverable: ApiDiscoverableAgent[] | undefined
+let isLoading = false
+vi.mock('@renderer/hooks/use-skillsets', () => ({ useSkillsets: () => ({ data: skillsets }) }))
+vi.mock('@renderer/hooks/use-agent-templates', () => ({
+  useDiscoverableAgents: () => ({ data: discoverable, isLoading }),
+  slugFromAgentPath: (path: string) => path.replace(/^agents\//, '').replace(/\/$/, ''),
+}))
+
+import { ExploreView } from './explore-view'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+function template(name: string, over: Partial<ApiDiscoverableAgent> = {}): ApiDiscoverableAgent {
+  return {
+    skillsetId: 'skillset-1',
+    skillsetName: 'Public',
+    name,
+    description: `${name} does things`,
+    version: '1.0.0',
+    path: `agents/${name.toLowerCase().replace(/\s+/g, '-')}/`,
+    category: 'Marketing',
+    ...over,
+  }
+}
+
+/** n templates in one category, so the section overflows its five-card preview. */
+function roster(n: number, over: Partial<ApiDiscoverableAgent> = {}) {
+  return Array.from({ length: n }, (_, i) => template(`Agent ${i + 1}`, over))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  skillsets = [{ id: 'skillset-1', name: 'Public' }]
+  discoverable = roster(9)
+  isLoading = false
+})
+
+/**
+ * The tile in a section's sixth slot is only ever a link to the category page,
+ * so it always needs a call to action. Only the "+ N" remainder is conditional
+ * — a section hiding no more than the three it names has nothing left to count,
+ * which is exactly where Featured (eight first-party templates) lands.
+ */
+describe('ExploreView section overflow tile', () => {
+  it('counts the remainder when more is hidden than named', () => {
+    discoverable = roster(12) // 5 shown, 7 hidden, 3 of them named
+    render(<ExploreView />)
+    expect(within(screen.getByTestId('explore-see-more')).getByText('Show 4 more')).toBeTruthy()
+  })
+
+  it('still offers a way through when the tile names every hidden template', () => {
+    discoverable = roster(8) // 5 shown, 3 hidden — all named, nothing to count
+    render(<ExploreView />)
+    const tile = screen.getByTestId('explore-see-more')
+    expect(within(tile).queryByText(/Show \d+ more/)).toBeNull()
+    expect(within(tile).getByText('See all')).toBeTruthy()
+  })
+
+  it('opens the category page from the tile', async () => {
+    render(<ExploreView />)
+    await userEvent.click(screen.getByTestId('explore-see-more'))
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/explore/category/$category',
+      params: { category: 'Marketing' },
+    })
+  })
+
+  it('draws no tile when the section fits', () => {
+    discoverable = roster(5)
+    render(<ExploreView />)
+    expect(screen.queryByTestId('explore-see-more')).toBeNull()
+  })
+})
+
+/**
+ * "Nothing checked" has to mean "no filter" for every filter on the page,
+ * skillsets included — an empty set would strand the grid on zero results with
+ * no chip on screen explaining why.
+ */
+describe('ExploreView skillset filter', () => {
+  beforeEach(() => {
+    skillsets = [
+      { id: 'skillset-1', name: 'Public' },
+      { id: 'skillset-2', name: 'Private' },
+    ]
+    // The filter offers the skillsets that actually contribute templates.
+    discoverable = [
+      template('From Public'),
+      template('From Private', { skillsetId: 'skillset-2', skillsetName: 'Private' }),
+    ]
+  })
+
+  it('narrows to one skillset, then falls back to all when the last is unchecked', async () => {
+    render(<ExploreView />)
+    await userEvent.click(screen.getByLabelText('Filter by skillset'))
+
+    // Both start checked. Unchecking one leaves a real filter…
+    await userEvent.click(await screen.findByText('Public'))
+    expect(screen.getAllByTestId('explore-template-card').map((c) => c.textContent)).toEqual([
+      expect.stringContaining('From Private'),
+    ])
+
+    // …and unchecking the last one means "no filter", not "match nothing".
+    await userEvent.click(screen.getByText('Private'))
+    expect(screen.getAllByTestId('explore-template-card')).toHaveLength(2)
+  })
+})
+
+describe('ExploreView with no skillsets', () => {
+  it('shows the empty state rather than a skeleton that never resolves', () => {
+    skillsets = []
+    discoverable = undefined
+    render(<ExploreView />)
+    expect(screen.getByTestId('explore-empty')).toBeTruthy()
+  })
+
+  it('shows a skeleton while the skillset list is still loading', () => {
+    skillsets = undefined
+    discoverable = undefined
+    const { container } = render(<ExploreView />)
+    expect(screen.queryByTestId('explore-empty')).toBeNull()
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+})

--- a/src/renderer/components/explore/explore-view.tsx
+++ b/src/renderer/components/explore/explore-view.tsx
@@ -1,17 +1,36 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import { Check, Filter, Search, SlidersHorizontal } from 'lucide-react'
+import { ArrowRight, Check, Filter, Plus, Search, Settings2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
 import { useSkillsets } from '@renderer/hooks/use-skillsets'
 import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { useDialogs } from '@renderer/context/dialog-context'
 import { ExploreTemplateCard } from './explore-template-card'
-import { templateCategory } from './template-meta'
+import {
+  connectionIconSlug,
+  connectionLabel,
+  FEATURED_SECTION_LABEL,
+  getTemplateAccent,
+  getTemplateIcon,
+  isFeaturedTemplate,
+  templateCategory,
+} from './template-meta'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+/** Cards shown per category. The "see more" tile takes the sixth slot, so a
+ *  full section is three even grid rows at the two-column breakpoint. */
+const SECTION_PREVIEW_COUNT = 5
+
+/** Templates named on the see-more tile before the "+ N more" line. */
+const SEE_MORE_NAMED_COUNT = 3
+
+/** Bucket for templates whose skillset predates the category field. */
+const OTHER_CATEGORY = 'Other'
 
 /**
  * The full-page agent template marketplace behind the sidebar's Explore item.
@@ -28,8 +47,9 @@ export function ExploreView() {
 
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
-  // `null` means "no category filter"; a set means only those are shown.
+  // `null` means "no filter"; a set means only those are shown.
   const [selectedCategories, setSelectedCategories] = useState<Set<string> | null>(null)
+  const [selectedConnections, setSelectedConnections] = useState<Set<string> | null>(null)
   const [selectedSkillsets, setSelectedSkillsets] = useState<Set<string> | null>(null)
 
   useEffect(() => {
@@ -52,6 +72,22 @@ export function ExploreView() {
       .map(([name, count]) => ({ name, count }))
   }, [templates])
 
+  // Every service the roster connects to, most common first.
+  const connections = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const t of templates) {
+      // A template listing the same service twice shouldn't double-count it.
+      for (const slug of new Set((t.worksWith ?? []).map((c) => c.slug))) {
+        counts.set(slug, (counts.get(slug) ?? 0) + 1)
+      }
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || connectionLabel(a[0]).localeCompare(connectionLabel(b[0])))
+      .map(([slug, count]) => ({ slug, count }))
+  }, [templates])
+
+  const filterCount = (selectedCategories?.size ?? 0) + (selectedConnections?.size ?? 0)
+
   const skillsetList = useMemo(() => {
     const seen = new Map<string, string>()
     for (const t of templates) {
@@ -73,6 +109,12 @@ export function ExploreView() {
         const c = templateCategory(t)
         if (!c || !selectedCategories.has(c)) return false
       }
+      // Compatibility is an OR within itself: pick Slack and Gmail to see
+      // everything touching either, not only templates using both.
+      if (selectedConnections) {
+        const slugs = t.worksWith ?? []
+        if (!slugs.some((c) => selectedConnections.has(c.slug))) return false
+      }
       if (!q) return true
       return (
         t.name.toLowerCase().includes(q) ||
@@ -80,7 +122,41 @@ export function ExploreView() {
         (t.tags?.some((tag) => tag.toLowerCase().includes(q)) ?? false)
       )
     })
-  }, [templates, debouncedSearch, selectedCategories, activeSkillsets])
+  }, [templates, debouncedSearch, selectedCategories, selectedConnections, activeSkillsets])
+
+  /**
+   * With no search or filter on, the roster is 160+ templates — a flat grid
+   * buries everything past the first screen. Group into category sections and
+   * show only the first few of each, with a row that filters to the rest. Any
+   * active search or filter means the user is already narrowing, so the flat
+   * grid of results is what they want.
+   */
+  const isBrowsing = !debouncedSearch.trim() && filterCount === 0
+  const grouped = useMemo(() => {
+    if (!isBrowsing) return null
+    const byCategory = new Map<string, ApiDiscoverableAgent[]>()
+    const featured: ApiDiscoverableAgent[] = []
+    for (const t of filtered) {
+      // First-party templates lead the page, and stay in their category below
+      // — they're the best of that category, not a separate kind of thing.
+      if (isFeaturedTemplate(t)) featured.push(t)
+      const c = templateCategory(t) ?? OTHER_CATEGORY
+      const list = byCategory.get(c)
+      if (list) list.push(t)
+      else byCategory.set(c, [t])
+    }
+    const sections = [...byCategory.entries()]
+      .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
+      .map(([category, items]) => ({ category, items }))
+    if (featured.length > 0) {
+      sections.unshift({ category: FEATURED_SECTION_LABEL, items: featured })
+    }
+    return sections.map(({ category, items }) => ({
+      category,
+      shown: items.slice(0, SECTION_PREVIEW_COUNT),
+      rest: items.slice(SECTION_PREVIEW_COUNT),
+    }))
+  }, [filtered, isBrowsing])
 
   const openTemplate = (template: ApiDiscoverableAgent) => {
     void navigate({
@@ -93,117 +169,146 @@ export function ExploreView() {
   const showSkeleton = skillsets === undefined || (hasSkillsets && isLoading)
 
   return (
-    <SettingsPageContainer fullScreen className="px-[88px]">
-      <PageTitle title="Discover New Agents" />
+    // `pt-12` rather than `fullScreen`'s `pt-4`: the notifications page sits a
+    // back button above its heading, and this page has none — without the extra
+    // lead-in the title crowds the header border.
+    <SettingsPageContainer fullScreen className="px-[88px] pb-16 pt-12">
+      <PageTitle
+        title="Discover New Agents"
+        actions={
+          <div className="flex items-center gap-2">
+              <div className="relative w-56">
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search templates..."
+                  className="pl-8"
+                />
+              </div>
 
-      <div className="space-y-4" data-testid="explore-view">
-        <div className="flex flex-wrap items-center gap-2">
-          {categories.length > 1 && (
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button type="button" variant="outline" className="h-9 gap-2">
-                  <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
-                  Category
-                  {selectedCategories && selectedCategories.size > 0 && (
-                    <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-foreground">
-                      {selectedCategories.size}
-                    </span>
-                  )}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-56 p-1 space-y-0.5">
-                {categories.map(({ name, count }) => {
-                  const checked = selectedCategories?.has(name) ?? false
-                  return (
-                    <button
-                      key={name}
+              {(categories.length > 1 || connections.length > 1) && (
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
                       type="button"
-                      onClick={() => {
-                        const next = new Set(selectedCategories ?? [])
-                        if (checked) next.delete(name)
-                        else next.add(name)
-                        // Empty set === no filter, so the list never goes blank.
-                        setSelectedCategories(next.size === 0 ? null : next)
-                      }}
-                      className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent ${
-                        checked ? 'bg-accent' : ''
-                      }`}
+                      variant="outline"
+                      className="h-9 gap-2 px-3"
+                      title="Filter"
+                      aria-label="Filter"
                     >
-                      <span className="min-w-0 flex-1 truncate text-xs">{name}</span>
-                      <span className="shrink-0 text-[11px] text-muted-foreground">{count}</span>
-                      {checked && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
-                    </button>
-                  )
-                })}
-                {selectedCategories && (
-                  <button
-                    type="button"
-                    onClick={() => setSelectedCategories(null)}
-                    className="mt-0.5 flex w-full items-center rounded-sm border-t px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
-                  >
-                    Clear
-                  </button>
-                )}
-              </PopoverContent>
-            </Popover>
-          )}
+                      <Settings2 className="h-4 w-4 text-muted-foreground" />
+                      {filterCount > 0 && (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-foreground">
+                          {filterCount}
+                        </span>
+                      )}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent align="end" className="w-64 p-0">
+                    {/* Compatibility can run to ~30 services, so the body scrolls
+                        and the Clear footer stays pinned below it. */}
+                    <div className="max-h-[340px] overflow-y-auto p-1">
+                      {categories.length > 1 && (
+                        <>
+                          <FilterSectionLabel>Category</FilterSectionLabel>
+                          {categories.map(({ name, count }) => (
+                            <FilterRow
+                              key={name}
+                              label={name}
+                              count={count}
+                              checked={selectedCategories?.has(name) ?? false}
+                              onToggle={() => toggleIn(selectedCategories, name, setSelectedCategories)}
+                            />
+                          ))}
+                        </>
+                      )}
 
-          {/* Search sits at the far right; `ml-auto` pushes it and the skillset
-              filter away from the category chips on the left. */}
-          <div className="relative ml-auto w-56">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search templates..."
-              className="pl-8"
-            />
+                      {connections.length > 1 && (
+                        <>
+                          <FilterSectionLabel className={categories.length > 1 ? 'mt-2' : undefined}>
+                            Compatibility
+                          </FilterSectionLabel>
+                          {connections.map(({ slug, count }) => (
+                            <FilterRow
+                              key={slug}
+                              label={connectionLabel(slug)}
+                              count={count}
+                              checked={selectedConnections?.has(slug) ?? false}
+                              onToggle={() => toggleIn(selectedConnections, slug, setSelectedConnections)}
+                              icon={<ServiceIcon slug={connectionIconSlug(slug)} className="size-3.5" />}
+                            />
+                          ))}
+                        </>
+                      )}
+                    </div>
+
+                    {filterCount > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setSelectedCategories(null)
+                          setSelectedConnections(null)
+                        }}
+                        className="flex w-full items-center border-t px-3 py-2 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+                      >
+                        Clear filters
+                      </button>
+                    )}
+                  </PopoverContent>
+                </Popover>
+              )}
+
+              {skillsetList.length > 1 && (
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="outline"
+                      className="h-9 w-9 relative"
+                      title="Filter by skillset"
+                      aria-label="Filter by skillset"
+                    >
+                      <Filter className="h-4 w-4 text-muted-foreground" />
+                      {selectedSkillsets && selectedSkillsets.size < skillsetList.length && (
+                        <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-primary" />
+                      )}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent align="end" className="w-56 p-1 space-y-0.5">
+                    {skillsetList.map((ss) => {
+                      const checked = activeSkillsets.has(ss.id)
+                      return (
+                        <button
+                          key={ss.id}
+                          type="button"
+                          onClick={() => {
+                            const next = new Set(activeSkillsets)
+                            if (checked) next.delete(ss.id)
+                            else next.add(ss.id)
+                            setSelectedSkillsets(next.size === skillsetList.length ? null : next)
+                          }}
+                          className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent ${
+                            checked ? 'bg-accent' : ''
+                          }`}
+                        >
+                          <span className="text-xs truncate flex-1 min-w-0">{ss.name}</span>
+                          {checked && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
+                        </button>
+                      )
+                    })}
+                  </PopoverContent>
+                </Popover>
+              )}
           </div>
+        }
+      />
 
-          {skillsetList.length > 1 && (
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="outline"
-                  className="h-9 w-9 relative"
-                  title="Filter by skillset"
-                  aria-label="Filter by skillset"
-                >
-                  <Filter className="h-4 w-4 text-muted-foreground" />
-                  {selectedSkillsets && selectedSkillsets.size < skillsetList.length && (
-                    <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-primary" />
-                  )}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent align="end" className="w-56 p-1 space-y-0.5">
-                {skillsetList.map((ss) => {
-                  const checked = activeSkillsets.has(ss.id)
-                  return (
-                    <button
-                      key={ss.id}
-                      type="button"
-                      onClick={() => {
-                        const next = new Set(activeSkillsets)
-                        if (checked) next.delete(ss.id)
-                        else next.add(ss.id)
-                        setSelectedSkillsets(next.size === skillsetList.length ? null : next)
-                      }}
-                      className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent ${
-                        checked ? 'bg-accent' : ''
-                      }`}
-                    >
-                      <span className="text-xs truncate flex-1 min-w-0">{ss.name}</span>
-                      {checked && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
-                    </button>
-                  )
-                })}
-              </PopoverContent>
-            </Popover>
-          )}
-        </div>
-
+      {/* `pt-*`, not `mt-*`: the container's `space-y-6` sets margin-top via a
+          descendant selector that outranks a margin utility here, so a margin
+          would be silently ignored. */}
+      <div className="space-y-4 pt-6" data-testid="explore-view">
         {showSkeleton ? (
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -225,6 +330,31 @@ export function ExploreView() {
               ? `No templates matching "${debouncedSearch}"`
               : 'No templates in this category'}
           </p>
+        ) : grouped ? (
+          <div className="space-y-10">
+            {grouped.map(({ category, shown, rest }) => (
+              <section key={category}>
+                <h3 className="mb-3 text-sm font-medium text-foreground">{category}</h3>
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                  {shown.map((template) => (
+                    <ExploreTemplateCard
+                      key={`${template.skillsetId}/${template.path}`}
+                      template={template}
+                      onOpen={openTemplate}
+                    />
+                  ))}
+                  {rest.length > 0 && (
+                    <SeeMoreCard
+                      rest={rest}
+                      onClick={() =>
+                        void navigate({ to: '/explore/category/$category', params: { category } })
+                      }
+                    />
+                  )}
+                </div>
+              </section>
+            ))}
+          </div>
         ) : (
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             {filtered.map((template) => (
@@ -241,3 +371,109 @@ export function ExploreView() {
   )
 }
 
+
+/** Add or remove one value from a filter set. An empty set collapses back to
+ *  `null` — "nothing checked" must mean "no filter", not "match nothing". */
+function toggleIn(
+  current: Set<string> | null,
+  value: string,
+  set: (next: Set<string> | null) => void,
+) {
+  const next = new Set(current ?? [])
+  if (next.has(value)) next.delete(value)
+  else next.add(value)
+  set(next.size === 0 ? null : next)
+}
+
+function FilterSectionLabel({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={`px-2 pb-1 pt-1.5 text-xs text-muted-foreground/60 ${className ?? ''}`}>
+      {children}
+    </div>
+  )
+}
+
+function FilterRow({
+  label,
+  count,
+  checked,
+  onToggle,
+  icon,
+}: {
+  label: string
+  count: number
+  checked: boolean
+  onToggle: () => void
+  icon?: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={checked}
+      className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent ${
+        checked ? 'bg-accent' : ''
+      }`}
+    >
+      {icon}
+      <span className="min-w-0 truncate text-sm">{label}</span>
+      <span className="shrink-0 text-xs text-muted-foreground/60">{count}</span>
+      {checked && <Check className="ml-auto h-3.5 w-3.5 shrink-0 text-foreground" />}
+    </button>
+  )
+}
+
+/**
+ * The section's sixth grid slot: a count header, a few of the hidden templates
+ * by name, and a footer link. Clicking anywhere filters the page to that
+ * category.
+ */
+function SeeMoreCard({ rest, onClick }: { rest: ApiDiscoverableAgent[]; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex h-[180px] w-full flex-col gap-3 rounded-3xl bg-muted/50 p-4 text-left transition-colors hover:bg-muted"
+    >
+      <span className="flex min-w-0 flex-1 flex-col justify-center gap-2">
+        {rest.slice(0, SEE_MORE_NAMED_COUNT).map((template) => {
+          const Icon = getTemplateIcon(template)
+          return (
+            <span
+              key={`${template.skillsetId}/${template.path}`}
+              className="flex min-w-0 items-center gap-2"
+            >
+              <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
+                <Icon className={`size-4 ${getTemplateAccent(template.name)}`} aria-hidden />
+              </span>
+              <span className="truncate text-[13px] text-muted-foreground">{template.name}</span>
+            </span>
+          )
+        })}
+        {rest.length > SEE_MORE_NAMED_COUNT && (
+          // The ellipsis sits in the glyph column, so the count lines up with
+          // the names above it.
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
+              <Plus className="size-4 text-muted-foreground/50" aria-hidden />
+            </span>
+            <span className="flex min-w-0 items-center gap-1 truncate text-[13px] text-muted-foreground/70">
+              Show {rest.length - SEE_MORE_NAMED_COUNT} more
+              <ArrowRight
+                className="size-3.5 shrink-0 transition-transform group-hover:translate-x-0.5"
+                aria-hidden
+              />
+            </span>
+          </span>
+        )}
+      </span>
+
+    </button>
+  )
+}

--- a/src/renderer/components/explore/explore-view.tsx
+++ b/src/renderer/components/explore/explore-view.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { Check, Filter, Search, SlidersHorizontal } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { Input } from '@renderer/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { Skeleton } from '@renderer/components/ui/skeleton'
+import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
+import { useSkillsets } from '@renderer/hooks/use-skillsets'
+import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
+import { useDialogs } from '@renderer/context/dialog-context'
+import { ExploreTemplateCard } from './explore-template-card'
+import { templateCategory } from './template-meta'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+/**
+ * The full-page agent template marketplace behind the sidebar's Explore item.
+ * Same data source as the browse dialog (`useDiscoverableAgents`); the
+ * category filter offers the real categories declared by the skillset index.
+ * Cards open `/explore/$skillsetId/$templateSlug`, which is where installing
+ * happens.
+ */
+export function ExploreView() {
+  const navigate = useNavigate()
+  const { openSettings } = useDialogs()
+  const { data: skillsets } = useSkillsets()
+  const { data: discoverableAgents, isLoading } = useDiscoverableAgents()
+
+  const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  // `null` means "no category filter"; a set means only those are shown.
+  const [selectedCategories, setSelectedCategories] = useState<Set<string> | null>(null)
+  const [selectedSkillsets, setSelectedSkillsets] = useState<Set<string> | null>(null)
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearch(search), 150)
+    return () => clearTimeout(id)
+  }, [search])
+
+  const templates = useMemo(() => discoverableAgents ?? [], [discoverableAgents])
+
+  // The categories this roster actually declares, with counts — most populated
+  // first so the long tail of one-off categories sorts last.
+  const categories = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const t of templates) {
+      const c = templateCategory(t)
+      if (c) counts.set(c, (counts.get(c) ?? 0) + 1)
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([name, count]) => ({ name, count }))
+  }, [templates])
+
+  const skillsetList = useMemo(() => {
+    const seen = new Map<string, string>()
+    for (const t of templates) {
+      if (!seen.has(t.skillsetId)) seen.set(t.skillsetId, t.skillsetName)
+    }
+    return Array.from(seen, ([id, name]) => ({ id, name }))
+  }, [templates])
+
+  const activeSkillsets = useMemo(
+    () => selectedSkillsets ?? new Set(skillsetList.map((s) => s.id)),
+    [selectedSkillsets, skillsetList],
+  )
+
+  const filtered = useMemo(() => {
+    const q = debouncedSearch.trim().toLowerCase()
+    return templates.filter((t) => {
+      if (!activeSkillsets.has(t.skillsetId)) return false
+      if (selectedCategories) {
+        const c = templateCategory(t)
+        if (!c || !selectedCategories.has(c)) return false
+      }
+      if (!q) return true
+      return (
+        t.name.toLowerCase().includes(q) ||
+        t.description.toLowerCase().includes(q) ||
+        (t.tags?.some((tag) => tag.toLowerCase().includes(q)) ?? false)
+      )
+    })
+  }, [templates, debouncedSearch, selectedCategories, activeSkillsets])
+
+  const openTemplate = (template: ApiDiscoverableAgent) => {
+    void navigate({
+      to: '/explore/$skillsetId/$templateSlug',
+      params: { skillsetId: template.skillsetId, templateSlug: slugFromAgentPath(template.path) },
+    })
+  }
+
+  const hasSkillsets = skillsets === undefined || skillsets.length > 0
+  const showSkeleton = skillsets === undefined || (hasSkillsets && isLoading)
+
+  return (
+    <SettingsPageContainer fullScreen className="px-[88px]">
+      <PageTitle title="Discover New Agents" />
+
+      <div className="space-y-4" data-testid="explore-view">
+        <div className="flex flex-wrap items-center gap-2">
+          {categories.length > 1 && (
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button type="button" variant="outline" className="h-9 gap-2">
+                  <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+                  Category
+                  {selectedCategories && selectedCategories.size > 0 && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-foreground">
+                      {selectedCategories.size}
+                    </span>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-56 p-1 space-y-0.5">
+                {categories.map(({ name, count }) => {
+                  const checked = selectedCategories?.has(name) ?? false
+                  return (
+                    <button
+                      key={name}
+                      type="button"
+                      onClick={() => {
+                        const next = new Set(selectedCategories ?? [])
+                        if (checked) next.delete(name)
+                        else next.add(name)
+                        // Empty set === no filter, so the list never goes blank.
+                        setSelectedCategories(next.size === 0 ? null : next)
+                      }}
+                      className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent ${
+                        checked ? 'bg-accent' : ''
+                      }`}
+                    >
+                      <span className="min-w-0 flex-1 truncate text-xs">{name}</span>
+                      <span className="shrink-0 text-[11px] text-muted-foreground">{count}</span>
+                      {checked && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
+                    </button>
+                  )
+                })}
+                {selectedCategories && (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedCategories(null)}
+                    className="mt-0.5 flex w-full items-center rounded-sm border-t px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+                  >
+                    Clear
+                  </button>
+                )}
+              </PopoverContent>
+            </Popover>
+          )}
+
+          {/* Search sits at the far right; `ml-auto` pushes it and the skillset
+              filter away from the category chips on the left. */}
+          <div className="relative ml-auto w-56">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search templates..."
+              className="pl-8"
+            />
+          </div>
+
+          {skillsetList.length > 1 && (
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  className="h-9 w-9 relative"
+                  title="Filter by skillset"
+                  aria-label="Filter by skillset"
+                >
+                  <Filter className="h-4 w-4 text-muted-foreground" />
+                  {selectedSkillsets && selectedSkillsets.size < skillsetList.length && (
+                    <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-primary" />
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-56 p-1 space-y-0.5">
+                {skillsetList.map((ss) => {
+                  const checked = activeSkillsets.has(ss.id)
+                  return (
+                    <button
+                      key={ss.id}
+                      type="button"
+                      onClick={() => {
+                        const next = new Set(activeSkillsets)
+                        if (checked) next.delete(ss.id)
+                        else next.add(ss.id)
+                        setSelectedSkillsets(next.size === skillsetList.length ? null : next)
+                      }}
+                      className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent ${
+                        checked ? 'bg-accent' : ''
+                      }`}
+                    >
+                      <span className="text-xs truncate flex-1 min-w-0">{ss.name}</span>
+                      {checked && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
+                    </button>
+                  )
+                })}
+              </PopoverContent>
+            </Popover>
+          )}
+        </div>
+
+        {showSkeleton ? (
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-40 rounded-2xl" />
+            ))}
+          </div>
+        ) : !hasSkillsets || templates.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-16 text-center">
+            <p className="text-sm text-muted-foreground">
+              No agent templates available. Connect a skillset with agent templates to get started.
+            </p>
+            <Button type="button" variant="outline" size="sm" onClick={() => openSettings('skillsets')}>
+              Manage skillsets
+            </Button>
+          </div>
+        ) : filtered.length === 0 ? (
+          <p className="py-16 text-center text-sm text-muted-foreground">
+            {debouncedSearch.trim()
+              ? `No templates matching "${debouncedSearch}"`
+              : 'No templates in this category'}
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {filtered.map((template) => (
+              <ExploreTemplateCard
+                key={`${template.skillsetId}/${template.path}`}
+                template={template}
+                onOpen={openTemplate}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </SettingsPageContainer>
+  )
+}
+

--- a/src/renderer/components/explore/explore-view.tsx
+++ b/src/renderer/components/explore/explore-view.tsx
@@ -7,12 +7,10 @@ import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
-import { useSkillsets } from '@renderer/hooks/use-skillsets'
-import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
-import { useDialogs } from '@renderer/context/dialog-context'
+import { slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { ExploreTemplateCard } from './explore-template-card'
+import { NoTemplatesEmptyState, useExploreTemplates } from './explore-templates'
 import {
-  connectionIconSlug,
   connectionLabel,
   FEATURED_SECTION_LABEL,
   getTemplateAccent,
@@ -41,9 +39,7 @@ const OTHER_CATEGORY = 'Other'
  */
 export function ExploreView() {
   const navigate = useNavigate()
-  const { openSettings } = useDialogs()
-  const { data: skillsets } = useSkillsets()
-  const { data: discoverableAgents, isLoading } = useDiscoverableAgents()
+  const { templates, hasSkillsets, isLoading } = useExploreTemplates()
 
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
@@ -56,8 +52,6 @@ export function ExploreView() {
     const id = setTimeout(() => setDebouncedSearch(search), 150)
     return () => clearTimeout(id)
   }, [search])
-
-  const templates = useMemo(() => discoverableAgents ?? [], [discoverableAgents])
 
   // The categories this roster actually declares, with counts — most populated
   // first so the long tail of one-off categories sorts last.
@@ -165,9 +159,6 @@ export function ExploreView() {
     })
   }
 
-  const hasSkillsets = skillsets === undefined || skillsets.length > 0
-  const showSkeleton = skillsets === undefined || (hasSkillsets && isLoading)
-
   return (
     // `pt-12` rather than `fullScreen`'s `pt-4`: the notifications page sits a
     // back button above its heading, and this page has none — without the extra
@@ -236,7 +227,7 @@ export function ExploreView() {
                               count={count}
                               checked={selectedConnections?.has(slug) ?? false}
                               onToggle={() => toggleIn(selectedConnections, slug, setSelectedConnections)}
-                              icon={<ServiceIcon slug={connectionIconSlug(slug)} className="size-3.5" />}
+                              icon={<ServiceIcon slug={slug} className="size-3.5 shrink-0" />}
                             />
                           ))}
                         </>
@@ -287,7 +278,13 @@ export function ExploreView() {
                             const next = new Set(activeSkillsets)
                             if (checked) next.delete(ss.id)
                             else next.add(ss.id)
-                            setSelectedSkillsets(next.size === skillsetList.length ? null : next)
+                            // Same rule as `toggleIn`: all checked and none
+                            // checked both mean "no filter". Letting the set
+                            // empty out would strand the page on zero results
+                            // with no filter chip explaining why.
+                            setSelectedSkillsets(
+                              next.size === 0 || next.size === skillsetList.length ? null : next,
+                            )
                           }}
                           className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent ${
                             checked ? 'bg-accent' : ''
@@ -309,26 +306,19 @@ export function ExploreView() {
           descendant selector that outranks a margin utility here, so a margin
           would be silently ignored. */}
       <div className="space-y-4 pt-6" data-testid="explore-view">
-        {showSkeleton ? (
+        {isLoading ? (
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             {Array.from({ length: 6 }).map((_, i) => (
               <Skeleton key={i} className="h-40 rounded-2xl" />
             ))}
           </div>
         ) : !hasSkillsets || templates.length === 0 ? (
-          <div className="flex flex-col items-center gap-3 py-16 text-center">
-            <p className="text-sm text-muted-foreground">
-              No agent templates available. Connect a skillset with agent templates to get started.
-            </p>
-            <Button type="button" variant="outline" size="sm" onClick={() => openSettings('skillsets')}>
-              Manage skillsets
-            </Button>
-          </div>
+          <NoTemplatesEmptyState />
         ) : filtered.length === 0 ? (
           <p className="py-16 text-center text-sm text-muted-foreground">
             {debouncedSearch.trim()
               ? `No templates matching "${debouncedSearch}"`
-              : 'No templates in this category'}
+              : 'No templates match these filters'}
           </p>
         ) : grouped ? (
           <div className="space-y-10">
@@ -430,16 +420,22 @@ function FilterRow({
 }
 
 /**
- * The section's sixth grid slot: a count header, a few of the hidden templates
- * by name, and a footer link. Clicking anywhere filters the page to that
- * category.
+ * The section's sixth grid slot: a few of the hidden templates by name over a
+ * call to action. Clicking anywhere opens that category's page.
+ *
+ * The call to action is unconditional — the tile is only ever a link, so one
+ * without it reads as a card that failed to render. Only the "+ N" count is
+ * conditional, since a section hiding no more than it names has no remainder
+ * to count (Featured, at eight templates, is exactly that case).
  */
 function SeeMoreCard({ rest, onClick }: { rest: ApiDiscoverableAgent[]; onClick: () => void }) {
+  const unnamed = rest.length - Math.min(rest.length, SEE_MORE_NAMED_COUNT)
   return (
     <button
       type="button"
+      data-testid="explore-see-more"
       onClick={onClick}
-      className="group flex h-[180px] w-full flex-col gap-3 rounded-3xl bg-muted/50 p-4 text-left transition-colors hover:bg-muted"
+      className="group flex h-[180px] w-full flex-col gap-3 rounded-3xl bg-muted/50 p-4 text-left transition-colors duration-200 hover:bg-muted"
     >
       <span className="flex min-w-0 flex-1 flex-col justify-center gap-2">
         {rest.slice(0, SEE_MORE_NAMED_COUNT).map((template) => {
@@ -456,22 +452,29 @@ function SeeMoreCard({ rest, onClick }: { rest: ApiDiscoverableAgent[]; onClick:
             </span>
           )
         })}
-        {rest.length > SEE_MORE_NAMED_COUNT && (
-          // The ellipsis sits in the glyph column, so the count lines up with
-          // the names above it.
-          <span className="flex min-w-0 items-center gap-2">
-            <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
+        {/* The glyph sits in the same column as the icons above, so the label
+            lines up with the names. */}
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
+            {unnamed > 0 ? (
               <Plus className="size-4 text-muted-foreground/50" aria-hidden />
-            </span>
-            <span className="flex min-w-0 items-center gap-1 truncate text-[13px] text-muted-foreground/70">
-              Show {rest.length - SEE_MORE_NAMED_COUNT} more
+            ) : (
               <ArrowRight
-                className="size-3.5 shrink-0 transition-transform group-hover:translate-x-0.5"
+                className="size-4 text-muted-foreground/50 transition-transform duration-200 group-hover:translate-x-0.5"
                 aria-hidden
               />
-            </span>
+            )}
           </span>
-        )}
+          <span className="flex min-w-0 items-center gap-1 truncate text-[13px] text-muted-foreground/70">
+            {unnamed > 0 ? `Show ${unnamed} more` : 'See all'}
+            {unnamed > 0 && (
+              <ArrowRight
+                className="size-3.5 shrink-0 transition-transform duration-200 group-hover:translate-x-0.5"
+                aria-hidden
+              />
+            )}
+          </span>
+        </span>
       </span>
 
     </button>

--- a/src/renderer/components/explore/template-detail-view.test.tsx
+++ b/src/renderer/components/explore/template-detail-view.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigate = vi.fn()
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => navigate }))
+
+const openSettings = vi.fn()
+vi.mock('@renderer/context/dialog-context', () => ({ useDialogs: () => ({ openSettings }) }))
+
+vi.mock('@renderer/hooks/use-complete-template-install', () => ({
+  useCompleteTemplateInstall: () => vi.fn(),
+}))
+vi.mock('@renderer/components/agents/template-install-dialog', () => ({
+  TemplateInstallDialog: () => null,
+}))
+
+let skillsets: unknown[] | undefined = []
+let discoverable: ApiDiscoverableAgent[] | undefined
+let isLoading = false
+vi.mock('@renderer/hooks/use-skillsets', () => ({ useSkillsets: () => ({ data: skillsets }) }))
+vi.mock('@renderer/hooks/use-agent-templates', () => ({
+  useDiscoverableAgents: () => ({ data: discoverable, isLoading }),
+  slugFromAgentPath: (path: string) => path.replace(/^agents\//, '').replace(/\/$/, ''),
+}))
+
+import { TemplateDetailView } from './template-detail-view'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+// The `## Credits` body verbatim from the public skillset's `Account Expert` —
+// the shape 160 of its 168 templates ship, absolute links and repo-relative
+// link together.
+const CREDITS =
+  '## Credits\n\nOriginal prompt credited to [@kristaletz](https://x.com/kristaletz) on ' +
+  '[Bot Directory](https://botdirectory.ai/bots/account-expert/). Imported from the ' +
+  'MIT-licensed catalog; see the [attribution and license](../../sources/botdirectory/NOTICE.md).'
+
+const template: ApiDiscoverableAgent = {
+  skillsetId: 'skillset-1',
+  skillsetName: 'Public',
+  name: 'Account Expert',
+  description: 'Tracks an account',
+  version: '1.0.0',
+  path: 'agents/account-expert/',
+  details: CREDITS,
+  developer: { name: '@kristaletz', url: 'https://x.com/kristaletz' },
+}
+
+function renderDetail(slug = 'account-expert') {
+  return render(<TemplateDetailView skillsetId="skillset-1" templateSlug={slug} />)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  skillsets = [{ id: 'skillset-1' }]
+  discoverable = [template]
+  isLoading = false
+})
+
+/**
+ * The details body is markdown from a third-party git repo. Nothing in front of
+ * a same-window navigation catches it: there is no `will-navigate` handler in
+ * the main process, and no Reload or Back in the app menu — so an unguarded
+ * link replaces the whole app and the only way back is relaunching.
+ * `target="_blank"` is what avoids that on BOTH targets: a tab on the web, and
+ * in Electron the one path that reaches setWindowOpenHandler → the default
+ * browser.
+ */
+describe('TemplateDetailView body links', () => {
+  it('opens absolute links out of the window', () => {
+    renderDetail()
+    const external = screen.getByRole('link', { name: 'Bot Directory' })
+    expect(external).toHaveAttribute('href', 'https://botdirectory.ai/bots/account-expert/')
+    expect(external).toHaveAttribute('target', '_blank')
+    expect(external).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+
+  it('never leaves a body link that would navigate this window', () => {
+    renderDetail()
+    for (const link of screen.getAllByRole('link')) {
+      expect(link).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  it('renders a repo-relative link as text, keeping its words', () => {
+    renderDetail()
+    expect(screen.queryByRole('link', { name: 'attribution and license' })).toBeNull()
+    expect(screen.getByText(/attribution and license/)).toBeTruthy()
+  })
+
+  it('refuses a dangerous scheme instead of linking it', () => {
+    discoverable = [
+      // eslint-disable-next-line no-script-url
+      { ...template, details: '## Credits\n\n[click me](javascript:alert(1))' },
+    ]
+    renderDetail()
+    expect(screen.queryByRole('link', { name: 'click me' })).toBeNull()
+    expect(screen.getByText('click me')).toBeTruthy()
+  })
+
+  it('applies the same policy to the developer row', () => {
+    discoverable = [{ ...template, details: undefined }]
+    renderDetail()
+    const developer = screen.getByRole('link', { name: '@kristaletz' })
+    expect(developer).toHaveAttribute('href', 'https://x.com/kristaletz')
+    expect(developer).toHaveAttribute('target', '_blank')
+
+    discoverable = [
+      { ...template, details: undefined, developer: { name: 'Someone', url: 'file:///etc/passwd' } },
+    ]
+    renderDetail()
+    expect(screen.queryByRole('link', { name: 'Someone' })).toBeNull()
+    expect(screen.getAllByText('Someone').length).toBeGreaterThan(0)
+  })
+})
+
+/**
+ * `useDiscoverableAgents` is `enabled: hasSkillsets`, so with none configured it
+ * never runs and its data stays undefined. Branching on the data alone leaves a
+ * skeleton that never resolves.
+ */
+describe('TemplateDetailView with no skillsets', () => {
+  it('shows the empty state rather than a skeleton that never resolves', () => {
+    skillsets = []
+    discoverable = undefined
+    renderDetail()
+    expect(screen.getByTestId('explore-empty')).toBeTruthy()
+    expect(screen.queryByTestId('template-not-found')).toBeNull()
+  })
+
+  it('still shows a skeleton while the skillset list is loading', () => {
+    skillsets = undefined
+    discoverable = undefined
+    const { container } = renderDetail()
+    expect(screen.queryByTestId('explore-empty')).toBeNull()
+    expect(screen.queryByTestId('template-not-found')).toBeNull()
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('reports a genuinely missing template as missing', () => {
+    renderDetail('not-a-real-template')
+    expect(screen.getByTestId('template-not-found')).toBeTruthy()
+  })
+})

--- a/src/renderer/components/explore/template-detail-view.tsx
+++ b/src/renderer/components/explore/template-detail-view.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import ReactMarkdown from 'react-markdown'
+import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { Button } from '@renderer/components/ui/button'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import {
@@ -11,13 +10,15 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@renderer/components/ui/tooltip'
+import { Button } from '@renderer/components/ui/button'
 import { SettingsPageContainer, PageTitle } from '@renderer/components/layout/settings-page'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
-import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
+import { slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { useCompleteTemplateInstall } from '@renderer/hooks/use-complete-template-install'
+import { markdownUrlTransform, safeHref } from '@renderer/lib/markdown-url-transform'
 import { TemplateAvatar } from './explore-template-card'
+import { NoTemplatesEmptyState, useExploreTemplates } from './explore-templates'
 import {
-  connectionIconSlug,
   connectionLabel,
   INVENTORY_SECTION_LABEL,
   INVENTORY_SECTION_TITLES,
@@ -33,6 +34,47 @@ import { ArrowUp } from 'lucide-react'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 const DETAILS_REMARK_PLUGINS = [remarkGfm]
+
+/**
+ * Whether a details-body href may be rendered as a link at all.
+ *
+ * Two things are being refused. `safeHref` (the renderer's single link policy,
+ * shared with the Electron shell opener) blanks dangerous schemes. Everything
+ * relative is refused on top of that: the imported templates' `Credits`
+ * sections link `../../sources/botdirectory/NOTICE.md`, a path inside the
+ * skillset repo that resolves against *this app's* document URL and means
+ * nothing here. Refused hrefs render as plain text rather than as a link that
+ * goes somewhere wrong.
+ */
+function externalHref(href: string | undefined): string | undefined {
+  if (!href || !safeHref(href)) return undefined
+  return /^https?:\/\//i.test(href) ? href : undefined
+}
+
+/**
+ * `target="_blank"` is what makes an outbound link safe here, on both targets:
+ * on the web it opens a tab, and in Electron it is the ONLY path that reaches
+ * `setWindowOpenHandler` → `safeOpenExternal` → the default browser. A
+ * same-window navigation has no guard in front of it — no `will-navigate`
+ * handler, no Reload or Back in the app menu — so it replaces the app with the
+ * destination and the only way back is relaunching.
+ */
+const DETAILS_MARKDOWN_COMPONENTS: Components = {
+  a: ({ children, href }) => {
+    const external = externalHref(href)
+    if (!external) return <>{children}</>
+    return (
+      <a
+        href={external}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-foreground underline underline-offset-2"
+      >
+        {children}
+      </a>
+    )
+  },
+}
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -66,16 +108,16 @@ export function TemplateDetailView({
   templateSlug: string
 }) {
   const navigate = useNavigate()
-  const { data: discoverableAgents, isLoading } = useDiscoverableAgents()
+  const { templates, hasSkillsets, isLoading } = useExploreTemplates()
   const completeInstall = useCompleteTemplateInstall()
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
 
   const template = useMemo(
     () =>
-      discoverableAgents?.find(
+      templates.find(
         (t) => t.skillsetId === skillsetId && slugFromAgentPath(t.path) === templateSlug,
       ),
-    [discoverableAgents, skillsetId, templateSlug],
+    [templates, skillsetId, templateSlug],
   )
   const backToExplore = {
     onClick: () => void navigate({ to: '/explore' }),
@@ -84,14 +126,19 @@ export function TemplateDetailView({
 
   if (!template) {
     return (
-      <SettingsPageContainer className="max-w-[768px] px-[88px]">
+      // `space-y-4`, not the container's default `space-y-10`: a margin utility
+      // on the child would lose to `.space-y-10 > :not([hidden]) ~ :not([hidden])`
+      // on specificity and do nothing at all.
+      <SettingsPageContainer className="max-w-[768px] px-[88px] space-y-4">
         <PageTitle title="" back={backToExplore} />
-        {isLoading || discoverableAgents === undefined ? (
+        {isLoading ? (
           <div className="space-y-4">
             <Skeleton className="size-16 rounded-2xl" />
             <Skeleton className="h-7 w-56" />
             <Skeleton className="h-48 rounded-2xl" />
           </div>
+        ) : !hasSkillsets ? (
+          <NoTemplatesEmptyState />
         ) : (
           <p className="py-16 text-center text-sm text-muted-foreground" data-testid="template-not-found">
             This template is no longer available in your connected skillsets.
@@ -107,10 +154,13 @@ export function TemplateDetailView({
   const useCases = getTemplateExamples(template.details)
 
   return (
-    <SettingsPageContainer className="max-w-[768px] px-[88px]">
+    // `space-y-4` on the container rather than a `-mt-*` pull on the child: the
+    // container's own `.space-y-10 > :not([hidden]) ~ :not([hidden])` outranks a
+    // margin utility, so the margin would be silently dropped.
+    <SettingsPageContainer className="max-w-[768px] px-[88px] space-y-4">
       <PageTitle title="" back={backToExplore} />
 
-      <div data-testid="template-detail-view" className="-mt-6">
+      <div data-testid="template-detail-view">
         {/* ── Header ───────────────────────────────────────────────────── */}
         <div data-testid="template-detail-header">
           <div className="flex items-center justify-between gap-6">
@@ -167,7 +217,7 @@ export function TemplateDetailView({
                   className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-[11px] text-muted-foreground"
                 >
                   <ServiceIcon
-                    slug={connectionIconSlug(connection.slug)}
+                    slug={connection.slug}
                     fallback={connection.type === 'mcp' ? 'mcp' : 'oauth'}
                     className="size-[15px] shrink-0"
                   />
@@ -218,7 +268,13 @@ export function TemplateDetailView({
                 </TooltipProvider>
               ) : (
                 <div className="prose prose-sm max-w-none break-words text-sm text-muted-foreground dark:prose-invert prose-headings:mt-5 prose-headings:mb-1.5 prose-headings:text-sm prose-headings:font-medium prose-headings:text-foreground prose-p:my-2 prose-p:leading-relaxed prose-li:my-0.5 prose-a:text-foreground prose-strong:text-foreground prose-code:text-foreground">
-                  <ReactMarkdown remarkPlugins={DETAILS_REMARK_PLUGINS}>{section.body}</ReactMarkdown>
+                  <ReactMarkdown
+                    remarkPlugins={DETAILS_REMARK_PLUGINS}
+                    components={DETAILS_MARKDOWN_COMPONENTS}
+                    urlTransform={markdownUrlTransform}
+                  >
+                    {section.body}
+                  </ReactMarkdown>
                 </div>
               )}
             </Section>
@@ -231,11 +287,14 @@ export function TemplateDetailView({
             {category && <InfoRow label="Category">{category}</InfoRow>}
             {template.developer && (
               <InfoRow label="Developer">
-                {template.developer.url ? (
+                {/* Same policy as the body links: the URL is third-party
+                    content from index.json, so it is only a link when it is one
+                    we would open, and it opens out of the window. */}
+                {externalHref(template.developer.url) ? (
                   <a
-                    href={template.developer.url}
+                    href={externalHref(template.developer.url)}
                     target="_blank"
-                    rel="noreferrer noopener"
+                    rel="noopener noreferrer"
                     className="underline underline-offset-2 hover:text-foreground"
                   >
                     {template.developer.name}

--- a/src/renderer/components/explore/template-detail-view.tsx
+++ b/src/renderer/components/explore/template-detail-view.tsx
@@ -2,10 +2,15 @@ import { useMemo, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { ChevronRight } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip'
 import { SettingsPageContainer, PageTitle } from '@renderer/components/layout/settings-page'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
 import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
@@ -14,11 +19,17 @@ import { TemplateAvatar } from './explore-template-card'
 import {
   connectionIconSlug,
   connectionLabel,
-  costTier,
-  getSuggestedModels,
-  getTemplateCost,
+  INVENTORY_SECTION_LABEL,
+  INVENTORY_SECTION_TITLES,
+  getTemplateExamples,
+  getTemplateGradient,
+  inventoryIcon,
+  inventoryLabel,
+  parseInventory,
+  parseTemplateDetails,
   templateCategory,
 } from './template-meta'
+import { ArrowUp } from 'lucide-react'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 const DETAILS_REMARK_PLUGINS = [remarkGfm]
@@ -43,10 +54,9 @@ function InfoRow({ label, children }: { label: string; children: React.ReactNode
 
 /**
  * The `/explore/$skillsetId/$templateSlug` details page — a single-column
- * marketplace listing. Name, description, category, icon, tags, connections,
- * developer, and the long-form body all come from the skillset index; only the
- * cost and model rows are illustrative (see `template-meta`), and the footnote
- * says so.
+ * marketplace listing. Every value on it comes from the skillset index: name,
+ * description, category, icon, tags, connections, developer, and the
+ * section-by-section body.
  */
 export function TemplateDetailView({
   skillsetId,
@@ -93,8 +103,8 @@ export function TemplateDetailView({
 
   const category = templateCategory(template)
   const connections = template.worksWith ?? []
-  const cost = getTemplateCost(template)
-  const tier = costTier(cost)
+  const detailSections = template.details ? parseTemplateDetails(template.details) : []
+  const useCases = getTemplateExamples(template.details)
 
   return (
     <SettingsPageContainer className="max-w-[768px] px-[88px]">
@@ -103,73 +113,117 @@ export function TemplateDetailView({
       <div data-testid="template-detail-view" className="-mt-6">
         {/* ── Header ───────────────────────────────────────────────────── */}
         <div data-testid="template-detail-header">
-          <TemplateAvatar template={template} size="lg" />
-          <div className="mt-5 flex items-start justify-between gap-6">
-            <div className="min-w-0">
-              <h2 className="text-3xl font-medium tracking-tight">{template.name}</h2>
-              <p className="mt-1.5 text-sm text-muted-foreground">{template.description}</p>
-            </div>
+          <div className="flex items-center justify-between gap-6">
+            <TemplateAvatar template={template} size="lg" />
             <Button
               type="button"
-              className="shrink-0 rounded-full px-5"
+              className="shrink-0"
               onClick={() => setTemplateToInstall(template)}
               data-testid="template-detail-install"
             >
               Install template
             </Button>
           </div>
+          <div className="mt-5 min-w-0">
+            <h2 className="text-2xl font-medium tracking-tight">{template.name}</h2>
+            <p className="mt-1.5 text-sm text-muted-foreground">{template.description}</p>
+          </div>
         </div>
 
-        {/* ── Tags ─────────────────────────────────────────────────────── */}
-        {template.tags && template.tags.length > 0 && (
-          <div className="mt-6 flex flex-wrap gap-2">
-            {template.tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center rounded-full border px-3 py-1 text-xs text-muted-foreground"
-              >
-                {tag}
-              </span>
-            ))}
+        {/* ── Hero: the template's own sample use cases, as example prompts.
+            Decorative and inert — the arrows are part of the picture, not
+            controls. The wash is the template's accent hue over the grey. ── */}
+        {useCases.length > 0 && (
+          <div className="relative mt-8 overflow-hidden rounded-2xl bg-muted/60">
+            <div
+              className={`absolute inset-0 bg-gradient-to-tl ${getTemplateGradient(template.name)}`}
+              aria-hidden
+            />
+            <div className="relative flex flex-col items-center gap-3 px-6 py-12" aria-hidden>
+              {useCases.slice(0, 3).map((useCase) => (
+                <span
+                  key={useCase}
+                  className="flex w-full max-w-[88%] items-center gap-3 rounded-2xl bg-card/85 py-2.5 pl-4 pr-2.5 shadow-sm backdrop-blur-xl"
+                >
+                  <span className="min-w-0 flex-1 text-sm/6 text-foreground">
+                    <span className="font-medium">@{template.name}</span> {useCase}
+                  </span>
+                  <span className="grid size-7 shrink-0 place-items-center rounded-lg border bg-white text-black shadow-sm">
+                    <ArrowUp className="size-3.5" />
+                  </span>
+                </span>
+              ))}
+            </div>
           </div>
         )}
 
         {/* ── Apps ─────────────────────────────────────────────────────── */}
         {connections.length > 0 && (
           <Section title="Works with">
-            <div className="border-t">
+            <div className="flex flex-wrap gap-2">
               {connections.map((connection) => (
-                <div key={`${connection.type}-${connection.slug}`} className="flex items-center gap-3 border-b py-3">
-                  <span className="grid size-9 shrink-0 place-items-center rounded-lg border bg-card">
-                    <ServiceIcon
-                      slug={connectionIconSlug(connection.slug)}
-                      fallback={connection.type === 'mcp' ? 'mcp' : 'oauth'}
-                      className="size-4"
-                    />
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm text-foreground">
-                      {connectionLabel(connection.slug)}
-                    </span>
-                    <span className="block truncate text-[13px] text-muted-foreground">
-                      {connection.type === 'mcp' ? 'MCP server' : 'Connected account'}
-                    </span>
-                  </span>
-                  <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" aria-hidden />
-                </div>
+                <span
+                  key={`${connection.type}-${connection.slug}`}
+                  className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-[11px] text-muted-foreground"
+                >
+                  <ServiceIcon
+                    slug={connectionIconSlug(connection.slug)}
+                    fallback={connection.type === 'mcp' ? 'mcp' : 'oauth'}
+                    className="size-[15px] shrink-0"
+                  />
+                  {connectionLabel(connection.slug)}
+                </span>
               ))}
             </div>
           </Section>
         )}
 
-        {/* ── Long-form body, straight from the skillset repo ──────────── */}
-        {template.details && (
-          <Section title="About">
-            <div className="prose prose-sm max-w-none break-words text-sm text-muted-foreground dark:prose-invert prose-headings:mt-6 prose-headings:mb-2 prose-headings:text-sm prose-headings:font-medium prose-headings:text-foreground prose-p:my-2 prose-p:leading-relaxed prose-li:my-0.5 prose-a:text-foreground prose-strong:text-foreground prose-code:text-foreground">
-              <ReactMarkdown remarkPlugins={DETAILS_REMARK_PLUGINS}>{template.details}</ReactMarkdown>
-            </div>
-          </Section>
-        )}
+        {/* ── The repo's own copy, one Section per `##` heading ─────────── */}
+        {detailSections.map((section) => {
+          const isInventory = INVENTORY_SECTION_TITLES.has(section.title)
+          const files = isInventory ? parseInventory(section.body) : []
+          return (
+            <Section
+              key={section.title}
+              title={isInventory ? INVENTORY_SECTION_LABEL : section.title}
+            >
+              {files.length > 0 ? (
+                <TooltipProvider delayDuration={200}>
+                  <div className="flex flex-wrap gap-2">
+                    {files.map((file) => {
+                      const ItemIcon = inventoryIcon(file)
+                      return (
+                        <Tooltip key={file.name}>
+                          <TooltipTrigger asChild>
+                            <span className="inline-flex cursor-default items-center gap-1.5 rounded-lg border px-2.5 py-1 font-mono text-xs text-muted-foreground">
+                              <ItemIcon
+                                className="size-3.5 shrink-0 text-muted-foreground/60"
+                                aria-hidden
+                              />
+                              {inventoryLabel(file.name)}
+                            </span>
+                          </TooltipTrigger>
+                          {/* The chip shows only the leaf name, so the tooltip
+                              carries the full path along with the blurb. */}
+                          <TooltipContent className="max-w-xs">
+                            <span className="block font-mono text-[11px]">{file.name}</span>
+                            {file.description && (
+                              <span className="mt-1 block">{file.description}</span>
+                            )}
+                          </TooltipContent>
+                        </Tooltip>
+                      )
+                    })}
+                  </div>
+                </TooltipProvider>
+              ) : (
+                <div className="prose prose-sm max-w-none break-words text-sm text-muted-foreground dark:prose-invert prose-headings:mt-5 prose-headings:mb-1.5 prose-headings:text-sm prose-headings:font-medium prose-headings:text-foreground prose-p:my-2 prose-p:leading-relaxed prose-li:my-0.5 prose-a:text-foreground prose-strong:text-foreground prose-code:text-foreground">
+                  <ReactMarkdown remarkPlugins={DETAILS_REMARK_PLUGINS}>{section.body}</ReactMarkdown>
+                </div>
+              )}
+            </Section>
+          )
+        })}
 
         {/* ── Information ──────────────────────────────────────────────── */}
         <Section title="Information">
@@ -191,14 +245,6 @@ export function TemplateDetailView({
                 )}
               </InfoRow>
             )}
-            <InfoRow label="Cost to run">
-              ${cost.min}–${cost.max} /mo
-              <span className="ml-2 font-mono text-xs text-muted-foreground">
-                <span className="text-foreground">{'$'.repeat(tier)}</span>
-                {'$'.repeat(4 - tier)}
-              </span>
-            </InfoRow>
-            <InfoRow label="Suggested models">{getSuggestedModels().join(', ')}</InfoRow>
             <InfoRow label="Source">{template.skillsetName}</InfoRow>
             <InfoRow label="Version">{template.version}</InfoRow>
           </div>
@@ -206,8 +252,7 @@ export function TemplateDetailView({
 
         <p className="mt-12 border-t pt-6 text-[13px]/6 text-muted-foreground">
           This template may connect to one or more apps, as listed above. When connected, the agent
-          can read and write on your behalf within the limits you grant it. Cost estimates are
-          illustrative while the marketplace is in preview.
+          can read and write on your behalf within the limits you grant it.
         </p>
       </div>
 

--- a/src/renderer/components/explore/template-detail-view.tsx
+++ b/src/renderer/components/explore/template-detail-view.tsx
@@ -1,0 +1,221 @@
+import { useMemo, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { ChevronRight } from 'lucide-react'
+import { Button } from '@renderer/components/ui/button'
+import { Skeleton } from '@renderer/components/ui/skeleton'
+import { ServiceIcon } from '@renderer/components/ui/service-icon'
+import { SettingsPageContainer, PageTitle } from '@renderer/components/layout/settings-page'
+import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
+import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
+import { useCompleteTemplateInstall } from '@renderer/hooks/use-complete-template-install'
+import { TemplateAvatar } from './explore-template-card'
+import {
+  connectionIconSlug,
+  connectionLabel,
+  costTier,
+  getSuggestedModels,
+  getTemplateCost,
+  templateCategory,
+} from './template-meta'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+const DETAILS_REMARK_PLUGINS = [remarkGfm]
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-12 first:mt-0">
+      <h3 className="text-base font-medium text-foreground">{title}</h3>
+      <div className="mt-4">{children}</div>
+    </section>
+  )
+}
+
+function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-6 border-b py-3.5 text-sm first:border-t">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span className="min-w-0 text-right text-foreground">{children}</span>
+    </div>
+  )
+}
+
+/**
+ * The `/explore/$skillsetId/$templateSlug` details page — a single-column
+ * marketplace listing. Name, description, category, icon, tags, connections,
+ * developer, and the long-form body all come from the skillset index; only the
+ * cost and model rows are illustrative (see `template-meta`), and the footnote
+ * says so.
+ */
+export function TemplateDetailView({
+  skillsetId,
+  templateSlug,
+}: {
+  skillsetId: string
+  templateSlug: string
+}) {
+  const navigate = useNavigate()
+  const { data: discoverableAgents, isLoading } = useDiscoverableAgents()
+  const completeInstall = useCompleteTemplateInstall()
+  const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
+
+  const template = useMemo(
+    () =>
+      discoverableAgents?.find(
+        (t) => t.skillsetId === skillsetId && slugFromAgentPath(t.path) === templateSlug,
+      ),
+    [discoverableAgents, skillsetId, templateSlug],
+  )
+  const backToExplore = {
+    onClick: () => void navigate({ to: '/explore' }),
+    label: 'Discover New Agents',
+  }
+
+  if (!template) {
+    return (
+      <SettingsPageContainer className="max-w-[768px] px-[88px]">
+        <PageTitle title="" back={backToExplore} />
+        {isLoading || discoverableAgents === undefined ? (
+          <div className="space-y-4">
+            <Skeleton className="size-16 rounded-2xl" />
+            <Skeleton className="h-7 w-56" />
+            <Skeleton className="h-48 rounded-2xl" />
+          </div>
+        ) : (
+          <p className="py-16 text-center text-sm text-muted-foreground" data-testid="template-not-found">
+            This template is no longer available in your connected skillsets.
+          </p>
+        )}
+      </SettingsPageContainer>
+    )
+  }
+
+  const category = templateCategory(template)
+  const connections = template.worksWith ?? []
+  const cost = getTemplateCost(template)
+  const tier = costTier(cost)
+
+  return (
+    <SettingsPageContainer className="max-w-[768px] px-[88px]">
+      <PageTitle title="" back={backToExplore} />
+
+      <div data-testid="template-detail-view" className="-mt-6">
+        {/* ── Header ───────────────────────────────────────────────────── */}
+        <div data-testid="template-detail-header">
+          <TemplateAvatar template={template} size="lg" />
+          <div className="mt-5 flex items-start justify-between gap-6">
+            <div className="min-w-0">
+              <h2 className="text-3xl font-medium tracking-tight">{template.name}</h2>
+              <p className="mt-1.5 text-sm text-muted-foreground">{template.description}</p>
+            </div>
+            <Button
+              type="button"
+              className="shrink-0 rounded-full px-5"
+              onClick={() => setTemplateToInstall(template)}
+              data-testid="template-detail-install"
+            >
+              Install template
+            </Button>
+          </div>
+        </div>
+
+        {/* ── Tags ─────────────────────────────────────────────────────── */}
+        {template.tags && template.tags.length > 0 && (
+          <div className="mt-6 flex flex-wrap gap-2">
+            {template.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full border px-3 py-1 text-xs text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* ── Apps ─────────────────────────────────────────────────────── */}
+        {connections.length > 0 && (
+          <Section title="Works with">
+            <div className="border-t">
+              {connections.map((connection) => (
+                <div key={`${connection.type}-${connection.slug}`} className="flex items-center gap-3 border-b py-3">
+                  <span className="grid size-9 shrink-0 place-items-center rounded-lg border bg-card">
+                    <ServiceIcon
+                      slug={connectionIconSlug(connection.slug)}
+                      fallback={connection.type === 'mcp' ? 'mcp' : 'oauth'}
+                      className="size-4"
+                    />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm text-foreground">
+                      {connectionLabel(connection.slug)}
+                    </span>
+                    <span className="block truncate text-[13px] text-muted-foreground">
+                      {connection.type === 'mcp' ? 'MCP server' : 'Connected account'}
+                    </span>
+                  </span>
+                  <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" aria-hidden />
+                </div>
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {/* ── Long-form body, straight from the skillset repo ──────────── */}
+        {template.details && (
+          <Section title="About">
+            <div className="prose prose-sm max-w-none break-words text-sm text-muted-foreground dark:prose-invert prose-headings:mt-6 prose-headings:mb-2 prose-headings:text-sm prose-headings:font-medium prose-headings:text-foreground prose-p:my-2 prose-p:leading-relaxed prose-li:my-0.5 prose-a:text-foreground prose-strong:text-foreground prose-code:text-foreground">
+              <ReactMarkdown remarkPlugins={DETAILS_REMARK_PLUGINS}>{template.details}</ReactMarkdown>
+            </div>
+          </Section>
+        )}
+
+        {/* ── Information ──────────────────────────────────────────────── */}
+        <Section title="Information">
+          <div>
+            {category && <InfoRow label="Category">{category}</InfoRow>}
+            {template.developer && (
+              <InfoRow label="Developer">
+                {template.developer.url ? (
+                  <a
+                    href={template.developer.url}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    {template.developer.name}
+                  </a>
+                ) : (
+                  template.developer.name
+                )}
+              </InfoRow>
+            )}
+            <InfoRow label="Cost to run">
+              ${cost.min}–${cost.max} /mo
+              <span className="ml-2 font-mono text-xs text-muted-foreground">
+                <span className="text-foreground">{'$'.repeat(tier)}</span>
+                {'$'.repeat(4 - tier)}
+              </span>
+            </InfoRow>
+            <InfoRow label="Suggested models">{getSuggestedModels().join(', ')}</InfoRow>
+            <InfoRow label="Source">{template.skillsetName}</InfoRow>
+            <InfoRow label="Version">{template.version}</InfoRow>
+          </div>
+        </Section>
+
+        <p className="mt-12 border-t pt-6 text-[13px]/6 text-muted-foreground">
+          This template may connect to one or more apps, as listed above. When connected, the agent
+          can read and write on your behalf within the limits you grant it. Cost estimates are
+          illustrative while the marketplace is in preview.
+        </p>
+      </div>
+
+      <TemplateInstallDialog
+        template={templateToInstall}
+        onClose={() => setTemplateToInstall(null)}
+        onInstalled={completeInstall}
+      />
+    </SettingsPageContainer>
+  )
+}

--- a/src/renderer/components/explore/template-meta.ts
+++ b/src/renderer/components/explore/template-meta.ts
@@ -1,0 +1,248 @@
+import {
+  Apple,
+  BadgeDollarSign,
+  Bot,
+  BookOpen,
+  Calculator,
+  CalendarCheck,
+  Code2,
+  House,
+  Inbox,
+  LifeBuoy,
+  ListChecks,
+  Mail,
+  Megaphone,
+  MessagesSquare,
+  Mic,
+  PenLine,
+  Plane,
+  Presentation,
+  Search,
+  SearchCheck,
+  ShieldCheck,
+  ShoppingCart,
+  Sparkles,
+  Target,
+  UserSearch,
+  Video,
+  WandSparkles,
+  Workflow,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+/**
+ * Presentation helpers for marketplace templates.
+ *
+ * Name, description, category, icon, tags, connections, developer, and the
+ * long-form details markdown are REAL — they come from the skillset repo's
+ * `index.json`. What the index still doesn't carry (run cost, suggested
+ * models, security review, starter prompts) is mocked at the bottom of this
+ * file and clearly marked.
+ */
+
+// ── Icons ────────────────────────────────────────────────────────────────────
+
+/**
+ * The kebab-case icon names the public skillset uses, mapped to their lucide
+ * components. Listed explicitly rather than resolved dynamically so the bundle
+ * only carries the icons we actually render.
+ */
+const ICONS_BY_NAME: Record<string, LucideIcon> = {
+  apple: Apple,
+  'badge-dollar-sign': BadgeDollarSign,
+  'book-open': BookOpen,
+  calculator: Calculator,
+  'calendar-check': CalendarCheck,
+  'code-2': Code2,
+  house: House,
+  inbox: Inbox,
+  'life-buoy': LifeBuoy,
+  'list-checks': ListChecks,
+  mail: Mail,
+  megaphone: Megaphone,
+  'messages-square': MessagesSquare,
+  mic: Mic,
+  'pen-line': PenLine,
+  plane: Plane,
+  presentation: Presentation,
+  search: Search,
+  'search-check': SearchCheck,
+  'shield-check': ShieldCheck,
+  'shopping-cart': ShoppingCart,
+  sparkles: Sparkles,
+  target: Target,
+  'user-search': UserSearch,
+  video: Video,
+  'wand-sparkles': WandSparkles,
+  workflow: Workflow,
+}
+
+/** Anything the index names but we don't bundle falls back to a generic glyph. */
+const FALLBACK_ICONS: LucideIcon[] = [Bot, Sparkles, Workflow, Zap]
+
+export function getTemplateIcon(template: ApiDiscoverableAgent): LucideIcon {
+  const named = template.icon ? ICONS_BY_NAME[template.icon] : undefined
+  if (named) return named
+  return FALLBACK_ICONS[hashString(template.name) % FALLBACK_ICONS.length]
+}
+
+// ── Accent colors ────────────────────────────────────────────────────────────
+
+/** Palette keys for the icon glyph (see ACCENT_CLASSES). */
+export type AccentColor =
+  | 'orange'
+  | 'salmon'
+  | 'yellow'
+  | 'green'
+  | 'teal'
+  | 'blue'
+  | 'violet'
+  | 'pink'
+
+/**
+ * Glyph colors, from the reference palette's hues extended to eight. Built on
+ * Tailwind's 600 ramp rather than raw hex so the set stays balanced and the
+ * dark-mode variants come along for free.
+ *
+ * 600 is deliberate: the 500s carry slightly more chroma but drop under 3:1
+ * against the grey tile for yellow (1.97), green (2.09), teal (2.28) and
+ * orange (2.57), which reads as washed out rather than vivid. 600 is the most
+ * saturated step that still clears the 3:1 graphics threshold everywhere.
+ * Class strings are written out in full so Tailwind's scanner keeps them.
+ */
+const ACCENT_CLASSES: Record<AccentColor, string> = {
+  orange: 'text-orange-600 dark:text-orange-400',
+  salmon: 'text-rose-600 dark:text-rose-400',
+  yellow: 'text-amber-600 dark:text-amber-400',
+  green: 'text-green-600 dark:text-green-400',
+  teal: 'text-teal-600 dark:text-teal-400',
+  blue: 'text-blue-600 dark:text-blue-400',
+  violet: 'text-violet-600 dark:text-violet-400',
+  pink: 'text-fuchsia-600 dark:text-fuchsia-400',
+}
+
+const ACCENT_COLOR_KEYS = Object.keys(ACCENT_CLASSES) as AccentColor[]
+
+/**
+ * Stable 32-bit hash. The avalanche step matters: a plain `*31` accumulator
+ * keeps its low bits correlated with the character sum, which clusters hard
+ * under a small modulo (our first roster landed on 2 of 6 colors without it).
+ */
+function hashString(value: string): number {
+  let hash = 0
+  for (let i = 0; i < value.length; i++) hash = (Math.imul(hash, 31) + value.charCodeAt(i)) >>> 0
+  hash ^= hash >>> 16
+  hash = Math.imul(hash, 0x7feb352d) >>> 0
+  hash ^= hash >>> 15
+  return hash >>> 0
+}
+
+/** The glyph color for a template, keyed off its name so a given template
+ *  always draws the same color. */
+export function getTemplateAccent(name: string): string {
+  return ACCENT_CLASSES[ACCENT_COLOR_KEYS[hashString(name) % ACCENT_COLOR_KEYS.length]]
+}
+
+// ── Categories ───────────────────────────────────────────────────────────────
+
+/**
+ * Categories come from the index verbatim, but the repo has near-duplicates
+ * ("Ops" and "Operations", "Email & Communication" alongside "Productivity").
+ * Fold those together so the filter list stays short.
+ */
+const CATEGORY_ALIASES: Record<string, string> = {
+  Operations: 'Ops',
+  'Email & Communication': 'Productivity',
+  'Human Resources': 'Recruiting',
+  'Health & Fitness': 'Personal',
+  'Design & Creative': 'Marketing',
+  'Agent Creation': 'Productivity',
+}
+
+export function templateCategory(template: ApiDiscoverableAgent): string | undefined {
+  const raw = template.category?.trim()
+  if (!raw) return undefined
+  return CATEGORY_ALIASES[raw] ?? raw
+}
+
+
+// ── Connections ──────────────────────────────────────────────────────────────
+
+/**
+ * Slugs the index references that have no matching SVG in
+ * public/service-icons. They render with the generic fallback glyph rather
+ * than a stand-in logo — a wrong brand mark is worse than none.
+ */
+const MISSING_CONNECTION_ICONS = new Set(['granola', 'microsoft_teams'])
+
+/** The service-icon slug for a connection, or undefined when we have no logo. */
+export function connectionIconSlug(slug: string): string | undefined {
+  return MISSING_CONNECTION_ICONS.has(slug) ? undefined : slug
+}
+
+/** Human label for a connection slug (the index only carries the slug). */
+export function connectionLabel(slug: string): string {
+  return CONNECTION_LABELS[slug] ?? slug.replace(/[_-]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+const CONNECTION_LABELS: Record<string, string> = {
+  ahrefs: 'Ahrefs',
+  airtable: 'Airtable',
+  datadog: 'Datadog',
+  dataforseo: 'DataForSEO',
+  discord: 'Discord',
+  figma: 'Figma',
+  github: 'GitHub',
+  gmail: 'Gmail',
+  googlecalendar: 'Google Calendar',
+  googledocs: 'Google Docs',
+  googledrive: 'Google Drive',
+  googlesheets: 'Google Sheets',
+  googleslides: 'Google Slides',
+  granola: 'Granola',
+  intercom: 'Intercom',
+  linear: 'Linear',
+  linkedin: 'LinkedIn',
+  microsoft_teams: 'Microsoft Teams',
+  notion: 'Notion',
+  outlook: 'Outlook',
+  posthog: 'PostHog',
+  quickbooks: 'QuickBooks',
+  salesforce: 'Salesforce',
+  slack: 'Slack',
+  stripe: 'Stripe',
+  webflow: 'Webflow',
+  xero: 'Xero',
+  youtube: 'YouTube',
+  zendesk: 'Zendesk',
+  zoom: 'Zoom',
+}
+
+// ── Still mocked ─────────────────────────────────────────────────────────────
+// The index carries no commercial or operational metadata, so everything below
+// is invented for layout purposes and marked as illustrative in the UI.
+
+/** Estimated monthly run cost, derived from how many services a template
+ *  touches — more connections means more calls, which is at least directionally
+ *  honest. MOCK. */
+export function getTemplateCost(template: ApiDiscoverableAgent): { min: number; max: number } {
+  const connections = template.worksWith?.length ?? 0
+  const base = 3 + connections * 6
+  return { min: base, max: base * 2 + 4 }
+}
+
+/** $ – $$$$ tier for a monthly cost range. */
+export function costTier(cost: { min: number; max: number }): number {
+  const mid = (cost.min + cost.max) / 2
+  if (mid < 10) return 1
+  if (mid < 30) return 2
+  if (mid < 60) return 3
+  return 4
+}
+
+/** MOCK — the index says nothing about model fit. */
+export function getSuggestedModels(): string[] {
+  return ['Opus 5', 'Sonnet 5']
+}

--- a/src/renderer/components/explore/template-meta.ts
+++ b/src/renderer/components/explore/template-meta.ts
@@ -6,6 +6,7 @@ import {
   Calculator,
   CalendarCheck,
   Code2,
+  FileText,
   House,
   Inbox,
   LifeBuoy,
@@ -35,11 +36,11 @@ import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 /**
  * Presentation helpers for marketplace templates.
  *
- * Name, description, category, icon, tags, connections, developer, and the
- * long-form details markdown are REAL — they come from the skillset repo's
- * `index.json`. What the index still doesn't carry (run cost, suggested
- * models, security review, starter prompts) is mocked at the bottom of this
- * file and clearly marked.
+ * Everything here maps or formats data the skillset repo's `index.json`
+ * actually provides — name, description, category, icon, tags, connections,
+ * developer, and the long-form details markdown. Nothing is invented: run
+ * cost and suggested models used to be mocked here and were removed rather
+ * than shown as fact.
  */
 
 // ── Icons ────────────────────────────────────────────────────────────────────
@@ -123,7 +124,27 @@ const ACCENT_CLASSES: Record<AccentColor, string> = {
   pink: 'text-fuchsia-600 dark:text-fuchsia-400',
 }
 
+/**
+ * The same hues as a wash for the hero band: a strong corner fading to nothing
+ * so the grey underneath still reads as the base. Written out in full so
+ * Tailwind's scanner keeps them.
+ */
+const ACCENT_GRADIENTS: Record<AccentColor, string> = {
+  orange: 'from-orange-400/30 via-orange-300/10 to-transparent',
+  salmon: 'from-rose-400/30 via-rose-300/10 to-transparent',
+  yellow: 'from-amber-400/30 via-amber-300/10 to-transparent',
+  green: 'from-green-400/30 via-green-300/10 to-transparent',
+  teal: 'from-teal-400/30 via-teal-300/10 to-transparent',
+  blue: 'from-blue-400/30 via-blue-300/10 to-transparent',
+  violet: 'from-violet-400/30 via-violet-300/10 to-transparent',
+  pink: 'from-fuchsia-400/30 via-fuchsia-300/10 to-transparent',
+}
+
 const ACCENT_COLOR_KEYS = Object.keys(ACCENT_CLASSES) as AccentColor[]
+
+function accentKey(name: string): AccentColor {
+  return ACCENT_COLOR_KEYS[hashString(name) % ACCENT_COLOR_KEYS.length]
+}
 
 /**
  * Stable 32-bit hash. The avalanche step matters: a plain `*31` accumulator
@@ -142,7 +163,12 @@ function hashString(value: string): number {
 /** The glyph color for a template, keyed off its name so a given template
  *  always draws the same color. */
 export function getTemplateAccent(name: string): string {
-  return ACCENT_CLASSES[ACCENT_COLOR_KEYS[hashString(name) % ACCENT_COLOR_KEYS.length]]
+  return ACCENT_CLASSES[accentKey(name)]
+}
+
+/** The hero wash in the template's own accent hue — same key as the glyph. */
+export function getTemplateGradient(name: string): string {
+  return ACCENT_GRADIENTS[accentKey(name)]
 }
 
 // ── Categories ───────────────────────────────────────────────────────────────
@@ -167,6 +193,20 @@ export function templateCategory(template: ApiDiscoverableAgent): string | undef
   return CATEGORY_ALIASES[raw] ?? raw
 }
 
+
+/**
+ * Templates authored by us rather than contributed — the 8 hand-built agents
+ * that predate the bulk Bot Directory import, and the only ones shipping real
+ * `.claude/skills/` directories. It's a first-party signal from the index, not
+ * editorial curation: the index has no `featured` flag.
+ */
+export const FEATURED_SECTION_LABEL = 'Featured'
+
+const FIRST_PARTY_DEVELOPER = 'SkillfulAgents'
+
+export function isFeaturedTemplate(template: ApiDiscoverableAgent): boolean {
+  return template.developer?.name === FIRST_PARTY_DEVELOPER
+}
 
 // ── Connections ──────────────────────────────────────────────────────────────
 
@@ -220,29 +260,170 @@ const CONNECTION_LABELS: Record<string, string> = {
   zoom: 'Zoom',
 }
 
-// ── Still mocked ─────────────────────────────────────────────────────────────
-// The index carries no commercial or operational metadata, so everything below
-// is invented for layout purposes and marked as illustrative in the UI.
+// ── Details markdown ─────────────────────────────────────────────────────────
 
-/** Estimated monthly run cost, derived from how many services a template
- *  touches — more connections means more calls, which is at least directionally
- *  honest. MOCK. */
-export function getTemplateCost(template: ApiDiscoverableAgent): { min: number; max: number } {
-  const connections = template.worksWith?.length ?? 0
-  const base = 3 + connections * 6
-  return { min: base, max: base * 2 + 4 }
+export interface TemplateDetailSection {
+  title: string
+  body: string
 }
 
-/** $ – $$$$ tier for a monthly cost range. */
-export function costTier(cost: { min: number; max: number }): number {
-  const mid = (cost.min + cost.max) / 2
-  if (mid < 10) return 1
-  if (mid < 30) return 2
-  if (mid < 60) return 3
-  return 4
+/** Authored prompts for the hero band — what a template should carry. */
+export const EXAMPLE_PROMPTS_SECTION_TITLE = 'Example prompts'
+
+/** The older heading, still the only one most imported templates have. */
+export const USE_CASES_SECTION_TITLE = 'Sample use cases'
+
+/**
+ * `Connect first` lists exactly the services already shown in Works with,
+ * directly above it; the two prompt sections are lifted into the hero band.
+ * All three would otherwise appear twice on one page.
+ */
+const SKIPPED_DETAIL_SECTIONS = new Set([
+  'Connect first',
+  EXAMPLE_PROMPTS_SECTION_TITLE,
+  USE_CASES_SECTION_TITLE,
+])
+
+/**
+ * Bullet lines of a section, stripped of their markers and trailing period. A
+ * question mark is left alone — example prompts are often questions. Dash
+ * variants are accepted since authors reach for en/em dashes by habit.
+ */
+export function parseBullets(body: string): string[] {
+  return body
+    .split('\n')
+    .map((line) => line.match(/^\s*[-*•–—]\s+(.*)$/)?.[1]?.trim())
+    .filter((text): text is string => Boolean(text))
+    .map((text) => text.replace(/\.$/, ''))
 }
 
-/** MOCK — the index says nothing about model fit. */
-export function getSuggestedModels(): string[] {
-  return ['Opus 5', 'Sonnet 5']
+/** The body of one `##` section, or undefined when the template has none. */
+function sectionBody(details: string | undefined, title: string): string | undefined {
+  if (!details) return undefined
+  const chunk = details
+    .split(/^##[ \t]+/m)
+    .slice(1)
+    .find((c) => c.split('\n')[0].trim() === title)
+  return chunk ? chunk.slice(chunk.indexOf('\n') + 1) : undefined
+}
+
+/** The `Sample use cases` bullets, or empty when the template has none. */
+export function getTemplateUseCases(details: string | undefined): string[] {
+  return parseBullets(sectionBody(details, USE_CASES_SECTION_TITLE) ?? '')
+}
+
+/**
+ * Openers used to top the hero up to three pills. Every agent in the roster
+ * ships exactly two use cases (or none), so at least one is always needed —
+ * these read as things you could actually type on a first run.
+ */
+const GENERIC_EXAMPLES = [
+  'Help me get started',
+  'What can you do?',
+  'Walk me through your first run',
+]
+
+/**
+ * Exactly three example prompts. Authored `Example prompts` win outright —
+ * they're written to be typed. Templates without them (most of the imported
+ * roster) fall back to `Sample use cases`, then to generic openers.
+ */
+export function getTemplateExamples(details: string | undefined): string[] {
+  const authored = parseBullets(sectionBody(details, EXAMPLE_PROMPTS_SECTION_TITLE) ?? '')
+  const examples = (authored.length > 0 ? authored : getTemplateUseCases(details)).slice(0, 3)
+  for (const generic of GENERIC_EXAMPLES) {
+    if (examples.length >= 3) break
+    examples.push(generic)
+  }
+  return examples
+}
+
+/**
+ * Split the index's `details` markdown into its `##` sections so each can be
+ * rendered under its own heading instead of one undifferentiated blob.
+ *
+ * Everything before the first `##` is dropped: it's an H1 of the agent name
+ * followed by the description, both already in the page header.
+ */
+/**
+ * Headings whose body inventories what ships with the template rather than
+ * prose. Two names for one thing: the bulk-imported agents call it `Files`
+ * (and all list the same three scaffolding files), while the hand-written ones
+ * call it `What's inside` and list their real skills. No agent has both.
+ */
+export const INVENTORY_SECTION_TITLES = new Set(['Files', "What's inside"])
+
+/** The one heading both render under. */
+export const INVENTORY_SECTION_LABEL = "What's Inside"
+
+export interface TemplateInventoryItem {
+  name: string
+  description: string
+}
+
+const CODE_EXTENSIONS =
+  /\.(sql|py|ts|tsx|js|jsx|mjs|cjs|sh|bash|zsh|rb|go|rs|java|php|css|html|db|sqlite3?)$/i
+
+/** Directories and files whose blurb says they hold code, for the many entries
+ *  that are paths with no extension (`nutrition/`, `artifacts/dashboard/`). */
+const CODE_BLURB = /\b(script|scripts|code|database|schema|sql|dashboard|python|bun|node)\b/i
+
+/** Just the last path segment — `.claude/skills/log-meal/` reads as
+ *  `log-meal`. The full path stays available for the tooltip. */
+export function inventoryLabel(name: string): string {
+  const trimmed = name.replace(/\/+$/, '')
+  const slash = trimmed.lastIndexOf('/')
+  return slash === -1 ? trimmed : trimmed.slice(slash + 1)
+}
+
+/**
+ * Which glyph an inventory entry gets: a book for skills, a code mark for
+ * anything executable or data-backed, and a plain file for the rest.
+ */
+export function inventoryIcon(item: TemplateInventoryItem): LucideIcon {
+  if (/(^|\/)\.?claude\/skills\//.test(item.name) || /(^|\/)skills\//.test(item.name)) {
+    return BookOpen
+  }
+  if (CODE_EXTENSIONS.test(item.name) || CODE_BLURB.test(item.description)) return Code2
+  return FileText
+}
+
+/**
+ * An inventory list, whose lines read `` - `NAME` — what it's for ``. A line
+ * may name more than one path (`` `a.db` + `a.sql` — database and schema ``),
+ * so every backticked token becomes its own item sharing the trailing blurb.
+ * Returns empty when no line matches, which is the caller's cue to render the
+ * section as ordinary markdown instead.
+ */
+export function parseInventory(body: string): TemplateInventoryItem[] {
+  const items: TemplateInventoryItem[] = []
+  for (const line of body.split('\n')) {
+    const bullet = line.match(/^\s*[-*]\s+(.*)$/)
+    if (!bullet) continue
+    const names = [...bullet[1].matchAll(/`([^`]+)`/g)]
+    if (names.length === 0) continue
+    const last = names[names.length - 1]
+    const description = bullet[1]
+      .slice((last.index ?? 0) + last[0].length)
+      .replace(/^[\s—–\-+·:]+/, '')
+      .trim()
+      .replace(/\.$/, '')
+    for (const match of names) {
+      const name = match[1].trim()
+      if (name) items.push({ name, description })
+    }
+  }
+  return items
+}
+
+export function parseTemplateDetails(details: string): TemplateDetailSection[] {
+  const sections: TemplateDetailSection[] = []
+  for (const chunk of details.split(/^##[ \t]+/m).slice(1)) {
+    const break_ = chunk.indexOf('\n')
+    const title = (break_ === -1 ? chunk : chunk.slice(0, break_)).trim()
+    const body = (break_ === -1 ? '' : chunk.slice(break_ + 1)).trim()
+    if (!title || !body || SKIPPED_DETAIL_SECTIONS.has(title)) continue
+    sections.push({ title, body })
+  }
+  return sections
 }

--- a/src/renderer/components/explore/template-meta.ts
+++ b/src/renderer/components/explore/template-meta.ts
@@ -217,16 +217,12 @@ export function isFeaturedTemplate(template: ApiDiscoverableAgent): boolean {
 // ── Connections ──────────────────────────────────────────────────────────────
 
 /**
- * Slugs the index references that have no matching SVG in
- * public/service-icons. They render with the generic fallback glyph rather
- * than a stand-in logo — a wrong brand mark is worse than none.
+ * Not every slug the index names has an SVG in public/service-icons (`granola`
+ * and `microsoft_teams` don't today). Those are left to `ServiceIcon`'s own
+ * onError fallback — a generic glyph beside the service's NAME still says which
+ * service it is, and deriving it from the actual load keeps no list to rot as
+ * the index and the icon set each move on.
  */
-const MISSING_CONNECTION_ICONS = new Set(['granola', 'microsoft_teams'])
-
-/** The service-icon slug for a connection, or undefined when we have no logo. */
-export function connectionIconSlug(slug: string): string | undefined {
-  return MISSING_CONNECTION_ICONS.has(slug) ? undefined : slug
-}
 
 /** Human label for a connection slug (the index only carries the slug). */
 export function connectionLabel(slug: string): string {

--- a/src/renderer/components/explore/template-meta.ts
+++ b/src/renderer/components/explore/template-meta.ts
@@ -195,10 +195,16 @@ export function templateCategory(template: ApiDiscoverableAgent): string | undef
 
 
 /**
- * Templates authored by us rather than contributed — the 8 hand-built agents
- * that predate the bulk Bot Directory import, and the only ones shipping real
- * `.claude/skills/` directories. It's a first-party signal from the index, not
- * editorial curation: the index has no `featured` flag.
+ * TODO: switch this to a real `featured` flag once the skillset READMEs carry
+ * one. Authorship is a stand-in, and it gets the two obvious cases wrong: a
+ * contributor shipping something excellent can never be featured, and anything
+ * mediocre we publish always is. The flag belongs in the README frontmatter
+ * beside `category` and `icon`, which means adding it to SkillsetIndexAgent
+ * and its Zod schema; this predicate then reads `template.featured === true`.
+ *
+ * Until then: templates authored by us rather than contributed — the 8
+ * hand-built agents that predate the bulk Bot Directory import, and the only
+ * ones shipping real `.claude/skills/` directories.
  */
 export const FEATURED_SECTION_LABEL = 'Featured'
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -954,6 +954,9 @@ export function AppSidebar() {
                       <AppLink to="/explore">
                         <Compass className="h-4 w-4" />
                         <span>Discover New Agents</span>
+                        <span className="rounded-full bg-blue-600 px-1.5 py-0.5 text-[10px] font-medium leading-tight text-white">
+                          New
+                        </span>
                       </AppLink>
                     </SidebarMenuButton>
                   </SidebarMenuItem>

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -98,7 +98,6 @@ import { useRenderTracker } from '@renderer/lib/perf'
 import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
 import { useSkillsets } from '@renderer/hooks/use-skillsets'
 import { useRememberedFlag } from '@renderer/hooks/use-remembered-flag'
-import { AgentTemplateBrowseDialog } from '@renderer/components/agents/agent-template-browse-dialog'
 
 // 4px-wide thin scrollbar with a muted-foreground/20 thumb. Reused on the
 // agents-list group; pull out as a constant so the call site stays readable.
@@ -743,7 +742,6 @@ export function AppSidebar() {
           ? null
           : discoverableAgents.length > 0
   const hasMarketplace = useRememberedFlag('marketplace', marketplaceAnswer)
-  const [marketplaceOpen, setMarketplaceOpen] = useState(false)
   const { data: userSettings } = useUserSettings()
   const updateSettings = useUpdateUserSettings()
   const { data: runtimeStatus } = useRuntimeStatus()
@@ -948,11 +946,15 @@ export function AppSidebar() {
                 {hasMarketplace && (
                   <SidebarMenuItem>
                     <SidebarMenuButton
-                      onClick={() => setMarketplaceOpen(true)}
+                      asChild
+                      // Prefix match: the details page (/explore/...) is still Explore.
+                      isActive={pathname === '/explore' || pathname.startsWith('/explore/')}
                       data-testid="marketplace-button"
                     >
-                      <Compass className="h-4 w-4" />
-                      <span>Explore</span>
+                      <AppLink to="/explore">
+                        <Compass className="h-4 w-4" />
+                        <span>Discover New Agents</span>
+                      </AppLink>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                 )}
@@ -1040,8 +1042,6 @@ export function AppSidebar() {
 
       <SidebarRail />
       </Sidebar>
-
-      <AgentTemplateBrowseDialog open={marketplaceOpen} onOpenChange={setMarketplaceOpen} />
     </>
   )
 }

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -99,6 +99,9 @@ import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
 import { useSkillsets } from '@renderer/hooks/use-skillsets'
 import { useRememberedFlag } from '@renderer/hooks/use-remembered-flag'
 
+/** Set once Explore has been opened, which retires its "New" badge. */
+const EXPLORE_SEEN_KEY = 'explore.seen'
+
 // 4px-wide thin scrollbar with a muted-foreground/20 thumb. Reused on the
 // agents-list group; pull out as a constant so the call site stays readable.
 const THIN_SCROLLBAR =
@@ -742,6 +745,13 @@ export function AppSidebar() {
           ? null
           : discoverableAgents.length > 0
   const hasMarketplace = useRememberedFlag('marketplace', marketplaceAnswer)
+  const exploreVisited = pathname === '/explore' || pathname.startsWith('/explore/')
+  // Sticky across reloads, and read once at mount so the badge doesn't vanish
+  // out from under the pointer mid-click.
+  const [seenExplore] = useState(() => localStorage.getItem(EXPLORE_SEEN_KEY) === '1')
+  useEffect(() => {
+    if (exploreVisited) localStorage.setItem(EXPLORE_SEEN_KEY, '1')
+  }, [exploreVisited])
   const { data: userSettings } = useUserSettings()
   const updateSettings = useUpdateUserSettings()
   const { data: runtimeStatus } = useRuntimeStatus()
@@ -948,15 +958,19 @@ export function AppSidebar() {
                     <SidebarMenuButton
                       asChild
                       // Prefix match: the details page (/explore/...) is still Explore.
-                      isActive={pathname === '/explore' || pathname.startsWith('/explore/')}
+                      isActive={exploreVisited}
                       data-testid="marketplace-button"
                     >
                       <AppLink to="/explore">
                         <Compass className="h-4 w-4" />
                         <span>Discover New Agents</span>
-                        <span className="rounded-full bg-blue-600 px-1.5 py-0.5 text-[10px] font-medium leading-tight text-white">
-                          New
-                        </span>
+                        {/* Retires itself the first time the page is opened —
+                            a badge that says "New" forever says nothing. */}
+                        {!seenExplore && (
+                          <span className="rounded-full bg-blue-600 px-1.5 py-0.5 text-[10px] font-medium leading-tight text-white">
+                            New
+                          </span>
+                        )}
                       </AppLink>
                     </SidebarMenuButton>
                   </SidebarMenuItem>

--- a/src/renderer/components/layout/explore-route.tsx
+++ b/src/renderer/components/layout/explore-route.tsx
@@ -1,0 +1,45 @@
+import { useParams } from '@tanstack/react-router'
+import { useSidebar } from '@renderer/components/ui/sidebar'
+import { useFullScreen } from '@renderer/hooks/use-fullscreen'
+import { isElectron, getPlatform } from '@renderer/lib/env'
+import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
+import { ExploreView } from '@renderer/components/explore/explore-view'
+import { TemplateDetailView } from '@renderer/components/explore/template-detail-view'
+import { ContentShell } from './content-shell'
+
+function useExploreShellProps() {
+  const { state: sidebarState } = useSidebar()
+  const isFullScreen = useFullScreen()
+  return {
+    needsTrafficLightPadding:
+      isElectron() && getPlatform() === 'darwin' && sidebarState === 'collapsed' && !isFullScreen,
+    headerContent: (
+      <span className="truncate text-sm font-light text-foreground">Discover New Agents</span>
+    ),
+  }
+}
+
+/** The global `/explore` route: the full-page agent template marketplace. */
+export function ExploreRoute() {
+  return (
+    <ContentShell {...useExploreShellProps()}>
+      <ErrorBoundary>
+        <ExploreView />
+      </ErrorBoundary>
+    </ContentShell>
+  )
+}
+
+/** The `/explore/$skillsetId/$templateSlug` route: one template's details page. */
+export function ExploreTemplateRoute() {
+  const params = useParams({ strict: false }) as { skillsetId?: string; templateSlug?: string }
+  return (
+    <ContentShell {...useExploreShellProps()}>
+      <ErrorBoundary>
+        {params.skillsetId && params.templateSlug && (
+          <TemplateDetailView skillsetId={params.skillsetId} templateSlug={params.templateSlug} />
+        )}
+      </ErrorBoundary>
+    </ContentShell>
+  )
+}

--- a/src/renderer/components/layout/explore-route.tsx
+++ b/src/renderer/components/layout/explore-route.tsx
@@ -4,6 +4,7 @@ import { useFullScreen } from '@renderer/hooks/use-fullscreen'
 import { isElectron, getPlatform } from '@renderer/lib/env'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { ExploreView } from '@renderer/components/explore/explore-view'
+import { CategoryView } from '@renderer/components/explore/category-view'
 import { TemplateDetailView } from '@renderer/components/explore/template-detail-view'
 import { ContentShell } from './content-shell'
 
@@ -40,6 +41,16 @@ export function ExploreTemplateRoute() {
           <TemplateDetailView skillsetId={params.skillsetId} templateSlug={params.templateSlug} />
         )}
       </ErrorBoundary>
+    </ContentShell>
+  )
+}
+
+/** The `/explore/category/$category` route: every template in one category. */
+export function ExploreCategoryRoute() {
+  const params = useParams({ strict: false }) as { category?: string }
+  return (
+    <ContentShell {...useExploreShellProps()}>
+      <ErrorBoundary>{params.category && <CategoryView category={params.category} />}</ErrorBoundary>
     </ContentShell>
   )
 }

--- a/src/renderer/hooks/use-complete-template-install.ts
+++ b/src/renderer/hooks/use-complete-template-install.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAnalyticsTracking } from '@renderer/context/analytics-context'
+import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import { completeAgentTemplateHandoff } from '@renderer/lib/agent-template-handoff'
+import type { ApiAgentTemplateInstallResult } from '@shared/lib/types/api'
+
+/**
+ * The one post-install path for a marketplace template: track, refresh the
+ * agent list, then hand off (seed the template prompt or start onboarding)
+ * and open the new agent. ONE definition shared by the browse dialog and the
+ * Explore pages so the flows can't drift.
+ */
+export function useCompleteTemplateInstall() {
+  const navigate = useNavigate()
+  const { track } = useAnalyticsTracking()
+  const startOnboardingSession = useStartOnboardingSession()
+  const queryClient = useQueryClient()
+  const draftsStore = useDraftsStore()
+
+  return useCallback(
+    async (agent: ApiAgentTemplateInstallResult) => {
+      track('agent_created', {
+        source: 'skillset',
+        num_skills_added_at_creation: 0,
+        has_template_prompt: Boolean(agent.templatePrompt),
+      })
+      await queryClient.refetchQueries({ queryKey: ['agents'] })
+      await completeAgentTemplateHandoff({
+        draftsStore,
+        agentSlug: agent.slug,
+        hasOnboarding: agent.hasOnboarding,
+        templatePrompt: agent.templatePrompt,
+        openAgent: () => { void navigate({ to: '/agents/$slug', params: { slug: agent.slug } }) },
+        startOnboardingSession,
+      })
+    },
+    [track, queryClient, draftsStore, navigate, startOnboardingSession],
+  )
+}

--- a/src/renderer/router/routes.ts
+++ b/src/renderer/router/routes.ts
@@ -22,6 +22,14 @@ const NotificationDetailRoute = lazyRouteComponent(
   () => import('@renderer/components/layout/notification-detail-route'),
   'NotificationDetailRoute',
 )
+const ExploreRoute = lazyRouteComponent(
+  () => import('@renderer/components/layout/explore-route'),
+  'ExploreRoute',
+)
+const ExploreTemplateRoute = lazyRouteComponent(
+  () => import('@renderer/components/layout/explore-route'),
+  'ExploreTemplateRoute',
+)
 const AgentShell = lazyRouteComponent(
   () => import('@renderer/components/layout/agent-shell'),
   'AgentShell',
@@ -85,6 +93,24 @@ export const notificationDetailRoute = createRoute({
   path: 'notifications/$id',
   params: { parse: (raw) => ({ id: z.string().min(1).parse(raw.id) }) },
   component: NotificationDetailRoute,
+})
+
+export const exploreRoute = createRoute({
+  getParentRoute: () => appShellRoute,
+  path: 'explore',
+  component: ExploreRoute,
+})
+
+export const exploreTemplateRoute = createRoute({
+  getParentRoute: () => appShellRoute,
+  path: 'explore/$skillsetId/$templateSlug',
+  params: {
+    parse: (raw) => ({
+      skillsetId: z.string().min(1).parse(raw.skillsetId),
+      templateSlug: z.string().min(1).parse(raw.templateSlug),
+    }),
+  },
+  component: ExploreTemplateRoute,
 })
 
 // ── AGENT LAYOUT: /agents/$slug — mount-survival anchor #2 (chat/SSE shell) ────
@@ -217,6 +243,8 @@ export const routeTree = rootRoute.addChildren([
     homeRoute,
     notificationsRoute,
     notificationDetailRoute,
+    exploreRoute,
+    exploreTemplateRoute,
     agentLayoutRoute.addChildren([
       agentHomeRoute,
       sessionRoute,

--- a/src/renderer/router/routes.ts
+++ b/src/renderer/router/routes.ts
@@ -30,6 +30,10 @@ const ExploreTemplateRoute = lazyRouteComponent(
   () => import('@renderer/components/layout/explore-route'),
   'ExploreTemplateRoute',
 )
+const ExploreCategoryRoute = lazyRouteComponent(
+  () => import('@renderer/components/layout/explore-route'),
+  'ExploreCategoryRoute',
+)
 const AgentShell = lazyRouteComponent(
   () => import('@renderer/components/layout/agent-shell'),
   'AgentShell',
@@ -99,6 +103,15 @@ export const exploreRoute = createRoute({
   getParentRoute: () => appShellRoute,
   path: 'explore',
   component: ExploreRoute,
+})
+
+// Static `category` outranks the `$skillsetId/$templateSlug` pattern below, so
+// this matches first despite both being two segments under /explore.
+export const exploreCategoryRoute = createRoute({
+  getParentRoute: () => appShellRoute,
+  path: 'explore/category/$category',
+  params: { parse: (raw) => ({ category: z.string().min(1).parse(raw.category) }) },
+  component: ExploreCategoryRoute,
 })
 
 export const exploreTemplateRoute = createRoute({
@@ -244,6 +257,7 @@ export const routeTree = rootRoute.addChildren([
     notificationsRoute,
     notificationDetailRoute,
     exploreRoute,
+    exploreCategoryRoute,
     exploreTemplateRoute,
     agentLayoutRoute.addChildren([
       agentHomeRoute,

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -892,6 +892,13 @@ export async function getDiscoverableAgents(
         description: agent.description,
         version: agent.version,
         path: agent.path,
+        // `works_with` is snake_case in index.json; the rest pass through as-is.
+        details: agent.details,
+        category: agent.category,
+        icon: agent.icon,
+        tags: agent.tags,
+        worksWith: agent.works_with,
+        developer: agent.developer,
       })
     }
   }

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -36,7 +36,7 @@ import type {
   SkillProvider,
   SkillsetCredentialInput,
 } from '@shared/lib/types/skillset'
-import { InstalledSkillMetadataSchema, SkillsetIndexSchema } from '@shared/lib/types/skillset-schema'
+import { InstalledSkillMetadataSchema, parseSkillsetIndex } from '@shared/lib/types/skillset-schema'
 import { getSkillsetProvider } from '@shared/lib/skillset-provider'
 import {
   copyDirectoryFiltered,
@@ -746,12 +746,22 @@ export async function readIndexJson(repoDir: string): Promise<SkillsetIndex> {
     throw new Error('index.json contains invalid JSON')
   }
 
-  const parsed = SkillsetIndexSchema.safeParse(raw)
-  if (!parsed.success) {
-    throw new Error(`Invalid index.json: ${parsed.error.issues[0]?.message ?? 'does not match the skillset index schema'}`)
+  const parsed = parseSkillsetIndex(raw)
+  if (!parsed.ok) {
+    throw new Error(`Invalid index.json: ${parsed.error}`)
   }
 
-  return parsed.data
+  // Individual bad entries are dropped, not fatal (see parseSkillsetIndex).
+  // Say so — the alternative is a skillset that quietly ships fewer templates
+  // than its repo lists, with nothing anywhere explaining why.
+  if (parsed.dropped.length > 0) {
+    console.warn(
+      `[readIndexJson] ${indexPath}: skipped ${parsed.dropped.length} malformed ` +
+      `entr${parsed.dropped.length === 1 ? 'y' : 'ies'}: ${parsed.dropped.join('; ')}`,
+    )
+  }
+
+  return parsed.index
 }
 
 // ============================================================================

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -36,7 +36,7 @@ import type {
   SkillProvider,
   SkillsetCredentialInput,
 } from '@shared/lib/types/skillset'
-import { InstalledSkillMetadataSchema } from '@shared/lib/types/skillset-schema'
+import { InstalledSkillMetadataSchema, SkillsetIndexSchema } from '@shared/lib/types/skillset-schema'
 import { getSkillsetProvider } from '@shared/lib/skillset-provider'
 import {
   copyDirectoryFiltered,
@@ -746,12 +746,12 @@ export async function readIndexJson(repoDir: string): Promise<SkillsetIndex> {
     throw new Error('index.json contains invalid JSON')
   }
 
-  const parsed = raw as Record<string, unknown>
-  if (!parsed.skillset_name || !Array.isArray(parsed.skills)) {
-    throw new Error('Invalid index.json: missing skillset_name or skills array')
+  const parsed = SkillsetIndexSchema.safeParse(raw)
+  if (!parsed.success) {
+    throw new Error(`Invalid index.json: ${parsed.error.issues[0]?.message ?? 'does not match the skillset index schema'}`)
   }
 
-  return raw as SkillsetIndex
+  return parsed.data
 }
 
 // ============================================================================

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -76,6 +76,16 @@ export interface ApiDiscoverableAgent {
   description: string
   version: string
   path: string
+  /** Long-form markdown for the details page. */
+  details?: string
+  /** Marketplace category, e.g. "Marketing", "Customer Success". */
+  category?: string
+  /** kebab-case lucide icon name, e.g. "badge-dollar-sign". */
+  icon?: string
+  tags?: string[]
+  /** Services the template connects to; `slug` matches the service-icon set. */
+  worksWith?: { type: string; slug: string }[]
+  developer?: { name: string; url?: string }
 }
 
 // ============================================================================

--- a/src/shared/lib/types/skillset-schema.test.ts
+++ b/src/shared/lib/types/skillset-schema.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { parseSkillsetIndex } from './skillset-schema'
+
+/**
+ * `index.json` comes from a git repo anyone can add, and a parse failure is not
+ * recoverable downstream: `getSkillsetIndex` turns the throw into `null`, which
+ * drops the skillset out of Explore AND out of skill discovery with nothing
+ * shown to the user. So the split matters — the envelope is fatal, individual
+ * entries are not.
+ */
+describe('parseSkillsetIndex', () => {
+  it('rejects a document with no skillset_name, naming the field', () => {
+    const result = parseSkillsetIndex({ skills: [] })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected a rejection')
+    expect(result.error).toContain('skillset_name')
+  })
+
+  it('keeps the good entries and reports the ones it drops', () => {
+    const result = parseSkillsetIndex({
+      skillset_name: 'Public',
+      skills: [
+        { name: 'query', path: 'skills/query/SKILL.md' },
+        { name: 'no-path' },
+      ],
+      agents: [
+        { name: 'Research Bot', path: 'agents/research-bot/' },
+        { name: 'Bad Tags', path: 'agents/bad-tags/', tags: 'one,two' },
+        { name: 'Bad Connection', path: 'agents/bad-conn/', works_with: [{ slug: 'slack' }] },
+      ],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.error)
+    expect(result.index.skills.map((s) => s.name)).toEqual(['query'])
+    expect(result.index.agents?.map((a) => a.name)).toEqual(['Research Bot'])
+    // Each drop says which list, which row, and which field — one malformed
+    // entry among 168 is otherwise unfindable.
+    expect(result.dropped).toHaveLength(3)
+    expect(result.dropped[0]).toContain('skills[1]')
+    expect(result.dropped[0]).toContain('path')
+    expect(result.dropped[1]).toContain('agents[1]')
+    expect(result.dropped[1]).toContain('tags')
+    expect(result.dropped[2]).toContain('agents[2]')
+  })
+
+  it('reports nothing dropped for a clean index', () => {
+    const result = parseSkillsetIndex({
+      skillset_name: 'Public',
+      skills: [],
+      agents: [{ name: 'A', path: 'agents/a/' }],
+    })
+    expect(result.ok && result.dropped).toEqual([])
+  })
+
+  it('keeps the marketplace fields, including the snake_case ones', () => {
+    const result = parseSkillsetIndex({
+      skillset_name: 'Public',
+      skills: [],
+      agents: [
+        {
+          name: 'A',
+          path: 'agents/a/',
+          category: 'Marketing',
+          icon: 'megaphone',
+          tags: ['seo'],
+          works_with: [{ type: 'api_account', slug: 'slack' }],
+          developer: { name: 'SkillfulAgents', url: 'https://github.com/SkillfulAgents' },
+          details: '## What it does\n\nThings.',
+        },
+      ],
+    })
+    if (!result.ok) throw new Error(result.error)
+    expect(result.index.agents?.[0]).toMatchObject({
+      category: 'Marketing',
+      icon: 'megaphone',
+      tags: ['seo'],
+      works_with: [{ type: 'api_account', slug: 'slack' }],
+      developer: { name: 'SkillfulAgents' },
+    })
+  })
+
+  it('still loads a skillset on the pre-marketplace shape', () => {
+    const result = parseSkillsetIndex({
+      skillset_name: 'Public',
+      description: 'old',
+      version: '1.0.0',
+      skills: [{ name: 'query', path: 'skills/query/SKILL.md', description: 'd', version: '1' }],
+      agents: [{ name: 'A', path: 'agents/a/', description: 'd', version: '1' }],
+    })
+    if (!result.ok) throw new Error(result.error)
+    expect(result.index.agents).toHaveLength(1)
+    expect(result.index.agents?.[0].category).toBeUndefined()
+    expect(result.dropped).toEqual([])
+  })
+
+  it('drops unknown keys rather than rejecting them', () => {
+    const result = parseSkillsetIndex({
+      skillset_name: 'Public',
+      skills: [],
+      agents: [{ name: 'A', path: 'agents/a/', future_field: { a: 1 } }],
+    })
+    if (!result.ok) throw new Error(result.error)
+    expect(result.index.agents?.[0]).not.toHaveProperty('future_field')
+    expect(result.dropped).toEqual([])
+  })
+})

--- a/src/shared/lib/types/skillset-schema.ts
+++ b/src/shared/lib/types/skillset-schema.ts
@@ -58,13 +58,93 @@ export const SkillsetIndexAgentSchema = z.object({
     .optional(),
 })
 
-export const SkillsetIndexSchema = z.object({
+/**
+ * The document minus its entry lists. Those stay raw here and are parsed a row
+ * at a time by `parseSkillsetIndex` — see the note there on why one bad row
+ * must not fail the document.
+ */
+const SkillsetIndexEnvelopeSchema = z.object({
   skillset_name: z.string(),
   description: z.string().default(''),
   version: z.string().default(''),
+  skills: z.array(z.unknown()).default([]),
+  agents: z.array(z.unknown()).optional(),
+})
+
+/**
+ * The document once parsed. Nothing runs this directly — it exists to name the
+ * shape `parseSkillsetIndex` returns, which assembles it row by row.
+ */
+const SkillsetIndexSchema = SkillsetIndexEnvelopeSchema.extend({
   skills: z.array(SkillsetIndexSkillSchema).default([]),
   agents: z.array(SkillsetIndexAgentSchema).optional(),
 })
+
+/** `<list>[<i>]: <path>: <message>` for one entry that failed to parse. */
+function describeDrop(list: string, index: number, error: z.ZodError): string {
+  const issue = error.issues[0]
+  const at = issue?.path.length ? `${issue.path.join('.')}: ` : ''
+  return `${list}[${index}]: ${at}${issue?.message ?? 'does not match the schema'}`
+}
+
+function parseRows<T extends z.ZodType>(
+  schema: T,
+  list: string,
+  rows: unknown[],
+  dropped: string[],
+): z.output<T>[] {
+  const kept: z.output<T>[] = []
+  rows.forEach((row, index) => {
+    const parsed = schema.safeParse(row)
+    if (parsed.success) kept.push(parsed.data)
+    else dropped.push(describeDrop(list, index, parsed.error))
+  })
+  return kept
+}
+
+export type SkillsetIndexParse =
+  | {
+      ok: true
+      index: z.output<typeof SkillsetIndexSchema>
+      /** Entries that didn't match and were left out, for logging. */
+      dropped: string[]
+    }
+  | { ok: false; error: string }
+
+/**
+ * Parse a skillset repo's `index.json`.
+ *
+ * The envelope must be right — with no `skillset_name` there is no skillset.
+ * Individual skill and agent entries are parsed one at a time and the ones that
+ * don't match are DROPPED rather than failing the document, because a document
+ * failure is not recoverable downstream: `getSkillsetIndex` turns any throw
+ * into `null`, which removes the skillset from Explore *and* from skill
+ * discovery with nothing shown to the user. One malformed row in a third-party
+ * repo — a missing `path`, `tags` written as a string — is not worth taking the
+ * other 167 entries offline with it.
+ */
+export function parseSkillsetIndex(raw: unknown): SkillsetIndexParse {
+  const envelope = SkillsetIndexEnvelopeSchema.safeParse(raw)
+  if (!envelope.success) {
+    const issue = envelope.error.issues[0]
+    const at = issue?.path.length ? `${issue.path.join('.')}: ` : ''
+    return { ok: false, error: `${at}${issue?.message ?? 'does not match the skillset index schema'}` }
+  }
+
+  const dropped: string[] = []
+  const { skills, agents, ...rest } = envelope.data
+  return {
+    ok: true,
+    dropped,
+    index: {
+      ...rest,
+      skills: parseRows(SkillsetIndexSkillSchema, 'skills', skills, dropped),
+      ...(agents === undefined
+        ? {}
+        : { agents: parseRows(SkillsetIndexAgentSchema, 'agents', agents, dropped) }),
+    },
+  }
+}
 
 export const SkillsetProviderDataSchema = z.record(z.string(), z.unknown())
 

--- a/src/shared/lib/types/skillset-schema.ts
+++ b/src/shared/lib/types/skillset-schema.ts
@@ -11,6 +11,61 @@ import { z } from 'zod'
 
 export const SkillProviderSchema = z.enum(['github', 'platform', 'public'])
 
+/**
+ * A skillset repo's `index.json`.
+ *
+ * Everything past `name`/`path`/`description`/`version` is OPTIONAL on
+ * purpose: the marketplace fields (category, icon, tags, works_with,
+ * developer, details) were added to the public skillset after the format
+ * shipped, and a skillset repo pinned to the older shape must keep loading.
+ * Unknown keys are stripped rather than rejected so the repo can add fields
+ * ahead of the app understanding them.
+ */
+export const SkillsetIndexSkillSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  description: z.string().default(''),
+  version: z.string().default(''),
+})
+
+export const SkillsetIndexAgentSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  description: z.string().default(''),
+  version: z.string().default(''),
+  /** Long-form markdown shown on the template details page. */
+  details: z.string().optional(),
+  createdAt: z.string().optional(),
+  /** Free-form marketplace category, e.g. "Marketing", "Customer Success". */
+  category: z.string().optional(),
+  /** kebab-case lucide icon name, e.g. "badge-dollar-sign". */
+  icon: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  /** Services the template connects to; `slug` matches our service-icon set. */
+  works_with: z
+    .array(
+      z.object({
+        type: z.string(),
+        slug: z.string(),
+      }),
+    )
+    .optional(),
+  developer: z
+    .object({
+      name: z.string(),
+      url: z.string().optional(),
+    })
+    .optional(),
+})
+
+export const SkillsetIndexSchema = z.object({
+  skillset_name: z.string(),
+  description: z.string().default(''),
+  version: z.string().default(''),
+  skills: z.array(SkillsetIndexSkillSchema).default([]),
+  agents: z.array(SkillsetIndexAgentSchema).optional(),
+})
+
 export const SkillsetProviderDataSchema = z.record(z.string(), z.unknown())
 
 export const SkillsetConfigSchema = z.object({

--- a/src/shared/lib/types/skillset.ts
+++ b/src/shared/lib/types/skillset.ts
@@ -149,12 +149,34 @@ export interface DiscoverableSkill {
 // Agent Template Types (for skillset-based agent sharing)
 // ============================================================================
 
-/** An agent entry within a skillset's index.json */
+/** A service an agent template connects to, as declared in index.json. */
+export interface SkillsetAgentConnection {
+  type: string // 'api_account' | 'mcp' | …
+  slug: string // matches public/service-icons/<slug>.svg where one exists
+}
+
+/**
+ * An agent entry within a skillset's index.json.
+ *
+ * The marketplace fields below are optional: they were added to the public
+ * skillset after the format shipped, so a repo on the older shape still loads
+ * (see SkillsetIndexAgentSchema).
+ */
 export interface SkillsetIndexAgent {
   name: string
   path: string // e.g. "agents/research-assistant/"
   description: string
   version: string
+  /** Long-form markdown for the template details page. */
+  details?: string
+  createdAt?: string
+  /** Marketplace category, e.g. "Marketing", "Customer Success". */
+  category?: string
+  /** kebab-case lucide icon name, e.g. "badge-dollar-sign". */
+  icon?: string
+  tags?: string[]
+  works_with?: SkillsetAgentConnection[]
+  developer?: { name: string; url?: string }
 }
 
 /** Metadata stored in workspace/.skillset-agent-metadata.json */
@@ -217,4 +239,11 @@ export interface DiscoverableAgent {
   description: string
   version: string
   path: string // path within skillset repo
+  // Marketplace presentation, absent on skillsets still on the older index shape.
+  details?: string
+  category?: string
+  icon?: string
+  tags?: string[]
+  worksWith?: SkillsetAgentConnection[]
+  developer?: { name: string; url?: string }
 }


### PR DESCRIPTION
Replaces the Explore modal with a browsable marketplace page, a per-template details page, and a per-category page — and wires all three to the metadata the public skillset recently started shipping.

## The data was already there

Every agent in the public skillset now carries `category`, `icon`, `tags`, `works_with`, `developer`, and a long-form `details` markdown. The app was dropping all of it: `readIndexJson` cast the raw JSON to a type declaring four fields, and `getDiscoverableAgents` rebuilt each entry from six.

`index.json` now parses through a Zod schema (per CLAUDE.md — that function predated the rule) with every new field optional, so skillsets on the older shape keep loading. Verified against both the 168-agent index and the previous 8-agent one.

## Nothing on the page is invented

Run cost and suggested models were the last mocked values — cost from a formula I wrote over the connection count, models from a hardcoded list ignoring its argument. Both rows are gone along with their generators, so every value traces back to `index.json`. The `@outpacelabs/avatars` dependency we tried for gradient icons is removed too.

## Structure

**Browsing** groups into category sections showing five cards plus a tile that opens `/explore/category/$category` — 168 templates in one grid buries everything past the first screen. Searching or filtering falls back to a flat grid, since you've already narrowed. **Featured** leads the page, keyed off `developer === 'SkillfulAgents'`: a first-party signal from the index rather than editorial curation, since the index has no `featured` flag. It selects exactly the eight hand-built agents — the only ones shipping real `.claude/skills/` directories.

**The details page** splits the markdown into one section per `##` heading instead of one undifferentiated blob, lifts the prompt bullets into a hero band washed in the template's accent hue, and renders the file inventory as chips. It prefers a `## Example prompts` section where an author has written one, falling back to `Sample use cases` then to generic openers — so that section can roll out template by template rather than needing a flag day. `Connect first` is dropped as a verbatim repeat of Works with.

**Install** moved to the details page, so the browse dialog and both pages share one `useCompleteTemplateInstall` hook rather than duplicating the track → refetch → handoff → navigate sequence. The dialog itself stays for the wizard and create-agent entry points, and its e2e test is untouched.

## Worth a second opinion

- **Featured means "authored by us,"** not "chosen." A contributor shipping something excellent can't be featured. A real `featured` flag in the README frontmatter would be the durable fix.
- **Icon color is arbitrary** — hashed from the agent name, so Account Expert being green means nothing. Keying it to category, or adding a `color:` field alongside `icon:`, would make it carry information.
- **`Getting started`** is identical boilerplate on ~165 agents telling you to import the directory manually, which the Install button already does. It renders because it's real repo content, but it may read as confusing.
- **Two connection slugs have no logo** in our set: `granola` and `microsoft_teams`. They render the generic fallback rather than a stand-in brand mark.

## Testing

Typecheck, lint, and 558 tests across the affected suites pass. Schema verified against both index formats; parsers verified against all 168 agents (no empty sections, all inventory lists parse, icon names all resolve).