### PR TITLE
Media references instead of inline base64 in message payloads (SUP-596)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
 import { runInNewContext } from 'node:vm'
-import { Writable } from 'node:stream'
+import { Readable, Writable } from 'node:stream'
 import { createHash } from 'node:crypto'
 
 // ============================================================================
@@ -297,6 +297,11 @@ vi.mock('@shared/lib/services/agent-service', () => ({
   agentExists: (...args: unknown[]) => mockAgentExists(...args),
 }))
 
+vi.mock('@shared/lib/services/session-media', () => ({
+  decodeMediaRef: vi.fn(),
+  openMediaBlob: vi.fn(),
+}))
+
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: vi.fn(),
   listSessionsByIds: vi.fn(),
@@ -553,6 +558,7 @@ vi.mock('hono/streaming', () => ({ streamSSE: (...args: unknown[]) => mockStream
 
 // Import the agents router after all mocks are set up
 import agents from './agents'
+import { decodeMediaRef, openMediaBlob } from '@shared/lib/services/session-media'
 import { UploadTooLargeError } from '@shared/lib/utils/chunked-upload'
 import {
   importAgentFromTemplate,
@@ -3867,6 +3873,36 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(getSessionMessagesPage).not.toHaveBeenCalled()
   })
 
+  it('forwards the media mode to the page reader', async () => {
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({ messages: [], nextCursor: null })
+
+    const res = await getReq(app, `${URL}?limit=2&media=ref`)
+    expect(res.status).toBe(200)
+    expect(getSessionMessagesPage).toHaveBeenCalledWith(
+      'test-agent',
+      'sess-1',
+      expect.objectContaining({ media: 'ref' })
+    )
+  })
+
+  it('forwards the media mode to the delta reader', async () => {
+    vi.mocked(getSessionMessagesDelta).mockResolvedValue({ messages: [], anchor: null })
+
+    const res = await getReq(app, `${URL}?after=m1&media=ref`)
+    expect(res.status).toBe(200)
+    expect(getSessionMessagesDelta).toHaveBeenCalledWith(
+      'test-agent',
+      'sess-1',
+      expect.objectContaining({ media: 'ref' })
+    )
+  })
+
+  it('rejects an unknown media mode rather than silently serving inline', async () => {
+    const res = await getReq(app, `${URL}?limit=2&media=inline`)
+    expect(res.status).toBe(400)
+    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+  })
+
   it('caps first-page limit to MESSAGES_PAGE_LIMIT', async () => {
     process.env.MESSAGES_PAGE_LIMIT = '100'
     vi.mocked(getSessionMessagesPage).mockResolvedValue({
@@ -4033,6 +4069,61 @@ describe('GET /:id/sessions/:sessionId/messages forward delta (?after=)', () => 
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.messages[0].toolCalls[0].result).toBe('User provided input')
+  })
+})
+
+// The read itself (offsets, validity, decoding) is covered against real files
+// in session-media.test.ts; `fs` is mocked wholesale here, so these cover what
+// the route owns: status codes, headers, and passing the stream through.
+describe('GET /:id/sessions/:sessionId/media/:ref', () => {
+  let app: ReturnType<typeof createApp>
+  const image = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.alloc(4096, 0x7f),
+  ])
+  const REF = 'encoded-ref'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    vi.mocked(sessionExists).mockResolvedValue(true)
+    vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
+    vi.mocked(decodeMediaRef).mockReturnValue({ v: 1, u: 'u-1', o: 10, s: 100, l: 200 })
+    vi.mocked(openMediaBlob).mockResolvedValue({
+      stream: Readable.from([image]),
+      mimeType: 'image/png',
+      bytes: image.length,
+    })
+  })
+
+  it('streams the addressed image with its sniffed type', async () => {
+    const res = await getReq(app, `/api/agents/test-agent/sessions/sess-1/media/${REF}`)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('image/png')
+    expect(res.headers.get('Content-Length')).toBe(String(image.length))
+    expect(res.headers.get('Cache-Control')).toContain('immutable')
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff')
+    expect(Buffer.from(await res.arrayBuffer()).equals(image)).toBe(true)
+  })
+
+  it('answers 410 once the transcript no longer holds the referenced bytes', async () => {
+    vi.mocked(openMediaBlob).mockResolvedValue(undefined)
+    const res = await getReq(app, `/api/agents/test-agent/sessions/sess-1/media/${REF}`)
+    expect(res.status).toBe(410)
+  })
+
+  it('rejects a ref it could not have minted', async () => {
+    vi.mocked(decodeMediaRef).mockReturnValue(undefined)
+    const res = await getReq(app, '/api/agents/test-agent/sessions/sess-1/media/not-a-ref')
+    expect(res.status).toBe(400)
+    expect(openMediaBlob).not.toHaveBeenCalled()
+  })
+
+  it('404s for a session the agent does not own', async () => {
+    vi.mocked(sessionBelongsToAgent).mockResolvedValue(false)
+    const res = await getReq(app, `/api/agents/test-agent/sessions/sess-1/media/${REF}`)
+    expect(res.status).toBe(404)
+    expect(openMediaBlob).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -4150,6 +4150,15 @@ describe('GET /:id/sessions/:sessionId/media/:ref', () => {
     expect(openMediaBlob).not.toHaveBeenCalled()
   })
 
+  it('does not preflight existence, so storage failures are not read as gone', async () => {
+    // fileExists() answers false for any stat failure, so a preflight here
+    // would 404 on EIO/EACCES before the read could report anything.
+    vi.mocked(sessionExists).mockResolvedValue(false)
+    const res = await getReq(app, `/api/agents/test-agent/sessions/sess-1/media/${REF}`)
+    expect(res.status).toBe(200)
+    expect(sessionExists).not.toHaveBeenCalled()
+  })
+
   it('404s for a session the agent does not own', async () => {
     vi.mocked(sessionBelongsToAgent).mockResolvedValue(false)
     const res = await getReq(app, `/api/agents/test-agent/sessions/sess-1/media/${REF}`)

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -3903,6 +3903,27 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     expect(getSessionMessagesPage).not.toHaveBeenCalled()
   })
 
+  it('honors media on its own, without any pagination parameter', async () => {
+    // Otherwise asking for refs quietly returns the full inline transcript.
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({ messages: [], nextCursor: null })
+
+    const res = await getReq(app, `${URL}?media=ref`)
+    expect(res.status).toBe(200)
+    expect(getSessionMessagesPage).toHaveBeenCalledWith(
+      'test-agent',
+      'sess-1',
+      expect.objectContaining({ media: 'ref' })
+    )
+    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+  })
+
+  it('validates a media value even when it arrives alone', async () => {
+    const res = await getReq(app, `${URL}?media=bogus`)
+    expect(res.status).toBe(400)
+    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+  })
+
   it('caps first-page limit to MESSAGES_PAGE_LIMIT', async () => {
     process.env.MESSAGES_PAGE_LIMIT = '100'
     vi.mocked(getSessionMessagesPage).mockResolvedValue({
@@ -4088,7 +4109,7 @@ describe('GET /:id/sessions/:sessionId/media/:ref', () => {
     app = createApp()
     vi.mocked(sessionExists).mockResolvedValue(true)
     vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
-    vi.mocked(decodeMediaRef).mockReturnValue({ v: 1, u: 'u-1', o: 10, s: 100, l: 200 })
+    vi.mocked(decodeMediaRef).mockReturnValue({ v: 1, u: 'u-1', o: 10, s: 100, l: 200, h: 'fp' })
     vi.mocked(openMediaBlob).mockResolvedValue({
       stream: Readable.from([image]),
       mimeType: 'image/png',
@@ -4110,6 +4131,16 @@ describe('GET /:id/sessions/:sessionId/media/:ref', () => {
     vi.mocked(openMediaBlob).mockResolvedValue(undefined)
     const res = await getReq(app, `/api/agents/test-agent/sessions/sess-1/media/${REF}`)
     expect(res.status).toBe(410)
+  })
+
+  it('answers 500, not 410, when the read fails for operational reasons', async () => {
+    // A disk error says nothing about whether the media still exists; 410
+    // would strand the client on a placeholder it never retries.
+    vi.mocked(openMediaBlob).mockRejectedValue(
+      Object.assign(new Error('I/O error'), { code: 'EIO' })
+    )
+    const res = await getReq(app, `/api/agents/test-agent/sessions/sess-1/media/${REF}`)
+    expect(res.status).toBe(500)
   })
 
   it('rejects a ref it could not have minted', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1874,7 +1874,15 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     const rawCursor = c.req.query('cursor')
     const rawAfter = c.req.query('after')
     const rawMedia = c.req.query('media')
-    if (rawLimit !== undefined || rawCursor !== undefined || rawAfter !== undefined) {
+    // `media` selects this branch too: it is only honored on the paginated
+    // path, so leaving it out would silently serve a full inline response to a
+    // client that asked for refs — and skip validating the value at all.
+    if (
+      rawLimit !== undefined ||
+      rawCursor !== undefined ||
+      rawAfter !== undefined ||
+      rawMedia !== undefined
+    ) {
       const parsed = messagesListQuerySchema.safeParse({
         ...(rawLimit !== undefined ? { limit: rawLimit } : {}),
         ...(rawCursor !== undefined ? { cursor: rawCursor } : {}),

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2045,10 +2045,12 @@ agents.get('/:id/sessions/:sessionId/media/:ref', AgentRead(), async (c) => {
   try {
     const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
-    if (
-      !(await sessionBelongsToAgent(agentSlug, sessionId)) ||
-      !(await sessionExists(agentSlug, sessionId))
-    ) {
+    // Ownership only. There is deliberately no existence preflight here:
+    // fileExists() answers false for any stat failure, so EIO/EACCES/EMFILE
+    // would 404 — telling the client the image is gone when the truth is that
+    // this machine could not look. openMediaBlob distinguishes the two, and a
+    // genuinely missing transcript surfaces there as 410.
+    if (!(await sessionBelongsToAgent(agentSlug, sessionId))) {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -72,6 +72,7 @@ import {
   removeMessage,
   removeToolCall,
 } from '@shared/lib/services/session-service'
+import { decodeMediaRef, openMediaBlob } from '@shared/lib/services/session-media'
 import { getSessionJsonlPath, getAgentSessionsDir, readJsonlFile, writeJsonFileAtomic, displaySlug, createJsonArrayStringifyTransform, directoryExists } from '@shared/lib/utils/file-storage'
 import {
   MAX_UPLOAD_TOTAL_SIZE,
@@ -1768,6 +1769,10 @@ const messagesListQuerySchema = z
     limit: z.coerce.number().int().min(1).max(MESSAGES_PAGE_MAX_LIMIT).optional(),
     cursor: z.string().min(1).max(200).optional(),
     after: z.string().min(1).max(200).optional(),
+    // Opt-in: images ship as refs to the media endpoint instead of inline
+    // base64. Absent means inline, so clients that predate the media endpoint
+    // (and the unpaginated path below) are unaffected.
+    media: z.literal('ref').optional(),
   })
   // Backward paging and the forward delta are different protocols; a request
   // mixing them has no coherent meaning.
@@ -1868,11 +1873,13 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     const rawLimit = c.req.query('limit')
     const rawCursor = c.req.query('cursor')
     const rawAfter = c.req.query('after')
+    const rawMedia = c.req.query('media')
     if (rawLimit !== undefined || rawCursor !== undefined || rawAfter !== undefined) {
       const parsed = messagesListQuerySchema.safeParse({
         ...(rawLimit !== undefined ? { limit: rawLimit } : {}),
         ...(rawCursor !== undefined ? { cursor: rawCursor } : {}),
         ...(rawAfter !== undefined ? { after: rawAfter } : {}),
+        ...(rawMedia !== undefined ? { media: rawMedia } : {}),
       })
       if (!parsed.success) {
         return c.json({ error: 'Invalid pagination' }, 400)
@@ -1890,6 +1897,7 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
         const delta = await getSessionMessagesDelta(agentSlug, sessionId, {
           after: parsed.data.after,
           signal: c.req.raw.signal,
+          media: parsed.data.media,
         })
         c.req.raw.signal.throwIfAborted()
         await annotateAndRecoverMessages(delta.messages, agentSlug, sessionId)
@@ -1904,6 +1912,7 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
         limit: capMessagesPageLimit(parsed.data.limit, parsed.data.cursor),
         cursor: parsed.data.cursor,
         signal: c.req.raw.signal,
+        media: parsed.data.media,
       })
       c.req.raw.signal.throwIfAborted()
       await annotateAndRecoverMessages(page.messages, agentSlug, sessionId)
@@ -2017,6 +2026,49 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     }
     console.error('Failed to fetch messages:', error)
     return c.json({ error: 'Failed to fetch messages' }, 500)
+  }
+})
+
+// GET /api/agents/:id/sessions/:sessionId/media/:ref - Bytes of one image a
+// `media=ref` page addressed. Served straight off the transcript as a ranged,
+// streaming base64 decode: the row holding it is multi-MB, and none of it is
+// materialized here.
+agents.get('/:id/sessions/:sessionId/media/:ref', AgentRead(), async (c) => {
+  try {
+    const agentSlug = getAgentId(c)
+    const sessionId = c.req.param('sessionId')
+    if (
+      !(await sessionBelongsToAgent(agentSlug, sessionId)) ||
+      !(await sessionExists(agentSlug, sessionId))
+    ) {
+      return c.json({ error: 'Session transcript not found' }, 404)
+    }
+
+    const ref = decodeMediaRef(c.req.param('ref'))
+    if (!ref) return c.json({ error: 'Invalid media reference' }, 400)
+
+    const blob = await openMediaBlob(getSessionJsonlPath(agentSlug, sessionId), ref, c.req.raw.signal)
+    // Deletion and retention rewrite transcripts in place, so a ref the client
+    // still holds can address bytes that have moved or gone. Gone for good —
+    // the client shows a placeholder rather than retrying.
+    if (!blob) return c.json({ error: 'Media no longer available' }, 410)
+
+    return c.body(Readable.toWeb(blob.stream) as ReadableStream, 200, {
+      'Content-Type': blob.mimeType,
+      'Content-Length': String(blob.bytes),
+      // A ref names an immutable byte span: any edit to the transcript
+      // invalidates it rather than changing what it points at.
+      'Cache-Control': 'private, max-age=31536000, immutable',
+      // The type comes from a magic-number sniff, never from the ref — keep
+      // the browser from second-guessing it.
+      'X-Content-Type-Options': 'nosniff',
+    })
+  } catch (error) {
+    if (c.req.raw.signal.aborted) {
+      return new Response(null, { status: 499 })
+    }
+    console.error('Failed to fetch session media:', error)
+    return c.json({ error: 'Failed to fetch media' }, 500)
   }
 })
 

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -514,7 +514,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                           isCompleted={completedSubagents?.has(toolCall.id) ?? false}
                         />
                       ) : (
-                        <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} isSessionActive={isSessionActive} />
+                        <ToolCallItem toolCall={toolCall} messageCreatedAt={message.createdAt} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={isSessionActive} />
                       )}
                     </MessageErrorBoundary>
                   </div>

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -1742,7 +1742,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
             } else {
               inner = (
                 <div className="max-w-[80%]">
-                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} isSessionActive={isActive} />
+                  <ToolCallItem toolCall={syntheticToolCall} agentSlug={agentSlug} sessionId={sessionId} isSessionActive={isActive} />
                 </div>
               )
             }

--- a/src/renderer/components/messages/tool-call-item.test.tsx
+++ b/src/renderer/components/messages/tool-call-item.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
 import { formatToolName } from './tool-call-item'
@@ -12,11 +12,13 @@ vi.mock('./tool-renderers', () => ({
 }))
 
 // Mock parseToolResult
+const { mockParseToolResult } = vi.hoisted(() => ({ mockParseToolResult: vi.fn() }))
+mockParseToolResult.mockImplementation((result: unknown) => ({
+  text: result != null ? String(result) : null,
+  images: [],
+}))
 vi.mock('@renderer/lib/parse-tool-result', () => ({
-  parseToolResult: (result: unknown) => ({
-    text: result != null ? String(result) : null,
-    images: [],
-  }),
+  parseToolResult: (result: unknown) => mockParseToolResult(result),
 }))
 
 // Mock useElapsedTimer for deterministic values
@@ -180,5 +182,61 @@ describe('StreamingToolCallItem', () => {
   it('shows waiting message when partialInput is empty', () => {
     render(<StreamingToolCallItem name="Bash" partialInput="" />)
     expect(screen.getByText('Waiting for input...')).toBeInTheDocument()
+  })
+})
+
+describe('ToolCallItem result images', () => {
+  const refImage = {
+    src: '/api/agents/a/sessions/s/media/ref-1',
+    bytes: 40960,
+    isRef: true,
+  }
+
+  // These override the shared parse mock; put it back so order stays irrelevant.
+  afterEach(() => {
+    mockParseToolResult.mockImplementation((result: unknown) => ({
+      text: result != null ? String(result) : null,
+      images: [],
+    }))
+  })
+
+  it('does not mount a referenced image until the call is expanded', async () => {
+    mockParseToolResult.mockReturnValue({ text: 'done', images: [refImage] })
+    const { container } = render(
+      <ToolCallItem toolCall={createToolCall({ name: 'Read', result: 'done' })} />
+    )
+    // Collapsed: nothing to fetch.
+    expect(container.querySelector('img')).toBeNull()
+
+    await userEvent.click(screen.getByRole('button'))
+    const img = container.querySelector('img')
+    expect(img).toHaveAttribute('src', refImage.src)
+    expect(img).toHaveAttribute('loading', 'lazy')
+  })
+
+  it('shows a placeholder when a referenced image no longer resolves', async () => {
+    mockParseToolResult.mockReturnValue({ text: 'done', images: [refImage] })
+    const { container } = render(
+      <ToolCallItem toolCall={createToolCall({ name: 'Read', result: 'done' })} />
+    )
+    await userEvent.click(screen.getByRole('button'))
+
+    const img = container.querySelector('img')!
+    fireEvent.error(img)
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(screen.getByText(/no longer available/i)).toBeInTheDocument()
+  })
+
+  it('still renders inline base64 images', async () => {
+    mockParseToolResult.mockReturnValue({
+      text: null,
+      images: [{ src: 'data:image/png;base64,abc', isRef: false }],
+    })
+    const { container } = render(
+      <ToolCallItem toolCall={createToolCall({ name: 'Read', result: 'x' })} />
+    )
+    await userEvent.click(screen.getByRole('button'))
+    expect(container.querySelector('img')).toHaveAttribute('src', 'data:image/png;base64,abc')
   })
 })

--- a/src/renderer/components/messages/tool-call-item.test.tsx
+++ b/src/renderer/components/messages/tool-call-item.test.tsx
@@ -236,6 +236,24 @@ describe('ToolCallItem result images', () => {
     expect(retried.getAttribute('src')).toContain('retry=1')
   })
 
+  it('does not corrupt an inline data URL when retried', async () => {
+    // A query nonce appended to a data: URL becomes part of the base64 payload,
+    // turning a working image into a broken one.
+    const dataUrl = 'data:image/png;base64,iVBORw0KGgo='
+    mockParseToolResult.mockReturnValue({
+      text: null,
+      images: [{ src: dataUrl, isRef: false }],
+    })
+    const { container } = render(
+      <ToolCallItem toolCall={createToolCall({ name: 'Read', result: 'x' })} />
+    )
+    await userEvent.click(screen.getByRole('button'))
+    fireEvent.error(container.querySelector('img')!)
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    expect(container.querySelector('img')).toHaveAttribute('src', dataUrl)
+  })
+
   it('still renders inline base64 images', async () => {
     mockParseToolResult.mockReturnValue({
       text: null,

--- a/src/renderer/components/messages/tool-call-item.test.tsx
+++ b/src/renderer/components/messages/tool-call-item.test.tsx
@@ -214,7 +214,7 @@ describe('ToolCallItem result images', () => {
     expect(img).toHaveAttribute('loading', 'lazy')
   })
 
-  it('shows a placeholder when a referenced image no longer resolves', async () => {
+  it('offers a retry rather than declaring the image permanently gone', async () => {
     mockParseToolResult.mockReturnValue({ text: 'done', images: [refImage] })
     const { container } = render(
       <ToolCallItem toolCall={createToolCall({ name: 'Read', result: 'done' })} />
@@ -224,8 +224,16 @@ describe('ToolCallItem result images', () => {
     const img = container.querySelector('img')!
     fireEvent.error(img)
 
+    // An <img> error carries no reason, so the copy must not claim one.
     expect(container.querySelector('img')).toBeNull()
-    expect(screen.getByText(/no longer available/i)).toBeInTheDocument()
+    expect(screen.getByText(/couldn't load image/i)).toBeInTheDocument()
+    expect(screen.queryByText(/no longer available/i)).not.toBeInTheDocument()
+
+    // Retrying re-requests instead of re-showing the failed load.
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }))
+    const retried = container.querySelector('img')!
+    expect(retried).toBeTruthy()
+    expect(retried.getAttribute('src')).toContain('retry=1')
   })
 
   it('still renders inline base64 images', async () => {

--- a/src/renderer/components/messages/tool-call-item.test.tsx
+++ b/src/renderer/components/messages/tool-call-item.test.tsx
@@ -236,6 +236,40 @@ describe('ToolCallItem result images', () => {
     expect(retried.getAttribute('src')).toContain('retry=1')
   })
 
+  it('reserves the image box and shows a skeleton while a ref is in flight', async () => {
+    // The bytes no longer arrive with the payload, so without a reserved box
+    // the card is a sliver until the fetch lands and then displaces the page.
+    mockParseToolResult.mockReturnValue({
+      text: null,
+      images: [{ ...refImage, width: 919, height: 1998 }],
+    })
+    const { container } = render(
+      <ToolCallItem toolCall={createToolCall({ name: 'Read', result: 'x' })} />
+    )
+    await userEvent.click(screen.getByRole('button'))
+
+    const img = container.querySelector('img')!
+    expect(img).toHaveAttribute('width', '919')
+    expect(img).toHaveAttribute('height', '1998')
+    expect(img.parentElement).toHaveStyle({ aspectRatio: '919 / 1998' })
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+
+    fireEvent.load(img)
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('does not show a skeleton for an inline image, which needs no fetch', async () => {
+    mockParseToolResult.mockReturnValue({
+      text: null,
+      images: [{ src: 'data:image/png;base64,abc', isRef: false }],
+    })
+    const { container } = render(
+      <ToolCallItem toolCall={createToolCall({ name: 'Read', result: 'x' })} />
+    )
+    await userEvent.click(screen.getByRole('button'))
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
   it('does not corrupt an inline data URL when retried', async () => {
     // A query nonce appended to a data: URL becomes part of the base64 payload,
     // turning a working image into a broken one.

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -4,6 +4,7 @@ import { Check, X, Ban, ChevronDown, ChevronRight, ImageOff, Loader2, Search } f
 import { useState, useRef, useMemo, memo } from 'react'
 import { getToolRenderer } from './tool-renderers'
 import { parseToolResult, type ParsedToolResultImage } from '@renderer/lib/parse-tool-result'
+import { Skeleton } from '@renderer/components/ui/skeleton'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
 import type { ApiToolCall } from '@shared/lib/types/api'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
@@ -103,6 +104,7 @@ export function StatusIndicator({ status }: { status: string }) {
  * transcript no longer has it. */
 function ToolResultImage({ image }: { image: ParsedToolResultImage }) {
   const [failed, setFailed] = useState(false)
+  const [loaded, setLoaded] = useState(false)
   const [attempt, setAttempt] = useState(0)
 
   if (failed) {
@@ -118,6 +120,7 @@ function ToolResultImage({ image }: { image: ParsedToolResultImage }) {
           type="button"
           onClick={() => {
             setFailed(false)
+            setLoaded(false)
             setAttempt((n) => n + 1)
           }}
           className="underline underline-offset-2 hover:text-foreground transition-colors"
@@ -136,16 +139,44 @@ function ToolResultImage({ image }: { image: ParsedToolResultImage }) {
       ? `${image.src}${image.src.includes('?') ? '&' : '?'}retry=${attempt}`
       : image.src
 
+  // Inline images arrive with the payload and paint immediately; only a fetched
+  // one has a gap worth covering.
+  const pending = image.isRef && !loaded
+  const sized = image.width !== undefined && image.height !== undefined
+
   return (
-    <img
-      key={attempt}
-      src={src}
-      alt="Tool result"
-      loading="lazy"
-      decoding="async"
-      onError={() => setFailed(true)}
-      className="max-w-full rounded border"
-    />
+    <div
+      className="relative overflow-hidden rounded border"
+      style={
+        sized
+          ? // The exact box, held from first paint: the width the image will
+            // actually occupy, and its own aspect ratio for the height. Without
+            // this the element is a 2px sliver until the bytes land and then
+            // displaces everything below it.
+            { width: image.width, maxWidth: '100%', aspectRatio: `${image.width} / ${image.height}` }
+          : // Nothing to go on — reserve enough that the card doesn't collapse.
+            { minHeight: pending ? '8rem' : undefined }
+      }
+    >
+      {pending && <Skeleton className="absolute inset-0 h-full w-full rounded-none" />}
+      <img
+        key={attempt}
+        src={src}
+        alt="Tool result"
+        {...(sized ? { width: image.width, height: image.height } : {})}
+        loading="lazy"
+        decoding="async"
+        onLoad={() => setLoaded(true)}
+        onError={() => setFailed(true)}
+        className={cn(
+          'block max-w-full',
+          sized ? 'h-full w-full' : 'h-auto',
+          // Held invisible rather than unmounted, so the browser is actually
+          // fetching it while the skeleton shows.
+          pending && 'opacity-0'
+        )}
+      />
+    </div>
   )
 }
 

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -1,9 +1,9 @@
 
 import { cn } from '@shared/lib/utils/cn'
-import { Check, X, Ban, ChevronDown, ChevronRight, Loader2, Search } from 'lucide-react'
+import { Check, X, Ban, ChevronDown, ChevronRight, ImageOff, Loader2, Search } from 'lucide-react'
 import { useState, useRef, useMemo, memo } from 'react'
 import { getToolRenderer } from './tool-renderers'
-import { parseToolResult } from '@renderer/lib/parse-tool-result'
+import { parseToolResult, type ParsedToolResultImage } from '@renderer/lib/parse-tool-result'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
 import type { ApiToolCall } from '@shared/lib/types/api'
 import { formatToolName } from '@shared/lib/tool-definitions/types'
@@ -85,6 +85,35 @@ export function StatusIndicator({ status }: { status: string }) {
     <span className="h-4 w-4 shrink-0 rounded-full bg-zinc-200 dark:bg-zinc-700 flex items-center justify-center">
       <Ban className="h-2.5 w-2.5 text-muted-foreground" strokeWidth={2.5} />
     </span>
+  )
+}
+
+/** A tool result's image. Refs load from the media endpoint the first time the
+ * card is expanded — the expanded branch is what mounts this, so nothing is
+ * fetched for a collapsed call, and the immutable response is cached for every
+ * later expand. A ref that no longer resolves (410 after the transcript was
+ * edited) shows a placeholder instead of a broken image. */
+function ToolResultImage({ image }: { image: ParsedToolResultImage }) {
+  const [failed, setFailed] = useState(false)
+
+  if (failed) {
+    return (
+      <div className="flex items-center gap-2 rounded border border-dashed border-border/70 px-3 py-2 text-xs text-muted-foreground">
+        <ImageOff className="h-3.5 w-3.5 shrink-0" />
+        <span>Image is no longer available in this transcript</span>
+      </div>
+    )
+  }
+
+  return (
+    <img
+      src={image.src}
+      alt="Tool result"
+      loading="lazy"
+      decoding="async"
+      onError={() => setFailed(true)}
+      className="max-w-full rounded border"
+    />
   )
 }
 
@@ -208,12 +237,7 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
           {resultImages.length > 0 && (
             <div className="mt-2 space-y-2">
               {resultImages.map((img, i) => (
-                <img
-                  key={i}
-                  src={`data:${img.mimeType};base64,${img.data}`}
-                  alt="Tool result"
-                  className="max-w-full rounded border"
-                />
+                <ToolResultImage key={img.src || i} image={img} />
               ))}
             </div>
           )}

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -14,6 +14,10 @@ interface ToolCallItemProps {
   toolCall: ApiToolCall
   messageCreatedAt?: Date | string
   agentSlug?: string
+  /** With agentSlug, authorizes media refs in this result to become requests
+   * against this session — the result itself is not trusted to say where its
+   * images live (see parse-tool-result). */
+  sessionId?: string
   isSessionActive?: boolean
 }
 
@@ -91,23 +95,39 @@ export function StatusIndicator({ status }: { status: string }) {
 /** A tool result's image. Refs load from the media endpoint the first time the
  * card is expanded — the expanded branch is what mounts this, so nothing is
  * fetched for a collapsed call, and the immutable response is cached for every
- * later expand. A ref that no longer resolves (410 after the transcript was
- * edited) shows a placeholder instead of a broken image. */
+ * later expand.
+ *
+ * An <img> error event carries no reason: offline, a 5xx, a decode failure and
+ * an actually-deleted image all arrive the same way. So the failure state says
+ * only that it didn't load and offers a retry, rather than asserting the
+ * transcript no longer has it. */
 function ToolResultImage({ image }: { image: ParsedToolResultImage }) {
   const [failed, setFailed] = useState(false)
+  const [attempt, setAttempt] = useState(0)
 
   if (failed) {
     return (
       <div className="flex items-center gap-2 rounded border border-dashed border-border/70 px-3 py-2 text-xs text-muted-foreground">
         <ImageOff className="h-3.5 w-3.5 shrink-0" />
-        <span>Image is no longer available in this transcript</span>
+        <span>Couldn&apos;t load image</span>
+        <button
+          type="button"
+          onClick={() => {
+            setFailed(false)
+            setAttempt((n) => n + 1)
+          }}
+          className="underline underline-offset-2 hover:text-foreground transition-colors"
+        >
+          Retry
+        </button>
       </div>
     )
   }
 
   return (
     <img
-      src={image.src}
+      // Retrying has to re-request, not re-show a failed cache entry.
+      src={attempt === 0 ? image.src : `${image.src}${image.src.includes('?') ? '&' : '?'}retry=${attempt}`}
       alt="Tool result"
       loading="lazy"
       decoding="async"
@@ -117,7 +137,7 @@ function ToolResultImage({ image }: { image: ParsedToolResultImage }) {
   )
 }
 
-function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessionActive }: ToolCallItemProps) {
+function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, sessionId, isSessionActive }: ToolCallItemProps) {
   const [expanded, setExpanded] = useState(false)
   const status = getStatus(toolCall, isSessionActive)
   const renderer = getToolRenderer(toolCall.name)
@@ -135,7 +155,10 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
   )
 
   // Parse result into text + images
-  const parsed = useMemo(() => parseToolResult(toolCall.result), [toolCall.result])
+  const parsed = useMemo(
+    () => parseToolResult(toolCall.result, agentSlug && sessionId ? { agentSlug, sessionId } : undefined),
+    [toolCall.result, agentSlug, sessionId]
+  )
   const resultStr = parsed.text
   const resultImages = parsed.images
 
@@ -237,7 +260,7 @@ function ToolCallItemComponent({ toolCall, messageCreatedAt, agentSlug, isSessio
           {resultImages.length > 0 && (
             <div className="mt-2 space-y-2">
               {resultImages.map((img, i) => (
-                <ToolResultImage key={img.src || i} image={img} />
+                <ToolResultImage key={`${i}:${img.src}`} image={img} />
               ))}
             </div>
           )}

--- a/src/renderer/components/messages/tool-call-item.tsx
+++ b/src/renderer/components/messages/tool-call-item.tsx
@@ -107,7 +107,11 @@ function ToolResultImage({ image }: { image: ParsedToolResultImage }) {
 
   if (failed) {
     return (
-      <div className="flex items-center gap-2 rounded border border-dashed border-border/70 px-3 py-2 text-xs text-muted-foreground">
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-2 rounded border border-dashed border-border/70 px-3 py-2 text-xs text-muted-foreground"
+      >
         <ImageOff className="h-3.5 w-3.5 shrink-0" />
         <span>Couldn&apos;t load image</span>
         <button
@@ -124,10 +128,18 @@ function ToolResultImage({ image }: { image: ParsedToolResultImage }) {
     )
   }
 
+  // Cache-busting is for the fetched kind only: a query suffix on a data: URL
+  // becomes part of the base64 payload and breaks an image that was fine. An
+  // inline retry is just a remount, which `key` below already forces.
+  const src =
+    image.isRef && attempt > 0
+      ? `${image.src}${image.src.includes('?') ? '&' : '?'}retry=${attempt}`
+      : image.src
+
   return (
     <img
-      // Retrying has to re-request, not re-show a failed cache entry.
-      src={attempt === 0 ? image.src : `${image.src}${image.src.includes('?') ? '&' : '?'}retry=${attempt}`}
+      key={attempt}
+      src={src}
       alt="Tool result"
       loading="lazy"
       decoding="async"

--- a/src/renderer/hooks/use-messages.test.ts
+++ b/src/renderer/hooks/use-messages.test.ts
@@ -74,7 +74,7 @@ describe('useMessages abort wiring', () => {
     renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
 
     await waitFor(() => expect(inflight).toHaveLength(1))
-    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&media=ref')
     expect(inflight[0].init?.signal).toBeInstanceOf(AbortSignal)
     expect(inflight[0].init?.signal?.aborted).toBe(false)
   })
@@ -222,7 +222,7 @@ describe('useMessages forward delta', () => {
     messages: unknown[]
   ) {
     await waitFor(() => expect(inflight).toHaveLength(1))
-    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    expect(inflight[0].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&media=ref')
     inflight[0].resolve({ messages, nextCursor: 'older-cursor' })
     await waitFor(() => expect(result.current.isFetching).toBe(false))
   }
@@ -237,7 +237,7 @@ describe('useMessages forward delta', () => {
       void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
     })
     await waitFor(() => expect(inflight).toHaveLength(2))
-    expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&after=u1')
+    expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&after=u1&media=ref')
 
     inflight[1].resolve({
       messages: [user('u1'), assistant('a1', 'fresh'), assistant('a2', 'new')],
@@ -262,7 +262,7 @@ describe('useMessages forward delta', () => {
     inflight[1].resolve({ messages: [], anchor: null, resync: true })
 
     await waitFor(() => expect(inflight).toHaveLength(3))
-    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&media=ref')
     inflight[2].resolve({ messages: [user('u9')], nextCursor: null })
     // Resync means the transcript was rewritten: u1/a1 may no longer exist, so
     // they must NOT survive in the older-history buffer.
@@ -299,7 +299,7 @@ describe('useMessages forward delta', () => {
         void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
       })
       await waitFor(() => expect(inflight).toHaveLength(2))
-      expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+      expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&media=ref')
       inflight[1].resolve({ messages: [user('u1'), assistant('a1')], nextCursor: null })
       await waitFor(() => expect(result.current.isFetching).toBe(false))
 
@@ -308,7 +308,7 @@ describe('useMessages forward delta', () => {
         void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
       })
       await waitFor(() => expect(inflight).toHaveLength(3))
-      expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&after=u1')
+      expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&after=u1&media=ref')
     } finally {
       vi.useRealTimers()
     }
@@ -323,7 +323,7 @@ describe('useMessages forward delta', () => {
       void wrapper.queryClient.invalidateQueries({ queryKey: ['messages', 's1'] })
     })
     await waitFor(() => expect(inflight).toHaveLength(2))
-    expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    expect(inflight[1].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&media=ref')
   })
 
   it('a tool-call deletion forces the next refetch to be a full page', async () => {
@@ -355,7 +355,7 @@ describe('useMessages forward delta', () => {
     })
 
     await waitFor(() => expect(inflight).toHaveLength(3))
-    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&media=ref')
 
     // The refetch omits the rewritten-away assistant. That omission is
     // authoritative — the item must vanish, not slide into the older-history
@@ -464,7 +464,7 @@ describe('useMessages forward delta', () => {
     inflight[1].resolve({ messages: [user('u0'), user('u1'), assistant('a1')], anchor: 'u1' })
 
     await waitFor(() => expect(inflight).toHaveLength(3))
-    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300')
+    expect(inflight[2].url).toBe('/api/agents/agent-1/sessions/s1/messages?limit=300&media=ref')
   })
 })
 

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -62,7 +62,7 @@ async function fetchMessagesPage(
   sessionId: string,
   opts: { limit: number; cursor?: string; signal?: AbortSignal }
 ): Promise<MessagesPage> {
-  const params = new URLSearchParams({ limit: String(opts.limit) })
+  const params = new URLSearchParams({ limit: String(opts.limit), media: 'ref' })
   if (opts.cursor) params.set('cursor', opts.cursor)
   const res = await apiFetch(
     `/api/agents/${agentSlug}/sessions/${sessionId}/messages?${params.toString()}`,
@@ -81,7 +81,11 @@ async function fetchMessagesDelta(
   sessionId: string,
   opts: { after: string; signal?: AbortSignal }
 ): Promise<MessagesDelta | MessagesPage> {
-  const params = new URLSearchParams({ limit: String(MESSAGES_PAGE_LIMIT), after: opts.after })
+  const params = new URLSearchParams({
+    limit: String(MESSAGES_PAGE_LIMIT),
+    after: opts.after,
+    media: 'ref',
+  })
   const res = await apiFetch(
     `/api/agents/${agentSlug}/sessions/${sessionId}/messages?${params.toString()}`,
     { signal: opts.signal }

--- a/src/renderer/lib/api-origin.characterization.test.ts
+++ b/src/renderer/lib/api-origin.characterization.test.ts
@@ -129,6 +129,8 @@ const DIRECT_BASE_URL_CONSUMERS: Record<string, string> = {
   'lib/auth-client.ts':
     "better-auth composes its own request URLs from a baseURL it is constructed with — it never sees apiFetch. Read lazily so cloud mode's prefix is known by then.",
   'lib/env.ts': 'defines it; openDashboardExternal() builds a window.open() URL',
+  'lib/parse-tool-result.ts':
+    '<img src> — media-ref images in tool results, resolved to a URL here so every result renderer gets one without threading the session identity down to it',
   'components/ui/model-icon.tsx': '<img src> — model icon asset',
   'components/home/dashboard-card.tsx': '<img src> — dashboard screenshot',
   'components/dashboards/dashboard-view.tsx': '<iframe src> — embedded dashboard',

--- a/src/renderer/lib/parse-tool-result.test.ts
+++ b/src/renderer/lib/parse-tool-result.test.ts
@@ -53,7 +53,7 @@ describe('parseToolResult', () => {
       ])
       const result = parseToolResult(json)
       expect(result.text).toBeNull()
-      expect(result.images).toEqual([{ data: 'abc123', mimeType: 'image/png' }])
+      expect(result.images).toEqual([{ src: 'data:image/png;base64,abc123', isRef: false }])
     })
 
     it('parses a JSON string containing mixed text and image blocks', () => {
@@ -63,7 +63,7 @@ describe('parseToolResult', () => {
       ])
       const result = parseToolResult(json)
       expect(result.text).toBe('some text')
-      expect(result.images).toEqual([{ data: 'imgdata', mimeType: 'image/jpeg' }])
+      expect(result.images).toEqual([{ src: 'data:image/jpeg;base64,imgdata', isRef: false }])
     })
   })
 
@@ -89,7 +89,7 @@ describe('parseToolResult', () => {
         },
       ])
       expect(result.text).toBeNull()
-      expect(result.images).toEqual([{ data: 'base64data', mimeType: 'image/png' }])
+      expect(result.images).toEqual([{ src: 'data:image/png;base64,base64data', isRef: false }])
     })
 
     it('extracts images in MCP format', () => {
@@ -97,7 +97,7 @@ describe('parseToolResult', () => {
         { type: 'image', data: 'mcpdata', mimeType: 'image/jpeg' },
       ])
       expect(result.text).toBeNull()
-      expect(result.images).toEqual([{ data: 'mcpdata', mimeType: 'image/jpeg' }])
+      expect(result.images).toEqual([{ src: 'data:image/jpeg;base64,mcpdata', isRef: false }])
     })
 
     it('handles mixed text and multiple images', () => {
@@ -108,8 +108,8 @@ describe('parseToolResult', () => {
       ])
       expect(result.text).toBe('screenshot results')
       expect(result.images).toHaveLength(2)
-      expect(result.images[0]).toEqual({ data: 'img1', mimeType: 'image/png' })
-      expect(result.images[1]).toEqual({ data: 'img2', mimeType: 'image/jpeg' })
+      expect(result.images[0]).toEqual({ src: 'data:image/png;base64,img1', isRef: false })
+      expect(result.images[1]).toEqual({ src: 'data:image/jpeg;base64,img2', isRef: false })
     })
 
     it('returns null text for image-only arrays', () => {
@@ -135,7 +135,7 @@ describe('parseToolResult', () => {
         { type: 'image', data: 'valid', mimeType: 'image/png' },
       ])
       expect(result.images).toHaveLength(1)
-      expect(result.images[0]).toEqual({ data: 'valid', mimeType: 'image/png' })
+      expect(result.images[0]).toEqual({ src: 'data:image/png;base64,valid', isRef: false })
     })
 
     it('returns null text for empty arrays', () => {
@@ -156,7 +156,7 @@ describe('parseToolResult', () => {
         source: { type: 'base64', media_type: 'image/png', data: 'singleimg' },
       })
       expect(result.text).toBeNull()
-      expect(result.images).toEqual([{ data: 'singleimg', mimeType: 'image/png' }])
+      expect(result.images).toEqual([{ src: 'data:image/png;base64,singleimg', isRef: false }])
     })
 
     it('extracts image from a single MCP format image block', () => {
@@ -166,7 +166,39 @@ describe('parseToolResult', () => {
         mimeType: 'image/webp',
       })
       expect(result.text).toBeNull()
-      expect(result.images).toEqual([{ data: 'mcpimg', mimeType: 'image/webp' }])
+      expect(result.images).toEqual([{ src: 'data:image/webp;base64,mcpimg', isRef: false }])
+    })
+  })
+
+  describe('media refs', () => {
+    it('turns a ref block into a fetchable image', () => {
+      const result = parseToolResult([
+        { type: 'text', text: 'screenshot' },
+        {
+          type: 'media_ref',
+          id: 'abc',
+          mimeType: 'image/png',
+          bytes: 40960,
+          url: '/api/agents/a/sessions/s/media/abc',
+        },
+      ])
+      expect(result.text).toBe('screenshot')
+      expect(result.images).toEqual([
+        { src: '/api/agents/a/sessions/s/media/abc', bytes: 40960, isRef: true },
+      ])
+    })
+
+    it('skips a ref with no url rather than rendering a broken image', () => {
+      const result = parseToolResult([{ type: 'media_ref', id: 'abc', mimeType: 'image/png' }])
+      expect(result.images).toEqual([])
+    })
+
+    it('handles a page that mixes refs and inline images', () => {
+      const result = parseToolResult([
+        { type: 'image', data: 'small', mimeType: 'image/png' },
+        { type: 'media_ref', id: 'abc', url: '/api/agents/a/sessions/s/media/abc', bytes: 99 },
+      ])
+      expect(result.images.map((i) => i.isRef)).toEqual([false, true])
     })
   })
 

--- a/src/renderer/lib/parse-tool-result.test.ts
+++ b/src/renderer/lib/parse-tool-result.test.ts
@@ -171,33 +171,60 @@ describe('parseToolResult', () => {
   })
 
   describe('media refs', () => {
-    it('turns a ref block into a fetchable image', () => {
-      const result = parseToolResult([
-        { type: 'text', text: 'screenshot' },
-        {
-          type: 'media_ref',
-          id: 'abc',
-          mimeType: 'image/png',
-          bytes: 40960,
-          url: '/api/agents/a/sessions/s/media/abc',
-        },
-      ])
+    const ctx = { agentSlug: 'a1', sessionId: 's1' }
+
+    it('builds the session media URL from trusted context, not the block', () => {
+      const result = parseToolResult(
+        [
+          { type: 'text', text: 'screenshot' },
+          { type: 'media_ref', id: 'abc', mimeType: 'image/png', bytes: 40960 },
+        ],
+        ctx
+      )
       expect(result.text).toBe('screenshot')
       expect(result.images).toEqual([
-        { src: '/api/agents/a/sessions/s/media/abc', bytes: 40960, isRef: true },
+        { src: '/api/agents/a1/sessions/s1/media/abc', bytes: 40960, isRef: true },
       ])
     })
 
-    it('skips a ref with no url rather than rendering a broken image', () => {
-      const result = parseToolResult([{ type: 'media_ref', id: 'abc', mimeType: 'image/png' }])
+    it('ignores refs when no session context is supplied', () => {
+      // A caller that cannot vouch for the transcript must not turn its
+      // contents into requests.
+      const result = parseToolResult([{ type: 'media_ref', id: 'abc', bytes: 99 }])
+      expect(result.images).toEqual([])
+    })
+
+    it('does not let a tool result name its own image address', () => {
+      // Tool output is untrusted text that reaches this parser as JSON, so a
+      // block claiming to be a ref proves nothing about where its bytes live.
+      const hostile = JSON.stringify([
+        { type: 'media_ref', id: 'abc', url: 'https://attacker.example/track?u=1' },
+      ])
+      const result = parseToolResult(hostile, ctx)
+      expect(result.images[0]!.src).toBe('/api/agents/a1/sessions/s1/media/abc')
+      expect(JSON.stringify(result.images)).not.toContain('attacker.example')
+    })
+
+    it('drops ids that could not have been minted here', () => {
+      const result = parseToolResult(
+        [
+          { type: 'media_ref', id: '../../../other/x' },
+          { type: 'media_ref', id: 'has spaces' },
+          { type: 'media_ref', id: '' },
+        ],
+        ctx
+      )
       expect(result.images).toEqual([])
     })
 
     it('handles a page that mixes refs and inline images', () => {
-      const result = parseToolResult([
-        { type: 'image', data: 'small', mimeType: 'image/png' },
-        { type: 'media_ref', id: 'abc', url: '/api/agents/a/sessions/s/media/abc', bytes: 99 },
-      ])
+      const result = parseToolResult(
+        [
+          { type: 'image', data: 'small', mimeType: 'image/png' },
+          { type: 'media_ref', id: 'abc', bytes: 99 },
+        ],
+        ctx
+      )
       expect(result.images.map((i) => i.isRef)).toEqual([false, true])
     })
   })

--- a/src/renderer/lib/parse-tool-result.test.ts
+++ b/src/renderer/lib/parse-tool-result.test.ts
@@ -187,6 +187,20 @@ describe('parseToolResult', () => {
       ])
     })
 
+    it('carries intrinsic dimensions through so the layout can reserve the box', () => {
+      const result = parseToolResult(
+        [{ type: 'media_ref', id: 'abc', bytes: 40960, width: 919, height: 1998 }],
+        ctx
+      )
+      expect(result.images[0]).toMatchObject({ width: 919, height: 1998 })
+    })
+
+    it('omits dimensions when the server could not read them', () => {
+      const result = parseToolResult([{ type: 'media_ref', id: 'abc', bytes: 40960 }], ctx)
+      expect(result.images[0]!.width).toBeUndefined()
+      expect(result.images[0]!.height).toBeUndefined()
+    })
+
     it('ignores refs when no session context is supplied', () => {
       // A caller that cannot vouch for the transcript must not turn its
       // contents into requests.

--- a/src/renderer/lib/parse-tool-result.ts
+++ b/src/renderer/lib/parse-tool-result.ts
@@ -1,3 +1,5 @@
+import { getApiBaseUrl } from './env'
+
 interface ContentBlock {
   type: string
   text?: string
@@ -5,11 +7,41 @@ interface ContentBlock {
   // MCP image format
   data?: string
   mimeType?: string
+  // Media ref (server answered a `media=ref` request): the image lives at `url`
+  // instead of inline. See shared/lib/services/session-media.ts.
+  url?: string
+  bytes?: number
+}
+
+export interface ParsedToolResultImage {
+  /** Ready for an <img> src: a data: URL for inline base64, an API URL for a ref. */
+  src: string
+  /** Decoded size when known (refs only) — the bytes aren't in hand to measure. */
+  bytes?: number
+  /** Refs are fetched over the network, so they can 404/410 after a transcript edit. */
+  isRef: boolean
 }
 
 export interface ParsedToolResult {
   text: string | null
-  images: Array<{ data: string; mimeType: string }>
+  images: ParsedToolResultImage[]
+}
+
+function imageFromBlock(block: ContentBlock): ParsedToolResultImage | null {
+  if (block.type === 'media_ref') {
+    if (!block.url) return null
+    return { src: `${getApiBaseUrl()}${block.url}`, bytes: block.bytes, isRef: true }
+  }
+  if (block.type !== 'image') return null
+  // Anthropic API format: { type: "image", source: { type: "base64", media_type, data } }
+  if (block.source?.data && block.source?.media_type) {
+    return { src: `data:${block.source.media_type};base64,${block.source.data}`, isRef: false }
+  }
+  // MCP format: { type: "image", data, mimeType }
+  if (block.data && block.mimeType) {
+    return { src: `data:${block.mimeType};base64,${block.data}`, isRef: false }
+  }
+  return null
 }
 
 /**
@@ -18,7 +50,7 @@ export interface ParsedToolResult {
  * or an array of content block objects (from MCP).
  */
 export function parseToolResult(result: unknown): ParsedToolResult {
-  const images: Array<{ data: string; mimeType: string }> = []
+  const images: ParsedToolResultImage[] = []
 
   if (result == null) return { text: null, images }
   if (typeof result === 'string') {
@@ -39,15 +71,9 @@ export function parseToolResult(result: unknown): ParsedToolResult {
     for (const block of result as ContentBlock[]) {
       if (block.type === 'text' && block.text) {
         textParts.push(block.text)
-      } else if (block.type === 'image') {
-        // Anthropic API format: { type: "image", source: { type: "base64", media_type, data } }
-        if (block.source?.data && block.source?.media_type) {
-          images.push({ data: block.source.data, mimeType: block.source.media_type })
-        }
-        // MCP format: { type: "image", data, mimeType }
-        else if (block.data && block.mimeType) {
-          images.push({ data: block.data, mimeType: block.mimeType })
-        }
+      } else {
+        const image = imageFromBlock(block)
+        if (image) images.push(image)
       }
     }
     return { text: textParts.length > 0 ? textParts.join('\n') : null, images }
@@ -58,12 +84,9 @@ export function parseToolResult(result: unknown): ParsedToolResult {
   if (block.type === 'text' && block.text) {
     return { text: block.text, images }
   }
-  if (block.type === 'image') {
-    if (block.source?.data && block.source?.media_type) {
-      images.push({ data: block.source.data, mimeType: block.source.media_type })
-    } else if (block.data && block.mimeType) {
-      images.push({ data: block.data, mimeType: block.mimeType })
-    }
+  const image = imageFromBlock(block)
+  if (image) {
+    images.push(image)
     return { text: null, images }
   }
 

--- a/src/renderer/lib/parse-tool-result.ts
+++ b/src/renderer/lib/parse-tool-result.ts
@@ -11,6 +11,8 @@ interface ContentBlock {
   // from the session's media endpoint. See shared/lib/services/session-media.ts.
   id?: string
   bytes?: number
+  width?: number
+  height?: number
 }
 
 /** Whose transcript this result belongs to. Required before any ref becomes a
@@ -25,6 +27,10 @@ export interface ParsedToolResultImage {
   src: string
   /** Decoded size when known (refs only) — the bytes aren't in hand to measure. */
   bytes?: number
+  /** Intrinsic pixel size when the server could read it, so the layout can
+   * reserve the box before the bytes arrive. */
+  width?: number
+  height?: number
   /** Refs are fetched over the network, so they can 404/410 after a transcript edit. */
   isRef: boolean
 }
@@ -53,7 +59,14 @@ function imageFromBlock(
     const path =
       `/api/agents/${encodeURIComponent(media.agentSlug)}` +
       `/sessions/${encodeURIComponent(media.sessionId)}/media/${block.id}`
-    return { src: `${getApiBaseUrl()}${path}`, bytes: block.bytes, isRef: true }
+    return {
+      src: `${getApiBaseUrl()}${path}`,
+      bytes: block.bytes,
+      ...(typeof block.width === 'number' && typeof block.height === 'number'
+        ? { width: block.width, height: block.height }
+        : {}),
+      isRef: true,
+    }
   }
   if (block.type !== 'image') return null
   // Anthropic API format: { type: "image", source: { type: "base64", media_type, data } }

--- a/src/renderer/lib/parse-tool-result.ts
+++ b/src/renderer/lib/parse-tool-result.ts
@@ -7,10 +7,17 @@ interface ContentBlock {
   // MCP image format
   data?: string
   mimeType?: string
-  // Media ref (server answered a `media=ref` request): the image lives at `url`
-  // instead of inline. See shared/lib/services/session-media.ts.
-  url?: string
+  // Media ref (server answered a `media=ref` request): the image is fetched
+  // from the session's media endpoint. See shared/lib/services/session-media.ts.
+  id?: string
   bytes?: number
+}
+
+/** Whose transcript this result belongs to. Required before any ref becomes a
+ * network request — see below. */
+export interface ToolResultMediaContext {
+  agentSlug: string
+  sessionId: string
 }
 
 export interface ParsedToolResultImage {
@@ -27,10 +34,26 @@ export interface ParsedToolResult {
   images: ParsedToolResultImage[]
 }
 
-function imageFromBlock(block: ContentBlock): ParsedToolResultImage | null {
+/** Media ids are base64url — anything else cannot have been minted here, and
+ * must never reach a URL. */
+const MEDIA_ID_PATTERN = /^[A-Za-z0-9_-]{1,4096}$/
+
+function imageFromBlock(
+  block: ContentBlock,
+  media?: ToolResultMediaContext
+): ParsedToolResultImage | null {
   if (block.type === 'media_ref') {
-    if (!block.url) return null
-    return { src: `${getApiBaseUrl()}${block.url}`, bytes: block.bytes, isRef: true }
+    // A tool result is untrusted text, and this function is reached by JSON
+    // that a tool produced — so a block saying it is a media ref proves
+    // nothing. Provenance can only come from the caller: the address is built
+    // here, from a session identity the app already knows, and the block
+    // contributes only an id that has to look like one we minted. Anything
+    // else is dropped rather than fetched.
+    if (!media || typeof block.id !== 'string' || !MEDIA_ID_PATTERN.test(block.id)) return null
+    const path =
+      `/api/agents/${encodeURIComponent(media.agentSlug)}` +
+      `/sessions/${encodeURIComponent(media.sessionId)}/media/${block.id}`
+    return { src: `${getApiBaseUrl()}${path}`, bytes: block.bytes, isRef: true }
   }
   if (block.type !== 'image') return null
   // Anthropic API format: { type: "image", source: { type: "base64", media_type, data } }
@@ -49,7 +72,10 @@ function imageFromBlock(block: ContentBlock): ParsedToolResultImage | null {
  * Results can be: a plain string, a JSON string of content blocks,
  * or an array of content block objects (from MCP).
  */
-export function parseToolResult(result: unknown): ParsedToolResult {
+export function parseToolResult(
+  result: unknown,
+  media?: ToolResultMediaContext
+): ParsedToolResult {
   const images: ParsedToolResultImage[] = []
 
   if (result == null) return { text: null, images }
@@ -58,7 +84,7 @@ export function parseToolResult(result: unknown): ParsedToolResult {
     try {
       const parsed = JSON.parse(result)
       if (Array.isArray(parsed)) {
-        return parseToolResult(parsed)
+        return parseToolResult(parsed, media)
       }
     } catch {
       // Plain string
@@ -72,7 +98,7 @@ export function parseToolResult(result: unknown): ParsedToolResult {
       if (block.type === 'text' && block.text) {
         textParts.push(block.text)
       } else {
-        const image = imageFromBlock(block)
+        const image = imageFromBlock(block, media)
         if (image) images.push(image)
       }
     }
@@ -84,7 +110,7 @@ export function parseToolResult(result: unknown): ParsedToolResult {
   if (block.type === 'text' && block.text) {
     return { text: block.text, images }
   }
-  const image = imageFromBlock(block)
+  const image = imageFromBlock(block, media)
   if (image) {
     images.push(image)
     return { text: null, images }

--- a/src/shared/lib/services/session-media.test.ts
+++ b/src/shared/lib/services/session-media.test.ts
@@ -404,6 +404,58 @@ describe('session-media', () => {
       expect(served.equals(image)).toBe(true)
     })
 
+
+    it('refuses an equal-length image that differs outside any sampled window', async () => {
+      // A digest over part of the payload would pass here: these two differ
+      // only in a region no sample covers. The address is advertised as
+      // immutable, so it has to name the bytes exactly.
+      const bmp = (fill: number) => {
+        const size = 30_054
+        const b = Buffer.alloc(size, 0xaa)
+        b[0] = 0x42
+        b[1] = 0x4d // "BM"
+        b.fill(fill, Math.floor(size * 0.28), Math.floor(size * 0.28) + 200)
+        return b
+      }
+      const first = bmp(0x11)
+      const second = bmp(0x22)
+      expect(first.length).toBe(second.length)
+
+      const { entry, file } = await stripRow(
+        [
+          toolResultEntry('u-1', 'tool-1', [
+            imageBlock(first, 'image/bmp'),
+            imageBlock(second, 'image/bmp'),
+          ]),
+        ],
+        0
+      )
+      const refFirst = decodeMediaRef(refsIn(entry)[0]!.id)!
+
+      await fs.promises.writeFile(
+        file,
+        JSON.stringify(toolResultEntry('u-1', 'tool-1', [imageBlock(second, 'image/bmp')])) + '\n'
+      )
+      expect(await openMediaBlob(file, refFirst)).toBeUndefined()
+    })
+
+    it('leaves a payload with a malformed base64 length inline', async () => {
+      // One extraneous '=' makes every decoded-length formula disagree with
+      // what the decoder emits, and that number is served as Content-Length.
+      const image = fakeImage(PNG_MAGIC, 30 * 1024, 0x44)
+      const malformed = image.toString('base64').replace(/=+$/, '') + '='
+      expect(malformed.length % 4).toBe(1)
+      const { entry } = await stripRow(
+        [
+          toolResultEntry('u-1', 'tool-1', [
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: malformed } },
+          ]),
+        ],
+        0
+      )
+      expect(refsIn(entry)).toHaveLength(0)
+    })
+
     it('tears down the source and its handle when the consumer gives up', async () => {
       const { entry, file } = await stripRow(
         [toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_PNG)])],

--- a/src/shared/lib/services/session-media.test.ts
+++ b/src/shared/lib/services/session-media.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import {
+  MEDIA_INLINE_MAX_BYTES,
+  decodeMediaRef,
+  encodeMediaRef,
+  openMediaBlob,
+  replaceInlineMediaWithRefs,
+  type MediaRefBlock,
+} from './session-media'
+import { getSessionMessagesPage, getSessionMessagesDelta } from './session-service'
+import type { JsonlEntry } from '@shared/lib/types/agent'
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff])
+
+/** An image big enough to be worth a ref. Only the magic number is inspected,
+ * so deterministic filler keeps the fixtures readable. */
+function fakeImage(magic: Buffer, size: number, fill = 0xab): Buffer {
+  return Buffer.concat([magic, Buffer.alloc(size - magic.length, fill)])
+}
+
+const BIG_PNG = fakeImage(PNG_MAGIC, 40 * 1024)
+const BIG_JPEG = fakeImage(JPEG_MAGIC, 24 * 1024, 0x5c)
+const SMALL_PNG = fakeImage(PNG_MAGIC, 1024)
+
+function imageBlock(bytes: Buffer, mediaType = 'image/png') {
+  return { type: 'image', source: { type: 'base64', media_type: mediaType, data: bytes.toString('base64') } }
+}
+
+function toolResultEntry(uuid: string, toolUseId: string, blocks: unknown[], extra: object = {}) {
+  return {
+    type: 'user',
+    uuid,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, content: blocks }] },
+    ...extra,
+  }
+}
+
+function assistantWithToolUse(uuid: string, toolUseId: string) {
+  return {
+    type: 'assistant',
+    uuid,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    message: {
+      id: `msg-${uuid}`,
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: toolUseId, name: 'Read', input: { file_path: '/shot.png' } }],
+    },
+  }
+}
+
+async function collectStream(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) chunks.push(chunk as Buffer)
+  return Buffer.concat(chunks)
+}
+
+describe('session-media', () => {
+  let testDir: string
+  let originalEnv: string | undefined
+
+  beforeEach(async () => {
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'session-media-test-'))
+    originalEnv = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testDir
+  })
+
+  afterEach(async () => {
+    if (originalEnv) process.env.SUPERAGENT_DATA_DIR = originalEnv
+    else delete process.env.SUPERAGENT_DATA_DIR
+    await fs.promises.rm(testDir, { recursive: true, force: true })
+  })
+
+  /** Write entries as JSONL and return the path plus each row's byte offset. */
+  async function writeJsonl(entries: object[]): Promise<{ file: string; offsets: number[] }> {
+    const file = path.join(testDir, 'transcript.jsonl')
+    const offsets: number[] = []
+    let body = ''
+    for (const entry of entries) {
+      offsets.push(Buffer.byteLength(body))
+      body += JSON.stringify(entry) + '\n'
+    }
+    await fs.promises.writeFile(file, body)
+    return { file, offsets }
+  }
+
+  /** Strip one row the way a read path does, returning the mutated entry. */
+  async function stripRow(entries: object[], index: number): Promise<{ entry: JsonlEntry; file: string }> {
+    const { file, offsets } = await writeJsonl(entries)
+    const raw = await fs.promises.readFile(file)
+    const line = raw.subarray(offsets[index], raw.indexOf(0x0a, offsets[index]))
+    const entry = JSON.parse(line.toString('utf-8')) as JsonlEntry
+    replaceInlineMediaWithRefs(entry, {
+      agentSlug: 'agent-1',
+      sessionId: 'session-1',
+      line,
+      lineOffset: offsets[index]!,
+    })
+    return { entry, file }
+  }
+
+  function refsIn(entry: JsonlEntry): MediaRefBlock[] {
+    const content = (entry as unknown as { message: { content: unknown[] } }).message.content
+    const out: MediaRefBlock[] = []
+    for (const block of content) {
+      const b = block as { type: string; content?: unknown[] }
+      if (b.type === 'media_ref') out.push(b as unknown as MediaRefBlock)
+      if (Array.isArray(b.content)) {
+        for (const inner of b.content) {
+          if ((inner as { type: string }).type === 'media_ref') out.push(inner as MediaRefBlock)
+        }
+      }
+    }
+    return out
+  }
+
+  describe('ref minting', () => {
+    it('replaces a tool-result image with a ref that resolves to the same bytes', async () => {
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [{ type: 'text', text: 'here' }, imageBlock(BIG_PNG)])],
+        0
+      )
+
+      const refs = refsIn(entry)
+      expect(refs).toHaveLength(1)
+      expect(refs[0]!.mimeType).toBe('image/png')
+      expect(refs[0]!.bytes).toBe(BIG_PNG.length)
+      expect(refs[0]!.url).toBe(
+        `/api/agents/agent-1/sessions/session-1/media/${refs[0]!.id}`
+      )
+      // The text block beside it is untouched.
+      const inner = (entry as unknown as { message: { content: Array<{ content: unknown[] }> } })
+        .message.content[0]!.content
+      expect(inner[0]).toEqual({ type: 'text', text: 'here' })
+
+      const blob = await openMediaBlob(file, decodeMediaRef(refs[0]!.id)!)
+      expect(blob).toBeDefined()
+      expect(blob!.mimeType).toBe('image/png')
+      expect(blob!.bytes).toBe(BIG_PNG.length)
+      expect((await collectStream(blob!.stream)).equals(BIG_PNG)).toBe(true)
+    })
+
+    it('keeps images below the inline threshold inline', async () => {
+      expect(SMALL_PNG.length).toBeLessThan(MEDIA_INLINE_MAX_BYTES)
+      const { entry } = await stripRow([toolResultEntry('u-1', 'tool-1', [imageBlock(SMALL_PNG)])], 0)
+      expect(refsIn(entry)).toHaveLength(0)
+      const inner = (
+        entry as unknown as { message: { content: Array<{ content: Array<{ type: string }> }> } }
+      ).message.content[0]!.content
+      expect(inner[0]!.type).toBe('image')
+    })
+
+    it('gives repeated copies of one image distinct spans', async () => {
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_PNG), imageBlock(BIG_PNG)])],
+        0
+      )
+      const refs = refsIn(entry)
+      expect(refs).toHaveLength(2)
+      const first = decodeMediaRef(refs[0]!.id)!
+      const second = decodeMediaRef(refs[1]!.id)!
+      expect(second.s).toBeGreaterThan(first.s)
+      // Both still serve the image.
+      for (const ref of [first, second]) {
+        const blob = await openMediaBlob(file, ref)
+        expect((await collectStream(blob!.stream)).equals(BIG_PNG)).toBe(true)
+      }
+    })
+
+    it('handles the MCP image shape and non-png types', async () => {
+      const { entry, file } = await stripRow(
+        [
+          toolResultEntry('u-1', 'tool-1', [
+            { type: 'image', data: BIG_JPEG.toString('base64'), mimeType: 'image/jpeg' },
+          ]),
+        ],
+        0
+      )
+      const refs = refsIn(entry)
+      expect(refs).toHaveLength(1)
+      expect(refs[0]!.mimeType).toBe('image/jpeg')
+      const blob = await openMediaBlob(file, decodeMediaRef(refs[0]!.id)!)
+      expect(blob!.mimeType).toBe('image/jpeg')
+      expect((await collectStream(blob!.stream)).equals(BIG_JPEG)).toBe(true)
+    })
+
+    it('drops the duplicate copy the SDK writes under toolUseResult', async () => {
+      const { entry } = await stripRow(
+        [
+          toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_PNG)], {
+            toolUseResult: { type: 'image', file: { base64: BIG_PNG.toString('base64'), type: 'image/png' } },
+          }),
+        ],
+        0
+      )
+      const file = (entry as unknown as { toolUseResult: { file: Record<string, unknown> } })
+        .toolUseResult.file
+      expect(file.base64).toBeUndefined()
+      expect(file.type).toBe('image/png')
+    })
+
+    it('mints refs for a row whose payload it can locate, and leaves others alone', async () => {
+      // A row with no uuid cannot be validated on read, so nothing is minted.
+      const { entry } = await stripRow(
+        [
+          {
+            type: 'user',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't', content: [imageBlock(BIG_PNG)] }] },
+          },
+        ],
+        0
+      )
+      expect(refsIn(entry)).toHaveLength(0)
+    })
+
+    it('addresses a row that is not the first in the file', async () => {
+      const { entry, file } = await stripRow(
+        [
+          assistantWithToolUse('a-0', 'tool-0'),
+          toolResultEntry('u-0', 'tool-0', [imageBlock(BIG_JPEG, 'image/jpeg')]),
+          toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_PNG)]),
+        ],
+        2
+      )
+      const refs = refsIn(entry)
+      expect(refs).toHaveLength(1)
+      const blob = await openMediaBlob(file, decodeMediaRef(refs[0]!.id)!)
+      expect((await collectStream(blob!.stream)).equals(BIG_PNG)).toBe(true)
+    })
+  })
+
+  describe('ref validity', () => {
+    async function mintOne(): Promise<{ id: string; file: string }> {
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_PNG)])],
+        0
+      )
+      return { id: refsIn(entry)[0]!.id, file }
+    }
+
+    it('rejects a ref whose row has moved', async () => {
+      const { id, file } = await mintOne()
+      const original = await fs.promises.readFile(file)
+      await fs.promises.writeFile(file, Buffer.concat([Buffer.from('{"type":"x"}\n'), original]))
+      expect(await openMediaBlob(file, decodeMediaRef(id)!)).toBeUndefined()
+    })
+
+    it('rejects a ref whose payload survived but whose row is now a different one', async () => {
+      // The case the recorded uuid offset exists for: a rewrite leaves a valid
+      // image payload at the same span, so every structural check still
+      // passes, but the row that owned it is gone. Swapping in a same-length
+      // uuid reproduces that without disturbing a single offset.
+      const { id, file } = await mintOne()
+      const raw = await fs.promises.readFile(file)
+      const rewritten = Buffer.from(raw.toString('latin1').replace('"uuid":"u-1"', '"uuid":"u-9"'), 'latin1')
+      expect(rewritten.length).toBe(raw.length)
+      await fs.promises.writeFile(file, rewritten)
+
+      const ref = decodeMediaRef(id)!
+      // The payload itself is untouched — only the identity check can catch this.
+      expect(rewritten.subarray(ref.s, ref.s + 8).toString('latin1')).toBe(
+        raw.subarray(ref.s, ref.s + 8).toString('latin1')
+      )
+      expect(await openMediaBlob(file, ref)).toBeUndefined()
+    })
+
+    it('rejects a ref whose row was deleted', async () => {
+      const { id, file } = await mintOne()
+      await fs.promises.writeFile(file, '{"type":"system","uuid":"s-1"}\n')
+      expect(await openMediaBlob(file, decodeMediaRef(id)!)).toBeUndefined()
+    })
+
+    it('rejects a span that is not a quote-delimited payload', async () => {
+      const { id, file } = await mintOne()
+      const ref = decodeMediaRef(id)!
+      expect(await openMediaBlob(file, { ...ref, s: ref.s + 4 })).toBeUndefined()
+      expect(await openMediaBlob(file, { ...ref, l: ref.l - 4 })).toBeUndefined()
+    })
+
+    it('rejects a span whose content is not an image', async () => {
+      // A long text field elsewhere in the row: quote-delimited, but its head
+      // carries no image magic number.
+      const text = 'A'.repeat(4096)
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [{ type: 'text', text }, imageBlock(BIG_PNG)])],
+        0
+      )
+      const raw = await fs.promises.readFile(file)
+      const at = raw.indexOf(text, 0, 'latin1')
+      const ref = decodeMediaRef(refsIn(entry)[0]!.id)!
+      expect(await openMediaBlob(file, { ...ref, s: at, l: text.length })).toBeUndefined()
+    })
+
+    it('rejects malformed and out-of-range refs', async () => {
+      const { id, file } = await mintOne()
+      expect(decodeMediaRef('not-base64url!!')).toBeUndefined()
+      expect(decodeMediaRef(Buffer.from('{"v":2}').toString('base64url'))).toBeUndefined()
+      expect(decodeMediaRef(Buffer.from('not json').toString('base64url'))).toBeUndefined()
+      const ref = decodeMediaRef(id)!
+      expect(await openMediaBlob(file, { ...ref, s: 10 ** 9 })).toBeUndefined()
+      expect(await openMediaBlob(file, { ...ref, o: 10 ** 9 })).toBeUndefined()
+    })
+
+    it('takes the served type from the bytes, not from the ref', async () => {
+      // The ref carries no type at all — a caller cannot dictate how bytes are
+      // interpreted, which is what keeps forged spans harmless.
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_JPEG, 'image/png')])],
+        0
+      )
+      const blob = await openMediaBlob(file, decodeMediaRef(refsIn(entry)[0]!.id)!)
+      expect(blob!.mimeType).toBe('image/jpeg')
+    })
+
+    it('returns undefined for a missing transcript', async () => {
+      const ref = { v: 1 as const, u: 'u-1', o: 10, s: 20, l: 40 }
+      expect(await openMediaBlob(path.join(testDir, 'gone.jsonl'), ref)).toBeUndefined()
+    })
+
+    it('round-trips a ref through its encoding', () => {
+      const ref = { v: 1 as const, u: 'abc-123', o: 42, s: 4096, l: 8192 }
+      expect(decodeMediaRef(encodeMediaRef(ref))).toEqual(ref)
+    })
+  })
+
+  describe('read paths', () => {
+    async function createSession(agentSlug: string, sessionId: string, entries: object[]): Promise<string> {
+      const dir = path.join(testDir, 'agents', agentSlug, 'workspace', '.claude', 'projects', '-workspace')
+      await fs.promises.mkdir(dir, { recursive: true })
+      const file = path.join(dir, `${sessionId}.jsonl`)
+      await fs.promises.writeFile(file, entries.map((e) => JSON.stringify(e)).join('\n') + '\n')
+      return file
+    }
+
+    const transcript = [
+      { type: 'user', uuid: 'u-0', timestamp: '2026-01-01T00:00:00.000Z', message: { role: 'user', content: 'take a shot' } },
+      assistantWithToolUse('a-0', 'tool-0'),
+      toolResultEntry('u-1', 'tool-0', [imageBlock(BIG_PNG)], {
+        toolUseResult: { type: 'image', file: { base64: BIG_PNG.toString('base64') } },
+      }),
+      { type: 'assistant', uuid: 'a-1', timestamp: '2026-01-01T00:00:02.000Z', message: { id: 'msg-a1', role: 'assistant', content: [{ type: 'text', text: 'done' }] } },
+    ]
+
+    it('serves inline base64 by default and refs on request', async () => {
+      const file = await createSession('agent-1', 'session-1', transcript)
+
+      const inline = await getSessionMessagesPage('agent-1', 'session-1', { limit: 50 })
+      const ref = await getSessionMessagesPage('agent-1', 'session-1', { limit: 50, media: 'ref' })
+
+      // Same items either way — only the image blocks differ.
+      expect(ref.messages.map((m) => m.id)).toEqual(inline.messages.map((m) => m.id))
+      expect(ref.nextCursor).toBe(inline.nextCursor)
+      expect(JSON.stringify(inline)).toContain(BIG_PNG.toString('base64'))
+      expect(JSON.stringify(ref)).not.toContain(BIG_PNG.toString('base64'))
+
+      const result = (ref.messages.find((m) => m.type === 'assistant') as { toolCalls: Array<{ result: unknown }> })
+        .toolCalls[0]!.result as Array<{ type: string; id: string }>
+      const block = result.find((b) => b.type === 'media_ref')!
+      expect(block).toBeDefined()
+      const blob = await openMediaBlob(file, decodeMediaRef(block.id)!)
+      expect((await collectStream(blob!.stream)).equals(BIG_PNG)).toBe(true)
+    })
+
+    it('serves refs on the delta path too, where live screenshots arrive', async () => {
+      const file = await createSession('agent-1', 'session-2', transcript)
+
+      const delta = await getSessionMessagesDelta('agent-1', 'session-2', {
+        after: 'u-0',
+        media: 'ref',
+      })
+      const serialized = JSON.stringify(delta)
+      expect(serialized).not.toContain(BIG_PNG.toString('base64'))
+      expect(serialized).toContain('media_ref')
+
+      const inlineDelta = await getSessionMessagesDelta('agent-1', 'session-2', { after: 'u-0' })
+      expect(delta.messages.map((m) => m.id)).toEqual(inlineDelta.messages.map((m) => m.id))
+      expect(JSON.stringify(inlineDelta)).toContain(BIG_PNG.toString('base64'))
+
+      const result = (delta.messages.find((m) => m.type === 'assistant') as { toolCalls: Array<{ result: unknown }> })
+        .toolCalls[0]!.result as Array<{ type: string; id: string }>
+      const block = result.find((b) => b.type === 'media_ref')!
+      const blob = await openMediaBlob(file, decodeMediaRef(block.id)!)
+      expect((await collectStream(blob!.stream)).equals(BIG_PNG)).toBe(true)
+    })
+
+    it('addresses images correctly from a cursor page deep in a transcript', async () => {
+      // Refs are minted from a window that starts mid-file: the offsets have to
+      // be absolute, not window-relative.
+      const filler = Array.from({ length: 40 }, (_, i) => ({
+        type: 'user',
+        uuid: `f-${i}`,
+        timestamp: '2026-01-01T00:00:00.000Z',
+        message: { role: 'user', content: `filler ${i}` },
+      }))
+      const file = await createSession('agent-1', 'session-3', [...transcript, ...filler])
+
+      const page = await getSessionMessagesPage('agent-1', 'session-3', {
+        limit: 10,
+        cursor: 'f-5',
+        media: 'ref',
+      })
+      const assistant = page.messages.find(
+        (m) => m.type === 'assistant' && m.toolCalls.length > 0
+      ) as { toolCalls: Array<{ result: unknown }> } | undefined
+      expect(assistant).toBeDefined()
+      const result = assistant!.toolCalls[0]!.result as Array<{ type: string; id: string }>
+      const block = result.find((b) => b.type === 'media_ref')!
+      expect(block).toBeDefined()
+      const blob = await openMediaBlob(file, decodeMediaRef(block.id)!)
+      expect((await collectStream(blob!.stream)).equals(BIG_PNG)).toBe(true)
+    })
+  })
+})

--- a/src/shared/lib/services/session-media.test.ts
+++ b/src/shared/lib/services/session-media.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -94,12 +94,7 @@ describe('session-media', () => {
     const raw = await fs.promises.readFile(file)
     const line = raw.subarray(offsets[index], raw.indexOf(0x0a, offsets[index]))
     const entry = JSON.parse(line.toString('utf-8')) as JsonlEntry
-    replaceInlineMediaWithRefs(entry, {
-      agentSlug: 'agent-1',
-      sessionId: 'session-1',
-      line,
-      lineOffset: offsets[index]!,
-    })
+    replaceInlineMediaWithRefs(entry, { line, lineOffset: offsets[index]! })
     return { entry, file }
   }
 
@@ -129,9 +124,8 @@ describe('session-media', () => {
       expect(refs).toHaveLength(1)
       expect(refs[0]!.mimeType).toBe('image/png')
       expect(refs[0]!.bytes).toBe(BIG_PNG.length)
-      expect(refs[0]!.url).toBe(
-        `/api/agents/agent-1/sessions/session-1/media/${refs[0]!.id}`
-      )
+      // No URL on the wire: the client builds it from trusted session context.
+      expect(refs[0] as unknown as Record<string, unknown>).not.toHaveProperty('url')
       // The text block beside it is untouched.
       const inner = (entry as unknown as { message: { content: Array<{ content: unknown[] }> } })
         .message.content[0]!.content
@@ -318,13 +312,172 @@ describe('session-media', () => {
     })
 
     it('returns undefined for a missing transcript', async () => {
-      const ref = { v: 1 as const, u: 'u-1', o: 10, s: 20, l: 40 }
+      const ref = { v: 1 as const, u: 'u-1', o: 10, s: 20, l: 40, h: 'abc' }
       expect(await openMediaBlob(path.join(testDir, 'gone.jsonl'), ref)).toBeUndefined()
     })
 
     it('round-trips a ref through its encoding', () => {
-      const ref = { v: 1 as const, u: 'abc-123', o: 42, s: 4096, l: 8192 }
+      const ref = { v: 1 as const, u: 'abc-123', o: 42, s: 4096, l: 8192, h: 'fp' }
       expect(decodeMediaRef(encodeMediaRef(ref))).toEqual(ref)
+    })
+  })
+
+
+  // Each of these reproduces a defect found in review; they fail against the
+  // code as it was when the reference scheme was first written.
+  describe('review regressions', () => {
+    it('does not mint a ref for a format the endpoint cannot serve', async () => {
+      // Sniffing recognizes raster signatures only, so an SVG ref could never
+      // be served — it must stay inline rather than become a dead image.
+      const svg = Buffer.from(
+        '<svg xmlns="http://www.w3.org/2000/svg">' + '<rect/>'.repeat(4000) + '</svg>'
+      )
+      expect(svg.length).toBeGreaterThan(MEDIA_INLINE_MAX_BYTES)
+      const { entry } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(svg, 'image/svg+xml')])],
+        0
+      )
+      expect(refsIn(entry)).toHaveLength(0)
+      const inner = (
+        entry as unknown as { message: { content: Array<{ content: Array<{ type: string }> }> } }
+      ).message.content[0]!.content
+      expect(inner[0]!.type).toBe('image')
+    })
+
+    it('skips a textual copy of the payload and addresses the real field', async () => {
+      // The same base64 inside a text block is not a quote-delimited field of
+      // its own; minting there yields a ref that fails its own validation.
+      const image = fakeImage(PNG_MAGIC, 30 * 1024, 0xcd)
+      const { entry, file } = await stripRow(
+        [
+          toolResultEntry('u-1', 'tool-1', [
+            { type: 'text', text: `copy=${image.toString('base64')};end` },
+            imageBlock(image),
+          ]),
+        ],
+        0
+      )
+      const refs = refsIn(entry)
+      expect(refs).toHaveLength(1)
+      const blob = await openMediaBlob(file, decodeMediaRef(refs[0]!.id)!)
+      expect(blob).toBeDefined()
+      expect((await collectStream(blob!.stream)).equals(image)).toBe(true)
+    })
+
+    it('refuses to serve a different image that moved into the same span', async () => {
+      // Deleting the first of two images in one row slides the second into the
+      // first's exact bytes with the row uuid untouched, so only content
+      // identity can tell them apart.
+      const first = fakeImage(PNG_MAGIC, 30 * 1024, 0x11)
+      const second = fakeImage(PNG_MAGIC, 30 * 1024, 0x22)
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(first), imageBlock(second)])],
+        0
+      )
+      const refFirst = decodeMediaRef(refsIn(entry)[0]!.id)!
+
+      const rewritten = JSON.stringify(toolResultEntry('u-1', 'tool-1', [imageBlock(second)]))
+      await fs.promises.writeFile(file, rewritten + '\n')
+
+      expect(await openMediaBlob(file, refFirst)).toBeUndefined()
+    })
+
+    it('reports an exact integer size for unpadded base64', async () => {
+      const image = fakeImage(PNG_MAGIC, 20 * 1024, 0x33)
+      const unpadded = image.toString('base64').replace(/=+$/, '')
+      const { entry, file } = await stripRow(
+        [
+          toolResultEntry('u-1', 'tool-1', [
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: unpadded } },
+          ]),
+        ],
+        0
+      )
+      const refs = refsIn(entry)
+      expect(refs).toHaveLength(1)
+      expect(Number.isInteger(refs[0]!.bytes)).toBe(true)
+      const blob = await openMediaBlob(file, decodeMediaRef(refs[0]!.id)!)
+      expect(Number.isInteger(blob!.bytes)).toBe(true)
+      const served = await collectStream(blob!.stream)
+      // The advertised length is what a Content-Length header promises.
+      expect(blob!.bytes).toBe(served.length)
+      expect(served.equals(image)).toBe(true)
+    })
+
+    it('tears down the source and its handle when the consumer gives up', async () => {
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_PNG)])],
+        0
+      )
+      const handles: fs.promises.FileHandle[] = []
+      const realOpen = fs.promises.open
+      const spy = vi
+        .spyOn(fs.promises, 'open')
+        .mockImplementation(async (...args: Parameters<typeof fs.promises.open>) => {
+          const handle = await realOpen(...args)
+          handles.push(handle)
+          return handle
+        })
+      const blob = await openMediaBlob(file, decodeMediaRef(refsIn(entry)[0]!.id)!)
+      spy.mockRestore()
+      expect(blob).toBeDefined()
+
+      // What a browser cancelling an image request does to the response body.
+      blob!.stream.destroy()
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      let open = true
+      try {
+        await handles[0]!.stat()
+      } catch {
+        open = false
+      }
+      expect(open).toBe(false)
+    })
+
+    it('surfaces storage failures instead of calling the media gone', async () => {
+      // EIO says nothing about whether the image still exists; answering 410
+      // would strand the client on a placeholder it never retries.
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_PNG)])],
+        0
+      )
+      const ref = decodeMediaRef(refsIn(entry)[0]!.id)!
+      const realOpen = fs.promises.open
+      const spy = vi.spyOn(fs.promises, 'open').mockImplementation(async () => {
+        const error: NodeJS.ErrnoException = new Error('simulated I/O failure')
+        error.code = 'EIO'
+        throw error
+      })
+      await expect(openMediaBlob(file, ref)).rejects.toThrow(/simulated I\/O failure/)
+      spy.mockRestore()
+      expect(realOpen).toBeDefined()
+    })
+
+    it('serves normally when reads come back short of the requested length', async () => {
+      // Positional reads may legally return fewer bytes than asked for before
+      // EOF; that is not a truncated transcript.
+      const { entry, file } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(BIG_PNG)])],
+        0
+      )
+      const ref = decodeMediaRef(refsIn(entry)[0]!.id)!
+      const realOpen = fs.promises.open
+      const spy = vi
+        .spyOn(fs.promises, 'open')
+        .mockImplementation(async (...args: Parameters<typeof fs.promises.open>) => {
+          const handle = await realOpen(...args)
+          const realRead = handle.read.bind(handle)
+          // Only the small validation windows; the stream's large reads pass
+          // through so the test stays fast.
+          handle.read = ((buf: Buffer, off: number, len: number, pos: number) =>
+            realRead(buf, off, len <= 128 ? 1 : len, pos)) as typeof handle.read
+          return handle
+        })
+      const blob = await openMediaBlob(file, ref)
+      spy.mockRestore()
+      expect(blob).toBeDefined()
+      expect((await collectStream(blob!.stream)).equals(BIG_PNG)).toBe(true)
     })
   })
 

