### PR TITLE
feat(x-agent): limit and quiet view on get_agent_session_transcript (SUP-661)

### DIFF
--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -513,7 +513,7 @@ You can collaborate with other agents in the same workspace using the `mcp__agen
 - `mcp__agents__create_agent` — Create a brand-new agent. Always requires manual approval; never remembered.
 - `mcp__agents__invoke_agent` — Send a prompt to another agent. Either start a new session (omit `session_id`) or continue an existing one. Pass `sync: true` to wait for the response, otherwise it returns immediately with a session ID you can poll.
 - `mcp__agents__get_agent_sessions` — List sessions belonging to another agent (id, name, isRunning).
-- `mcp__agents__get_agent_session_transcript` — Read another agent's session. Pass `limit` (e.g. `limit: 1` for the last message). Omit it only when you need the whole transcript. Pass `sync: true` to wait if the session is currently running.
+- `mcp__agents__get_agent_session_transcript` — Read another agent's session. Pass `limit` (e.g. `limit: 1` for the last message). Default view is spoken turns only. Pass `full_transcript: true` only when you need tool calls, tool results, or thinking. Pass `sync: true` to wait if the session is currently running.
 - `mcp__user-input__deliver_session` — Surface a session to the user as a clickable card (pass `session_id` + `agent_slug`). Use after starting an x-agent session or finding a relevant existing one, instead of dumping the transcript into chat.
 
 **When to use:**
@@ -524,7 +524,7 @@ You can collaborate with other agents in the same workspace using the `mcp__agen
 **Important:**
 - Usually when a user sends a first message with "Create an agent..." they actually want you to be that agent, not to create a separate one. Only create a new agent if the user explicitly and unambiguously asks for a separate agent. Otherwise build the relevant skills etc in your current agent workspace and do the work yourself.
 - Use `invoke_agent` with `sync: true` only when you need the answer to continue. Async + transcript polling scales better for parallel work.
