### PR TITLE
SUP-657/SUP-658: add visibility-safe iOS session APIs

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -306,6 +306,17 @@ vi.mock('@shared/lib/services/session-media', () => ({
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: vi.fn(),
   listSessionsByIds: vi.fn(),
+  sortSessionsNewestFirst: vi.fn((sessions: Array<{
+    id: string
+    createdAt: Date
+    lastActivityAt?: Date | null
+  }>) => [...sessions].sort((a, b) => {
+    const byActivity =
+      (b.lastActivityAt ?? b.createdAt).getTime() -
+      (a.lastActivityAt ?? a.createdAt).getTime()
+    return byActivity || a.id.localeCompare(b.id)
+  })),
+  SESSIONS_LIST_MAX_LIMIT: 100,
   updateSessionName: vi.fn(),
   registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(),
@@ -5825,6 +5836,15 @@ describe('GET /api/agents (enriched summary)', () => {
     containerPort: 8080,
   }
 
+  const sessionInfo = (id: string, agentSlug = 'agent-1') => ({
+    id,
+    agentSlug,
+    name: 'Settled conversation',
+    createdAt: new Date('2026-01-01T11:00:00.000Z'),
+    lastActivityAt: new Date('2026-01-01T12:00:00.000Z'),
+    messageCount: 2,
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
@@ -5832,8 +5852,232 @@ describe('GET /api/agents (enriched summary)', () => {
     // Default: no sessions or artifacts
     vi.mocked(getSessionSummary).mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null })
     vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(sessionExists).mockResolvedValue(true)
     vi.mocked(listPendingScheduledTasks).mockResolvedValue([])
     vi.mocked(listArtifactsFromFilesystem).mockResolvedValue([])
+  })
+
+  it.each([
+    ['/api/agents'],
+    ['/api/agents?include_latest_visible_session_tail=false'],
+  ])('keeps the default response and cost unchanged for %s', async (url) => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+
+    const res = await getReq(app, url)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0]).not.toHaveProperty('latestVisibleSession')
+    expect(listSessions).not.toHaveBeenCalled()
+    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+  })
+
+  it('returns the newest ordinary visible session with a bounded media-ref tail', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('settled-visible')])
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+      messages: [{
+        id: 'message-2',
+        type: 'assistant',
+        content: { text: 'Latest settled reply' },
+        toolCalls: [],
+        createdAt: new Date('2026-01-01T12:00:00.000Z'),
+      }],
+      nextCursor: 'message-1',
+    })
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0].latestVisibleSession).toMatchObject({
+      session: {
+        id: 'settled-visible',
+        isActive: false,
+        isAwaitingInput: false,
+        hasUnreadNotifications: false,
+      },
+      messageTail: {
+        messages: [{
+          id: 'message-2',
+          content: { text: 'Latest settled reply' },
+        }],
+        nextCursor: 'message-1',
+      },
+    })
+    expect(listSessions).toHaveBeenCalledWith('agent-1', {
+      excludeAutomated: true,
+      sortBy: 'last_activity_at',
+      limit: 1,
+    })
+    expect(getSessionMessagesPage).toHaveBeenCalledWith(
+      'agent-1',
+      'settled-visible',
+      {
+        limit: 20,
+        byteBudget: 256 * 1024,
+        media: 'ref',
+        signal: expect.any(AbortSignal),
+      },
+    )
+    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+  })
+
+  it('returns null when an agent has no visible session and skips transcript work', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([])
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0].latestVisibleSession).toBeNull()
+    expect(getSessionMessagesPage).not.toHaveBeenCalled()
+  })
+
+  it('returns null and reports a latest visible session whose transcript is missing', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('missing-transcript')])
+    vi.mocked(sessionExists).mockResolvedValue(false)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      const res = await getReq(
+        app,
+        '/api/agents?include_latest_visible_session_tail=true',
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      expect(body[0].latestVisibleSession).toBeNull()
+      expect(getSessionMessagesPage).not.toHaveBeenCalled()
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to fetch latest visible session tail for agent agent-1:',
+        expect.objectContaining({
+          message: 'Latest visible session transcript not found for agent-1/missing-transcript',
+        }),
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('hydrates every agent in one collection response without legacy full-transcript reads', async () => {
+    const agent2 = { ...baseAgent, slug: 'agent-2', name: 'Agent Two' }
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent, agent2])
+    vi.mocked(listSessions).mockImplementation(async (slug) => [
+      sessionInfo('session-' + slug, slug),
+    ])
+    vi.mocked(getSessionMessagesPage).mockImplementation(async (_slug, sessionId) => ({
+      messages: [{
+        id: 'message-' + sessionId,
+        type: 'assistant',
+        content: { text: sessionId },
+        toolCalls: [],
+        createdAt: new Date('2026-01-01T12:00:00.000Z'),
+      }],
+      nextCursor: null,
+    }))
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.map((agent: { latestVisibleSession: { session: { id: string } } }) =>
+      agent.latestVisibleSession.session.id,
+    )).toEqual(['session-agent-1', 'session-agent-2'])
+    expect(listSessions).toHaveBeenCalledTimes(2)
+    expect(getSessionMessagesPage).toHaveBeenCalledTimes(2)
+    expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+  })
+
+  it('isolates a missing or corrupt transcript to its agent', async () => {
+    const agent2 = { ...baseAgent, slug: 'agent-2', name: 'Agent Two' }
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent, agent2])
+    vi.mocked(listSessions).mockImplementation(async (slug) => [
+      sessionInfo('session-' + slug, slug),
+    ])
+    vi.mocked(getSessionMessagesPage).mockImplementation(async (slug) => {
+      if (slug === 'agent-1') throw new Error('corrupt transcript')
+      return { messages: [], nextCursor: null }
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      const res = await getReq(
+        app,
+        '/api/agents?include_latest_visible_session_tail=true',
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      const bySlug = new Map(body.map((agent: { slug: string }) => [agent.slug, agent]))
+
+      expect(bySlug.get('agent-1')).toMatchObject({ latestVisibleSession: null })
+      expect(bySlug.get('agent-2')).toMatchObject({
+        latestVisibleSession: {
+          session: { id: 'session-agent-2' },
+          messageTail: { messages: [], nextCursor: null },
+        },
+      })
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to fetch latest visible session tail for agent agent-1:',
+        expect.any(Error),
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('reads expansion data only for agents admitted by the ACL list', async () => {
+    mockIsAuthMode.mockReturnValue(true)
+    mockDbSelectFrom.mockReturnValue({
+      where: vi.fn().mockResolvedValue([{ agentSlug: 'agent-1' }]),
+    })
+    vi.mocked(getAgentWithStatus).mockResolvedValue(baseAgent)
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('visible-session')])
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+      messages: [],
+      nextCursor: null,
+    })
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body).toHaveLength(1)
+    expect(body[0].slug).toBe('agent-1')
+    expect(listSessions).toHaveBeenCalledTimes(1)
+    expect(listSessions).toHaveBeenCalledWith('agent-1', expect.any(Object))
+    expect(getSessionMessagesPage).toHaveBeenCalledWith(
+      'agent-1',
+      'visible-session',
+      expect.any(Object),
+    )
+  })
+
+  it('rejects a malformed expansion flag before listing or reading agents', async () => {
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=yes',
+    )
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid agent list query' })
+    expect(listAgentsWithStatus).not.toHaveBeenCalled()
+    expect(getSessionSummary).not.toHaveBeenCalled()
+    expect(listSessions).not.toHaveBeenCalled()
   })
 
   it('returns enriched agents with summary fields', async () => {
@@ -7379,6 +7623,108 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
 })
 
 // ============================================================================