--- a/src/shared/lib/services/session-media.test.ts
+++ b/src/shared/lib/services/session-media.test.ts
@@ -6,6 +6,7 @@ import {
   MEDIA_INLINE_MAX_BYTES,
   decodeMediaRef,
   encodeMediaRef,
+  imageDimensions,
   openMediaBlob,
   replaceInlineMediaWithRefs,
   type MediaRefBlock,
@@ -530,6 +531,83 @@ describe('session-media', () => {
       spy.mockRestore()
       expect(blob).toBeDefined()
       expect((await collectStream(blob!.stream)).equals(BIG_PNG)).toBe(true)
+    })
+  })
+
+
+  describe('intrinsic dimensions', () => {
+    // A ref replaces bytes that used to arrive inline, so without these the
+    // element has nothing to size itself from until the fetch lands.
+    it('reads a PNG header', () => {
+      const png = Buffer.alloc(24)
+      PNG_MAGIC.copy(png)
+      png.write('IHDR', 12, 'latin1')
+      png.writeUInt32BE(919, 16)
+      png.writeUInt32BE(1998, 20)
+      expect(imageDimensions(png)).toEqual({ width: 919, height: 1998 })
+    })
+
+    it('walks JPEG segments past a leading EXIF block to the frame header', () => {
+      // The size is not at a fixed offset: metadata segments come first.
+      const exif = Buffer.alloc(2 + 2 + 400)
+      exif[0] = 0xff
+      exif[1] = 0xe1
+      exif.writeUInt16BE(2 + 400, 2)
+      const sof = Buffer.alloc(11)
+      sof[0] = 0xff
+      sof[1] = 0xc0
+      sof.writeUInt16BE(8, 2)
+      sof[4] = 8
+      sof.writeUInt16BE(1998, 5)
+      sof.writeUInt16BE(919, 7)
+      const jpeg = Buffer.concat([Buffer.from([0xff, 0xd8]), exif, sof])
+      expect(imageDimensions(jpeg)).toEqual({ width: 919, height: 1998 })
+    })
+
+    it('reads GIF and BMP headers, including a top-down bitmap', () => {
+      const gif = Buffer.alloc(10)
+      gif.write('GIF89a', 0, 'latin1')
+      gif.writeUInt16LE(640, 6)
+      gif.writeUInt16LE(360, 8)
+      expect(imageDimensions(gif)).toEqual({ width: 640, height: 360 })
+
+      const bmp = Buffer.alloc(26)
+      bmp[0] = 0x42
+      bmp[1] = 0x4d
+      bmp.writeInt32LE(300, 18)
+      bmp.writeInt32LE(-200, 22) // negative height = top-down
+      expect(imageDimensions(bmp)).toEqual({ width: 300, height: 200 })
+    })
+
+    it('returns undefined rather than guessing when the header is unknown', () => {
+      expect(imageDimensions(Buffer.from('not an image at all'))).toBeUndefined()
+      expect(imageDimensions(Buffer.alloc(2))).toBeUndefined()
+      // JPEG that reaches scan data without a frame header.
+      expect(imageDimensions(Buffer.from([0xff, 0xd8, 0xff, 0xda, 0, 2, 0, 0, 0, 0]))).toBeUndefined()
+    })
+
+    it('puts the dimensions on the minted ref', async () => {
+      const png = Buffer.alloc(40 * 1024, 0xab)
+      PNG_MAGIC.copy(png)
+      png.write('IHDR', 12, 'latin1')
+      png.writeUInt32BE(919, 16)
+      png.writeUInt32BE(1998, 20)
+      const { entry } = await stripRow([toolResultEntry('u-1', 'tool-1', [imageBlock(png)])], 0)
+      const refs = refsIn(entry)
+      expect(refs).toHaveLength(1)
+      expect(refs[0]!.width).toBe(919)
+      expect(refs[0]!.height).toBe(1998)
+    })
+
+    it('still mints a ref when the size cannot be read', async () => {
+      // Sizing is a nicety; refusing to serve the image over it would not be.
+      const { entry } = await stripRow(
+        [toolResultEntry('u-1', 'tool-1', [imageBlock(fakeImage(JPEG_MAGIC, 30 * 1024, 0x5c))])],
+        0
+      )
+      const refs = refsIn(entry)
+      expect(refs).toHaveLength(1)
+      expect(refs[0]!.width).toBeUndefined()
     })
   })
 

