### PR TITLE
Agent folders in the left nav

### DIFF
--- a/e2e/specs/agent-folders.spec.ts
+++ b/e2e/specs/agent-folders.spec.ts
@@ -1,0 +1,566 @@
+import { test, expect, type Locator, type Page } from '@playwright/test'
+import { createAgent, uniqueName } from '../helpers/agents'
+
+/**
+ * Left-nav agent folders.
+ *
+ * Folders are a per-user projection over the shared agent list (see
+ * `src/renderer/lib/agent-folders.ts`), stored in user settings alongside
+ * `agentOrder`. The top level is folders only — "Your Agents" is the
+ * always-present default folder that unfiled agents live in. What this spec
+ * protects is the round trip: what a drag produced has to survive a reload,
+ * and deleting a folder has to release its agents into "Your Agents" rather
+ * than take them with it.
+ */
+
+/**
+ * Steer a live drag onto `target`, letting the list auto-scroll when the target
+ * is off screen.
+ *
+ * By the time a user has enough agents to want folders, the row being dragged
+ * and the folder it is headed for often cannot both be on screen — which is the
+ * whole reason dnd-kit auto-scrolls when the pointer nears an edge. Measuring
+ * both boxes up front and moving once between them silently misses in exactly
+ * that case, so this holds the pointer against the edge the target lies beyond
+ * and re-reads its position until it comes into view.
+ *
+ * Returns false if the target never arrives, so the caller can retry the whole
+ * gesture rather than releasing over nothing.
+ */
+async function steerOnto(page: Page, x: number, target: Locator, list: Locator): Promise<boolean> {
+  /** Is the target sitting inside the scroller's visible band right now? */
+  const inView = () =>
+    target
+      .evaluate((el) => {
+        const scroller = el.closest('[data-testid="agent-list-scroll"]')
+        if (!scroller) return false
+        const row = el.getBoundingClientRect()
+        const band = scroller.getBoundingClientRect()
+        const centre = row.y + row.height / 2
+        return centre > band.y + 12 && centre < band.y + band.height - 12
+      })
+      .catch(() => false)
+
+  if (!(await inView())) {
+    const listBox = await list.boundingBox()
+    const box = await target.boundingBox()
+    if (!listBox || !box) return false
+
+    // Park against the edge the target lies beyond. dnd-kit's auto-scroll runs
+    // on its own frame loop from there, so this waits on the list actually
+    // scrolling rather than on a fixed delay.
+    const edgeY = box.y <= listBox.y ? listBox.y + 12 : listBox.y + listBox.height - 12
+    await page.mouse.move(x, edgeY, { steps: 4 })
+    try {
+      await expect.poll(inView, { timeout: 10_000, intervals: [100] }).toBe(true)
+    } catch {
+      return false
+    }
+  }
+
+  const box = await target.boundingBox()
+  if (!box) return false
+  await page.mouse.move(x, box.y + box.height / 2, { steps: 6 })
+  // Rows reflow as an agent drag re-parents on its way past them, and leaving
+  // the edge stops the auto-scroll, so take one final reading before releasing.
+  const reflowed = await target.boundingBox()
+  if (reflowed) await page.mouse.move(x, reflowed.y + reflowed.height / 2, { steps: 4 })
+  return true
+}
+
+/**
+ * Drag a sidebar row onto another and keep at it until `settled` agrees the
+ * drop landed.
+ *
+ * Two things make a single attempt unreliable, and both are properties of the
+ * real UI rather than of the test:
+ * - dnd-kit only engages past a 5px activation threshold, so a gesture can end
+ *   up a no-op click. The drag overlay mounting is the signal that it took.
+ * - The list scrolls, and crossing it re-parents the row mid-drag. Both are
+ *   handled by steering toward the target rather than jumping at it.
+ *
+ * Only the vertical delta matters: the list is under `restrictToVerticalAxis`.
+ */
+async function dragRowOnto(
+  page: Page,
+  source: Locator,
+  target: Locator,
+  settled: () => Promise<void>
+): Promise<void> {
+  const overlay = page.getByTestId('agent-drag-overlay')
+  const list = page.getByTestId('agent-list-scroll')
+  let lastError: unknown = new Error('dragRowOnto: the drop never landed')
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await source.scrollIntoViewIfNeeded()
+    const from = await source.boundingBox()
+    expect(from, 'drag source is off screen').not.toBeNull()
+
+    const x = from!.x + from!.width / 2
+    const startY = from!.y + from!.height / 2
+
+    await page.mouse.move(x, startY)
+    await page.mouse.down()
+    await page.mouse.move(x, startY + 10, { steps: 4 })
+
+    try {
+      await expect(overlay).toBeVisible({ timeout: 2_000 })
+    } catch (error) {
+      lastError = error
+      await page.mouse.up()
+      continue
+    }
+
+    const reached = await steerOnto(page, x, target, list)
+    await page.mouse.up()
+    await expect(overlay).toBeHidden()
+
+    if (!reached) {
+      lastError = new Error('dragRowOnto: the target never scrolled into view')
+      continue
+    }
+
+    try {
+      await settled()
+      return
+    } catch (error) {
+      lastError = error
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError))
+}
+
+/** Create a folder from the + on the "Your Agents" folder header. */
+async function createFolder(page: Page, name: string): Promise<Locator> {
+  await page.getByTestId('new-folder-button').click()
+  // The freshly created row mounts straight into rename mode.
+  const input = page.getByTestId('folder-name-input')
+  await expect(input).toBeVisible()
+  await input.fill(name)
+  await input.press('Enter')
+
+  const row = page.locator('[data-testid^="agent-folder-"]').filter({ hasText: name })
+  await expect(row).toBeVisible()
+  return row
+}
+
+/** The list body belonging to a folder row, which is where its agents render. */
+async function folderBody(page: Page, folderRow: Locator): Promise<Locator> {
+  return page.locator(`[data-container-id="agent-section::${await folderIdOf(folderRow)}"]`)
+}
+
+async function folderIdOf(folderRow: Locator): Promise<string> {
+  const testId = await folderRow.getAttribute('data-testid')
+  return testId!.replace('agent-folder-', '')
+}
+
+/**
+ * The left nav top to bottom, as `agent-item-<slug>` / `agent-folder-<id>` ids
+ * in DOM order. Other specs leave their agents in this sidebar, so callers
+ * narrow it to the rows they created.
+ */
+async function listOrder(page: Page): Promise<string[]> {
+  return page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll('[data-testid^="agent-item-"], [data-testid^="agent-folder-"]')
+    )
+      .map((el) => el.getAttribute('data-testid')!)
+      .filter(
+        (id) =>
+          !id.startsWith('agent-folder-empty-') &&
+          !id.startsWith('agent-folder-count-') &&
+          !id.startsWith('agent-folder-chevron-')
+      )
+  )
+}
+
+test.describe('agent folders in the left nav', () => {
+  // Every other spec in the suite leaves its agents behind, so by the time this
+  // one runs the sidebar can be long enough to scroll. A tall window keeps the
+  // rows being dragged between on screen at the same time, which a pointer
+  // gesture needs and dnd-kit's auto-scroll cannot be driven into reliably.
+  test.use({ viewport: { width: 1280, height: 1800 } })
+
+  test('files an agent by drag, keeps it across a reload, and releases it on delete', async ({
+    page,
+    request,
+  }, testInfo) => {
+    test.setTimeout(90_000)
+
+    const filed = await createAgent(request, uniqueName(testInfo, 'Folder Filed'))
+    const loose = await createAgent(request, uniqueName(testInfo, 'Folder Loose'))
+
+    await page.goto('/')
+    const filedRow = page.getByTestId(`agent-item-${filed.slug}`)
+    const looseRow = page.getByTestId(`agent-item-${loose.slug}`)
+    await expect(filedRow).toBeVisible()
+    await expect(looseRow).toBeVisible()
+
+    const folderName = uniqueName(testInfo, 'Clients')
+    const folderRow = await createFolder(page, folderName)
+    const body = await folderBody(page, folderRow)
+
+    // An empty folder says what it is for, and is the drop target itself.
+    await expect(body).toContainText('Drag agents here')
+
+    // Dropping on the header files the agent at the end of that folder.
+    await dragRowOnto(page, filedRow, folderRow, async () => {
+      await expect(body.getByTestId(`agent-item-${filed.slug}`)).toBeVisible({ timeout: 3_000 })
+    })
+    await expect(body.getByTestId(`agent-item-${loose.slug}`)).toHaveCount(0)
+
+    // Collapsing hides only that folder's members — the strongest available
+    // statement that the agent really is inside it. (Hidden, not unmounted:
+    // expanding a large folder must not pay to mount every row.)
+    await folderRow.click()
+    await expect(filedRow).toBeHidden()
+    await expect(looseRow).toBeVisible()
+
+    // The whole tree is user settings, so it has to survive a reload.
+    await page.reload()
+    const reloadedFolder = page.locator('[data-testid^="agent-folder-"]').filter({ hasText: folderName })
+    await expect(reloadedFolder).toBeVisible()
+    await expect(filedRow).toBeHidden()
+    await expect(looseRow).toBeVisible()
+
+    await reloadedFolder.click()
+    await expect(filedRow).toBeVisible()
+
+    // Deleting a folder must release its agents, not take them with it.
+    await reloadedFolder.click({ button: 'right' })
+    await page.getByTestId('delete-folder-item').click()
+
+    await expect(reloadedFolder).toHaveCount(0)
+    await expect(filedRow).toBeVisible()
+    await expect(looseRow).toBeVisible()
+  })
+
+  test('drags agents between folders, back out again, and places folders among them', async ({
+    page,
+    request,
+  }, testInfo) => {
+    test.setTimeout(120_000)
+
+    const alpha = await createAgent(request, uniqueName(testInfo, 'Folder Alpha'))
+    const beta = await createAgent(request, uniqueName(testInfo, 'Folder Beta'))
+    const loose = await createAgent(request, uniqueName(testInfo, 'Folder Stays'))
+
+    await page.goto('/')
+    const alphaRow = page.getByTestId(`agent-item-${alpha.slug}`)
+    const betaRow = page.getByTestId(`agent-item-${beta.slug}`)
+    const looseRow = page.getByTestId(`agent-item-${loose.slug}`)
+    await expect(looseRow).toBeVisible()
+
+    const firstName = uniqueName(testInfo, 'First')
+    const secondName = uniqueName(testInfo, 'Second')
+    const firstRow = await createFolder(page, firstName)
+    const secondRow = await createFolder(page, secondName)
+    const firstBody = await folderBody(page, firstRow)
+    const secondBody = await folderBody(page, secondRow)
+
+    await dragRowOnto(page, alphaRow, firstRow, async () => {
+      await expect(firstBody.getByTestId(`agent-item-${alpha.slug}`)).toBeVisible({ timeout: 3_000 })
+    })
+    await dragRowOnto(page, betaRow, secondRow, async () => {
+      await expect(secondBody.getByTestId(`agent-item-${beta.slug}`)).toBeVisible({ timeout: 3_000 })
+    })
+
+    // Folder to folder — the path that re-parents mid-drag rather than only on
+    // release.
+    await dragRowOnto(page, alphaRow, secondRow, async () => {
+      await expect(secondBody.getByTestId(`agent-item-${alpha.slug}`)).toBeVisible({ timeout: 3_000 })
+    })
+    await expect(firstBody.getByTestId(`agent-item-${alpha.slug}`)).toHaveCount(0)
+    await expect(firstBody).toContainText('Drag agents here')
+
+    // And back out to the ungrouped list, by aiming at an agent already there.
+    await dragRowOnto(page, alphaRow, looseRow, async () => {
+      await expect(secondBody.getByTestId(`agent-item-${alpha.slug}`)).toHaveCount(0, { timeout: 3_000 })
+    })
+    // Landed in the ROOT section specifically — "not in the second folder and
+    // still visible" would also pass on a misfile into the first folder.
+    const rootBody = page.locator('[data-container-id="agent-section::root"]')
+    await expect(rootBody.getByTestId(`agent-item-${alpha.slug}`)).toBeVisible()
+    await expect(firstBody.getByTestId(`agent-item-${alpha.slug}`)).toHaveCount(0)
+
+    // Folders take a place in the same order as the unfiled agents, so the
+    // second one can be dragged above an agent that is not in any folder.
+    const secondId = await folderIdOf(secondRow)
+    const firstId = await folderIdOf(firstRow)
+    const mine = async () => {
+      const ids = await listOrder(page)
+      return ids.filter((id) =>
+        id === `agent-item-${loose.slug}` ||
+        id === `agent-item-${alpha.slug}` ||
+        id === `agent-folder-${firstId}` ||
+        id === `agent-folder-${secondId}`
+      )
+    }
+
+    /** Assert `first` renders above `second` in the left nav. */
+    const expectAbove = async (first: string, second: string) => {
+      const ids = await mine()
+      expect(ids.indexOf(first), `${first} should render above ${second}: ${ids.join(' → ')}`)
+        .toBeLessThan(ids.indexOf(second))
+    }
+
+    await dragRowOnto(page, secondRow, looseRow, () =>
+      expectAbove(`agent-folder-${secondId}`, `agent-item-${loose.slug}`)
+    )
+
+    // And the arrangement is user settings, so it survives a reload.
+    const arranged = await mine()
+    await page.reload()
+    await expect(firstRow).toBeVisible()
+    expect(await mine()).toEqual(arranged)
+
+    // Folders still reorder past each other.
+    await dragRowOnto(page, firstRow, secondRow, () =>
+      expectAbove(`agent-folder-${firstId}`, `agent-folder-${secondId}`)
+    )
+  })
+
+  test.describe('with the whole list on screen', () => {
+    // This test's folder is created last, so it renders at the very bottom of
+    // the list — and repeat runs accumulate every previous test's agents above
+    // it. If the list overflows, the end of the drag sits inside dnd-kit's
+    // auto-scroll band (20% of the container), the folder slides up under the
+    // stationary pointer, and in content coordinates the pointer descends out
+    // of the folder — a genuine leave, but not the gesture under test. A tall
+    // enough viewport keeps the list overflow-free so auto-scroll never runs.
+    test.use({ viewport: { width: 1280, height: 3200 } })
+
+    test('never advertises the folder as a drop target while sorting inside it', async ({
+      page,
+      request,
+    }, testInfo) => {
+      test.setTimeout(120_000)
+
+    // Five members so the drag crosses several row boundaries and gaps.
+    const members = []
+    for (let i = 0; i < 5; i++) {
+      members.push(await createAgent(request, uniqueName(testInfo, `Sort ${i}`)))
+    }
+
+    await page.goto('/')
+    await expect(page.getByTestId(`agent-item-${members[0].slug}`)).toBeVisible()
+
+    const folderName = uniqueName(testInfo, 'SortHome')
+    const folderRow = await createFolder(page, folderName)
+    const folderId = await folderIdOf(folderRow)
+    for (const m of members) {
+      await page.getByTestId(`agent-item-${m.slug}`).click({ button: 'right' })
+      await page.getByTestId('move-agent-to-folder-trigger').hover()
+      await page.getByTestId(`move-agent-to-folder-${folderId}`).click()
+    }
+    const body = await folderBody(page, folderRow)
+    await expect(body.getByTestId(`agent-item-${members[4].slug}`)).toBeVisible()
+
+    // While sorting INSIDE a folder, the folder must never light up as a drop
+    // target: in the gap between two member rows the pointer is over no row,
+    // and before the collision detector snapped gaps to the nearest member
+    // row, `over` fell to the folder body there — flashing the header ring and
+    // body tint on and off with every gap the pointer crossed. Watch for the
+    // highlight classes appearing at all during the sort.
+    await page.evaluate((id) => {
+      ;(window as any).__highlightFlashes = 0
+      const watch = (el: Element | null) => {
+        if (!el) return
+        new MutationObserver(() => {
+          if ((el as HTMLElement).className.includes('bg-sidebar-accent')) {
+            ;(window as any).__highlightFlashes++
+          }
+        }).observe(el, { attributes: true, attributeFilter: ['class'] })
+      }
+      watch(document.querySelector(`[data-testid="agent-folder-${id}"]`))
+      watch(document.querySelector(`[data-container-id="agent-section::${id}"]`))
+    }, folderId)
+
+    // Drag the top member down to the bottom row in 2px steps so the pointer
+    // dwells in every gap. (Newest-created renders first, so members[4] is the
+    // top row.)
+    const firstRow = body.getByTestId(`agent-item-${members[4].slug}`)
+    const lastRow = body.getByTestId(`agent-item-${members[0].slug}`)
+    const overlay = page.getByTestId('agent-drag-overlay')
+
+    // Same activation retry as dragRowOnto: a gesture can end up a no-op click
+    // when the 5px threshold races a mid-animation row.
+    // Keep the whole travel clear of the auto-scroll zone at the container's
+    // bottom edge — this test is about sorting inside a stationary folder.
+    await lastRow.scrollIntoViewIfNeeded()
+
+    let x = 0
+    let y = 0
+    let engaged = false
+    for (let attempt = 0; attempt < 3 && !engaged; attempt++) {
+      await firstRow.scrollIntoViewIfNeeded()
+      const from = await firstRow.boundingBox()
+      expect(from).not.toBeNull()
+      x = from!.x + from!.width / 2
+      y = from!.y + from!.height / 2
+      await page.mouse.move(x, y)
+      await page.mouse.down()
+      await page.mouse.move(x, y + 6, { steps: 3 })
+      engaged = await overlay.isVisible().catch(() => false)
+      if (!engaged) {
+        await expect(overlay).toBeVisible({ timeout: 1_000 }).then(() => { engaged = true }, () => {})
+      }
+      if (!engaged) await page.mouse.up()
+    }
+    expect(engaged, 'drag never engaged').toBe(true)
+    const to = await lastRow.boundingBox()
+    const endY = to!.y + to!.height / 2
+
+    while (y < endY) {
+      y = Math.min(y + 2, endY)
+      await page.mouse.move(x, y)
+    }
+    const flashes = await page.evaluate(() => (window as any).__highlightFlashes)
+    await page.mouse.up()
+    await expect(overlay).toBeHidden()
+
+    // The folder never advertised itself as a drop target mid-sort…
+    expect(flashes, 'drop-target highlight flashed during a within-folder sort').toBe(0)
+
+    // …and the drop is a genuine within-folder reorder: the top row moved
+    // down, and nothing left the folder. (Exactly which slot it lands in at
+    // the end of travel depends on displaced-row geometry — the precise index
+    // math is pinned by the moveAgent unit tests, not here.)
+    const order = await body
+      .locator('[data-testid^="agent-item-"]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')))
+    expect(order).toHaveLength(5)
+    expect(order.indexOf(`agent-item-${members[4].slug}`)).toBeGreaterThan(0)
+    })
+  })
+
+  test('folder reordering: drop above everything to be first, and the line lands where the drop does', async ({
+    page,
+    request,
+  }, testInfo) => {
+    test.setTimeout(120_000)
+
+    await createAgent(request, uniqueName(testInfo, 'Reorder Anchor'))
+    await page.goto('/')
+    const overlay = page.getByTestId('agent-drag-overlay')
+    await expect(page.getByTestId('agent-folder-root')).toBeVisible()
+
+    const folderName = uniqueName(testInfo, 'Edges')
+    const folderRow = await createFolder(page, folderName)
+    const edgesId = `agent-folder-${await folderIdOf(folderRow)}`
+
+    // Repeat runs accumulate earlier folders, so every step works on the
+    // CURRENT top-level order rather than assuming who the neighbours are.
+    const folders = async () =>
+      (await listOrder(page)).filter((id) => id.startsWith('agent-folder-'))
+    const indicatorFor = (testId: string) =>
+      page.getByTestId(testId.replace('agent-folder-', 'folder-insert-indicator-'))
+    const blockFor = (testId: string) =>
+      page.locator('li').filter({ has: page.getByTestId(testId) }).first()
+
+    /** Engage a drag on the row with `testId`, retrying the 5px threshold. */
+    const startDrag = async (testId: string): Promise<number> => {
+      // The previous drop's overlay animates out for ~250ms; a new press in
+      // that window can miss while the old overlay still reads as visible.
+      await expect(overlay).toBeHidden()
+      const row = page.getByTestId(testId)
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const box = await row.boundingBox()
+        expect(box).not.toBeNull()
+        const x = box!.x + box!.width / 2
+        await page.mouse.move(x, box!.y + box!.height / 2)
+        await page.mouse.down()
+        await page.mouse.move(x, box!.y + box!.height / 2 + 10, { steps: 4 })
+        if (await overlay.isVisible().catch(() => false)) return x
+        await page.mouse.up()
+      }
+      throw new Error('drag never engaged')
+    }
+
+    // A freshly created folder lands last, so Edges starts at the bottom.
+    expect((await folders()).at(-1)).toBe(edgesId)
+
+    // ── The natural "make it first" gesture: drop in the space ABOVE the
+    // first block. There used to be nothing droppable there, so the drag
+    // just snapped back.
+    {
+      const topId = (await folders())[0]
+      const x = await startDrag(edgesId)
+      const topBox = await page.getByTestId(topId).boundingBox()
+      // Well above the first header, in the nav area.
+      await page.mouse.move(x, topBox!.y - 30, { steps: 10 })
+      await expect(indicatorFor(topId)).toHaveAttribute('data-edge', 'above')
+      await page.mouse.up()
+
+      await expect.poll(async () => (await folders())[0]).toBe(edgesId)
+    }
+
+    // ── Dragging DOWN into a block's lower half: the line must sit on its
+    // BOTTOM edge and the drop must land after it. The line used to draw at
+    // the top while the drop landed below — lying about the landing spot.
+    {
+      const below = (await folders())[1]
+      const x = await startDrag(edgesId)
+      const blockBox = await blockFor(below).boundingBox()
+      await page.mouse.move(x, blockBox!.y + blockBox!.height * 0.85, { steps: 10 })
+      await expect(indicatorFor(below)).toHaveAttribute('data-edge', 'below')
+      await page.mouse.up()
+
+      // Poll the position relation itself — both ids are always present, so
+      // polling for mere presence would pass before the drop's React commit
+      // and race the real assertion.
+      await expect
+        .poll(async () => {
+          const after = await folders()
+          return after.indexOf(edgesId) - after.indexOf(below)
+        }, { message: `${edgesId} should sit right after ${below}` })
+        .toBe(1)
+    }
+
+    // ── And the empty space BELOW the whole list means "last".
+    {
+      const dragged = (await folders())[0]
+      const lastId = (await folders()).at(-1)!
+      const x = await startDrag(dragged)
+      const lastBox = await blockFor(lastId).boundingBox()
+      await page.mouse.move(x, lastBox!.y + lastBox!.height + 120, { steps: 10 })
+      await expect(indicatorFor(lastId)).toHaveAttribute('data-edge', 'below')
+      await page.mouse.up()
+
+      await expect.poll(async () => (await folders()).at(-1)).toBe(dragged)
+    }
+  })
+
+  test('files an agent from its context menu, which is the path that works on touch', async ({
+    page,
+    request,
+  }, testInfo) => {
+    test.setTimeout(90_000)
+
+    const agent = await createAgent(request, uniqueName(testInfo, 'Folder Menu'))
+
+    await page.goto('/')
+    const row = page.getByTestId(`agent-item-${agent.slug}`)
+    await expect(row).toBeVisible()
+
+    const folderName = uniqueName(testInfo, 'Menu Target')
+    const folderRow = await createFolder(page, folderName)
+    const body = await folderBody(page, folderRow)
+    const folderId = (await folderRow.getAttribute('data-testid'))!.replace('agent-folder-', '')
+
+    await row.click({ button: 'right' })
+    await page.getByTestId('move-agent-to-folder-trigger').hover()
+    await page.getByTestId(`move-agent-to-folder-${folderId}`).click()
+
+    await expect(body.getByTestId(`agent-item-${agent.slug}`)).toBeVisible()
+
+    // And back out again.
+    await row.click({ button: 'right' })
+    await page.getByTestId('move-agent-to-folder-trigger').hover()
+    await page.getByTestId('move-agent-to-no-folder-item').click()
+
+    await expect(body.getByTestId(`agent-item-${agent.slug}`)).toHaveCount(0)
+    await expect(row).toBeVisible()
+  })
+})

--- a/e2e/specs/agent-folders.spec.ts
+++ b/e2e/specs/agent-folders.spec.ts
@@ -1,6 +1,15 @@
 import { test, expect, type Locator, type Page } from '@playwright/test'
 import { createAgent, uniqueName } from '../helpers/agents'
 
