### PR TITLE
Add refresh chrome to dashboard pop-outs

### DIFF
--- a/src/main/dashboard-window-chrome.ts
+++ b/src/main/dashboard-window-chrome.ts
@@ -1,0 +1,152 @@
+export const DASHBOARD_CHROME_HEIGHT = 30
+
+/**
+ * Electron cannot add arbitrary controls to the native title bar. Dashboard
+ * popouts therefore extend their renderer into the title-bar area and install
+ * this small, app-owned chrome in the standalone wrapper document. The
+ * dashboard itself remains isolated in the wrapper's iframe.
+ *
+ * This is injected by the desktop app instead of being served by the `/view`
+ * route so it also works when a cloud workspace is running an older release of
+ * that route.
+ */
+export function dashboardChromeScript(platform: NodeJS.Platform, titlePrefix: string): string {
+  const platformClass = platform === 'darwin'
+    ? 'darwin'
+    : platform === 'win32'
+      ? 'win32'
+      : 'linux'
+  const css = `
+    html, body {
+      height: 100%;
+    }
+    body {
+      min-height: 100vh !important;
+      padding-top: ${DASHBOARD_CHROME_HEIGHT}px !important;
+    }
+    body > iframe {
+      top: ${DASHBOARD_CHROME_HEIGHT}px !important;
+      height: calc(100vh - ${DASHBOARD_CHROME_HEIGHT}px) !important;
+    }
+    #gamut-dashboard-window-chrome {
+      -webkit-app-region: drag;
+      align-items: center;
+      background: rgba(17, 17, 17, 0.97);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      box-sizing: border-box;
+      color: #d4d4d4;
+      display: flex;
+      height: ${DASHBOARD_CHROME_HEIGHT}px;
+      left: 0;
+      position: fixed;
+      right: 0;
+      top: 0;
+      user-select: none;
+      z-index: 2147483647;
+    }
+    #gamut-dashboard-window-chrome.gamut-dashboard-window-chrome--darwin {
+      padding: 0 10px 0 78px;
+    }
+    #gamut-dashboard-window-chrome.gamut-dashboard-window-chrome--win32 {
+      height: env(titlebar-area-height, ${DASHBOARD_CHROME_HEIGHT}px);
+      left: env(titlebar-area-x, 0px);
+      padding: 0 8px;
+      right: auto;
+      width: env(titlebar-area-width, calc(100% - 138px));
+    }
+    #gamut-dashboard-window-chrome.gamut-dashboard-window-chrome--linux {
+      padding: 0 10px;
+    }
+    #gamut-dashboard-window-title {
+      font: 500 12px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      left: 50%;
+      max-width: calc(100% - 120px);
+      overflow: hidden;
+      pointer-events: none;
+      position: absolute;
+      text-overflow: ellipsis;
+      transform: translateX(-50%);
+      white-space: nowrap;
+    }
+    #gamut-dashboard-refresh {
+      -webkit-app-region: no-drag;
+      align-items: center;
+      background: transparent;
+      border: 0;
+      border-radius: 5px;
+      color: #a3a3a3;
+      cursor: pointer;
+      display: inline-flex;
+      height: 24px;
+      justify-content: center;
+      margin-left: auto;
+      padding: 0;
+      width: 24px;
+    }
+    #gamut-dashboard-refresh:hover {
+      background: rgba(255, 255, 255, 0.08);
+      color: #f5f5f5;
+    }
+    #gamut-dashboard-refresh:focus-visible {
+      outline: 2px solid #60a5fa;
+      outline-offset: -2px;
+    }
+    #gamut-dashboard-refresh:disabled {
+      cursor: default;
+    }
+    #gamut-dashboard-refresh.is-refreshing svg {
+      animation: gamut-dashboard-refresh-spin 0.7s linear infinite;
+    }
+    @keyframes gamut-dashboard-refresh-spin {
+      to { transform: rotate(360deg); }
+    }
+  `
+
+  return `(() => {
+    if (document.getElementById('gamut-dashboard-window-chrome')) return;
+
+    const style = document.createElement('style');
+    style.id = 'gamut-dashboard-window-chrome-style';
+    style.textContent = ${JSON.stringify(css)};
+    document.head.appendChild(style);
+
+    const chrome = document.createElement('header');
+    chrome.id = 'gamut-dashboard-window-chrome';
+    chrome.className = 'gamut-dashboard-window-chrome--${platformClass}';
+
+    const title = document.createElement('div');
+    title.id = 'gamut-dashboard-window-title';
+    const updateTitle = () => {
+      const pageTitle = document.title || 'Gamut Dashboard';
+      const titlePrefix = ${JSON.stringify(titlePrefix)};
+      title.textContent = titlePrefix && !pageTitle.startsWith(titlePrefix)
+        ? titlePrefix + pageTitle
+        : pageTitle;
+    };
+    updateTitle();
+    const titleElement = document.querySelector('title');
+    if (titleElement) {
+      new MutationObserver(updateTitle).observe(titleElement, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+    }
+
+    const refresh = document.createElement('button');
+    refresh.id = 'gamut-dashboard-refresh';
+    refresh.type = 'button';
+    refresh.title = 'Refresh dashboard';
+    refresh.setAttribute('aria-label', 'Refresh dashboard');
+    refresh.innerHTML = '<svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-2.64-6.36L21 8"></path><path d="M21 3v5h-5"></path></svg>';
+    refresh.addEventListener('click', () => {
+      refresh.classList.add('is-refreshing');
+      refresh.disabled = true;
+      refresh.setAttribute('aria-busy', 'true');
+      window.location.reload();
+    });
+
+    chrome.append(title, refresh);
+    document.body.appendChild(chrome);
+  })()`
+}

