### PR TITLE
feat: MicroVM death classification and mid-turn recovery plan

### DIFF
--- a/src/api/routes/settings.test.ts
+++ b/src/api/routes/settings.test.ts
@@ -2054,6 +2054,20 @@ describe('settings route', () => {
       const body = await res.json()
       expect(body.error).toMatch(/warmStartOnType/)
     })
+
+    it('PUT accepts autoResumeOnUnexpectedDeath boolean under app', async () => {
+      const res = await putSettings({ app: { autoResumeOnUnexpectedDeath: false } })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.app.autoResumeOnUnexpectedDeath).toBe(false)
+    })
+
+    it('PUT rejects non-boolean autoResumeOnUnexpectedDeath', async () => {
+      const res = await putSettings({ app: { autoResumeOnUnexpectedDeath: 'yes' } })
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toMatch(/autoResumeOnUnexpectedDeath/)
+    })
   })
 
   describe('model icon uploads', () => {

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -37,7 +37,10 @@ const mockSettings = {
     hasRunningAgents: false,
     customEnvVars: {},
     dataDir: '/tmp/superagent',
-    app: { autoSleepTimeoutMinutes: 30 },
+    app: {
+      autoSleepTimeoutMinutes: 30,
+      autoResumeOnUnexpectedDeath: undefined as boolean | undefined,
+    },
     agentLimits: {},
   },
   isLoading: false,
@@ -177,6 +180,56 @@ describe('RuntimeTab', () => {
 
       expect(screen.queryByText('Agent image is required.')).not.toBeInTheDocument()
     })
+  })
+
+  it('hides the MicroVM auto-resume toggle on other runtimes', () => {
+    renderWithProviders(<RuntimeTab />)
+
+    expect(screen.queryByRole('switch', { name: 'Auto-resume mid-turn sessions' })).not.toBeInTheDocument()
+  })
+
+  it('defaults auto-resume on for MicroVM and persists the toggle immediately', async () => {
+    const user = userEvent.setup()
+    mockSettings.data.container.containerRunner = 'lambda-microvm'
+    mockSettings.data.runnerAvailability = [
+      {
+        runner: 'lambda-microvm',
+        installed: true,
+        running: true,
+        available: true,
+        canStart: false,
+        supportsCustomAgentImage: false,
+      },
+    ]
+    renderWithProviders(<RuntimeTab />)
+
+    const toggle = screen.getByRole('switch', { name: 'Auto-resume mid-turn sessions' })
+    expect(toggle).toBeChecked()
+
+    await user.click(toggle)
+
+    expect(mockUpdateSettings.mutate).toHaveBeenCalledWith({
+      app: { autoResumeOnUnexpectedDeath: false },
+    })
+  })
+
+  it('renders auto-resume off when the MicroVM preference is disabled', () => {
+    mockSettings.data.container.containerRunner = 'lambda-microvm'
+    mockSettings.data.runnerAvailability = [
+      {
+        runner: 'lambda-microvm',
+        installed: true,
+        running: true,
+        available: true,
+        canStart: false,
+        supportsCustomAgentImage: false,
+      },
+    ]
+    mockSettings.data.app = { autoSleepTimeoutMinutes: 30, autoResumeOnUnexpectedDeath: false }
+
+    renderWithProviders(<RuntimeTab />)
+
+    expect(screen.getByRole('switch', { name: 'Auto-resume mid-turn sessions' })).not.toBeChecked()
   })
 
   it('adds a custom environment variable through the dialog', async () => {

--- a/src/renderer/components/settings/runtime-tab.test.tsx
+++ b/src/renderer/components/settings/runtime-tab.test.tsx
@@ -90,7 +90,7 @@ describe('RuntimeTab', () => {
     mockSettings.data.container.agentImage = 'ghcr.io/skillfulagents/superagent-agent-container-base:latest'
     mockSettings.data.container.runtimeSettings = {}
     mockSettings.data.hostTotalMemoryBytes = 64 * 1024 ** 3
-    mockSettings.data.app = { autoSleepTimeoutMinutes: 30 }
+    mockSettings.data.app = { autoSleepTimeoutMinutes: 30, autoResumeOnUnexpectedDeath: undefined }
     mockSettings.data.customEnvVars = {}
     mockSettings.data.runnerAvailability = [
       {

--- a/src/renderer/components/settings/runtime-tab.tsx
+++ b/src/renderer/components/settings/runtime-tab.tsx
@@ -26,6 +26,7 @@ import {
   useRestartRunner,
   useRefreshAvailability,
   isWarmStartOnTypeEnabled,
+  isAutoResumeOnUnexpectedDeathEnabled,
 } from '@renderer/hooks/use-settings'
 import { AlertCircle, AlertTriangle, Play, Download, Loader2, RefreshCw, Plus, X } from 'lucide-react'
 import { RunnerSetupErrorPanel, getRunnerSetupPayload } from '@renderer/components/settings/runner-setup-error-panel'
@@ -806,6 +807,25 @@ export function RuntimeTab() {
           disabled={isLoading}
         />
       </div>
+
+      {containerRunner === 'lambda-microvm' && (
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-0.5 min-w-0">
+            <Label htmlFor="auto-resume-on-unexpected-death">Auto-resume mid-turn sessions</Label>
+            <p className="text-xs text-muted-foreground">
+              If the MicroVM dies while a session is still working, continue the turn instead of showing a connection-lost error.
+            </p>
+          </div>
+          <Switch
+            id="auto-resume-on-unexpected-death"
+            checked={isAutoResumeOnUnexpectedDeathEnabled(settings)}
+            onCheckedChange={(checked: boolean) => {
+              updateSettings.mutate({ app: { autoResumeOnUnexpectedDeath: checked } })
+            }}
+            disabled={isLoading}
+          />
+        </div>
+      )}
 
       {/* Agent Limits */}
       <div className="space-y-4 pt-2">

--- a/src/renderer/hooks/use-settings.ts
+++ b/src/renderer/hooks/use-settings.ts
@@ -39,6 +39,13 @@ export function isWarmStartOnTypeEnabled(
   return settings?.app?.warmStartOnType !== false
 }
 
+/** Default-on MicroVM preference; treat missing as enabled. */
+export function isAutoResumeOnUnexpectedDeathEnabled(
+  settings?: Pick<GlobalSettingsResponse, 'app'> | null,
+): boolean {
+  return settings?.app?.autoResumeOnUnexpectedDeath !== false
+}
+
 /**
  * Whether warm-start-on-type should fire. Returns false until settings have
  * loaded so a disabled preference cannot race a speculative start.

--- a/src/shared/lib/config/settings-patch.ts
+++ b/src/shared/lib/config/settings-patch.ts
@@ -75,6 +75,7 @@ export const appSettingsPatchSchema = z.object({
   notifications: notificationSettingsSchema,
   autoSleepTimeoutMinutes: z.number(),
   warmStartOnType: z.boolean(),
+  autoResumeOnUnexpectedDeath: z.boolean(),
   autoDeleteInactiveDays: z.number(),
   setupCompleted: z.boolean(),
   accountProvider: z.enum(['composio', 'nango']),

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -31,6 +31,7 @@ import {
   getCustomEnvVars,
   DEFAULT_SETTINGS,
   DEFAULT_AUTH_SETTINGS,
+  isAutoResumeOnUnexpectedDeathEnabled,
 } from './settings'
 import type { AppSettings } from './settings'
 
@@ -1366,6 +1367,10 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.app?.showMenuBarIcon).toBe(true)
     expect(DEFAULT_SETTINGS.app?.autoSleepTimeoutMinutes).toBe(30)
     expect(DEFAULT_SETTINGS.app?.warmStartOnType).toBe(true)
+    expect(DEFAULT_SETTINGS.app?.autoResumeOnUnexpectedDeath).toBe(true)
+    expect(isAutoResumeOnUnexpectedDeathEnabled(undefined)).toBe(true)
+    expect(isAutoResumeOnUnexpectedDeathEnabled({ app: {} })).toBe(true)
+    expect(isAutoResumeOnUnexpectedDeathEnabled({ app: { autoResumeOnUnexpectedDeath: false } })).toBe(false)
   })
 
   it('has expected notification defaults', () => {

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -108,6 +108,8 @@ export interface AppPreferences {
   autoSleepTimeoutMinutes?: number
   /** Pre-start the agent container when the user begins typing a first message. */
   warmStartOnType?: boolean
+  /** MicroVM-only. Resume mid-turn sessions after unexpected VM death. Default on. */
+  autoResumeOnUnexpectedDeath?: boolean
   autoDeleteInactiveDays?: number
   setupCompleted?: boolean
   accountProvider?: AccountProviderType
@@ -135,6 +137,13 @@ export interface AppPreferences {
   browserbaseProxyCountry?: string
   browserbaseProxyState?: string
   browserbaseProxyCity?: string
+}
+
+/** Default-on MicroVM preference; other runtimes ignore this setting. */
+export function isAutoResumeOnUnexpectedDeathEnabled(
+  settings?: { app?: Pick<AppPreferences, 'autoResumeOnUnexpectedDeath'> } | null,
+): boolean {
+  return settings?.app?.autoResumeOnUnexpectedDeath !== false
 }
 
 export interface AuthSettings {
@@ -430,6 +439,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     showMenuBarIcon: true,
     autoSleepTimeoutMinutes: 30,
     warmStartOnType: true,
+    autoResumeOnUnexpectedDeath: true,
     globalDispatchShortcut: DEFAULT_GLOBAL_DISPATCH_SHORTCUT,
     notifications: {
       enabled: true,

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -20,7 +20,12 @@ import type {
   StopResult,
   StreamMessage,
 } from './types'
-import type { ObserveUnexpectedDeathInput, RuntimeFatalKind, UnexpectedDeathPlan } from './runtime-death'
+import type {
+  ObserveUnexpectedDeathInput,
+  RuntimeDeathProbe,
+  RuntimeFatalKind,
+  UnexpectedDeathPlan,
+} from './runtime-death'
 import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getAgentCapabilitySettings, getSettings } from '@shared/lib/config/settings'
@@ -381,23 +386,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
   async observeUnexpectedDeath(input?: ObserveUnexpectedDeathInput): Promise<UnexpectedDeathPlan> {
     try {
-      if (!(await this.isHealthy())) return { action: 'settle' }
-      const sessionIds = input?.sessionIds ?? []
-      if (sessionIds.length === 0) return { action: 'ignore' }
-      const liveSessionIds: string[] = []
-      for (const sessionId of sessionIds) {
-        try {
-          const session = await this.getSession(sessionId)
-          if (session?.isRunning) liveSessionIds.push(sessionId)
-        } catch (error) {
-          captureException(error, {
-            tags: { area: 'container', op: 'runtime.observeDeath.probeSession' },
-            extra: { agentId: this.config.agentId, sessionId },
-          })
-        }
-      }
-      if (liveSessionIds.length === 0) return { action: 'settle' }
-      return { action: 'ignore', liveSessionIds }
+      const probe = await this.probeRuntimeDeath(input?.sessionIds ?? [])
+      if (probe.status !== 'live') return { action: 'settle' }
+      return { action: 'ignore', liveSessionIds: probe.liveSessionIds }
     } catch (error) {
       captureException(error, {
         tags: { area: 'container', op: 'runtime.observeDeath.default' },
@@ -405,6 +396,25 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       })
       return { action: 'settle' }
     }
+  }
+
+  protected async probeRuntimeDeath(sessionIds: string[], knownPort?: number): Promise<RuntimeDeathProbe> {
+    if (!(await this.isHealthy(knownPort))) return { status: 'unreachable' }
+    if (sessionIds.length === 0) return { status: 'live' }
+    const liveSessionIds: string[] = []
+    for (const sessionId of sessionIds) {
+      try {
+        const session = await this.getSession(sessionId)
+        if (session?.isRunning) liveSessionIds.push(sessionId)
+      } catch (error) {
+        // Not live; keep probing siblings.
+        captureException(error, {
+          tags: { area: 'container', op: 'runtime.observeDeath.probeSession' },
+          extra: { agentId: this.config.agentId, sessionId },
+        })
+      }
+    }
+    return { status: liveSessionIds.length > 0 ? 'live' : 'idle', liveSessionIds }
   }
 
   getRuntimeGenerationId(): string | null {

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -1528,6 +1528,7 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
     await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
       action: 'recover',
       reason: 'max_lifetime',
+      resumePrompt: expect.stringContaining('8-hour lifetime'),
       replaceGeneration: true,
     })
   })
@@ -1547,6 +1548,7 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
     ).resolves.toEqual({
       action: 'recover',
       reason: 'guest_oom',
+      resumePrompt: expect.stringContaining('ran out of memory'),
       replaceGeneration: false,
     })
   })

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -42,7 +42,7 @@ vi.mock('@shared/lib/config/settings', () => ({
   getSettings: () => ({ app: { autoSleepTimeoutMinutes: autoSleepTimeoutMinutes() }, enableToolSearch: true }),
 }))
 
-import { captureException } from '@shared/lib/error-reporting'
+import { addErrorBreadcrumb, captureException } from '@shared/lib/error-reporting'
 import {
   LambdaMicroVmRuntimeClient,
   LocalAuthForwardProxy,
@@ -80,7 +80,9 @@ beforeEach(() => {
   tlsConnectMock.mockReset()
   sendMock.mockImplementation(async (cmd: { type: string }) => {
     if (cmd.type === 'Run') return { microvmId: 'mvm-1', endpoint: 'ep.lambda-microvm.aws' }
-    if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+    if (cmd.type === 'Get') {
+      return { state: responses.getState ?? 'RUNNING', stateReason: responses.getStateReason }
+    }
     if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
     return {}
   })
@@ -603,6 +605,58 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-2' })
     expect(runCount).toBe(1)
     expect(superCreate).toHaveBeenCalledTimes(2)
+    expect(addErrorBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          reason: 'post_create_unreachable',
+          classification: 'runtime_lost',
+          state: 'TERMINATED',
+        }),
+      }),
+    )
+    superCreate.mockRestore()
+  })
+
+  it('replaceGeneration breadcrumb classifies max-lifetime stateReason', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+    vi.mocked(addErrorBreadcrumb).mockClear()
+
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Run') {
+        responses.getState = 'RUNNING'
+        delete responses.getStateReason
+        return { microvmId: 'mvm-retry-8h', endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Get') {
+        return { state: responses.getState ?? 'RUNNING', stateReason: responses.getStateReason }
+      }
+      if (cmd.type === 'Terminate') return {}
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate
+      .mockImplementationOnce(async () => {
+        responses.getState = 'TERMINATED'
+        responses.getStateReason = 'MicroVM exceeded maximum lifetime.'
+        throw refusedConnectError()
+      })
+      .mockResolvedValueOnce({ id: 'sess-8h' } as never)
+
+    await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-8h' })
+    expect(addErrorBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          classification: 'max_lifetime',
+          state: 'TERMINATED',
+          stateReason: 'MicroVM exceeded maximum lifetime.',
+        }),
+      }),
+    )
     superCreate.mockRestore()
   })
 