+// Every test here mutates ONE user's settings row (folders are a per-user
+// projection), and folder writes replace whole fields — so two of these tests
+// in different workers silently erase each other's folders: created folders
+// vanish across reloads, the move-to-folder menu misses them, order
+// assertions find foreign rows. `default` pins the file to one worker in
+// order, without `serial`'s failure cascade — the tests stay independent and
+// retry individually. Other spec files still parallelize around this one.
+test.describe.configure({ mode: 'default' })
+
 /**
  * Left-nav agent folders.
  *
@@ -66,6 +75,65 @@ async function steerOnto(page: Page, x: number, target: Locator, list: Locator):
   const reflowed = await target.boundingBox()
   if (reflowed) await page.mouse.move(x, reflowed.y + reflowed.height / 2, { steps: 4 })
   return true
+}
+
+/**
+ * Engage a drag on the block with `testId`, retrying dnd-kit's 5px activation
+ * threshold, and return the pointer's x. For folder drags aimed at a block
+ * EDGE — dropping at a target's centre resolves by the pointer's half of the
+ * block, which encodes the block's current height into the gesture; agents
+ * accumulated by other suites make the same centre land on the other half.
+ */
+async function startBlockDrag(page: Page, testId: string): Promise<number> {
+  const overlay = page.getByTestId('agent-drag-overlay')
+  // The previous drop's overlay animates out for ~250ms; a new press in that
+  // window can miss while the old overlay still reads as visible.
+  await expect(overlay).toBeHidden()
+  const row = page.getByTestId(testId)
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await row.scrollIntoViewIfNeeded()
+    const box = await row.boundingBox()
+    expect(box, 'drag source is off screen').not.toBeNull()
+    const x = box!.x + box!.width / 2
+    await page.mouse.move(x, box!.y + box!.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(x, box!.y + box!.height / 2 + 10, { steps: 4 })
+    if (await overlay.isVisible().catch(() => false)) return x
+    await page.mouse.up()
+  }
+  throw new Error('drag never engaged')
+}
+
+/**
+ * Mid-drag, park the pointer just inside the TOP edge of `block` and wait for
+ * its insert line to promise the ABOVE edge, then release. `steerOnto` gets
+ * the block into the scroller's band first when it is off screen.
+ */
+async function dropAboveBlock(page: Page, x: number, block: Locator, folderId: string): Promise<void> {
+  const list = page.getByTestId('agent-list-scroll')
+  expect(await steerOnto(page, x, block, list), 'target block never scrolled into view').toBe(true)
+  // Park the block's top edge mid-band before aiming. An aim point inside the
+  // scroller's auto-scroll zone (the top 20% of the container) keeps the list
+  // crawling under the stationary pointer and the block slides away from the
+  // cue. Centering the top edge both consumes the upward scroll headroom and
+  // puts the aim point outside both zones; dnd-kit honors mid-drag ancestor
+  // scrolls by offsetting its droppable rects.
+  await block.evaluate((el) => {
+    const scroller = el.closest('[data-testid="agent-list-scroll"]')
+    if (!scroller) return
+    const row = el.getBoundingClientRect()
+    const band = scroller.getBoundingClientRect()
+    scroller.scrollTop += row.top - (band.top + band.height / 2)
+  })
+  const box = await block.boundingBox()
+  expect(box).not.toBeNull()
+  await page.mouse.move(x, box!.y + Math.min(12, box!.height / 4), { steps: 6 })
+  await expect(page.getByTestId(`folder-insert-indicator-${folderId}`)).toHaveAttribute(
+    'data-edge',
+    'above'
+  )
+  await page.mouse.up()
+  await expect(page.getByTestId('agent-drag-overlay')).toBeHidden()
 }
 
 /**
@@ -298,16 +366,38 @@ test.describe('agent folders in the left nav', () => {
       )
     }
 
-    /** Assert `first` renders above `second` in the left nav. */
+    /** Assert `first` renders above `second`, polling past the drop's commit. */
     const expectAbove = async (first: string, second: string) => {
-      const ids = await mine()
-      expect(ids.indexOf(first), `${first} should render above ${second}: ${ids.join(' → ')}`)
-        .toBeLessThan(ids.indexOf(second))
+      await expect
+        .poll(
+          async () => {
+            const ids = await mine()
+            const a = ids.indexOf(first)
+            const b = ids.indexOf(second)
+            // A missing row must read as failure — indexOf's -1 would
+            // otherwise pass "above" for a row that is not there at all.
+            if (a === -1 || b === -1) return Number.POSITIVE_INFINITY
+            return a - b
+          },
+          { message: `${first} should render above ${second}` }
+        )
+        .toBeLessThan(0)
     }
 
-    await dragRowOnto(page, secondRow, looseRow, () =>
-      expectAbove(`agent-folder-${secondId}`, `agent-item-${loose.slug}`)
-    )
+    const blockFor = (testId: string) =>
+      page.locator('li').filter({ has: page.getByTestId(testId) }).first()
+
+    // Folders interleave with the whole ROOT block at the top level (a folder
+    // dropped "on a loose agent" resolves against the block that HOLDS it),
+    // so putting the second folder above every unfiled agent means dropping
+    // on the root block's ABOVE edge — aimed explicitly, because the block's
+    // height, and with it which half a given row sits in, depends on how many
+    // agents other suites have accumulated.
+    {
+      const x = await startBlockDrag(page, `agent-folder-${secondId}`)
+      await dropAboveBlock(page, x, blockFor('agent-folder-root'), 'root')
+      await expectAbove(`agent-folder-${secondId}`, `agent-item-${loose.slug}`)
+    }
 
     // And the arrangement is user settings, so it survives a reload.
     const arranged = await mine()
