### PR TITLE
Gate tool search on the provider, not a global flag

### DIFF
--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -224,8 +224,11 @@ ENV AGENT_BROWSER_ARGS="--no-sandbox,--disable-dev-shm-usage,--disable-blink-fea
 ENV AGENT_BROWSER_USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 ENV AGENT_BROWSER_PROFILE=/workspace/.browser-profile
 ENV DISABLE_AUTOUPDATER=1
-# Default to on; the host overrides at `docker run` from LLM settings.
-ENV ENABLE_TOOL_SEARCH=true
+# ENABLE_TOOL_SEARCH is deliberately NOT set here. The host passes it at
+# `docker run` only for providers whose endpoint expands deferred tools; for
+# the rest it must stay unset so the CLI applies its own guard (it disables
+# tool search for base URLs that aren't first-party Anthropic hosts). An image
+# default would make "unset" impossible to express.
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/src/renderer/components/settings/llm-tab.tsx
+++ b/src/renderer/components/settings/llm-tab.tsx
@@ -313,7 +313,7 @@ export function LlmTab() {
           <SettingRow
             name="Tool search"
             htmlFor="enable-tool-search"
-            subtitle="Load tool definitions on demand to save ~15-20K tokens per turn. Disable only when debugging. Requires Sonnet/Opus 4+; ignored on Haiku."
+            subtitle="Load tool definitions on demand to save ~15-20K tokens per turn. Disable only when debugging. Requires Sonnet/Opus 4+; ignored on Haiku, and on OpenRouter or a custom endpoint, which can't expand deferred tools."
             right={
               <Switch
                 id="enable-tool-search"

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -292,7 +292,11 @@ export interface AppSettings {
   platformNotifications?: PlatformNotificationsSettings
   /** APNs relay push delivery for the native iOS companion app. */
   push?: PushSettings
-  /** Anthropic SDK tool search — defaults on; passed as `ENABLE_TOOL_SEARCH` to the container. */
+  /**
+   * Master switch for CLI tool search. Only ever switches it OFF: whether it
+   * may be on is the active provider's call, because the endpoint has to
+   * expand deferred tools (see BaseLlmProvider.toolSearchEnv).
+   */
   enableToolSearch?: boolean
   /** Launch policies for subagents (Task/Agent) and workflows (Workflow tool). */
   agentCapabilities?: AgentCapabilitySettings

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -10,8 +10,9 @@ vi.mock('@shared/lib/config/settings', () => ({
   getSettings: () => ({ enableToolSearch: enableToolSearch() }),
 }))
 const getContainerEnvVars = vi.fn(() => ({ ANTHROPIC_API_KEY: 'provider-key' }))
+const toolSearchEnv = vi.fn((): 'true' | undefined => 'true')
 vi.mock('@shared/lib/llm-provider', () => ({
-  getActiveLlmProvider: () => ({ getContainerEnvVars }),
+  getActiveLlmProvider: () => ({ getContainerEnvVars, toolSearchEnv: toolSearchEnv() }),
 }))
 
 /** Minimal concrete subclass to exercise protected run-error classification. */
@@ -32,7 +33,10 @@ class TestContainerClient extends BaseContainerClient {
 }
 
 describe('buildAgentEnv', () => {
-  afterEach(() => enableToolSearch.mockReturnValue(true))
+  afterEach(() => {
+    enableToolSearch.mockReturnValue(true)
+    toolSearchEnv.mockReturnValue('true')
+  })
 
   it('merges provider env, constants, config.envVars and per-start extra (later wins)', () => {
     const client = new TestContainerClient({
@@ -49,6 +53,21 @@ describe('buildAgentEnv', () => {
 
   it('sets ENABLE_TOOL_SEARCH=false only when the setting is explicitly false', () => {
     enableToolSearch.mockReturnValue(false)
+    const env = new TestContainerClient({ agentId: 'a', envVars: {} }).testBuildAgentEnv()
+    expect(env.ENABLE_TOOL_SEARCH).toBe('false')
+  })
+
+  it('leaves ENABLE_TOOL_SEARCH unset when the provider does not declare one', () => {
+    toolSearchEnv.mockReturnValue(undefined)
+    const env = new TestContainerClient({ agentId: 'a', envVars: {} }).testBuildAgentEnv()
+    expect('ENABLE_TOOL_SEARCH' in env).toBe(false)
+  })
+
+  // The setting is a master switch, not a way to force tool search onto an
+  // endpoint that rejects deferred tools.
+  it('keeps ENABLE_TOOL_SEARCH=false over the provider value when the setting is off', () => {
+    enableToolSearch.mockReturnValue(false)
+    toolSearchEnv.mockReturnValue(undefined)
     const env = new TestContainerClient({ agentId: 'a', envVars: {} }).testBuildAgentEnv()
     expect(env.ENABLE_TOOL_SEARCH).toBe('false')
   })

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1624,10 +1624,15 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   // Merge order: provider defaults < runtime constants < config.envVars < extra.
   protected buildAgentEnv(extra?: Record<string, string>): Record<string, string> {
     const settings = getSettings()
+    const provider = getActiveLlmProvider()
     const merged: Record<string, string | undefined> = {
-      ...getActiveLlmProvider().getContainerEnvVars(this.agentIdentityForEnv()),
+      ...provider.getContainerEnvVars(this.agentIdentityForEnv()),
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
-      ENABLE_TOOL_SEARCH: settings.enableToolSearch !== false ? 'true' : 'false',
+      // The setting only switches tool search OFF; whether it may be on is the
+      // provider's call, because it depends on the endpoint expanding deferred
+      // tools (see BaseLlmProvider.toolSearchEnv). Undefined leaves the var
+      // unset — the image must not define it either, or unset would read as on.
+      ENABLE_TOOL_SEARCH: settings.enableToolSearch === false ? 'false' : provider.toolSearchEnv,
       ...this.config.envVars,
       ...extra,
     }

--- a/src/shared/lib/container/lima-container-client.ts
+++ b/src/shared/lib/container/lima-container-client.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { BaseContainerClient, checkCommandAvailable, execWithPath, writeEnvFile } from './base-container-client'
 import { getSettings } from '@shared/lib/config/settings'
-import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import { DEFAULT_LIMA_VM_MEMORY } from './types'
 import type { ContainerConfig } from './types'
 import os from 'os'
@@ -414,18 +413,12 @@ export class LimaContainerClient extends BaseContainerClient {
    * (macOS temp dir) is not accessible inside the VM.
    */
   protected buildEnvFile(additionalEnvVars?: Record<string, string>): { flag: string; cleanup: () => void } {
-    const envVars: Record<string, string | undefined> = {
-      ...getActiveLlmProvider().getContainerEnvVars(this.agentIdentityForEnv()),
-      CLAUDE_CONFIG_DIR: '/workspace/.claude',
-      ...this.config.envVars,
-      ...additionalEnvVars,
-    }
     const home = process.env.HOME
     if (!home) {
       throw new Error('HOME environment variable is not set — cannot write container env file')
     }
     const tmpDir = path.join(home, '.superagent', 'tmp')
-    return writeEnvFile(envVars, this.config.agentId, tmpDir)
+    return writeEnvFile(this.buildAgentEnv(additionalEnvVars), this.config.agentId, tmpDir)
   }
 
   /**

--- a/src/shared/lib/container/wsl2-container-client.test.ts
+++ b/src/shared/lib/container/wsl2-container-client.test.ts
@@ -43,6 +43,13 @@ vi.mock('./base-container-client', () => ({
     config: any
     constructor(config: any) { this.config = config }
     protected agentIdentityForEnv() { return { id: this.config.agentId } }
+    // Stands in for the real merge, which these tests don't exercise: they
+    // cover where the env file lands and how its path is translated. What the
+    // merge itself produces (provider env, ENABLE_TOOL_SEARCH, precedence) is
+    // covered in base-container-client.test.ts.
+    protected buildAgentEnv(extra?: Record<string, string>) {
+      return { CLAUDE_CONFIG_DIR: '/workspace/.claude', ...this.config.envVars, ...extra }
+    }
   },
   checkCommandAvailable: vi.fn(),
   execWithPath: vi.fn(),
@@ -638,7 +645,6 @@ describe('WSL2ContainerClient.buildEnvFile', () => {
     const [envVars, agentId] = mockedWriteEnvFile.mock.calls[0]
     expect(agentId).toBe('my-agent')
     expect(envVars).toMatchObject({
-      ANTHROPIC_API_KEY: 'test-key',
       CLAUDE_CONFIG_DIR: '/workspace/.claude',
       FOO: 'bar',
       EXTRA: 'val',

--- a/src/shared/lib/container/wsl2-container-client.ts
+++ b/src/shared/lib/container/wsl2-container-client.ts
@@ -4,7 +4,6 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import { BaseContainerClient, checkCommandAvailable, execWithPath, writeEnvFile } from './base-container-client'
-import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import type { ContainerConfig, HostPortProbeResult } from './types'
 import { getDataDir } from '@shared/lib/config/data-dir'
 import { captureException, captureMessage, addErrorBreadcrumb } from '@shared/lib/error-reporting'
@@ -447,16 +446,9 @@ export class WSL2ContainerClient extends BaseContainerClient {
    * translate the path for WSL2.
    */
   protected buildEnvFile(additionalEnvVars?: Record<string, string>): { flag: string; cleanup: () => void } {
-    const envVars: Record<string, string | undefined> = {
-      ...getActiveLlmProvider().getContainerEnvVars(this.agentIdentityForEnv()),
-      CLAUDE_CONFIG_DIR: '/workspace/.claude',
-      ...this.config.envVars,
-      ...additionalEnvVars,
-    }
-
     const home = os.homedir()
     const tmpDir = path.join(home, '.superagent', 'tmp')
-    const { filePath, cleanup } = writeEnvFile(envVars, this.config.agentId, tmpDir)
+    const { filePath, cleanup } = writeEnvFile(this.buildAgentEnv(additionalEnvVars), this.config.agentId, tmpDir)
 
     // Translate the Windows file path to a WSL2 path for the --env-file flag
     const wslPath = windowsToWSLPath(filePath)

--- a/src/shared/lib/llm-provider/anthropic-provider.test.ts
+++ b/src/shared/lib/llm-provider/anthropic-provider.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@anthropic-ai/sdk', () => ({ default: class {} }))
+
+import { AnthropicLlmProvider } from './anthropic-provider'
+
+describe('AnthropicLlmProvider — tool search', () => {
+  // Deferred tool loading is expanded by Anthropic's own API, so this is the
+  // one endpoint that needs no compatibility work.
+  it('turns ENABLE_TOOL_SEARCH on', () => {
+    expect(new AnthropicLlmProvider().toolSearchEnv).toBe('true')
+  })
+})

--- a/src/shared/lib/llm-provider/anthropic-provider.ts
+++ b/src/shared/lib/llm-provider/anthropic-provider.ts
@@ -9,6 +9,8 @@ export class AnthropicLlmProvider extends BaseLlmProvider {
   readonly name = 'Anthropic'
   readonly defaultModelOptions = CLAUDE_DEFAULT_MODEL_OPTIONS
   readonly catalogDefaultModels = ANTHROPIC_CATALOG_DEFAULT_MODELS
+  // Anthropic's own API is where deferred tool loading is expanded server-side.
+  override readonly toolSearchEnv = 'true' as const
   protected readonly settingsKeyField = 'anthropicApiKey' as const
   protected readonly envVarName = 'ANTHROPIC_API_KEY'
 

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -51,6 +51,22 @@ export abstract class BaseLlmProvider {
   /** Whether this provider can discover remote catalog models by search query. */
   readonly supportsModelSearch: boolean = false
 
+  /**
+   * Value of `ENABLE_TOOL_SEARCH` for containers on this provider, or
+   * undefined to leave the variable unset so the CLI decides for itself.
+   *
+   * Tool search omits tool definitions from the request and loads them back on
+   * demand, which the endpoint has to expand: the CLI re-sends a loaded tool
+   * with `defer_loading: true`, and since agent SDK 0.3.219 it also sends a
+   * `DeferredToolPlaceholder` tool carrying that flag on EVERY request.
+   * Endpoints that don't understand the flag reject the whole request
+   * (OpenRouter 400s it for every non-Anthropic model), so only providers whose
+   * endpoint handles it turn this on. Left unset, the CLI disables tool search
+   * for any base URL that isn't a first-party Anthropic host — the right
+   * default for endpoints we can't vouch for.
+   */
+  readonly toolSearchEnv: 'true' | undefined = undefined
+
   /** Check whether an API key is configured and its source. */
   getApiKeyStatus(): ApiKeyStatus {
     const settings = getSettings()

--- a/src/shared/lib/llm-provider/bedrock-provider.test.ts
+++ b/src/shared/lib/llm-provider/bedrock-provider.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@anthropic-ai/sdk', () => ({ default: class {} }))
+vi.mock('../config/settings', () => ({ getSettings: () => ({}) }))
+
+import { BedrockLlmProvider } from './bedrock-provider'
+
+describe('BedrockLlmProvider — tool search', () => {
+  // Bedrock serves Claude models, and the CLI's non-first-party guard never
+  // fires in Bedrock mode — so unset would mean on anyway. Declared for intent.
+  it('turns ENABLE_TOOL_SEARCH on', () => {
+    expect(new BedrockLlmProvider().toolSearchEnv).toBe('true')
+  })
+})

--- a/src/shared/lib/llm-provider/bedrock-provider.ts
+++ b/src/shared/lib/llm-provider/bedrock-provider.ts
@@ -12,6 +12,9 @@ export class BedrockLlmProvider extends BaseLlmProvider {
   readonly defaultModelOptions = CLAUDE_DEFAULT_MODEL_OPTIONS
   readonly catalogDefaultModels = BEDROCK_CATALOG_DEFAULT_MODELS
   // Used for simple Bedrock API Key auth (AWS_BEARER_TOKEN_BEDROCK)
+  // Bedrock serves Claude models, and the CLI's own guard (which only fires
+  // for custom first-party base URLs) never applies in Bedrock mode.
+  override readonly toolSearchEnv = 'true' as const
   protected readonly settingsKeyField = 'bedrockApiKey' as const
   protected readonly envVarName = 'AWS_BEARER_TOKEN_BEDROCK'
 

--- a/src/shared/lib/llm-provider/generic-provider.test.ts
+++ b/src/shared/lib/llm-provider/generic-provider.test.ts
@@ -46,6 +46,11 @@ afterEach(() => {
 })
 
 describe('GenericLlmProvider — catalog and capabilities', () => {
+  // The endpoint is whatever the user pointed us at, so the CLI decides.
+  it('declares no ENABLE_TOOL_SEARCH value', () => {
+    expect(new GenericLlmProvider().toolSearchEnv).toBeUndefined()
+  })
+
   it('ships an empty built-in catalog and opts into model search', () => {
     expect(provider.getBuiltinCatalog()).toEqual([])
     expect(provider.supportsModelSearch).toBe(true)

--- a/src/shared/lib/llm-provider/generic-provider.ts
+++ b/src/shared/lib/llm-provider/generic-provider.ts
@@ -87,6 +87,8 @@ export class GenericLlmProvider extends BaseLlmProvider {
   readonly defaultModelOptions = []
   readonly catalogDefaultModels = GENERIC_CATALOG_DEFAULT_MODELS
   override readonly supportsModelSearch = true
+  // Left unset (see BaseLlmProvider.toolSearchEnv): the endpoint is whatever
+  // the user pointed us at, so the CLI's own guard decides.
   protected readonly settingsKeyField = 'genericApiKey' as const
   protected readonly envVarName = 'GENERIC_API_KEY'
 

--- a/src/shared/lib/llm-provider/openrouter-provider.test.ts
+++ b/src/shared/lib/llm-provider/openrouter-provider.test.ts
@@ -228,6 +228,12 @@ describe('OpenRouterLlmProvider.searchModels — error paths', () => {
 })
 
 describe('OpenRouterLlmProvider — capabilities and defaults', () => {
+  // OpenRouter 400s deferred custom tools for every non-Anthropic model, so
+  // the var stays unset and the CLI's own guard turns tool search off.
+  it('declares no ENABLE_TOOL_SEARCH value', () => {
+    expect(provider.toolSearchEnv).toBeUndefined()
+  })
+
   it('opts into model search and exposes bare-alias purpose defaults', () => {
     expect(provider.supportsModelSearch).toBe(true)
     expect(provider.getDefaultModel('summarizer')).toBe('haiku')

--- a/src/shared/lib/llm-provider/openrouter-provider.ts
+++ b/src/shared/lib/llm-provider/openrouter-provider.ts
@@ -136,6 +136,11 @@ export class OpenRouterLlmProvider extends BaseLlmProvider {
   readonly defaultModelOptions = CLAUDE_DEFAULT_MODEL_OPTIONS
   readonly catalogDefaultModels = OPENROUTER_CATALOG_DEFAULT_MODELS
   override readonly supportsModelSearch = true
+  // Left unset (see BaseLlmProvider.toolSearchEnv): OpenRouter rejects
+  // deferred custom tools for every non-Anthropic model, so the CLI's own
+  // non-first-party guard is exactly the behaviour we want. This also gives
+  // up tool search for `anthropic/*` models routed here, where it does work —
+  // the endpoint, not the model, is what this provider can vouch for.
   protected readonly settingsKeyField = 'openrouterApiKey' as const
   protected readonly envVarName = 'OPENROUTER_API_KEY'
 

--- a/src/shared/lib/llm-provider/platform-provider.test.ts
+++ b/src/shared/lib/llm-provider/platform-provider.test.ts
@@ -25,6 +25,13 @@ beforeEach(() => {
   currentAttribution.mockReturnValue(null)
 })
 
+describe('PlatformLlmProvider — tool search', () => {
+  // The proxy expands the CLI's deferred tools for every model it serves.
+  it('turns ENABLE_TOOL_SEARCH on', () => {
+    expect(new PlatformLlmProvider().toolSearchEnv).toBe('true')
+  })
+})
+
 describe('getContainerEnvVars agent identity', () => {
   it('injects agent id and name env vars when identity is provided', () => {
     const env = provider.getContainerEnvVars({ id: 'abc123', name: 'My Agent' })

--- a/src/shared/lib/llm-provider/platform-provider.ts
+++ b/src/shared/lib/llm-provider/platform-provider.ts
@@ -26,6 +26,11 @@ export class PlatformLlmProvider extends BaseLlmProvider {
   readonly catalogDefaultModels = PLATFORM_CATALOG_DEFAULT_MODELS
   // Not used — getApiKeyStatus/getEffectiveApiKey are both overridden to
   // read the platform token instead of a settings-stored API key.
+  // The platform proxy handles deferred tool loading for the non-Anthropic
+  // models it serves: it expands the CLI's `tool_reference` blocks on the
+  // Anthropic-wire upstreams, and the Responses codec rebuilds every tool
+  // (dropping `defer_loading`) for the xAI/OpenAI ones.
+  override readonly toolSearchEnv = 'true' as const
   protected readonly settingsKeyField = 'anthropicApiKey' as const
   protected readonly envVarName = 'PLATFORM_TOKEN'
 


### PR DESCRIPTION
## The bug

A user switching to OpenRouter to run Grok hits this on the first turn:

> API Error: 400 Deferred custom tools are only supported on Anthropic models. Non-Anthropic models cannot call tools omitted from tools[]. Received x-ai/grok-4.6-20260810.

We were setting `ENABLE_TOOL_SEARCH=true` for every provider, with no idea whether the endpoint on the other side can expand deferred tools. Tool search is server-side: the CLI omits tool definitions and re-sends a loaded tool with `defer_loading: true`, which the API is expected to expand. OpenRouter only does that for Anthropic models.

Worse, the CLI already protects against this — left unset it disables tool search for any base URL that isn't a first-party Anthropic host, and says so in its own debug output. Setting `true` explicitly is precisely what skips that check.

## Why it surfaced in July, not May

The flag was flipped on in May (`59e57b9a`), but sessions kept working — Iddo's transcripts show `gpt-5.5` (Jun 18), `kimi` (Jun 23), `glm` (Jun 26), `grok-4.5` (Jul 10) all fine. Running both pinned CLIs against a logging proxy in front of OpenRouter shows why:

| CLI | model | `ENABLE_TOOL_SEARCH` | tools on wire | deferred | result |
|---|---|---|---|---|---|
| 0.3.206 (pinned until Jul 24) | grok-4.6 | true | 9 | — | ok |
| 0.3.219 (pinned since #580) | grok-4.6 | true | 10 | `DeferredToolPlaceholder` | **400** |
| 0.3.219 | grok-4.6 | unset | 24 | — | ok |
| 0.3.219 | claude-opus-4.5 | true | 10 | `DeferredToolPlaceholder` | ok |

`f24b2f96` (#580) bumped 0.3.206 → 0.3.219, and the newer CLI injects a decoy tool on every request — *"Reserved placeholder that keeps deferred tool loading active; never call this tool"* — a prompt-cache stability hack. That one tool carries `defer_loading`, so the failure moved from "the first time the model calls ToolSearch" to "turn 1". Still present in latest (0.3.236), and it can't be removed via `disallowedTools`.

To be clear about what is lost: nothing that worked. On 0.3.206 the same session died as soon as the model actually searched (`req1 deferred=['WebFetch']` → 400) — it just usually never got there. Meanwhile the loaded tool round trip completes normally on `anthropic/claude-opus-4.5` through OpenRouter.

## The change

`BaseLlmProvider.toolSearchEnv: 'true' | undefined` — default `undefined`, with the reasoning documented on the property.

| provider | value | why |
|---|---|---|
| Anthropic | `'true'` | expands deferred tools natively |
| Platform | `'true'` | the proxy expands `tool_reference` on its Anthropic-wire upstreams, and the Responses codec rebuilds every tool (dropping `defer_loading`) for the xAI/OpenAI ones |
| Bedrock | `'true'` | Claude models; the CLI's guard never fires in Bedrock mode, so this only records intent |
| OpenRouter | unset | 400s deferred custom tools for every non-Anthropic model |
| Generic | unset | endpoint is whatever the user pointed us at |

`buildAgentEnv` now resolves `settings.enableToolSearch === false ? 'false' : provider.toolSearchEnv`. The setting stays a master switch that can only turn tool search **off**; it can't force it onto an endpoint that rejects it.

Two things that had to come along:

- **`ENV ENABLE_TOOL_SEARCH=true` removed from the Dockerfile.** With an image default, "unset" isn't expressible. Needs an image rebuild to take effect — existing images still carry the old ENV.
- **Lima and WSL2 now call `buildAgentEnv`.** Both overrode `buildEnvFile` only to relocate the env file but re-merged the env by hand, so they never passed `ENABLE_TOOL_SEARCH` at all — the toggle in settings did nothing there and the value came from the image default. Without this they'd have silently lost tool search once the image ENV went away.

## Verification

- `tsc --noEmit` clean; `eslint 'src/**/*.{ts,tsx}'` 0 errors
- 1475 tests pass across container / llm-provider / settings / llm-tab; new coverage for all five providers, the unset case, and master-switch-wins
- Real CLI 0.3.219 through a logging proxy confirms the shipped env shapes (unset + grok → 24 tools, no deferral, 200; `true` + claude → deferral, 200)

## Known tradeoff

`anthropic/*` models routed through OpenRouter lose tool search (24 → 10 tools of savings) even though it works there. That's provider-level granularity by choice; the comment in `openrouter-provider.ts` records it so it isn't rediscovered as a bug. Model-aware gating is a follow-up if we want those savings back.

## Not in this PR

- Fireworks (GLM/Kimi) forwards `defer_loading` verbatim and our code documents it as the strict upstream ("Fireworks 400s on the unknown block type" where Meta silently drops). Untested against a `defer_loading` tool — worth one live call, since a strict answer means those models are failing today the same way.
- Platform proxy: `expandToolReferences` isn't wired into the Responses codec, so Grok/GPT read a raw `{"type":"tool_reference","tool_name":"…"}` instead of a rendered schema. Measured harmless (10/10 trials on grok-4.6 and gpt-5.5 call the loaded tool anyway), so it's a robustness/test gap, not a bug.
- Upstream: the CLI already strips this placeholder for Foundry deployments; extending that to non-first-party base URLs would fix turn-1 failures for every OpenRouter user.

https://claude.ai/code/session_01GnkTm9p1VZtDcozny7XnCR