-- Tool calls in transcripts are summarized — you'll see `[tool_use: name]` markers but not the full input/output.
+- Transcripts default to spoken turns. Tool calls, tool results, and thinking are collapsed. Pass `full_transcript: true` to see them.
 - Cross-agent invocation is **one hop deep**: a session that was started by another agent cannot itself call `invoke_agent` or `create_agent`. This prevents chains and cycles. If you were invoked, do the work and return a result — don't delegate further.
 
 ## Chat Integrations

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -513,12 +513,12 @@ You can collaborate with other agents in the same workspace using the `mcp__agen
 - `mcp__agents__create_agent` — Create a brand-new agent. Always requires manual approval; never remembered.
 - `mcp__agents__invoke_agent` — Send a prompt to another agent. Either start a new session (omit `session_id`) or continue an existing one. Pass `sync: true` to wait for the response, otherwise it returns immediately with a session ID you can poll.
 - `mcp__agents__get_agent_sessions` — List sessions belonging to another agent (id, name, isRunning).
-- `mcp__agents__get_agent_session_transcript` — Read the messages in another agent's session. Pass `sync: true` to wait if the session is currently running.
+- `mcp__agents__get_agent_session_transcript` — Read another agent's session. Pass `limit` (e.g. `limit: 1` for the last message). Omit it only when you need the whole transcript. Pass `sync: true` to wait if the session is currently running.
 - `mcp__user-input__deliver_session` — Surface a session to the user as a clickable card (pass `session_id` + `agent_slug`). Use after starting an x-agent session or finding a relevant existing one, instead of dumping the transcript into chat.
 
 **When to use:**
 - You need a specialist on a focused task (e.g. "ask the email-triager to draft a reply") — `invoke_agent` with `sync: true`.
-- You're orchestrating long-running work — `invoke_agent` async, then poll with `get_agent_session_transcript`.
+- You're orchestrating long-running work — `invoke_agent` async, then poll with `get_agent_session_transcript` and `limit`.
 - You need to spin up a new specialist — `create_agent` with a clear name + instructions.
 
 **Important:**

--- a/agent-container/src/tools/agents/get-session-transcript.test.ts
+++ b/agent-container/src/tools/agents/get-session-transcript.test.ts
@@ -14,7 +14,12 @@ describe('get_agent_session_transcript limit rendering', () => {
     mockCallHost.mockReset()
   })
 
-  async function invoke(args: { slug: string; session_id: string; limit?: number }) {
+  async function invoke(args: {
+    slug: string
+    session_id: string
+    limit?: number
+    full_transcript?: boolean
+  }) {
     const { getSessionTranscriptTool } = await import('./get-session-transcript')
     return (getSessionTranscriptTool as { handler: (a: unknown) => Promise<{ content: Array<{ text: string }> }> }).handler(args)
   }
@@ -43,5 +48,22 @@ describe('get_agent_session_transcript limit rendering', () => {
     expect(text).toContain('--- #5 assistant ---')
     expect(text).toContain('two')
     expect(text).toContain('three')
+  })
+
+  it('forwards full_transcript when set', async () => {
+    mockCallHost.mockResolvedValue({
+      status: 'idle',
+      total: 1,
+      messages: [{ role: 'assistant', content: '[tool_use: Bash]', toolName: 'Bash' }],
+    })
+
+    await invoke({ slug: 'target', session_id: 'sess-1', full_transcript: true })
+
+    expect(mockCallHost).toHaveBeenCalledWith('get-transcript', {
+      slug: 'target',
+      sessionId: 'sess-1',
+      sync: false,
+      fullTranscript: true,
+    })
   })
 })

--- a/agent-container/src/tools/agents/get-session-transcript.test.ts
+++ b/agent-container/src/tools/agents/get-session-transcript.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockCallHost = vi.fn()
+vi.mock('./host-client', async () => {
+  const actual = await vi.importActual<typeof import('./host-client')>('./host-client')
+  return {
+    ...actual,
+    callHost: (...args: unknown[]) => mockCallHost(...args),
+  }
+})
+
+describe('get_agent_session_transcript limit rendering', () => {
+  beforeEach(() => {
+    mockCallHost.mockReset()
+  })
+
+  async function invoke(args: { slug: string; session_id: string; limit?: number }) {
+    const { getSessionTranscriptTool } = await import('./get-session-transcript')
+    return (getSessionTranscriptTool as { handler: (a: unknown) => Promise<{ content: Array<{ text: string }> }> }).handler(args)
+  }
+
+  it('forwards limit and numbers from the host total', async () => {
+    mockCallHost.mockResolvedValue({
+      status: 'idle',
+      total: 5,
+      messages: [
+        { role: 'assistant', content: 'two' },
+        { role: 'assistant', content: 'three' },
+      ],
+    })
+
+    const result = await invoke({ slug: 'target', session_id: 'sess-1', limit: 2 })
+
+    expect(mockCallHost).toHaveBeenCalledWith('get-transcript', {
+      slug: 'target',
+      sessionId: 'sess-1',
+      sync: false,
+      limit: 2,
+    })
+    const text = result.content[0].text
+    expect(text).toContain('showing last 2 of 5')
+    expect(text).toContain('--- #4 assistant ---')
+    expect(text).toContain('--- #5 assistant ---')
+    expect(text).toContain('two')
+    expect(text).toContain('three')
+  })
+})

--- a/agent-container/src/tools/agents/get-session-transcript.ts
+++ b/agent-container/src/tools/agents/get-session-transcript.ts
@@ -18,16 +18,17 @@ export const getSessionTranscriptTool = tool(
   'get_agent_session_transcript',
   `Read the message transcript of a session belonging to another agent. Returns a status line ('running' | 'idle' | 'awaiting_input') followed by the messages.
 
