### PR TITLE
Restore Discover scroll position after viewing a template

### DIFF
--- a/e2e/specs/explore-scroll-restoration.spec.ts
+++ b/e2e/specs/explore-scroll-restoration.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+
+const templates = Array.from({ length: 18 }, (_, index) => {
+  const number = index + 1
+  return {
+    skillsetId: 'e2e-public-skillset',
+    skillsetName: 'E2E Public Skillset',
+    name: `E2E Template ${number}`,
+    description: `Template ${number} used to exercise marketplace scrolling`,
+    version: '1.0.0',
+    path: `agents/e2e-template-${number}/`,
+    category: `Category ${String(number).padStart(2, '0')}`,
+  }
+})
+
+test('template back arrow restores the Discover page scroll position', async ({ page }) => {
+  await page.route('**/api/agents/discoverable-agents*', async (route) => {
+    await route.fulfill({ json: { agents: templates } })
+  })
+
+  await page.goto('/explore')
+  await expect(page.getByTestId('explore-template-card')).toHaveCount(templates.length)
+
+  const scrollContainer = page.locator('[data-scroll-restoration-id="explore-marketplace"]')
+  const targetCard = page.getByRole('button', { name: 'E2E Template 14 — details' })
+  await targetCard.scrollIntoViewIfNeeded()
+
+  const savedScrollTop = await scrollContainer.evaluate((element) => element.scrollTop)
+  expect(savedScrollTop).toBeGreaterThan(500)
+
+  await targetCard.click()
+  await expect(page).toHaveURL(/\/explore\/e2e-public-skillset\/e2e-template-14$/)
+  await expect(page.getByTestId('template-detail-view')).toBeVisible()
+
+  await page
+    .getByTestId('main-content')
+    .getByRole('button', { name: 'Discover New Agents' })
+    .click()
+
+  await expect(page).toHaveURL(/\/explore$/)
+  await expect(page.getByTestId('explore-view')).toBeVisible()
+  await expect
+    .poll(async () => {
+      const restoredScrollTop = await page
+        .locator('[data-scroll-restoration-id="explore-marketplace"]')
+        .evaluate((element) => element.scrollTop)
+      return Math.abs(restoredScrollTop - savedScrollTop)
+    })
+    .toBeLessThan(2)
+})

--- a/src/renderer/components/explore/explore-scroll-restoration.ts
+++ b/src/renderer/components/explore/explore-scroll-restoration.ts
@@ -1,0 +1,53 @@
+const STORAGE_PREFIX = 'gamut:explore-scroll:'
+
+const fallbackPositions = new Map<string, number>()
+
+declare module '@tanstack/history' {
+  interface HistoryState {
+    /** History entry for the marketplace page that opened this sub-view. */
+    exploreReturnKey?: string
+  }
+}
+
+function storage(): Storage | undefined {
+  try {
+    return sessionStorage
+  } catch {
+    return undefined
+  }
+}
+
+/** Save the nested marketplace scroller for one concrete browser-history entry. */
+export function rememberExploreScrollPosition(entryKey: string, scrollTop: number): void {
+  if (!Number.isFinite(scrollTop) || scrollTop < 0) return
+
+  const session = storage()
+  if (session) {
+    try {
+      session.setItem(`${STORAGE_PREFIX}${entryKey}`, String(scrollTop))
+      return
+    } catch {
+      // Fall through to the in-memory cache for restricted storage contexts.
+    }
+  }
+
+  fallbackPositions.set(entryKey, scrollTop)
+}
+
+/** Read a previously saved position, including after a detail-page reload. */
+export function getRememberedExploreScrollPosition(entryKey: string): number | undefined {
+  const session = storage()
+  if (session) {
+    try {
+      const stored = session.getItem(`${STORAGE_PREFIX}${entryKey}`)
+      if (stored !== null) {
+        const scrollTop = Number(stored)
+        if (Number.isFinite(scrollTop) && scrollTop >= 0) return scrollTop
+      }
+    } catch {
+      // Fall through to the in-memory cache for restricted storage contexts.
+    }
+  }
+
+  return fallbackPositions.get(entryKey)
+}

--- a/src/renderer/components/explore/explore-view.test.tsx
+++ b/src/renderer/components/explore/explore-view.test.tsx
@@ -5,7 +5,12 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const navigate = vi.fn()
-vi.mock('@tanstack/react-router', () => ({ useNavigate: () => navigate }))
+let historyEntryKey = 'explore-entry'
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigate,
+  useLocation: ({ select }: { select: (location: object) => unknown }) =>
+    select({ state: { __TSR_key: historyEntryKey }, href: '/explore' }),
+}))
 
 const openSettings = vi.fn()
 vi.mock('@renderer/context/dialog-context', () => ({ useDialogs: () => ({ openSettings }) }))