@@ -1433,5 +1487,84 @@ describe('attachMicrovmUpstreamKeepalive', () => {
     vi.advanceTimersByTime(MICROVM_STREAM_KEEPALIVE_MS)
     expect(write).not.toHaveBeenCalled()
     dispose()
+  })
+})
+
+describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
+  beforeEach(() => {
+    Object.assign(process.env, FULL_ENV)
+    resetMicrovmRuntimeForTests()
+  })
+
+  function newClient() {
+    return new LambdaMicroVmRuntimeClient({
+      agentId: 'agent-xyz',
+      envVars: { FOO: 'bar' },
+      restartAgent: async () => {},
+    })
+  }
+
+  function sessionFetch(isRunning: boolean) {
+    vi.mocked(fetch).mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
+      const url = String(input)
+      if (url.includes('/sessions/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'sess-1', isRunning }),
+        } as unknown as Response
+      }
+      return { ok: true } as Response
+    })
+  }
+
+  it('recovers max_lifetime with replace when GetMicrovm reports the 8h reason', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'TERMINATED'
+    responses.getStateReason = 'MicroVM exceeded maximum lifetime.'
+    sessionFetch(false)
+
+    await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
+      action: 'recover',
+      reason: 'max_lifetime',
+      replaceGeneration: true,
+    })
+  })
+
+  it('recovers guest_oom without replace when SIGKILL + RUNNING + probe fail', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'RUNNING'
+    delete responses.getStateReason
+    sessionFetch(false)
+
+    await expect(
+      client.observeUnexpectedDeath({
+        lastFatalResult: 'oom_sigkill',
+        sessionIds: ['sess-1'],
+      }),
+    ).resolves.toEqual({
+      action: 'recover',
+      reason: 'guest_oom',
+      replaceGeneration: false,
+    })
+  })
+
+  it('ignores a WS blip when the VM is RUNNING and the session probe succeeds', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'RUNNING'
+    sessionFetch(true)
+
+    await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
+      action: 'ignore',
+    })
+  })
+
+  it('defers SIGKILL fatals and settles other fatals', () => {
+    const client = newClient()
+    expect(client.onFatalResult('oom_sigkill')).toBe('defer_for_recovery')
+    expect(client.onFatalResult(null)).toBe('settle')
   })
 })

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -1514,16 +1514,29 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
     })
   }
 