-Pass limit to get only the most recent N messages (limit: 1 = the agent's final message). Omit limit for the full transcript. Prefer a small limit: full transcripts can be very large.
+Pass limit to get only the most recent N messages (limit: 1 = the agent's final message). Omit limit for the whole view. Prefer a small limit.
 
-If sync=true and the session is currently running, the tool waits up to ~2 minutes for the target agent's turn to complete before returning. If the turn is still in progress after that, it returns the transcript so far with status 'running' — call again with sync=true to keep waiting. Otherwise it returns the current transcript immediately.
+By default the view is spoken turns only. Tool calls, tool results, and thinking are collapsed into a stub. Pass full_transcript: true to see today's compact view (tool names and tool results).
 
-Tool calls in the transcript are summarized — the raw tool input/output is omitted to keep the result compact.`,
+If sync=true and the session is currently running, the tool waits up to ~2 minutes for the target agent's turn to complete before returning. If the turn is still in progress after that, it returns the transcript so far with status 'running' — call again with sync=true to keep waiting. Otherwise it returns the current transcript immediately.`,
   {
     slug: z.string().describe('Slug of the target agent (from list_agents)'),
     session_id: z.string().describe('Session ID (from get_agent_sessions)'),
     sync: z.boolean().optional().describe('If true, wait for the session to idle before reading. Default false.'),
-    limit: z.number().int().min(1).max(500).optional().describe('Return only the most recent N messages. Omit for the full transcript.'),
+    limit: z.number().int().min(1).max(500).optional().describe('Return only the most recent N messages. Omit for the whole view.'),
+    full_transcript: z.boolean().optional().describe('If true, include tool calls, tool results, and thinking. Default false.'),
   },
   async (args) => {
     try {
@@ -36,6 +37,7 @@ Tool calls in the transcript are summarized — the raw tool input/output is omi
         sessionId: args.session_id,
         sync: args.sync ?? false,
         ...(args.limit ? { limit: args.limit } : {}),
+        ...(args.full_transcript ? { fullTranscript: true } : {}),
       })
       const shown = data.messages.length
       const header = shown < data.total

--- a/agent-container/src/tools/agents/get-session-transcript.ts
+++ b/agent-container/src/tools/agents/get-session-transcript.ts
@@ -11,11 +11,14 @@ interface TranscriptMessage {
 interface TranscriptResult {
   status: 'running' | 'idle' | 'awaiting_input'
   messages: TranscriptMessage[]
+  total: number
 }
 
 export const getSessionTranscriptTool = tool(
   'get_agent_session_transcript',
   `Read the message transcript of a session belonging to another agent. Returns a status line ('running' | 'idle' | 'awaiting_input') followed by the messages.
+
+Pass limit to get only the most recent N messages (limit: 1 = the agent's final message). Omit limit for the full transcript. Prefer a small limit: full transcripts can be very large.
 
 If sync=true and the session is currently running, the tool waits up to ~2 minutes for the target agent's turn to complete before returning. If the turn is still in progress after that, it returns the transcript so far with status 'running' — call again with sync=true to keep waiting. Otherwise it returns the current transcript immediately.
 
@@ -24,6 +27,7 @@ Tool calls in the transcript are summarized — the raw tool input/output is omi
     slug: z.string().describe('Slug of the target agent (from list_agents)'),
     session_id: z.string().describe('Session ID (from get_agent_sessions)'),
     sync: z.boolean().optional().describe('If true, wait for the session to idle before reading. Default false.'),
+    limit: z.number().int().min(1).max(500).optional().describe('Return only the most recent N messages. Omit for the full transcript.'),
   },
   async (args) => {
     try {
@@ -31,15 +35,20 @@ Tool calls in the transcript are summarized — the raw tool input/output is omi
         slug: args.slug,
         sessionId: args.session_id,
         sync: args.sync ?? false,
+        ...(args.limit ? { limit: args.limit } : {}),
       })
-      const header = `status: ${data.status}\nmessages: ${data.messages.length}`
+      const shown = data.messages.length
+      const header = shown < data.total
+        ? `status: ${data.status}\nmessages: showing last ${shown} of ${data.total}`
+        : `status: ${data.status}\nmessages: ${data.total}`
       if (data.messages.length === 0) {
         return textResult(`${header}\n(no messages)`)
       }
+      const offset = data.total - shown
       const body = data.messages
         .map((m, i) => {
           const tool = m.toolName ? ` [${m.toolName}]` : ''
-          return `--- #${i + 1} ${m.role}${tool} ---\n${m.content}`
+          return `--- #${offset + i + 1} ${m.role}${tool} ---\n${m.content}`
         })
         .join('\n\n')
       return textResult(`${header}\n\n${body}`)

--- a/e2e/specs/x-agent-transcript-limit.spec.ts
+++ b/e2e/specs/x-agent-transcript-limit.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, type APIRequestContext, type TestInfo } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import {
+  createAgent,
+  createSession,
+  listSessionMessages,
+  uniqueName,
+  waitForSessionIdle,
+  type TestAgent,
+  type TestSession,
+} from '../helpers/agents'
+
+/**
+ * Host route the container tool calls: limit returns the compacted tail.
+ */
+
+const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
+const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+
+interface MockRecord {
+  type: string
+  agentSlug: string
+  proxyToken?: string
+}
+
+function readRecords(): MockRecord[] {
+  if (!fs.existsSync(RECORDER_FILE)) return []
+  return fs
+    .readFileSync(RECORDER_FILE, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as MockRecord)
+}
+
+async function waitForProxyToken(agentSlug: string, timeoutMs = 12000): Promise<string> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const found = readRecords().find((r) => r.type === 'container_start' && r.agentSlug === agentSlug)
+    if (found?.proxyToken) return found.proxyToken
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error(`Timed out waiting for proxy token for ${agentSlug}`)
+}
+
+async function allowRead(
+  request: APIRequestContext,
+  caller: TestAgent,
+  target: TestAgent,
+) {
+  const response = await request.put(`/api/agents/${caller.slug}/x-agent-policies`, {
+    data: { policies: [{ operation: 'read', targetSlug: target.slug, decision: 'allow' }] },
+  })
+  expect(response.ok()).toBeTruthy()
+}
+
+async function sendFollowUp(
+  request: APIRequestContext,
+  agent: TestAgent,
+  session: TestSession,
+  content: string,
+) {
+  const response = await request.post(`/api/agents/${agent.slug}/sessions/${session.id}/messages`, {
+    data: { content },
+  })
+  expect(response.ok()).toBeTruthy()
+  await waitForSessionIdle(request, agent, session)
+}
+
+test.describe('x-agent get-transcript limit', () => {
+  test.describe.configure({ timeout: 60000 })
+
+  test('returns the last N compacted messages and the total', async ({ request }, testInfo) => {
+    const caller = await createAgent(request, uniqueName(testInfo, 'Transcript Caller'))
+    const target = await createAgent(request, uniqueName(testInfo, 'Transcript Target'))
+    await createSession(request, caller, `caller ${uniqueName(testInfo, 'wake')}`)
+    const token = await waitForProxyToken(caller.slug)
+    const session = await createSession(request, target, 'first turn')
+    await waitForSessionIdle(request, target, session)
+    await sendFollowUp(request, target, session, 'second turn')
+    await sendFollowUp(request, target, session, 'third turn')
+    await allowRead(request, caller, target)
+
+    const uiMessages = await listSessionMessages(request, target, session)
+    expect(uiMessages.length).toBeGreaterThanOrEqual(4)
+
+    const limited = await request.post('/api/x-agent/get-transcript', {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { slug: target.slug, sessionId: session.id, limit: 2 },
+    })
+    expect(limited.status()).toBe(200)
+    const limitedBody = await limited.json() as { total: number; messages: Array<{ content: string }> }
+    expect(limitedBody.total).toBeGreaterThanOrEqual(4)
+    expect(limitedBody.messages).toHaveLength(2)
+
+    const full = await request.post('/api/x-agent/get-transcript', {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { slug: target.slug, sessionId: session.id },
+    })
+    const fullBody = await full.json() as { total: number; messages: Array<{ content: string }> }
+    expect(fullBody.total).toBe(limitedBody.total)
+    expect(fullBody.messages.length).toBe(limitedBody.total)
+    expect(limitedBody.messages.map((m) => m.content)).toEqual(
+      fullBody.messages.slice(-2).map((m) => m.content),
+    )
+  })
+})