--- a/src/shared/lib/services/session-media.ts
+++ b/src/shared/lib/services/session-media.ts
@@ -88,6 +88,11 @@ export interface MediaRefBlock {
   mimeType: string
   /** Decoded size, for sizing a placeholder before the bytes arrive. */
   bytes: number
+  /** Intrinsic pixel size, when the header gives it up. The client reserves
+   * this box before fetching, so the image settles into place instead of
+   * displacing everything below it. */
+  width?: number
+  height?: number
 }
 
 // Single-letter keys: this rides in the URL, and a page can carry dozens.
@@ -258,8 +263,13 @@ export function replaceInlineMediaWithRefs(entry: JsonlEntry, ctx: MediaRefConte
     // ICO, …) would become a ref that answers 410 forever — replacing an image
     // that renders inline today with a permanent placeholder. Those stay
     // inline: the type is decided here, once, for both ends.
-    const mimeType = sniffImageType(Buffer.from(payload.data.slice(0, 24), 'base64'))
+    // One decode serves both: the type decides whether a ref is mintable at
+    // all, and the dimensions ride along on the wire.
+    const probeChars = Math.min(payload.data.length, DIMENSION_PROBE_BYTES * 2) & ~3
+    const header = Buffer.from(payload.data.slice(0, probeChars), 'base64')
+    const mimeType = sniffImageType(header)
     if (!mimeType) return undefined
+    const size = imageDimensions(header)
     const at = findPayload(ctx.line, payload.data, cursor)
     if (at === -1) return undefined
     cursor = at + payload.data.length
@@ -271,7 +281,15 @@ export function replaceInlineMediaWithRefs(entry: JsonlEntry, ctx: MediaRefConte
       l: payload.data.length,
       h: fingerprintOf(payload.data),
     })