+// Sessions list query contract — GET /:id/sessions
+// ============================================================================
+
+describe('sessions list query contract — GET /:id/sessions', () => {
+  const URL = '/api/agents/test-agent/sessions'
+  let app: ReturnType<typeof createApp>
+
+  const sessionInfo = (id: string, lastActivityAt: string) => ({
+    id,
+    agentSlug: 'test-agent',
+    name: id,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    lastActivityAt: new Date(lastActivityAt),
+    messageCount: 0,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+    vi.mocked(listSessions).mockResolvedValue([])
+  })
+
+  it('preserves the full visible-list behavior when no query is supplied', async () => {
+    vi.mocked(listSessions).mockResolvedValue([
+      sessionInfo('newer-visible', '2026-01-02T00:00:00Z'),
+      sessionInfo('older-visible', '2026-01-01T00:00:00Z'),
+    ])
+
+    const res = await getReq(app, URL)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.map((session: { id: string }) => session.id)).toEqual([
+      'newer-visible',
+      'older-visible',
+    ])
+    expect(listSessions).toHaveBeenCalledWith('test-agent', {
+      excludeAutomated: true,
+    })
+  })
+
+  it('forwards deterministic activity ordering and limit to the visibility-safe service', async () => {
+    vi.mocked(listSessions).mockResolvedValue([
+      sessionInfo('newest-visible', '2026-01-03T00:00:00Z'),
+    ])
+
+    const res = await getReq(
+      app,
+      URL + '?sort_by=last_activity_at&limit=1',
+    )
+
+    expect(res.status).toBe(200)
+    expect((await res.json()).map((session: { id: string }) => session.id))
+      .toEqual(['newest-visible'])
+    expect(listSessions).toHaveBeenCalledWith('test-agent', {
+      excludeAutomated: true,
+      sortBy: 'last_activity_at',
+      limit: 1,
+    })
+  })
+
+  it('caps a valid oversized limit at the public maximum', async () => {
+    const res = await getReq(app, URL + '?limit=1000')
+
+    expect(res.status).toBe(200)
+    expect(listSessions).toHaveBeenCalledWith('test-agent', {
+      excludeAutomated: true,
+      limit: 100,
+    })
+  })
+
+  it('accepts notable=false as the ordinary visible-list path', async () => {
+    const res = await getReq(app, URL + '?notable=false&limit=2')
+
+    expect(res.status).toBe(200)
+    expect(listSessions).toHaveBeenCalledWith('test-agent', {
+      excludeAutomated: true,
+      limit: 2,
+    })
+    expect(listSessionsByIds).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['unsupported sort', 'sort_by=created_at'],
+    ['malformed boolean', 'notable=yes'],
+    ['numeric boolean', 'notable=1'],
+    ['zero limit', 'limit=0'],
+    ['negative limit', 'limit=-1'],
+    ['fractional limit', 'limit=1.5'],
+    ['non-numeric limit', 'limit=many'],
+    ['unsafe integer limit', 'limit=9007199254740992'],
+  ])('rejects %s', async (_label, query) => {
+    const res = await getReq(app, URL + '?' + query)
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid sessions query' })
+    expect(listSessions).not.toHaveBeenCalled()
+    expect(listSessionsByIds).not.toHaveBeenCalled()
+  })
+})
+
+// ============================================================================
 // Notable sessions fast path — GET /:id/sessions?notable=true
 // ============================================================================
 
@@ -7401,17 +7747,33 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
     vi.mocked(listSessionsByIds).mockResolvedValue([])
   })
 
-  it('requests exactly the union of live and unread ids, deduped, automated excluded', async () => {
-    vi.mocked(messagePersister.getActiveSessionIdsForAgent).mockReturnValue(['s-live', 's-both'])
+  it('includes active, awaiting, and unread sessions but no ordinary settled/read session', async () => {
+    vi.mocked(messagePersister.getActiveSessionIdsForAgent).mockReturnValue([
+      's-live',
+      's-awaiting',
+      's-both',
+    ])
     vi.mocked(getSessionIdsWithUnreadNotifications).mockResolvedValue(new Set(['s-both', 's-unread']))
+    vi.mocked(messagePersister.isSessionActive).mockImplementation(
+      (id: string) => id === 's-live' || id === 's-awaiting' || id === 's-both',
+    )
+    vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
+      (id: string) => id === 's-awaiting',
+    )
+    vi.mocked(listSessionsByIds).mockImplementation(async (_slug, ids) =>
+      ids.map((id) => sessionInfo(id, '2026-01-02T10:00:00Z')),
+    )
 
     const res = await getReq(app, NOTABLE_URL)
     expect(res.status).toBe(200)
     expect(vi.mocked(listSessionsByIds)).toHaveBeenCalledWith(
       'test-agent',
-      ['s-live', 's-both', 's-unread'],
+      ['s-live', 's-awaiting', 's-both', 's-unread'],
       { excludeAutomated: true },
     )
+    const ids = (await res.json()).map((session: { id: string }) => session.id)
+    expect(ids.sort()).toEqual(['s-awaiting', 's-both', 's-live', 's-unread'])
+    expect(ids).not.toContain('s-ordinary')
   })
 
   it('live sessions survive the cap even when idle ones have newer activity', async () => {
@@ -7425,6 +7787,45 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
     const body = await res.json()
     expect(body.map((s: { id: string }) => s.id)).toEqual(['s-live-older'])
     expect(body[0].isActive).toBe(true)
+  })
+
+  it('composes notable filtering, requested activity ordering, and limit in that order', async () => {
+    vi.mocked(messagePersister.getActiveSessionIdsForAgent).mockReturnValue(['s-live-older'])
+    vi.mocked(getSessionIdsWithUnreadNotifications).mockResolvedValue(new Set(['s-unread-newer']))
+    vi.mocked(listSessionsByIds).mockResolvedValue([
+      sessionInfo('s-live-older', '2026-01-02T09:00:00Z'),
+      sessionInfo('s-unread-newer', '2026-01-02T12:00:00Z'),
+    ])
+    vi.mocked(messagePersister.isSessionActive).mockImplementation(
+      (id: string) => id === 's-live-older',
+    )
+
+    const res = await getReq(
+      app,
+      NOTABLE_URL + '&sort_by=last_activity_at&limit=1',
+    )
+    const body = await res.json()
+
+    // Explicit activity ordering applies after the notable filter, so the
+    // newer unread session wins even though the older session is live.
+    expect(body.map((session: { id: string }) => session.id))
+      .toEqual(['s-unread-newer'])
+  })
+
+  it('uses session id as the deterministic tie-breaker for requested ordering', async () => {
+    vi.mocked(getSessionIdsWithUnreadNotifications).mockResolvedValue(
+      new Set(['z-tied', 'a-tied']),
+    )
+    vi.mocked(listSessionsByIds).mockResolvedValue([
+      sessionInfo('z-tied', '2026-01-02T10:00:00Z'),
+      sessionInfo('a-tied', '2026-01-02T10:00:00Z'),
+    ])
+
+    const res = await getReq(app, NOTABLE_URL + '&sort_by=last_activity_at')
+    const body = await res.json()
+
+    expect(body.map((session: { id: string }) => session.id))
+      .toEqual(['a-tied', 'z-tied'])
   })
 
   it('sorts newest-first within a band and carries the unread flag', async () => {
@@ -7461,13 +7862,13 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
     expect(bySessionId.get('s-idle')?.isAwaitingInput).toBe(false)
   })
 
-  it('falls back to the default cap when the limit is garbage', async () => {
+  it('uses the default cap when notable has no explicit limit', async () => {
     vi.mocked(listSessionsByIds).mockResolvedValue(
       Array.from({ length: 30 }, (_, i) =>
         sessionInfo(`s-${String(i).padStart(2, '0')}`, `2026-01-01T00:${String(i).padStart(2, '0')}:00Z`),
       ),
     )
-    const res = await getReq(app, `${NOTABLE_URL}&limit=zero`)
+    const res = await getReq(app, NOTABLE_URL)
     const body = await res.json()
     expect(body).toHaveLength(25)
   })

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -5849,10 +5849,27 @@ describe('GET /api/agents (enriched summary)', () => {
     vi.clearAllMocks()
     app = createApp()
     mockIsAuthMode.mockReturnValue(false)
-    // Default: no sessions or artifacts
-    vi.mocked(getSessionSummary).mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null })
+    userInputRequestManager.reset()
+    // Default: no sessions, attention, or artifacts.
+    vi.mocked(getSessionSummary).mockResolvedValue({
+      sessionIds: [],
+      sessionCount: 0,
+      lastActivityAt: null,
+    })
     vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(readSessionMetadata).mockResolvedValue({})
     vi.mocked(sessionExists).mockResolvedValue(true)
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map())
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(false)
+    vi.mocked(messagePersister.isSessionAwaitingInput).mockReturnValue(false)
+    vi.mocked(messagePersister.getActiveSessionIdsForAgent).mockReturnValue([])
+    vi.mocked(messagePersister.hasActiveSessionsForAgent).mockReturnValue(false)
+    vi.mocked(messagePersister.hasSessionsAwaitingInputForAgent).mockReturnValue(false)
+    mockGetPendingReviewsForAgent.mockReturnValue([])
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+      messages: [],
+      nextCursor: null,
+    })
     vi.mocked(listPendingScheduledTasks).mockResolvedValue([])
     vi.mocked(listArtifactsFromFilesystem).mockResolvedValue([])
   })