--- a/src/api/routes/x-agent-transcript-view.test.ts
+++ b/src/api/routes/x-agent-transcript-view.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  pageTranscript,
+  toTranscriptView,
+  type CompactedMessage,
+} from './x-agent-transcript-view'
+
+const spoken = (content: string, role = 'assistant'): CompactedMessage => ({
+  role,
+  content,
+  spoken: content,
+})
+
+const internal = (content: string, toolName?: string): CompactedMessage => ({
+  role: toolName ? 'assistant' : 'user',
+  content,
+  spoken: '',
+  ...(toolName ? { toolName } : {}),
+})
+
+describe('toTranscriptView', () => {
+  it('keeps spoken turns and collapses a tool/thinking run into one stub', () => {
+    const view = toTranscriptView(
+      [
+        spoken('Those two exclusions look like a demo false-positive.'),
+        internal('[tool_use: Bash]', 'Bash'),
+        internal('[tool_result] members […]'),
+        internal('[thinking only — no text response]'),
+        spoken('One banned signup that week has snapshot spend over $10.'),
+      ],
+      false,
+    )
+    expect(view).toEqual([
+      { role: 'assistant', content: 'Those two exclusions look like a demo false-positive.' },
+      { role: 'system', content: 'tool calls + thinking' },
+      { role: 'assistant', content: 'One banned signup that week has snapshot spend over $10.' },
+    ])
+  })
+
+  it('strips tool lines from a mixed spoken turn', () => {
+    const view = toTranscriptView(
+      [
+        {
+          role: 'assistant',
+          content: 'hi\n[tool_use: Bash]',
+          spoken: 'hi',
+          toolName: 'Bash',
+        },
+      ],
+      false,
+    )
+    expect(view).toEqual([{ role: 'assistant', content: 'hi' }])
+  })
+
+  it('returns today compact view when fullTranscript is true', () => {
+    const compacted: CompactedMessage[] = [
+      spoken('hi'),
+      internal('[tool_use: Bash]', 'Bash'),
+    ]
+    expect(toTranscriptView(compacted, true)).toEqual([
+      { role: 'assistant', content: 'hi' },
+      { role: 'assistant', content: '[tool_use: Bash]', toolName: 'Bash' },
+    ])
+  })
+})
+
+describe('pageTranscript', () => {
+  const entries = [
+    {
+      type: 'assistant' as const,
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'do not leak this' },
+        ],
+      },
+    },
+    {
+      type: 'assistant' as const,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'secret' } }],
+      },
+    },
+    {
+      type: 'assistant' as const,
+      message: { role: 'assistant', content: 'final' },
+    },
+  ]
+
+  it('defaults to the quiet view and slices after it', () => {
+    const page = pageTranscript(entries as never, { limit: 1 })
+    expect(page.total).toBe(2)
+    expect(page.messages).toEqual([{ role: 'assistant', content: 'final' }])
+    expect(JSON.stringify(page)).not.toContain('do not leak this')
+    expect(JSON.stringify(page)).not.toContain('secret')
+  })
+
+  it('counts thinking and tool_use as messages when fullTranscript is true', () => {
+    const page = pageTranscript(entries as never, { fullTranscript: true, limit: 1 })
+    expect(page.total).toBe(3)
+    expect(page.messages).toEqual([{ role: 'assistant', content: 'final' }])
+  })
+})

