### PR TITLE
fix: restore the cloud proxy prefix on dashboard urls (SUP-646)

### DIFF
--- a/docs/cloud-workspace.md
+++ b/docs/cloud-workspace.md
@@ -168,9 +168,12 @@ Other properties worth not regressing:
   `cloud-proxy.integration.test.ts` is for.
 - **Only `/api` paths are forwarded**; anything else 404s, as does a bad key
   (a prober learns nothing either way).
-- **Documents served through the proxy don't inherit its prefix.** A dashboard
-  iframe is loaded from the keyed URL, but the HTML comes back unchanged, and a
-  root-relative `/api/...` inside it resolves against the *loopback* origin. The
+- **A dashboard's own urls get the prefix back; nothing else does.** A dashboard
+  iframe is loaded from the keyed URL, and `cloud-proxy.ts` substitutes the
+  prefix onto occurrences of that dashboard's own mount in html, javascript and
+  css bodies — without it a root-absolute entry module resolves against the
+  *loopback* origin, 404s on the local API, and the dashboard renders blank. Any
+  other `/api/...` inside the document is left alone. The
   LLM and speech shims injected into dashboards therefore derive their prefix
   from `location` at runtime (`api/polyfill-api-prefix.ts`) instead of
   hardcoding it — otherwise a cloud dashboard's LLM calls would silently run on

--- a/src/api/routes/cloud-proxy.ts
+++ b/src/api/routes/cloud-proxy.ts
@@ -191,6 +191,49 @@ function buildClientHeaders(upstream: { headers: Headers }): Headers {
   return headers
 }
 