@@ -5868,13 +5885,26 @@ describe('GET /api/agents (enriched summary)', () => {
     const body = await res.json()
 
     expect(body[0]).not.toHaveProperty('latestVisibleSession')
+    expect(body[0]).not.toHaveProperty('attentionOutsideLatest')
     expect(listSessions).not.toHaveBeenCalled()
     expect(getSessionMessagesPage).not.toHaveBeenCalled()
   })
 
-  it('returns the newest ordinary visible session with a bounded media-ref tail', async () => {
+  it('returns the latest tail and excludes attention on that session', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
     vi.mocked(listSessions).mockResolvedValue([sessionInfo('settled-visible')])
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([
+      ['agent-1', new Set(['settled-visible'])],
+    ]))
+    vi.mocked(messagePersister.isSessionActive).mockImplementation(
+      (id: string) => id === 'settled-visible',
+    )
+    vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
+      (id: string) => id === 'settled-visible',
+    )
+    vi.mocked(messagePersister.getActiveSessionIdsForAgent)
+      .mockReturnValue(['settled-visible'])
+    vi.mocked(messagePersister.hasSessionsAwaitingInputForAgent).mockReturnValue(true)
     vi.mocked(getSessionMessagesPage).mockResolvedValue({
       messages: [{
         id: 'message-2',
@@ -5896,9 +5926,9 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(body[0].latestVisibleSession).toMatchObject({
       session: {
         id: 'settled-visible',
-        isActive: false,
-        isAwaitingInput: false,
-        hasUnreadNotifications: false,
+        isActive: true,
+        isAwaitingInput: true,
+        hasUnreadNotifications: true,
       },
       messageTail: {
         messages: [{
@@ -5908,10 +5938,13 @@ describe('GET /api/agents (enriched summary)', () => {
         nextCursor: 'message-1',
       },
     })
+    expect(body[0].attentionOutsideLatest).toEqual({
+      hasUnreadNotification: false,
+      hasPendingInput: false,
+    })
     expect(listSessions).toHaveBeenCalledWith('agent-1', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
-      limit: 1,
     })
     expect(getSessionMessagesPage).toHaveBeenCalledWith(
       'agent-1',
@@ -5926,6 +5959,168 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
+  it('reports unread and pending attention on an older visible session', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([
+      sessionInfo('latest-visible'),
+      sessionInfo('older-visible'),
+    ])
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([
+      ['agent-1', new Set(['older-visible'])],
+    ]))
+    vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
+      (id: string) => id === 'older-visible',
+    )
+    vi.mocked(messagePersister.getActiveSessionIdsForAgent)
+      .mockReturnValue(['older-visible'])
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0].latestVisibleSession.session.id).toBe('latest-visible')
+    expect(body[0].attentionOutsideLatest).toEqual({
+      hasUnreadNotification: true,
+      hasPendingInput: true,
+    })
+    expect(getSessionMessagesPage).toHaveBeenCalledTimes(1)
+    expect(getSessionMessagesPage).toHaveBeenCalledWith(
+      'agent-1',
+      'latest-visible',
+      expect.any(Object),
+    )
+  })
+
+  it('ignores unread and pending attention from hidden automation', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(readSessionMetadata).mockResolvedValue({
+      'hidden-scheduled': {
+        isScheduledExecution: true,
+      },
+    })
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([
+      ['agent-1', new Set(['hidden-scheduled'])],
+    ]))
+    vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
+      (id: string) => id === 'hidden-scheduled',
+    )
+    vi.mocked(messagePersister.getActiveSessionIdsForAgent)
+      .mockReturnValue(['hidden-scheduled'])
+    expect(userInputRequestManager.register({
+      id: 'hidden-request',
+      kind: 'question',
+      scope: { agentSlug: 'agent-1', sessionId: 'hidden-scheduled' },
+      blocking: true,
+      autoApproved: false,
+      payload: {},
+    })).not.toBeNull()
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0].attentionOutsideLatest).toEqual({
+      hasUnreadNotification: false,
+      hasPendingInput: false,
+    })
+  })
+
+  it('counts promoted automation as visible outside attention', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([
+      sessionInfo('latest-visible'),
+      sessionInfo('promoted-scheduled'),
+    ])
+    vi.mocked(readSessionMetadata).mockResolvedValue({
+      'promoted-scheduled': {
+        isScheduledExecution: true,
+        promotedToInteractive: true,
+      },
+    })
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([
+      ['agent-1', new Set(['promoted-scheduled'])],
+    ]))
+    expect(userInputRequestManager.register({
+      id: 'promoted-request',
+      kind: 'question',
+      scope: { agentSlug: 'agent-1', sessionId: 'promoted-scheduled' },
+      blocking: true,
+      autoApproved: false,
+      payload: {},
+    })).not.toBeNull()
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0].attentionOutsideLatest).toEqual({
+      hasUnreadNotification: true,
+      hasPendingInput: true,
+    })
+    expect(getSessionMessagesPage).toHaveBeenCalledTimes(1)
+    expect(getSessionMessagesPage).toHaveBeenCalledWith(
+      'agent-1',
+      'latest-visible',
+      expect.any(Object),
+    )
+  })
+
+  it('counts unattributed unread and agent-scoped pending attention as outside', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([
+      ['agent-1', new Set(['unknown-session'])],
+    ]))
+    expect(userInputRequestManager.register({
+      id: 'agent-scoped-review',
+      kind: 'proxy_review',
+      scope: { agentSlug: 'agent-1' },
+      blocking: true,
+      autoApproved: false,
+      payload: {},
+    })).not.toBeNull()
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0].attentionOutsideLatest).toEqual({
+      hasUnreadNotification: true,
+      hasPendingInput: true,
+    })
+  })
+
+  it('treats an unattributable positive pending-input aggregate as outside', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(messagePersister.hasSessionsAwaitingInputForAgent).mockReturnValue(true)
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0].attentionOutsideLatest).toEqual({
+      hasUnreadNotification: false,
+      hasPendingInput: true,
+    })
+  })
+
   it('returns null when an agent has no visible session and skips transcript work', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
     vi.mocked(listSessions).mockResolvedValue([])
@@ -5938,6 +6133,10 @@ describe('GET /api/agents (enriched summary)', () => {
     const body = await res.json()
 
     expect(body[0].latestVisibleSession).toBeNull()
+    expect(body[0].attentionOutsideLatest).toEqual({
+      hasUnreadNotification: false,
+      hasPendingInput: false,
+    })
     expect(getSessionMessagesPage).not.toHaveBeenCalled()
   })
 
@@ -5956,6 +6155,10 @@ describe('GET /api/agents (enriched summary)', () => {
       const body = await res.json()
 
       expect(body[0].latestVisibleSession).toBeNull()
+      expect(body[0].attentionOutsideLatest).toEqual({
+        hasUnreadNotification: false,
+        hasPendingInput: false,
+      })
       expect(getSessionMessagesPage).not.toHaveBeenCalled()
       expect(consoleError).toHaveBeenCalledWith(
         'Failed to fetch latest visible session tail for agent agent-1:',
@@ -5964,6 +6167,61 @@ describe('GET /api/agents (enriched summary)', () => {
         }),
       )
     } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('returns null attention instead of false when visible-session selection fails', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockRejectedValue(new Error('visibility unavailable'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      const res = await getReq(
+        app,
+        '/api/agents?include_latest_visible_session_tail=true',
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      expect(body[0].latestVisibleSession).toBeNull()
+      expect(body[0].attentionOutsideLatest).toBeNull()
+      expect(getSessionMessagesPage).not.toHaveBeenCalled()
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to select latest visible session for agent agent-1:',
+        expect.objectContaining({ message: 'visibility unavailable' }),
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('keeps the latest tail but returns null when attention computation fails', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    const attentionRead = vi
+      .spyOn(userInputRequestManager, 'getOpenRequestsForAgent')
+      .mockImplementationOnce(() => {
+        throw new Error('attention unavailable')
+      })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      const res = await getReq(
+        app,
+        '/api/agents?include_latest_visible_session_tail=true',
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      expect(body[0].latestVisibleSession.session.id).toBe('latest-visible')
+      expect(body[0].attentionOutsideLatest).toBeNull()
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to compute attention outside latest for agent agent-1:',
+        expect.objectContaining({ message: 'attention unavailable' }),
+      )
+    } finally {
+      attentionRead.mockRestore()
       consoleError.mockRestore()
     }
   })
@@ -6021,11 +6279,21 @@ describe('GET /api/agents (enriched summary)', () => {
       const body = await res.json()
       const bySlug = new Map(body.map((agent: { slug: string }) => [agent.slug, agent]))
 
-      expect(bySlug.get('agent-1')).toMatchObject({ latestVisibleSession: null })
+      expect(bySlug.get('agent-1')).toMatchObject({
+        latestVisibleSession: null,
+        attentionOutsideLatest: {
+          hasUnreadNotification: false,
+          hasPendingInput: false,
+        },
+      })
       expect(bySlug.get('agent-2')).toMatchObject({
         latestVisibleSession: {
           session: { id: 'session-agent-2' },
           messageTail: { messages: [], nextCursor: null },
+        },
+        attentionOutsideLatest: {
+          hasUnreadNotification: false,
+          hasPendingInput: false,
         },
       })
       expect(consoleError).toHaveBeenCalledWith(

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -303,20 +303,15 @@ vi.mock('@shared/lib/services/session-media', () => ({
   openMediaBlob: vi.fn(),
 }))
 
-vi.mock('@shared/lib/services/session-service', () => ({
+vi.mock('@shared/lib/services/session-service', async (importOriginal) => {
+  // The route's ordering and cap contracts must exercise the real sort helper
+  // and constant — a reimplementation here can drift from what ships.
+  const actual = await importOriginal<typeof import('@shared/lib/services/session-service')>()
+  return {
   listSessions: vi.fn(),
   listSessionsByIds: vi.fn(),
-  sortSessionsNewestFirst: vi.fn((sessions: Array<{
-    id: string
-    createdAt: Date
-    lastActivityAt?: Date | null
-  }>) => [...sessions].sort((a, b) => {
-    const byActivity =
-      (b.lastActivityAt ?? b.createdAt).getTime() -
-      (a.lastActivityAt ?? a.createdAt).getTime()
-    return byActivity || a.id.localeCompare(b.id)
-  })),
-  SESSIONS_LIST_MAX_LIMIT: 100,
+  sortSessionsNewestFirst: actual.sortSessionsNewestFirst,
+  SESSIONS_LIST_MAX_LIMIT: actual.SESSIONS_LIST_MAX_LIMIT,
   updateSessionName: vi.fn(),
   registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(),
@@ -335,7 +330,8 @@ vi.mock('@shared/lib/services/session-service', () => ({
   removeToolCall: vi.fn(),
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
   readSessionMetadata: vi.fn(() => Promise.resolve({})),
-}))
+  }
+})
 
 const mockLoadSessionUsageTotals = vi.fn()
 vi.mock('@shared/lib/services/usage-service', () => ({
@@ -5959,6 +5955,37 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
+  it('annotates the tail like a transcript page read', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+      messages: [
+        {
+          id: 'message-1',
+          type: 'assistant',
+          content: { text: '' },
+          toolCalls: [{ id: 'tool-1', name: 'AskUserQuestion', input: {}, result: undefined }],
+          createdAt: new Date('2026-01-01T12:00:00.000Z'),
+        },
+      ],
+      nextCursor: null,
+    })
+    vi.mocked(messagePersister.getSettledInputRequests).mockReturnValueOnce(
+      new Map([['tool-1', 'answered']])
+    )
+
+    const res = await getReq(
+      app,
+      '/api/agents?include_latest_visible_session_tail=true',
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body[0].latestVisibleSession.messageTail.messages[0].toolCalls[0].result)
+      .toBe('User provided input')
+    expect(messagePersister.getSettledInputRequests).toHaveBeenCalledWith('latest-visible')
+  })
+
   it('reports unread and pending attention on an older visible session', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
     vi.mocked(listSessions).mockResolvedValue([
@@ -6140,10 +6167,11 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(getSessionMessagesPage).not.toHaveBeenCalled()
   })
 
-  it('returns null and reports a latest visible session whose transcript is missing', async () => {
+  it('returns null and reports a latest visible session with neither transcript nor registration', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
     vi.mocked(listSessions).mockResolvedValue([sessionInfo('missing-transcript')])
     vi.mocked(sessionExists).mockResolvedValue(false)
+    vi.mocked(sessionIsKnown).mockResolvedValue(false)
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     try {
@@ -6166,6 +6194,36 @@ describe('GET /api/agents (enriched summary)', () => {
           message: 'Latest visible session transcript not found for agent-1/missing-transcript',
         }),
       )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('serves a registered session with an empty tail before its first transcript write', async () => {
+    vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
+    vi.mocked(listSessions).mockResolvedValue([sessionInfo('registered-pending')])
+    vi.mocked(sessionExists).mockResolvedValue(false)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      const res = await getReq(
+        app,
+        '/api/agents?include_latest_visible_session_tail=true',
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+
+      expect(body[0].latestVisibleSession).toMatchObject({
+        session: { id: 'registered-pending' },
+        messageTail: { messages: [], nextCursor: null },
+      })
+      expect(body[0].attentionOutsideLatest).toEqual({
+        hasUnreadNotification: false,
+        hasPendingInput: false,
+      })
+      expect(sessionIsKnown).toHaveBeenCalledWith('agent-1', 'registered-pending')
+      expect(getSessionMessagesPage).not.toHaveBeenCalled()
+      expect(consoleError).not.toHaveBeenCalled()
     } finally {
       consoleError.mockRestore()
     }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -53,6 +53,9 @@ import type {
 import {
   listSessions,
   listSessionsByIds,
+  sortSessionsNewestFirst,
+  SESSIONS_LIST_MAX_LIMIT,
+  type SessionSortBy,
   getSessionSummary,
   readSessionMetadata,
   updateSessionName,
@@ -406,12 +409,83 @@ function toSkillsetRef(config: Pick<SkillsetConfig, 'id' | 'url' | 'name' | 'pro
   }
 }
 
+const strictBooleanQuerySchema = z
+  .enum(['true', 'false'])
+  .transform((value) => value === 'true')
+
+const positiveIntegerQuerySchema = z
+  .string()
+  .regex(/^[1-9]\d*$/)
+  .transform(Number)
+  .refine((value) => Number.isSafeInteger(value))
+
+const sessionsListQuerySchema = z.object({
+  sortBy: z.literal('last_activity_at').optional(),
+  notable: strictBooleanQuerySchema.optional(),
+  limit: positiveIntegerQuerySchema.optional(),
+})
+
+const agentsListQuerySchema = z.object({
+  includeLatestVisibleSessionTail: strictBooleanQuerySchema.optional(),
+})
+
+// Agent-list hydration only needs enough recent display items to derive a
+// preview. Keep both item count and raw tail window far below the chat page
+// limits because this cost is multiplied by the number of agents.
+const LATEST_VISIBLE_SESSION_TAIL_LIMIT = 20
+const LATEST_VISIBLE_SESSION_TAIL_BYTE_BUDGET = 256 * 1024
+
+interface AgentSummaryOptions {
+  includeLatestVisibleSessionTail?: boolean
+  signal?: AbortSignal
+}
+
+async function getLatestVisibleSessionTail(
+  agentSlug: string,
+  unreadSessionIds: Set<string>,
+  signal?: AbortSignal,
+): Promise<NonNullable<ApiAgent['latestVisibleSession']> | null> {
+  const [session] = await listSessions(agentSlug, {
+    excludeAutomated: true,
+    sortBy: 'last_activity_at',
+    limit: 1,
+  })
+  if (!session) return null
+
+  signal?.throwIfAborted()
+  if (!(await sessionExists(agentSlug, session.id))) {
+    throw new Error(
+      'Latest visible session transcript not found for ' + agentSlug + '/' + session.id,
+    )
+  }
+  const messageTail = await getSessionMessagesPage(agentSlug, session.id, {
+    limit: LATEST_VISIBLE_SESSION_TAIL_LIMIT,
+    byteBudget: LATEST_VISIBLE_SESSION_TAIL_BYTE_BUDGET,
+    media: 'ref',
+    signal,
+  })
+  signal?.throwIfAborted()
+
+  return {
+    session: {
+      ...session,
+      isActive: messagePersister.isSessionActive(session.id),
+      isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id),
+      hasUnreadNotifications: unreadSessionIds.has(session.id),
+    },
+    messageTail,
+  }
+}
+
 /**
  * Enrich an array of ApiAgent objects with summary fields:
  * active/awaiting sessions, last activity, and dashboards.
  * Batch notification lookup upfront, then parallelize per-agent FS operations.
  */
-async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> {
+async function enrichAgentsWithSummary(
+  agents: ApiAgent[],
+  options: AgentSummaryOptions = {},
+): Promise<ApiAgent[]> {
   const slugs = agents.map(a => a.slug)
 
   const unreadByAgent = await getUnreadNotificationsByAgents(slugs)
@@ -419,14 +493,31 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
   const limit = pLimit(5)
   return Promise.all(
     agents.map((agent) => limit(async () => {
-      // Only FS operations remain per-agent (parallelized)
-      const [sessionSummary, artifacts, sessionMetadata] = await Promise.all([
+      const unreadSessionIds = unreadByAgent.get(agent.slug) ?? new Set<string>()
+      const latestVisibleSessionPromise = options.includeLatestVisibleSessionTail
+        ? getLatestVisibleSessionTail(agent.slug, unreadSessionIds, options.signal)
+            .catch((error): null => {
+              if (options.signal?.aborted) throw error
+              console.error(
+                'Failed to fetch latest visible session tail for agent ' + agent.slug + ':',
+                error,
+              )
+              captureException(error, {
+                tags: { component: 'agents', operation: 'latest-visible-session-tail' },
+                extra: { agentSlug: agent.slug },
+              })
+              return null
+            })
+        : Promise.resolve(undefined)
+
+      // Only FS operations remain per-agent (parallelized and bounded by the
+      // outer p-limit).
+      const [sessionSummary, artifacts, sessionMetadata, latestVisibleSession] = await Promise.all([
         getSessionSummary(agent.slug),
         listArtifactsFromFilesystem(agent.slug),
         readSessionMetadata(agent.slug),
+        latestVisibleSessionPromise,
       ])
-
-      const unreadSessionIds = unreadByAgent.get(agent.slug) ?? new Set<string>()
 
       // Compute session flags from in-memory state (no I/O needed).
       // `unreadByAgent` is already filtered to user-actionable notification types
@@ -479,6 +570,9 @@ async function enrichAgentsWithSummary(agents: ApiAgent[]): Promise<ApiAgent[]> 
           name: a.name || a.slug,
           ...(a.hasScreenshot ? { hasScreenshot: true } : {}),
         })),
+        ...(options.includeLatestVisibleSessionTail
+          ? { latestVisibleSession: latestVisibleSession ?? null }
+          : {}),
       }
     }))
   )
@@ -971,8 +1065,20 @@ Respond with ONLY the session name, nothing else. No quotes, no explanation.`,
 
 // GET /api/agents - List agents with status (filtered by ACL in auth mode)
 // Response includes pre-aggregated summary: session activity and dashboards.
+// ?include_latest_visible_session_tail=true additionally returns one
+// visibility-safe session and a small media-ref transcript page per agent.
 agents.get('/', async (c) => {
   try {
+    const includeTailRaw = c.req.query('include_latest_visible_session_tail')
+    const parsedQuery = agentsListQuerySchema.safeParse({
+      ...(includeTailRaw === undefined
+        ? {}
+        : { includeLatestVisibleSessionTail: includeTailRaw }),
+    })
+    if (!parsedQuery.success) {
+      return c.json({ error: 'Invalid agent list query' }, 400)
+    }
+
     // In auth mode, only return agents the user has explicit ACL entries for.
     // Note: Admins do NOT get implicit access to all agents in the listing.
     // This is intentional — admin privileges grant bypass access to individual
@@ -1004,7 +1110,11 @@ agents.get('/', async (c) => {
       agentList = await listAgentsWithStatus()
     }
 
-    return c.json(await enrichAgentsWithSummary(agentList))
+    return c.json(await enrichAgentsWithSummary(agentList, {
+      includeLatestVisibleSessionTail:
+        parsedQuery.data.includeLatestVisibleSessionTail === true,
+      signal: c.req.raw.signal,
+    }))
   } catch (error) {
     console.error('Failed to fetch agents:', error)
     return c.json({ error: 'Failed to fetch agents' }, 500)
@@ -1553,16 +1663,33 @@ agents.post('/:id/open-directory', AgentAdmin(), async (c) => {
 })
 
 // GET /api/agents/:id/sessions - List sessions for an agent
-// ?notable=true&limit=N — fast path for badge/toolbar consumers: only
-// sessions that are live or carry unread notifications, built from targeted
-// stats instead of statting every transcript in the directory.
+// ?notable=true means active/awaiting-input or unread. Its fast path intersects
+// those targeted IDs with server-visible sessions before sort_by and limit,
+// avoiding a stat of every transcript. Supported ordering is deterministic
+// newest-first activity via sort_by=last_activity_at.
 agents.get('/:id/sessions', AgentRead(), async (c) => {
   try {
     const slug = getAgentId(c)
+    const sortByRaw = c.req.query('sort_by')
+    const notableRaw = c.req.query('notable')
+    const limitRaw = c.req.query('limit')
+    const parsedQuery = sessionsListQuerySchema.safeParse({
+      ...(sortByRaw === undefined ? {} : { sortBy: sortByRaw }),
+      ...(notableRaw === undefined ? {} : { notable: notableRaw }),
+      ...(limitRaw === undefined ? {} : { limit: limitRaw }),
+    })
+    if (!parsedQuery.success) {
+      return c.json({ error: 'Invalid sessions query' }, 400)
+    }
 
-    if (c.req.query('notable') === 'true') {
-      const limitRaw = Number(c.req.query('limit'))
-      const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.trunc(limitRaw), 100) : 25
+    const sortBy: SessionSortBy = parsedQuery.data.sortBy ?? 'last_activity_at'
+    const isNotable = parsedQuery.data.notable === true
+    const requestedLimit = parsedQuery.data.limit === undefined
+      ? undefined
+      : Math.min(parsedQuery.data.limit, SESSIONS_LIST_MAX_LIMIT)
+    const resultLimit = requestedLimit ?? (isNotable ? 25 : undefined)
+
+    if (isNotable) {
       const unreadIds = await getSessionIdsWithUnreadNotifications(slug)
       const activeIds = messagePersister.getActiveSessionIdsForAgent(slug)
       const infos = await listSessionsByIds(slug, [...new Set([...activeIds, ...unreadIds])], {
@@ -1579,17 +1706,25 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
           hasUnreadNotifications: unreadIds.has(session.id),
         }
       })
-      // Live sessions must survive the cap; within each band, newest first.
-      enriched.sort((a, b) => {
-        const aLive = a.isActive || a.isAwaitingInput ? 1 : 0
-        const bLive = b.isActive || b.isAwaitingInput ? 1 : 0
-        if (aLive !== bLive) return bLive - aLive
-        return b.lastActivityAt.getTime() - a.lastActivityAt.getTime()
-      })
-      return c.json(enriched.slice(0, limit))
+      const ordered = sortSessionsNewestFirst(enriched, sortBy)
+      if (sortByRaw === undefined) {
+        // Preserve the existing notable-only contract when no explicit order
+        // was requested: live sessions survive the default/caller cap. The
+        // stable sort retains deterministic newest-first ordering per band.
+        ordered.sort((a, b) => {
+          const aLive = a.isActive || a.isAwaitingInput ? 1 : 0
+          const bLive = b.isActive || b.isAwaitingInput ? 1 : 0
+          return bLive - aLive
+        })
+      }
+      return c.json(ordered.slice(0, resultLimit ?? 25))
     }
 
-    const sessionList = await listSessions(slug, { excludeAutomated: true })
+    const sessionList = await listSessions(slug, {
+      excludeAutomated: true,
+      ...(sortByRaw === undefined ? {} : { sortBy }),
+      ...(resultLimit === undefined ? {} : { limit: resultLimit }),
+    })
     const unreadSessionIds = await getSessionIdsWithUnreadNotifications(slug)
     const pendingWakes = await listPendingWakesByAgent(slug)
     const wakesBySession = new Map(pendingWakes.map((w) => [w.resumeSessionId!, w]))

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -528,17 +528,29 @@ async function getLatestVisibleSessionTail(
   signal?: AbortSignal,
 ): Promise<NonNullable<ApiAgent['latestVisibleSession']>> {
   signal?.throwIfAborted()
-  if (!(await sessionExists(agentSlug, session.id))) {
+  // A registered session with no transcript yet (created, nothing streamed) is
+  // a normal state and serves an empty tail. Only an id with neither a
+  // transcript nor a registration — a session that vanished after listing —
+  // is an error.
+  const transcriptExists = await sessionExists(agentSlug, session.id)
+  if (!transcriptExists && !(await sessionIsKnown(agentSlug, session.id))) {
     throw new Error(
       'Latest visible session transcript not found for ' + agentSlug + '/' + session.id,
     )
   }
-  const messageTail = await getSessionMessagesPage(agentSlug, session.id, {
-    limit: LATEST_VISIBLE_SESSION_TAIL_LIMIT,
-    byteBudget: LATEST_VISIBLE_SESSION_TAIL_BYTE_BUDGET,
-    media: 'ref',
-    signal,
-  })
+  const messageTail = transcriptExists
+    ? await getSessionMessagesPage(agentSlug, session.id, {
+        limit: LATEST_VISIBLE_SESSION_TAIL_LIMIT,
+        byteBudget: LATEST_VISIBLE_SESSION_TAIL_BYTE_BUDGET,
+        media: 'ref',
+        signal,
+      })
+    : { messages: [], nextCursor: null }
+  signal?.throwIfAborted()
+  // Same treatment as the transcript page endpoint, so the tail matches what
+  // opening the session shows. Must run before the session flags below so
+  // recovered awaiting-input state is reflected in them.
+  await annotateAndRecoverMessages(messageTail.messages, agentSlug, session.id)
   signal?.throwIfAborted()
 
   return {
@@ -604,6 +616,8 @@ async function getVisibleSessionExpansion(
     ? getLatestVisibleSessionTail(agentSlug, latestSession, unreadSessionIds, signal)
         .catch((error): null => {
           if (signal?.aborted) throw error
+          // Attention still excludes this session as latest, so on this path
+          // its own unread/pending is reported nowhere until the next poll.
           console.error(
             'Failed to fetch latest visible session tail for agent ' + agentSlug + ':',
             error,
@@ -1862,7 +1876,7 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
           return bLive - aLive
         })
       }
-      return c.json(ordered.slice(0, resultLimit ?? 25))
+      return c.json(ordered.slice(0, resultLimit))
     }
 
     const sessionList = await listSessions(slug, {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -197,6 +197,7 @@ import { pipeline as streamPipeline } from 'stream/promises'
 import pLimit from 'p-limit'
 import * as path from 'path'
 import type { ApiAgent } from '@shared/lib/types/api'
+import type { SessionInfo, SessionMetadataMap } from '@shared/lib/types/agent'
 import { toPublicChatIntegration } from '@shared/lib/chat-integrations/public'
 import { toPublicWebhookTrigger } from '@shared/lib/webhook-triggers/public'
 import {
@@ -440,18 +441,92 @@ interface AgentSummaryOptions {
   signal?: AbortSignal
 }
 
+function attentionSessionCountsOutsideLatest(
+  sessionId: string,
+  latestSessionId: string | undefined,
+  visibleSessionIds: Set<string>,
+  sessionMetadata: SessionMetadataMap,
+): boolean {
+  if (sessionId === latestSessionId) return false
+  if (visibleSessionIds.has(sessionId)) return true
+
+  // An ID absent from the visible snapshot is either confirmed-hidden or
+  // unresolved (for example a just-created or stale attention source). Only a
+  // metadata-confirmed hidden automation is safe to ignore. Unknown ordinary
+  // and promoted sessions conservatively count as outside.
+  return !isHiddenAutomatedSession(sessionMetadata[sessionId])
+}
+
+function getAttentionOutsideLatest(
+  agentSlug: string,
+  visibleSessions: SessionInfo[],
+  unreadSessionIds: Set<string>,
+  sessionMetadata: SessionMetadataMap,
+): NonNullable<ApiAgent['attentionOutsideLatest']> {
+  const latestSessionId = visibleSessions[0]?.id
+  const visibleSessionIds = new Set(visibleSessions.map((session) => session.id))
+  const countsOutside = (sessionId: string) => attentionSessionCountsOutsideLatest(
+    sessionId,
+    latestSessionId,
+    visibleSessionIds,
+    sessionMetadata,
+  )
+
+  const hasUnreadNotification = [...unreadSessionIds].some(countsOutside)
+
+  let hasPendingInput = false
+  let observedPendingInput = false
+
+  // The registry is authoritative for open requests and exposes explicit
+  // session attribution when it exists. Agent-scoped requests have no unique
+  // session, so they must conservatively count as outside latest.
+  for (const request of userInputRequestManager.getOpenRequestsForAgent(agentSlug)) {
+    if (!request.blocking || request.autoApproved) continue
+    observedPendingInput = true
+    const sessionId = request.scope.sessionId
+    if (sessionId === undefined || countsOutside(sessionId)) {
+      hasPendingInput = true
+      break
+    }
+  }
+
+  // Also sample the persister projection. It covers recovered/racing state and
+  // lets us classify hidden active sessions without ever returning their IDs.
+  if (!hasPendingInput) {
+    const candidateIds = new Set([
+      ...visibleSessionIds,
+      ...messagePersister.getActiveSessionIdsForAgent(agentSlug),
+    ])
+    for (const sessionId of candidateIds) {
+      if (!messagePersister.isSessionAwaitingInput(sessionId)) continue
+      observedPendingInput = true
+      if (countsOutside(sessionId)) {
+        hasPendingInput = true
+        break
+      }
+    }
+  }
+
+  // A positive aggregate with no attributable request/session is unresolved.
+  // Never collapse that uncertainty to false: iOS uses false/false to open the
+  // latest session directly.
+  if (
+    !hasPendingInput &&
+    !observedPendingInput &&
+    messagePersister.hasSessionsAwaitingInputForAgent(agentSlug)
+  ) {
+    hasPendingInput = true
+  }
+
+  return { hasUnreadNotification, hasPendingInput }
+}
+
 async function getLatestVisibleSessionTail(
   agentSlug: string,
+  session: SessionInfo,
   unreadSessionIds: Set<string>,
   signal?: AbortSignal,
-): Promise<NonNullable<ApiAgent['latestVisibleSession']> | null> {
-  const [session] = await listSessions(agentSlug, {
-    excludeAutomated: true,
-    sortBy: 'last_activity_at',
-    limit: 1,
-  })
-  if (!session) return null
-
+): Promise<NonNullable<ApiAgent['latestVisibleSession']>> {
   signal?.throwIfAborted()
   if (!(await sessionExists(agentSlug, session.id))) {
     throw new Error(
@@ -477,6 +552,77 @@ async function getLatestVisibleSessionTail(
   }
 }
 
+interface AgentVisibleSessionExpansion {
+  latestVisibleSession: ApiAgent['latestVisibleSession']
+  attentionOutsideLatest: ApiAgent['attentionOutsideLatest']
+}
+
+async function getVisibleSessionExpansion(
+  agentSlug: string,
+  unreadSessionIds: Set<string>,
+  sessionMetadataPromise: Promise<SessionMetadataMap>,
+  signal?: AbortSignal,
+): Promise<AgentVisibleSessionExpansion> {
+  let visibleSessions: SessionInfo[]
+  try {
+    // Keep the complete visibility-filtered snapshot: its first item selects
+    // latest, while the remaining metadata-only items answer the two attention
+    // booleans without loading older transcripts.
+    visibleSessions = await listSessions(agentSlug, {
+      excludeAutomated: true,
+      sortBy: 'last_activity_at',
+    })
+  } catch (error) {
+    if (signal?.aborted) throw error
+    console.error('Failed to select latest visible session for agent ' + agentSlug + ':', error)
+    captureException(error, {
+      tags: { component: 'agents', operation: 'latest-visible-session-selection' },
+      extra: { agentSlug },
+    })
+    return { latestVisibleSession: null, attentionOutsideLatest: null }
+  }
+
+  const latestSession = visibleSessions[0]
+  const attentionOutsideLatestPromise = sessionMetadataPromise
+    .then((sessionMetadata) => getAttentionOutsideLatest(
+      agentSlug,
+      visibleSessions,
+      unreadSessionIds,
+      sessionMetadata,
+    ))
+    .catch((error): null => {
+      if (signal?.aborted) throw error
+      console.error('Failed to compute attention outside latest for agent ' + agentSlug + ':', error)
+      captureException(error, {
+        tags: { component: 'agents', operation: 'attention-outside-latest' },
+        extra: { agentSlug },
+      })
+      return null
+    })
+
+  const latestVisibleSessionPromise = latestSession
+    ? getLatestVisibleSessionTail(agentSlug, latestSession, unreadSessionIds, signal)
+        .catch((error): null => {
+          if (signal?.aborted) throw error
+          console.error(
+            'Failed to fetch latest visible session tail for agent ' + agentSlug + ':',
+            error,
+          )
+          captureException(error, {
+            tags: { component: 'agents', operation: 'latest-visible-session-tail' },
+            extra: { agentSlug },
+          })
+          return null
+        })
+    : Promise.resolve(null)
+
+  const [latestVisibleSession, attentionOutsideLatest] = await Promise.all([
+    latestVisibleSessionPromise,
+    attentionOutsideLatestPromise,
+  ])
+  return { latestVisibleSession, attentionOutsideLatest }
+}
+
 /**
  * Enrich an array of ApiAgent objects with summary fields:
  * active/awaiting sessions, last activity, and dashboards.
@@ -494,30 +640,25 @@ async function enrichAgentsWithSummary(
   return Promise.all(
     agents.map((agent) => limit(async () => {
       const unreadSessionIds = unreadByAgent.get(agent.slug) ?? new Set<string>()
-      const latestVisibleSessionPromise = options.includeLatestVisibleSessionTail
-        ? getLatestVisibleSessionTail(agent.slug, unreadSessionIds, options.signal)
-            .catch((error): null => {
-              if (options.signal?.aborted) throw error
-              console.error(
-                'Failed to fetch latest visible session tail for agent ' + agent.slug + ':',
-                error,
-              )
-              captureException(error, {
-                tags: { component: 'agents', operation: 'latest-visible-session-tail' },
-                extra: { agentSlug: agent.slug },
-              })
-              return null
-            })
+      const sessionMetadataPromise = readSessionMetadata(agent.slug)
+      const visibleSessionExpansionPromise = options.includeLatestVisibleSessionTail
+        ? getVisibleSessionExpansion(
+            agent.slug,
+            unreadSessionIds,
+            sessionMetadataPromise,
+            options.signal,
+          )
         : Promise.resolve(undefined)
 
       // Only FS operations remain per-agent (parallelized and bounded by the
       // outer p-limit).
-      const [sessionSummary, artifacts, sessionMetadata, latestVisibleSession] = await Promise.all([
-        getSessionSummary(agent.slug),
-        listArtifactsFromFilesystem(agent.slug),
-        readSessionMetadata(agent.slug),
-        latestVisibleSessionPromise,
-      ])
+      const [sessionSummary, artifacts, sessionMetadata, visibleSessionExpansion] =
+        await Promise.all([
+          getSessionSummary(agent.slug),
+          listArtifactsFromFilesystem(agent.slug),
+          sessionMetadataPromise,
+          visibleSessionExpansionPromise,
+        ])
 
       // Compute session flags from in-memory state (no I/O needed).
       // `unreadByAgent` is already filtered to user-actionable notification types
@@ -571,7 +712,11 @@ async function enrichAgentsWithSummary(
           ...(a.hasScreenshot ? { hasScreenshot: true } : {}),
         })),
         ...(options.includeLatestVisibleSessionTail
-          ? { latestVisibleSession: latestVisibleSession ?? null }
+          ? {
+              latestVisibleSession: visibleSessionExpansion?.latestVisibleSession ?? null,
+              attentionOutsideLatest:
+                visibleSessionExpansion?.attentionOutsideLatest ?? null,
+            }
           : {}),
       }
     }))

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   listSessions,
   listSessionsByIds,
+  sortSessionsNewestFirst,
   getSession,
   getSessionMessages,
   getSessionMessagesPage,
@@ -386,6 +387,99 @@ describe('session-service', () => {
       const filtered = await listSessions('test-agent', { excludeAutomated: true })
       expect(filtered.length).toBe(1)
       expect(filtered[0].name).toBe('Promoted Pending')
+    })
+
+    it('filters newer hidden automations before ordering and limit', async () => {
+      await createSessionsDir('test-agent')
+      await createSessionMetadata('test-agent', {
+        'manual-visible': {
+          name: 'Manual',
+          createdAt: '2026-01-24T10:00:00.000Z',
+        },
+        'scheduled-hidden': {
+          name: 'Scheduled',
+          createdAt: '2026-01-24T11:00:00.000Z',
+          isScheduledExecution: true,
+        },
+        'webhook-hidden': {
+          name: 'Webhook',
+          createdAt: '2026-01-24T12:00:00.000Z',
+          isWebhookExecution: true,
+        },
+        'chat-hidden': {
+          name: 'Chat',
+          createdAt: '2026-01-24T13:00:00.000Z',
+          isChatIntegrationSession: true,
+        },
+      })
+
+      const sessions = await listSessions('test-agent', {
+        excludeAutomated: true,
+        sortBy: 'last_activity_at',
+        limit: 1,
+      })
+
+      expect(sessions.map((session) => session.id)).toEqual(['manual-visible'])
+    })
+
+    it('keeps promoted automation eligible before ordering and limit', async () => {
+      await createSessionsDir('test-agent')
+      await createSessionMetadata('test-agent', {
+        'manual-visible': {
+          createdAt: '2026-01-24T10:00:00.000Z',
+        },
+        'promoted-scheduled': {
+          createdAt: '2026-01-24T11:00:00.000Z',
+          isScheduledExecution: true,
+          promotedToInteractive: true,
+        },
+        'newer-hidden': {
+          createdAt: '2026-01-24T12:00:00.000Z',
+          isScheduledExecution: true,
+        },
+      })
+
+      const sessions = await listSessions('test-agent', {
+        excludeAutomated: true,
+        sortBy: 'last_activity_at',
+        limit: 1,
+      })
+
+      expect(sessions.map((session) => session.id)).toEqual(['promoted-scheduled'])
+    })
+
+    it('uses createdAt fallback, sorts invalid dates last, and breaks ties by id', () => {
+      const ordered = sortSessionsNewestFirst([
+        {
+          id: 'z-tied',
+          createdAt: new Date('2026-01-24T11:00:00.000Z'),
+          lastActivityAt: null,
+        },
+        {
+          id: 'older',
+          createdAt: new Date('2026-01-24T10:00:00.000Z'),
+          lastActivityAt: null,
+        },
+        {
+          id: 'a-tied',
+          createdAt: new Date('2026-01-24T11:00:00.000Z'),
+          lastActivityAt: null,
+        },
+        {
+          id: 'z-invalid',
+          createdAt: new Date('invalid'),
+          lastActivityAt: null,
+        },
+        {
+          id: 'a-invalid',
+          createdAt: new Date('invalid'),
+          lastActivityAt: null,
+        },
+      ])
+
+      expect(ordered.map((session) => session.id)).toEqual([
+        'a-tied', 'z-tied', 'older', 'a-invalid', 'z-invalid',
+      ])
     })
 
     it('sorts sessions by last activity (newest first)', async () => {

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -707,13 +707,64 @@ export async function getSessionSummary(agentSlug: string): Promise<{
   }
 }
 
+export type SessionSortBy = 'last_activity_at'
+
+export const SESSIONS_LIST_MAX_LIMIT = 100
+
+export interface ListSessionsOptions {
+  excludeAutomated?: boolean
+  sortBy?: SessionSortBy
+  limit?: number
+}
+
+type SessionOrderFields = {
+  id: string
+  createdAt: Date
+  lastActivityAt?: Date | null
+}
+
+function sessionActivityTimestamp(session: SessionOrderFields): number {
+  const lastActivity = session.lastActivityAt?.getTime()
+  if (Number.isFinite(lastActivity)) return lastActivity!
+  const created = session.createdAt.getTime()
+  return Number.isFinite(created) ? created : Number.NEGATIVE_INFINITY
+}
+
+/**
+ * Return a deterministically ordered copy of a session list.
+ *
+ * Keep this shared between the full sessions endpoint, its notable projection,
+ * and aggregate agent responses. In particular, callers must visibility-filter
+ * before invoking this helper and applying a limit.
+ */
+export function sortSessionsNewestFirst<T extends SessionOrderFields>(
+  sessions: readonly T[],
+  sortBy: SessionSortBy = 'last_activity_at',
+): T[] {
+  return [...sessions].sort((a, b) => {
+    let aTimestamp: number
+    let bTimestamp: number
+    switch (sortBy) {
+      case 'last_activity_at':
+        aTimestamp = sessionActivityTimestamp(a)
+        bTimestamp = sessionActivityTimestamp(b)
+        break
+    }
+    if (aTimestamp < bTimestamp) return 1
+    if (aTimestamp > bTimestamp) return -1
+    if (a.id < b.id) return -1
+    if (a.id > b.id) return 1
+    return 0
+  })
+}
+
 /**
  * List all sessions for an agent using file stats and metadata.
  * Does NOT read full JSONL file contents — safe for large session directories.
  */
 export async function listSessions(
   agentSlug: string,
-  options?: { excludeAutomated?: boolean },
+  options?: ListSessionsOptions,
 ): Promise<SessionInfo[]> {
   const sessionsDir = getAgentSessionsDir(agentSlug)
 
@@ -789,10 +840,13 @@ export async function listSessions(
     }
   }
 
-  // Sort by last activity, newest first
-  sessions.sort((a, b) => b.lastActivityAt.getTime() - a.lastActivityAt.getTime())
+  // Visibility filtering above must happen before ordering and limiting: a
+  // newer hidden automation must never consume a mobile client's limit.
+  const ordered = sortSessionsNewestFirst(sessions, options?.sortBy)
 
-  return sessions
+  return options?.limit === undefined
+    ? ordered
+    : ordered.slice(0, options.limit)
 }
 
 /**

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -35,6 +35,8 @@ export interface ApiAgent {
   sessionCount?: number
   lastActivityAt?: Date | null
   dashboards?: ApiAgentDashboard[]
+  /** Opt-in expansion from GET /api/agents?include_latest_visible_session_tail=true. */
+  latestVisibleSession?: ApiLatestVisibleSession | null
 }
 
 /** Response returned when an agent template has been installed or imported. */
@@ -48,6 +50,16 @@ export interface ApiAgentDashboard {
   slug: string
   name: string
   hasScreenshot?: boolean
+}
+
+export interface ApiLatestVisibleSession {
+  session: ApiSession
+  messageTail: ApiTranscriptPage
+}
+
+export interface ApiTranscriptPage {
+  messages: ApiMessageOrBoundary[]
+  nextCursor: string | null
 }
 
 /**

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -37,6 +37,8 @@ export interface ApiAgent {
   dashboards?: ApiAgentDashboard[]
   /** Opt-in expansion from GET /api/agents?include_latest_visible_session_tail=true. */
   latestVisibleSession?: ApiLatestVisibleSession | null
+  /** Attention on visible sessions other than latestVisibleSession. Null means unavailable. */
+  attentionOutsideLatest?: ApiAttentionOutsideLatest | null
 }
 
 /** Response returned when an agent template has been installed or imported. */
@@ -55,6 +57,11 @@ export interface ApiAgentDashboard {
 export interface ApiLatestVisibleSession {
   session: ApiSession
   messageTail: ApiTranscriptPage
+}
+
+export interface ApiAttentionOutsideLatest {
+  hasUnreadNotification: boolean
+  hasPendingInput: boolean
 }
 
 export interface ApiTranscriptPage {


### PR DESCRIPTION
## Summary

- Honor validated sort_by=last_activity_at, notable, and capped limit parameters on the sessions endpoint, with visibility filtering before ordering and limiting and a deterministic session-ID tie-break.
- Preserve manual sessions and promoted automations while excluding unpromoted scheduled, webhook, and chat-integration sessions from mobile-facing results.
- Add opt-in include_latest_visible_session_tail=true hydration to the agents collection, returning the latest ordinary visible session plus a 20-item, 256 KiB, media-reference transcript page and cursor.
- Return attentionOutsideLatest with hasUnreadNotification and hasPendingInput from the same visible-session snapshot, excluding the selected latest ID. Hidden automation is ignored, promoted automation is eligible, and unattributed attention conservatively counts as outside.
- Keep the default agent-list shape and I/O unchanged. Opt-in failures are isolated per agent and unavailable attention is returned as null rather than a misleading false/false value.
- Add regression coverage for hidden newer automations, promoted automation, latest-only and older attention, unresolved attribution, notable semantics/order, malformed query values, ACL gating, missing transcripts, and multi-agent failure isolation.

## Verification

- npm run typecheck -- --pretty false
- npm run lint (0 errors; 42 existing warnings)
- SUPERAGENT_DATA_DIR=/tmp/codex-superagent-test-data npm run test:run (608 files passed; 10,003 tests passed)
- Focused API/service suites: 584 tests passed

## Linear

- [SUP-657](https://linear.app/datawizz/issue/SUP-657/sessions-api-honor-sort-by-notable-and-limit-with-visibility-safe)
- [SUP-658](https://linear.app/datawizz/issue/SUP-658/agents-api-optionally-include-latest-visible-session-and-bounded)