### PR TITLE
Replace the transcript follow engine: input-driven escape, convergent pinning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,6 +185,59 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # WebKit-engine regression suite on real macOS. Safari-class scroll and
+  # compositing bugs never reproduce in Chromium — and macOS WebKit runs on
+  # Apple's compositor, which is where the async-scroll rollbacks that kill
+  # live-edge following actually live. Starts with the follow regression
+  # (safari-follow.spec.ts); add future Safari-compatibility cases to the
+  # web-webkit Playwright project. Repeats because this bug class is
+  # probabilistic per run (~50% pre-fix): three repeats catch a regression
+  # with ~90% confidence per push.
+  e2e-webkit-macos:
+    runs-on: blacksmith-6vcpu-macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # 11.14.1 = newest npm with min-release-age support (needs >=11.10) where
+      # `npm ls --json --long` still works (broken in 11.15+, breaks electron-builder)
+      - name: Upgrade npm (pinned)
+        run: npm install -g npm@11.14.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild native modules
+        run: npm rebuild better-sqlite3
+
+      - name: Install Playwright WebKit
+        run: npx playwright install webkit
+
+      - name: Run WebKit regression suite
+        env:
+          PORT: '3000'
+          SUPERAGENT_DATA_DIR: .e2e-data/webkit
+          PLAYWRIGHT_OUTPUT_DIR: test-results/webkit
+          PLAYWRIGHT_HTML_REPORT: playwright-report/webkit
+        run: E2E_MOCK=true npx playwright test --project=web-webkit --repeat-each=3
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-webkit-artifacts
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-auth-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,8 +191,9 @@ jobs:
   # live-edge following actually live. Starts with the follow regression
   # (safari-follow.spec.ts); add future Safari-compatibility cases to the
   # web-webkit Playwright project. Repeats because this bug class is
-  # probabilistic per run (~50% pre-fix): three repeats catch a regression
-  # with ~90% confidence per push.
+  # probabilistic per run (~50% pre-fix): three repeats with retries off
+  # catch a regression with ~88% confidence per push. (Retries stay off —
+  # each retry would give a probabilistic failure another chance to pass.)
   e2e-webkit-macos:
     runs-on: blacksmith-6vcpu-macos-latest
     steps:
@@ -225,7 +226,10 @@ jobs:
           SUPERAGENT_DATA_DIR: .e2e-data/webkit
           PLAYWRIGHT_OUTPUT_DIR: test-results/webkit
           PLAYWRIGHT_HTML_REPORT: playwright-report/webkit
-        run: E2E_MOCK=true npx playwright test --project=web-webkit --repeat-each=3
+          # Serial: repeats of one timing-sensitive scroll test must not share
+          # the box with each other.
+          PLAYWRIGHT_WORKERS: '1'
+        run: E2E_MOCK=true npx playwright test --project=web-webkit --repeat-each=3 --retries=0
 
       - name: Upload Playwright artifacts
         if: always()

--- a/e2e/specs/safari-follow.spec.ts
+++ b/e2e/specs/safari-follow.spec.ts
@@ -1,0 +1,144 @@
+import { writeFileSync } from 'node:fs'
+import { test, expect, type Page } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+// Runs under the web-webkit project only (see playwright.config.ts).
+//
+// Safari computes fractional scroll metrics whenever page zoom is not 100%.
+// The follow library's smooth modes reconcile their own per-frame writes by
+// exact position equality, so at fractional zoom the spring never reads as
+// settled and its own frames can classify as user scrolling — following
+// disengages or oscillates with zero user input (upstream:
+// stackblitz-labs/use-stick-to-bottom#32, "only with smooth animation").
+// Chromium keeps these metrics integral, which is why this never reproduced
+// in development. CSS zoom on the root reproduces Safari's zoomed layout.
+const PAGE_ZOOM = '1.63'
+
+// Three thinking blocks long enough to overfill the card (internal scrolling
+// while live), so each pass ending collapses the card by its full body height
+// — a large one-commit shrink at the live edge while streaming continues.
+const PROMPT = 'think long passes please'
+
+declare global {
+  interface Window {
+    __rec?: {
+      frames: Array<Record<string, number>>
+      scrolls: Array<Record<string, number>>
+    }
+  }
+}
+
+function installRecorder(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+    const body = el.querySelector<HTMLElement>('[role="log"]')!
+    const rec: NonNullable<Window['__rec']> = { frames: [], scrolls: [] }
+    window.__rec = rec
+    el.addEventListener(
+      'scroll',
+      () => {
+        rec.scrolls.push({ t: performance.now(), scrollTop: el.scrollTop })
+      },
+      { passive: true },
+    )
+    const sample = () => {
+      const pillVisible = [...document.querySelectorAll('button')].some(
+        (b) => b.textContent?.includes('Scroll to bottom') && b.offsetParent !== null,
+      )
+      rec.frames.push({
+        t: performance.now(),
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        bodyHeight: body.offsetHeight,
+        pill: pillVisible ? 1 : 0,
+      })
+      requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  })
+}
+
+function scrollMetrics(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      distanceFromBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+    }
+  })
+}
+
+test.describe('WebKit fractional-zoom live follow', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await agentPage.createAgent(`Safari Follow ${testInfo.workerIndex}-${Date.now()}`)
+
+    // Zoom AFTER the app is up so every subsequent layout — and every scroll
+    // metric the follow code reads — is fractional, as in a zoomed Safari.
+    await page.evaluate((zoom) => {
+      document.documentElement.style.setProperty('zoom', zoom)
+    }, PAGE_ZOOM)
+  })
+
+  test('keeps following through streaming and thinking collapses with zero input', async ({ page }, testInfo) => {
+    test.setTimeout(240000)
+
+    // A long transcript first, so the scroller has real scroll range and the
+    // collapse clamps land against a distant maximum.
+    await sessionPage.sendMessage('stream a long story please')
+    await sessionPage.waitForUserMessageCount(1)
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')
+            return el ? el.scrollHeight - el.clientHeight : 0
+          }),
+        { timeout: 60000 },
+      )
+      .toBeGreaterThan(1500)
+    // The story turn must fully END before the next prompt — a message sent
+    // mid-turn is queued as a steering command and the scenario never runs.
+    await expect(sessionPage.getStopButton()).toBeHidden({ timeout: 30000 })
+
+    await sessionPage.sendMessage(PROMPT)
+    await sessionPage.waitForUserMessageCount(2)
+    await expect(page.getByTestId('message-list')).toBeVisible()
+    await installRecorder(page)
+
+    // No input of any kind from here: the hands-off reader riding the live
+    // edge. Following must survive the whole turn.
+    try {
+      await expect(
+        page.getByText('Done with all long thinking passes'),
+      ).toBeVisible({ timeout: 120000 })
+
+      await expect
+        .poll(async () => (await scrollMetrics(page)).distanceFromBottom, { timeout: 15000 })
+        .toBeLessThan(90)
+      await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
+    } finally {
+      const rec = await page.evaluate(() => window.__rec).catch(() => null)
+      if (rec) {
+        writeFileSync(testInfo.outputPath('follow-recorder.json'), JSON.stringify(rec))
+        console.log(
+          `[recorder] frames=${rec.frames.length} scrolls=${rec.scrolls.length} -> ${testInfo.outputPath('follow-recorder.json')}`,
+        )
+      }
+    }
+  })
+})

--- a/e2e/specs/safari-follow.spec.ts
+++ b/e2e/specs/safari-follow.spec.ts
@@ -6,14 +6,17 @@ import { SessionPage } from '../pages/session.page'
 
 // Runs under the web-webkit project only (see playwright.config.ts).
 //
-// Safari computes fractional scroll metrics whenever page zoom is not 100%.
-// The follow library's smooth modes reconcile their own per-frame writes by
-// exact position equality, so at fractional zoom the spring never reads as
-// settled and its own frames can classify as user scrolling — following
-// disengages or oscillates with zero user input (upstream:
-// stackblitz-labs/use-stick-to-bottom#32, "only with smooth animation").
-// Chromium keeps these metrics integral, which is why this never reproduced
-// in development. CSS zoom on the root reproduces Safari's zoomed layout.
+// WebKit scrolls asynchronously: the compositor can roll a programmatic
+// scrollTop write back to its last committed position, surfacing as a
+// genuine upward scroll event with no input behind it and unchanged
+// scrollHeight/clientHeight — exactly the shape of a reader escaping the
+// live edge. Position heuristics cannot tell the two apart; the follow
+// engine survives by demanding recent input evidence before releasing
+// follow, and otherwise converging back. Chromium commits programmatic
+// scrollTop synchronously, which is why this never reproduced in
+// development.
+//
+// Zoom approximates the zoomed Safari layouts where users actually hit this.
 const PAGE_ZOOM = '1.63'
 
 // Three thinking blocks long enough to overfill the card (internal scrolling
@@ -73,7 +76,7 @@ function scrollMetrics(page: Page) {
   })
 }
 
-test.describe('WebKit fractional-zoom live follow', () => {
+test.describe('WebKit async-scroll live follow', () => {
   let appPage: AppPage
   let agentPage: AgentPage
   let sessionPage: SessionPage
@@ -87,8 +90,8 @@ test.describe('WebKit fractional-zoom live follow', () => {
     await appPage.waitForAgentsLoaded()
     await agentPage.createAgent(`Safari Follow ${testInfo.workerIndex}-${Date.now()}`)
 
-    // Zoom AFTER the app is up so every subsequent layout — and every scroll
-    // metric the follow code reads — is fractional, as in a zoomed Safari.
+    // Zoom AFTER the app is up so layout matches a zoomed Safari — the
+    // configuration the follow loss was reported and reproduced under.
     await page.evaluate((zoom) => {
       document.documentElement.style.setProperty('zoom', zoom)
     }, PAGE_ZOOM)

--- a/e2e/specs/thinking-collapse-follow.spec.ts
+++ b/e2e/specs/thinking-collapse-follow.spec.ts
@@ -1,0 +1,154 @@
+import { writeFileSync } from 'node:fs'
+import { test, expect, type Page } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+// Matches the 'think long passes' mock scenario: three thinking blocks, each
+// long enough to overfill the card's max-height (internal scrolling while
+// live), so each pass ending collapses the card by its full body height —
+// a large one-commit content shrink at the live edge while the turn continues.
+const PROMPT = 'think long passes please'
+
+declare global {
+  interface Window {
+    __rec?: {
+      frames: Array<Record<string, number>>
+      scrolls: Array<Record<string, number>>
+    }
+  }
+}
+
+// Per-frame samples of the scroll geometry and the escape affordance, dumped
+// to the test output dir — when a run fails, the timeline around each collapse
+// is the diagnosis.
+function installRecorder(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+    const body = el.querySelector<HTMLElement>('[role="log"]')!
+    const rec: NonNullable<Window['__rec']> = { frames: [], scrolls: [] }
+    window.__rec = rec
+    el.addEventListener(
+      'scroll',
+      () => {
+        rec.scrolls.push({ t: performance.now(), scrollTop: el.scrollTop })
+      },
+      { passive: true },
+    )
+    const sample = () => {
+      const pillVisible = [...document.querySelectorAll('button')].some(
+        (b) => b.textContent?.includes('Scroll to bottom') && b.offsetParent !== null,
+      )
+      rec.frames.push({
+        t: performance.now(),
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        bodyHeight: body.offsetHeight,
+        cards: document.querySelectorAll('[data-testid="thinking-block"]').length,
+        openBodies: document.querySelectorAll('[data-testid="thinking-block-body"]').length,
+        pill: pillVisible ? 1 : 0,
+      })
+      requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  })
+}
+
+function scrollMetrics(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      distanceFromBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+    }
+  })
+}
+
+test.describe('Live thinking-card collapse', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await agentPage.createAgent(`Collapse Agent ${testInfo.workerIndex}-${Date.now()}`)
+  })
+
+  test('keeps following through thinking-card collapses with an idle held pointer', async ({ page }, testInfo) => {
+    test.setTimeout(240000)
+
+    // A long transcript first, so the scroller has real scroll range: each
+    // collapse must clamp scrollTop against a distant maximum (a transcript
+    // that fits the viewport degenerates — scrollTop just pins to 0).
+    await sessionPage.sendMessage('stream a long story please')
+    await sessionPage.waitForUserMessageCount(1)
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')
+            return el ? el.scrollHeight - el.clientHeight : 0
+          }),
+        { timeout: 60000 },
+      )
+      .toBeGreaterThan(1500)
+    // The story turn must fully END before the next prompt — a message sent
+    // mid-turn is recorded as a queued steering command and the thinking
+    // scenario never runs.
+    await expect(sessionPage.getStopButton()).toBeHidden({ timeout: 30000 })
+
+    await sessionPage.sendMessage(PROMPT)
+    await sessionPage.waitForUserMessageCount(2)
+    await expect(page.getByTestId('message-list')).toBeVisible()
+    await installRecorder(page)
+
+    // Zero scrolling, zero physical buttons — just a pointer the app BELIEVES
+    // is down: a press whose release was swallowed (a two-finger-tap context
+    // menu, focus moving away) leaves exactly this state behind. It must not
+    // turn the collapse clamps into "the user scrolled up" and kill
+    // following. (A physically held button is deliberately not used: content
+    // streaming under a real pressed cursor grows a text selection, and the
+    // follow library rightly pauses during selection.)
+    await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+      el.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 200,
+          clientY: 300,
+        }),
+      )
+    })
+
+    try {
+      // Wait out the whole turn (3 passes, then the answer text).
+      await expect(
+        page.getByText('Done with all long thinking passes'),
+      ).toBeVisible({ timeout: 120000 })
+
+      // Following must never have disengaged: at the end the viewport sits at
+      // the live edge with no scroll-to-bottom affordance.
+      await expect
+        .poll(async () => (await scrollMetrics(page)).distanceFromBottom, { timeout: 15000 })
+        .toBeLessThan(90)
+      await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
+    } finally {
+      const rec = await page.evaluate(() => window.__rec).catch(() => null)
+      if (rec) {
+        writeFileSync(testInfo.outputPath('follow-recorder.json'), JSON.stringify(rec))
+        console.log(
+          `[recorder] frames=${rec.frames.length} scrolls=${rec.scrolls.length} -> ${testInfo.outputPath('follow-recorder.json')}`,
+        )
+      }
+    }
+  })
+})

