### PR TITLE
fix: stream agent export zips instead of buffering them in memory

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -6068,6 +6068,19 @@ describe('POST /api/agents/:id/export-full', () => {
     expect(res.status).toBe(500)
     expect(await res.json()).toEqual({ error: 'Agent workspace not found' })
   })
+
+  it('returns 409 when another export is already in progress', async () => {
+    const err = new Error('An export is already in progress')
+    err.name = 'ExportInProgressError'
+    vi.mocked(exportAgentFull).mockRejectedValue(err)
+
+    const res = await app.request('http://localhost/api/agents/pvb86kldy6/export-full', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ error: 'An export is already in progress' })
+  })
 })
 
 describe('POST /api/agents/:id/export-template', () => {
@@ -6093,6 +6106,19 @@ describe('POST /api/agents/:id/export-template', () => {
     expect(res.headers.get('Content-Length')).toBeNull()
     expect(Buffer.from(await res.arrayBuffer())).toEqual(fakeZip)
     expect(exportAgentTemplate).toHaveBeenCalledWith('pvb86kldy6', expect.any(AbortSignal))
+  })
+
+  it('returns 409 when another export is already in progress', async () => {
+    const err = new Error('An export is already in progress')
+    err.name = 'ExportInProgressError'
+    vi.mocked(exportAgentTemplate).mockRejectedValue(err)
+
+    const res = await app.request('http://localhost/api/agents/pvb86kldy6/export-template', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ error: 'An export is already in progress' })
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -580,7 +580,7 @@ import { computerUsePermissionManager } from '@shared/lib/computer-use/permissio
 import { containerManager } from '@shared/lib/container/container-manager'
 import { listUserSecrets, setSecret, updateSecret, getSecret, getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { keyToEnvVar } from '@shared/lib/utils/secrets'
-import { logAuditEventOrThrow } from '@shared/lib/services/audit-log-service'
+import { logAuditEvent, logAuditEventOrThrow } from '@shared/lib/services/audit-log-service'
 import { readJsonFileStrict, readJsonlFile, writeJsonFileAtomic, readFileOrNull } from '@shared/lib/utils/file-storage'
 import { listChatIntegrations } from '@shared/lib/services/chat-integration-service'
 import { listWebhookTriggers } from '@shared/lib/services/webhook-trigger-service'
@@ -6094,6 +6094,31 @@ describe('POST /api/agents/:id/export-full', () => {
     expect(res.status).toBe(500)
     expect(exportAgentFull).not.toHaveBeenCalled()
   })
+
+  it('destroys the zip stream when packaging the download throws', async () => {
+    const zipStream = Readable.from(Buffer.from('PK\x03\x04full-export'))
+    const destroy = vi.spyOn(zipStream, 'destroy')
+    vi.mocked(exportAgentFull).mockResolvedValue(zipStream)
+    vi.mocked(getAgent).mockResolvedValue({ frontmatter: { name: 'Nutrition Agent' } } as any)
+    vi.mocked(logAuditEvent).mockImplementationOnce(() => {
+      throw new Error('audit failed')
+    })
+
+    const res = await app.request('http://localhost/api/agents/pvb86kldy6/export-full', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(500)
+    expect(destroy).toHaveBeenCalled()
+
+    const nextZip = Readable.from(Buffer.from('PK\x03\x04next'))
+    vi.mocked(exportAgentFull).mockResolvedValue(nextZip)
+    const next = await app.request('http://localhost/api/agents/pvb86kldy6/export-full', {
+      method: 'POST',
+    })
+    expect(next.status).toBe(200)
+    expect(Buffer.from(await next.arrayBuffer())).toEqual(Buffer.from('PK\x03\x04next'))
+  })
 })
 
 describe('POST /api/agents/:id/export-template', () => {
@@ -6143,6 +6168,30 @@ describe('POST /api/agents/:id/export-template', () => {
 
     expect(res.status).toBe(500)
     expect(exportAgentTemplate).not.toHaveBeenCalled()
+  })
+
+  it('destroys the zip stream when packaging the download throws', async () => {
+    const zipStream = Readable.from(Buffer.from('PK\x03\x04template'))
+    const destroy = vi.spyOn(zipStream, 'destroy')
+    vi.mocked(exportAgentTemplate).mockResolvedValue(zipStream)
+    vi.mocked(getAgent).mockResolvedValue({ frontmatter: { name: 'Nutrition Agent' } } as any)
+    vi.mocked(logAuditEvent).mockImplementationOnce(() => {
+      throw new Error('audit failed')
+    })
+
+    const res = await app.request('http://localhost/api/agents/pvb86kldy6/export-template', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(500)
+    expect(destroy).toHaveBeenCalled()
+
+    const nextZip = Readable.from(Buffer.from('PK\x03\x04next'))
+    vi.mocked(exportAgentTemplate).mockResolvedValue(nextZip)
+    const next = await app.request('http://localhost/api/agents/pvb86kldy6/export-template', {
+      method: 'POST',
+    })
+    expect(next.status).toBe(200)
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -555,10 +555,13 @@ vi.mock('hono/streaming', () => ({ streamSSE: (...args: unknown[]) => mockStream
 import agents from './agents'
 import { UploadTooLargeError } from '@shared/lib/utils/chunked-upload'
 import {
+  exportAgentFull,
+  exportAgentTemplate,
   importAgentFromTemplate,
   hasOnboardingSkill,
   getAgentTemplatePrompt,
 } from '@shared/lib/services/agent-template-service'
+import { Readable } from 'stream'
 import {
   deleteSkill,
   exportSkill,
@@ -6028,6 +6031,70 @@ describe('POST /api/agents/:id/keep-alive', () => {
 // ============================================================================
 // Skill ZIP Export / Import Tests
 // ============================================================================
+
+describe('POST /api/agents/:id/export-full', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAgentExists.mockResolvedValue(true)
+    app = createApp()
+  })
+
+  it('streams the zip without Content-Length', async () => {
+    const fakeZip = Buffer.from('PK\x03\x04full-export')
+    vi.mocked(exportAgentFull).mockResolvedValue(Readable.from(fakeZip))
+    vi.mocked(getAgent).mockResolvedValue({ frontmatter: { name: 'Nutrition Agent' } } as any)
+
+    const res = await app.request('http://localhost/api/agents/pvb86kldy6/export-full', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
+    expect(res.headers.get('Content-Disposition')).toContain('Nutrition%20Agent-full.agent')
+    expect(res.headers.get('Content-Length')).toBeNull()
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(fakeZip)
+    expect(exportAgentFull).toHaveBeenCalledWith('pvb86kldy6', expect.any(AbortSignal))
+  })
+
+  it('returns 500 when export throws before the stream starts', async () => {
+    vi.mocked(exportAgentFull).mockRejectedValue(new Error('Agent workspace not found'))
+
+    const res = await app.request('http://localhost/api/agents/missing/export-full', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Agent workspace not found' })
+  })
+})
+
+describe('POST /api/agents/:id/export-template', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAgentExists.mockResolvedValue(true)
+    app = createApp()
+  })
+
+  it('streams the template zip', async () => {
+    const fakeZip = Buffer.from('PK\x03\x04template')
+    vi.mocked(exportAgentTemplate).mockResolvedValue(Readable.from(fakeZip))
+    vi.mocked(getAgent).mockResolvedValue({ frontmatter: { name: 'Nutrition Agent' } } as any)
+
+    const res = await app.request('http://localhost/api/agents/pvb86kldy6/export-template', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Disposition')).toContain('Nutrition%20Agent-template.agent')
+    expect(res.headers.get('Content-Length')).toBeNull()
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(fakeZip)
+    expect(exportAgentTemplate).toHaveBeenCalledWith('pvb86kldy6', expect.any(AbortSignal))
+  })
+})
 
 describe('POST /api/agents/:id/skills/:dir/export', () => {
   let app: ReturnType<typeof createApp>

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -6081,6 +6081,17 @@ describe('POST /api/agents/:id/export-full', () => {
     expect(res.status).toBe(409)
     expect(await res.json()).toEqual({ error: 'An export is already in progress' })
   })
+
+  it('never starts the export (and its lock) when getAgent fails', async () => {
+    vi.mocked(getAgent).mockRejectedValue(new Error('agent metadata unreadable'))
+
+    const res = await app.request('http://localhost/api/agents/pvb86kldy6/export-full', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(500)
+    expect(exportAgentFull).not.toHaveBeenCalled()
+  })
 })
 
 describe('POST /api/agents/:id/export-template', () => {
@@ -6119,6 +6130,17 @@ describe('POST /api/agents/:id/export-template', () => {
 
     expect(res.status).toBe(409)
     expect(await res.json()).toEqual({ error: 'An export is already in progress' })
+  })
+
+  it('never starts the export (and its lock) when getAgent fails', async () => {
+    vi.mocked(getAgent).mockRejectedValue(new Error('agent metadata unreadable'))
+
+    const res = await app.request('http://localhost/api/agents/pvb86kldy6/export-template', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(500)
+    expect(exportAgentTemplate).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -413,6 +413,7 @@ vi.mock('@shared/lib/proxy/review-manager', () => ({
 vi.mock('@shared/lib/services/agent-template-service', () => ({
   exportAgentTemplate: vi.fn(),
   exportAgentFull: vi.fn(),
+  isHostExportBusy: vi.fn(() => false),
   importAgentFromTemplate: vi.fn(),
   MAX_COMPRESSED_SIZE: 500 * 1024 * 1024,
   installAgentFromSkillset: vi.fn(),
@@ -557,6 +558,7 @@ import { UploadTooLargeError } from '@shared/lib/utils/chunked-upload'
 import {
   exportAgentFull,
   exportAgentTemplate,
+  isHostExportBusy,
   importAgentFromTemplate,
   hasOnboardingSkill,
   getAgentTemplatePrompt,
@@ -6141,6 +6143,33 @@ describe('POST /api/agents/:id/export-template', () => {
 
     expect(res.status).toBe(500)
     expect(exportAgentTemplate).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/agents/export-status', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isHostExportBusy).mockReturnValue(false)
+    app = createApp()
+  })
+
+  it('returns inProgress false when the host is idle', async () => {
+    const res = await app.request('http://localhost/api/agents/export-status')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ inProgress: false })
+    expect(getAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns inProgress true while an export is running', async () => {
+    vi.mocked(isHostExportBusy).mockReturnValue(true)
+
+    const res = await app.request('http://localhost/api/agents/export-status')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ inProgress: true })
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -4766,7 +4766,10 @@ function exportRouteError(c: Context, error: unknown, fallback: string) {
 agents.post('/:id/export-template', AgentAdmin(), async (c) => {
   try {
     const slug = getAgentId(c)
-    const [agent, zipStream] = await Promise.all([getAgent(slug), exportAgentTemplate(slug, c.req.raw.signal)])
+    const agent = await getAgent(slug)
+    // Lock is taken inside the export call and released only when the stream
+    // closes, so it must be the last throwing step before the Response.
+    const zipStream = await exportAgentTemplate(slug, c.req.raw.signal)
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'template' } })
     return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-template${AGENT_PACKAGE_EXTENSION}`)
@@ -4779,7 +4782,10 @@ agents.post('/:id/export-template', AgentAdmin(), async (c) => {
 agents.post('/:id/export-full', AgentAdmin(), async (c) => {
   try {
     const slug = getAgentId(c)
-    const [agent, zipStream] = await Promise.all([getAgent(slug), exportAgentFull(slug, c.req.raw.signal)])
+    const agent = await getAgent(slug)
+    // Lock is taken inside the export call and released only when the stream
+    // closes, so it must be the last throwing step before the Response.
+    const zipStream = await exportAgentFull(slug, c.req.raw.signal)
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'full' } })
     return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-full${AGENT_PACKAGE_EXTENSION}`)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -4759,6 +4759,16 @@ function packageDownloadResponse(body: Readable | Buffer, filename: string): Res
   return new Response(Readable.toWeb(nodeStream) as ReadableStream, { status: 200, headers })
 }
 
+// Lock lives on the stream ('close' releases it). Destroy if Response construction throws.
+function sendLockedExportStream(zipStream: Readable, build: () => Response): Response {
+  try {
+    return build()
+  } catch (err) {
+    zipStream.destroy()
+    throw err
+  }
+}
+
 function exportRouteError(c: Context, error: unknown, fallback: string) {
   if (error instanceof Error && error.name === 'ExportInProgressError') {
     return c.json({ error: error.message }, 409)
@@ -4773,12 +4783,11 @@ agents.post('/:id/export-template', AgentAdmin(), async (c) => {
   try {
     const slug = getAgentId(c)
     const agent = await getAgent(slug)
-    // Lock is taken inside the export call and released only when the stream
-    // closes, so it must be the last throwing step before the Response.
     const zipStream = await exportAgentTemplate(slug, c.req.raw.signal)
-
-    logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'template' } })
-    return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-template${AGENT_PACKAGE_EXTENSION}`)
+    return sendLockedExportStream(zipStream, () => {
+      logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'template' } })
+      return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-template${AGENT_PACKAGE_EXTENSION}`)
+    })
   } catch (error) {
     return exportRouteError(c, error, 'Failed to export template')
   }
@@ -4789,12 +4798,11 @@ agents.post('/:id/export-full', AgentAdmin(), async (c) => {
   try {
     const slug = getAgentId(c)
     const agent = await getAgent(slug)
-    // Lock is taken inside the export call and released only when the stream
-    // closes, so it must be the last throwing step before the Response.
     const zipStream = await exportAgentFull(slug, c.req.raw.signal)
-
-    logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'full' } })
-    return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-full${AGENT_PACKAGE_EXTENSION}`)
+    return sendLockedExportStream(zipStream, () => {
+      logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'full' } })
+      return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-full${AGENT_PACKAGE_EXTENSION}`)
+    })
   } catch (error) {
     return exportRouteError(c, error, 'Failed to export agent')
   }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -4753,6 +4753,15 @@ function packageDownloadResponse(body: Readable | Buffer, filename: string): Res
   return new Response(Readable.toWeb(nodeStream) as ReadableStream, { status: 200, headers })
 }
 
+function exportRouteError(c: Context, error: unknown, fallback: string) {
+  if (error instanceof Error && error.name === 'ExportInProgressError') {
+    return c.json({ error: error.message }, 409)
+  }
+  const message = error instanceof Error ? error.message : fallback
+  console.error(fallback, error)
+  return c.json({ error: message }, 500)
+}
+
 // POST /api/agents/:id/export-template - Export agent as ZIP download
 agents.post('/:id/export-template', AgentAdmin(), async (c) => {
   try {
@@ -4762,9 +4771,7 @@ agents.post('/:id/export-template', AgentAdmin(), async (c) => {
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'template' } })
     return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-template${AGENT_PACKAGE_EXTENSION}`)
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to export template'
-    console.error('Failed to export template:', error)
-    return c.json({ error: message }, 500)
+    return exportRouteError(c, error, 'Failed to export template')
   }
 })
 
@@ -4777,9 +4784,7 @@ agents.post('/:id/export-full', AgentAdmin(), async (c) => {
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'full' } })
     return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-full${AGENT_PACKAGE_EXTENSION}`)
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to export agent'
-    console.error('Failed to export full agent:', error)
-    return c.json({ error: message }, 500)
+    return exportRouteError(c, error, 'Failed to export agent')
   }
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -4740,26 +4740,27 @@ agents.post('/:id/skills/:dir/publish', AgentAdmin(), async (c) => {
  * display name (slugs are opaque minted ids), encoded per the same quoted +
  * RFC 5987 `filename*` convention as workspace-file downloads.
  */
-function packageDownloadResponse(zipBuffer: Buffer, filename: string): Response {
+function packageDownloadResponse(body: Readable | Buffer, filename: string): Response {
   const encoded = encodeURIComponent(filename)
-  return new Response(new Uint8Array(zipBuffer), {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/octet-stream',
-      'Content-Disposition': `attachment; filename="${encoded}"; filename*=UTF-8''${encoded}`,
-      'Content-Length': zipBuffer.byteLength.toString(),
-    },
-  })
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/octet-stream',
+    'Content-Disposition': `attachment; filename="${encoded}"; filename*=UTF-8''${encoded}`,
+  }
+  if (Buffer.isBuffer(body)) {
+    headers['Content-Length'] = body.byteLength.toString()
+  }
+  const nodeStream = Buffer.isBuffer(body) ? Readable.from(body) : body
+  return new Response(Readable.toWeb(nodeStream) as ReadableStream, { status: 200, headers })
 }
 
 // POST /api/agents/:id/export-template - Export agent as ZIP download
 agents.post('/:id/export-template', AgentAdmin(), async (c) => {
   try {
     const slug = getAgentId(c)
-    const [agent, zipBuffer] = await Promise.all([getAgent(slug), exportAgentTemplate(slug)])
+    const [agent, zipStream] = await Promise.all([getAgent(slug), exportAgentTemplate(slug, c.req.raw.signal)])
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'template' } })
-    return packageDownloadResponse(zipBuffer, `${agent?.frontmatter.name || slug}-template${AGENT_PACKAGE_EXTENSION}`)
+    return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-template${AGENT_PACKAGE_EXTENSION}`)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to export template'
     console.error('Failed to export template:', error)
@@ -4771,10 +4772,10 @@ agents.post('/:id/export-template', AgentAdmin(), async (c) => {
 agents.post('/:id/export-full', AgentAdmin(), async (c) => {
   try {
     const slug = getAgentId(c)
-    const [agent, zipBuffer] = await Promise.all([getAgent(slug), exportAgentFull(slug)])
+    const [agent, zipStream] = await Promise.all([getAgent(slug), exportAgentFull(slug, c.req.raw.signal)])
 
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: slug, action: 'exported', details: { type: 'full' } })
-    return packageDownloadResponse(zipBuffer, `${agent?.frontmatter.name || slug}-full${AGENT_PACKAGE_EXTENSION}`)
+    return packageDownloadResponse(zipStream, `${agent?.frontmatter.name || slug}-full${AGENT_PACKAGE_EXTENSION}`)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to export agent'
     console.error('Failed to export full agent:', error)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -148,6 +148,7 @@ import {
 import {
   exportAgentTemplate,
   exportAgentFull,
+  isHostExportBusy,
   importAgentFromTemplate,
   MAX_COMPRESSED_SIZE,
   installAgentFromSkillset,
@@ -715,6 +716,11 @@ agents.get('/discoverable-agents', async (c) => {
     console.error('Failed to fetch discoverable agents:', error)
     return c.json({ error: 'Failed to fetch discoverable agents' }, 500)
   }
+})
+
+// GET /api/agents/export-status — host-wide; registered before /:id
+agents.get('/export-status', (c) => {
+  return c.json({ inProgress: isHostExportBusy() })
 })
 
 // POST /api/agents/install-from-skillset - Install agent from skillset

--- a/src/renderer/components/agents/settings/general-tab.tsx
+++ b/src/renderer/components/agents/settings/general-tab.tsx
@@ -27,6 +27,7 @@ import {
   useUpdateAgentTemplate,
   useExportAgentTemplate,
   useExportAgentFull,
+  useHostExportStatus,
 } from '@renderer/hooks/use-agent-templates'
 import { StatusBadge } from '@renderer/components/agents/status-badge'
 import { AgentTemplatePRDialog } from '@renderer/components/agents/agent-template-pr-dialog'
@@ -59,6 +60,9 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
   const updateTemplate = useUpdateAgentTemplate()
   const exportTemplate = useExportAgentTemplate()
   const exportFull = useExportAgentFull()
+  const { data: hostExportStatus } = useHostExportStatus()
+  const exportBusy =
+    !!hostExportStatus?.inProgress || exportTemplate.isPending || exportFull.isPending
   const templateSourceLabel = templateStatus?.sourceLabel || null
   const publishMode = useSkillsetPublishMode(templateStatus?.skillsetId)
   const isPR = isPullRequestPublishMode(publishMode)
@@ -170,9 +174,9 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
             size="sm"
             variant="outline"
             onClick={() => exportTemplate.mutate({ agentSlug, agentName: name })}
-            disabled={exportTemplate.isPending}
+            disabled={exportBusy}
           >
-            {exportTemplate.isPending ? (
+            {exportBusy ? (
               <Loader2 className="h-3 w-3 mr-1 animate-spin" />
             ) : (
               <Download className="h-3 w-3 mr-1" />
@@ -184,9 +188,9 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
               <Button
                 size="sm"
                 variant="outline"
-                disabled={exportFull.isPending}
+                disabled={exportBusy}
               >
-                {exportFull.isPending ? (
+                {exportBusy ? (
                   <Loader2 className="h-3 w-3 mr-1 animate-spin" />
                 ) : (
                   <HardDriveDownload className="h-3 w-3 mr-1" />
@@ -206,6 +210,7 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
               <AlertDialogFooter>
                 <AlertDialogCancel>Cancel</AlertDialogCancel>
                 <AlertDialogAction
+                  disabled={exportBusy}
                   onClick={() => exportFull.mutate({ agentSlug, agentName: name })}
                 >
                   Export

--- a/src/renderer/hooks/use-agent-templates.export-status.test.ts
+++ b/src/renderer/hooks/use-agent-templates.export-status.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const apiFetchMock = vi.fn()
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+vi.mock('@renderer/lib/download', () => ({
+  downloadBlob: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@renderer/lib/upload', () => ({
+  uploadFileChunked: vi.fn(),
+}))
+vi.mock('@renderer/context/analytics-context', () => ({
+  useAnalyticsTracking: () => ({ track: vi.fn() }),
+}))
+vi.mock('@renderer/hooks/use-skillsets', () => ({
+  useSkillsets: () => ({ data: [] }),
+}))
+
+import {
+  HOST_EXPORT_STATUS_QUERY_KEY,
+  useExportAgentFull,
+  useHostExportStatus,
+} from './use-agent-templates'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+  return Object.assign(wrapper, { queryClient })
+}
+
+beforeEach(() => {
+  apiFetchMock.mockReset()
+})
+
+describe('useHostExportStatus', () => {
+  it('parses inProgress from the host status endpoint', async () => {
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ inProgress: true }),
+    })
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useHostExportStatus(), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toEqual({ inProgress: true }))
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/agents/export-status')
+  })
+
+  it('rejects a malformed status payload', async () => {
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ busy: true }),
+    })
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useHostExportStatus(), { wrapper })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useExportAgentFull host status cache', () => {
+  it('marks the host busy before the export request starts', async () => {
+    let resolveExport: ((value: { ok: boolean; json: () => Promise<unknown> }) => void) | undefined
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/agents/export-status') {
+        return Promise.resolve({ ok: true, json: async () => ({ inProgress: false }) })
+      }
+      return new Promise((resolve) => {
+        resolveExport = resolve
+      })
+    })
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useExportAgentFull(), { wrapper })
+
+    act(() => {
+      result.current.mutate({ agentSlug: 'open-slide', agentName: 'OpenSlide Studio' })
+    })
+
+    await waitFor(() => {
+      expect(wrapper.queryClient.getQueryData(HOST_EXPORT_STATUS_QUERY_KEY)).toEqual({
+        inProgress: true,
+      })
+    })
+
+    resolveExport?.({ ok: true, json: async () => ({}) })
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+  })
+})

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -2,11 +2,18 @@ import { useEffect, useRef } from 'react'
 import { apiFetch } from '@renderer/lib/api'
 import { uploadFileChunked, type UploadProgress } from '@renderer/lib/upload'
 import { downloadBlob } from '@renderer/lib/download'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useSkillsets } from '@renderer/hooks/use-skillsets'
 import type { ApiAgentTemplateInstallResult, ApiDiscoverableAgent, ApiItemStatus } from '@shared/lib/types/api'
 import { AGENT_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
+import {
+  hostExportStatusSchema,
+  type HostExportStatus,
+} from '@shared/lib/services/export-status-schema'
+
+export const HOST_EXPORT_STATUS_QUERY_KEY = ['host-export-status'] as const
+const HOST_EXPORT_STATUS_POLL_MS = 2000
 
 /** Normalize discoverable agent path `agents/<dir>/` → `<dir>` (website template_slug). */
 export function slugFromAgentPath(path: string): string {
@@ -61,7 +68,28 @@ export function useDiscoverableAgents() {
   })
 }
 
+export function useHostExportStatus() {
+  return useQuery<HostExportStatus>({
+    queryKey: HOST_EXPORT_STATUS_QUERY_KEY,
+    queryFn: async () => {
+      const res = await apiFetch('/api/agents/export-status')
+      if (!res.ok) throw new Error('Failed to fetch export status')
+      return hostExportStatusSchema.parse(await res.json())
+    },
+    refetchInterval: (query) => (query.state.data?.inProgress ? HOST_EXPORT_STATUS_POLL_MS : false),
+  })
+}
+
+function markHostExportBusy(queryClient: QueryClient) {
+  queryClient.setQueryData(HOST_EXPORT_STATUS_QUERY_KEY, { inProgress: true })
+}
+
+function settleHostExportStatus(queryClient: QueryClient) {
+  void queryClient.invalidateQueries({ queryKey: HOST_EXPORT_STATUS_QUERY_KEY })
+}
+
 export function useExportAgentTemplate() {
+  const queryClient = useQueryClient()
   const { track } = useAnalyticsTracking()
 
   return useMutation<void, Error, { agentSlug: string; agentName: string }>({
@@ -77,10 +105,17 @@ export function useExportAgentTemplate() {
 
       await downloadBlob(res, `${agentName || agentSlug}-template${AGENT_PACKAGE_EXTENSION}`)
     },
+    onMutate: () => {
+      markHostExportBusy(queryClient)
+    },
+    onSettled: () => {
+      settleHostExportStatus(queryClient)
+    },
   })
 }
 
 export function useExportAgentFull() {
+  const queryClient = useQueryClient()
   const { track } = useAnalyticsTracking()
 
   return useMutation<void, Error, { agentSlug: string; agentName: string }>({
@@ -95,6 +130,12 @@ export function useExportAgentFull() {
       }
 
       await downloadBlob(res, `${agentName || agentSlug}-full${AGENT_PACKAGE_EXTENSION}`)
+    },
+    onMutate: () => {
+      markHostExportBusy(queryClient)
+    },
+    onSettled: () => {
+      settleHostExportStatus(queryClient)
     },
   })
 }

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -55,8 +55,8 @@ vi.mock('@shared/lib/platform-auth/config', () => ({
 import {
   validateAgentTemplate,
   validateTemplateEntries,
-  exportAgentTemplate,
-  exportAgentFull,
+  exportAgentTemplate as exportAgentTemplateStream,
+  exportAgentFull as exportAgentFullStream,
   importAgentFromTemplate,
   installAgentFromSkillset,
   computeAgentTemplateHash,
@@ -73,6 +73,22 @@ import { getSkillsetIndex } from '@shared/lib/services/skillset-service'
 // ============================================================================
 // Shared Constants & Helpers
 // ============================================================================
+
+async function readableToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+async function exportAgentTemplate(slug: string): Promise<Buffer> {
+  return readableToBuffer(await exportAgentTemplateStream(slug))
+}
+
+async function exportAgentFull(slug: string): Promise<Buffer> {
+  return readableToBuffer(await exportAgentFullStream(slug))
+}
 
 const MINIMAL_CLAUDE_MD = `---
 name: Test Agent
@@ -1929,6 +1945,20 @@ describe('exportAgentFull', () => {
     await expect(exportAgentFull('nonexistent-agent')).rejects.toThrow(
       'Agent workspace not found'
     )
+  })
+
+  it('returns a readable zip stream', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'full-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'CLAUDE.md'), MINIMAL_CLAUDE_MD)
+
+    const stream = await exportAgentFullStream('full-agent')
+    expect(typeof stream.pipe).toBe('function')
+    const zipBuffer = await readableToBuffer(stream)
+    const reader = await openZipFromBuffer(zipBuffer)
+    const entryNames = reader.entries.map((e) => e.fileName)
+    reader.close()
+    expect(entryNames).toContain('CLAUDE.md')
   })
 
   it('includes .env in the export', async () => {

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import http from 'node:http'
+import { Readable } from 'node:stream'
+import type { AddressInfo } from 'node:net'
+import { Hono } from 'hono'
+import { serve } from '@hono/node-server'
+import type { ServerType } from '@hono/node-server'
 import { createZipBuffer, openZipFromBuffer, type ZipEntryMeta } from '@shared/lib/utils/zip'
 import type { SkillsetConfig, InstalledAgentMetadata } from '@shared/lib/types/skillset'
+import { armAbortSignal } from '@/api/middleware/arm-abort-signal'
 
 // ============================================================================
 // Hoisted Mocks - must come before imports of the module under test
@@ -83,6 +90,15 @@ async function readableToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> 
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
   }
   return Buffer.concat(chunks)
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error('timed out waiting for condition')
 }
 
 async function exportAgentTemplate(slug: string): Promise<Buffer> {
@@ -2091,6 +2107,97 @@ describe('exportAgentFull', () => {
     reader.close()
 
     expect(entryNames).not.toContain('.browser-profile/cookies.db')
+  })
+
+  it('releases the lock when the caller destroys the stream before reading it', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'full-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'CLAUDE.md'), MINIMAL_CLAUDE_MD)
+
+    const first = await exportAgentFullStream('full-agent')
+    expect(isHostExportBusy()).toBe(true)
+    first.destroy()
+    await waitUntil(() => !isHostExportBusy())
+
+    const second = await exportAgentFullStream('full-agent')
+    const zipBuffer = await readableToBuffer(second)
+    expect(zipBuffer.length).toBeGreaterThan(0)
+    expect(isHostExportBusy()).toBe(false)
+  })
+
+  it('releases the lock when the abort signal fires mid-export', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'full-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'CLAUDE.md'), MINIMAL_CLAUDE_MD)
+    for (let i = 0; i < 40; i++) {
+      const blob = Buffer.alloc(64 * 1024)
+      for (let j = 0; j < blob.length; j++) blob[j] = (i + j * 31) & 0xff
+      fs.writeFileSync(path.join(workspaceDir, `blob-${i}.bin`), blob)
+    }
+
+    const ac = new AbortController()
+    const first = await exportAgentFullStream('full-agent', ac.signal)
+    first.resume()
+    ac.abort()
+    await waitUntil(() => !isHostExportBusy())
+
+    const second = await exportAgentFullStream('full-agent')
+    const zipBuffer = await readableToBuffer(second)
+    expect(zipBuffer.length).toBeGreaterThan(0)
+  })
+
+  it('releases the lock when the HTTP client hangs up mid-download', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'full-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'CLAUDE.md'), MINIMAL_CLAUDE_MD)
+    for (let i = 0; i < 8; i++) {
+      const blob = Buffer.alloc(256 * 1024)
+      for (let j = 0; j < blob.length; j++) blob[j] = (i * 17 + j * 13) & 0xff
+      fs.writeFileSync(path.join(workspaceDir, `blob-${i}.bin`), blob)
+    }
+
+    const app = new Hono()
+    app.use('*', armAbortSignal)
+    app.post('/export/:slug', async (c) => {
+      const zipStream = await exportAgentFullStream(c.req.param('slug'), c.req.raw.signal)
+      return new Response(Readable.toWeb(zipStream) as ReadableStream)
+    })
+
+    let server: ServerType | undefined
+    const port = await new Promise<number>((resolve) => {
+      server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) =>
+        resolve((info as AddressInfo).port)
+      )
+    })
+
+    try {
+      await new Promise<void>((resolve) => {
+        const req = http.request(
+          { host: '127.0.0.1', port, path: '/export/full-agent', method: 'POST' },
+          (res) => {
+            let received = 0
+            res.on('data', (chunk: Buffer) => {
+              received += chunk.length
+              if (received >= 64 * 1024) req.destroy()
+            })
+            res.on('error', () => {})
+            res.on('close', () => resolve())
+          },
+        )
+        req.on('error', () => resolve())
+        req.end()
+      })
+
+      await waitUntil(() => !isHostExportBusy())
+      const second = await exportAgentFullStream('full-agent')
+      const zipBuffer = await readableToBuffer(second)
+      expect(zipBuffer.length).toBeGreaterThan(0)
+    } finally {
+      await new Promise<void>((resolve) => {
+        if (!server) return resolve()
+        server.close(() => resolve())
+      })
+    }
   })
 })
 

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -57,6 +57,8 @@ import {
   validateTemplateEntries,
   exportAgentTemplate as exportAgentTemplateStream,
   exportAgentFull as exportAgentFullStream,
+  ExportInProgressError,
+  resetHostExportLockForTests,
   importAgentFromTemplate,
   installAgentFromSkillset,
   computeAgentTemplateHash,
@@ -89,6 +91,10 @@ async function exportAgentTemplate(slug: string): Promise<Buffer> {
 async function exportAgentFull(slug: string): Promise<Buffer> {
   return readableToBuffer(await exportAgentFullStream(slug))
 }
+
+afterEach(() => {
+  resetHostExportLockForTests()
+})
 
 const MINIMAL_CLAUDE_MD = `---
 name: Test Agent
@@ -1899,6 +1905,7 @@ describe('exportAgentTemplate - error cases', () => {
   })
 
   afterEach(async () => {
+    resetHostExportLockForTests()
     process.env.SUPERAGENT_DATA_DIR = originalEnv
     await fs.promises.rm(testDir, { recursive: true, force: true })
   })
@@ -1917,6 +1924,18 @@ describe('exportAgentTemplate - error cases', () => {
     await expect(exportAgentTemplate('no-claude')).rejects.toThrow(
       'CLAUDE.md not found'
     )
+  })
+
+  it('does not hold the lock when CLAUDE.md is missing', async () => {
+    const missingDir = path.join(testDir, 'agents', 'no-claude', 'workspace')
+    fs.mkdirSync(missingDir, { recursive: true })
+    await expect(exportAgentTemplate('no-claude')).rejects.toThrow('CLAUDE.md not found')
+
+    const workspaceDir = path.join(testDir, 'agents', 'ok-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'CLAUDE.md'), MINIMAL_CLAUDE_MD)
+    const zipBuffer = await exportAgentTemplate('ok-agent')
+    expect(zipBuffer.length).toBeGreaterThan(0)
   })
 })
 
@@ -1937,6 +1956,7 @@ describe('exportAgentFull', () => {
   })
 
   afterEach(async () => {
+    resetHostExportLockForTests()
     process.env.SUPERAGENT_DATA_DIR = originalEnv
     await fs.promises.rm(testDir, { recursive: true, force: true })
   })
@@ -1945,6 +1965,32 @@ describe('exportAgentFull', () => {
     await expect(exportAgentFull('nonexistent-agent')).rejects.toThrow(
       'Agent workspace not found'
     )
+  })
+
+  it('rejects a second export while the first stream is still open', async () => {
+    const workspaceDir = path.join(testDir, 'agents', 'full-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'CLAUDE.md'), MINIMAL_CLAUDE_MD)
+
+    const first = await exportAgentFullStream('full-agent')
+    await expect(exportAgentFullStream('full-agent')).rejects.toBeInstanceOf(ExportInProgressError)
+    await expect(exportAgentTemplateStream('full-agent')).rejects.toBeInstanceOf(ExportInProgressError)
+
+    await readableToBuffer(first)
+    const second = await exportAgentFullStream('full-agent')
+    const zipBuffer = await readableToBuffer(second)
+    const reader = await openZipFromBuffer(zipBuffer)
+    reader.close()
+    expect(reader.entries.some((e) => e.fileName === 'CLAUDE.md')).toBe(true)
+  })
+
+  it('does not hold the lock when the workspace is missing', async () => {
+    await expect(exportAgentFull('missing')).rejects.toThrow('Agent workspace not found')
+    const workspaceDir = path.join(testDir, 'agents', 'full-agent', 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.writeFileSync(path.join(workspaceDir, 'CLAUDE.md'), MINIMAL_CLAUDE_MD)
+    const zipBuffer = await exportAgentFull('full-agent')
+    expect(zipBuffer.length).toBeGreaterThan(0)
   })
 
   it('returns a readable zip stream', async () => {

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -58,6 +58,7 @@ import {
   exportAgentTemplate as exportAgentTemplateStream,
   exportAgentFull as exportAgentFullStream,
   ExportInProgressError,
+  isHostExportBusy,
   resetHostExportLockForTests,
   importAgentFromTemplate,
   installAgentFromSkillset,
@@ -1972,11 +1973,14 @@ describe('exportAgentFull', () => {
     fs.mkdirSync(workspaceDir, { recursive: true })
     fs.writeFileSync(path.join(workspaceDir, 'CLAUDE.md'), MINIMAL_CLAUDE_MD)
 
+    expect(isHostExportBusy()).toBe(false)
     const first = await exportAgentFullStream('full-agent')
+    expect(isHostExportBusy()).toBe(true)
     await expect(exportAgentFullStream('full-agent')).rejects.toBeInstanceOf(ExportInProgressError)
     await expect(exportAgentTemplateStream('full-agent')).rejects.toBeInstanceOf(ExportInProgressError)
 
     await readableToBuffer(first)
+    expect(isHostExportBusy()).toBe(false)
     const second = await exportAgentFullStream('full-agent')
     const zipBuffer = await readableToBuffer(second)
     const reader = await openZipFromBuffer(zipBuffer)

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -8,6 +8,7 @@
 import crypto from 'crypto'
 import path from 'path'
 import fs from 'fs'
+import { Readable } from 'stream'
 import archiver from 'archiver'
 import {
   openZipFromBuffer,
@@ -227,15 +228,15 @@ async function walkTemplateFiles(workspaceDir: string): Promise<string[]> {
   return files
 }
 
-/**
- * Walk the agent workspace for a full export, returning all file paths.
- * Uses explicit walking instead of archive.glob() to avoid hangs on Windows
- * caused by broken symlinks and permission issues with readdir-glob.
- */
-async function walkFullExportFiles(workspaceDir: string): Promise<string[]> {
-  const files: string[] = []
-
+// Visitor walk (not glob — glob hangs on Windows broken symlinks). No path list in RAM.
+async function walkFullExportFiles(
+  workspaceDir: string,
+  onFile: (relativePath: string) => void,
+  signal?: AbortSignal,
+): Promise<void> {
   async function walk(dir: string, relativeBase: string): Promise<void> {
+    if (signal?.aborted) return
+
     let entries: fs.Dirent[]
     try {
       entries = await fs.promises.readdir(dir, { withFileTypes: true })
@@ -244,6 +245,7 @@ async function walkFullExportFiles(workspaceDir: string): Promise<string[]> {
     }
 
     for (const entry of entries) {
+      if (signal?.aborted) return
       if (FULL_EXPORT_EXCLUDE.has(entry.name)) continue
 
       const relativePath = relativeBase ? path.join(relativeBase, entry.name) : entry.name
@@ -254,23 +256,52 @@ async function walkFullExportFiles(workspaceDir: string): Promise<string[]> {
       if (entry.isDirectory()) {
         await walk(path.join(dir, entry.name), relativePath)
       } else if (entry.isFile()) {
-        files.push(relativePath)
+        onFile(relativePath)
       }
     }
   }
 
   await walk(workspaceDir, '')
-  return files
 }
 
 // ============================================================================
 // ZIP Export
 // ============================================================================
 
-/**
- * Export an agent's workspace as a ZIP template buffer.
- */
-export async function exportAgentTemplate(agentSlug: string): Promise<Buffer> {
+// Queue files into an archiver and return it immediately so the HTTP response
+// can start flushing. Level 1: level 9 pegged 0.5 vCPU hosts on large exports.
+function createWorkspaceZipStream(
+  addFiles: (archive: ReturnType<typeof archiver>) => Promise<void>,
+  signal?: AbortSignal,
+): Readable {
+  const archive = archiver('zip', { zlib: { level: 1 } })
+  const onAbort = () => {
+    if (!archive.destroyed) archive.destroy()
+  }
+  signal?.addEventListener('abort', onAbort, { once: true })
+
+  void (async () => {
+    try {
+      if (signal?.aborted) {
+        onAbort()
+        return
+      }
+      await addFiles(archive)
+      if (signal?.aborted || archive.destroyed) return
+      await archive.finalize()
+    } catch (err) {
+      if (!archive.destroyed) {
+        archive.destroy(err instanceof Error ? err : new Error(String(err)))
+      }
+    } finally {
+      signal?.removeEventListener('abort', onAbort)
+    }
+  })()
+
+  return archive
+}
+
+export async function exportAgentTemplate(agentSlug: string, signal?: AbortSignal): Promise<Readable> {
   const workspaceDir = getAgentWorkspaceDir(agentSlug)
 
   if (!(await directoryExists(workspaceDir))) {
@@ -284,52 +315,26 @@ export async function exportAgentTemplate(agentSlug: string): Promise<Buffer> {
   }
 
   const templateFiles = await walkTemplateFiles(workspaceDir)
-
-  return new Promise((resolve, reject) => {
-    const archive = archiver('zip', { zlib: { level: 9 } })
-    const chunks: Buffer[] = []
-
-    archive.on('data', (chunk: Buffer) => chunks.push(chunk))
-    archive.on('end', () => resolve(Buffer.concat(chunks)))
-    archive.on('error', reject)
-
+  return createWorkspaceZipStream(async (archive) => {
     for (const relativePath of templateFiles) {
-      const fullPath = path.join(workspaceDir, relativePath)
-      archive.file(fullPath, { name: relativePath })
+      if (signal?.aborted) return
+      archive.file(path.join(workspaceDir, relativePath), { name: relativePath })
     }
-
-    archive.finalize()
-  })
+  }, signal)
 }
 
-/**
- * Export a full agent workspace as a ZIP buffer (includes .env, sessions, etc).
- * Used for migrating agents between machines.
- */
-export async function exportAgentFull(agentSlug: string): Promise<Buffer> {
+export async function exportAgentFull(agentSlug: string, signal?: AbortSignal): Promise<Readable> {
   const workspaceDir = getAgentWorkspaceDir(agentSlug)
 
   if (!(await directoryExists(workspaceDir))) {
     throw new Error('Agent workspace not found')
   }
 
-  const fullFiles = await walkFullExportFiles(workspaceDir)
-
-  return new Promise((resolve, reject) => {
-    const archive = archiver('zip', { zlib: { level: 9 } })
-    const chunks: Buffer[] = []
-
-    archive.on('data', (chunk: Buffer) => chunks.push(chunk))
-    archive.on('end', () => resolve(Buffer.concat(chunks)))
-    archive.on('error', reject)
-
-    for (const relativePath of fullFiles) {
-      const fullPath = path.join(workspaceDir, relativePath)
-      archive.file(fullPath, { name: relativePath })
-    }
-
-    archive.finalize()
-  })
+  return createWorkspaceZipStream(async (archive) => {
+    await walkFullExportFiles(workspaceDir, (relativePath) => {
+      archive.file(path.join(workspaceDir, relativePath), { name: relativePath })
+    }, signal)
+  }, signal)
 }
 
 // ============================================================================

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -321,7 +321,11 @@ function createWorkspaceZipStream(
 
   const archive = archiver('zip', { zlib: { level: zlibLevel } })
   archive.once('close', release)
-  archive.once('error', release)
+  // on(), not once(): a workspace that changes under the walk (agent deleted
+  // mid-export) makes archiver emit an ENOENT per queued file, and the first
+  // listener would be the only one. Zero listeners on the second error is an
+  // uncaughtException, which quits the app. release() is idempotent.
+  archive.on('error', release)
 
   const stopArchive = (err?: Error) => {
     if (archive.destroyed) return

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -268,14 +268,57 @@ async function walkFullExportFiles(
 // ZIP Export
 // ============================================================================
 
+export class ExportInProgressError extends Error {
+  constructor() {
+    super('An export is already in progress')
+    this.name = 'ExportInProgressError'
+  }
+}
+
+let hostExportBusy = false
+
+function beginHostExport(): void {
+  if (hostExportBusy) throw new ExportInProgressError()
+  hostExportBusy = true
+}
+
+function endHostExport(): void {
+  hostExportBusy = false
+}
+
+export function resetHostExportLockForTests(): void {
+  hostExportBusy = false
+}
+
+async function withHostExportLock<T>(fn: () => Promise<T>): Promise<T> {
+  beginHostExport()
+  try {
+    return await fn()
+  } catch (err) {
+    endHostExport()
+    throw err
+  }
+}
+
 // Queue files into an archiver and return it immediately so the HTTP response
 // can start flushing. Level 1: level 9 pegged 0.5 vCPU hosts on large exports.
 function createWorkspaceZipStream(
   addFiles: (archive: ReturnType<typeof archiver>) => Promise<void>,
   signal?: AbortSignal,
 ): Readable {
+  let released = false
+  const release = () => {
+    if (released) return
+    released = true
+    endHostExport()
+  }
+
   const archive = archiver('zip', { zlib: { level: 1 } })
+  archive.once('close', release)
+  archive.once('error', release)
+
   const onAbort = () => {
+    release()
     if (!archive.destroyed) archive.destroy()
   }
   signal?.addEventListener('abort', onAbort, { once: true })
@@ -293,6 +336,7 @@ function createWorkspaceZipStream(
       if (!archive.destroyed) {
         archive.destroy(err instanceof Error ? err : new Error(String(err)))
       }
+      release()
     } finally {
       signal?.removeEventListener('abort', onAbort)
     }
@@ -302,39 +346,43 @@ function createWorkspaceZipStream(
 }
 
 export async function exportAgentTemplate(agentSlug: string, signal?: AbortSignal): Promise<Readable> {
-  const workspaceDir = getAgentWorkspaceDir(agentSlug)
+  return withHostExportLock(async () => {
+    const workspaceDir = getAgentWorkspaceDir(agentSlug)
 
-  if (!(await directoryExists(workspaceDir))) {
-    throw new Error('Agent workspace not found')
-  }
-
-  const claudeMdPath = getAgentClaudeMdPath(agentSlug)
-  const claudeMdContent = await readFileOrNull(claudeMdPath)
-  if (!claudeMdContent) {
-    throw new Error('CLAUDE.md not found in agent workspace')
-  }
-
-  const templateFiles = await walkTemplateFiles(workspaceDir)
-  return createWorkspaceZipStream(async (archive) => {
-    for (const relativePath of templateFiles) {
-      if (signal?.aborted) return
-      archive.file(path.join(workspaceDir, relativePath), { name: relativePath })
+    if (!(await directoryExists(workspaceDir))) {
+      throw new Error('Agent workspace not found')
     }
-  }, signal)
+
+    const claudeMdPath = getAgentClaudeMdPath(agentSlug)
+    const claudeMdContent = await readFileOrNull(claudeMdPath)
+    if (!claudeMdContent) {
+      throw new Error('CLAUDE.md not found in agent workspace')
+    }
+
+    const templateFiles = await walkTemplateFiles(workspaceDir)
+    return createWorkspaceZipStream(async (archive) => {
+      for (const relativePath of templateFiles) {
+        if (signal?.aborted) return
+        archive.file(path.join(workspaceDir, relativePath), { name: relativePath })
+      }
+    }, signal)
+  })
 }
 
 export async function exportAgentFull(agentSlug: string, signal?: AbortSignal): Promise<Readable> {
-  const workspaceDir = getAgentWorkspaceDir(agentSlug)
+  return withHostExportLock(async () => {
+    const workspaceDir = getAgentWorkspaceDir(agentSlug)
 
-  if (!(await directoryExists(workspaceDir))) {
-    throw new Error('Agent workspace not found')
-  }
+    if (!(await directoryExists(workspaceDir))) {
+      throw new Error('Agent workspace not found')
+    }
 
-  return createWorkspaceZipStream(async (archive) => {
-    await walkFullExportFiles(workspaceDir, (relativePath) => {
-      archive.file(path.join(workspaceDir, relativePath), { name: relativePath })
+    return createWorkspaceZipStream(async (archive) => {
+      await walkFullExportFiles(workspaceDir, (relativePath) => {
+        archive.file(path.join(workspaceDir, relativePath), { name: relativePath })
+      }, signal)
     }, signal)
-  }, signal)
+  })
 }
 
 // ============================================================================

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -290,6 +290,10 @@ export function resetHostExportLockForTests(): void {
   hostExportBusy = false
 }
 
+export function isHostExportBusy(): boolean {
+  return hostExportBusy
+}
+
 async function withHostExportLock<T>(fn: () => Promise<T>): Promise<T> {
   beginHostExport()
   try {

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -275,6 +275,7 @@ export class ExportInProgressError extends Error {
   }
 }
 
+// One zip at a time on the host. Two large exports OOM a 1 GB box.
 let hostExportBusy = false
 
 function beginHostExport(): void {
@@ -305,10 +306,11 @@ async function withHostExportLock<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 // Queue files into an archiver and return it immediately so the HTTP response
-// can start flushing. Level 1: level 9 pegged 0.5 vCPU hosts on large exports.
+// can start flushing. zlibLevel is per-call: full export uses 1, templates stay at 9.
 function createWorkspaceZipStream(
   addFiles: (archive: ReturnType<typeof archiver>) => Promise<void>,
-  signal?: AbortSignal,
+  signal: AbortSignal | undefined,
+  zlibLevel: number,
 ): Readable {
   let released = false
   const release = () => {
@@ -317,13 +319,19 @@ function createWorkspaceZipStream(
     endHostExport()
   }
 
-  const archive = archiver('zip', { zlib: { level: 1 } })
+  const archive = archiver('zip', { zlib: { level: zlibLevel } })
   archive.once('close', release)
   archive.once('error', release)
 
+  const stopArchive = (err?: Error) => {
+    if (archive.destroyed) return
+    archive.abort()
+    archive.destroy(err)
+  }
+
   const onAbort = () => {
     release()
-    if (!archive.destroyed) archive.destroy()
+    stopArchive()
   }
   signal?.addEventListener('abort', onAbort, { once: true })
 
@@ -337,9 +345,7 @@ function createWorkspaceZipStream(
       if (signal?.aborted || archive.destroyed) return
       await archive.finalize()
     } catch (err) {
-      if (!archive.destroyed) {
-        archive.destroy(err instanceof Error ? err : new Error(String(err)))
-      }
+      stopArchive(err instanceof Error ? err : new Error(String(err)))
       release()
     } finally {
       signal?.removeEventListener('abort', onAbort)
@@ -369,7 +375,7 @@ export async function exportAgentTemplate(agentSlug: string, signal?: AbortSigna
         if (signal?.aborted) return
         archive.file(path.join(workspaceDir, relativePath), { name: relativePath })
       }
-    }, signal)
+    }, signal, 9) // shareable .agent — size over host CPU
   })
 }
 
@@ -385,7 +391,7 @@ export async function exportAgentFull(agentSlug: string, signal?: AbortSignal): 
       await walkFullExportFiles(workspaceDir, (relativePath) => {
         archive.file(path.join(workspaceDir, relativePath), { name: relativePath })
       }, signal)
-    }, signal)
+    }, signal, 1) // large workspaces — level 9 pegs 0.5 vCPU hosts
   })
 }
 

--- a/src/shared/lib/services/export-status-schema.ts
+++ b/src/shared/lib/services/export-status-schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const hostExportStatusSchema = z.object({
+  inProgress: z.boolean(),
+})
+
+export type HostExportStatus = z.infer<typeof hostExportStatusSchema>


### PR DESCRIPTION
## Why

A large **Export full** took the host down. The zip was built entirely in RAM, so a big workspace OOM-killed a 1 GB host and returned 503. Export is also slow enough that someone can close Settings and click again, which used to start a second zip.

## What

1. **Stream the export on the host.** The zip is written out as it is built instead of held in host RAM. The host starts sending bytes as files are added. In the desktop app the renderer still buffers via `downloadBlob` (`await res.blob()`) before the save dialog — the OOM we hit was on the cloud host, where the browser is on someone else's machine. Streaming also drops `Content-Length`, so browsers and `curl -O` lose download progress.
2. **One export at a time, host-wide.** Template and full export share one lock. A second request gets 409 until the first zip finishes. Skill export is unchanged. This is deliberate: a 1 GB host cannot run two large zips. In multi-user auth mode that means one person's export blocks everyone else's.
3. **Status check so the spinner survives closing Settings.** Both export buttons stay disabled and spinning while the host is still zipping, so it is obvious an export is still happening.

(2) and (3) exist so a slow large-agent export cannot be stacked by a retry.

zlib: full export uses level 1 (level 9 pegs 0.5 vCPU hosts on large workspaces). Template export stays at 9 — the shareable `.agent` is small and size matters more.

Lock lifetime: the lock is released when the zip stream closes. If anything throws between starting the export and returning the `Response`, the stream is destroyed so the lock cannot leak. Cancel uses `archive.abort()` then `destroy()` so pending stat/append queues stop.

## Staging

Tested on staging with a workspace in the same size range as the agent that OOM'd (~500 MB / ~700 files). Host stayed healthy; RAM rose about 100–130 MB over idle during the zip, then returned to baseline. No OOM.

## Test plan

- [x] `npx vitest run src/shared/lib/services/agent-template-service.test.ts src/api/routes/agents.test.ts src/renderer/hooks/use-agent-templates.export-status.test.ts`
- [x] Staging export of a ~500 MB / ~700-file agent — host stayed healthy, memory did not climb with zip size
- [ ] Export template still downloads a valid `.agent` zip
- [x] Cancel the download mid-flight — host walk stops (covered by the real-socket hangup test)
- [ ] Start a second export while the first is still downloading — 409 "An export is already in progress"
- [ ] Close and reopen Settings during an export — both export buttons stay disabled and spinning