### PR TITLE
feat(agent): advertise built-in X reads (SUP-668)

### DIFF
--- a/agent-container/docs/README.md
+++ b/agent-container/docs/README.md
@@ -34,6 +34,7 @@ itself important.
 - `chat-integrations.md`
 - `browser-use.md`
 - `computer-use.md`
+- `x.md`
 
 Dashboard guidance is not here — it lives in the `dashboards` skill
 (`agent-container/skills/dashboards/`), which the agent already discovers

--- a/agent-container/docs/x.md
+++ b/agent-container/docs/x.md
@@ -1,0 +1,70 @@
+# Built-In X (Twitter) Reads
+
+Read this guide before searching or reading X posts or profiles through the
+Gamut platform service.
+
+## Availability and Endpoint
+
+This capability is available only when the system prompt advertises built-in
+X reads. It uses the platform's X-compatible proxy and does not require the
+user to have an X account or an X API key.
+
+Use:
+
+```text
+Base: $ANTHROPIC_BASE_URL/v1/x
+Authorization: Bearer $ANTHROPIC_AUTH_TOKEN
+```
+
+Never print either environment variable.
+
+## What You Can Call
+
+All calls are `GET`. Paths are X API v2 paths under the base above. Nothing
+outside this list works; the platform returns `404` before contacting X.
+
+| Call | Path | Cost |
+|---|---|---|
+| Search recent posts (last 7 days) | `/2/tweets/search/recent?query=...&max_results=10..100` | $0.005 per post returned |
+| Look up posts by id | `/2/tweets?ids=...` or `/2/tweets/{id}` | $0.005 per post |
+| Count matching posts | `/2/tweets/counts/recent?query=...` | $0.005 per request |
+| Look up users | `/2/users/by/username/{username}`, `/2/users/by?usernames=...`, `/2/users/{id}`, `/2/users?ids=...` | $0.010 per user |
+| A user's recent posts | `/2/users/{id}/tweets` or `/2/users/by/username/{username}/tweets` | $0.005 per post |
+| Mentions of a user | `/2/users/{id}/mentions` | $0.005 per post |
+| Followers or following | `/2/users/{id}/followers`, `/2/users/{id}/following` | $0.010 per user, at most 100 per call |
+
+Example:
+
+```bash
+curl -sS "$ANTHROPIC_BASE_URL/v1/x/2/tweets/search/recent?query=gamut%20agents&max_results=10&tweet.fields=created_at,public_metrics" \
+  -H "Authorization: Bearer $ANTHROPIC_AUTH_TOKEN"
+```
+
+## Every Result Costs Money
+
+The platform bills every post and every user object X returns, including the
+user objects in `includes.users`. Keep the bill to what the task needs:
+
+- Set `max_results` to the number you will actually read. Post endpoints default to 10; followers and following default to 100 (the platform caps them at 100).
+- Omit `expansions` unless you need author names. `expansions=author_id`
+  adds one billed user per distinct author.
+- Request only the fields you will use with `tweet.fields` and `user.fields`.
+- Search covers the last 7 days only. There is no full-archive search.
+
+## Rate Limits
+
+X limits requests per 15 minutes and the limit is shared across the whole
+platform. On `429`, read `x-rate-limit-reset` (epoch seconds), wait until
+then, and retry once. Do not loop on `429`.
+
+## Errors
+
+- `404`: the path is not on the list above. Do not invent alternate paths.
+- `503`: the platform's X access is not configured or its credits are
+  exhausted. Tell the user the capability is unavailable right now.
+- `429`: see Rate Limits.
+
+## Attribution
+
+Quote posts with the author's username and a link of the form
+`https://x.com/{username}/status/{id}` when presenting them to the user.

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -54,6 +54,7 @@ describe('generateSystemPrompt rendering', () => {
     expect(out.includes('## Built-in X reads')).toBe(webhook)
     expect(out.includes('/opt/gamut/docs/x.md')).toBe(webhook)
     expect(out.includes('Never invent an X endpoint')).toBe(webhook)
+    expect(out.includes('$0.01 per person')).toBe(webhook)
     expect(out).not.toContain('v1/replicate')
     expect(out).not.toContain('v1/x')
     expect(out).not.toContain('ANTHROPIC_AUTH_TOKEN')

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -51,7 +51,11 @@ describe('generateSystemPrompt rendering', () => {
     // procedure moved out.
     expect(out.includes('cost from that model')).toBe(webhook)
     expect(out.includes('Never invent a model slug')).toBe(webhook)
+    expect(out.includes('## Built-in X reads')).toBe(webhook)
+    expect(out.includes('/opt/gamut/docs/x.md')).toBe(webhook)
+    expect(out.includes('Never invent an X endpoint')).toBe(webhook)
     expect(out).not.toContain('v1/replicate')
+    expect(out).not.toContain('v1/x')
     expect(out).not.toContain('ANTHROPIC_AUTH_TOKEN')
   })
 
@@ -75,6 +79,16 @@ describe('generateSystemPrompt rendering', () => {
     expect(guide).not.toContain('Available models')
   })
 
+  it('teaches the X read contract in the guide', () => {
+    const guide = readFileSync(join(__dirname, '..', 'docs', 'x.md'), 'utf8')
+    expect(guide).toContain('/2/tweets/search/recent')
+    expect(guide).toContain('/2/users/by/username/{username}')
+    expect(guide).toContain('/tweets`')
+    expect(guide).toContain('7 days')
+    expect(guide).toContain('followers')
+    expect(guide).toContain('Never print either environment variable')
+  })
+
   it('references every image-owned capability guide and keeps its source file present', () => {
     process.env.COMPOSIO_PLATFORM_MODE = 'true'
     process.env.PLATFORM_AUTH_ACTIVE = 'true'
@@ -87,6 +101,7 @@ describe('generateSystemPrompt rendering', () => {
       'chat-integrations.md',
       'browser-use.md',
       'computer-use.md',
+      'x.md',
     ]
 
     for (const guide of guides) {

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -506,7 +506,7 @@ Before video, music, 3D, talking-head, or voice cloning, tell the user the cost 
 
 ## Built-in X reads
 
-Search recent public X (Twitter) posts and read public profiles, timelines, mentions, and follower lists through the platform without asking the user for an X account or API key. Before using this capability, read `/opt/gamut/docs/x.md`. Every post and user object returned costs money, so request only what the task needs. Never invent an X endpoint; the guide's table is the only allowlist.
+Search recent public X (Twitter) posts and read public profiles, timelines, mentions, and follower lists through the platform without asking the user for an X account or API key. Before using this capability, read `/opt/gamut/docs/x.md`. Every post and user object returned costs money, so request only what the task needs. Never invent an X endpoint; the guide's table is the only allowlist. Before followers or following, tell the user it is $0.01 per person, up to $1 per page, and get an OK.
 <%/platformServices%>
 
 ## Cross-Agent Work

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -51,6 +51,7 @@ This catalog is an index: sets that have a dedicated section further down includ
 - **Scheduling and triggers** — see "Scheduling Tasks" and "Webhook Triggers" below.
 <%#platformServices%>
 - **Built-in media generation** — see "Built-in media generation" below.
+- **Built-in X reads** — see "Built-in X reads" below.
 <%/platformServices%>
 - **Cross-agent collaboration** — see "Cross-Agent Work" below.
 - **Chat integrations** — see "Chat Integrations" below.
@@ -502,6 +503,10 @@ Triggers and webhooks are platform-dependent and are not available without a con
 Generate or edit images, video, speech, music, 3D, or talking-head clips through the platform without asking the user for a Replicate account or API key. Before using this capability, read `/opt/gamut/docs/media-generation.md` — the flow is list, then schema, then create, and the platform's list is the only allowlist. Never invent a model slug.
 
 Before video, music, 3D, talking-head, or voice cloning, tell the user the cost from that model's list row and get an OK. Save expiring outputs into `/workspace` immediately.
+
+## Built-in X reads
+
+Search recent public X (Twitter) posts and read public profiles, timelines, mentions, and follower lists through the platform without asking the user for an X account or API key. Before using this capability, read `/opt/gamut/docs/x.md`. Every post and user object returned costs money, so request only what the task needs. Never invent an X endpoint; the guide's table is the only allowlist.
 <%/platformServices%>
 
 ## Cross-Agent Work


### PR DESCRIPTION
The agent can search public X when a platform account is connected. Procedure lives in an on-demand guide, same split as media generation.

Related to https://linear.app/datawizz/issue/SUP-668/feat-built-in-x-twitter-read-lane-through-the-platform-proxy

4 files, +91 lines.

```
prompt index (only with a platform account)
  → prompt: capability exists, read the guide, do not invent an endpoint
  → guide: paths, costs, 7-day window, 429
```

The prompt never names the proxy path or the token variable.

Do not merge until SkillfulAgents/platform#333 is deployed. Shipping this first advertises a path that does not exist yet.