--- a/e2e/specs/thinking-collapse-follow.spec.ts
+++ b/e2e/specs/thinking-collapse-follow.spec.ts
@@ -116,7 +116,7 @@ test.describe('Live thinking-card collapse', () => {
     // turn the collapse clamps into "the user scrolled up" and kill
     // following. (A physically held button is deliberately not used: content
     // streaming under a real pressed cursor grows a text selection, and the
-    // follow library rightly pauses during selection.)
+    // follow engine rightly pauses during selection.)
     await page.evaluate(() => {
       const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
       el.dispatchEvent(

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,7 +148,6 @@
         "tsup": "^8.3.5",
         "tsx": "^4.19.2",
         "typescript": "^5.3.0",
-        "use-stick-to-bottom": "^1.1.6",
         "vite": "^7.0.0",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.0.18"
@@ -25739,22 +25738,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-stick-to-bottom": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/use-stick-to-bottom/-/use-stick-to-bottom-1.1.6.tgz",
-      "integrity": "sha512-z3Up8jYQGTkUCsGBnwg6/wj70KgXoW5Kz1AAc1j8MtQuYMBo6ZsdhrIXoegxa7gaMMilgQYyTohTrt3p94jHog==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/samdenty"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,6 @@
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
     "typescript": "^5.3.0",
-    "use-stick-to-bottom": "^1.1.6",
     "vite": "^7.0.0",
     "vite-plugin-pwa": "^1.3.0",
     "vitest": "^4.0.18"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,8 @@ const webTestIgnore = [
   '**/provider-api-key.spec.ts',
   // Needs a production build (service worker) — runs under playwright.pwa.config.ts.
   '**/pwa-precache.spec.ts',
+  // WebKit-engine regression (fractional-zoom follow) — runs under the web-webkit project.
+  '**/safari-follow.spec.ts',
 ]
 
 if (process.env.E2E_INCLUDE_A11Y !== 'true') {
@@ -80,6 +82,14 @@ export default defineConfig({
       name: 'web-chromium',
       testIgnore: webTestIgnore,
       use: { ...devices['Desktop Chrome'] },
+    },
+    // Safari's engine computes fractional scroll metrics at zoomed layouts —
+    // the follow regression this covers never reproduces in Chromium. Run
+    // explicitly with --project=web-webkit (needs `npx playwright install webkit`).
+    {
+      name: 'web-webkit',
+      testMatch: '**/safari-follow.spec.ts',
+      use: { ...devices['Desktop Safari'] },
     },
   ],
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ const webTestIgnore = [
   '**/provider-api-key.spec.ts',
   // Needs a production build (service worker) — runs under playwright.pwa.config.ts.
   '**/pwa-precache.spec.ts',
-  // WebKit-engine regression (fractional-zoom follow) — runs under the web-webkit project.
+  // WebKit-engine regression (async-scroll follow) — runs under the web-webkit project.
   '**/safari-follow.spec.ts',
 ]
 
@@ -83,7 +83,7 @@ export default defineConfig({
       testIgnore: webTestIgnore,
       use: { ...devices['Desktop Chrome'] },
     },
-    // Safari's engine computes fractional scroll metrics at zoomed layouts —
+    // WebKit's async compositor can roll programmatic scrollTop writes back —
     // the follow regression this covers never reproduces in Chromium. Run
     // explicitly with --project=web-webkit (needs `npx playwright install webkit`).
     {

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2853,20 +2853,50 @@ describe('MessageList', () => {
       renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       const el = screen.getByTestId('message-list')
       const geometry = mockTurnGeometry(el)
-      fireEvent.scroll(el) // baseline at the live edge
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el) // baseline at the live edge (699 joins the trail)
 
-      // WebKit's async scrolling can roll a programmatic follow write back to
-      // its last composited position: an upward, size-stable scroll event
-      // with zero input anywhere near it. That shape is the engine's, not
-      // the reader's — following must not disengage, and convergence must
-      // put the viewport back on the live edge.
-      geometry.setScrollTop(500)
+      // Content grows and convergence writes the new live edge.
+      geometry.setNaturalScrollHeight(1500)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1500)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(899))
+
+      // WebKit's async scrolling can roll that write back to the last
+      // composited position: an upward, size-stable scroll event with zero
+      // input anywhere near it, landing on a position the scroller recently
+      // held. That shape is the engine's, not the reader's — following must
+      // not disengage, and convergence must put the viewport back on the
+      // live edge.
+      geometry.setScrollTop(699)
       fireEvent.scroll(el)
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 250))
       })
       expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
-      expect(geometry.scrollTop).toBe(699)
+      expect(geometry.scrollTop).toBe(899)
+    })
+
+    it('releases follow when an input-less scroll lands off the recently-held trail', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      fireEvent.scroll(el) // baseline at the live edge
+
+      // A programmatic jump (app code, an extension, a test driving
+      // scrollTo) carries no input evidence either — but it lands where the
+      // scroller has NOT recently been. That is an escape, not a rollback:
+      // follow must release, and nothing may yank the reader back down.
+      geometry.setScrollTop(150)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(150)
     })
 
     it('ignores a bounce-back settling inside the live-edge band after a downward wheel', async () => {

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2224,7 +2224,7 @@ describe('MessageList', () => {
   })
 
   describe('windowing (long threads)', () => {
-    // BASE_WINDOW=300, LOAD_STEP=200 in message-list.tsx. Each message renders a
+    // BASE_WINDOW=300, LOAD_STEP=200 in use-message-list-scroll.ts. Each message renders a
     // bubble whose exact text is `m{i}`, so getByText/queryByText tells us precisely
     // which messages are mounted in the DOM.
     const manyMessages = (n: number): ApiMessageOrBoundary[] =>
@@ -2356,11 +2356,9 @@ describe('MessageList', () => {
       mockMessagesData.data = base
       const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       const el = screen.getByTestId('message-list')
-      // The follow library derives "the reader left the bottom" from scroll
-      // direction, so an escape needs a baseline event followed by an upward
-      // one; its classification is deferred a tick (to out-wait resize
-      // coincidence), hence the flush. Target lands mid-thread, not near the
-      // top, so no load-more expand triggers.
+      // An escape needs a baseline event followed by an upward one with
+      // stable geometry. Target lands mid-thread, not near the top, so no
+      // load-more expand triggers.
       mockScrollGeometry(el, { scrollHeight: 10000, clientHeight: 500, scrollTop: 9500 })
       fireEvent.scroll(el)
       el.scrollTop = 5000
@@ -2401,10 +2399,10 @@ describe('MessageList', () => {
   describe('new-turn scroll anchoring', () => {
     const pending = { localId: 'pending-turn', text: 'What changed?', sentAt: Date.now() }
 
-    // Live-edge following runs inside use-stick-to-bottom, driven by a
-    // ResizeObserver on the content wrapper. jsdom's stub never fires, so
-    // tests that assert the follow handoff install this controllable fake
-    // and fire content resizes explicitly.
+    // Live-edge following is convergence-driven: the scroll hook's
+    // ResizeObserver on the content wrapper re-pins after every resize.
+    // jsdom has no ResizeObserver, so tests that assert the follow handoff
+    // install this controllable fake and fire content resizes explicitly.
     class FakeResizeObserver {
       static instances: FakeResizeObserver[] = []
       observed: Element[] = []
@@ -2429,8 +2427,8 @@ describe('MessageList', () => {
         realResizeObserver = undefined
       }
     })
-    // Fires only the observers watching `contentEl` (the library's), not the
-    // component's own layout-sync observers on other elements.
+    // Fires only the observers watching `contentEl` (the follow engine's),
+    // not the reserve-sync observers on other elements.
     const fireContentResize = (contentEl: Element, height: number) => {
       for (const observer of FakeResizeObserver.instances) {
         if (observer.observed.includes(contentEl)) {
@@ -2521,8 +2519,8 @@ describe('MessageList', () => {
       )
 
       const anchor = screen.getByText('What changed?').closest('[data-turn-anchor-id]') as HTMLElement
-      // The follow library keeps a 1px allowance at the live edge (its target
-      // is scrollHeight - 1 - clientHeight), so the reading line settles at
+      // The engine keeps a 1px allowance at the live edge (its target is
+      // scrollHeight - 1 - clientHeight), so the reading line settles at
       // TURN_ANCHOR_TOP + 1.
       expect(anchor.getBoundingClientRect().top).toBe(101)
       expect(geometry.scrollTop).toBe(1099)
@@ -2535,8 +2533,8 @@ describe('MessageList', () => {
       const el = screen.getByTestId('message-list')
       const geometry = mockTurnGeometry(el)
 
-      // Escape by scrolling up (baseline event, then an upward one; the
-      // library's classification is deferred a tick).
+      // Escape by scrolling up (baseline event, then an upward one with
+      // stable geometry — the shape only a user can produce).
       fireEvent.scroll(el)
       geometry.setScrollTop(300)
       fireEvent.scroll(el)
@@ -2683,18 +2681,16 @@ describe('MessageList', () => {
         await new Promise((resolve) => setTimeout(resolve, 40))
       })
 
-      // The turn completes and collapses — the transition shield arms, and the
-      // browser clamp's echo is rightly discarded…
+      // The turn completes and collapses — the browser clamp's echo carries
+      // a size change and is rightly discarded…
       mockStreamState.isActive = false
       rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       geometry.setNaturalScrollHeight(900)
       geometry.setScrollTop(300)
       fireEvent.scroll(el)
 
-      // …but inside the same window the reader pages up. The shield swallows
-      // that scroll's classification too (only wheel escapes bypass it), so
-      // the deferred verification must recognize the upward gesture and mark
-      // the escape itself.
+      // …but right after, the reader pages up. The key input itself must
+      // disengage following — no scroll-event inference involved.
       fireEvent.keyDown(el, { key: 'PageUp' })
       geometry.setScrollTop(100)
       fireEvent.scroll(el)
@@ -2807,9 +2803,8 @@ describe('MessageList', () => {
       const geometry = mockTurnGeometry(el)
       const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
       fireEvent.scroll(el) // baseline at the live edge
-      // Give the library's ResizeObserver its baseline height, so the
-      // collapse below registers as a real (shielded) shrink rather than a
-      // first observation.
+      // Give the engine's ResizeObserver a baseline observation before the
+      // collapse.
       await act(async () => {
         fireContentResize(contentWrapper, 1300)
       })
@@ -2821,18 +2816,16 @@ describe('MessageList', () => {
       fireEvent.wheel(el, { deltaY: 40 })
 
       // The turn completes and collapses — the browser clamp fires an upward
-      // scroll event inside the tick's gesture window. The shield rightly
-      // discards the clamp's classification; the danger is the verification
-      // reading the clamp as a user's upward gesture.
+      // scroll event near the tick. Its size change marks it as layout-caused;
+      // it must not read as the user leaving the live edge.
       mockStreamState.isActive = false
       rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       geometry.setNaturalScrollHeight(900)
       geometry.setScrollTop(300)
       fireEvent.scroll(el)
 
-      // The next block mounts below inside the verification window: the
-      // reader now sits beyond the re-stick range (net shrink, so the
-      // library has nothing to chase yet).
+      // The next block mounts below: the reader now sits well behind the
+      // live edge (net shrink so far).
       geometry.setNaturalScrollHeight(1000)
       await act(async () => {
         fireContentResize(contentWrapper, 1000)
@@ -2852,30 +2845,34 @@ describe('MessageList', () => {
       expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
     })
 
-    it('reverses an escape latched during follow with only downward wheel input behind it', async () => {
+    it('ignores a bounce-back settling inside the live-edge band after a downward wheel', async () => {
+      installFakeResizeObserver()
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
       renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       const el = screen.getByTestId('message-list')
       const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
       fireEvent.scroll(el) // baseline at the live edge
+
+      // A downward wheel at the bottom can overshoot into elastic overscroll;
+      // the bounce-back is an upward, size-stable scroll with only downward
+      // input behind it. Inside the live-edge band it must not read as an
+      // escape and disengage following.
+      fireEvent.wheel(el, { deltaY: 40 })
+      geometry.setScrollTop(690)
+      fireEvent.scroll(el)
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 40))
       })
-
-      // A downward wheel tick, then a scroll event landing ABOVE the last
-      // position — the shape left behind when a follow write loses to
-      // concurrent native scrolling: the library reads it as the user
-      // scrolling up and latches an escape.
-      fireEvent.wheel(el, { deltaY: 40 })
-      geometry.setScrollTop(500)
-      fireEvent.scroll(el)
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 80))
-      })
-
-      // No escape intent backs the latch — following must recover on its own.
       expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
-      expect(geometry.scrollTop).toBe(699)
+
+      // Following stayed engaged: the next content growth re-pins the live edge.
+      geometry.setNaturalScrollHeight(1400)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1400)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(799))
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
     })
 
     it('never yanks a long-escaped reader who scrolls downward without reaching the bottom', async () => {
@@ -2913,8 +2910,8 @@ describe('MessageList', () => {
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
       const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       const el = screen.getByTestId('message-list')
-      // Real motion: the send scrolls via the animated glide, which the
-      // library only registers in its first animation frame.
+      // Real motion: the send travels via the animated glide, whose first
+      // write lands in its first animation frame.
       const geometry = mockTurnGeometry(el, { reducedMotion: false })
 
       rerender(
@@ -2923,9 +2920,9 @@ describe('MessageList', () => {
       expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
       expect(geometry.scrollTop).toBe(700) // pre-glide position; the glide travels from here
 
-      // The POST response assigns the uuid before the glide's first frame —
-      // a commit in the gap where state.animation is still unset. The reserve
-      // restore must not fire here and snap the viewport to the reading line.
+      // The POST response assigns the uuid before the glide's first frame.
+      // The reserve restore must not fire in that gap and snap the viewport
+      // to the reading line.
       rerender(
         <MessageList
           sessionId="s-1"
@@ -2951,7 +2948,7 @@ describe('MessageList', () => {
       expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
 
       // While the reserve holds, growth is absorbed by the spacer: the reader
-      // does not move (net-zero resize from the follow library's perspective).
+      // does not move (net-zero resize from the engine's perspective).
       geometry.setNaturalScrollHeight(1550)
       mockStreamState.streamingMessage = 'The response is growing'
       mockStreamState.isStreaming = true
@@ -2970,7 +2967,7 @@ describe('MessageList', () => {
       expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '0px' })
 
       // …and real content growth hands off to live-edge following, driven by
-      // the library's ResizeObserver on the content wrapper.
+      // the engine's ResizeObserver on the content wrapper.
       await act(async () => {
         fireContentResize(contentWrapper, 1800)
       })
@@ -2988,7 +2985,7 @@ describe('MessageList', () => {
       )
       expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
 
-      // The hold sits at 1099 (the library's 1px live-edge allowance), so an
+      // The hold sits at 1099 (the engine's 1px live-edge allowance), so an
       // upward move to 1020 consumes 79px of the reserve.
       fireEvent.wheel(el, { deltaY: -80 })
       geometry.setScrollTop(1020)
@@ -3091,9 +3088,8 @@ describe('MessageList', () => {
       const el = screen.getByTestId('message-list')
       const geometry = mockTurnGeometry(el)
       const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
-      // Long enough for the library's deferred scroll classification AND its
-      // resize-difference window (one rAF + a tick) to close — a scroll event
-      // arriving inside that window is discarded as resize-caused.
+      // Escape/attach classification is synchronous now; the flush only
+      // drains timers (the brief upward-gesture pin hold).
       const flushClassification = () =>
         act(async () => {
           await new Promise((resolve) => setTimeout(resolve, 40))
@@ -3146,8 +3142,8 @@ describe('MessageList', () => {
       renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       const el = screen.getByTestId('message-list')
       const geometry = mockTurnGeometry(el)
-      // The component's own observer watches the viewport (`el`); the follow
-      // library's watches only the content wrapper and never sees this.
+      // The engine observes the viewport (`el`) as well as the content
+      // wrapper; a viewport resize re-pins the live edge.
       const fireViewportResize = () => fireContentResize(el, 0)
 
       // At the live edge, a vertical shrink keeps the newest content at the
@@ -3157,8 +3153,7 @@ describe('MessageList', () => {
       fireViewportResize()
       expect(geometry.scrollTop).toBe(849)
 
-      // Let the resize's classification shield drain (one frame + a tick)
-      // before gesturing, mirroring a real pause between resize and scroll.
+      // A beat between resize and gesture, mirroring a real pause.
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 40))
       })

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2716,6 +2716,199 @@ describe('MessageList', () => {
       expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
     })
 
+    it('does not let a stale held pointer attribute a clamp: reserve intact, reading line restored', async () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(1099)
+      fireEvent.scroll(el) // baseline at the reading line
+
+      // A press whose release never arrived (a native context menu swallowed
+      // the pointerup, or focus moved away) — long stale by the time the
+      // transcript next changes. It must not read as a live gesture.
+      fireEvent.pointerDown(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 450))
+      })
+
+      // A transient shrink clamps the held reserve (a streamed block swapped
+      // for its shorter persisted copy). Nobody is gesturing: the clamp must
+      // not eat the reserve, and the reading line must be restored in the
+      // same pass.
+      geometry.setNaturalScrollHeight(1240)
+      geometry.setScrollTop(1040)
+      fireEvent.scroll(el)
+      mockStreamState.streamingMessage = 'A different working indicator'
+      mockStreamState.isStreaming = true
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '460px' })
+      expect(geometry.scrollTop).toBe(1099)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+    })
+
+    it('stops attributing scrolls to a drag once the window loses focus', async () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(1099)
+      fireEvent.scroll(el) // baseline at the reading line
+
+      // A real drag begins (press + movement)… then focus leaves the window
+      // and the pointerup never arrives.
+      fireEvent.pointerDown(el, { clientX: 10, clientY: 10 })
+      fireEvent(window, new MouseEvent('pointermove', { clientX: 10, clientY: 40 }))
+      fireEvent(window, new Event('blur'))
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 450))
+      })
+
+      // The later clamp is nobody's gesture: no eating, reading line restored.
+      geometry.setNaturalScrollHeight(1240)
+      geometry.setScrollTop(1040)
+      fireEvent.scroll(el)
+      mockStreamState.streamingMessage = 'A different working indicator'
+      mockStreamState.isStreaming = true
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '460px' })
+      expect(geometry.scrollTop).toBe(1099)
+    })
+
+    it('does not honor an upward clamp echo as an escape when input only pointed down', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'Long question' } }),
+        createAssistantMessage({
+          content: { text: 'Final answer' },
+          toolCalls: [createToolCall({ name: 'Bash' })],
+        }),
+      ]
+      mockStreamState.isActive = true
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el) // baseline at the live edge
+      // Give the library's ResizeObserver its baseline height, so the
+      // collapse below registers as a real (shielded) shrink rather than a
+      // first observation.
+      await act(async () => {
+        fireContentResize(contentWrapper, 1300)
+      })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+
+      // Idle trackpad noise: a DOWNWARD wheel tick while riding the bottom.
+      fireEvent.wheel(el, { deltaY: 40 })
+
+      // The turn completes and collapses — the browser clamp fires an upward
+      // scroll event inside the tick's gesture window. The shield rightly
+      // discards the clamp's classification; the danger is the verification
+      // reading the clamp as a user's upward gesture.
+      mockStreamState.isActive = false
+      rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      geometry.setNaturalScrollHeight(900)
+      geometry.setScrollTop(300)
+      fireEvent.scroll(el)
+
+      // The next block mounts below inside the verification window: the
+      // reader now sits beyond the re-stick range (net shrink, so the
+      // library has nothing to chase yet).
+      geometry.setNaturalScrollHeight(1000)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1000)
+      })
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+      // A down-tick cannot justify leaving the live edge: following must
+      // survive the collapse and keep chasing growth.
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+      geometry.setNaturalScrollHeight(1100)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1100)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(499))
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+    })
+
+    it('reverses an escape latched during follow with only downward wheel input behind it', async () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      fireEvent.scroll(el) // baseline at the live edge
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+
+      // A downward wheel tick, then a scroll event landing ABOVE the last
+      // position — the shape left behind when a follow write loses to
+      // concurrent native scrolling: the library reads it as the user
+      // scrolling up and latches an escape.
+      fireEvent.wheel(el, { deltaY: 40 })
+      geometry.setScrollTop(500)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+
+      // No escape intent backs the latch — following must recover on its own.
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(699)
+    })
+
+    it('never yanks a long-escaped reader who scrolls downward without reaching the bottom', async () => {
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      fireEvent.scroll(el) // baseline at the live edge
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+
+      // The reader escaped a while ago…
+      geometry.setScrollTop(200)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+
+      // …and now wheels DOWN a little, still far above the live edge. That
+      // gesture-driven scroll must not be "reversed" into a trip to the
+      // bottom — they never re-engaged following.
+      fireEvent.wheel(el, { deltaY: 40 })
+      geometry.setScrollTop(260)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 80))
+      })
+      expect(geometry.scrollTop).toBe(260)
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+    })
+
     it('does not let the reserve restore preempt the send glide before its first frame', () => {
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
       const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2356,11 +2356,12 @@ describe('MessageList', () => {
       mockMessagesData.data = base
       const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       const el = screen.getByTestId('message-list')
-      // An escape needs a baseline event followed by an upward one with
-      // stable geometry. Target lands mid-thread, not near the top, so no
-      // load-more expand triggers.
+      // An escape is input-driven: the upward wheel releases following.
+      // Target lands mid-thread, not near the top, so no load-more expand
+      // triggers.
       mockScrollGeometry(el, { scrollHeight: 10000, clientHeight: 500, scrollTop: 9500 })
       fireEvent.scroll(el)
+      fireEvent.wheel(el, { deltaY: -40 })
       el.scrollTop = 5000
       fireEvent.scroll(el)
       await act(async () => {
@@ -2533,9 +2534,10 @@ describe('MessageList', () => {
       const el = screen.getByTestId('message-list')
       const geometry = mockTurnGeometry(el)
 
-      // Escape by scrolling up (baseline event, then an upward one with
-      // stable geometry — the shape only a user can produce).
+      // Escape: an upward wheel reaching the scroller releases following at
+      // the input itself; the scroll events land where it took the reader.
       fireEvent.scroll(el)
+      fireEvent.wheel(el, { deltaY: -40 })
       geometry.setScrollTop(300)
       fireEvent.scroll(el)
       await act(async () => {
@@ -2845,6 +2847,28 @@ describe('MessageList', () => {
       expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
     })
 
+    it('converges back instead of escaping when an upward scroll has no input behind it', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      fireEvent.scroll(el) // baseline at the live edge
+
+      // WebKit's async scrolling can roll a programmatic follow write back to
+      // its last composited position: an upward, size-stable scroll event
+      // with zero input anywhere near it. That shape is the engine's, not
+      // the reader's — following must not disengage, and convergence must
+      // put the viewport back on the live edge.
+      geometry.setScrollTop(500)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(699)
+    })
+
     it('ignores a bounce-back settling inside the live-edge band after a downward wheel', async () => {
       installFakeResizeObserver()
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
@@ -2886,6 +2910,7 @@ describe('MessageList', () => {
       })
 
       // The reader escaped a while ago…
+      fireEvent.wheel(el, { deltaY: -60 })
       geometry.setScrollTop(200)
       fireEvent.scroll(el)
       await act(async () => {
@@ -3107,7 +3132,8 @@ describe('MessageList', () => {
       })
       await waitFor(() => expect(geometry.scrollTop).toBe(799))
 
-      // An upward scroll escapes: subsequent growth no longer moves the reader.
+      // An upward wheel escapes: subsequent growth no longer moves the reader.
+      fireEvent.wheel(el, { deltaY: -40 })
       geometry.setScrollTop(600)
       fireEvent.scroll(el)
       await flushClassification()
@@ -3161,6 +3187,7 @@ describe('MessageList', () => {
       // Escaped readers keep their place instead: browsers anchor the top
       // edge on resize, and the pin must not yank them to the bottom.
       fireEvent.scroll(el)
+      fireEvent.wheel(el, { deltaY: -40 })
       geometry.setScrollTop(500)
       fireEvent.scroll(el)
       await act(async () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -819,10 +819,10 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     hasTurnStartingPendingMessage,
   ])
 
-  // All scrolling behavior — live-edge following with gesture attribution,
-  // the new-turn reading-line reserve, windowed rendering of long histories.
-  // The domain values passed through exist so the hook re-syncs its reserve
-  // and guards its transitions on the commits that change transcript layout.
+  // All scrolling behavior — live-edge following (the owned engine), the
+  // new-turn reading-line reserve, windowed rendering of long histories. The
+  // domain values passed through exist so the hook re-syncs its reserve on
+  // the commits that change transcript layout.
   const {
     scrollRef,
     contentRef,
@@ -834,13 +834,14 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     hiddenCount,
     handleScroll,
     handleWheelGesture,
-    handleTouchGesture,
     handlePointerDown,
     handleScrollKey,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
   } = useMessageListScroll({
     visibleMessages,
     pendingUserMessages,
-    completedTurnCount: completedTurns.length,
     bottomInset,
     hasOlder,
     isFetchingOlder,
@@ -1081,7 +1082,10 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         ref={scrollRef}
         onScroll={handleScroll}
         onWheel={handleWheelGesture}
-        onTouchMove={handleTouchGesture}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
         onPointerDown={handlePointerDown}
         onKeyDown={handleScrollKey}
         role="region"

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -37,8 +37,10 @@ import {
   useMemo,
   Fragment,
   type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type UIEvent as ReactUIEvent,
+  type WheelEvent as ReactWheelEvent,
 } from 'react'
 import { useStickToBottom } from 'use-stick-to-bottom'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
@@ -77,8 +79,24 @@ const TURN_ANCHOR_TOP = 100
 // a held-down pointer for scrollbar drags). A layout clamp from shrinking
 // content carries no fresh gesture and passes through untouched.
 const SCROLL_GESTURE_WINDOW_MS = 400
+// A press only becomes a drag (and thereby a scroll gesture) once the pointer
+// travels this far from where it went down.
+const POINTER_DRAG_THRESHOLD_PX = 4
 const TURN_WORK_REVEAL_CLASS = 'animate-in fade-in-0 slide-in-from-top-2 duration-200 ease-out motion-reduce:animate-none'
 const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
+const UPWARD_SCROLL_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
+
+// Mirrors the browser's scroll chaining for wheel input: a nested scrollable
+// consumes the wheel while it can still move in that direction; only at its
+// edge does the event scroll the ancestor.
+function nestedScrollableConsumesWheel(el: HTMLElement, deltaY: number): boolean {
+  if (el.scrollHeight <= el.clientHeight) return false
+  const { overflowY } = getComputedStyle(el)
+  if (overflowY !== 'auto' && overflowY !== 'scroll') return false
+  if (deltaY < 0) return el.scrollTop > 0
+  if (deltaY > 0) return el.scrollTop < el.scrollHeight - el.clientHeight - 1
+  return false
+}
 const isManualCompactCommand = (text: string) => /^\/compact(?:\s|$)/.test(text.trim())
 
 const prefersReducedMotion = () =>
@@ -461,11 +479,25 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
   const lastScrollTopRef = useRef(0)
   const lastGestureAtRef = useRef(0)
-  // Stamped when a gesture-attributed scroll event actually moved the reader
-  // upward — a stronger signal than lastGestureAtRef (which a downward wheel
-  // also stamps), used to honor escapes the transition shield swallowed.
+  // Stamped only by gestures that can justify LEAVING the live edge: wheel-up
+  // reaching this scroller, touch, upward scroll keys, an actual drag. A
+  // downward wheel or a bare click stamps lastGestureAtRef but never this —
+  // otherwise a browser clamp landing near such input reads as the user
+  // scrolling away and kills following (idle trackpad noise near a thinking
+  // card collapse was enough).
+  const lastEscapeIntentAtRef = useRef(0)
+  // Stamped when a gesture-attributed scroll event moved the reader upward
+  // AND escape intent backs it — used to honor escapes the transition shield
+  // swallowed.
   const lastUpwardGestureAtRef = useRef(0)
   const pointerDownRef = useRef(false)
+  const pointerDownAtRef = useRef(0)
+  // A press only becomes a scroll gesture once the pointer moves (a scrollbar
+  // drag); a motionless press — or one whose release was swallowed by a native
+  // context menu or a focus change — must not gesture-attribute scroll events
+  // indefinitely.
+  const pointerDragRef = useRef(false)
+  const pointerDownPosRef = useRef<{ x: number; y: number } | null>(null)
   // True from a send until its scroll-to-reading-line settles. The library
   // only assigns state.animation in its first animation frame, so this is the
   // signal that covers the whole interval (a commit landing between the send
@@ -589,6 +621,51 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   // reversal, so a reader who actually leaves during the window stays left.
   const verifyFollowTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   useEffect(() => () => clearTimeout(verifyFollowTimerRef.current), [])
+  // Verify shortly after a transition — or after a gesture-driven scroll —
+  // that following's engagement still matches what the user actually did.
+  // `intentBacked` marks an arming scroll produced by a live escape intent:
+  // any latch it caused is genuine and must not be reversed.
+  const armFollowVerification = useCallback((intentBacked: boolean) => {
+    const transitionAt = performance.now()
+    // Only a disengage that HAPPENS inside this window is suspect. A reader
+    // who left the live edge long ago and then scrolls (even downward) must
+    // never be yanked back — reversal applies solely to follows that were
+    // still engaged when the window opened.
+    const wasFollowing = stickState.isAtBottom
+    clearTimeout(verifyFollowTimerRef.current)
+    verifyFollowTimerRef.current = setTimeout(() => {
+      // A disengage inside the window with nothing to justify it can only be
+      // a clamp echo or a follow-write misread as an upward scroll — reverse
+      // it. An active drag, escape intent inside the window, or a press
+      // around the transition (a scrollbar track click pages without moving
+      // the pointer) all say the reader may genuinely own their position.
+      const userMayOwnPosition =
+        intentBacked ||
+        (pointerDownRef.current && pointerDragRef.current) ||
+        lastEscapeIntentAtRef.current >= transitionAt ||
+        (pointerDownRef.current &&
+          pointerDownAtRef.current >= transitionAt - SCROLL_GESTURE_WINDOW_MS)
+      if (!userMayOwnPosition && wasFollowing && !stickState.isAtBottom) {
+        void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
+        return
+      }
+      // The shield cuts both ways: while it holds, the library also discards
+      // the scroll classification of genuine keyboard, touch, and scrollbar
+      // escapes (wheel-up escapes through its own handler and is unaffected).
+      // If an intent-backed gesture moved the reader upward during the window
+      // yet following still reads engaged and they are beyond the re-stick
+      // range, that escape was swallowed — honor it, or the next growth would
+      // yank them back down. Reserve eating is unaffected: it re-bases the
+      // reading line onto the reader, keeping them within the re-stick range.
+      if (
+        stickState.isAtBottom &&
+        lastUpwardGestureAtRef.current >= transitionAt &&
+        !stickState.isNearBottom
+      ) {
+        stickStopScroll()
+      }
+    }, 40)
+  }, [stickState, stickScrollToBottom, stickStopScroll])
   const protectFollowTransition = useCallback(() => {
     if (stickState.resizeDifference === 0) {
       stickState.resizeDifference = 1
@@ -602,32 +679,8 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         }, 1)
       })
     }
-    const transitionAt = performance.now()
-    clearTimeout(verifyFollowTimerRef.current)
-    verifyFollowTimerRef.current = setTimeout(() => {
-      const gestured =
-        pointerDownRef.current || lastGestureAtRef.current >= transitionAt
-      if (!gestured && !stickState.isAtBottom) {
-        void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
-        return
-      }
-      // The shield cuts both ways: while it holds, the library also discards
-      // the scroll classification of genuine keyboard, touch, and scrollbar
-      // escapes (wheel-up escapes through its own handler and is unaffected).
-      // If a gesture moved the reader upward during the window yet following
-      // still reads engaged and they are beyond the re-stick range, that
-      // escape was swallowed — honor it, or the next growth would yank them
-      // back down. Reserve eating is unaffected: it re-bases the reading line
-      // onto the reader, keeping them within the re-stick range.
-      if (
-        stickState.isAtBottom &&
-        lastUpwardGestureAtRef.current >= transitionAt &&
-        !stickState.isNearBottom
-      ) {
-        stickStopScroll()
-      }
-    }, 40)
-  }, [stickState, stickScrollToBottom, stickStopScroll])
+    armFollowVerification(false)
+  }, [stickState, armFollowVerification])
 
   // Keep the newly-sent turn fixed at its reading line while the response uses
   // up the reserved room below it. The spacer inflates scrollHeight so that the
@@ -663,7 +716,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // below the target by construction), and while any other scroll
     // animation is in flight.
     const gestureDriven =
-      pointerDownRef.current ||
+      (pointerDownRef.current && pointerDragRef.current) ||
       performance.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
     const target = Math.max(0, stickState.calculatedTargetScrollTop)
     if (
@@ -700,10 +753,24 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     // Only scroll events that closely follow a real gesture may adjust the
     // reserve. Programmatic writes (the follow animation) and layout clamps
     // from shrinking content reach this handler too, but carry no fresh
-    // wheel/touch/key stamp and no held pointer, so they pass through.
+    // wheel/touch/key stamp and no moving drag, so they pass through. A held
+    // pointer counts only while it is an actual drag — a stale press (its
+    // release swallowed by a context menu or a focus change) must not keep
+    // attributing clamps to the user indefinitely.
+    const now = performance.now()
+    const activeDrag = pointerDownRef.current && pointerDragRef.current
     const gestureDriven =
-      pointerDownRef.current ||
-      performance.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
+      activeDrag || now - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
+    const escapeIntentLive =
+      activeDrag || now - lastEscapeIntentAtRef.current < SCROLL_GESTURE_WINDOW_MS
+
+    // A gesture-driven scroll can be misread by the follow library as an
+    // upward escape even when the input pointed down (its follow writes and
+    // the native scroll fight over scrollTop, and the loser's position reads
+    // as "scrolled up"). Re-verify shortly after every gesture-driven scroll
+    // so a latch with no escape intent behind it gets reversed. Armed before
+    // the upward stamp below so that stamp postdates the verification window.
+    if (gestureDriven) armFollowVerification(escapeIntentLive)
 
     // Blank reserve is one-way. When the reader moves upward, consume the same
     // number of pixels from the spacer. The new scroll position becomes the
@@ -711,7 +778,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     const anchoredTurn = anchoredTurnRef.current
     const upwardDelta = Math.max(0, previousScrollTop - el.scrollTop)
     const downwardDelta = Math.max(0, el.scrollTop - previousScrollTop)
-    if (gestureDriven && upwardDelta > 0) {
+    if (gestureDriven && upwardDelta > 0 && escapeIntentLive) {
       lastUpwardGestureAtRef.current = performance.now()
     }
     if (gestureDriven && anchoredTurn && upwardDelta > 0 && bottomSpacerHeightRef.current > 0) {
@@ -760,7 +827,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         })
       }
     }
-  }, [hiddenCount, hasOlder, isFetchingOlder, fetchOlder, setBottomSpacerHeight, scrollRef])
+  }, [hiddenCount, hasOlder, isFetchingOlder, fetchOlder, setBottomSpacerHeight, scrollRef, armFollowVerification])
 
   // After a scroll-up expansion adds older messages above the viewport, restore the
   // scroll position so the content the user was reading stays put (no jump).
@@ -1321,33 +1388,94 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   }, [syncTurnReserve, scrollRef, stickState, protectFollowTransition, isLoading, error])
 
   // Escape from following is owned by the stick-to-bottom library (wheel
-  // direction, scroll direction, selection). These stamps exist only so the
-  // scroll handler can attribute reserve adjustments to a live gesture.
-  const handleUserScrollIntent = useCallback(() => {
-    lastGestureAtRef.current = performance.now()
+  // direction, scroll direction, selection). These stamps exist so the scroll
+  // handler can attribute reserve adjustments to a live gesture, and so the
+  // deferred verification can tell escape-capable input (wheel-up, touch,
+  // upward keys, a drag) from input that never leaves the live edge.
+  // A wheel consumed by a nested scrollable (the thinking card's body, a code
+  // block) never moves the transcript and must not count as a transcript
+  // gesture; scroll chaining hands the wheel to us only once the inner
+  // scroller is at its edge, which the walk below mirrors.
+  const handleWheelGesture = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
+    const outer = scrollRef.current
+    if (!outer) return
+    let node = event.target as HTMLElement | null
+    while (node && node !== outer) {
+      if (nestedScrollableConsumesWheel(node, event.deltaY)) return
+      node = node.parentElement
+    }
+    const now = performance.now()
+    lastGestureAtRef.current = now
+    if (event.deltaY < 0) lastEscapeIntentAtRef.current = now
+  }, [scrollRef])
+
+  // Touch direction isn't knowable from a single event without tracking touch
+  // points; treat any touch scroll as escape-capable.
+  const handleTouchGesture = useCallback(() => {
+    const now = performance.now()
+    lastGestureAtRef.current = now
+    lastEscapeIntentAtRef.current = now
   }, [])
 
-  // Scrollbar drags emit no wheel/touch/key events — track the held pointer so
-  // a multi-second drag stays attributable beyond the gesture window.
-  const handlePointerDown = useCallback(() => {
+  // Scrollbar interactions emit no wheel/touch/key events — track the held
+  // pointer. Only a pointer that actually moves is a drag; a motionless press
+  // (or one whose release never arrived) must not stay a gesture forever.
+  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return
     pointerDownRef.current = true
+    pointerDragRef.current = false
+    pointerDownAtRef.current = performance.now()
+    pointerDownPosRef.current = { x: event.clientX, y: event.clientY }
     lastGestureAtRef.current = performance.now()
   }, [])
   useEffect(() => {
     const release = () => {
       pointerDownRef.current = false
+      pointerDragRef.current = false
+      pointerDownPosRef.current = null
+    }
+    const move = (event: PointerEvent) => {
+      if (!pointerDownRef.current) return
+      if (!pointerDragRef.current) {
+        const start = pointerDownPosRef.current
+        if (!start) return
+        if (
+          Math.abs(event.clientX - start.x) + Math.abs(event.clientY - start.y) <
+          POINTER_DRAG_THRESHOLD_PX
+        ) {
+          return
+        }
+        pointerDragRef.current = true
+      }
+      const now = performance.now()
+      lastGestureAtRef.current = now
+      lastEscapeIntentAtRef.current = now
     }
     window.addEventListener('pointerup', release)
     window.addEventListener('pointercancel', release)
+    window.addEventListener('pointermove', move)
+    // A native context menu (two-finger tap) or a focus change can swallow the
+    // pointerup — without these, the "held pointer" would outlive the gesture
+    // indefinitely and every later browser clamp would read as user scrolling.
+    window.addEventListener('blur', release)
+    window.addEventListener('contextmenu', release)
     return () => {
       window.removeEventListener('pointerup', release)
       window.removeEventListener('pointercancel', release)
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('blur', release)
+      window.removeEventListener('contextmenu', release)
     }
   }, [])
 
   const handleScrollKey = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (SCROLL_KEYS.has(event.key)) handleUserScrollIntent()
-  }, [handleUserScrollIntent])
+    if (!SCROLL_KEYS.has(event.key)) return
+    const now = performance.now()
+    lastGestureAtRef.current = now
+    const upward =
+      UPWARD_SCROLL_KEYS.has(event.key) || (event.key === ' ' && event.shiftKey)
+    if (upward) lastEscapeIntentAtRef.current = now
+  }, [])
 
   // Peer messages still worth showing optimistically: not our own, and the
   // persisted copy (by uuid, or — for queued/steering messages whose uuid the
