### PR TITLE
perf(dashboards): fast-path the standalone popout wrapper

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -648,18 +648,26 @@ describe('GET /:id/artifacts/:artifactSlug/view', () => {
     mockAgentExists.mockResolvedValue(true)
   })
 
-  it('reuses the initial running status instead of entering the poll loop', async () => {
-    const res = await getReq(createApp(), '/api/agents/test-agent/artifacts/sales/view')
-    const html = await res.text()
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify([
-        { slug: 'sales', name: 'Sales', status: 'running' },
-      ]), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'running' }), { status: 200 }))
-    const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+  /** Iframe stand-in with a src-assignment counter (reload = second set). */
+  function makeIframe() {
+    const iframe: Record<string, unknown> & { style: Record<string, string> } = { style: {} }
+    let srcSets = 0
+    Object.defineProperty(iframe, 'src', {
+      set(value: string) {
+        srcSets++
+        ;(this as Record<string, unknown>)._src = value
+      },
+      get() {
+        return (this as Record<string, unknown>)._src
+      },
+    })
+    return { iframe, srcSetCount: () => srcSets }
+  }
+
+  function makeDom() {
     const loadingRemove = vi.fn()
     const appendChild = vi.fn()
-    const iframe: Record<string, string> = {}
+    const { iframe, srcSetCount } = makeIframe()
     const statusElement = { textContent: '', classList: { add: vi.fn() } }
     const loadingElement = { remove: loadingRemove }
     const document = {
@@ -668,24 +676,89 @@ describe('GET /:id/artifacts/:artifactSlug/view', () => {
       createElement: () => iframe,
       body: { appendChild },
     }
+    return { document, iframe, srcSetCount, loadingRemove, appendChild, statusElement }
+  }
+
+  it('paints the warm path from one artifacts fetch, without awaiting the start call', async () => {
+    const res = await getReq(createApp(), '/api/agents/test-agent/artifacts/sales/view')
+    const html = await res.text()
+    const fetchMock = vi.fn()
+      // The start is fired first (idempotent), artifacts resolves the state
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { slug: 'sales', name: 'Sales', status: 'running' },
+      ]), { status: 200 }))
+    const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+    const dom = makeDom()
 
     expect(script).toBeDefined()
     runInNewContext(script!, {
-      document,
+      document: dom.document,
       fetch: fetchMock,
       setTimeout,
     })
 
     await vi.waitFor(() => {
-      expect(appendChild).toHaveBeenCalledWith(iframe)
+      expect(dom.appendChild).toHaveBeenCalledWith(dom.iframe)
     })
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/agents/test-agent/artifacts')
-    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/agents/test-agent')
-    expect(loadingRemove).toHaveBeenCalledOnce()
-    expect(iframe.src).toBe('/api/agents/test-agent/artifacts/sales/')
-    expect(iframe.sandbox).toContain('allow-downloads')
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/agents/test-agent/start', { method: 'POST' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/agents/test-agent/artifacts')
+    expect(dom.iframe.src).toBe('/api/agents/test-agent/artifacts/sales/')
+    expect(dom.iframe.sandbox).toContain('allow-downloads')
+
+    // The spinner stays until the document actually loads
+    expect(dom.loadingRemove).not.toHaveBeenCalled()
+    ;(dom.iframe.onload as () => void)()
+    expect(dom.loadingRemove).toHaveBeenCalledOnce()
+    expect(dom.iframe.style.visibility).toBe('visible')
+  })
+
+  it('reloads a document that finished loading before the dashboard was running', async () => {
+    const res = await getReq(createApp(), '/api/agents/test-agent/artifacts/sales/view')
+    const html = await res.text()
+    let releaseRunning: (value: Response) => void = () => {}
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { slug: 'sales', name: 'Sales', status: 'starting', startupPhase: 'starting-server' },
+      ]), { status: 200 }))
+      .mockImplementationOnce(() => new Promise<Response>((resolve) => {
+        releaseRunning = resolve
+      }))
+    const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+    const dom = makeDom()
+
+    expect(script).toBeDefined()
+    runInNewContext(script!, {
+      document: dom.document,
+      fetch: fetchMock,
+      setTimeout,
+    })
+
+    // Optimistically mounted while still starting
+    await vi.waitFor(() => {
+      expect(dom.appendChild).toHaveBeenCalledWith(dom.iframe)
+    })
+    expect(dom.srcSetCount()).toBe(1)
+
+    // The held document resolves before the poll observes 'running'
+    ;(dom.iframe.onload as () => void)()
+    expect(dom.loadingRemove).not.toHaveBeenCalled()
+
+    releaseRunning(new Response(JSON.stringify([
+      { slug: 'sales', name: 'Sales', status: 'running' },
+    ]), { status: 200 }))
+
+    // 'running' arrives → the early document is refetched exactly once
+    await vi.waitFor(() => {
+      expect(dom.srcSetCount()).toBe(2)
+    })
+    expect(dom.loadingRemove).not.toHaveBeenCalled()
+    ;(dom.iframe.onload as () => void)()
+    expect(dom.loadingRemove).toHaveBeenCalledOnce()
+    expect(dom.iframe.style.visibility).toBe('visible')
   })
 
   it('shows the first-run dependency phase while the standalone view waits', async () => {
@@ -699,27 +772,18 @@ describe('GET /:id/artifacts/:artifactSlug/view', () => {
       firstRun: true,
     }
     const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify([installing]), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'running' }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify([installing]), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify([
         { slug: 'sales', name: 'Sales', status: 'running' },
       ]), { status: 200 }))
     const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
