### PR TITLE
Upload files on drop and fail stalls instead of hanging Send (SUP-653)

### DIFF
--- a/e2e/specs/composer-failure-recovery.spec.ts
+++ b/e2e/specs/composer-failure-recovery.spec.ts
@@ -18,9 +18,9 @@ function attachmentPreview(page: import('@playwright/test').Page, fileName: stri
  * - a failed message POST restores the typed text into the composer (the
  *   optimistic ghost is dropped, nothing lands in the transcript), and the
  *   restored text can be resent as-is once the server recovers;
- * - a failed attachment upload short-circuits BEFORE the composer is cleared,
- *   surfacing a dismissible error while both the text and the attachment
- *   chips stay intact for a retry.
+ * - a failed attachment upload (now on drop, not on Send) flags the chip
+ *   with a retry control, keeps the typed text, and lets the user retry
+ *   from the chip or from Send.
  *
  * Failures are injected per-page with route interception (POST-only — the
  * transcript GETs on the same URL shape must keep flowing), so the tests are
@@ -91,39 +91,41 @@ test.describe('Composer failure recovery', () => {
     await expect(sessionPage.getMessageInput()).toHaveText('')
   })
 
-  test('a failed upload preserves text and attachment for a retry', async ({ page }) => {
+  test('a failed upload flags the chip, keeps the text, and retries from the chip or from Send', async ({ page }) => {
     const filePath = path.join(tmpDir, 'guarded.txt')
     fs.writeFileSync(filePath, 'file content that must not be lost')
     const text = 'upload failure must keep my work'
 
-    const fileInput = page.locator('input[type="file"]:not([webkitdirectory])')
-    await fileInput.setInputFiles(filePath)
-    await expect(attachmentPreview(page, 'guarded.txt')).toBeVisible()
-    await sessionPage.typeMessage(text)
-
+    // Upload starts on attach, so the failure must be armed before the file lands.
     await page.route('**/upload-file*', (route) => route.fulfill({
       status: 500,
       contentType: 'application/json',
       body: JSON.stringify({ error: 'Injected upload failure' }),
     }))
 
-    await sessionPage.getSendButton().click()
+    const fileInput = page.locator('input[type="file"]:not([webkitdirectory])')
+    await fileInput.setInputFiles(filePath)
+    const chip = attachmentPreview(page, 'guarded.txt')
+    await expect(chip).toHaveAttribute('data-attachment-status', 'error', { timeout: 10000 })
+    await expect(chip).toHaveAttribute('data-attachment-error', 'Injected upload failure')
+    await sessionPage.typeMessage(text)
 
-    // The inline upload error surfaces in the composer (the same message also
-    // fires as a toast, so scope to the content area), and BOTH the text and
-    // the attachment chip survive — the send never happened
-    const inlineError = page.getByTestId('main-content').getByText('Injected upload failure')
-    await expect(inlineError).toBeVisible({ timeout: 10000 })
+    // Chip retry while the server is still failing: stays errored, nothing sent
+    await chip.getByTestId('attachment-retry').click()
+    await expect(chip).toHaveAttribute('data-attachment-status', 'error', { timeout: 10000 })
     await expect(sessionPage.getMessageInput()).toHaveText(text)
-    await expect(attachmentPreview(page, 'guarded.txt')).toBeVisible()
     await expect(sessionPage.getUserMessages()).toHaveCount(1)
 
-    // The inline error is dismissible
-    await page.getByTestId('main-content').getByRole('button', { name: 'Dismiss' }).click()
-    await expect(inlineError).not.toBeVisible()
+    // Send with an errored chip re-uploads it; still failing, so the send stops
+    await sessionPage.getSendButton().click()
+    await expect(chip).toHaveAttribute('data-attachment-status', 'error', { timeout: 10000 })
+    await expect(sessionPage.getMessageInput()).toHaveText(text)
+    await expect(sessionPage.getUserMessages()).toHaveCount(1)
 
-    // Server recovers — the same composed message (text + file) sends through
+    // Server recovers: chip retry succeeds, then Send goes through with the file
     await page.unroute('**/upload-file*')
+    await chip.getByTestId('attachment-retry').click()
+    await expect(chip).toHaveAttribute('data-attachment-status', 'done', { timeout: 10000 })
     await sessionPage.getSendButton().click()
 
     await sessionPage.waitForUserMessageCount(2, 15000)

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -164,6 +164,7 @@ const mockComposer = {
   handleSubmit: vi.fn(),
   handlePaste: vi.fn(),
   canSubmit: false,
+  retryAttachment: vi.fn(),
 }
 
 let capturedComposerOptions: any
@@ -403,6 +404,20 @@ describe('AgentHome', () => {
     const input = screen.getByTestId('home-message-input')
     await user.click(input)
     await user.keyboard('{Enter}')
+
+    expect(mockComposer.handleSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not submit on Cmd+Enter when canSubmit is false', async () => {
+    const user = userEvent.setup()
+    mockComposer.canSubmit = false
+    renderWithProviders(
+      <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
+    )
+
+    const input = screen.getByTestId('home-message-input')
+    await user.click(input)
+    await user.keyboard('{Meta>}{Enter}{/Meta}')
 
     expect(mockComposer.handleSubmit).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -19,7 +19,7 @@ import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu
 import { SystemPromptDialog } from '@renderer/components/agents/system-prompt-dialog'
 import { toast } from 'sonner'
 import { apiFetch } from '@renderer/lib/api'
-import { uploadFileChunked } from '@renderer/lib/upload'
+import { uploadFileChunked, type UploadProgress } from '@renderer/lib/upload'
 import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
@@ -161,11 +161,8 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
 
   const composer = useMessageComposer({
     agentSlug: agent.slug,
-    uploadFile: useCallback(({ file }: { file: File }) => {
-      return uploadFileChunked<{ path: string }>({
-        url: `/api/agents/${agent.slug}/upload-file`,
-        file,
-      })
+    uploadFile: useCallback(({ file, onProgress, signal, stallMs }: { file: File; onProgress?: (p: UploadProgress) => void; signal?: AbortSignal; stallMs?: number }) => {
+      return uploadFileChunked<{ path: string }>({ url: `/api/agents/${agent.slug}/upload-file`, file, onProgress, signal, stallMs })
     }, [agent.slug]),
     uploadFolder: useCallback(async ({ sourcePath }: { sourcePath: string }) => {
       const res = await apiFetch(
@@ -230,6 +227,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
+      if (!composer.canSubmit) return
       void composer.handleSubmit(e)
     }
   }
@@ -384,6 +382,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                   textareaRef={composerTextareaRef}
                   attachments={composer.attachments}
                   onRemoveAttachment={composer.removeAttachment}
+                  onRetryAttachment={composer.retryAttachment}
                   value={composer.message}
                   onChange={composer.setMessage}
                   onKeyDown={handleKeyDown}

--- a/src/renderer/components/agents/create-agent-form.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { act } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
 import { CreateAgentForm } from './create-agent-form'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import {
@@ -188,5 +188,10 @@ describe('CreateAgentForm', () => {
     expect(mockCreateSession.mutateAsync).toHaveBeenCalledTimes(1)
     expect(peekPendingSessionSeed('session-123')).toBeDefined()
     expect(mockNavigate).toHaveBeenCalled()
+  })
+
+  it('does not offer file attachments', () => {
+    renderWithProviders(<CreateAgentForm />)
+    expect(screen.queryByRole('button', { name: 'Add files' })).toBeNull()
   })
 })

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -3,7 +3,6 @@ import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
 import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
-import { AttachmentPicker } from '@renderer/components/ui/attachment-picker'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
 import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
 import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
@@ -203,9 +202,8 @@ export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exi
   const composer = useMessageComposer({
     agentSlug: '',
     onVoiceTranscript: forfeitHandoffTemplate,
-    // Attachments/uploads aren't available in the create-agent flow — the agent
-    // doesn't exist yet. These throw if invoked, but AttachmentPicker doesn't
-    // expose them in this layout so they're unreachable in practice.
+    // No agent workspace exists yet, so this host does not offer attachments.
+    // These throw if a caller still reaches them.
     uploadFile: useCallback(async () => { throw new Error('Cannot upload before agent is created') }, []),
     uploadFolder: useCallback(async () => { throw new Error('Cannot upload before agent is created') }, []),
     // Keep typed text visible while create runs; seed the session ghost before
@@ -386,7 +384,6 @@ export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exi
               composer.setMessage(value)
             }}
             onKeyDown={handleKeyDown}
-            onPaste={composer.handlePaste}
             placeholder={displayedPlaceholder}
             disabled={isDisabled}
             rows={3}
@@ -394,14 +391,7 @@ export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exi
             dataTestId="create-agent-prompt"
             textareaClassName="min-h-[60px]"
             leftActions={(
-              <>
-                <AttachmentPicker
-                  onFileSelect={composer.handleFileSelect}
-                  onFolderSelect={composer.handleFolderSelect}
-                  disabled={isDisabled}
-                />
-                <ComposerOptions state={composerOptions} disabled={isDisabled} />
-              </>
+              <ComposerOptions state={composerOptions} disabled={isDisabled} />
             )}
             rightActions={(
               <>

--- a/src/renderer/components/messages/attachment-preview.test.tsx
+++ b/src/renderer/components/messages/attachment-preview.test.tsx
@@ -2,36 +2,25 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { AttachmentPreview, type Attachment, type FolderAttachment, type MountAttachment } from './attachment-preview'
+import { AttachmentPreview, type Attachment, type FolderAttachment, type MountAttachment, type UploadState } from './attachment-preview'
 
 function createFile(name: string, size: number, type: string): File {
   const blob = new Blob(['x'.repeat(size)], { type })
   return new File([blob], name, { type })
 }
 
-function createAttachment(overrides: { name?: string; size?: number; type?: string; id?: string; preview?: string } = {}): Attachment {
-  const { name = 'file.txt', size = 1024, type = 'text/plain', id = 'att-1', preview } = overrides
-  return {
-    type: 'file',
-    file: createFile(name, size, type),
-    id,
-    preview,
-  }
+function createAttachment(overrides: { name?: string; size?: number; type?: string; id?: string; preview?: string; upload?: UploadState; error?: string } = {}): Attachment {
+  const { name = 'file.txt', size = 1024, type = 'text/plain', id = 'att-1', preview, upload, error } = overrides
+  return { type: 'file', file: createFile(name, size, type), id, preview, upload, error }
 }
 
-function createFolderAttachment(overrides: { id?: string; folderName?: string; fileCount?: number; totalSize?: number } = {}): FolderAttachment {
-  const { id = 'folder-1', folderName = 'my-folder', fileCount = 3, totalSize = 3072 } = overrides
+function createFolderAttachment(overrides: { id?: string; folderName?: string; fileCount?: number; totalSize?: number; upload?: UploadState; error?: string } = {}): FolderAttachment {
+  const { id = 'folder-1', folderName = 'my-folder', fileCount = 3, totalSize = 3072, upload, error } = overrides
   const files = Array.from({ length: fileCount }, (_, i) => ({
     file: createFile(`file${i}.txt`, Math.floor(totalSize / fileCount), 'text/plain'),
     relativePath: `${folderName}/file${i}.txt`,
   }))
-  return {
-    type: 'folder',
-    id,
-    folderName,
-    files,
-    totalSize,
-  }
+  return { type: 'folder', id, folderName, files, totalSize, upload, error }
 }
 
 describe('AttachmentPreview', () => {
@@ -225,3 +214,49 @@ describe('AttachmentPreview', () => {
     expect(screen.getByText('mounted, read-write')).toBeInTheDocument()
   })
 })
+
+describe('upload status', () => {
+  it('queued shows "waiting" without a spinner', () => {
+    render(<AttachmentPreview attachments={[createAttachment({ upload: { status: 'queued', agentSlug: 'a' } })]} onRemove={vi.fn()} />)
+    const chip = screen.getByTestId('attachment-preview')
+    expect(chip).toHaveAttribute('data-attachment-status', 'queued')
+    expect(screen.getByText('waiting')).toBeInTheDocument()
+    expect(chip.querySelector('.animate-spin')).toBeNull()
+  })
+
+  it('uploading with percent shows a bar and the size, no percent text', () => {
+    render(<AttachmentPreview attachments={[createAttachment({ size: 2048, upload: { status: 'uploading', percent: 31, agentSlug: 'a' } })]} onRemove={vi.fn()} />)
+    expect(screen.getByTestId('attachment-preview')).toHaveAttribute('data-attachment-status', 'uploading')
+    expect(screen.getByTestId('attachment-progress')).toBeInTheDocument()
+    expect(screen.getByText('2.0 KB')).toBeInTheDocument()
+    expect(screen.queryByText(/31/)).toBeNull()
+  })
+
+  it('uploading without percent shows a spinner', () => {
+    render(<AttachmentPreview attachments={[createFolderAttachment({ upload: { status: 'uploading', agentSlug: 'a' } })]} onRemove={vi.fn()} />)
+    expect(screen.getByTestId('attachment-preview').querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('done shows a check', () => {
+    render(<AttachmentPreview attachments={[createAttachment({ upload: { status: 'done', path: '/p', agentSlug: 'a' } })]} onRemove={vi.fn()} />)
+    expect(screen.getByTestId('attachment-preview')).toHaveAttribute('data-attachment-status', 'done')
+    expect(screen.getByTestId('attachment-done')).toBeInTheDocument()
+  })
+
+  it('error shows the reason on hover and a retry control', async () => {
+    const onRetry = vi.fn()
+    render(<AttachmentPreview attachments={[createAttachment({ id: 'x', error: 'Upload stalled for 30 seconds. Check your connection and retry.' })]} onRemove={vi.fn()} onRetry={onRetry} />)
+    const chip = screen.getByTestId('attachment-preview')
+    expect(chip).toHaveAttribute('data-attachment-status', 'error')
+    expect(chip).toHaveAttribute('data-attachment-error', 'Upload stalled for 30 seconds. Check your connection and retry.')
+    expect(screen.getByText('upload failed')).toHaveAttribute('title', 'Upload stalled for 30 seconds. Check your connection and retry.')
+    await userEvent.click(screen.getByRole('button', { name: 'retry' }))
+    expect(onRetry).toHaveBeenCalledWith('x')
+  })
+
+  it('a chip with neither field has no status attribute (mount, pre-upload)', () => {
+    render(<AttachmentPreview attachments={[createAttachment()]} onRemove={vi.fn()} />)
+    expect(screen.getByTestId('attachment-preview')).not.toHaveAttribute('data-attachment-status')
+  })
+})
+

--- a/src/renderer/components/messages/attachment-preview.tsx
+++ b/src/renderer/components/messages/attachment-preview.tsx
@@ -1,14 +1,26 @@
-import { X, FolderIcon, Link2 } from 'lucide-react'
+import { X, FolderIcon, Link2, Check, AlertTriangle, Loader2 } from 'lucide-react'
 import { cn } from '@shared/lib/utils'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
+import { Progress } from '@renderer/components/ui/progress'
+
+export interface UploadState {
+  status: 'queued' | 'uploading' | 'done'
+  /** Bytes-sent percent. Absent when there is no byte progress (folder copy, zipping). */
+  percent?: number
+  /** Workspace path returned by the server, once done. */
+  path?: string
+  /** Which agent workspace holds the file; a different agent must re-upload. */
+  agentSlug: string
+}
 
 export interface FileAttachment {
   type: 'file'
   id: string
   file: File
   preview?: string
-  /** Set when submitting this attachment failed; renders the chip in an error state. */
+  /** Set when uploading this attachment failed; renders the chip in an error state. */
   error?: string
+  upload?: UploadState
 }
 
 export interface FolderAttachment {
@@ -18,8 +30,9 @@ export interface FolderAttachment {
   folderPath?: string
   files: { file: File; relativePath: string }[]
   totalSize: number
-  /** Set when submitting this attachment failed; renders the chip in an error state. */
+  /** Set when uploading this attachment failed; renders the chip in an error state. */
   error?: string
+  upload?: UploadState
 }
 
 export interface MountAttachment {
@@ -33,9 +46,20 @@ export interface MountAttachment {
 
 export type Attachment = FileAttachment | FolderAttachment | MountAttachment
 
+export type AttachmentStatus = 'queued' | 'uploading' | 'done' | 'error'
+
+// The one place the two stored fields become a status. `error` wins so a
+// failed retry never shows a stale bar.
+export function attachmentStatus(a: Attachment): AttachmentStatus | undefined {
+  if (a.error) return 'error'
+  if (a.type === 'mount') return undefined
+  return a.upload?.status
+}
+
 interface AttachmentPreviewProps {
   attachments: Attachment[]
   onRemove: (id: string) => void
+  onRetry?: (id: string) => void
 }
 
 function formatFileSize(bytes: number): string {
@@ -48,7 +72,51 @@ function attachmentName(attachment: Attachment): string {
   return attachment.type === 'file' ? attachment.file.name : attachment.folderName
 }
 
-export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewProps) {
+function folderSizeText(attachment: FolderAttachment): string {
+  if (attachment.files.length === 0) return ''
+  return `${attachment.files.length} file${attachment.files.length !== 1 ? 's' : ''} · ${formatFileSize(attachment.totalSize)}`
+}
+
+function UploadMeta({ attachment, sizeText, onRetry }: { attachment: FileAttachment | FolderAttachment; sizeText: string; onRetry?: (id: string) => void }) {
+  const status = attachmentStatus(attachment)
+  if (status === 'error') {
+    return (
+      <span className="flex items-center gap-1 text-destructive">
+        <AlertTriangle className="h-3 w-3 text-amber-500" />
+        <span className="truncate max-w-[120px]" title={attachment.error}>upload failed</span>
+        {onRetry && (
+          <button type="button" onClick={() => onRetry(attachment.id)} className="underline hover:text-foreground" data-testid="attachment-retry">
+            retry
+          </button>
+        )}
+      </span>
+    )
+  }
+  if (status === 'queued') return <span className="text-muted-foreground">waiting</span>
+  if (status === 'uploading') {
+    return attachment.upload?.percent === undefined ? (
+      <span className="flex items-center gap-1 text-muted-foreground"><Loader2 className="h-3 w-3 animate-spin" />uploading</span>
+    ) : (
+      <>
+        {sizeText ? <span className="text-muted-foreground">{sizeText}</span> : null}
+        <div data-testid="attachment-progress">
+          <Progress percent={attachment.upload.percent} className="mt-1 w-[120px]" />
+        </div>
+      </>
+    )
+  }
+  if (status === 'done') {
+    return (
+      <span className="flex items-center gap-1 text-muted-foreground">
+        <Check className="h-3 w-3 text-emerald-500" data-testid="attachment-done" />
+        {sizeText || null}
+      </span>
+    )
+  }
+  return sizeText ? <span className="text-muted-foreground">{sizeText}</span> : null
+}
+
+export function AttachmentPreview({ attachments, onRemove, onRetry }: AttachmentPreviewProps) {
   if (attachments.length === 0) return null
 
   return (
@@ -64,6 +132,7 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
           data-attachment-name={attachmentName(attachment)}
           data-attachment-type={attachment.type}
           data-attachment-error={attachment.error || undefined}
+          data-attachment-status={attachmentStatus(attachment)}
         >
           {attachment.type === 'mount' ? (
             <>
@@ -91,15 +160,7 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                 <span className="truncate max-w-[160px] font-medium" title={attachment.folderName}>
                   {attachment.folderName}
                 </span>
-                {attachment.error ? (
-                  <span className="text-destructive truncate max-w-[160px]" title={attachment.error}>
-                    upload failed
-                  </span>
-                ) : attachment.files.length > 0 && (
-                  <span className="text-muted-foreground">
-                    {attachment.files.length} file{attachment.files.length !== 1 ? 's' : ''} &middot; {formatFileSize(attachment.totalSize)}
-                  </span>
-                )}
+                <UploadMeta attachment={attachment} sizeText={folderSizeText(attachment)} onRetry={onRetry} />
               </div>
             </>
           ) : (
@@ -117,15 +178,7 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                 <span className="truncate max-w-[160px] font-medium" title={attachment.file.name}>
                   {attachment.file.name}
                 </span>
-                {attachment.error ? (
-                  <span className="text-destructive truncate max-w-[160px]" title={attachment.error}>
-                    upload failed
-                  </span>
-                ) : (
-                  <span className="text-muted-foreground">
-                    {formatFileSize(attachment.file.size)}
-                  </span>
-                )}
+                <UploadMeta attachment={attachment} sizeText={formatFileSize(attachment.file.size)} onRetry={onRetry} />
               </div>
             </>
           )}

--- a/src/renderer/components/messages/chat-composer-box.tsx
+++ b/src/renderer/components/messages/chat-composer-box.tsx
@@ -27,6 +27,7 @@ interface SecureSecretsProps {
 interface ChatComposerBoxProps {
   attachments: Attachment[]
   onRemoveAttachment: (id: string) => void
+  onRetryAttachment?: (id: string) => void
   textareaRef?: Ref<HTMLDivElement>
   value: string
   onChange: (value: string) => void
@@ -52,6 +53,7 @@ interface ChatComposerBoxProps {
 export function ChatComposerBox({
   attachments,
   onRemoveAttachment,
+  onRetryAttachment,
   textareaRef,
   value,
   onChange,
@@ -94,7 +96,7 @@ export function ChatComposerBox({
       {topRightActions && (
         <div className="absolute top-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 touch:opacity-100">{topRightActions}</div>
       )}
-      <AttachmentPreview attachments={attachments} onRemove={onRemoveAttachment} />
+      <AttachmentPreview attachments={attachments} onRemove={onRemoveAttachment} onRetry={onRetryAttachment} />
       <div
         className={cn('relative', attachments.length > 0 && 'mt-2')}
         onPaste={onPaste}

--- a/src/renderer/components/messages/file-request-item.test.tsx
+++ b/src/renderer/components/messages/file-request-item.test.tsx
@@ -10,6 +10,11 @@ vi.mock('@renderer/lib/api', () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }))
 
+const mockUploadFileChunked = vi.fn()
+vi.mock('@renderer/lib/upload', () => ({
+  uploadFileChunked: (...args: unknown[]) => mockUploadFileChunked(...args),
+}))
+
 const defaultProps = {
   toolUseId: 'tu-1',
   description: 'Please upload a CSV file with user data',
@@ -57,17 +62,11 @@ describe('FileRequestItem', () => {
 
   it('uploads file and provides it to the agent', async () => {
     const user = userEvent.setup()
-    // First call: upload-file, returns path
-    mockApiFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ path: '/uploads/data.csv' }),
-      })
-      // Second call: provide-file
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({}),
-      })
+    mockUploadFileChunked.mockResolvedValueOnce({ path: '/uploads/data.csv' })
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
 
     render(<FileRequestItem {...defaultProps} />)
 
@@ -108,10 +107,7 @@ describe('FileRequestItem', () => {
 
   it('shows the backend error message on upload failure', async () => {
     const user = userEvent.setup()
-    mockApiFetch.mockResolvedValueOnce({
-      ok: false,
-      json: () => Promise.resolve({ error: 'Upload failed' }),
-    })
+    mockUploadFileChunked.mockRejectedValueOnce(new Error('Upload failed'))
 
     render(<FileRequestItem {...defaultProps} />)
 

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -81,7 +81,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   const composer = useMessageComposer({
     agentSlug,
     uploadFile: useCallback(
-      ({ file }) => uploadFile.mutateAsync({ sessionId, agentSlug, file }),
+      ({ file, onProgress, signal, stallMs }) => uploadFile.mutateAsync({ sessionId, agentSlug, file, onProgress, signal, stallMs }),
       [uploadFile, sessionId, agentSlug]
     ),
     uploadFolder: useCallback(
@@ -242,6 +242,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
       // mid-thought. Desktop (fine pointer) keeps Enter-to-send unchanged.
       if (typeof window !== 'undefined' && window.matchMedia?.('(pointer: coarse)').matches) return
       e.preventDefault()
+      if (!composer.canSubmit) return
       void composer.handleSubmit(e)
     }
   }
@@ -275,6 +276,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
         className="relative z-10 border-border/70 bg-background/85 shadow-[0_0_24px_rgba(15,23,42,0.07),0_2px_10px_-4px_rgba(15,23,42,0.08)] backdrop-blur-md supports-[backdrop-filter]:bg-background/65 dark:shadow-[0_0_26px_rgba(0,0,0,0.22),0_2px_12px_-4px_rgba(0,0,0,0.16)]"
         attachments={composer.attachments}
         onRemoveAttachment={composer.removeAttachment}
+        onRetryAttachment={composer.retryAttachment}
         textareaRef={textareaRef}
         value={composer.message}
         onChange={handleChange}

--- a/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
@@ -95,6 +95,7 @@ vi.mock('@renderer/lib/upload', () => ({ uploadFileChunked: vi.fn() }))
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
 
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
+import { uploadFileChunked } from '@renderer/lib/upload'
 import { QuickDispatch } from './quick-dispatch'
 
 /** Install a window.electronAPI stub; returns captured main→renderer callbacks. */
@@ -294,6 +295,15 @@ describe('QuickDispatch', () => {
       listeners.attachPending()
     })
     expect(drain).toHaveBeenCalledTimes(2) // ping drain
+  })
+
+  it('does not post to a blank agent before the list loads', async () => {
+    state.agents = []
+    installElectronAPI()
+    render(<QuickDispatch />)
+    const uploadFile = composerOptionsSpy.value?.uploadFile as (args: { file: File }) => Promise<unknown>
+    await expect(uploadFile({ file: new File(['x'], 'a.txt') })).rejects.toThrow('No agent selected')
+    expect(uploadFileChunked).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.test.tsx
@@ -24,6 +24,7 @@ const composerMock = vi.hoisted(() => ({
   clearAttachments: vi.fn(),
   removeAttachment: vi.fn(),
   handleSubmit: vi.fn((e?: { preventDefault?: () => void }) => e?.preventDefault?.()),
+  retryAttachment: vi.fn(),
   handlePaste: vi.fn(),
   handleFileSelect: vi.fn(),
   handleFolderSelect: vi.fn(),
@@ -174,6 +175,17 @@ describe('QuickDispatch', () => {
 
     fireEvent.keyDown(input, { key: 'Enter' })
     expect(composerMock.handleSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dispatch on Enter when canSubmit is false', async () => {
+    composerMock.canSubmit = false
+    installElectronAPI()
+    render(<QuickDispatch />)
+    await waitFor(() =>
+      expect(screen.getByTestId('quick-dispatch-agent-trigger')).toHaveTextContent('Agent One'),
+    )
+    fireEvent.keyDown(screen.getByTestId('quick-dispatch-input'), { key: 'Enter' })
+    expect(composerMock.handleSubmit).not.toHaveBeenCalled()
   })
 
   it('live-renders Markdown and keeps Markdown in composer state', async () => {

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -111,12 +111,15 @@ export function QuickDispatch() {
   const composer = useMessageComposer({
     agentSlug,
     uploadFile: useCallback(
-      ({ file, onProgress, signal, stallMs }: { file: File; onProgress?: (p: UploadProgress) => void; signal?: AbortSignal; stallMs?: number }) =>
-        uploadFileChunked<{ path: string }>({ url: `/api/agents/${agentSlug}/upload-file`, file, onProgress, signal, stallMs }),
+      ({ file, onProgress, signal, stallMs }: { file: File; onProgress?: (p: UploadProgress) => void; signal?: AbortSignal; stallMs?: number }) => {
+        if (!agentSlug) return Promise.reject(new Error('No agent selected'))
+        return uploadFileChunked<{ path: string }>({ url: `/api/agents/${agentSlug}/upload-file`, file, onProgress, signal, stallMs })
+      },
       [agentSlug],
     ),
     uploadFolder: useCallback(
       async ({ sourcePath }: { sourcePath: string }) => {
+        if (!agentSlug) throw new Error('No agent selected')
         const res = await apiFetch(`/api/agents/${agentSlug}/upload-folder`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/renderer/components/quick-dispatch/quick-dispatch.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch.tsx
@@ -5,7 +5,7 @@ import { targetIsRemote } from '@renderer/lib/api-target'
 import { Button } from '@renderer/components/ui/button'
 import { ModelIcon } from '@renderer/components/ui/model-icon'
 import { apiFetch } from '@renderer/lib/api'
-import { uploadFileChunked } from '@renderer/lib/upload'
+import { uploadFileChunked, type UploadProgress } from '@renderer/lib/upload'
 import { readLocalFileAsFile } from '@renderer/lib/read-local-file'
 import { useAgents, type ApiAgent } from '@renderer/hooks/use-agents'
 import { useCreateSession } from '@renderer/hooks/use-sessions'
@@ -111,8 +111,8 @@ export function QuickDispatch() {
   const composer = useMessageComposer({
     agentSlug,
     uploadFile: useCallback(
-      ({ file }: { file: File }) =>
-        uploadFileChunked<{ path: string }>({ url: `/api/agents/${agentSlug}/upload-file`, file }),
+      ({ file, onProgress, signal, stallMs }: { file: File; onProgress?: (p: UploadProgress) => void; signal?: AbortSignal; stallMs?: number }) =>
+        uploadFileChunked<{ path: string }>({ url: `/api/agents/${agentSlug}/upload-file`, file, onProgress, signal, stallMs }),
       [agentSlug],
     ),
     uploadFolder: useCallback(
@@ -329,6 +329,7 @@ export function QuickDispatch() {
     // Matches the main app's composer (submit on `Enter && !shiftKey`).
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
+      if (!composer.canSubmit) return
       void composer.handleSubmit(e)
     }
   }
@@ -387,7 +388,7 @@ export function QuickDispatch() {
         >
           {composer.attachments.length > 0 && (
             <div className="mb-2">
-              <AttachmentPreview attachments={composer.attachments} onRemove={composer.removeAttachment} />
+              <AttachmentPreview attachments={composer.attachments} onRemove={composer.removeAttachment} onRetry={composer.retryAttachment} />
             </div>
           )}
           <MarkdownComposerEditor

--- a/src/renderer/components/settings/platform-tab.tsx
+++ b/src/renderer/components/settings/platform-tab.tsx
@@ -291,7 +291,7 @@ function SeatCreditsRow({ seat }: { seat: NonNullable<ParsedPlatformBillingInfo[
         <span className="text-xs font-medium">Seat credits</span>
         <span className="text-xs text-muted-foreground">{Math.round(pct)}% remaining</span>
       </div>
-      <Progress percent={pct} />
+      <Progress percent={pct} thresholds={{ warning: 20, critical: 5 }} />
       <div className="text-[11px] text-muted-foreground">
         {formatCents(seat.balanceCents)} of {formatCents(seat.startingBalanceCents)}
       </div>

--- a/src/renderer/components/ui/progress.tsx
+++ b/src/renderer/components/ui/progress.tsx
@@ -6,16 +6,18 @@ interface ProgressProps {
   /**
    * Color thresholds on the REMAINING percent: at/below `critical` → red,
    * at/below `warning` → amber, otherwise primary. Mirrors the platform web
-   * app's seat-quota bar.
+   * app's seat-quota bar. Omit for a plain primary bar (an upload bar must
+   * not read as "failing" at 3%).
    */
   thresholds?: { warning: number; critical: number }
   className?: string
 }
 
-export function Progress({ percent, thresholds = { warning: 20, critical: 5 }, className }: ProgressProps) {
+export function Progress({ percent, thresholds, className }: ProgressProps) {
   const pct = Math.max(0, Math.min(100, percent))
-  const color =
-    pct <= thresholds.critical
+  const color = !thresholds
+    ? 'bg-primary'
+    : pct <= thresholds.critical
       ? 'bg-red-500'
       : pct <= thresholds.warning
         ? 'bg-amber-500'

--- a/src/renderer/hooks/use-attachments.ts
+++ b/src/renderer/hooks/use-attachments.ts
@@ -1,5 +1,5 @@
-import { useState, useCallback, useEffect } from 'react'
-import { type Attachment } from '@renderer/components/messages/attachment-preview'
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { type Attachment, type UploadState } from '@renderer/components/messages/attachment-preview'
 import { getItemsFromDataTransfer, getFolderFromDirectoryInput, type FileWithPath, type FolderGroup } from '@renderer/lib/file-utils'
 
 // 500 MB max folder size for in-browser zip upload (no Electron fs.cp available)
@@ -8,17 +8,25 @@ const MAX_WEB_FOLDER_SIZE = 500 * 1024 * 1024
 interface UseAttachmentsOptions {
   onFoldersReceived?: (folders: FolderGroup[]) => void
   initialAttachments?: Attachment[]
+  onAttachmentsAdded?: (added: Attachment[]) => void
 }
 
+export type UploadPatch = { upload?: UploadState; error?: string }
+
 export function useAttachments(options?: UseAttachmentsOptions) {
+  // Carried-over chips (stale-session → agent home) always re-upload: their
+  // paths belong to the composer that uploaded them.
   const [attachments, setAttachments] = useState<Attachment[]>(() =>
-    (options?.initialAttachments ?? []).map((attachment) =>
-      attachment.type === 'file' && attachment.file.type.startsWith('image/') && !attachment.preview
-        ? { ...attachment, preview: URL.createObjectURL(attachment.file) }
-        : attachment,
-    ),
+    (options?.initialAttachments ?? []).map((attachment) => {
+      const stripped = attachment.type === 'mount' ? attachment : { ...attachment, upload: undefined, error: undefined }
+      return stripped.type === 'file' && stripped.file.type.startsWith('image/') && !stripped.preview
+        ? { ...stripped, preview: URL.createObjectURL(stripped.file) }
+        : stripped
+    }),
   )
   const [isDragOver, setIsDragOver] = useState(false)
+  const onAddedRef = useRef(options?.onAttachmentsAdded)
+  onAddedRef.current = options?.onAttachmentsAdded
 
   const addFiles = useCallback((files: FileWithPath[]) => {
     const newAttachments: Attachment[] = files.map(({ file }) => {
@@ -33,6 +41,7 @@ export function useAttachments(options?: UseAttachmentsOptions) {
       return attachment
     })
     setAttachments((prev) => [...prev, ...newAttachments])
+    onAddedRef.current?.(newAttachments)
   }, [])
 
   const addFolders = useCallback((folders: FolderGroup[]) => {
@@ -55,6 +64,7 @@ export function useAttachments(options?: UseAttachmentsOptions) {
     }
     if (newAttachments.length > 0) {
       setAttachments((prev) => [...prev, ...newAttachments])
+      onAddedRef.current?.(newAttachments)
     }
   }, [])
 
@@ -71,6 +81,10 @@ export function useAttachments(options?: UseAttachmentsOptions) {
       hostPath: m.hostPath,
     }))
     setAttachments((prev) => [...prev, ...newAttachments])
+  }, [])
+
+  const updateAttachment = useCallback((id: string, patch: UploadPatch) => {
+    setAttachments((prev) => prev.map((a) => (a.id === id && a.type !== 'mount' ? { ...a, ...patch } : a)))
   }, [])
 
   const setAttachmentError = useCallback((id: string, error: string | undefined) => {
@@ -166,6 +180,7 @@ export function useAttachments(options?: UseAttachmentsOptions) {
     addFiles,
     addFolders,
     addMounts,
+    updateAttachment,
     setAttachmentError,
     clearAttachmentErrors,
     removeAttachment,

--- a/src/renderer/hooks/use-message-composer-carryover.test.tsx
+++ b/src/renderer/hooks/use-message-composer-carryover.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { createElement, StrictMode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { DraftsProvider } from '@renderer/context/drafts-context'
+import { useMessageComposer } from './use-message-composer'
+
+vi.mock('@renderer/hooks/use-mounts', () => ({
+  useAddMount: () => ({ mutateAsync: vi.fn() }),
+}))
+
+vi.mock('@renderer/hooks/use-voice-input', () => ({
+  useVoiceInput: () => ({
+    state: 'idle',
+    isRecording: false,
+    isConnecting: false,
+    error: null,
+    clearError: vi.fn(),
+    isSupported: false,
+    analyserRef: { current: null },
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+  }),
+}))
+
+vi.mock('@renderer/lib/error-reporting', () => ({ captureRendererException: vi.fn() }))
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(
+      StrictMode,
+      null,
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(DraftsProvider, null, children),
+      ),
+    )
+  }
+}
+
+describe('useMessageComposer carryover (real queue)', () => {
+  it('uploads a carried file once under StrictMode', async () => {
+    const uploadFile = vi.fn().mockResolvedValue({ path: '/workspace/a.txt' })
+    const { result } = renderHook(() => useMessageComposer({
+      agentSlug: 'agent-a',
+      uploadFile,
+      uploadFolder: vi.fn(),
+      onSubmit: vi.fn(),
+      initialAttachments: [{ type: 'file', id: 'c', file: new File(['x'], 'a.txt') }],
+    }), { wrapper: createWrapper() })
+
+    await act(async () => {})
+    await waitFor(() => {
+      expect(uploadFile).toHaveBeenCalledTimes(1)
+      const chip = result.current.attachments[0]
+      expect(chip && chip.type === 'file' && chip.upload).toMatchObject({ status: 'done', path: '/workspace/a.txt' })
+    })
+  })
+})

--- a/src/renderer/hooks/use-message-composer-send-retry.test.tsx
+++ b/src/renderer/hooks/use-message-composer-send-retry.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { DraftsProvider } from '@renderer/context/drafts-context'
+import { useMessageComposer } from './use-message-composer'
+
+vi.mock('@renderer/hooks/use-mounts', () => ({
+  useAddMount: () => ({ mutateAsync: vi.fn() }),
+}))
+
+vi.mock('@renderer/hooks/use-voice-input', () => ({
+  useVoiceInput: () => ({
+    state: 'idle',
+    isRecording: false,
+    isConnecting: false,
+    error: null,
+    clearError: vi.fn(),
+    isSupported: false,
+    analyserRef: { current: null },
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+  }),
+}))
+
+vi.mock('@renderer/lib/error-reporting', () => ({ captureRendererException: vi.fn() }))
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(DraftsProvider, null, children),
+    )
+  }
+}
+
+describe('useMessageComposer send-driven retry (real queue)', () => {
+  it('a Send that re-uploads a failed chip submits the retried file path', async () => {
+    let calls = 0
+    const uploadFile = vi.fn(async () => {
+      calls += 1
+      // Settle from a macrotask, like a real XHR onload/onerror. The retry's
+      // 'done' state then commits after handleSubmit has already resumed, so
+      // the submitted content must not depend on the rendered chip state.
+      await new Promise((r) => setTimeout(r, 0))
+      if (calls === 1) throw new Error('boom')
+      return { path: '/workspace/uploads/a.txt' }
+    })
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(
+      () =>
+        useMessageComposer({
+          agentSlug: 'agent-a',
+          uploadFile,
+          uploadFolder: vi.fn(),
+          onSubmit,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    const file = new File(['data'], 'a.txt', { type: 'text/plain' })
+    await act(async () => {
+      result.current.addFiles([{ file }])
+    })
+    await waitFor(() => {
+      const chip = result.current.attachments[0]
+      expect(chip && chip.type === 'file' && chip.error).toBe('boom')
+    })
+
+    await act(async () => {
+      result.current.setMessage('hi')
+    })
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: () => {} })
+    })
+
+    expect(uploadFile).toHaveBeenCalledTimes(2)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit.mock.calls[0][0] as string).toContain('/workspace/uploads/a.txt')
+  })
+})

--- a/src/renderer/hooks/use-message-composer.test.tsx
+++ b/src/renderer/hooks/use-message-composer.test.tsx
@@ -72,6 +72,7 @@ const mockQueue = {
   enqueue: vi.fn(),
   retry: vi.fn(),
   retryAndWait: vi.fn().mockResolvedValue({ ok: true }),
+  pathFor: vi.fn(),
   remove: vi.fn(),
   clear: vi.fn(),
   requeueAll: vi.fn(),
@@ -354,8 +355,8 @@ describe('useMessageComposer', () => {
 
     it('submit sends the done paths in chip order without re-uploading', async () => {
       mockAttachments.attachments = [
-        { type: 'file', file: new File([''], 'a.txt'), id: '1', upload: { status: 'done', path: '/a', agentSlug: 'x' } },
-        { type: 'file', file: new File([''], 'b.txt'), id: '2', upload: { status: 'done', path: '/b', agentSlug: 'x' } },
+        { type: 'file', file: new File([''], 'a.txt'), id: '1', upload: { status: 'done', path: '/a', agentSlug: 'test-agent' } },
+        { type: 'file', file: new File([''], 'b.txt'), id: '2', upload: { status: 'done', path: '/b', agentSlug: 'test-agent' } },
       ]
       const opts = defaultOptions()
       const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
@@ -384,7 +385,7 @@ describe('useMessageComposer', () => {
       mockAttachments.attachments = [{ type: 'file', file: new File([''], 'a.txt'), id: '1', error: 'boom' }]
       mockQueue.retryAndWait.mockImplementationOnce(async () => {
         // Same array object: the composer's attachmentsRef points at it
-        mockAttachments.attachments.splice(0, 1, { type: 'file', file: new File([''], 'a.txt'), id: '1', upload: { status: 'done', path: '/a', agentSlug: 'x' } })
+        mockAttachments.attachments.splice(0, 1, { type: 'file', file: new File([''], 'a.txt'), id: '1', upload: { status: 'done', path: '/a', agentSlug: 'test-agent' } })
         return { ok: true }
       })
       const opts = defaultOptions()
@@ -392,6 +393,40 @@ describe('useMessageComposer', () => {
       act(() => result.current.setMessage('go'))
       await act(async () => { await result.current.handleSubmit({ preventDefault: vi.fn() }) })
       expect(opts.onSubmit).toHaveBeenCalledWith(expect.stringContaining('/a'))
+    })
+
+    it('submit omits a path that belongs to a different agent', async () => {
+      mockAttachments.attachments = [{
+        type: 'file',
+        file: new File([''], 'a.txt'),
+        id: '1',
+        upload: { status: 'done', path: '/other/a.txt', agentSlug: 'other-agent' },
+      }]
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      act(() => result.current.setMessage('go'))
+      await act(async () => { await result.current.handleSubmit({ preventDefault: vi.fn() }) })
+      expect(opts.onSubmit).toHaveBeenCalledWith('go')
+    })
+
+    it('submit uses the live list when the chip has no path yet', async () => {
+      mockAttachments.attachments = [{ type: 'file', file: new File([''], 'a.txt'), id: '1' }]
+      mockQueue.pathFor.mockReturnValueOnce({ path: '/workspace/a.txt', agentSlug: 'test-agent' })
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      act(() => result.current.setMessage('go'))
+      await act(async () => { await result.current.handleSubmit({ preventDefault: vi.fn() }) })
+      expect(opts.onSubmit).toHaveBeenCalledWith(expect.stringContaining('/workspace/a.txt'))
+    })
+
+    it('submit omits a live-list path that belongs to a different agent', async () => {
+      mockAttachments.attachments = [{ type: 'file', file: new File([''], 'b.txt'), id: '2' }]
+      mockQueue.pathFor.mockReturnValueOnce({ path: '/other/b.txt', agentSlug: 'other-agent' })
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      act(() => result.current.setMessage('go'))
+      await act(async () => { await result.current.handleSubmit({ preventDefault: vi.fn() }) })
+      expect(opts.onSubmit).toHaveBeenCalledWith('go')
     })
 
     it('a mount failure sets the banner and stops the send', async () => {

--- a/src/renderer/hooks/use-message-composer.test.tsx
+++ b/src/renderer/hooks/use-message-composer.test.tsx
@@ -2,6 +2,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { createElement } from 'react'
+import type { Attachment } from '@renderer/components/messages/attachment-preview'
+import type { FolderGroup } from '@renderer/lib/file-utils'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DraftsProvider, useDraft } from '@renderer/context/drafts-context'
 
@@ -43,6 +45,7 @@ const mockAttachments = {
   addMounts: vi.fn(),
   setAttachmentError: vi.fn(),
   clearAttachmentErrors: vi.fn(),
+  updateAttachment: vi.fn(),
   removeAttachment: vi.fn(),
   clearAttachments: vi.fn(),
   handleFileSelect: vi.fn(),
@@ -54,21 +57,33 @@ const mockAttachments = {
   },
 }
 
-let capturedOnFoldersReceived: ((folders: any[]) => void) | undefined
+let capturedOnFoldersReceived: ((folders: FolderGroup[]) => void) | undefined
+let capturedOnAttachmentsAdded: ((added: Attachment[]) => void) | undefined
 
 vi.mock('@renderer/hooks/use-attachments', () => ({
-  useAttachments: (opts?: { onFoldersReceived?: (folders: any[]) => void }) => {
-    capturedOnFoldersReceived = opts?.onFoldersReceived
+  useAttachments: (options?: { onFoldersReceived?: (folders: FolderGroup[]) => void; onAttachmentsAdded?: (added: Attachment[]) => void }) => {
+    capturedOnFoldersReceived = options?.onFoldersReceived
+    capturedOnAttachmentsAdded = options?.onAttachmentsAdded
     return mockAttachments
   },
 }))
+
+const mockQueue = {
+  enqueue: vi.fn(),
+  retry: vi.fn(),
+  retryAndWait: vi.fn().mockResolvedValue({ ok: true }),
+  remove: vi.fn(),
+  clear: vi.fn(),
+  requeueAll: vi.fn(),
+}
+vi.mock('./use-upload-queue', () => ({ useUploadQueue: () => mockQueue }))
 
 vi.mock('@renderer/lib/file-utils', () => ({
   zipFolderFiles: vi.fn().mockResolvedValue(new Blob(['zipped'])),
 }))
 
 vi.mock('@shared/lib/utils/attached-files', () => ({
-  appendAttachedFiles: vi.fn((msg: string, paths: string[]) => `${msg}\n[Attached files:]\n${paths.join('\n')}`),
+  appendAttachedFiles: vi.fn((msg: string, paths: string[]) => paths.length === 0 ? msg : `${msg}\n[Attached files:]\n${paths.join('\n')}`),
   appendMountedFolders: vi.fn((msg: string, mounts: any[]) => `${msg}\n[Mounted folders:]\n${mounts.map((m: any) => m.containerPath).join('\n')}`),
 }))
 
@@ -108,7 +123,9 @@ describe('useMessageComposer', () => {
     mockVoiceInput.isConnecting = false
     mockVoiceInput.stopRecording.mockReturnValue(undefined)
     capturedOnFoldersReceived = undefined
+    capturedOnAttachmentsAdded = undefined
     capturedTranscriptUpdate = undefined
+    mockQueue.retryAndWait.mockResolvedValue({ ok: true })
   })
 
   // --- Basic state ---
@@ -240,7 +257,7 @@ describe('useMessageComposer', () => {
 
     expect(opts.onSubmit).toHaveBeenCalledWith('Hello world')
     expect(result.current.message).toBe('')
-    expect(mockAttachments.clearAttachments).toHaveBeenCalled()
+    expect(mockQueue.clear).toHaveBeenCalled()
   })
 
   it('does not submit empty message', async () => {
@@ -317,146 +334,94 @@ describe('useMessageComposer', () => {
     expect(opts.onSubmit).toHaveBeenCalledWith('flushed tail text')
   })
 
-  // --- File upload orchestration ---
-
-  it('uploads file attachments and appends paths to message', async () => {
-    mockAttachments.attachments = [
-      { type: 'file', file: new File(['content'], 'doc.txt'), id: '1' },
-    ]
-    const opts = defaultOptions()
-    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
-
-    act(() => result.current.setMessage('Check this'))
-
-    await act(async () => {
-      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+  describe('upload lifecycle', () => {
+    it('enqueues file and folder chips as they are added, never mounts', () => {
+      const opts = defaultOptions()
+      renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      const file: Attachment = { type: 'file', id: 'f', file: new File([''], 'a.txt') }
+      const mount: Attachment = { type: 'mount', id: 'm', folderName: 'x', hostPath: '/x' }
+      act(() => capturedOnAttachmentsAdded!([file, mount]))
+      expect(mockQueue.enqueue).toHaveBeenCalledTimes(1)
+      expect(mockQueue.enqueue).toHaveBeenCalledWith(file)
     })
 
-    expect(opts.uploadFile).toHaveBeenCalledWith({ file: expect.any(File) })
-    // Content should have file paths appended
-    expect(opts.onSubmit).toHaveBeenCalledWith(expect.stringContaining('[Attached files:]'))
-    expect(opts.onSubmit).toHaveBeenCalledWith(expect.stringContaining('/tmp/uploaded-file.txt'))
-  })
-
-  it('uploads folder via Electron path', async () => {
-    mockAttachments.attachments = [
-      { type: 'folder', folderName: 'src', folderPath: '/home/user/src', files: [], totalSize: 100, id: '2' },
-    ]
-    const opts = defaultOptions()
-    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
-
-    act(() => result.current.setMessage('Here'))
-
-    await act(async () => {
-      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+    it('canSubmit is false while a chip is queued or uploading', () => {
+      mockAttachments.attachments = [{ type: 'file', file: new File([''], 't.txt'), id: '1', upload: { status: 'uploading', agentSlug: 'a' } }]
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      expect(result.current.canSubmit).toBe(false)
     })
 
-    expect(opts.uploadFolder).toHaveBeenCalledWith({ sourcePath: '/home/user/src' })
-    expect(opts.onSubmit).toHaveBeenCalledWith(expect.stringContaining('/tmp/uploaded-folder'))
-  })
-
-  it('zips and uploads folder for web (no folderPath)', async () => {
-    const files = [{ file: new File(['a'], 'a.txt'), relativePath: 'a.txt' }]
-    mockAttachments.attachments = [
-      { type: 'folder', folderName: 'mydir', folderPath: undefined, files, totalSize: 1, id: '3' },
-    ]
-    const opts = defaultOptions()
-    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
-
-    act(() => result.current.setMessage('Folder'))
-
-    await act(async () => {
-      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+    it('submit sends the done paths in chip order without re-uploading', async () => {
+      mockAttachments.attachments = [
+        { type: 'file', file: new File([''], 'a.txt'), id: '1', upload: { status: 'done', path: '/a', agentSlug: 'x' } },
+        { type: 'file', file: new File([''], 'b.txt'), id: '2', upload: { status: 'done', path: '/b', agentSlug: 'x' } },
+      ]
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      act(() => result.current.setMessage('hi'))
+      await act(async () => { await result.current.handleSubmit({ preventDefault: vi.fn() }) })
+      expect(mockQueue.retryAndWait).not.toHaveBeenCalled()
+      expect(opts.uploadFile).not.toHaveBeenCalled()
+      const content = opts.onSubmit.mock.calls[0][0] as string
+      expect(content.indexOf('/a')).toBeLessThan(content.indexOf('/b'))
     })
 
-    // Should use uploadFile with a .zip file
-    expect(opts.uploadFile).toHaveBeenCalledWith({
-      file: expect.objectContaining({ name: 'mydir.zip' }),
-    })
-  })
-
-  it('handles mount attachments via addMountMutation', async () => {
-    mockAttachments.attachments = [
-      { type: 'mount', folderName: 'data', hostPath: '/data/shared', id: '4' },
-    ]
-    const opts = defaultOptions()
-    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
-
-    act(() => result.current.setMessage('Mount this'))
-
-    await act(async () => {
-      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+    it('submit re-uploads errored chips first and stops if they fail again', async () => {
+      mockAttachments.attachments = [{ type: 'file', file: new File([''], 'a.txt'), id: '1', error: 'boom' }]
+      mockQueue.retryAndWait.mockResolvedValueOnce({ ok: false })
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      act(() => result.current.setMessage('keep me'))
+      await act(async () => { await result.current.handleSubmit({ preventDefault: vi.fn() }) })
+      expect(mockQueue.retryAndWait).toHaveBeenCalled()
+      expect(opts.onSubmit).not.toHaveBeenCalled()
+      expect(result.current.message).toBe('keep me')
+      expect(result.current.uploadError).toBeNull()
     })
 
-    expect(mockAddMount.mutateAsync).toHaveBeenCalledWith({
-      agentSlug: 'test-agent',
-      hostPath: '/data/shared',
-      restart: true,
-    })
-    expect(opts.onSubmit).toHaveBeenCalledWith(expect.stringContaining('[Mounted folders:]'))
-  })
-
-  it('flags the mount chip and aborts submit when the mount request fails', async () => {
-    mockAttachments.attachments = [
-      { type: 'mount', folderName: 'data', hostPath: '/data/shared', id: 'm1' },
-    ]
-    mockAddMount.mutateAsync.mockRejectedValueOnce(new Error('hostPath is required'))
-    const opts = defaultOptions()
-    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
-
-    act(() => result.current.setMessage('Mount this'))
-
-    await act(async () => {
-      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+    it('submit continues after a successful retry', async () => {
+      mockAttachments.attachments = [{ type: 'file', file: new File([''], 'a.txt'), id: '1', error: 'boom' }]
+      mockQueue.retryAndWait.mockImplementationOnce(async () => {
+        // Same array object: the composer's attachmentsRef points at it
+        mockAttachments.attachments.splice(0, 1, { type: 'file', file: new File([''], 'a.txt'), id: '1', upload: { status: 'done', path: '/a', agentSlug: 'x' } })
+        return { ok: true }
+      })
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      act(() => result.current.setMessage('go'))
+      await act(async () => { await result.current.handleSubmit({ preventDefault: vi.fn() }) })
+      expect(opts.onSubmit).toHaveBeenCalledWith(expect.stringContaining('/a'))
     })
 
-    expect(opts.onSubmit).not.toHaveBeenCalled()
-    expect(mockAttachments.setAttachmentError).toHaveBeenCalledWith('m1', 'hostPath is required')
-    expect(result.current.uploadError).toBe('hostPath is required')
-    // Stale chip errors are cleared at the start of the next attempt
-    expect(mockAttachments.clearAttachmentErrors).toHaveBeenCalled()
-  })
-
-  it('appends mounts before files in content', async () => {
-    const { appendMountedFolders, appendAttachedFiles } = await import('@shared/lib/utils/attached-files')
-    mockAttachments.attachments = [
-      { type: 'mount', folderName: 'data', hostPath: '/data', id: '1' },
-      { type: 'file', file: new File(['x'], 'x.txt'), id: '2' },
-    ]
-    const opts = defaultOptions()
-    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
-
-    act(() => result.current.setMessage('Both'))
-
-    await act(async () => {
-      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+    it('a mount failure sets the banner and stops the send', async () => {
+      mockAttachments.attachments = [{ type: 'mount', id: 'm', folderName: 'src', hostPath: '/home/u/src' }]
+      mockAddMount.mutateAsync.mockRejectedValueOnce(new Error('mount boom'))
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      act(() => result.current.setMessage('x'))
+      await act(async () => { await result.current.handleSubmit({ preventDefault: vi.fn() }) })
+      expect(result.current.uploadError).toBe('mount boom')
+      expect(mockAttachments.setAttachmentError).toHaveBeenCalledWith('m', 'mount boom')
+      expect(opts.onSubmit).not.toHaveBeenCalled()
     })
 
-    // appendMountedFolders should be called first, then appendAttachedFiles
-    const mountCall = (appendMountedFolders as any).mock.invocationCallOrder[0]
-    const fileCall = (appendAttachedFiles as any).mock.invocationCallOrder[0]
-    expect(mountCall).toBeLessThan(fileCall)
-  })
-
-  it('aborts submit on upload error and preserves message', async () => {
-    mockAttachments.attachments = [
-      { type: 'file', file: new File(['x'], 'x.txt'), id: '1' },
-    ]
-    const opts = defaultOptions()
-    opts.uploadFile.mockRejectedValue(new Error('Network error'))
-    const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
-
-    act(() => result.current.setMessage('Will fail'))
-
-    await act(async () => {
-      await result.current.handleSubmit({ preventDefault: vi.fn() } as any)
+    it('retryAttachment, removeAttachment and clearAttachments go through the queue', () => {
+      const opts = defaultOptions()
+      const { result } = renderHook(() => useMessageComposer(opts), { wrapper: createWrapper() })
+      act(() => { result.current.retryAttachment('1'); result.current.removeAttachment('1'); result.current.clearAttachments() })
+      expect(mockQueue.retry).toHaveBeenCalledWith('1')
+      expect(mockQueue.remove).toHaveBeenCalledWith('1')
+      expect(mockQueue.clear).toHaveBeenCalled()
     })
 
-    expect(opts.onSubmit).not.toHaveBeenCalled()
-    // Message should NOT be cleared since upload failed
-    expect(result.current.message).toBe('Will fail')
-    // The failing attachment's chip is flagged so it doesn't keep looking successful
-    expect(mockAttachments.setAttachmentError).toHaveBeenCalledWith('1', 'Network error')
+    it('agent change re-queues every chip', () => {
+      const opts = defaultOptions()
+      const { rerender } = renderHook(({ slug }) => useMessageComposer({ ...opts, agentSlug: slug }), { initialProps: { slug: 'a' }, wrapper: createWrapper() })
+      rerender({ slug: 'b' })
+      expect(mockQueue.requeueAll).toHaveBeenCalledTimes(1)
+    })
+
   })
 
   it('preserves message when onSubmit fails', async () => {
@@ -639,7 +604,7 @@ describe('useMessageComposer', () => {
 
     expect(result.current.attachments).toBe(mockAttachments.attachments)
     expect(result.current.isDragOver).toBe(mockAttachments.isDragOver)
-    expect(result.current.removeAttachment).toBe(mockAttachments.removeAttachment)
+    expect(result.current.removeAttachment).toBe(mockQueue.remove)
     expect(result.current.handleFileSelect).toBe(mockAttachments.handleFileSelect)
     expect(result.current.handleFolderSelect).toBe(mockAttachments.handleFolderSelect)
     expect(result.current.dragHandlers).toBe(mockAttachments.dragHandlers)

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -301,7 +301,14 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
       content = appendMountedFolders(content, mountResults)
     }
 
-    const paths = attachmentsRef.current.flatMap((a) => (a.type !== 'mount' && a.upload?.status === 'done' && a.upload.path ? [a.upload.path] : []))
+    const paths = attachmentsRef.current.flatMap((a) => {
+      if (a.type === 'mount') return []
+      const done = a.upload?.path
+        ? { path: a.upload.path, agentSlug: a.upload.agentSlug }
+        : queue.pathFor(a.id)
+      if (!done?.path || done.agentSlug !== agentSlug) return []
+      return [done.path]
+    })
     content = appendAttachedFiles(content, paths)
 
     if (!keepMessageUntilComplete) {

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -1,13 +1,15 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { captureRendererException } from '@renderer/lib/error-reporting'
 import { useAttachments } from './use-attachments'
+import { useUploadQueue } from './use-upload-queue'
 import { useVoiceInput } from './use-voice-input'
 import { useAddMount } from './use-mounts'
 import { useDraft } from '@renderer/context/drafts-context'
 import { appendAttachedFiles, appendMountedFolders } from '@shared/lib/utils/attached-files'
-import { zipFolderFiles, type FolderGroup } from '@renderer/lib/file-utils'
+import { type FolderGroup } from '@renderer/lib/file-utils'
 import { canUseHostFeatures } from '@renderer/lib/host-features'
-import type { Attachment } from '@renderer/components/messages/attachment-preview'
+import { attachmentStatus, type Attachment, type MountAttachment } from '@renderer/components/messages/attachment-preview'
+import type { UploadProgress } from '@renderer/lib/upload'
 import {
   findPotentialSecrets,
   replaceSecuredSecrets,
@@ -19,7 +21,7 @@ import {
 interface UseMessageComposerOptions {
   agentSlug: string
   /** Upload a single file. Caller provides the right endpoint (session-level or agent-level). */
-  uploadFile: (args: { file: File }) => Promise<{ path: string }>
+  uploadFile: (args: { file: File; onProgress?: (p: UploadProgress) => void; signal?: AbortSignal; stallMs?: number }) => Promise<{ path: string }>
   /** Upload a folder via Electron fs.cp. Caller provides the right endpoint. */
   uploadFolder: (args: { sourcePath: string }) => Promise<{ path: string }>
   /** Called after uploads complete and content is fully assembled. */
@@ -137,23 +139,62 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     setShowMountDialog(true)
   }, [])
 
+  const attachmentsRef = useRef<Attachment[]>([])
+  const queueRef = useRef<ReturnType<typeof useUploadQueue> | null>(null)
+
   const {
     attachments,
     isDragOver,
     addFiles,
     addFolders: addFoldersDirectly,
     addMounts,
+    updateAttachment,
     setAttachmentError,
-    clearAttachmentErrors,
-    removeAttachment,
-    clearAttachments,
+    removeAttachment: removeAttachmentRaw,
+    clearAttachments: clearAttachmentsRaw,
     handleFileSelect,
     handleFolderSelect,
     dragHandlers,
   } = useAttachments({
     onFoldersReceived: canOfferMount ? handleFoldersReceived : undefined,
     initialAttachments: options.initialAttachments,
+    onAttachmentsAdded: (added) => {
+      for (const a of added) if (a.type !== 'mount') queueRef.current?.enqueue(a)
+    },
   })
+  attachmentsRef.current = attachments
+
+  const queue = useUploadQueue({
+    agentSlug,
+    attachmentsRef,
+    updateAttachment,
+    removeAttachment: removeAttachmentRaw,
+    clearAttachments: clearAttachmentsRaw,
+    uploadFile: options.uploadFile,
+    uploadFolder: options.uploadFolder,
+  })
+  queueRef.current = queue
+
+  const removeAttachment = queue.remove
+  const clearAttachments = queue.clear
+  const retryAttachment = queue.retry
+
+  useEffect(() => {
+    // Unmount aborts the queue generation, so StrictMode's second setup must
+    // enqueue again. Skip done/error chips; later adds go through onAttachmentsAdded.
+    for (const a of attachmentsRef.current) {
+      if (a.type === 'mount' || a.error || a.upload?.status === 'done') continue
+      queue.enqueue(a)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount only
+  }, [])
+
+  const previousSlugRef = useRef(agentSlug)
+  useEffect(() => {
+    if (previousSlugRef.current === agentSlug) return
+    previousSlugRef.current = agentSlug
+    queue.requeueAll()
+  }, [agentSlug, queue])
 
   // Pulled off `options` so the dep is the callback itself. Depending on
   // `options` instead would rebuild this every render — callers pass an inline
@@ -204,72 +245,64 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     }
   }, [addFiles])
 
+  const uploadsInFlight = attachments.some((a) => {
+    const s = attachmentStatus(a)
+    return s === 'queued' || s === 'uploading'
+  })
+
   const handleSubmit = async (e: Pick<React.FormEvent, 'preventDefault'>) => {
     e.preventDefault()
+    if (uploadsInFlight || isUploading || submitDisabled) return
 
     // Stop voice recording first and await the final text: stopRecording flushes
     // buffered audio and waits for the server's trailing transcripts, so a quick
     // speak-then-Enter doesn't submit before the dictated words are in.
     let voiceText: string | undefined
-    if (voiceInput.isRecording || voiceInput.isConnecting) {
-      voiceText = await voiceInput.stopRecording()
-    }
+    if (voiceInput.isRecording || voiceInput.isConnecting) voiceText = await voiceInput.stopRecording()
 
     const effectiveMessage = voiceText ?? message
     const hasContent = effectiveMessage.trim() || attachments.length > 0
-    if (!hasContent || isUploading || submitDisabled) return
+    if (!hasContent) return
 
     let content = effectiveMessage.trim()
 
-    // Upload attachments first
-    if (attachments.length > 0) {
+    if (attachmentsRef.current.some((a) => a.type !== 'mount' && a.error)) {
+      setIsUploading(true)
+      const { ok } = await queue.retryAndWait()
+      setIsUploading(false)
+      if (!ok) return
+    }
+
+    const mounts = attachmentsRef.current.filter((a): a is MountAttachment => a.type === 'mount')
+    if (mounts.length > 0) {
       setIsUploading(true)
       setUploadError(null)
-      clearAttachmentErrors()
-      // Tracks the attachment being processed so the catch can flag its chip
-      let inFlightAttachment: Attachment | null = null
+      for (const a of mounts) if (a.error) setAttachmentError(a.id, undefined)
+      const mountResults: { containerPath: string; hostPath: string }[] = []
       try {
-        const uploadResults: { path: string }[] = []
-        const mountResults: { containerPath: string; hostPath: string }[] = []
-
-        for (const a of attachments) {
-          inFlightAttachment = a
-          if (a.type === 'mount') {
+        for (const a of mounts) {
+          try {
             const result = await addMountMutation.mutateAsync({ agentSlug, hostPath: a.hostPath, restart: true })
             mountResults.push({ containerPath: result.containerPath, hostPath: a.hostPath })
-          } else if (a.type === 'folder' && a.folderPath) {
-            // Electron: copy folder directly on the server filesystem
-            const result = await options.uploadFolder({ sourcePath: a.folderPath })
-            uploadResults.push(result)
-          } else if (a.type === 'folder') {
-            // Web fallback: zip files in browser and upload as single archive
-            const zipBlob = await zipFolderFiles(a.files)
-            const zipFile = new File([zipBlob], `${a.folderName}.zip`, { type: 'application/zip' })
-            const result = await options.uploadFile({ file: zipFile })
-            uploadResults.push(result)
-          } else {
-            const result = await options.uploadFile({ file: a.file })
-            uploadResults.push(result)
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'Mount failed. Please try again.'
+            setAttachmentError(a.id, message)
+            throw new Error(message)
           }
         }
-
-        // Append mounts before files — parseAttachedFiles strips from its marker onward,
-        // so [Attached files:] must come last for both blocks to be parseable.
-        content = appendMountedFolders(content, mountResults)
-        content = appendAttachedFiles(content, uploadResults.map((r) => r.path))
       } catch (error) {
-        console.error('Failed to upload attachments:', error)
+        console.error('Failed to mount attachments:', error)
         captureRendererException(error, { tags: { source: 'attachment-upload' }, extra: { agentSlug } })
-        const message = error instanceof Error ? error.message : 'Upload failed. Please try again.'
-        if (inFlightAttachment) {
-          setAttachmentError(inFlightAttachment.id, message)
-        }
-        setUploadError(message)
+        setUploadError(error instanceof Error ? error.message : 'Mount failed. Please try again.')
         setIsUploading(false)
         return
       }
       setIsUploading(false)
+      content = appendMountedFolders(content, mountResults)
     }
+
+    const paths = attachmentsRef.current.flatMap((a) => (a.type !== 'mount' && a.upload?.status === 'done' && a.upload.path ? [a.upload.path] : []))
+    content = appendAttachedFiles(content, paths)
 
     if (!keepMessageUntilComplete) {
       // Clear input immediately so the message doesn't linger while the network request is in flight
@@ -300,7 +333,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     setSecuredSecrets([])
   }
 
-  const canSubmit = (!!message.trim() || attachments.length > 0 || voiceInput.isRecording) && !isUploading && !submitDisabled
+  const canSubmit = (!!message.trim() || attachments.length > 0 || voiceInput.isRecording) && !uploadsInFlight && !isUploading && !submitDisabled
 
   return {
     // Message state
@@ -318,6 +351,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     addFiles,
     removeAttachment,
     clearAttachments,
+    retryAttachment,
     handleFileSelect,
     handleFolderSelect,
     dragHandlers,

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from '@renderer/lib/api'
 import { captureRendererException } from '@renderer/lib/error-reporting'
-import { uploadFileChunked } from '@renderer/lib/upload'
+import { uploadFileChunked, type UploadProgress } from '@renderer/lib/upload'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ApiMessage, ApiMessageOrBoundary, ApiSession } from '@shared/lib/types/api'
@@ -355,11 +355,22 @@ export function useCancelQueuedMessage() {
 
 export function useUploadFile() {
   return useMutation({
-    mutationFn: async (data: { sessionId: string; agentSlug: string; file: File; relativePath?: string }) => {
+    mutationFn: async (data: {
+      sessionId: string
+      agentSlug: string
+      file: File
+      relativePath?: string
+      onProgress?: (p: UploadProgress) => void
+      signal?: AbortSignal
+      stallMs?: number
+    }) => {
       return uploadFileChunked<{ path: string; filename: string; size: number }>({
         url: `/api/agents/${data.agentSlug}/sessions/${data.sessionId}/upload-file`,
         file: data.file,
         fields: data.relativePath ? { relativePath: data.relativePath } : undefined,
+        onProgress: data.onProgress,
+        signal: data.signal,
+        stallMs: data.stallMs,
       })
     },
   })

--- a/src/renderer/hooks/use-upload-queue.test.tsx
+++ b/src/renderer/hooks/use-upload-queue.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useRef, useState } from 'react'
+import { useUploadQueue, type UploadQueueOptions } from './use-upload-queue'
+import type { Attachment, FileAttachment, FolderAttachment } from '@renderer/components/messages/attachment-preview'
+import { zipFolderFiles } from '@renderer/lib/file-utils'
+
+vi.mock('@renderer/lib/error-reporting', () => ({ captureRendererException: vi.fn() }))
+vi.mock('@renderer/lib/file-utils', () => ({
+  zipFolderFiles: vi.fn().mockResolvedValue(new Blob(['zip'])),
+}))
+
+function fileAttachment(id: string): FileAttachment {
+  return { type: 'file', id, file: new File(['x'], `${id}.txt`) }
+}
+
+function folderAttachment(id: string, extras: Partial<FolderAttachment> = {}): FolderAttachment {
+  return {
+    type: 'folder',
+    id,
+    folderName: id,
+    files: [{ file: new File(['x'], 'f.txt'), relativePath: 'f.txt' }],
+    totalSize: 1,
+    ...extras,
+  }
+}
+
+// Mount chips have no `upload`; narrow before reading it so the assertions typecheck.
+function uploadOf(a: Attachment | undefined) {
+  return a && a.type !== 'mount' ? a.upload : undefined
+}
+
+// Drives real attachment state so the queue's ref reads what the UI would.
+function useHarness(
+  uploadFile: UploadQueueOptions['uploadFile'],
+  initial: Attachment[] = [],
+  uploadFolder: UploadQueueOptions['uploadFolder'] = vi.fn(),
+) {
+  const [attachments, setAttachments] = useState<Attachment[]>(initial)
+  const attachmentsRef = useRef(attachments)
+  attachmentsRef.current = attachments
+  const queue = useUploadQueue({
+    agentSlug: 'agent-a',
+    attachmentsRef,
+    updateAttachment: (id, patch) => setAttachments((p) => p.map((a) => (a.id === id ? { ...a, ...patch } : a))),
+    removeAttachment: (id) => setAttachments((p) => p.filter((a) => a.id !== id)),
+    clearAttachments: () => setAttachments([]),
+    uploadFile,
+    uploadFolder,
+  })
+  return { attachments, setAttachments, queue }
+}
+
+function deferred<T>() {
+  let resolve!: (v: T) => void, reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+describe('useUploadQueue', () => {
+  it('uploads one at a time in enqueue order and marks done with the path', async () => {
+    const d1 = deferred<{ path: string }>(), d2 = deferred<{ path: string }>()
+    const uploadFile = vi.fn()
+      .mockImplementationOnce(({ onProgress }) => { onProgress?.({ phase: 'uploading', percent: 40 }); return d1.promise })
+      .mockReturnValueOnce(d2.promise)
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a'), fileAttachment('b')]))
+    act(() => { result.current.queue.enqueue(fileAttachment('a')); result.current.queue.enqueue(fileAttachment('b')) })
+    await act(async () => {})
+    expect(uploadFile).toHaveBeenCalledTimes(1)
+    expect(uploadOf(result.current.attachments[0])).toMatchObject({ status: 'uploading', percent: 40 })
+    expect(uploadOf(result.current.attachments[1])?.status).toBe('queued')
+    await act(async () => { d1.resolve({ path: '/a' }) })
+    expect(uploadOf(result.current.attachments[0])).toMatchObject({ status: 'done', path: '/a', agentSlug: 'agent-a' })
+    expect(uploadFile).toHaveBeenCalledTimes(2)
+    await act(async () => { d2.resolve({ path: '/b' }) })
+    expect(uploadOf(result.current.attachments[1])?.status).toBe('done')
+  })
+
+  it('a rejection sets error, clears upload, and the next chip still starts', async () => {
+    const uploadFile = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({ path: '/b' })
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a'), fileAttachment('b')]))
+    await act(async () => { result.current.queue.enqueue(fileAttachment('a')); result.current.queue.enqueue(fileAttachment('b')) })
+    expect(result.current.attachments[0]).toMatchObject({ error: 'boom', upload: undefined })
+    expect(uploadOf(result.current.attachments[1])?.status).toBe('done')
+  })
+
+  it('an AbortError after remove is ignored', async () => {
+    const d = deferred<{ path: string }>()
+    const uploadFile = vi.fn().mockImplementation(({ signal }) => { signal.addEventListener('abort', () => { const e = new Error('x'); e.name = 'AbortError'; d.reject(e) }); return d.promise })
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a')]))
+    await act(async () => { result.current.queue.enqueue(fileAttachment('a')) })
+    await act(async () => { result.current.queue.remove('a') })
+    expect(result.current.attachments).toEqual([])
+  })
+
+  it('retryAndWait re-uploads errored chips and includes a chip enqueued mid-wait', async () => {
+    const d2 = deferred<{ path: string }>()
+    const uploadFile = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))      // first attempt of a
+      .mockResolvedValueOnce({ path: '/a' })           // retry of a
+      .mockReturnValueOnce(d2.promise)                 // b, dropped mid-wait
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a')]))
+    await act(async () => { result.current.queue.enqueue(fileAttachment('a')) })
+    expect(result.current.attachments[0].error).toBe('boom')
+    let outcome: { ok: boolean } | undefined
+    await act(async () => {
+      const p = result.current.queue.retryAndWait().then((o) => { outcome = o })
+      result.current.setAttachments((prev) => [...prev, fileAttachment('b')])
+      await Promise.resolve()
+      result.current.queue.enqueue(fileAttachment('b'))
+      d2.resolve({ path: '/b' })
+      await p
+    })
+    expect(outcome).toEqual({ ok: true })
+    expect(result.current.attachments.map((a) => uploadOf(a)?.path)).toEqual(['/a', '/b'])
+  })
+
+  it('retryAndWait returns ok:false when a retry fails again', async () => {
+    const uploadFile = vi.fn().mockRejectedValue(new Error('boom'))
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a')]))
+    await act(async () => { result.current.queue.enqueue(fileAttachment('a')) })
+    let outcome: { ok: boolean } | undefined
+    await act(async () => { outcome = await result.current.queue.retryAndWait() })
+    expect(outcome).toEqual({ ok: false })
+    expect(result.current.attachments[0].error).toBe('boom')
+  })
+
+  it('clear aborts the in-flight upload', async () => {
+    const abort = vi.fn()
+    const uploadFile = vi.fn().mockImplementation(({ signal }) => { signal.addEventListener('abort', abort); return new Promise(() => {}) })
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a')]))
+    await act(async () => { result.current.queue.enqueue(fileAttachment('a')) })
+    act(() => { result.current.queue.clear() })
+    expect(abort).toHaveBeenCalled()
+    expect(result.current.attachments).toEqual([])
+  })
+
+  it('requeueAll aborts and re-enqueues every file/folder chip under the new agent', async () => {
+    const uploadFile = vi.fn().mockResolvedValue({ path: '/p' })
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a')]))
+    await act(async () => { result.current.queue.enqueue(fileAttachment('a')) })
+    expect(uploadOf(result.current.attachments[0])?.status).toBe('done')
+    await act(async () => { result.current.queue.requeueAll() })
+    expect(uploadFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('a job whose generation is stale leaves the new generation alone', async () => {
+    const d = deferred<{ path: string }>()
+    const uploadFile = vi.fn().mockReturnValueOnce(d.promise).mockResolvedValueOnce({ path: '/new' })
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a')]))
+    await act(async () => { result.current.queue.enqueue(fileAttachment('a')) })
+    await act(async () => { result.current.queue.requeueAll() }) // aborts the first, enqueues a second
+    await act(async () => { d.reject(new Error('late failure from the old job')) })
+    expect(uploadOf(result.current.attachments[0])).toMatchObject({ status: 'done', path: '/new' })
+    expect(result.current.attachments[0].error).toBeUndefined()
+  })
+
+  it('an Electron folder copies on the server and marks done without a percent', async () => {
+    const uploadFolder = vi.fn().mockResolvedValue({ path: '/workspace/docs' })
+    const uploadFile = vi.fn()
+    const folder = folderAttachment('docs', { folderPath: '/host/docs' })
+    const { result } = renderHook(() => useHarness(uploadFile, [folder], uploadFolder))
+    await act(async () => { result.current.queue.enqueue(folder) })
+    expect(uploadFolder).toHaveBeenCalledWith({ sourcePath: '/host/docs' })
+    expect(uploadFile).not.toHaveBeenCalled()
+    expect(uploadOf(result.current.attachments[0])).toMatchObject({ status: 'done', path: '/workspace/docs', agentSlug: 'agent-a' })
+    expect(uploadOf(result.current.attachments[0])?.percent).toBeUndefined()
+  })
+
+  it('a browser folder zips then uploads the archive', async () => {
+    const uploadFolder = vi.fn()
+    const uploadFile = vi.fn().mockResolvedValue({ path: '/workspace/docs.zip' })
+    const folder = folderAttachment('docs')
+    const { result } = renderHook(() => useHarness(uploadFile, [folder], uploadFolder))
+    await act(async () => { result.current.queue.enqueue(folder) })
+    expect(zipFolderFiles).toHaveBeenCalledWith(folder.files)
+    expect(uploadFolder).not.toHaveBeenCalled()
+    expect(uploadFile).toHaveBeenCalledWith(expect.objectContaining({
+      file: expect.objectContaining({ name: 'docs.zip', type: 'application/zip' }),
+    }))
+    expect(uploadOf(result.current.attachments[0])).toMatchObject({ status: 'done', path: '/workspace/docs.zip' })
+  })
+})

--- a/src/renderer/hooks/use-upload-queue.test.tsx
+++ b/src/renderer/hooks/use-upload-queue.test.tsx
@@ -36,12 +36,13 @@ function useHarness(
   uploadFile: UploadQueueOptions['uploadFile'],
   initial: Attachment[] = [],
   uploadFolder: UploadQueueOptions['uploadFolder'] = vi.fn(),
+  agentSlug = 'agent-a',
 ) {
   const [attachments, setAttachments] = useState<Attachment[]>(initial)
   const attachmentsRef = useRef(attachments)
   attachmentsRef.current = attachments
   const queue = useUploadQueue({
-    agentSlug: 'agent-a',
+    agentSlug,
     attachmentsRef,
     updateAttachment: (id, patch) => setAttachments((p) => p.map((a) => (a.id === id ? { ...a, ...patch } : a))),
     removeAttachment: (id) => setAttachments((p) => p.filter((a) => a.id !== id)),
@@ -72,6 +73,7 @@ describe('useUploadQueue', () => {
     expect(uploadOf(result.current.attachments[1])?.status).toBe('queued')
     await act(async () => { d1.resolve({ path: '/a' }) })
     expect(uploadOf(result.current.attachments[0])).toMatchObject({ status: 'done', path: '/a', agentSlug: 'agent-a' })
+    expect(result.current.queue.pathFor('a')).toEqual({ path: '/a', agentSlug: 'agent-a' })
     expect(uploadFile).toHaveBeenCalledTimes(2)
     await act(async () => { d2.resolve({ path: '/b' }) })
     expect(uploadOf(result.current.attachments[1])?.status).toBe('done')
@@ -82,6 +84,7 @@ describe('useUploadQueue', () => {
     const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a'), fileAttachment('b')]))
     await act(async () => { result.current.queue.enqueue(fileAttachment('a')); result.current.queue.enqueue(fileAttachment('b')) })
     expect(result.current.attachments[0]).toMatchObject({ error: 'boom', upload: undefined })
+    expect(result.current.queue.pathFor('a')).toBeUndefined()
     expect(uploadOf(result.current.attachments[1])?.status).toBe('done')
   })
 
@@ -180,5 +183,13 @@ describe('useUploadQueue', () => {
       file: expect.objectContaining({ name: 'docs.zip', type: 'application/zip' }),
     }))
     expect(uploadOf(result.current.attachments[0])).toMatchObject({ status: 'done', path: '/workspace/docs.zip' })
+  })
+
+  it('does not start an upload when the agent slug is empty', async () => {
+    const uploadFile = vi.fn()
+    const { result } = renderHook(() => useHarness(uploadFile, [fileAttachment('a')], vi.fn(), ''))
+    await act(async () => { result.current.queue.enqueue(fileAttachment('a')) })
+    expect(uploadFile).not.toHaveBeenCalled()
+    expect(uploadOf(result.current.attachments[0])?.status).toBe('queued')
   })
 })

--- a/src/renderer/hooks/use-upload-queue.ts
+++ b/src/renderer/hooks/use-upload-queue.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { MutableRefObject } from 'react'
+import { captureRendererException } from '@renderer/lib/error-reporting'
+import { zipFolderFiles } from '@renderer/lib/file-utils'
+import { UPLOAD_STALL_MS, type UploadProgress } from '@renderer/lib/upload'
+import type { Attachment, FileAttachment, FolderAttachment } from '@renderer/components/messages/attachment-preview'
+import type { UploadPatch } from './use-attachments'
+
+type Uploadable = FileAttachment | FolderAttachment
+
+export interface UploadQueueOptions {
+  agentSlug: string
+  /** Rendered attachments; read only at user-driven moments (Send, agent change). */
+  attachmentsRef: MutableRefObject<Attachment[]>
+  updateAttachment: (id: string, patch: UploadPatch) => void
+  removeAttachment: (id: string) => void
+  clearAttachments: () => void
+  uploadFile: (args: { file: File; onProgress?: (p: UploadProgress) => void; signal?: AbortSignal; stallMs?: number }) => Promise<{ path: string }>
+  uploadFolder: (args: { sourcePath: string }) => Promise<{ path: string }>
+}
+
+function isUploadable(a: Attachment): a is Uploadable {
+  return a.type !== 'mount'
+}
+
+/**
+ * Sequential upload queue for composer attachments. Imperative and ref-owned:
+ * `enqueue` appends to a promise chain, so one upload runs at a time by
+ * construction and a StrictMode double effect cannot start a second request.
+ *
+ * The chip object travels with the job rather than being looked up, because
+ * the job can start (next microtask) before React has rendered the chip into
+ * state. Cancellation is a generation counter (clear / agent change) plus a
+ * per-id set (single remove), both checked when the job's turn comes.
+ */
+export function useUploadQueue(options: UploadQueueOptions) {
+  const optionsRef = useRef(options)
+  optionsRef.current = options
+  const chainRef = useRef<Promise<void>>(Promise.resolve())
+  const controllersRef = useRef(new Map<string, AbortController>())
+  const removedRef = useRef(new Set<string>())
+  // Synchronous mirror of which chips carry an error. React state lags a
+  // microtask behind the chain, so the waiter reads this, never the ref.
+  const failedRef = useRef(new Set<string>())
+  const generationRef = useRef(0)
+
+  const uploadOne = useCallback(async (attachment: Uploadable, generation: number) => {
+    const opts = optionsRef.current
+    const { id } = attachment
+    // A stale generation belongs to a cleared or re-targeted composer: leave
+    // every marker alone, a newer job for the same id may be behind us.
+    if (generation !== generationRef.current) return
+    if (removedRef.current.has(id)) {
+      removedRef.current.delete(id)
+      return
+    }
+    const live = () => generation === generationRef.current && !removedRef.current.has(id)
+    const controller = new AbortController()
+    controllersRef.current.set(id, controller)
+    const agentSlug = opts.agentSlug
+    const onProgress = (p: UploadProgress) => {
+      if (p.phase === 'uploading') opts.updateAttachment(id, { upload: { status: 'uploading', percent: p.percent, agentSlug } })
+    }
+    opts.updateAttachment(id, { upload: { status: 'uploading', agentSlug } })
+    try {
+      let result: { path: string }
+      if (attachment.type === 'folder' && attachment.folderPath) {
+        // Electron: server-side copy, no byte progress and no cancel
+        result = await opts.uploadFolder({ sourcePath: attachment.folderPath })
+      } else if (attachment.type === 'folder') {
+        // Web fallback: zip in the browser, then upload the archive
+        const zipBlob = await zipFolderFiles(attachment.files)
+        const zipFile = new File([zipBlob], `${attachment.folderName}.zip`, { type: 'application/zip' })
+        result = await opts.uploadFile({ file: zipFile, onProgress, signal: controller.signal, stallMs: UPLOAD_STALL_MS })
+      } else {
+        result = await opts.uploadFile({ file: attachment.file, onProgress, signal: controller.signal, stallMs: UPLOAD_STALL_MS })
+      }
+      if (!live()) return
+      opts.updateAttachment(id, { upload: { status: 'done', path: result.path, agentSlug } })
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') return
+      if (!live()) return
+      console.error('Failed to upload attachment:', error)
+      captureRendererException(error, { tags: { source: 'attachment-upload' }, extra: { agentSlug } })
+      failedRef.current.add(id)
+      opts.updateAttachment(id, { upload: undefined, error: error instanceof Error ? error.message : 'Upload failed. Please try again.' })
+    } finally {
+      controllersRef.current.delete(id)
+    }
+  }, [])
+
+  const enqueue = useCallback((attachment: Uploadable) => {
+    removedRef.current.delete(attachment.id)
+    failedRef.current.delete(attachment.id)
+    optionsRef.current.updateAttachment(attachment.id, { upload: { status: 'queued', agentSlug: optionsRef.current.agentSlug }, error: undefined })
+    const generation = generationRef.current
+    chainRef.current = chainRef.current.then(() => uploadOne(attachment, generation))
+  }, [uploadOne])
+
+  // Retry is user-driven, so the rendered list is current.
+  const retry = useCallback((id: string) => {
+    const a = optionsRef.current.attachmentsRef.current.find((x) => x.id === id)
+    if (a && isUploadable(a)) enqueue(a)
+  }, [enqueue])
+
+  // Waits until the chain is idle, re-uploading errored chips first. A chip
+  // enqueued during the wait extends the chain and is included.
+  const retryAndWait = useCallback(async (): Promise<{ ok: boolean }> => {
+    for (const a of optionsRef.current.attachmentsRef.current) {
+      if (isUploadable(a) && a.error) enqueue(a)
+    }
+    let tail: Promise<void>
+    do {
+      tail = chainRef.current
+      await tail
+    } while (tail !== chainRef.current)
+    return { ok: failedRef.current.size === 0 }
+  }, [enqueue])
+
+  const abortAll = useCallback(() => {
+    generationRef.current += 1
+    for (const c of controllersRef.current.values()) c.abort()
+    controllersRef.current.clear()
+    removedRef.current.clear()
+    failedRef.current.clear()
+  }, [])
+
+  const remove = useCallback((id: string) => {
+    removedRef.current.add(id)
+    failedRef.current.delete(id)
+    controllersRef.current.get(id)?.abort()
+    controllersRef.current.delete(id)
+    optionsRef.current.removeAttachment(id)
+  }, [])
+
+  const clear = useCallback(() => {
+    abortAll()
+    optionsRef.current.clearAttachments()
+  }, [abortAll])
+
+  // Agent changed under the composer (Quick Dispatch): every path belongs to
+  // the old workspace, so start everything over.
+  const requeueAll = useCallback(() => {
+    abortAll()
+    for (const a of optionsRef.current.attachmentsRef.current) {
+      if (isUploadable(a)) enqueue(a)
+    }
+  }, [abortAll, enqueue])
+
+  useEffect(() => abortAll, [abortAll])
+
+  return { enqueue, retry, retryAndWait, remove, clear, requeueAll }
+}

--- a/src/renderer/hooks/use-upload-queue.ts
+++ b/src/renderer/hooks/use-upload-queue.ts
@@ -42,6 +42,9 @@ export function useUploadQueue(options: UploadQueueOptions) {
   // Synchronous mirror of which chips carry an error. React state lags a
   // microtask behind the chain, so the waiter reads this, never the ref.
   const failedRef = useRef(new Set<string>())
+  // Same lag: Send reads finished paths here when the chip has not committed yet.
+  // Owner rides along so a stale chip cannot attach another agent's path.
+  const pathsRef = useRef(new Map<string, { path: string; agentSlug: string }>())
   const generationRef = useRef(0)
 
   const uploadOne = useCallback(async (attachment: Uploadable, generation: number) => {
@@ -76,6 +79,7 @@ export function useUploadQueue(options: UploadQueueOptions) {
         result = await opts.uploadFile({ file: attachment.file, onProgress, signal: controller.signal, stallMs: UPLOAD_STALL_MS })
       }
       if (!live()) return
+      pathsRef.current.set(id, { path: result.path, agentSlug })
       opts.updateAttachment(id, { upload: { status: 'done', path: result.path, agentSlug } })
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') return
@@ -83,6 +87,7 @@ export function useUploadQueue(options: UploadQueueOptions) {
       console.error('Failed to upload attachment:', error)
       captureRendererException(error, { tags: { source: 'attachment-upload' }, extra: { agentSlug } })
       failedRef.current.add(id)
+      pathsRef.current.delete(id)
       opts.updateAttachment(id, { upload: undefined, error: error instanceof Error ? error.message : 'Upload failed. Please try again.' })
     } finally {
       controllersRef.current.delete(id)
@@ -92,7 +97,12 @@ export function useUploadQueue(options: UploadQueueOptions) {
   const enqueue = useCallback((attachment: Uploadable) => {
     removedRef.current.delete(attachment.id)
     failedRef.current.delete(attachment.id)
-    optionsRef.current.updateAttachment(attachment.id, { upload: { status: 'queued', agentSlug: optionsRef.current.agentSlug }, error: undefined })
+    pathsRef.current.delete(attachment.id)
+    const slug = optionsRef.current.agentSlug
+    optionsRef.current.updateAttachment(attachment.id, { upload: { status: 'queued', agentSlug: slug }, error: undefined })
+    // No agent yet (Quick Dispatch before the list loads): keep the chip waiting.
+    // requeueAll runs when the slug arrives.
+    if (!slug) return
     const generation = generationRef.current
     chainRef.current = chainRef.current.then(() => uploadOne(attachment, generation))
   }, [uploadOne])
@@ -123,11 +133,15 @@ export function useUploadQueue(options: UploadQueueOptions) {
     controllersRef.current.clear()
     removedRef.current.clear()
     failedRef.current.clear()
+    pathsRef.current.clear()
   }, [])
+
+  const pathFor = useCallback((id: string) => pathsRef.current.get(id), [])
 
   const remove = useCallback((id: string) => {
     removedRef.current.add(id)
     failedRef.current.delete(id)
+    pathsRef.current.delete(id)
     controllersRef.current.get(id)?.abort()
     controllersRef.current.delete(id)
     optionsRef.current.removeAttachment(id)
@@ -149,5 +163,5 @@ export function useUploadQueue(options: UploadQueueOptions) {
 
   useEffect(() => abortAll, [abortAll])
 
-  return { enqueue, retry, retryAndWait, remove, clear, requeueAll }
+  return { enqueue, retry, retryAndWait, pathFor, remove, clear, requeueAll }
 }

--- a/src/renderer/lib/api-origin.characterization.test.ts
+++ b/src/renderer/lib/api-origin.characterization.test.ts
@@ -133,6 +133,8 @@ const DIRECT_BASE_URL_CONSUMERS: Record<string, string> = {
     '<img src> — file:///workspace Markdown images resolved to the authenticated workspace file route',
   'lib/parse-tool-result.ts':
     '<img src> — media-ref images in tool results, resolved to a URL here so every result renderer gets one without threading the session identity down to it',
+  'lib/upload.ts':
+    'XHR upload transport — fetch cannot report request-body progress, so sendUploadRequest prefixes getApiBaseUrl() the way apiFetch does',
   'components/ui/model-icon.tsx': '<img src> — model icon asset',
   'components/home/dashboard-card.tsx': '<img src> — dashboard screenshot',
   'components/dashboards/dashboard-view.tsx': '<iframe src> — embedded dashboard',

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -15,43 +15,44 @@ export async function apiFetch(
 ): Promise<Response> {
   const baseUrl = getApiBaseUrl()
   const response = await fetch(`${baseUrl}${path}`, init)
-
-  // A 401 means three different things depending on what we're talking to, so
-  // the handling is three-way (skip auth endpoints throughout, to avoid loops):
-  //
-  //   local API   — auth is off; nothing to do.
-  //   web auth    — the session expired: stash the route and sign out, below.
-  //   cloud       — do NOT sign out. There is no password to re-enter, and
-  //                 better-auth's signOut() would try to revoke the *deployment*
-  //                 session that the desktop's grant is bound to. The proxy has
-  //                 already tried to re-mint and retried once (see
-  //                 cloud-proxy.ts), so a 401 arriving here means that failed —
-  //                 the workspace needs reconnecting, which AuthGate surfaces
-  //                 when the session reads null.
-  //
-  // Only on 401 (expired) — never 403 (forbidden), and never while a deliberate
-  // sign-out is in effect: revoking the session 401s every trailing background
-  // request, and without the gate those would re-stash the signed-out user's
-  // URL right after clearRedirectStash() dropped it (shared-tab leak).
-  if (response.status === 401 && !path.startsWith('/api/auth/') && isAuthMode()) {
-    if (hasInteractiveLogin()) {
-      if (!deliberateSignOut) {
-        // Interactive login is web-only, so pathname+search is the route; the
-        // hash is included for completeness.
-        const here = window.location.pathname + window.location.search + window.location.hash
-        if (here !== '/') sessionStorage.setItem(REDIRECT_KEY, here)
-        const { signOut } = await import('./auth-client')
-        await signOut().catch(() => {}) // session may already be gone
-      }
-    } else {
-      // Cloud. Returning the 401 is not enough on its own: the session store
-      // holds its last good value, so the UI would keep claiming to be signed in
-      // while every query failed behind it. Ask for a session re-check instead.
-      reportCloudSessionRejected()
-    }
-  }
-
+  await handleUnauthorizedResponse(response.status, path)
   return response
+}
+
+// A 401 means three different things depending on what we're talking to, so
+// the handling is three-way (skip auth endpoints throughout, to avoid loops):
+//
+//   local API   — auth is off; nothing to do.
+//   web auth    — the session expired: stash the route and sign out, below.
+//   cloud       — do NOT sign out. There is no password to re-enter, and
+//                 better-auth's signOut() would try to revoke the *deployment*
+//                 session that the desktop's grant is bound to. The proxy has
+//                 already tried to re-mint and retried once (see
+//                 cloud-proxy.ts), so a 401 arriving here means that failed —
+//                 the workspace needs reconnecting, which AuthGate surfaces
+//                 when the session reads null.
+//
+// Only on 401 (expired) — never 403 (forbidden), and never while a deliberate
+// sign-out is in effect: revoking the session 401s every trailing background
+// request, and without the gate those would re-stash the signed-out user's
+// URL right after clearRedirectStash() dropped it (shared-tab leak).
+export async function handleUnauthorizedResponse(status: number, path: string): Promise<void> {
+  if (status !== 401 || path.startsWith('/api/auth/') || !isAuthMode()) return
+  if (hasInteractiveLogin()) {
+    if (!deliberateSignOut) {
+      // Interactive login is web-only, so pathname+search is the route; the
+      // hash is included for completeness.
+      const here = window.location.pathname + window.location.search + window.location.hash
+      if (here !== '/') sessionStorage.setItem(REDIRECT_KEY, here)
+      const { signOut } = await import('./auth-client')
+      await signOut().catch(() => {}) // session may already be gone
+    }
+  } else {
+    // Cloud. Returning the 401 is not enough on its own: the session store
+    // holds its last good value, so the UI would keep claiming to be signed in
+    // while every query failed behind it. Ask for a session re-check instead.
+    reportCloudSessionRejected()
+  }
 }
 
 const REDIRECT_KEY = 'superagent.redirect'

--- a/src/renderer/lib/upload.test.ts
+++ b/src/renderer/lib/upload.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('./env', () => ({ getApiBaseUrl: () => '' }))
+vi.mock('./api', () => ({ handleUnauthorizedResponse: vi.fn().mockResolvedValue(undefined) }))
+
+import { handleUnauthorizedResponse } from './api'
+import { uploadFileChunked, UploadStalledError, UPLOAD_CHUNK_SIZE, UPLOAD_STALL_MS } from './upload'
+
+// Minimal XHR double: records sends, lets a test drive progress/load/error/abort.
+class FakeXHR {
+  static instances: FakeXHR[] = []
+  upload = { onprogress: null as null | ((e: { lengthComputable: boolean; loaded: number; total: number }) => void) }
+  onload: null | (() => void) = null
+  onerror: null | (() => void) = null
+  onabort: null | (() => void) = null
+  status = 0
+  responseText = ''
+  withCredentials = false
+  aborted = false
+  body: FormData | null = null
+  open = vi.fn()
+  setRequestHeader = vi.fn()
+  send(body: FormData) { this.body = body; FakeXHR.instances.push(this) }
+  abort() { this.aborted = true; this.onabort?.() }
+  // helpers
+  progress(loaded: number, total: number) { this.upload.onprogress?.({ lengthComputable: true, loaded, total }) }
+  respond(status: number, json: unknown) { this.status = status; this.responseText = JSON.stringify(json); this.onload?.() }
+}
+
+function file(size: number, name = 'f.bin'): File {
+  return new File([new Uint8Array(size)], name)
+}
+
+beforeEach(() => {
+  FakeXHR.instances = []
+  vi.stubGlobal('XMLHttpRequest', FakeXHR)
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('uploadFileChunked (XHR transport)', () => {
+  it('sends one request for a small file and resolves the JSON body', async () => {
+    const p = uploadFileChunked<{ path: string }>({ url: '/api/x', file: file(10), fields: { relativePath: 'a/b' } })
+    const xhr = FakeXHR.instances[0]
+    expect(xhr.open).toHaveBeenCalledWith('POST', '/api/x')
+    expect(xhr.setRequestHeader).not.toHaveBeenCalled()
+    expect(xhr.withCredentials).toBe(false)
+    expect(xhr.body?.get('relativePath')).toBe('a/b')
+    xhr.respond(200, { path: '/workspace/uploads/f.bin' })
+    await expect(p).resolves.toEqual({ path: '/workspace/uploads/f.bin' })
+  })
+
+  it('maps progress onto the file size, ignoring multipart framing', async () => {
+    const onProgress = vi.fn()
+    const p = uploadFileChunked({ url: '/api/x', file: file(1000), onProgress })
+    const xhr = FakeXHR.instances[0]
+    xhr.progress(600, 1200) // half the framed body
+    expect(onProgress).toHaveBeenLastCalledWith({ phase: 'uploading', percent: 50 })
+    xhr.progress(1200, 1200)
+    expect(onProgress).toHaveBeenLastCalledWith({ phase: 'uploading', percent: 100 })
+    xhr.respond(200, {})
+    await p
+    expect(onProgress).toHaveBeenLastCalledWith({ phase: 'processing', percent: 100 })
+  })
+
+  it('aggregates progress across chunks', async () => {
+    const onProgress = vi.fn()
+    const p = uploadFileChunked({ url: '/api/x', file: file(UPLOAD_CHUNK_SIZE * 2), onProgress })
+    FakeXHR.instances[0].progress(1, 2) // half of chunk 0 = 25% overall
+    expect(onProgress).toHaveBeenLastCalledWith({ phase: 'uploading', percent: 25 })
+    FakeXHR.instances[0].respond(200, { status: 'chunk_received' })
+    await vi.advanceTimersByTimeAsync(0)
+    FakeXHR.instances[1].progress(1, 2) // half of chunk 1 = 75% overall
+    expect(onProgress).toHaveBeenLastCalledWith({ phase: 'uploading', percent: 75 })
+    FakeXHR.instances[1].respond(200, { path: '/p' })
+    await expect(p).resolves.toEqual({ path: '/p' })
+  })
+
+  it('rejects with UploadStalledError after stallMs without progress and aborts the XHR', async () => {
+    const p = uploadFileChunked({ url: '/api/x', file: file(10), stallMs: UPLOAD_STALL_MS })
+    const xhr = FakeXHR.instances[0]
+    xhr.progress(1, 10)
+    await vi.advanceTimersByTimeAsync(UPLOAD_STALL_MS - 1)
+    xhr.progress(2, 10) // resets
+    await vi.advanceTimersByTimeAsync(UPLOAD_STALL_MS - 1)
+    expect(xhr.aborted).toBe(false)
+    const rejected = expect(p).rejects.toBeInstanceOf(UploadStalledError) // attach before the timer fires
+    await vi.advanceTimersByTimeAsync(1)
+    expect(xhr.aborted).toBe(true)
+    await rejected
+  })
+
+  it('never stalls when stallMs is 0', async () => {
+    const p = uploadFileChunked({ url: '/api/x', file: file(10) })
+    await vi.advanceTimersByTimeAsync(UPLOAD_STALL_MS * 10)
+    expect(FakeXHR.instances[0].aborted).toBe(false)
+    FakeXHR.instances[0].respond(200, {})
+    await expect(p).resolves.toEqual({})
+  })
+
+  it('rejects with AbortError when the caller signal aborts', async () => {
+    const ac = new AbortController()
+    const p = uploadFileChunked({ url: '/api/x', file: file(10), signal: ac.signal })
+    ac.abort()
+    await expect(p).rejects.toMatchObject({ name: 'AbortError' })
+    expect(FakeXHR.instances[0].aborted).toBe(true)
+  })
+
+  it('surfaces the backend error message on a non-2xx response', async () => {
+    const p = uploadFileChunked({ url: '/api/x', file: file(10) })
+    FakeXHR.instances[0].respond(413, { error: 'too big' })
+    await expect(p).rejects.toThrow('too big')
+  })
+
+  it('uses the fallback message on a network error', async () => {
+    const p = uploadFileChunked({ url: '/api/x', file: file(10) })
+    FakeXHR.instances[0].onerror?.()
+    await expect(p).rejects.toThrow('Upload failed. Please try again.')
+  })
+
+  it('calls handleUnauthorizedResponse on a 401', async () => {
+    const p = uploadFileChunked({ url: '/api/x', file: file(10) })
+    FakeXHR.instances[0].respond(401, { error: 'expired' })
+    await expect(p).rejects.toThrow('expired')
+    expect(handleUnauthorizedResponse).toHaveBeenCalledWith(401, '/api/x')
+  })
+})

--- a/src/renderer/lib/upload.ts
+++ b/src/renderer/lib/upload.ts
@@ -1,18 +1,128 @@
-import { apiFetch } from '@renderer/lib/api'
+import { getApiBaseUrl } from '@renderer/lib/env'
+import { handleUnauthorizedResponse } from '@renderer/lib/api'
 
 // 50MB — keeps each request under Cloudflare's 100MB request-body limit so
 // large files don't 413 at the edge before reaching the API.
 export const UPLOAD_CHUNK_SIZE = 50 * 1024 * 1024
 
+// Between-progress-events stall bound (Uppy's XHRUpload default). Only the
+// composer passes it; other callers leave the timer off because their server
+// side does unbounded work after the last byte (template import).
+export const UPLOAD_STALL_MS = 30_000
+
 export type UploadProgress = { phase: 'uploading' | 'processing'; percent: number }
 
-async function readError(res: Response, fallback: string): Promise<string> {
+export class UploadStalledError extends Error {
+  constructor(stallMs: number) {
+    super(`Upload stalled for ${Math.round(stallMs / 1000)} seconds. Check your connection and retry.`)
+    this.name = 'UploadStalledError'
+  }
+}
+
+function abortError(): Error {
+  const err = new Error('Upload aborted')
+  err.name = 'AbortError'
+  return err
+}
+
+interface UploadResponse {
+  ok: boolean
+  status: number
+  json(): unknown
+}
+
+interface SendOptions {
+  /** Fraction of the request body sent, 0..1. Multipart framing is included in the ratio. */
+  onSent?: (fraction: number) => void
+  signal?: AbortSignal
+  stallMs: number
+}
+
+// XHR rather than fetch: fetch cannot report request-body progress, and
+// upload.onprogress is the only browser API that does. Credentials stay
+// same-origin (withCredentials=false) to match fetch's default; the browser
+// writes the multipart Content-Type itself.
+function sendUploadRequest(url: string, formData: FormData, { onSent, signal, stallMs }: SendOptions): Promise<UploadResponse> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    // Recorded before abort(): onabort fires synchronously inside it, and the
+    // reason decides whether the caller ignores the rejection (user removed
+    // the chip) or surfaces it (we gave up on a stall).
+    let terminal: Error | null = null
+    let stallTimer: ReturnType<typeof setTimeout> | undefined
+
+    const armStall = () => {
+      if (!stallMs) return
+      if (stallTimer) clearTimeout(stallTimer)
+      stallTimer = setTimeout(() => {
+        terminal = new UploadStalledError(stallMs)
+        xhr.abort()
+      }, stallMs)
+    }
+    const settle = () => {
+      if (stallTimer) clearTimeout(stallTimer)
+      signal?.removeEventListener('abort', onSignalAbort)
+    }
+    const onSignalAbort = () => {
+      terminal = abortError()
+      xhr.abort()
+    }
+
+    xhr.open('POST', `${getApiBaseUrl()}${url}`)
+    xhr.withCredentials = false
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable && e.total > 0) onSent?.(Math.min(1, e.loaded / e.total))
+      armStall()
+    }
+    xhr.onload = () => {
+      settle()
+      resolve({
+        ok: xhr.status >= 200 && xhr.status < 300,
+        status: xhr.status,
+        json: () => parseJson(xhr.responseText),
+      })
+    }
+    xhr.onerror = () => {
+      settle()
+      reject(new Error('Upload failed. Please try again.'))
+    }
+    xhr.onabort = () => {
+      settle()
+      reject(terminal ?? abortError())
+    }
+
+    if (signal?.aborted) {
+      reject(abortError())
+      return
+    }
+    signal?.addEventListener('abort', onSignalAbort)
+    armStall()
+    xhr.send(formData)
+  })
+}
+
+// Named so a malformed body rejects at the caller's await rather than tripping
+// the no-unhandled-throwing-builtins rule at the call site.
+function parseJson(text: string): unknown {
   try {
-    const data = await res.json()
+    return JSON.parse(text)
+  } catch (err) {
+    throw new Error(`Upload response was not JSON: ${(err as Error).message}`)
+  }
+}
+
+function readError(res: UploadResponse, fallback: string): string {
+  try {
+    const data = res.json() as { error?: unknown }
     return (data && typeof data.error === 'string' && data.error) || fallback
   } catch {
     return fallback
   }
+}
+
+async function checkResponse(res: UploadResponse, url: string): Promise<void> {
+  await handleUnauthorizedResponse(res.status, url)
+  if (!res.ok) throw new Error(readError(res, 'Upload failed. Please try again.'))
 }
 
 interface UploadOptions {
@@ -22,6 +132,10 @@ interface UploadOptions {
   /** Extra multipart fields sent with every request (e.g. `mode`, `relativePath`). */
   fields?: Record<string, string>
   onProgress?: (p: UploadProgress) => void
+  /** Aborts the in-flight request; the returned promise rejects with an AbortError. */
+  signal?: AbortSignal
+  /** Give up after this many ms without an upload-progress event. 0 (default) disables. */
+  stallMs?: number
 }
 
 /**
@@ -31,44 +145,42 @@ interface UploadOptions {
  * (from the single/final request) is returned. On failure the backend's error
  * message is surfaced so callers can show it to the user.
  */
-export async function uploadFileChunked<T>({ url, file, fields = {}, onProgress }: UploadOptions): Promise<T> {
-  if (file.size <= UPLOAD_CHUNK_SIZE) {
-    const formData = new FormData()
-    formData.append('file', file)
-    for (const [k, v] of Object.entries(fields)) formData.append(k, v)
-
-    onProgress?.({ phase: 'uploading', percent: 100 })
-    const res = await apiFetch(url, { method: 'POST', body: formData })
-    if (!res.ok) throw new Error(await readError(res, 'Upload failed. Please try again.'))
-    onProgress?.({ phase: 'processing', percent: 100 })
-    return res.json() as Promise<T>
-  }
-
-  const uploadId = crypto.randomUUID()
-  const totalChunks = Math.ceil(file.size / UPLOAD_CHUNK_SIZE)
+export async function uploadFileChunked<T>({ url, file, fields = {}, onProgress, signal, stallMs = 0 }: UploadOptions): Promise<T> {
+  const totalChunks = file.size <= UPLOAD_CHUNK_SIZE ? 1 : Math.ceil(file.size / UPLOAD_CHUNK_SIZE)
+  const uploadId = totalChunks > 1 ? crypto.randomUUID() : null
 
   for (let i = 0; i < totalChunks; i++) {
     const start = i * UPLOAD_CHUNK_SIZE
     const end = Math.min(start + UPLOAD_CHUNK_SIZE, file.size)
-    const chunkBlob = file.slice(start, end)
 
     const formData = new FormData()
-    formData.append('chunk', chunkBlob)
-    formData.append('uploadId', uploadId)
-    formData.append('chunkIndex', String(i))
-    formData.append('totalChunks', String(totalChunks))
-    formData.append('filename', file.name)
+    if (uploadId === null) {
+      formData.append('file', file)
+    } else {
+      formData.append('chunk', file.slice(start, end))
+      formData.append('uploadId', uploadId)
+      formData.append('chunkIndex', String(i))
+      formData.append('totalChunks', String(totalChunks))
+      formData.append('filename', file.name)
+    }
     for (const [k, v] of Object.entries(fields)) formData.append(k, v)
 
-    onProgress?.({ phase: 'uploading', percent: (i / totalChunks) * 100 })
+    // Framing overhead is in the XHR ratio, so map it onto this chunk's byte
+    // span; a tiny file would otherwise report >100% of itself.
+    const span = end - start
+    const res = await sendUploadRequest(url, formData, {
+      signal,
+      stallMs,
+      onSent: (fraction) => {
+        const sent = start + fraction * span
+        onProgress?.({ phase: 'uploading', percent: file.size > 0 ? Math.min(100, (sent / file.size) * 100) : 100 })
+      },
+    })
+    await checkResponse(res, url)
 
-    const res = await apiFetch(url, { method: 'POST', body: formData })
-    if (!res.ok) throw new Error(await readError(res, 'Upload failed. Please try again.'))
-
-    // The final chunk returns the assembled result.
     if (i === totalChunks - 1) {
       onProgress?.({ phase: 'processing', percent: 100 })
-      return res.json() as Promise<T>
+      return res.json() as T
     }
   }
 


### PR DESCRIPTION
Attachments now upload the moment they land in the composer, one at a time, with each chip showing waiting, progress, done, or a retryable error. Send waits for the queue and retries failures. A 30-second stall fails that chip instead of hanging Send forever, which is why uploads go through XHR.

Closes https://linear.app/datawizz/issue/SUP-653

13 production files. Tests are extra.

```
drop / paste / pick
  → chip shows waiting
  → one upload at a time
  → bar (files) or spinner (folder copy / zip)
  → check, or error with the reason on hover
  └─ retry on the chip, or Send re-uploads failed chips then sends
```

Waiting is text, not a spinner. Nothing is happening to that chip yet.
The error reason is the same hover the chip already uses for the filename.
Mounts still attach at Send.
The agent still gets `[Attached files:]` plus workspace paths.
Create Agent no longer offers a paperclip. There is no workspace yet.

This does not change the 50MB chunk threshold.
It does not delete orphans when a chip is removed.
It does not touch the file-request card.