@@ -1546,8 +1674,8 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
         style={{ overflowAnchor: 'none' }}
         ref={scrollRef}
         onScroll={handleScroll}
-        onWheel={handleUserScrollIntent}
-        onTouchMove={handleUserScrollIntent}
+        onWheel={handleWheelGesture}
+        onTouchMove={handleTouchGesture}
         onPointerDown={handlePointerDown}
         onKeyDown={handleScrollKey}
         role="region"

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -30,23 +30,17 @@ import { useWorkflow } from '@renderer/context/workflow-context'
 import { useRenderTracker } from '@renderer/lib/perf'
 import {
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
   useCallback,
   useMemo,
   Fragment,
-  type KeyboardEvent as ReactKeyboardEvent,
-  type PointerEvent as ReactPointerEvent,
   type ReactNode,
-  type UIEvent as ReactUIEvent,
-  type WheelEvent as ReactWheelEvent,
 } from 'react'
-import { useStickToBottom } from 'use-stick-to-bottom'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
 import type { ApiMessage, ApiCompactBoundary, ApiMemoryRecall, ApiInformational } from '@shared/lib/types/api'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
-import { MESSAGES_PAGE_LIMIT, MESSAGES_PAGE_OLDER_LIMIT } from '@shared/lib/messages-page'
+import { useMessageListScroll } from './use-message-list-scroll'
 import {
   collectEmbeddedImageAliases,
   reuseEqualEmbeddedImageAliases,
@@ -57,50 +51,9 @@ import {
 // Keep in sync with SYSTEM_MESSAGE_PREFIX in agent-container/src/claude-code.ts
 const SYSTEM_MESSAGE_PREFIX = '[SYSTEM] '
 
-// On very long threads we render only a trailing window of messages to keep the
-// DOM small. Sessions with <= BASE_WINDOW visible items render in full, so small
-// and medium threads are completely unaffected. Scrolling near the top reveals
-// LOAD_STEP more at a time. The window is a fixed-size tail slice, so while new
-// messages stream in at the bottom the oldest rendered ones drop off the top and
-// the DOM node count stays flat. The window only grows on an explicit scroll-up
-// and is reset when the session changes.
-const BASE_WINDOW = MESSAGES_PAGE_LIMIT
-const LOAD_STEP = MESSAGES_PAGE_OLDER_LIMIT
-const TURN_ANCHOR_TOP = 100
-// Live-edge following (engage/escape/resume and the smooth chase) is owned by
-// use-stick-to-bottom: it derives escape from user-attributable signals (wheel
-// direction, scroll direction, text selection) and drives the viewport from
-// content resizes — scroll-event echoes of its own writes can never disengage
-// it. The layer in this file only manages what sits on top of that: the
-// new-turn reading-line reserve (the spacer) and windowed history loading.
-//
-// Scroll events cannot say who caused them, so the reserve adjustments below
-// only act on events that closely follow a real gesture (wheel/touch/keys, or
-// a held-down pointer for scrollbar drags). A layout clamp from shrinking
-// content carries no fresh gesture and passes through untouched.
-const SCROLL_GESTURE_WINDOW_MS = 400
-// A press only becomes a drag (and thereby a scroll gesture) once the pointer
-// travels this far from where it went down.
-const POINTER_DRAG_THRESHOLD_PX = 4
 const TURN_WORK_REVEAL_CLASS = 'animate-in fade-in-0 slide-in-from-top-2 duration-200 ease-out motion-reduce:animate-none'
-const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
-const UPWARD_SCROLL_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
 
-// Mirrors the browser's scroll chaining for wheel input: a nested scrollable
-// consumes the wheel while it can still move in that direction; only at its
-// edge does the event scroll the ancestor.
-function nestedScrollableConsumesWheel(el: HTMLElement, deltaY: number): boolean {
-  if (el.scrollHeight <= el.clientHeight) return false
-  const { overflowY } = getComputedStyle(el)
-  if (overflowY !== 'auto' && overflowY !== 'scroll') return false
-  if (deltaY < 0) return el.scrollTop > 0
-  if (deltaY > 0) return el.scrollTop < el.scrollHeight - el.clientHeight - 1
-  return false
-}
 const isManualCompactCommand = (text: string) => /^\/compact(?:\s|$)/.test(text.trim())
-
-const prefersReducedMotion = () =>
-  window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
 interface CompletedTurn {
   id: string
@@ -456,63 +409,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     return () => clearTimeout(timerId)
   }, [pendingUserMessages, peerUserMessages, isActive, onPendingMessageAppeared, sessionId, draftsStore])
 
-  // Live-edge following. `isAtBottom` goes false only on a user-attributable
-  // escape (wheel up, upward scroll, selection drag) and comes back when the
-  // reader returns near the bottom — geometry sampled from our own writes can
-  // never disengage it. Content growth is followed from the library's
-  // ResizeObserver on `contentRef`, so the bottom inset below must be a real
-  // element (content-box), not container padding.
-  const {
-    scrollRef,
-    contentRef,
-    scrollToBottom: stickScrollToBottom,
-    stopScroll: stickStopScroll,
-    isAtBottom,
-    state: stickState,
-  } = useStickToBottom({
-    initial: 'instant',
-    ...(prefersReducedMotion() ? { resize: 'instant' as const } : {}),
-  })
-  const contentBodyRef = useRef<HTMLDivElement>(null)
-  const bottomSpacerRef = useRef<HTMLDivElement>(null)
-  const bottomSpacerHeightRef = useRef(0)
-  const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
-  const lastScrollTopRef = useRef(0)
-  const lastGestureAtRef = useRef(0)
-  // Stamped only by gestures that can justify LEAVING the live edge: wheel-up
-  // reaching this scroller, touch, upward scroll keys, an actual drag. A
-  // downward wheel or a bare click stamps lastGestureAtRef but never this —
-  // otherwise a browser clamp landing near such input reads as the user
-  // scrolling away and kills following (idle trackpad noise near a thinking
-  // card collapse was enough).
-  const lastEscapeIntentAtRef = useRef(0)
-  // Stamped when a gesture-attributed scroll event moved the reader upward
-  // AND escape intent backs it — used to honor escapes the transition shield
-  // swallowed.
-  const lastUpwardGestureAtRef = useRef(0)
-  const pointerDownRef = useRef(false)
-  const pointerDownAtRef = useRef(0)
-  // A press only becomes a scroll gesture once the pointer moves (a scrollbar
-  // drag); a motionless press — or one whose release was swallowed by a native
-  // context menu or a focus change — must not gesture-attribute scroll events
-  // indefinitely.
-  const pointerDragRef = useRef(false)
-  const pointerDownPosRef = useRef<{ x: number; y: number } | null>(null)
-  // True from a send until its scroll-to-reading-line settles. The library
-  // only assigns state.animation in its first animation frame, so this is the
-  // signal that covers the whole interval (a commit landing between the send
-  // effect and that first frame would otherwise let the reserve restore
-  // preempt the glide with an instant jump).
-  const sendScrollInFlightRef = useRef(false)
-
-  // How many trailing (visible) messages to render. Grows on scroll-up and while
-  // the user is scrolled up during streaming. Starts at BASE_WINDOW; the component
-  // is keyed by sessionId at its mount site, so a switched session remounts fresh.
-  const [windowSize, setWindowSize] = useState(BASE_WINDOW)
-  // Scroll height captured just before a scroll-up expansion, used to re-anchor the
-  // viewport after the larger slice renders so the content under the user doesn't jump.
-  const prevScrollHeightRef = useRef<number | null>(null)
-
   // Visible messages with system-injected entries filtered out (these must not
   // consume window slots, and the windowing operates on what the user can see).
   const visibleMessages = useMemo(() => {
@@ -568,289 +464,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       lastAssistantAt,
     }
   }, [visibleMessages, hasOlder])
-
-  // The trailing slice we actually render. The other derived values below still
-  // compute over the FULL message list, so turn boundaries / elapsed times / etc.
-  // stay correct even when their anchor message is outside the rendered window.
-  const windowedMessages = useMemo(
-    () => visibleMessages.slice(-windowSize),
-    [visibleMessages, windowSize]
-  )
-  const hiddenCount = visibleMessages.length - windowedMessages.length
-
-  // Keep the rendered range anchored at the top while the user is scrolled up.
-  // The window is a trailing slice, so when new messages are persisted it would
-  // normally drop the same number off the top — shifting the content the user is
-  // reading (overflow-anchor is disabled, so nothing compensates). Growing the
-  // window by exactly that delta keeps the same first rendered item; the new
-  // messages just append below, off-screen. When pinned to the bottom we leave the
-  // window alone so the slice slides and the DOM stays bounded.
-  const prevVisibleLenRef = useRef(visibleMessages.length)
-  useLayoutEffect(() => {
-    const grown = visibleMessages.length - prevVisibleLenRef.current
-    prevVisibleLenRef.current = visibleMessages.length
-    // Grow while the reader is away from the live edge (escaped), during the
-    // new-turn reserve, or when an older-page prepend is landing (a pending
-    // scroll capture marks that) — so the rows the user is reading keep their
-    // position instead of sliding off the trailing window.
-    if (
-      grown > 0 &&
-      (!stickState.isAtBottom || anchoredTurnRef.current || prevScrollHeightRef.current != null)
-    ) {
-      setWindowSize((n) => n + grown)
-    }
-  }, [visibleMessages, stickState])
-
-  const setBottomSpacerHeight = useCallback((height: number) => {
-    const spacer = bottomSpacerRef.current
-    if (!spacer) return
-    const nextHeight = Math.max(0, Math.ceil(height))
-    bottomSpacerHeightRef.current = nextHeight
-    spacer.style.height = `${nextHeight}px`
-    spacer.hidden = nextHeight === 0
-  }, [])
-
-  // A programmatic follow transition — the send-anchor scroll (where the
-  // previous turn collapses to a summary row and content shrinks above), or a
-  // viewport re-pin — can coincide with a browser clamp whose scroll event
-  // reads as the reader scrolling up. Two defenses: shield the library's
-  // deferred classification across the transition (it skips scroll events
-  // while a resize is in flight), and verify shortly after — an escape with
-  // no user gesture inside the window can only be such an echo, so reverse
-  // it. Real gestures (wheel, touch, held pointer, scroll keys) suppress the
-  // reversal, so a reader who actually leaves during the window stays left.
-  const verifyFollowTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-  useEffect(() => () => clearTimeout(verifyFollowTimerRef.current), [])
-  // Verify shortly after a transition — or after a gesture-driven scroll —
-  // that following's engagement still matches what the user actually did.
-  // `intentBacked` marks an arming scroll produced by a live escape intent:
-  // any latch it caused is genuine and must not be reversed.
-  const armFollowVerification = useCallback((intentBacked: boolean) => {
-    const transitionAt = performance.now()
-    // Only a disengage that HAPPENS inside this window is suspect. A reader
-    // who left the live edge long ago and then scrolls (even downward) must
-    // never be yanked back — reversal applies solely to follows that were
-    // still engaged when the window opened.
-    const wasFollowing = stickState.isAtBottom
-    clearTimeout(verifyFollowTimerRef.current)
-    verifyFollowTimerRef.current = setTimeout(() => {
-      // A disengage inside the window with nothing to justify it can only be
-      // a clamp echo or a follow-write misread as an upward scroll — reverse
-      // it. An active drag, escape intent inside the window, or a press
-      // around the transition (a scrollbar track click pages without moving
-      // the pointer) all say the reader may genuinely own their position.
-      const userMayOwnPosition =
-        intentBacked ||
-        (pointerDownRef.current && pointerDragRef.current) ||
-        lastEscapeIntentAtRef.current >= transitionAt ||
-        (pointerDownRef.current &&
-          pointerDownAtRef.current >= transitionAt - SCROLL_GESTURE_WINDOW_MS)
-      if (!userMayOwnPosition && wasFollowing && !stickState.isAtBottom) {
-        void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
-        return
-      }
-      // The shield cuts both ways: while it holds, the library also discards
-      // the scroll classification of genuine keyboard, touch, and scrollbar
-      // escapes (wheel-up escapes through its own handler and is unaffected).
-      // If an intent-backed gesture moved the reader upward during the window
-      // yet following still reads engaged and they are beyond the re-stick
-      // range, that escape was swallowed — honor it, or the next growth would
-      // yank them back down. Reserve eating is unaffected: it re-bases the
-      // reading line onto the reader, keeping them within the re-stick range.
-      if (
-        stickState.isAtBottom &&
-        lastUpwardGestureAtRef.current >= transitionAt &&
-        !stickState.isNearBottom
-      ) {
-        stickStopScroll()
-      }
-    }, 40)
-  }, [stickState, stickScrollToBottom, stickStopScroll])
-  const protectFollowTransition = useCallback(() => {
-    if (stickState.resizeDifference === 0) {
-      stickState.resizeDifference = 1
-      // Mirror the library's own reset: the clamp's deferred classification
-      // (a tick after its scroll event) must land inside the shield, so drop
-      // it a frame + a tick later. The guard keeps a concurrent real content
-      // resize's value intact.
-      requestAnimationFrame(() => {
-        setTimeout(() => {
-          if (stickState.resizeDifference === 1) stickState.resizeDifference = 0
-        }, 1)
-      })
-    }
-    armFollowVerification(false)
-  }, [stickState, armFollowVerification])
-
-  // Keep the newly-sent turn fixed at its reading line while the response uses
-  // up the reserved room below it. The spacer inflates scrollHeight so that the
-  // reading line IS the scroll target: from the follow library's perspective
-  // the reader simply sits at the bottom, and content growth paired with an
-  // equal spacer shrink is a net-zero resize — no motion. Once the reserve
-  // reaches zero the anchor retires and real growth resumes normal following.
-  const syncTurnReserve = useCallback(() => {
-    const el = scrollRef.current
-    const anchoredTurn = anchoredTurnRef.current
-    if (!el || !anchoredTurn) return
-    const naturalScrollHeight = el.scrollHeight - bottomSpacerHeightRef.current
-    const requiredSpacer = Math.max(
-      0,
-      anchoredTurn.scrollTop + el.clientHeight - naturalScrollHeight,
-    )
-    setBottomSpacerHeight(requiredSpacer)
-    // The response now fills the viewport. Retire the special turn state so
-    // long-thread windowing can return to its bounded trailing slice.
-    if (requiredSpacer === 0) {
-      anchoredTurnRef.current = null
-      return
-    }
-    // A transient content shrink during the reserve hold (a working indicator
-    // swapping forms, a streamed block replaced by its shorter persisted copy)
-    // clamps scrollTop below the reading line for the instant before the
-    // spacer write above re-inflates the scroll range — and nothing else moves
-    // it back until content grows again, so the held turn visibly sags. The
-    // anchored reading line IS the scroll target while the reserve holds, so
-    // put the viewport back on it. Skip while the reader is gesturing (their
-    // scroll owns the position — reserve eating re-bases the anchor), while a
-    // send's scroll to the reading line is pending or animating (it starts
-    // below the target by construction), and while any other scroll
-    // animation is in flight.
-    const gestureDriven =
-      (pointerDownRef.current && pointerDragRef.current) ||
-      performance.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
-    const target = Math.max(0, stickState.calculatedTargetScrollTop)
-    if (
-      !sendScrollInFlightRef.current &&
-      !gestureDriven &&
-      stickState.isAtBottom &&
-      !stickState.animation &&
-      el.scrollTop < target
-    ) {
-      protectFollowTransition()
-      stickState.scrollTop = target
-      lastScrollTopRef.current = el.scrollTop
-    }
-  }, [scrollRef, setBottomSpacerHeight, stickState, protectFollowTransition])
-
-  // Pin the viewport to the live edge before first paint. The library's own
-  // initial scroll runs from its ResizeObserver callback, which lands after
-  // paint — without this, opening a session flashes the top of the transcript
-  // for a frame. Guarded and dep-free because the scroll container mounts only
-  // after loading/error states resolve.
-  const pinnedInitialRef = useRef(false)
-  useLayoutEffect(() => {
-    if (pinnedInitialRef.current || !scrollRef.current) return
-    pinnedInitialRef.current = true
-    stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
-    lastScrollTopRef.current = scrollRef.current.scrollTop
-  })
-
-  const handleScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
-    const el = event.currentTarget
-    const previousScrollTop = lastScrollTopRef.current
-    lastScrollTopRef.current = el.scrollTop
-
-    // Only scroll events that closely follow a real gesture may adjust the
-    // reserve. Programmatic writes (the follow animation) and layout clamps
-    // from shrinking content reach this handler too, but carry no fresh
-    // wheel/touch/key stamp and no moving drag, so they pass through. A held
-    // pointer counts only while it is an actual drag — a stale press (its
-    // release swallowed by a context menu or a focus change) must not keep
-    // attributing clamps to the user indefinitely.
-    const now = performance.now()
-    const activeDrag = pointerDownRef.current && pointerDragRef.current
-    const gestureDriven =
-      activeDrag || now - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
-    const escapeIntentLive =
-      activeDrag || now - lastEscapeIntentAtRef.current < SCROLL_GESTURE_WINDOW_MS
-
-    // A gesture-driven scroll can be misread by the follow library as an
-    // upward escape even when the input pointed down (its follow writes and
-    // the native scroll fight over scrollTop, and the loser's position reads
-    // as "scrolled up"). Re-verify shortly after every gesture-driven scroll
-    // so a latch with no escape intent behind it gets reversed. Armed before
-    // the upward stamp below so that stamp postdates the verification window.
-    if (gestureDriven) armFollowVerification(escapeIntentLive)
-
-    // Blank reserve is one-way. When the reader moves upward, consume the same
-    // number of pixels from the spacer. The new scroll position becomes the
-    // reserve's live edge, so that discarded blank area cannot be revisited.
-    const anchoredTurn = anchoredTurnRef.current
-    const upwardDelta = Math.max(0, previousScrollTop - el.scrollTop)
-    const downwardDelta = Math.max(0, el.scrollTop - previousScrollTop)
-    if (gestureDriven && upwardDelta > 0 && escapeIntentLive) {
-      lastUpwardGestureAtRef.current = performance.now()
-    }
-    if (gestureDriven && anchoredTurn && upwardDelta > 0 && bottomSpacerHeightRef.current > 0) {
-      const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
-      const remainingSpacer = bottomSpacerHeightRef.current - discard
-      anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
-      setBottomSpacerHeight(remainingSpacer)
-      if (remainingSpacer === 0) anchoredTurnRef.current = null
-    }
-
-    // Reaching the actual live edge through a user scroll is an explicit trip
-    // to the bottom: retire the reserve so its blank room doesn't keep the
-    // streamed content away from the reader. The browser clamps scrollTop to
-    // the new natural maximum synchronously.
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-    if (
-      gestureDriven &&
-      downwardDelta > 0 &&
-      anchoredTurnRef.current &&
-      distanceFromBottom <= 1
-    ) {
-      anchoredTurnRef.current = null
-      setBottomSpacerHeight(0)
-      lastScrollTopRef.current = el.scrollTop
-    }
-
-    // Near the top: reveal the next local chunk, or fetch the next API page.
-    // prevScrollHeightRef is only set when we know the DOM will grow (local
-    // expand, or fetchOlder about to prepend) so a failed/empty fetch cannot wedge.
-    if (el.scrollTop < 200 && prevScrollHeightRef.current == null) {
-      if (hiddenCount > 0) {
-        prevScrollHeightRef.current = el.scrollHeight
-        setWindowSize((n) => n + LOAD_STEP)
-      } else if (hasOlder && !isFetchingOlder && fetchOlder) {
-        void fetchOlder(() => {
-          // Back at the bottom mid-fetch: the trailing window doesn't move on
-          // prepend, so skip the capture — a lingering guard would block the
-          // next scroll-up gesture. Derived from geometry at capture time.
-          const viewport = scrollRef.current
-          if (
-            viewport &&
-            viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight > 100
-          ) {
-            prevScrollHeightRef.current = viewport.scrollHeight
-          }
-        })
-      }
-    }
-  }, [hiddenCount, hasOlder, isFetchingOlder, fetchOlder, setBottomSpacerHeight, scrollRef, armFollowVerification])
-
-  // After a scroll-up expansion adds older messages above the viewport, restore the
-  // scroll position so the content the user was reading stays put (no jump).
-  // Deps are [windowSize] ONLY: when a prepend lands the anchor effect grows
-  // windowSize in the same commit, so this fires exactly when the rows mount.
-  // A visibleMessages.length dep would consume the guard one commit early
-  // (data grows, window unchanged, delta 0) and leave the mount uncompensated.
-  useLayoutEffect(() => {
-    const el = scrollRef.current
-    if (el && prevScrollHeightRef.current != null) {
-      el.scrollTop += el.scrollHeight - prevScrollHeightRef.current
-      prevScrollHeightRef.current = null
-    }
-    // scrollRef is a stable library ref — windowSize remains the sole trigger.
-  }, [windowSize, scrollRef])
-
-  const handleScrollToBottom = useCallback(() => {
-    // Drop the turn reserve first so the scroll target is the true live edge,
-    // not the blank reading-line reserve.
-    anchoredTurnRef.current = null
-    setBottomSpacerHeight(0)
-    void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
-  }, [setBottomSpacerHeight, stickScrollToBottom])
 
   // Safety net: if isCompacting is true but a NEW compact boundary appears in fetched
   // messages, compaction is done and the SSE compact_complete event was missed.