-    const appendChild = vi.fn()
-    const iframe: Record<string, string> = {}
-    const statusElement = { textContent: '', classList: { add: vi.fn() } }
-    const loadingElement = { remove: vi.fn() }
-    const document = {
-      title: '',
-      getElementById: (id: string) => id === 'status' ? statusElement : loadingElement,
-      createElement: () => iframe,
-      body: { appendChild },
-    }
+    const dom = makeDom()
 
     expect(script).toBeDefined()
     runInNewContext(script!, {
-      document,
+      document: dom.document,
       fetch: fetchMock,
       setTimeout: (callback: () => void) => {
         callback()
@@ -728,11 +792,13 @@ describe('GET /:id/artifacts/:artifactSlug/view', () => {
     })
 
     await vi.waitFor(() => {
-      expect(appendChild).toHaveBeenCalledWith(iframe)
+      expect(dom.appendChild).toHaveBeenCalledWith(dom.iframe)
     })
 
-    expect(statusElement.textContent).toBe('Preparing dashboard for first use…')
-    expect(fetchMock).toHaveBeenCalledTimes(4)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(4)
+    })
+    expect(dom.statusElement.textContent).toBe('Preparing dashboard for first use…')
   })
 })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -6121,55 +6121,78 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
       return undefined;
     }
 