--- a/src/main/dashboard-window.cloud.test.ts
+++ b/src/main/dashboard-window.cloud.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runInNewContext } from 'node:vm'
 
 /**
  * A dashboard popout is built in main, so it is told which Superagent it is
@@ -8,7 +9,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  */
 
 type FakeWindow = {
-  webContents: { setWindowOpenHandler: ReturnType<typeof vi.fn>; downloadURL: ReturnType<typeof vi.fn> }
+  webContents: {
+    setWindowOpenHandler: ReturnType<typeof vi.fn>
+    downloadURL: ReturnType<typeof vi.fn>
+    on: ReturnType<typeof vi.fn>
+    executeJavaScript: ReturnType<typeof vi.fn>
+  }
   loadURL: ReturnType<typeof vi.fn>
   on: ReturnType<typeof vi.fn>
   setTitle: ReturnType<typeof vi.fn>
@@ -16,6 +22,7 @@ type FakeWindow = {
   focus: ReturnType<typeof vi.fn>
   close: ReturnType<typeof vi.fn>
   isDestroyed: ReturnType<typeof vi.fn>
+  removeMenu: ReturnType<typeof vi.fn>
   options: Record<string, any>
   handlers: Record<string, (...args: any[]) => void>
 }
@@ -30,7 +37,14 @@ vi.mock('electron', () => {
   const BrowserWindow = vi.fn(function (options: Record<string, any>) {
     const handlers: Record<string, (...args: any[]) => void> = {}
     const win: FakeWindow = {
-      webContents: { setWindowOpenHandler: vi.fn(), downloadURL: vi.fn() },
+      webContents: {
+        setWindowOpenHandler: vi.fn(),
+        downloadURL: vi.fn(),
+        on: vi.fn((event: string, cb: (...args: any[]) => void) => {
+          handlers[`webContents:${event}`] = cb
+        }),
+        executeJavaScript: vi.fn(() => Promise.resolve()),
+      },
       loadURL: vi.fn(),
       on: vi.fn((event: string, cb: (...args: any[]) => void) => {
         handlers[event] = cb
@@ -40,6 +54,7 @@ vi.mock('electron', () => {
       focus: vi.fn(),
       close: vi.fn(),
       isDestroyed: vi.fn(() => false),
+      removeMenu: vi.fn(),
       options,
       handlers,
     }
@@ -164,5 +179,92 @@ describe('marking a cloud popout', () => {
   it('leaves a local popout’s title to the dashboard', () => {
     openDashboardWindow('sales', 'weekly', LOCAL)
     expect(createdWindows[0].handlers['page-title-updated']).toBeUndefined()
+  })
+})
+
+describe('dashboard popout chrome', () => {
+  it('installs a draggable refresh control in each loaded wrapper document', () => {
+    openDashboardWindow('sales', 'weekly', CLOUD)
+    const win = createdWindows[0]
+
+    expect(win.options.autoHideMenuBar).toBe(true)
+    expect(win.handlers['webContents:dom-ready']).toBeTypeOf('function')
+
+    win.handlers['webContents:dom-ready']()
+
+    expect(win.webContents.executeJavaScript).toHaveBeenCalledOnce()
+    const script = win.webContents.executeJavaScript.mock.calls[0][0] as string
+    expect(script).toContain('gamut-dashboard-window-chrome')
+    expect(script).toContain('-webkit-app-region: drag')
+    expect(script).toContain('env(titlebar-area-x, 0px)')
+    expect(script).toContain('env(titlebar-area-width, calc(100% - 138px))')
+    expect(script).not.toContain('padding: 0 148px')
+    expect(script).toContain("classList.add('is-refreshing')")
+
+    // Exercise the injected script as JavaScript, not only as an opaque string:
+    // the button should enter its spinner state and reload the outer lifecycle
+    // wrapper so a stopped dashboard gets another chance to start.
+    const elements: Array<Record<string, any>> = []
+    const makeElement = (tagName: string) => {
+      const listeners: Record<string, () => void> = {}
+      const classes = new Set<string>()
+      const element: Record<string, any> = {
+        tagName,
+        listeners,
+        children: [] as unknown[],
+        classList: { add: (name: string) => classes.add(name), contains: (name: string) => classes.has(name) },
+        addEventListener: (event: string, callback: () => void) => { listeners[event] = callback },
+        append(...children: unknown[]) { element.children.push(...children) },
+        setAttribute(name: string, value: string) { element[name] = value },
+      }
+      elements.push(element)
+      return element
+    }
+    const reload = vi.fn()
+    const titleElement = makeElement('title')
+    const observe = vi.fn()
+    const document = {
+      title: 'Weekly — Gamut',
+      head: { appendChild: vi.fn() },
+      body: { appendChild: vi.fn() },
+      createElement: makeElement,
+      getElementById: vi.fn(() => null),
+      querySelector: vi.fn(() => titleElement),
+    }
+
+    runInNewContext(script, {
+      document,
+      window: { location: { reload } },
+      MutationObserver: class { observe = observe },
+    })
+
+    const refresh = elements.find((element) => element.id === 'gamut-dashboard-refresh')
+    const title = elements.find((element) => element.id === 'gamut-dashboard-window-title')
+    expect(title?.textContent).toBe('Cloud workspace — Weekly — Gamut')
+    expect(refresh).toBeDefined()
+    refresh!.listeners.click()
+    expect(refresh!.classList.contains('is-refreshing')).toBe(true)
+    expect(refresh!.disabled).toBe(true)
+    expect(refresh!['aria-busy']).toBe('true')
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('uses native window controls but removes the inherited menu on Windows', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      openDashboardWindow('sales', 'windows-dashboard', LOCAL)
+      const win = createdWindows[0]
+
+      expect(win.options.titleBarStyle).toBe('hidden')
+      expect(win.options.titleBarOverlay).toEqual({
+        color: '#111111',
+        symbolColor: '#d4d4d4',
+        height: 30,
+      })
+      expect(win.removeMenu).toHaveBeenCalledOnce()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
   })
 })

--- a/src/main/dashboard-window.ts
+++ b/src/main/dashboard-window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, session, type WebContents } from 'electron'
 import { buildDashboardViewUrl } from '@shared/lib/dashboard-url'
+import { DASHBOARD_CHROME_HEIGHT, dashboardChromeScript } from './dashboard-window-chrome'
 import { safeOpenExternal } from './safe-open-external'
 
 // Open dashboard popouts, keyed by API base URL + `${agentSlug}/${dashboardSlug}`.
@@ -8,6 +9,17 @@ import { safeOpenExternal } from './safe-open-external'
 // wrong one's dashboard under the right one's name. The raw join is fine as a
 // dedup key — only the loaded URL needs per-segment encoding.
 const dashboardWindows: Map<string, BrowserWindow> = new Map()
+
+function installDashboardChrome(win: BrowserWindow, titlePrefix = ''): void {
+  const script = dashboardChromeScript(process.platform, titlePrefix)
+  win.webContents.on('dom-ready', () => {
+    void win.webContents.executeJavaScript(script).catch((error) => {
+      // A close or navigation can destroy the document between dom-ready and
+      // execution. That is harmless; the next document gets its own attempt.
+      if (!win.isDestroyed()) console.error('Failed to install dashboard window chrome:', error)
+    })
+  })
+}
 
 /**
  * Deny-and-route popup policy for a window's webContents.
@@ -112,19 +124,36 @@ export function openDashboardWindow(agentSlug: string, dashboardSlug: string, ap
     width: 1000,
     height: 700,
     title: 'Gamut Dashboard',
+    backgroundColor: '#111111',
+    autoHideMenuBar: true,
+    ...(process.platform === 'darwin' && {
+      titleBarStyle: 'hiddenInset' as const,
+      trafficLightPosition: { x: 14, y: 8 },
+    }),
+    ...(process.platform === 'win32' && {
+      titleBarStyle: 'hidden' as const,
+      titleBarOverlay: {
+        color: '#111111',
+        symbolColor: '#d4d4d4',
+        height: DASHBOARD_CHROME_HEIGHT,
+      },
+    }),
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
       ...(partition ? { partition } : {}),
     },
   })
+  // Unlike autoHideMenuBar, removeMenu prevents the inherited File/Edit menu
+  // from reappearing when Alt is pressed on Windows.
+  if (process.platform === 'win32') win.removeMenu()
+  installDashboardChrome(win, route ? 'Cloud workspace — ' : '')
   // Dashboard content is agent-generated/untrusted — apply the same deny-and-route
   // popup policy as the main window so window.open() can't spawn child windows.
   installPopupHandler(win.webContents)
-  // A cloud popout is otherwise indistinguishable from a local one: same chrome,
-  // and the wrapper replaces the generic title with the dashboard's own name.
-  // The title is the only surface main owns here — injecting a frame would mean
-  // writing into an agent-generated document — so it carries the marker.
+  // A cloud popout is otherwise indistinguishable from a local one. Keep the
+  // workspace marker in both the native/taskbar title and the app-owned title
+  // bar above the dashboard iframe.
   if (route) {
     win.on('page-title-updated', (event, title) => {
       event.preventDefault()

--- a/src/main/index.popout-window-handler.sup219.test.ts
+++ b/src/main/index.popout-window-handler.sup219.test.ts
@@ -10,6 +10,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 type FakeWebContents = {
   setWindowOpenHandler: ReturnType<typeof vi.fn>
   downloadURL: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
+  executeJavaScript: ReturnType<typeof vi.fn>
 }
 type FakeWindow = {
   webContents: FakeWebContents
@@ -19,6 +21,7 @@ type FakeWindow = {
   focus: ReturnType<typeof vi.fn>
   close: ReturnType<typeof vi.fn>
   isDestroyed: ReturnType<typeof vi.fn>
+  removeMenu: ReturnType<typeof vi.fn>
 }
 
 // --- electron mock ----------------------------------------------------------
@@ -37,6 +40,8 @@ vi.mock('electron', () => {
       webContents: {
         setWindowOpenHandler: vi.fn(),
         downloadURL: vi.fn(),
+        on: vi.fn(),
+        executeJavaScript: vi.fn(() => Promise.resolve()),
       },
       loadURL: vi.fn(),
       on: vi.fn(),
@@ -44,6 +49,7 @@ vi.mock('electron', () => {
       focus: vi.fn(),
       close: vi.fn(),
       isDestroyed: vi.fn(() => false),
+      removeMenu: vi.fn(),
     }
     createdWindows.push(win)
     return win


### PR DESCRIPTION
## Summary

- add a compact 30px draggable chrome to Electron dashboard pop-outs
- add an accessible refresh control with a loading animation that reloads the dashboard lifecycle wrapper
- preserve native macOS traffic lights and native Windows window controls
- remove the inherited File/Edit menu from Windows pop-outs
- use Electron title-bar safe-area variables for Windows DPI, RTL, and native-control spacing
- inject the outer chrome from the desktop app so older cloud workspace wrappers remain compatible

## Testing

- npm test -- --run src/main/dashboard-window.cloud.test.ts src/main/index.popout-window-handler.sup219.test.ts
- npm run typecheck
- npm exec -- eslint src/main/dashboard-window.ts src/main/dashboard-window-chrome.ts src/main/dashboard-window.cloud.test.ts
- launched with npm run dev:electron and visually checked the macOS pop-out chrome