@@ -316,9 +406,11 @@ test.describe('agent folders in the left nav', () => {
     expect(await mine()).toEqual(arranged)
 
     // Folders still reorder past each other.
-    await dragRowOnto(page, firstRow, secondRow, () =>
-      expectAbove(`agent-folder-${firstId}`, `agent-folder-${secondId}`)
-    )
+    {
+      const x = await startBlockDrag(page, `agent-folder-${firstId}`)
+      await dropAboveBlock(page, x, blockFor(`agent-folder-${secondId}`), secondId)
+      await expectAbove(`agent-folder-${firstId}`, `agent-folder-${secondId}`)
+    }
   })
 
   test.describe('with the whole list on screen', () => {

--- a/src/api/routes/user-settings.ts
+++ b/src/api/routes/user-settings.ts
@@ -1,7 +1,11 @@
 import { Hono } from 'hono'
 import { Authenticated } from '../middleware/auth'
 import { getCurrentUserId } from '@shared/lib/auth/config'
-import { getUserSettings, updateUserSettings } from '@shared/lib/services/user-settings-service'
+import {
+  agentFolderSettingsWriteSchema,
+  getUserSettings,
+  updateUserSettings,
+} from '@shared/lib/services/user-settings-service'
 
 const userSettingsRouter = new Hono()
 
@@ -18,6 +22,13 @@ userSettingsRouter.get('/', (c) => {
 userSettingsRouter.put('/', async (c) => {
   const userId = getCurrentUserId(c)
   const body = await c.req.json()
+  // The stored schema is read-tolerant for the folder fields — it drops what
+  // it cannot parse instead of failing — so a malformed write would silently
+  // erase the field it targets. Reject it here instead.
+  const folderFields = agentFolderSettingsWriteSchema.safeParse(body)
+  if (!folderFields.success) {
+    return c.json({ error: 'Invalid agent folder settings' }, 400)
+  }
   const updated = updateUserSettings(userId, body)
   return c.json(updated)
 })

--- a/src/renderer/components/agents/agent-context-menu.test.tsx
+++ b/src/renderer/components/agents/agent-context-menu.test.tsx
@@ -18,22 +18,55 @@ vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQue
 vi.mock('@renderer/context/user-context', () => ({
   useUser: () => ({ canAdminAgent: () => true, isAuthMode: false }),
 }))
+
+const { mockUserSettings, mockUpdateSettings } = vi.hoisted(() => ({
+  mockUserSettings: vi.fn(),
+  mockUpdateSettings: vi.fn(),
+}))
+vi.mock('@renderer/hooks/use-user-settings', () => ({
+  useUserSettings: () => ({ data: mockUserSettings() }),
+  useUpdateUserSettings: () => ({ mutate: mockUpdateSettings }),
+}))
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 // Radix context menus never open in jsdom without a real pointer; render the
 // items inline so the action is reachable.
-vi.mock('@renderer/components/ui/context-menu', () => ({
-  ContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ContextMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  ContextMenuItem: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" onClick={onClick} {...props}>{children}</button>
-  ),
-  ContextMenuSeparator: () => <hr />,
-  ContextMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}))
+vi.mock('@renderer/components/ui/context-menu', async () => {
+  const React = await import('react')
+  return {
+    ContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    ContextMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    ContextMenuItem: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button type="button" onClick={onClick} {...props}>{children}</button>
+    ),
+    ContextMenuSeparator: () => <hr />,
+    ContextMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    // Radix routes the selection through context; the stub hands each item its
+    // own value so a click reports the same thing the real menu would.
+    ContextMenuRadioGroup: ({ children, value, onValueChange }: any) => (
+      <div>
+        {React.Children.map(children, (child) =>
+          React.isValidElement<{ value: string }>(child)
+            ? React.cloneElement(child as never, {
+                onClick: () => onValueChange?.(child.props.value),
+                'aria-checked': child.props.value === value,
+              })
+            : child
+        )}
+      </div>
+    ),
+    // aria-checked is spread in from the group above; the literal default is
+    // there so the role is never rendered without its required attribute.
+    ContextMenuRadioItem: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button type="button" role="menuitemradio" aria-checked={false} onClick={onClick} {...props}>
+        {children}
+      </button>
+    ),
+  }
+})
 
 import { render, screen, cleanup, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -56,6 +89,7 @@ function drive(target: 'local' | 'cloud') {
 beforeEach(() => {
   vi.clearAllMocks()
   mockApiFetch.mockResolvedValue({ ok: true, json: async () => ({ path: '/srv/agents/sales' }) })
+  mockUserSettings.mockReturnValue({ agentFolders: [], agentFolderAssignments: {} })
   window.electronAPI = { platform: 'darwin' } as never
   drive('local')
 })
@@ -107,5 +141,149 @@ describe('the agent directory action', () => {
 
     await userEvent.click(screen.getByTestId('open-agent-directory-item'))
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('/srv/agents/sales'))
+  })
+})
+
+describe('moving an agent into a left-nav folder', () => {
+  const FOLDERS = [
+    { id: 'f1', name: 'Work' },
+    { id: 'f2', name: 'Personal' },
+  ]
+
+  // The menu writes settings in the updater form — a function of the latest
+  // cached settings, resolved when the (scope-serialized) mutation actually
+  // runs — so a filing queued behind an in-flight write cannot revert it.
+  // Tests resolve the captured updater against explicit "current" settings.
+  const patchWith = (settings: Record<string, unknown>) => {
+    const arg = mockUpdateSettings.mock.calls[0][0]
+    return typeof arg === 'function' ? arg(settings) : arg
+  }
+
+  it('lists every folder plus the default "Your Agents" option', () => {
+    mockUserSettings.mockReturnValue({ agentFolders: FOLDERS, agentFolderAssignments: {} })
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    expect(screen.getByTestId('move-agent-to-no-folder-item')).toHaveTextContent('Your Agents')
+    expect(screen.getByTestId('move-agent-to-folder-f1')).toHaveTextContent('Work')
+    expect(screen.getByTestId('move-agent-to-folder-f2')).toHaveTextContent('Personal')
+  })
+
+  it('writes only the assignment, leaving the agent where it sits in the order', async () => {
+    mockUserSettings.mockReturnValue({ agentFolders: FOLDERS, agentFolderAssignments: {} })
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    await userEvent.click(screen.getByTestId('move-agent-to-folder-f1'))
+
+    expect(patchWith({ agentFolders: FOLDERS, agentFolderAssignments: {} })).toEqual({
+      agentFolderAssignments: { sales: 'f1' },
+    })
+  })
+
+  it('preserves other agents\u2019 assignments when filing this one', async () => {
+    const settings = { agentFolders: FOLDERS, agentFolderAssignments: { support: 'f2' } }
+    mockUserSettings.mockReturnValue(settings)
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    await userEvent.click(screen.getByTestId('move-agent-to-folder-f1'))
+
+    expect(patchWith(settings)).toEqual({
+      agentFolderAssignments: { support: 'f2', sales: 'f1' },
+    })
+  })
+
+  it('builds the write from the settings at mutation run time, not click time', async () => {
+    // A filing queued while another settings write (say, a drag in the
+    // sidebar) is still in flight runs after it settles. The payload must be
+    // built from THAT write's result \u2014 a snapshot taken at click time would
+    // silently revert it.
+    mockUserSettings.mockReturnValue({ agentFolders: FOLDERS, agentFolderAssignments: {} })
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    await userEvent.click(screen.getByTestId('move-agent-to-folder-f1'))
+
+    expect(patchWith({ agentFolders: FOLDERS, agentFolderAssignments: { support: 'f2' } })).toEqual({
+      agentFolderAssignments: { support: 'f2', sales: 'f1' },
+    })
+  })
+
+  it('moving to "Your Agents" drops the key rather than storing a folder id', async () => {
+    const settings = { agentFolders: FOLDERS, agentFolderAssignments: { sales: 'f1' } }
+    mockUserSettings.mockReturnValue(settings)
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    await userEvent.click(screen.getByTestId('move-agent-to-no-folder-item'))
+
+    expect(patchWith(settings)).toEqual({ agentFolderAssignments: {} })
+  })
+
+  it('marks the folder the agent is currently in', () => {
+    mockUserSettings.mockReturnValue({
+      agentFolders: FOLDERS,
+      agentFolderAssignments: { sales: 'f2' },
+    })
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    expect(screen.getByTestId('move-agent-to-folder-f2')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('move-agent-to-folder-f1')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('reads an assignment naming a deleted folder as the default folder', () => {
+    // The sidebar renders such an agent under "Your Agents", so the menu has
+    // to agree rather than showing a checkmark against nothing.
+    mockUserSettings.mockReturnValue({
+      agentFolders: FOLDERS,
+      agentFolderAssignments: { sales: 'gone' },
+    })
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    expect(screen.getByTestId('move-agent-to-no-folder-item')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('creates a named folder and files the agent into it in one write', async () => {
+    const settings = { agentFolders: FOLDERS, agentFolderAssignments: {} }
+    mockUserSettings.mockReturnValue(settings)
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    await userEvent.click(screen.getByTestId('move-agent-to-new-folder-item'))
+    await userEvent.type(screen.getByTestId('new-agent-folder-name-input'), 'Clients')
+    await userEvent.click(screen.getByTestId('confirm-new-agent-folder-button'))
+
+    expect(mockUpdateSettings).toHaveBeenCalledTimes(1)
+    const patch = patchWith(settings)
+    expect(patch.agentFolders).toHaveLength(3)
+    expect(patch.agentFolders[2].name).toBe('Clients')
+    expect(patch.agentFolderAssignments).toEqual({ sales: patch.agentFolders[2].id })
+  })
+
+  it('deduplicates a typed name that collides with an existing folder', async () => {
+    const settings = { agentFolders: FOLDERS, agentFolderAssignments: {} }
+    mockUserSettings.mockReturnValue(settings)
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    await userEvent.click(screen.getByTestId('move-agent-to-new-folder-item'))
+    await userEvent.type(screen.getByTestId('new-agent-folder-name-input'), 'Work')
+    await userEvent.click(screen.getByTestId('confirm-new-agent-folder-button'))
+
+    const patch = patchWith(settings)
+    expect(patch.agentFolders[2].name).toBe('Work 2')
+  })
+
+  it('does not create a folder with a blank name', async () => {
+    mockUserSettings.mockReturnValue({ agentFolders: [], agentFolderAssignments: {} })
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    await userEvent.click(screen.getByTestId('move-agent-to-new-folder-item'))
+    await userEvent.type(screen.getByTestId('new-agent-folder-name-input'), '   ')
+
+    expect(screen.getByTestId('confirm-new-agent-folder-button')).toBeDisabled()
+    expect(mockUpdateSettings).not.toHaveBeenCalled()
+  })
+
+  it('offers the folder submenu with no folders defined yet', () => {
+    mockUserSettings.mockReturnValue(undefined)
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    expect(screen.getByTestId('move-agent-to-no-folder-item')).toBeInTheDocument()
+    expect(screen.getByTestId('move-agent-to-new-folder-item')).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/agents/agent-context-menu.test.tsx
+++ b/src/renderer/components/agents/agent-context-menu.test.tsx
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const { mockApiFetch } = vi.hoisted(() => ({ mockApiFetch: vi.fn() }))
 vi.mock('@renderer/lib/api', () => ({ apiFetch: mockApiFetch }))
 
+const { mockUseAgents } = vi.hoisted(() => ({ mockUseAgents: vi.fn() }))
 vi.mock('@renderer/hooks/use-agents', () => ({
+  useAgents: () => mockUseAgents(),
   useDeleteAgent: () => ({ mutateAsync: vi.fn() }),
   useUpdateAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useRouteAgentId: () => undefined,
@@ -80,6 +82,12 @@ import { AgentContextMenu } from './agent-context-menu'
  */
 
 const AGENT = { slug: 'sales', name: 'Sales', status: 'running' } as never
+// The canonical filing write rebuilds the whole tree from the agent list, so
+// the mock provides the agents the tests file and order-assert against.
+const ALL_AGENTS = [
+  { slug: 'sales', name: 'Sales', status: 'running' },
+  { slug: 'support', name: 'Support', status: 'stopped' },
+]
 
 function drive(target: 'local' | 'cloud') {
   _resetApiTargetForTest() // the global setup already settled it to 'local'
@@ -90,6 +98,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockApiFetch.mockResolvedValue({ ok: true, json: async () => ({ path: '/srv/agents/sales' }) })
   mockUserSettings.mockReturnValue({ agentFolders: [], agentFolderAssignments: {} })
+  mockUseAgents.mockReturnValue({ data: ALL_AGENTS, isLoading: false, error: null })
   window.electronAPI = { platform: 'darwin' } as never
   drive('local')
 })
@@ -168,15 +177,38 @@ describe('moving an agent into a left-nav folder', () => {
     expect(screen.getByTestId('move-agent-to-folder-f2')).toHaveTextContent('Personal')
   })
 
-  it('writes only the assignment, leaving the agent where it sits in the order', async () => {
+  it('files the agent at the end of the folder and keeps agentOrder canonical', async () => {
+    // Filing writes the same whole-tree shape a drag writes, so the flat
+    // agentOrder the home grid/graph/tray read always matches the sidebar's
+    // reading order — an assignment-only write left it stale until the next
+    // drag.
     mockUserSettings.mockReturnValue({ agentFolders: FOLDERS, agentFolderAssignments: {} })
     render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
 
     await userEvent.click(screen.getByTestId('move-agent-to-folder-f1'))
 
-    expect(patchWith({ agentFolders: FOLDERS, agentFolderAssignments: {} })).toEqual({
+    const patch = patchWith({ agentFolders: FOLDERS, agentFolderAssignments: {} })
+    expect(patch.agentFolderAssignments).toEqual({ sales: 'f1' })
+    // sales appended to f1, which follows the root block in reading order.
+    expect(patch.agentOrder).toEqual(['support', 'sales'])
+    expect(patch.agentListOrder).toEqual([
+      'agent-folder::root',
+      'agent-folder::f1',
+      'agent-folder::f2',
+    ])
+    expect(patch.agentFolders).toEqual(FOLDERS)
+  })
+
+  it('does not write anything when the current folder is re-selected', async () => {
+    mockUserSettings.mockReturnValue({
+      agentFolders: FOLDERS,
       agentFolderAssignments: { sales: 'f1' },
     })
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+
+    await userEvent.click(screen.getByTestId('move-agent-to-folder-f1'))
+
+    expect(mockUpdateSettings).not.toHaveBeenCalled()
   })
 
   it('preserves other agents\u2019 assignments when filing this one', async () => {
@@ -186,8 +218,9 @@ describe('moving an agent into a left-nav folder', () => {
 
     await userEvent.click(screen.getByTestId('move-agent-to-folder-f1'))
 
-    expect(patchWith(settings)).toEqual({
-      agentFolderAssignments: { support: 'f2', sales: 'f1' },
+    expect(patchWith(settings).agentFolderAssignments).toEqual({
+      support: 'f2',
+      sales: 'f1',
     })
   })
 
@@ -201,9 +234,10 @@ describe('moving an agent into a left-nav folder', () => {
 
     await userEvent.click(screen.getByTestId('move-agent-to-folder-f1'))
 
-    expect(patchWith({ agentFolders: FOLDERS, agentFolderAssignments: { support: 'f2' } })).toEqual({
-      agentFolderAssignments: { support: 'f2', sales: 'f1' },
-    })
+    expect(
+      patchWith({ agentFolders: FOLDERS, agentFolderAssignments: { support: 'f2' } })
+        .agentFolderAssignments
+    ).toEqual({ support: 'f2', sales: 'f1' })
   })
 
   it('moving to "Your Agents" drops the key rather than storing a folder id', async () => {
@@ -213,7 +247,11 @@ describe('moving an agent into a left-nav folder', () => {
 
     await userEvent.click(screen.getByTestId('move-agent-to-no-folder-item'))
 
-    expect(patchWith(settings)).toEqual({ agentFolderAssignments: {} })
+    const patch = patchWith(settings)
+    expect(patch.agentFolderAssignments).toEqual({})
+    // Un-filing appends to the end of "Your Agents", mirroring how filing
+    // appends to a folder.
+    expect(patch.agentOrder).toEqual(['support', 'sales'])
   })
 
   it('marks the folder the agent is currently in', () => {

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -1,11 +1,16 @@
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@renderer/components/ui/context-menu'
 import {
@@ -24,8 +29,18 @@ import { useUser } from '@renderer/context/user-context'
 import { AgentSettingsDialog } from './agent-settings-dialog'
 import { apiFetch } from '@renderer/lib/api'
 import { canUseHostFeatures } from '@renderer/lib/host-features'
-import { Settings, FolderOpen, Copy, Trash2, LogOut, Move } from 'lucide-react'
+import { Settings, FolderOpen, Copy, Trash2, LogOut, Move, FolderInput } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
+import { Input } from '@renderer/components/ui/input'
+import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
+import {
+  ROOT_FOLDER_ID,
+  ROOT_FOLDER_NAME,
+  assignAgentToFolder,
+  newFolderId,
+  sanitizeFolders,
+  uniqueFolderName,
+} from '@renderer/lib/agent-folders'
 
 interface AgentContextMenuProps {
   agent: ApiAgent
@@ -49,6 +64,8 @@ export function AgentContextMenu({
   const [showLeaveDialog, setShowLeaveDialog] = useState(false)
   const [showSettingsDialog, setShowSettingsDialog] = useState(false)
   const [showPathDialog, setShowPathDialog] = useState(false)
+  const [showNewFolderDialog, setShowNewFolderDialog] = useState(false)
+  const [newFolderName, setNewFolderName] = useState('')
   const [agentPath, setAgentPath] = useState('')
   const [isDeleting, setIsDeleting] = useState(false)
   const [isLeaving, setIsLeaving] = useState(false)
@@ -61,6 +78,58 @@ export function AgentContextMenu({
   const { canAdminAgent, isAuthMode } = useUser()
   const queryClient = useQueryClient()
   const isOwner = canAdminAgent(agent.slug)
+
+  // Left-nav folders are a per-user projection (see `agent-folders.ts`), so
+  // this is offered for shared agents too — filing one moves it for nobody
+  // else. It is also the only way to file an agent on touch, where dragging a
+  // row between folders is not a realistic gesture.
+  const { data: userSettings } = useUserSettings()
+  const updateSettings = useUpdateUserSettings()
+  const folders = useMemo(() => sanitizeFolders(userSettings?.agentFolders), [userSettings?.agentFolders])
+  const currentFolderId = userSettings?.agentFolderAssignments?.[agent.slug]
+  // An assignment naming a folder that no longer exists reads as the default
+  // folder, the same way the sidebar renders it.
+  const selectedFolderValue =
+    currentFolderId && folders.some((f) => f.id === currentFolderId)
+      ? currentFolderId
+      : ROOT_FOLDER_ID
+
+  // Only the assignment changes: the agent keeps its position in agentOrder, so
+  // it lands in the folder wherever its existing place in the list puts it.
+  // Both writes below use the updater form: the payload is a whole-field
+  // replacement derived from current settings, and the sidebar's drag path
+  // writes the same fields. A snapshot captured at click time would silently
+  // revert whatever write was still in flight (file A by drag, quickly file B
+  // here → A pops back out); the updater resolves against the settled cache.
+  const handleMoveToFolder = useCallback((value: string) => {
+    updateSettings.mutate((current) => ({
+      // assignAgentToFolder treats the default folder as "delete the key".
+      agentFolderAssignments: assignAgentToFolder(
+        current?.agentFolderAssignments,
+        agent.slug,
+        value
+      ),
+    }))
+  }, [agent.slug, updateSettings])
+
+  const handleCreateFolderWithAgent = useCallback(() => {
+    const name = newFolderName.trim()
+    if (!name) return
+    const id = newFolderId()
+    updateSettings.mutate((current) => {
+      const currentFolders = sanitizeFolders(current?.agentFolders)
+      return {
+        agentFolders: [...currentFolders, { id, name: uniqueFolderName(currentFolders, name) }],
+        agentFolderAssignments: assignAgentToFolder(
+          current?.agentFolderAssignments,
+          agent.slug,
+          id
+        ),
+      }
+    })
+    setShowNewFolderDialog(false)
+    setNewFolderName('')
+  }, [agent.slug, newFolderName, updateSettings])
 
   // `open: true` makes the API run the file manager on ITS OWN host. That is
   // what you want when the API is this computer; against a cloud workspace it
@@ -144,6 +213,45 @@ export function AgentContextMenu({
           )}
           {additionalOptions}
           {(onArrange || additionalOptions) && <ContextMenuSeparator />}
+          <ContextMenuSub>
+            <ContextMenuSubTrigger data-testid="move-agent-to-folder-trigger">
+              <FolderInput className="h-4 w-4 mr-2" />
+              Move to Folder
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              <ContextMenuRadioGroup
+                value={selectedFolderValue}
+                onValueChange={handleMoveToFolder}
+              >
+                <ContextMenuRadioItem
+                  value={ROOT_FOLDER_ID}
+                  data-testid="move-agent-to-no-folder-item"
+                >
+                  {ROOT_FOLDER_NAME}
+                </ContextMenuRadioItem>
+                {folders.map((folder) => (
+                  <ContextMenuRadioItem
+                    key={folder.id}
+                    value={folder.id}
+                    data-testid={`move-agent-to-folder-${folder.id}`}
+                  >
+                    {folder.name}
+                  </ContextMenuRadioItem>
+                ))}
+              </ContextMenuRadioGroup>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                onClick={() => {
+                  setNewFolderName('')
+                  setShowNewFolderDialog(true)
+                }}
+                data-testid="move-agent-to-new-folder-item"
+              >
+                New Folder…
+              </ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+          <ContextMenuSeparator />
           <ContextMenuItem
             onClick={() => setShowSettingsDialog(true)}
             data-testid="agent-settings-item"
@@ -242,6 +350,43 @@ export function AgentContextMenu({
               data-testid="confirm-leave-agent-button"
             >
               {isLeaving ? 'Leaving...' : 'Leave'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={showNewFolderDialog} onOpenChange={setShowNewFolderDialog}>
+        <AlertDialogContent data-testid="new-agent-folder-dialog">
+          <AlertDialogHeader>
+            <AlertDialogTitle>New Folder</AlertDialogTitle>
+            <AlertDialogDescription>
+              Folders organise your left nav only. Shared agents keep their own
+              place for everybody else.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Input
+            value={newFolderName}
+            onChange={(e) => setNewFolderName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                handleCreateFolderWithAgent()
+              }
+            }}
+            placeholder="Folder name"
+            aria-label="Folder name"
+            autoFocus
+            maxLength={120}
+            data-testid="new-agent-folder-name-input"
+          />
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleCreateFolderWithAgent}
+              disabled={!newFolderName.trim()}
+              data-testid="confirm-new-agent-folder-button"
+            >
+              Create &amp; Move
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -23,7 +23,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
-import { useDeleteAgent, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
+import { useAgents, useDeleteAgent, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
 import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { AgentSettingsDialog } from './agent-settings-dialog'
@@ -32,14 +32,18 @@ import { canUseHostFeatures } from '@renderer/lib/host-features'
 import { Settings, FolderOpen, Copy, Trash2, LogOut, Move, FolderInput } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Input } from '@renderer/components/ui/input'
-import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
+import { useUserSettings, useUpdateUserSettings, type UserSettingsData } from '@renderer/hooks/use-user-settings'
+import { applyAgentOrder } from '@renderer/lib/agent-ordering'
 import {
   ROOT_FOLDER_ID,
   ROOT_FOLDER_NAME,
-  assignAgentToFolder,
+  applyTreeOperation,
+  buildFolderSections,
   newFolderId,
   sanitizeFolders,
+  sectionsToSettings,
   uniqueFolderName,
+  type FolderSection,
 } from '@renderer/lib/agent-folders'
 
 interface AgentContextMenuProps {
@@ -84,6 +88,7 @@ export function AgentContextMenu({
   // else. It is also the only way to file an agent on touch, where dragging a
   // row between folders is not a realistic gesture.
   const { data: userSettings } = useUserSettings()
+  const { data: allAgents } = useAgents()
   const updateSettings = useUpdateUserSettings()
   const folders = useMemo(() => sanitizeFolders(userSettings?.agentFolders), [userSettings?.agentFolders])
   const currentFolderId = userSettings?.agentFolderAssignments?.[agent.slug]
@@ -94,42 +99,65 @@ export function AgentContextMenu({
       ? currentFolderId
       : ROOT_FOLDER_ID
 
-  // Only the assignment changes: the agent keeps its position in agentOrder, so
-  // it lands in the folder wherever its existing place in the list puts it.
-  // Both writes below use the updater form: the payload is a whole-field
-  // replacement derived from current settings, and the sidebar's drag path
-  // writes the same fields. A snapshot captured at click time would silently
-  // revert whatever write was still in flight (file A by drag, quickly file B
-  // here → A pops back out); the updater resolves against the settled cache.
-  const handleMoveToFolder = useCallback((value: string) => {
-    updateSettings.mutate((current) => ({
-      // assignAgentToFolder treats the default folder as "delete the key".
-      agentFolderAssignments: assignAgentToFolder(
-        current?.agentFolderAssignments,
-        agent.slug,
-        value
+  // Filing writes the whole canonical tree — the same shape a drag writes —
+  // so the two filing paths leave identical settings and the flat agentOrder
+  // the home grid, graph and tray read always matches the sidebar's reading
+  // order. (An assignment-only write left agentOrder stale until the next
+  // drag.) Both writes use the updater form: they resolve against the
+  // settings as of when the (scope-serialized) mutation runs, so a filing
+  // queued behind an in-flight write cannot revert it. Filing appends to the
+  // target folder, matching a drop on the folder's header.
+  const buildSections = useCallback(
+    (current: UserSettingsData) =>
+      buildFolderSections(
+        applyAgentOrder(allAgents ?? [], current.agentOrder),
+        current.agentFolders,
+        current.agentFolderAssignments,
+        current.agentListOrder
       ),
-    }))
-  }, [agent.slug, updateSettings])
+    [allAgents]
+  )
+
+  const handleMoveToFolder = useCallback((value: string) => {
+    // Radix reports a selection even when the checked item is re-picked; the
+    // agent is already there, so there is nothing to write (and nothing to
+    // move to the folder's end).
+    if (value === selectedFolderValue) return
+    updateSettings.mutate((current) =>
+      sectionsToSettings(
+        applyTreeOperation(buildSections(current), {
+          kind: 'placeAgent',
+          slug: agent.slug,
+          folderId: value,
+          index: Number.MAX_SAFE_INTEGER,
+        })
+      )
+    )
+  }, [agent.slug, buildSections, selectedFolderValue, updateSettings])
 
   const handleCreateFolderWithAgent = useCallback(() => {
     const name = newFolderName.trim()
     if (!name) return
     const id = newFolderId()
     updateSettings.mutate((current) => {
-      const currentFolders = sanitizeFolders(current?.agentFolders)
-      return {
-        agentFolders: [...currentFolders, { id, name: uniqueFolderName(currentFolders, name) }],
-        agentFolderAssignments: assignAgentToFolder(
-          current?.agentFolderAssignments,
-          agent.slug,
-          id
-        ),
-      }
+      const sections = buildSections(current)
+      const currentFolders = sections.filter((s) => !s.isRoot).map((s) => s.folder)
+      const withFolder: FolderSection[] = [
+        ...sections,
+        { folder: { id, name: uniqueFolderName(currentFolders, name) }, isRoot: false, agents: [] },
+      ]
+      return sectionsToSettings(
+        applyTreeOperation(withFolder, {
+          kind: 'placeAgent',
+          slug: agent.slug,
+          folderId: id,
+          index: 0,
+        })
+      )
     })
     setShowNewFolderDialog(false)
     setNewFolderName('')
-  }, [agent.slug, newFolderName, updateSettings])
+  }, [agent.slug, buildSections, newFolderName, updateSettings])
 
   // `open: true` makes the API run the file manager on ITS OWN host. That is
   // what you want when the API is this computer; against a cloud workspace it

--- a/src/renderer/components/layout/agent-folder-block.test.tsx
+++ b/src/renderer/components/layout/agent-folder-block.test.tsx
@@ -1,0 +1,396 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const { mockUseSortable, mockUseDroppable } = vi.hoisted(() => ({
+  mockUseSortable: vi.fn(),
+  mockUseDroppable: vi.fn(),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: (args: unknown) => mockUseSortable(args),
+}))
+vi.mock('@dnd-kit/core', () => ({ useDroppable: (args: unknown) => mockUseDroppable(args) }))
+vi.mock('@dnd-kit/utilities', () => ({ CSS: { Transform: { toString: () => '' } } }))
+
+// Radix context menus never open in jsdom without a real pointer; render the
+// items inline so the folder actions are reachable.
+vi.mock('@renderer/components/ui/context-menu', () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuItem: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" onClick={onClick} {...props}>{children}</button>
+  ),
+}))
+
+vi.mock('@renderer/components/ui/sidebar', () => ({
+  SidebarMenuButton: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>{children}</button>
+  ),
+}))
+
+import { AgentDragOverlayRow, AgentFolderBlock } from './agent-folder-block'
+
+const FOLDER = { id: 'f1', name: 'Work' }
+
+/**
+ * Stand in for dnd-kit's useSortable, reproducing the one behaviour this block
+ * has to work around: the real hook puts `aria-disabled` into `attributes`
+ * whenever the sortable is disabled.
+ */
+const nodes: { sortable: Element | null; activator: Element | null } = {
+  sortable: null,
+  activator: null,
+}
+
+function sortableState(args: { disabled?: boolean } | undefined, isOver = false) {
+  return {
+    attributes: { role: 'button', 'aria-disabled': !!args?.disabled },
+    listeners: {},
+    setNodeRef: (el: Element | null) => { nodes.sortable = el ?? nodes.sortable },
+    setActivatorNodeRef: (el: Element | null) => { nodes.activator = el ?? nodes.activator },
+    transform: null,
+    transition: null,
+    isDragging: false,
+    isOver,
+  }
+}
+
+function renderBlock(overrides: Partial<React.ComponentProps<typeof AgentFolderBlock>> = {}) {
+  const props = {
+    folder: FOLDER,
+    agentCount: 2,
+    isCollapsed: false,
+    activeDragType: null,
+    onToggle: vi.fn(),
+    onRename: vi.fn(),
+    onRenameEnd: vi.fn(),
+    onDelete: vi.fn(),
+    children: <li data-testid="member-row">member</li>,
+    ...overrides,
+  }
+  render(<ul><AgentFolderBlock {...props} /></ul>)
+  return props
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  nodes.sortable = null
+  nodes.activator = null
+  mockUseSortable.mockImplementation((args) => sortableState(args))
+  mockUseDroppable.mockReturnValue({ setNodeRef: vi.fn(), isOver: false })
+})
+
+afterEach(cleanup)
+
+describe('AgentFolderBlock', () => {
+  it('shows the folder name and how many agents it holds', () => {
+    renderBlock()
+    const row = screen.getByTestId('agent-folder-f1')
+    expect(row).toHaveTextContent('Work')
+    expect(row).toHaveTextContent('2')
+  })
+
+  it('reveals the chevron only on hover, in the count’s slot', () => {
+    // The header reads as a section label at rest (name + count, no icon);
+    // hovering swaps the count for the expand/collapse affordance.
+    renderBlock()
+    expect(screen.getByTestId('agent-folder-count-f1').className).toContain(
+      'group-hover/folder-header:hidden'
+    )
+    const chevron = screen.getByTestId('agent-folder-chevron-f1')
+    expect(chevron.getAttribute('class')).toContain('hidden')
+    expect(chevron.getAttribute('class')).toContain('group-hover/folder-header:block')
+  })
+
+  it('points the chevron down while expanded and right while collapsed', () => {
+    renderBlock({ isCollapsed: false })
+    expect(screen.getByTestId('agent-folder-chevron-f1').getAttribute('class')).toContain('rotate-90')
+    cleanup()
+    renderBlock({ isCollapsed: true })
+    expect(screen.getByTestId('agent-folder-chevron-f1').getAttribute('class')).not.toContain('rotate-90')
+  })
+
+  it('renders its agents nested inside the block', () => {
+    renderBlock()
+    expect(screen.getByTestId('member-row')).toBeInTheDocument()
+  })
+
+  it('keeps the whole block one list item so the top level stays contiguous', () => {
+    // The top-level sorting strategy measures a list of siblings. If a folder's
+    // header and body were separate items, the rows in between would throw its
+    // measurements off and a folder could not be dropped between two agents.
+    renderBlock()
+    const top = document.querySelector('ul')!
+    expect(top.children).toHaveLength(1)
+    expect(top.children[0].tagName).toBe('LI')
+    expect(document.querySelector('ul > li > div > ul > li')).not.toBeNull()
+  })
+
+  it('identifies itself to the drag layer as a folder', () => {
+    renderBlock()
+    expect(mockUseSortable).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'agent-folder::f1', data: { type: 'folder', folderId: 'f1' } })
+    )
+  })
+
+  it('puts the drag handle on the header, not the whole block', () => {
+    // The block is the measured node so the top level sorts correctly, but only
+    // the header listens — otherwise starting a drag on a member row would
+    // start the folder's drag too.
+    renderBlock()
+
+    expect(nodes.sortable?.tagName).toBe('LI')
+    expect(nodes.activator?.tagName).toBe('DIV')
+    expect(nodes.sortable?.contains(nodes.activator!)).toBe(true)
+    expect(nodes.activator?.contains(screen.getByTestId('member-row'))).toBe(false)
+  })
+
+  it('registers its body as a drop target of its own', () => {
+    renderBlock()
+    expect(mockUseDroppable).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'agent-section::f1' })
+    )
+  })
+
+  it('reports its expanded state to assistive tech', () => {
+    renderBlock({ isCollapsed: true })
+    expect(screen.getByTestId('agent-folder-f1')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('hides its agents when collapsed but keeps them mounted', () => {
+    // Unmounting made expanding a large folder a visible hitch; the rows stay
+    // alive and the body hides via the `hidden` attribute.
+    renderBlock({ isCollapsed: true })
+    expect(screen.getByTestId('member-row')).not.toBeVisible()
+  })
+
+  it('disables the body drop target while collapsed', () => {
+    // A display:none body measures as a phantom rect at the viewport origin.
+    renderBlock({ isCollapsed: true })
+    expect(mockUseDroppable).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'agent-section::f1', disabled: true })
+    )
+  })
+
+  it('toggles on click', async () => {
+    const props = renderBlock()
+    await userEvent.click(screen.getByTestId('agent-folder-f1'))
+    expect(props.onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('invites a drop when it holds nothing', () => {
+    renderBlock({ agentCount: 0, children: null })
+    expect(screen.getByTestId('agent-folder-empty-f1')).toBeInTheDocument()
+  })
+
+  it('shows no placeholder once it holds something', () => {
+    renderBlock()
+    expect(screen.queryByTestId('agent-folder-empty-f1')).not.toBeInTheDocument()
+  })
+
+  it('renames on Enter', async () => {
+    const props = renderBlock()
+    await userEvent.click(screen.getByTestId('rename-folder-item'))
+    const input = screen.getByTestId('folder-name-input')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Clients{Enter}')
+
+    expect(props.onRename).toHaveBeenCalledWith('Clients')
+    expect(props.onRenameEnd).toHaveBeenCalled()
+  })
+
+  it('abandons a rename on Escape', async () => {
+    const props = renderBlock()
+    await userEvent.click(screen.getByTestId('rename-folder-item'))
+    const input = screen.getByTestId('folder-name-input')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Clients{Escape}')
+
+    expect(props.onRename).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('folder-name-input')).not.toBeInTheDocument()
+  })
+
+  it('commits a rename on blur, the way the dashboard rename does', async () => {
+    const props = renderBlock()
+    await userEvent.click(screen.getByTestId('rename-folder-item'))
+    const input = screen.getByTestId('folder-name-input')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Clients')
+    await userEvent.tab()
+
+    expect(props.onRename).toHaveBeenCalledWith('Clients')
+  })
+
+  it('does not write a rename that only adds whitespace', async () => {
+    const props = renderBlock()
+    await userEvent.click(screen.getByTestId('rename-folder-item'))
+    await userEvent.type(screen.getByTestId('folder-name-input'), '   {Enter}')
+
+    expect(props.onRename).not.toHaveBeenCalled()
+    expect(props.onRenameEnd).toHaveBeenCalled()
+  })
+
+  it('does not write a rename that changes nothing', async () => {
+    const props = renderBlock()
+    await userEvent.click(screen.getByTestId('rename-folder-item'))
+    await userEvent.type(screen.getByTestId('folder-name-input'), '{Enter}')
+
+    expect(props.onRename).not.toHaveBeenCalled()
+  })
+
+  it('commits a rename exactly once when Enter is followed by the blur it causes', async () => {
+    const props = renderBlock()
+    await userEvent.click(screen.getByTestId('rename-folder-item'))
+    const input = screen.getByTestId('folder-name-input')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Clients{Enter}')
+    await userEvent.tab()
+
+    expect(props.onRename).toHaveBeenCalledTimes(1)
+  })
+
+  it('swaps the header out for the input rather than nesting one inside a button', async () => {
+    // A form control inside a <button> is invalid markup, and the click that
+    // should place the caret lands on the button instead.
+    renderBlock()
+    await userEvent.click(screen.getByTestId('rename-folder-item'))
+
+    expect(screen.queryByTestId('agent-folder-f1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('folder-name-input').closest('button')).toBeNull()
+  })
+
+  it('strips the aria-disabled flag dnd-kit stamps into its attributes', () => {
+    // dnd-kit ALWAYS includes `aria-disabled` in `attributes` — `false` at
+    // rest — and React renders boolean aria-* values as literal strings, so
+    // spreading it unstripped would put aria-disabled="false" on every header
+    // (and "true" on any future layout that renders the carrier while the
+    // sortable is disabled). Asserting at rest keeps this falsifiable: while
+    // renaming, the carrier is not rendered at all, so nothing could match.
+    renderBlock()
+
+    expect(document.querySelector('[aria-disabled]')).toBeNull()
+  })
+
+  it('suspends the drag while a rename is open', async () => {
+    renderBlock()
+    await userEvent.click(screen.getByTestId('rename-folder-item'))
+
+    expect(mockUseSortable).toHaveBeenLastCalledWith(expect.objectContaining({ disabled: true }))
+  })
+
+  it('opens straight into rename mode for a freshly created folder', () => {
+    renderBlock({ initialRenaming: true })
+    expect(screen.getByTestId('folder-name-input')).toBeInTheDocument()
+  })
+
+  it('deletes on request', async () => {
+    const props = renderBlock()
+    await userEvent.click(screen.getByTestId('delete-folder-item'))
+    expect(props.onDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('highlights as a drop target when an agent is dragged over it', () => {
+    mockUseSortable.mockImplementation((args) => sortableState(args, true))
+    renderBlock({ activeDragType: 'agent' })
+    expect(screen.getByTestId('agent-folder-f1').className).toContain('ring-1')
+  })
+
+  it('draws the insert line on the edge the drop will use', () => {
+    // Folders do not nest — a folder over a folder is a reorder. The line and
+    // the drop read the same cue, so above means above and below means below.
+    renderBlock({ activeDragType: 'folder', insertEdge: 'above' })
+    const above = screen.getByTestId('folder-insert-indicator-f1')
+    expect(above).toHaveAttribute('data-edge', 'above')
+    expect(above.className).toContain('-top-0.5')
+    cleanup()
+
+    renderBlock({ activeDragType: 'folder', insertEdge: 'below' })
+    const below = screen.getByTestId('folder-insert-indicator-f1')
+    expect(below).toHaveAttribute('data-edge', 'below')
+    expect(below.className).toContain('-bottom-0.5')
+  })
+
+  it('shows no insert line without a cue, and no drop-target fill for folders', () => {
+    mockUseSortable.mockImplementation((args) => sortableState(args, true))
+    renderBlock({ activeDragType: 'folder' })
+    expect(screen.queryByTestId('folder-insert-indicator-f1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('agent-folder-f1').className).not.toContain('ring-1')
+  })
+})
+
+describe('AgentFolderBlock — the default folder', () => {
+  function renderRoot(overrides: Partial<React.ComponentProps<typeof AgentFolderBlock>> = {}) {
+    const props = {
+      folder: { id: 'root', name: 'Your Agents' },
+      isRoot: true,
+      agentCount: 2,
+      isCollapsed: false,
+      activeDragType: null,
+      onToggle: vi.fn(),
+      onRename: vi.fn(),
+      onRenameEnd: vi.fn(),
+      onDelete: vi.fn(),
+      onCreateFolder: vi.fn(),
+      children: <li data-testid="member-row">member</li>,
+      ...overrides,
+    } satisfies React.ComponentProps<typeof AgentFolderBlock>
+    render(<ul><AgentFolderBlock {...props} /></ul>)
+    return props
+  }
+
+  it('renders like any folder header', () => {
+    renderRoot()
+    const row = screen.getByTestId('agent-folder-root')
+    expect(row).toHaveTextContent('Your Agents')
+    expect(row).toHaveTextContent('2')
+  })
+
+  it('offers no rename or delete — it is the fallback bucket', () => {
+    renderRoot()
+    expect(screen.queryByTestId('rename-folder-item')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('delete-folder-item')).not.toBeInTheDocument()
+  })
+
+  it('hosts the new-folder button', async () => {
+    const props = renderRoot()
+    await userEvent.click(screen.getByTestId('new-folder-button'))
+    expect(props.onCreateFolder).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the new-folder button outside the header button', () => {
+    // A button cannot nest inside a button, and pressing + must not begin the
+    // folder's drag — so it overlays as a sibling of the drag activator.
+    renderRoot()
+    const plus = screen.getByTestId('new-folder-button')
+    expect(plus.closest('button')).toBe(plus)
+    expect(screen.getByTestId('agent-folder-root').contains(plus)).toBe(false)
+  })
+
+  it('does not render the new-folder button on ordinary folders', () => {
+    renderBlock()
+    expect(screen.queryByTestId('new-folder-button')).not.toBeInTheDocument()
+  })
+
+  it('still collapses like any folder', async () => {
+    const props = renderRoot()
+    await userEvent.click(screen.getByTestId('agent-folder-root'))
+    expect(props.onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('identifies itself to the drag layer as a folder, so it can be reordered', () => {
+    renderRoot()
+    expect(mockUseSortable).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'agent-folder::root', data: { type: 'folder', folderId: 'root' } })
+    )
+  })
+})
+
+describe('AgentDragOverlayRow', () => {
+  it('names what is being dragged', () => {
+    render(<AgentDragOverlayRow label="Sales" isFolder={false} />)
+    expect(screen.getByText('Sales')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/layout/agent-folder-block.tsx
+++ b/src/renderer/components/layout/agent-folder-block.tsx
@@ -1,0 +1,359 @@
+import React, { useState } from 'react'
+import { ChevronRight, Folder, FolderPlus, Pencil, Trash2 } from 'lucide-react'
+import { useSortable } from '@dnd-kit/sortable'
+import { useDroppable } from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+import { cn } from '@shared/lib/utils/cn'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@renderer/components/ui/context-menu'
+import { SidebarMenuButton } from '@renderer/components/ui/sidebar'
+import {
+  containerIdForFolder,
+  sortableIdForFolder,
+  type AgentFolder,
+} from '@renderer/lib/agent-folders'
+
+/**
+ * Inline rename for a folder. Mirrors the dashboard rename in `app-sidebar.tsx`
+ * — commit on Enter or blur, abandon on Escape — but writes to user settings
+ * through the caller rather than hitting an API of its own.
+ */
+function FolderNameInput({
+  currentName,
+  onCommit,
+  onDone,
+}: {
+  currentName: string
+  onCommit: (name: string) => void
+  onDone: () => void
+}) {
+  const [value, setValue] = useState(currentName)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const settledRef = React.useRef(false)
+
+  React.useEffect(() => {
+    inputRef.current?.select()
+  }, [])
+
+  const submit = () => {
+    if (settledRef.current) return
+    settledRef.current = true
+    const trimmed = value.trim()
+    if (trimmed && trimmed !== currentName) onCommit(trimmed)
+    onDone()
+  }
+
+  const cancel = () => {
+    if (settledRef.current) return
+    settledRef.current = true
+    onDone()
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={(e) => {
+        e.stopPropagation()
+        if (e.key === 'Enter') submit()
+        if (e.key === 'Escape') cancel()
+      }}
+      onBlur={submit}
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      autoFocus
+      aria-label="Folder name"
+      data-testid="folder-name-input"
+      className="w-full bg-background border border-input rounded px-1 py-0 text-[13px] outline-none focus:ring-1 focus:ring-ring"
+    />
+  )
+}
+
+/**
+ * The folder header's interactive row. Memoized because the block around it
+ * re-renders on every drag tick (its dnd-kit hooks subscribe to the live drag
+ * context) and a Radix context menu is too much tree to rebuild at pointer
+ * rate; every prop is stable across ticks except the two booleans that
+ * genuinely change what it shows.
+ */
+const FolderHeader = React.memo(function FolderHeader({
+  folder,
+  isRoot,
+  agentCount,
+  isCollapsed,
+  isDropTarget,
+  onToggle,
+  onStartRename,
+  onDelete,
+}: {
+  folder: AgentFolder
+  isRoot: boolean
+  agentCount: number
+  isCollapsed: boolean
+  isDropTarget: boolean
+  onToggle: () => void
+  onStartRename: () => void
+  onDelete: () => void
+}) {
+  // Styled like a section label rather than as a row of the list: small muted
+  // text, no icon. The member count sits at the right and yields to the
+  // expand/collapse chevron on hover.
+  const header = (
+        <SidebarMenuButton
+          onClick={onToggle}
+          aria-expanded={!isCollapsed}
+          className={cn(
+            'group/folder-header h-8 justify-between text-xs font-normal text-sidebar-foreground/50 hover:text-sidebar-foreground/70',
+            isDropTarget && 'bg-sidebar-accent ring-1 ring-sidebar-ring text-sidebar-foreground'
+          )}
+          data-testid={`agent-folder-${folder.id}`}
+        >
+          <span className="truncate">{folder.name}</span>
+          <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
+            <span
+              className="text-[11px] tabular-nums text-muted-foreground/70 group-hover/folder-header:hidden"
+              data-testid={`agent-folder-count-${folder.id}`}
+            >
+              {agentCount}
+            </span>
+            <ChevronRight
+              aria-hidden
+              data-testid={`agent-folder-chevron-${folder.id}`}
+              className={cn(
+                'hidden h-3.5 w-3.5 text-muted-foreground group-hover/folder-header:block transition-transform',
+                !isCollapsed && 'rotate-90'
+              )}
+            />
+          </span>
+        </SidebarMenuButton>
+  )
+
+  // The default folder is the fallback bucket — it cannot be renamed or
+  // deleted, so it gets no context menu at all.
+  if (isRoot) return header
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{header}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={onStartRename} data-testid="rename-folder-item">
+          <Pencil className="h-4 w-4 mr-2" />
+          Rename Folder
+        </ContextMenuItem>
+        <ContextMenuItem
+          className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+          onClick={onDelete}
+          data-testid="delete-folder-item"
+        >
+          <Trash2 className="h-4 w-4 mr-2" />
+          Delete Folder
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+})
+
+/**
+ * A folder and the agents inside it, as one row of the left nav's top level.
+ *
+ * The whole block is the sortable node while only the header carries the drag
+ * listeners. That split matters twice over: it keeps every top-level item a
+ * single contiguous element, so the vertical sorting strategy measures the list
+ * correctly and a folder can be dropped between two unfiled agents; and it
+ * leaves the member rows free to start drags of their own, which they could not
+ * if the block itself were listening.
+ */
+export function AgentFolderBlock({
+  folder,
+  isRoot = false,
+  agentCount,
+  isCollapsed,
+  activeDragType,
+  insertEdge,
+  initialRenaming,
+  onToggle,
+  onRename,
+  onRenameEnd,
+  onDelete,
+  onCreateFolder,
+  children,
+}: {
+  folder: AgentFolder
+  /** The default "Your Agents" folder: no rename/delete, hosts the + button. */
+  isRoot?: boolean
+  agentCount: number
+  isCollapsed: boolean
+  /** What kind of thing is currently being dragged, if anything. */
+  activeDragType: 'agent' | 'folder' | null
+  /** Which edge of this block a dragged folder would land on, if hovered. */
+  insertEdge?: 'above' | 'below' | null
+  /** Mount straight into rename mode — used by the just-created folder. */
+  initialRenaming?: boolean
+  onToggle: () => void
+  onRename: (name: string) => void
+  onRenameEnd?: () => void
+  onDelete: () => void
+  /** Rendered as a hover + on the default folder's header row. */
+  onCreateFolder?: () => void
+  children: React.ReactNode
+}) {
+  const [isRenaming, setIsRenaming] = useState(initialRenaming ?? false)
+  const startRename = React.useCallback(() => setIsRenaming(true), [])
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isOver,
+  } = useSortable({
+    id: sortableIdForFolder(folder.id),
+    data: { type: 'folder', folderId: folder.id },
+    disabled: isRenaming,
+  })
+
+  const { setNodeRef: setBodyRef, isOver: isBodyOver } = useDroppable({
+    id: containerIdForFolder(folder.id),
+    // Collapsed: the body is display:none, so its rect would be a phantom.
+    // The header stays the way in (drop on it files at the end).
+    disabled: isCollapsed,
+    data: { type: 'container' },
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : undefined,
+    zIndex: isDragging ? 1 : undefined,
+  }
+
+  // dnd-kit always includes `aria-disabled` in `attributes` — `false` at rest,
+  // `true` while a rename suspends the drag — and React renders boolean aria-*
+  // values as literal strings. The header is a live control either way (only
+  // its DRAG is ever disabled), so the flag is stripped rather than spread.
+  const { 'aria-disabled': dragDisabled, ...handleAttributes } = attributes
+  void dragDisabled
+
+  // Dropping an agent on the header files it at the end of the folder, which is
+  // the only way into a collapsed one.
+  const isAgentTarget = (isOver || isBodyOver) && activeDragType === 'agent'
+
+  return (
+    <li ref={setNodeRef} style={style} className="group/folder-block relative list-none">
+      {insertEdge && !isDragging && (
+        // A folder over a folder is a reorder, not a nest — folders do not
+        // nest — so it gets an insert line rather than the fill an agent drop
+        // gets. The line sits on the edge the drop will actually use: the
+        // pointer's half of this block decides above or below, and the drop
+        // handler reads the same cue, so the line can never lie about where
+        // the folder lands.
+        <span
+          aria-hidden
+          className={cn(
+            'pointer-events-none absolute inset-x-1 z-10 h-0.5 rounded-full bg-sidebar-ring',
+            insertEdge === 'above' ? '-top-0.5' : '-bottom-0.5'
+          )}
+          data-edge={insertEdge}
+          data-testid={`folder-insert-indicator-${folder.id}`}
+        />
+      )}
+
+      {isRenaming ? (
+        // The input REPLACES the header rather than sitting inside it: a form
+        // control nested in a <button> is invalid markup, and clicking it would
+        // land on the button and toggle the folder shut mid-edit.
+        <div className="flex h-8 items-center rounded-md px-2">
+          <FolderNameInput
+            currentName={folder.name}
+            onCommit={onRename}
+            onDone={() => {
+              setIsRenaming(false)
+              onRenameEnd?.()
+            }}
+          />
+        </div>
+      ) : (
+        <div ref={setActivatorNodeRef} {...handleAttributes} {...listeners} className="relative">
+          <FolderHeader
+            folder={folder}
+            isRoot={isRoot}
+            agentCount={agentCount}
+            isCollapsed={isCollapsed}
+            isDropTarget={isAgentTarget}
+            onToggle={onToggle}
+            onStartRename={startRename}
+            onDelete={onDelete}
+          />
+        </div>
+      )}
+
+      {isRoot && onCreateFolder && !isRenaming && (
+        <button
+          type="button"
+          onClick={onCreateFolder}
+          aria-label="New folder"
+          title="New folder"
+          data-testid="new-folder-button"
+          className="absolute right-8 top-4 z-10 -translate-y-1/2 rounded p-0.5 text-sidebar-foreground/50 opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring group-hover/folder-block:opacity-100"
+        >
+          <FolderPlus className="h-3.5 w-3.5" />
+        </button>
+      )}
+
+      {/*
+        The body stays MOUNTED while collapsed and hides via the `hidden`
+        attribute — unmounting made expanding a large folder a visible hitch
+        (~170ms for 80 rows), where the pre-folders sidebar kept every row
+        alive. The hidden rows' drag targets need no per-row bookkeeping here,
+        but they are NOT free: display:none rects measure 0×0, which the
+        containment and overlap detectors can never hit, but DISTANCE-based
+        collision (the sidebar's closest-row snap, keyboard coordinate
+        getters) happily returns — so the sidebar's collision detection
+        filters zero-height rects out of the snap explicitly.
+      */}
+      <div
+          ref={setBodyRef}
+          hidden={isCollapsed}
+          data-container-id={containerIdForFolder(folder.id)}
+          // No indent: rows sit at the same offset as before folders existed,
+          // the way they always did under the old "Your Agents" label.
+          className={cn(isBodyOver && activeDragType === 'agent' && 'rounded-md bg-sidebar-accent/40')}
+        >
+          <ul className="flex w-full min-w-0 flex-col gap-1">{children}</ul>
+          {agentCount === 0 && (
+            // An empty folder has no rows to aim at, so it needs a body with
+            // real height or it cannot be dropped into at all.
+            <div
+              className={cn(
+                'mx-1 my-0.5 rounded-md border border-dashed border-sidebar-border px-2 py-1.5 text-[11px] text-muted-foreground/70',
+                isBodyOver && 'border-sidebar-ring text-sidebar-foreground'
+              )}
+              data-testid={`agent-folder-empty-${folder.id}`}
+            >
+              Drag agents here
+            </div>
+          )}
+        </div>
+    </li>
+  )
+}
+
+/** The row that follows the cursor during a drag. */
+export function AgentDragOverlayRow({ label, isFolder }: { label: string; isFolder: boolean }) {
+  return (
+    <div
+      className="flex items-center gap-1.5 rounded-md border border-sidebar-border bg-sidebar px-2 py-1.5 text-[13px] shadow-lg"
+      data-testid="agent-drag-overlay"
+    >
+      {isFolder && <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+      <span className="truncate">{label}</span>
+    </div>
+  )
+}

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { cloneElement, isValidElement, type ReactElement } from 'react'
 import { act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { pointerWithin } from '@dnd-kit/core'
 import { AppSidebar } from './app-sidebar'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
@@ -66,9 +67,16 @@ vi.mock('@renderer/hooks/use-settings', () => ({
   }),
 }))
 
+const { mockUserSettings, mockUpdateSettings, dndContextProps } = vi.hoisted(() => ({
+  mockUserSettings: vi.fn(),
+  mockUpdateSettings: vi.fn(),
+  // The latest props AppSidebar passed to the mocked DndContext, so tests can
+  // drive the drag orchestration (collision detection → move → end) directly.
+  dndContextProps: { current: null as any },
+}))
 vi.mock('@renderer/hooks/use-user-settings', () => ({
-  useUserSettings: () => ({ data: { setupCompleted: true, agentOrder: [] } }),
-  useUpdateUserSettings: () => ({ mutate: vi.fn() }),
+  useUserSettings: () => ({ data: mockUserSettings() }),
+  useUpdateUserSettings: () => ({ mutate: mockUpdateSettings }),
 }))
 
 vi.mock('@renderer/hooks/use-runtime-status', () => ({
@@ -254,12 +262,24 @@ vi.mock('@renderer/components/ui/alert', () => ({
 // Stub out @dnd-kit so SortableAgentMenuItem renders the real AgentMenuItem
 // directly — drag-and-drop is out of scope for these tests.
 vi.mock('@dnd-kit/core', () => ({
-  DndContext: ({ children }: any) => <>{children}</>,
-  closestCenter: vi.fn(),
+  DndContext: (props: any) => {
+    dndContextProps.current = props
+    return <>{props.children}</>
+  },
+  DragOverlay: ({ children }: any) => <>{children}</>,
+  MeasuringStrategy: { Always: 'always' },
+  // Faithful enough for the sticky-snap tests: returns whatever candidates it
+  // was given, nearest-first ordering not modeled (callers take [0]).
+  closestCenter: vi.fn(({ droppableContainers }: any) =>
+    (droppableContainers ?? []).map((d: any) => ({ id: d.id }))
+  ),
+  pointerWithin: vi.fn(() => []),
+  rectIntersection: vi.fn(() => []),
   PointerSensor: vi.fn(),
   KeyboardSensor: vi.fn(),
   useSensor: vi.fn(),
   useSensors: vi.fn(() => []),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
 }))
 vi.mock('@dnd-kit/sortable', () => ({
   SortableContext: ({ children }: any) => <>{children}</>,
@@ -270,9 +290,11 @@ vi.mock('@dnd-kit/sortable', () => ({
     attributes: {},
     listeners: {},
     setNodeRef: vi.fn(),
+    setActivatorNodeRef: vi.fn(),
     transform: null,
     transition: null,
     isDragging: false,
+    isOver: false,
   }),
 }))
 vi.mock('@dnd-kit/utilities', () => ({
@@ -342,6 +364,7 @@ beforeEach(() => {
     isLoading: false,
   }))
   mockUnreadCount.mockReturnValue({ data: { count: 0 } })
+  mockUserSettings.mockReturnValue({ setupCompleted: true, agentOrder: [] })
 })
 
 describe('AppSidebar — layout & top nav', () => {
@@ -388,9 +411,9 @@ describe('AppSidebar — layout & top nav', () => {
     expect(screen.getByTestId('notifications-button')).toHaveAttribute('data-active', 'true')
   })
 
-  it('renders the "Your Agents" group label', () => {
+  it('renders "Your Agents" as the default folder header', () => {
     renderWithProviders(<AppSidebar />)
-    expect(screen.getByText('Your Agents')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-folder-root')).toHaveTextContent('Your Agents')
   })
 
   it('renders Settings + version in the footer', () => {
@@ -740,4 +763,523 @@ describe('TargetSwitcher placement', () => {
     renderWithProviders(<AppSidebar />)
     expect(screen.queryByTestId('target-switcher')).not.toBeInTheDocument()
   })
+})
+
+describe('AppSidebar — agent folders', () => {
+  const FOLDERS = [
+    { id: 'f1', name: 'Work' },
+    { id: 'f2', name: 'Personal' },
+  ]
+  const FOLDER_1 = 'agent-folder::f1'
+  const FOLDER_2 = 'agent-folder::f2'
+  const ROOT = 'agent-folder::root'
+
+  function withThreeAgents() {
+    mockUseAgents.mockReturnValue({
+      data: [
+        makeAgent(),
+        makeAgent({ slug: 'other-agent', name: 'Other Agent' }),
+        makeAgent({ slug: 'third-agent', name: 'Third Agent' }),
+      ],
+      isLoading: false,
+      error: null,
+    })
+  }
+
+  /**
+   * The left nav top to bottom: agent slugs and `folder:<id>` in DOM order,
+   * which is the order the user reads them in.
+   */
+  function listOrder(): string[] {
+    return Array.from(
+      document.querySelectorAll('[data-testid^="agent-item-"], [data-testid^="agent-folder-"]')
+    )
+      .map((el) => el.getAttribute('data-testid')!)
+      .filter(
+        (id) =>
+          !id.startsWith('agent-folder-empty-') &&
+          !id.startsWith('agent-folder-count-') &&
+          !id.startsWith('agent-folder-chevron-')
+      )
+      .map((id) =>
+        id.startsWith('agent-item-')
+          ? id.replace('agent-item-', '')
+          : id.replace('agent-folder-', 'folder:')
+      )
+  }
+
+  it('renders every agent under the always-present default folder', () => {
+    renderWithProviders(<AppSidebar />)
+    expect(listOrder()).toEqual(['folder:root', 'test-agent', 'other-agent'])
+    expect(screen.getByTestId('agent-folder-root')).toHaveTextContent('Your Agents')
+  })
+
+  it('renders a folder with its name and how many agents are in it', () => {
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [FOLDERS[0]],
+      agentFolderAssignments: { 'test-agent': 'f1', 'other-agent': 'f1' },
+    })
+    renderWithProviders(<AppSidebar />)
+
+    const folder = screen.getByTestId('agent-folder-f1')
+    expect(folder).toHaveTextContent('Work')
+    expect(folder).toHaveTextContent('2')
+  })
+
+  it('defaults the default folder first before anything is arranged', () => {
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [FOLDERS[0]],
+      agentFolderAssignments: { 'test-agent': 'f1' },
+    })
+    renderWithProviders(<AppSidebar />)
+
+    expect(listOrder()).toEqual(['folder:root', 'other-agent', 'folder:f1', 'test-agent'])
+  })
+
+  it('lets the default folder be placed among the others', () => {
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [FOLDERS[0]],
+      agentFolderAssignments: { 'other-agent': 'f1' },
+      agentListOrder: [FOLDER_1, ROOT],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    expect(listOrder()).toEqual(['folder:f1', 'other-agent', 'folder:root', 'test-agent'])
+  })
+
+  it('orders several folders by the stored order', () => {
+    withThreeAgents()
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent', 'third-agent'],
+      agentFolders: FOLDERS,
+      agentFolderAssignments: { 'other-agent': 'f1' },
+      agentListOrder: [FOLDER_2, ROOT, FOLDER_1],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    expect(listOrder()).toEqual([
+      'folder:f2', 'folder:root', 'test-agent', 'third-agent', 'folder:f1', 'other-agent',
+    ])
+  })
+
+  it('ignores stored order entries in the old interleaved format', () => {
+    // The top level used to store agent slugs between folder markers; those
+    // blobs must render under the new model with folders keeping their order.
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [FOLDERS[0]],
+      agentListOrder: ['test-agent', FOLDER_1, 'other-agent'],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    // The slug entries are ignored; the unmarked default folder ranks first.
+    expect(listOrder()).toEqual(['folder:root', 'test-agent', 'other-agent', 'folder:f1'])
+  })
+
+  it('hides a collapsed folder’s agents but keeps its header', () => {
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [FOLDERS[0]],
+      agentFolderAssignments: { 'test-agent': 'f1' },
+      collapsedAgentFolders: ['f1'],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('agent-folder-f1')).toBeInTheDocument()
+    // Hidden, not unmounted — expanding a big folder must not mount every row.
+    expect(screen.getByTestId('agent-item-test-agent')).not.toBeVisible()
+    expect(screen.getByTestId('agent-item-other-agent')).toBeVisible()
+  })
+
+  it('collapses the default folder too, and records it in settings', async () => {
+    mockUserSettings.mockReturnValue({ agentOrder: ['test-agent', 'other-agent'] })
+    renderWithProviders(<AppSidebar />)
+
+    await userEvent.click(screen.getByTestId('agent-folder-root'))
+
+    expect(mockUpdateSettings).toHaveBeenCalledWith(
+      { collapsedAgentFolders: ['root'] },
+      expect.anything()
+    )
+    // Painted locally rather than waiting on the write, so it feels instant
+    // even against a cloud workspace.
+    expect(screen.getByTestId('agent-item-test-agent')).not.toBeVisible()
+  })
+
+  it('shows an agent whose folder was deleted under the default folder', () => {
+    // Deleting a folder leaves dangling assignments on purpose — this is the
+    // behaviour that lets folder and agent deletion skip a cascade.
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [],
+      agentFolderAssignments: { 'test-agent': 'deleted-folder' },
+    })
+    renderWithProviders(<AppSidebar />)
+
+    expect(listOrder()).toEqual(['folder:root', 'test-agent', 'other-agent'])
+  })
+
+  // Folder create/rename use the updater form — a function of the latest
+  // cached settings, resolved when the serialized mutation runs — so tests
+  // resolve the captured payload against explicit "current" settings.
+  const patchWith = (settings: Record<string, unknown>, call = 0) => {
+    const arg = mockUpdateSettings.mock.calls[call][0]
+    return typeof arg === 'function' ? arg(settings) : arg
+  }
+
+  it('adds a uniquely-named folder from the default folder’s header', async () => {
+    renderWithProviders(<AppSidebar />)
+
+    await userEvent.click(screen.getByTestId('new-folder-button'))
+
+    expect(mockUpdateSettings).toHaveBeenCalledTimes(1)
+    const patch = patchWith({ agentFolders: [] })
+    expect(patch.agentFolders).toHaveLength(1)
+    expect(patch.agentFolders[0].name).toBe('New Folder')
+    expect(patch.agentFolders[0].id).toBeTruthy()
+  })
+
+  it('does not reuse an existing folder name when adding another', async () => {
+    const settings = {
+      agentOrder: [],
+      agentFolders: [{ id: 'f1', name: 'New Folder' }],
+    }
+    mockUserSettings.mockReturnValue(settings)
+    renderWithProviders(<AppSidebar />)
+
+    await userEvent.click(screen.getByTestId('new-folder-button'))
+
+    const patch = patchWith(settings)
+    expect(patch.agentFolders[1].name).toBe('New Folder 2')
+  })
+
+  it('names a created folder against the folder list at mutation run time', async () => {
+    // A create queued behind an in-flight write resolves after it settles: if
+    // that write added "New Folder", this one must come out "New Folder 2" —
+    // and must carry the other write's folder rather than reverting it.
+    renderWithProviders(<AppSidebar />)
+
+    await userEvent.click(screen.getByTestId('new-folder-button'))
+
+    const patch = patchWith({ agentFolders: [{ id: 'f9', name: 'New Folder' }] })
+    expect(patch.agentFolders).toHaveLength(2)
+    expect(patch.agentFolders[0]).toEqual({ id: 'f9', name: 'New Folder' })
+    expect(patch.agentFolders[1].name).toBe('New Folder 2')
+  })
+
+  it('puts a newly created folder at the end of the list', () => {
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [FOLDERS[0]],
+      agentListOrder: [ROOT],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    expect(listOrder()).toEqual(['folder:root', 'test-agent', 'other-agent', 'folder:f1'])
+  })
+
+  it('still renders folders when the user has no agents at all', () => {
+    // The "No agents yet" empty state must not swallow the folder the user
+    // just created on an empty install.
+    mockUseAgents.mockReturnValue({ data: [], isLoading: false, error: null })
+    mockUserSettings.mockReturnValue({ agentOrder: [], agentFolders: [FOLDERS[0]] })
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('agent-folder-f1')).toBeInTheDocument()
+    expect(screen.queryByText('No agents yet. Create one to get started.')).not.toBeInTheDocument()
+  })
+
+  it('keeps the empty state when there are neither agents nor folders', () => {
+    mockUseAgents.mockReturnValue({ data: [], isLoading: false, error: null })
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByText('No agents yet. Create one to get started.')).toBeInTheDocument()
+  })
+
+  it('invites a drop into an empty folder', () => {
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [FOLDERS[0]],
+      agentFolderAssignments: {},
+    })
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByText('Drag agents here')).toBeInTheDocument()
+  })
+})
+
+
+describe('AppSidebar — drag orchestration', () => {
+  // These drive the real handlers through the props AppSidebar hands the
+  // (mocked) DndContext: collision detection computes the folder drop cue,
+  // onDragMove commits it for the insert line, onDragEnd resolves the drop.
+  const dnd = () => dndContextProps.current
+
+  const folderBlock = (folderId: string, top: number, height = 40) => ({
+    id: `agent-folder::${folderId}`,
+    data: { current: { type: 'folder' } },
+    rect: { current: { top, bottom: top + height, height, left: 0, right: 200, width: 200 } },
+  })
+
+  const folderActive = (folderId: string) => ({
+    id: `agent-folder::${folderId}`,
+    data: { current: { type: 'folder', folderId } },
+  })
+
+  const agentActive = (slug: string) => ({
+    id: slug,
+    data: { current: { type: 'agent' } },
+  })
+
+  const patchWith = (settings: Record<string, unknown>, call = 0) => {
+    const arg = mockUpdateSettings.mock.calls[call][0]
+    return typeof arg === 'function' ? arg(settings) : arg
+  }
+
+  const THREE_FOLDERS = [
+    { id: 'f1', name: 'A' },
+    { id: 'f2', name: 'B' },
+    { id: 'f3', name: 'C' },
+  ]
+  const THREE_FOLDER_ORDER = [
+    'agent-folder::root',
+    'agent-folder::f1',
+    'agent-folder::f2',
+    'agent-folder::f3',
+  ]
+  const THREE_FOLDER_BLOCKS = [
+    folderBlock('root', 0),
+    folderBlock('f1', 40),
+    folderBlock('f2', 80),
+    folderBlock('f3', 120),
+  ]
+
+  function renderThreeFolders() {
+    const settings = {
+      setupCompleted: true,
+      agentOrder: [],
+      agentFolders: THREE_FOLDERS,
+      agentListOrder: THREE_FOLDER_ORDER,
+    }
+    mockUserSettings.mockReturnValue(settings)
+    renderWithProviders(<AppSidebar />)
+    return settings
+  }
+
+  /** Run one collision pass with the pointer over `folderId` at height `y`. */
+  function hoverFolder(active: any, folderId: string, y: number) {
+    vi.mocked(pointerWithin).mockReturnValueOnce([{ id: `agent-folder::${folderId}` }])
+    dnd().collisionDetection({
+      active,
+      droppableContainers: THREE_FOLDER_BLOCKS,
+      pointerCoordinates: { x: 10, y },
+    })
+  }
+
+  it('lands a folder dragged DOWN on the upper half where the line showed, before the target', () => {
+    // The two quadrants the E2E does not walk (down+above, up+below) are
+    // exactly where cue semantics and "take the target's slot" disagree — a
+    // drop handler that loses the cue still passes the other two by luck.
+    const settings = renderThreeFolders()
+    const active = folderActive('f1')
+
+    act(() => dnd().onDragStart({ active }))
+    hoverFolder(active, 'f3', 125) // upper half of f3 (120..160)
+    act(() => dnd().onDragMove({}))
+    const line = screen.getByTestId('folder-insert-indicator-f3')
+    expect(line).toHaveAttribute('data-edge', 'above')
+    act(() => dnd().onDragEnd({ active, over: { id: 'agent-folder::f3' } }))
+
+    expect(patchWith(settings).agentListOrder).toEqual([
+      'agent-folder::root',
+      'agent-folder::f2',
+      'agent-folder::f1',
+      'agent-folder::f3',
+    ])
+  })
+
+  it('lands a folder dragged UP on the lower half where the line showed, after the target', () => {
+    const settings = renderThreeFolders()
+    const active = folderActive('f3')
+
+    act(() => dnd().onDragStart({ active }))
+    hoverFolder(active, 'f1', 75) // lower half of f1 (40..80)
+    act(() => dnd().onDragMove({}))
+    expect(screen.getByTestId('folder-insert-indicator-f1')).toHaveAttribute('data-edge', 'below')
+    act(() => dnd().onDragEnd({ active, over: { id: 'agent-folder::f1' } }))
+
+    expect(patchWith(settings).agentListOrder).toEqual([
+      'agent-folder::root',
+      'agent-folder::f1',
+      'agent-folder::f3',
+      'agent-folder::f2',
+    ])
+  })
+
+  it('falls back to slot semantics without a pointer cue, as keyboard drags have none', () => {
+    const settings = renderThreeFolders()
+    const active = folderActive('f3')
+
+    act(() => dnd().onDragStart({ active }))
+    act(() => dnd().onDragEnd({ active, over: { id: 'agent-folder::f1' } }))
+
+    expect(patchWith(settings).agentListOrder).toEqual([
+      'agent-folder::root',
+      'agent-folder::f3',
+      'agent-folder::f1',
+      'agent-folder::f2',
+    ])
+  })
+
+  it('keeps a collapsed folder header as the drop target instead of its hidden rows', () => {
+    // Hidden member rows measure 0×0 — inert for containment/overlap
+    // detectors but perfectly valid for the DISTANCE snap. Unfiltered, the
+    // snap steals `over` from the header one tick after the live re-parent,
+    // killing the drop highlight and landing the agent at the hidden row's
+    // index instead of appending.
+    mockUserSettings.mockReturnValue({
+      setupCompleted: true,
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [{ id: 'f1', name: 'Work' }],
+      agentFolderAssignments: { 'test-agent': 'f1' },
+      agentListOrder: ['agent-folder::root', 'agent-folder::f1'],
+      collapsedAgentFolders: ['f1'],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    const active = agentActive('test-agent')
+    const collapsedBlock = folderBlock('f1', 40)
+    const hiddenRow = {
+      id: 'test-agent',
+      data: { current: { type: 'agent' } },
+      rect: { current: { top: 0, bottom: 0, height: 0, left: 0, right: 0, width: 0 } },
+    }
+    act(() => dnd().onDragStart({ active }))
+    vi.mocked(pointerWithin).mockReturnValueOnce([{ id: 'agent-folder::f1' }])
+    const result = dnd().collisionDetection({
+      active,
+      droppableContainers: [folderBlock('root', 0), collapsedBlock, hiddenRow],
+      pointerCoordinates: { x: 10, y: 60 },
+    })
+
+    expect(result.map((c: any) => c.id)).toEqual(['agent-folder::f1'])
+  })
+
+  it('puts a live cross-folder re-parent back where it was when the drag cancels', () => {
+    mockUserSettings.mockReturnValue({
+      setupCompleted: true,
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [{ id: 'f1', name: 'Work' }],
+      agentListOrder: ['agent-folder::root', 'agent-folder::f1'],
+    })
+    renderWithProviders(<AppSidebar />)
+    const active = agentActive('test-agent')
+
+    act(() => dnd().onDragStart({ active }))
+    act(() => dnd().onDragOver({ active, over: { id: 'agent-section::f1' } }))
+    expect(listOrderOf()).toEqual(['folder:root', 'other-agent', 'folder:f1', 'test-agent'])
+
+    act(() => dnd().onDragCancel())
+    expect(listOrderOf()).toEqual(['folder:root', 'test-agent', 'other-agent', 'folder:f1'])
+    expect(mockUpdateSettings).not.toHaveBeenCalled()
+  })
+
+  it("an older drop settling does not clear a newer drop's optimistic tree", () => {
+    mockUseAgents.mockReturnValue({
+      data: [
+        makeAgent(),
+        makeAgent({ slug: 'other-agent', name: 'Other Agent' }),
+        makeAgent({ slug: 'third-agent', name: 'Third Agent' }),
+      ],
+      isLoading: false,
+      error: null,
+    })
+    mockUserSettings.mockReturnValue({
+      setupCompleted: true,
+      agentOrder: ['test-agent', 'other-agent', 'third-agent'],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    const first = agentActive('third-agent')
+    act(() => dnd().onDragStart({ active: first }))
+    act(() => dnd().onDragEnd({ active: first, over: { id: 'test-agent' } }))
+    const second = agentActive('other-agent')
+    act(() => dnd().onDragStart({ active: second }))
+    act(() => dnd().onDragEnd({ active: second, over: { id: 'third-agent' } }))
+    expect(listOrderOf()).toEqual(['folder:root', 'other-agent', 'third-agent', 'test-agent'])
+
+    // The FIRST drop's write settles now, after the second was issued. Its
+    // stale token must not tear down the second drop's optimistic view.
+    act(() => mockUpdateSettings.mock.calls[0][1].onSettled())
+    expect(listOrderOf()).toEqual(['folder:root', 'other-agent', 'third-agent', 'test-agent'])
+  })
+
+  it("a drop settling mid-drag does not clear the active drag's re-parent", () => {
+    mockUserSettings.mockReturnValue({
+      setupCompleted: true,
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [{ id: 'f1', name: 'Work' }],
+      agentListOrder: ['agent-folder::root', 'agent-folder::f1'],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    const first = agentActive('other-agent')
+    act(() => dnd().onDragStart({ active: first }))
+    act(() => dnd().onDragEnd({ active: first, over: { id: 'test-agent' } }))
+    expect(listOrderOf()).toEqual(['folder:root', 'other-agent', 'test-agent', 'folder:f1'])
+
+    // A second drag is live and has re-parented a row when the drop's write
+    // settles. Over-change events only fire when `over` CHANGES, so a
+    // mid-drag snap-back would stick for the rest of the drag.
+    const second = agentActive('test-agent')
+    act(() => dnd().onDragStart({ active: second }))
+    act(() => dnd().onDragOver({ active: second, over: { id: 'agent-section::f1' } }))
+    act(() => mockUpdateSettings.mock.calls[0][1].onSettled())
+    expect(listOrderOf()).toEqual(['folder:root', 'other-agent', 'folder:f1', 'test-agent'])
+  })
+
+  it('an earlier collapse settling does not reopen a folder collapsed after it', async () => {
+    mockUserSettings.mockReturnValue({
+      setupCompleted: true,
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [
+        { id: 'f1', name: 'Work' },
+        { id: 'f2', name: 'Personal' },
+      ],
+      agentFolderAssignments: { 'test-agent': 'f1', 'other-agent': 'f2' },
+    })
+    renderWithProviders(<AppSidebar />)
+
+    await userEvent.click(screen.getByTestId('agent-folder-f1'))
+    await userEvent.click(screen.getByTestId('agent-folder-f2'))
+    expect(screen.getByTestId('agent-item-other-agent')).not.toBeVisible()
+
+    // The first toggle's write settles after the second was issued; its stale
+    // token must not drop the fold back to the cached (all-open) state.
+    act(() => mockUpdateSettings.mock.calls[0][1].onSettled())
+    expect(screen.getByTestId('agent-item-other-agent')).not.toBeVisible()
+  })
+
+  /** Same reading as the folders describe's listOrder, local to this one. */
+  function listOrderOf(): string[] {
+    return Array.from(
+      document.querySelectorAll('[data-testid^="agent-item-"], [data-testid^="agent-folder-"]')
+    )
+      .map((el) => el.getAttribute('data-testid')!)
+      .filter(
+        (id) =>
+          !id.startsWith('agent-folder-empty-') &&
+          !id.startsWith('agent-folder-count-') &&
+          !id.startsWith('agent-folder-chevron-') &&
+          !id.startsWith('agent-folder-insert-indicator-')
+      )
+      .map((id) =>
+        id.startsWith('agent-item-')
+          ? id.replace('agent-item-', '')
+          : id.replace('agent-folder-', 'folder:')
+      )
+  }
 })

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -1168,6 +1168,62 @@ describe('AppSidebar — drag orchestration', () => {
     expect(result.map((c: any) => c.id)).toEqual(['agent-folder::f1'])
   })
 
+  it("a drop's write keeps a folder created while the drop was in flight", () => {
+    // The drop below was aimed while settings held [root,f1,f2,f3]; by the
+    // time its (scope-serialized) write runs, a concurrent create added f9.
+    // Writing the drop's snapshot back would erase f9 — the write must
+    // re-apply the drop to the settings it actually lands on.
+    renderThreeFolders()
+    const active = folderActive('f1')
+
+    act(() => dnd().onDragStart({ active }))
+    hoverFolder(active, 'f3', 125)
+    act(() => dnd().onDragEnd({ active, over: { id: 'agent-folder::f3' } }))
+
+    const patch = patchWith({
+      agentOrder: [],
+      agentFolders: [...THREE_FOLDERS, { id: 'f9', name: 'Fresh' }],
+      agentListOrder: [...THREE_FOLDER_ORDER, 'agent-folder::f9'],
+    })
+    expect(patch.agentFolders.map((f: { id: string }) => f.id)).toContain('f9')
+    expect(patch.agentListOrder).toEqual([
+      'agent-folder::root',
+      'agent-folder::f2',
+      'agent-folder::f1',
+      'agent-folder::f3',
+      'agent-folder::f9',
+    ])
+  })
+
+  it("a drop's write keeps a filing made while the drop was in flight", () => {
+    // While the drop's write was queued, a context-menu filing moved
+    // test-agent into f1. The drop recorded other-agent's FINAL place (top of
+    // "Your Agents" — the place the user saw it land), so the write puts it
+    // there and carries the concurrent filing. The pre-fix snapshot write
+    // carried the pre-drag assignment map instead, silently un-filing
+    // test-agent.
+    mockUserSettings.mockReturnValue({
+      setupCompleted: true,
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [{ id: 'f1', name: 'Work' }],
+      agentListOrder: ['agent-folder::root', 'agent-folder::f1'],
+    })
+    renderWithProviders(<AppSidebar />)
+
+    const active = agentActive('other-agent')
+    act(() => dnd().onDragStart({ active }))
+    act(() => dnd().onDragEnd({ active, over: { id: 'test-agent' } }))
+
+    const patch = patchWith({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [{ id: 'f1', name: 'Work' }],
+      agentFolderAssignments: { 'test-agent': 'f1' },
+      agentListOrder: ['agent-folder::root', 'agent-folder::f1'],
+    })
+    expect(patch.agentFolderAssignments).toEqual({ 'test-agent': 'f1' })
+    expect(patch.agentOrder[0]).toBe('other-agent')
+  })
+
   it('puts a live cross-folder re-parent back where it was when the drag cancels', () => {
     mockUserSettings.mockReturnValue({
       setupCompleted: true,

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -117,7 +117,8 @@ import {
   sectionsToSettings,
   sortableIdForFolder,
   uniqueFolderName,
-  type FolderSection,
+  applyTreeOperation,
+  type TreeOperation,
 } from '@renderer/lib/agent-folders'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
@@ -899,6 +900,10 @@ export function AppSidebar() {
   // before React has re-derived `sections` from the state the first one set.
   const sectionsRef = React.useRef(sections)
   sectionsRef.current = sections
+  // The raw agent list for the write-time rebase in writeTree below, which
+  // rebuilds sections from the settings as of when the mutation runs.
+  const agentsRef = React.useRef<ApiAgent[]>([])
+  agentsRef.current = agents ?? []
   // Whether this drag has actually changed anything, so a drag that ends where
   // it started does not write settings.
   const dragDirtyRef = React.useRef(false)
@@ -909,22 +914,36 @@ export function AppSidebar() {
   // flight and clearing its optimistic view.
   const pendingTreeRef = React.useRef<AgentTreeSettings | null>(null)
 
-  const writeTree = useCallback((patch: AgentTreeSettings & { collapsedAgentFolders?: string[] }) => {
-    pendingTreeRef.current = patch
-    setLocalTree(patch)
+  const writeTree = useCallback((
+    optimistic: AgentTreeSettings & { collapsedAgentFolders?: string[] },
+    operation: TreeOperation
+  ) => {
+    pendingTreeRef.current = optimistic
+    setLocalTree(optimistic)
     updateSettings.mutate(
       (current) => {
-        // A drag changes structure, never names. A rename that settled after
-        // this drop's sections were captured must survive the wholesale
-        // agentFolders write, so names are rebased onto the freshest settings
-        // when the (scope-serialized) mutation actually runs.
-        const names = new Map(sanitizeFolders(current?.agentFolders).map((f) => [f.id, f.name]))
+        // Re-derive the change against the settings as of when this
+        // (scope-serialized) mutation actually runs. The drop's sections
+        // snapshot goes stale the moment a concurrent write — a folder
+        // create, a rename, a context-menu filing — lands first, and writing
+        // the snapshot back would replace agentFolders, assignments and
+        // order wholesale, silently undoing that work. The snapshot stays
+        // exactly right for the optimistic paint above, and with nothing in
+        // flight the rebase reproduces it byte for byte (the operation
+        // records the moved thing's FINAL position).
+        const sections = buildFolderSections(
+          applyAgentOrder(agentsRef.current, current?.agentOrder),
+          current?.agentFolders,
+          current?.agentFolderAssignments,
+          current?.agentListOrder
+        )
+        const rebased = sectionsToSettings(applyTreeOperation(sections, operation))
+        if (operation.kind !== 'dissolveFolder') return rebased
         return {
-          ...patch,
-          agentFolders: patch.agentFolders.map((f) => ({
-            ...f,
-            name: names.get(f.id) ?? f.name,
-          })),
+          ...rebased,
+          collapsedAgentFolders: (current?.collapsedAgentFolders ?? []).filter(
+            (id) => id !== operation.folderId
+          ),
         }
       },
       {
@@ -935,7 +954,7 @@ export function AppSidebar() {
           toast.error("Couldn't save the new layout")
         },
         onSettled: () => {
-          if (pendingTreeRef.current !== patch) return
+          if (pendingTreeRef.current !== optimistic) return
           pendingTreeRef.current = null
           // A newer drag may be holding its own mid-drag re-parent in
           // localTree; clearing it now would snap the dragged row back to its
@@ -948,10 +967,6 @@ export function AppSidebar() {
     )
   }, [updateSettings])
 
-  const commitSections = useCallback(
-    (next: FolderSection[]) => writeTree(sectionsToSettings(next)),
-    [writeTree]
-  )
 
   // Prefer whatever the pointer is directly inside, falling back to rect
   // overlap when a fast drag has outrun every droppable. Then bias toward the
@@ -1174,8 +1189,33 @@ export function AppSidebar() {
       setLocalTree(pendingTreeRef.current)
       return
     }
-    commitSections(next)
-  }, [commitSections, clearFolderDropCue])
+
+    // Record the drop as the moved thing's FINAL position in `next`, so the
+    // write can re-apply it to whatever the settings say by the time it runs
+    // (see writeTree). Deriving from `next` makes the serial case exact.
+    let operation: TreeOperation | null = null
+    if (active.data.current?.type === 'folder') {
+      const folderId = String(active.data.current.folderId)
+      const index = next.findIndex((s) => s.folder.id === folderId)
+      if (index !== -1) operation = { kind: 'placeFolder', folderId, index }
+    } else {
+      const slug = String(active.id)
+      const location = locateAgent(next, slug)
+      if (location) {
+        operation = {
+          kind: 'placeAgent',
+          slug,
+          folderId: next[location.sectionIndex].folder.id,
+          index: location.memberIndex,
+        }
+      }
+    }
+    if (!operation) {
+      setLocalTree(pendingTreeRef.current)
+      return
+    }
+    writeTree(sectionsToSettings(next), operation)
+  }, [writeTree, clearFolderDropCue])
 
   /**
    * The shift preview opens a gap by displacing the rows between the dragged
@@ -1228,10 +1268,13 @@ export function AppSidebar() {
     const current = sectionsRef.current
     const next = dissolveFolder(current, folderId)
     if (next === current) return
-    writeTree({
-      ...sectionsToSettings(next),
-      collapsedAgentFolders: (collapsedFolders ?? []).filter((id) => id !== folderId),
-    })
+    writeTree(
+      {
+        ...sectionsToSettings(next),
+        collapsedAgentFolders: (collapsedFolders ?? []).filter((id) => id !== folderId),
+      },
+      { kind: 'dissolveFolder', folderId }
+    )
   }, [collapsedFolders, writeTree])
 
   const handleToggleFolder = useCallback((folderId: string) => {

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,6 +1,7 @@
 
 import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
+import { toast } from 'sonner'
 import { cn } from '@shared/lib/utils/cn'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
@@ -22,7 +23,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -78,22 +78,47 @@ import { useIsOnline } from '@renderer/context/connectivity-context'
 import { HoverScrollText } from '@renderer/components/ui/hover-scroll-text'
 import {
   DndContext,
-  closestCenter,
+  DragOverlay,
   PointerSensor,
   KeyboardSensor,
+  closestCenter,
+  pointerWithin,
+  rectIntersection,
   useSensor,
   useSensors,
+  type UniqueIdentifier,
+  type CollisionDetection,
   type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
 } from '@dnd-kit/core'
 import {
   SortableContext,
   verticalListSortingStrategy,
-  arrayMove,
   sortableKeyboardCoordinates,
+  type SortingStrategy,
 } from '@dnd-kit/sortable'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { SortableAgentMenuItem } from './sortable-agent-item'
+import { SidebarDragProvider, useSidebarDragActive } from './sidebar-drag-context'
+import { AgentDragOverlayRow, AgentFolderBlock } from './agent-folder-block'
 import { applyAgentOrder } from '@renderer/lib/agent-ordering'
+import {
+  containerIdForFolder,
+  buildFolderSections,
+  dissolveFolder,
+  locateAgent,
+  moveAgent,
+  moveFolder,
+  newFolderId,
+  resolveAgentDrop,
+  resolveFolderDrop,
+  sanitizeFolders,
+  sectionsToSettings,
+  sortableIdForFolder,
+  uniqueFolderName,
+  type FolderSection,
+} from '@renderer/lib/agent-folders'
 import { useRenderTracker } from '@renderer/lib/perf'
 import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
 import { useSkillsets } from '@renderer/hooks/use-skillsets'
@@ -108,6 +133,24 @@ const THIN_SCROLLBAR =
   '[scrollbar-width:thin] [scrollbar-color:hsl(var(--muted-foreground)/0.2)_transparent] ' +
   '[&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-transparent ' +
   '[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/20'
+
+// Sensor options MUST be referentially stable. `useSensor` memoizes on the
+// options object, so an inline literal here mints new sensor descriptors on
+// every AppSidebar render — which makes DndContext rebuild its activators,
+// which hands every `useSortable` row a brand-new `listeners` object, which
+// breaks AgentMenuItem's memo for the entire list on every unrelated sidebar
+// render. Measured: 80 filed agents cost 2 full row re-renders per row per
+// toggle with inline options, ~0 with these hoisted.
+const POINTER_SENSOR_OPTIONS = { activationConstraint: { distance: 5 } }
+const KEYBOARD_SENSOR_OPTIONS = { coordinateGetter: sortableKeyboardCoordinates }
+
+/** The user-settings fields that together describe the left-nav tree. */
+type AgentTreeSettings = ReturnType<typeof sectionsToSettings>
+
+type ActiveDrag = { type: 'agent' | 'folder'; label: string; folderId?: string }
+
+/** Where a dragged folder is currently set to land. */
+type FolderDropCue = { folderId: string; edge: 'above' | 'below' }
 
 // Session sub-item that tracks its streaming state
 function SessionSubItem({
@@ -367,7 +410,7 @@ function AgentRowIndicator({
 }
 
 // Agent menu item with expandable sessions
-export const AgentMenuItem = React.forwardRef<
+const AgentMenuItemInner = React.forwardRef<
   HTMLLIElement,
   { agent: ApiAgent } & React.HTMLAttributes<HTMLLIElement>
 >(({ agent, style, ...rest }, ref) => {
@@ -387,6 +430,10 @@ export const AgentMenuItem = React.forwardRef<
     (agent.sessionCount ?? 0) > 0 ||
     (agent.dashboards?.length ?? 0) > 0
   const [isOpen, setIsOpen] = useState(isSelected && hasInitialContent)
+  // Collapse visually for the duration of a drag so drop targets stay still.
+  // `isOpen` itself is untouched, so nothing refetches and the row reopens on
+  // drop; only the rendered height changes.
+  const isDragActive = useSidebarDragActive()
 
   // Once the user navigates into a sub-item (session / task / webhook / chat /
   // dashboard) we want the agent's submenu open so the active row is visible.
@@ -456,7 +503,7 @@ export const AgentMenuItem = React.forwardRef<
   const { ref: hintRef, hint } = useCmdHintTarget()
 
   return (
-    <Collapsible asChild open={isOpen} onOpenChange={setIsOpen}>
+    <Collapsible asChild open={isOpen && !isDragActive} onOpenChange={setIsOpen}>
       <SidebarMenuItem ref={ref} style={style} {...rest} onMouseEnter={handleMouseEnter}>
         {/*
           Wrap the row + chevron in a relative box so the absolutely-positioned
@@ -501,7 +548,7 @@ export const AgentMenuItem = React.forwardRef<
               <ChevronRight
                 className={cn(
                   'h-3.5 w-3.5 text-muted-foreground/60 transition-[color,transform] group-hover/menu-item:text-sidebar-foreground',
-                  isOpen && 'rotate-90'
+                  isOpen && !isDragActive && 'rotate-90'
                 )}
               />
             </button>
@@ -558,7 +605,22 @@ export const AgentMenuItem = React.forwardRef<
     </Collapsible>
   )
 })
-AgentMenuItem.displayName = 'AgentMenuItem'
+AgentMenuItemInner.displayName = 'AgentMenuItem'
+
+/**
+ * Memoized so that dnd-kit's per-tick context churn stops at the sortable
+ * wrapper. During a drag, dnd-kit publishes a new internal context value on
+ * essentially every pointer tick, which re-renders every `useSortable`
+ * consumer — that is every row wrapper in the list. This row's subtree is the
+ * expensive part (a Radix context menu, a mounted-but-closed settings dialog,
+ * three alert dialogs, session queries), so the wrapper must be able to bail
+ * before reaching it. All of the wrapper's props are referentially stable
+ * across those ticks — dnd-kit memoizes `attributes` and `listeners`, and the
+ * wrapper memoizes `style` — so a plain identity memo holds. Profiled: without
+ * this, a 40-agent list spends whole frames (60–90ms) re-rendering rows whose
+ * output cannot change.
+ */
+export const AgentMenuItem = React.memo(AgentMenuItemInner)
 
 if (__RENDER_TRACKING__) {
   (SessionSubItem as any).whyDidYouRender = true;
@@ -769,35 +831,432 @@ export function AppSidebar() {
 
   // Drag-and-drop sensors: distance threshold prevents click conflicts
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+    useSensor(PointerSensor, POINTER_SENSOR_OPTIONS),
+    useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS)
   )
 
-  // Optimistic local order during mutation
-  const [localOrder, setLocalOrder] = useState<string[] | null>(null)
-  const effectiveOrder = localOrder ?? userSettings?.agentOrder
+  // ─── Agent list tree (order + folders) ────────────────────────────────────
+  //
+  // The left nav is one ordered list in which unfiled agents and folders sit
+  // side by side, so a folder can be placed anywhere among them. That order
+  // cannot be derived from agentOrder — an empty folder has no member to sit
+  // behind — so it has a field of its own. agentOrder is still written on every
+  // change as the flat reading order, which is what the home grid, the graph
+  // and the tray read without knowing folders exist.
+
+  // Optimistic copy of the fields the tree is built from. Held from the first
+  // drag movement until the settings write settles, so the list never flashes
+  // back to its pre-drag shape.
+  const [localTree, setLocalTree] = useState<AgentTreeSettings | null>(null)
+  const [localCollapsed, setLocalCollapsed] = useState<string[] | null>(null)
+  // Last-write token for localCollapsed, same job as pendingTreeRef below.
+  const pendingCollapsedRef = React.useRef<string[] | null>(null)
+  // The folder a just-created row should open in rename mode.
+  const [pendingRenameFolderId, setPendingRenameFolderId] = useState<string | null>(null)
+  const [activeDrag, setActiveDrag] = useState<ActiveDrag | null>(null)
+  // The insertion point for a live folder drag. Computed by collision
+  // detection (which alone knows the pointer's half of the target block) and
+  // read both by the blocks (to place the insert line) and by the drop handler
+  // — one source of truth is what keeps the line honest about the landing
+  // spot. Collision detection runs in DndContext's RENDER (it may only write
+  // the ref — a setState there is a render-phase update of this component),
+  // so the state the insert line renders from is committed one step later by
+  // onDragMove, which fires from an effect after every render whose drag
+  // translate changed — i.e. after every render that recomputed the cue.
+  const [folderDropCue, setFolderDropCue] = useState<FolderDropCue | null>(null)
+  const folderDropCueRef = React.useRef<FolderDropCue | null>(null)
+  const commitFolderDropCue = useCallback(() => {
+    setFolderDropCue((prev) => {
+      const next = folderDropCueRef.current
+      if (prev?.folderId === next?.folderId && prev?.edge === next?.edge) return prev
+      return next
+    })
+  }, [])
+  const clearFolderDropCue = useCallback(() => {
+    folderDropCueRef.current = null
+    setFolderDropCue(null)
+  }, [])
+
+  const effectiveOrder = localTree?.agentOrder ?? userSettings?.agentOrder
+  const effectiveFolders = localTree?.agentFolders ?? userSettings?.agentFolders
+  const effectiveAssignments =
+    localTree?.agentFolderAssignments ?? userSettings?.agentFolderAssignments
+  const effectiveListOrder = localTree?.agentListOrder ?? userSettings?.agentListOrder
+  const collapsedFolders = localCollapsed ?? userSettings?.collapsedAgentFolders
+
   const orderedAgents = useMemo(
     () => applyAgentOrder(agents ?? [], effectiveOrder),
     [agents, effectiveOrder]
   )
+  const sections = useMemo(
+    () => buildFolderSections(orderedAgents, effectiveFolders, effectiveAssignments, effectiveListOrder),
+    [orderedAgents, effectiveFolders, effectiveAssignments, effectiveListOrder]
+  )
+  const hasFolders = (effectiveFolders?.length ?? 0) > 0
+
+  // Drag handlers fire between renders, so they read the sections through a
+  // ref rather than a closed-over render value — two pointer moves can land
+  // before React has re-derived `sections` from the state the first one set.
+  const sectionsRef = React.useRef(sections)
+  sectionsRef.current = sections
+  // Whether this drag has actually changed anything, so a drag that ends where
+  // it started does not write settings.
+  const dragDirtyRef = React.useRef(false)
+  // Whether a drag is in progress right now. Mirrors `activeDrag` for the
+  // settle callbacks below, which fire between renders.
+  const activeDragRef = React.useRef(false)
+  // Guards against an earlier write settling while a later one is still in
+  // flight and clearing its optimistic view.
+  const pendingTreeRef = React.useRef<AgentTreeSettings | null>(null)
+
+  const writeTree = useCallback((patch: AgentTreeSettings & { collapsedAgentFolders?: string[] }) => {
+    pendingTreeRef.current = patch
+    setLocalTree(patch)
+    updateSettings.mutate(
+      (current) => {
+        // A drag changes structure, never names. A rename that settled after
+        // this drop's sections were captured must survive the wholesale
+        // agentFolders write, so names are rebased onto the freshest settings
+        // when the (scope-serialized) mutation actually runs.
+        const names = new Map(sanitizeFolders(current?.agentFolders).map((f) => [f.id, f.name]))
+        return {
+          ...patch,
+          agentFolders: patch.agentFolders.map((f) => ({
+            ...f,
+            name: names.get(f.id) ?? f.name,
+          })),
+        }
+      },
+      {
+        onError: () => {
+          // Settings writes deliberately skip the global error toast, but a
+          // drag is a big gesture to lose without a word — the tree is about
+          // to snap back to its server shape.
+          toast.error("Couldn't save the new layout")
+        },
+        onSettled: () => {
+          if (pendingTreeRef.current !== patch) return
+          pendingTreeRef.current = null
+          // A newer drag may be holding its own mid-drag re-parent in
+          // localTree; clearing it now would snap the dragged row back to its
+          // source folder for the rest of that drag (over-change events only
+          // fire when `over` CHANGES, so nothing would restore it). The
+          // drag's own end/cancel paths reset localTree instead.
+          if (!activeDragRef.current) setLocalTree(null)
+        },
+      }
+    )
+  }, [updateSettings])
+
+  const commitSections = useCallback(
+    (next: FolderSection[]) => writeTree(sectionsToSettings(next)),
+    [writeTree]
+  )
+
+  // Prefer whatever the pointer is directly inside, falling back to rect
+  // overlap when a fast drag has outrun every droppable. Then bias toward the
+  // kind of thing being dragged: an agent aims at rows (which carry a real
+  // insertion index), a folder aims at other folders' slots.
+  //
+  // Two rules on top of that:
+  //
+  // The dragged agent's CURRENT folder is sticky. Live re-parenting reshapes
+  // the list — pulling the row out shrinks the folder, which moves the very
+  // boundary the pointer just crossed, which re-parents it straight back — so
+  // a within-folder sort near the folder's edge used to flicker in and out of
+  // it. While the pointer remains inside the folder block's rect, only targets
+  // inside that folder are eligible; leaving the rect really does mean leaving
+  // the folder, and by then the shrink moves the boundary AWAY from the
+  // pointer, so it cannot oscillate. In sticky mode the gap between two member
+  // rows (where nothing row-like is under the pointer) snaps to the nearest
+  // member row, so the sort preview never resets mid-gap and the folder never
+  // lights up as a drop target for a row it already holds.
+  //
+  // A dragged FOLDER over an agent row is promoted to that row's section
+  // header: the drop takes the whole section's slot, so the header — where the
+  // insert line renders — is what `over` should report, not the row.
+  const collisionDetection = useCallback<CollisionDetection>((args) => {
+    const activeType = args.active.data.current?.type
+    const pointerHits = pointerWithin(args)
+    let collisions = pointerHits.length > 0 ? pointerHits : rectIntersection(args)
+    const wantedType = activeType === 'folder' ? 'folder' : 'agent'
+    const typeOf = (id: UniqueIdentifier) =>
+      args.droppableContainers.find((d) => d.id === id)?.data.current?.type
+
+    if (activeType === 'agent' && args.pointerCoordinates) {
+      const location = locateAgent(sectionsRef.current, String(args.active.id))
+      const section = location ? sectionsRef.current[location.sectionIndex] : null
+      if (section) {
+        const blockRect = args.droppableContainers.find(
+          (d) => d.id === sortableIdForFolder(section.folder.id)
+        )?.rect.current
+        const { x, y } = args.pointerCoordinates
+        // The vertical grace band absorbs boundary jitter that is not the
+        // user's doing: while dnd-kit auto-scrolls, the block slides under a
+        // stationary pointer a few px per tick, and without the band each
+        // tick at the edge re-parents the row out and back in.
+        const grace = 8
+        if (
+          blockRect &&
+          x >= blockRect.left && x <= blockRect.right &&
+          y >= blockRect.top - grace && y <= blockRect.bottom + grace
+        ) {
+          const inside = new Set<string>([
+            sortableIdForFolder(section.folder.id),
+            containerIdForFolder(section.folder.id),
+            ...section.agents.map((a) => a.slug),
+          ])
+          const filtered = collisions.filter((c) => inside.has(String(c.id)))
+          if (filtered.length > 0) collisions = filtered
+          if (!collisions.some((c) => typeOf(c.id) === 'agent')) {
+            const memberRows = args.droppableContainers.filter((d) => {
+              if (!section.agents.some((a) => a.slug === String(d.id))) return false
+              // A collapsed folder's member rows stay mounted but hidden, and
+              // a hidden row measures 0×0 — inert for the containment and
+              // overlap detectors above, but a perfectly good candidate for a
+              // DISTANCE snap, which would steal `over` from the header and
+              // land the drop at the hidden row's index instead of appending.
+              const rect = d.rect.current
+              return !!rect && rect.width > 0 && rect.height > 0
+            })
+            const closest = closestCenter({ ...args, droppableContainers: memberRows })
+            if (closest.length > 0) return [closest[0]]
+          }
+        }
+      }
+    }
+
+    if (wantedType === 'folder') {
+      // Resolve the drag to a target BLOCK: a direct hit, an agent row
+      // promoted to its section, or — in the empty sidebar area above the
+      // first block or below the last — the nearest outermost block. Then the
+      // pointer's half of that block decides which edge the folder lands on;
+      // the cue drives both the insert line and the drop itself.
+      const blockOf = (id: UniqueIdentifier) =>
+        args.droppableContainers.find((d) => d.id === id)
+
+      let target = collisions.find((c) => typeOf(c.id) === 'folder')
+      if (!target) {
+        const rowHit = collisions.find((c) => typeOf(c.id) === 'agent')
+        const location = rowHit ? locateAgent(sectionsRef.current, String(rowHit.id)) : null
+        if (location) {
+          target = {
+            id: sortableIdForFolder(sectionsRef.current[location.sectionIndex].folder.id),
+          }
+        }
+      }
+      if (!target && args.pointerCoordinates) {
+        const blocks = args.droppableContainers
+          .filter((d) => d.data.current?.type === 'folder' && d.rect.current)
+          .sort((a, b) => a.rect.current!.top - b.rect.current!.top)
+        if (blocks.length > 0) {
+          const y = args.pointerCoordinates.y
+          const first = blocks[0]
+          const last = blocks[blocks.length - 1]
+          if (y <= first.rect.current!.top) target = { id: first.id }
+          else if (y >= last.rect.current!.bottom) target = { id: last.id }
+        }
+      }
+
+      if (target) {
+        const rect = blockOf(target.id)?.rect.current
+        const y = args.pointerCoordinates?.y
+        const folderId = String(target.id).replace('agent-folder::', '')
+        if (rect && y !== undefined) {
+          // Ref only — this runs during render; onDragMove commits it.
+          folderDropCueRef.current = {
+            folderId,
+            edge: y < rect.top + rect.height / 2 ? 'above' : 'below',
+          }
+        }
+        return [target]
+      }
+      folderDropCueRef.current = null
+      return collisions
+    }
+
+    if (collisions.length === 0) return collisions
+    const preferred = collisions.find((c) => typeOf(c.id) === wantedType)
+    return preferred ? [preferred] : collisions
+  }, [])
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    dragDirtyRef.current = false
+    activeDragRef.current = true
+    const data = event.active.data.current
+    clearFolderDropCue()
+    if (data?.type === 'folder') {
+      const section = sectionsRef.current.find((s) => s.folder.id === data.folderId)
+      setActiveDrag({
+        type: 'folder',
+        label: section?.folder.name ?? 'Folder',
+        folderId: String(data.folderId),
+      })
+      return
+    }
+    const slug = String(event.active.id)
+    const agent = sectionsRef.current
+      .flatMap((s) => s.agents)
+      .find((a) => a.slug === slug)
+    setActiveDrag({ type: 'agent', label: agent?.name ?? slug })
+  }, [clearFolderDropCue])
+
+  // Move an agent between containers live, so the row is already sitting in its
+  // new folder before the pointer is released. Reordering inside one container
+  // is left to the sortable preview and settled on drop.
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    const { active, over } = event
+    if (!over || active.data.current?.type !== 'agent') return
+
+    const current = sectionsRef.current
+    const slug = String(active.id)
+    const target = resolveAgentDrop(current, String(over.id))
+    const from = locateAgent(current, slug)
+    if (!target || !from) return
+
+    if (current[from.sectionIndex].folder.id === target.folderId) return
+
+    const next = moveAgent(current, slug, target)
+    if (next === current) return
+
+    sectionsRef.current = next
+    dragDirtyRef.current = true
+    setLocalTree(sectionsToSettings(next))
+  }, [])
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event
-    if (!over || active.id === over.id) return
-    if (typeof active.id !== 'string' || typeof over.id !== 'string') return
+    setActiveDrag(null)
+    activeDragRef.current = false
+    // Read BEFORE clearing — the cue is what decides where a folder drop
+    // lands. Clearing first would silently fall every pointer drop through to
+    // the keyboard branch's "take the target's slot" semantics, which only
+    // coincides with the cue's promise in two of the four direction/edge
+    // quadrants — the insert line would lie in the other two.
+    const cue = folderDropCueRef.current
+    clearFolderDropCue()
 
-    const currentSlugs = orderedAgents.map(a => a.slug)
-    const oldIndex = currentSlugs.indexOf(active.id)
-    const newIndex = currentSlugs.indexOf(over.id)
-    if (oldIndex === -1 || newIndex === -1) return
+    // Released outside every droppable — treat it as an escape hatch and put
+    // the list back the way it was, including any mid-drag move.
+    if (!over) {
+      setLocalTree(pendingTreeRef.current)
+      return
+    }
 
-    const newOrder = arrayMove(currentSlugs, oldIndex, newIndex)
-    setLocalOrder(newOrder)
+    const current = sectionsRef.current
+    const overId = String(over.id)
+    let next = current
+
+    if (active.data.current?.type === 'folder') {
+      const folderId = String(active.data.current.folderId)
+      if (cue) {
+        // Insertion-point semantics: land on the cued edge of the cued block.
+        // "Take the target's slot" (below) is kept only for keyboard drags,
+        // which never produce a pointer-derived cue.
+        const from = current.findIndex((s) => s.folder.id === folderId)
+        const targetIndex = current.findIndex((s) => s.folder.id === cue.folderId)
+        if (from !== -1 && targetIndex !== -1) {
+          let insertAt = targetIndex + (cue.edge === 'below' ? 1 : 0)
+          if (from < insertAt) insertAt -= 1
+          next = moveFolder(current, folderId, insertAt)
+        }
+      } else {
+        const index = resolveFolderDrop(current, overId)
+        if (index !== null) next = moveFolder(current, folderId, index)
+      }
+    } else {
+      const target = resolveAgentDrop(current, overId)
+      if (target) next = moveAgent(current, String(active.id), target)
+    }
+
+    if (next === current && !dragDirtyRef.current) {
+      // A drag that ended where it started writes nothing.
+      setLocalTree(pendingTreeRef.current)
+      return
+    }
+    commitSections(next)
+  }, [commitSections, clearFolderDropCue])
+
+  /**
+   * The shift preview opens a gap by displacing the rows between the dragged
+   * item and the one under the pointer, by the dragged item's own height. For
+   * an agent row that is a few dozen pixels and reads well. For a folder it is
+   * the height of the whole block, which throws the hovered row clear of the
+   * pointer, flips the drop target, and lands the folder a slot away from where
+   * it was aimed. Folders therefore move without displacing anything, and say
+   * where they will land with an insert line instead.
+   */
+  const topLevelStrategy = useCallback<SortingStrategy>(
+    (args) => (activeDrag?.type === 'folder' ? null : verticalListSortingStrategy(args)),
+    [activeDrag?.type]
+  )
+
+  const handleDragCancel = useCallback(() => {
+    setActiveDrag(null)
+    activeDragRef.current = false
+    clearFolderDropCue()
+    setLocalTree(pendingTreeRef.current)
+  }, [clearFolderDropCue])
+
+  // ─── Folder CRUD ──────────────────────────────────────────────────────────
+
+  // Create and rename replace `agentFolders` wholesale, so they use the
+  // updater form: the folder list is read when the (scope-serialized)
+  // mutation runs, not when the click happened — a payload snapshotted at
+  // click time would revert whatever folder write was still in flight.
+  const handleCreateFolder = useCallback(() => {
+    const id = newFolderId()
+    // A folder with no recorded place renders at the end of the list, which is
+    // where the user just asked for it. The row mounts in rename mode, so
+    // creating a folder and naming it is one gesture.
+    setPendingRenameFolderId(id)
+    updateSettings.mutate((current) => {
+      const folders = sanitizeFolders(current?.agentFolders)
+      return { agentFolders: [...folders, { id, name: uniqueFolderName(folders) }] }
+    })
+  }, [updateSettings])
+
+  const handleRenameFolder = useCallback((folderId: string, name: string) => {
+    updateSettings.mutate((current) => ({
+      agentFolders: sanitizeFolders(current?.agentFolders).map((f) =>
+        f.id === folderId ? { ...f, name } : f
+      ),
+    }))
+  }, [updateSettings])
+
+  const handleDeleteFolder = useCallback((folderId: string) => {
+    const current = sectionsRef.current
+    const next = dissolveFolder(current, folderId)
+    if (next === current) return
+    writeTree({
+      ...sectionsToSettings(next),
+      collapsedAgentFolders: (collapsedFolders ?? []).filter((id) => id !== folderId),
+    })
+  }, [collapsedFolders, writeTree])
+
+  const handleToggleFolder = useCallback((folderId: string) => {
+    const current = collapsedFolders ?? []
+    const next = current.includes(folderId)
+      ? current.filter((id) => id !== folderId)
+      : [...current, folderId]
+    // Collapsing has to feel instant even against a cloud workspace, so paint
+    // it locally and let the write catch up. Only the LATEST toggle may clear
+    // the optimistic view — with two toggles in flight, the first settling
+    // would otherwise drop the second's fold back to the cached state until
+    // its own write lands (a visible flap on a slow connection).
+    pendingCollapsedRef.current = next
+    setLocalCollapsed(next)
     updateSettings.mutate(
-      { agentOrder: newOrder },
-      { onSettled: () => setLocalOrder(null) }
+      { collapsedAgentFolders: next },
+      {
+        onSettled: () => {
+          if (pendingCollapsedRef.current !== next) return
+          pendingCollapsedRef.current = null
+          setLocalCollapsed(null)
+        },
+      }
     )
-  }, [orderedAgents, updateSettings])
+  }, [collapsedFolders, updateSettings])
 
   const isOnline = useIsOnline()
 
@@ -988,8 +1447,10 @@ export function AppSidebar() {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-          <SidebarGroup className={cn('flex-1 min-h-0 overflow-y-auto p-0', THIN_SCROLLBAR)}>
-            <SidebarGroupLabel className="mt-0.5 font-normal text-sidebar-foreground/50">Your Agents</SidebarGroupLabel>
+          <SidebarGroup
+            className={cn('group/agents-group flex-1 min-h-0 overflow-y-auto p-0', THIN_SCROLLBAR)}
+            data-testid="agent-list-scroll"
+          >
             <SidebarGroupContent>
               <SidebarMenu className="gap-1">
                 {isLoading ? (
@@ -1004,26 +1465,75 @@ export function AppSidebar() {
                   <div className="px-2 py-4 text-sm text-destructive select-text">
                     Failed to load agents
                   </div>
-                ) : !agents?.length ? (
+                ) : !agents?.length && !hasFolders ? (
                   <div className="px-2 py-4 text-sm text-muted-foreground">
                     No agents yet. Create one to get started.
                   </div>
                 ) : (
-                  <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                    modifiers={[restrictToVerticalAxis]}
-                  >
-                    <SortableContext
-                      items={orderedAgents.map(a => a.slug)}
-                      strategy={verticalListSortingStrategy}
+                  <SidebarDragProvider value={activeDrag?.type ?? null}>
+                    <DndContext
+                      sensors={sensors}
+                      collisionDetection={collisionDetection}
+                      onDragStart={handleDragStart}
+                      onDragMove={commitFolderDropCue}
+                      onDragOver={handleDragOver}
+                      onDragEnd={handleDragEnd}
+                      onDragCancel={handleDragCancel}
+                      modifiers={[restrictToVerticalAxis]}
                     >
-                      {orderedAgents.map((agent) => (
-                        <SortableAgentMenuItem key={agent.slug} agent={agent} />
-                      ))}
-                    </SortableContext>
-                  </DndContext>
+                      {/*
+                        The top level is folders and nothing else — "Your
+                        Agents" is the always-present default one, so every
+                        agent sits under some header and the headers read as
+                        peers. Each folder's members are a nested sortable
+                        list of their own.
+                      */}
+                      <SortableContext
+                        items={sections.map((s) => sortableIdForFolder(s.folder.id))}
+                        strategy={topLevelStrategy}
+                      >
+                        {sections.map((section) => (
+                          <AgentFolderBlock
+                            key={section.folder.id}
+                            folder={section.folder}
+                            isRoot={section.isRoot}
+                            agentCount={section.agents.length}
+                            isCollapsed={(collapsedFolders ?? []).includes(section.folder.id)}
+                            activeDragType={activeDrag?.type ?? null}
+                            insertEdge={
+                              folderDropCue?.folderId === section.folder.id &&
+                              activeDrag?.folderId !== section.folder.id
+                                ? folderDropCue.edge
+                                : null
+                            }
+                            initialRenaming={section.folder.id === pendingRenameFolderId}
+                            onToggle={() => handleToggleFolder(section.folder.id)}
+                            onRename={(name) => handleRenameFolder(section.folder.id, name)}
+                            onRenameEnd={() => setPendingRenameFolderId(null)}
+                            onDelete={() => handleDeleteFolder(section.folder.id)}
+                            onCreateFolder={section.isRoot ? handleCreateFolder : undefined}
+                          >
+                            <SortableContext
+                              items={section.agents.map((a) => a.slug)}
+                              strategy={verticalListSortingStrategy}
+                            >
+                              {section.agents.map((agent) => (
+                                <SortableAgentMenuItem key={agent.slug} agent={agent} />
+                              ))}
+                            </SortableContext>
+                          </AgentFolderBlock>
+                        ))}
+                      </SortableContext>
+                      <DragOverlay>
+                        {activeDrag ? (
+                          <AgentDragOverlayRow
+                            label={activeDrag.label}
+                            isFolder={activeDrag.type === 'folder'}
+                          />
+                        ) : null}
+                      </DragOverlay>
+                    </DndContext>
+                  </SidebarDragProvider>
                 )}
               </SidebarMenu>
             </SidebarGroupContent>

--- a/src/renderer/components/layout/sidebar-drag-context.tsx
+++ b/src/renderer/components/layout/sidebar-drag-context.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext } from 'react'
+
+export type SidebarDragType = 'agent' | 'folder' | null
+
+/**
+ * What is currently being dragged in the left nav, if anything.
+ *
+ * Two rows need this. Agent rows are collapsible — an expanded one carries its
+ * sessions and dashboards with it — so leaving them open during a drag makes
+ * the drop geometry tall and jumpy as rows reflow underneath the cursor; they
+ * render collapsed for the duration WITHOUT touching their own `isOpen` state,
+ * so nothing refetches and every row springs back on drop. And a row being
+ * hovered by a dragged *folder* has to show where that folder will land, since
+ * folder drags deliberately suppress the sortable shift preview.
+ */
+const SidebarDragContext = createContext<SidebarDragType>(null)
+
+export const SidebarDragProvider = SidebarDragContext.Provider
+
+export function useSidebarDragType(): SidebarDragType {
+  return useContext(SidebarDragContext)
+}
+
+export function useSidebarDragActive(): boolean {
+  return useContext(SidebarDragContext) !== null
+}
+

--- a/src/renderer/components/layout/sortable-agent-item.tsx
+++ b/src/renderer/components/layout/sortable-agent-item.tsx
@@ -1,8 +1,18 @@
+import { useMemo } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
 import { AgentMenuItem } from './app-sidebar'
 
+/**
+ * The thin sortable shell around a heavy row. dnd-kit re-renders every
+ * `useSortable` consumer on each drag tick (its internal context carries the
+ * live `over` state), so this component is deliberately nothing but the hook
+ * and prop plumbing: `AgentMenuItem` is memoized and every prop handed to it
+ * here is referentially stable across those ticks, which is what lets the
+ * heavy subtree skip the churn. Keep it that way — an inline object or
+ * closure prop added here would silently defeat the memo.
+ */
 export function SortableAgentMenuItem({ agent }: { agent: ApiAgent }) {
   const {
     attributes,
@@ -11,14 +21,21 @@ export function SortableAgentMenuItem({ agent }: { agent: ApiAgent }) {
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: agent.slug })
+  } = useSortable({ id: agent.slug, data: { type: 'agent', slug: agent.slug } })
 
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.4 : undefined,
-    zIndex: isDragging ? 1 : undefined,
-  }
+  // CSS.Transform.toString collapses the transform object to a string, so the
+  // memo key is by value: rows the current tick did not displace keep a stable
+  // style object even though useSortable handed back a fresh transform object.
+  const transformString = CSS.Transform.toString(transform)
+  const style = useMemo(
+    () => ({
+      transform: transformString,
+      transition,
+      opacity: isDragging ? 0.4 : undefined,
+      zIndex: isDragging ? 1 : undefined,
+    }),
+    [transformString, transition, isDragging]
+  )
 
   return (
     <AgentMenuItem

--- a/src/renderer/hooks/use-user-settings.test.tsx
+++ b/src/renderer/hooks/use-user-settings.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useUpdateUserSettings, type UserSettingsData } from './use-user-settings'
+
+const { mockApiFetch } = vi.hoisted(() => ({ mockApiFetch: vi.fn() }))
+vi.mock('@renderer/lib/api', () => ({ apiFetch: mockApiFetch }))
+
+const SERVER_SETTINGS = {
+  theme: 'dark',
+  agentFolders: [{ id: 'f1', name: 'Work' }],
+  agentFolderAssignments: { support: 'f1' },
+} as unknown as UserSettingsData
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, json: async () => body }
+}
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const { result } = renderHook(() => useUpdateUserSettings(), { wrapper })
+  return { queryClient, mutation: result }
+}
+
+const putCalls = () =>
+  mockApiFetch.mock.calls.filter(([, init]) => (init as RequestInit | undefined)?.method === 'PUT')
+const getCalls = () =>
+  mockApiFetch.mock.calls.filter(([, init]) => !(init as RequestInit | undefined)?.method)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useUpdateUserSettings with a functional patch', () => {
+  it('fetches the settings first when the cache is empty, and builds the write from them', async () => {
+    // The updater form exists to derive whole-field replacements from current
+    // settings. Before the first GET settles the cache is empty; an updater
+    // fed nothing would rebuild those fields from scratch and erase every
+    // stored filing the moment the write lands.
+    mockApiFetch.mockImplementation(async (_url: string, init?: RequestInit) =>
+      init?.method === 'PUT'
+        ? jsonResponse({ ...SERVER_SETTINGS })
+        : jsonResponse(SERVER_SETTINGS)
+    )
+    const { mutation } = setup()
+
+    await mutation.current.mutateAsync((current) => ({
+      agentFolderAssignments: { ...current.agentFolderAssignments, sales: 'f1' },
+    }))
+
+    expect(getCalls()).toHaveLength(1)
+    const body = JSON.parse(putCalls()[0][1].body as string)
+    expect(body.agentFolderAssignments).toEqual({ support: 'f1', sales: 'f1' })
+  })
+
+  it('uses the cache without a fetch when it is already populated', async () => {
+    mockApiFetch.mockResolvedValue(jsonResponse({ ...SERVER_SETTINGS }))
+    const { queryClient, mutation } = setup()
+    queryClient.setQueryData(['user-settings'], SERVER_SETTINGS)
+
+    await mutation.current.mutateAsync((current) => ({
+      agentFolderAssignments: { ...current.agentFolderAssignments, sales: 'f1' },
+    }))
+
+    expect(getCalls()).toHaveLength(0)
+    const body = JSON.parse(putCalls()[0][1].body as string)
+    expect(body.agentFolderAssignments).toEqual({ support: 'f1', sales: 'f1' })
+  })
+
+  it('fails the mutation instead of writing when the settings cannot be loaded', async () => {
+    mockApiFetch.mockResolvedValue(jsonResponse({ error: 'nope' }, false))
+    const { mutation } = setup()
+
+    await expect(
+      mutation.current.mutateAsync(() => ({ agentFolderAssignments: {} }))
+    ).rejects.toThrow()
+
+    expect(putCalls()).toHaveLength(0)
+  })
+
+  it('sends a plain-object patch as-is without touching the settings query', async () => {
+    mockApiFetch.mockResolvedValue(jsonResponse({ ...SERVER_SETTINGS }))
+    const { mutation } = setup()
+
+    await mutation.current.mutateAsync({ theme: 'light' })
+
+    expect(getCalls()).toHaveLength(0)
+    expect(JSON.parse(putCalls()[0][1].body as string)).toEqual({ theme: 'light' })
+  })
+})

--- a/src/renderer/hooks/use-user-settings.ts
+++ b/src/renderer/hooks/use-user-settings.ts
@@ -4,14 +4,18 @@ import type { UserSettingsData } from '@shared/lib/services/user-settings-servic
 
 export type { UserSettingsData }
 
+const USER_SETTINGS_QUERY_KEY = ['user-settings']
+
+async function fetchUserSettings(): Promise<UserSettingsData> {
+  const res = await apiFetch('/api/user-settings')
+  if (!res.ok) throw new Error('Failed to fetch user settings')
+  return res.json()
+}
+
 export function useUserSettings() {
   return useQuery<UserSettingsData>({
-    queryKey: ['user-settings'],
-    queryFn: async () => {
-      const res = await apiFetch('/api/user-settings')
-      if (!res.ok) throw new Error('Failed to fetch user settings')
-      return res.json()
-    },
+    queryKey: USER_SETTINGS_QUERY_KEY,
+    queryFn: fetchUserSettings,
   })
 }
 
@@ -28,7 +32,7 @@ export function useUserSettings() {
  */
 export type UserSettingsPatch =
   | Partial<UserSettingsData>
-  | ((current: UserSettingsData | undefined) => Partial<UserSettingsData>)
+  | ((current: UserSettingsData) => Partial<UserSettingsData>)
 
 export function useUpdateUserSettings() {
   const queryClient = useQueryClient()
@@ -40,9 +44,20 @@ export function useUpdateUserSettings() {
     scope: { id: 'user-settings' },
     meta: { skipGlobalErrorToast: true },
     mutationFn: async (patch) => {
+      // A functional patch must never see an empty cache: before the first
+      // GET settles (or after it failed) the cache is undefined, and an
+      // updater fed nothing would rebuild whole fields from scratch — one
+      // early filing would erase every stored one the moment it lands.
+      // ensureQueryData returns the cache when present and fetches when not;
+      // a failed fetch fails the MUTATION instead of clobbering the row.
       const data =
         typeof patch === 'function'
-          ? patch(queryClient.getQueryData<UserSettingsData>(['user-settings']))
+          ? patch(
+              await queryClient.ensureQueryData({
+                queryKey: USER_SETTINGS_QUERY_KEY,
+                queryFn: fetchUserSettings,
+              })
+            )
           : patch
       const res = await apiFetch('/api/user-settings', {
         method: 'PUT',
@@ -60,7 +75,7 @@ export function useUpdateUserSettings() {
       // the cache. (invalidate + refetch left a window where consumers that
       // clear optimistic state on settle briefly rendered the stale cache,
       // e.g. a resized home card flickering back to its old size.)
-      queryClient.setQueryData(['user-settings'], data)
+      queryClient.setQueryData(USER_SETTINGS_QUERY_KEY, data)
     },
   })
 }

--- a/src/renderer/hooks/use-user-settings.ts
+++ b/src/renderer/hooks/use-user-settings.ts
@@ -15,16 +15,35 @@ export function useUserSettings() {
   })
 }
 
+/**
+ * A settings write: either the fields to store, or a function of the latest
+ * cached settings returning them. Use the function form whenever the payload
+ * is derived from current settings (e.g. "add one assignment to the map") —
+ * it resolves when the mutation actually RUNS, not when it was queued. The
+ * scope below serializes runs, and each run writes the server's response into
+ * the cache before releasing the scope, so the function form always sees the
+ * writes queued ahead of it; a plain object built from `useUserSettings` data
+ * captures whatever the cache held at call time and silently reverts any
+ * write that was still in flight.
+ */
+export type UserSettingsPatch =
+  | Partial<UserSettingsData>
+  | ((current: UserSettingsData | undefined) => Partial<UserSettingsData>)
+
 export function useUpdateUserSettings() {
   const queryClient = useQueryClient()
 
-  return useMutation<UserSettingsData, Error, Partial<UserSettingsData>>({
+  return useMutation<UserSettingsData, Error, UserSettingsPatch>({
     // Settings writes are partial read/merge/write operations on one document.
     // Serialize every instance of this mutation so rapid layout/visibility
     // changes cannot complete out of order and restore an older snapshot.
     scope: { id: 'user-settings' },
     meta: { skipGlobalErrorToast: true },
-    mutationFn: async (data) => {
+    mutationFn: async (patch) => {
+      const data =
+        typeof patch === 'function'
+          ? patch(queryClient.getQueryData<UserSettingsData>(['user-settings']))
+          : patch
       const res = await apiFetch('/api/user-settings', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },

--- a/src/renderer/lib/agent-folders.test.ts
+++ b/src/renderer/lib/agent-folders.test.ts
@@ -9,6 +9,7 @@ import {
   moveAgent,
   moveFolder,
   newFolderId,
+  applyTreeOperation,
   resolveAgentDrop,
   resolveFolderDrop,
   sanitizeFolders,
@@ -343,6 +344,64 @@ describe('uniqueFolderName', () => {
     ]
     expect(uniqueFolderName(folders, 'Clients')).toBe('Clients 3')
     expect(uniqueFolderName(folders, 'Fresh')).toBe('Fresh')
+  })
+})
+
+describe('applyTreeOperation', () => {
+  const base = () =>
+    buildFolderSections([a, b, c], [work, personal], { a: 'f1' }, undefined)
+  // base: root[b,c] f1[a] f2[]
+
+  it('reproduces a drop exactly when nothing changed in between', () => {
+    // placeAgent records the agent's FINAL member index; on the same sections
+    // it must land precisely there — the serial case is byte-for-byte.
+    const next = applyTreeOperation(base(), { kind: 'placeAgent', slug: 'b', folderId: 'f1', index: 0 })
+    expect(shapeOf(next)).toEqual(['root[c]', 'f1[b,a]', 'f2[]'])
+  })
+
+  it('appends on an out-of-range index, which is how menu filing lands', () => {
+    const next = applyTreeOperation(base(), {
+      kind: 'placeAgent',
+      slug: 'b',
+      folderId: 'f1',
+      index: Number.MAX_SAFE_INTEGER,
+    })
+    expect(shapeOf(next)).toEqual(['root[c]', 'f1[a,b]', 'f2[]'])
+  })
+
+  it('leaves the tree alone when the agent or folder vanished concurrently', () => {
+    const sections = base()
+    expect(applyTreeOperation(sections, { kind: 'placeAgent', slug: 'ghost', folderId: 'f1', index: 0 }))
+      .toBe(sections)
+    expect(applyTreeOperation(sections, { kind: 'placeAgent', slug: 'b', folderId: 'gone', index: 0 }))
+      .toBe(sections)
+    expect(applyTreeOperation(sections, { kind: 'placeFolder', folderId: 'gone', index: 0 }))
+      .toBe(sections)
+  })
+
+  it('moves a folder to its recorded final slot, clamped past the end', () => {
+    expect(shapeOf(applyTreeOperation(base(), { kind: 'placeFolder', folderId: 'f2', index: 0 })))
+      .toEqual(['f2[]', 'root[b,c]', 'f1[a]'])
+    expect(shapeOf(applyTreeOperation(base(), { kind: 'placeFolder', folderId: 'root', index: 99 })))
+      .toEqual(['f1[a]', 'f2[]', 'root[b,c]'])
+  })
+
+  it('dissolves a folder into the default one', () => {
+    expect(shapeOf(applyTreeOperation(base(), { kind: 'dissolveFolder', folderId: 'f1' })))
+      .toEqual(['root[b,c,a]', 'f2[]'])
+  })
+
+  it('keeps work that landed while the drop was in flight', () => {
+    // The whole point: a drop recorded against [root,f1,f2] re-applied to
+    // sections where a THIRD folder was created concurrently keeps it.
+    const withExtra = buildFolderSections(
+      [a, b, c],
+      [work, personal, { id: 'f9', name: 'Fresh' }],
+      { a: 'f1', c: 'f9' },
+      undefined
+    )
+    const next = applyTreeOperation(withExtra, { kind: 'placeAgent', slug: 'b', folderId: 'f1', index: 1 })
+    expect(shapeOf(next)).toEqual(['root[]', 'f1[a,b]', 'f2[]', 'f9[c]'])
   })
 })
 

--- a/src/renderer/lib/agent-folders.test.ts
+++ b/src/renderer/lib/agent-folders.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ROOT_FOLDER_ID,
+  assignAgentToFolder,
+  buildFolderSections,
+  containerIdForFolder,
+  dissolveFolder,
+  locateAgent,
+  moveAgent,
+  moveFolder,
+  newFolderId,
+  resolveAgentDrop,
+  resolveFolderDrop,
+  sanitizeFolders,
+  sectionsToSettings,
+  sortableIdForFolder,
+  uniqueFolderName,
+  type AgentFolder,
+  type FolderSection,
+} from './agent-folders'
+import type { ApiAgent } from '@renderer/hooks/use-agents'
+
+function makeAgent(slug: string): ApiAgent {
+  return {
+    slug,
+    displaySlug: slug,
+    name: slug,
+    createdAt: new Date('2025-01-01'),
+    status: 'stopped',
+    containerPort: null,
+  }
+}
+
+const a = makeAgent('a')
+const b = makeAgent('b')
+const c = makeAgent('c')
+const d = makeAgent('d')
+const work: AgentFolder = { id: 'f1', name: 'Work' }
+const personal: AgentFolder = { id: 'f2', name: 'Personal' }
+
+/** Compact shape: 'root[a,b]' then 'f1[c]' in render order. */
+function shapeOf(sections: FolderSection[]): string[] {
+  return sections.map((s) => `${s.folder.id}[${s.agents.map((x) => x.slug).join(',')}]`)
+}
+
+const F1 = sortableIdForFolder('f1')
+const F2 = sortableIdForFolder('f2')
+const ROOT = sortableIdForFolder(ROOT_FOLDER_ID)
+
+describe('buildFolderSections', () => {
+  it('renders every agent inside the default folder when there are no others', () => {
+    expect(shapeOf(buildFolderSections([a, b], undefined, undefined, undefined)))
+      .toEqual(['root[a,b]'])
+  })
+
+  it('renders one section per folder id even if the stored list repeats it', () => {
+    const sections = buildFolderSections(
+      [a, b],
+      [{ id: 'f1', name: 'Work' }, { id: 'f1', name: 'Twin' }],
+      { a: 'f1' },
+      undefined
+    )
+    expect(shapeOf(sections)).toEqual(['root[b]', 'f1[a]'])
+  })
+
+  it('always renders the default folder, even empty', () => {
+    const sections = buildFolderSections([a], [work], { a: 'f1' }, undefined)
+    expect(shapeOf(sections)).toEqual(['root[]', 'f1[a]'])
+    expect(sections[0].isRoot).toBe(true)
+    expect(sections[0].folder.name).toBe('Your Agents')
+  })
+
+  it('defaults the default folder first — the pre-folders layout on an untouched install', () => {
+    const sections = buildFolderSections([a, b], [work], { a: 'f1' }, undefined)
+    expect(shapeOf(sections)).toEqual(['root[b]', 'f1[a]'])
+  })
+
+  it('orders folders by the stored top-level order, default folder included', () => {
+    const sections = buildFolderSections([a, b], [work], { a: 'f1' }, [F1, ROOT])
+    expect(shapeOf(sections)).toEqual(['f1[a]', 'root[b]'])
+  })
+
+  it('ranks a folder with no stored place last — it was just created', () => {
+    const sections = buildFolderSections([a], [work, personal], { a: 'f1' }, [F1, ROOT])
+    expect(shapeOf(sections)).toEqual(['f1[a]', 'root[]', 'f2[]'])
+  })
+
+  it('ignores stored order entries that are agent slugs — the pre-refactor format', () => {
+    // The top level used to interleave agents and folders; those blobs must
+    // parse under the new model with the folder markers keeping their order.
+    const sections = buildFolderSections([a, b], [work], { b: 'f1' }, ['a', F1, 'deleted', ROOT])
+    expect(shapeOf(sections)).toEqual(['f1[b]', 'root[a]'])
+  })
+
+  it('preserves the incoming agent order inside each section', () => {
+    const sections = buildFolderSections([c, a, b], [work], { a: 'f1', c: 'f1' }, undefined)
+    expect(shapeOf(sections)).toEqual(['root[b]', 'f1[c,a]'])
+  })
+
+  it('drops an agent whose folder no longer exists into the default folder', () => {
+    const sections = buildFolderSections([a, b], [work], { a: 'f1', b: 'gone' }, undefined)
+    expect(shapeOf(sections)).toEqual(['root[b]', 'f1[a]'])
+  })
+
+  it('ignores assignments for agents that are not in the list', () => {
+    const sections = buildFolderSections([a], [work], { a: 'f1', ghost: 'f1' }, undefined)
+    expect(shapeOf(sections)).toEqual(['root[]', 'f1[a]'])
+  })
+
+  it('discards a stored folder that claims the default folder id', () => {
+    const sections = buildFolderSections([a], [{ id: ROOT_FOLDER_ID, name: 'Impostor' }], {}, undefined)
+    expect(shapeOf(sections)).toEqual(['root[a]'])
+    expect(sections[0].folder.name).toBe('Your Agents')
+  })
+})
+
+describe('sectionsToSettings', () => {
+  it('flattens reading order into agentOrder', () => {
+    const sections = buildFolderSections([a, b, c], [work], { b: 'f1' }, [F1, ROOT])
+    expect(sectionsToSettings(sections).agentOrder).toEqual(['b', 'a', 'c'])
+  })
+
+  it('records the top level as folder markers only', () => {
+    const sections = buildFolderSections([a], [work], {}, [F1, ROOT])
+    expect(sectionsToSettings(sections).agentListOrder).toEqual([F1, ROOT])
+  })
+
+  it('writes no assignment for default-folder members', () => {
+    const sections = buildFolderSections([a, b], [work], { b: 'f1' }, undefined)
+    expect(sectionsToSettings(sections).agentFolderAssignments).toEqual({ b: 'f1' })
+  })
+
+  it('does not write the default folder into agentFolders', () => {
+    const sections = buildFolderSections([a], [work], {}, undefined)
+    expect(sectionsToSettings(sections).agentFolders).toEqual([work])
+  })
+
+  it('round-trips through buildFolderSections unchanged', () => {
+    const original = buildFolderSections([a, b, c, d], [work, personal], { a: 'f2', c: 'f1' }, [
+      F2, ROOT, F1,
+    ])
+    const settings = sectionsToSettings(original)
+    const reparsed = buildFolderSections(
+      settings.agentOrder.map((slug) => [a, b, c, d].find((x) => x.slug === slug)!),
+      settings.agentFolders,
+      settings.agentFolderAssignments,
+      settings.agentListOrder
+    )
+    expect(shapeOf(reparsed)).toEqual(shapeOf(original))
+  })
+})
+
+describe('resolveAgentDrop', () => {
+  const sections = buildFolderSections([a, b, c], [work], { b: 'f1' }, undefined)
+
+  it('files into a folder at the end when dropped on its header or body', () => {
+    expect(resolveAgentDrop(sections, F1)).toEqual({ folderId: 'f1', index: 1 })
+    expect(resolveAgentDrop(sections, containerIdForFolder('f1'))).toEqual({ folderId: 'f1', index: 1 })
+  })
+
+  it('treats the default folder like any other target', () => {
+    expect(resolveAgentDrop(sections, ROOT)).toEqual({ folderId: ROOT_FOLDER_ID, index: 2 })
+    expect(resolveAgentDrop(sections, containerIdForFolder(ROOT_FOLDER_ID)))
+      .toEqual({ folderId: ROOT_FOLDER_ID, index: 2 })
+  })
+
+  it('takes the slot of the row it is dropped on', () => {
+    expect(resolveAgentDrop(sections, 'c')).toEqual({ folderId: ROOT_FOLDER_ID, index: 1 })
+    expect(resolveAgentDrop(sections, 'b')).toEqual({ folderId: 'f1', index: 0 })
+  })
+
+  it('returns null for anything unrecognised', () => {
+    expect(resolveAgentDrop(sections, 'nope')).toBeNull()
+  })
+})
+
+describe('resolveFolderDrop', () => {
+  const sections = buildFolderSections([a, b, c], [work, personal], { b: 'f1' }, [ROOT, F1, F2])
+
+  it('takes the slot of a folder it is dropped on, default folder included', () => {
+    expect(resolveFolderDrop(sections, F2)).toBe(2)
+    expect(resolveFolderDrop(sections, ROOT)).toBe(0)
+  })
+
+  it('resolves an agent row to the slot of the section holding it', () => {
+    expect(resolveFolderDrop(sections, 'a')).toBe(0)
+    expect(resolveFolderDrop(sections, 'b')).toBe(1)
+  })
+
+  it('returns null for anything unrecognised', () => {
+    expect(resolveFolderDrop(sections, 'nope')).toBeNull()
+  })
+})
+
+describe('moveAgent', () => {
+  it('reorders within the default folder', () => {
+    const sections = buildFolderSections([a, b, c], undefined, undefined, undefined)
+    expect(shapeOf(moveAgent(sections, 'a', { folderId: ROOT_FOLDER_ID, index: 2 })))
+      .toEqual(['root[b,c,a]'])
+  })
+
+  it('files an agent into a folder at a given index', () => {
+    const sections = buildFolderSections([a, b, c], [work], { b: 'f1', c: 'f1' }, undefined)
+    expect(shapeOf(moveAgent(sections, 'a', { folderId: 'f1', index: 1 })))
+      .toEqual(['root[]', 'f1[b,a,c]'])
+  })
+
+  it('appends when the index is past the end', () => {
+    const sections = buildFolderSections([a, b], [work], { b: 'f1' }, undefined)
+    expect(shapeOf(moveAgent(sections, 'a', { folderId: 'f1', index: 99 })))
+      .toEqual(['root[]', 'f1[b,a]'])
+  })
+
+  it('unfiles by moving into the default folder at a chosen slot', () => {
+    const sections = buildFolderSections([a, b, c], [work], { a: 'f1' }, undefined)
+    expect(shapeOf(moveAgent(sections, 'a', { folderId: ROOT_FOLDER_ID, index: 1 })))
+      .toEqual(['root[b,a,c]', 'f1[]'])
+  })
+
+  it('moves straight between two folders', () => {
+    const sections = buildFolderSections([a, b], [work, personal], { a: 'f1', b: 'f2' }, undefined)
+    expect(shapeOf(moveAgent(sections, 'a', { folderId: 'f2', index: 0 })))
+      .toEqual(['root[]', 'f1[]', 'f2[a,b]'])
+  })
+
+  it('returns the same sections when the agent is unknown', () => {
+    const sections = buildFolderSections([a], undefined, undefined, undefined)
+    expect(moveAgent(sections, 'ghost', { folderId: ROOT_FOLDER_ID, index: 0 })).toBe(sections)
+  })
+
+  it('returns the same sections when the destination folder is gone', () => {
+    const sections = buildFolderSections([a], undefined, undefined, undefined)
+    expect(moveAgent(sections, 'a', { folderId: 'nope', index: 0 })).toBe(sections)
+  })
+
+  it('returns the same sections when nothing would move', () => {
+    const sections = buildFolderSections([a, b], undefined, undefined, undefined)
+    expect(moveAgent(sections, 'a', { folderId: ROOT_FOLDER_ID, index: 0 })).toBe(sections)
+  })
+
+  it('does not mutate its input', () => {
+    const sections = buildFolderSections([a, b], [work], {}, undefined)
+    const before = shapeOf(sections)
+    moveAgent(sections, 'a', { folderId: 'f1', index: 0 })
+    expect(shapeOf(sections)).toEqual(before)
+  })
+})
+
+describe('moveFolder', () => {
+  it('reorders folders past each other', () => {
+    const sections = buildFolderSections([a], [work, personal], {}, [ROOT, F1, F2])
+    expect(shapeOf(moveFolder(sections, 'f2', 1))).toEqual(['root[a]', 'f2[]', 'f1[]'])
+  })
+
+  it('moves the default folder like any other', () => {
+    const sections = buildFolderSections([a, b], [work], { b: 'f1' }, [ROOT, F1])
+    expect(shapeOf(moveFolder(sections, ROOT_FOLDER_ID, 1))).toEqual(['f1[b]', 'root[a]'])
+  })
+
+  it('carries a folder’s agents with it', () => {
+    const sections = buildFolderSections([a, b, c], [work], { b: 'f1', c: 'f1' }, [ROOT, F1])
+    expect(shapeOf(moveFolder(sections, 'f1', 0))).toEqual(['f1[b,c]', 'root[a]'])
+  })
+
+  it('clamps a slot past the end', () => {
+    const sections = buildFolderSections([a], [work], {}, [ROOT, F1])
+    expect(shapeOf(moveFolder(sections, ROOT_FOLDER_ID, 99))).toEqual(['f1[]', 'root[a]'])
+  })
+
+  it('is a no-op for an unknown folder', () => {
+    const sections = buildFolderSections([a], [work], {}, undefined)
+    expect(moveFolder(sections, 'nope', 0)).toBe(sections)
+  })
+})
+
+describe('dissolveFolder', () => {
+  it('appends the folder’s members to the default folder', () => {
+    const sections = buildFolderSections([a, b, c], [work], { b: 'f1', c: 'f1' }, undefined)
+    expect(shapeOf(dissolveFolder(sections, 'f1'))).toEqual(['root[a,b,c]'])
+  })
+
+  it('keeps the released agents’ relative order', () => {
+    const sections = buildFolderSections([a, b, c, d], [work], { c: 'f1', b: 'f1' }, undefined)
+    expect(shapeOf(dissolveFolder(sections, 'f1'))).toEqual(['root[a,d,b,c]'])
+  })
+
+  it('clears the released agents’ assignments when written back', () => {
+    const sections = buildFolderSections([a, b], [work], { b: 'f1' }, undefined)
+    const settings = sectionsToSettings(dissolveFolder(sections, 'f1'))
+    expect(settings.agentFolderAssignments).toEqual({})
+    expect(settings.agentFolders).toEqual([])
+  })
+
+  it('refuses to dissolve the default folder', () => {
+    const sections = buildFolderSections([a], undefined, undefined, undefined)
+    expect(dissolveFolder(sections, ROOT_FOLDER_ID)).toBe(sections)
+  })
+
+  it('is a no-op for an unknown folder', () => {
+    const sections = buildFolderSections([a], [work], {}, undefined)
+    expect(dissolveFolder(sections, 'nope')).toBe(sections)
+  })
+})
+
+describe('locateAgent', () => {
+  const sections = buildFolderSections([a, b], [work], { b: 'f1' }, undefined)
+
+  it('finds agents in the default folder and in others', () => {
+    expect(locateAgent(sections, 'a')).toEqual({ sectionIndex: 0, memberIndex: 0 })
+    expect(locateAgent(sections, 'b')).toEqual({ sectionIndex: 1, memberIndex: 0 })
+    expect(locateAgent(sections, 'zzz')).toBeNull()
+  })
+})
+
+describe('assignAgentToFolder', () => {
+  it('files an agent', () => {
+    expect(assignAgentToFolder({}, 'a', 'f1')).toEqual({ a: 'f1' })
+  })
+
+  it('treats the default folder as unfiled — the key is deleted, not written', () => {
+    expect(assignAgentToFolder({ a: 'f1' }, 'a', ROOT_FOLDER_ID)).toEqual({})
+    expect(assignAgentToFolder({ a: 'f1' }, 'a', null)).toEqual({})
+  })
+
+  it('tolerates an absent assignments map and does not mutate its input', () => {
+    expect(assignAgentToFolder(undefined, 'a', 'f1')).toEqual({ a: 'f1' })
+    const original = { a: 'f1' }
+    assignAgentToFolder(original, 'b', 'f2')
+    expect(original).toEqual({ a: 'f1' })
+  })
+})
+
+describe('uniqueFolderName', () => {
+  it('suffixes a counter on collision', () => {
+    expect(uniqueFolderName([])).toBe('New Folder')
+    expect(uniqueFolderName([{ id: 'f1', name: 'New Folder' }])).toBe('New Folder 2')
+  })
+
+  it('deduplicates a typed base name against existing folders', () => {
+    const folders = [
+      { id: 'f1', name: 'Clients' },
+      { id: 'f2', name: 'Clients 2' },
+    ]
+    expect(uniqueFolderName(folders, 'Clients')).toBe('Clients 3')
+    expect(uniqueFolderName(folders, 'Fresh')).toBe('Fresh')
+  })
+})
+
+describe('sanitizeFolders', () => {
+  it('keeps only the first entry when two folders share an id', () => {
+    // Two entries with one id would render two sections aliasing one member
+    // array — moves into either would silently revert on the next write, a
+    // state no gesture can repair — so the read boundary drops the repeat.
+    expect(
+      sanitizeFolders([
+        { id: 'f1', name: 'Kept' },
+        { id: 'f1', name: 'Dropped' },
+        { id: 'f2', name: 'Other' },
+      ])
+    ).toEqual([
+      { id: 'f1', name: 'Kept' },
+      { id: 'f2', name: 'Other' },
+    ])
+  })
+
+  it('drops a stored folder claiming the default folder id', () => {
+    expect(sanitizeFolders([{ id: ROOT_FOLDER_ID, name: 'Impostor' }])).toEqual([])
+  })
+
+  it('passes a clean list through unchanged', () => {
+    const folders = [{ id: 'f1', name: 'Work' }]
+    expect(sanitizeFolders(folders)).toEqual(folders)
+    expect(sanitizeFolders(undefined)).toEqual([])
+  })
+})
+
+describe('newFolderId', () => {
+  it('never mints the default folder id', () => {
+    expect(newFolderId()).not.toBe(ROOT_FOLDER_ID)
+  })
+})

--- a/src/renderer/lib/agent-folders.ts
+++ b/src/renderer/lib/agent-folders.ts
@@ -304,6 +304,41 @@ export function dissolveFolder(sections: FolderSection[], folderId: string): Fol
     )
 }
 
+/**
+ * A structural change to the tree, expressed as the moved thing's FINAL
+ * position rather than as a settings snapshot. A drop's snapshot goes stale
+ * the moment a concurrent write (a folder create, a context-menu filing)
+ * lands first — writing it back would replace agentFolders, assignments and
+ * order wholesale and silently undo that work. Re-applying the operation to
+ * the settings as they are when the write actually runs keeps concurrent
+ * work; with nothing in flight it reproduces the snapshot byte for byte,
+ * because every primitive here has final-position semantics.
+ */
+export type TreeOperation =
+  | { kind: 'placeAgent'; slug: string; folderId: string; index: number }
+  | { kind: 'placeFolder'; folderId: string; index: number }
+  | { kind: 'dissolveFolder'; folderId: string }
+
+export function applyTreeOperation(
+  sections: FolderSection[],
+  operation: TreeOperation
+): FolderSection[] {
+  switch (operation.kind) {
+    case 'placeAgent':
+      // Out-of-range indexes clamp/append; a slug or folder that vanished
+      // concurrently leaves the sections untouched — the same dangling
+      // tolerance every read path already has.
+      return moveAgent(sections, operation.slug, {
+        folderId: operation.folderId,
+        index: operation.index,
+      })
+    case 'placeFolder':
+      return moveFolder(sections, operation.folderId, operation.index)
+    case 'dissolveFolder':
+      return dissolveFolder(sections, operation.folderId)
+  }
+}
+
 // ─── Mutations on the stored fields ──────────────────────────────────────────
 
 /**

--- a/src/renderer/lib/agent-folders.ts
+++ b/src/renderer/lib/agent-folders.ts
@@ -1,0 +1,333 @@
+import type { ApiAgent } from '@renderer/hooks/use-agents'
+
+/**
+ * Left-nav agent folders.
+ *
+ * Folders are a *user projection* over the shared agent list, exactly like
+ * `agentOrder` in `agent-ordering.ts`: they live in that user's row of
+ * `user_settings`, so filing a shared agent never moves it for anybody else.
+ *
+ * The left nav's top level is a list of folders and nothing else. "Your
+ * Agents" is one of them — the always-present default folder that holds every
+ * agent not filed anywhere. It can be reordered and collapsed like the rest,
+ * but never renamed or deleted, because it is where everything falls back to:
+ * an agent whose folder was deleted, an agent another user shared, a brand-new
+ * agent. Folders do not nest.
+ *
+ * Everything here is pure and dnd-kit-free — the sidebar owns the drag
+ * plumbing, this file owns the shape of the sections and every mutation on
+ * them.
+ *
+ * Two properties the rest of the feature leans on:
+ *
+ * 1. **Dangling references resolve to "Your Agents".** An assignment naming a
+ *    deleted folder, an order entry naming something gone, an agent with no
+ *    assignment at all — each lands in the default folder rather than being
+ *    repaired. That is why deleting an agent or a folder needs no cascade, and
+ *    why there is no migration: settings written before this model (which
+ *    stored agent slugs in the top-level order) parse fine, the slug entries
+ *    are simply ignored.
+ * 2. **The rendered sections are the source of truth for order.** Flattening
+ *    them in reading order yields the one flat `agentOrder` that the home
+ *    grid, the graph and the tray consume without knowing folders exist.
+ */
+
+export interface AgentFolder {
+  id: string
+  name: string
+}
+
+/** One top-level block: a folder (the default one included) and its agents. */
+export interface FolderSection {
+  folder: AgentFolder
+  isRoot: boolean
+  agents: ApiAgent[]
+}
+
+/**
+ * The default folder's id. User folders get uuids, so this can never collide;
+ * a stored folder claiming this id is discarded defensively.
+ */
+export const ROOT_FOLDER_ID = 'root'
+export const ROOT_FOLDER_NAME = 'Your Agents'
+
+export const DEFAULT_FOLDER_NAME = 'New Folder'
+
+/**
+ * Ids for a folder's two drag roles. The `::` separator cannot occur in an
+ * agent slug (they are filesystem directory names), so neither can ever
+ * collide with an agent id inside the same DndContext.
+ */
+export function containerIdForFolder(folderId: string): string {
+  return `agent-section::${folderId}`
+}
+
+export function sortableIdForFolder(folderId: string): string {
+  return `agent-folder::${folderId}`
+}
+
+export function newFolderId(): string {
+  return crypto.randomUUID()
+}
+
+/**
+ * Drop stored folder entries that can only come from a hand-edited or buggy
+ * write: one claiming the default folder's id, and any repeat of an id already
+ * seen (first occurrence wins). Two entries sharing an id would render two
+ * sections aliasing one member list, and every move involving them would
+ * silently revert on the next write — a state no gesture can repair.
+ */
+export function sanitizeFolders(folders: AgentFolder[] | undefined): AgentFolder[] {
+  const seen = new Set<string>([ROOT_FOLDER_ID])
+  return (folders ?? []).filter((folder) => {
+    if (seen.has(folder.id)) return false
+    seen.add(folder.id)
+    return true
+  })
+}
+
+// ─── Read ────────────────────────────────────────────────────────────────────
+
+/**
+ * Assemble the sections from an already-ordered agent list plus the stored
+ * fields. Within a section, agents keep their relative order from
+ * `orderedAgents` (i.e. from `applyAgentOrder`).
+ *
+ * Placement fallbacks double as the upgrade path: a folder with no place in
+ * the stored order was just created and renders last; the default folder with
+ * no place renders first, which — together with unassigned agents landing in
+ * it — reproduces the pre-folders layout exactly on an untouched install.
+ */
+export function buildFolderSections(
+  orderedAgents: ApiAgent[],
+  folders: AgentFolder[] | undefined,
+  assignments: Record<string, string> | undefined,
+  listOrder: string[] | undefined
+): FolderSection[] {
+  const userFolders = sanitizeFolders(folders)
+  const members = new Map<string, ApiAgent[]>(userFolders.map((f) => [f.id, []]))
+  const rootAgents: ApiAgent[] = []
+
+  for (const agent of orderedAgents) {
+    const folderId = assignments?.[agent.slug]
+    const bucket = folderId ? members.get(folderId) : undefined
+    if (bucket) bucket.push(agent)
+    else rootAgents.push(agent)
+  }
+
+  const sections: FolderSection[] = [
+    {
+      folder: { id: ROOT_FOLDER_ID, name: ROOT_FOLDER_NAME },
+      isRoot: true,
+      agents: rootAgents,
+    },
+    ...userFolders.map((folder) => ({
+      folder,
+      isRoot: false,
+      agents: members.get(folder.id)!,
+    })),
+  ]
+
+  const rank = new Map((listOrder ?? []).map((key, index) => [key, index]))
+  const placeOf = (section: FolderSection) => {
+    const stored = rank.get(sortableIdForFolder(section.folder.id))
+    if (stored !== undefined) return stored
+    return section.isRoot ? -1 : rank.size + 1
+  }
+
+  return sections
+    .map((section, index) => ({ section, index, place: placeOf(section) }))
+    .sort((a, b) => a.place - b.place || a.index - b.index)
+    .map((entry) => entry.section)
+}
+
+/** Collapse the rendered sections back into the stored fields. */
+export function sectionsToSettings(sections: FolderSection[]): {
+  agentOrder: string[]
+  agentListOrder: string[]
+  agentFolders: AgentFolder[]
+  agentFolderAssignments: Record<string, string>
+} {
+  const agentOrder: string[] = []
+  const agentListOrder: string[] = []
+  const agentFolders: AgentFolder[] = []
+  const agentFolderAssignments: Record<string, string> = {}
+
+  for (const section of sections) {
+    agentListOrder.push(sortableIdForFolder(section.folder.id))
+    if (!section.isRoot) agentFolders.push(section.folder)
+    for (const agent of section.agents) {
+      agentOrder.push(agent.slug)
+      // Default-folder members get NO assignment entry — "unfiled" stays the
+      // fallback state, which is what keeps dangling references self-healing.
+      if (!section.isRoot) agentFolderAssignments[agent.slug] = section.folder.id
+    }
+  }
+
+  return { agentOrder, agentListOrder, agentFolders, agentFolderAssignments }
+}
+
+// ─── Lookup ──────────────────────────────────────────────────────────────────
+
+export interface AgentLocation {
+  sectionIndex: number
+  memberIndex: number
+}
+
+export function locateAgent(sections: FolderSection[], slug: string): AgentLocation | null {
+  for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+    const memberIndex = sections[sectionIndex].agents.findIndex((a) => a.slug === slug)
+    if (memberIndex !== -1) return { sectionIndex, memberIndex }
+  }
+  return null
+}
+
+function sectionIndexForContainer(sections: FolderSection[], overId: string): number {
+  return sections.findIndex(
+    (s) =>
+      overId === sortableIdForFolder(s.folder.id) || overId === containerIdForFolder(s.folder.id)
+  )
+}
+
+/** Where a dragged agent would land, given whatever the pointer is over. */
+export interface AgentDropTarget {
+  folderId: string
+  index: number
+}
+
+export function resolveAgentDrop(
+  sections: FolderSection[],
+  overId: string
+): AgentDropTarget | null {
+  // The header and the body both mean "into this folder, at the end" — the
+  // header is the only way into a collapsed folder, which renders no body.
+  const bySection = sectionIndexForContainer(sections, overId)
+  if (bySection !== -1) {
+    const section = sections[bySection]
+    return { folderId: section.folder.id, index: section.agents.length }
+  }
+
+  const location = locateAgent(sections, overId)
+  if (!location) return null
+  return {
+    folderId: sections[location.sectionIndex].folder.id,
+    index: location.memberIndex,
+  }
+}
+
+/** The top-level slot a dragged folder would land in. */
+export function resolveFolderDrop(sections: FolderSection[], overId: string): number | null {
+  const bySection = sectionIndexForContainer(sections, overId)
+  if (bySection !== -1) return bySection
+
+  // Over an agent row: the slot of the section holding it.
+  const location = locateAgent(sections, overId)
+  return location ? location.sectionIndex : null
+}
+
+// ─── Mutations on the sections ───────────────────────────────────────────────
+
+/** Same semantics as dnd-kit's arrayMove: the item ends up AT `to`. */
+function move<T>(items: T[], from: number, to: number): T[] {
+  const next = items.slice()
+  const [item] = next.splice(from, 1)
+  next.splice(to, 0, item)
+  return next
+}
+
+function clamp(value: number, max: number): number {
+  return Math.max(0, Math.min(value, max))
+}
+
+export function moveAgent(
+  sections: FolderSection[],
+  slug: string,
+  target: AgentDropTarget
+): FolderSection[] {
+  const from = locateAgent(sections, slug)
+  if (!from) return sections
+  const source = sections[from.sectionIndex]
+
+  if (source.folder.id === target.folderId) {
+    const to = clamp(target.index, source.agents.length - 1)
+    if (to === from.memberIndex) return sections
+    const next = sections.slice()
+    next[from.sectionIndex] = { ...source, agents: move(source.agents, from.memberIndex, to) }
+    return next
+  }
+
+  const targetIndex = sections.findIndex((s) => s.folder.id === target.folderId)
+  if (targetIndex === -1) return sections
+
+  const agent = source.agents[from.memberIndex]
+  const next = sections.slice()
+  next[from.sectionIndex] = {
+    ...source,
+    agents: source.agents.filter((a) => a.slug !== slug),
+  }
+  const destination = next[targetIndex]
+  const agents = destination.agents.slice()
+  const insertAt = target.index < 0 || target.index > agents.length ? agents.length : target.index
+  agents.splice(insertAt, 0, agent)
+  next[targetIndex] = { ...destination, agents }
+  return next
+}
+
+/** Move a folder (the default one included) to a top-level slot. */
+export function moveFolder(
+  sections: FolderSection[],
+  folderId: string,
+  toIndex: number
+): FolderSection[] {
+  const from = sections.findIndex((s) => s.folder.id === folderId)
+  if (from === -1) return sections
+  const to = clamp(toIndex, sections.length - 1)
+  return to === from ? sections : move(sections, from, to)
+}
+
+/**
+ * Delete a folder, appending its members to the default folder. They would
+ * land there anyway once their assignments dangle; doing it explicitly keeps
+ * their relative order and lets the caller write the result in one update.
+ * The default folder itself cannot be dissolved.
+ */
+export function dissolveFolder(sections: FolderSection[], folderId: string): FolderSection[] {
+  if (folderId === ROOT_FOLDER_ID) return sections
+  const index = sections.findIndex((s) => s.folder.id === folderId)
+  if (index === -1) return sections
+  const dissolved = sections[index]
+
+  return sections
+    .filter((_, i) => i !== index)
+    .map((section) =>
+      section.isRoot ? { ...section, agents: [...section.agents, ...dissolved.agents] } : section
+    )
+}
+
+// ─── Mutations on the stored fields ──────────────────────────────────────────
+
+/**
+ * Assign an agent to a folder. `null` or the default folder both mean
+ * "unfiled": the key is deleted rather than written, preserving absence as
+ * the fallback state.
+ */
+export function assignAgentToFolder(
+  assignments: Record<string, string> | undefined,
+  slug: string,
+  folderId: string | null
+): Record<string, string> {
+  const next = { ...(assignments ?? {}) }
+  if (folderId === null || folderId === ROOT_FOLDER_ID) delete next[slug]
+  else next[slug] = folderId
+  return next
+}
+
+/** A name that does not collide with an existing folder ("New Folder 2", …). */
+export function uniqueFolderName(folders: AgentFolder[], base = DEFAULT_FOLDER_NAME): string {
+  const taken = new Set(folders.map((f) => f.name))
+  if (!taken.has(base)) return base
+  for (let n = 2; ; n++) {
+    const candidate = `${base} ${n}`
+    if (!taken.has(candidate)) return candidate
+  }
+}

--- a/src/shared/lib/services/user-settings-schema.test.ts
+++ b/src/shared/lib/services/user-settings-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { userSettingsSchema } from './user-settings-service'
+import { agentFolderSettingsWriteSchema, userSettingsSchema } from './user-settings-service'
 
 describe('userSettingsSchema agentOrder', () => {
   it('defaults to undefined when not provided', () => {
@@ -63,5 +63,180 @@ describe('userSettingsSchema home grid layouts', () => {
     })
 
     expect(result.homeGridMobileLayout).toBeUndefined()
+  })
+})
+
+describe('userSettingsSchema agent folders', () => {
+  it('leaves every folder field absent when not provided', () => {
+    const result = userSettingsSchema.parse({})
+    expect(result.agentFolders).toBeUndefined()
+    expect(result.agentFolderAssignments).toBeUndefined()
+    expect(result.agentListOrder).toBeUndefined()
+    expect(result.collapsedAgentFolders).toBeUndefined()
+  })
+
+  it('accepts a folder list and a slug→folder map', () => {
+    const result = userSettingsSchema.parse({
+      agentFolders: [{ id: 'f1', name: 'Work' }],
+      agentFolderAssignments: { 'my-agent': 'f1' },
+      collapsedAgentFolders: ['f1'],
+    })
+    expect(result.agentFolders).toEqual([{ id: 'f1', name: 'Work' }])
+    expect(result.agentFolderAssignments).toEqual({ 'my-agent': 'f1' })
+    expect(result.collapsedAgentFolders).toEqual(['f1'])
+  })
+
+  it('accepts a top-level order mixing agent slugs and folder markers', () => {
+    const result = userSettingsSchema.parse({
+      agentListOrder: ['my-agent', 'agent-folder::f1', 'other-agent'],
+    })
+    expect(result.agentListOrder).toEqual(['my-agent', 'agent-folder::f1', 'other-agent'])
+  })
+
+  it('keeps an order entry naming something that no longer exists', () => {
+    // buildAgentList ignores unresolvable entries at render time, which is what
+    // lets agent and folder deletion skip repairing this array.
+    const result = userSettingsSchema.parse({
+      agentListOrder: ['agent-folder::deleted', 'gone-agent'],
+    })
+    expect(result.agentListOrder).toEqual(['agent-folder::deleted', 'gone-agent'])
+  })
+
+  it('drops a malformed top-level order instead of failing the whole document', () => {
+    const result = userSettingsSchema.parse({ theme: 'dark', agentListOrder: { nope: 1 } })
+    expect(result.agentListOrder).toBeUndefined()
+    expect(result.theme).toBe('dark')
+  })
+
+  it('allows an empty folder name so a rename can be cleared mid-edit', () => {
+    const result = userSettingsSchema.parse({ agentFolders: [{ id: 'f1', name: '' }] })
+    expect(result.agentFolders).toEqual([{ id: 'f1', name: '' }])
+  })
+
+  it('keeps an assignment pointing at a folder that no longer exists', () => {
+    // Dangling assignments are resolved at render time (they fall back to the
+    // ungrouped root), so the schema must not reject or strip them — that is
+    // what lets folder deletion skip a cascade.
+    const result = userSettingsSchema.parse({
+      agentFolders: [],
+      agentFolderAssignments: { 'my-agent': 'deleted-folder' },
+    })
+    expect(result.agentFolderAssignments).toEqual({ 'my-agent': 'deleted-folder' })
+  })
+
+  it('drops a malformed folder list instead of failing the whole document', () => {
+    // getUserSettings() falls back to ALL defaults if the document fails to
+    // parse, so a bad folder blob must not be able to blank out theme or
+    // notification preferences.
+    const result = userSettingsSchema.parse({
+      theme: 'dark',
+      agentFolders: 'not-an-array',
+    })
+    expect(result.agentFolders).toBeUndefined()
+    expect(result.theme).toBe('dark')
+  })
+
+  it('drops a malformed assignments map instead of failing the whole document', () => {
+    const result = userSettingsSchema.parse({
+      theme: 'dark',
+      agentFolderAssignments: [1, 2, 3],
+    })
+    expect(result.agentFolderAssignments).toBeUndefined()
+    expect(result.theme).toBe('dark')
+  })
+
+  it('drops a folder entry missing an id without taking its siblings down', () => {
+    // Array validation must be per-element: the whole document is rewritten on
+    // every settings write, so an all-or-nothing failure here would turn one
+    // corrupt entry into permanent loss of every good folder on the next
+    // unrelated write.
+    const result = userSettingsSchema.parse({
+      agentFolders: [{ id: 'f1', name: 'Work' }, { name: 'no-id' }, { id: 'f2', name: 'Home' }],
+    })
+    expect(result.agentFolders).toEqual([
+      { id: 'f1', name: 'Work' },
+      { id: 'f2', name: 'Home' },
+    ])
+  })
+
+  it('drops a non-string assignment value without taking the rest of the map down', () => {
+    const result = userSettingsSchema.parse({
+      agentFolderAssignments: { 'my-agent': 'f1', 'other-agent': 5 },
+    })
+    expect(result.agentFolderAssignments).toEqual({ 'my-agent': 'f1' })
+  })
+
+  it('drops a non-string order entry without taking the rest of the order down', () => {
+    const result = userSettingsSchema.parse({
+      agentListOrder: ['agent-folder::f1', 42, 'agent-folder::f2'],
+    })
+    expect(result.agentListOrder).toEqual(['agent-folder::f1', 'agent-folder::f2'])
+  })
+
+  it('survives a round-trip through JSON', () => {
+    const original = userSettingsSchema.parse({
+      agentFolders: [{ id: 'f1', name: 'Work' }],
+      agentFolderAssignments: { 'my-agent': 'f1' },
+      agentListOrder: ['agent-folder::f1', 'my-agent'],
+    })
+    const roundTripped = userSettingsSchema.parse(JSON.parse(JSON.stringify(original)))
+    expect(roundTripped.agentFolders).toEqual([{ id: 'f1', name: 'Work' }])
+    expect(roundTripped.agentFolderAssignments).toEqual({ 'my-agent': 'f1' })
+    expect(roundTripped.agentListOrder).toEqual(['agent-folder::f1', 'my-agent'])
+  })
+
+  it('replaces the folder list on spread merge (not deep-merged)', () => {
+    const current = userSettingsSchema.parse({
+      agentFolders: [{ id: 'f1', name: 'Work' }, { id: 'f2', name: 'Personal' }],
+    })
+    const merged = { ...current, ...{ agentFolders: [{ id: 'f2', name: 'Personal' }] } }
+    const result = userSettingsSchema.parse(merged)
+    expect(result.agentFolders).toEqual([{ id: 'f2', name: 'Personal' }])
+  })
+})
+
+describe('agentFolderSettingsWriteSchema', () => {
+  // The stored schema above is lenient by design — reads must survive a
+  // corrupt blob — which means it can only DROP bad input, never reject it.
+  // On the write path that leniency would silently erase the field a
+  // malformed PUT targets, so the API route validates against this strict
+  // schema first and refuses the write instead.
+
+  it('accepts a well-formed folder write alongside unrelated fields', () => {
+    const result = agentFolderSettingsWriteSchema.safeParse({
+      theme: 'dark',
+      agentFolders: [{ id: 'f1', name: 'Work' }],
+      agentFolderAssignments: { 'my-agent': 'f1' },
+      agentListOrder: ['agent-folder::root', 'agent-folder::f1'],
+      collapsedAgentFolders: ['f1'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a write that touches none of the folder fields', () => {
+    expect(agentFolderSettingsWriteSchema.safeParse({ theme: 'dark' }).success).toBe(true)
+  })
+
+  it('rejects a folder entry missing an id instead of dropping it', () => {
+    const result = agentFolderSettingsWriteSchema.safeParse({
+      agentFolders: [{ id: 'f1', name: 'Work' }, { name: 'no-id' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a non-array folder list instead of erasing the stored one', () => {
+    expect(agentFolderSettingsWriteSchema.safeParse({ agentFolders: null }).success).toBe(false)
+  })
+
+  it('rejects a non-string assignment value instead of dropping it', () => {
+    const result = agentFolderSettingsWriteSchema.safeParse({
+      agentFolderAssignments: { 'my-agent': 5 },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a non-object body', () => {
+    expect(agentFolderSettingsWriteSchema.safeParse(null).success).toBe(false)
+    expect(agentFolderSettingsWriteSchema.safeParse([1]).success).toBe(false)
   })
 })

--- a/src/shared/lib/services/user-settings-service.ts
+++ b/src/shared/lib/services/user-settings-service.ts
@@ -25,6 +25,58 @@ const homeGridLayoutSchema = z.record(
   })
 )
 
+const agentFolderSchema = z.object({
+  id: z.string().min(1),
+  name: z.string(),
+})
+
+/**
+ * Read-tolerant list: a malformed element is dropped alone. Zod's array
+ * validation is all-or-nothing, so a plain `.catch(undefined)` would let one
+ * bad element discard every good sibling — and because writes re-serialize the
+ * whole document, the next unrelated write would persist that as real data
+ * loss.
+ */
+const lenientArray = <T extends z.ZodType>(element: T) =>
+  z
+    .array(z.unknown())
+    .transform((items) =>
+      items.flatMap((item) => {
+        const parsed = element.safeParse(item)
+        return parsed.success ? [parsed.data] : []
+      })
+    )
+    .optional()
+    .catch(undefined)
+
+/** Read-tolerant string map: a non-string value is dropped alone, same
+ * reasoning as `lenientArray`. */
+const lenientStringRecord = z
+  .record(z.string(), z.unknown())
+  .transform((record) => {
+    const out: Record<string, string> = {}
+    for (const [key, value] of Object.entries(record)) {
+      if (typeof value === 'string') out[key] = value
+    }
+    return out
+  })
+  .optional()
+  .catch(undefined)
+
+/**
+ * Strict shapes for the folder fields on the write path. The stored schema is
+ * deliberately lenient — reads must survive a corrupt blob — which means it
+ * can only drop bad input, never reject it. The API route validates incoming
+ * writes against this instead, so a malformed PUT is refused rather than
+ * silently erasing the user's folders.
+ */
+export const agentFolderSettingsWriteSchema = z.object({
+  agentFolders: z.array(agentFolderSchema).optional(),
+  agentFolderAssignments: z.record(z.string(), z.string()).optional(),
+  agentListOrder: z.array(z.string()).optional(),
+  collapsedAgentFolders: z.array(z.string()).optional(),
+})
+
 export const userSettingsSchema = z.object({
   theme: z.enum(['system', 'light', 'dark']).default('system'),
   notifications: notificationSettingsSchema.default({
@@ -41,6 +93,26 @@ export const userSettingsSchema = z.object({
   autoCheckUpdates: z.boolean().default(true),
   timezone: z.string().optional(),
   agentOrder: z.array(z.string()).optional(),
+  // Left-nav folders. A per-user projection over the shared agent list, like
+  // agentOrder — filing a shared agent never moves it for anyone else. Array
+  // order is the order folders render in. One level only, no nesting.
+  agentFolders: lenientArray(agentFolderSchema),
+  // agent slug → folder id. Both sides of this map are allowed to dangle: an
+  // id pointing at a deleted folder, or a slug for an agent the user can no
+  // longer see, resolves to the ungrouped root. That is what keeps folders
+  // free of referential cleanup on agent/folder deletion.
+  agentFolderAssignments: lenientStringRecord,
+  // Top level of the left nav, in order: `agent-folder::<id>` markers for
+  // every folder, the synthesized root included. Written wholesale from the
+  // rendered sections on every change; it cannot be derived from agentOrder
+  // because an empty folder has no member to sit behind. An earlier version of
+  // this model interleaved unfiled agent slugs here — those entries still
+  // parse and are ignored on read, which is the whole upgrade path. Entries
+  // naming something that no longer exists are ignored, and anything missing
+  // falls back to a sensible end of the list, so it never needs repairing.
+  agentListOrder: lenientArray(z.string()),
+  // Folder ids the user has collapsed. Absent id = expanded.
+  collapsedAgentFolders: lenientArray(z.string()),
   // Home graph view: user-dragged node positions, keyed by stable node id
   // (e.g. 'agent:{slug}', 'account:{id}'). Absent entries fall back to auto-layout.
   graphNodePositions: z.record(z.string(), z.object({ x: z.number(), y: z.number() })).optional(),


### PR DESCRIPTION
## What

One-level **folders** for organizing agents in the left nav. Like `agentOrder`, this is a per-user projection over the shared agent list — filing a shared agent never moves it for anyone else.

- The top level is folders only. **"Your Agents"** is a synthesized, always-present default folder (`id: 'root'`, never stored) holding every unfiled agent — reorderable and collapsible like the rest, never renamed or deleted. Its header hosts the hover **new-folder** button.
- File agents by **drag-and-drop** (live re-parenting mid-drag) or from the agent **context menu** ("Move to Folder", the path that works on touch), which can also create-and-file in one write.
- **Folder reordering** uses an insertion-point cue: the pointer's half of the target block decides above/below, and the same cue drives both the insert line and the drop, so the line cannot lie about the landing spot. Empty space above/below the list means first/last.
- **Dangling references self-heal** to the default folder (assignment → deleted folder, agent no longer visible), so agent/folder deletion needs no cascade and pre-folders settings need no migration. Deleting a folder releases its agents back to "Your Agents".
- The flat `agentOrder` is still written on every change, so the home grid, agent graph, and tray needed zero edits.

## Storage

Four new fields in the user-settings blob: `agentFolders`, `agentFolderAssignments` (slug → folder id; absence = unfiled), `agentListOrder` (folder markers — cannot be derived from `agentOrder`: an empty folder has no member to sit behind), `collapsedAgentFolders`. Stored fields parse **per-element** (one corrupt entry can't erase its siblings on the next write) and the PUT route **rejects** malformed folder fields with a 400 instead of silently dropping them.

## Correctness details worth knowing

- Settings writes derived from current settings use an **updater form** resolved when the scope-serialized mutation actually runs, so a filing queued behind an in-flight write can't revert it; tree writes rebase folder *names* the same way (drags own structure, renames own names).
- Custom collision detection is **pure at render** (dnd-kit calls it in `DndContext`'s render body); the folder drop cue commits from `onDragMove`. Hidden 0×0 member rows are excluded from the distance snap so drops on **collapsed** folders target the header and append. The dragged agent's current folder is *sticky* in collision detection, which is what kills the highlight-flash when sorting inside a folder.
- Optimistic views (tree, collapse state) are cleared only by their **own** write's settle — guards cover an older drop settling during a newer drag and rapid collapse toggles on slow connections. A failed tree write shows a toast instead of silently snapping back.
- Heavy row content is memoized behind thin sortable wrappers; sensor options are module constants (an inline literal rebuilds DndContext activators every render and breaks every row memo). Collapsed folder bodies stay **mounted** (`hidden`) so expanding 80 rows doesn't hitch.

## Tests

- **190 unit tests** across the folder lib, schema, sidebar, folder block, and context menu — including a harness that drives the real drag orchestration (collision detection → move → end) through the mocked `DndContext`'s captured props: cue-quadrant landings, keyboard fallback, drag cancel, settle races, collapsed-folder snap.
- **E2E** (`agent-folders.spec.ts`, 5 scenarios): drag filing + reload persistence + release-on-delete, cross-folder drags + folder placement among agents, within-folder sort flash regression (MutationObserver, proven 12→0), three-phase folder reordering with insert-line assertions, context-menu filing. Green 3× over: `--workers 1 --repeat-each 3` (repeats accumulate agents/folders, which is what surfaces long-list bugs; parallel workers share one settings row and clobber each other — not a product bug).
- `tsc`, `eslint`, unit suite, E2E all verified by exit code.

## Known limitations (deliberate)

Cross-**tab** writes can still revert each other's folder ops (whole-record writes from cache — the same exposure `agentOrder` has always had); keyboard drags mis-target when collapsed folders hold members (`sortableKeyboardCoordinates` accepts 0×0 rects — a11y follow-up); agent drops in the empty space below the list revert rather than appending.

https://claude.ai/code/session_011bCQPm4mXXSQoUpRZG5pcw