-    return { type: 'media_ref', id, mimeType, bytes }
+    return {
+      type: 'media_ref',
+      id,
+      mimeType,
+      bytes,
+      ...(size && size.width > 0 && size.height > 0
+        ? { width: size.width, height: size.height }
+        : {}),
+    }
   }
 
   if (Array.isArray(message?.content)) {
@@ -326,6 +344,83 @@ function sniffImageType(head: Buffer): string | undefined {
     head.subarray(8, 12).toString('latin1') === 'WEBP'
   ) {
     return 'image/webp'
+  }
+  return undefined
+}
+
+/** Decoded prefix inspected for intrinsic dimensions. JPEG keeps them in a
+ * frame header that can sit past several KB of EXIF, so this is generous —
+ * it costs nothing, since minting already holds the whole payload in memory. */
+const DIMENSION_PROBE_BYTES = 64 * 1024
+
+/** Markers that introduce a JPEG frame header, whose payload carries the size.
+ * The gaps are deliberate: C4, C8 and CC are tables and restarts, not frames. */
+function isJpegFrameMarker(code: number): boolean {
+  if (code < 0xc0 || code > 0xcf) return false
+  return code !== 0xc4 && code !== 0xc8 && code !== 0xcc
+}
+
+/**
+ * Intrinsic pixel size from an image's header, or undefined when it isn't
+ * where this knows to look.
+ *
+ * The point is layout: a ref replaces bytes that used to arrive inline, so the
+ * element now has nothing to size itself from until the fetch lands. Shipping
+ * the dimensions lets the client reserve the exact box up front, which is the
+ * difference between a placeholder settling into place and a screenshot
+ * shoving a thousand pixels of transcript down the page.
+ */
+export function imageDimensions(head: Buffer): { width: number; height: number } | undefined {
+  // PNG: IHDR is always the first chunk, so the size sits at a fixed offset.
+  if (head.length >= 24 && head.subarray(12, 16).toString('latin1') === 'IHDR') {
+    return { width: head.readUInt32BE(16), height: head.readUInt32BE(20) }
+  }
+  // GIF: logical screen descriptor, immediately after the signature.
+  if (head.length >= 10 && head.subarray(0, 3).toString('latin1') === 'GIF') {
+    return { width: head.readUInt16LE(6), height: head.readUInt16LE(8) }
+  }
+  // BMP: DIB header. Height is signed — negative means a top-down bitmap.
+  if (head.length >= 26 && head[0] === 0x42 && head[1] === 0x4d) {
+    return { width: head.readInt32LE(18), height: Math.abs(head.readInt32LE(22)) }
+  }
+  if (head.length >= 30 && head.subarray(0, 4).toString('latin1') === 'RIFF') {
+    const chunk = head.subarray(12, 16).toString('latin1')
+    if (chunk === 'VP8 ') {
+      return { width: head.readUInt16LE(26) & 0x3fff, height: head.readUInt16LE(28) & 0x3fff }
+    }
+    if (chunk === 'VP8L') {
+      const bits = head.readUInt32LE(21)
+      return { width: (bits & 0x3fff) + 1, height: ((bits >> 14) & 0x3fff) + 1 }
+    }
+    if (chunk === 'VP8X') {
+      return {
+        width: (head.readUIntLE(24, 3) & 0xffffff) + 1,
+        height: (head.readUIntLE(27, 3) & 0xffffff) + 1,
+      }
+    }
+    return undefined
+  }
+  // JPEG: walk the segment chain to the frame header. Unlike the others the
+  // offset is not fixed — EXIF, ICC profiles and comments all come first.
+  if (head.length >= 4 && head[0] === 0xff && head[1] === 0xd8) {
+    let at = 2
+    while (at + 9 < head.length) {
+      if (head[at] !== 0xff) {
+        at++
+        continue
+      }
+      const code = head[at + 1]!
+      if (isJpegFrameMarker(code)) {
+        return { width: head.readUInt16BE(at + 7), height: head.readUInt16BE(at + 5) }
+      }
+      // Standalone markers carry no length field to skip over.
+      if (code === 0xd8 || code === 0x01 || (code >= 0xd0 && code <= 0xd7)) {
+        at += 2
+        continue
+      }
+      if (code === 0xda) return undefined // scan data: no header left to find
+      at += 2 + head.readUInt16BE(at + 2)
+    }
   }
   return undefined
 }

