### PR TITLE
Reveal page titles in the nav on scroll

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -55,6 +55,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { useNewSessionCarryover } from '@renderer/lib/new-session-carryover'
 import { useDraftsStore } from '@renderer/context/drafts-context'
 import { completeAgentTemplateHandoff } from '@renderer/lib/agent-template-handoff'
+import { ScrollAwarePageTitle } from '@renderer/components/layout/scroll-aware-title'
 
 interface AgentHomeProps {
   agent: ApiAgent
@@ -314,7 +315,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
       >
         {/* Left Column — Chat composer + Sessions */}
         <div className="space-y-6 w-full min-w-0 xl:min-w-[480px] xl:max-w-[720px]">
-          <div className="flex items-center justify-between gap-2 intro-step intro-step-1">
+          <ScrollAwarePageTitle className="flex items-center justify-between gap-2 intro-step intro-step-1">
             <AgentContextMenu agent={agent}>
               <div className="flex-1 min-w-0 cursor-context-menu">
                 <InlineEditableTitle
@@ -346,7 +347,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
             <Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={() => handleOpenSettings()} aria-label="Agent settings" data-testid="agent-settings-button">
               <Settings2 className="h-4 w-4" />
             </Button>
-          </div>
+          </ScrollAwarePageTitle>
           {isViewOnly ? (
             <div className="flex items-center justify-center gap-2 text-sm font-medium text-muted-foreground border rounded-lg p-6" data-testid="view-only-banner">
               <Eye className="h-5 w-5" />

--- a/src/renderer/components/explore/explore-view.tsx
+++ b/src/renderer/components/explore/explore-view.tsx
@@ -195,6 +195,7 @@ export function ExploreView() {
     >
       <PageTitle
         title="Discover New Agents"
+        scrollAware
         actions={
           <div className="flex items-center gap-2">
               <div className="relative w-56">

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -19,6 +19,7 @@ import { HoverScrollText } from '@renderer/components/ui/hover-scroll-text'
 import { useDashboardHeader } from '@renderer/context/dashboard-header-context'
 import { DashboardHeaderActions } from '@renderer/components/dashboards/dashboard-header-actions'
 import type { ContainerStatus } from '@shared/lib/container/types'
+import { ScrollAwareNavTitle } from './scroll-aware-title'
 
 interface AgentHeaderProps {
   slug: string
@@ -76,33 +77,35 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
           className="w-fit max-w-full app-no-drag"
           data-testid="breadcrumb-trail"
         >
-        {agent ? (
-          <AgentContextMenu agent={agent}>
+        <ScrollAwareNavTitle>
+          {agent ? (
+            <AgentContextMenu agent={agent}>
+              <AppLink
+                to="/agents/$slug"
+                params={{ slug }}
+                activeOptions={{ exact: true }}
+                noDrag
+                // Route-derived leaf styling: foreground only when this link is the
+                // exact active route (`data-status=active`), muted/clickable otherwise.
+                className="text-sm font-light transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground cursor-context-menu"
+                data-testid="agent-breadcrumb"
+              >
+                {agent.name}
+              </AppLink>
+            </AgentContextMenu>
+          ) : (
             <AppLink
               to="/agents/$slug"
               params={{ slug }}
               activeOptions={{ exact: true }}
               noDrag
-              // Route-derived leaf styling: foreground only when this link is the
-              // exact active route (`data-status=active`), muted/clickable otherwise.
-              className="text-sm font-light transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground cursor-context-menu"
+              className="text-sm font-light transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground"
               data-testid="agent-breadcrumb"
             >
-              {agent.name}
+              Loading...
             </AppLink>
-          </AgentContextMenu>
-        ) : (
-          <AppLink
-            to="/agents/$slug"
-            params={{ slug }}
-            activeOptions={{ exact: true }}
-            noDrag
-            className="text-sm font-light transition-colors text-muted-foreground hover:text-foreground data-[status=active]:text-foreground"
-            data-testid="agent-breadcrumb"
-          >
-            Loading...
-          </AppLink>
-        )}
+          )}
+        </ScrollAwareNavTitle>
         {(() => {
           const taskCrumbId = scheduledTaskId ?? (sessionId ? session?.scheduledTaskId ?? null : null)
           const taskCrumbName = scheduledTask?.name ?? (sessionId ? session?.scheduledTaskName : null)

--- a/src/renderer/components/layout/content-shell.tsx
+++ b/src/renderer/components/layout/content-shell.tsx
@@ -1,6 +1,7 @@
 import { SidebarTrigger } from '@renderer/components/ui/sidebar'
 import { Separator } from '@renderer/components/ui/separator'
 import { isElectron } from '@renderer/lib/env'
+import { ScrollAwareTitleProvider } from './scroll-aware-title'
 
 /**
  * The header + body frame shared by the agent view and the notifications route.
@@ -15,15 +16,17 @@ export function ContentShell({
   children: React.ReactNode
 }) {
   return (
-    <div className="h-full flex flex-col" data-testid="main-content">
-      <header
-        className={`shrink-0 flex min-h-12 py-1.5 md:py-0 md:h-12 items-center gap-2 border-b bg-background pl-4 pr-2 ${isElectron() ? 'app-drag-region' : ''}`}
-      >
-        <SidebarTrigger className={`app-no-drag ${needsTrafficLightPadding ? 'ml-16' : '-ml-1'}`} />
-        <Separator orientation="vertical" className="h-5 hidden md:block" />
-        {headerContent}
-      </header>
-      {children}
-    </div>
+    <ScrollAwareTitleProvider>
+      <div className="h-full flex flex-col" data-testid="main-content">
+        <header
+          className={`shrink-0 flex min-h-12 py-1.5 md:py-0 md:h-12 items-center gap-2 border-b bg-background pl-4 pr-2 ${isElectron() ? 'app-drag-region' : ''}`}
+        >
+          <SidebarTrigger className={`app-no-drag ${needsTrafficLightPadding ? 'ml-16' : '-ml-1'}`} />
+          <Separator orientation="vertical" className="h-5 hidden md:block" />
+          {headerContent}
+        </header>
+        {children}
+      </div>
+    </ScrollAwareTitleProvider>
   )
 }

--- a/src/renderer/components/layout/explore-route.tsx
+++ b/src/renderer/components/layout/explore-route.tsx
@@ -7,6 +7,7 @@ import { ExploreView } from '@renderer/components/explore/explore-view'
 import { CategoryView } from '@renderer/components/explore/category-view'
 import { TemplateDetailView } from '@renderer/components/explore/template-detail-view'
 import { ContentShell } from './content-shell'
+import { ScrollAwareNavTitle } from './scroll-aware-title'
 
 function useExploreShellProps() {
   const { state: sidebarState } = useSidebar()
@@ -15,7 +16,9 @@ function useExploreShellProps() {
     needsTrafficLightPadding:
       isElectron() && getPlatform() === 'darwin' && sidebarState === 'collapsed' && !isFullScreen,
     headerContent: (
-      <span className="truncate text-sm font-light text-foreground">Discover New Agents</span>
+      <ScrollAwareNavTitle className="truncate text-sm font-light text-foreground">
+        Discover New Agents
+      </ScrollAwareNavTitle>
     ),
   }
 }

--- a/src/renderer/components/layout/notifications-route.tsx
+++ b/src/renderer/components/layout/notifications-route.tsx
@@ -4,6 +4,7 @@ import { isElectron, getPlatform } from '@renderer/lib/env'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { NotificationsView } from '@renderer/components/notifications/notifications-view'
 import { ContentShell } from './content-shell'
+import { ScrollAwareNavTitle } from './scroll-aware-title'
 
 /**
  * The global `/notifications` route: its own top-level view (no agent slug),
@@ -18,7 +19,11 @@ export function NotificationsRoute() {
   return (
     <ContentShell
       needsTrafficLightPadding={needsTrafficLightPadding}
-      headerContent={<span className="truncate text-sm font-light text-foreground">Notifications</span>}
+      headerContent={
+        <ScrollAwareNavTitle className="truncate text-sm font-light text-foreground">
+          Notifications
+        </ScrollAwareNavTitle>
+      }
     >
       <ErrorBoundary>
         <NotificationsView />

--- a/src/renderer/components/layout/scroll-aware-title.test.tsx
+++ b/src/renderer/components/layout/scroll-aware-title.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ScrollAwareNavTitle,
+  ScrollAwarePageTitle,
+  ScrollAwareTitleProvider,
+} from './scroll-aware-title'
+
+interface ObserverRecord {
+  callback: IntersectionObserverCallback
+  disconnect: ReturnType<typeof vi.fn>
+  observe: ReturnType<typeof vi.fn>
+}
+
+let observers: ObserverRecord[]
+
+describe('scroll-aware title coordination', () => {
+  beforeEach(() => {
+    observers = []
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        callback: IntersectionObserverCallback
+        disconnect = vi.fn()
+        observe = vi.fn()
+
+        constructor(callback: IntersectionObserverCallback) {
+          this.callback = callback
+          observers.push(this)
+        }
+
+        unobserve() {}
+        takeRecords() { return [] }
+        root = null
+        rootMargin = '0px'
+        thresholds = [0]
+      },
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reveals the nav title only after the page title leaves view, then reverses', () => {
+    render(
+      <ScrollAwareTitleProvider>
+        <ScrollAwareNavTitle data-testid="nav-title">Notifications</ScrollAwareNavTitle>
+        <ScrollAwarePageTitle data-testid="page-title">
+          <h1>Notifications</h1>
+        </ScrollAwarePageTitle>
+      </ScrollAwareTitleProvider>,
+    )
+
+    const navTitle = screen.getByTestId('nav-title')
+    const pageTitle = screen.getByTestId('page-title')
+    expect(navTitle).toHaveAttribute('data-scroll-aware-nav-title', 'hidden')
+    expect(observers).toHaveLength(1)
+    expect(observers[0].observe).toHaveBeenCalledWith(pageTitle)
+
+    act(() => {
+      observers[0].callback(
+        [{ target: pageTitle, isIntersecting: false } as unknown as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      )
+    })
+    expect(navTitle).toHaveAttribute('data-scroll-aware-nav-title', 'visible')
+
+    act(() => {
+      observers[0].callback(
+        [{ target: pageTitle, isIntersecting: true } as unknown as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      )
+    })
+    expect(navTitle).toHaveAttribute('data-scroll-aware-nav-title', 'hidden')
+  })
+
+  it('keeps the nav title visible when a route has no tracked page title', () => {
+    const { rerender } = render(
+      <ScrollAwareTitleProvider>
+        <ScrollAwareNavTitle data-testid="nav-title">Agent name</ScrollAwareNavTitle>
+        <ScrollAwarePageTitle data-testid="page-title">Agent name</ScrollAwarePageTitle>
+      </ScrollAwareTitleProvider>,
+    )
+
+    expect(screen.getByTestId('nav-title')).toHaveAttribute(
+      'data-scroll-aware-nav-title',
+      'hidden',
+    )
+
+    rerender(
+      <ScrollAwareTitleProvider>
+        <ScrollAwareNavTitle data-testid="nav-title">Agent name</ScrollAwareNavTitle>
+      </ScrollAwareTitleProvider>,
+    )
+
+    expect(screen.getByTestId('nav-title')).toHaveAttribute(
+      'data-scroll-aware-nav-title',
+      'visible',
+    )
+    expect(observers[0].disconnect).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/layout/scroll-aware-title.tsx
+++ b/src/renderer/components/layout/scroll-aware-title.tsx
@@ -1,0 +1,170 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react'
+import { cn } from '@shared/lib/utils/cn'
+
+interface ScrollAwareTitleContextValue {
+  isNavTitleVisible: boolean
+  registerPageTitle: (element: HTMLElement) => () => void
+}
+
+const ScrollAwareTitleContext = createContext<ScrollAwareTitleContextValue | null>(null)
+
+/**
+ * Coordinates a page heading with the matching title in the persistent nav.
+ * Page headings register themselves below; the nav title stays hidden while
+ * any registered heading is visible and reveals once all of them are clipped.
+ */
+export function ScrollAwareTitleProvider({ children }: { children: ReactNode }) {
+  const nextRegistrationId = useRef(0)
+  const [pageTitleVisibility, setPageTitleVisibility] = useState<Map<number, boolean>>(
+    () => new Map(),
+  )
+
+  const registerPageTitle = useCallback((element: HTMLElement) => {
+    const registrationId = nextRegistrationId.current++
+
+    // Headings mount in view in the common case. Register synchronously from a
+    // layout effect so the duplicate nav title is removed before first paint;
+    // IntersectionObserver corrects this after restored/offscreen mounts.
+    setPageTitleVisibility((current) => {
+      const next = new Map(current)
+      next.set(registrationId, true)
+      return next
+    })
+
+    const observer =
+      typeof IntersectionObserver === 'undefined'
+        ? null
+        : new IntersectionObserver(
+            ([entry]) => {
+              if (!entry) return
+              setPageTitleVisibility((current) => {
+                if (!current.has(registrationId)) return current
+                const isVisible = entry.isIntersecting
+                if (current.get(registrationId) === isVisible) return current
+                const next = new Map(current)
+                next.set(registrationId, isVisible)
+                return next
+              })
+            },
+            // The viewport root still accounts for clipping by nested scroll
+            // containers, so each page can place its heading at any height.
+            { threshold: 0 },
+          )
+
+    observer?.observe(element)
+
+    return () => {
+      observer?.disconnect()
+      setPageTitleVisibility((current) => {
+        if (!current.has(registrationId)) return current
+        const next = new Map(current)
+        next.delete(registrationId)
+        return next
+      })
+    }
+  }, [])
+
+  const isNavTitleVisible =
+    pageTitleVisibility.size === 0 ||
+    Array.from(pageTitleVisibility.values()).every((isVisible) => !isVisible)
+
+  const value = useMemo(
+    () => ({ isNavTitleVisible, registerPageTitle }),
+    [isNavTitleVisible, registerPageTitle],
+  )
+
+  return (
+    <ScrollAwareTitleContext.Provider value={value}>
+      {children}
+    </ScrollAwareTitleContext.Provider>
+  )
+}
+
+/**
+ * Marks the real, in-page heading whose visibility controls the nav title.
+ * It observes the rendered element rather than a scroll offset, which keeps
+ * the behavior correct when pages use different top padding or back buttons.
+ */
+export function ScrollAwarePageTitle({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  const context = useContext(ScrollAwareTitleContext)
+  const registerPageTitle = context?.registerPageTitle
+  const titleRef = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    const element = titleRef.current
+    if (!element || !registerPageTitle) return
+    return registerPageTitle(element)
+  }, [registerPageTitle])
+
+  return (
+    <div
+      ref={titleRef}
+      className={className}
+      data-scroll-aware-page-title=""
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Nav-side counterpart to ScrollAwarePageTitle. With no registered page title
+ * (for example an agent sub-route), its contents remain visible as normal.
+ */
+export function ScrollAwareNavTitle({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLSpanElement>) {
+  const context = useContext(ScrollAwareTitleContext)
+  const isVisible = context?.isNavTitleVisible ?? true
+  const [canAnimate, setCanAnimate] = useState(false)
+
+  // A page title registers from a layout effect on the first commit. Defer the
+  // transition class by one frame so that initial deduplication is immediate,
+  // while subsequent scroll-driven changes still animate in both directions.
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => setCanAnimate(true))
+    return () => window.cancelAnimationFrame(frame)
+  }, [])
+
+  // React 18's HTML attribute types predate the now-baseline `inert` attribute.
+  // An empty boolean attribute keeps hidden nav links out of keyboard focus.
+  const inertProps = isVisible ? {} : { inert: '' }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex min-w-0',
+        canAnimate &&
+          'transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none',
+        isVisible
+          ? 'translate-y-0 opacity-100'
+          : 'pointer-events-none -translate-y-1 opacity-0',
+        className,
+      )}
+      aria-hidden={!isVisible}
+      data-scroll-aware-nav-title={isVisible ? 'visible' : 'hidden'}
+      {...props}
+      {...inertProps}
+    >
+      {children}
+    </span>
+  )
+}

--- a/src/renderer/components/layout/settings-page.tsx
+++ b/src/renderer/components/layout/settings-page.tsx
@@ -2,6 +2,7 @@ import type { ReactNode, Ref } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { cn } from '@shared/lib/utils/cn'
+import { ScrollAwarePageTitle } from './scroll-aware-title'
 
 interface SettingsPageContainerProps {
   children: ReactNode
@@ -51,14 +52,16 @@ interface PageTitleProps {
   title: ReactNode
   back?: { onClick: () => void; label?: string; testId?: string }
   actions?: ReactNode
+  /** Hide the matching nav title until this in-page heading scrolls away. */
+  scrollAware?: boolean
 }
 
 /**
  * Page heading with optional back button and right-aligned actions.
  */
-export function PageTitle({ title, back, actions }: PageTitleProps) {
-  return (
-    <div>
+export function PageTitle({ title, back, actions, scrollAware = false }: PageTitleProps) {
+  const content = (
+    <>
       {back && (
         <Button
           type="button"
@@ -80,6 +83,8 @@ export function PageTitle({ title, back, actions }: PageTitleProps) {
         )}
         {actions && <div className="shrink-0">{actions}</div>}
       </div>
-    </div>
+    </>
   )
+
+  return scrollAware ? <ScrollAwarePageTitle>{content}</ScrollAwarePageTitle> : <div>{content}</div>
 }

--- a/src/renderer/components/notifications/notifications-view.tsx
+++ b/src/renderer/components/notifications/notifications-view.tsx
@@ -280,6 +280,7 @@ export function NotificationsView() {
     <SettingsPageContainer fullScreen>
       <PageTitle
         title="Notifications"
+        scrollAware
         back={{
           onClick: () => {
             void navigate(


### PR DESCRIPTION
## Summary

- add shared `ScrollAwareTitleProvider`, `ScrollAwarePageTitle`, and `ScrollAwareNavTitle` primitives
- observe the real in-page heading with `IntersectionObserver`, so each page can keep its own title height and spacing
- animate the matching top-nav title in only after the page heading is fully out of view, and reverse the transition on scroll up
- apply the behavior to Agent Home, Discover New Agents, and Notifications while preserving normal breadcrumbs on agent sub-routes
- keep hidden nav content out of pointer and keyboard interaction

## Testing

- `npm run test:run -- src/renderer/components/layout/scroll-aware-title.test.tsx src/renderer/components/layout/agent-header.test.tsx src/renderer/components/agents/agent-home/agent-home.test.tsx src/renderer/components/explore/explore-view.test.tsx src/renderer/components/notifications/notifications-view.test.tsx` (73 tests)
- `npm run typecheck`
- ESLint on all touched source and test files
- `npm run build:web`
- browser-verified top → scroll down → scroll back up on all three pages with no console errors