### PR TITLE
Treat x-agent sessions as automated and add call history

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -194,6 +194,7 @@ app.post('/sessions/:id/messages', async (c) => {
       speed: speedLevelSchema.parse(body.speed),
       model: body.model,
       shouldQuery: body.shouldQuery,
+      isAutomated: body.isAutomated,
       capabilityPolicies: agentCapabilityPoliciesSchema.parse(body.capabilityPolicies),
     });
 

--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -538,6 +538,33 @@ describe('SessionManager idle eviction', () => {
     }
   })
 
+  it('an automated follow-up preserves the automated session class', async () => {
+    const promoManager = new SessionManager(workDir, {
+      prewarmEnabled: false,
+      idleEvictionMs: 60 * 60_000,
+      automatedIdleEvictionMs: 0,
+    })
+    try {
+      const session = await promoManager.createSession({
+        initialMessage: 'hi',
+        metadata: { isAutomated: true },
+      })
+      const proc = spawnedProcesses[spawnedProcesses.length - 1]
+      emitSettled(proc)
+
+      await promoManager.sendMessage(session.id, 'agent follow-up', undefined, { isAutomated: true })
+      emitSettled(proc)
+      await promoManager.evictIdleSessions()
+
+      expect(proc.stopCalls).toBe(1)
+      expect(
+        (persistedSessions.get(session.id)?.metadata as { isAutomated?: boolean })?.isAutomated
+      ).toBe(true)
+    } finally {
+      await promoManager.stopAll()
+    }
+  })
+
   it('eviction stops the process GRACEFULLY (transcript-flush protection)', async () => {
     // A hard abort races the CLI's transcript flush — the durability E2E
     // proved probabilistic loss of the latest turns. This pins the graceful

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -735,7 +735,7 @@ export class SessionManager extends EventEmitter {
     sessionId: string,
     content: string,
     uuid?: UUID,
-    options?: { effort?: EffortLevel; speed?: SpeedLevel; model?: string; shouldQuery?: boolean; capabilityPolicies?: AgentCapabilityPolicies }
+    options?: { effort?: EffortLevel; speed?: SpeedLevel; model?: string; shouldQuery?: boolean; isAutomated?: boolean; capabilityPolicies?: AgentCapabilityPolicies }
   ): Promise<void> {
     let sessionData = this.sessions.get(sessionId);
 
@@ -757,12 +757,11 @@ export class SessionManager extends EventEmitter {
     const expectsResponse = options?.shouldQuery !== false;
     sessionData.settlement.noteOutboundMessage({ expectsResponse });
 
-    // A real message into an automated session is human-originated (the
-    // scheduler and trigger-manager only ever CREATE sessions; cross-agent
-    // chat appends are shouldQuery:false) — promote it to the interactive
-    // eviction class so the conversation doesn't pay a cold restart after
-    // every turn.
-    if (expectsResponse && sessionData.session.metadata?.isAutomated) {
+    // A real message into an automated session is human-originated unless the
+    // host explicitly marks it as another automated turn (x-agent follow-up).
+    // Human input promotes the session to the interactive eviction class so
+    // the conversation doesn't pay a cold restart after every turn.
+    if (expectsResponse && !options?.isAutomated && sessionData.session.metadata?.isAutomated) {
       console.log(`[Session ${sessionId}] Promoting automated session to interactive (human message)`);
       sessionData.session.metadata = { ...sessionData.session.metadata, isAutomated: false };
       this.persistence.updateMetadata(sessionId, sessionData.session.metadata);

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -113,5 +113,6 @@ export interface SendMessageRequest {
   speed?: SpeedLevel; // If set and different from current session speed, triggers interrupt+restart with new speed
   model?: string; // If set and different from current session model, triggers interrupt+restart with new model
   shouldQuery?: boolean; // When false, appends to transcript without triggering an assistant turn
+  isAutomated?: boolean; // Agent-originated follow-up: preserve the session's automated runtime class
   capabilityPolicies?: AgentCapabilityPolicies; // Current launch policies; a block-boundary change triggers interrupt+restart
 }

--- a/src/api/routes/activity.test.ts
+++ b/src/api/routes/activity.test.ts
@@ -40,7 +40,13 @@ function createApp() {
 describe('activity API', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetAgentActivityStats.mockResolvedValue({ days: 14, cronByTaskId: {}, webhookByTriggerId: {}, connectionById: {} })
+    mockGetAgentActivityStats.mockResolvedValue({
+      days: 14,
+      cronByTaskId: {},
+      webhookByTriggerId: {},
+      inboundXAgent: { total: 0, lastInvokedAt: null, activity: [] },
+      connectionById: {},
+    })
     mockGetConnectionActivityStats.mockResolvedValue({ days: 14, connectionById: {} })
   })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -171,6 +171,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     isSubscribed: vi.fn(() => true),
     subscribeToSession: vi.fn(),
     unsubscribeFromSession: vi.fn(),
+    promoteAutomatedSession: vi.fn(),
     markSessionActive: vi.fn(),
     markSessionInterrupted: vi.fn(),
     cancelAwaitingInput: vi.fn(),
@@ -3667,6 +3668,31 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
     const cancelOrder = vi.mocked(messagePersister.cancelAwaitingInput).mock.invocationCallOrder[0]
     const sendOrder = mockSendMessage.mock.invocationCallOrder[0]
     expect(cancelOrder).toBeLessThan(sendOrder)
+  })
+
+  it('awaits automated-session promotion before forwarding the human message', async () => {
+    mockIsAuthMode.mockReturnValue(false)
+    let finishPromotion!: () => void
+    vi.mocked(messagePersister.promoteAutomatedSession).mockImplementationOnce(
+      () => new Promise<void>((resolve) => { finishPromotion = resolve }),
+    )
+
+    const response = postJson(app, URL, { content: 'take it from here' })
+    await vi.waitFor(() => {
+      expect(messagePersister.promoteAutomatedSession).toHaveBeenCalledWith('sess-1', 'test-agent')
+    })
+    expect(mockSendMessage).not.toHaveBeenCalled()
+
+    finishPromotion()
+    const res = await response
+    expect(res.status).toBe(201)
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'sess-1',
+      'take it from here',
+      expect.any(String),
+      {},
+    )
   })
 
   it('strips model/effort when the session is already active (mid-turn send)', async () => {

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -5409,6 +5409,43 @@ describe('typing indicator — POST /:id/sessions/:sessionId/typing', () => {
 // GET /api/agents - List with enriched summary
 // ============================================================================
 
+describe('GET /api/agents/:id/inbound-x-agent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAuthMode.mockReturnValue(false)
+    mockAgentExists.mockResolvedValue(true)
+  })
+
+  it('returns x-agent session history for the resolved target agent', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([{
+      slug: 'target',
+      displaySlug: 'target',
+      name: 'Target',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      status: 'stopped',
+      containerPort: null,
+    }])
+    vi.mocked(readSessionMetadata).mockResolvedValue({
+      'session-a': {
+        invokedByAgentSlug: 'deleted-caller',
+        createdAt: '2026-08-20T12:00:00.000Z',
+      },
+    })
+
+    const res = await getReq(createApp(), '/api/agents/target/inbound-x-agent')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      sessions: [{
+        id: 'session-a',
+        createdAt: '2026-08-20T12:00:00.000Z',
+        triggeredBy: { slug: 'deleted-caller', name: 'deleted-caller' },
+      }],
+      callers: [],
+    })
+  })
+})
+
 describe('GET /api/agents (enriched summary)', () => {
   let app: ReturnType<typeof createApp>
 
@@ -5505,16 +5542,17 @@ describe('GET /api/agents (enriched summary)', () => {
   it('ignores unread notifications on hidden automated sessions — no session list shows them', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
     vi.mocked(getSessionSummary).mockResolvedValue({
-      sessionIds: ['sess-chat', 'sess-cron'],
-      sessionCount: 2,
+      sessionIds: ['sess-chat', 'sess-cron', 'sess-x-agent'],
+      sessionCount: 3,
       lastActivityAt: new Date(),
     })
     vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(
-      new Map([['agent-1', new Set(['sess-chat', 'sess-cron'])]]),
+      new Map([['agent-1', new Set(['sess-chat', 'sess-cron', 'sess-x-agent'])]]),
     )
     vi.mocked(readSessionMetadata).mockResolvedValue({
       'sess-chat': { isChatIntegrationSession: true },
       'sess-cron': { isScheduledExecution: true },
+      'sess-x-agent': { invokedByAgentSlug: 'caller-agent' },
     })
 
     const res = await getReq(app, '/api/agents')

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -131,6 +131,7 @@ import {
 import { type ArtifactInfo, listArtifactsFromFilesystem, deleteArtifactFromFilesystem, renameArtifactOnFilesystem } from '@shared/lib/services/artifact-service'
 import { getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents, deleteNotificationsBySessionIds } from '@shared/lib/services/notification-service'
 import { isHiddenAutomatedSession } from '@shared/lib/services/session-visibility'
+import { getInboundXAgentDetails } from '@shared/lib/services/inbound-x-agent-service'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
 import { isValidApiScope } from '@shared/lib/proxy/scope-matcher'
 import { isLabelDefaultKey } from '@shared/lib/proxy/policy-sentinels'
@@ -6582,6 +6583,27 @@ agents.post('/:id/proxy-review/:reviewId/always', AgentUser(), async (c) => {
 // =============================================================================
 // X-Agent invoke policies (per-agent remembered cross-agent permissions)
 // =============================================================================
+
+// GET /api/agents/:id/inbound-x-agent - Sessions created by other agents, plus
+// every agent currently eligible to invoke this target. The target's read ACL
+// protects the page; caller rows remain visible but carry canAccess=false when
+// the viewing user cannot open that caller agent.
+agents.get('/:id/inbound-x-agent', AgentRead(), async (c) => {
+  try {
+    const authMode = isAuthMode()
+    const viewer = authMode
+      ? c.get('user' as never) as { role?: string } | undefined
+      : undefined
+    return c.json(await getInboundXAgentDetails(getAgentId(c), {
+      authMode,
+      viewerUserId: authMode ? getCurrentUserId(c) : undefined,
+      viewerCanAccessAll: viewer?.role === 'admin',
+    }))
+  } catch (error) {
+    console.error('Failed to fetch inbound x-agent activity:', error)
+    return c.json({ error: 'Failed to fetch calls from other agents' }, 500)
+  }
+})
 
 /**
  * Agents the caller may see: their agentAcl entries in auth mode, everything

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2260,6 +2260,13 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
       return c.json({ error: 'Agent not found' }, 404)
     }
 
+    // A message through this AgentUser route is human-originated. Promote any
+    // hidden automation before delivery so the host and container agree that
+    // a person has joined the session. This must precede sendMessage: a fast
+    // turn can settle immediately, and completion notification visibility is
+    // decided from the host-side promotedToInteractive marker.
+    await messagePersister.promoteAutomatedSession(sessionId, agentSlug)
+
     const client = containerManager.getClient(agentSlug)
     // Use cached status to avoid spawning docker process
     let info = containerManager.getCachedInfo(agentSlug)

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -546,16 +546,20 @@ describe('/invoke', () => {
     expect(body).toEqual({ sessionId: 'new-sess-id', status: 'running' })
     expect(mockEnsureRunning).toHaveBeenCalledWith(TARGET_SLUG)
     expect(mockCreateSession).toHaveBeenCalledWith(
-      expect.objectContaining({ initialMessage: 'hello' }),
+      expect.objectContaining({
+        initialMessage: 'hello',
+        metadata: { isAutomated: true },
+      }),
     )
     expect(mockCreateSession.mock.calls[0][0]).not.toHaveProperty('initialMessageUuid')
     expect(mockReserveSessionOwnership).toHaveBeenCalledWith(TARGET_SLUG, 'new-sess-id')
     expect(mockReserveSessionOwnership.mock.invocationCallOrder[0]).toBeLessThan(
       mockMarkSessionActive.mock.invocationCallOrder[0],
     )
-    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+    expect(mockRegisterSession).toHaveBeenCalledWith(
       TARGET_SLUG,
       'new-sess-id',
+      expect.any(String),
       expect.objectContaining({ invokedByAgentSlug: CALLER_SLUG }),
     )
   })
@@ -587,6 +591,7 @@ describe('/invoke', () => {
       TARGET_SLUG,
       'new-sess-id',
       'Invoked by Business Analyst Agent',
+      expect.objectContaining({ invokedByAgentSlug: CALLER_SLUG }),
     )
   })
 
@@ -611,6 +616,7 @@ describe('/invoke', () => {
       TARGET_SLUG,
       'new-sess-id',
       `Invoked by ${CALLER_SLUG}`,
+      expect.objectContaining({ invokedByAgentSlug: CALLER_SLUG }),
     )
   })
 
@@ -661,9 +667,10 @@ describe('/invoke', () => {
         userId: OTHER_USER_ID,
       }),
     ])
-    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+    expect(mockRegisterSession).toHaveBeenCalledWith(
       TARGET_SLUG,
       'new-sess-id',
+      expect.any(String),
       expect.objectContaining({ createdByUserId: OTHER_USER_ID }),
     )
   })
@@ -693,9 +700,10 @@ describe('/invoke', () => {
     expect(targetAuthors).toEqual([
       expect.objectContaining({ userId: OTHER_USER_ID }),
     ])
-    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+    expect(mockRegisterSession).toHaveBeenCalledWith(
       TARGET_SLUG,
       'new-sess-id',
+      expect.any(String),
       expect.objectContaining({ createdByUserId: OTHER_USER_ID }),
     )
   })
@@ -719,9 +727,10 @@ describe('/invoke', () => {
     expect(targetAuthors).toEqual([
       expect.objectContaining({ userId: OWNER_USER_ID }),
     ])
-    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+    expect(mockRegisterSession).toHaveBeenCalledWith(
       TARGET_SLUG,
       'new-sess-id',
+      expect.any(String),
       expect.objectContaining({ createdByUserId: OWNER_USER_ID }),
     )
   })
@@ -749,9 +758,10 @@ describe('/invoke', () => {
       .from(schema.messageAuthor)
       .where(eq(schema.messageAuthor.sessionId, 'new-sess-id'))
     expect(targetAuthors).toEqual([])
-    expect(mockUpdateSessionMetadata).toHaveBeenCalledWith(
+    expect(mockRegisterSession).toHaveBeenCalledWith(
       TARGET_SLUG,
       'new-sess-id',
+      expect.any(String),
       { invokedByAgentSlug: CALLER_SLUG },
     )
   })
@@ -781,6 +791,7 @@ describe('/invoke', () => {
       'existing-sess',
       'follow-up',
       expect.any(String),
+      { isAutomated: true },
     )
     const sentMessageUuid = mockSendMessage.mock.calls[0][2]
     const targetAuthors = await testDb
@@ -1363,7 +1374,12 @@ describe('/invoke', () => {
       sessionId: 'existing-sess',
     })
     expect(res.status).toBe(200)
-    expect(mockSendMessage).toHaveBeenCalledWith('existing-sess', 'follow-up')
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'existing-sess',
+      'follow-up',
+      undefined,
+      { isAutomated: true },
+    )
     expect(mockCreateSession).not.toHaveBeenCalled()
   })
 
@@ -1778,7 +1794,12 @@ describe('display-slug resolution', () => {
     await setPolicy(CALLER_SLUG, 'invoke', TARGET_ID, 'allow')
     const res = await authedFetch('/x-agent/invoke', { slug: DISPLAY_SLUG, prompt: 'hello' })
     expect(res.status).toBe(200)
-    expect(mockRegisterSession).toHaveBeenCalledWith(TARGET_ID, expect.any(String), expect.any(String))
+    expect(mockRegisterSession).toHaveBeenCalledWith(
+      TARGET_ID,
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ invokedByAgentSlug: CALLER_SLUG }),
+    )
   })
 
   it('/invoke accepts a wrong-prefix slug (the prefix is decorative)', async () => {

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -34,7 +34,6 @@ import {
   getSessionMetadata,
   registerSession,
   reserveSessionOwnership,
-  updateSessionMetadata,
   sessionIsKnown,
 } from '@shared/lib/services/session-service'
 import { containerManager } from '@shared/lib/container/container-manager'
@@ -868,9 +867,9 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         }
         try {
           if (messageUuid) {
-            await client.sendMessage(existingSessionId, prompt, messageUuid)
+            await client.sendMessage(existingSessionId, prompt, messageUuid, { isAutomated: true })
           } else {
-            await client.sendMessage(existingSessionId, prompt)
+            await client.sendMessage(existingSessionId, prompt, undefined, { isAutomated: true })
           }
         } catch (sendError) {
           if (messageUuid) await deleteMessageAuthorBestEffort(messageUuid)
@@ -957,6 +956,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         maxBudgetUsd: agentLimits.maxBudgetUsd,
         customEnvVars: Object.keys(customEnvVars).length > 0 ? customEnvVars : undefined,
         maxBrowserTabs: getSettings().app?.maxBrowserTabs,
+        metadata: { isAutomated: true },
       })
       const created = await raceDeadline(createPromise, deliveryCutoff)
       if (created === DEADLINE) {
@@ -993,7 +993,19 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
 
       stage = 'register_session'
       try {
-        await registerSession(targetSlug, newSessionId, `Invoked by ${callerName}`)
+        await registerSession(targetSlug, newSessionId, `Invoked by ${callerName}`, {
+          invokedByAgentSlug: callerSlug,
+          ...(authorRecorded && attributedUserId ? { createdByUserId: attributedUserId } : {}),
+        })
+        // markSessionActive ran before registration so runtime waiters could
+        // not miss a fast result. Publish a metadata-aware update now that the
+        // x-agent provenance exists, allowing the target's trigger/history UI
+        // to appear immediately instead of waiting for its polling interval.
+        messagePersister.broadcastGlobal({
+          type: 'session_updated',
+          sessionId: newSessionId,
+          agentSlug: targetSlug,
+        })
       } catch (registerErr) {
         const message = registerErr instanceof Error ? registerErr.message : String(registerErr)
         console.error('[x-agent] invoke failed', {
@@ -1018,20 +1030,6 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         }
         messagePersister.unsubscribeFromSession(newSessionId)
         return c.json({ error: `Failed to register invoked session: ${message}` }, 500)
-      }
-
-      try {
-        await updateSessionMetadata(targetSlug, newSessionId, {
-          invokedByAgentSlug: callerSlug,
-          ...(authorRecorded && attributedUserId ? { createdByUserId: attributedUserId } : {}),
-        })
-      } catch (metaErr) {
-        console.warn('[x-agent] updateSessionMetadata failed (session usable, provenance not recorded)', {
-          callerSlug,
-          targetSlug,
-          sessionId: newSessionId,
-          error: metaErr instanceof Error ? metaErr.message : String(metaErr),
-        })
       }
 
       stage = 'subscribe'

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -564,6 +564,9 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
               onSelectWebhook={(webhookId: string) => {
                 void navigate({ to: '/agents/$slug/webhooks/$webhookId', params: { slug: agent.slug, webhookId } })
               }}
+              onSelectInboundXAgent={() => {
+                void navigate({ to: '/agents/$slug/called-from-agents', params: { slug: agent.slug } })
+              }}
             />
             <HomeConnections className="intro-step intro-step-5" agentSlug={agent.slug} />
             <HomeSkills className="intro-step intro-step-6" agentSlug={agent.slug} onRunSkill={(skillPath) => {

--- a/src/renderer/components/agents/agent-home/home-connections.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.test.tsx
@@ -82,6 +82,7 @@ describe('HomeConnections — row navigation', () => {
           generatedAt: '2026-07-09T12:00:00.000Z',
           cronByTaskId: {},
           webhookByTriggerId: {},
+          inboundXAgent: { total: 0, lastInvokedAt: null, activity: [] },
           connectionById: {
             'account-acc-1': [
               { date: '2026-07-08', succeeded: 2, failed: 1 },
@@ -163,6 +164,7 @@ describe('HomeConnections — row navigation', () => {
           generatedAt: '2026-07-19T12:00:00.000Z',
           cronByTaskId: {},
           webhookByTriggerId: {},
+          inboundXAgent: { total: 0, lastInvokedAt: null, activity: [] },
           connectionById: {},
         }))
       }

--- a/src/renderer/components/agents/agent-home/home-triggers.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-triggers.test.tsx
@@ -82,6 +82,14 @@ describe('HomeTriggers activity charts', () => {
             { date: '2026-07-09', succeeded: 1, failed: 0 },
           ],
         },
+        inboundXAgent: {
+          total: 2,
+          lastInvokedAt: '2026-07-09T11:30:00.000Z',
+          activity: [
+            { date: '2026-07-08', succeeded: 1, failed: 0 },
+            { date: '2026-07-09', succeeded: 1, failed: 0 },
+          ],
+        },
         connectionById: {},
       },
     })
@@ -93,6 +101,7 @@ describe('HomeTriggers activity charts', () => {
       scheduledTasks={[task]}
       onSelectTask={vi.fn()}
       onSelectWebhook={vi.fn()}
+      onSelectInboundXAgent={vi.fn()}
     />)
 
     expect(mockUseAgentActivityStats).toHaveBeenCalledWith('agent-a')
@@ -101,6 +110,10 @@ describe('HomeTriggers activity charts', () => {
     })).toBeInTheDocument()
     expect(screen.getByRole('img', {
       name: 'Inbound webhook activity: 4 calls over 2 days, 3 succeeded and 1 failed.',
+    })).toBeInTheDocument()
+    expect(screen.getByText('Called from Other Agents')).toBeInTheDocument()
+    expect(screen.getByRole('img', {
+      name: 'Calls from other agents: 2 calls over 2 days, 2 succeeded and 0 failed.',
     })).toBeInTheDocument()
   })
 
@@ -111,6 +124,7 @@ describe('HomeTriggers activity charts', () => {
       scheduledTasks={[task]}
       onSelectTask={vi.fn()}
       onSelectWebhook={vi.fn()}
+      onSelectInboundXAgent={vi.fn()}
     />)
 
     expect(screen.getAllByTestId('activity-chart-skeleton')).toHaveLength(2)
@@ -124,6 +138,7 @@ describe('HomeTriggers activity charts', () => {
       scheduledTasks={[task]}
       onSelectTask={vi.fn()}
       onSelectWebhook={vi.fn()}
+      onSelectInboundXAgent={vi.fn()}
     />)
 
     expect(screen.getByText('Hourly report')).toBeInTheDocument()

--- a/src/renderer/components/agents/agent-home/home-triggers.tsx
+++ b/src/renderer/components/agents/agent-home/home-triggers.tsx
@@ -47,18 +47,24 @@ interface HomeTriggersProps {
   scheduledTasks: ApiScheduledTask[]
   onSelectTask: (taskId: string) => void
   onSelectWebhook: (webhookId: string) => void
+  onSelectInboundXAgent: () => void
   className?: string
 }
 
-type TriggerItem =
+type DeletableTriggerItem =
   | { kind: 'cron'; createdAtMs: number; task: ApiScheduledTask }
   | { kind: 'webhook'; createdAtMs: number; trigger: WebhookTrigger }
+
+type TriggerItem =
+  | DeletableTriggerItem
+  | { kind: 'inbound-x-agent'; createdAtMs: number }
 
 export function HomeTriggers({
   agentSlug,
   scheduledTasks,
   onSelectTask,
   onSelectWebhook,
+  onSelectInboundXAgent,
   className,
 }: HomeTriggersProps) {
   const { data: webhookTriggersData } = useWebhookTriggers(agentSlug, 'active')
@@ -78,16 +84,25 @@ export function HomeTriggers({
       createdAtMs: new Date(trigger.createdAt).getTime(),
       trigger,
     }))
-    return [...cronItems, ...webhookItems].sort((a, b) => b.createdAtMs - a.createdAtMs)
-  }, [scheduledTasks, webhookTriggersData])
+    const inboundItems: TriggerItem[] = activityStats?.inboundXAgent.total
+      ? [{
+          kind: 'inbound-x-agent',
+          createdAtMs: activityStats.inboundXAgent.lastInvokedAt
+            ? new Date(activityStats.inboundXAgent.lastInvokedAt).getTime()
+            : 0,
+        }]
+      : []
+    return [...cronItems, ...webhookItems, ...inboundItems]
+      .sort((a, b) => b.createdAtMs - a.createdAtMs)
+  }, [scheduledTasks, webhookTriggersData, activityStats?.inboundXAgent])
 
-  const deletedItems = useMemo<TriggerItem[]>(() => {
-    const cronItems: TriggerItem[] = (Array.isArray(cancelledTasksData) ? cancelledTasksData : []).map((task) => ({
+  const deletedItems = useMemo<DeletableTriggerItem[]>(() => {
+    const cronItems: DeletableTriggerItem[] = (Array.isArray(cancelledTasksData) ? cancelledTasksData : []).map((task) => ({
       kind: 'cron',
       createdAtMs: new Date(task.createdAt).getTime(),
       task,
     }))
-    const webhookItems: TriggerItem[] = (Array.isArray(cancelledWebhooksData) ? cancelledWebhooksData : []).map((trigger) => ({
+    const webhookItems: DeletableTriggerItem[] = (Array.isArray(cancelledWebhooksData) ? cancelledWebhooksData : []).map((trigger) => ({
       kind: 'webhook',
       createdAtMs: new Date(trigger.createdAt).getTime(),
       trigger,
@@ -111,7 +126,7 @@ export function HomeTriggers({
                 activity={activityStats?.cronByTaskId[item.task.id]}
                 activityPending={activityPending}
               />
-            ) : (
+            ) : item.kind === 'webhook' ? (
               <WebhookRow
                 key={`w-${item.trigger.id}`}
                 trigger={item.trigger}
@@ -119,6 +134,14 @@ export function HomeTriggers({
                 onSelect={() => onSelectWebhook(item.trigger.id)}
                 activity={activityStats?.webhookByTriggerId[item.trigger.id]}
                 activityPending={activityPending}
+              />
+            ) : (
+              <InboundXAgentRow
+                key="inbound-x-agent"
+                total={activityStats!.inboundXAgent.total}
+                lastInvokedAt={activityStats!.inboundXAgent.lastInvokedAt}
+                activity={activityStats!.inboundXAgent.activity}
+                onSelect={onSelectInboundXAgent}
               />
             ),
           )}
@@ -344,6 +367,51 @@ function TriggerRow({
         </AlertDialogContent>
       </AlertDialog>
     </>
+  )
+}
+
+function InboundXAgentRow({
+  total,
+  lastInvokedAt,
+  activity,
+  onSelect,
+}: {
+  total: number
+  lastInvokedAt: string | null
+  activity: DailyActivityPoint[]
+  onSelect: () => void
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onSelect()
+        }
+      }}
+      className="group w-full cursor-pointer px-4 py-3 text-left transition-colors hover:bg-muted/50"
+    >
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium">Called from Other Agents</div>
+          <div className="mt-0.5 flex items-center justify-between gap-2 text-xs text-muted-foreground">
+            <span>x-agent · {total} {total === 1 ? 'call' : 'calls'}</span>
+            {lastInvokedAt && (
+              <span className="shrink-0">
+                <span className="text-muted-foreground">last run </span>
+                {formatDistanceToNow(new Date(lastInvokedAt), { addSuffix: true })}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="shrink-0">
+          <ActivitySparkChart label="Calls from other agents" data={activity} />
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/src/renderer/components/agents/inbound-x-agent/inbound-x-agent-view.test.tsx
+++ b/src/renderer/components/agents/inbound-x-agent/inbound-x-agent-view.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '@renderer/test/test-utils'
+import { InboundXAgentView } from './inbound-x-agent-view'
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  useDetails: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mocks.navigate,
+}))
+
+vi.mock('@renderer/hooks/use-inbound-x-agent', () => ({
+  useInboundXAgentDetails: (...args: unknown[]) => mocks.useDetails(...args),
+}))
+
+describe('InboundXAgentView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useDetails.mockReturnValue({
+      data: {
+        sessions: [{
+          id: 'session-a',
+          createdAt: '2026-08-20T18:00:00.000Z',
+          triggeredBy: { slug: 'caller-a', name: 'Caller A' },
+        }],
+        callers: [
+          {
+            slug: 'caller-a',
+            displaySlug: 'caller-a-display',
+            name: 'Caller A',
+            decision: 'allow',
+            canAccess: true,
+          },
+          {
+            slug: 'caller-b',
+            displaySlug: 'caller-b-display',
+            name: 'Caller B',
+            decision: 'review',
+            canAccess: false,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('shows history and greys callers the viewer cannot access', () => {
+    renderWithProviders(<InboundXAgentView agentSlug="target" />)
+
+    expect(screen.getByText('Called from Other Agents')).toBeInTheDocument()
+    expect(screen.getByText('Triggered by')).toBeInTheDocument()
+    expect(screen.getByText('Approval required · No access').closest('[aria-disabled="true"]'))
+      .toHaveTextContent('Caller B')
+    expect(screen.getByRole('button', { name: 'Open Caller A' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Caller B/ })).not.toBeInTheDocument()
+  })
+
+  it('opens the selected run and accessible caller agent', () => {
+    renderWithProviders(<InboundXAgentView agentSlug="target" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open call from Caller A' }))
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: '/agents/$slug/sessions/$sessionId',
+      params: { slug: 'target', sessionId: 'session-a' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Caller A' }))
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: '/agents/$slug',
+      params: { slug: 'caller-a-display' },
+    })
+  })
+})

--- a/src/renderer/components/agents/inbound-x-agent/inbound-x-agent-view.tsx
+++ b/src/renderer/components/agents/inbound-x-agent/inbound-x-agent-view.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from 'react'
+import { ChevronRight, Loader2 } from 'lucide-react'
+import { useNavigate } from '@tanstack/react-router'
+import { SettingsPageContainer, PageTitle } from '@renderer/components/layout/settings-page'
+import { IntegrationList, IntegrationRow } from '@renderer/components/connections/integration-row'
+import { DetailCard } from '@renderer/components/triggers/detail-card'
+import { SortPopover } from '@renderer/components/sessions/sort-popover'
+import type { SortOrder } from '@renderer/components/sessions/related-sessions'
+import { SectionHeader } from '@renderer/components/ui/section-header'
+import { useInboundXAgentDetails } from '@renderer/hooks/use-inbound-x-agent'
+
+interface InboundXAgentViewProps {
+  agentSlug: string
+}
+
+export function InboundXAgentView({ agentSlug }: InboundXAgentViewProps) {
+  const navigate = useNavigate()
+  const { data, isLoading, error } = useInboundXAgentDetails(agentSlug)
+  const [sortOrder, setSortOrder] = useState<SortOrder>('newest')
+
+  const sessions = useMemo(() => {
+    const rows = [...(data?.sessions ?? [])]
+    return sortOrder === 'newest' ? rows : rows.reverse()
+  }, [data?.sessions, sortOrder])
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Loading calls from other agents...
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-destructive">
+        Failed to load calls from other agents
+      </div>
+    )
+  }
+
+  return (
+    <SettingsPageContainer fullScreen>
+      <PageTitle
+        title="Called from Other Agents"
+        back={{
+          onClick: () => {
+            void navigate({ to: '/agents/$slug', params: { slug: agentSlug } })
+          },
+          testId: 'inbound-x-agent-back-button',
+        }}
+      />
+
+      <div className="grid grid-cols-1 gap-y-6 lg:grid-cols-[3fr_2fr] lg:gap-x-10 lg:gap-y-0">
+        <section className="order-2 lg:order-1">
+          <SectionHeader
+            title="Run History"
+            actions={sessions.length > 1 ? (
+              <SortPopover value={sortOrder} onChange={setSortOrder} ariaLabel="Sort calls" />
+            ) : undefined}
+          />
+
+          {sessions.length === 0 ? (
+            <p className="py-6 text-xs text-muted-foreground">
+              No calls from other agents yet.
+            </p>
+          ) : (
+            <div>
+              <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b px-2 py-2 text-[11px] font-medium text-muted-foreground">
+                <span>Time</span>
+                <span>Triggered by</span>
+              </div>
+              {sessions.map((session) => (
+                <div
+                  key={session.id}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Open call from ${session.triggeredBy.name}`}
+                  className="group grid cursor-pointer grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)] items-center gap-4 border-b px-2 py-3 text-xs transition-colors hover:bg-muted/50"
+                  onClick={() => {
+                    void navigate({
+                      to: '/agents/$slug/sessions/$sessionId',
+                      params: { slug: agentSlug, sessionId: session.id },
+                    })
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return
+                    event.preventDefault()
+                    void navigate({
+                      to: '/agents/$slug/sessions/$sessionId',
+                      params: { slug: agentSlug, sessionId: session.id },
+                    })
+                  }}
+                >
+                  <span>{new Date(session.createdAt).toLocaleString()}</span>
+                  <span className="flex min-w-0 items-center justify-between gap-2">
+                    <span className="truncate">{session.triggeredBy.name}</span>
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <div className="order-1 lg:order-2">
+          <DetailCard label="Agents that can trigger this agent">
+            {data.callers.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No other agents can currently trigger this agent.
+              </p>
+            ) : (
+              <IntegrationList>
+                {data.callers.map((caller) => (
+                  <IntegrationRow
+                    key={caller.slug}
+                    icon={null}
+                    name={caller.name}
+                    subtitle={caller.canAccess
+                      ? caller.decision === 'allow' ? 'Allowed' : 'Approval required'
+                      : `${caller.decision === 'allow' ? 'Allowed' : 'Approval required'} · No access`}
+                    disabled={!caller.canAccess}
+                    ariaLabel={caller.canAccess
+                      ? `Open ${caller.name}`
+                      : `${caller.name}, you do not have access`}
+                    onActivate={caller.canAccess ? () => {
+                      void navigate({
+                        to: '/agents/$slug',
+                        params: { slug: caller.displaySlug },
+                      })
+                    } : undefined}
+                    right={caller.canAccess ? (
+                      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+                    ) : undefined}
+                  />
+                ))}
+              </IntegrationList>
+            )}
+          </DetailCard>
+        </div>
+      </div>
+    </SettingsPageContainer>
+  )
+}

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -48,6 +48,7 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
   const sessionId = view.kind === 'session' ? view.id : null
   const scheduledTaskId = view.kind === 'task' ? view.id : null
   const webhookTriggerId = view.kind === 'webhook' ? view.id : null
+  const inboundXAgentOpen = view.kind === 'inboundXAgent'
   const apiLogsOpen = view.kind === 'apiLogs'
   const secretsOpen = view.kind === 'secrets'
   const xAgentPermissionsOpen = view.kind === 'xAgentPermissions'
@@ -208,6 +209,12 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
           <>
             <BreadcrumbSeparator />
             <span className="text-sm font-light text-foreground">Agent-to-agent Connections</span>
+          </>
+        )}
+        {inboundXAgentOpen && (
+          <>
+            <BreadcrumbSeparator />
+            <span className="text-sm font-light text-foreground">Called from Other Agents</span>
           </>
         )}
         {connectionsOpen && (

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -436,6 +436,10 @@ export function GlobalNotificationHandler() {
             if (sessionId) {
               queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
             }
+            if (agentSlug) {
+              queryClient.invalidateQueries({ queryKey: ['activity-stats', 'agent', agentSlug] })
+              queryClient.invalidateQueries({ queryKey: ['inbound-x-agent', agentSlug] })
+            }
             break
           }
 

--- a/src/renderer/hooks/use-activity-stats.test.tsx
+++ b/src/renderer/hooks/use-activity-stats.test.tsx
@@ -32,6 +32,7 @@ describe('activity hooks', () => {
       generatedAt: '2026-07-09T12:00:00.000Z',
       cronByTaskId: { task: [{ scheduledAt: '2026-07-09T10:00:00.000Z', status: 'succeeded' }] },
       webhookByTriggerId: { hook: [] },
+      inboundXAgent: { total: 0, lastInvokedAt: null, activity: [] },
       connectionById: { 'account-a': [{ date: '2026-07-09', succeeded: 1, failed: 0 }] },
     }
     mockApiFetch.mockResolvedValue(jsonResponse(payload))

--- a/src/renderer/hooks/use-document-title.test.tsx
+++ b/src/renderer/hooks/use-document-title.test.tsx
@@ -76,6 +76,9 @@ describe('getDocumentTitle', () => {
       getDocumentTitle({ location: location({ kind: 'xAgentPermissions' }, 'agent-one'), agentName: 'Agent One' }),
     ).toBe(`Agent One${DASH}Agent-to-agent Connections`)
     expect(
+      getDocumentTitle({ location: location({ kind: 'inboundXAgent' }, 'agent-one'), agentName: 'Agent One' }),
+    ).toBe(`Agent One${DASH}Called from Other Agents`)
+    expect(
       getDocumentTitle({
         location: location({ kind: 'dashboard', slug: 'sales-dashboard' }, 'agent-one'),
         agentName: 'Agent One',

--- a/src/renderer/hooks/use-document-title.ts
+++ b/src/renderer/hooks/use-document-title.ts
@@ -98,6 +98,8 @@ function titleForAgentView(view: AgentView, input: DocumentTitleInput): string {
       return joinView(agentTitle, 'Scheduled Task')
     case 'webhook':
       return joinView(agentTitle, 'Webhook Trigger')
+    case 'inboundXAgent':
+      return joinView(agentTitle, 'Called from Other Agents')
     case 'chat':
       return joinView(agentTitle, 'Remote Chat')
     case 'dashboard':

--- a/src/renderer/hooks/use-inbound-x-agent.ts
+++ b/src/renderer/hooks/use-inbound-x-agent.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@renderer/lib/api'
+import { inboundXAgentDetailsSchema } from '@shared/lib/types/inbound-x-agent-schema'
+
+export function useInboundXAgentDetails(agentSlug: string | null) {
+  return useQuery({
+    queryKey: ['inbound-x-agent', agentSlug],
+    queryFn: async () => {
+      const response = await apiFetch(
+        `/api/agents/${encodeURIComponent(agentSlug!)}/inbound-x-agent`,
+      )
+      if (!response.ok) throw new Error('Failed to fetch calls from other agents')
+      return inboundXAgentDetailsSchema.parse(await response.json())
+    },
+    enabled: !!agentSlug,
+    staleTime: 30_000,
+  })
+}

--- a/src/renderer/router/lazy-routes/inbound-x-agent-route.tsx
+++ b/src/renderer/router/lazy-routes/inbound-x-agent-route.tsx
@@ -1,0 +1,10 @@
+import { InboundXAgentView } from '@renderer/components/agents/inbound-x-agent/inbound-x-agent-view'
+import { useAgent } from '@renderer/hooks/use-agents'
+import { useAgentSlug } from './use-agent-slug'
+
+export function InboundXAgentRoute() {
+  const slug = useAgentSlug()
+  const { data: agent } = useAgent(slug)
+  if (!slug || !agent) return null
+  return <InboundXAgentView agentSlug={agent.slug} />
+}

--- a/src/renderer/router/route-state.test.ts
+++ b/src/renderer/router/route-state.test.ts
@@ -31,6 +31,7 @@ const cases: AppLocation[] = [
   { selectedAgentSlug: SLUG, view: { kind: 'session', id: 'sess-1' } },
   { selectedAgentSlug: SLUG, view: { kind: 'task', id: 'task-1' } },
   { selectedAgentSlug: SLUG, view: { kind: 'webhook', id: 'wh-1' } },
+  { selectedAgentSlug: SLUG, view: { kind: 'inboundXAgent' } },
   { selectedAgentSlug: SLUG, view: { kind: 'chat', integrationId: 'int-1' } },
   { selectedAgentSlug: SLUG, view: { kind: 'chat', integrationId: 'int-1', sessionId: 'cs-1' } },
   { selectedAgentSlug: SLUG, view: { kind: 'dashboard', slug: 'dash-1' } },

--- a/src/renderer/router/route-state.ts
+++ b/src/renderer/router/route-state.ts
@@ -11,6 +11,7 @@ export type AgentView =
   | { kind: 'session'; id: string }
   | { kind: 'task'; id: string }
   | { kind: 'webhook'; id: string }
+  | { kind: 'inboundXAgent' }
   | { kind: 'chat'; integrationId: string; sessionId?: string }
   | { kind: 'dashboard'; slug: string }
   | { kind: 'apiLogs' }
@@ -76,6 +77,8 @@ export function encodeLocation(loc: AppLocation): NavigateOptions {
       return { to: '/agents/$slug/tasks/$taskId', params: { slug, taskId: view.id } }
     case 'webhook':
       return { to: '/agents/$slug/webhooks/$webhookId', params: { slug, webhookId: view.id } }
+    case 'inboundXAgent':
+      return { to: '/agents/$slug/called-from-agents', params: { slug } }
     case 'chat':
       return {
         to: '/agents/$slug/chat/$integrationId',
@@ -129,6 +132,8 @@ export function decodeLocation(snap: RouteSnapshot): AppLocation {
       return { selectedAgentSlug: p.slug ?? null, view: { kind: 'task', id: p.taskId ?? '' } }
     case '/agents/$slug/webhooks/$webhookId':
       return { selectedAgentSlug: p.slug ?? null, view: { kind: 'webhook', id: p.webhookId ?? '' } }
+    case '/agents/$slug/called-from-agents':
+      return { selectedAgentSlug: p.slug ?? null, view: { kind: 'inboundXAgent' } }
     case '/agents/$slug/chat/$integrationId': {
       const session = typeof search.session === 'string' ? search.session : undefined
       return {

--- a/src/renderer/router/routes.ts
+++ b/src/renderer/router/routes.ts
@@ -39,6 +39,7 @@ const AgentShell = lazyRouteComponent(
   'AgentShell',
 )
 const AgentHomeRoute = lazyRouteComponent(() => import('./lazy-routes/agent-home-route'), 'AgentHomeRoute')
+const InboundXAgentRoute = lazyRouteComponent(() => import('./lazy-routes/inbound-x-agent-route'), 'InboundXAgentRoute')
 const XAgentPermissionsRoute = lazyRouteComponent(() => import('./lazy-routes/x-agent-permissions-route'), 'XAgentPermissionsRoute')
 const ApiLogsRoute = lazyRouteComponent(() => import('./lazy-routes/api-logs-route'), 'ApiLogsRoute')
 const ChatRoute = lazyRouteComponent(() => import('./lazy-routes/chat-route'), 'ChatRoute')
@@ -179,6 +180,12 @@ export const webhookRoute = createRoute({
   component: WebhookRoute,
 })
 
+export const inboundXAgentRoute = createRoute({
+  getParentRoute: () => agentLayoutRoute,
+  path: 'called-from-agents',
+  component: InboundXAgentRoute,
+})
+
 export const chatRoute = createRoute({
   getParentRoute: () => agentLayoutRoute,
   path: 'chat/$integrationId',
@@ -264,6 +271,7 @@ export const routeTree = rootRoute.addChildren([
       sessionRoute,
       taskRoute,
       webhookRoute,
+      inboundXAgentRoute,
       chatRoute,
       dashboardRoute,
       apiLogsRoute,

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -14,12 +14,12 @@ import type {
   ContainerStats,
   CreateSessionOptions,
   HostPortProbeResult,
+  SendMessageOptions,
   StartOptions,
   StopOptions,
   StopResult,
   StreamMessage,
 } from './types'
-import type { RuntimeOptions } from './runtime-options'
 import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getAgentCapabilitySettings, getSettings } from '@shared/lib/config/settings'
@@ -1251,13 +1251,14 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     return response.ok
   }
 
-  async sendMessage(sessionId: string, content: string, uuid?: string, options?: RuntimeOptions): Promise<void> {
+  async sendMessage(sessionId: string, content: string, uuid?: string, options?: SendMessageOptions): Promise<void> {
     const port = await this.getPortOrThrow()
     const timeoutMs = 30000 // 30 second timeout
     const effort = options?.effort
     const speed = options?.speed
     const model = resolveContainerModel(options?.model, 'agent')
     const shouldQuery = options?.shouldQuery
+    const isAutomated = options?.isAutomated
     // Refreshed on every message so a long-lived session tracks settings
     // changes; the container restarts its query only on a block-boundary flip.
     const capabilityPolicies = getAgentCapabilitySettings()
@@ -1278,6 +1279,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
             ...(speed ? { speed } : {}),
             ...(model ? { model } : {}),
             ...(shouldQuery !== undefined ? { shouldQuery } : {}),
+            ...(isAutomated !== undefined ? { isAutomated } : {}),
             capabilityPolicies,
           }),
           signal: controller.signal,

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -4095,6 +4095,24 @@ describe('MessagePersister', () => {
       })
     })
 
+    it('promotes an x-agent session when user input is requested', async () => {
+      vi.mocked(getSessionMetadata).mockResolvedValueOnce({
+        invokedByAgentSlug: 'caller-agent',
+      })
+
+      simulateToolUse('AskUserQuestion', 'tool-1', {
+        questions: [{ question: 'Pick?', header: 'Q', options: [], multiSelect: false }],
+      })
+
+      await vi.waitFor(() => {
+        expect(updateSessionMetadata).toHaveBeenCalledWith(
+          AGENT_SLUG,
+          SESSION_ID,
+          { promotedToInteractive: true },
+        )
+      })
+    })
+
     it('does not promote a regular (non-automated) session', async () => {
       vi.mocked(getSessionMetadata).mockResolvedValueOnce({
         name: 'Regular session',
@@ -4373,6 +4391,14 @@ describe('MessagePersister', () => {
 
     it('releases the stream when a webhook session settles', async () => {
       await resubscribeWithMetadata({ isWebhookExecution: true, webhookTriggerId: 'trigger-1' })
+
+      settleSession()
+
+      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+    })
+
+    it('releases the stream when an x-agent session settles', async () => {
+      await resubscribeWithMetadata({ invokedByAgentSlug: 'caller-agent' })
 
       settleSession()
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -544,10 +544,10 @@ class MessagePersister {
     await ready
   }
 
-  // Resolve whether this subscription belongs to an unpromoted cron/webhook
-  // session. Non-blocking: automation runs last long enough that the verdict
-  // lands well before finalizeIdle consumes it, and an unresolved read just
-  // means the stream is kept (the pre-fix behavior). Scheduler and trigger
+  // Resolve whether this subscription belongs to an unpromoted cron, webhook,
+  // or x-agent session. Non-blocking: automation runs last long enough that
+  // the verdict lands well before finalizeIdle consumes it, and an unresolved
+  // read just means the stream is kept (the pre-fix behavior). Automation
   // paths register metadata before subscribing, so the read can't miss them.
   private resolveReleaseStreamOnSettle(sessionId: string, agentSlug?: string): void {
     if (!agentSlug) return
@@ -560,7 +560,7 @@ class MessagePersister {
         // Promote wins: its marker is set synchronously, this read may be stale.
         if (current.promotedToInteractive) return
         current.releaseStreamOnSettle = Boolean(
-          (meta?.isScheduledExecution || meta?.isWebhookExecution) &&
+          (meta?.isScheduledExecution || meta?.isWebhookExecution || meta?.invokedByAgentSlug) &&
             !meta?.promotedToInteractive
         )
       })
@@ -1371,10 +1371,11 @@ class MessagePersister {
     this.syncSessionAwaiting(sessionId)
   }
 
-  // Promote an automated session (cron/webhook/chat) to a regular session so it
-  // appears in the sidebar and receives completion notifications. Public: the
-  // notification manager promotes on session_waiting so blocked automations
-  // surface in session lists instead of accruing unread rows nothing displays.
+  // Promote an automated session (cron/webhook/chat/x-agent) to a regular
+  // session so it appears in the sidebar and receives completion notifications.
+  // Public: the notification manager promotes on session_waiting so blocked
+  // automations surface in session lists instead of accruing unread rows
+  // nothing displays.
   async promoteAutomatedSession(sessionId: string, agentSlug: string): Promise<void> {
     const meta = await getSessionMetadata(agentSlug, sessionId)
     if (!isHiddenAutomatedSession(meta)) return

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -9,11 +9,11 @@ import type {
   ContainerSession,
   ContainerStats,
   CreateSessionOptions,
+  SendMessageOptions,
   StartOptions,
   StopOptions,
   StreamMessage,
 } from './types'
-import type { RuntimeOptions } from './runtime-options'
 import { resolveContainerModel } from './resolve-model'
 import { getAgentWorkspaceDir, getSessionJsonlPath } from '../utils/file-storage'
 import { reviewManager } from '../proxy/review-manager'
@@ -2654,7 +2654,7 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
   // Message operations
 
-  async sendMessage(sessionId: string, content: string, uuid?: string, options?: RuntimeOptions): Promise<void> {
+  async sendMessage(sessionId: string, content: string, uuid?: string, options?: SendMessageOptions): Promise<void> {
     // Resolve like the real container client so E2E sees the concrete wire id.
     const model = resolveContainerModel(options?.model, 'agent')
     // Record for E2E test assertions

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -1,5 +1,10 @@
 import type { RuntimeOptions } from './runtime-options'
 
+export interface SendMessageOptions extends RuntimeOptions {
+  /** Keep an automated session in its automated runtime class for agent-originated follow-ups. */
+  isAutomated?: boolean
+}
+
 export const CONTAINER_RUNNER_IDS = [
   'docker',
   'podman',
@@ -214,7 +219,7 @@ export interface ContainerClient {
   deleteSession(sessionId: string): Promise<boolean>
 
   // Message operations
-  sendMessage(sessionId: string, content: string, uuid?: string, options?: RuntimeOptions): Promise<void>
+  sendMessage(sessionId: string, content: string, uuid?: string, options?: SendMessageOptions): Promise<void>
   // Cancel a queued (not yet picked up) message by the uuid it was sent with.
   // false = too late (already picked up) or session not live — never throws for that.
   cancelQueuedMessage(sessionId: string, uuid: string): Promise<boolean>

--- a/src/shared/lib/notifications/notification-manager.test.ts
+++ b/src/shared/lib/notifications/notification-manager.test.ts
@@ -272,6 +272,12 @@ describe('triggerSessionComplete — automated-session gating', () => {
     expect(mockCreateNotification).not.toHaveBeenCalled()
   })
 
+  it('skips creation for an x-agent session', async () => {
+    mockGetSessionMetadata.mockResolvedValue({ invokedByAgentSlug: 'caller-agent' })
+    await notificationManager.triggerSessionComplete('sess-1', 'agent-x')
+    expect(mockCreateNotification).not.toHaveBeenCalled()
+  })
+
   it('creates notification for a promoted scheduled session', async () => {
     mockGetSessionMetadata.mockResolvedValue({
       isScheduledExecution: true,

--- a/src/shared/lib/services/activity-stats-service.test.ts
+++ b/src/shared/lib/services/activity-stats-service.test.ts
@@ -173,6 +173,10 @@ describe('activity stats data pathways', () => {
         automationStatus: 'running',
         createdAt: '2026-07-09T11:30:00.000Z',
       },
+      'x-agent-session': {
+        invokedByAgentSlug: 'caller-agent',
+        createdAt: '2026-07-08T18:00:00.000Z',
+      },
     })
 
     const result = await getAgentActivityStats('agent-a', { days: 2, now: NOW, cronSlots: 2 })
@@ -185,6 +189,14 @@ describe('activity stats data pathways', () => {
       { date: '2026-07-08', succeeded: 3, failed: 0 },
       { date: '2026-07-09', succeeded: 0, failed: 3 },
     ])
+    expect(result.inboundXAgent).toEqual({
+      total: 1,
+      lastInvokedAt: '2026-07-08T18:00:00.000Z',
+      activity: [
+        { date: '2026-07-08', succeeded: 1, failed: 0 },
+        { date: '2026-07-09', succeeded: 0, failed: 0 },
+      ],
+    })
     expect(result.connectionById['account-account-a']).toEqual([
       { date: '2026-07-08', succeeded: 1, failed: 0 },
       { date: '2026-07-09', succeeded: 0, failed: 1 },

--- a/src/shared/lib/services/activity-stats-service.ts
+++ b/src/shared/lib/services/activity-stats-service.ts
@@ -317,11 +317,35 @@ export async function getAgentActivityStats(
   )
   const connectionById = dailyEventsById(connectionIds, requestEvents, { ...options, now, tzOffsetMinutes })
 
+  const inboundEvents: DailyActivityEvent[] = []
+  let inboundTotal = 0
+  let lastInvokedAt: string | null = null
+  let lastInvokedAtMs = Number.NEGATIVE_INFINITY
+  for (const meta of Object.values(metadata)) {
+    if (!meta.invokedByAgentSlug || !meta.createdAt) continue
+    const createdAt = new Date(meta.createdAt)
+    if (!Number.isFinite(createdAt.getTime())) continue
+    inboundTotal += 1
+    inboundEvents.push({
+      day: activityDayKey(createdAt, tzOffsetMinutes),
+      outcome: 'succeeded',
+    })
+    if (createdAt.getTime() > lastInvokedAtMs) {
+      lastInvokedAtMs = createdAt.getTime()
+      lastInvokedAt = createdAt.toISOString()
+    }
+  }
+
   return {
     days: options.days,
     generatedAt: now.toISOString(),
     cronByTaskId,
     webhookByTriggerId,
+    inboundXAgent: {
+      total: inboundTotal,
+      lastInvokedAt,
+      activity: buildDailyActivitySeries(inboundEvents, { ...options, now, tzOffsetMinutes }),
+    },
     connectionById,
   }
 }

--- a/src/shared/lib/services/inbound-x-agent-service.test.ts
+++ b/src/shared/lib/services/inbound-x-agent-service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { ApiAgent } from '@shared/lib/types/api'
+import { buildInboundXAgentDetails } from './inbound-x-agent-service'
+
+function agent(slug: string, name: string): ApiAgent {
+  return {
+    slug,
+    displaySlug: `${name.toLowerCase().replaceAll(' ', '-')}-${slug}`,
+    name,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    status: 'stopped',
+    containerPort: null,
+  }
+}
+
+describe('buildInboundXAgentDetails', () => {
+  it('sorts call history newest-first and excludes self and blocked callers', () => {
+    const result = buildInboundXAgentDetails({
+      targetSlug: 'target',
+      metadata: {
+        old: { invokedByAgentSlug: 'caller-a', createdAt: '2026-08-19T10:00:00.000Z' },
+        newest: { invokedByAgentSlug: 'caller-b', createdAt: '2026-08-20T10:00:00.000Z' },
+        human: { createdAt: '2026-08-21T10:00:00.000Z' },
+      },
+      agents: [agent('target', 'Target'), agent('caller-a', 'Alpha'), agent('caller-b', 'Beta')],
+      authMode: false,
+      aclRows: [],
+      evaluatePolicy: (caller) => caller === 'caller-b' ? 'block' : 'review',
+    })
+
+    expect(result.sessions.map((session) => session.id)).toEqual(['newest', 'old'])
+    expect(result.sessions[0].triggeredBy.name).toBe('Beta')
+    expect(result.callers).toEqual([{
+      slug: 'caller-a',
+      displaySlug: 'alpha-caller-a',
+      name: 'Alpha',
+      decision: 'review',
+      canAccess: true,
+    }])
+  })
+
+  it('requires a caller owner with user access to the target and greys inaccessible callers', () => {
+    const result = buildInboundXAgentDetails({
+      targetSlug: 'target',
+      metadata: {},
+      agents: [
+        agent('target', 'Target'),
+        agent('caller-a', 'Alpha'),
+        agent('caller-b', 'Beta'),
+        agent('caller-c', 'Charlie'),
+      ],
+      authMode: true,
+      viewerUserId: 'viewer',
+      aclRows: [
+        { agentSlug: 'target', userId: 'owner-a', role: 'user' },
+        { agentSlug: 'target', userId: 'owner-b', role: 'viewer' },
+        { agentSlug: 'caller-a', userId: 'owner-a', role: 'owner' },
+        { agentSlug: 'caller-b', userId: 'owner-b', role: 'owner' },
+        { agentSlug: 'caller-c', userId: 'owner-a', role: 'owner' },
+        { agentSlug: 'caller-c', userId: 'viewer', role: 'viewer' },
+      ],
+      evaluatePolicy: () => 'allow',
+    })
+
+    expect(result.callers.map((caller) => [caller.slug, caller.canAccess])).toEqual([
+      ['caller-a', false],
+      ['caller-c', true],
+    ])
+  })
+
+  it('keeps eligible caller rows accessible for an admin viewer without caller ACL rows', () => {
+    const result = buildInboundXAgentDetails({
+      targetSlug: 'target',
+      metadata: {},
+      agents: [agent('target', 'Target'), agent('caller', 'Caller')],
+      authMode: true,
+      viewerUserId: 'admin',
+      viewerCanAccessAll: true,
+      aclRows: [
+        { agentSlug: 'target', userId: 'owner', role: 'user' },
+        { agentSlug: 'caller', userId: 'owner', role: 'owner' },
+      ],
+      evaluatePolicy: () => 'review',
+    })
+
+    expect(result.callers[0].canAccess).toBe(true)
+  })
+})

--- a/src/shared/lib/services/inbound-x-agent-service.ts
+++ b/src/shared/lib/services/inbound-x-agent-service.ts
@@ -1,0 +1,136 @@
+import { inArray } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { agentAcl } from '@shared/lib/db/schema'
+import type { ApiAgent } from '@shared/lib/types/api'
+import type { AgentRole, SessionMetadataMap } from '@shared/lib/types/agent'
+import { hasMinRole } from '@shared/lib/types/agent'
+import type { InboundXAgentDetails } from '@shared/lib/types/inbound-x-agent-schema'
+import { listAgentsWithStatus } from './agent-service'
+import { readSessionMetadata } from './session-service'
+import {
+  evaluate as evaluateXAgentPolicy,
+  type XAgentDecision,
+} from './x-agent-policy-service'
+
+interface AgentAclRow {
+  agentSlug: string
+  userId: string
+  role: string
+}
+
+interface BuildInboundXAgentDetailsInput {
+  targetSlug: string
+  metadata: SessionMetadataMap
+  agents: ApiAgent[]
+  authMode: boolean
+  viewerUserId?: string
+  viewerCanAccessAll?: boolean
+  aclRows: AgentAclRow[]
+  evaluatePolicy?: (callerSlug: string, targetSlug: string) => XAgentDecision
+}
+
+/**
+ * Build the permission-aware history payload without doing I/O. Keeping the
+ * ACL/policy projection pure makes the security-sensitive visibility rules
+ * straightforward to test independently of the route and database adapters.
+ */
+export function buildInboundXAgentDetails({
+  targetSlug,
+  metadata,
+  agents,
+  authMode,
+  viewerUserId,
+  viewerCanAccessAll = false,
+  aclRows,
+  evaluatePolicy = (callerSlug, target) => evaluateXAgentPolicy(callerSlug, 'invoke', target),
+}: BuildInboundXAgentDetailsInput): InboundXAgentDetails {
+  const agentBySlug = new Map(agents.map((agent) => [agent.slug, agent]))
+  const sessions = Object.entries(metadata)
+    .flatMap(([id, meta]) => {
+      if (!meta.invokedByAgentSlug || !meta.createdAt) return []
+      const createdAt = new Date(meta.createdAt)
+      if (!Number.isFinite(createdAt.getTime())) return []
+      const caller = agentBySlug.get(meta.invokedByAgentSlug)
+      return [{
+        id,
+        createdAt: createdAt.toISOString(),
+        triggeredBy: {
+          slug: meta.invokedByAgentSlug,
+          name: caller?.name ?? meta.invokedByAgentSlug,
+        },
+      }]
+    })
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+
+  const targetUsers = new Set(
+    aclRows
+      .filter((row) => row.agentSlug === targetSlug && hasMinRole(row.role as AgentRole, 'user'))
+      .map((row) => row.userId),
+  )
+  const viewerAgents = new Set(
+    aclRows
+      .filter((row) => row.userId === viewerUserId)
+      .map((row) => row.agentSlug),
+  )
+  const ownerUsersByAgent = new Map<string, Set<string>>()
+  for (const row of aclRows) {
+    if (row.role !== 'owner') continue
+    const owners = ownerUsersByAgent.get(row.agentSlug) ?? new Set<string>()
+    owners.add(row.userId)
+    ownerUsersByAgent.set(row.agentSlug, owners)
+  }
+
+  const callers = agents
+    .filter((agent) => agent.slug !== targetSlug)
+    .flatMap((agent) => {
+      if (authMode) {
+        const callerOwners = ownerUsersByAgent.get(agent.slug)
+        if (!callerOwners || ![...callerOwners].some((userId) => targetUsers.has(userId))) return []
+      }
+
+      const decision = evaluatePolicy(agent.slug, targetSlug)
+      if (decision === 'block') return []
+      return [{
+        slug: agent.slug,
+        displaySlug: agent.displaySlug,
+        name: agent.name,
+        decision,
+        canAccess: !authMode || viewerCanAccessAll || viewerAgents.has(agent.slug),
+      }]
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  return { sessions, callers }
+}
+
+export async function getInboundXAgentDetails(
+  targetSlug: string,
+  options: { authMode: boolean; viewerUserId?: string; viewerCanAccessAll?: boolean },
+): Promise<InboundXAgentDetails> {
+  const [metadata, agents] = await Promise.all([
+    readSessionMetadata(targetSlug),
+    listAgentsWithStatus(),
+  ])
+
+  const agentSlugs = agents.map((agent) => agent.slug)
+  const aclRows = options.authMode && agentSlugs.length > 0
+    ? await db
+        .select({
+          agentSlug: agentAcl.agentSlug,
+          userId: agentAcl.userId,
+          role: agentAcl.role,
+        })
+        .from(agentAcl)
+        .where(inArray(agentAcl.agentSlug, agentSlugs))
+    : []
+
+  return buildInboundXAgentDetails({
+    targetSlug,
+    metadata,
+    agents,
+    authMode: options.authMode,
+    viewerUserId: options.viewerUserId,
+    viewerCanAccessAll: options.viewerCanAccessAll,
+    aclRows,
+  })
+}

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -306,18 +306,20 @@ describe('session-service', () => {
       expect(sessions[0].messageCount).toBe(0)
     })
 
-    it('excludes scheduled/webhook sessions when excludeAutomated is set', async () => {
+    it('excludes scheduled/webhook/x-agent sessions when excludeAutomated is set', async () => {
       await createSessionFile('test-agent', 'manual-session', SAMPLE_JSONL_ENTRIES)
       await createSessionFile('test-agent', 'scheduled-session', SAMPLE_JSONL_ENTRIES)
       await createSessionFile('test-agent', 'webhook-session', SAMPLE_JSONL_ENTRIES)
+      await createSessionFile('test-agent', 'x-agent-session', SAMPLE_JSONL_ENTRIES)
       await createSessionMetadata('test-agent', {
         'manual-session': { name: 'Manual' },
         'scheduled-session': { name: 'Scheduled', isScheduledExecution: true, scheduledTaskId: 'task-1' },
         'webhook-session': { name: 'Webhook', isWebhookExecution: true, webhookTriggerId: 'trigger-1' },
+        'x-agent-session': { name: 'X-Agent', invokedByAgentSlug: 'caller-agent' },
       })
 
       const allSessions = await listSessions('test-agent')
-      expect(allSessions.length).toBe(3)
+      expect(allSessions.length).toBe(4)
 
       const filtered = await listSessions('test-agent', { excludeAutomated: true })
       expect(filtered.length).toBe(1)
@@ -3742,15 +3744,19 @@ describe('session-service', () => {
       await createSessionFile('test-agent', 'cron-run', SAMPLE_JSONL_ENTRIES)
       await createSessionFile('test-agent', 'promoted', SAMPLE_JSONL_ENTRIES)
       await createSessionFile('test-agent', 'chat-run', SAMPLE_JSONL_ENTRIES)
+      await createSessionFile('test-agent', 'x-agent-run', SAMPLE_JSONL_ENTRIES)
       await createSessionMetadata('test-agent', {
         'cron-run': { createdAt: '2026-01-01T00:00:00Z', isScheduledExecution: true },
         promoted: { createdAt: '2026-01-01T00:00:00Z', isScheduledExecution: true, promotedToInteractive: true },
         'chat-run': { createdAt: '2026-01-01T00:00:00Z', isChatIntegrationSession: true },
+        'x-agent-run': { createdAt: '2026-01-01T00:00:00Z', invokedByAgentSlug: 'caller-agent' },
       })
 
-      const sessions = await listSessionsByIds('test-agent', ['cron-run', 'promoted', 'chat-run'], {
-        excludeAutomated: true,
-      })
+      const sessions = await listSessionsByIds(
+        'test-agent',
+        ['cron-run', 'promoted', 'chat-run', 'x-agent-run'],
+        { excludeAutomated: true },
+      )
       expect(sessions.map((s) => s.id)).toEqual(['promoted'])
     })
 

--- a/src/shared/lib/services/session-visibility.test.ts
+++ b/src/shared/lib/services/session-visibility.test.ts
@@ -15,11 +15,13 @@ describe('isHiddenAutomatedSession', () => {
     expect(isHiddenAutomatedSession({ isScheduledExecution: true })).toBe(true)
     expect(isHiddenAutomatedSession({ isWebhookExecution: true })).toBe(true)
     expect(isHiddenAutomatedSession({ isChatIntegrationSession: true })).toBe(true)
+    expect(isHiddenAutomatedSession({ invokedByAgentSlug: 'caller-agent' })).toBe(true)
   })
 
   it('is false once the session is promoted to interactive', () => {
     expect(isHiddenAutomatedSession({ isScheduledExecution: true, promotedToInteractive: true })).toBe(false)
     expect(isHiddenAutomatedSession({ isChatIntegrationSession: true, promotedToInteractive: true })).toBe(false)
+    expect(isHiddenAutomatedSession({ invokedByAgentSlug: 'caller-agent', promotedToInteractive: true })).toBe(false)
   })
 
   it('is false when automation flags are explicitly false', () => {

--- a/src/shared/lib/services/session-visibility.ts
+++ b/src/shared/lib/services/session-visibility.ts
@@ -1,14 +1,19 @@
 import type { SessionMetadata } from '@shared/lib/types/agent'
 
 /**
- * True when a session is automated (scheduled / webhook / chat integration)
- * and has not been promoted to interactive. These sessions are excluded from
- * every user-facing session list (`excludeAutomated`), so per-session signals
- * derived elsewhere — unread-notification flags, badge dots — must skip them
- * too: a signal on a hidden session points at nothing the user can see or
- * clear, and it can never be marked read.
+ * True when a session is automated (scheduled / webhook / chat integration /
+ * x-agent invocation) and has not been promoted to interactive. These sessions
+ * are excluded from every user-facing session list (`excludeAutomated`), so
+ * per-session signals derived elsewhere — unread-notification flags, badge
+ * dots — must skip them too: a signal on a hidden session points at nothing
+ * the user can see or clear, and it can never be marked read.
  */
 export function isHiddenAutomatedSession(meta: SessionMetadata | null | undefined): boolean {
   if (!meta || meta.promotedToInteractive) return false
-  return !!(meta.isScheduledExecution || meta.isWebhookExecution || meta.isChatIntegrationSession)
+  return !!(
+    meta.isScheduledExecution ||
+    meta.isWebhookExecution ||
+    meta.isChatIntegrationSession ||
+    meta.invokedByAgentSlug
+  )
 }

--- a/src/shared/lib/types/activity-schema.ts
+++ b/src/shared/lib/types/activity-schema.ts
@@ -27,6 +27,11 @@ export const agentActivityStatsSchema = z.object({
   generatedAt: z.string(),
   cronByTaskId: z.record(z.string(), z.array(cronActivityPointSchema)),
   webhookByTriggerId: z.record(z.string(), z.array(dailyActivityPointSchema)),
+  inboundXAgent: z.object({
+    total: z.number().int().nonnegative(),
+    lastInvokedAt: z.string().nullable(),
+    activity: z.array(dailyActivityPointSchema),
+  }),
   connectionById: z.record(z.string(), z.array(dailyActivityPointSchema)),
 }) satisfies z.ZodType<AgentActivityStats>
 

--- a/src/shared/lib/types/activity.ts
+++ b/src/shared/lib/types/activity.ts
@@ -24,6 +24,11 @@ export interface AgentActivityStats {
   generatedAt: string
   cronByTaskId: Record<string, CronActivityPoint[]>
   webhookByTriggerId: Record<string, DailyActivityPoint[]>
+  inboundXAgent: {
+    total: number
+    lastInvokedAt: string | null
+    activity: DailyActivityPoint[]
+  }
   /** Unified connection row keys: `account-<id>` and `mcp-<id>`. */
   connectionById: Record<string, DailyActivityPoint[]>
 }

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -123,7 +123,8 @@ export interface SessionMetadata {
   // Last model used by the user on this session (seeds the composer on reload).
   // Stored as the provider's pinned ID, not the family.
   model?: string
-  // X-Agent: present when this session was created by another agent invoking this one
+  // X-Agent: present when this session was created by another agent invoking this one.
+  // Such sessions are hidden as automated until promoted for human input.
   invokedByAgentSlug?: string
 }
 

--- a/src/shared/lib/types/inbound-x-agent-schema.ts
+++ b/src/shared/lib/types/inbound-x-agent-schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const inboundXAgentCallerSchema = z.object({
+  slug: z.string(),
+  displaySlug: z.string(),
+  name: z.string(),
+  decision: z.enum(['allow', 'review']),
+  canAccess: z.boolean(),
+})
+
+export const inboundXAgentSessionSchema = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  triggeredBy: z.object({
+    slug: z.string(),
+    name: z.string(),
+  }),
+})
+
+export const inboundXAgentDetailsSchema = z.object({
+  sessions: z.array(inboundXAgentSessionSchema),
+  callers: z.array(inboundXAgentCallerSchema),
+})
+
+export type InboundXAgentCaller = z.infer<typeof inboundXAgentCallerSchema>
+export type InboundXAgentSession = z.infer<typeof inboundXAgentSessionSchema>
+export type InboundXAgentDetails = z.infer<typeof inboundXAgentDetailsSchema>


### PR DESCRIPTION
## Summary

- treat x-agent invocations as automated sessions, hiding them from human session lists until a user-input or review request promotes them
- add a **Called from Other Agents** trigger row with inbound activity and a dedicated call-history page
- show eligible caller agents with permission-aware disabled states, and keep the view fresh when session metadata changes

## Testing

- `npm run typecheck -- --pretty false`
- `npm run lint` (0 errors; existing warnings only)
- focused host test suite: 543 tests passed across agents API, x-agent routing, inbound ACLs, trigger/detail UI, activity, routing, titles, and notifications
- focused agent-container lifecycle suite: 33 tests passed
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SkillfulAgents/codesmith/SuperAgent/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789864264&installation_model_id=433436&pr_number=820&repository=SkillfulAgents%2FSuperAgent&return_to=https%3A%2F%2Fgithub.com%2FSkillfulAgents%2FSuperAgent%2Fpull%2F820&signature=8accc946a9ef26159925a078f8ff8a79fc7077c060719729e9eb93da15f8300b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->