### PR TITLE
Remove provider icon from model picker trigger buttons

### DIFF
--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -3,7 +3,6 @@ import { ChevronDown, Settings2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
-import { ModelIcon } from '@renderer/components/ui/model-icon'
 import { EFFORT_LEVELS } from '@shared/lib/container/types'
 import { type ComposerOptionsState } from './composer-options'
 import { ModelFamilyList, findCatalogModel } from './model-family-list'
@@ -67,7 +66,6 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true, foo
           aria-label={`${includeEffort ? 'Model and effort' : 'Model'}: ${triggerAriaLabel}. Click to change.`}
           data-testid="composer-options-trigger"
         >
-          {selectedModel && <ModelIcon icon={selectedModel.icon} className="h-3.5 w-3.5 shrink-0 max-[420px]:hidden" />}
           <Settings2 className="hidden h-3.5 w-3.5 max-[420px]:block" aria-hidden="true" />
           <span className="max-[420px]:hidden">
             {selectedModelLabel}

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -3,7 +3,6 @@ import { ArrowUp, AtSign, ChevronDown, Cloud, Loader2, Paperclip } from 'lucide-
 import { cn } from '@shared/lib/utils'
 import { targetIsRemote } from '@renderer/lib/api-target'
 import { Button } from '@renderer/components/ui/button'
-import { ModelIcon } from '@renderer/components/ui/model-icon'
 import { apiFetch } from '@renderer/lib/api'
 import { uploadFileChunked } from '@renderer/lib/upload'
 import { readLocalFileAsFile } from '@renderer/lib/read-local-file'
@@ -417,7 +416,6 @@ export function QuickDispatch() {
             <Paperclip className="h-3.5 w-3.5 shrink-0" />
           </TriggerButton>
           <TriggerButton active={openMenu === 'model'} onClick={() => toggleMenu('model')} testId="composer-options-trigger">
-            {selectedModel && <ModelIcon icon={selectedModel.icon} className="h-3.5 w-3.5 shrink-0" />}
             <span className="truncate">
               {selectedModel?.label}
               <span className="text-muted-foreground">

--- a/src/renderer/components/settings/settings-model-select.tsx
+++ b/src/renderer/components/settings/settings-model-select.tsx
@@ -3,7 +3,6 @@ import { ChevronDown, RotateCcw, Settings } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import { Separator } from '@renderer/components/ui/separator'
-import { ModelIcon } from '@renderer/components/ui/model-icon'
 import { useModelSettings } from '@renderer/hooks/use-settings'
 import { DialogContext } from '@renderer/context/dialog-context'
 import { useUser } from '@renderer/context/user-context'
@@ -112,7 +111,6 @@ function SettingsModelSelectImpl({
           aria-label={`Model: ${triggerLabel ?? 'select'}. Click to change.`}
           data-testid="settings-model-trigger"
         >
-          {resolved && <ModelIcon icon={resolved.icon} className="h-3.5 w-3.5 shrink-0" />}
           <span>
             {triggerLabel ?? 'Select model'}
             {includeEffort && (


### PR DESCRIPTION
## Summary
- Remove the provider icon (e.g. the Anthropic asterisk) from the model picker trigger button in the chat composer, quick-dispatch, and settings model select
- Triggers now show just the label, e.g. "Opus 5 · Medium ⌄"
- Icons inside the popover (vendor tabs, model rows) and the model catalog editor are unchanged

## Testing
- `npm run typecheck` and `npm run lint` clean (no errors; no warnings in touched files)
- All 57 tests across composer-options, composer-options-popover, quick-dispatch, and settings-model-select pass
- Verified visually in the dev Electron app

🤖 Generated with [Claude Code](https://claude.com/claude-code)