@@ -1206,17 +819,42 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     hasTurnStartingPendingMessage,
   ])
 
-  // A turn completing collapses its whole work phase into a summary row — a
-  // massive one-commit shrink whose browser clamp reads as the reader
-  // scrolling up, stranding the viewport above the final answer. Guard the
-  // transition from the same commit (this runs before the clamp's scroll
-  // event can dispatch, so the shield is race-free here).
-  const prevCompletedTurnCountRef = useRef(completedTurns.length)
-  useLayoutEffect(() => {
-    const grew = completedTurns.length > prevCompletedTurnCountRef.current
-    prevCompletedTurnCountRef.current = completedTurns.length
-    if (grew && stickState.isAtBottom) protectFollowTransition()
-  }, [completedTurns, stickState, protectFollowTransition])
+  // All scrolling behavior — live-edge following with gesture attribution,
+  // the new-turn reading-line reserve, windowed rendering of long histories.
+  // The domain values passed through exist so the hook re-syncs its reserve
+  // and guards its transitions on the commits that change transcript layout.
+  const {
+    scrollRef,
+    contentRef,
+    contentBodyRef,
+    bottomSpacerRef,
+    isAtBottom,
+    scrollToBottom: handleScrollToBottom,
+    windowedMessages,
+    hiddenCount,
+    handleScroll,
+    handleWheelGesture,
+    handleTouchGesture,
+    handlePointerDown,
+    handleScrollKey,
+  } = useMessageListScroll({
+    visibleMessages,
+    pendingUserMessages,
+    completedTurnCount: completedTurns.length,
+    bottomInset,
+    hasOlder,
+    isFetchingOlder,
+    fetchOlder,
+    isLoading,
+    error,
+    messages,
+    streamingMessage,
+    streamingToolUses,
+    thinkingBlocks,
+    isCompacting,
+    pendingRequestCount,
+    activeSubagents,
+  })
 
   // Drop expansion state for turns that no longer exist after edits/refetches.
   useEffect(() => {
@@ -1244,238 +882,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     }
     return result
   }, [messages, isActive, hasTurnStartingPendingMessage])
