### PR TITLE
fix: detect broken snapshot parent chains as corrupt-image errors

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -506,14 +506,17 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
    * Whether a run failure means the image's unpacked snapshot in the runtime's
    * store is corrupt — containerd's "mount callback failed on /tmp/containerd-
    * mountNNN: ..." (e.g. ": no users found" when resolving the Dockerfile USER
-   * against a truncated /etc/passwd). Seen after disk exhaustion during image
+   * against a truncated /etc/passwd), or "failed to stat parent: stat /var/lib/
+   * containerd/.../snapshots/N/fs: no such file or directory" when the
+   * snapshotter's metadata references a layer directory missing from disk.
+   * Seen after disk exhaustion or a dirty VM shutdown during image
    * pull/unpack. The corruption lives in the image store, not in this
    * container, so retrying the same run can never succeed — recovery is
    * removing the image (removeCorruptImage) and rebuilding it.
    */
   protected isCorruptImageSnapshotError(error: any): boolean {
     const msg = String(error?.message || error?.stderr || error || '')
-    return /mount callback failed on/i.test(msg)
+    return /mount callback failed on|failed to stat parent/i.test(msg)
   }
 
   /**

--- a/src/shared/lib/container/corrupt-image-snapshot-recovery.test.ts
+++ b/src/shared/lib/container/corrupt-image-snapshot-recovery.test.ts
@@ -25,6 +25,13 @@ const CORRUPT_SNAPSHOT_MSG =
   'Command failed: /Users/nick/.superagent/bin/lima-nerdctl run -d --name superagent-abc123 ' +
   'time="2026-07-13T11:33:27-07:00" level=fatal msg="mount callback failed on /tmp/containerd-mount3006401431: no users found"'
 
+// The other corruption shape: the snapshotter's metadata references a layer
+// directory that is missing from disk (dirty VM shutdown mid-unpack).
+const BROKEN_PARENT_CHAIN_MSG =
+  'Command failed: /Users/nick/.superagent/bin/lima-nerdctl run -d --name superagent-abc123 ' +
+  'time="2026-08-24T17:22:54+01:00" level=fatal msg="failed to stat parent: stat ' +
+  '/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/402/fs: no such file or directory"'
+
 vi.mock('child_process', () => {
   // promisify(exec) calls exec(command, options, callback) and resolves with
   // the callback's second arg, so every command resolves with { stdout, stderr }
@@ -178,6 +185,17 @@ describe('start() recovers from a corrupt image snapshot', () => {
     // No build context (packaged app) → the registry pull restores the image.
     expect(pullImageMock).toHaveBeenCalledWith('docker', IMAGE)
     expect(buildImageMock).not.toHaveBeenCalled()
+    expect(countRunAttempts()).toBe(2)
+  })
+
+  it('recovers from a broken snapshot parent chain the same way', async () => {
+    runScript = [BROKEN_PARENT_CHAIN_MSG, 'ok']
+    const client = new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+
+    await client.start()
+
+    expect(execCommands.some((c) => c.includes(`rmi -f ${IMAGE}`))).toBe(true)
+    expect(pullImageMock).toHaveBeenCalledWith('docker', IMAGE)
     expect(countRunAttempts()).toBe(2)
   })
 


### PR DESCRIPTION
## What

Extends `isCorruptImageSnapshotError` to also match containerd's `failed to stat parent: stat /var/lib/containerd/.../snapshots/N/fs: no such file or directory`, so the existing corrupt-image recovery (remove image → recreate → retry once, #460) covers this variant instead of surfacing the raw `run` failure to the user.

## Why

A production user hit this today on 0.5.9 (Sentry ELECTRON-S7, 8 identical failures in 6 minutes of retrying): the overlayfs snapshotter's metadata referenced a layer directory missing from disk, so every container start failed identically. It's the same class as the `mount callback failed` corruption the autoheal already handles — the damage lives in the image store, retrying can never succeed — but the detection regex didn't match this error text.

The failure also slips past Lima's `handleRunError`: the message is lowercase `no such file or directory` (misses the case-sensitive `'No such file'` pattern) and the VM health probe reports healthy, because the VM genuinely is — so nothing recovered and the user was hard-stuck.

Likely corruption origin in the observed case: memory-pressure force-kill of the VM mid-write (host had 130MB free on an 8GB machine; disk was fine), leaving containerd's bolt metadata pointing at a snapshot dir that never hit disk.

## How

- `base-container-client.ts`: regex gains `|failed to stat parent`; doc comment covers the new shape. The string is containerd-specific, matching the existing recovery's containerd-only scope.
- `corrupt-image-snapshot-recovery.test.ts`: new case with the exact production error text, asserting `rmi -f` + re-pull + exactly one retry.

## Verification

- `npx vitest run src/shared/lib/container/corrupt-image-snapshot-recovery.test.ts` — 6/6 passed
- `npx tsc --noEmit` — clean
- `npx eslint` on both changed files — clean

Fixes ELECTRON-S7

https://claude.ai/code/session_01HZhnxCc23meMqkpsNF7jWB