### PR TITLE
Give the Browse Templates tests something to fail on

### DIFF
--- a/e2e/specs/getting-started-wizard.spec.ts
+++ b/e2e/specs/getting-started-wizard.spec.ts
@@ -237,9 +237,16 @@ test.describe('Getting Started Wizard', () => {
     await expect(page.locator('[data-testid="template-detail-view"]')).toBeVisible()
     await page.locator('[data-testid="template-detail-install"]').click()
 
-    await expect(page.locator('[data-testid="app-sidebar"]')).toBeVisible()
+    // Both assertions have to be things the details page itself cannot satisfy.
+    // A bare `app-sidebar` check is not one: /explore renders inside the same
+    // shell, so it is already visible. Neither is an unscoped name match — the
+    // details page heading IS the template name. The install opens the new
+    // agent, so the URL leaves /explore and the name appears in the sidebar.
+    await expect(page).toHaveURL(/\/agents\//)
     await expect(
-      page.getByText('E2E Onboarding Template', { exact: true }).first(),
+      page
+        .locator('[data-testid="app-sidebar"]')
+        .getByText('E2E Onboarding Template', { exact: true }),
     ).toBeVisible()
 
     const response = await request.get('/api/user-settings')

--- a/src/renderer/components/agents/agent-creation-aids.on-aid-opened.test.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.on-aid-opened.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -66,5 +66,58 @@ describe('AgentCreationAids onAidOpened', () => {
 
     await user.click(screen.getByRole('button', { name: /Import an Agent/i }))
     expect(mockOnAidOpened).toHaveBeenCalledTimes(3)
+  })
+})
+
+/**
+ * Browse Templates leaves for `/explore`, and the wizard hosts this component
+ * in a full-screen overlay mounted ABOVE the router. Navigating first would
+ * park the user on a page the overlay covers, so the hook has to finish before
+ * the navigation — an ordering neither the component's own render nor the
+ * wizard e2e can observe, since both orders reach the same end state.
+ */
+describe('AgentCreationAids onNavigateAway', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function renderAids(onNavigateAway?: () => Promise<void>) {
+    render(
+      <AgentCreationAids
+        onVoiceResult={mockOnVoiceResult}
+        onImportComplete={mockOnImportComplete}
+        onNavigateAway={onNavigateAway}
+      />,
+    )
+  }
+
+  it('waits for the hook to settle before navigating', async () => {
+    const user = userEvent.setup()
+    let finishNavigateAway = () => {}
+    const onNavigateAway = vi.fn(
+      () => new Promise<void>((resolve) => { finishNavigateAway = resolve }),
+    )
+    renderAids(onNavigateAway)
+
+    await user.click(screen.getByRole('button', { name: /Browse Templates/i }))
+    expect(onNavigateAway).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalled()
+
+    await act(async () => { finishNavigateAway() })
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/explore' })
+  })
+
+  it('still navigates when the hook rejects', async () => {
+    const user = userEvent.setup()
+    // The wizard's hook is a settings PUT whose mutation sets
+    // `skipGlobalErrorToast`, so a rejection here is silent — swallowing the
+    // navigation with it would leave the card looking dead.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    renderAids(vi.fn(() => Promise.reject(new Error('settings write failed'))))
+
+    await user.click(screen.getByRole('button', { name: /Browse Templates/i }))
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/explore' })
+    consoleError.mockRestore()
   })
 })

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -18,6 +18,7 @@ import { apiFetch } from '@renderer/lib/api'
 import { useImportAgentTemplate, useDiscoverableAgents, type ImportProgress } from '@renderer/hooks/use-agent-templates'
 import { AGENT_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
 import { useIsVoiceAgentConfigured } from '@renderer/hooks/use-voice-input'
+import { captureRendererException } from '@renderer/lib/error-reporting'
 import type { VoiceAgentConfig } from '@renderer/lib/voice-agent'
 import type { ApiAgentTemplateInstallResult } from '@shared/lib/types/api'
 
@@ -60,7 +61,18 @@ export function AgentCreationAids({
 
   const browseTemplates = useCallback(async () => {
     onAidOpened?.()
-    await onNavigateAway?.()
+    // The hook can reject — the wizard's is a settings PUT, and that mutation
+    // carries `skipGlobalErrorToast`, so a failure is otherwise silent. Leave
+    // for the marketplace either way: a click that does nothing at all is the
+    // worse outcome, and the host staying open is its own visible signal.
+    try {
+      await onNavigateAway?.()
+    } catch (error) {
+      console.error('[create-agent] navigate-away hook failed:', error)
+      captureRendererException(error, {
+        tags: { area: 'create-agent', op: 'browse-templates' },
+      })
+    }
     void navigate({ to: '/explore' })
   }, [onAidOpened, onNavigateAway, navigate])
 

--- a/src/renderer/components/agents/template-install-dialog.test.tsx
+++ b/src/renderer/components/agents/template-install-dialog.test.tsx
@@ -69,9 +69,9 @@ describe('TemplateInstallDialog', () => {
     await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1))
   })
 
-  // The close-before-install ordering is shared by EVERY caller, including
-  // AgentTemplateBrowseDialog, whose onInstalled awaits a refetch and an
-  // onboarding session. Asserting it on the bare props keeps that caller covered.
+  // The close-before-install ordering is shared by EVERY caller, including the
+  // Explore details page, whose onInstalled awaits a refetch and an onboarding
+  // session. Asserting it on the bare props keeps those callers covered.
   it('closes before onInstalled so setup UI is not stacked', async () => {
     const order: string[] = []
     mutateAsync.mockResolvedValue({

--- a/src/renderer/hooks/use-complete-template-install.ts
+++ b/src/renderer/hooks/use-complete-template-install.ts
@@ -10,8 +10,8 @@ import type { ApiAgentTemplateInstallResult } from '@shared/lib/types/api'
 /**
  * The one post-install path for a marketplace template: track, refresh the
  * agent list, then hand off (seed the template prompt or start onboarding)
- * and open the new agent. ONE definition shared by the browse dialog and the
- * Explore pages so the flows can't drift.
+ * and open the new agent. ONE definition shared by every Explore surface so
+ * the flows can't drift.
  */
 export function useCompleteTemplateInstall() {
   const navigate = useNavigate()


### PR DESCRIPTION
Follow-up to #807, which merged before this landed.

## The e2e asserted things the details page already satisfied

After clicking Install, the wizard spec checked that `app-sidebar` was visible and that the text `E2E Onboarding Template` appeared. Both are true *before* the install: `/explore/*` renders inside the same `AppShellLayout` that owns the sidebar, and the details page uses the template's name as its own `<h2>`.

Proven by dropping the install click and running the spec — it stayed green. It now asserts the URL left `/explore` and that the name reached the sidebar, which only a successful install produces. With the install click removed, that fails:

```
Expected pattern: /\/agents\//
Received string:  ".../explore/e2e-public-skillset/e2e-onboarding-template"
```

The version before #807 asserted a `Date.now()` name and did have this coverage; the rewrite lost it.

## The await-then-navigate ordering had no coverage at all

`AgentCreationAids` awaits `onNavigateAway` before leaving for `/explore` so the wizard — mounted above the router — closes first. Reversing those two lines kept the unit test *and* the wizard e2e green, since both orders reach the same end state.

A deferred `onNavigateAway` now pins it. Reversed, it fails: `expected "vi.fn()" to not be called at all, but actually been called 1 times`.

## A failed settings write ate the navigation

The wizard's hook is a settings PUT whose mutation carries `skipGlobalErrorToast`, and the call site was `void browseTemplates()` with no catch — so a failed write meant a dead card, no toast, and an unhandled rejection. It now reports the failure and navigates anyway. Second new test covers it.

Also refreshes two comments that still named the deleted `AgentTemplateBrowseDialog`.

## Testing

Typecheck and lint clean. Wizard e2e 11/11 locally (`E2E_PORT=3177 npm run test:e2e:wizard`). Both new assertions verified by mutation, as above.

https://claude.ai/code/session_01NLyzeCQ26bmyJ8bABi3rda