### PR TITLE
perf(dashboards): cut cold-start latency (cached proxy port, build skip, poll floor, bun cache)

### DIFF
--- a/agent-container/Dockerfile
+++ b/agent-container/Dockerfile
@@ -224,6 +224,11 @@ ENV AGENT_BROWSER_ARGS="--no-sandbox,--disable-dev-shm-usage,--disable-blink-fea
 ENV AGENT_BROWSER_USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 ENV AGENT_BROWSER_PROFILE=/workspace/.browser-profile
 ENV DISABLE_AUTOUPDATER=1
+# Keep bun's package cache on the persistent workspace mount. The default
+# ($HOME/.bun/install/cache) lives in the container's writable layer, which is
+# discarded on every restart (each start is `rm -f` + a fresh `run`), so any
+# dashboard dependency install after a wake re-downloaded every package.
+ENV BUN_INSTALL_CACHE_DIR=/workspace/.bun-cache
 # ENABLE_TOOL_SEARCH is deliberately NOT set here. The host passes it at
 # `docker run` only for providers whose endpoint expands deferred tools; for
 # the rest it must stay unset so the CLI applies its own guard (it disables

--- a/agent-container/skills/dashboards/SKILL.md
+++ b/agent-container/skills/dashboards/SKILL.md
@@ -96,7 +96,7 @@ The template structure:
     └── App.jsx          # Edit this to build your dashboard
 ```
 
-React dashboards are **built to static files** (`vite build`) and served via `serve.js` by default. The start script runs `bun run build && bun run serve.js`. The included adapter also supports the Vite dev server and keeps HMR beneath the artifact mount.
+React dashboards are **built to static files** (`vite build`) and served via `serve.js` by default. The start script runs `bun run build-if-needed.js && bun run serve.js` — the build is skipped when no source file is newer than `dist/` (container restarts reuse the previous build; set `DASHBOARD_FORCE_BUILD=1` to force one). The included adapter also supports the Vite dev server and keeps HMR beneath the artifact mount.
 
 **CRITICAL:** Keep `gamutDashboard()` in `vite.config.js`. The dashboard manager supplies `DASHBOARD_BASE_PATH`; in development the adapter applies it to Vite's entry modules and HMR client. Production assets, dynamic imports, CSS/worker URLs, fonts, and images remain relative, while `serve.js` and the injected runtime provide a stable document/router base. This keeps one production build relocatable.
 

--- a/agent-container/skills/dashboards/templates/react-vite/build-if-needed.js
+++ b/agent-container/skills/dashboards/templates/react-vite/build-if-needed.js
@@ -1,0 +1,66 @@
+// Runs `vite build` only when a source file is newer than the build output.
+// Container restarts re-run the start script with unchanged sources, so an
+// unconditional build wastes seconds of the user's dashboard wait; mtime
+// comparison keeps the rebuild automatic after any real edit.
+// Set DASHBOARD_FORCE_BUILD=1 to build unconditionally.
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Build inputs/outputs that must not count as sources.
+const EXCLUDES = new Set([
+  'node_modules',
+  'dist',
+  'dashboard.log',
+  'screenshot.png',
+  'bun.lock',
+  'bun.lockb',
+]);
+// A tree bigger than this rebuilds rather than risk an incomplete scan.
+const MAX_ENTRIES = 2000;
+
+function newestMtimeMs(dir, excludes) {
+  let newest = 0;
+  let seen = 0;
+  const stack = [dir];
+  try {
+    while (stack.length > 0) {
+      const current = stack.pop();
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        if (excludes.has(entry.name)) continue;
+        if (++seen > MAX_ENTRIES) return null;
+        const full = path.join(current, entry.name);
+        if (entry.isDirectory()) stack.push(full);
+        else if (entry.isFile()) {
+          const mtime = fs.statSync(full).mtimeMs;
+          if (mtime > newest) newest = mtime;
+        }
+      }
+    }
+  } catch {
+    return null;
+  }
+  return newest;
+}
+
+const distStamp = newestMtimeMs(path.join(__dirname, 'dist'), new Set());
+const sourceStamp = newestMtimeMs(__dirname, EXCLUDES);
+const fresh =
+  !process.env.DASHBOARD_FORCE_BUILD &&
+  distStamp !== null &&
+  distStamp !== 0 &&
+  sourceStamp !== null &&
+  sourceStamp <= distStamp;
+
+if (fresh) {
+  console.log('[build-if-needed] dist is up to date, skipping build');
+} else {
+  const result = spawnSync('bun', ['run', 'build'], {
+    cwd: __dirname,
+    stdio: 'inherit',
+  });
+  process.exit(result.status ?? 1);
+}

--- a/agent-container/skills/dashboards/templates/react-vite/package.json
+++ b/agent-container/skills/dashboards/templates/react-vite/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "bunx --bun vite build",
     "dev": "bunx --bun vite",
-    "start": "bun run build && bun run serve.js"
+    "start": "bun run build-if-needed.js && bun run serve.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -380,6 +380,105 @@ describe('DashboardManager log stream lifecycle', () => {
     )
   })
 
+  describe('build skip semantics', () => {
+    const TEMPLATE_START = 'bun run build && bun run serve.js'
+
+    /** Record every spawn; auto-exit `bun install` procs. */
+    function recordSpawns() {
+      const spawns: Array<{ command: string; args: string[] }> = []
+      spawnHolder.impl = (command, args) => {
+        const proc = new FakeChildProcess()
+        procs.push(proc)
+        spawns.push({ command, args })
+        if (args[0] === 'install') setImmediate(() => proc.exit(0))
+        return proc
+      }
+      return spawns
+    }
+
+    /** Template-shaped dashboard: template start script, serve.js, built dist. */
+    async function scaffoldTemplateDashboard(opts?: {
+      start?: string
+      dist?: boolean
+      distFresh?: boolean
+    }): Promise<string> {
+      const slug = await scaffoldDashboard({ scripts: { start: opts?.start ?? TEMPLATE_START } })
+      const dir = path.join(testDir, slug)
+      await fs.promises.writeFile(path.join(dir, 'serve.js'), '// server')
+      await fs.promises.mkdir(path.join(dir, 'src'), { recursive: true })
+      await fs.promises.writeFile(path.join(dir, 'src', 'App.jsx'), '// app')
+      if (opts?.dist !== false) {
+        await fs.promises.mkdir(path.join(dir, 'dist'), { recursive: true })
+        await fs.promises.writeFile(path.join(dir, 'dist', 'index.html'), '<html></html>')
+        const stamp = new Date(Date.now() + (opts?.distFresh === false ? -600_000 : 120_000))
+        await fs.promises.utimes(path.join(dir, 'dist', 'index.html'), stamp, stamp)
+      }
+      return slug
+    }
+
+    it('boot start serves directly when the template dist is fresh', async () => {
+      const slug = await scaffoldTemplateDashboard()
+      const spawns = recordSpawns()
+
+      const info = await manager.startDashboard(slug, { forceInstall: false })
+
+      expect(spawns.map((s) => s.args)).toEqual([['run', 'serve.js']])
+      expect(info.status).toBe('running')
+    })
+
+    it('boot start serves directly for the build-if-needed template variant too', async () => {
+      const slug = await scaffoldTemplateDashboard({
+        start: 'bun run build-if-needed.js && bun run serve.js',
+      })
+      const spawns = recordSpawns()
+
+      await manager.startDashboard(slug, { forceInstall: false })
+
+      expect(spawns.map((s) => s.args)).toEqual([['run', 'serve.js']])
+    })
+
+    it('boot start rebuilds when a source file is newer than dist', async () => {
+      const slug = await scaffoldTemplateDashboard({ distFresh: false })
+      const spawns = recordSpawns()
+
+      await manager.startDashboard(slug, { forceInstall: false })
+
+      expect(spawns.map((s) => s.args)).toEqual([['run', 'start']])
+    })
+
+    it('boot start rebuilds when dist is missing', async () => {
+      const slug = await scaffoldTemplateDashboard({ dist: false })
+      const spawns = recordSpawns()
+
+      await manager.startDashboard(slug, { forceInstall: false })
+
+      expect(spawns.map((s) => s.args)).toEqual([['run', 'start']])
+    })
+
+    it('agent-initiated start never skips the build, even with a fresh dist', async () => {
+      const slug = await scaffoldTemplateDashboard()
+      const spawns = recordSpawns()
+
+      await manager.startDashboard(slug)
+
+      expect(spawns.map((s) => s.args)).toEqual([
+        ['install', '--network-concurrency=8'],
+        ['run', 'start'],
+      ])
+    })
+
+    it('a customized start script always runs as written', async () => {
+      const slug = await scaffoldTemplateDashboard({
+        start: 'bun run build && bun run migrate.js && bun run serve.js',
+      })
+      const spawns = recordSpawns()
+
+      await manager.startDashboard(slug, { forceInstall: false })
+
+      expect(spawns.map((s) => s.args)).toEqual([['run', 'start']])
+    })
+  })
+
   describe('install semantics', () => {
     /** Record every spawn; auto-exit `bun install` procs with queued codes. */
     function recordSpawns(installExitCodes: number[]) {

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -65,6 +65,65 @@ export async function truncateOversizedLog(
   }
 }
 
+// Start scripts the react-vite template has shipped with (current and legacy).
+// Both reduce to "ensure dist is built, then run serve.js", so the boot path
+// may substitute `bun run serve.js` directly when the build output is fresh
+// (see canSkipTemplateBuild) — that also skips the wrapper-script spawn chain.
+// Matched by exact equality — any customized start script (extra steps,
+// different server) always runs as written.
+export const TEMPLATE_BUILD_AND_SERVE_STARTS: ReadonlySet<string> = new Set([
+  'bun run build-if-needed.js && bun run serve.js',
+  'bun run build && bun run serve.js',
+])
+
+// Safety bound for the freshness walk; a dashboard tree bigger than this
+// rebuilds rather than risk an incomplete scan.
+const FRESHNESS_WALK_MAX_ENTRIES = 2000
+
+// Build inputs/outputs the freshness walk must not treat as sources.
+const FRESHNESS_WALK_EXCLUDES = new Set([
+  'node_modules',
+  'dist',
+  'dashboard.log',
+  SCREENSHOT_FILENAME,
+  'bun.lock',
+  'bun.lockb',
+])
+
+/**
+ * Newest mtime (ms) of any file under `dir`, skipping `excludes` at every
+ * level. Returns null when the walk exceeds `maxEntries` (caller must treat
+ * that as "unknown → stale") or the directory is unreadable.
+ */
+export function newestMtimeMs(
+  dir: string,
+  excludes: ReadonlySet<string> = FRESHNESS_WALK_EXCLUDES,
+  maxEntries: number = FRESHNESS_WALK_MAX_ENTRIES,
+): number | null {
+  let newest = 0
+  let seen = 0
+  const stack = [dir]
+  try {
+    while (stack.length > 0) {
+      const current = stack.pop()!
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        if (excludes.has(entry.name)) continue
+        if (++seen > maxEntries) return null
+        const full = path.join(current, entry.name)
+        if (entry.isDirectory()) {
+          stack.push(full)
+        } else if (entry.isFile()) {
+          const mtime = fs.statSync(full).mtimeMs
+          if (mtime > newest) newest = mtime
+        }
+      }
+    }
+  } catch {
+    return null
+  }
+  return newest
+}
+
 export function validateSlug(slug: string): void {
   if (!SLUG_REGEX.test(slug)) {
     throw new Error(`Invalid dashboard slug: "${slug}". Must be lowercase alphanumeric with hyphens, not starting/ending with hyphen.`)
@@ -301,7 +360,15 @@ class DashboardManager {
       // Start the dashboard server
       info.startupPhase = 'starting-server'
       const dashboardBasePath = getDashboardBasePath(slug)
-      const proc = spawn('bun', ['run', 'start'], {
+      // Boot/crash-restart path: sources only change through agent-initiated
+      // starts (which pass forceInstall and always run the full start script),
+      // so a fresh dist/ can serve directly and skip the template's
+      // unconditional Vite rebuild.
+      const skipBuild = !forceInstall && this.canSkipTemplateBuild(dashboardDir)
+      if (skipBuild) {
+        info.logStream?.write('[DashboardManager] dist up-to-date, skipping build (bun run serve.js)\n')
+      }
+      const proc = spawn('bun', skipBuild ? ['run', 'serve.js'] : ['run', 'start'], {
         cwd: dashboardDir,
         env: {
           ...process.env,
@@ -410,6 +477,29 @@ class DashboardManager {
     // Forced (agent-initiated) or no/stale lockfile: plain install, which
     // resolves and updates the lockfile as needed.
     return this.runBunInstall(dir, logStream)
+  }
+
+  /**
+   * True when this dashboard uses the stock template start script
+   * (`build && serve`) verbatim AND its build output is at least as new as
+   * every source file — in which case `bun run serve.js` is equivalent to
+   * `bun run start` minus the rebuild. Any doubt (custom start script, missing
+   * dist, unreadable tree, oversized tree) returns false and the full start
+   * script runs.
+   */
+  private canSkipTemplateBuild(dir: string): boolean {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'))
+      if (!TEMPLATE_BUILD_AND_SERVE_STARTS.has(pkg?.scripts?.start)) return false
+      if (!fs.existsSync(path.join(dir, 'serve.js'))) return false
+      const distStamp = newestMtimeMs(path.join(dir, 'dist'), new Set())
+      if (distStamp === null || distStamp === 0) return false
+      const sourceStamp = newestMtimeMs(dir)
+      if (sourceStamp === null) return false
+      return sourceStamp <= distStamp
+    } catch {
+      return false
+    }
   }
 
   private hasLockfile(dir: string): boolean {

--- a/src/renderer/components/dashboards/dashboard-view.tsx
+++ b/src/renderer/components/dashboards/dashboard-view.tsx
@@ -26,6 +26,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   useRenderTracker('DashboardView')
   const [dockDialogOpen, setDockDialogOpen] = useState(false)
   const [pollFast, setPollFast] = useState(false)
+  const [pollWatching, setPollWatching] = useState(false)
   const [now, setNow] = useState(() => Date.now())
   const [restarting, setRestarting] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
@@ -36,7 +37,7 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   const autoStartedRef = useRef<string | null>(null)
   const wasDocumentHiddenRef = useRef(document.visibilityState === 'hidden')
   const { data: agent, refetch: refetchAgent } = useAgent(agentSlug)
-  const { data: artifacts } = useArtifacts(agentSlug, { pollFast })
+  const { data: artifacts } = useArtifacts(agentSlug, { pollFast, watching: pollWatching })
   const startAgent = useStartAgent()
   const stopAgent = useStopAgent()
   const { canUseAgent } = useUser()
@@ -81,9 +82,13 @@ export function DashboardView({ agentSlug, dashboardSlug }: DashboardViewProps) 
   })
 
   const nextPollFast = 'pollFast' in viewState && viewState.pollFast
+  // Any state carrying pollFast is a mounted-and-unresolved view; it keeps a
+  // 1s polling floor even after pollFast turns off at the slow bound.
+  const nextPollWatching = 'pollFast' in viewState
   useEffect(() => {
     setPollFast((prev) => (prev === nextPollFast ? prev : nextPollFast))
-  }, [nextPollFast])
+    setPollWatching((prev) => (prev === nextPollWatching ? prev : nextPollWatching))
+  }, [nextPollFast, nextPollWatching])
 
   const baseUrl = getApiBaseUrl()
   // Dashboard processes receive the canonical agent id in

--- a/src/renderer/hooks/use-artifacts.test.ts
+++ b/src/renderer/hooks/use-artifacts.test.ts
@@ -13,4 +13,17 @@ describe('artifactsRefetchIntervalMs', () => {
     expect(artifactsRefetchIntervalMs([artifact('stopped')], true)).toBe(300)
     expect(artifactsRefetchIntervalMs(undefined, true)).toBe(300)
   })
+
+  it('keeps a 1s floor while a dashboard view is watching, even without a starting artifact', () => {
+    // The slow-start case: pollFast has turned off at the wait bound and the
+    // queued dashboard still reports 'stopped' — watching must prevent the
+    // fall-back to the 60s idle cadence.
+    expect(artifactsRefetchIntervalMs([artifact('stopped')], false, true)).toBe(1_000)
+    expect(artifactsRefetchIntervalMs(undefined, false, true)).toBe(1_000)
+    expect(artifactsRefetchIntervalMs([artifact('running')], false, true)).toBe(1_000)
+    // pollFast still wins over the floor
+    expect(artifactsRefetchIntervalMs([artifact('stopped')], true, true)).toBe(300)
+    // not watching, nothing starting → idle cadence unchanged
+    expect(artifactsRefetchIntervalMs([artifact('running')], false, false)).toBe(60_000)
+  })
 })

--- a/src/renderer/hooks/use-artifacts.ts
+++ b/src/renderer/hooks/use-artifacts.ts
@@ -16,21 +16,29 @@ export interface ArtifactInfo {
  * a dashboard becomes serveable in well under a second once its port is up,
  * so a 1s poll was a large share of the perceived wait. The fast interval
  * only applies while a DashboardView is mounted and unresolved (pollFast).
+ *
+ * `watching` is the 1s floor for that same mounted-and-unresolved window:
+ * pollFast deliberately turns off after the slow bound, and a queued
+ * dashboard still reports 'stopped' — without the floor, exactly the
+ * slowest starts fell back to the 60s idle cadence and sat invisible for
+ * up to a minute after coming up.
  */
 export function artifactsRefetchIntervalMs(
   data: ArtifactInfo[] | undefined,
   pollFast: boolean,
+  watching: boolean = false,
 ): number {
   if (pollFast) return 300
   const hasStarting = data?.some((a) => a.status === 'starting')
-  return hasStarting ? 1_000 : 60_000
+  return watching || hasStarting ? 1_000 : 60_000
 }
 
 export function useArtifacts(
   agentSlug: string | null,
-  options?: { pollFast?: boolean },
+  options?: { pollFast?: boolean; watching?: boolean },
 ) {
   const pollFast = options?.pollFast ?? false
+  const watching = options?.watching ?? false
   return useQuery<ArtifactInfo[]>({
     queryKey: ['artifacts', agentSlug],
     queryFn: async () => {
@@ -40,6 +48,6 @@ export function useArtifacts(
     },
     enabled: !!agentSlug,
     staleTime: 60_000,
-    refetchInterval: (query) => artifactsRefetchIntervalMs(query.state.data, pollFast),
+    refetchInterval: (query) => artifactsRefetchIntervalMs(query.state.data, pollFast, watching),
   })
 }

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -761,6 +761,23 @@ describe('BaseContainerClient.fetch port caching', () => {
     expect(client.infoCalls).toBe(2)
   })
 
+  it('session-scoped calls clear a stale cached port on connection failure', async () => {
+    const client = new RunningTestClient({ agentId: 'test-agent' } as ContainerConfig)
+    const fetchMock = vi
+      .fn(async () => new Response('{}'))
+      .mockResolvedValueOnce(new Response('ok'))
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:4123'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await client.fetch('/artifacts')
+    // Container was recreated on another port: the very next session call
+    // fails once, clears the cache, and the call after re-resolves the port.
+    await expect(client.getSession('sess-1')).rejects.toThrow('ECONNREFUSED')
+    await client.getSession('sess-1')
+
+    expect(client.infoCalls).toBe(2)
+  })
+
   it('does not clear the cached port on HTTP-level failures', async () => {
     const client = new RunningTestClient({ agentId: 'test-agent' } as ContainerConfig)
     const fetchMock = vi.fn(async () => new Response('nope', { status: 500 }))

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -706,6 +706,74 @@ describe('subscribeToStream failure handling', () => {
 })
 
 // ============================================================================
+// fetch() port caching — one runtime inspect per container lifetime, not per
+// request (every proxied dashboard asset used to pay a CLI spawn)
+// ============================================================================
+
+class RunningTestClient extends BaseContainerClient {
+  infoCalls = 0
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    this.infoCalls++
+    return { status: 'running', port: 4123 }
+  }
+  // The real implementation lazily persists a per-agent token file on disk
+  getHostAuthHeaders(): Record<string, string> {
+    return {}
+  }
+}
+
+describe('BaseContainerClient.fetch port caching', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('resolves the port from the runtime once and reuses it across fetches', async () => {
+    const client = new RunningTestClient({ agentId: 'test-agent' } as ContainerConfig)
+    const fetchMock = vi.fn(async () => new Response('ok'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await client.fetch('/artifacts')
+    await client.fetch('/artifacts')
+    await client.fetch('/health')
+
+    expect(client.infoCalls).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:4123/artifacts', expect.anything())
+  })
+
+  it('clears the cached port on a connection error and re-resolves on the next fetch', async () => {
+    const client = new RunningTestClient({ agentId: 'test-agent' } as ContainerConfig)
+    const fetchMock = vi
+      .fn(async () => new Response('ok'))
+      .mockResolvedValueOnce(new Response('ok'))
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:4123'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await client.fetch('/artifacts')
+    await expect(client.fetch('/artifacts')).rejects.toThrow('ECONNREFUSED')
+    await client.fetch('/artifacts')
+
+    // First fetch primes the cache, the refused fetch clears it, the third
+    // re-resolves — two inspects total, never one per request.
+    expect(client.infoCalls).toBe(2)
+  })
+
+  it('does not clear the cached port on HTTP-level failures', async () => {
+    const client = new RunningTestClient({ agentId: 'test-agent' } as ContainerConfig)
+    const fetchMock = vi.fn(async () => new Response('nope', { status: 500 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await client.fetch('/artifacts')
+    await client.fetch('/artifacts')
+
+    expect(client.infoCalls).toBe(1)
+  })
+})
+
+// ============================================================================
 // run-error classification (port races, inaccessible mounts)
 // ============================================================================
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -318,6 +318,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
    * Handle a connection error - notify via callback if configured.
    */
   protected handleConnectionError(): void {
+    // The port may have changed if the container was restarted out from under
+    // us — force the next fetch() to re-resolve it from the runtime.
+    this.cachedRunningPort = null
     if (this.config.onConnectionError) {
       this.config.onConnectionError()
     }
@@ -630,6 +633,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const info = await this.getInfo()
     if (info.status === 'running') {
       console.log(`Container ${this.getContainerName()} is already running on port ${info.port}`)
+      this.cachedRunningPort = info.port
       return info
     }
 
@@ -801,6 +805,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       }
 
       console.log(`Container ${containerName} is now running on port ${port}`)
+      this.cachedRunningPort = port
       return { status: 'running', port }
     } catch (error: any) {
       // Only capture if not already captured (health check errors are captured
@@ -841,6 +846,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   async stop(options?: StopOptions): Promise<StopResult> {
+    this.cachedRunningPort = null
     let forceStopUsed = false
     const stopTimeoutMs = options?.stopTimeoutMs ?? 10_000
     const killTimeoutMs = options?.killTimeoutMs ?? 5_000
@@ -1038,7 +1044,16 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     }
   }
 
+  // Host port of the running container. A port mapping is immutable for the
+  // container's lifetime, so once known it never needs re-resolving — without
+  // this, every fetch() paid a runtime CLI inspect (an SSH round trip on Lima)
+  // before the HTTP request even started. Cleared on stop() and on connection
+  // errors; a stale value degrades to one failed fetch followed by a live
+  // re-resolve, which is exactly the pre-cache behavior.
+  private cachedRunningPort: number | null = null
+
   private async getPortOrThrow(): Promise<number> {
+    if (this.cachedRunningPort !== null) return this.cachedRunningPort
     const info = await this.getInfo()
     if (info.status !== 'running' || !info.port) {
       // Container is not running - trigger connection error handler
@@ -1046,6 +1061,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       this.handleConnectionError()
       throw new Error('Container is not running')
     }
+    this.cachedRunningPort = info.port
     return info.port
   }
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1238,13 +1238,12 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     }
   }
 
+  // getSession/deleteSession/cancelQueuedMessage/interruptSession go through
+  // this.fetch() rather than a raw fetch on getPortOrThrow()'s result: fetch()
+  // clears the cached port on connection errors, so a container recreated on
+  // another port costs one failed call instead of failing until restart.
   async getSession(sessionId: string): Promise<ContainerSession | null> {
-    const port = await this.getPortOrThrow()
-
-    const response = await fetch(
-      `${this.getBaseUrl(port)}/sessions/${sessionId}`,
-      { headers: this.getHostAuthHeaders() }
-    )
+    const response = await this.fetch(`/sessions/${sessionId}`)
 
     if (response.status === 404) return null
     if (!response.ok) {
@@ -1255,14 +1254,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   async deleteSession(sessionId: string): Promise<boolean> {
-    const port = await this.getPortOrThrow()
-
     this.closeTrackedWebSocket(sessionId)
 
-    const response = await fetch(
-      `${this.getBaseUrl(port)}/sessions/${sessionId}`,
-      { method: 'DELETE', headers: this.getHostAuthHeaders() }
-    )
+    const response = await this.fetch(`/sessions/${sessionId}`, { method: 'DELETE' })
 
     return response.ok
   }
@@ -1342,11 +1336,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   async cancelQueuedMessage(sessionId: string, uuid: string): Promise<boolean> {
-    const port = await this.getPortOrThrow()
-
-    const response = await fetch(
-      `http://127.0.0.1:${port}/sessions/${sessionId}/queued-messages/${encodeURIComponent(uuid)}`,
-      { method: 'DELETE', headers: this.getHostAuthHeaders() }
+    const response = await this.fetch(
+      `/sessions/${sessionId}/queued-messages/${encodeURIComponent(uuid)}`,
+      { method: 'DELETE' }
     )
     if (response.status === 404) {
       // Route missing = the container is running a build that predates the
@@ -1366,12 +1358,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   async interruptSession(sessionId: string): Promise<boolean> {
-    const port = await this.getPortOrThrow()
-
-    const response = await fetch(
-      `${this.getBaseUrl(port)}/sessions/${sessionId}/interrupt`,
-      { method: 'POST', headers: this.getHostAuthHeaders() }
-    )
+    const response = await this.fetch(`/sessions/${sessionId}/interrupt`, { method: 'POST' })
 
     return response.ok
   }
@@ -1433,12 +1420,18 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       })
 
       ws.on('error', (error) => {
+        const err = error instanceof Error ? error : new Error(String(error))
+        // A refused/reset socket may mean the cached port is stale (container
+        // recreated elsewhere) — clear it so the next attempt re-resolves.
+        if (this.isConnectionError(err)) {
+          this.handleConnectionError()
+        }
         // Only log and emit if this connection is still tracked (not cleaned up by stop())
         if (this.wsConnections.has(sessionId)) {
           console.error(`WebSocket error for session ${sessionId}:`, error)
           this.safeEmitError(error)
         }
-        rejectReady(error instanceof Error ? error : new Error(String(error)))
+        rejectReady(err)
       })
 
       ws.on('close', () => {


### PR DESCRIPTION
## Summary

Four fixes from a cold-start audit of the dashboard path (container wake → dashboard visible). Full ranked audit lives in `dashboard-coldstart-audit.md` locally (not committed).

1. **Cached proxy port** — every proxied dashboard request and every 300 ms artifacts poll spawned a `docker inspect` (on Lima: an SSH round trip, 100–300 ms per asset) just to resolve the container's host port, which is immutable per container. The client now caches it for the container's lifetime; cleared on stop/connection error, so staleness degrades to one failed fetch followed by a live re-resolve (exactly the pre-cache behavior). The WS artifact proxy already worked this way.
2. **Skip Vite rebuild on boot** — the React template's start script rebuilt unconditionally on every container start. The manager now serves template dashboards directly via `bun run serve.js` when `dist/` is newer than every source (exact start-script match — customized scripts always run as written; bounded mtime walk fails safe to a full build). The template itself now ships a `build-if-needed.js` wrapper so agent-customized dashboards get the same skip; `DASHBOARD_FORCE_BUILD=1` forces a build.
3. **1 s poll floor while waiting** — `pollFast` deliberately turns off at the 120 s slow bound, and a queued dashboard still reports `stopped`, which dropped exactly the slowest starts to the 60 s idle cadence — up to a minute of invisible readiness. A mounted-and-unresolved dashboard view now keeps a 1 s floor.
4. **Persist bun's install cache** — `BUN_INSTALL_CACHE_DIR=/workspace/.bun-cache`. Every start is `rm -f` + `run`, so the default cache in the writable layer was discarded on every restart and any post-wake install re-downloaded from the network. (Ships with the next image build.)

## Benchmarks

Isolated env (pristine-HEAD worktree vs same + this diff, local Docker on Linux; deltas are larger on Lima where each saved inspect is an SSH round trip). `container-benchmark`, 4 runs, all 32 validations pass before and after:

| metric (p50) | before | after |
|---|---|---|
| dashboard status lookup | 22 ms | 4 ms |
| first HTML serve | 22 ms | 6 ms |
| total start→HTML (plain Bun dashboard) | 779 ms | 764 ms |

React (Vite) dashboard, warm restart (deps installed, sources unchanged):

| metric | before | after |
|---|---|---|
| dashboard-ready after container start | +533 ms (full rebuild) | **+3 ms** |
| total start→HTML | 1289 ms | **759 ms** |

Staleness validated end-to-end: a source edit → restart triggers a real rebuild and serves the new bundle; the next restart skips again. Bun cache confirmed populating on the workspace mount and surviving `rm`+`run`.

## Test plan

- New unit tests: 6 build-skip cases (fresh/stale/missing dist, forced start never skips, custom start scripts untouched, both template start-script variants), 3 port-cache cases (reuse, cleared on connection error, kept on HTTP errors), watching-floor cadence cases.
- `tsc --noEmit` clean (root + agent-container); eslint clean on touched files.
- Pre-existing failures not from this PR: 2 `isHealthy` tests in `base-container-client.test.ts` fail identically on pristine HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)