--- a/src/api/routes/x-agent-transcript-view.ts
+++ b/src/api/routes/x-agent-transcript-view.ts
@@ -1,0 +1,113 @@
+import type { JsonlMessageEntry, JsonlSystemEntry } from '@shared/lib/types/agent'
+
+export type TranscriptMessage = {
+  role: string
+  content: string
+  toolName?: string
+}
+
+export type CompactedMessage = TranscriptMessage & {
+  spoken: string
+}
+
+const INTERNAL_STUB: TranscriptMessage = {
+  role: 'system',
+  content: 'tool calls + thinking',
+}
+
+/**
+ * Convert a JSONL message entry into a compact { role, content, spoken } shape.
+ * Strips internal SDK fields. `content` is today's compact view (tool stubs
+ * kept). `spoken` is text-only, empty when the entry was only tools/thinking.
+ */
+export function compactMessage(entry: JsonlMessageEntry | JsonlSystemEntry): CompactedMessage | null {
+  if (entry.type === 'system') {
+    const content = entry.subtype === 'compact_boundary'
+      ? '[context compacted]'
+      : `[system: ${entry.subtype ?? 'unknown'}]`
+    return { role: 'system', content, spoken: content }
+  }
+  const msg = entry.message
+  if (typeof msg.content === 'string') {
+    return { role: entry.type, content: msg.content, spoken: msg.content }
+  }
+  const parts: string[] = []
+  const spokenParts: string[] = []
+  let firstToolName: string | undefined
+  let hadThinking = false
+  for (const block of msg.content) {
+    if (block.type === 'text') {
+      parts.push(block.text)
+      spokenParts.push(block.text)
+    } else if (block.type === 'tool_use') {
+      firstToolName = firstToolName ?? block.name
+      parts.push(`[tool_use: ${block.name}]`)
+    } else if (block.type === 'tool_result') {
+      const text = Array.isArray(block.content)
+        ? block.content
+            .filter((p) => p && typeof p === 'object' && 'text' in p)
+            .map((p) => (p as { text: string }).text)
+            .join('\n')
+        : typeof block.content === 'string'
+          ? block.content
+          : ''
+      parts.push(text ? `[tool_result] ${text}` : '[tool_result]')
+    } else if (block.type === 'thinking') {
+      hadThinking = true
+    }
+  }
+  let content = parts.join('\n').trim()
+  if (!content) {
+    content = hadThinking ? '[thinking only — no text response]' : '[no text response]'
+  }
+  return {
+    role: entry.type,
+    content,
+    spoken: spokenParts.join('\n').trim(),
+    ...(firstToolName ? { toolName: firstToolName } : {}),
+  }
+}
+
+export function toTranscriptView(
+  compacted: CompactedMessage[],
+  fullTranscript: boolean,
+): TranscriptMessage[] {
+  if (fullTranscript) {
+    return compacted.map(({ role, content, toolName }) => ({
+      role,
+      content,
+      ...(toolName ? { toolName } : {}),
+    }))
+  }
+  const out: TranscriptMessage[] = []
+  let pendingInternal = false
+  for (const message of compacted) {
+    if (message.spoken.length > 0) {
+      if (pendingInternal) {
+        out.push(INTERNAL_STUB)
+        pendingInternal = false
+      }
+      out.push({ role: message.role, content: message.spoken })
+      continue
+    }
+    pendingInternal = true
+  }
+  if (pendingInternal) {
+    out.push(INTERNAL_STUB)
+  }
+  return out
+}
+
+export function pageTranscript(
+  entries: Array<JsonlMessageEntry | JsonlSystemEntry>,
+  opts: { fullTranscript?: boolean; limit?: number } = {},
+): { messages: TranscriptMessage[]; total: number } {
+  const compacted = entries
+    .map(compactMessage)
+    .filter((message): message is CompactedMessage => message !== null)
+  const view = toTranscriptView(compacted, opts.fullTranscript === true)
+  return {
+    messages: opts.limit ? view.slice(-opts.limit) : view,
+    total: view.length,
+  }
+}

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -1733,6 +1733,87 @@ describe('/get-transcript', () => {
     // must short-circuit before the response transcript is assembled.
     expect(mockGetTranscript).toHaveBeenCalledTimes(1)
   })