-    function showDashboard() {
+    // The iframe is mounted (hidden behind the spinner) as soon as the agent
+    // start is underway: the container proxy holds a document request for a
+    // 'starting' dashboard until its server binds, so the fetch overlaps
+    // startup instead of following it. The spinner drops once a load event
+    // arrives after 'running' has been observed; a document that finished
+    // loading earlier (e.g. the hold timed out into an error body) is
+    // refetched exactly once when 'running' arrives.
+    let iframe = null;
+    let confirmedRunning = false;
+    let loadedEarly = false;
+    let revealed = false;
+
+    function reveal() {
+      if (revealed) return;
+      revealed = true;
       loadingEl.remove();
-      const iframe = document.createElement('iframe');
+      iframe.style.visibility = 'visible';
+    }
+
+    function mountFrame() {
+      if (iframe) return;
+      iframe = document.createElement('iframe');
+      iframe.style.visibility = 'hidden';
       iframe.src = dashboardUrl;
       iframe.sandbox = 'allow-scripts allow-same-origin allow-forms allow-popups allow-downloads';
       iframe.allow = 'microphone; camera';
+      iframe.onload = () => {
+        if (confirmedRunning) reveal();
+        else loadedEarly = true;
+      };
       document.body.appendChild(iframe);
+    }
+
+    function onRunning(name) {
+      if (confirmedRunning) return;
+      confirmedRunning = true;
+      setTitle(name);
+      mountFrame();
+      if (loadedEarly) {
+        loadedEarly = false;
+        iframe.src = dashboardUrl;
+      }
     }
 
     async function run() {
       try {
-        // 1. Seed both dashboard metadata and live status. This works while the
-        // agent is stopped too, though that fallback reports stopped.
+        statusEl.textContent = 'Starting agent…';
+        // Fire the start immediately — it is idempotent and returns fast for a
+        // running agent — and fetch dashboard metadata/status in parallel.
+        const startPromise = fetch(basePath + '/start', { method: 'POST' });
+        startPromise.catch(() => {});
         const initialDashboard = await fetchDashboard();
 
-        // 2. Check agent status
-        const agentRes = await fetch(basePath);
-        if (!agentRes.ok) { throw new Error('Failed to fetch agent info'); }
-        const agent = await agentRes.json();
-        const agentWasRunning = agent.status === 'running';
-
-        if (!agentWasRunning) {
-          // 3. Start the agent
-          statusEl.textContent = 'Starting agent…';
-          const startRes = await fetch(basePath + '/start', { method: 'POST' });
-          if (!startRes.ok) {
-            const err = await startRes.json().catch(() => ({}));
-            throw new Error(err.error || 'Failed to start agent');
-          }
+        if (initialDashboard === null) { throw new Error('Dashboard not found.'); }
+        if (initialDashboard && initialDashboard.status === 'running') {
+          // Warm path: both processes already up — paint without waiting for
+          // the start round trip.
+          onRunning(initialDashboard.name);
+          return;
         }
 
-        // The initial artifacts request already gave us a fresh status. When
-        // both processes were running, avoid flashing a redundant wait screen
-        // and let the iframe paint immediately.
-        if (agentWasRunning && initialDashboard !== undefined) {
-          if (!initialDashboard) { throw new Error('Dashboard not found.'); }
-          if (initialDashboard.status === 'crashed') { throw new Error('Dashboard crashed.'); }
-          if (initialDashboard.status === 'running') {
-            showDashboard();
-            return;
-          }
+        const startRes = await startPromise;
+        if (!startRes.ok) {
+          const err = await startRes.json().catch(() => ({}));
+          throw new Error(err.error || 'Failed to start agent');
         }
 
-        // 4. Poll until dashboard is running
+        // Optimistic mount: the held document request resolves the moment the
+        // dashboard server binds, while the poll below confirms the outcome.
+        mountFrame();
         statusEl.textContent = 'Waiting for dashboard…';
         await pollDashboard();
-
-        // 5. Show the dashboard
-        showDashboard();
       } catch (err) {
         statusEl.textContent = err.message;
         statusEl.classList.add('error');
@@ -6177,27 +6200,26 @@ agents.get('/:id/artifacts/:artifactSlug/view', AgentRead(), async (c) => {
     }
 
     async function pollDashboard() {
-      for (let i = 0; i < 120; i++) {
+      // Fast cadence while startup is expected to be quick, then back off.
+      for (let i = 0; i < 280; i++) {
         const res = await fetch(basePath + '/artifacts');
         if (res.ok) {
           const artifacts = await res.json();
-          if (!Array.isArray(artifacts)) {
-            await new Promise(r => setTimeout(r, 1000));
-            continue;
-          }
-          const d = artifacts.find(a => a.slug === artifactSlug);
-          if (!d) { throw new Error('Dashboard not found.'); }
-          if (d.status === 'crashed') { throw new Error('Dashboard crashed.'); }
-          if (d.status === 'running') { setTitle(d.name); return; }
-          if (d.status === 'starting' && d.startupPhase === 'installing-dependencies') {
-            statusEl.textContent = d.firstRun
-              ? 'Preparing dashboard for first use…'
-              : 'Installing dashboard dependencies…';
-          } else {
-            statusEl.textContent = 'Starting dashboard…';
+          if (Array.isArray(artifacts)) {
+            const d = artifacts.find(a => a.slug === artifactSlug);
+            if (!d) { throw new Error('Dashboard not found.'); }
+            if (d.status === 'crashed') { throw new Error('Dashboard crashed.'); }
+            if (d.status === 'running') { onRunning(d.name); return; }
+            if (d.status === 'starting' && d.startupPhase === 'installing-dependencies') {
+              statusEl.textContent = d.firstRun
+                ? 'Preparing dashboard for first use…'
+                : 'Installing dashboard dependencies…';
+            } else {
+              statusEl.textContent = 'Starting dashboard…';
+            }
           }
         }
-        await new Promise(r => setTimeout(r, 1000));
+        await new Promise(r => setTimeout(r, i < 100 ? 300 : 1000));
       }
       throw new Error('Dashboard did not start in time');
     }


### PR DESCRIPTION
## Summary

Stacked on #833 (→ #832 → #831). Item 9 from the dashboard cold-start audit: the popout wrapper ran three serial round trips (artifacts → agent status → start) and then polled at a fixed 1 s × 120 before creating the iframe, making popped-out dashboards systematically slower than in-app ones.

- **Parallel seed**: the start POST fires immediately (idempotent, fast no-op for a running agent) with the artifacts fetch in parallel; the agent-status round trip is gone. The warm path paints from the single artifacts response without awaiting the start call.
- **Optimistic mount**: the iframe mounts hidden behind the spinner as soon as the start succeeds — #833's held-request proxy resolves the document the moment the dashboard server binds, so the fetch overlaps startup. The spinner drops on the first load event observed after `running`; a document that loaded earlier (a hold that timed out into an error body) is refetched exactly once — same recovery contract as the in-app view.
- **Poll cadence**: 300 ms (matching the in-app view) for the first 30 s, then 1 s backoff; overall budget slightly larger than the old 120 s.

## Test plan

- Rewrote the wrapper-script tests for the new flow (they execute the served script in a sandbox against a mocked DOM/fetch): warm path paints from one artifacts fetch with spinner-until-load, first-run install messaging still surfaces, and a new case covers the early-load → refetch-once-on-running recovery.
- Full `agents.test.ts` suite: 409 passed. `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)