@@ -42,9 +47,39 @@ function roster(n: number, over: Partial<ApiDiscoverableAgent> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  sessionStorage.clear()
+  historyEntryKey = 'explore-entry'
   skillsets = [{ id: 'skillset-1', name: 'Public' }]
   discoverable = roster(9)
   isLoading = false
+})
+
+function getScrollContainer(): HTMLDivElement {
+  const container = screen
+    .getByTestId('explore-view')
+    .closest('[data-scroll-restoration-id="explore-marketplace"]')
+  if (!(container instanceof HTMLDivElement)) {
+    throw new Error('Explore scroll container not found')
+  }
+  return container
+}
+
+describe('ExploreView scroll restoration', () => {
+  it('restores its nested scroll position after opening a template', async () => {
+    const firstRender = render(<ExploreView />)
+    getScrollContainer().scrollTop = 640
+
+    await userEvent.click(screen.getAllByTestId('explore-template-card')[0]!)
+    expect(navigate).toHaveBeenCalledWith({
+      to: '/explore/$skillsetId/$templateSlug',
+      params: { skillsetId: 'skillset-1', templateSlug: 'agent-1' },
+      state: { exploreReturnKey: historyEntryKey },
+    })
+
+    firstRender.unmount()
+    render(<ExploreView />)
+    expect(getScrollContainer().scrollTop).toBe(640)
+  })
 })
 
 /**

--- a/src/renderer/components/explore/explore-view.tsx
+++ b/src/renderer/components/explore/explore-view.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
-import { useNavigate } from '@tanstack/react-router'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useLocation, useNavigate } from '@tanstack/react-router'
 import { ArrowRight, Check, Filter, Plus, Search, Settings2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
@@ -10,6 +10,10 @@ import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/se
 import { slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { ExploreTemplateCard } from './explore-template-card'
 import { NoTemplatesEmptyState, useExploreTemplates } from './explore-templates'
+import {
+  getRememberedExploreScrollPosition,
+  rememberExploreScrollPosition,
+} from './explore-scroll-restoration'
 import {
   connectionLabel,
   FEATURED_SECTION_LABEL,
@@ -39,7 +43,12 @@ const OTHER_CATEGORY = 'Other'
  */
 export function ExploreView() {
   const navigate = useNavigate()
+  const historyEntryKey = useLocation({
+    select: (location) => location.state.__TSR_key ?? location.href,
+  })
   const { templates, hasSkillsets, isLoading } = useExploreTemplates()
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const restoredEntryRef = useRef<string | null>(null)
 
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
@@ -52,6 +61,19 @@ export function ExploreView() {
     const id = setTimeout(() => setDebouncedSearch(search), 150)
     return () => clearTimeout(id)
   }, [search])
+
+  // This page scrolls a nested container, not `window`, so the browser cannot
+  // restore it when the route remounts. Restore only after the cached roster is
+  // back in the DOM, before paint, and only once for this history entry.
+  useLayoutEffect(() => {
+    if (isLoading || restoredEntryRef.current === historyEntryKey) return
+
+    const scrollTop = getRememberedExploreScrollPosition(historyEntryKey)
+    if (scrollTop !== undefined && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = scrollTop
+    }
+    restoredEntryRef.current = historyEntryKey
+  }, [historyEntryKey, isLoading])
 
   // The categories this roster actually declares, with counts — most populated
   // first so the long tail of one-off categories sorts last.
@@ -153,9 +175,11 @@ export function ExploreView() {
   }, [filtered, isBrowsing])
 
   const openTemplate = (template: ApiDiscoverableAgent) => {
+    rememberExploreScrollPosition(historyEntryKey, scrollContainerRef.current?.scrollTop ?? 0)
     void navigate({
       to: '/explore/$skillsetId/$templateSlug',
       params: { skillsetId: template.skillsetId, templateSlug: slugFromAgentPath(template.path) },
+      state: { exploreReturnKey: historyEntryKey },
     })
   }
 
@@ -163,7 +187,12 @@ export function ExploreView() {
     // `pt-12` rather than `fullScreen`'s `pt-4`: the notifications page sits a
     // back button above its heading, and this page has none — without the extra
     // lead-in the title crowds the header border.
-    <SettingsPageContainer fullScreen className="px-[88px] pb-16 pt-12">
+    <SettingsPageContainer
+      fullScreen
+      scrollContainerRef={scrollContainerRef}
+      scrollRestorationId="explore-marketplace"
+      className="px-[88px] pb-16 pt-12"
+    >
       <PageTitle
         title="Discover New Agents"
         actions={

--- a/src/renderer/components/explore/template-detail-view.test.tsx
+++ b/src/renderer/components/explore/template-detail-view.test.tsx
@@ -1,10 +1,25 @@
 // @vitest-environment jsdom
 
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const navigate = vi.fn()
-vi.mock('@tanstack/react-router', () => ({ useNavigate: () => navigate }))
+const historyBack = vi.fn()
+const canGoBack = vi.fn()
+let locationState: { __TSR_index: number; exploreReturnKey?: string } = { __TSR_index: 0 }
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigate,
+  useRouter: () => ({
+    history: {
+      location: { state: locationState },
+      canGoBack,
+      back: historyBack,
+    },
+  }),
+  useLocation: ({ select }: { select: (location: object) => unknown }) =>
+    select({ state: locationState }),
+}))
 
 const openSettings = vi.fn()
 vi.mock('@renderer/context/dialog-context', () => ({ useDialogs: () => ({ openSettings }) }))
