### PR TITLE
fix: default MicroVM hosts to the lambda-microvm runner

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -617,6 +617,26 @@ describe('settings route', () => {
       expect(mockUpdateSettings).not.toHaveBeenCalled()
     })
 
+    it('returns 400 when changing containerRunner while lambda-microvm is configured', async () => {
+      mockGetSettings.mockReturnValue({
+        ...defaultSettings(),
+        container: {
+          containerRunner: 'lambda-microvm',
+          agentImage: 'superagent:latest',
+          resourceLimits: { cpu: 2, memory: '4g' },
+        },
+      })
+
+      const res = await putSettings({
+        container: { containerRunner: 'docker' },
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toContain('managed by the deployment')
+      expect(mockUpdateSettings).not.toHaveBeenCalled()
+    })
+
     it('accepts an unchanged agentImage for lambda-microvm', async () => {
       mockGetSettings.mockReturnValue({
         ...defaultSettings(),

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -176,6 +176,14 @@ describe('RuntimeTab', () => {
 
       expect(screen.queryByText('Agent image is required.')).not.toBeInTheDocument()
     })
+
+    it('shows AWS Lambda MicroVM and does not allow changing the runner', () => {
+      renderWithProviders(<RuntimeTab />)
+
+      const runtimeSelect = screen.getByRole('combobox', { name: 'Container Runtime' })
+      expect(runtimeSelect).toHaveTextContent('AWS Lambda MicroVM')
+      expect(runtimeSelect).toBeDisabled()
+    })
   })
 
   it('adds a custom environment variable through the dialog', async () => {

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -52,6 +52,8 @@ const RUNNER_LABELS: Record<string, string> = {
   podman: 'Podman',
   lima: 'Built-in Runtime',
   wsl2: 'Built-in Runtime',
+  kubernetes: 'Kubernetes',
+  'lambda-microvm': 'AWS Lambda MicroVM',
 }
 
 function normalizeEnvVarName(name: string): string {
@@ -168,8 +170,8 @@ export function RuntimeTab() {
     return map
   }, [settings?.runnerAvailability])
 
-  // Runners whose image is fixed by the deployment (e.g. lambda-microvm) ignore
-  // settings.container.agentImage — lock the field so edits aren't misleading.
+  // Runners whose image is fixed by the deployment (e.g. lambda-microvm) also
+  // lock the runner itself — cloud Settings cannot switch it.
   const agentImageLocked =
     runnerAvailabilityMap.get(containerRunner)?.supportsCustomAgentImage === false
 
@@ -264,8 +266,9 @@ export function RuntimeTab() {
     try {
       await updateSettings.mutateAsync({
         container: {
-          containerRunner,
-          // A locked field never submits edits — keep whatever is persisted.
+          containerRunner: agentImageLocked
+            ? (settings?.container.containerRunner ?? containerRunner)
+            : containerRunner,
           agentImage: agentImageLocked
             ? (settings?.container.agentImage ?? trimmedAgentImage)
             : trimmedAgentImage,
@@ -468,9 +471,9 @@ export function RuntimeTab() {
           <Select
             value={containerRunner}
             onValueChange={setContainerRunner}
-            disabled={isLoading || hasRunningAgents}
+            disabled={isLoading || hasRunningAgents || agentImageLocked}
           >
-            <SelectTrigger id="container-runner" className={`flex-1 ${hasRunningAgents ? 'bg-muted' : ''}`}>
+            <SelectTrigger id="container-runner" className={`flex-1 ${hasRunningAgents || agentImageLocked ? 'bg-muted' : ''}`}>
               <SelectValue placeholder="Select a container runtime" />
             </SelectTrigger>
             <SelectContent>

--- a/src/shared/lib/config/settings-patch.test.ts
+++ b/src/shared/lib/config/settings-patch.test.ts
@@ -210,6 +210,14 @@ describe('validateSettingsTransition', () => {
     ).toContainEqual(expect.objectContaining({ status: 400 }))
   })
 
+  it('rejects a runner change away from a deployment-managed runtime', () => {
+    const before = currentSettings()
+    before.container.containerRunner = 'lambda-microvm'
+    expect(
+      problemsFor(before, { container: { containerRunner: 'docker' } }),
+    ).toContainEqual(expect.objectContaining({ status: 400 }))
+  })
+
   it('rejects a requested Lima VM size at or above host memory', () => {
     expect(
       problemsFor(

--- a/src/shared/lib/config/settings-patch.ts
+++ b/src/shared/lib/config/settings-patch.ts
@@ -308,6 +308,13 @@ export const containerSettingsComponent = {
 
     const imageChanged = after.container.agentImage !== before.container.agentImage
     const effectiveRunner = after.container.containerRunner as ContainerRunner
+    const beforeRunner = before.container.containerRunner as ContainerRunner
+    if (runnerChanged && !context.supportsCustomAgentImage(beforeRunner)) {
+      problems.push({
+        status: 400,
+        message: `Container runtime is managed by the deployment for the ${beforeRunner} runner and cannot be changed here.`,
+      })
+    }
     if (imageChanged && !context.supportsCustomAgentImage(effectiveRunner)) {
       problems.push({
         status: 400,

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -94,6 +94,10 @@ beforeEach(() => {
   delete process.env.ANTHROPIC_API_KEY
   delete process.env.COMPOSIO_API_KEY
   delete process.env.COMPOSIO_USER_ID
+  delete process.env.MICROVM_AGENT_IMAGE_ARN
+  delete process.env.MICROVM_EXECUTION_ROLE_ARN
+  delete process.env.MICROVM_EGRESS_CONNECTOR_ARN
+  delete process.env.MICROVM_AWS_REGION
 })
 
 afterEach(() => {
@@ -1352,6 +1356,20 @@ describe('getModelCatalogSettings', () => {
 // ============================================================================
 // DEFAULT_SETTINGS export
 // ============================================================================
+
+describe('MicroVM container runner default', () => {
+  it('reads a persisted docker default as lambda-microvm when MicroVM env is set', () => {
+    Object.assign(process.env, {
+      AWS_REGION: 'us-east-2',
+      MICROVM_AGENT_IMAGE_ARN: 'arn:img',
+      MICROVM_EXECUTION_ROLE_ARN: 'arn:role',
+      MICROVM_EGRESS_CONNECTOR_ARN: 'arn:egress',
+    })
+    mockSettingsFile(JSON.stringify({ container: { containerRunner: 'docker' } }))
+
+    expect(loadSettings().container.containerRunner).toBe('lambda-microvm')
+  })
+})
 
 describe('DEFAULT_SETTINGS', () => {
   it('has expected container defaults', () => {

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { getDataDir } from './data-dir'
-import { isRunningInKubernetes } from '@shared/lib/container/runtime-env'
+import { isMicrovmRuntimeEnvPresent, isRunningInKubernetes } from '@shared/lib/container/runtime-env'
 import { getDefaultAgentImage, AGENT_IMAGE_REGISTRY } from './version'
 import {
   writeFileAtomicSync,
@@ -405,10 +405,11 @@ export type ModelPickerSettingsResponse = Pick<
 >
 
 /**
- * Default container runner: Lima on macOS (bundled, no install needed),
- * WSL2 on Windows (bundled, no install needed), Docker elsewhere.
+ * Default container runner: MicroVM when that backend is configured,
+ * Kubernetes in-cluster, Lima on macOS, WSL2 on Windows, Docker elsewhere.
  */
 function getDefaultContainerRunner(): string {
+  if (isMicrovmRuntimeEnvPresent()) return 'lambda-microvm'
   if (isRunningInKubernetes()) return 'kubernetes'
   const p = os.platform()
   if (p === 'darwin') return 'lima'
@@ -520,6 +521,11 @@ function mergeLoadedSettings(loaded: Record<string, any>): AppSettings {
       },
       // Ensure runtimeSettings exists (may be missing in old settings files)
       runtimeSettings: loaded.container?.runtimeSettings ?? {},
+      ...(isMicrovmRuntimeEnvPresent() &&
+      (loaded.container?.containerRunner === 'docker' ||
+        loaded.container?.containerRunner === 'kubernetes')
+        ? { containerRunner: 'lambda-microvm' as const }
+        : {}),
     },
     app: {
       ...DEFAULT_SETTINGS.app,

--- a/src/shared/lib/container/runtime-env.ts
+++ b/src/shared/lib/container/runtime-env.ts
@@ -4,3 +4,15 @@
 export function isRunningInKubernetes(): boolean {
   return Boolean(process.env.KUBERNETES_SERVICE_HOST)
 }
+
+// Host-app was deployed with the MicroVM agent backend. Settings defaults use
+// this; the runtime client still zod-validates the full MICROVM_* config.
+export function isMicrovmRuntimeEnvPresent(): boolean {
+  const region = process.env.MICROVM_AWS_REGION || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION
+  return Boolean(
+    region?.trim() &&
+    process.env.MICROVM_AGENT_IMAGE_ARN?.trim() &&
+    process.env.MICROVM_EXECUTION_ROLE_ARN?.trim() &&
+    process.env.MICROVM_EGRESS_CONNECTOR_ARN?.trim(),
+  )
+}


### PR DESCRIPTION
## Bug

Linux host-app images default `containerRunner` to `docker`. Cloud ECS injects `MICROVM_*` and actually runs agents as MicroVMs, but Settings still showed **Docker** — especially after first boot, when `settings.json` already had that default and the infra seed no longer rewrites the file.

## Repro

1. Run host-app with `MICROVM_AGENT_IMAGE_ARN`, `MICROVM_EXECUTION_ROLE_ARN`, `MICROVM_EGRESS_CONNECTOR_ARN`, and an AWS region set.
2. Open Settings → Container Runtime.
3. Before: selected runtime is Docker (or the raw `lambda-microvm` id if already switched).
4. After: selected runtime is **AWS Lambda MicroVM**, and the control is locked.

## What changed

- Default runner is `lambda-microvm` when the MicroVM deployment env is present (same contract as Kubernetes via `KUBERNETES_SERVICE_HOST`).
- A persisted `docker` / `kubernetes` default on that host is read as `lambda-microvm`.
- Deployment-managed runners lock both the runner and the agent image (UI + API). Local Docker / Lima / Podman can still be changed.

## Test plan

- [x] `settings`, `settings-patch`, `runtime-tab`, and settings route unit tests
- [ ] Open Settings on a MicroVM-configured host-app and confirm the label is AWS Lambda MicroVM and the select is disabled
- [ ] Confirm a local Docker/Lima install still lets you change the runner

Made with [Cursor](https://cursor.com)