### PR TITLE
ci: speed up unit tests with Blacksmith

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,7 @@ on:
 
 jobs:
   unit-tests:
-    name: unit-tests (${{ matrix.label }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - label: github-ubuntu
-            runner: ubuntu-latest
-          - label: blacksmith-4vcpu
-            runner: blacksmith-4vcpu-ubuntu-2404
-          - label: blacksmith-8vcpu
-            runner: blacksmith-8vcpu-ubuntu-2404
-          - label: blacksmith-16vcpu
-            runner: blacksmith-16vcpu-ubuntu-2404
-          - label: blacksmith-32vcpu
-            runner: blacksmith-32vcpu-ubuntu-2404
-    runs-on: ${{ matrix.runner }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -33,9 +18,6 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-
-      - name: Show available parallelism
-        run: node --print "require('node:os').availableParallelism()"
 
       # 11.14.1 = newest npm with min-release-age support (needs >=11.10) where
       # `npm ls --json --long` still works (broken in 11.15+, breaks electron-builder)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,22 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    name: unit-tests (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: github-ubuntu
+            runner: ubuntu-latest
+          - label: blacksmith-4vcpu
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - label: blacksmith-8vcpu
+            runner: blacksmith-8vcpu-ubuntu-2404
+          - label: blacksmith-16vcpu
+            runner: blacksmith-16vcpu-ubuntu-2404
+          - label: blacksmith-32vcpu
+            runner: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -18,6 +33,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+
+      - name: Show available parallelism
+        run: node --print "require('node:os').availableParallelism()"
 
       # 11.14.1 = newest npm with min-release-age support (needs >=11.10) where
       # `npm ls --json --long` still works (broken in 11.15+, breaks electron-builder)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- move `unit-tests` from `ubuntu-latest` to `blacksmith-8vcpu-ubuntu-2404`
- keep Vitest default file parallelism, which automatically uses all 8 available CPUs in run mode
- avoid test sharding or test-level concurrency changes; the runner move alone clears the target

## Same-revision benchmark

[Benchmark workflow run](https://github.com/SkillfulAgents/SuperAgent/actions/runs/32507662957)

| Runner | Full unit job | Vitest coverage |
| --- | ---: | ---: |
| GitHub Ubuntu (4 vCPU) | 7m47s | 5m58s |
| Blacksmith 4 vCPU | 4m09s | 2m58s |
| Blacksmith 8 vCPU | 3m18s | 1m57s |
| Blacksmith 16 vCPU | 2m23s | 1m09s |
| Blacksmith 32 vCPU | 1m37s | 0m41s |

The same benchmark run put `e2e-tests` at 6m37s.

## Runner selection

The 4-vCPU tier initially hit the requested range, but a production-only repeat took 5m25s, so it is marginal as a reliable ceiling. The 8-vCPU tier completed in 3m18s in the matrix and 3m36s in the production-only repeat, leaving useful headroom without paying for the 16- or 32-vCPU tiers.

## Verification

- [x] Compared GitHub and Blacksmith 4/8/16/32-vCPU jobs on identical code
- [x] Confirmed Vitest receives the expected runner parallelism
- [x] Replaced the temporary matrix with the 8-vCPU production configuration
- [x] [Final Tests workflow](https://github.com/SkillfulAgents/SuperAgent/actions/runs/32509070855) passed: unit-tests 3m36s, e2e-tests 6m46s