+/** A dashboard mount inside the deployment: `/api/agents/<agent>/artifacts/<slug>/`. */
+const DASHBOARD_MOUNT_PATH = /^\/api\/agents\/[^/]+\/artifacts\/[^/]+\//
+
+/** Bodies whose text can name the dashboard's own mount. */
+const REWRITABLE_DASHBOARD_TYPES =
+  /^(?:text\/html|text\/javascript|application\/javascript|text\/css)\b/i
+
+/**
+ * Put this proxy's prefix back onto the urls a dashboard writes about itself.
+ *
+ * The deployment is never told the prefix exists (`cloud-proxy-key.ts`), so a
+ * dashboard writes its mount unprefixed into its markup and into every module
+ * specifier. Root-absolute urls ignore `<base>`, so those requests reach the
+ * *local* API, which has no such agent, and the dashboard renders blank.
+ *
+ * Substitution is sound because the string replaced is the request's own mount:
+ * an occurrence of it in a body served from that mount is by construction a url
+ * pointing back at the same dashboard. JSON is deliberately excluded — a mount
+ * inside a data payload is not necessarily a url.
+ *
+ * Contained by intent: the prefix is an authentication mechanism occupying the
+ * application's url namespace, and that collision is the thing worth removing.
+ */
+async function withDashboardPrefix(
+  response: Response,
+  mount: string,
+  prefix: string,
+): Promise<Response> {
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!REWRITABLE_DASHBOARD_TYPES.test(contentType)) return response
+  // A 304 still carries the asset's content-type but no body, and a null-body
+  // status cannot be given one — rebuilding it would throw. Dropping the etag
+  // below makes revalidation the common case, so this is a normal path.
+  if (response.body === null) return response
+
+  const body = (await response.text()).split(mount).join(prefix + mount)
+  const headers = new Headers(response.headers)
+  // The bytes are no longer the ones upstream validated or measured.
+  headers.delete('etag')
+  headers.set('cache-control', 'no-cache')
+  return new Response(body, { status: response.status, statusText: response.statusText, headers })
+}
+
 /**
  * Request headers that make this GET a different question from the one main
  * asked on the app's behalf. A conditional or ranged request expects a 304 or a
@@ -276,7 +319,9 @@ cloudProxy.all('/*', async (c) => {
     if (prefetched) return fromPrefetch(prefetched)
   }
 
-  return forwardRequest(c.req.raw, target, pathAndQuery)
+  const response = await forwardRequest(c.req.raw, target, pathAndQuery)
+  const mount = upstreamPath.match(DASHBOARD_MOUNT_PATH)?.[0]
+  return mount ? withDashboardPrefix(response, mount, `${CLOUD_PROXY_PREFIX}/${key}`) : response
 })
 
 async function forwardRequest(

--- a/src/api/routes/dashboard-proxy-prefix.test.ts
+++ b/src/api/routes/dashboard-proxy-prefix.test.ts
@@ -138,6 +138,22 @@ describe('dashboard served through the cloud proxy prefix', () => {
     }
   })
 
+  it('passes a revalidation 304 straight through', async () => {
+    // A rewritten response drops its etag and asks the browser to revalidate,
+    // so a conditional request on a dashboard asset is the expected next call
+    // rather than an edge case. 304 carries no body and cannot be given one,
+    // so it has to bypass the rewrite instead of being rebuilt from its text.
+    mockFetch.mockResolvedValue(
+      new Response(null, { status: 304, headers: { 'content-type': 'text/javascript' } }),
+    )
+
+    const res = await app.request(`${ORIGIN}${proxiedPath(`${MOUNT}main.tsx`)}`, {
+      headers: { 'if-modified-since': 'Wed, 20 Aug 2026 00:00:00 GMT' },
+    })
+
+    expect(res.status).toBe(304)
+  })
+
   it('keeps a relative asset url inside the proxy prefix', async () => {
     // Relative urls are the usual advice for a proxied app, and they do not
     // help here: the injected `<base>` names the mount without the prefix, so

--- a/src/api/routes/dashboard-proxy-prefix.test.ts
+++ b/src/api/routes/dashboard-proxy-prefix.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+/**
+ * A dashboard served through the desktop cloud proxy must stay inside the
+ * proxy's prefix.
+ *
+ * The desktop drives a remote deployment through `/cloud/<key>` on the local
+ * origin, and the deployment is deliberately never told that prefix exists
+ * (`cloud-proxy-key.ts`). Anything the dashboard emits as a root-absolute URL
+ * therefore resolves against the origin, loses the prefix, and reaches the
+ * local API instead of the deployment, which answers 404. A dashboard whose
+ * entry module 404s never mounts and paints an empty `#root`.
+ *
+ * The browser is modelled the way it actually behaves, which is the part that
+ * makes this bug survive the obvious fixes: URLs are resolved against the
+ * *statically parsed* `<base>`, not the corrected one. Chromium's preload
+ * scanner runs ahead of the parser and does not see a `<base>` that a later
+ * inline script rewrites, so correcting the base from the injected runtime
+ * lands after the fetches have already been issued.
+ */
+
+let remoteAddress: string | undefined = '127.0.0.1'
+vi.mock('@hono/node-server/conninfo', () => ({
+  getConnInfo: () => ({ remote: { address: remoteAddress } }),
+}))
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => false }))
+
+const mockResolveTarget = vi.fn()
+const mockRefreshTarget = vi.fn()
+vi.mock('@shared/lib/services/cloud-proxy-target', () => ({
+  resolveCloudProxyTarget: () => mockResolveTarget(),
+  refreshCloudProxyTarget: () => mockRefreshTarget(),
+}))
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import cloudProxy, { CLOUD_PROXY_PREFIX } from './cloud-proxy'
+import { getCloudProxyKey } from '@shared/lib/services/cloud-proxy-key'
+import { injectDashboardRuntime, dashboardMountPath } from '../dashboard-runtime'
+
+const app = new Hono()
+app.route(CLOUD_PROXY_PREFIX, cloudProxy)
+
+const TARGET = { deploymentUrl: 'https://workspace.example.com', token: 'deployment-token' }
+const ORIGIN = 'http://127.0.0.1:3000'
+const AGENT = 'a0i89srqo6'
+const SLUG = 'open-slide-studio'
+const MOUNT = dashboardMountPath(AGENT, SLUG)
+
+function proxiedPath(suffix: string): string {
+  return `${CLOUD_PROXY_PREFIX}/${getCloudProxyKey()}${suffix}`
+}
+
+/**
+ * What a Vite dev server serves at a dashboard mount: an empty shell whose
+ * entry points are root-absolute, built from the `base` it was configured
+ * with. Passed through the real injection so the fixture tracks production.
+ */
+function upstreamDocument(): string {
+  return injectDashboardRuntime(
+    '<!doctype html><html><head>'
+    + `<script type="module" src="${MOUNT}@vite/client"></script>`
+    + '</head><body><div id="root"></div>'
+    + `<script type="module" src="${MOUNT}main.tsx"></script>`
+    + '</body></html>',
+    { basePath: MOUNT, slug: SLUG },
+  )
+}
+
+/** Vite rewrites every import specifier to the same root-absolute base. */
+function upstreamEntryModule(): string {
+  return [
+    `import "${MOUNT}@fs/workspace/node_modules/vite/dist/client/env.mjs";`,
+    `import App from "${MOUNT}app.tsx";`,
+    `import "${MOUNT}styles.css";`,
+  ].join('\n')
+}
+
+/** Same-origin urls the browser is told to fetch from a document. */
+function documentAssetUrls(html: string): string[] {
+  return [...html.matchAll(/<(?:script|link)\b[^>]*?\b(?:src|href)="([^"]+)"/g)]
+    .map((m) => m[1])
+    .filter((u) => !/^[a-z]+:/i.test(u) && !u.startsWith('//'))
+}
+
+/** Same-origin specifiers the browser is told to fetch from a module. */
+function moduleImportUrls(js: string): string[] {
+  return [...js.matchAll(/(?:from|import)\s*"([^"]+)"/g)]
+    .map((m) => m[1])
+    .filter((u) => !/^[a-z]+:/i.test(u) && !u.startsWith('//'))
+}
+
+/**
+ * Resolve as the preload scanner does: against the `<base>` present in the
+ * markup, before any script has had a chance to correct it.
+ */
+function resolveStatically(url: string, documentUrl: string, html?: string): string {
+  const declaredBase = html?.match(/<base\b[^>]*\bhref="([^"]*)"/i)?.[1]
+  const base = declaredBase ? new URL(declaredBase, documentUrl).toString() : documentUrl
+  return new URL(url, base).pathname
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  remoteAddress = '127.0.0.1'
+  mockResolveTarget.mockReturnValue(TARGET)
+  mockRefreshTarget.mockResolvedValue(null)
+})
+
+describe('dashboard served through the cloud proxy prefix', () => {
+  it('keeps the document\'s asset urls inside the proxy prefix', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(upstreamDocument(), {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      }),
+    )
+
+    const documentPath = proxiedPath(MOUNT)
+    const res = await app.request(`${ORIGIN}${documentPath}`, {
+      headers: { accept: 'text/html' },
+    })
+    expect(res.status).toBe(200)
+
+    const html = await res.text()
+    const documentUrl = `${ORIGIN}${documentPath}`
+    const assets = documentAssetUrls(html)
+    expect(assets.length).toBeGreaterThan(0)
+
+    for (const asset of assets) {
+      const resolved = resolveStatically(asset, documentUrl, html)
+      expect(
+        resolved.startsWith(`${CLOUD_PROXY_PREFIX}/`),
+        `asset "${asset}" left the proxy prefix: resolved to ${resolved}`,
+      ).toBe(true)
+    }
+  })
+
+  it('keeps a relative asset url inside the proxy prefix', async () => {
+    // Relative urls are the usual advice for a proxied app, and they do not
+    // help here: the injected `<base>` names the mount without the prefix, so
+    // the scanner resolves against that rather than against the document url.
+    mockFetch.mockResolvedValue(
+      new Response(
+        injectDashboardRuntime(
+          '<!doctype html><html><head><link rel="stylesheet" href="./app.css" />'
+          + '</head><body><div id="root"></div>'
+          + '<script type="module" src="./main.js"></script></body></html>',
+          { basePath: MOUNT, slug: SLUG },
+        ),
+        { status: 200, headers: { 'content-type': 'text/html' } },
+      ),
+    )
+
+    const documentPath = proxiedPath(MOUNT)
+    const html = await (
+      await app.request(`${ORIGIN}${documentPath}`, { headers: { accept: 'text/html' } })
+    ).text()
+
+    for (const asset of documentAssetUrls(html)) {
+      const resolved = resolveStatically(asset, `${ORIGIN}${documentPath}`, html)
+      expect(
+        resolved.startsWith(`${CLOUD_PROXY_PREFIX}/`),
+        `asset "${asset}" left the proxy prefix: resolved to ${resolved}`,
+      ).toBe(true)
+    }
+  })
+
+  it('keeps the entry module\'s imports inside the proxy prefix', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(upstreamEntryModule(), {
+        status: 200,
+        headers: { 'content-type': 'text/javascript' },
+      }),
+    )
+
+    const modulePath = proxiedPath(`${MOUNT}main.tsx`)
+    const res = await app.request(`${ORIGIN}${modulePath}`)
+    expect(res.status).toBe(200)
+
+    const js = await res.text()
+    const imports = moduleImportUrls(js)
+    expect(imports.length).toBeGreaterThan(0)
+
+    for (const specifier of imports) {
+      const resolved = new URL(specifier, `${ORIGIN}${modulePath}`).pathname
+      expect(
+        resolved.startsWith(`${CLOUD_PROXY_PREFIX}/`),
+        `import "${specifier}" left the proxy prefix: resolved to ${resolved}`,
+      ).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
**Footprint:** 3 files, +263/-4. One line of existing code changes.

## The bug

In the desktop app driving a cloud workspace, any dashboard that fetches a same-origin subresource renders blank. Confirmed live: `open-slide-studio` returned a 200 document and 404 on `main.tsx` and `@vite/client`, leaving `#root` empty.

The desktop reaches the deployment through `/cloud/<key>` on the loopback origin. The deployment is never told that prefix exists, so it writes the dashboard's mount unprefixed into the markup and into every module specifier. Root-absolute urls ignore `<base>`, so those requests land on the local API, which has no such agent.

The predicate is whether the dashboard fetches anything same-origin, not which toolchain built it. Our own tooling emits single self-contained files, which is why this went unnoticed. Relative urls do not avoid it either: the injected `<base>` names the mount without the prefix, and Chromium's preload scanner resolves against that before the inline runtime can correct it.

## The change

`cloud-proxy.ts` substitutes the prefix back onto occurrences of the request's own mount, in html, javascript and css bodies. The replaced string is the mount the request was served from, so an occurrence of it in that body is by construction a url pointing back at the same dashboard. Nothing is parsed and nothing is inferred.

Applied at the handler's exit rather than threaded through `forwardRequest`, so `forwardRequest` and `toClientResponse` are byte-identical to `main` and the streaming path is untouched.

## Verification

- `dashboard-proxy-prefix.test.ts` drives the real proxy and the real runtime injection with no network, modelling the browser as the preload scanner behaves. Three cases: document asset urls, a relative asset url, and the entry module's import specifiers. All three were red before the fix and pass after, unedited.
- The real proxy on a real socket against a live deployment, driven by headless Chromium at the real prefix: dashboard mounts, zero 4xx.
- By hand in a dev desktop build driving a cloud workspace, dashboard rendering in the real iframe.
- Full suite: 599 files, 9838 tests. Typecheck and lint clean.

## Review notes

- **Bodies are buffered, not streamed**, for dashboard html/js/css. That is the only way to substitute across chunk boundaries. Everything else, including SSE, still streams untouched.
- **JSON is deliberately excluded.** A mount inside a data payload is not necessarily a url. A dashboard that fetches self-referential urls as JSON would still break.
- **Sourcemap offsets shift** after substitution. Dev-server dashboards only.
- **`etag` is dropped** on rewritten responses, because the bytes no longer match what upstream validated. That makes revalidation the common case, so a bodyless `304` bypasses the rewrite rather than being rebuilt — reconstructing a null-body status throws, and without the guard the renderer got a 500 instead of a 304.
- `docs/cloud-workspace.md` claimed documents come back unchanged. That claim is now false, so it is corrected in place; the surrounding text about injected shims deriving their own prefix is untouched.

## What this does not fix

The prefix is an authentication mechanism occupying the application's url namespace. This substitution works and is contained, but it inherits whatever a future dashboard invents. SUP-646 stays open with the architecture options and a spike result on the most promising one.
