### PR TITLE
feat: inline the template marketplace into the create-agent wizard step

### DIFF
--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -39,7 +39,7 @@ export class AppPage {
     }
 
     const manualSetup = this.page.locator('[data-testid="wizard-manual-setup"]')
-    const agentOnlyHeading = wizard.getByRole('heading', { name: /create your first agent/i })
+    const agentOnlyHeading = wizard.getByRole('heading', { name: /describe your first ai teammate/i })
     await expect(manualSetup.or(agentOnlyHeading).first()).toBeVisible({ timeout: 5000 })
 
     if (await manualSetup.isVisible()) {

--- a/e2e/specs/getting-started-wizard.spec.ts
+++ b/e2e/specs/getting-started-wizard.spec.ts
@@ -159,7 +159,7 @@ test.describe('Getting Started Wizard', () => {
     // Step 6: Create Agent (skippable)
     await wizardPage.clickNext()
     await wizardPage.expectStep(6)
-    await expect(page.getByRole('heading', { name: /create your first agent/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /describe your first ai teammate/i })).toBeVisible()
 
     // Skip on last step finishes
     await wizardPage.clickSkip()
@@ -224,25 +224,19 @@ test.describe('Getting Started Wizard', () => {
     await wizardPage.clickNext() // Privacy -> Agent
     await wizardPage.expectStep(6)
 
-    // Browsing templates leaves the wizard for the marketplace page. The wizard
-    // renders above the router, so it must finish itself on the way out —
-    // that's what completes onboarding here, before anything is installed.
-    await page.getByRole('button', { name: /Browse Templates/ }).click()
-    await wizardPage.expectNotVisible()
-    await expect(page.locator('[data-testid="explore-view"]')).toBeVisible()
+    // The template roster renders inline under the composer; clicking a card
+    // installs it in place (no marketplace detour, no naming step — the agent
+    // takes the template's own name) and finishing the install completes the
+    // wizard.
+    await page
+      .locator('[data-testid="explore-template-card"]', { hasText: 'E2E Onboarding Template' })
+      .click()
 
-    // Card → details page → install. The agent takes the template's own name;
-    // there is no naming step.
-    await page.getByRole('button', { name: /E2E Onboarding Template/ }).first().click()
-    await expect(page.locator('[data-testid="template-detail-view"]')).toBeVisible()
-    await page.locator('[data-testid="template-detail-install"]').click()
-
-    // Both assertions have to be things the details page itself cannot satisfy.
-    // A bare `app-sidebar` check is not one: /explore renders inside the same
-    // shell, so it is already visible. Neither is an unscoped name match — the
-    // details page heading IS the template name. The install opens the new
-    // agent, so the URL leaves /explore and the name appears in the sidebar.
+    // Both assertions have to be things the wizard itself cannot satisfy: the
+    // install navigates to the new agent's page and the name appears in the
+    // sidebar, neither of which exists while the wizard overlay is up.
     await expect(page).toHaveURL(/\/agents\//)
+    await wizardPage.expectNotVisible()
     await expect(
       page
         .locator('[data-testid="app-sidebar"]')

--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -106,10 +106,10 @@ vi.mock('@renderer/hooks/use-typewriter-placeholder', () => ({
   DEFAULT_AGENT_PROMPT_EXAMPLES: [],
 }))
 
-vi.mock('@renderer/components/agents/agent-creation-aids', () => ({
-  AgentCreationAids: ({ onAidOpened }: { onAidOpened?: () => void }) => (
-    <button type="button" data-testid="aid-opened" onClick={() => onAidOpened?.()}>
-      aid
+vi.mock('@renderer/components/agents/create-agent-templates', () => ({
+  CreateAgentTemplates: ({ onImportClick }: { onImportClick?: () => void }) => (
+    <button type="button" data-testid="aid-opened" onClick={() => onImportClick?.()}>
+      import
     </button>
   ),
 }))
@@ -162,6 +162,7 @@ vi.mock('@renderer/components/ui/voice-input-button', () => ({
 vi.mock('@renderer/components/messages/chat-composer-box', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@renderer/components/messages/chat-composer-box')>()
   return {
+    FLOATING_COMPOSER_CLASS: actual.FLOATING_COMPOSER_CLASS,
     ChatComposerBox: (props: Parameters<typeof actual.ChatComposerBox>[0]) => {
       lastComposerAutoFocus = props.autoFocus
       return actual.ChatComposerBox(props)
@@ -606,7 +607,7 @@ describe('CreateAgentForm signup handoff', () => {
     expect(lastDialogProps?.template).toEqual(discoverable('model-bot'))
   })
 
-  it('opening a creation aid forfeits before a late match can open the dialog', async () => {
+  it('opening the import card forfeits before a late match can open the dialog', async () => {
     mockDiscoverableAgents = []
     mockSignupHandoff = { template_slug: 'aid-bot' }
     const user = userEvent.setup()

--- a/src/renderer/components/agents/create-agent-form.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.test.tsx
@@ -63,6 +63,13 @@ vi.mock('@renderer/components/messages/composer-options', () => ({
 vi.mock('@renderer/hooks/use-agent-templates', () => ({
   useDiscoverableAgents: () => ({ data: [], isError: false }),
   slugFromAgentPath: vi.fn(),
+  // The form mounts ImportAgentDialog (closed) for the strip's end-cap card.
+  useImportAgentTemplate: () => ({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
 }))
 
 vi.mock('@renderer/hooks/use-start-onboarding-session', () => ({
@@ -108,8 +115,8 @@ vi.mock('@renderer/hooks/use-message-composer', () => ({
   },
 }))
 
-vi.mock('@renderer/components/agents/agent-creation-aids', () => ({
-  AgentCreationAids: () => null,
+vi.mock('@renderer/components/agents/create-agent-templates', () => ({
+  CreateAgentTemplates: () => null,
 }))
 
 vi.mock('@renderer/components/agents/template-install-dialog', () => ({

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@renderer/components/ui/button'
-import { ChatComposerBox } from '@renderer/components/messages/chat-composer-box'
+import { ChatComposerBox, FLOATING_COMPOSER_CLASS } from '@renderer/components/messages/chat-composer-box'
+import { cn } from '@shared/lib/utils'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
-import { AgentCreationAids, type ImportResult } from '@renderer/components/agents/agent-creation-aids'
+import { CreateAgentTemplates } from '@renderer/components/agents/create-agent-templates'
+import { ImportAgentDialog } from '@renderer/components/agents/import-agent-dialog'
 import { useStartOnboardingSession } from '@renderer/hooks/use-start-onboarding-session'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
 import { useCreateAgent, useDeleteAgent, useUpdateAgent } from '@renderer/hooks/use-agents'
@@ -32,7 +34,7 @@ import {
 import { captureRendererException } from '@renderer/lib/error-reporting'
 import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
-import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+import type { ApiAgentTemplateInstallResult, ApiDiscoverableAgent } from '@shared/lib/types/api'
 
 /**
  * Ceiling, not a delay: the offer resolves the instant the discoverable list
@@ -47,11 +49,33 @@ import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
  */
 const HANDOFF_TEMPLATE_WAIT_MS = 10000
 
+/**
+ * Soft edges for the template roster's scroll viewport, same recipe as the
+ * voice-agent transcript: cards dissolve over 32px instead of clipping at the
+ * top of the composer above and the footer below. Top padding (the measured
+ * composer overlap plus this gap) keeps at-rest content clear of the bands,
+ * so nothing looks faded until it is actually leaving.
+ */
+const ROSTER_FADE_MASK =
+  'linear-gradient(to bottom, transparent 0, black 32px, black calc(100% - 32px), transparent 100%)'
+
+/** At-rest gap between the composer's bottom edge and the roster heading. */
+const ROSTER_TOP_GAP_PX = 64
+
 export interface CreateAgentFormProps {
   /**
-   * Awaited before the form navigates away (Browse Templates → the
-   * marketplace). The wizard uses it to finish itself first, since it renders
-   * above the router and would otherwise cover the page we just went to.
+   * Rendered directly above the composer, inside the block the form keeps
+   * vertically centered (the step's title). It has to live inside the form:
+   * the centering is a pair of equal flex spacers around the header+composer
+   * block, and a title rendered outside the form would sit above the top
+   * spacer instead of moving with the block it labels.
+   */
+  header?: React.ReactNode
+  /**
+   * Awaited before the form navigates away (a see-more tile → the Explore
+   * category page). The wizard uses it to finish itself first, since it
+   * renders above the router and would otherwise cover the page we just went
+   * to.
    */
   onNavigateAway?: () => Promise<void> | void
   /** Fires after an agent is successfully created (via any path). Parent uses this to close the overlay/wizard. */
@@ -62,7 +86,7 @@ export interface CreateAgentFormProps {
   exiting?: boolean
 }
 
-export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exiting = false }: CreateAgentFormProps) {
+export function CreateAgentForm({ header, onAgentCreated, onNavigateAway, className, exiting = false }: CreateAgentFormProps) {
   // Staggered reveal: items start hidden on first render, flip to visible on the next frame,
   // then flip back to hidden when `exiting` becomes true. Reverse the stagger on exit.
   const [revealed, setRevealed] = useState(false)
@@ -72,8 +96,13 @@ export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exi
   }, [])
 
   const itemHidden = exiting || !revealed
-  const itemProps = (inDelayMs: number, outDelayMs: number) => ({
-    className: 'create-agent-item',
+  const itemProps = (
+    inDelayMs: number,
+    outDelayMs: number,
+    extraClassName = '',
+    base = 'create-agent-item',
+  ) => ({
+    className: `${base} ${extraClassName}`.trim(),
     'data-hidden': itemHidden ? 'true' : 'false',
     style: { transitionDelay: `${exiting ? outDelayMs : inDelayMs}ms` },
   })
@@ -177,7 +206,7 @@ export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exi
 
   const finishCreatedAgent = useCallback(
     async (
-      agent: ImportResult,
+      agent: ApiAgentTemplateInstallResult,
       source: 'import' | 'skillset',
     ) => {
       await discardWarmAgent()
@@ -340,19 +369,29 @@ export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exi
     }
   }, [])
 
-  const handleVoiceResult = useCallback(
-    ({ prompt }: { name: string; prompt: string }) => {
-      if (prompt) {
-        composer.setMessage(prompt)
-        setTimeout(() => textareaRef.current?.focus(), 0)
-      }
-    },
-    [composer],
+  const handleImportComplete = useCallback(
+    (agent: ApiAgentTemplateInstallResult) => finishCreatedAgent(agent, 'import'),
+    [finishCreatedAgent],
   )
 
-  const handleImportComplete = useCallback(
-    (agent: ImportResult) => finishCreatedAgent(agent, 'import'),
-    [finishCreatedAgent],
+  // The strip's end-cap card. Forfeits like the old aid chips did: an armed
+  // signup handoff resolving underneath the import dialog would stack the
+  // template-install dialog on top of it.
+  const [showImportDialog, setShowImportDialog] = useState(false)
+  const handleImportClick = useCallback(() => {
+    forfeitHandoffTemplate()
+    setShowImportDialog(true)
+  }, [forfeitHandoffTemplate])
+
+  // Picking a card is the user choosing a template outright, so it also
+  // forfeits any armed signup handoff — otherwise the handoff's own offer
+  // could still resolve and replace the one they just clicked.
+  const handleTemplateSelected = useCallback(
+    (template: ApiDiscoverableAgent) => {
+      forfeitHandoffTemplate()
+      setTemplateToInstall(template)
+    },
+    [forfeitHandoffTemplate],
   )
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -364,66 +403,142 @@ export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exi
 
   const isDisabled = isSubmitting
 
-  return (
-    <div className={className}>
-      <div className="space-y-8">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault()
-            void composer.handleSubmit(e)
-          }}
-          {...itemProps(80, 130)}
-        >
-          <ChatComposerBox
-            textareaRef={textareaRef}
-            attachments={composer.attachments}
-            onRemoveAttachment={composer.removeAttachment}
-            value={composer.message}
-            onChange={(value) => {
-              forfeitHandoffTemplate()
-              composer.setMessage(value)
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder={displayedPlaceholder}
-            disabled={isDisabled}
-            rows={3}
-            autoFocus={!templateToInstall && !handoffTemplateSlug}
-            dataTestId="create-agent-prompt"
-            textareaClassName="min-h-[60px]"
-            leftActions={(
-              <ComposerOptions state={composerOptions} disabled={isDisabled} />
-            )}
-            rightActions={(
-              <>
-                <VoiceInputButton voiceInput={composer.voiceInput} message={composer.message} disabled={isDisabled} />
-                <Button
-                  type="submit"
-                  size="sm"
-                  data-testid="create-agent-submit"
-                >
-                  {isDisabled ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                      Creating...
-                    </>
-                  ) : (
-                    'Create Agent'
-                  )}
-                </Button>
-              </>
-            )}
-            footer={(
-              <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2 justify-center" />
-            )}
-          />
-        </form>
+  // How far the roster's scroll viewport reaches UP behind the composer. The
+  // composer's translucent chrome only reads as glass when something actually
+  // scrolls behind it (sessions overlay it on the message list for the same
+  // reason), so the viewport's top edge sits at the composer's top edge —
+  // measured, because attachments and errors change the composer's height —
+  // and matching top padding keeps every at-rest position unchanged.
+  const composerBlockRef = useRef<HTMLFormElement>(null)
+  const [composerOverlap, setComposerOverlap] = useState(0)
+  // At rest the composer sits flush on the page; its floating shadow appears
+  // only once the roster is scrolled, reading as the box lifting so the cards
+  // can pass underneath.
+  const [rosterScrolled, setRosterScrolled] = useState(false)
+  useLayoutEffect(() => {
+    const el = composerBlockRef.current
+    if (!el) return
+    const measure = () => {
+      const next = Math.ceil(el.getBoundingClientRect().height)
+      setComposerOverlap((current) => (current === next ? current : next))
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
 
-        <div {...itemProps(160, 70)}>
-          <AgentCreationAids
-            onVoiceResult={handleVoiceResult}
-            onImportComplete={handleImportComplete}
-            onAidOpened={forfeitHandoffTemplate}
+  return (
+    // The header+composer block floats in the upper third of the screen —
+    // one part of the leftover height above it, five parts below — and stays
+    // pinned there; only the template roster below it scrolls. The flex
+    // spacers ARE the positioning: the empty spacer above and the roster's
+    // scroll viewport below split the leftover 1:5, which sits the block
+    // about a fifth of the screen above true center and gives the roster the
+    // difference. Height comes from the wizard (the step chain is h-full flex
+    // columns).
+    <div className={`flex h-full min-h-0 flex-col ${className ?? ''}`}>
+      <div className="min-h-0 flex-1 shrink" aria-hidden />
+
+      {header}
+
+      <form
+        ref={composerBlockRef}
+        onSubmit={(e) => {
+          e.preventDefault()
+          void composer.handleSubmit(e)
+        }}
+        // The -glass reveal variant: the plain item's filter/will-change
+        // would make this a backdrop root and blind the composer's
+        // backdrop-blur to the roster behind it (see globals.css). z-10: the
+        // roster viewport reaches up behind this block and both siblings are
+        // stacking contexts, so the later sibling (the roster) would paint
+        // over the composer without explicit z-order.
+        {...itemProps(80, 130, 'relative z-10 shrink-0', 'create-agent-item-glass')}
+      >
+        <ChatComposerBox
+          className={cn(
+            FLOATING_COMPOSER_CLASS,
+            'transition-shadow duration-500',
+            // twMerge keeps the last shadow per variant, so these override
+            // the floating shadows until the roster starts moving.
+            !rosterScrolled && 'shadow-none dark:shadow-none',
+          )}
+          textareaRef={textareaRef}
+          attachments={composer.attachments}
+          onRemoveAttachment={composer.removeAttachment}
+          value={composer.message}
+          onChange={(value) => {
+            forfeitHandoffTemplate()
+            composer.setMessage(value)
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={displayedPlaceholder}
+          disabled={isDisabled}
+          rows={3}
+          autoFocus={!templateToInstall && !handoffTemplateSlug}
+          dataTestId="create-agent-prompt"
+          // One line taller on phones: the typewriter placeholder wraps to
+          // three lines in a narrow composer, which reads as already full.
+          textareaClassName="min-h-[80px] sm:min-h-[60px]"
+          leftActions={(
+            <ComposerOptions state={composerOptions} disabled={isDisabled} />
+          )}
+          rightActions={(
+            <>
+              <VoiceInputButton voiceInput={composer.voiceInput} message={composer.message} disabled={isDisabled} />
+              <Button
+                type="submit"
+                size="sm"
+                data-testid="create-agent-submit"
+              >
+                {isDisabled ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  'Create Agent'
+                )}
+              </Button>
+            </>
+          )}
+          footer={(
+            <VoiceInputError error={composer.voiceInput.error} onDismiss={composer.voiceInput.clearError} className="mt-2 justify-center" />
+          )}
+        />
+      </form>
+
+      {/* No aid chips here: browsing lives in the roster below, the
+          composer's mic covers voice, and importing is the roster's own
+          final tile. The outer div is the flex layout box (and reveal-
+          animation item); the scroll viewport inside it is absolute so it can
+          extend `composerOverlap` px above the box — behind the glass —
+          without shifting the flex layout. The 2px side padding gives hovered
+          cards' lift shadow room inside the scroller instead of clipping at
+          its edge. */}
+      <div {...itemProps(160, 70, 'relative z-0 min-h-0 flex-[5_1_0%]')}>
+        <div
+          // Scrollbar hidden: it would run up behind the glass composer and
+          // fade oddly through the edge masks. Trackpad/wheel and the cards'
+          // own tab-into-view scrolling still work; the fade bands are the
+          // "there's more" signal.
+          onScroll={(e) => {
+            const scrolled = e.currentTarget.scrollTop > 4
+            setRosterScrolled((current) => (current === scrolled ? current : scrolled))
+          }}
+          className="absolute -left-2 -right-2 bottom-0 overflow-y-auto px-2 pb-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          style={{
+            top: -composerOverlap,
+            paddingTop: composerOverlap + ROSTER_TOP_GAP_PX,
+            maskImage: ROSTER_FADE_MASK,
+            WebkitMaskImage: ROSTER_FADE_MASK,
+          }}
+        >
+          <CreateAgentTemplates
+            onSelect={handleTemplateSelected}
             onNavigateAway={onNavigateAway}
+            onImportClick={handleImportClick}
           />
         </div>
       </div>
@@ -432,6 +547,12 @@ export function CreateAgentForm({ onAgentCreated, onNavigateAway, className, exi
         template={templateToInstall}
         onClose={() => setTemplateToInstall(null)}
         onInstalled={(agent) => finishCreatedAgent(agent, 'skillset')}
+      />
+
+      <ImportAgentDialog
+        open={showImportDialog}
+        onClose={() => setShowImportDialog(false)}
+        onComplete={handleImportComplete}
       />
     </div>
   )

--- a/src/renderer/components/agents/create-agent-templates.test.tsx
+++ b/src/renderer/components/agents/create-agent-templates.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigate = vi.fn()
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => navigate }))
+
+let skillsets: { id: string; name: string }[] | undefined = []
+let discoverable: ApiDiscoverableAgent[] | undefined
+let isLoading = false
+vi.mock('@renderer/hooks/use-skillsets', () => ({ useSkillsets: () => ({ data: skillsets }) }))
+vi.mock('@renderer/hooks/use-agent-templates', () => ({
+  useDiscoverableAgents: () => ({ data: discoverable, isLoading }),
+}))
+vi.mock('@renderer/context/dialog-context', () => ({ useDialogs: () => ({ openSettings: vi.fn() }) }))
+
+import { CreateAgentTemplates } from './create-agent-templates'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+function template(name: string, over: Partial<ApiDiscoverableAgent> = {}): ApiDiscoverableAgent {
+  return {
+    skillsetId: 'skillset-1',
+    skillsetName: 'Public',
+    name,
+    description: `${name} does things`,
+    version: '1.0.0',
+    path: `agents/${name.toLowerCase().replace(/\s+/g, '-')}/`,
+    category: 'Marketing',
+    ...over,
+  }
+}
+
+function roster(n: number, over: Partial<ApiDiscoverableAgent> = {}) {
+  return Array.from({ length: n }, (_, i) => template(`Agent ${i + 1}`, over))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  skillsets = [{ id: 'skillset-1', name: 'Public' }]
+  discoverable = roster(7)
+  isLoading = false
+})
+
+describe('CreateAgentTemplates', () => {
+  it('renders stacked category sections: five cards plus the see-more tile', () => {
+    render(<CreateAgentTemplates onSelect={vi.fn()} />)
+
+    expect(screen.getByText('Marketing')).toBeInTheDocument()
+    expect(screen.getAllByTestId('explore-template-card')).toHaveLength(5)
+    expect(screen.getByTestId('explore-see-more')).toBeInTheDocument()
+  })
+
+  it('see-more finishes the wizard, then opens the Explore category page', async () => {
+    const user = userEvent.setup()
+    // Ordering is the contract: the wizard overlay sits above the router, so
+    // navigating before onNavigateAway resolves lands on a page it covers.
+    const order: string[] = []
+    const onNavigateAway = vi.fn(async () => { order.push('away') })
+    navigate.mockImplementation(() => order.push('navigate'))
+    discoverable = roster(9)
+    render(<CreateAgentTemplates onSelect={vi.fn()} onNavigateAway={onNavigateAway} />)
+
+    await user.click(screen.getByTestId('explore-see-more'))
+
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith({
+        to: '/explore/category/$category',
+        params: { category: 'Marketing' },
+      }),
+    )
+    expect(order).toEqual(['away', 'navigate'])
+  })
+
+  it('still leaves for the category page when the navigate-away hook rejects', async () => {
+    const user = userEvent.setup()
+    discoverable = roster(9)
+    render(
+      <CreateAgentTemplates
+        onSelect={vi.fn()}
+        onNavigateAway={vi.fn(async () => { throw new Error('settings PUT failed') })}
+      />,
+    )
+
+    await user.click(screen.getByTestId('explore-see-more'))
+
+    await waitFor(() => expect(navigate).toHaveBeenCalled())
+  })
+
+  it('leads with Featured, keeping first-party templates in their category too', () => {
+    discoverable = [
+      template('Community One'),
+      template('First Party', { developer: { name: 'SkillfulAgents' } }),
+    ]
+    render(<CreateAgentTemplates onSelect={vi.fn()} />)
+
+    const headings = screen.getAllByRole('heading', { level: 4 }).map((h) => h.textContent)
+    expect(headings).toEqual(['Featured', 'Marketing'])
+    expect(within(screen.getByTestId('create-agent-templates')).getAllByText('First Party')).toHaveLength(2)
+  })
+
+  it('hands the clicked template back to the caller', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    discoverable = [template('Inbox Zero')]
+    render(<CreateAgentTemplates onSelect={onSelect} />)
+
+    await user.click(screen.getByTestId('explore-template-card'))
+
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'Inbox Zero' }))
+  })
+
+  it('previews three cards per section on mobile widths', () => {
+    // useIsMobile reads window.innerWidth against its 768px line.
+    const original = window.innerWidth
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 500 })
+    try {
+      render(<CreateAgentTemplates onSelect={vi.fn()} />)
+
+      expect(screen.getAllByTestId('explore-template-card')).toHaveLength(3)
+      expect(screen.getByTestId('explore-see-more')).toBeInTheDocument()
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: original })
+    }
+  })
+
+  it('renders the import tile after the last section when wired', async () => {
+    const user = userEvent.setup()
+    const onImportClick = vi.fn()
+    render(<CreateAgentTemplates onSelect={vi.fn()} onImportClick={onImportClick} />)
+
+    const container = screen.getByTestId('create-agent-templates')
+    const tile = screen.getByTestId('import-agent-card')
+    expect(container.lastElementChild?.lastElementChild).toBe(tile)
+
+    await user.click(tile)
+    expect(onImportClick).toHaveBeenCalledOnce()
+  })
+
+  it('omits the import tile when no handler is wired', () => {
+    render(<CreateAgentTemplates onSelect={vi.fn()} />)
+    expect(screen.queryByTestId('import-agent-card')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when no skillset supplies templates', () => {
+    skillsets = []
+    discoverable = []
+    const { container } = render(<CreateAgentTemplates onSelect={vi.fn()} />)
+
+    // Deliberately silent rather than an empty state — the composer above is
+    // already a complete way to create an agent.
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/renderer/components/agents/create-agent-templates.test.tsx
+++ b/src/renderer/components/agents/create-agent-templates.test.tsx
@@ -10,9 +10,10 @@ vi.mock('@tanstack/react-router', () => ({ useNavigate: () => navigate }))
 let skillsets: { id: string; name: string }[] | undefined = []
 let discoverable: ApiDiscoverableAgent[] | undefined
 let isLoading = false
+let isError = false
 vi.mock('@renderer/hooks/use-skillsets', () => ({ useSkillsets: () => ({ data: skillsets }) }))
 vi.mock('@renderer/hooks/use-agent-templates', () => ({
-  useDiscoverableAgents: () => ({ data: discoverable, isLoading }),
+  useDiscoverableAgents: () => ({ data: discoverable, isLoading, isError }),
 }))
 vi.mock('@renderer/context/dialog-context', () => ({ useDialogs: () => ({ openSettings: vi.fn() }) }))
 
@@ -41,6 +42,7 @@ beforeEach(() => {
   skillsets = [{ id: 'skillset-1', name: 'Public' }]
   discoverable = roster(7)
   isLoading = false
+  isError = false
 })
 
 describe('CreateAgentTemplates', () => {
@@ -145,7 +147,7 @@ describe('CreateAgentTemplates', () => {
     expect(screen.queryByTestId('import-agent-card')).not.toBeInTheDocument()
   })
 
-  it('renders nothing when no skillset supplies templates', () => {
+  it('renders nothing when no skillset supplies templates and no import is wired', () => {
     skillsets = []
     discoverable = []
     const { container } = render(<CreateAgentTemplates onSelect={vi.fn()} />)
@@ -153,5 +155,32 @@ describe('CreateAgentTemplates', () => {
     // Deliberately silent rather than an empty state — the composer above is
     // already a complete way to create an agent.
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('keeps the import tile — and only it — when the roster is empty', async () => {
+    const user = userEvent.setup()
+    const onImportClick = vi.fn()
+    skillsets = []
+    discoverable = []
+    render(<CreateAgentTemplates onSelect={vi.fn()} onImportClick={onImportClick} />)
+
+    // No cards and no "Or start from a template" heading (it would promise
+    // templates that are not there) — but importing a file must survive: the
+    // aid chips this roster replaced offered it unconditionally.
+    expect(screen.queryAllByTestId('explore-template-card')).toHaveLength(0)
+    expect(screen.queryByText('Or start from a template')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('import-agent-card'))
+    expect(onImportClick).toHaveBeenCalledOnce()
+  })
+
+  it('settles to the import tile when the template fetch fails, not a forever-skeleton', () => {
+    // After react-query gives up, data stays undefined with isLoading false —
+    // only isError distinguishes this from "still waiting".
+    discoverable = undefined
+    isError = true
+    render(<CreateAgentTemplates onSelect={vi.fn()} onImportClick={vi.fn()} />)
+
+    expect(screen.queryByTestId('create-agent-templates-loading')).not.toBeInTheDocument()
+    expect(screen.getByTestId('import-agent-card')).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/agents/create-agent-templates.test.tsx
+++ b/src/renderer/components/agents/create-agent-templates.test.tsx
@@ -106,7 +106,9 @@ describe('CreateAgentTemplates', () => {
     discoverable = [template('Inbox Zero')]
     render(<CreateAgentTemplates onSelect={onSelect} />)
 
-    await user.click(screen.getByTestId('explore-template-card'))
+    // By accessible name: unlike Explore (where a card opens a details page),
+    // clicking here installs in place, and the card must say so.
+    await user.click(screen.getByRole('button', { name: 'Inbox Zero — install' }))
 
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'Inbox Zero' }))
   })

--- a/src/renderer/components/agents/create-agent-templates.tsx
+++ b/src/renderer/components/agents/create-agent-templates.tsx
@@ -129,6 +129,10 @@ export function CreateAgentTemplates({
                   key={`${template.skillsetId}/${template.path}`}
                   template={template}
                   onOpen={onSelect}
+                  // Here a click installs in place — there is no details page
+                  // between the card and the agent, so "details" would promise
+                  // a preview the click does not give.
+                  action="install"
                 />
               ))}
               {rest.length > 0 && (

--- a/src/renderer/components/agents/create-agent-templates.tsx
+++ b/src/renderer/components/agents/create-agent-templates.tsx
@@ -41,10 +41,14 @@ const MOBILE_SECTION_PREVIEW_COUNT = 3
  * wizard pins the composer and scrolls this component underneath it, so the
  * main event stays put while the roster runs as deep as it needs to.
  *
- * Renders nothing at all when the roster is empty. There is no "connect a
- * skillset" empty state here on purpose — the composer above is a complete way
- * to create an agent, and a first-run user with no skillsets should see a
- * clean page rather than a dead end for a feature they never asked for.
+ * An empty roster (no skillsets, none supplying templates, or the fetch
+ * failed) renders only the import tile. There is no "connect a skillset"
+ * empty state here on purpose — the composer above is a complete way to
+ * create an agent, and a first-run user with no skillsets should see a clean
+ * page rather than a dead end for a feature they never asked for. But the
+ * import tile is not part of the browsing teaser: it is the wizard's only
+ * import-a-file path (the aid chips it replaced offered it unconditionally),
+ * so it must not disappear with the cards.
  */
 export function CreateAgentTemplates({
   onSelect,
@@ -114,7 +118,17 @@ export function CreateAgentTemplates({
     )
   }
 
-  if (templates.length === 0) return null
+  if (templates.length === 0) {
+    // No cards to browse, but the import path survives: no heading ("Or start
+    // from a template" would promise templates that are not there), just the
+    // tile the roster would have ended with anyway.
+    if (!onImportClick) return null
+    return (
+      <div className={className} data-testid="create-agent-templates">
+        <ImportTile onClick={onImportClick} />
+      </div>
+    )
+  }
 
   return (
     <div className={className} data-testid="create-agent-templates">

--- a/src/renderer/components/agents/create-agent-templates.tsx
+++ b/src/renderer/components/agents/create-agent-templates.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useMemo } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { ArrowDownToLine } from 'lucide-react'
+import { Skeleton } from '@renderer/components/ui/skeleton'
+import {
+  ExploreTemplateCard,
+  SeeMoreCard,
+} from '@renderer/components/explore/explore-template-card'
+import {
+  groupTemplatesByCategory,
+  useExploreTemplates,
+} from '@renderer/components/explore/explore-templates'
+import { useIsMobile } from '@renderer/hooks/use-mobile'
+import { captureRendererException } from '@renderer/lib/error-reporting'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+/**
+ * Template cards shown per category section; the see-more tile takes the next
+ * slot, so a section always ends on a full row. Desktop is a 3x2 grid (five
+ * cards + the tile); mobile is a single column, where six full-width cards
+ * per category would bury the next heading — three plus the tile keeps every
+ * category within a couple of swipes. Both counts pair with the grid's
+ * `md:` breakpoint, which is the same 768px line `useIsMobile` watches.
+ */
+const SECTION_PREVIEW_COUNT = 5
+const MOBILE_SECTION_PREVIEW_COUNT = 3
+
+/**
+ * The Explore roster, inlined under the create-agent composer.
+ *
+ * Same data, same cards, same grouping as `/explore` — but this renders inside
+ * the onboarding wizard, which is a full-screen overlay mounted ABOVE the
+ * router. A card hands its template back to the caller, which installs it in
+ * place through `TemplateInstallDialog`. The see-more tile (shared with
+ * Explore) opens the same category page it does there — which means leaving
+ * the wizard, so it awaits `onNavigateAway` first and the wizard finishes
+ * itself before the router moves.
+ *
+ * Each category is a six-slot 3x2 section — five cards plus the see-more tile
+ * — and the sections stack vertically. The caller owns the scrolling: the
+ * wizard pins the composer and scrolls this component underneath it, so the
+ * main event stays put while the roster runs as deep as it needs to.
+ *
+ * Renders nothing at all when the roster is empty. There is no "connect a
+ * skillset" empty state here on purpose — the composer above is a complete way
+ * to create an agent, and a first-run user with no skillsets should see a
+ * clean page rather than a dead end for a feature they never asked for.
+ */
+export function CreateAgentTemplates({
+  onSelect,
+  onNavigateAway,
+  onImportClick,
+  className,
+}: {
+  onSelect: (template: ApiDiscoverableAgent) => void
+  /**
+   * Awaited before the see-more tile leaves for the Explore category page.
+   * The wizard hosts this in a full-screen overlay ABOVE the router, so it
+   * has to finish itself first or the user navigates to a page they can't
+   * see.
+   */
+  onNavigateAway?: () => void | Promise<void>
+  /**
+   * Renders the "Import an Agent" tile after the last section, opening the
+   * caller's import dialog. Omitted → no tile.
+   */
+  onImportClick?: () => void
+  className?: string
+}) {
+  const navigate = useNavigate()
+  const { templates, isLoading } = useExploreTemplates()
+  const isMobile = useIsMobile()
+
+  const openCategory = useCallback(
+    async (category: string) => {
+      // Same contract as the old Browse Templates aid: the hook can reject
+      // (the wizard's is a settings PUT that carries `skipGlobalErrorToast`,
+      // so a failure is otherwise silent). Leave for the category page either
+      // way — a click that does nothing at all is the worse outcome, and the
+      // host staying open is its own visible signal.
+      try {
+        await onNavigateAway?.()
+      } catch (error) {
+        console.error('[create-agent] navigate-away hook failed:', error)
+        captureRendererException(error, {
+          tags: { area: 'create-agent', op: 'see-more-templates' },
+        })
+      }
+      void navigate({ to: '/explore/category/$category', params: { category } })
+    },
+    [onNavigateAway, navigate],
+  )
+
+  // No search here on purpose: the sections are a browsing teaser, and
+  // Explore — one see-more click away — already owns search and filtering. A
+  // second, smaller search box beside the composer also competes with it for
+  // "the place you type".
+  const previewCount = isMobile ? MOBILE_SECTION_PREVIEW_COUNT : SECTION_PREVIEW_COUNT
+  const grouped = useMemo(
+    () => groupTemplatesByCategory(templates, previewCount),
+    [templates, previewCount],
+  )
+
+  if (isLoading) {
+    return (
+      <div className={className} data-testid="create-agent-templates-loading">
+        <SectionHeading>Or start from a template</SectionHeading>
+        <TemplateGrid>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-[180px] rounded-2xl" />
+          ))}
+        </TemplateGrid>
+      </div>
+    )
+  }
+
+  if (templates.length === 0) return null
+
+  return (
+    <div className={className} data-testid="create-agent-templates">
+      <SectionHeading>Or start from a template</SectionHeading>
+      <div className="space-y-8">
+        {grouped.map(({ category, shown, rest }) => (
+          <section key={category}>
+            <h4 className="mb-2 text-[13px] font-medium text-muted-foreground">{category}</h4>
+            <TemplateGrid>
+              {shown.map((template) => (
+                <ExploreTemplateCard
+                  key={`${template.skillsetId}/${template.path}`}
+                  template={template}
+                  onOpen={onSelect}
+                />
+              ))}
+              {rest.length > 0 && (
+                <SeeMoreCard rest={rest} onClick={() => void openCategory(category)} />
+              )}
+            </TemplateGrid>
+          </section>
+        ))}
+        {onImportClick && <ImportTile onClick={onImportClick} />}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The list's last row: bring-your-own-agent. Full width and deliberately not
+ * card-shaped — it's an offer, not a template.
+ */
+function ImportTile({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      data-testid="import-agent-card"
+      onClick={onClick}
+      className="flex h-[100px] w-full flex-col items-center justify-center gap-2 rounded-2xl bg-muted/50 p-4 transition-colors duration-200 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span className="grid size-9 place-items-center rounded-xl bg-card shadow-[0_1px_2px_0_rgba(0,0,0,0.06)]">
+        <ArrowDownToLine className="size-4 text-muted-foreground" aria-hidden />
+      </span>
+      <span className="text-[13px] font-medium text-foreground">Import an Agent</span>
+    </button>
+  )
+}
+
+/** Same size as the step's "Describe your first AI teammate" title, but in
+ *  the muted color — the roster is the alternative path, one register below
+ *  the question it answers. */
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return <h3 className="mb-6 text-2xl font-normal text-muted-foreground">{children}</h3>
+}
+
+/** Three fluid columns on desktop, one on phones; the see-more tile fills
+ *  the slot after the last card either way. */
+function TemplateGrid({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 gap-3 md:grid-cols-3">{children}</div>
+}

--- a/src/renderer/components/explore/explore-template-card.tsx
+++ b/src/renderer/components/explore/explore-template-card.tsx
@@ -76,15 +76,20 @@ export function TemplateAvatar({
 
 /**
  * Marketplace card for one agent template: the icon stacked above the name,
- * blurb, and the services it connects to. The whole card opens the details
- * page, which is where installing happens.
+ * blurb, and the services it connects to. On Explore the whole card opens the
+ * details page, which is where installing happens; the wizard's roster wires
+ * `onOpen` to an immediate install instead, so the accessible name has to say
+ * which one a click actually does.
  */
 export function ExploreTemplateCard({
   template,
   onOpen,
+  action = 'details',
 }: {
   template: ApiDiscoverableAgent
   onOpen: (template: ApiDiscoverableAgent) => void
+  /** What clicking the card does, for the aria-label: "{name} — {action}". */
+  action?: string
 }) {
   const Icon = getTemplateIcon(template)
   return (
@@ -102,7 +107,7 @@ export function ExploreTemplateCard({
       type="button"
       data-testid="explore-template-card"
       onClick={() => onOpen(template)}
-      aria-label={`${template.name} — details`}
+      aria-label={`${template.name} — ${action}`}
       // 200ms: hover is feedback, not an animation. The lift is 2px, so a
       // longer curve spends its tail finishing a sub-pixel move that already
       // looks arrived — which reads as lag. Matches the renderer's dominant

--- a/src/renderer/components/explore/explore-templates.tsx
+++ b/src/renderer/components/explore/explore-templates.tsx
@@ -20,21 +20,29 @@ import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
  * `hasSkillsets` optimistically reads true and `isLoading` covers the wait —
  * flashing "connect a skillset" at someone who has one is worse than a beat of
  * skeleton.
+ *
+ * Either query ERRORING settles the roster as empty rather than loading:
+ * `data` stays `undefined` after react-query gives up, so without the
+ * `isError` terms the skeleton would spin forever on a failed fetch. Empty is
+ * the degrade every consumer already handles — Explore falls through to its
+ * empty state, the wizard to its composer-plus-import-tile floor.
  */
 export function useExploreTemplates(): {
   templates: ApiDiscoverableAgent[]
   hasSkillsets: boolean
   isLoading: boolean
 } {
-  const { data: skillsets } = useSkillsets()
-  const { data: discoverableAgents, isLoading } = useDiscoverableAgents()
+  const { data: skillsets, isError: skillsetsFailed } = useSkillsets()
+  const { data: discoverableAgents, isLoading, isError: templatesFailed } = useDiscoverableAgents()
 
   const hasSkillsets = skillsets === undefined || skillsets.length > 0
   return {
     templates: useMemo(() => discoverableAgents ?? [], [discoverableAgents]),
     hasSkillsets,
     isLoading:
-      skillsets === undefined || (hasSkillsets && (isLoading || discoverableAgents === undefined)),
+      !skillsetsFailed &&
+      !templatesFailed &&
+      (skillsets === undefined || (hasSkillsets && (isLoading || discoverableAgents === undefined))),
   }
 }
 

--- a/src/renderer/components/explore/explore-view.test.tsx
+++ b/src/renderer/components/explore/explore-view.test.tsx
@@ -18,9 +18,10 @@ vi.mock('@renderer/context/dialog-context', () => ({ useDialogs: () => ({ openSe
 let skillsets: { id: string; name: string }[] | undefined = []
 let discoverable: ApiDiscoverableAgent[] | undefined
 let isLoading = false
+let isError = false
 vi.mock('@renderer/hooks/use-skillsets', () => ({ useSkillsets: () => ({ data: skillsets }) }))
 vi.mock('@renderer/hooks/use-agent-templates', () => ({
-  useDiscoverableAgents: () => ({ data: discoverable, isLoading }),
+  useDiscoverableAgents: () => ({ data: discoverable, isLoading, isError }),
   slugFromAgentPath: (path: string) => path.replace(/^agents\//, '').replace(/\/$/, ''),
 }))
 
@@ -52,6 +53,7 @@ beforeEach(() => {
   skillsets = [{ id: 'skillset-1', name: 'Public' }]
   discoverable = roster(9)
   isLoading = false
+  isError = false
 })
 
 function getScrollContainer(): HTMLDivElement {
@@ -167,5 +169,15 @@ describe('ExploreView with no skillsets', () => {
     const { container } = render(<ExploreView />)
     expect(screen.queryByTestId('explore-empty')).toBeNull()
     expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('settles to the empty state when the template fetch fails', () => {
+    // After react-query gives up, data stays undefined with isLoading false —
+    // without the hook's isError term this page would skeleton forever.
+    discoverable = undefined
+    isError = true
+    const { container } = render(<ExploreView />)
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+    expect(screen.getByTestId('explore-empty')).toBeTruthy()
   })
 })

--- a/src/renderer/components/wizard/create-agent-step.tsx
+++ b/src/renderer/components/wizard/create-agent-step.tsx
@@ -5,12 +5,18 @@ interface CreateAgentStepProps {
 }
 
 export function CreateAgentStep({ onAgentCreated }: CreateAgentStepProps) {
+  // The title rides inside the form's centered hero block (see the form's
+  // `header` prop for why it cannot sit outside).
   return (
-    <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-normal max-w-sm">Let&apos;s create your first agent</h2>
-      </div>
-      <CreateAgentForm onAgentCreated={onAgentCreated} onNavigateAway={onAgentCreated} />
-    </div>
+    <CreateAgentForm
+      className="h-full"
+      header={
+        <div className="shrink-0 pb-8">
+          <h2 className="text-2xl font-normal max-w-sm">Describe your first AI teammate</h2>
+        </div>
+      }
+      onAgentCreated={onAgentCreated}
+      onNavigateAway={onAgentCreated}
+    />
   )
 }

--- a/src/renderer/components/wizard/getting-started-wizard.tsx
+++ b/src/renderer/components/wizard/getting-started-wizard.tsx
@@ -62,6 +62,23 @@ export function stepsForPath(path: 'platform' | 'manual' | null) {
   return targetIsRemote() ? all.filter((step) => step.id !== 'runtime') : all
 }
 
+/**
+ * The create-agent step is the one step wider than a form: it inlines the
+ * template roster under the composer, which wants three card columns. It also
+ * carries the only horizontal padding in the wizard — 480px of form has
+ * gutters to spare in any window big enough to run the app, but the roster at
+ * this width does not. `max-w` is border-box, so the cap is 760px of content
+ * plus that padding.
+ *
+ * Unlike the other steps this one is a HEIGHT-FILLING column, not a centered
+ * block, and the step container must not scroll: the composer stays pinned
+ * while CreateAgentForm scrolls the template roster in the room below it, so
+ * every layer between here and the form passes height down (h-full/flex-1
+ * with min-h-0 at each level — any level missing min-h-0 lets flex content
+ * push the column taller than the window and the pin silently breaks).
+ */
+const AGENT_STEP_MAX_WIDTH = 'max-w-[808px] px-6'
+
 interface GettingStartedWizardProps {
   agentOnly?: boolean
   onClose: () => void
@@ -172,14 +189,14 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
       <div className="flex h-svh bg-background overflow-hidden" data-testid="wizard-container">
         {isElectron() && <div className="absolute top-0 left-0 right-0 h-12 app-drag-region z-10" />}
         <div className="relative flex flex-col h-svh w-full">
-          <div className="flex flex-1 min-h-0 flex-col py-10 w-full mx-auto max-w-[640px] justify-center">
-            <div className="w-full">
-              <div className="min-h-[320px]" data-testid="wizard-step-content">
+          <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+            <div className={`flex h-full min-h-0 w-full mx-auto flex-col pt-10 ${AGENT_STEP_MAX_WIDTH}`}>
+              <div className="min-h-0 flex-1" data-testid="wizard-step-content">
                 <CreateAgentStep onAgentCreated={handleFinish} />
               </div>
             </div>
           </div>
-          <div className="flex justify-end pb-10 w-full mx-auto max-w-[640px]">
+          <div className={`flex justify-end pb-10 w-full mx-auto ${AGENT_STEP_MAX_WIDTH}`}>
             <Button
               variant="outline"
               onClick={() => void handleFinish()}
@@ -203,11 +220,12 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
       <div className={`relative flex flex-col h-svh transition-[width] duration-500 ease-in-out ${isAgentStep ? 'w-full' : 'w-full lg:w-1/2'}`}>
         <h1 className="sr-only">Getting Started</h1>
 
-        <div className={`flex flex-1 min-h-0 flex-col py-10 w-full mx-auto transition-[max-width] duration-500 justify-center ${isAgentStep ? 'max-w-[640px]' : 'max-w-[480px]'}`}>
-          <div className="w-full">
+        <div className={`flex flex-1 min-h-0 flex-col ${isAgentStep ? 'overflow-hidden' : 'justify-center'}`}>
+          <div className={`w-full mx-auto transition-[max-width] duration-500 ${isAgentStep ? `${AGENT_STEP_MAX_WIDTH} flex h-full min-h-0 flex-col pt-10` : 'max-w-[480px] py-10'}`}>
 
-          {/* Step content */}
-          <div className="min-h-[320px]" data-testid="wizard-step-content" data-step={currentStep}>
+          {/* Step content. The agent step fills the column height (its roster
+              scrolls internally); the rest keep the centered min-height block. */}
+          <div className={isAgentStep ? 'min-h-0 flex-1' : 'min-h-[320px]'} data-testid="wizard-step-content" data-step={currentStep}>
             {!welcomePath && (
               <WelcomeStep
                 onChoosePlatform={handleWelcomePlatformPath}
@@ -230,7 +248,7 @@ export function GettingStartedWizard({ agentOnly, onClose }: GettingStartedWizar
         </div>
 
         {/* Navigation buttons — hidden on welcome page */}
-        <div className={`flex items-center justify-between pb-10 w-full mx-auto transition-[max-width] duration-500 ${isAgentStep ? 'max-w-[640px]' : 'max-w-[480px]'} ${!welcomePath ? 'hidden' : ''}`}>
+        <div className={`flex items-center justify-between pb-10 w-full mx-auto transition-[max-width] duration-500 ${isAgentStep ? AGENT_STEP_MAX_WIDTH : 'max-w-[480px]'} ${!welcomePath ? 'hidden' : ''}`}>
           {!welcomePath ? (
             <div />
           ) : (

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -697,8 +697,32 @@ html[data-keyboard-open] [data-composer-footer] {
   transform: translateY(0);
 }
 
+/* Reveal variant for the create-agent composer, which carries backdrop-blur
+   glass: same entrance minus the blur filter and will-change. `filter` (even
+   blur(0)) and `will-change: filter/opacity` make the element a backdrop
+   root, which would blind the composer's backdrop-filter to the template
+   roster scrolling behind it — the glass sampled nothing and read as plain
+   transparency. Once settled (opacity 1, no filter) nothing groups, so the
+   blur sees the page like the session composer's does. */
+.create-agent-item-glass {
+  transition:
+    opacity 360ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 360ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.create-agent-item-glass[data-hidden="true"] {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+.create-agent-item-glass[data-hidden="false"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .create-agent-item {
+  .create-agent-item,
+  .create-agent-item-glass {
     transition-duration: 1ms;
   }
 }


### PR DESCRIPTION
Stacked on #851 (merge that first). The wizard's last step becomes composer-plus-roster instead of composer-plus-aid-chips:

- **"Describe your first AI teammate"** and the composer sit pinned in the upper third of the screen; the Explore roster scrolls underneath, grouped into the same 3×2 category sections as `/explore` (five cards plus the shared see-more tile; one column and three cards per section below the 768px mobile line), ending in an **Import an Agent** tile that opens the extracted import dialog.
- **Glass composer**: the composer wears the session composer's translucent chrome, and the roster's scroll viewport reaches up behind it (measured, so attachment rows keep it accurate) so cards genuinely frost through the blur. This required a `create-agent-item-glass` reveal variant — the standard reveal's `filter`/`will-change` make the wrapper a backdrop root, which blinds `backdrop-filter` to everything outside it. The floating shadow appears only while the roster is scrolled, reading as the box lifting so cards can pass under; scroll edges dissolve through mask fades and the scrollbar is hidden.
- **Install in place**: clicking a card installs the template via `TemplateInstallDialog` — no marketplace detour — and forfeits any armed signup handoff so its own install offer cannot stack. See-more awaits `onNavigateAway` (the wizard finishes itself first, since it renders above the router) then opens that category's Explore page.
- **The aid-chip row is gone**: browsing is the roster, voice is the composer's mic, import is the roster's final tile. An empty roster renders nothing — the composer alone is a complete create path.
- The agent step becomes a height-filling flex column (`min-h-0` at every level) so the composer pin holds; other steps keep their centered block. The wizard e2e template test now exercises the in-place install instead of the removed Browse Templates flow.

Validation: wizard e2e 11/11, renderer unit suites green (the only full-run failure is the pre-existing sup226 webhook flake at base), typecheck and lint clean. Verified live in light/dark, desktop/mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)