### PR TITLE
Fix dashboard wake on tab refocus

### DIFF
--- a/src/renderer/components/dashboards/dashboard-view.test.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DashboardHeaderProvider } from '@renderer/context/dashboard-header-context'
 import { DashboardHeaderActions } from './dashboard-header-actions'
 import { DashboardView } from './dashboard-view'
@@ -9,6 +9,7 @@ import { DashboardView } from './dashboard-view'
 const mocks = vi.hoisted(() => ({
   agentSlug: 'agent',
   agentStatus: 'running',
+  refetchedAgentStatus: 'running',
   dashboardStatus: 'crashed',
   dashboardDescription: '',
   dashboardStartupPhase: undefined as undefined | 'installing-dependencies' | 'starting-server',
@@ -24,6 +25,7 @@ const mocks = vi.hoisted(() => ({
     mutateAsync: vi.fn(),
     isPending: false,
   },
+  refetchAgent: vi.fn(),
   openDashboardExternal: vi.fn(),
 }))
 
@@ -33,6 +35,7 @@ vi.mock('@renderer/hooks/use-agents', () => ({
       slug: mocks.agentSlug,
       status: mocks.agentStatus,
     },
+    refetch: mocks.refetchAgent,
   }),
   useStartAgent: () => mocks.start,
   useStopAgent: () => mocks.stop,
@@ -103,11 +106,64 @@ describe('DashboardView restart', () => {
     vi.clearAllMocks()
     mocks.agentSlug = 'agent'
     mocks.agentStatus = 'running'
+    mocks.refetchedAgentStatus = 'running'
     mocks.dashboardStatus = 'crashed'
     mocks.dashboardDescription = ''
     mocks.dashboardStartupPhase = undefined
     mocks.dashboardFirstRun = undefined
     mocks.start.mutateAsync.mockResolvedValue({})
+    mocks.refetchAgent.mockImplementation(async () => ({
+      data: {
+        slug: mocks.agentSlug,
+        status: mocks.refetchedAgentStatus,
+      },
+    }))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('wakes a sleeping agent on visibility return even when its cached status is stale', async () => {
+    let visibilityState: DocumentVisibilityState = 'visible'
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibilityState)
+    mocks.dashboardStatus = 'running'
+
+    const view = renderDashboard()
+    expect(mocks.start.mutate).not.toHaveBeenCalled()
+
+    visibilityState = 'hidden'
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+
+    // The visibility event can precede delivery of the stopped status. Keep
+    // the rendered cache stale and let the foreground refetch discover sleep.
+    mocks.refetchedAgentStatus = 'stopped'
+    view.rerender(<DashboardHarness />)
+    expect(mocks.start.mutate).not.toHaveBeenCalled()
+
+    visibilityState = 'visible'
+    await act(async () => document.dispatchEvent(new Event('visibilitychange')))
+
+    expect(mocks.refetchAgent).toHaveBeenCalledOnce()
+    expect(mocks.start.mutate).toHaveBeenCalledOnce()
+    expect(mocks.start.mutate).toHaveBeenCalledWith('agent')
+  })
+
+  it('does not undo auto-sleep while the dashboard tab remains hidden', () => {
+    let visibilityState: DocumentVisibilityState = 'visible'
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibilityState)
+    mocks.dashboardStatus = 'running'
+
+    const view = renderDashboard()
+    visibilityState = 'hidden'
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+
+    mocks.agentStatus = 'stopped'
+    mocks.dashboardStatus = 'stopped'
+    view.rerender(<DashboardHarness />)
+
+    expect(mocks.start.mutate).not.toHaveBeenCalled()
+    expect(mocks.refetchAgent).not.toHaveBeenCalled()
   })
 
   it('does not auto-start a second time while a deliberate stop is pending', async () => {

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -34,7 +34,8 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const waitStartedAtRef = useRef<number | null>(null)
   const autoStartedRef = useRef<string | null>(null)
-  const { data: agent } = useAgent(agentSlug)
+  const wasDocumentHiddenRef = useRef(document.visibilityState === 'hidden')
+  const { data: agent, refetch: refetchAgent } = useAgent(agentSlug)
   const { data: artifacts } = useArtifacts(agentSlug, { pollFast })
   const startAgent = useStartAgent()
   const stopAgent = useStopAgent()
@@ -130,13 +131,74 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     }
   }, [isAgentRunning, stopAgent, startAgent, agentSlug])
 
-  useEffect(() => {
-    if (autoStartedRef.current === agentSlug) return
-    if (!agent || isAgentRunning || isAgentStarting || !canStart) return
+  const autoStartAgent = useCallback((currentAgent = agent, force = false) => {
+    // A hidden dashboard must be allowed to auto-sleep. It is explicitly
+    // re-armed by the visibility listener below when the user returns.
+    if (document.visibilityState === 'hidden') return
+
+    // Treat the current foreground visit as handled while the agent is
+    // running. This keeps a deliberate stop from being immediately undone.
+    if (currentAgent?.status === 'running') {
+      autoStartedRef.current = agentSlug
+      return
+    }
+
+    if (!force && autoStartedRef.current === agentSlug) return
+    if (!currentAgent || isAgentStarting || restarting || !canStart) return
     if (startAgent.isError) return
     autoStartedRef.current = agentSlug
     startAgent.mutate(agentSlug)
-  }, [agent, agentSlug, isAgentRunning, isAgentStarting, canStart, startAgent])
+  }, [
+    agent,
+    agentSlug,
+    isAgentStarting,
+    restarting,
+    canStart,
+    startAgent,
+  ])
+  const autoStartAgentRef = useRef(autoStartAgent)
+  const refetchAgentRef = useRef(refetchAgent)
+  autoStartAgentRef.current = autoStartAgent
+  refetchAgentRef.current = refetchAgent
+
+  useEffect(() => {
+    autoStartAgent()
+  }, [autoStartAgent])
+
+  useEffect(() => {
+    let visibilityCheck = 0
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        wasDocumentHiddenRef.current = true
+        visibilityCheck += 1
+        return
+      }
+      if (!wasDocumentHiddenRef.current) return
+      wasDocumentHiddenRef.current = false
+      const currentCheck = ++visibilityCheck
+
+      // Reconcile first: the browser may deliver the stopped status only after
+      // visibilitychange, so the cached agent can still say "running" here.
+      // The old one-shot latch otherwise survives for the component's entire
+      // mounted life, which is why navigation used to be the only recovery.
+      void refetchAgentRef.current()
+        .then(({ data: currentAgent }) => {
+          if (
+            currentCheck !== visibilityCheck
+            || document.visibilityState === 'hidden'
+          ) return
+          autoStartAgentRef.current(currentAgent, true)
+        })
+        .catch(() => {})
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      visibilityCheck += 1
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [agentSlug])
 
   const showFrame = isAgentRunning && dashboard?.status === 'running'
   const actionPending = restarting || stopAgent.isPending || startAgent.isPending
@@ -145,6 +207,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     agentSlug,
     dashboardSlug,
     dashboardName: dashboard?.name || dashboardSlug,
+    isAgentStarting,
     actions: showFrame
       ? {
           onOpenExternal: handlePopOut,
@@ -157,6 +220,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
     agentSlug,
     dashboardSlug,
     dashboard?.name,
+    isAgentStarting,
     showFrame,
     handlePopOut,
     handleRefresh,

--- a/src/renderer/components/layout/agent-header.test.tsx
+++ b/src/renderer/components/layout/agent-header.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
     id?: string
     slug?: string
   },
+  agentStatus: 'running' as 'running' | 'stopped',
 }))
 
 const agent: ApiAgent = {
@@ -34,7 +35,7 @@ vi.mock('@renderer/router/use-route-location', () => ({
 }))
 
 vi.mock('@renderer/hooks/use-agents', () => ({
-  useAgent: () => ({ data: agent }),
+  useAgent: () => ({ data: { ...agent, status: mocks.agentStatus } }),
 }))
 
 vi.mock('@renderer/hooks/use-sessions', () => ({
@@ -118,14 +119,19 @@ const dashboardRegistration: DashboardHeaderRegistration = {
   },
 }
 
-function RegisterDashboardHeader() {
-  useRegisterDashboardHeader(dashboardRegistration)
+function RegisterDashboardHeader({
+  registration = dashboardRegistration,
+}: {
+  registration?: DashboardHeaderRegistration
+}) {
+  useRegisterDashboardHeader(registration)
   return null
 }
 
 describe('AgentHeader breadcrumbs', () => {
   beforeEach(() => {
     mocks.routeView = { kind: 'session', id: 'session-1' }
+    mocks.agentStatus = 'running'
     vi.clearAllMocks()
   })
 
@@ -233,5 +239,33 @@ describe('AgentHeader breadcrumbs', () => {
     expect(separators).toHaveLength(2)
     expect(separators[0].className).toBe(separators[1].className)
     expect(separators[0]).not.toHaveClass('ml-2')
+  })
+
+  it('shows the power-control spinner while the dashboard view wakes the agent', () => {
+    mocks.routeView = { kind: 'dashboard', slug: 'nutrition' }
+    mocks.agentStatus = 'stopped'
+    const mutation = { mutate: vi.fn(), isPending: false }
+
+    render(
+      <DashboardHeaderProvider>
+        <AgentHeader
+          slug="test-agent"
+          isViewOnly={false}
+          startAgent={mutation as never}
+          stopAgent={mutation as never}
+        />
+        <RegisterDashboardHeader
+          registration={{
+            ...dashboardRegistration,
+            actions: null,
+            isAgentStarting: true,
+          }}
+        />
+      </DashboardHeaderProvider>,
+    )
+
+    const startButton = screen.getByRole('button', { name: 'Start Agent' })
+    expect(startButton).toBeDisabled()
+    expect(startButton.querySelector('.animate-spin')).not.toBeNull()
   })
 })

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -69,6 +69,7 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
   const isRuntimeReady = isRuntimePending || readiness?.status === 'READY'
   const isPulling = readiness?.status === 'PULLING_IMAGE'
   const apiKeyConfigured = runtimeStatus?.apiKeyConfigured !== false
+  const isAgentStarting = startAgent.isPending || dashboardHeader?.isAgentStarting === true
 
   return (
     <>
@@ -275,10 +276,10 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
                           variant="ghost"
                           size="icon"
                           onClick={() => startAgent.mutate(slug)}
-                          disabled={startAgent.isPending || !isRuntimeReady}
+                          disabled={isAgentStarting || !isRuntimeReady}
                           aria-label="Start Agent"
                         >
-                          {isPulling || startAgent.isPending ? (
+                          {isPulling || isAgentStarting ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
                           ) : (
                             <Power className="h-4 w-4" />
@@ -316,8 +317,8 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
                 hasSessionsAwaitingInput={hasSessionsAwaitingInput}
                 startAgent={startAgent}
                 stopAgent={stopAgent}
-                startDisabled={startAgent.isPending || !isRuntimeReady}
-                isStarting={isPulling || startAgent.isPending}
+                startDisabled={isAgentStarting || !isRuntimeReady}
+                isStarting={isPulling || isAgentStarting}
                 wakeDisabledReason={
                   !apiKeyConfigured
                     ? 'No API key configured. An administrator needs to set up the LLM API key.'

--- a/src/renderer/context/dashboard-header-context.tsx
+++ b/src/renderer/context/dashboard-header-context.tsx
@@ -11,6 +11,8 @@ export interface DashboardHeaderRegistration {
   agentSlug: string
   dashboardSlug: string
   dashboardName: string
+  /** Start mutations owned by the dashboard view, outside AgentShell. */
+  isAgentStarting?: boolean
   actions: {
     onOpenExternal: () => void
     onRefresh: () => void

--- a/src/renderer/hooks/use-keep-alive.test.tsx
+++ b/src/renderer/hooks/use-keep-alive.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('@renderer/lib/api', () => ({ apiFetch: mocks.apiFetch }))
+
+import { useKeepAlive } from './use-keep-alive'
+
+describe('useKeepAlive', () => {
+  let visibilityState: DocumentVisibilityState
+
+  beforeEach(() => {
+    visibilityState = 'visible'
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibilityState)
+    mocks.apiFetch.mockResolvedValue(new Response(null, { status: 200 }))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('refreshes the dashboard lease immediately after a hidden tab becomes visible', () => {
+    const { unmount } = renderHook(() => useKeepAlive('agent-a'))
+
+    expect(mocks.apiFetch).toHaveBeenCalledOnce()
+    expect(mocks.apiFetch).toHaveBeenLastCalledWith(
+      '/api/agents/agent-a/keep-alive',
+      { method: 'POST' },
+    )
+
+    visibilityState = 'hidden'
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+    expect(mocks.apiFetch).toHaveBeenCalledOnce()
+
+    visibilityState = 'visible'
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+    expect(mocks.apiFetch).toHaveBeenCalledTimes(2)
+
+    unmount()
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+    expect(mocks.apiFetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/hooks/use-keep-alive.ts
+++ b/src/renderer/hooks/use-keep-alive.ts
@@ -14,6 +14,13 @@ export function useKeepAlive(agentSlug: string): void {
 
     ping()
     const id = setInterval(ping, INTERVAL_MS)
-    return () => clearInterval(id)
+    // Browser timers are throttled while a tab is backgrounded. Refresh the
+    // lease immediately when the dashboard becomes visible again instead of
+    // waiting for whichever interval tick the browser next schedules.
+    document.addEventListener('visibilitychange', ping)
+    return () => {
+      clearInterval(id)
+      document.removeEventListener('visibilitychange', ping)
+    }
   }, [agentSlug])
 }


### PR DESCRIPTION
## Summary

- reconcile the agent status when a mounted dashboard tab becomes visible again and wake it when autosleep stopped it
- keep hidden dashboard tabs asleep while immediately refreshing their keep-alive lease on return
- surface dashboard-owned start progress in the shared desktop and mobile header controls
- add regression coverage for stale cached status, hidden tabs, keep-alive refresh, and the header spinner

## Testing

- `npm test -- --run src/renderer/components/dashboards src/renderer/components/layout/agent-header.test.tsx src/renderer/components/layout/agent-shell.test.tsx src/renderer/hooks/use-keep-alive.test.tsx` (34 tests)
- `npm run typecheck`
- targeted ESLint on all changed TypeScript files