### PR TITLE
Fix /compact draft restoration race

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -919,6 +919,7 @@ describe('MessageList', () => {
     try {
       mockMessagesData.data = []
       mockStreamState.isActive = true
+      mockStreamState.isCompacting = true
 
       const CompactRaceHarness = () => {
         const [pending, setPending] = useState([
@@ -948,10 +949,12 @@ describe('MessageList', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Type next message' }))
       expect(screen.getByTestId('draft-probe')).toHaveTextContent('the next message')
 
-      // Manual compaction persists a boundary, not a user message carrying the
-      // POST uuid. The compact command must still be considered delivered.
-      mockMessagesData.data = [createCompactBoundary({ createdAt: new Date() })]
+      // The completion event can reach the renderer before the refetched compact
+      // boundary. The accepted command has no persisted user-message counterpart,
+      // so the generic idle rescue must not mistake it for lost user text while
+      // the boundary is still absent.
       mockStreamState.isActive = false
+      mockStreamState.isCompacting = false
       rerender(<CompactRaceHarness />)
 
       await act(async () => {
@@ -960,6 +963,7 @@ describe('MessageList', () => {
 
       expect(screen.getByTestId('draft-probe')).toHaveTextContent('the next message')
       expect(screen.getByTestId('draft-probe')).not.toHaveTextContent('/compact')
+      expect(screen.queryByText('/compact')).not.toBeInTheDocument()
     } finally {
       vi.useRealTimers()
     }

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -74,6 +74,7 @@ const TURN_ANCHOR_TOP = 100
 const SCROLL_GESTURE_WINDOW_MS = 400
 const TURN_WORK_REVEAL_CLASS = 'animate-in fade-in-0 slide-in-from-top-2 duration-200 ease-out motion-reduce:animate-none'
 const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
+const isManualCompactCommand = (text: string) => /^\/compact(?:\s|$)/.test(text.trim())
 
 const prefersReducedMotion = () =>
   window.matchMedia('(prefers-reduced-motion: reduce)').matches
@@ -311,7 +312,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         match = findTextMatch(pending.text, pending.sentAt - 5000)
         if (match) claimed.add(match.id)
       }
-      if (!match && /^\/compact(?:\s|$)/.test(pending.text.trim())) {
+      if (!match && isManualCompactCommand(pending.text)) {
         match = messages.find(
           (m) =>
             m.type === 'compact_boundary' &&
@@ -389,13 +390,23 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // materializes above), so restoring it here would yank back a message that
   // is actually mid-delivery — it then lands in the transcript AND sits in
   // the composer, baiting a duplicate resend. Leave those pending.
+  //
+  // Manual /compact is also not restorable user text. It persists as a compact
+  // boundary rather than a user message, and compact_complete can beat the
+  // boundary refetch by more than this grace period. Consume its ghost at idle
+  // without prepending the command over a draft typed during compaction.
   useEffect(() => {
     if (isActive || ((pendingUserMessages?.length ?? 0) === 0 && peerUserMessages.length === 0)) return
     const undelivered = (pendingUserMessages ?? []).filter((p) => p.queued || p.uuid)
     const timerId = setTimeout(() => {
       if (undelivered.length > 0) {
-        const restored = undelivered.map((p) => p.text.trim()).filter(Boolean)
-        appendToSessionDraft(draftsStore, sessionId, restored.join('\n\n'), { prepend: true })
+        const restored = undelivered
+          .filter((p) => !isManualCompactCommand(p.text))
+          .map((p) => p.text.trim())
+          .filter(Boolean)
+        if (restored.length > 0) {
+          appendToSessionDraft(draftsStore, sessionId, restored.join('\n\n'), { prepend: true })
+        }
         for (const pending of undelivered) onPendingMessageAppeared?.(pending.localId)
       }
       clearPeerUserMessages(sessionId)


### PR DESCRIPTION
## Summary

- prevent the `/compact` control command from being restored into a draft by idle-message recovery
- consume its optimistic ghost when the compact-boundary refetch lags completion
- cover the completion-before-boundary race in the existing regression test

## Testing

- `npm run test:run -- src/renderer/components/messages/message-list.test.tsx` (115 tests)
- `./node_modules/.bin/eslint src/renderer/components/messages/message-list.tsx src/renderer/components/messages/message-list.test.tsx`
- `npm run typecheck`