-  function sessionFetch(isRunning: boolean) {
+  function sessionFetchBy(running: Record<string, boolean>) {
     vi.mocked(fetch).mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
       const url = String(input)
-      if (url.includes('/sessions/')) {
+      const match = url.match(/\/sessions\/([^/?]+)/)
+      if (match) {
         return {
           ok: true,
           status: 200,
-          json: async () => ({ id: 'sess-1', isRunning }),
+          json: async () => ({ id: match[1], isRunning: running[match[1]] ?? false }),
         } as unknown as Response
       }
+      return { ok: true } as Response
+    })
+  }
+
+  function sessionFetch(isRunning: boolean) {
+    sessionFetchBy({ 'sess-1': isRunning })
+  }
+
+  function healthDown() {
+    vi.mocked(fetch).mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
+      const url = String(input)
+      if (url.includes('/health')) return { ok: false, status: 502 } as Response
       return { ok: true } as Response
     })
   }
@@ -1556,7 +1569,7 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
     })
   })
 
-  it('recovers guest_oom without replace when SIGKILL + RUNNING + probe fail', async () => {
+  it('recovers guest_oom without replace when SIGKILL + RUNNING + sessions idle over live HTTP', async () => {
     const client = newClient()
     await client.start()
     responses.getState = 'RUNNING'
@@ -1576,6 +1589,26 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
     })
   })
 
+  it('recovers guest_oom with replace when the container HTTP surface is unreachable', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'RUNNING'
+    delete responses.getStateReason
+    healthDown()
+
+    await expect(
+      client.observeUnexpectedDeath({
+        lastFatalResult: 'oom_sigkill',
+        sessionIds: ['sess-1'],
+      }),
+    ).resolves.toEqual({
+      action: 'recover',
+      reason: 'guest_oom',
+      resumePrompt: expect.stringContaining('ran out of memory'),
+      replaceGeneration: true,
+    })
+  })
+
   it('still ignores a WS blip when the MicroVM auto-resume toggle is off', async () => {
     autoResumeOnUnexpectedDeath.mockReturnValue(false)
     const client = newClient()
@@ -1585,6 +1618,7 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
 
     await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
       action: 'ignore',
+      liveSessionIds: ['sess-1'],
     })
   })
 
@@ -1596,6 +1630,21 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
 
     await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
       action: 'ignore',
+      liveSessionIds: ['sess-1'],
+    })
+  })
+
+  it('reports only the still-running sessions so dead siblings settle', async () => {
+    const client = newClient()
+    await client.start()
+    responses.getState = 'RUNNING'
+    sessionFetchBy({ 'sess-1': true, 'sess-2': false })
+
+    await expect(
+      client.observeUnexpectedDeath({ sessionIds: ['sess-1', 'sess-2'] }),
+    ).resolves.toEqual({
+      action: 'ignore',
+      liveSessionIds: ['sess-1'],
     })
   })
 
@@ -1615,6 +1664,7 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
 
     await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
       action: 'ignore',
+      liveSessionIds: ['sess-1'],
     })
   })
 

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -38,8 +38,17 @@ vi.mock('@shared/lib/llm-provider', () => ({
 }))
 
 const autoSleepTimeoutMinutes = vi.fn((): number | undefined => 30)
+const autoResumeOnUnexpectedDeath = vi.fn((): boolean => true)
 vi.mock('@shared/lib/config/settings', () => ({
-  getSettings: () => ({ app: { autoSleepTimeoutMinutes: autoSleepTimeoutMinutes() }, enableToolSearch: true }),
+  getSettings: () => ({
+    app: {
+      autoSleepTimeoutMinutes: autoSleepTimeoutMinutes(),
+      autoResumeOnUnexpectedDeath: autoResumeOnUnexpectedDeath(),
+    },
+    enableToolSearch: true,
+  }),
+  isAutoResumeOnUnexpectedDeathEnabled: (settings?: { app?: { autoResumeOnUnexpectedDeath?: boolean } }) =>
+    settings?.app?.autoResumeOnUnexpectedDeath !== false,
 }))
 
 import { addErrorBreadcrumb, captureException } from '@shared/lib/error-reporting'
@@ -1494,6 +1503,7 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
   beforeEach(() => {
     Object.assign(process.env, FULL_ENV)
     resetMicrovmRuntimeForTests()
+    autoResumeOnUnexpectedDeath.mockReturnValue(true)
   })
 
   function newClient() {
@@ -1533,6 +1543,19 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
     })
   })
 
+  it('settles a recover plan when the MicroVM auto-resume toggle is off', async () => {
+    autoResumeOnUnexpectedDeath.mockReturnValue(false)
+    const client = newClient()
+    await client.start()
+    responses.getState = 'TERMINATED'
+    responses.getStateReason = 'MicroVM exceeded maximum lifetime.'
+    sessionFetch(false)
+
+    await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
+      action: 'settle',
+    })
+  })
+
   it('recovers guest_oom without replace when SIGKILL + RUNNING + probe fail', async () => {
     const client = newClient()
     await client.start()
@@ -1550,6 +1573,18 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
       reason: 'guest_oom',
       resumePrompt: expect.stringContaining('ran out of memory'),
       replaceGeneration: false,
+    })
+  })
+
+  it('still ignores a WS blip when the MicroVM auto-resume toggle is off', async () => {
+    autoResumeOnUnexpectedDeath.mockReturnValue(false)
+    const client = newClient()
+    await client.start()
+    responses.getState = 'RUNNING'
+    sessionFetch(true)
+
+    await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
+      action: 'ignore',
     })
   })
 

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -1564,6 +1564,36 @@ describe('LambdaMicroVmRuntimeClient.observeUnexpectedDeath', () => {
     })
   })
 