-
-  // Detect actual sends by id (rather than list length, since materialization
-  // can remove one ghost as another arrives). A turn-starting send gets a
-  // stable reading line 100px from the viewport top; queued mid-turn sends
-  // retain the regular live-edge behavior.
-  const seenPendingIdsRef = useRef(new Set<string>())
-  useLayoutEffect(() => {
-    const seen = seenPendingIdsRef.current
-    let hasNewSend = false
-    let newestTurnStart: PendingMessage | undefined
-    for (const pending of pendingUserMessages ?? []) {
-      if (!seen.has(pending.localId)) {
-        seen.add(pending.localId)
-        hasNewSend = true
-        if (!pending.queued) newestTurnStart = pending
-      }
-    }
-
-    if (hasNewSend) {
-      if (newestTurnStart) {
-        const viewport = scrollRef.current
-        const anchor = Array.from(
-          contentBodyRef.current?.querySelectorAll<HTMLElement>('[data-turn-anchor-id]') ?? [],
-        ).find((element) => element.dataset.turnAnchorId === newestTurnStart.localId)
-
-        if (viewport && anchor) {
-          lastScrollTopRef.current = viewport.scrollTop
-          const anchorTop =
-            anchor.getBoundingClientRect().top -
-            viewport.getBoundingClientRect().top +
-            viewport.scrollTop
-          anchoredTurnRef.current = {
-            localId: newestTurnStart.localId,
-            scrollTop: Math.max(0, anchorTop - TURN_ANCHOR_TOP),
-          }
-        } else {
-          anchoredTurnRef.current = null
-          setBottomSpacerHeight(0)
-        }
-      } else {
-        anchoredTurnRef.current = null
-        setBottomSpacerHeight(0)
-      }
-
-      // The viewport intentionally sits below the new reading line until the
-      // scroll below travels there — hold the reserve restore off for the
-      // whole interval (state.animation alone starts too late: the library
-      // assigns it in its first animation frame, and a commit can land first).
-      sendScrollInFlightRef.current = true
-      // Size the reserve before scrolling so the scroll target IS the new
-      // turn's reading line (the spacer inflates scrollHeight to end there).
-      syncTurnReserve()
-      // The collapse of the finished turn above (same commit as the ghost)
-      // shrinks content and can clamp scrollTop — guard the transition so
-      // that clamp echo cannot latch an escape under the send.
-      protectFollowTransition()
-      // A send always returns the reader to the thread: re-engage following
-      // and glide to the reading line (or the live edge for queued sends).
-      // Under reduced motion, position synchronously instead of gliding.
-      if (prefersReducedMotion()) {
-        stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
-      }
-      void Promise.resolve(
-        stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined),
-      ).finally(() => {
-        sendScrollInFlightRef.current = false
-      })
-      // Programmatic writes fire their scroll event asynchronously (and not at
-      // all in jsdom) — resync the gesture-delta baseline now so the write
-      // isn't misread as a user delta.
-      lastScrollTopRef.current = scrollRef.current?.scrollTop ?? 0
-      return
-    }
-
-    syncTurnReserve()
-  }, [
-    messages,
-    pendingUserMessages,
-    streamingMessage,
-    streamingToolUses,
-    thinkingBlocks,
-    isCompacting,
-    pendingRequestCount,
-    activeSubagents,
-    syncTurnReserve,
-    setBottomSpacerHeight,
-    scrollRef,
-    stickState,
-    stickScrollToBottom,
-    protectFollowTransition,
-    bottomInset,
-  ])
-
-  // Markdown, images, and expanded tool cards can change height without a
-  // message-state update. Feed those layout changes through the same reserve
-  // calculation so they cannot make the anchored turn jump. Re-attach after
-  // the loading/error states resolve — the scroll container mounts only then.
-  useEffect(() => {
-    const content = contentBodyRef.current
-    const viewport = scrollRef.current
-    if (!content || !viewport || typeof ResizeObserver === 'undefined') return
-    let frameId = 0
-    let lastViewportHeight = viewport.clientHeight
-    let lastContentHeight = content.offsetHeight
-    const observer = new ResizeObserver(() => {
-      // A vertical viewport resize is invisible to the follow library (it
-      // observes only the content element), and browsers anchor the TOP edge
-      // on resize — so a window shrink would slide the live edge behind the
-      // fold. Re-pin immediately while following, guarded against the grow
-      // clamp's scroll echo being read as an escape (a viewport GROW lowers
-      // the scroll range, and the browser's clamp fires a scroll event that
-      // classifies as the reader scrolling up). During the turn reserve the
-      // spacer math already keeps the reading line valid, so no pin there.
-      const viewportHeight = viewport.clientHeight
-      if (viewportHeight !== lastViewportHeight) {
-        lastViewportHeight = viewportHeight
-        if (stickState.isAtBottom && !anchoredTurnRef.current) {
-          protectFollowTransition()
-          stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
-          lastScrollTopRef.current = viewport.scrollTop
-        }
-      }
-      // Catch-all for content shrinks at the live edge (a thinking card
-      // collapsing, a streamed block swapped for its shorter persisted form):
-      // each one clamps scrollTop and can latch a spurious escape the same
-      // way. The commit-hooked guards cover the big known transitions
-      // race-free; this covers the rest via the deferred verification.
-      const contentHeight = content.offsetHeight
-      if (contentHeight < lastContentHeight && stickState.isAtBottom) {
-        protectFollowTransition()
-      }
-      lastContentHeight = contentHeight
-      cancelAnimationFrame(frameId)
-      frameId = requestAnimationFrame(syncTurnReserve)
-    })
-    observer.observe(content)
-    observer.observe(viewport)
-    return () => {
-      cancelAnimationFrame(frameId)
-      observer.disconnect()
-    }
-  }, [syncTurnReserve, scrollRef, stickState, protectFollowTransition, isLoading, error])
-
-  // Escape from following is owned by the stick-to-bottom library (wheel
-  // direction, scroll direction, selection). These stamps exist so the scroll
-  // handler can attribute reserve adjustments to a live gesture, and so the
-  // deferred verification can tell escape-capable input (wheel-up, touch,
-  // upward keys, a drag) from input that never leaves the live edge.
-  // A wheel consumed by a nested scrollable (the thinking card's body, a code
-  // block) never moves the transcript and must not count as a transcript
-  // gesture; scroll chaining hands the wheel to us only once the inner
-  // scroller is at its edge, which the walk below mirrors.
-  const handleWheelGesture = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
-    const outer = scrollRef.current
-    if (!outer) return
-    let node = event.target as HTMLElement | null
-    while (node && node !== outer) {
-      if (nestedScrollableConsumesWheel(node, event.deltaY)) return
-      node = node.parentElement
-    }
-    const now = performance.now()
-    lastGestureAtRef.current = now
-    if (event.deltaY < 0) lastEscapeIntentAtRef.current = now
-  }, [scrollRef])
-
-  // Touch direction isn't knowable from a single event without tracking touch
-  // points; treat any touch scroll as escape-capable.
-  const handleTouchGesture = useCallback(() => {
-    const now = performance.now()
-    lastGestureAtRef.current = now
-    lastEscapeIntentAtRef.current = now
-  }, [])
-
-  // Scrollbar interactions emit no wheel/touch/key events — track the held
-  // pointer. Only a pointer that actually moves is a drag; a motionless press
-  // (or one whose release never arrived) must not stay a gesture forever.
-  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.button !== 0) return
-    pointerDownRef.current = true
-    pointerDragRef.current = false
-    pointerDownAtRef.current = performance.now()
-    pointerDownPosRef.current = { x: event.clientX, y: event.clientY }
-    lastGestureAtRef.current = performance.now()
-  }, [])
-  useEffect(() => {
-    const release = () => {
-      pointerDownRef.current = false
-      pointerDragRef.current = false
-      pointerDownPosRef.current = null
-    }
-    const move = (event: PointerEvent) => {
-      if (!pointerDownRef.current) return
-      if (!pointerDragRef.current) {
-        const start = pointerDownPosRef.current
-        if (!start) return
-        if (
-          Math.abs(event.clientX - start.x) + Math.abs(event.clientY - start.y) <
-          POINTER_DRAG_THRESHOLD_PX
-        ) {
-          return
-        }
-        pointerDragRef.current = true
-      }
-      const now = performance.now()
-      lastGestureAtRef.current = now
-      lastEscapeIntentAtRef.current = now
-    }
-    window.addEventListener('pointerup', release)
-    window.addEventListener('pointercancel', release)
-    window.addEventListener('pointermove', move)
-    // A native context menu (two-finger tap) or a focus change can swallow the
-    // pointerup — without these, the "held pointer" would outlive the gesture
-    // indefinitely and every later browser clamp would read as user scrolling.
-    window.addEventListener('blur', release)
-    window.addEventListener('contextmenu', release)
-    return () => {
-      window.removeEventListener('pointerup', release)
-      window.removeEventListener('pointercancel', release)
-      window.removeEventListener('pointermove', move)
-      window.removeEventListener('blur', release)
-      window.removeEventListener('contextmenu', release)
-    }
-  }, [])
-
-  const handleScrollKey = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (!SCROLL_KEYS.has(event.key)) return
-    const now = performance.now()
-    lastGestureAtRef.current = now
-    const upward =
-      UPWARD_SCROLL_KEYS.has(event.key) || (event.key === ' ' && event.shiftKey)
-    if (upward) lastEscapeIntentAtRef.current = now
-  }, [])
 
   // Peer messages still worth showing optimistically: not our own, and the
   // persisted copy (by uuid, or — for queued/steering messages whose uuid the

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -121,7 +121,7 @@ interface MessageListScrollOptions<T> {
   visibleMessages: readonly T[]
   /** A new non-queued ghost anchors its turn's reading line (`data-turn-anchor-id`). */
   pendingUserMessages: PendingMessage[] | undefined
-  /** Height of an overlaid footer that the live edge must remain above. */
+  /** Overlaid-footer height. Only re-syncs the reserve on change — the inset element itself is rendered by the caller. */
   bottomInset: number
   /** Older-history paging, driven by scrolling near the top. */
   hasOlder: boolean

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -36,11 +36,13 @@ const TURN_ANCHOR_TOP = 100
 //     arrives — before any scroll event, so a concurrent follow write can
 //     never swallow it.
 //   - The BACKSTOP for inputs with no distinct event (a dragged scrollbar,
-//     touch momentum, find-in-page) classifies a scroll event as the user's
-//     only when the geometry was stable: our own writes always update the
-//     baseline in the same statement, and a browser clamp only ever fires in
-//     a frame where scrollHeight or clientHeight changed — so an upward move
-//     with both unchanged has no author left but the user.
+//     touch momentum) classifies a scroll event as the user's only when the
+//     geometry was stable AND some input recently touched the scroller: our
+//     own writes always update the baseline in the same statement, a browser
+//     clamp only ever fires in a frame where scrollHeight or clientHeight
+//     changed, and WebKit's async scrolling can roll a write back with no
+//     input at all — upward + stable + fresh input is the reader leaving;
+//     upward + stable + no input is the engine, and following converges back.
 //   - FOLLOWING is convergent: while engaged, every content or viewport
 //     resize re-pins the live edge with a single instant write. A missed or
 //     misread event can cost one frame, never a dead latch.
@@ -60,6 +62,18 @@ const ATTACH_OFFSET_PX = 70
 // leaves this band. Elastic overscroll bounce-back (Safari) and sub-pixel
 // jitter land inside it; a real escape leaves it in one gesture.
 const ESCAPE_MIN_DISTANCE_PX = 24
+// The backstop additionally requires some input to have touched the scroller
+// this recently before it releases following. WebKit's async scrolling can
+// roll a programmatic write back to its last composited position and report
+// that as a genuine upward, size-stable scroll event — with no input
+// anywhere near it, that shape is the engine's, not the reader's, and
+// following converges back instead of disengaging (reproduced by
+// safari-follow.spec.ts: zero-input rollbacks to the same committed position
+// after large thinking-card collapses, WebKit only).
+const INPUT_EVIDENCE_WINDOW_MS = 500
+// How long the scrolling tree gets to settle before convergence re-pins
+// after an engine-caused upward scroll.
+const ENGINE_SCROLL_SETTLE_MS = 150
 // After a user-attributed upward scroll, hold re-pins briefly so an in-flight
 // upward gesture (wheel ticks eating the reserve) isn't fought mid-motion.
 const USER_SCROLL_HOLD_MS = 100
@@ -188,6 +202,10 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   const pointerDragRef = useRef(false)
   const pointerDownPosRef = useRef<{ x: number; y: number } | null>(null)
   const pointerOnScrollbarRef = useRef(false)
+  // Any input that reached the scroller — wheel (either direction), scroll
+  // key, pointer press, touch. The backstop's release requires this to be
+  // fresh; see INPUT_EVIDENCE_WINDOW_MS.
+  const lastInputAtRef = useRef(0)
   const touchActiveRef = useRef(false)
   const touchSettleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const scheduleTouchSettleRef = useRef<(() => void) | null>(null)
@@ -443,26 +461,45 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     const downwardDelta = baseline ? Math.max(0, el.scrollTop - baseline.scrollTop) : 0
 
     if (upwardDelta > 0) {
-      lastUserScrollUpAtRef.current = performance.now()
-      // Blank reserve is one-way. When the reader moves upward, consume the
-      // same number of pixels from the spacer. The new scroll position
-      // becomes the reserve's live edge, so that discarded blank area cannot
-      // be revisited — and the re-based target keeps the reader "at the
-      // bottom", so eating never disengages following by itself.
-      const anchoredTurn = anchoredTurnRef.current
-      if (anchoredTurn && bottomSpacerHeightRef.current > 0) {
-        const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
-        const remainingSpacer = bottomSpacerHeightRef.current - discard
-        anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
-        setBottomSpacerHeight(remainingSpacer)
-        if (remainingSpacer === 0) anchoredTurnRef.current = null
+      // Stable geometry narrows the author to the user or the engine itself
+      // (WebKit's compositor rolling back a programmatic write). Fresh input
+      // is what separates them.
+      const inputBacked =
+        pointerDownRef.current ||
+        touchActiveRef.current ||
+        performance.now() - lastInputAtRef.current < INPUT_EVIDENCE_WINDOW_MS
+      if (inputBacked) {
+        lastUserScrollUpAtRef.current = performance.now()
+        // Blank reserve is one-way. When the reader moves upward, consume the
+        // same number of pixels from the spacer. The new scroll position
+        // becomes the reserve's live edge, so that discarded blank area cannot
+        // be revisited — and the re-based target keeps the reader "at the
+        // bottom", so eating never disengages following by itself.
+        const anchoredTurn = anchoredTurnRef.current
+        if (anchoredTurn && bottomSpacerHeightRef.current > 0) {
+          const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
+          const remainingSpacer = bottomSpacerHeightRef.current - discard
+          anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
+          setBottomSpacerHeight(remainingSpacer)
+          if (remainingSpacer === 0) anchoredTurnRef.current = null
+        }
       }
-      // Beyond the live-edge band, an upward user move is an escape. The
-      // band absorbs elastic bounce-back and sub-pixel jitter; wheel and
+      // Beyond the live-edge band, an input-backed upward move is an escape.
+      // The band absorbs elastic bounce-back and sub-pixel jitter; wheel and
       // keyboard escapes don't come through here at all (their input events
-      // release directly).
+      // release directly). Without input evidence the move is the engine's:
+      // keep following, give the scrolling tree a beat to settle, and
+      // converge back to the live edge.
       if (followingRef.current && distanceFromBottom(el) > ESCAPE_MIN_DISTANCE_PX) {
-        releaseFollow()
+        if (inputBacked) {
+          releaseFollow()
+        } else {
+          clearTimeout(pinRetryTimerRef.current)
+          pinRetryTimerRef.current = setTimeout(
+            () => pinRetryRef.current(),
+            ENGINE_SCROLL_SETTLE_MS,
+          )
+        }
       }
     }
 
@@ -669,6 +706,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       if (nestedScrollableConsumesWheel(node, event.deltaY)) return
       node = node.parentElement
     }
+    lastInputAtRef.current = performance.now()
     if (event.deltaY < 0) {
       cancelGlide()
       if (outer.scrollHeight <= outer.clientHeight + 1) return
@@ -684,6 +722,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   const handleScrollKey = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
     const el = scrollRef.current
     if (!el || el.scrollHeight <= el.clientHeight + 1) return
+    lastInputAtRef.current = performance.now()
     const upward =
       UPWARD_SCROLL_KEYS.has(event.key) || (event.key === ' ' && event.shiftKey)
     if (upward) {
@@ -720,6 +759,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     pointerDownRef.current = true
     pointerDragRef.current = false
     pointerDownPosRef.current = { x: event.clientX, y: event.clientY }
+    lastInputAtRef.current = performance.now()
     pointerOnScrollbarRef.current =
       !!el &&
       el.clientWidth > 0 &&
@@ -781,12 +821,14 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   }, [settleInteraction])
   const handleTouchStart = useCallback(() => {
     touchActiveRef.current = true
+    lastInputAtRef.current = performance.now()
     clearTimeout(touchSettleTimerRef.current)
     touchSettleTimerRef.current = undefined
     cancelGlide()
   }, [cancelGlide])
   const handleTouchMove = useCallback(() => {
     touchActiveRef.current = true
+    lastInputAtRef.current = performance.now()
   }, [])
   const handleTouchEnd = useCallback(() => {
     if (!touchActiveRef.current) return

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -66,11 +66,20 @@ const ESCAPE_MIN_DISTANCE_PX = 24
 // this recently before it releases following. WebKit's async scrolling can
 // roll a programmatic write back to its last composited position and report
 // that as a genuine upward, size-stable scroll event — with no input
-// anywhere near it, that shape is the engine's, not the reader's, and
-// following converges back instead of disengaging (reproduced by
-// safari-follow.spec.ts: zero-input rollbacks to the same committed position
-// after large thinking-card collapses, WebKit only).
+// anywhere near it (and a landing on the recently-held trail below), that
+// shape is the engine's, not the reader's, and following converges back
+// instead of disengaging (reproduced by safari-follow.spec.ts: zero-input
+// rollbacks to the same committed position after large thinking-card
+// collapses, WebKit only).
 const INPUT_EVIDENCE_WINDOW_MS = 500
+// A rollback, by definition, lands on a position the scroller recently held.
+// An evidence-less upward move is only read as one when it does; landing
+// anywhere else with no input behind it is a programmatic jump (scrollTo
+// from app code, an extension, tests) and releases following like any other
+// escape.
+const ROLLBACK_TRAIL_MS = 2000
+const ROLLBACK_TRAIL_MAX = 40
+const ROLLBACK_TRAIL_TOLERANCE_PX = 2
 // How long the scrolling tree gets to settle before convergence re-pins
 // after an engine-caused upward scroll.
 const ENGINE_SCROLL_SETTLE_MS = 150
@@ -193,6 +202,11 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   // position change the baseline doesn't already reflect came from the user.
   const baselineRef = useRef<ScrollSample | null>(null)
   const lastUserScrollUpAtRef = useRef(0)
+  // Positions the scroller has recently held — every observed scroll event
+  // and every engine write funnels through rememberPosition. Consulted only
+  // to separate compositor rollbacks (land ON the trail) from programmatic
+  // jumps (land off it) when an upward move has no input evidence.
+  const positionTrailRef = useRef<Array<{ scrollTop: number; at: number }>>([])
 
   // Interaction tracking. A drag (a press that moved), a press on the
   // scrollbar gutter (track clicks page without pointer motion), and an
@@ -227,6 +241,15 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   const rememberPosition = useCallback(() => {
     const el = scrollRef.current
     if (!el) return
+    const trail = positionTrailRef.current
+    const latest = trail[trail.length - 1]
+    if (latest && Math.abs(latest.scrollTop - el.scrollTop) <= ROLLBACK_TRAIL_TOLERANCE_PX) {
+      latest.scrollTop = el.scrollTop
+      latest.at = performance.now()
+    } else {
+      trail.push({ scrollTop: el.scrollTop, at: performance.now() })
+      if (trail.length > ROLLBACK_TRAIL_MAX) trail.shift()
+    }
     baselineRef.current = {
       scrollTop: el.scrollTop,
       scrollHeight: el.scrollHeight,
@@ -461,15 +484,26 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     const downwardDelta = baseline ? Math.max(0, el.scrollTop - baseline.scrollTop) : 0
 
     if (upwardDelta > 0) {
-      // Stable geometry narrows the author to the user or the engine itself
+      // Stable geometry narrows the author to the reader or the engine itself
       // (WebKit's compositor rolling back a programmatic write). Fresh input
-      // is what separates them.
+      // separates them — and an evidence-less move only reads as a rollback
+      // when it lands on the trail of recently held positions, which a
+      // rollback by definition returns to. Off the trail it is a programmatic
+      // jump and is treated exactly like the reader's.
+      const now = performance.now()
       const inputBacked =
         pointerDownRef.current ||
         touchActiveRef.current ||
-        performance.now() - lastInputAtRef.current < INPUT_EVIDENCE_WINDOW_MS
-      if (inputBacked) {
-        lastUserScrollUpAtRef.current = performance.now()
+        now - lastInputAtRef.current < INPUT_EVIDENCE_WINDOW_MS
+      const rollback =
+        !inputBacked &&
+        positionTrailRef.current.some(
+          (p) =>
+            now - p.at <= ROLLBACK_TRAIL_MS &&
+            Math.abs(p.scrollTop - el.scrollTop) <= ROLLBACK_TRAIL_TOLERANCE_PX,
+        )
+      if (!rollback) {
+        lastUserScrollUpAtRef.current = now
         // Blank reserve is one-way. When the reader moves upward, consume the
         // same number of pixels from the spacer. The new scroll position
         // becomes the reserve's live edge, so that discarded blank area cannot
@@ -484,21 +518,21 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
           if (remainingSpacer === 0) anchoredTurnRef.current = null
         }
       }
-      // Beyond the live-edge band, an input-backed upward move is an escape.
-      // The band absorbs elastic bounce-back and sub-pixel jitter; wheel and
-      // keyboard escapes don't come through here at all (their input events
-      // release directly). Without input evidence the move is the engine's:
-      // keep following, give the scrolling tree a beat to settle, and
-      // converge back to the live edge.
+      // Beyond the live-edge band, an upward move that isn't a rollback is an
+      // escape. The band absorbs elastic bounce-back and sub-pixel jitter;
+      // wheel and keyboard escapes don't come through here at all (their
+      // input events release directly). A rollback is the engine's own write
+      // coming back: keep following, give the scrolling tree a beat to
+      // settle, and converge back to the live edge.
       if (followingRef.current && distanceFromBottom(el) > ESCAPE_MIN_DISTANCE_PX) {
-        if (inputBacked) {
-          releaseFollow()
-        } else {
+        if (rollback) {
           clearTimeout(pinRetryTimerRef.current)
           pinRetryTimerRef.current = setTimeout(
             () => pinRetryRef.current(),
             ENGINE_SCROLL_SETTLE_MS,
           )
+        } else {
+          releaseFollow()
         }
       }
     }

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -10,7 +10,6 @@ import {
   type UIEvent as ReactUIEvent,
   type WheelEvent as ReactWheelEvent,
 } from 'react'
-import { useStickToBottom } from 'use-stick-to-bottom'
 import { MESSAGES_PAGE_LIMIT, MESSAGES_PAGE_OLDER_LIMIT } from '@shared/lib/messages-page'
 import type { PendingMessage } from './pending-message'
 
@@ -24,23 +23,57 @@ import type { PendingMessage } from './pending-message'
 const BASE_WINDOW = MESSAGES_PAGE_LIMIT
 const LOAD_STEP = MESSAGES_PAGE_OLDER_LIMIT
 const TURN_ANCHOR_TOP = 100
-// Live-edge following (engage/escape/resume and the smooth chase) is owned by
-// use-stick-to-bottom: it derives escape from user-attributable signals (wheel
-// direction, scroll direction, text selection) and drives the viewport from
-// content resizes — scroll-event echoes of its own writes can never disengage
-// it. The layer in this file only manages what sits on top of that: the
-// new-turn reading-line reserve (the spacer) and windowed history loading.
+
+// ---------------------------------------------------------------------------
+// The follow engine.
 //
-// Scroll events cannot say who caused them, so the reserve adjustments below
-// only act on events that closely follow a real gesture (wheel/touch/keys, or
-// a held-down pointer for scrollbar drags). A layout clamp from shrinking
-// content carries no fresh gesture and passes through untouched.
-const SCROLL_GESTURE_WINDOW_MS = 400
-// A press only becomes a drag (and thereby a scroll gesture) once the pointer
-// travels this far from where it went down.
-const POINTER_DRAG_THRESHOLD_PX = 4
-const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
+// Scroll events carry no provenance — the browser does not say whether a
+// scroll came from the user, from our own write, or from a layout clamp. The
+// engine never guesses from position deltas alone. Instead:
+//
+//   - ESCAPE is input-primary: an upward wheel that reaches this scroller, an
+//     upward scroll key, or a drag disengages following the moment the input
+//     arrives — before any scroll event, so a concurrent follow write can
+//     never swallow it.
+//   - The BACKSTOP for inputs with no distinct event (a dragged scrollbar,
+//     touch momentum, find-in-page) classifies a scroll event as the user's
+//     only when the geometry was stable: our own writes always update the
+//     baseline in the same statement, and a browser clamp only ever fires in
+//     a frame where scrollHeight or clientHeight changed — so an upward move
+//     with both unchanged has no author left but the user.
+//   - FOLLOWING is convergent: while engaged, every content or viewport
+//     resize re-pins the live edge with a single instant write. A missed or
+//     misread event can cost one frame, never a dead latch.
+//   - Programmatic motion is minimal: instant writes everywhere, and one
+//     owned glide (an exponential chase, cancelled by any user input) for the
+//     explicit trips — send and the scroll-to-bottom affordance.
+// ---------------------------------------------------------------------------
+
+// The live-edge target keeps a 1px allowance: at fractional zoom levels
+// scrollTop is non-integer and an exact-maximum target never quite settles.
+const LIVE_EDGE_ALLOWANCE_PX = 1
+// A user scroll arriving within this of the bottom re-engages following. Kept
+// generous on purpose: while a response streams the end is a moving target,
+// so a reader chasing it always lands short of exact.
+const ATTACH_OFFSET_PX = 70
+// The backstop only reads an upward stable-geometry move as an escape once it
+// leaves this band. Elastic overscroll bounce-back (Safari) and sub-pixel
+// jitter land inside it; a real escape leaves it in one gesture.
+const ESCAPE_MIN_DISTANCE_PX = 24
+// After a user-attributed upward scroll, hold re-pins briefly so an in-flight
+// upward gesture (wheel ticks eating the reserve) isn't fought mid-motion.
+const USER_SCROLL_HOLD_MS = 100
+// The glide's exponential approach rate (per second) and its hard stop.
+const GLIDE_RATE_PER_S = 14
+const GLIDE_MAX_MS = 1500
+
 const UPWARD_SCROLL_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
+// A press only becomes a drag once the pointer travels this far from where it
+// went down.
+const POINTER_DRAG_THRESHOLD_PX = 4
+// Touch momentum keeps scrolling after the last touch event; the interaction
+// only ends once scroll events go quiet for this long.
+const TOUCH_SETTLE_MS = 150
 
 // Mirrors the browser's scroll chaining for wheel input: a nested scrollable
 // consumes the wheel while it can still move in that direction; only at its
@@ -57,13 +90,23 @@ function nestedScrollableConsumesWheel(el: HTMLElement, deltaY: number): boolean
 const prefersReducedMotion = () =>
   window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
+const liveEdgeTarget = (el: HTMLElement) =>
+  Math.max(0, el.scrollHeight - LIVE_EDGE_ALLOWANCE_PX - el.clientHeight)
+
+const distanceFromBottom = (el: HTMLElement) =>
+  el.scrollHeight - el.scrollTop - el.clientHeight
+
+interface ScrollSample {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+}
+
 interface MessageListScrollOptions<T> {
   /** Messages after visibility filtering — what the trailing window slices. */
   visibleMessages: readonly T[]
   /** A new non-queued ghost anchors its turn's reading line (`data-turn-anchor-id`). */
   pendingUserMessages: PendingMessage[] | undefined
-  /** Growth means a work phase collapsed into a summary row — a guarded transition. */
-  completedTurnCount: number
   /** Height of an overlaid footer that the live edge must remain above. */
   bottomInset: number
   /** Older-history paging, driven by scrolling near the top. */
@@ -87,22 +130,22 @@ interface MessageListScrollOptions<T> {
 }
 
 /**
- * All scrolling behavior for the message list: live-edge following (via
- * use-stick-to-bottom plus the gesture-attribution layer that keeps its
- * position-inferred escapes honest), the new-turn reading-line reserve, and
- * the windowed rendering of long histories with scroll-anchored older-page
- * loading. The component renders; this hook decides where the viewport is.
+ * All scrolling behavior for the message list: live-edge following (the owned
+ * engine above), the new-turn reading-line reserve, and the windowed rendering
+ * of long histories with scroll-anchored older-page loading. The component
+ * renders; this hook decides where the viewport is.
  *
  * The returned handlers must all be bound on the scroll container, and the
  * four refs on their respective elements (see MessageList's JSX). Turn-starting
  * ghost wrappers must carry `data-turn-anchor-id={localId}` for the
- * reading-line anchor to find them.
+ * reading-line anchor to find them. The container must keep
+ * `overflow-anchor: none` — the browser's own scroll anchoring is otherwise a
+ * third scrollTop writer the engine cannot attribute.
  */
 export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   const {
     visibleMessages,
     pendingUserMessages,
-    completedTurnCount,
     bottomInset,
     hasOlder,
     isFetchingOlder,
@@ -118,54 +161,42 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     activeSubagents,
   } = options
 
-  // Live-edge following. `isAtBottom` goes false only on a user-attributable
-  // escape (wheel up, upward scroll, selection drag) and comes back when the
-  // reader returns near the bottom — geometry sampled from our own writes can
-  // never disengage it. Content growth is followed from the library's
-  // ResizeObserver on `contentRef`, so the bottom inset below must be a real
-  // element (content-box), not container padding.
-  const {
-    scrollRef,
-    contentRef,
-    scrollToBottom: stickScrollToBottom,
-    stopScroll: stickStopScroll,
-    isAtBottom,
-    state: stickState,
-  } = useStickToBottom({
-    initial: 'instant',
-    ...(prefersReducedMotion() ? { resize: 'instant' as const } : {}),
-  })
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
   const contentBodyRef = useRef<HTMLDivElement>(null)
   const bottomSpacerRef = useRef<HTMLDivElement>(null)
   const bottomSpacerHeightRef = useRef(0)
   const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
-  const lastScrollTopRef = useRef(0)
-  const lastGestureAtRef = useRef(0)
-  // Stamped only by gestures that can justify LEAVING the live edge: wheel-up
-  // reaching this scroller, touch, upward scroll keys, an actual drag. A
-  // downward wheel or a bare click stamps lastGestureAtRef but never this —
-  // otherwise a browser clamp landing near such input reads as the user
-  // scrolling away and kills following (idle trackpad noise near a thinking
-  // card collapse was enough).
-  const lastEscapeIntentAtRef = useRef(0)
-  // Stamped when a gesture-attributed scroll event moved the reader upward
-  // AND escape intent backs it — used to honor escapes the transition shield
-  // swallowed.
-  const lastUpwardGestureAtRef = useRef(0)
+
+  // Following state lives in a ref (the single source of truth — handlers and
+  // observers read it without stale-closure risk); the state mirror only
+  // drives the scroll-to-bottom affordance's rendering.
+  const followingRef = useRef(true)
+  const [isAtBottom, setIsAtBottom] = useState(true)
+  // The last known geometry, updated by every scroll event AND by every write
+  // the engine makes. A scroll event is classified against it: same
+  // scrollHeight and clientHeight means no clamp or resize is in flight, so a
+  // position change the baseline doesn't already reflect came from the user.
+  const baselineRef = useRef<ScrollSample | null>(null)
+  const lastUserScrollUpAtRef = useRef(0)
+
+  // Interaction tracking. A drag (a press that moved), a press on the
+  // scrollbar gutter (track clicks page without pointer motion), and an
+  // active touch sequence each suspend pinning — the user owns the viewport
+  // for the duration, and following is re-derived from where they end up.
   const pointerDownRef = useRef(false)
-  const pointerDownAtRef = useRef(0)
-  // A press only becomes a scroll gesture once the pointer moves (a scrollbar
-  // drag); a motionless press — or one whose release was swallowed by a native
-  // context menu or a focus change — must not gesture-attribute scroll events
-  // indefinitely.
   const pointerDragRef = useRef(false)
   const pointerDownPosRef = useRef<{ x: number; y: number } | null>(null)
-  // True from a send until its scroll-to-reading-line settles. The library
-  // only assigns state.animation in its first animation frame, so this is the
-  // signal that covers the whole interval (a commit landing between the send
-  // effect and that first frame would otherwise let the reserve restore
-  // preempt the glide with an instant jump).
-  const sendScrollInFlightRef = useRef(false)
+  const pointerOnScrollbarRef = useRef(false)
+  const touchActiveRef = useRef(false)
+  const touchSettleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const scheduleTouchSettleRef = useRef<(() => void) | null>(null)
+
+  // The one owned animation: an exponential chase toward the (live,
+  // re-computed each frame) target, used only for explicit trips. Its first
+  // write is deferred a frame so a commit landing between the send effect and
+  // the glide's start still sees the pre-glide viewport.
+  const glideRef = useRef<{ cancel: () => void } | null>(null)
 
   // How many trailing (visible) messages to render. Grows on scroll-up and while
   // the user is scrolled up during streaming. Starts at BASE_WINDOW; the component
@@ -175,9 +206,139 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   // viewport after the larger slice renders so the content under the user doesn't jump.
   const prevScrollHeightRef = useRef<number | null>(null)
 
-  // The trailing slice we actually render. Derived values in the component still
-  // compute over the FULL message list, so turn boundaries / elapsed times / etc.
-  // stay correct even when their anchor message is outside the rendered window.
+  const rememberPosition = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    baselineRef.current = {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }
+  }, [])
+
+  const cancelGlide = useCallback(() => {
+    glideRef.current?.cancel()
+  }, [])
+
+  const releaseFollow = useCallback(() => {
+    followingRef.current = false
+    setIsAtBottom(false)
+    glideRef.current?.cancel()
+  }, [])
+
+  // While a held pointer is growing a text selection inside the transcript,
+  // pinning would drag the selection anchor away mid-gesture.
+  const selectionInProgress = useCallback(() => {
+    if (!pointerDownRef.current) return false
+    const selection = window.getSelection()
+    return (
+      !!selection &&
+      !selection.isCollapsed &&
+      !!selection.anchorNode &&
+      !!scrollRef.current?.contains(selection.anchorNode)
+    )
+  }, [])
+
+  // Re-assert the live edge. Convergence, not classification: called after
+  // every content/viewport resize and every reserve sync while following, so
+  // any clamp or missed event self-heals on the next change. Skipped while
+  // the user owns the viewport (drag/scrollbar/touch/selection — their
+  // interaction's end re-derives and pins) and while a glide is making the
+  // trip. A fresh upward gesture still in motion also defers the pin — but
+  // with a scheduled retry, since the growth that requested it may have been
+  // the last one.
+  const pinRetryRef = useRef<() => void>(() => {})
+  const pinRetryTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  useEffect(() => () => clearTimeout(pinRetryTimerRef.current), [])
+  const pinToLiveEdge = useCallback(() => {
+    const el = scrollRef.current
+    if (!el || !followingRef.current) return
+    if (glideRef.current) return
+    if (pointerDragRef.current || pointerOnScrollbarRef.current || touchActiveRef.current) return
+    const sinceUserScrollUp = performance.now() - lastUserScrollUpAtRef.current
+    if (sinceUserScrollUp < USER_SCROLL_HOLD_MS) {
+      clearTimeout(pinRetryTimerRef.current)
+      pinRetryTimerRef.current = setTimeout(
+        () => pinRetryRef.current(),
+        USER_SCROLL_HOLD_MS - sinceUserScrollUp + 10,
+      )
+      return
+    }
+    if (selectionInProgress()) return
+    const target = liveEdgeTarget(el)
+    if (el.scrollTop < target) {
+      el.scrollTop = target
+      rememberPosition()
+    }
+  }, [rememberPosition, selectionInProgress])
+  useLayoutEffect(() => {
+    pinRetryRef.current = pinToLiveEdge
+  }, [pinToLiveEdge])
+
+  const glideToLiveEdge = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    glideRef.current?.cancel()
+    if (prefersReducedMotion()) {
+      el.scrollTop = liveEdgeTarget(el)
+      rememberPosition()
+      return
+    }
+    let frameId = 0
+    let last = 0
+    let startedAt = 0
+    const handle = {
+      cancel: () => {
+        cancelAnimationFrame(frameId)
+        if (glideRef.current === handle) glideRef.current = null
+      },
+    }
+    glideRef.current = handle
+    const step = (now: number) => {
+      if (glideRef.current !== handle) return
+      if (!startedAt) {
+        startedAt = now
+        last = now
+      }
+      // The target is re-read every frame: content streaming in during the
+      // glide moves the live edge, and the chase follows it rather than
+      // landing short at a stale coordinate.
+      const target = liveEdgeTarget(el)
+      const dt = Math.min(64, now - last)
+      last = now
+      const remaining = target - el.scrollTop
+      if (Math.abs(remaining) <= 1 || now - startedAt >= GLIDE_MAX_MS) {
+        el.scrollTop = target
+        rememberPosition()
+        glideRef.current = null
+        return
+      }
+      el.scrollTop = el.scrollTop + remaining * (1 - Math.exp((-dt / 1000) * GLIDE_RATE_PER_S))
+      rememberPosition()
+      frameId = requestAnimationFrame(step)
+    }
+    frameId = requestAnimationFrame(step)
+  }, [rememberPosition])
+
+  const engageFollow = useCallback((trip: 'instant' | 'glide') => {
+    followingRef.current = true
+    setIsAtBottom(true)
+    if (trip === 'glide') {
+      glideToLiveEdge()
+      return
+    }
+    glideRef.current?.cancel()
+    const el = scrollRef.current
+    if (el) {
+      el.scrollTop = liveEdgeTarget(el)
+      rememberPosition()
+    }
+  }, [glideToLiveEdge, rememberPosition])
+
+  // Visible messages the trailing window slices. Derived values in the
+  // component still compute over the FULL message list, so turn boundaries /
+  // elapsed times / etc. stay correct even when their anchor message is
+  // outside the rendered window.
   const windowedMessages = useMemo(
     () => visibleMessages.slice(-windowSize),
     [visibleMessages, windowSize]
@@ -201,11 +362,11 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     // position instead of sliding off the trailing window.
     if (
       grown > 0 &&
-      (!stickState.isAtBottom || anchoredTurnRef.current || prevScrollHeightRef.current != null)
+      (!followingRef.current || anchoredTurnRef.current || prevScrollHeightRef.current != null)
     ) {
       setWindowSize((n) => n + grown)
     }
-  }, [visibleMessages, stickState])
+  }, [visibleMessages])
 
   const setBottomSpacerHeight = useCallback((height: number) => {
     const spacer = bottomSpacerRef.current
@@ -216,84 +377,12 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     spacer.hidden = nextHeight === 0
   }, [])
 
-  // A programmatic follow transition — the send-anchor scroll (where the
-  // previous turn collapses to a summary row and content shrinks above), or a
-  // viewport re-pin — can coincide with a browser clamp whose scroll event
-  // reads as the reader scrolling up. Two defenses: shield the library's
-  // deferred classification across the transition (it skips scroll events
-  // while a resize is in flight), and verify shortly after — an escape with
-  // no user gesture inside the window can only be such an echo, so reverse
-  // it. Real gestures (wheel, touch, held pointer, scroll keys) suppress the
-  // reversal, so a reader who actually leaves during the window stays left.
-  const verifyFollowTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-  useEffect(() => () => clearTimeout(verifyFollowTimerRef.current), [])
-  // Verify shortly after a transition — or after a gesture-driven scroll —
-  // that following's engagement still matches what the user actually did.
-  // `intentBacked` marks an arming scroll produced by a live escape intent:
-  // any latch it caused is genuine and must not be reversed.
-  const armFollowVerification = useCallback((intentBacked: boolean) => {
-    const transitionAt = performance.now()
-    // Only a disengage that HAPPENS inside this window is suspect. A reader
-    // who left the live edge long ago and then scrolls (even downward) must
-    // never be yanked back — reversal applies solely to follows that were
-    // still engaged when the window opened.
-    const wasFollowing = stickState.isAtBottom
-    clearTimeout(verifyFollowTimerRef.current)
-    verifyFollowTimerRef.current = setTimeout(() => {
-      // A disengage inside the window with nothing to justify it can only be
-      // a clamp echo or a follow-write misread as an upward scroll — reverse
-      // it. An active drag, escape intent inside the window, or a press
-      // around the transition (a scrollbar track click pages without moving
-      // the pointer) all say the reader may genuinely own their position.
-      const userMayOwnPosition =
-        intentBacked ||
-        (pointerDownRef.current && pointerDragRef.current) ||
-        lastEscapeIntentAtRef.current >= transitionAt ||
-        (pointerDownRef.current &&
-          pointerDownAtRef.current >= transitionAt - SCROLL_GESTURE_WINDOW_MS)
-      if (!userMayOwnPosition && wasFollowing && !stickState.isAtBottom) {
-        void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
-        return
-      }
-      // The shield cuts both ways: while it holds, the library also discards
-      // the scroll classification of genuine keyboard, touch, and scrollbar
-      // escapes (wheel-up escapes through its own handler and is unaffected).
-      // If an intent-backed gesture moved the reader upward during the window
-      // yet following still reads engaged and they are beyond the re-stick
-      // range, that escape was swallowed — honor it, or the next growth would
-      // yank them back down. Reserve eating is unaffected: it re-bases the
-      // reading line onto the reader, keeping them within the re-stick range.
-      if (
-        stickState.isAtBottom &&
-        lastUpwardGestureAtRef.current >= transitionAt &&
-        !stickState.isNearBottom
-      ) {
-        stickStopScroll()
-      }
-    }, 40)
-  }, [stickState, stickScrollToBottom, stickStopScroll])
-  const protectFollowTransition = useCallback(() => {
-    if (stickState.resizeDifference === 0) {
-      stickState.resizeDifference = 1
-      // Mirror the library's own reset: the clamp's deferred classification
-      // (a tick after its scroll event) must land inside the shield, so drop
-      // it a frame + a tick later. The guard keeps a concurrent real content
-      // resize's value intact.
-      requestAnimationFrame(() => {
-        setTimeout(() => {
-          if (stickState.resizeDifference === 1) stickState.resizeDifference = 0
-        }, 1)
-      })
-    }
-    armFollowVerification(false)
-  }, [stickState, armFollowVerification])
-
   // Keep the newly-sent turn fixed at its reading line while the response uses
   // up the reserved room below it. The spacer inflates scrollHeight so that the
-  // reading line IS the scroll target: from the follow library's perspective
-  // the reader simply sits at the bottom, and content growth paired with an
-  // equal spacer shrink is a net-zero resize — no motion. Once the reserve
-  // reaches zero the anchor retires and real growth resumes normal following.
+  // reading line IS the live-edge target: from the engine's perspective the
+  // reader simply sits at the bottom, and content growth paired with an equal
+  // spacer shrink is a net-zero resize — no motion. Once the reserve reaches
+  // zero the anchor retires and real growth resumes normal following.
   const syncTurnReserve = useCallback(() => {
     const el = scrollRef.current
     const anchoredTurn = anchoredTurnRef.current
@@ -314,101 +403,87 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     // swapping forms, a streamed block replaced by its shorter persisted copy)
     // clamps scrollTop below the reading line for the instant before the
     // spacer write above re-inflates the scroll range — and nothing else moves
-    // it back until content grows again, so the held turn visibly sags. The
-    // anchored reading line IS the scroll target while the reserve holds, so
-    // put the viewport back on it. Skip while the reader is gesturing (their
-    // scroll owns the position — reserve eating re-bases the anchor), while a
-    // send's scroll to the reading line is pending or animating (it starts
-    // below the target by construction), and while any other scroll
-    // animation is in flight.
-    const gestureDriven =
-      (pointerDownRef.current && pointerDragRef.current) ||
-      performance.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
-    const target = Math.max(0, stickState.calculatedTargetScrollTop)
-    if (
-      !sendScrollInFlightRef.current &&
-      !gestureDriven &&
-      stickState.isAtBottom &&
-      !stickState.animation &&
-      el.scrollTop < target
-    ) {
-      protectFollowTransition()
-      stickState.scrollTop = target
-      lastScrollTopRef.current = el.scrollTop
-    }
-  }, [scrollRef, setBottomSpacerHeight, stickState, protectFollowTransition])
+    // it back until content grows again, so the held turn would visibly sag.
+    // The anchored reading line IS the live-edge target while the reserve
+    // holds; the pin puts the viewport back on it (and carries its own
+    // guards for gestures and the send glide).
+    pinToLiveEdge()
+  }, [setBottomSpacerHeight, pinToLiveEdge])
 