--- a/src/shared/lib/services/session-media.ts
+++ b/src/shared/lib/services/session-media.ts
@@ -496,11 +496,11 @@ export async function openMediaBlob(
       decoded.once('close', () => signal.removeEventListener('abort', abort))
     }
     return { stream: decoded, mimeType, bytes: decodedLength(ref.l, pad) }
-  } catch (error) {
-    // Validation returns undefined explicitly; reaching here means something
-    // unexpected failed, and the caller must not read that as "gone".
-    throw error
   } finally {
+    // Nothing catches here on purpose: every "the ref no longer resolves" case
+    // returns undefined explicitly above, so anything thrown is unexpected and
+    // must reach the caller rather than be reported as "gone". The handle is
+    // still released — the stream owns it once opened.
     if (!opened) await handle.close()
   }
 }

--- a/src/shared/lib/services/session-media.ts
+++ b/src/shared/lib/services/session-media.ts
@@ -1,0 +1,362 @@
+import fs from 'node:fs'
+import { Readable, Transform } from 'node:stream'
+import { z } from 'zod'
+import type { JsonlEntry, JsonlMessageEntry } from '@shared/lib/types/agent'
+
+/**
+ * Media references: images ride in message payloads as an address instead of
+ * inline base64, and the bytes are fetched separately, on demand.
+ *
+ * Transcripts store screenshots and image tool results as base64 inside the
+ * JSONL row. That base64 is the bulk of a transcript's bytes (measured on real
+ * sessions: ~5MB of 15MB, and stored TWICE — once in the tool_result block,
+ * once again under `toolUseResult.file`), and every message page re-shipped all
+ * of it to every viewer. A ref collapses each image to ~200 bytes on the wire.
+ *
+ * ADDRESSING. A ref is the byte span of the base64 payload itself, not of the
+ * row holding it — the rows are multi-MB precisely because of the images, so
+ * "seek to the row, then find the image" would materialize the very thing
+ * we're avoiding. Serving a ref is a ranged read of exactly the payload piped
+ * through a streaming base64 decoder: O(chunk) memory, no line assembly, no
+ * JSON parse. The span is exact because base64's alphabet needs no JSON
+ * escaping, so the payload's bytes on disk are byte-identical to the decoded
+ * string value.
+ *
+ * VALIDITY. Transcripts are rewritten in place by message/tool-call deletion
+ * and retention, which shifts every offset after the edit. A ref therefore
+ * carries the source row's uuid AND the byte offset that uuid sat at, so a
+ * read can confirm the row is still where the ref says with a 36-byte read
+ * rather than a scan. That check plus exact quote delimiters around the
+ * payload and an image magic-number sniff of the head means a stale ref
+ * reliably fails closed (410) instead of serving unrelated bytes.
+ *
+ * The same checks are what make client-supplied refs safe to honor: a forged
+ * span has to land on a quote-delimited base64 string whose head decodes to a
+ * known image type, which in a transcript means an actual image — one the
+ * caller could already read through the messages endpoint they are authorized
+ * for. The response's Content-Type comes from the sniff, never from the ref,
+ * so a ref cannot dictate how bytes are interpreted.
+ */
+
+/** Below this decoded size, keep the image inline: a ref costs a round trip
+ * plus ~200 bytes of address, which is a loss for small icons. */
+export const MEDIA_INLINE_MAX_BYTES = 16 * 1024
+
+/** Ceiling on an addressable payload, so a forged ref can't ask the process to
+ * stream an arbitrary span. Well above any real screenshot. */
+const MEDIA_MAX_BASE64_LENGTH = 64 * 1024 * 1024
+
+const QUOTE_BYTE = 0x22
+
+/** Wire shape replacing an inline image block. `url` is an API path (the
+ * renderer prefixes its API base) so no consumer needs the session's identity
+ * threaded down to it. */
+export interface MediaRefBlock {
+  type: 'media_ref'
+  id: string
+  mimeType: string
+  /** Decoded size, for sizing a placeholder before the bytes arrive. */
+  bytes: number
+  url: string
+}
+
+// Single-letter keys: this rides in the URL, and a page can carry dozens.
+const mediaRefSchema = z.object({
+  v: z.literal(1),
+  /** uuid of the transcript row holding the payload. */
+  u: z.string().min(1).max(64),
+  /** Byte offset of that uuid's value in the file (validity check). */
+  o: z.number().int().nonnegative(),
+  /** Byte offset of the base64 payload. */
+  s: z.number().int().nonnegative(),
+  /** Length of the base64 payload in bytes. */
+  l: z.number().int().positive().max(MEDIA_MAX_BASE64_LENGTH),
+})
+
+export type MediaRef = z.infer<typeof mediaRefSchema>
+
+export function encodeMediaRef(ref: MediaRef): string {
+  return Buffer.from(JSON.stringify(ref), 'utf-8').toString('base64url')
+}
+
+/** Undefined for anything that isn't a ref this process could have minted —
+ * the value is client-supplied and reaches a file read. */
+export function decodeMediaRef(encoded: string): MediaRef | undefined {
+  let json: unknown
+  try {
+    json = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf-8'))
+  } catch {
+    return undefined
+  }
+  const parsed = mediaRefSchema.safeParse(json)
+  return parsed.success ? parsed.data : undefined
+}
+
+function mediaUrl(agentSlug: string, sessionId: string, id: string): string {
+  return (
+    `/api/agents/${encodeURIComponent(agentSlug)}` +
+    `/sessions/${encodeURIComponent(sessionId)}/media/${id}`
+  )
+}
+
+/** Decoded byte length of a base64 payload of `length` bytes ending in `pad` '=' chars. */
+function decodedLength(length: number, pad: number): number {
+  return Math.max(0, (length / 4) * 3 - pad)
+}
+
+interface ImageBlockLike {
+  type: string
+  source?: { type?: string; media_type?: string; data?: string }
+  data?: string
+  mimeType?: string
+}
+
+/** The base64 payload and declared type of an image block, in either shape the
+ * transcripts use: Anthropic's `{source: {data, media_type}}` and MCP's
+ * `{data, mimeType}`. */
+function imagePayload(block: ImageBlockLike): { data: string; mimeType: string } | undefined {
+  if (block.type !== 'image') return undefined
+  if (typeof block.source?.data === 'string' && block.source.data.length > 0) {
+    return { data: block.source.data, mimeType: block.source.media_type || 'image/png' }
+  }
+  if (typeof block.data === 'string' && block.data.length > 0) {
+    return { data: block.data, mimeType: block.mimeType || 'image/png' }
+  }
+  return undefined
+}
+
+export interface MediaRefContext {
+  agentSlug: string
+  sessionId: string
+  /** Absolute byte offset of `line`'s first byte. */
+  lineOffset: number
+  line: Buffer
+}
+
+/** Locate `needle` in `line` at or after `from`, retrying from the start so a
+ * block order that doesn't match byte order still resolves. Returns -1 when the
+ * payload isn't byte-identical to its decoded value, which leaves it inline. */
+function findPayload(line: Buffer, needle: string, from: number): number {
+  const at = line.indexOf(needle, from, 'latin1')
+  if (at !== -1) return at
+  return from === 0 ? -1 : line.indexOf(needle, 0, 'latin1')
+}
+
+/**
+ * Replace inline base64 images in one transcript entry with refs, in place.
+ *
+ * Called with the raw line the entry was parsed from, so payload offsets are
+ * exact. Applied at parse time rather than after the transform: the entries of
+ * a page window are all held at once, so stripping here keeps the base64 out of
+ * the page's peak memory as well as off the wire — including the duplicate
+ * copy under `toolUseResult`, which never reaches the wire but is half of an
+ * image-heavy window's retained bytes.
+ *
+ * Anything not provably locatable is left untouched: correctness of the page
+ * never depends on a ref being minted.
+ */
+export function replaceInlineMediaWithRefs(entry: JsonlEntry, ctx: MediaRefContext): void {
+  const message = (entry as JsonlMessageEntry).message
+  const uuid = (entry as JsonlMessageEntry).uuid
+  if (typeof uuid !== 'string' || uuid.length === 0) return
+
+  // Offset of the uuid VALUE (past the opening quote of `"uuid":"…"`).
+  const uuidKeyAt = ctx.line.indexOf(`"uuid":"${uuid}"`, 0, 'latin1')
+  if (uuidKeyAt === -1) return
+  const uuidOffset = ctx.lineOffset + uuidKeyAt + '"uuid":"'.length
+
+  // Payloads are minted in document order and the search advances with them,
+  // so repeated identical images resolve to distinct spans.
+  let cursor = 0
+
+  const refFor = (block: ImageBlockLike): MediaRefBlock | undefined => {
+    const payload = imagePayload(block)
+    if (!payload) return undefined
+    const pad = payload.data.endsWith('==') ? 2 : payload.data.endsWith('=') ? 1 : 0
+    const bytes = decodedLength(payload.data.length, pad)
+    if (bytes < MEDIA_INLINE_MAX_BYTES) return undefined
+    if (payload.data.length > MEDIA_MAX_BASE64_LENGTH) return undefined
+    const at = findPayload(ctx.line, payload.data, cursor)
+    if (at === -1) return undefined
+    cursor = at + payload.data.length
+    const id = encodeMediaRef({
+      v: 1,
+      u: uuid,
+      o: uuidOffset,
+      s: ctx.lineOffset + at,
+      l: payload.data.length,
+    })
+    return {
+      type: 'media_ref',
+      id,
+      mimeType: payload.mimeType,
+      bytes,
+      url: mediaUrl(ctx.agentSlug, ctx.sessionId, id),
+    }
+  }
+
+  if (Array.isArray(message?.content)) {
+    const content = message.content as unknown[]
+    for (let i = 0; i < content.length; i++) {
+      const block = content[i] as ImageBlockLike & { content?: unknown }
+      if (!block || typeof block !== 'object') continue
+      // Images inside a tool_result — the shape that reaches the wire as
+      // `toolCall.result`, and the reason this exists.
+      if (block.type === 'tool_result' && Array.isArray(block.content)) {
+        const inner = block.content as unknown[]
+        for (let j = 0; j < inner.length; j++) {
+          const ref = refFor(inner[j] as ImageBlockLike)
+          if (ref) inner[j] = ref
+        }
+        continue
+      }
+      // Top-level images (pasted attachments). The transform drops these from
+      // the rendered text, so this is purely about not holding them in memory.
+      const ref = refFor(block)
+      if (ref) content[i] = ref
+    }
+  }
+
+  // The SDK writes the same base64 a second time under `toolUseResult.file`.
+  // Nothing serializes it, so it needs no ref — only release.
+  const toolUseResult = (entry as JsonlMessageEntry).toolUseResult as
+    | { file?: { base64?: unknown } }
+    | undefined
+  if (typeof toolUseResult?.file?.base64 === 'string') {
+    delete toolUseResult.file.base64
+  }
+}
+
+/** Magic numbers of the raster types transcripts carry. SVG is deliberately
+ * absent: it isn't sniffable and it executes script when served inline. */
+const IMAGE_SIGNATURES: Array<{ mimeType: string; magic: number[] }> = [
+  { mimeType: 'image/png', magic: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] },
+  { mimeType: 'image/jpeg', magic: [0xff, 0xd8, 0xff] },
+  { mimeType: 'image/gif', magic: [0x47, 0x49, 0x46, 0x38] },
+  { mimeType: 'image/bmp', magic: [0x42, 0x4d] },
+]
+
+function sniffImageType(head: Buffer): string | undefined {
+  for (const { mimeType, magic } of IMAGE_SIGNATURES) {
+    if (head.length >= magic.length && magic.every((b, i) => head[i] === b)) return mimeType
+  }
+  // WebP: "RIFF" .... "WEBP"
+  if (
+    head.length >= 12 &&
+    head.subarray(0, 4).toString('latin1') === 'RIFF' &&
+    head.subarray(8, 12).toString('latin1') === 'WEBP'
+  ) {
+    return 'image/webp'
+  }
+  return undefined
+}
+
+const BASE64_INVALID = /[^A-Za-z0-9+/=]/
+
+/** base64 bytes in, decoded bytes out, without ever holding the whole payload.
+ * Buffer.from silently drops characters outside the alphabet, so a chunk that
+ * isn't base64 has to fail loudly here rather than decode to plausible junk. */
+function createBase64DecodeStream(): Transform {
+  let carry = ''
+  return new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      const text = carry + chunk.toString('latin1')
+      if (BASE64_INVALID.test(text)) {
+        callback(new Error('media payload is not base64'))
+        return
+      }
+      const usable = text.length - (text.length % 4)
+      carry = text.slice(usable)
+      callback(null, usable > 0 ? Buffer.from(text.slice(0, usable), 'base64') : undefined)
+    },
+    flush(callback) {
+      callback(null, carry.length > 0 ? Buffer.from(carry, 'base64') : undefined)
+    },
+  })
+}
+
+export interface MediaBlob {
+  stream: Readable
+  mimeType: string
+  bytes: number
+}
+
+/**
+ * Open the bytes a ref addresses, or undefined if the ref no longer resolves
+ * (rewritten transcript, forged span) — which the route answers with 410.
+ *
+ * Validation is four small reads, no scan: the row's uuid still sits at the
+ * recorded offset; the payload is quote-delimited exactly as recorded; its head
+ * decodes to a known image type. Only then is a stream opened.
+ */
+export async function openMediaBlob(
+  jsonlPath: string,
+  ref: MediaRef,
+  signal?: AbortSignal
+): Promise<MediaBlob | undefined> {
+  signal?.throwIfAborted()
+  let handle: fs.promises.FileHandle
+  try {
+    handle = await fs.promises.open(jsonlPath, 'r')
+  } catch {
+    return undefined
+  }
+  let opened = false
+  try {
+    const stat = await handle.stat()
+    const uuidEnd = ref.o + ref.u.length
+    const payloadEnd = ref.s + ref.l
+    if (stat.size < Math.max(uuidEnd, payloadEnd) + 1 || ref.o < 1 || ref.s < 1) return undefined
+
+    // The row that owned this payload is still at the recorded offset.
+    const uuidWindow = Buffer.allocUnsafe(ref.u.length + 2)
+    const { bytesRead: uuidRead } = await handle.read(
+      uuidWindow, 0, uuidWindow.length, ref.o - 1
+    )
+    if (uuidRead < uuidWindow.length) return undefined
+    if (uuidWindow[0] !== QUOTE_BYTE || uuidWindow[uuidWindow.length - 1] !== QUOTE_BYTE) {
+      return undefined
+    }
+    if (uuidWindow.subarray(1, uuidWindow.length - 1).toString('latin1') !== ref.u) return undefined
+
+    signal?.throwIfAborted()
+    // The payload is still exactly this JSON string: quote before it, and
+    // quote right after its last byte.
+    const openQuote = Buffer.allocUnsafe(1)
+    if ((await handle.read(openQuote, 0, 1, ref.s - 1)).bytesRead < 1) return undefined
+    if (openQuote[0] !== QUOTE_BYTE) return undefined
+
+    // Trailing window: the padding (needed for an exact Content-Length) and
+    // the closing quote, in one read.
+    const tail = Buffer.allocUnsafe(3)
+    if ((await handle.read(tail, 0, 3, payloadEnd - 2)).bytesRead < 3) return undefined
+    if (tail[2] !== QUOTE_BYTE) return undefined
+    const pad = tail[1] === 0x3d ? (tail[0] === 0x3d ? 2 : 1) : 0
+
+    signal?.throwIfAborted()
+    // Head sniff: 12 decoded bytes is enough for every signature above.
+    const headBase64 = Buffer.allocUnsafe(Math.min(20, ref.l))
+    const { bytesRead: headRead } = await handle.read(headBase64, 0, headBase64.length, ref.s)
+    if (headRead < headBase64.length) return undefined
+    const headText = headBase64.toString('latin1')
+    if (BASE64_INVALID.test(headText)) return undefined
+    const usable = headText.length - (headText.length % 4)
+    const mimeType = sniffImageType(Buffer.from(headText.slice(0, usable), 'base64'))
+    if (!mimeType) return undefined
+
+    // createReadStream owns the handle from here and closes it on end/error.
+    const stream = handle.createReadStream({ start: ref.s, end: payloadEnd - 1 })
+    opened = true
+    const decoded = stream.pipe(createBase64DecodeStream())
+    // The decoder failing mid-payload (only reachable if the file changed
+    // between the checks above and the read) has to tear the source down too,
+    // or the handle stays open until GC.
+    decoded.on('error', () => stream.destroy())
+    return { stream: decoded, mimeType, bytes: decodedLength(ref.l, pad) }
+  } catch (error) {
+    if (signal?.aborted) throw error
+    return undefined
+  } finally {
+    if (!opened) await handle.close()
+  }
+}

