### PR TITLE
feat(dashboards): push dashboard startup outcomes over SSE

### DIFF
--- a/agent-container/src/dashboard-manager.test.ts
+++ b/agent-container/src/dashboard-manager.test.ts
@@ -20,6 +20,7 @@ const screenshotMocks = vi.hoisted(() => ({
   capture: vi.fn(),
   notifyReady: vi.fn(),
 }))
+const statusEventMock = vi.hoisted(() => vi.fn())
 
 vi.mock('./dashboard-screenshot', () => ({
   captureDashboardScreenshot: (...args: unknown[]) => screenshotMocks.capture(...args),
@@ -27,6 +28,7 @@ vi.mock('./dashboard-screenshot', () => ({
 
 vi.mock('./host-events', () => ({
   notifyDashboardScreenshotReady: (...args: unknown[]) => screenshotMocks.notifyReady(...args),
+  notifyDashboardStatusChanged: (...args: unknown[]) => statusEventMock(...args),
 }))
 
 vi.mock('child_process', async (importOriginal) => {
@@ -223,6 +225,7 @@ describe('DashboardManager log stream lifecycle', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'))
     screenshotMocks.capture.mockReset().mockResolvedValue({ ok: false, reason: 'not captured' })
     screenshotMocks.notifyReady.mockReset().mockResolvedValue(true)
+    statusEventMock.mockReset().mockResolvedValue(true)
 
     // Fresh module (and singleton) pointed at the temp artifacts dir
     vi.resetModules()
@@ -378,6 +381,37 @@ describe('DashboardManager log stream lifecycle', () => {
       expect.stringContaining(`Invalid package.json metadata for ${slug}`),
       expect.anything(),
     )
+  })
+
+  describe('status change events', () => {
+    it('publishes running when the dashboard becomes serveable', async () => {
+      const slug = await scaffoldDashboard()
+
+      await manager.startDashboard(slug, { forceInstall: false })
+
+      expect(statusEventMock).toHaveBeenCalledWith(slug, 'running')
+    })
+
+    it('publishes crashed when the restart budget is exhausted', async () => {
+      const slug = await scaffoldDashboard()
+      const info = await manager.startDashboard(slug, { forceInstall: false })
+      statusEventMock.mockClear()
+
+      info.restartTimestamps.push(Date.now(), Date.now(), Date.now())
+      procs[0].exit(1, null)
+
+      expect(statusEventMock).toHaveBeenCalledWith(slug, 'crashed')
+    })
+
+    it('publishes crashed when the process errors without exiting', async () => {
+      const slug = await scaffoldDashboard()
+      await manager.startDashboard(slug, { forceInstall: false })
+      statusEventMock.mockClear()
+
+      procs[0].emit('error', new Error('spawn ENOENT'))
+
+      expect(statusEventMock).toHaveBeenCalledWith(slug, 'crashed')
+    })
   })
 
   describe('build skip semantics', () => {

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -2,7 +2,7 @@ import { spawn, ChildProcess } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 import { captureDashboardScreenshot, type ScreenshotResult } from './dashboard-screenshot'
-import { notifyDashboardScreenshotReady } from './host-events'
+import { notifyDashboardScreenshotReady, notifyDashboardStatusChanged } from './host-events'
 import { DashboardPackageSchema } from './dashboard-package-schema'
 
 const SCREENSHOT_FILENAME = 'screenshot.png'
@@ -197,6 +197,16 @@ class DashboardManager {
     const stream = info.logStream
     info.logStream = null
     stream?.end()
+  }
+
+  /**
+   * Push a terminal startup transition to the host (best-effort — the
+   * renderer's artifacts poll remains the fallback for a missed event).
+   */
+  private publishStatus(slug: string, status: 'running' | 'crashed'): void {
+    void notifyDashboardStatusChanged(slug, status).catch((error) => {
+      console.warn(`[DashboardManager] Failed to publish ${status} event for ${slug}:`, error)
+    })
   }
 
   async scanAndStartAll(): Promise<void> {
@@ -409,6 +419,7 @@ class DashboardManager {
         info.logStream?.write(`[process error] ${error.message}\n`)
         info.status = 'crashed'
         info.process = null
+        this.publishStatus(slug, 'crashed')
         // On spawn failure 'close' isn't guaranteed — close here too (no-op if
         // the 'close' handler already ran).
         this.closeLogStream(info)
@@ -421,6 +432,7 @@ class DashboardManager {
       if (ready && info.status === 'starting') {
         info.status = 'running'
         console.log(`[DashboardManager] Dashboard ${slug} is now running on port ${port}`)
+        this.publishStatus(slug, 'running')
       } else if (info.status === 'starting') {
         // Timed out waiting for port — process may be slow or broken
         console.error(`[DashboardManager] Dashboard ${slug} did not become ready in time`)
@@ -430,12 +442,14 @@ class DashboardManager {
           info.process.kill('SIGTERM')
           info.process = null
         }
+        this.publishStatus(slug, 'crashed')
       }
     } catch (error: any) {
       console.error(`[DashboardManager] Failed to start dashboard ${slug}:`, error)
       info.logStream?.write(`[DashboardManager] Failed to start: ${error?.message || error}\n`)
       this.closeLogStream(info)
       info.status = 'crashed'
+      this.publishStatus(slug, 'crashed')
     }
 
     return info
@@ -580,6 +594,7 @@ class DashboardManager {
     if (info.restartTimestamps.length >= MAX_RESTARTS) {
       console.log(`[DashboardManager] Dashboard ${slug} exhausted restart attempts`)
       info.status = 'crashed'
+      this.publishStatus(slug, 'crashed')
       return
     }
 

--- a/agent-container/src/host-events.test.ts
+++ b/agent-container/src/host-events.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { notifyDashboardScreenshotReady } from './host-events'
+import { notifyDashboardScreenshotReady, notifyDashboardStatusChanged } from './host-events'
 
 describe('notifyDashboardScreenshotReady', () => {
   beforeEach(() => {
@@ -45,5 +45,31 @@ describe('notifyDashboardScreenshotReady', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 403 }))
 
     await expect(notifyDashboardScreenshotReady('sales-dashboard')).rejects.toThrow('HTTP 403')
+  })
+
+  it('posts dashboard status transitions with container authentication', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+
+    await expect(notifyDashboardStatusChanged('sales-dashboard', 'running')).resolves.toBe(true)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://host.internal/api/agent-bootstrap/agent-a/events/dashboard-status-changed',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer proxy-token',
+        },
+        body: JSON.stringify({ dashboardSlug: 'sales-dashboard', status: 'running' }),
+      },
+    )
+  })
+
+  it('status notifier is a no-op when host callback configuration is unavailable', async () => {
+    delete process.env.SUPERAGENT_HOST_API_URL
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    await expect(notifyDashboardStatusChanged('sales-dashboard', 'crashed')).resolves.toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 })

--- a/agent-container/src/host-events.ts
+++ b/agent-container/src/host-events.ts
@@ -1,23 +1,39 @@
 /** Best-effort container → host events that keep renderer caches precise. */
-export async function notifyDashboardScreenshotReady(dashboardSlug: string): Promise<boolean> {
+async function postHostEvent(event: string, body: Record<string, unknown>): Promise<boolean> {
   const baseUrl = process.env.SUPERAGENT_HOST_API_URL
   const token = process.env.PROXY_TOKEN
   const agentSlug = process.env.SUPERAGENT_AGENT_SLUG
   if (!baseUrl || !token || !agentSlug) return false
 
   const response = await fetch(
-    `${baseUrl.replace(/\/$/, '')}/agent-bootstrap/${encodeURIComponent(agentSlug)}/events/dashboard-screenshot-ready`,
+    `${baseUrl.replace(/\/$/, '')}/agent-bootstrap/${encodeURIComponent(agentSlug)}/events/${event}`,
     {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ dashboardSlug }),
+      body: JSON.stringify(body),
     },
   )
   if (!response.ok) {
-    throw new Error(`Host rejected dashboard screenshot event (HTTP ${response.status})`)
+    throw new Error(`Host rejected ${event} event (HTTP ${response.status})`)
   }
   return true
+}
+
+export async function notifyDashboardScreenshotReady(dashboardSlug: string): Promise<boolean> {
+  return postHostEvent('dashboard-screenshot-ready', { dashboardSlug })
+}
+
+/**
+ * Terminal dashboard startup transitions ('running' | 'crashed'), pushed so
+ * the renderer flips the moment a dashboard is serveable instead of waiting
+ * out its artifacts-poll interval. Intermediate states stay poll-only.
+ */
+export async function notifyDashboardStatusChanged(
+  dashboardSlug: string,
+  status: 'running' | 'crashed',
+): Promise<boolean> {
+  return postHostEvent('dashboard-status-changed', { dashboardSlug, status })
 }

--- a/src/api/routes/agent-bootstrap.test.ts
+++ b/src/api/routes/agent-bootstrap.test.ts
@@ -121,3 +121,62 @@ describe('POST /:agentSlug/events/dashboard-screenshot-ready', () => {
     expect(broadcastGlobal).not.toHaveBeenCalled()
   })
 })
+
+describe('POST /:agentSlug/events/dashboard-status-changed', () => {
+  it('broadcasts an authenticated status event to renderer clients', async () => {
+    validateProxyToken.mockResolvedValue('agent-1')
+
+    const res = await post(
+      '/agent-1/events/dashboard-status-changed',
+      { dashboardSlug: 'sales-dashboard', status: 'running' },
+      { Authorization: 'Bearer synth_x' },
+    )
+
+    expect(res.status).toBe(204)
+    expect(broadcastGlobal).toHaveBeenCalledWith({
+      type: 'dashboard_status_changed',
+      agentSlug: 'agent-1',
+      dashboardSlug: 'sales-dashboard',
+      status: 'running',
+    })
+  })
+
+  it('rejects a token belonging to another agent', async () => {
+    validateProxyToken.mockResolvedValue('agent-2')
+
+    const res = await post(
+      '/agent-1/events/dashboard-status-changed',
+      { dashboardSlug: 'sales-dashboard', status: 'running' },
+      { Authorization: 'Bearer synth_other' },
+    )
+
+    expect(res.status).toBe(403)
+    expect(broadcastGlobal).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-terminal statuses', async () => {
+    validateProxyToken.mockResolvedValue('agent-1')
+
+    const res = await post(
+      '/agent-1/events/dashboard-status-changed',
+      { dashboardSlug: 'sales-dashboard', status: 'starting' },
+      { Authorization: 'Bearer synth_x' },
+    )
+
+    expect(res.status).toBe(400)
+    expect(broadcastGlobal).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsafe dashboard slugs', async () => {
+    validateProxyToken.mockResolvedValue('agent-1')
+
+    const res = await post(
+      '/agent-1/events/dashboard-status-changed',
+      { dashboardSlug: '../sales', status: 'running' },
+      { Authorization: 'Bearer synth_x' },
+    )
+
+    expect(res.status).toBe(400)
+    expect(broadcastGlobal).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/routes/agent-bootstrap.ts
+++ b/src/api/routes/agent-bootstrap.ts
@@ -8,8 +8,14 @@ import { readBootstrapEnv } from '@shared/lib/container/agent-bootstrap-env-stor
 import { messagePersister } from '@shared/lib/container/message-persister'
 
 const agentBootstrap = new Hono()
+const DASHBOARD_SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 const DashboardScreenshotReadySchema = z.object({
-  dashboardSlug: z.string().regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/),
+  dashboardSlug: z.string().regex(DASHBOARD_SLUG_REGEX),
+})
+const DashboardStatusChangedSchema = z.object({
+  dashboardSlug: z.string().regex(DASHBOARD_SLUG_REGEX),
+  // Terminal startup transitions only — intermediate states stay poll-only.
+  status: z.enum(['running', 'crashed']),
 })
 
 agentBootstrap.get('/:agentSlug/env', async (c) => {
@@ -51,6 +57,29 @@ agentBootstrap.post('/:agentSlug/events/dashboard-screenshot-ready', async (c) =
     type: 'dashboard_screenshot_ready',
     agentSlug,
     dashboardSlug: parsed.data.dashboardSlug,
+  })
+  return c.body(null, 204)
+})
+
+// Dashboard startup outcomes ('running' | 'crashed') pushed by the container's
+// dashboard manager, so the renderer flips the moment a dashboard is serveable
+// instead of waiting out its artifacts-poll interval.
+agentBootstrap.post('/:agentSlug/events/dashboard-status-changed', async (c) => {
+  const agentSlug = c.req.param('agentSlug')
+  const token = c.req.header('Authorization')?.replace('Bearer ', '')
+  if (!token) return c.json({ error: 'Unauthorized' }, 401)
+  const callerSlug = await validateProxyToken(token)
+  if (!callerSlug) return c.json({ error: 'Unauthorized' }, 401)
+  if (callerSlug !== agentSlug) return c.json({ error: 'Token does not match agent' }, 403)
+
+  const parsed = DashboardStatusChangedSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) return c.json({ error: 'Invalid dashboard status event' }, 400)
+
+  messagePersister.broadcastGlobal({
+    type: 'dashboard_status_changed',
+    agentSlug,
+    dashboardSlug: parsed.data.dashboardSlug,
+    status: parsed.data.status,
   })
   return c.body(null, 204)
 })

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -562,6 +562,40 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     expect(invalidateSpy).not.toHaveBeenCalled()
   })
 
+  it('applies a pushed dashboard status to cached artifacts and refetches the list', () => {
+    queryClient.setQueryData(['agents'], [{
+      slug: 'agent-a',
+      displaySlug: 'agent-a-display',
+      name: 'Agent A',
+      status: 'running',
+      containerPort: 3456,
+    }])
+    queryClient.setQueryData(['artifacts', 'agent-a'], [
+      { slug: 'sales', name: 'Sales', description: '', status: 'starting', port: 5000 },
+      { slug: 'support', name: 'Support', description: '', status: 'stopped', port: 0 },
+    ])
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+
+    simulateSSEMessage(getLatestEventSource(), {
+      type: 'dashboard_status_changed',
+      agentSlug: 'agent-a',
+      dashboardSlug: 'sales',
+      status: 'running',
+    })
+
+    expect(queryClient.getQueryData<Array<{ slug: string; status: string }>>(['artifacts', 'agent-a']))
+      .toEqual([
+        expect.objectContaining({ slug: 'sales', status: 'running' }),
+        expect.objectContaining({ slug: 'support', status: 'stopped' }),
+      ])
+    expect(queryClient.getQueryState(['artifacts', 'agent-a'])?.isInvalidated).toBe(true)
+  })
+
   it('agent_created invalidates visible agents and personal roles together', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -23,6 +23,7 @@ import { usePlatformUnreadCount } from '@renderer/hooks/use-platform-notificatio
 import { useUserSettings } from '@renderer/hooks/use-user-settings'
 import { setMountWarning } from '@renderer/hooks/use-mount-warnings'
 import {
+  applyDashboardRuntimeStatus,
   invalidateAgentArtifacts,
   markDashboardScreenshotReady,
   updateAgentRuntimeCache,
@@ -394,6 +395,22 @@ export function GlobalNotificationHandler() {
             const dashboardSlug = data.dashboardSlug as string | undefined
             if (agentSlug && dashboardSlug) {
               markDashboardScreenshotReady(queryClient, agentSlug, dashboardSlug)
+            }
+            break
+          }
+
+          case 'dashboard_status_changed': {
+            // Patch the cached artifact status so a waiting DashboardView flips
+            // immediately, then refetch for the authoritative list (port,
+            // startup phase, entries the cache has not seen yet).
+            const agentSlug = data.agentSlug as string | undefined
+            const dashboardSlug = data.dashboardSlug as string | undefined
+            const status = data.status === 'running' || data.status === 'crashed'
+              ? data.status
+              : undefined
+            if (agentSlug && dashboardSlug && status) {
+              applyDashboardRuntimeStatus(queryClient, agentSlug, dashboardSlug, status)
+              invalidateAgentArtifacts(queryClient, agentSlug)
             }
             break
           }

--- a/src/renderer/lib/agent-cache.ts
+++ b/src/renderer/lib/agent-cache.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query'
 import type { ApiAgent } from '@shared/lib/types/api'
+import type { ArtifactInfo } from '@renderer/hooks/use-artifacts'
 
 function matchesAgent(agent: ApiAgent, slug: string): boolean {
   return agent.slug === slug || agent.displaySlug === slug
@@ -39,8 +40,8 @@ export function updateAgentRuntimeCache(
   }))
 }
 
-/** Invalidate artifact queries for one agent, including decorative route aliases. */
-export function invalidateAgentArtifacts(queryClient: QueryClient, slug: string): void {
+/** All slugs an agent's artifact queries may be keyed by (canonical + decorative). */
+function artifactQueryAliases(queryClient: QueryClient, slug: string): Set<string> {
   const aliases = new Set([slug])
   const addAliases = (agent: ApiAgent | undefined) => {
     if (!agent || !matchesAgent(agent, slug)) return
@@ -53,7 +54,12 @@ export function invalidateAgentArtifacts(queryClient: QueryClient, slug: string)
   })) {
     addAliases(agent)
   }
+  return aliases
+}
 
+/** Invalidate artifact queries for one agent, including decorative route aliases. */
+export function invalidateAgentArtifacts(queryClient: QueryClient, slug: string): void {
+  const aliases = artifactQueryAliases(queryClient, slug)
   queryClient.invalidateQueries({
     predicate: (query) => (
       query.queryKey[0] === 'artifacts'
@@ -61,6 +67,32 @@ export function invalidateAgentArtifacts(queryClient: QueryClient, slug: string)
       && aliases.has(query.queryKey[1])
     ),
   })
+}
+
+/**
+ * Apply a pushed dashboard startup outcome directly to cached artifact lists,
+ * so the dashboard view flips without waiting for its next poll. Entries not
+ * present yet are left to the accompanying invalidation's refetch.
+ */
+export function applyDashboardRuntimeStatus(
+  queryClient: QueryClient,
+  agentSlug: string,
+  dashboardSlug: string,
+  status: ArtifactInfo['status'],
+): void {
+  const aliases = artifactQueryAliases(queryClient, agentSlug)
+  queryClient.setQueriesData<ArtifactInfo[]>(
+    {
+      predicate: (query) => (
+        query.queryKey[0] === 'artifacts'
+        && typeof query.queryKey[1] === 'string'
+        && aliases.has(query.queryKey[1])
+      ),
+    },
+    (artifacts) => artifacts?.map((artifact) => (
+      artifact.slug === dashboardSlug ? { ...artifact, status } : artifact
+    )),
+  )
 }
 
 /** Mark one dashboard thumbnail ready in every cached projection of its agent. */


### PR DESCRIPTION
## Summary

Stacked on #831. Item 4 from the dashboard cold-start audit: dashboard readiness was discovered only by polling `/artifacts` (300 ms–1 s cadence), so a dashboard whose port just came up sat invisible for up to a full poll interval.

- **Container**: the dashboard manager pushes terminal startup transitions (`running` | `crashed`) through the existing container→host event channel (same authenticated path as `dashboard-screenshot-ready`). Intermediate states (installing, starting) stay poll-only; the push is best-effort and the poll remains the fallback for a missed event.
- **Host**: new `POST /agent-bootstrap/:agentSlug/events/dashboard-status-changed` (proxy-token auth, slug + status validated, terminal statuses only) broadcasting a `dashboard_status_changed` SSE event.
- **Renderer**: patches the cached artifact lists in place — a waiting `DashboardView` flips to the iframe the moment the event lands — then invalidates for the authoritative refetch (ports, entries the cache hasn't seen).

## Validation

- Live end-to-end: container start with two dashboards pushed both `running` events through container → host endpoint → SSE stream (observed on `/api/notifications/stream`).
- New tests: 3 manager transition cases (running, crash-budget exhausted, spawn error), 2 host-events notifier cases, 4 endpoint cases (broadcast, cross-agent token 403, non-terminal status 400, unsafe slug 400), renderer handler patch+invalidate case.
- `tsc --noEmit` clean (root + agent-container), eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)