-  // Pin the viewport to the live edge before first paint. The library's own
-  // initial scroll runs from its ResizeObserver callback, which lands after
-  // paint — without this, opening a session flashes the top of the transcript
-  // for a frame. Guarded and dep-free because the scroll container mounts only
-  // after loading/error states resolve.
+  // Pin the viewport to the live edge before first paint — without this,
+  // opening a session flashes the top of the transcript for a frame. Guarded
+  // and dep-free because the scroll container mounts only after loading/error
+  // states resolve.
   const pinnedInitialRef = useRef(false)
   useLayoutEffect(() => {
-    if (pinnedInitialRef.current || !scrollRef.current) return
+    const el = scrollRef.current
+    if (pinnedInitialRef.current || !el) return
     pinnedInitialRef.current = true
-    stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
-    lastScrollTopRef.current = scrollRef.current.scrollTop
+    el.scrollTop = liveEdgeTarget(el)
+    rememberPosition()
   })
 
   const handleScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
     const el = event.currentTarget
-    const previousScrollTop = lastScrollTopRef.current
-    lastScrollTopRef.current = el.scrollTop
+    const baseline = baselineRef.current
 
-    // Only scroll events that closely follow a real gesture may adjust the
-    // reserve. Programmatic writes (the follow animation) and layout clamps
-    // from shrinking content reach this handler too, but carry no fresh
-    // wheel/touch/key stamp and no moving drag, so they pass through. A held
-    // pointer counts only while it is an actual drag — a stale press (its
-    // release swallowed by a context menu or a focus change) must not keep
-    // attributing clamps to the user indefinitely.
-    const now = performance.now()
-    const activeDrag = pointerDownRef.current && pointerDragRef.current
-    const gestureDriven =
-      activeDrag || now - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
-    const escapeIntentLive =
-      activeDrag || now - lastEscapeIntentAtRef.current < SCROLL_GESTURE_WINDOW_MS
+    // Upward classification requires stable geometry. Our own writes refresh
+    // the baseline in the same statement, so their echoes read as zero
+    // deltas; a layout clamp only fires in a frame where the scroll range
+    // changed, so it fails the stability check. What remains — an upward
+    // move with both dimensions unchanged — has no author but the user (a
+    // dragged scrollbar, touch momentum, find-in-page). Downward needs no
+    // stability gate at all: clamps only ever DECREASE scrollTop, so an
+    // increase the baseline doesn't already reflect is always the user.
+    const sizeStable =
+      !!baseline &&
+      baseline.scrollHeight === el.scrollHeight &&
+      baseline.clientHeight === el.clientHeight
+    const upwardDelta = sizeStable ? Math.max(0, baseline.scrollTop - el.scrollTop) : 0
+    const downwardDelta = baseline ? Math.max(0, el.scrollTop - baseline.scrollTop) : 0
 
-    // A gesture-driven scroll can be misread by the follow library as an
-    // upward escape even when the input pointed down (its follow writes and
-    // the native scroll fight over scrollTop, and the loser's position reads
-    // as "scrolled up"). Re-verify shortly after every gesture-driven scroll
-    // so a latch with no escape intent behind it gets reversed. Armed before
-    // the upward stamp below so that stamp postdates the verification window.
-    if (gestureDriven) armFollowVerification(escapeIntentLive)
-
-    // Blank reserve is one-way. When the reader moves upward, consume the same
-    // number of pixels from the spacer. The new scroll position becomes the
-    // reserve's live edge, so that discarded blank area cannot be revisited.
-    const anchoredTurn = anchoredTurnRef.current
-    const upwardDelta = Math.max(0, previousScrollTop - el.scrollTop)
-    const downwardDelta = Math.max(0, el.scrollTop - previousScrollTop)
-    if (gestureDriven && upwardDelta > 0 && escapeIntentLive) {
-      lastUpwardGestureAtRef.current = performance.now()
+    if (upwardDelta > 0) {
+      lastUserScrollUpAtRef.current = performance.now()
+      // Blank reserve is one-way. When the reader moves upward, consume the
+      // same number of pixels from the spacer. The new scroll position
+      // becomes the reserve's live edge, so that discarded blank area cannot
+      // be revisited — and the re-based target keeps the reader "at the
+      // bottom", so eating never disengages following by itself.
+      const anchoredTurn = anchoredTurnRef.current
+      if (anchoredTurn && bottomSpacerHeightRef.current > 0) {
+        const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
+        const remainingSpacer = bottomSpacerHeightRef.current - discard
+        anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
+        setBottomSpacerHeight(remainingSpacer)
+        if (remainingSpacer === 0) anchoredTurnRef.current = null
+      }
+      // Beyond the live-edge band, an upward user move is an escape. The
+      // band absorbs elastic bounce-back and sub-pixel jitter; wheel and
+      // keyboard escapes don't come through here at all (their input events
+      // release directly).
+      if (followingRef.current && distanceFromBottom(el) > ESCAPE_MIN_DISTANCE_PX) {
+        releaseFollow()
+      }
     }
-    if (gestureDriven && anchoredTurn && upwardDelta > 0 && bottomSpacerHeightRef.current > 0) {
-      const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
-      const remainingSpacer = bottomSpacerHeightRef.current - discard
-      anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
-      setBottomSpacerHeight(remainingSpacer)
-      if (remainingSpacer === 0) anchoredTurnRef.current = null
+
+    if (downwardDelta > 0) {
+      // Reaching the actual live edge through a user scroll is an explicit
+      // trip to the bottom: retire the reserve so its blank room doesn't
+      // keep the streamed content away from the reader.
+      if (anchoredTurnRef.current && distanceFromBottom(el) <= 1) {
+        anchoredTurnRef.current = null
+        setBottomSpacerHeight(0)
+      }
+      // Arriving near the live edge re-engages following.
+      if (!followingRef.current && distanceFromBottom(el) <= ATTACH_OFFSET_PX) {
+        engageFollow('instant')
+      }
     }
 
-    // Reaching the actual live edge through a user scroll is an explicit trip
-    // to the bottom: retire the reserve so its blank room doesn't keep the
-    // streamed content away from the reader. The browser clamps scrollTop to
-    // the new natural maximum synchronously.
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-    if (
-      gestureDriven &&
-      downwardDelta > 0 &&
-      anchoredTurnRef.current &&
-      distanceFromBottom <= 1
-    ) {
-      anchoredTurnRef.current = null
-      setBottomSpacerHeight(0)
-      lastScrollTopRef.current = el.scrollTop
+    // Touch momentum is still delivering scroll events — push the settle
+    // deadline out; the interaction ends when they go quiet.
+    if (touchActiveRef.current && touchSettleTimerRef.current !== undefined) {
+      scheduleTouchSettleRef.current?.()
     }
 
     // Near the top: reveal the next local chunk, or fetch the next API page.
@@ -433,7 +508,11 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
         })
       }
     }
-  }, [hiddenCount, hasOlder, isFetchingOlder, fetchOlder, setBottomSpacerHeight, scrollRef, armFollowVerification])
+
+    // Re-read rather than reuse the entry sample: reserve eating above may
+    // have changed the spacer (and with it scrollHeight) inside this handler.
+    rememberPosition()
+  }, [hiddenCount, hasOlder, isFetchingOlder, fetchOlder, setBottomSpacerHeight, releaseFollow, engageFollow, rememberPosition])
 
   // After a scroll-up expansion adds older messages above the viewport, restore the
   // scroll position so the content the user was reading stays put (no jump).
@@ -446,29 +525,17 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     if (el && prevScrollHeightRef.current != null) {
       el.scrollTop += el.scrollHeight - prevScrollHeightRef.current
       prevScrollHeightRef.current = null
+      rememberPosition()
     }
-    // scrollRef is a stable library ref — windowSize remains the sole trigger.
-  }, [windowSize, scrollRef])
+  }, [windowSize, rememberPosition])
 
   const scrollToBottom = useCallback(() => {
-    // Drop the turn reserve first so the scroll target is the true live edge,
+    // Drop the turn reserve first so the trip's target is the true live edge,
     // not the blank reading-line reserve.
     anchoredTurnRef.current = null
     setBottomSpacerHeight(0)
-    void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
-  }, [setBottomSpacerHeight, stickScrollToBottom])
-
-  // A turn completing collapses its whole work phase into a summary row — a
-  // massive one-commit shrink whose browser clamp reads as the reader
-  // scrolling up, stranding the viewport above the final answer. Guard the
-  // transition from the same commit (this runs before the clamp's scroll
-  // event can dispatch, so the shield is race-free here).
-  const prevCompletedTurnCountRef = useRef(completedTurnCount)
-  useLayoutEffect(() => {
-    const grew = completedTurnCount > prevCompletedTurnCountRef.current
-    prevCompletedTurnCountRef.current = completedTurnCount
-    if (grew && stickState.isAtBottom) protectFollowTransition()
-  }, [completedTurnCount, stickState, protectFollowTransition])
+    engageFollow('glide')
+  }, [setBottomSpacerHeight, engageFollow])
 
   // Detect actual sends by id (rather than list length, since materialization
   // can remove one ghost as another arrives). A turn-starting send gets a
@@ -495,7 +562,6 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
         ).find((element) => element.dataset.turnAnchorId === newestTurnStart.localId)
 
         if (viewport && anchor) {
-          lastScrollTopRef.current = viewport.scrollTop
           const anchorTop =
             anchor.getBoundingClientRect().top -
             viewport.getBoundingClientRect().top +
@@ -513,33 +579,19 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
         setBottomSpacerHeight(0)
       }
 
-      // The viewport intentionally sits below the new reading line until the
-      // scroll below travels there — hold the reserve restore off for the
-      // whole interval (state.animation alone starts too late: the library
-      // assigns it in its first animation frame, and a commit can land first).
-      sendScrollInFlightRef.current = true
-      // Size the reserve before scrolling so the scroll target IS the new
-      // turn's reading line (the spacer inflates scrollHeight to end there).
-      syncTurnReserve()
-      // The collapse of the finished turn above (same commit as the ghost)
-      // shrinks content and can clamp scrollTop — guard the transition so
-      // that clamp echo cannot latch an escape under the send.
-      protectFollowTransition()
       // A send always returns the reader to the thread: re-engage following
-      // and glide to the reading line (or the live edge for queued sends).
-      // Under reduced motion, position synchronously instead of gliding.
+      // and travel to the new turn's reading line (the spacer inflates
+      // scrollHeight so the live-edge target IS that line). Order differs by
+      // mode: the instant write needs the spacer sized first, while the
+      // glide must claim the viewport before the reserve sync — its pin
+      // would otherwise jump the trip's starting point.
       if (prefersReducedMotion()) {
-        stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
+        syncTurnReserve()
+        engageFollow('instant')
+      } else {
+        engageFollow('glide')
+        syncTurnReserve()
       }
-      void Promise.resolve(
-        stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined),
-      ).finally(() => {
-        sendScrollInFlightRef.current = false
-      })
-      // Programmatic writes fire their scroll event asynchronously (and not at
-      // all in jsdom) — resync the gesture-delta baseline now so the write
-      // isn't misread as a user delta.
-      lastScrollTopRef.current = scrollRef.current?.scrollTop ?? 0
       return
     }
 
@@ -555,52 +607,39 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     activeSubagents,
     syncTurnReserve,
     setBottomSpacerHeight,
-    scrollRef,
-    stickState,
-    stickScrollToBottom,
-    protectFollowTransition,
+    engageFollow,
     bottomInset,
   ])
 
+  // The engine's convergence driver: any content or viewport resize re-pins
+  // the live edge while following. This covers streamed growth, thinking-card
+  // collapses (the clamp's echo fails the stability check; the pin puts the
+  // viewport back), vertical window resizes (browsers anchor the TOP edge, so
+  // a shrink would slide the live edge behind the fold), and container-only
+  // resizes (a growing composer). Re-attach after the loading/error states
+  // resolve — the scroll container mounts only then.
+  useEffect(() => {
+    const content = contentRef.current
+    const viewport = scrollRef.current
+    if (!content || !viewport || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => {
+      pinToLiveEdge()
+    })
+    observer.observe(content)
+    observer.observe(viewport)
+    return () => observer.disconnect()
+  }, [pinToLiveEdge, isLoading, error])
+
   // Markdown, images, and expanded tool cards can change height without a
-  // message-state update. Feed those layout changes through the same reserve
-  // calculation so they cannot make the anchored turn jump. Re-attach after
-  // the loading/error states resolve — the scroll container mounts only then.
+  // message-state update — and the spacer math depends on the viewport's
+  // clientHeight, so window resizes matter too. Feed both through the same
+  // reserve calculation so they cannot make the anchored turn jump.
   useEffect(() => {
     const content = contentBodyRef.current
     const viewport = scrollRef.current
     if (!content || !viewport || typeof ResizeObserver === 'undefined') return
     let frameId = 0
-    let lastViewportHeight = viewport.clientHeight
-    let lastContentHeight = content.offsetHeight
     const observer = new ResizeObserver(() => {
-      // A vertical viewport resize is invisible to the follow library (it
-      // observes only the content element), and browsers anchor the TOP edge
-      // on resize — so a window shrink would slide the live edge behind the
-      // fold. Re-pin immediately while following, guarded against the grow
-      // clamp's scroll echo being read as an escape (a viewport GROW lowers
-      // the scroll range, and the browser's clamp fires a scroll event that
-      // classifies as the reader scrolling up). During the turn reserve the
-      // spacer math already keeps the reading line valid, so no pin there.
-      const viewportHeight = viewport.clientHeight
-      if (viewportHeight !== lastViewportHeight) {
-        lastViewportHeight = viewportHeight
-        if (stickState.isAtBottom && !anchoredTurnRef.current) {
-          protectFollowTransition()
-          stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
-          lastScrollTopRef.current = viewport.scrollTop
-        }
-      }
-      // Catch-all for content shrinks at the live edge (a thinking card
-      // collapsing, a streamed block swapped for its shorter persisted form):
-      // each one clamps scrollTop and can latch a spurious escape the same
-      // way. The commit-hooked guards cover the big known transitions
-      // race-free; this covers the rest via the deferred verification.
-      const contentHeight = content.offsetHeight
-      if (contentHeight < lastContentHeight && stickState.isAtBottom) {
-        protectFollowTransition()
-      }
-      lastContentHeight = contentHeight
       cancelAnimationFrame(frameId)
       frameId = requestAnimationFrame(syncTurnReserve)
     })
@@ -610,17 +649,18 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       cancelAnimationFrame(frameId)
       observer.disconnect()
     }
-  }, [syncTurnReserve, scrollRef, stickState, protectFollowTransition, isLoading, error])
+  }, [syncTurnReserve, isLoading, error])
 
-  // Escape from following is owned by the stick-to-bottom library (wheel
-  // direction, scroll direction, selection). These stamps exist so the scroll
-  // handler can attribute reserve adjustments to a live gesture, and so the
-  // deferred verification can tell escape-capable input (wheel-up, touch,
-  // upward keys, a drag) from input that never leaves the live edge.
+  // --- Input handlers: where escape and re-engage actually come from. -------
+
   // A wheel consumed by a nested scrollable (the thinking card's body, a code
-  // block) never moves the transcript and must not count as a transcript
-  // gesture; scroll chaining hands the wheel to us only once the inner
-  // scroller is at its edge, which the walk below mirrors.
+  // block) never moves the transcript and must not count; scroll chaining
+  // hands the wheel to us only once the inner scroller is at its edge, which
+  // the walk below mirrors. An upward wheel releases following before its
+  // scroll event can be fought over — unless the reserve is holding, where
+  // upward motion eats the spacer instead (the scroll handler re-bases the
+  // reading line onto the reader). A downward wheel that will land within the
+  // attach range re-engages.
   const handleWheelGesture = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
     const outer = scrollRef.current
     if (!outer) return
@@ -629,59 +669,91 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       if (nestedScrollableConsumesWheel(node, event.deltaY)) return
       node = node.parentElement
     }
-    const now = performance.now()
-    lastGestureAtRef.current = now
-    if (event.deltaY < 0) lastEscapeIntentAtRef.current = now
-  }, [scrollRef])
+    if (event.deltaY < 0) {
+      cancelGlide()
+      if (outer.scrollHeight <= outer.clientHeight + 1) return
+      if (anchoredTurnRef.current && bottomSpacerHeightRef.current > 0) return
+      if (followingRef.current) releaseFollow()
+    } else if (event.deltaY > 0 && !followingRef.current) {
+      if (distanceFromBottom(outer) - event.deltaY <= ATTACH_OFFSET_PX) {
+        engageFollow('instant')
+      }
+    }
+  }, [cancelGlide, releaseFollow, engageFollow])
 