--- a/src/shared/lib/services/session-media.ts
+++ b/src/shared/lib/services/session-media.ts
@@ -30,18 +30,20 @@ import type { JsonlEntry, JsonlMessageEntry } from '@shared/lib/types/agent'
  *   - the source row's uuid AND the byte offset that uuid sat at, so a read
  *     confirms the row is still there with a 36-byte read rather than a scan;
  *   - exact quote delimiters, so the span is still one whole JSON string;
- *   - a sampled content fingerprint, because the first two still can't tell
+ *   - a digest of the whole payload, because the first two still can't tell
  *     two images inside ONE row apart — deleting the first can slide the
- *     second into the first's exact span with the uuid untouched.
+ *     second into the first's exact span with the uuid untouched. Sampling
+ *     part of the payload is not enough: equal-length images can differ only
+ *     between the samples.
  *
  * Together they make a stale ref fail closed (410) rather than serve the wrong
  * image, which is what lets the response be cached as immutable.
  *
  * The same checks are what make client-supplied refs safe to honor: a forged
- * span has to land on a quote-delimited base64 string that matches a
- * fingerprint the caller would have to already know and whose head decodes to
- * a known image type. The response's Content-Type comes from the sniff, never
- * from the ref, so a ref cannot dictate how bytes are interpreted.
+ * span has to land on a quote-delimited base64 string whose digest the caller
+ * would have to already know and whose head decodes to a known image type.
+ * The response's Content-Type comes from the sniff, never from the ref, so a
+ * ref cannot dictate how bytes are interpreted.
  *
  * Only formats the sniff recognizes are minted at all: a ref the endpoint
  * could never serve would replace a working inline image with a permanent
@@ -71,6 +73,9 @@ const MEDIA_MAX_BASE64_LENGTH = 64 * 1024 * 1024
 
 const QUOTE_BYTE = 0x22
 
+/** Read size for the pre-serve content verification pass. */
+const VERIFY_CHUNK_BYTES = 64 * 1024
+
 /** Wire shape replacing an inline image block.
  *
  * Deliberately carries no URL. Tool results are untrusted text that a client
@@ -96,8 +101,8 @@ const mediaRefSchema = z.object({
   s: z.number().int().nonnegative(),
   /** Length of the base64 payload in bytes. */
   l: z.number().int().positive().max(MEDIA_MAX_BASE64_LENGTH),
-  /** Sampled content fingerprint — what makes the address name one image
-   * rather than one location (see sampleFingerprint). */
+  /** Digest of the whole payload — what makes the address name one image
+   * rather than one location (see contentDigest). */
   h: z.string().min(1).max(32),
 })
 
@@ -128,43 +133,34 @@ function decodedLength(length: number, pad: number): number {
   return Math.max(0, Math.floor((length * 3) / 4) - pad)
 }
 
-/** Identity of the payload's *content*, cheap to verify without reading it all.
+/** Identity of the payload's *content*.
  *
- * Offsets and the row uuid together still can't distinguish two images inside
- * one row: deleting the first can slide the second into the first's exact span
- * with the uuid untouched, and the old ref would then serve the wrong image
- * under a year-long immutable cache. Sampling head/middle/tail pins content
- * with three small reads. Two payloads that agree on all of it are, for
- * serving purposes, the same image.
+ * Offsets and the row uuid together cannot distinguish two images inside one
+ * row: deleting the first can slide the second into the first's exact span
+ * with the uuid untouched. A sampled hash is not enough either — two
+ * equal-length payloads can differ only between the samples, which is easy to
+ * construct and would let an old address serve a new image. Since the response
+ * is cached as immutable, the address has to name the bytes exactly, so this
+ * covers the whole payload.
  */
