### PR TITLE
Install a template without asking for a name

### DIFF
--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -17,7 +17,7 @@ let mockSignupHandoff: SignupHandoff | null = null
 let mockWarmStartEnabled = false
 let mockDiscoverableAgents: ApiDiscoverableAgent[] | undefined = []
 let mockDiscoverableAgentsFailed = false
-let lastDialogProps: { template: unknown; handoffOrigin?: boolean } | null = null
+let lastDialogProps: { template: unknown } | null = null
 let latestTranscriptUpdate: ((text: string) => void) | null = null
 let lastComposerAutoFocus: boolean | undefined
 let mockAgentModel = 'opus'
@@ -144,7 +144,7 @@ vi.mock('@renderer/hooks/use-voice-input', () => ({
 }))
 
 vi.mock('@renderer/components/agents/template-install-dialog', () => ({
-  TemplateInstallDialog: (props: { template: unknown; handoffOrigin?: boolean }) => {
+  TemplateInstallDialog: (props: { template: unknown }) => {
     lastDialogProps = props
     return props.template ? <div data-testid="template-install-dialog" /> : null
   },
@@ -354,7 +354,7 @@ describe('CreateAgentForm signup handoff', () => {
     expect(mockStartAgent).not.toHaveBeenCalled()
   })
 
-  it('opens install dialog with matched public template and handoffOrigin', async () => {
+  it('opens install dialog with the matched public template', async () => {
     mockDiscoverableAgents = [discoverable('research-bot')]
     mockSignupHandoff = { template_slug: 'research-bot' }
     renderForm()
@@ -362,7 +362,6 @@ describe('CreateAgentForm signup handoff', () => {
     await waitFor(() => {
       expect(screen.getByTestId('template-install-dialog')).toBeTruthy()
     })
-    expect(lastDialogProps?.handoffOrigin).toBe(true)
     expect(lastDialogProps?.template).toEqual(discoverable('research-bot'))
   })
 
@@ -604,7 +603,7 @@ describe('CreateAgentForm signup handoff', () => {
     await waitFor(() => {
       expect(screen.getByTestId('template-install-dialog')).toBeTruthy()
     })
-    expect(lastDialogProps?.handoffOrigin).toBe(true)
+    expect(lastDialogProps?.template).toEqual(discoverable('model-bot'))
   })
 
   it('opening a creation aid forfeits before a late match can open the dialog', async () => {

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -434,7 +434,6 @@ export function CreateAgentForm({ onAgentCreated, className, exiting = false }: 
 
       <TemplateInstallDialog
         template={templateToInstall}
-        handoffOrigin
         onClose={() => setTemplateToInstall(null)}
         onInstalled={(agent) => finishCreatedAgent(agent, 'skillset')}
       />

--- a/src/renderer/components/agents/template-install-dialog.test.tsx
+++ b/src/renderer/components/agents/template-install-dialog.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mutateAsync = vi.fn()
@@ -27,37 +26,53 @@ const template: ApiDiscoverableAgent = {
   path: 'agents/research-bot/',
 }
 
-describe('TemplateInstallDialog handoffOrigin', () => {
+describe('TemplateInstallDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('suppresses autoFocus when handoffOrigin is true', () => {
-    render(
-      <TemplateInstallDialog
-        template={template}
-        handoffOrigin
-        onClose={() => {}}
-        onInstalled={() => {}}
-      />,
+  it('installs on open under the template name, with nothing to confirm', async () => {
+    mutateAsync.mockResolvedValue({ slug: 'research-bot', displaySlug: 'research-bot' })
+
+    render(<TemplateInstallDialog template={template} onClose={() => {}} onInstalled={() => {}} />)
+
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({
+        skillsetId: 'skillset-1',
+        agentPath: 'agents/research-bot/',
+        agentName: 'Research Bot',
+        agentVersion: '1.0.0',
+      }),
     )
-    const input = screen.getByPlaceholderText('Agent name')
-    expect(input).not.toHaveAttribute('autofocus')
+    // The naming step is gone: no field, and no button to press to begin.
+    expect(screen.queryByPlaceholderText('Agent name')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Install' })).toBeNull()
   })
 
-  it('autoFocuses the name field when handoffOrigin is omitted', () => {
-    render(
+  it('shows progress while the install is in flight', () => {
+    mutateAsync.mockReturnValue(new Promise(() => {})) // never settles
+
+    render(<TemplateInstallDialog template={template} onClose={() => {}} onInstalled={() => {}} />)
+
+    expect(screen.getByTestId('template-install-status').textContent).toContain('Installing')
+  })
+
+  it('fires the install exactly once even if the parent re-renders', async () => {
+    mutateAsync.mockResolvedValue({ slug: 'research-bot', displaySlug: 'research-bot' })
+
+    const { rerender } = render(
       <TemplateInstallDialog template={template} onClose={() => {}} onInstalled={() => {}} />,
     )
-    const input = screen.getByPlaceholderText('Agent name')
-    expect(input).toHaveFocus()
+    rerender(<TemplateInstallDialog template={template} onClose={() => {}} onInstalled={() => {}} />)
+    rerender(<TemplateInstallDialog template={template} onClose={() => {}} onInstalled={() => {}} />)
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1))
   })
 
-  // No handoffOrigin: the close-before-install ordering is shared by EVERY caller,
-  // including AgentTemplateBrowseDialog, whose onInstalled awaits a refetch and an
+  // The close-before-install ordering is shared by EVERY caller, including
+  // AgentTemplateBrowseDialog, whose onInstalled awaits a refetch and an
   // onboarding session. Asserting it on the bare props keeps that caller covered.
-  it('closes the install dialog before onInstalled so setup UI is not stacked', async () => {
-    const user = userEvent.setup()
+  it('closes before onInstalled so setup UI is not stacked', async () => {
     const order: string[] = []
     mutateAsync.mockResolvedValue({
       slug: 'research-bot',
@@ -68,21 +83,17 @@ describe('TemplateInstallDialog handoffOrigin', () => {
     render(
       <TemplateInstallDialog
         template={template}
-        onClose={() => {
-          order.push('close')
-        }}
+        onClose={() => order.push('close')}
         onInstalled={async () => {
           order.push('onInstalled')
         }}
       />,
     )
 
-    await user.click(screen.getByRole('button', { name: 'Install' }))
     await waitFor(() => expect(order).toEqual(['close', 'onInstalled']))
   })
 
   it('passes the template prompt through to the navigation handoff', async () => {
-    const user = userEvent.setup()
     const onInstalled = vi.fn()
     mutateAsync.mockResolvedValue({
       slug: 'research-bot',
@@ -91,19 +102,31 @@ describe('TemplateInstallDialog handoffOrigin', () => {
     })
 
     render(
-      <TemplateInstallDialog
-        template={template}
-        onClose={() => {}}
-        onInstalled={onInstalled}
-      />,
+      <TemplateInstallDialog template={template} onClose={() => {}} onInstalled={onInstalled} />,
     )
 
-    await user.click(screen.getByRole('button', { name: 'Install' }))
-    await waitFor(() => expect(onInstalled).toHaveBeenCalledWith(
-      expect.objectContaining({
-        slug: 'research-bot',
-        templatePrompt: 'Investigate this company',
-      }),
-    ))
+    await waitFor(
+      () =>
+        expect(onInstalled).toHaveBeenCalledWith(
+          expect.objectContaining({
+            slug: 'research-bot',
+            templatePrompt: 'Investigate this company',
+          }),
+        ),
+      { timeout: 3000 },
+    )
+  })
+
+  it('surfaces a failure instead of closing on it', async () => {
+    const onInstalled = vi.fn()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mutateAsync.mockRejectedValue(new Error('Skillset unreachable'))
+
+    render(
+      <TemplateInstallDialog template={template} onClose={() => {}} onInstalled={onInstalled} />,
+    )
+
+    await waitFor(() => expect(screen.getByText('Skillset unreachable')).toBeTruthy())
+    expect(onInstalled).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/agents/template-install-dialog.tsx
+++ b/src/renderer/components/agents/template-install-dialog.tsx
@@ -1,104 +1,110 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@renderer/components/ui/dialog'
 import { Button } from '@renderer/components/ui/button'
-import { Input } from '@renderer/components/ui/input'
 import { useInstallAgentFromSkillset } from '@renderer/hooks/use-agent-templates'
 import type { ApiAgentTemplateInstallResult, ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+type Phase = 'installing' | 'error'
 
 interface TemplateInstallDialogProps {
   template: ApiDiscoverableAgent | null
   onClose: () => void
   /** Called after the agent is fully installed. */
   onInstalled: (agent: ApiAgentTemplateInstallResult) => void | Promise<void>
-  /** Signup handoff: softer name-field focus (no autofocus steal). */
-  handoffOrigin?: boolean
 }
 
 /**
- * Lightweight template-install dialog. Pure UI: it only fires `onInstalled`
- * on success — callers decide what to do with the new agent (select it,
- * track, kick off onboarding, etc).
+ * Install progress for a marketplace template. There is nothing to fill in —
+ * the agent takes the template's own name — so opening this dialog starts the
+ * install immediately and hands off the moment it lands. The spinner shows
+ * only for as long as the request actually takes; it is not paced.
  */
-export function TemplateInstallDialog({ template, onClose, onInstalled, handoffOrigin }: TemplateInstallDialogProps) {
-  const [name, setName] = useState('')
+export function TemplateInstallDialog({ template, onClose, onInstalled }: TemplateInstallDialogProps) {
+  const [phase, setPhase] = useState<Phase>('installing')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const install = useInstallAgentFromSkillset()
 
-  useEffect(() => {
-    if (template) setName(template.name)
-    else {
-      setName('')
-      install.reset()
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- install.reset is stable enough; reinit on template change
-  }, [template])
+  // One install per opening. A re-render must not fire a second one, and the
+  // ref (not state) is what makes that true even under StrictMode double-invoke.
+  const startedFor = useRef<string | null>(null)
 
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault()
-      if (!template || !name.trim()) return
+  const run = useCallback(
+    async (target: ApiDiscoverableAgent) => {
+      setPhase('installing')
+      setErrorMessage(null)
       try {
         const agent = await install.mutateAsync({
-          skillsetId: template.skillsetId,
-          agentPath: template.path,
-          agentName: name.trim(),
-          agentVersion: template.version,
+          skillsetId: target.skillsetId,
+          agentPath: target.path,
+          agentName: target.name,
+          agentVersion: target.version,
         })
-
         // Close before onInstalled — that path may open the onboarding
         // "Setting up your agent..." dialog; stacking both looks broken.
         onClose()
         await onInstalled(agent)
       } catch (error) {
         console.error('Failed to install agent from skillset:', error)
+        setErrorMessage(error instanceof Error ? error.message : 'Something went wrong.')
+        setPhase('error')
       }
     },
-    [template, name, install, onInstalled, onClose],
+    [install, onClose, onInstalled],
   )
 
+  useEffect(() => {
+    if (!template) {
+      startedFor.current = null
+      return
+    }
+    const id = `${template.skillsetId}/${template.path}`
+    if (startedFor.current === id) return
+    startedFor.current = id
+    void run(template)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the template; `run` changes identity every render
+  }, [template])
+
   return (
-    <Dialog open={!!template} onOpenChange={(open) => { if (!open) onClose() }}>
-      <DialogContent className="max-w-lg">
+    <Dialog
+      open={!!template}
+      onOpenChange={(open) => {
+        // No dismissing mid-install: the request is already in flight, and a
+        // half-installed agent behind a closed dialog is worse than waiting.
+        if (!open && phase !== 'installing') onClose()
+      }}
+    >
+      <DialogContent className="max-w-sm" hideClose={phase === 'installing'}>
         <DialogHeader>
-          <DialogTitle>Install {template?.name}</DialogTitle>
+          <DialogTitle>
+            {phase === 'error' ? `Couldn't install ${template?.name}` : `Installing ${template?.name}`}
+          </DialogTitle>
           <DialogDescription>
-            {template?.description || `From ${template?.skillsetName}`}
+            {phase === 'error' ? errorMessage : `From ${template?.skillsetName}`}
           </DialogDescription>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4 pt-2">
-          <Input
-            placeholder="Agent name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            autoFocus={!handoffOrigin}
-            disabled={install.isPending}
-          />
-          {install.error && (
-            <p className="text-sm text-destructive">{install.error.message}</p>
-          )}
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={onClose} disabled={install.isPending}>
-              Cancel
+
+        {phase === 'error' ? (
+          <div className="flex justify-end pt-2">
+            <Button type="button" variant="outline" onClick={onClose}>
+              Close
             </Button>
-            <Button type="submit" disabled={!name.trim() || install.isPending}>
-              {install.isPending ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Installing...
-                </>
-              ) : (
-                'Install'
-              )}
-            </Button>
-          </DialogFooter>
-        </form>
+          </div>
+        ) : (
+          <div
+            className="flex items-center gap-2.5 pt-2 text-sm text-muted-foreground"
+            data-testid="template-install-status"
+          >
+            <Loader2 className="size-4 animate-spin" aria-hidden />
+            Installing…
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/components/explore/category-view.tsx
+++ b/src/renderer/components/explore/category-view.tsx
@@ -51,7 +51,7 @@ export function CategoryView({ category }: { category: string }) {
         {isLoading ? (
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-[180px] rounded-3xl" />
+              <Skeleton key={i} className="h-[180px] rounded-2xl" />
             ))}
           </div>
         ) : !hasSkillsets ? (

--- a/src/renderer/components/explore/explore-template-card.tsx
+++ b/src/renderer/components/explore/explore-template-card.tsx
@@ -106,7 +106,7 @@ export function ExploreTemplateCard({
       // longer curve spends its tail finishing a sub-pixel move that already
       // looks arrived — which reads as lag. Matches the renderer's dominant
       // duration and the see-more tile beside it.
-      className="flex h-[180px] w-full flex-col items-start gap-5 rounded-3xl border border-black/[0.06] bg-card p-4 text-left shadow-none transition-[box-shadow,transform] duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/[0.06] dark:hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)]"
+      className="flex h-[180px] w-full flex-col items-start gap-5 rounded-2xl border border-black/[0.06] bg-card p-4 text-left shadow-none transition-[box-shadow,transform] duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/[0.06] dark:hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)]"
     >
       <span className="flex w-full items-center gap-2">
         {/* The glyph is debossed — it drops a 1px light highlight beneath its

--- a/src/renderer/components/explore/explore-view.tsx
+++ b/src/renderer/components/explore/explore-view.tsx
@@ -435,7 +435,7 @@ function SeeMoreCard({ rest, onClick }: { rest: ApiDiscoverableAgent[]; onClick:
       type="button"
       data-testid="explore-see-more"
       onClick={onClick}
-      className="group flex h-[180px] w-full flex-col gap-3 rounded-3xl bg-muted/50 p-4 text-left transition-colors duration-200 hover:bg-muted"
+      className="group flex h-[180px] w-full flex-col gap-3 rounded-2xl bg-muted/50 p-4 text-left transition-colors duration-200 hover:bg-muted"
     >
       <span className="flex min-w-0 flex-1 flex-col justify-center gap-2">
         {rest.slice(0, SEE_MORE_NAMED_COUNT).map((template) => {


### PR DESCRIPTION
Follow-up to #802.

## The naming step asked a question that was already answered

Installing a marketplace template opened a dialog with a text field prefilled with the template's own name and a button to confirm it. Nobody renames at that moment — they've just picked "SEO Agent" off a marketplace page titled *SEO Agent*. The step existed because the install API needs a name, not because anyone needed to supply one.

Opening the dialog now starts the install immediately under the template's name and only reports progress.

## What that changed around it

- **No dismissing mid-install.** The request is already away; a half-installed agent behind a closed dialog is worse than waiting the moment it takes. The close button is suppressed while in flight.
- **Failures stop and say so**, with a Close button, instead of dropping the user somewhere unexplained.
- **The install fires exactly once per opening**, latched in a ref rather than state so a parent re-render — or StrictMode's double-invoke — can't start a second one. There's a test for this specifically, because the failure mode is two agents from one click and it wouldn't surface in normal use.
- **`handoffOrigin` is gone.** It existed only to suppress autofocus on the name input, so with the field removed it described nothing. The two handoff-test assertions that checked it were verifying a prop rather than behavior; they now assert the dialog opens on the matched template.

I first built this with a paced "Installing… → Installed" sequence on a 900ms floor, then removed it — the spinner now shows for exactly as long as the request takes. A simulated delay is a real delay for the user.

## Also

Marketplace cards drop from `rounded-3xl` to `rounded-2xl` to match the composer — applied to the card, the "show more" tile, and the loading skeletons so nothing is left rounder than the rest.

## Testing

Typecheck, lint, and the agents + explore suites pass. The dialog's own tests were rewritten around the new flow: installs on open under the template name, shows progress while in flight, fires once across re-renders, closes before `onInstalled` so onboarding UI isn't stacked, forwards the template prompt, and surfaces a failure instead of closing on it.