### PR TITLE
Fix Electron header drag region

### DIFF
--- a/src/renderer/components/layout/agent-header.test.tsx
+++ b/src/renderer/components/layout/agent-header.test.tsx
@@ -189,6 +189,27 @@ describe('AgentHeader breadcrumbs', () => {
     expect(trail).toHaveStyle({ '--hover-scroll-distance': '180px' })
   })
 
+  it('keeps unused breadcrumb header space in the window drag region', () => {
+    const mutation = { mutate: vi.fn(), isPending: false }
+    render(
+      <AgentHeader
+        slug="test-agent"
+        isViewOnly={false}
+        startAgent={mutation as never}
+        stopAgent={mutation as never}
+      />,
+    )
+
+    const dragArea = screen.getByTestId('breadcrumb-drag-area')
+    const trail = screen.getByTestId('breadcrumb-trail')
+
+    // ContentShell marks the header as draggable. Keep its flex-filling blank
+    // area in that region and opt out only the fitted, interactive breadcrumb.
+    expect(dragArea).toHaveClass('min-w-0', 'flex-1')
+    expect(dragArea).not.toHaveClass('app-no-drag')
+    expect(trail).toHaveClass('w-fit', 'max-w-full', 'app-no-drag')
+  })
+
   it('renders the dashboard name as a breadcrumb and its actions in the shared toolbar', () => {
     mocks.routeView = { kind: 'dashboard', slug: 'nutrition' }
     const mutation = { mutate: vi.fn(), isPending: false }

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -70,10 +70,11 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
 
   return (
     <>
-      <HoverScrollText
-        className="min-w-0 flex-1 app-no-drag"
-        data-testid="breadcrumb-trail"
-      >
+      <div className="min-w-0 flex-1" data-testid="breadcrumb-drag-area">
+        <HoverScrollText
+          className="w-fit max-w-full app-no-drag"
+          data-testid="breadcrumb-trail"
+        >
         {agent ? (
           <AgentContextMenu agent={agent}>
             <AppLink
@@ -215,7 +216,8 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
             detail={view.kind === 'connections' ? view.detail ?? null : null}
           />
         )}
-      </HoverScrollText>
+        </HoverScrollText>
+      </div>
       <div className="flex items-center gap-0 md:gap-2 shrink-0 app-no-drag">
         <DashboardHeaderActions agentSlug={slug} dashboardSlug={dashboardSlug} />
         {dashboardHeader?.actions && (


### PR DESCRIPTION
## Summary

- keep the flex-filling agent header space inside Electron's draggable window region
- limit `app-no-drag` to the fitted interactive breadcrumb so links and hover scrolling still work
- add regression coverage for the unused breadcrumb header area

## Testing

- `npm run test:run -- src/renderer/components/layout/agent-header.test.tsx`
- `npx eslint src/renderer/components/layout/agent-header.tsx src/renderer/components/layout/agent-header.test.tsx`
- `npm run build:electron`
- `git diff --check`

`npm run typecheck` is currently blocked on `main` by duplicate `Readable` imports in `src/api/routes/agents.test.ts` (lines 4 and 572), unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SkillfulAgents/codesmith/SuperAgent/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789838377&installation_model_id=433436&pr_number=814&repository=SkillfulAgents%2FSuperAgent&return_to=https%3A%2F%2Fgithub.com%2FSkillfulAgents%2FSuperAgent%2Fpull%2F814&signature=0c16a4e91740f3af989f48e0a057c0cc646c030f09dc136cdb64f52da5a70197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->