@@ -53,9 +68,32 @@ function renderDetail(slug = 'account-expert') {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  locationState = { __TSR_index: 0 }
+  canGoBack.mockReturnValue(true)
   skillsets = [{ id: 'skillset-1' }]
   discoverable = [template]
   isLoading = false
+})
+
+describe('TemplateDetailView back navigation', () => {
+  it('returns to the originating marketplace history entry', async () => {
+    locationState = { __TSR_index: 1, exploreReturnKey: 'explore-entry' }
+    renderDetail()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Discover New Agents' }))
+
+    expect(historyBack).toHaveBeenCalledOnce()
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the marketplace route for a directly opened template', async () => {
+    renderDetail()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Discover New Agents' }))
+
+    expect(historyBack).not.toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledWith({ to: '/explore' })
+  })
 })
 
 /**

--- a/src/renderer/components/explore/template-detail-view.tsx
+++ b/src/renderer/components/explore/template-detail-view.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { useNavigate } from '@tanstack/react-router'
+import { useLocation, useNavigate, useRouter } from '@tanstack/react-router'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Skeleton } from '@renderer/components/ui/skeleton'
@@ -108,6 +108,10 @@ export function TemplateDetailView({
   templateSlug: string
 }) {
   const navigate = useNavigate()
+  const router = useRouter()
+  const exploreReturnKey = useLocation({
+    select: (location) => location.state.exploreReturnKey,
+  })
   const { templates, hasSkillsets, isLoading } = useExploreTemplates()
   const completeInstall = useCompleteTemplateInstall()
   const [templateToInstall, setTemplateToInstall] = useState<ApiDiscoverableAgent | null>(null)
@@ -120,7 +124,20 @@ export function TemplateDetailView({
     [templates, skillsetId, templateSlug],
   )
   const backToExplore = {
-    onClick: () => void navigate({ to: '/explore' }),
+    onClick: () => {
+      // A card click records the originating history entry. Return to that
+      // entry so ExploreView can restore its nested scroller; direct/deep links
+      // still have a deterministic route fallback.
+      if (
+        exploreReturnKey &&
+        router.history.location.state.__TSR_index > 0 &&
+        router.history.canGoBack()
+      ) {
+        router.history.back()
+        return
+      }
+      void navigate({ to: '/explore' })
+    },
     label: 'Discover New Agents',
   }
 

--- a/src/renderer/components/layout/settings-page.tsx
+++ b/src/renderer/components/layout/settings-page.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, Ref } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { cn } from '@shared/lib/utils/cn'
@@ -6,6 +6,8 @@ import { cn } from '@shared/lib/utils/cn'
 interface SettingsPageContainerProps {
   children: ReactNode
   className?: string
+  scrollContainerRef?: Ref<HTMLDivElement>
+  scrollRestorationId?: string
   /** Use a wider, less padded frame for content like tables. */
   fullScreen?: boolean
   /** Drop the 720px cap and fill the full inset width (sub-views lay out their own width). */
@@ -17,9 +19,20 @@ interface SettingsPageContainerProps {
  * sibling pages). Centers content at 720px, adds vertical rhythm, and scrolls
  * independently of the app shell.
  */
-export function SettingsPageContainer({ children, className, fullScreen, fullWidth }: SettingsPageContainerProps) {
+export function SettingsPageContainer({
+  children,
+  className,
+  scrollContainerRef,
+  scrollRestorationId,
+  fullScreen,
+  fullWidth,
+}: SettingsPageContainerProps) {
   return (
-    <div className="flex-1 overflow-auto">
+    <div
+      ref={scrollContainerRef}
+      data-scroll-restoration-id={scrollRestorationId}
+      className="flex-1 overflow-auto"
+    >
       <div
         className={cn(
           'mx-auto w-full px-6 pt-10 pb-6 space-y-10',


### PR DESCRIPTION
## Summary

- remember the nested Discover scroll offset before opening a template
- make the template back arrow return through the originating history entry while preserving a safe `/explore` fallback for direct links
- add unit and browser regression coverage for scroll restoration

## Test plan

- `npx vitest run src/renderer/components/explore` — 23 passed
- targeted ESLint on changed files — passed
- `E2E_MOCK=true npx playwright test e2e/specs/explore-scroll-restoration.spec.ts --project=web-chromium --workers=1` — 1 passed

## Baseline checks

- `npm run typecheck` and full `npm run lint` currently stop on the pre-existing duplicate `Readable` import in `src/api/routes/agents.test.ts` at lines 4 and 572; changed files introduce no lint errors.