+
+  it('returns only the last `limit` messages and the total count', async () => {
+    reviewDecisions.push('allow')
+    mockGetTranscript.mockResolvedValue([
+      { type: 'user', message: { role: 'user', content: 'first' } },
+      { type: 'assistant', message: { role: 'assistant', content: 'one' } },
+      { type: 'user', message: { role: 'user', content: 'second' } },
+      { type: 'assistant', message: { role: 'assistant', content: 'two' } },
+      { type: 'assistant', message: { role: 'assistant', content: 'three' } },
+    ])
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'sess-1',
+      limit: 2,
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.total).toBe(5)
+    expect(body.messages).toHaveLength(2)
+    expect(body.messages.map((m: { content: string }) => m.content)).toEqual(['two', 'three'])
+  })
+
+  it('returns the full transcript and total when limit is omitted', async () => {
+    reviewDecisions.push('allow')
+    mockGetTranscript.mockResolvedValue([
+      { type: 'user', message: { role: 'user', content: 'a' } },
+      { type: 'assistant', message: { role: 'assistant', content: 'b' } },
+    ])
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'sess-1',
+    })
+    const body = await res.json()
+    expect(body.total).toBe(2)
+    expect(body.messages).toHaveLength(2)
+  })
+
+  it('rejects limit below 1 and above 500', async () => {
+    reviewDecisions.push('allow')
+    for (const limit of [0, 501]) {
+      const res = await authedFetch('/x-agent/get-transcript', {
+        slug: TARGET_SLUG,
+        sessionId: 'sess-1',
+        limit,
+      })
+      expect(res.status).toBe(400)
+    }
+  })
+
+  it('slices after compaction, so thinking and tool_use count as messages', async () => {
+    reviewDecisions.push('allow')
+    mockGetTranscript.mockResolvedValue([
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'do not leak this' }],
+        },
+      },
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'secret' } }],
+        },
+      },
+      { type: 'assistant', message: { role: 'assistant', content: 'final' } },
+    ])
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'sess-1',
+      limit: 1,
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.total).toBe(3)
+    expect(body.messages).toHaveLength(1)
+    expect(body.messages[0].content).toBe('final')
+    expect(JSON.stringify(body)).not.toContain('do not leak this')
+    expect(JSON.stringify(body)).not.toContain('secret')
+  })
 })
 
 describe('resolveSyncWaitTimeoutMs', () => {

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -1575,6 +1575,30 @@ describe('/get-transcript', () => {
     expect(body.status).toBe('idle')
     expect(body.messages).toHaveLength(2)
     expect(body.messages[0]).toEqual({ role: 'user', content: 'hello' })
+    expect(body.messages[1]).toEqual({ role: 'assistant', content: 'hi' })
+  })
+
+  it('keeps tool stubs when fullTranscript is true', async () => {
+    reviewDecisions.push('allow')
+    mockGetTranscript.mockResolvedValue([
+      { type: 'user', message: { role: 'user', content: 'hello' } },
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'hi' },
+            { type: 'tool_use', id: 't1', name: 'Bash', input: {} },
+          ],
+        },
+      },
+    ])
+    const res = await authedFetch('/x-agent/get-transcript', {
+      slug: TARGET_SLUG,
+      sessionId: 'sess-1',
+      fullTranscript: true,
+    })
+    const body = await res.json()
     expect(body.messages[1]).toEqual({
       role: 'assistant',
       content: 'hi\n[tool_use: Bash]',
@@ -1782,7 +1806,7 @@ describe('/get-transcript', () => {
     }
   })
 
-  it('slices after compaction, so thinking and tool_use count as messages', async () => {
+  it('slices after the quiet view, so limit 1 is the last spoken turn', async () => {
     reviewDecisions.push('allow')
     mockGetTranscript.mockResolvedValue([
       {
@@ -1808,7 +1832,7 @@ describe('/get-transcript', () => {
     })
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.total).toBe(3)
+    expect(body.total).toBe(2)
     expect(body.messages).toHaveLength(1)
     expect(body.messages[0].content).toBe('final')
     expect(JSON.stringify(body)).not.toContain('do not leak this')

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -394,6 +394,8 @@ const getTranscriptBodySchema = z.object({
   slug: z.string(),
   sessionId: z.string(),
   sync: z.boolean().optional(),
+  // Most recent N compacted messages. Omitted = full transcript.
+  limit: z.number().int().min(1).max(500).optional(),
 })
 
 /**
@@ -646,7 +648,7 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
   // a human decision) so the total response time stays under the transport cap.
   const syncDeadline = Date.now() + SYNC_WAIT_TIMEOUT_MS
   const callerSlug = getCallerSlug(c)
-  const { slug: rawTargetSlug, sessionId, sync } = c.req.valid('json')
+  const { slug: rawTargetSlug, sessionId, sync, limit } = c.req.valid('json')
 
   // Resolve the model-supplied display slug to the canonical id and rebind.
   const targetSlug = await resolveAgentId(rawTargetSlug)
@@ -714,11 +716,12 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
       : 'idle'
 
   const entries = await getSessionMessagesWithCompact(targetSlug, sessionId)
-  const messages = entries
+  const all = entries
     .map(compactMessage)
     .filter((m): m is NonNullable<ReturnType<typeof compactMessage>> => m !== null)
+  const messages = limit ? all.slice(-limit) : all
 
-  return c.json({ status, messages })
+  return c.json({ status, messages, total: all.length })
 })
 
 // ----------------------------------------------------------------------------

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -49,6 +49,7 @@ import { getSecretEnvVars } from '@shared/lib/services/secrets-service'
 import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { captureException } from '@shared/lib/error-reporting'
 import type { JsonlMessageEntry, JsonlSystemEntry } from '@shared/lib/types/agent'
+import { compactMessage, pageTranscript } from './x-agent-transcript-view'
 
 const X_AGENT_SENTRY = { area: 'x-agent', op: 'invoke' } as const
 
@@ -394,70 +395,11 @@ const getTranscriptBodySchema = z.object({
   slug: z.string(),
   sessionId: z.string(),
   sync: z.boolean().optional(),
-  // Most recent N compacted messages. Omitted = full transcript.
+  // Most recent N view-rows. Omitted = the whole view.
   limit: z.number().int().min(1).max(500).optional(),
+  // Default quiet: spoken turns, internals collapsed. true = today's compact view.
+  fullTranscript: z.boolean().optional(),
 })
-
-/**
- * Convert a JSONL message entry into a compact { role, content, toolName? } shape.
- * Strips internal SDK fields, keeps text and tool name only.
- */
-function compactMessage(entry: JsonlMessageEntry | JsonlSystemEntry): {
-  role: string
-  content: string
-  toolName?: string
-} | null {
-  if (entry.type === 'system') {
-    if (entry.subtype === 'compact_boundary') {
-      return { role: 'system', content: '[context compacted]' }
-    }
-    // Surface unknown system subtypes rather than silently dropping them — keeps
-    // future SDK additions visible to invoking agents (and to debugging).
-    return { role: 'system', content: `[system: ${entry.subtype ?? 'unknown'}]` }
-  }
-  const msg = entry.message
-  if (typeof msg.content === 'string') {
-    return { role: entry.type, content: msg.content }
-  }
-  // Array of content blocks: collapse text + summarize tool calls.
-  // Thinking blocks are stripped (internal), but we track whether the turn
-  // *only* had thinking so we can surface a placeholder rather than returning
-  // empty content (which would otherwise look like "the agent didn't respond").
-  const parts: string[] = []
-  let firstToolName: string | undefined
-  let hadThinking = false
-  for (const block of msg.content) {
-    if (block.type === 'text') {
-      parts.push(block.text)
-    } else if (block.type === 'tool_use') {
-      firstToolName = firstToolName ?? block.name
-      parts.push(`[tool_use: ${block.name}]`)
-    } else if (block.type === 'tool_result') {
-      const text = Array.isArray(block.content)
-        ? block.content
-            .filter((p) => p && typeof p === 'object' && 'text' in p)
-            .map((p) => (p as { text: string }).text)
-            .join('\n')
-        : typeof block.content === 'string'
-          ? block.content
-          : ''
-      parts.push(text ? `[tool_result] ${text}` : '[tool_result]')
-    } else if (block.type === 'thinking') {
-      hadThinking = true
-    }
-  }
-  let content = parts.join('\n').trim()
-  if (!content) {
-    // Distinguish thinking-only turns from genuinely-empty turns so callers
-    // (especially sync invoke's lastMessage) don't silently look "blank".
-    content = hadThinking ? '[thinking only — no text response]' : '[no text response]'
-  }
-  return {
-    role: entry.type,
-    content,
-    ...(firstToolName ? { toolName: firstToolName } : {}),
-  }
-}
 
 /**
  * After a sync invoke, the SDK may emit 'result' (which clears isActive) before
@@ -634,7 +576,13 @@ async function readLastAssistantMessage(
     const isStaleBoundary = boundaryUuid !== undefined && entry?.uuid === boundaryUuid
     if (entry && !isStaleBoundary) {
       const compact = compactMessage(entry)
-      if (compact) return compact
+      if (compact) {
+        return {
+          role: compact.role,
+          content: compact.content,
+          ...(compact.toolName ? { toolName: compact.toolName } : {}),
+        }
+      }
     }
     if (i < READ_RETRY_ATTEMPTS - 1) {
       await new Promise((r) => setTimeout(r, READ_RETRY_INTERVAL_MS))
@@ -648,7 +596,7 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
   // a human decision) so the total response time stays under the transport cap.
   const syncDeadline = Date.now() + SYNC_WAIT_TIMEOUT_MS
   const callerSlug = getCallerSlug(c)
-  const { slug: rawTargetSlug, sessionId, sync, limit } = c.req.valid('json')
+  const { slug: rawTargetSlug, sessionId, sync, limit, fullTranscript } = c.req.valid('json')
 
   // Resolve the model-supplied display slug to the canonical id and rebind.
   const targetSlug = await resolveAgentId(rawTargetSlug)
@@ -716,12 +664,9 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
       : 'idle'
 
   const entries = await getSessionMessagesWithCompact(targetSlug, sessionId)
-  const all = entries
-    .map(compactMessage)
-    .filter((m): m is NonNullable<ReturnType<typeof compactMessage>> => m !== null)
-  const messages = limit ? all.slice(-limit) : all
+  const { messages, total } = pageTranscript(entries, { fullTranscript, limit })
 
-  return c.json({ status, messages, total: all.length })
+  return c.json({ status, messages, total })
 })
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
An invoking agent almost always wants the other agent's last spoken reply, but it has to pull the whole transcript - tools and all - to find it.
This adds an optional `limit` and a quiet default so it can take the last N spoken turns.

Related to https://linear.app/datawizz/issue/SUP-661/wake-the-invoking-agent-when-an-invoked-agents-session-finishes

4 production files, 4 test files.

The host builds a view after compaction, then slices.

```
omit both              quiet view, every row + total
limit N                last N of the chosen view + total
full_transcript true   today's compact view (tool stubs + tool results)
limit 0 or 501         400
no token               401
```

Default is spoken turns.
Consecutive tool calls, tool results, and thinking collapse to one stub.
`full_transcript: true` restores today's compact view.
`total` is the view count before the slice.

The system prompt tells the model to pass `limit`, and to pass `full_transcript` only when it needs the internals.
The name is `limit` because this route already paginates sessions with that word.

If the session ends on tools, quiet `limit: 1` returns the stub, not the last spoken line.
Status still says `running` when the agent is mid-turn.

The agent image has to be rebuilt before a live caller sees the new args.

This does not add a cursor, change invoke or delete, or wake the caller when the other agent finishes.