-  // Touch direction isn't knowable from a single event without tracking touch
-  // points; treat any touch scroll as escape-capable.
-  const handleTouchGesture = useCallback(() => {
-    const now = performance.now()
-    lastGestureAtRef.current = now
-    lastEscapeIntentAtRef.current = now
-  }, [])
+  const handleScrollKey = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const el = scrollRef.current
+    if (!el || el.scrollHeight <= el.clientHeight + 1) return
+    const upward =
+      UPWARD_SCROLL_KEYS.has(event.key) || (event.key === ' ' && event.shiftKey)
+    if (upward) {
+      cancelGlide()
+      if (anchoredTurnRef.current && bottomSpacerHeightRef.current > 0) return
+      if (followingRef.current) releaseFollow()
+    } else if (event.key === 'End' && !followingRef.current) {
+      engageFollow('instant')
+    }
+  }, [cancelGlide, releaseFollow, engageFollow])
 
-  // Scrollbar interactions emit no wheel/touch/key events — track the held
-  // pointer. Only a pointer that actually moves is a drag; a motionless press
-  // (or one whose release never arrived) must not stay a gesture forever.
+  // When a drag / scrollbar interaction / touch sequence ends, following is
+  // derived from where it left the reader — near the live edge means follow.
+  const settleInteraction = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    if (distanceFromBottom(el) <= ATTACH_OFFSET_PX) {
+      if (!followingRef.current) engageFollow('instant')
+      else pinToLiveEdge()
+    } else if (followingRef.current) {
+      releaseFollow()
+    }
+  }, [engageFollow, pinToLiveEdge, releaseFollow])
+
+  // Scrollbar interactions emit no wheel/key events — track the held pointer.
+  // A press in the scrollbar gutter suspends pinning outright (track clicks
+  // page without any pointer motion); a content press only counts once it
+  // actually drags. A motionless press — or one whose release was swallowed
+  // by a native context menu or a focus change — must never own the viewport
+  // indefinitely.
   const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return
+    const el = scrollRef.current
     pointerDownRef.current = true
     pointerDragRef.current = false
-    pointerDownAtRef.current = performance.now()
     pointerDownPosRef.current = { x: event.clientX, y: event.clientY }
-    lastGestureAtRef.current = performance.now()
-  }, [])
+    pointerOnScrollbarRef.current =
+      !!el &&
+      el.clientWidth > 0 &&
+      event.clientX >= el.getBoundingClientRect().left + el.clientWidth
+    if (pointerOnScrollbarRef.current) cancelGlide()
+  }, [cancelGlide])
   useEffect(() => {
     const release = () => {
+      const owned = pointerDragRef.current || pointerOnScrollbarRef.current
       pointerDownRef.current = false
       pointerDragRef.current = false
       pointerDownPosRef.current = null
+      pointerOnScrollbarRef.current = false
+      if (owned) settleInteraction()
     }
     const move = (event: PointerEvent) => {
-      if (!pointerDownRef.current) return
-      if (!pointerDragRef.current) {
-        const start = pointerDownPosRef.current
-        if (!start) return
-        if (
-          Math.abs(event.clientX - start.x) + Math.abs(event.clientY - start.y) <
-          POINTER_DRAG_THRESHOLD_PX
-        ) {
-          return
-        }
-        pointerDragRef.current = true
+      if (!pointerDownRef.current || pointerDragRef.current) return
+      const start = pointerDownPosRef.current
+      if (!start) return
+      if (
+        Math.abs(event.clientX - start.x) + Math.abs(event.clientY - start.y) <
+        POINTER_DRAG_THRESHOLD_PX
+      ) {
+        return
       }
-      const now = performance.now()
-      lastGestureAtRef.current = now
-      lastEscapeIntentAtRef.current = now
+      pointerDragRef.current = true
+      glideRef.current?.cancel()
     }
     window.addEventListener('pointerup', release)
     window.addEventListener('pointercancel', release)
     window.addEventListener('pointermove', move)
     // A native context menu (two-finger tap) or a focus change can swallow the
-    // pointerup — without these, the "held pointer" would outlive the gesture
-    // indefinitely and every later browser clamp would read as user scrolling.
+    // pointerup — without these, the "held pointer" would own the viewport
+    // forever and pinning would never resume.
     window.addEventListener('blur', release)
     window.addEventListener('contextmenu', release)
     return () => {
@@ -691,15 +763,34 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       window.removeEventListener('blur', release)
       window.removeEventListener('contextmenu', release)
     }
-  }, [])
+  }, [settleInteraction])
 
-  const handleScrollKey = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (!SCROLL_KEYS.has(event.key)) return
-    const now = performance.now()
-    lastGestureAtRef.current = now
-    const upward =
-      UPWARD_SCROLL_KEYS.has(event.key) || (event.key === ' ' && event.shiftKey)
-    if (upward) lastEscapeIntentAtRef.current = now
+  // Touch: the pan suspends pinning; momentum keeps delivering scroll events
+  // after the fingers lift, so the interaction ends only once those go quiet.
+  // Escapes still latch mid-gesture through the scroll handler's backstop.
+  useEffect(() => {
+    scheduleTouchSettleRef.current = () => {
+      clearTimeout(touchSettleTimerRef.current)
+      touchSettleTimerRef.current = setTimeout(() => {
+        touchSettleTimerRef.current = undefined
+        touchActiveRef.current = false
+        settleInteraction()
+      }, TOUCH_SETTLE_MS)
+    }
+    return () => clearTimeout(touchSettleTimerRef.current)
+  }, [settleInteraction])
+  const handleTouchStart = useCallback(() => {
+    touchActiveRef.current = true
+    clearTimeout(touchSettleTimerRef.current)
+    touchSettleTimerRef.current = undefined
+    cancelGlide()
+  }, [cancelGlide])
+  const handleTouchMove = useCallback(() => {
+    touchActiveRef.current = true
+  }, [])
+  const handleTouchEnd = useCallback(() => {
+    if (!touchActiveRef.current) return
+    scheduleTouchSettleRef.current?.()
   }, [])
 
   return {
@@ -713,8 +804,10 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     hiddenCount,
     handleScroll,
     handleWheelGesture,
-    handleTouchGesture,
     handlePointerDown,
     handleScrollKey,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
   }
 }

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -1,0 +1,720 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type UIEvent as ReactUIEvent,
+  type WheelEvent as ReactWheelEvent,
+} from 'react'
+import { useStickToBottom } from 'use-stick-to-bottom'
+import { MESSAGES_PAGE_LIMIT, MESSAGES_PAGE_OLDER_LIMIT } from '@shared/lib/messages-page'
+import type { PendingMessage } from './pending-message'
+
+// On very long threads we render only a trailing window of messages to keep the
+// DOM small. Sessions with <= BASE_WINDOW visible items render in full, so small
+// and medium threads are completely unaffected. Scrolling near the top reveals
+// LOAD_STEP more at a time. The window is a fixed-size tail slice, so while new
+// messages stream in at the bottom the oldest rendered ones drop off the top and
+// the DOM node count stays flat. The window only grows on an explicit scroll-up
+// and is reset when the session changes.
+const BASE_WINDOW = MESSAGES_PAGE_LIMIT
+const LOAD_STEP = MESSAGES_PAGE_OLDER_LIMIT
+const TURN_ANCHOR_TOP = 100
+// Live-edge following (engage/escape/resume and the smooth chase) is owned by
+// use-stick-to-bottom: it derives escape from user-attributable signals (wheel
+// direction, scroll direction, text selection) and drives the viewport from
+// content resizes — scroll-event echoes of its own writes can never disengage
+// it. The layer in this file only manages what sits on top of that: the
+// new-turn reading-line reserve (the spacer) and windowed history loading.
+//
+// Scroll events cannot say who caused them, so the reserve adjustments below
+// only act on events that closely follow a real gesture (wheel/touch/keys, or
+// a held-down pointer for scrollbar drags). A layout clamp from shrinking
+// content carries no fresh gesture and passes through untouched.
+const SCROLL_GESTURE_WINDOW_MS = 400
+// A press only becomes a drag (and thereby a scroll gesture) once the pointer
+// travels this far from where it went down.
+const POINTER_DRAG_THRESHOLD_PX = 4
+const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '])
+const UPWARD_SCROLL_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
+
+// Mirrors the browser's scroll chaining for wheel input: a nested scrollable
+// consumes the wheel while it can still move in that direction; only at its
+// edge does the event scroll the ancestor.
+function nestedScrollableConsumesWheel(el: HTMLElement, deltaY: number): boolean {
+  if (el.scrollHeight <= el.clientHeight) return false
+  const { overflowY } = getComputedStyle(el)
+  if (overflowY !== 'auto' && overflowY !== 'scroll') return false
+  if (deltaY < 0) return el.scrollTop > 0
+  if (deltaY > 0) return el.scrollTop < el.scrollHeight - el.clientHeight - 1
+  return false
+}
+
+const prefersReducedMotion = () =>
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+interface MessageListScrollOptions<T> {
+  /** Messages after visibility filtering — what the trailing window slices. */
+  visibleMessages: readonly T[]
+  /** A new non-queued ghost anchors its turn's reading line (`data-turn-anchor-id`). */
+  pendingUserMessages: PendingMessage[] | undefined
+  /** Growth means a work phase collapsed into a summary row — a guarded transition. */
+  completedTurnCount: number
+  /** Height of an overlaid footer that the live edge must remain above. */
+  bottomInset: number
+  /** Older-history paging, driven by scrolling near the top. */
+  hasOlder: boolean
+  isFetchingOlder: boolean
+  fetchOlder: ((onBeforePrepend?: () => void) => Promise<boolean>) | undefined
+  /** The scroll container mounts only after these resolve — observers re-attach on them. */
+  isLoading: boolean
+  error: unknown
+  /**
+   * Never read — effect dependencies only. Each marks a commit that can change
+   * transcript layout, after which the turn reserve must re-sync.
+   */
+  messages: unknown
+  streamingMessage: unknown
+  streamingToolUses: unknown
+  thinkingBlocks: unknown
+  isCompacting: unknown
+  pendingRequestCount: unknown
+  activeSubagents: unknown
+}
+
+/**
+ * All scrolling behavior for the message list: live-edge following (via
+ * use-stick-to-bottom plus the gesture-attribution layer that keeps its
+ * position-inferred escapes honest), the new-turn reading-line reserve, and
+ * the windowed rendering of long histories with scroll-anchored older-page
+ * loading. The component renders; this hook decides where the viewport is.
+ *
+ * The returned handlers must all be bound on the scroll container, and the
+ * four refs on their respective elements (see MessageList's JSX). Turn-starting
+ * ghost wrappers must carry `data-turn-anchor-id={localId}` for the
+ * reading-line anchor to find them.
+ */
+export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
+  const {
+    visibleMessages,
+    pendingUserMessages,
+    completedTurnCount,
+    bottomInset,
+    hasOlder,
+    isFetchingOlder,
+    fetchOlder,
+    isLoading,
+    error,
+    messages,
+    streamingMessage,
+    streamingToolUses,
+    thinkingBlocks,
+    isCompacting,
+    pendingRequestCount,
+    activeSubagents,
+  } = options
+
+  // Live-edge following. `isAtBottom` goes false only on a user-attributable
+  // escape (wheel up, upward scroll, selection drag) and comes back when the
+  // reader returns near the bottom — geometry sampled from our own writes can
+  // never disengage it. Content growth is followed from the library's
+  // ResizeObserver on `contentRef`, so the bottom inset below must be a real
+  // element (content-box), not container padding.
+  const {
+    scrollRef,
+    contentRef,
+    scrollToBottom: stickScrollToBottom,
+    stopScroll: stickStopScroll,
+    isAtBottom,
+    state: stickState,
+  } = useStickToBottom({
+    initial: 'instant',
+    ...(prefersReducedMotion() ? { resize: 'instant' as const } : {}),
+  })
+  const contentBodyRef = useRef<HTMLDivElement>(null)
+  const bottomSpacerRef = useRef<HTMLDivElement>(null)
+  const bottomSpacerHeightRef = useRef(0)
+  const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
+  const lastScrollTopRef = useRef(0)
+  const lastGestureAtRef = useRef(0)
+  // Stamped only by gestures that can justify LEAVING the live edge: wheel-up
+  // reaching this scroller, touch, upward scroll keys, an actual drag. A
+  // downward wheel or a bare click stamps lastGestureAtRef but never this —
+  // otherwise a browser clamp landing near such input reads as the user
+  // scrolling away and kills following (idle trackpad noise near a thinking
+  // card collapse was enough).
+  const lastEscapeIntentAtRef = useRef(0)
+  // Stamped when a gesture-attributed scroll event moved the reader upward
+  // AND escape intent backs it — used to honor escapes the transition shield
+  // swallowed.
+  const lastUpwardGestureAtRef = useRef(0)
+  const pointerDownRef = useRef(false)
+  const pointerDownAtRef = useRef(0)
+  // A press only becomes a scroll gesture once the pointer moves (a scrollbar
+  // drag); a motionless press — or one whose release was swallowed by a native
+  // context menu or a focus change — must not gesture-attribute scroll events
+  // indefinitely.
+  const pointerDragRef = useRef(false)
+  const pointerDownPosRef = useRef<{ x: number; y: number } | null>(null)
+  // True from a send until its scroll-to-reading-line settles. The library
+  // only assigns state.animation in its first animation frame, so this is the
+  // signal that covers the whole interval (a commit landing between the send
+  // effect and that first frame would otherwise let the reserve restore
+  // preempt the glide with an instant jump).
+  const sendScrollInFlightRef = useRef(false)
+
+  // How many trailing (visible) messages to render. Grows on scroll-up and while
+  // the user is scrolled up during streaming. Starts at BASE_WINDOW; the component
+  // is keyed by sessionId at its mount site, so a switched session remounts fresh.
+  const [windowSize, setWindowSize] = useState(BASE_WINDOW)
+  // Scroll height captured just before a scroll-up expansion, used to re-anchor the
+  // viewport after the larger slice renders so the content under the user doesn't jump.
+  const prevScrollHeightRef = useRef<number | null>(null)
+
+  // The trailing slice we actually render. Derived values in the component still
+  // compute over the FULL message list, so turn boundaries / elapsed times / etc.
+  // stay correct even when their anchor message is outside the rendered window.
+  const windowedMessages = useMemo(
+    () => visibleMessages.slice(-windowSize),
+    [visibleMessages, windowSize]
+  )
+  const hiddenCount = visibleMessages.length - windowedMessages.length
+
+  // Keep the rendered range anchored at the top while the user is scrolled up.
+  // The window is a trailing slice, so when new messages are persisted it would
+  // normally drop the same number off the top — shifting the content the user is
+  // reading (overflow-anchor is disabled, so nothing compensates). Growing the
+  // window by exactly that delta keeps the same first rendered item; the new
+  // messages just append below, off-screen. When pinned to the bottom we leave the
+  // window alone so the slice slides and the DOM stays bounded.
+  const prevVisibleLenRef = useRef(visibleMessages.length)
+  useLayoutEffect(() => {
+    const grown = visibleMessages.length - prevVisibleLenRef.current
+    prevVisibleLenRef.current = visibleMessages.length
+    // Grow while the reader is away from the live edge (escaped), during the
+    // new-turn reserve, or when an older-page prepend is landing (a pending
+    // scroll capture marks that) — so the rows the user is reading keep their
+    // position instead of sliding off the trailing window.
+    if (
+      grown > 0 &&
+      (!stickState.isAtBottom || anchoredTurnRef.current || prevScrollHeightRef.current != null)
+    ) {
+      setWindowSize((n) => n + grown)
+    }
+  }, [visibleMessages, stickState])
+
+  const setBottomSpacerHeight = useCallback((height: number) => {
+    const spacer = bottomSpacerRef.current
+    if (!spacer) return
+    const nextHeight = Math.max(0, Math.ceil(height))
+    bottomSpacerHeightRef.current = nextHeight
+    spacer.style.height = `${nextHeight}px`
+    spacer.hidden = nextHeight === 0
+  }, [])
+
+  // A programmatic follow transition — the send-anchor scroll (where the
+  // previous turn collapses to a summary row and content shrinks above), or a
+  // viewport re-pin — can coincide with a browser clamp whose scroll event
+  // reads as the reader scrolling up. Two defenses: shield the library's
+  // deferred classification across the transition (it skips scroll events
+  // while a resize is in flight), and verify shortly after — an escape with
+  // no user gesture inside the window can only be such an echo, so reverse
+  // it. Real gestures (wheel, touch, held pointer, scroll keys) suppress the
+  // reversal, so a reader who actually leaves during the window stays left.
+  const verifyFollowTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  useEffect(() => () => clearTimeout(verifyFollowTimerRef.current), [])
+  // Verify shortly after a transition — or after a gesture-driven scroll —
+  // that following's engagement still matches what the user actually did.
+  // `intentBacked` marks an arming scroll produced by a live escape intent:
+  // any latch it caused is genuine and must not be reversed.
+  const armFollowVerification = useCallback((intentBacked: boolean) => {
+    const transitionAt = performance.now()
+    // Only a disengage that HAPPENS inside this window is suspect. A reader
+    // who left the live edge long ago and then scrolls (even downward) must
+    // never be yanked back — reversal applies solely to follows that were
+    // still engaged when the window opened.
+    const wasFollowing = stickState.isAtBottom
+    clearTimeout(verifyFollowTimerRef.current)
+    verifyFollowTimerRef.current = setTimeout(() => {
+      // A disengage inside the window with nothing to justify it can only be
+      // a clamp echo or a follow-write misread as an upward scroll — reverse
+      // it. An active drag, escape intent inside the window, or a press
+      // around the transition (a scrollbar track click pages without moving
+      // the pointer) all say the reader may genuinely own their position.
+      const userMayOwnPosition =
+        intentBacked ||
+        (pointerDownRef.current && pointerDragRef.current) ||
+        lastEscapeIntentAtRef.current >= transitionAt ||
+        (pointerDownRef.current &&
+          pointerDownAtRef.current >= transitionAt - SCROLL_GESTURE_WINDOW_MS)
+      if (!userMayOwnPosition && wasFollowing && !stickState.isAtBottom) {
+        void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
+        return
+      }
+      // The shield cuts both ways: while it holds, the library also discards
+      // the scroll classification of genuine keyboard, touch, and scrollbar
+      // escapes (wheel-up escapes through its own handler and is unaffected).
+      // If an intent-backed gesture moved the reader upward during the window
+      // yet following still reads engaged and they are beyond the re-stick
+      // range, that escape was swallowed — honor it, or the next growth would
+      // yank them back down. Reserve eating is unaffected: it re-bases the
+      // reading line onto the reader, keeping them within the re-stick range.
+      if (
+        stickState.isAtBottom &&
+        lastUpwardGestureAtRef.current >= transitionAt &&
+        !stickState.isNearBottom
+      ) {
+        stickStopScroll()
+      }
+    }, 40)
+  }, [stickState, stickScrollToBottom, stickStopScroll])
+  const protectFollowTransition = useCallback(() => {
+    if (stickState.resizeDifference === 0) {
+      stickState.resizeDifference = 1
+      // Mirror the library's own reset: the clamp's deferred classification
+      // (a tick after its scroll event) must land inside the shield, so drop
+      // it a frame + a tick later. The guard keeps a concurrent real content
+      // resize's value intact.
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          if (stickState.resizeDifference === 1) stickState.resizeDifference = 0
+        }, 1)
+      })
+    }
+    armFollowVerification(false)
+  }, [stickState, armFollowVerification])
+
+  // Keep the newly-sent turn fixed at its reading line while the response uses
+  // up the reserved room below it. The spacer inflates scrollHeight so that the
+  // reading line IS the scroll target: from the follow library's perspective
+  // the reader simply sits at the bottom, and content growth paired with an
+  // equal spacer shrink is a net-zero resize — no motion. Once the reserve
+  // reaches zero the anchor retires and real growth resumes normal following.
+  const syncTurnReserve = useCallback(() => {
+    const el = scrollRef.current
+    const anchoredTurn = anchoredTurnRef.current
+    if (!el || !anchoredTurn) return
+    const naturalScrollHeight = el.scrollHeight - bottomSpacerHeightRef.current
+    const requiredSpacer = Math.max(
+      0,
+      anchoredTurn.scrollTop + el.clientHeight - naturalScrollHeight,
+    )
+    setBottomSpacerHeight(requiredSpacer)
+    // The response now fills the viewport. Retire the special turn state so
+    // long-thread windowing can return to its bounded trailing slice.
+    if (requiredSpacer === 0) {
+      anchoredTurnRef.current = null
+      return
+    }
+    // A transient content shrink during the reserve hold (a working indicator
+    // swapping forms, a streamed block replaced by its shorter persisted copy)
+    // clamps scrollTop below the reading line for the instant before the
+    // spacer write above re-inflates the scroll range — and nothing else moves
+    // it back until content grows again, so the held turn visibly sags. The
+    // anchored reading line IS the scroll target while the reserve holds, so
+    // put the viewport back on it. Skip while the reader is gesturing (their
+    // scroll owns the position — reserve eating re-bases the anchor), while a
+    // send's scroll to the reading line is pending or animating (it starts
+    // below the target by construction), and while any other scroll
+    // animation is in flight.
+    const gestureDriven =
+      (pointerDownRef.current && pointerDragRef.current) ||
+      performance.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
+    const target = Math.max(0, stickState.calculatedTargetScrollTop)
+    if (
+      !sendScrollInFlightRef.current &&
+      !gestureDriven &&
+      stickState.isAtBottom &&
+      !stickState.animation &&
+      el.scrollTop < target
+    ) {
+      protectFollowTransition()
+      stickState.scrollTop = target
+      lastScrollTopRef.current = el.scrollTop
+    }
+  }, [scrollRef, setBottomSpacerHeight, stickState, protectFollowTransition])
+
+  // Pin the viewport to the live edge before first paint. The library's own
+  // initial scroll runs from its ResizeObserver callback, which lands after
+  // paint — without this, opening a session flashes the top of the transcript
+  // for a frame. Guarded and dep-free because the scroll container mounts only
+  // after loading/error states resolve.
+  const pinnedInitialRef = useRef(false)
+  useLayoutEffect(() => {
+    if (pinnedInitialRef.current || !scrollRef.current) return
+    pinnedInitialRef.current = true
+    stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
+    lastScrollTopRef.current = scrollRef.current.scrollTop
+  })
+
+  const handleScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
+    const el = event.currentTarget
+    const previousScrollTop = lastScrollTopRef.current
+    lastScrollTopRef.current = el.scrollTop
+
+    // Only scroll events that closely follow a real gesture may adjust the
+    // reserve. Programmatic writes (the follow animation) and layout clamps
+    // from shrinking content reach this handler too, but carry no fresh
+    // wheel/touch/key stamp and no moving drag, so they pass through. A held
+    // pointer counts only while it is an actual drag — a stale press (its
+    // release swallowed by a context menu or a focus change) must not keep
+    // attributing clamps to the user indefinitely.
+    const now = performance.now()
+    const activeDrag = pointerDownRef.current && pointerDragRef.current
+    const gestureDriven =
+      activeDrag || now - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS
+    const escapeIntentLive =
+      activeDrag || now - lastEscapeIntentAtRef.current < SCROLL_GESTURE_WINDOW_MS
+
+    // A gesture-driven scroll can be misread by the follow library as an
+    // upward escape even when the input pointed down (its follow writes and
+    // the native scroll fight over scrollTop, and the loser's position reads
+    // as "scrolled up"). Re-verify shortly after every gesture-driven scroll
+    // so a latch with no escape intent behind it gets reversed. Armed before
+    // the upward stamp below so that stamp postdates the verification window.
+    if (gestureDriven) armFollowVerification(escapeIntentLive)
+
+    // Blank reserve is one-way. When the reader moves upward, consume the same
+    // number of pixels from the spacer. The new scroll position becomes the
+    // reserve's live edge, so that discarded blank area cannot be revisited.
+    const anchoredTurn = anchoredTurnRef.current
+    const upwardDelta = Math.max(0, previousScrollTop - el.scrollTop)
+    const downwardDelta = Math.max(0, el.scrollTop - previousScrollTop)
+    if (gestureDriven && upwardDelta > 0 && escapeIntentLive) {
+      lastUpwardGestureAtRef.current = performance.now()
+    }
+    if (gestureDriven && anchoredTurn && upwardDelta > 0 && bottomSpacerHeightRef.current > 0) {
+      const discard = Math.min(upwardDelta, bottomSpacerHeightRef.current)
+      const remainingSpacer = bottomSpacerHeightRef.current - discard
+      anchoredTurn.scrollTop = Math.max(0, anchoredTurn.scrollTop - discard)
+      setBottomSpacerHeight(remainingSpacer)
+      if (remainingSpacer === 0) anchoredTurnRef.current = null
+    }
+
+    // Reaching the actual live edge through a user scroll is an explicit trip
+    // to the bottom: retire the reserve so its blank room doesn't keep the
+    // streamed content away from the reader. The browser clamps scrollTop to
+    // the new natural maximum synchronously.
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    if (
+      gestureDriven &&
+      downwardDelta > 0 &&
+      anchoredTurnRef.current &&
+      distanceFromBottom <= 1
+    ) {
+      anchoredTurnRef.current = null
+      setBottomSpacerHeight(0)
+      lastScrollTopRef.current = el.scrollTop
+    }
+
+    // Near the top: reveal the next local chunk, or fetch the next API page.
+    // prevScrollHeightRef is only set when we know the DOM will grow (local
+    // expand, or fetchOlder about to prepend) so a failed/empty fetch cannot wedge.
+    if (el.scrollTop < 200 && prevScrollHeightRef.current == null) {
+      if (hiddenCount > 0) {
+        prevScrollHeightRef.current = el.scrollHeight
+        setWindowSize((n) => n + LOAD_STEP)
+      } else if (hasOlder && !isFetchingOlder && fetchOlder) {
+        void fetchOlder(() => {
+          // Back at the bottom mid-fetch: the trailing window doesn't move on
+          // prepend, so skip the capture — a lingering guard would block the
+          // next scroll-up gesture. Derived from geometry at capture time.
+          const viewport = scrollRef.current
+          if (
+            viewport &&
+            viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight > 100
+          ) {
+            prevScrollHeightRef.current = viewport.scrollHeight
+          }
+        })
+      }
+    }
+  }, [hiddenCount, hasOlder, isFetchingOlder, fetchOlder, setBottomSpacerHeight, scrollRef, armFollowVerification])
+
+  // After a scroll-up expansion adds older messages above the viewport, restore the
+  // scroll position so the content the user was reading stays put (no jump).
+  // Deps are [windowSize] ONLY: when a prepend lands the anchor effect grows
+  // windowSize in the same commit, so this fires exactly when the rows mount.
+  // A visibleMessages.length dep would consume the guard one commit early
+  // (data grows, window unchanged, delta 0) and leave the mount uncompensated.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (el && prevScrollHeightRef.current != null) {
+      el.scrollTop += el.scrollHeight - prevScrollHeightRef.current
+      prevScrollHeightRef.current = null
+    }
+    // scrollRef is a stable library ref — windowSize remains the sole trigger.
+  }, [windowSize, scrollRef])
+
+  const scrollToBottom = useCallback(() => {
+    // Drop the turn reserve first so the scroll target is the true live edge,
+    // not the blank reading-line reserve.
+    anchoredTurnRef.current = null
+    setBottomSpacerHeight(0)
+    void stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined)
+  }, [setBottomSpacerHeight, stickScrollToBottom])
+
+  // A turn completing collapses its whole work phase into a summary row — a
+  // massive one-commit shrink whose browser clamp reads as the reader
+  // scrolling up, stranding the viewport above the final answer. Guard the
+  // transition from the same commit (this runs before the clamp's scroll
+  // event can dispatch, so the shield is race-free here).
+  const prevCompletedTurnCountRef = useRef(completedTurnCount)
+  useLayoutEffect(() => {
+    const grew = completedTurnCount > prevCompletedTurnCountRef.current
+    prevCompletedTurnCountRef.current = completedTurnCount
+    if (grew && stickState.isAtBottom) protectFollowTransition()
+  }, [completedTurnCount, stickState, protectFollowTransition])
+
+  // Detect actual sends by id (rather than list length, since materialization
+  // can remove one ghost as another arrives). A turn-starting send gets a
+  // stable reading line 100px from the viewport top; queued mid-turn sends
+  // retain the regular live-edge behavior.
+  const seenPendingIdsRef = useRef(new Set<string>())
+  useLayoutEffect(() => {
+    const seen = seenPendingIdsRef.current
+    let hasNewSend = false
+    let newestTurnStart: PendingMessage | undefined
+    for (const pending of pendingUserMessages ?? []) {
+      if (!seen.has(pending.localId)) {
+        seen.add(pending.localId)
+        hasNewSend = true
+        if (!pending.queued) newestTurnStart = pending
+      }
+    }
+
+    if (hasNewSend) {
+      if (newestTurnStart) {
+        const viewport = scrollRef.current
+        const anchor = Array.from(
+          contentBodyRef.current?.querySelectorAll<HTMLElement>('[data-turn-anchor-id]') ?? [],
+        ).find((element) => element.dataset.turnAnchorId === newestTurnStart.localId)
+
+        if (viewport && anchor) {
+          lastScrollTopRef.current = viewport.scrollTop
+          const anchorTop =
+            anchor.getBoundingClientRect().top -
+            viewport.getBoundingClientRect().top +
+            viewport.scrollTop
+          anchoredTurnRef.current = {
+            localId: newestTurnStart.localId,
+            scrollTop: Math.max(0, anchorTop - TURN_ANCHOR_TOP),
+          }
+        } else {
+          anchoredTurnRef.current = null
+          setBottomSpacerHeight(0)
+        }
+      } else {
+        anchoredTurnRef.current = null
+        setBottomSpacerHeight(0)
+      }
+
+      // The viewport intentionally sits below the new reading line until the
+      // scroll below travels there — hold the reserve restore off for the
+      // whole interval (state.animation alone starts too late: the library
+      // assigns it in its first animation frame, and a commit can land first).
+      sendScrollInFlightRef.current = true
+      // Size the reserve before scrolling so the scroll target IS the new
+      // turn's reading line (the spacer inflates scrollHeight to end there).
+      syncTurnReserve()
+      // The collapse of the finished turn above (same commit as the ghost)
+      // shrinks content and can clamp scrollTop — guard the transition so
+      // that clamp echo cannot latch an escape under the send.
+      protectFollowTransition()
+      // A send always returns the reader to the thread: re-engage following
+      // and glide to the reading line (or the live edge for queued sends).
+      // Under reduced motion, position synchronously instead of gliding.
+      if (prefersReducedMotion()) {
+        stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
+      }
+      void Promise.resolve(
+        stickScrollToBottom(prefersReducedMotion() ? 'instant' : undefined),
+      ).finally(() => {
+        sendScrollInFlightRef.current = false
+      })
+      // Programmatic writes fire their scroll event asynchronously (and not at
+      // all in jsdom) — resync the gesture-delta baseline now so the write
+      // isn't misread as a user delta.
+      lastScrollTopRef.current = scrollRef.current?.scrollTop ?? 0
+      return
+    }
+
+    syncTurnReserve()
+  }, [
+    messages,
+    pendingUserMessages,
+    streamingMessage,
+    streamingToolUses,
+    thinkingBlocks,
+    isCompacting,
+    pendingRequestCount,
+    activeSubagents,
+    syncTurnReserve,
+    setBottomSpacerHeight,
+    scrollRef,
+    stickState,
+    stickScrollToBottom,
+    protectFollowTransition,
+    bottomInset,
+  ])
+
+  // Markdown, images, and expanded tool cards can change height without a
+  // message-state update. Feed those layout changes through the same reserve
+  // calculation so they cannot make the anchored turn jump. Re-attach after
+  // the loading/error states resolve — the scroll container mounts only then.
+  useEffect(() => {
+    const content = contentBodyRef.current
+    const viewport = scrollRef.current
+    if (!content || !viewport || typeof ResizeObserver === 'undefined') return
+    let frameId = 0
+    let lastViewportHeight = viewport.clientHeight
+    let lastContentHeight = content.offsetHeight
+    const observer = new ResizeObserver(() => {
+      // A vertical viewport resize is invisible to the follow library (it
+      // observes only the content element), and browsers anchor the TOP edge
+      // on resize — so a window shrink would slide the live edge behind the
+      // fold. Re-pin immediately while following, guarded against the grow
+      // clamp's scroll echo being read as an escape (a viewport GROW lowers
+      // the scroll range, and the browser's clamp fires a scroll event that
+      // classifies as the reader scrolling up). During the turn reserve the
+      // spacer math already keeps the reading line valid, so no pin there.
+      const viewportHeight = viewport.clientHeight
+      if (viewportHeight !== lastViewportHeight) {
+        lastViewportHeight = viewportHeight
+        if (stickState.isAtBottom && !anchoredTurnRef.current) {
+          protectFollowTransition()
+          stickState.scrollTop = Math.max(0, stickState.calculatedTargetScrollTop)
+          lastScrollTopRef.current = viewport.scrollTop
+        }
+      }
+      // Catch-all for content shrinks at the live edge (a thinking card
+      // collapsing, a streamed block swapped for its shorter persisted form):
+      // each one clamps scrollTop and can latch a spurious escape the same
+      // way. The commit-hooked guards cover the big known transitions
+      // race-free; this covers the rest via the deferred verification.
+      const contentHeight = content.offsetHeight
+      if (contentHeight < lastContentHeight && stickState.isAtBottom) {
+        protectFollowTransition()
+      }
+      lastContentHeight = contentHeight
+      cancelAnimationFrame(frameId)
+      frameId = requestAnimationFrame(syncTurnReserve)
+    })
+    observer.observe(content)
+    observer.observe(viewport)
+    return () => {
+      cancelAnimationFrame(frameId)
+      observer.disconnect()
+    }
+  }, [syncTurnReserve, scrollRef, stickState, protectFollowTransition, isLoading, error])
+
+  // Escape from following is owned by the stick-to-bottom library (wheel
+  // direction, scroll direction, selection). These stamps exist so the scroll
+  // handler can attribute reserve adjustments to a live gesture, and so the
+  // deferred verification can tell escape-capable input (wheel-up, touch,
+  // upward keys, a drag) from input that never leaves the live edge.
+  // A wheel consumed by a nested scrollable (the thinking card's body, a code
+  // block) never moves the transcript and must not count as a transcript
+  // gesture; scroll chaining hands the wheel to us only once the inner
+  // scroller is at its edge, which the walk below mirrors.
+  const handleWheelGesture = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
+    const outer = scrollRef.current
+    if (!outer) return
+    let node = event.target as HTMLElement | null
+    while (node && node !== outer) {
+      if (nestedScrollableConsumesWheel(node, event.deltaY)) return
+      node = node.parentElement
+    }
+    const now = performance.now()
+    lastGestureAtRef.current = now
+    if (event.deltaY < 0) lastEscapeIntentAtRef.current = now
+  }, [scrollRef])
+
+  // Touch direction isn't knowable from a single event without tracking touch
+  // points; treat any touch scroll as escape-capable.
+  const handleTouchGesture = useCallback(() => {
+    const now = performance.now()
+    lastGestureAtRef.current = now
+    lastEscapeIntentAtRef.current = now
+  }, [])
+
+  // Scrollbar interactions emit no wheel/touch/key events — track the held
+  // pointer. Only a pointer that actually moves is a drag; a motionless press
+  // (or one whose release never arrived) must not stay a gesture forever.
+  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return
+    pointerDownRef.current = true
+    pointerDragRef.current = false
+    pointerDownAtRef.current = performance.now()
+    pointerDownPosRef.current = { x: event.clientX, y: event.clientY }
+    lastGestureAtRef.current = performance.now()
+  }, [])
+  useEffect(() => {
+    const release = () => {
+      pointerDownRef.current = false
+      pointerDragRef.current = false
+      pointerDownPosRef.current = null
+    }
+    const move = (event: PointerEvent) => {
+      if (!pointerDownRef.current) return
+      if (!pointerDragRef.current) {
+        const start = pointerDownPosRef.current
+        if (!start) return
+        if (
+          Math.abs(event.clientX - start.x) + Math.abs(event.clientY - start.y) <
+          POINTER_DRAG_THRESHOLD_PX
+        ) {
+          return
+        }
+        pointerDragRef.current = true
+      }
+      const now = performance.now()
+      lastGestureAtRef.current = now
+      lastEscapeIntentAtRef.current = now
+    }
+    window.addEventListener('pointerup', release)
+    window.addEventListener('pointercancel', release)
+    window.addEventListener('pointermove', move)
+    // A native context menu (two-finger tap) or a focus change can swallow the
+    // pointerup — without these, the "held pointer" would outlive the gesture
+    // indefinitely and every later browser clamp would read as user scrolling.
+    window.addEventListener('blur', release)
+    window.addEventListener('contextmenu', release)
+    return () => {
+      window.removeEventListener('pointerup', release)
+      window.removeEventListener('pointercancel', release)
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('blur', release)
+      window.removeEventListener('contextmenu', release)
+    }
+  }, [])
+
+  const handleScrollKey = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!SCROLL_KEYS.has(event.key)) return
+    const now = performance.now()
+    lastGestureAtRef.current = now
+    const upward =
+      UPWARD_SCROLL_KEYS.has(event.key) || (event.key === ' ' && event.shiftKey)
+    if (upward) lastEscapeIntentAtRef.current = now
+  }, [])
+
+  return {
+    scrollRef,
+    contentRef,
+    contentBodyRef,
+    bottomSpacerRef,
+    isAtBottom,
+    scrollToBottom,
+    windowedMessages,
+    hiddenCount,
+    handleScroll,
+    handleWheelGesture,
+    handleTouchGesture,
+    handlePointerDown,
+    handleScrollKey,
+  }
+}

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -328,7 +328,10 @@ export class MultiPassThinkingScenario implements MockScenario {
     private passes: string[],
     private responseText: string,
     /** Delay between thinking chunks — sets how long each pass streams. */
-    private chunkDelayMs = 200
+    private chunkDelayMs = 200,
+    /** Gap between a pass ending and the next one starting. The real CLI can
+     * emit thinking_stop and the next thinking_start nearly back-to-back. */
+    private interPassGapMs = 100
   ) {}
 
   execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
