### PR TITLE
Fix duplicate Readable import blocking unit tests

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -569,7 +569,6 @@ import {
   hasOnboardingSkill,
   getAgentTemplatePrompt,
 } from '@shared/lib/services/agent-template-service'
-import { Readable } from 'stream'
 import {
   deleteSkill,
   exportSkill,


### PR DESCRIPTION
## Summary

- remove the redundant `Readable` import in `agents.test.ts`
- restore the main unit-test job past TypeScript compilation so Vitest and coverage can run

## Context

PRs #804 and #805 both added a `Readable` import from the same base in different parts of the test file. They merged consecutively without a textual conflict, leaving equivalent `node:stream` and `stream` imports that declare the same binding and fail with `TS2300`.

## Test plan

- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/api/routes/agents.test.ts` — 395 passed
- `npx vitest run --coverage` — 598 files, 9,834 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SkillfulAgents/codesmith/SuperAgent/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789835789&installation_model_id=433436&pr_number=813&repository=SkillfulAgents%2FSuperAgent&return_to=https%3A%2F%2Fgithub.com%2FSkillfulAgents%2FSuperAgent%2Fpull%2F813&signature=810ce57e72bd76f7e97a78ea6a8d9d6876f9b59ff8dfbf6c318e59644b0f86ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->