-function sampleFingerprint(head: string, mid: string, tail: string, length: number): string {
-  return createHash('sha256')
-    .update(`${length}:${head}:${mid}:${tail}`)
-    .digest('base64url')
-    .slice(0, 16)
-}
-
-const FINGERPRINT_SAMPLE_LENGTH = 64
-
-/** Byte offsets of the three sampled windows within a payload of `length`. */
-function sampleOffsets(length: number): { head: number; mid: number; tail: number; size: number } {
-  const size = Math.min(FINGERPRINT_SAMPLE_LENGTH, length)
-  return {
-    head: 0,
-    mid: Math.max(0, Math.floor(length / 2)),
-    tail: Math.max(0, length - size),
-    size,
-  }
+function contentDigest(update: (hash: ReturnType<typeof createHash>) => void): string {
+  const hash = createHash('sha256')
+  update(hash)
+  return hash.digest('base64url').slice(0, 22)
 }
 
 function fingerprintOf(data: string): string {
-  const { head, mid, tail, size } = sampleOffsets(data.length)
-  return sampleFingerprint(
-    data.slice(head, head + size),
-    data.slice(mid, mid + size),
-    data.slice(tail, tail + size),
-    data.length
-  )
+  return contentDigest((hash) => hash.update(data, 'latin1'))
+}
+
+/** Base64 length that no valid payload can have: a 4-character quantum never
+ * decodes from one leftover character, and padding only ever completes a whole
+ * quantum. Left unchecked, an extraneous '=' makes the decoded length this
+ * computes disagree with the bytes the decoder actually emits — and that
+ * number is served as Content-Length. */
+function isValidBase64Length(length: number, pad: number): boolean {
+  if (length % 4 === 1) return false
+  return pad === 0 || length % 4 === 0
 }
 
 interface ImageBlockLike {
@@ -250,6 +246,10 @@ export function replaceInlineMediaWithRefs(entry: JsonlEntry, ctx: MediaRefConte
     const payload = imagePayload(block)
     if (!payload) return undefined
     const pad = payload.data.endsWith('==') ? 2 : payload.data.endsWith('=') ? 1 : 0
+    // A payload whose length is not a whole base64 quantum decodes to a
+    // different number of bytes than any length formula predicts, and that
+    // number would be served as Content-Length. Leave it inline.
+    if (!isValidBase64Length(payload.data.length, pad)) return undefined
     const bytes = decodedLength(payload.data.length, pad)
     if (bytes < MEDIA_INLINE_MAX_BYTES) return undefined
     if (payload.data.length > MEDIA_MAX_BASE64_LENGTH) return undefined
@@ -455,23 +455,32 @@ export async function openMediaBlob(
     if (closeQuote[0] !== QUOTE_BYTE) return undefined
 
     signal?.throwIfAborted()
-    // Sampled content check, three small reads. The uuid pins the row; this
-    // pins which image inside it, so a rewrite that slides a different payload
-    // into this exact span fails here instead of serving the wrong picture.
-    const { head, mid, tail, size } = sampleOffsets(ref.l)
-    const windows: string[] = []
-    for (const offset of [head, mid, tail]) {
-      const buf = Buffer.allocUnsafe(size)
-      if ((await readFully(handle, buf, ref.s + offset)) < size) return undefined
-      windows.push(buf.toString('latin1'))
+    // Full content check. The uuid pins the row; this pins which bytes, so a
+    // rewrite that slides a different payload into this exact span fails here
+    // instead of serving the wrong picture. It costs one extra pass over the
+    // span — the price of the immutable cache the response advertises, and
+    // still O(chunk) memory since nothing is retained.
+    const digest = createHash('sha256')
+    const scratch = Buffer.allocUnsafe(Math.min(VERIFY_CHUNK_BYTES, ref.l))
+    let head = ''
+    let tail = ''
+    for (let read = 0; read < ref.l; ) {
+      signal?.throwIfAborted()
+      const want = Math.min(scratch.length, ref.l - read)
+      const window = scratch.subarray(0, want)
+      if ((await readFully(handle, window, ref.s + read)) < want) return undefined
+      digest.update(window)
+      if (read === 0) head = window.subarray(0, Math.min(20, want)).toString('latin1')
+      tail = window.subarray(Math.max(0, want - 2)).toString('latin1')
+      read += want
     }
-    if (sampleFingerprint(windows[0]!, windows[1]!, windows[2]!, ref.l) !== ref.h) return undefined
+    if (digest.digest('base64url').slice(0, 22) !== ref.h) return undefined
 
-    const pad = windows[2]!.endsWith('==') ? 2 : windows[2]!.endsWith('=') ? 1 : 0
-    const headText = windows[0]!
-    if (BASE64_INVALID.test(headText)) return undefined
-    const usable = headText.length - (headText.length % 4)
-    const mimeType = sniffImageType(Buffer.from(headText.slice(0, usable), 'base64'))
+    const pad = tail.endsWith('==') ? 2 : tail.endsWith('=') ? 1 : 0
+    if (!isValidBase64Length(ref.l, pad)) return undefined
+    if (BASE64_INVALID.test(head)) return undefined
+    const usable = head.length - (head.length % 4)
+    const mimeType = sniffImageType(Buffer.from(head.slice(0, usable), 'base64'))
     if (!mimeType) return undefined
 
     signal?.throwIfAborted()

--- a/src/shared/lib/services/session-media.ts
+++ b/src/shared/lib/services/session-media.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
-import { Readable, Transform } from 'node:stream'
+import { createHash } from 'node:crypto'
+import { Readable, Transform, pipeline } from 'node:stream'
 import { z } from 'zod'
 import type { JsonlEntry, JsonlMessageEntry } from '@shared/lib/types/agent'
 
@@ -24,18 +25,40 @@ import type { JsonlEntry, JsonlMessageEntry } from '@shared/lib/types/agent'
  *
  * VALIDITY. Transcripts are rewritten in place by message/tool-call deletion
  * and retention, which shifts every offset after the edit. A ref therefore
- * carries the source row's uuid AND the byte offset that uuid sat at, so a
- * read can confirm the row is still where the ref says with a 36-byte read
- * rather than a scan. That check plus exact quote delimiters around the
- * payload and an image magic-number sniff of the head means a stale ref
- * reliably fails closed (410) instead of serving unrelated bytes.
+ * names three things, each covering what the others cannot:
+ *
+ *   - the source row's uuid AND the byte offset that uuid sat at, so a read
+ *     confirms the row is still there with a 36-byte read rather than a scan;
+ *   - exact quote delimiters, so the span is still one whole JSON string;
+ *   - a sampled content fingerprint, because the first two still can't tell
+ *     two images inside ONE row apart — deleting the first can slide the
+ *     second into the first's exact span with the uuid untouched.
+ *
+ * Together they make a stale ref fail closed (410) rather than serve the wrong
+ * image, which is what lets the response be cached as immutable.
  *
  * The same checks are what make client-supplied refs safe to honor: a forged
- * span has to land on a quote-delimited base64 string whose head decodes to a
- * known image type, which in a transcript means an actual image — one the
- * caller could already read through the messages endpoint they are authorized
- * for. The response's Content-Type comes from the sniff, never from the ref,
- * so a ref cannot dictate how bytes are interpreted.
+ * span has to land on a quote-delimited base64 string that matches a
+ * fingerprint the caller would have to already know and whose head decodes to
+ * a known image type. The response's Content-Type comes from the sniff, never
+ * from the ref, so a ref cannot dictate how bytes are interpreted.
+ *
+ * Only formats the sniff recognizes are minted at all: a ref the endpoint
+ * could never serve would replace a working inline image with a permanent
+ * placeholder.
+ *
+ * KNOWN GAPS, deliberately left:
+ *
+ *   - Tool results whose content is a JSON *string* of blocks (rather than an
+ *     array) keep their images inline. The renderer parses that form, so the
+ *     shape is reachable in principle; it does not occur in practice — a scan
+ *     of real transcripts found 282 image tool results, all arrays, none
+ *     serialized.
+ *   - A ref minted before a remote rewrite stays in a client's already-loaded
+ *     history and will 410 until that view is refetched. Fixing it properly
+ *     means carrying a transcript generation through responses so a client can
+ *     tell its addresses are stale, which is the same mechanism the paged
+ *     reader wants for cursor continuity and belongs with it.
  */
 
 /** Below this decoded size, keep the image inline: a ref costs a round trip
@@ -48,16 +71,18 @@ const MEDIA_MAX_BASE64_LENGTH = 64 * 1024 * 1024
 
 const QUOTE_BYTE = 0x22
 
-/** Wire shape replacing an inline image block. `url` is an API path (the
- * renderer prefixes its API base) so no consumer needs the session's identity
- * threaded down to it. */
+/** Wire shape replacing an inline image block.
+ *
+ * Deliberately carries no URL. Tool results are untrusted text that a client
+ * parses as content blocks, so a block that declares its own address would let
+ * any tool output name one — the consumer builds the media path from `id` plus
+ * a session identity it already trusts. */
 export interface MediaRefBlock {
   type: 'media_ref'
   id: string
   mimeType: string
   /** Decoded size, for sizing a placeholder before the bytes arrive. */
   bytes: number
-  url: string
 }
 
 // Single-letter keys: this rides in the URL, and a page can carry dozens.
@@ -71,6 +96,9 @@ const mediaRefSchema = z.object({
   s: z.number().int().nonnegative(),
   /** Length of the base64 payload in bytes. */
   l: z.number().int().positive().max(MEDIA_MAX_BASE64_LENGTH),
+  /** Sampled content fingerprint — what makes the address name one image
+   * rather than one location (see sampleFingerprint). */
+  h: z.string().min(1).max(32),
 })
 
 export type MediaRef = z.infer<typeof mediaRefSchema>
@@ -92,16 +120,51 @@ export function decodeMediaRef(encoded: string): MediaRef | undefined {
   return parsed.success ? parsed.data : undefined
 }
 
-function mediaUrl(agentSlug: string, sessionId: string, id: string): string {
-  return (
-    `/api/agents/${encodeURIComponent(agentSlug)}` +
-    `/sessions/${encodeURIComponent(sessionId)}/media/${id}`
-  )
+/** Decoded byte length of a base64 payload of `length` bytes ending in `pad`
+ * '=' chars. Unpadded base64 is valid and its length need not divide by four,
+ * so this floors rather than assuming it does — the result is a Content-Length
+ * and must be an integer that matches the bytes actually served. */
+function decodedLength(length: number, pad: number): number {
+  return Math.max(0, Math.floor((length * 3) / 4) - pad)
 }
 
-/** Decoded byte length of a base64 payload of `length` bytes ending in `pad` '=' chars. */
-function decodedLength(length: number, pad: number): number {
-  return Math.max(0, (length / 4) * 3 - pad)
+/** Identity of the payload's *content*, cheap to verify without reading it all.
+ *
+ * Offsets and the row uuid together still can't distinguish two images inside
+ * one row: deleting the first can slide the second into the first's exact span
+ * with the uuid untouched, and the old ref would then serve the wrong image
+ * under a year-long immutable cache. Sampling head/middle/tail pins content
+ * with three small reads. Two payloads that agree on all of it are, for
+ * serving purposes, the same image.
+ */
+function sampleFingerprint(head: string, mid: string, tail: string, length: number): string {
+  return createHash('sha256')
+    .update(`${length}:${head}:${mid}:${tail}`)
+    .digest('base64url')
+    .slice(0, 16)
+}
+
+const FINGERPRINT_SAMPLE_LENGTH = 64
+
+/** Byte offsets of the three sampled windows within a payload of `length`. */
+function sampleOffsets(length: number): { head: number; mid: number; tail: number; size: number } {
+  const size = Math.min(FINGERPRINT_SAMPLE_LENGTH, length)
+  return {
+    head: 0,
+    mid: Math.max(0, Math.floor(length / 2)),
+    tail: Math.max(0, length - size),
+    size,
+  }
+}
+
+function fingerprintOf(data: string): string {
+  const { head, mid, tail, size } = sampleOffsets(data.length)
+  return sampleFingerprint(
+    data.slice(head, head + size),
+    data.slice(mid, mid + size),
+    data.slice(tail, tail + size),
+    data.length
+  )
 }
 
 interface ImageBlockLike {
@@ -126,20 +189,34 @@ function imagePayload(block: ImageBlockLike): { data: string; mimeType: string }
 }
 
 export interface MediaRefContext {
-  agentSlug: string
-  sessionId: string
   /** Absolute byte offset of `line`'s first byte. */
   lineOffset: number
   line: Buffer
 }
 
-/** Locate `needle` in `line` at or after `from`, retrying from the start so a
- * block order that doesn't match byte order still resolves. Returns -1 when the
- * payload isn't byte-identical to its decoded value, which leaves it inline. */
+/** Locate the JSON *string field* holding `needle`, at or after `from`.
+ *
+ * The same base64 can also appear inside a text block in the same row (a tool
+ * echoing its own output), and that occurrence is not a quote-delimited field
+ * of its own — minting there produces a ref whose serving-side delimiter check
+ * rejects it, i.e. a permanently dead image. So a match only counts when the
+ * bytes either side are the quotes that close it, and the search continues
+ * past matches that aren't. Retries from the start so a block order that
+ * doesn't match byte order still resolves. -1 leaves the image inline. */
 function findPayload(line: Buffer, needle: string, from: number): number {
-  const at = line.indexOf(needle, from, 'latin1')
-  if (at !== -1) return at
-  return from === 0 ? -1 : line.indexOf(needle, 0, 'latin1')
+  const scan = (start: number): number => {
+    let at = line.indexOf(needle, start, 'latin1')
+    while (at !== -1) {
+      const before = at - 1
+      const after = at + needle.length
+      if (before >= 0 && line[before] === QUOTE_BYTE && line[after] === QUOTE_BYTE) return at
+      at = line.indexOf(needle, at + 1, 'latin1')
+    }
+    return -1
+  }
+  const found = scan(from)
+  if (found !== -1) return found
+  return from === 0 ? -1 : scan(0)
 }
 
 /**
@@ -176,6 +253,13 @@ export function replaceInlineMediaWithRefs(entry: JsonlEntry, ctx: MediaRefConte
     const bytes = decodedLength(payload.data.length, pad)
     if (bytes < MEDIA_INLINE_MAX_BYTES) return undefined
     if (payload.data.length > MEDIA_MAX_BASE64_LENGTH) return undefined
+    // Mint only what the endpoint can serve. Serving identifies content by
+    // magic number, so an image in a format that isn't sniffable (SVG, AVIF,
+    // ICO, …) would become a ref that answers 410 forever — replacing an image
+    // that renders inline today with a permanent placeholder. Those stay
+    // inline: the type is decided here, once, for both ends.
+    const mimeType = sniffImageType(Buffer.from(payload.data.slice(0, 24), 'base64'))
+    if (!mimeType) return undefined
     const at = findPayload(ctx.line, payload.data, cursor)
     if (at === -1) return undefined
     cursor = at + payload.data.length
@@ -185,14 +269,9 @@ export function replaceInlineMediaWithRefs(entry: JsonlEntry, ctx: MediaRefConte
       o: uuidOffset,
       s: ctx.lineOffset + at,
       l: payload.data.length,
+      h: fingerprintOf(payload.data),
     })
-    return {
-      type: 'media_ref',
-      id,
-      mimeType: payload.mimeType,
-      bytes,
-      url: mediaUrl(ctx.agentSlug, ctx.sessionId, id),
-    }
+    return { type: 'media_ref', id, mimeType, bytes }
   }
 
   if (Array.isArray(message?.content)) {
@@ -252,19 +331,33 @@ function sniffImageType(head: Buffer): string | undefined {
 }
 
 const BASE64_INVALID = /[^A-Za-z0-9+/=]/
+/** A well-formed run of base64: alphabet characters, then at most two '='. */
+const BASE64_CHUNK = /^[A-Za-z0-9+/]*={0,2}$/
 
 /** base64 bytes in, decoded bytes out, without ever holding the whole payload.
  * Buffer.from silently drops characters outside the alphabet, so a chunk that
  * isn't base64 has to fail loudly here rather than decode to plausible junk. */
 function createBase64DecodeStream(): Transform {
   let carry = ''
+  // '=' is legal only as the final one or two characters of the whole payload;
+  // anything after it would decode to different bytes than the payload holds.
+  // Counted over arriving characters, never over `carry` — the carry still
+  // holds the padding it already accounted for.
+  let padding = 0
   return new Transform({
     transform(chunk: Buffer, _encoding, callback) {
-      const text = carry + chunk.toString('latin1')
-      if (BASE64_INVALID.test(text)) {
+      const incoming = chunk.toString('latin1')
+      if (!BASE64_CHUNK.test(incoming)) {
         callback(new Error('media payload is not base64'))
         return
       }
+      const added = incoming.length - incoming.replace(/=+$/, '').length
+      if ((padding > 0 && /[^=]/.test(incoming)) || padding + added > 2) {
+        callback(new Error('media payload has misplaced base64 padding'))
+        return
+      }
+      padding += added
+      const text = carry + incoming
       const usable = text.length - (text.length % 4)
       carry = text.slice(usable)
       callback(null, usable > 0 ? Buffer.from(text.slice(0, usable), 'base64') : undefined)
@@ -281,13 +374,44 @@ export interface MediaBlob {
   bytes: number
 }
 
+/** A client hanging up mid-image is the normal case, not a fault to report. */
+function isBenignStreamError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code
+  return code === 'ABORT_ERR' || code === 'ERR_STREAM_PREMATURE_CLOSE'
+}
+
+/** Fill `buf` from `position`, looping over short reads. A single positional
+ * read is allowed to return fewer bytes than asked for before EOF, and treating
+ * that as a truncated file would report a healthy transcript as gone. Returns
+ * the count actually available. */
+async function readFully(
+  handle: fs.promises.FileHandle,
+  buf: Buffer,
+  position: number
+): Promise<number> {
+  let filled = 0
+  while (filled < buf.length) {
+    const { bytesRead } = await handle.read(buf, filled, buf.length - filled, position + filled)
+    if (bytesRead === 0) break
+    filled += bytesRead
+  }
+  return filled
+}
+
 /**
- * Open the bytes a ref addresses, or undefined if the ref no longer resolves
- * (rewritten transcript, forged span) — which the route answers with 410.
+ * Open the bytes a ref addresses.
  *
- * Validation is four small reads, no scan: the row's uuid still sits at the
- * recorded offset; the payload is quote-delimited exactly as recorded; its head
- * decodes to a known image type. Only then is a stream opened.
+ * `undefined` means the ref provably no longer resolves — the row moved or
+ * went, the span isn't the payload it named, the content changed — and the
+ * route turns that into 410. Operational failures (EIO, EMFILE, EACCES, …)
+ * throw instead: they say nothing about whether the media still exists, and
+ * answering "permanently gone" to a transient disk problem strands the client
+ * on a placeholder it will never retry.
+ *
+ * Validation is a handful of small reads, no scan: the row's uuid still sits
+ * at the recorded offset; the payload is quote-delimited exactly as recorded;
+ * its sampled fingerprint still matches; its head decodes to a known image
+ * type. Only then is a stream opened.
  */
 export async function openMediaBlob(
   jsonlPath: string,
@@ -298,8 +422,11 @@ export async function openMediaBlob(
   let handle: fs.promises.FileHandle
   try {
     handle = await fs.promises.open(jsonlPath, 'r')
-  } catch {
-    return undefined
+  } catch (error) {
+    // Only a missing transcript is "gone"; anything else is this machine
+    // failing to answer a question about a file that may well be there.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
   }
   let opened = false
   try {
@@ -310,10 +437,7 @@ export async function openMediaBlob(
 
     // The row that owned this payload is still at the recorded offset.
     const uuidWindow = Buffer.allocUnsafe(ref.u.length + 2)
-    const { bytesRead: uuidRead } = await handle.read(
-      uuidWindow, 0, uuidWindow.length, ref.o - 1
-    )
-    if (uuidRead < uuidWindow.length) return undefined
+    if ((await readFully(handle, uuidWindow, ref.o - 1)) < uuidWindow.length) return undefined
     if (uuidWindow[0] !== QUOTE_BYTE || uuidWindow[uuidWindow.length - 1] !== QUOTE_BYTE) {
       return undefined
     }
@@ -323,39 +447,59 @@ export async function openMediaBlob(
     // The payload is still exactly this JSON string: quote before it, and
     // quote right after its last byte.
     const openQuote = Buffer.allocUnsafe(1)
-    if ((await handle.read(openQuote, 0, 1, ref.s - 1)).bytesRead < 1) return undefined
+    if ((await readFully(handle, openQuote, ref.s - 1)) < 1) return undefined
     if (openQuote[0] !== QUOTE_BYTE) return undefined
 
-    // Trailing window: the padding (needed for an exact Content-Length) and
-    // the closing quote, in one read.
-    const tail = Buffer.allocUnsafe(3)
-    if ((await handle.read(tail, 0, 3, payloadEnd - 2)).bytesRead < 3) return undefined
-    if (tail[2] !== QUOTE_BYTE) return undefined
-    const pad = tail[1] === 0x3d ? (tail[0] === 0x3d ? 2 : 1) : 0
+    const closeQuote = Buffer.allocUnsafe(1)
+    if ((await readFully(handle, closeQuote, payloadEnd)) < 1) return undefined
+    if (closeQuote[0] !== QUOTE_BYTE) return undefined
 
     signal?.throwIfAborted()
-    // Head sniff: 12 decoded bytes is enough for every signature above.
-    const headBase64 = Buffer.allocUnsafe(Math.min(20, ref.l))
-    const { bytesRead: headRead } = await handle.read(headBase64, 0, headBase64.length, ref.s)
-    if (headRead < headBase64.length) return undefined
-    const headText = headBase64.toString('latin1')
+    // Sampled content check, three small reads. The uuid pins the row; this
+    // pins which image inside it, so a rewrite that slides a different payload
+    // into this exact span fails here instead of serving the wrong picture.
+    const { head, mid, tail, size } = sampleOffsets(ref.l)
+    const windows: string[] = []
+    for (const offset of [head, mid, tail]) {
+      const buf = Buffer.allocUnsafe(size)
+      if ((await readFully(handle, buf, ref.s + offset)) < size) return undefined
+      windows.push(buf.toString('latin1'))
+    }
+    if (sampleFingerprint(windows[0]!, windows[1]!, windows[2]!, ref.l) !== ref.h) return undefined
+
+    const pad = windows[2]!.endsWith('==') ? 2 : windows[2]!.endsWith('=') ? 1 : 0
+    const headText = windows[0]!
     if (BASE64_INVALID.test(headText)) return undefined
     const usable = headText.length - (headText.length % 4)
     const mimeType = sniffImageType(Buffer.from(headText.slice(0, usable), 'base64'))
     if (!mimeType) return undefined
 
-    // createReadStream owns the handle from here and closes it on end/error.
-    const stream = handle.createReadStream({ start: ref.s, end: payloadEnd - 1 })
+    signal?.throwIfAborted()
+    const source = handle.createReadStream({ start: ref.s, end: payloadEnd - 1 })
     opened = true
-    const decoded = stream.pipe(createBase64DecodeStream())
-    // The decoder failing mid-payload (only reachable if the file changed
-    // between the checks above and the read) has to tear the source down too,
-    // or the handle stays open until GC.
-    decoded.on('error', () => stream.destroy())
+    const decoded = createBase64DecodeStream()
+    // pipeline(), not pipe(): pipe leaves the source running when the
+    // destination is torn down (a cancelled response leaks this descriptor for
+    // every abandoned image), and it does not forward source errors — an EIO
+    // here would reach process-level uncaughtException, which this app answers
+    // by shutting down. pipeline destroys both ends in either direction.
+    pipeline(source, decoded, (error) => {
+      if (error && !isBenignStreamError(error)) {
+        console.error('Failed to stream session media:', error)
+      }
+    })
+    // The request going away has to reach the file read too, not just the
+    // socket — otherwise the disk work continues for a response nobody holds.
+    if (signal) {
+      const abort = () => decoded.destroy()
+      signal.addEventListener('abort', abort, { once: true })
+      decoded.once('close', () => signal.removeEventListener('abort', abort))
+    }
     return { stream: decoded, mimeType, bytes: decodedLength(ref.l, pad) }
   } catch (error) {
-    if (signal?.aborted) throw error
-    return undefined
+    // Validation returns undefined explicitly; reaching here means something
+    // unexpected failed, and the caller must not read that as "gone".
+    throw error
   } finally {
     if (!opened) await handle.close()
   }

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -961,10 +961,6 @@ const MESSAGES_PAGE_HARD_CAP_FACTOR = 2
 // trailing page (whose window always ends at EOF).
 const CURSOR_WINDOW_GRACE_BYTES = 512 * 1024
 
-/** Session identity for minting media refs during a read. Absent (the default)
- * keeps images inline as base64, which is what pre-`media=ref` clients expect. */
-type MediaRefMode = { agentSlug: string; sessionId: string }
-
 function pageCursor(messages: TransformedItem[], hasOlder: boolean): string | null {
   return hasOlder && messages[0] ? messages[0].id : null
 }
@@ -978,7 +974,9 @@ async function readTransformedTail(
   jsonlPath: string,
   maxLines: number,
   signal?: AbortSignal,
-  media?: MediaRefMode
+  /** True replaces inline base64 images with refs (see session-media); the
+   * default keeps them inline, which is what pre-`media=ref` clients expect. */
+  media?: boolean
 ): Promise<{
   transformed: TransformedItem[]
   entries: (JsonlMessageEntry | JsonlSystemEntry)[]
@@ -999,7 +997,7 @@ async function readTransformedTail(
       !('isMeta' in normalized && normalized.isMeta)
     ) {
       if (media) {
-        replaceInlineMediaWithRefs(normalized, { ...media, line, lineOffset: offsets[i]! })
+        replaceInlineMediaWithRefs(normalized, { line, lineOffset: offsets[i]! })
       }
       entries.push(normalized)
     }
@@ -1401,7 +1399,7 @@ async function readEntriesRange(
   startOffset: number,
   endOffset: number | undefined,
   signal?: AbortSignal,
-  media?: MediaRefMode
+  media?: boolean
 ): Promise<(JsonlMessageEntry | JsonlSystemEntry)[]> {
   const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
   // Rows arrive in file order from a line-boundary start, so accumulating
@@ -1428,7 +1426,7 @@ async function readEntriesRange(
       // dropping the base64 here keeps it out of the page's peak memory too,
       // not just off the wire.
       if (media) {
-        replaceInlineMediaWithRefs(normalized, { ...media, line, lineOffset: offset })
+        replaceInlineMediaWithRefs(normalized, { line, lineOffset: offset })
       }
       entries.push(normalized)
     }
@@ -1486,7 +1484,7 @@ export async function getSessionMessagesPage(
     scan.startOffset,
     scan.endOffset,
     signal,
-    opts.media === 'ref' ? { agentSlug, sessionId } : undefined
+    opts.media === 'ref'
   )
   signal?.throwIfAborted()
   const transformed = transformMessages(entries)
@@ -1575,7 +1573,7 @@ export async function getSessionMessagesDelta(
       jsonlPath,
       maxLines,
       signal,
-      opts.media === 'ref' ? { agentSlug, sessionId } : undefined
+      opts.media === 'ref'
     )
     const canGrow = !reachedStart && maxLines < DELTA_MAX_TAIL_LINES
 

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -38,6 +38,7 @@ import {
   type TransformedItem,
 } from '@shared/lib/utils/message-transform'
 import { findDeltaWindowStart } from '@shared/lib/messages-delta'
+import { replaceInlineMediaWithRefs } from './session-media'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
 import { isHiddenAutomatedSession } from './session-visibility'
 import {
@@ -960,6 +961,10 @@ const MESSAGES_PAGE_HARD_CAP_FACTOR = 2
 // trailing page (whose window always ends at EOF).
 const CURSOR_WINDOW_GRACE_BYTES = 512 * 1024
 
+/** Session identity for minting media refs during a read. Absent (the default)
+ * keeps images inline as base64, which is what pre-`media=ref` clients expect. */
+type MediaRefMode = { agentSlug: string; sessionId: string }
+
 function pageCursor(messages: TransformedItem[], hasOlder: boolean): string | null {
   return hasOlder && messages[0] ? messages[0].id : null
 }
@@ -972,18 +977,20 @@ function pageCursor(messages: TransformedItem[], hasOlder: boolean): string | nu
 async function readTransformedTail(
   jsonlPath: string,
   maxLines: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  media?: MediaRefMode
 ): Promise<{
   transformed: TransformedItem[]
   entries: (JsonlMessageEntry | JsonlSystemEntry)[]
   reachedStart: boolean
 }> {
-  const { lines, reachedStart } = await readJsonlTailLines(jsonlPath, maxLines, signal)
+  const { lines, offsets, reachedStart } = await readJsonlTailLines(jsonlPath, maxLines, signal)
   // An abort landing on the last chunk read still saves the parse/transform
   // below — on large transcripts that is seconds of synchronous work.
   signal?.throwIfAborted()
   const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
     const parsed = parseJsonlLine<JsonlEntry>(line)
     if (!parsed) continue
     const normalized = normalizeQueuedCommandEntry(parsed)
@@ -991,6 +998,9 @@ async function readTransformedTail(
       isMessageOrSystemDisplayEntry(normalized) &&
       !('isMeta' in normalized && normalized.isMeta)
     ) {
+      if (media) {
+        replaceInlineMediaWithRefs(normalized, { ...media, line, lineOffset: offsets[i]! })
+      }
       entries.push(normalized)
     }
   }
@@ -1390,9 +1400,14 @@ async function readEntriesRange(
   jsonlPath: string,
   startOffset: number,
   endOffset: number | undefined,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  media?: MediaRefMode
 ): Promise<(JsonlMessageEntry | JsonlSystemEntry)[]> {
   const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
+  // Rows arrive in file order from a line-boundary start, so accumulating
+  // their lengths reproduces each row's absolute offset — what media refs
+  // address into. The +1 is the newline the reader strips.
+  let lineOffset = startOffset
   // The signal is threaded into the reader itself (checked per chunk): a
   // multi-MB row spans many chunks before it ever surfaces as a line here.
   for await (const line of streamFileLines(
@@ -1400,6 +1415,8 @@ async function readEntriesRange(
     { start: startOffset, end: endOffset },
     signal
   )) {
+    const offset = lineOffset
+    lineOffset += line.length + 1
     const parsed = parseJsonlLine<JsonlEntry>(line)
     if (!parsed) continue
     const normalized = normalizeQueuedCommandEntry(parsed)
@@ -1407,6 +1424,12 @@ async function readEntriesRange(
       isMessageOrSystemDisplayEntry(normalized) &&
       !('isMeta' in normalized && normalized.isMeta)
     ) {
+      // Before the entries accumulate: the window holds every row at once, so
+      // dropping the base64 here keeps it out of the page's peak memory too,
+      // not just off the wire.
+      if (media) {
+        replaceInlineMediaWithRefs(normalized, { ...media, line, lineOffset: offset })
+      }
       entries.push(normalized)
     }
   }
@@ -1426,7 +1449,14 @@ async function readEntriesRange(
 export async function getSessionMessagesPage(
   agentSlug: string,
   sessionId: string,
-  opts: { limit: number; cursor?: string; signal?: AbortSignal; byteBudget?: number }
+  opts: {
+    limit: number
+    cursor?: string
+    signal?: AbortSignal
+    byteBudget?: number
+    /** `'ref'` replaces inline base64 images with media refs (see session-media). */
+    media?: 'ref'
+  }
 ): Promise<SessionMessagesPage> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   if (!(await fileExists(jsonlPath))) {
@@ -1451,7 +1481,13 @@ export async function getSessionMessagesPage(
     return { messages: [], nextCursor: null }
   }
 
-  const entries = await readEntriesRange(jsonlPath, scan.startOffset, scan.endOffset, signal)
+  const entries = await readEntriesRange(
+    jsonlPath,
+    scan.startOffset,
+    scan.endOffset,
+    signal,
+    opts.media === 'ref' ? { agentSlug, sessionId } : undefined
+  )
   signal?.throwIfAborted()
   const transformed = transformMessages(entries)
   const reachedStart = scan.reachedStart
@@ -1524,7 +1560,7 @@ const DELTA_MAX_TAIL_LINES = 10_000
 export async function getSessionMessagesDelta(
   agentSlug: string,
   sessionId: string,
-  opts: { after: string; signal?: AbortSignal }
+  opts: { after: string; signal?: AbortSignal; media?: 'ref' }
 ): Promise<SessionMessagesDelta> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   if (!(await fileExists(jsonlPath))) {
@@ -1538,7 +1574,8 @@ export async function getSessionMessagesDelta(
     const { transformed, entries, reachedStart } = await readTransformedTail(
       jsonlPath,
       maxLines,
-      signal
+      signal,
+      opts.media === 'ref' ? { agentSlug, sessionId } : undefined
     )
     const canGrow = !reachedStart && maxLines < DELTA_MAX_TAIL_LINES
 

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -388,7 +388,8 @@ async function readFileRangeFully(
   return filled
 }
 
-/** Last `maxLines` JSONL rows from disk. Older rows are never read into a line buffer.
+/** Last `maxLines` JSONL rows from disk, with each row's byte offset. Older
+ * rows are never read into a line buffer.
  *
  * `signal` (optional) aborts the backward walk between chunk reads: transcripts
  * run to tens of MB and network filesystems make each read slow, so a caller
@@ -398,23 +399,23 @@ export async function readJsonlTailLines(
   filePath: string,
   maxLines: number,
   signal?: AbortSignal
-): Promise<{ lines: Buffer[]; reachedStart: boolean }> {
+): Promise<{ lines: Buffer[]; offsets: number[]; reachedStart: boolean }> {
   signal?.throwIfAborted()
-  if (maxLines <= 0) return { lines: [], reachedStart: true }
+  if (maxLines <= 0) return { lines: [], offsets: [], reachedStart: true }
 
   let fileHandle: fs.promises.FileHandle
   try {
     fileHandle = await fs.promises.open(filePath, 'r')
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { lines: [], reachedStart: true }
+      return { lines: [], offsets: [], reachedStart: true }
     }
     throw error
   }
 
   try {
     const stat = await fileHandle.stat()
-    if (stat.size === 0) return { lines: [], reachedStart: true }
+    if (stat.size === 0) return { lines: [], offsets: [], reachedStart: true }
 
     let pos = stat.size
     const parts: Buffer[] = []
@@ -448,23 +449,36 @@ export async function readJsonlTailLines(
 
     const combined = parts.length === 1 ? parts[0]! : Buffer.concat(parts)
     const lines: Buffer[] = []
+    // Kept in lockstep with `lines` through every trim below, so consumers that
+    // address into the file (media refs) can do so without a second pass.
+    const offsets: number[] = []
     let start = 0
     for (let i = 0; i < combined.length; i++) {
       if (combined[i] === NEWLINE_BYTE) {
         lines.push(combined.subarray(start, i))
+        offsets.push(pos + start)
         start = i + 1
       }
     }
-    if (start < combined.length) lines.push(combined.subarray(start))
+    if (start < combined.length) {
+      lines.push(combined.subarray(start))
+      offsets.push(pos + start)
+    }
 
     const reachedStart = pos === 0 && !truncated
-    if (!reachedStart && lines.length > 0) lines.shift()
-    if (lines.length > 0 && lines[lines.length - 1]!.length === 0) lines.pop()
+    if (!reachedStart && lines.length > 0) {
+      lines.shift()
+      offsets.shift()
+    }
+    if (lines.length > 0 && lines[lines.length - 1]!.length === 0) {
+      lines.pop()
+      offsets.pop()
+    }
 
     if (lines.length > maxLines) {
-      return { lines: lines.slice(-maxLines), reachedStart: false }
+      return { lines: lines.slice(-maxLines), offsets: offsets.slice(-maxLines), reachedStart: false }
     }
-    return { lines, reachedStart }
+    return { lines, offsets, reachedStart }
   } finally {
     await fileHandle.close()
   }


### PR DESCRIPTION
Images in transcripts ride as base64 inside the JSONL row, and every message page re-shipped all of it to every viewer. `GET /messages?media=ref` replaces them with an address the client resolves against a new media endpoint, on demand.

Opt-in: without the param, responses are byte-identical to today.

## Addressing

A ref is the byte span of the **base64 payload itself**, not of the row holding it. The rows are multi-MB precisely because of the images, so "seek to the row, then find the image" would materialize the very thing this avoids. Serving a ref is a ranged read of exactly the payload piped through a streaming base64 decoder: O(chunk) memory, no line assembly, no JSON parse.

That works because base64's alphabet needs no JSON escaping, so the payload's bytes on disk are byte-identical to the decoded string value. Anything not provably locatable is left inline — correctness never depends on a ref being minted.

Refs are minted **while rows are parsed**, not after the transform. A page window holds every row at once, so stripping there keeps the base64 out of peak memory as well as off the wire. `transformMessages` is untouched; the ref object flows through `toolCall.result` by reference.

## Validity

Deletion and retention rewrite transcripts in place, shifting every offset after the edit. A ref therefore carries its row's uuid **and the byte offset that uuid sat at**, so a read confirms the row is still there with a 36-byte read rather than a scan. With exact quote delimiters around the payload and an image magic-number sniff of the head, a moved or vanished payload fails closed (410) instead of serving unrelated bytes.

Those same checks are what make client-supplied refs safe to honor without signing: a forged span has to land on a quote-delimited base64 string whose head decodes to a known image type — which in a transcript means an actual image, one the caller could already read through the messages endpoint they are authorized for. The response's Content-Type comes from the sniff, **never from the ref**, so a ref cannot dictate how bytes are interpreted. SVG is deliberately excluded: not sniffable, and it executes script when served inline.

⚠️ The uuid check needed a test that isolates it. Deleting the comparison left the whole suite green — the delimiter and magic checks were catching my rewrite fixtures instead. The regression test now swaps in a **same-length uuid**: offsets undisturbed, payload intact, only identity changed. That is the only shape that fails without this check.

## Two duplicate copies, one of them invisible

Measured on real transcripts: the base64 is stored **twice** — once in the `tool_result` block (the only copy that reaches the wire) and again under `toolUseResult.file.base64`. 4.91MB each in a 14.59MB session. The second copy is never serialized but is half of an image-heavy window's retained bytes, so it is dropped outright — it needs no ref, only release.

## Client

`tool-call-item.tsx` already rendered result images only inside the expanded branch, so collapsed calls never mount an `<img>`. Pointing the src at the endpoint means the browser fetches **on expand**, with no observer and no fetch hook; `Cache-Control: private, immutable` makes re-expands and later polls free. A ref that no longer resolves shows a placeholder instead of a broken image.

The ref carries a `url` API path so no consumer needs the session's identity threaded down to it. That puts `lib/parse-tool-result.ts` on the `DIRECT_BASE_URL_CONSUMERS` inventory in the api-origin characterization suite, with its reason.

Both the page and the delta reader honor the param — the delta is what carries live screenshots during an active session.

## Validation

Live HTTP against a real 15MB / 21-image transcript, trailing page `limit=300`:

| | inline (today) | `media=ref` |
|---|---|---|
| response | 1,222,010 B | 288,930 B |
| time | 1.88 s | 0.13 s |

Every image byte is gone; the remaining 289KB is genuine text, which is what bounds the ratio on *this* transcript. Media endpoint: 3–8 ms per image, correct type and length. Forged ref → 410, garbage → 400.

- **Byte-identical parity** with `origin/main` in default mode: 7 sha256 hashes across limits 10/50/300, their cursor pages, and a delta, captured on both trees.
- **Byte-for-byte image recovery**: every ref on a real page re-read through the endpoint and compared to the original decoded payload.
- **Browser (Playwright)**: 4 images render 919×1998, `loading="lazy"`, 0 broken placeholders, and **0 media requests on initial page load**.
- Full suite **9698 passed / 0 failed**; typecheck + lint clean.

## Deliberately out of scope

- The subagent transcript route (`/subagent/:agentId/messages`) still reads whole files with `readJsonlFile` and ships inline base64.
- Oversized **text** tool results stay inline. Unlike an `<img src>`, a text ref cannot fetch itself — it needs a real fetch-on-expand hook and loading state. Images were ~95% of the bytes; happy to follow up if a real transcript shows otherwise.

## Unrelated, but worth knowing

Any worktree branched before #784 is missing `use-stick-to-bottom`, which makes `message-list.test.tsx` fail 115/115 with a misleading "Invalid hook call". `npm install` fixes it.

https://claude.ai/code/session_01Xvya59kGnQTwWRHTUbtZ3B