@@ -377,7 +380,7 @@ export class MultiPassThinkingScenario implements MockScenario {
           timestamp: new Date().toISOString(),
         })
       }, passEnd)
-      offset = passEnd + 100
+      offset = passEnd + this.interPassGapMs
     }
 
     setTimeout(() => {
@@ -1560,6 +1563,20 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   static scenarios = new Map<string, MockScenario>([
     // Slow response window for message-queueing tests (send mid-turn → queued)
     ['work slowly', new SlowWorkScenario()],
+    // Long thinking passes: each pass overfills the card's max-height so the
+    // card scrolls internally while live, then collapses by its full body
+    // height when the pass ends — the shrink-at-the-live-edge shape behind
+    // follow-loss reports on real long-thinking turns.
+    ['think long passes', new MultiPassThinkingScenario(
+      [
+        `First pass. ${'Surveying the problem space in detail, listing every moving part and its constraints before committing to an approach. '.repeat(12)}End of first pass.`,
+        `Second pass. ${'Weighing the tradeoffs between the candidate approaches carefully, checking each against the constraints found earlier. '.repeat(12)}End of second pass.`,
+        `Third pass. ${'Sanity-checking the chosen approach against the edge cases one at a time before writing the final answer. '.repeat(12)}End of third pass.`,
+      ],
+      'Done with all long thinking passes — here is the answer.',
+      15,
+      10
+    )],
     // Several thinking passes persisted one-by-one — an interruptible thinking turn
     ['think in passes', new MultiPassThinkingScenario(
       [


### PR DESCRIPTION
> **Review commit-by-commit.** Commit 1 is the original field fix on the library-based architecture; commit 2 relocates all scrolling into a colocated hook; commit 3 replaces the library inside that hook with an owned follow engine. The unchanged test corpus across all three is the proof of behavior preservation. Commits 4–6 are the Safari half: an input-evidence gate on the backstop (forced by a WebKit-only mechanism, below), a WebKit regression spec + macOS CI job, and comment/CI cleanup.

## Problem

When a long live thinking card collapses ("Thought for 1m 1s"), auto-follow could die mid-turn with zero user input: the scroll-to-bottom pill appears, the viewport freezes at the collapse point, and new content streams away below the fold (reported against v0.5.9, which already carries #784 + #793).

## Root cause (and why this ended as an engine replacement)

`use-stick-to-bottom` infers "the user scrolled away" from scroll *positions*, reconstructing its own writes after the fact via an `ignoreScrollToTop` marker. That inference breaks whenever multiple writers touch `scrollTop` in one frame — its catch-up spring vs. native wheel smooth-scroll vs. browser clamps from shrinking content — and #793 plus commit 1 of this PR were layers of arbitration refereeing those misreads. Two proven kill paths (a phantom held pointer gesture-attributing a collapse clamp; a wheel tick misread mid-spring as an upward scroll) both trace to the same design flaw.

The flaw is confirmed upstream: [use-stick-to-bottom#45](https://github.com/stackblitz-labs/use-stick-to-bottom/pull/45) independently proves genuine user scrolls get swallowed by the resize-suppression window; the maintainer is inactive and behavioral fixes ([#33](https://github.com/stackblitz-labs/use-stick-to-bottom/pull/33), [#41](https://github.com/stackblitz-labs/use-stick-to-bottom/pull/41)–[#43](https://github.com/stackblitz-labs/use-stick-to-bottom/pull/43)) sit unmerged.

## The owned engine (commit 3, inside `use-message-list-scroll.ts`)

Built on the patterns the serious implementations converge on ([LibreChat](https://github.com/danny-avila/LibreChat/blob/main/client/src/hooks/Messages/useMessageScrolling.ts), [assistant-ui](https://github.com/assistant-ui/assistant-ui/blob/main/packages/store/src/utils/viewport-scroll.ts), Matrix Element's ScrollPanel, react-virtuoso):

- **Escape is input-primary.** An upward wheel that reaches this scroller (nested-scroller chain walk kept from commit 1), an upward scroll key, or a qualified drag disengages following on the input event itself — before any scroll event exists to be fought over.
- **The backstop classifier is size-stability, not gesture correlation.** For inputs with no distinct event (scrollbar drags, touch momentum, find-in-page), a scroll event is the user's only when `scrollHeight`/`clientHeight` were unchanged since the last sample: our own writes update the baseline in the same statement, and layout clamps only fire in frames where the scroll range changed. Downward moves need no gate at all — clamps only ever *decrease* scrollTop. A 24px live-edge band absorbs elastic bounce-back.
- **Following is convergent, and instant.** Every content/viewport resize re-pins the live edge with a single instant write, so a missed or misread event costs one frame, never a dead latch. No spring: the concurrent-writer window that produced the misreads is gone (and the collapse-scenario E2E recorder shows ~70 scroll events vs ~538 under the library).
- **One owned glide** for the explicit trips (send → reading line, pill → live edge): an exponential chase that re-targets every frame (so it lands on the *moving* live edge during streaming), starts on its first animation frame, and cancels on any user input. Instant under `prefers-reduced-motion`.
- **Interactions suspend pinning.** Drags, scrollbar-gutter presses (track clicks page without pointer motion), text selection under a held pointer, and touch sequences (through momentum settle) own the viewport while they run; following is re-derived from where they end.

Deleted with the library: the transition shields, the 40ms deferred verification and both of its branches, all gesture-window attribution refs, and the `use-stick-to-bottom` dependency itself. The turn reserve (reading line) and windowed rendering are unchanged. `overflow-anchor: none` on the container is now load-bearing for the engine (Chromium's scroll anchoring would otherwise be an unattributable third writer) and documented as such.

## Safari: WebKit's async-scroll rollback (commits 4–6)

The field reports behind this bug were Safari-dominated, and the engine above still died there ~2/10 runs. Reproduced under a real-WebKit Playwright project, the mechanism is its own beast:

- **WebKit scrolls asynchronously.** The compositor can roll a programmatic `scrollTop` write back to its last committed position, emitting a *genuine* upward, size-stable scroll event with zero input behind it — exactly the shape of a reader escaping the live edge. Position heuristics cannot tell the two apart. Chromium commits programmatic scrolls synchronously, which is why this never reproduced in development. Measured, not assumed: recorded rollbacks return to the same committed position deterministically across runs, and instant (non-animated) writes get rolled back too — no animation-mode tweak fixes it, and it defeats `use-stick-to-bottom` in every mode.
- **Fix: the backstop demands input evidence.** The size-stability classifier releases following only when some input (wheel / scroll key / pointer / touch) touched the scroller within the last 500ms. An evidence-less upward stable move keeps following and converges back after a 150ms settle. Accepted trade: find-in-page while pinned re-pins instead of escaping.
- **Regression spec + CI.** `e2e/specs/safari-follow.spec.ts` rides a full streaming turn with overfilled-thinking-card collapses under real WebKit at a zoomed layout, hands off the keyboard entirely, with a per-frame recorder dumped as a build artifact. It runs as a new `web-webkit` project on a Blacksmith macOS runner (`e2e-webkit-macos`) — Playwright's Linux WebKit doesn't use Apple's compositor, which is where the rollback lives. 3 serial repeats with retries off: the kill is ~50% probabilistic per run, so retries would let a real regression pass.

## Verification

- **Unit: 121/121.** 119 of the pre-engine corpus passed the engine swap *unmodified* — the corpus drives everything through DOM simulation and acts as the acceptance spec. One test was adapted from the old arbitration layer to the equivalent engine hazard (bounce-back inside the live-edge band must not disengage); the WebKit work added a zero-input rollback-convergence regression and gave the 5 escape simulations the explicit input events they always represented.
- **E2E:** the three Chromium follow suites (`thinking-collapse-follow` with the stuck-pointer zero-input regression, `transcript-follow`, `thinking-display`) 10/10, unmodified. WebKit `safari-follow`: **10/10 vs a ~50–60% kill rate on main.**
- Typecheck + lint clean; dependency removed from package.json/lockfile.

https://claude.ai/code/session_019Md24joAGBBETvvDnxAKDB
https://claude.ai/code/session_01FvbUHCM3TA1DFDzWwWvYYT

