### PR TITLE
refactor: extract shared pieces for the wizard template roster

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,6 +9,16 @@
         "export SUPERAGENT_DATA_DIR=\"${TMPDIR:-/tmp}/superagent-mock-web-data\" E2E_MOCK=true PORT=47899 VITE_CACHE_DIR=\"${TMPDIR:-/tmp}/superagent-mock-web-vite\"; node e2e/setup-e2e-data.js && npm run dev:web"
       ],
       "port": 47899
+    },
+    {
+      "name": "web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
+      "port": 47891,
+      "autoPort": true
     }
   ]
 }

--- a/src/renderer/components/agents/agent-creation-aids.tsx
+++ b/src/renderer/components/agents/agent-creation-aids.tsx
@@ -1,22 +1,19 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import { AudioLines, Upload, ArrowDownToLine, FileArchive, Loader2, Shapes } from 'lucide-react'
+import { AudioLines, ArrowDownToLine, Shapes } from 'lucide-react'
 import { toast } from 'sonner'
-import { Button } from '@renderer/components/ui/button'
 import { OptionCard } from '@renderer/components/ui/option-card'
-import { Checkbox } from '@renderer/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@renderer/components/ui/dialog'
 import { VoiceAgent } from '@renderer/components/ui/voice-agent'
 import { apiFetch } from '@renderer/lib/api'