+  function failGetMicrovm() {
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Get') throw new Error('ThrottlingException')
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+  }
+
+  it('ignores when GetMicrovm fails but the live probe still sees the session running', async () => {
+    const client = newClient()
+    await client.start()
+    sessionFetch(true)
+    failGetMicrovm()
+
+    await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
+      action: 'ignore',
+    })
+  })
+
+  it('fails closed to settle when GetMicrovm fails and the probe cannot confirm the session', async () => {
+    const client = newClient()
+    await client.start()
+    sessionFetch(false)
+    failGetMicrovm()
+
+    await expect(client.observeUnexpectedDeath({ sessionIds: ['sess-1'] })).resolves.toEqual({
+      action: 'settle',
+    })
+  })
+
   it('defers SIGKILL fatals and settles other fatals', () => {
     const client = newClient()
     expect(client.onFatalResult('oom_sigkill')).toBe('defer_for_recovery')

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -30,6 +30,14 @@ import type {
 } from './types'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
+import {
+  classifyMicrovmDeath,
+  planFromClassification,
+  type MicrovmDeathReason,
+  type MicrovmFatalResult,
+  type MicrovmProbeResult,
+} from './microvm-death-classifier'
+import type { ObserveUnexpectedDeathInput, UnexpectedDeathPlan } from './runtime-death'
 
 // RunMicrovm caps runHookPayload at 4096 bytes. We only put a small bootstrap
 // credential + mount params here; the full agent env is fetched at boot (see
@@ -614,7 +622,12 @@ interface AgentMicrovmState {
 }
 const agentStates = new Map<string, AgentMicrovmState>()
 
-type MicrovmDetail = { state?: string; endpoint?: string }
+const microvmDetailSchema = z.object({
+  state: z.string().optional(),
+  endpoint: z.string().optional(),
+  stateReason: z.string().optional(),
+})
+type MicrovmDetail = z.infer<typeof microvmDetailSchema>
 
 // Control plane selection, keyed on MICROVM_PROXY_URL:
 //
@@ -732,11 +745,19 @@ async function runMicrovm(
 
 async function getMicrovm(region: string, microvmId: string): Promise<MicrovmDetail> {
   const svc = microvmService()
-  if (svc) return serviceFetch(svc, 'GET', `/microvm/${encodeURIComponent(microvmId)}`)
+  if (svc) {
+    return microvmDetailSchema.parse(
+      await serviceFetch<unknown>(svc, 'GET', `/microvm/${encodeURIComponent(microvmId)}`),
+    )
+  }
   const res = (await getMicrovmClient(region).send(
     new GetMicrovmCommand({ microvmIdentifier: microvmId }),
   )) as GetMicrovmCommandOutput
-  return { state: res.state, endpoint: res.endpoint }
+  return microvmDetailSchema.parse({
+    state: res.state,
+    endpoint: res.endpoint,
+    stateReason: res.stateReason,
+  })
 }
 
 async function terminateMicrovm(region: string, microvmId: string): Promise<void> {
@@ -805,9 +826,79 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   static readonly supportsCustomAgentImage = false
 
   private replaceInFlight: Promise<void> | null = null
+  private lastFatalResult: MicrovmFatalResult = null
 
   constructor(config: ContainerConfig) {
     super(config)
+  }
+
+  onFatalResult(kind: MicrovmFatalResult): 'settle' | 'defer_for_recovery' {
+    if (kind !== 'oom_sigkill') return 'settle'
+    this.lastFatalResult = kind
+    return 'defer_for_recovery'
+  }
+
+  getRuntimeGenerationId(): string | null {
+    return agentStates.get(this.config.agentId)?.microvmId ?? null
+  }
+
+  async observeUnexpectedDeath(input?: ObserveUnexpectedDeathInput): Promise<UnexpectedDeathPlan> {
+    const lastFatalResult = input?.lastFatalResult ?? this.lastFatalResult
+    this.lastFatalResult = null
+    const sessionIds = input?.sessionIds ?? []
+    const installed = agentStates.get(this.config.agentId)
+    const probeResult = await this.probeUnexpectedDeath(sessionIds, installed?.proxyPort)
+
+    if (!installed) {
+      return planFromClassification(
+        classifyMicrovmDeath({ notFound: true, lastFatalResult, probeResult }),
+        { probeResult },
+      )
+    }
+
+    const config = getMicrovmRuntimeConfig()
+    try {
+      const mvm = await getMicrovm(config.region, installed.microvmId)
+      return planFromClassification(
+        classifyMicrovmDeath({
+          state: mvm.state,
+          stateReason: mvm.stateReason,
+          lastFatalResult,
+          probeResult,
+        }),
+        { state: mvm.state, probeResult },
+      )
+    } catch (error) {
+      if (isNotFound(error)) {
+        return planFromClassification(
+          classifyMicrovmDeath({ notFound: true, lastFatalResult, probeResult }),
+          { probeResult },
+        )
+      }
+      captureException(error, {
+        tags: { area: 'container', op: 'microvm.observeDeath' },
+        extra: { agentId: this.config.agentId, microvmId: installed.microvmId },
+      })
+      return { action: 'ignore' }
+    }
+  }
+
+  // Health fail, or HTTP up but no mid-turn process still running.
+  private async probeUnexpectedDeath(
+    sessionIds: string[],
+    knownPort?: number,
+  ): Promise<MicrovmProbeResult> {
+    if (!(await this.isHealthy(knownPort))) return 'fail'
+    if (sessionIds.length === 0) return 'ok'
+    for (const sessionId of sessionIds) {
+      try {
+        const session = await this.getSession(sessionId)
+        if (session?.isRunning) return 'ok'
+      } catch {
+        // Session probe failed; keep checking siblings / treat as fail below.
+      }
+    }
+    return 'fail'
   }
 
   protected getRunnerCommand(): string {
@@ -1025,13 +1116,35 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   }
 
   private async replaceGenerationInner(reason: string, observedId: string | null): Promise<void> {
+    const config = getMicrovmRuntimeConfig()
+    let classification: MicrovmDeathReason = 'runtime_lost'
+    let state: string | undefined
+    let stateReason: string | undefined
+    if (observedId) {
+      try {
+        const mvm = await getMicrovm(config.region, observedId)
+        state = mvm.state
+        stateReason = mvm.stateReason
+        classification = classifyMicrovmDeath({ state, stateReason })
+      } catch (error) {
+        if (isNotFound(error)) classification = classifyMicrovmDeath({ notFound: true })
+      }
+    }
+
     console.warn(
-      `[LambdaMicroVmRuntimeClient] Replacing dead MicroVM generation agent=${this.config.agentId} reason=${reason} old=${observedId ?? 'none'}`,
+      `[LambdaMicroVmRuntimeClient] Replacing dead MicroVM generation agent=${this.config.agentId} reason=${reason} old=${observedId ?? 'none'} classification=${classification}`,
     )
     addErrorBreadcrumb({
       category: 'container',
       message: `MicroVM generation replaced: ${reason}`,
-      data: { agentId: this.config.agentId, oldMicrovmId: observedId, reason },
+      data: {
+        agentId: this.config.agentId,
+        oldMicrovmId: observedId,
+        reason,
+        classification,
+        state,
+        stateReason,
+      },
       level: 'warning',
     })
 

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -28,6 +28,7 @@ import type {
   StopOptions,
   StopResult,
 } from './types'
+import { getSettings, isAutoResumeOnUnexpectedDeathEnabled } from '@shared/lib/config/settings'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
 import {
@@ -818,6 +819,13 @@ function isUnreachableCreateSessionError(error: unknown): boolean {
   return false
 }
 
+function honorMicrovmAutoResume(plan: UnexpectedDeathPlan): UnexpectedDeathPlan {
+  if (plan.action === 'recover' && !isAutoResumeOnUnexpectedDeathEnabled(getSettings())) {
+    return { action: 'settle' }
+  }
+  return plan
+}
+
 export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   static readonly runnerName = 'lambda-microvm'
   // Image is built once via create-microvm-image and run by AWS; nothing local.
@@ -850,29 +858,35 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const probeResult = await this.probeUnexpectedDeath(sessionIds, installed?.proxyPort)
 
     if (!installed) {
-      return planFromClassification(
-        classifyMicrovmDeath({ notFound: true, lastFatalResult, probeResult }),
-        { probeResult },
+      return honorMicrovmAutoResume(
+        planFromClassification(
+          classifyMicrovmDeath({ notFound: true, lastFatalResult, probeResult }),
+          { probeResult },
+        ),
       )
     }
 
     const config = getMicrovmRuntimeConfig()
     try {
       const mvm = await getMicrovm(config.region, installed.microvmId)
-      return planFromClassification(
-        classifyMicrovmDeath({
-          state: mvm.state,
-          stateReason: mvm.stateReason,
-          lastFatalResult,
-          probeResult,
-        }),
-        { state: mvm.state, probeResult },
+      return honorMicrovmAutoResume(
+        planFromClassification(
+          classifyMicrovmDeath({
+            state: mvm.state,
+            stateReason: mvm.stateReason,
+            lastFatalResult,
+            probeResult,
+          }),
+          { state: mvm.state, probeResult },
+        ),
       )
     } catch (error) {
       if (isNotFound(error)) {
-        return planFromClassification(
-          classifyMicrovmDeath({ notFound: true, lastFatalResult, probeResult }),
-          { probeResult },
+        return honorMicrovmAutoResume(
+          planFromClassification(
+            classifyMicrovmDeath({ notFound: true, lastFatalResult, probeResult }),
+            { probeResult },
+          ),
         )
       }
       captureException(error, {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -36,7 +36,6 @@ import {
   planFromClassification,
   type MicrovmDeathReason,
   type MicrovmFatalResult,
-  type MicrovmProbeResult,
 } from './microvm-death-classifier'
 import type { ObserveUnexpectedDeathInput, UnexpectedDeathPlan } from './runtime-death'
 
@@ -834,16 +833,15 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   static readonly supportsCustomAgentImage = false
 
   private replaceInFlight: Promise<void> | null = null
-  private lastFatalResult: MicrovmFatalResult = null
 
   constructor(config: ContainerConfig) {
     super(config)
   }
 
   onFatalResult(kind: MicrovmFatalResult): 'settle' | 'defer_for_recovery' {
-    if (kind !== 'oom_sigkill') return 'settle'
-    this.lastFatalResult = kind
-    return 'defer_for_recovery'
+    // The persister records the fatal and runtime-recovery hands it back via
+    // ObserveUnexpectedDeathInput; keeping a second copy here would go stale.
+    return kind === 'oom_sigkill' ? 'defer_for_recovery' : 'settle'
   }
 
   getRuntimeGenerationId(): string | null {
@@ -851,17 +849,16 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   }
 
   async observeUnexpectedDeath(input?: ObserveUnexpectedDeathInput): Promise<UnexpectedDeathPlan> {
-    const lastFatalResult = input?.lastFatalResult ?? this.lastFatalResult
-    this.lastFatalResult = null
+    const lastFatalResult = input?.lastFatalResult ?? null
     const sessionIds = input?.sessionIds ?? []
     const installed = agentStates.get(this.config.agentId)
-    const probeResult = await this.probeUnexpectedDeath(sessionIds, installed?.proxyPort)
+    const probe = await this.probeRuntimeDeath(sessionIds, installed?.proxyPort)
 
     if (!installed) {
       return honorMicrovmAutoResume(
         planFromClassification(
-          classifyMicrovmDeath({ notFound: true, lastFatalResult, probeResult }),
-          { probeResult },
+          classifyMicrovmDeath({ notFound: true, lastFatalResult, probe }),
+          { probe },
         ),
       )
     }
@@ -875,17 +872,17 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
             state: mvm.state,
             stateReason: mvm.stateReason,
             lastFatalResult,
-            probeResult,
+            probe,
           }),
-          { state: mvm.state, probeResult },
+          { state: mvm.state, probe },
         ),
       )
     } catch (error) {
       if (isNotFound(error)) {
         return honorMicrovmAutoResume(
           planFromClassification(
-            classifyMicrovmDeath({ notFound: true, lastFatalResult, probeResult }),
-            { probeResult },
+            classifyMicrovmDeath({ notFound: true, lastFatalResult, probe }),
+            { probe },
           ),
         )
       }
@@ -896,26 +893,11 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
       // Control plane unreachable (throttle/outage): fall back to the live
       // probe. Reachable + still running is safe to leave alone; anything
       // unconfirmable fails closed to settle.
-      return probeResult === 'ok' ? { action: 'ignore' } : { action: 'settle' }
-    }
-  }
-
-  // Health fail, or HTTP up but no mid-turn process still running.
-  private async probeUnexpectedDeath(
-    sessionIds: string[],
-    knownPort?: number,
-  ): Promise<MicrovmProbeResult> {
-    if (!(await this.isHealthy(knownPort))) return 'fail'
-    if (sessionIds.length === 0) return 'ok'
-    for (const sessionId of sessionIds) {
-      try {
-        const session = await this.getSession(sessionId)
-        if (session?.isRunning) return 'ok'
-      } catch {
-        // Session probe failed; keep checking siblings / treat as fail below.
+      if (probe.status === 'live') {
+        return { action: 'ignore', liveSessionIds: probe.liveSessionIds }
       }
+      return { action: 'settle' }
     }
-    return 'fail'
   }
 
   protected getRunnerCommand(): string {
@@ -1144,7 +1126,18 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
         stateReason = mvm.stateReason
         classification = classifyMicrovmDeath({ state, stateReason })
       } catch (error) {
-        if (isNotFound(error)) classification = classifyMicrovmDeath({ notFound: true })
+        if (isNotFound(error)) {
+          classification = classifyMicrovmDeath({ notFound: true })
+        } else {
+          // Classification is telemetry-only here; the replace proceeds regardless.
+          console.warn(
+            `[LambdaMicroVmRuntimeClient] GetMicrovm failed while classifying replaced generation agent=${this.config.agentId} microvm=${observedId}: ${String(error)}`,
+          )
+          captureException(error, {
+            tags: { area: 'container', op: 'microvm.replaceClassify' },
+            extra: { agentId: this.config.agentId, microvmId: observedId },
+          })
+        }
       }
     }
 

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -879,7 +879,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
         tags: { area: 'container', op: 'microvm.observeDeath' },
         extra: { agentId: this.config.agentId, microvmId: installed.microvmId },
       })
-      return { action: 'ignore' }
+      // Control plane unreachable (throttle/outage): fall back to the live
+      // probe. Reachable + still running is safe to leave alone; anything
+      // unconfirmable fails closed to settle.
+      return probeResult === 'ok' ? { action: 'ignore' } : { action: 'settle' }
     }
   }
 

--- a/src/shared/lib/container/microvm-death-classifier.test.ts
+++ b/src/shared/lib/container/microvm-death-classifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   MICROVM_MAX_LIFETIME_REASON,
+  MICROVM_RECOVERY_PROMPTS,
   classifyMicrovmDeath,
   planFromClassification,
 } from './microvm-death-classifier'
@@ -78,15 +79,18 @@ describe('classifyMicrovmDeath', () => {
 })
 
 describe('planFromClassification', () => {
-  it('recovers max_lifetime and runtime_lost with replace', () => {
+  it('recovers max_lifetime and runtime_lost with replace and reason-specific prompts', () => {
     expect(planFromClassification('max_lifetime')).toEqual({
       action: 'recover',
       reason: 'max_lifetime',
+      resumePrompt: MICROVM_RECOVERY_PROMPTS.max_lifetime,
       replaceGeneration: true,
     })
+    expect(MICROVM_RECOVERY_PROMPTS.max_lifetime).toContain('8-hour lifetime')
     expect(planFromClassification('runtime_lost')).toEqual({
       action: 'recover',
       reason: 'runtime_lost',
+      resumePrompt: MICROVM_RECOVERY_PROMPTS.runtime_lost,
       replaceGeneration: true,
     })
   })
@@ -95,6 +99,7 @@ describe('planFromClassification', () => {
     expect(planFromClassification('guest_oom')).toEqual({
       action: 'recover',
       reason: 'guest_oom',
+      resumePrompt: MICROVM_RECOVERY_PROMPTS.guest_oom,
       replaceGeneration: false,
     })
   })

--- a/src/shared/lib/container/microvm-death-classifier.test.ts
+++ b/src/shared/lib/container/microvm-death-classifier.test.ts
@@ -31,31 +31,41 @@ describe('classifyMicrovmDeath', () => {
     ).toBe('runtime_lost')
   })
 
-  it('classifies SIGKILL + RUNNING + failed probe as guest_oom', () => {
+  it('classifies SIGKILL + RUNNING + idle probe as guest_oom', () => {
     expect(
       classifyMicrovmDeath({
         state: 'RUNNING',
         lastFatalResult: 'oom_sigkill',
-        probeResult: 'fail',
+        probe: { status: 'idle', liveSessionIds: [] },
       }),
     ).toBe('guest_oom')
   })
 
-  it('does not classify guest_oom from a WS drop while the probe succeeds', () => {
+  it('classifies SIGKILL + RUNNING + unreachable probe as guest_oom', () => {
     expect(
       classifyMicrovmDeath({
         state: 'RUNNING',
         lastFatalResult: 'oom_sigkill',
-        probeResult: 'ok',
+        probe: { status: 'unreachable' },
+      }),
+    ).toBe('guest_oom')
+  })
+
+  it('does not classify guest_oom from a WS drop while the probe sees a live session', () => {
+    expect(
+      classifyMicrovmDeath({
+        state: 'RUNNING',
+        lastFatalResult: 'oom_sigkill',
+        probe: { status: 'live', liveSessionIds: ['sess-1'] },
       }),
     ).toBe('not_dead')
   })
 
-  it('does not classify guest_oom from probe fail without a SIGKILL result', () => {
+  it('does not classify guest_oom from a dead probe without a SIGKILL result', () => {
     expect(
       classifyMicrovmDeath({
         state: 'RUNNING',
-        probeResult: 'fail',
+        probe: { status: 'idle', liveSessionIds: [] },
       }),
     ).toBe('not_dead')
   })
@@ -72,7 +82,7 @@ describe('classifyMicrovmDeath', () => {
   })
 
   it('classifies a live VM as not_dead', () => {
-    expect(classifyMicrovmDeath({ state: 'RUNNING', probeResult: 'ok' })).toBe('not_dead')
+    expect(classifyMicrovmDeath({ state: 'RUNNING', probe: { status: 'live' } })).toBe('not_dead')
     expect(classifyMicrovmDeath({ state: 'SUSPENDED' })).toBe('not_dead')
     expect(classifyMicrovmDeath({})).toBe('not_dead')
   })
@@ -95,8 +105,8 @@ describe('planFromClassification', () => {
     })
   })
 
-  it('recovers guest_oom without replace', () => {
-    expect(planFromClassification('guest_oom')).toEqual({
+  it('recovers guest_oom without replace only while the container HTTP surface is up', () => {
+    expect(planFromClassification('guest_oom', { probe: { status: 'idle', liveSessionIds: [] } })).toEqual({
       action: 'recover',
       reason: 'guest_oom',
       resumePrompt: MICROVM_RECOVERY_PROMPTS.guest_oom,
@@ -104,13 +114,31 @@ describe('planFromClassification', () => {
     })
   })
 
-  it('ignores a live RUNNING probe and settles other not_dead cases', () => {
-    expect(planFromClassification('not_dead', { state: 'RUNNING', probeResult: 'ok' })).toEqual({
-      action: 'ignore',
+  it('recovers guest_oom with replace when the container HTTP surface is unreachable', () => {
+    expect(planFromClassification('guest_oom', { probe: { status: 'unreachable' } })).toEqual({
+      action: 'recover',
+      reason: 'guest_oom',
+      resumePrompt: MICROVM_RECOVERY_PROMPTS.guest_oom,
+      replaceGeneration: true,
     })
-    expect(planFromClassification('not_dead', { state: 'RUNNING', probeResult: 'fail' })).toEqual({
-      action: 'settle',
-    })
+  })
+
+  it('ignores a live RUNNING probe with its live-session list and settles other not_dead cases', () => {
+    expect(
+      planFromClassification('not_dead', {
+        state: 'RUNNING',
+        probe: { status: 'live', liveSessionIds: ['sess-1'] },
+      }),
+    ).toEqual({ action: 'ignore', liveSessionIds: ['sess-1'] })
+    expect(
+      planFromClassification('not_dead', { state: 'RUNNING', probe: { status: 'live' } }),
+    ).toEqual({ action: 'ignore', liveSessionIds: undefined })
+    expect(
+      planFromClassification('not_dead', {
+        state: 'RUNNING',
+        probe: { status: 'idle', liveSessionIds: [] },
+      }),
+    ).toEqual({ action: 'settle' })
     expect(planFromClassification('not_dead', { state: 'SUSPENDED' })).toEqual({ action: 'settle' })
   })
 })

--- a/src/shared/lib/container/microvm-death-classifier.test.ts
+++ b/src/shared/lib/container/microvm-death-classifier.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MICROVM_MAX_LIFETIME_REASON,
+  classifyMicrovmDeath,
+  planFromClassification,
+} from './microvm-death-classifier'
+
+describe('classifyMicrovmDeath', () => {
+  it('classifies TERMINATED + max-lifetime stateReason as max_lifetime', () => {
+    expect(
+      classifyMicrovmDeath({
+        state: 'TERMINATED',
+        stateReason: MICROVM_MAX_LIFETIME_REASON,
+      }),
+    ).toBe('max_lifetime')
+  })
+
+  it('classifies TERMINATING + max-lifetime stateReason as max_lifetime', () => {
+    expect(
+      classifyMicrovmDeath({
+        state: 'TERMINATING',
+        stateReason: `  ${MICROVM_MAX_LIFETIME_REASON}  `,
+      }),
+    ).toBe('max_lifetime')
+  })
+
+  it('does not treat operator Success. as max_lifetime', () => {
+    expect(
+      classifyMicrovmDeath({ state: 'TERMINATED', stateReason: 'Success.' }),
+    ).toBe('runtime_lost')
+  })
+
+  it('classifies SIGKILL + RUNNING + failed probe as guest_oom', () => {
+    expect(
+      classifyMicrovmDeath({
+        state: 'RUNNING',
+        lastFatalResult: 'oom_sigkill',
+        probeResult: 'fail',
+      }),
+    ).toBe('guest_oom')
+  })
+
+  it('does not classify guest_oom from a WS drop while the probe succeeds', () => {
+    expect(
+      classifyMicrovmDeath({
+        state: 'RUNNING',
+        lastFatalResult: 'oom_sigkill',
+        probeResult: 'ok',
+      }),
+    ).toBe('not_dead')
+  })
+
+  it('does not classify guest_oom from probe fail without a SIGKILL result', () => {
+    expect(
+      classifyMicrovmDeath({
+        state: 'RUNNING',
+        probeResult: 'fail',
+      }),
+    ).toBe('not_dead')
+  })
+
+  it('classifies TERMINATED without a max-lifetime reason as runtime_lost', () => {
+    expect(classifyMicrovmDeath({ state: 'TERMINATED' })).toBe('runtime_lost')
+    expect(classifyMicrovmDeath({ state: 'TERMINATING', stateReason: 'Success.' })).toBe(
+      'runtime_lost',
+    )
+  })
+
+  it('classifies GetMicrovm 404 as runtime_lost', () => {
+    expect(classifyMicrovmDeath({ notFound: true })).toBe('runtime_lost')
+  })
+
+  it('classifies a live VM as not_dead', () => {
+    expect(classifyMicrovmDeath({ state: 'RUNNING', probeResult: 'ok' })).toBe('not_dead')
+    expect(classifyMicrovmDeath({ state: 'SUSPENDED' })).toBe('not_dead')
+    expect(classifyMicrovmDeath({})).toBe('not_dead')
+  })
+})
+
+describe('planFromClassification', () => {
+  it('recovers max_lifetime and runtime_lost with replace', () => {
+    expect(planFromClassification('max_lifetime')).toEqual({
+      action: 'recover',
+      reason: 'max_lifetime',
+      replaceGeneration: true,
+    })
+    expect(planFromClassification('runtime_lost')).toEqual({
+      action: 'recover',
+      reason: 'runtime_lost',
+      replaceGeneration: true,
+    })
+  })
+
+  it('recovers guest_oom without replace', () => {
+    expect(planFromClassification('guest_oom')).toEqual({
+      action: 'recover',
+      reason: 'guest_oom',
+      replaceGeneration: false,
+    })
+  })
+
+  it('ignores a live RUNNING probe and settles other not_dead cases', () => {
+    expect(planFromClassification('not_dead', { state: 'RUNNING', probeResult: 'ok' })).toEqual({
+      action: 'ignore',
+    })
+    expect(planFromClassification('not_dead', { state: 'RUNNING', probeResult: 'fail' })).toEqual({
+      action: 'settle',
+    })
+    expect(planFromClassification('not_dead', { state: 'SUSPENDED' })).toEqual({ action: 'settle' })
+  })
+})

--- a/src/shared/lib/container/microvm-death-classifier.ts
+++ b/src/shared/lib/container/microvm-death-classifier.ts
@@ -1,0 +1,57 @@
+import {
+  RUNTIME_DEATH_REASONS,
+  type RecoverableDeathReason,
+  type RuntimeFatalKind,
+  type UnexpectedDeathPlan,
+} from './runtime-death'
+
+export const MICROVM_DEATH_REASONS = [...RUNTIME_DEATH_REASONS, 'not_dead'] as const
+
+export type MicrovmDeathReason = RecoverableDeathReason | 'not_dead'
+
+export type MicrovmFatalResult = RuntimeFatalKind
+export type MicrovmProbeResult = 'ok' | 'fail' | null
+
+// Verified in SUP-571: GetMicrovm stateReason when AWS hits the 8h cap.
+export const MICROVM_MAX_LIFETIME_REASON = 'MicroVM exceeded maximum lifetime.'
+
+const TERMINAL = new Set(['TERMINATED', 'TERMINATING'])
+
+export type ClassifyMicrovmDeathInput = {
+  state?: string | null
+  stateReason?: string | null
+  lastFatalResult?: MicrovmFatalResult
+  probeResult?: MicrovmProbeResult
+  notFound?: boolean
+}
+
+export function isMaxLifetimeReason(stateReason: string | null | undefined): boolean {
+  return stateReason?.trim() === MICROVM_MAX_LIFETIME_REASON
+}
+
+export function classifyMicrovmDeath(input: ClassifyMicrovmDeathInput): MicrovmDeathReason {
+  if (isMaxLifetimeReason(input.stateReason)) return 'max_lifetime'
+
+  const running = input.state === 'RUNNING'
+  if (running && input.lastFatalResult === 'oom_sigkill' && input.probeResult === 'fail') {
+    return 'guest_oom'
+  }
+
+  if (input.notFound || TERMINAL.has(input.state ?? '')) return 'runtime_lost'
+  return 'not_dead'
+}
+
+export function planFromClassification(
+  reason: MicrovmDeathReason,
+  opts?: { probeResult?: MicrovmProbeResult; state?: string | null },
+): UnexpectedDeathPlan {
+  if (reason !== 'not_dead') {
+    return {
+      action: 'recover',
+      reason,
+      replaceGeneration: reason !== 'guest_oom',
+    }
+  }
+  if (opts?.state === 'RUNNING' && opts.probeResult === 'ok') return { action: 'ignore' }
+  return { action: 'settle' }
+}

--- a/src/shared/lib/container/microvm-death-classifier.ts
+++ b/src/shared/lib/container/microvm-death-classifier.ts
@@ -1,15 +1,8 @@
-import {
-  RECOVERY_PROMPTS,
-  RUNTIME_DEATH_REASONS,
-  type RecoverableDeathReason,
-  type RuntimeFatalKind,
-  type UnexpectedDeathPlan,
-} from './runtime-death'
+import type { RuntimeFatalKind, UnexpectedDeathPlan } from './runtime-death'
 
-// max_lifetime is MicroVM-specific (AWS 8h cap); it extends the generic reasons here.
-export const MICROVM_DEATH_REASONS = ['max_lifetime', ...RUNTIME_DEATH_REASONS, 'not_dead'] as const
+export const MICROVM_DEATH_REASONS = ['max_lifetime', 'guest_oom', 'runtime_lost', 'not_dead'] as const
 
-export type MicrovmDeathReason = 'max_lifetime' | RecoverableDeathReason | 'not_dead'
+export type MicrovmDeathReason = (typeof MICROVM_DEATH_REASONS)[number]
 
 export type MicrovmFatalResult = RuntimeFatalKind
 export type MicrovmProbeResult = 'ok' | 'fail' | null
@@ -20,7 +13,10 @@ export const MICROVM_MAX_LIFETIME_REASON = 'MicroVM exceeded maximum lifetime.'
 export const MICROVM_RECOVERY_PROMPTS: Record<Exclude<MicrovmDeathReason, 'not_dead'>, string> = {
   max_lifetime:
     'The previous turn was cut off because the runtime hit its 8-hour lifetime. Continue from where you left off. Check what already completed before redoing work.',
-  ...RECOVERY_PROMPTS,
+  guest_oom:
+    'The previous turn was killed because the process ran out of memory. Continue from where you left off, and avoid large in-memory work or huge tool payloads. Check what already completed before redoing work.',
+  runtime_lost:
+    'The previous turn was interrupted because the runtime stopped unexpectedly. Continue from where you left off. Check what already completed before redoing work.',
 }
 
 const TERMINAL = new Set(['TERMINATED', 'TERMINATING'])

--- a/src/shared/lib/container/microvm-death-classifier.ts
+++ b/src/shared/lib/container/microvm-death-classifier.ts
@@ -1,19 +1,27 @@
 import {
+  RECOVERY_PROMPTS,
   RUNTIME_DEATH_REASONS,
   type RecoverableDeathReason,
   type RuntimeFatalKind,
   type UnexpectedDeathPlan,
 } from './runtime-death'
 
-export const MICROVM_DEATH_REASONS = [...RUNTIME_DEATH_REASONS, 'not_dead'] as const
+// max_lifetime is MicroVM-specific (AWS 8h cap); it extends the generic reasons here.
+export const MICROVM_DEATH_REASONS = ['max_lifetime', ...RUNTIME_DEATH_REASONS, 'not_dead'] as const
 
-export type MicrovmDeathReason = RecoverableDeathReason | 'not_dead'
+export type MicrovmDeathReason = 'max_lifetime' | RecoverableDeathReason | 'not_dead'
 
 export type MicrovmFatalResult = RuntimeFatalKind
 export type MicrovmProbeResult = 'ok' | 'fail' | null
 
 // Verified in SUP-571: GetMicrovm stateReason when AWS hits the 8h cap.
 export const MICROVM_MAX_LIFETIME_REASON = 'MicroVM exceeded maximum lifetime.'
+
+export const MICROVM_RECOVERY_PROMPTS: Record<Exclude<MicrovmDeathReason, 'not_dead'>, string> = {
+  max_lifetime:
+    'The previous turn was cut off because the runtime hit its 8-hour lifetime. Continue from where you left off. Check what already completed before redoing work.',
+  ...RECOVERY_PROMPTS,
+}
 
 const TERMINAL = new Set(['TERMINATED', 'TERMINATING'])
 
@@ -49,6 +57,7 @@ export function planFromClassification(
     return {
       action: 'recover',
       reason,
+      resumePrompt: MICROVM_RECOVERY_PROMPTS[reason],
       replaceGeneration: reason !== 'guest_oom',
     }
   }

--- a/src/shared/lib/container/microvm-death-classifier.ts
+++ b/src/shared/lib/container/microvm-death-classifier.ts
@@ -1,11 +1,10 @@
-import type { RuntimeFatalKind, UnexpectedDeathPlan } from './runtime-death'
+import type { RuntimeDeathProbe, RuntimeFatalKind, UnexpectedDeathPlan } from './runtime-death'
 
 export const MICROVM_DEATH_REASONS = ['max_lifetime', 'guest_oom', 'runtime_lost', 'not_dead'] as const
 
 export type MicrovmDeathReason = (typeof MICROVM_DEATH_REASONS)[number]
 
 export type MicrovmFatalResult = RuntimeFatalKind
-export type MicrovmProbeResult = 'ok' | 'fail' | null
 
 // Verified in SUP-571: GetMicrovm stateReason when AWS hits the 8h cap.
 export const MICROVM_MAX_LIFETIME_REASON = 'MicroVM exceeded maximum lifetime.'
@@ -25,7 +24,7 @@ export type ClassifyMicrovmDeathInput = {
   state?: string | null
   stateReason?: string | null
   lastFatalResult?: MicrovmFatalResult
-  probeResult?: MicrovmProbeResult
+  probe?: RuntimeDeathProbe | null
   notFound?: boolean
 }
 
@@ -37,7 +36,9 @@ export function classifyMicrovmDeath(input: ClassifyMicrovmDeathInput): MicrovmD
   if (isMaxLifetimeReason(input.stateReason)) return 'max_lifetime'
 
   const running = input.state === 'RUNNING'
-  if (running && input.lastFatalResult === 'oom_sigkill' && input.probeResult === 'fail') {
+  const probeStatus = input.probe?.status
+  const sessionDead = probeStatus === 'idle' || probeStatus === 'unreachable'
+  if (running && input.lastFatalResult === 'oom_sigkill' && sessionDead) {
     return 'guest_oom'
   }
 
@@ -47,16 +48,22 @@ export function classifyMicrovmDeath(input: ClassifyMicrovmDeathInput): MicrovmD
 
 export function planFromClassification(
   reason: MicrovmDeathReason,
-  opts?: { probeResult?: MicrovmProbeResult; state?: string | null },
+  opts?: { probe?: RuntimeDeathProbe | null; state?: string | null },
 ): UnexpectedDeathPlan {
   if (reason !== 'not_dead') {
+    // guest_oom with the container HTTP surface still up: the VM survived and
+    // can accept a resume in place. If HTTP is down too, replace the VM —
+    // resuming against a dead endpoint would only fail into settle.
+    const keepGeneration = reason === 'guest_oom' && opts?.probe?.status === 'idle'
     return {
       action: 'recover',
       reason,
       resumePrompt: MICROVM_RECOVERY_PROMPTS[reason],
-      replaceGeneration: reason !== 'guest_oom',
+      replaceGeneration: !keepGeneration,
     }
   }
-  if (opts?.state === 'RUNNING' && opts.probeResult === 'ok') return { action: 'ignore' }
+  if (opts?.state === 'RUNNING' && opts?.probe?.status === 'live') {
+    return { action: 'ignore', liveSessionIds: opts.probe.liveSessionIds }
+  }
   return { action: 'settle' }
 }

--- a/src/shared/lib/container/runtime-death.ts
+++ b/src/shared/lib/container/runtime-death.ts
@@ -28,6 +28,16 @@ export type ObserveUnexpectedDeathInput = {
   sessionIds?: string[]
 }
 
+// Result of probing the runtime HTTP surface after a suspected death.
+// 'live' = HTTP up and a probed session is still running (or none to probe);
+// 'idle' = HTTP up, no probed session running; 'unreachable' = health failed.
+export type RuntimeDeathProbe = {
+  status: 'live' | 'idle' | 'unreachable'
+  // Only present when sessions were probed. Omitted (no sessions to probe)
+  // maps onto the plan's "omitted = all live" convention.
+  liveSessionIds?: string[]
+}
+
 // Contract with agent-container's fatal error wording (locked by runtime-death.test.ts).
 // If the container ever emits a structured fatal kind, switch to that instead.
 export function inferOomSigkillFatal(content: { fatal?: unknown; error?: unknown }): boolean {

--- a/src/shared/lib/services/settings-audit.ts
+++ b/src/shared/lib/services/settings-audit.ts
@@ -82,6 +82,7 @@ const SECTION_RULES: Array<[prefix: string, label: string]> = [
   ['app.browserbase', 'Browser Use'],
   ['app.autoSleepTimeoutMinutes', 'Container Runtime'],
   ['app.warmStartOnType', 'Container Runtime'],
+  ['app.autoResumeOnUnexpectedDeath', 'Container Runtime'],
   ['app.', 'General'],
 ]
 


### PR DESCRIPTION
## What was broken

Stacked on #827. The generic bridge in #827 changes nothing by itself — no runtime observes its own death yet, so MicroVM deaths (8h lifetime cap, guest OOM, silent termination) still settle every mid-turn session with "connection lost".

## What this PR does

Implements the runtime-specific half for the Lambda MicroVM runtime — the only job a runtime has in this design is collecting and classifying the "runtime broke" error:

- **`microvm-death-classifier.ts`** — pure classifier mapping `GetMicrovm` state/stateReason + the agent's last fatal result + a container liveness probe onto MicroVM-owned reasons (`MICROVM_DEATH_REASONS`, with prompts in `MICROVM_RECOVERY_PROMPTS` — the generic layer has no reason vocabulary):
  - `max_lifetime` — verified 8h-cap `stateReason` (SUP-571)
  - `guest_oom` — SIGKILL fatal + VM still `RUNNING` + failed probe
  - `runtime_lost` — terminal state or `GetMicrovm` 404
- **`planFromClassification`** — recover vs ignore (VM live, probe ok — WS blip) vs settle; recover plans carry the reason-specific `resumePrompt`. `guest_oom` recovers **without** replacing the VM since the MicroVM itself is healthy.
- **`LambdaMicroVmRuntimeClient`** overrides `observeUnexpectedDeath` (GetMicrovm + probe + classify), defers SIGKILL/OOM fatal results for recovery instead of settling, and exposes the MicroVM id as the runtime generation id so recovery breadcrumbs record old → new VM.
- **Auto-resume toggle** — Settings → Container Runtime shows "Auto-resume mid-turn sessions" only when MicroVM is selected (default on). Off makes `observeUnexpectedDeath` return settle instead of recover; live-session blips still ignore.
- **Fail-closed control-plane fallback** — if `GetMicrovm` fails with an unknown error (throttle/outage), the live probe decides: reachable + session still running → ignore (an AWS API blip never kills a healthy session); anything unconfirmable → settle. Previously this blindly ignored, which could strand sessions on a dead VM.

## Testing

- `microvm-death-classifier.test.ts` — every classification branch incl. operator `Success.` not misread as max-lifetime, probe-ok WS drops not misread as OOM, plus `planFromClassification` recover/ignore/settle with reason-specific prompts.
- `lambda-microvm-runtime.test.ts` — `observeUnexpectedDeath` wiring: 8h death → recover+replace, OOM → recover w/o replace, live VM → ignore, 404 → recover, GetMicrovm failure + probe ok → ignore, GetMicrovm failure + probe fail → settle, auto-resume off → settle recover / still ignore blips.
- `npm run typecheck` clean (src), full container directory green on this branch (1045 tests).

Made with [Cursor](https://cursor.com)