-import { useImportAgentTemplate, useDiscoverableAgents, type ImportProgress } from '@renderer/hooks/use-agent-templates'
-import { AGENT_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
+import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
+import { ImportAgentDialog } from '@renderer/components/agents/import-agent-dialog'
 import { useIsVoiceAgentConfigured } from '@renderer/hooks/use-voice-input'
 import { captureRendererException } from '@renderer/lib/error-reporting'
 import type { VoiceAgentConfig } from '@renderer/lib/voice-agent'
@@ -131,72 +128,8 @@ export function AgentCreationAids({
     setVoiceAgentConfig(null)
   }, [])
 
-  // --- Import flow ---
+  // --- Import flow (dialog extracted to ImportAgentDialog) ---
   const [showImportDialog, setShowImportDialog] = useState(false)
-  const [importFile, setImportFile] = useState<File | null>(null)
-  const [importFull, setImportFull] = useState(false)
-  const [uploadProgress, setUploadProgress] = useState<ImportProgress | null>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const importTemplate = useImportAgentTemplate()
-
-  const acceptFile = useCallback((file: File | null | undefined) => {
-    if (!file) return
-    const name = file.name.toLowerCase()
-    if (!name.endsWith(AGENT_PACKAGE_EXTENSION) && !name.endsWith('.zip')) {
-      toast.error(`Only ${AGENT_PACKAGE_EXTENSION} or .zip template files are supported`)
-      return
-    }
-    setImportFile(file)
-  }, [])
-
-  const resetImport = useCallback(() => {
-    setImportFile(null)
-    setImportFull(false)
-    setUploadProgress(null)
-    importTemplate.reset()
-  }, [importTemplate])
-
-  const closeImportDialog = useCallback(() => {
-    setShowImportDialog(false)
-    resetImport()
-  }, [resetImport])
-
-  const finishImport = useCallback(
-    async (agent: ApiAgentTemplateInstallResult) => {
-      await onImportComplete(agent)
-    },
-    [onImportComplete],
-  )
-
-  const handleImport = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault()
-      if (!importFile) return
-
-      try {
-        setUploadProgress({ phase: 'uploading', percent: 0 })
-        const result = await importTemplate.mutateAsync({
-          file: importFile,
-          mode: importFull ? 'full' : 'template',
-          onProgress: setUploadProgress,
-        })
-        setUploadProgress(null)
-
-        setShowImportDialog(false)
-        resetImport()
-        await finishImport(result)
-      } catch (error) {
-        setUploadProgress(null)
-        console.error('Failed to import template:', error)
-      }
-    },
-    [importFile, importFull, importTemplate, resetImport, finishImport],
-  )
-
-  const handleFileDrop = (e: React.DragEvent) => {
-    e.preventDefault()
-    acceptFile(e.dataTransfer.files[0])
-  }
 
   return (
     <div className={className}>
@@ -250,144 +183,11 @@ export function AgentCreationAids({
         </DialogContent>
       </Dialog>
 
-      <Dialog open={showImportDialog} onOpenChange={(open) => { if (!open) closeImportDialog() }}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="font-medium">Import an Agent</DialogTitle>
-            <DialogDescription className="sr-only">
-              Upload a .agent or .zip template to create a new agent.
-            </DialogDescription>
-          </DialogHeader>
-          <form onSubmit={handleImport}>
-            <div className="py-4 space-y-4">
-              <div
-                className={`border border-dashed rounded-lg p-6 text-center transition-colors bg-muted/50 ${
-                  importTemplate.isPending
-                    ? 'opacity-50 pointer-events-none'
-                    : 'cursor-pointer'
-                }`}
-                role="button"
-                tabIndex={0}
-                onClick={() => !importTemplate.isPending && fileInputRef.current?.click()}
-                onKeyDown={(e) => {
-                  if ((e.key === 'Enter' || e.key === ' ') && !importTemplate.isPending) {
-                    e.preventDefault()
-                    fileInputRef.current?.click()
-                  }
-                }}
-                onDragOver={(e) => e.preventDefault()}
-                onDrop={importTemplate.isPending ? undefined : handleFileDrop}
-              >
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept={`${AGENT_PACKAGE_EXTENSION},.zip`}
-                  className="hidden"
-                  disabled={importTemplate.isPending}
-                  onChange={(e) => {
-                    acceptFile(e.target.files?.[0])
-                    e.target.value = ''
-                  }}
-                />
-                {importFile ? (
-                  <div className="flex items-center justify-center gap-2">
-                    <FileArchive className="h-5 w-5 text-primary" />
-                    <span className="text-sm font-medium">{importFile.name}</span>
-                    {!importTemplate.isPending && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 text-xs"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setImportFile(null)
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    )}
-                  </div>
-                ) : (
-                  <>
-                    <Upload className="h-5 w-5 mx-auto text-muted-foreground mb-2" />
-                    <p className="text-sm text-muted-foreground">
-                      Drop a .agent or .zip template file here<br />
-                      or click to browse
-                    </p>
-                  </>
-                )}
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="creation-aids-import-full"
-                  checked={importFull}
-                  onCheckedChange={(checked) => setImportFull(checked === true)}
-                  disabled={importTemplate.isPending}
-                />
-                <label
-                  htmlFor="creation-aids-import-full"
-                  className="text-sm text-muted-foreground cursor-pointer select-none"
-                >
-                  Import includes env. variables and session data
-                </label>
-              </div>
-
-              {uploadProgress && (
-                <div className="space-y-1">
-                  <div className="flex justify-between text-xs text-muted-foreground">
-                    <span className="flex items-center gap-1.5">
-                      {uploadProgress.phase === 'processing' && (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      )}
-                      {uploadProgress.phase === 'uploading' ? 'Uploading...' : 'Processing...'}
-                    </span>
-                    {uploadProgress.phase === 'uploading' && (
-                      <span>{Math.round(uploadProgress.percent)}%</span>
-                    )}
-                  </div>
-                  <div className="h-2 rounded-full bg-muted overflow-hidden">
-                    <div
-                      className="h-full bg-primary rounded-full transition-all duration-300"
-                      style={{
-                        width: uploadProgress.phase === 'processing'
-                          ? '100%'
-                          : `${uploadProgress.percent}%`,
-                      }}
-                    />
-                  </div>
-                </div>
-              )}
-
-              {importTemplate.error && (
-                <p className="text-sm text-destructive">{importTemplate.error.message}</p>
-              )}
-            </div>
-
-            <DialogFooter className="mt-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={closeImportDialog}
-                disabled={importTemplate.isPending}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={!importFile || importTemplate.isPending}>
-                {importTemplate.isPending ? (
-                  <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    {uploadProgress?.phase === 'uploading' ? 'Uploading...' : 'Processing...'}
-                  </>
-                ) : (
-                  'Import'
-                )}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
+      <ImportAgentDialog
+        open={showImportDialog}
+        onClose={() => setShowImportDialog(false)}
+        onComplete={onImportComplete}
+      />
 
     </div>
   )

--- a/src/renderer/components/agents/import-agent-dialog.tsx
+++ b/src/renderer/components/agents/import-agent-dialog.tsx
@@ -1,0 +1,231 @@
+import { useCallback, useRef, useState } from 'react'
+import { Upload, FileArchive, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@renderer/components/ui/button'
+import { Checkbox } from '@renderer/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/components/ui/dialog'
+import { useImportAgentTemplate, type ImportProgress } from '@renderer/hooks/use-agent-templates'
+import { AGENT_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
+import type { ApiAgentTemplateInstallResult } from '@shared/lib/types/api'
+
+/**
+ * The "Import an Agent" upload dialog, extracted from AgentCreationAids so
+ * surfaces without the aid chips (the wizard's template strip) can open it
+ * too. Controlled: the caller owns `open`; file/progress state lives here and
+ * resets whenever the dialog closes.
+ */
+export function ImportAgentDialog({
+  open,
+  onClose,
+  onComplete,
+}: {
+  open: boolean
+  onClose: () => void
+  /** Called after a successful import (post-env-var prompt if any). */
+  onComplete: (result: ApiAgentTemplateInstallResult) => void | Promise<void>
+}) {
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const [importFull, setImportFull] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState<ImportProgress | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const importTemplate = useImportAgentTemplate()
+
+  const acceptFile = useCallback((file: File | null | undefined) => {
+    if (!file) return
+    const name = file.name.toLowerCase()
+    if (!name.endsWith(AGENT_PACKAGE_EXTENSION) && !name.endsWith('.zip')) {
+      toast.error(`Only ${AGENT_PACKAGE_EXTENSION} or .zip template files are supported`)
+      return
+    }
+    setImportFile(file)
+  }, [])
+
+  const resetImport = useCallback(() => {
+    setImportFile(null)
+    setImportFull(false)
+    setUploadProgress(null)
+    importTemplate.reset()
+  }, [importTemplate])
+
+  const closeDialog = useCallback(() => {
+    onClose()
+    resetImport()
+  }, [onClose, resetImport])
+
+  const handleImport = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!importFile) return
+
+      try {
+        setUploadProgress({ phase: 'uploading', percent: 0 })
+        const result = await importTemplate.mutateAsync({
+          file: importFile,
+          mode: importFull ? 'full' : 'template',
+          onProgress: setUploadProgress,
+        })
+        setUploadProgress(null)
+
+        closeDialog()
+        await onComplete(result)
+      } catch (error) {
+        setUploadProgress(null)
+        console.error('Failed to import template:', error)
+      }
+    },
+    [importFile, importFull, importTemplate, closeDialog, onComplete],
+  )
+
+  const handleFileDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    acceptFile(e.dataTransfer.files[0])
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) closeDialog() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="font-medium">Import an Agent</DialogTitle>
+          <DialogDescription className="sr-only">
+            Upload a .agent or .zip template to create a new agent.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleImport}>
+          <div className="py-4 space-y-4">
+            <div
+              className={`border border-dashed rounded-lg p-6 text-center transition-colors bg-muted/50 ${
+                importTemplate.isPending
+                  ? 'opacity-50 pointer-events-none'
+                  : 'cursor-pointer'
+              }`}
+              role="button"
+              tabIndex={0}
+              onClick={() => !importTemplate.isPending && fileInputRef.current?.click()}
+              onKeyDown={(e) => {
+                if ((e.key === 'Enter' || e.key === ' ') && !importTemplate.isPending) {
+                  e.preventDefault()
+                  fileInputRef.current?.click()
+                }
+              }}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={importTemplate.isPending ? undefined : handleFileDrop}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={`${AGENT_PACKAGE_EXTENSION},.zip`}
+                className="hidden"
+                disabled={importTemplate.isPending}
+                onChange={(e) => {
+                  acceptFile(e.target.files?.[0])
+                  e.target.value = ''
+                }}
+              />
+              {importFile ? (
+                <div className="flex items-center justify-center gap-2">
+                  <FileArchive className="h-5 w-5 text-primary" />
+                  <span className="text-sm font-medium">{importFile.name}</span>
+                  {!importTemplate.isPending && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 text-xs"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setImportFile(null)
+                      }}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <Upload className="h-5 w-5 mx-auto text-muted-foreground mb-2" />
+                  <p className="text-sm text-muted-foreground">
+                    Drop a .agent or .zip template file here<br />
+                    or click to browse
+                  </p>
+                </>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="creation-aids-import-full"
+                checked={importFull}
+                onCheckedChange={(checked) => setImportFull(checked === true)}
+                disabled={importTemplate.isPending}
+              />
+              <label
+                htmlFor="creation-aids-import-full"
+                className="text-sm text-muted-foreground cursor-pointer select-none"
+              >
+                Import includes env. variables and session data
+              </label>
+            </div>
+
+            {uploadProgress && (
+              <div className="space-y-1">
+                <div className="flex justify-between text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1.5">
+                    {uploadProgress.phase === 'processing' && (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    )}
+                    {uploadProgress.phase === 'uploading' ? 'Uploading...' : 'Processing...'}
+                  </span>
+                  {uploadProgress.phase === 'uploading' && (
+                    <span>{Math.round(uploadProgress.percent)}%</span>
+                  )}
+                </div>
+                <div className="h-2 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className="h-full bg-primary rounded-full transition-all duration-300"
+                    style={{
+                      width: uploadProgress.phase === 'processing'
+                        ? '100%'
+                        : `${uploadProgress.percent}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+
+            {importTemplate.error && (
+              <p className="text-sm text-destructive">{importTemplate.error.message}</p>
+            )}
+          </div>
+
+          <DialogFooter className="mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeDialog}
+              disabled={importTemplate.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!importFile || importTemplate.isPending}>
+              {importTemplate.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  {uploadProgress?.phase === 'uploading' ? 'Uploading...' : 'Processing...'}
+                </>
+              ) : (
+                'Import'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/explore/explore-template-card.tsx
+++ b/src/renderer/components/explore/explore-template-card.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight, Plus } from 'lucide-react'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { connectionLabel, getTemplateAccent, getTemplateIcon } from './template-meta'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
@@ -106,7 +107,7 @@ export function ExploreTemplateCard({
       // longer curve spends its tail finishing a sub-pixel move that already
       // looks arrived — which reads as lag. Matches the renderer's dominant
       // duration and the see-more tile beside it.
-      className="flex h-[180px] w-full flex-col items-start gap-5 rounded-2xl border border-black/[0.06] bg-card p-4 text-left shadow-none transition-[box-shadow,transform] duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/[0.06] dark:hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)]"
+      className={`flex h-[180px] w-full flex-col items-start gap-5 rounded-2xl border border-black/[0.06] bg-card p-4 text-left shadow-none transition-[box-shadow,transform] duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/[0.06] dark:hover:shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)]`}
     >
       <span className="flex w-full items-center gap-2">
         {/* The glyph is debossed — it drops a 1px light highlight beneath its
@@ -133,6 +134,71 @@ export function ExploreTemplateCard({
       <span className="flex w-full items-center gap-2 overflow-hidden">
         <ToolStack template={template} />
       </span>
+    </button>
+  )
+}
+
+/** Templates named on the see-more tile before the "+ N more" line. */
+const SEE_MORE_NAMED_COUNT = 3
+
+/**
+ * The section's sixth grid slot: a few of the hidden templates by name over a
+ * call to action. Clicking anywhere opens that category's page.
+ *
+ * The call to action is unconditional — the tile is only ever a link, so one
+ * without it reads as a card that failed to render. Only the "+ N" count is
+ * conditional, since a section hiding no more than it names has no remainder
+ * to count (Featured, at eight templates, is exactly that case).
+ */
+export function SeeMoreCard({ rest, onClick }: { rest: ApiDiscoverableAgent[]; onClick: () => void }) {
+  const unnamed = rest.length - Math.min(rest.length, SEE_MORE_NAMED_COUNT)
+  return (
+    <button
+      type="button"
+      data-testid="explore-see-more"
+      onClick={onClick}
+      className="group flex h-[180px] w-full flex-col gap-3 rounded-2xl bg-muted/50 p-4 text-left transition-colors duration-200 hover:bg-muted"
+    >
+      <span className="flex min-w-0 flex-1 flex-col justify-center gap-2">
+        {rest.slice(0, SEE_MORE_NAMED_COUNT).map((template) => {
+          const Icon = getTemplateIcon(template)
+          return (
+            <span
+              key={`${template.skillsetId}/${template.path}`}
+              className="flex min-w-0 items-center gap-2"
+            >
+              <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
+                <Icon className={`size-4 ${getTemplateAccent(template.name)}`} aria-hidden />
+              </span>
+              <span className="truncate text-[13px] text-muted-foreground">{template.name}</span>
+            </span>
+          )
+        })}
+        {/* The glyph sits in the same column as the icons above, so the label
+            lines up with the names. */}
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
+            {unnamed > 0 ? (
+              <Plus className="size-4 text-muted-foreground/50" aria-hidden />
+            ) : (
+              <ArrowRight
+                className="size-4 text-muted-foreground/50 transition-transform duration-200 group-hover:translate-x-0.5"
+                aria-hidden
+              />
+            )}
+          </span>
+          <span className="flex min-w-0 items-center gap-1 truncate text-[13px] text-muted-foreground/70">
+            {unnamed > 0 ? `Show ${unnamed} more` : 'See all'}
+            {unnamed > 0 && (
+              <ArrowRight
+                className="size-3.5 shrink-0 transition-transform duration-200 group-hover:translate-x-0.5"
+                aria-hidden
+              />
+            )}
+          </span>
+        </span>
+      </span>
+
     </button>
   )
 }

--- a/src/renderer/components/explore/explore-templates.tsx
+++ b/src/renderer/components/explore/explore-templates.tsx
@@ -3,6 +3,7 @@ import { Button } from '@renderer/components/ui/button'
 import { useSkillsets } from '@renderer/hooks/use-skillsets'
 import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
 import { useDialogs } from '@renderer/context/dialog-context'
+import { FEATURED_SECTION_LABEL, isFeaturedTemplate, templateCategory } from './template-meta'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 /**
@@ -50,4 +51,56 @@ export function NoTemplatesEmptyState() {
       </Button>
     </div>
   )
+}
+
+/** Bucket for templates whose skillset predates the category field. */
+export const OTHER_CATEGORY = 'Other'
+
+export interface TemplateSection {
+  category: string
+  /** The first `previewCount` templates — what a section shows up front. */
+  shown: ApiDiscoverableAgent[]
+  /** Everything past the preview, for a "show more" affordance. */
+  rest: ApiDiscoverableAgent[]
+}
+
+/**
+ * The roster split into the sections every browse surface shows: Featured
+ * first, then the real categories most-populated first, each cut at
+ * `previewCount`.
+ *
+ * A flat grid of 160+ templates buries everything past the first screen, so
+ * both the Explore page and the wizard's create step group first — and they
+ * have to group *identically*, or the same template sits under different
+ * headings in two places. Shared here rather than duplicated for that reason.
+ * `previewCount` splits each section into the `shown` cards and the `rest`
+ * that waits behind a see-more affordance.
+ *
+ * First-party templates lead the page AND stay in their own category below:
+ * they're the best of that category, not a separate kind of thing.
+ */
+export function groupTemplatesByCategory(
+  templates: ApiDiscoverableAgent[],
+  previewCount: number,
+): TemplateSection[] {
+  const byCategory = new Map<string, ApiDiscoverableAgent[]>()
+  const featured: ApiDiscoverableAgent[] = []
+  for (const t of templates) {
+    if (isFeaturedTemplate(t)) featured.push(t)
+    const c = templateCategory(t) ?? OTHER_CATEGORY
+    const list = byCategory.get(c)
+    if (list) list.push(t)
+    else byCategory.set(c, [t])
+  }
+  const sections = [...byCategory.entries()]
+    .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
+    .map(([category, items]) => ({ category, items }))
+  if (featured.length > 0) {
+    sections.unshift({ category: FEATURED_SECTION_LABEL, items: featured })
+  }
+  return sections.map(({ category, items }) => ({
+    category,
+    shown: items.slice(0, previewCount),
+    rest: items.slice(previewCount),
+  }))
 }

--- a/src/renderer/components/explore/explore-view.tsx
+++ b/src/renderer/components/explore/explore-view.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from '@tanstack/react-router'
-import { ArrowRight, Check, Filter, Plus, Search, Settings2 } from 'lucide-react'
+import { Check, Filter, Search, Settings2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
@@ -8,31 +8,22 @@ import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { Skeleton } from '@renderer/components/ui/skeleton'
 import { PageTitle, SettingsPageContainer } from '@renderer/components/layout/settings-page'
 import { slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
-import { ExploreTemplateCard } from './explore-template-card'
-import { NoTemplatesEmptyState, useExploreTemplates } from './explore-templates'
+import { ExploreTemplateCard, SeeMoreCard } from './explore-template-card'
+import {
+  groupTemplatesByCategory,
+  NoTemplatesEmptyState,
+  useExploreTemplates,
+} from './explore-templates'
 import {
   getRememberedExploreScrollPosition,
   rememberExploreScrollPosition,
 } from './explore-scroll-restoration'
-import {
-  connectionLabel,
-  FEATURED_SECTION_LABEL,
-  getTemplateAccent,
-  getTemplateIcon,
-  isFeaturedTemplate,
-  templateCategory,
-} from './template-meta'
+import { connectionLabel, templateCategory } from './template-meta'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 /** Cards shown per category. The "see more" tile takes the sixth slot, so a
  *  full section is three even grid rows at the two-column breakpoint. */
 const SECTION_PREVIEW_COUNT = 5
-
-/** Templates named on the see-more tile before the "+ N more" line. */
-const SEE_MORE_NAMED_COUNT = 3
-
-/** Bucket for templates whose skillset predates the category field. */
-const OTHER_CATEGORY = 'Other'
 
 /**
  * The full-page agent template marketplace behind the sidebar's Explore item.
@@ -148,31 +139,10 @@ export function ExploreView() {
    * grid of results is what they want.
    */
   const isBrowsing = !debouncedSearch.trim() && filterCount === 0
-  const grouped = useMemo(() => {
-    if (!isBrowsing) return null
-    const byCategory = new Map<string, ApiDiscoverableAgent[]>()
-    const featured: ApiDiscoverableAgent[] = []
-    for (const t of filtered) {
-      // First-party templates lead the page, and stay in their category below
-      // — they're the best of that category, not a separate kind of thing.
-      if (isFeaturedTemplate(t)) featured.push(t)
-      const c = templateCategory(t) ?? OTHER_CATEGORY
-      const list = byCategory.get(c)
-      if (list) list.push(t)
-      else byCategory.set(c, [t])
-    }
-    const sections = [...byCategory.entries()]
-      .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
-      .map(([category, items]) => ({ category, items }))
-    if (featured.length > 0) {
-      sections.unshift({ category: FEATURED_SECTION_LABEL, items: featured })
-    }
-    return sections.map(({ category, items }) => ({
-      category,
-      shown: items.slice(0, SECTION_PREVIEW_COUNT),
-      rest: items.slice(SECTION_PREVIEW_COUNT),
-    }))
-  }, [filtered, isBrowsing])
+  const grouped = useMemo(
+    () => (isBrowsing ? groupTemplatesByCategory(filtered, SECTION_PREVIEW_COUNT) : null),
+    [filtered, isBrowsing],
+  )
 
   const openTemplate = (template: ApiDiscoverableAgent) => {
     rememberExploreScrollPosition(historyEntryKey, scrollContainerRef.current?.scrollTop ?? 0)
@@ -445,68 +415,6 @@ function FilterRow({
       <span className="min-w-0 truncate text-sm">{label}</span>
       <span className="shrink-0 text-xs text-muted-foreground/60">{count}</span>
       {checked && <Check className="ml-auto h-3.5 w-3.5 shrink-0 text-foreground" />}
-    </button>
-  )
-}
-
-/**
- * The section's sixth grid slot: a few of the hidden templates by name over a
- * call to action. Clicking anywhere opens that category's page.
- *
- * The call to action is unconditional — the tile is only ever a link, so one
- * without it reads as a card that failed to render. Only the "+ N" count is
- * conditional, since a section hiding no more than it names has no remainder
- * to count (Featured, at eight templates, is exactly that case).
- */
-function SeeMoreCard({ rest, onClick }: { rest: ApiDiscoverableAgent[]; onClick: () => void }) {
-  const unnamed = rest.length - Math.min(rest.length, SEE_MORE_NAMED_COUNT)
-  return (
-    <button
-      type="button"
-      data-testid="explore-see-more"
-      onClick={onClick}
-      className="group flex h-[180px] w-full flex-col gap-3 rounded-2xl bg-muted/50 p-4 text-left transition-colors duration-200 hover:bg-muted"
-    >
-      <span className="flex min-w-0 flex-1 flex-col justify-center gap-2">
-        {rest.slice(0, SEE_MORE_NAMED_COUNT).map((template) => {
-          const Icon = getTemplateIcon(template)
-          return (
-            <span
-              key={`${template.skillsetId}/${template.path}`}
-              className="flex min-w-0 items-center gap-2"
-            >
-              <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
-                <Icon className={`size-4 ${getTemplateAccent(template.name)}`} aria-hidden />
-              </span>
-              <span className="truncate text-[13px] text-muted-foreground">{template.name}</span>
-            </span>
-          )
-        })}
-        {/* The glyph sits in the same column as the icons above, so the label
-            lines up with the names. */}
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
-            {unnamed > 0 ? (
-              <Plus className="size-4 text-muted-foreground/50" aria-hidden />
-            ) : (
-              <ArrowRight
-                className="size-4 text-muted-foreground/50 transition-transform duration-200 group-hover:translate-x-0.5"
-                aria-hidden
-              />
-            )}
-          </span>
-          <span className="flex min-w-0 items-center gap-1 truncate text-[13px] text-muted-foreground/70">
-            {unnamed > 0 ? `Show ${unnamed} more` : 'See all'}
-            {unnamed > 0 && (
-              <ArrowRight
-                className="size-3.5 shrink-0 transition-transform duration-200 group-hover:translate-x-0.5"
-                aria-hidden
-              />
-            )}
-          </span>
-        </span>
-      </span>
-
     </button>
   )
 }

--- a/src/renderer/components/messages/chat-composer-box.tsx
+++ b/src/renderer/components/messages/chat-composer-box.tsx
@@ -15,6 +15,14 @@ import { MarkdownComposerEditor } from './markdown-composer-editor'
 const EMPTY_POTENTIAL_SECRETS: PotentialSecret[] = []
 const EMPTY_SECURED_SECRETS: SecuredSecret[] = []
 
+/**
+ * The floating translucent treatment for a composer that sits over content —
+ * the session composer's look, shared so the wizard's create-agent composer
+ * matches it instead of drifting on its own copy of the recipe.
+ */
+export const FLOATING_COMPOSER_CLASS =
+  'relative z-10 border-border/70 bg-background/85 shadow-[0_0_24px_rgba(15,23,42,0.07),0_2px_10px_-4px_rgba(15,23,42,0.08)] backdrop-blur-md supports-[backdrop-filter]:bg-background/65 dark:shadow-[0_0_26px_rgba(0,0,0,0.22),0_2px_12px_-4px_rgba(0,0,0,0.16)]'
+
 interface SecureSecretsProps {
   agentSlug: string
   potentialSecrets?: PotentialSecret[]

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -15,7 +15,7 @@ import { MountChoiceDialog } from '@renderer/components/ui/mount-choice-dialog'
 import { useMessageComposer } from '@renderer/hooks/use-message-composer'
 import { registerSessionComposerFocus } from './composer-focus'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
-import { ChatComposerBox } from './chat-composer-box'
+import { ChatComposerBox, FLOATING_COMPOSER_CLASS } from './chat-composer-box'
 import { ComposerOptions, useComposerOptions } from './composer-options'
 import { AgentDefaultFooter } from './agent-default-footer'
 import { useAgentPreferences } from '@renderer/hooks/use-agent-preferences'
@@ -273,7 +273,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
         filter={slashFilter ?? ''}
       />
       <ChatComposerBox
-        className="relative z-10 border-border/70 bg-background/85 shadow-[0_0_24px_rgba(15,23,42,0.07),0_2px_10px_-4px_rgba(15,23,42,0.08)] backdrop-blur-md supports-[backdrop-filter]:bg-background/65 dark:shadow-[0_0_26px_rgba(0,0,0,0.22),0_2px_12px_-4px_rgba(0,0,0,0.16)]"
+        className={FLOATING_COMPOSER_CLASS}
         attachments={composer.attachments}
         onRemoveAttachment={composer.removeAttachment}
         onRetryAttachment={composer.retryAttachment}


### PR DESCRIPTION
Pure extractions, no behavior change, staged ahead of #2 of this stack (inlining the template marketplace into the create-agent wizard step):

- **`SeeMoreCard`** moves from `explore-view` into `explore-template-card` and is exported; the category grouping (Featured first, then categories by size, split at a preview count) hoists from `ExploreView` into `explore-templates` as `groupTemplatesByCategory`, so a second surface can group identically instead of drifting.
- **`ImportAgentDialog`** extracts the Import an Agent upload dialog from `AgentCreationAids` into its own controlled component; the aids render it unchanged (agent-home behavior identical).
- **`FLOATING_COMPOSER_CLASS`** hoists the session composer's floating translucent chrome from `message-input` into an exported constant on `chat-composer-box`.
- `launch.json` gains a `web` dev-server entry (auto-port; 47891 is held by an installed Gamut app).

Verified standalone: typecheck clean, 1,029 renderer tests green with only this commit applied.

Merge order: this PR first, then the wizard feature PR stacked on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)