### PR TITLE
Rename sessions, dashboards, folders, and agents in place (SUP-685)

### DIFF
--- a/e2e/specs/session-rename.spec.ts
+++ b/e2e/specs/session-rename.spec.ts
@@ -49,11 +49,11 @@ test.describe('Session Rename (names must persist)', () => {
     await sessionItem.click({ button: 'right' })
     await page.locator('[data-testid="rename-session-item"]').click()
 
-    const dialog = page.getByRole('dialog', { name: 'Rename Session' })
-    await expect(dialog).toBeVisible()
-    await dialog.getByPlaceholder('Session name').fill(newName)
-    await dialog.getByRole('button', { name: /^Rename$/ }).click()
-    await expect(dialog).not.toBeVisible()
+    const input = page.getByLabel('Session name')
+    await expect(input).toBeVisible()
+    await input.fill(newName)
+    await input.press('Enter')
+    await expect(input).toHaveCount(0)
     await expect(sessionItem).toContainText(newName, { timeout: 10000 })
   }
 

--- a/src/renderer/components/agents/agent-context-menu.test.tsx
+++ b/src/renderer/components/agents/agent-context-menu.test.tsx
@@ -325,3 +325,22 @@ describe('moving an agent into a left-nav folder', () => {
     expect(screen.getByTestId('move-agent-to-new-folder-item')).toBeInTheDocument()
   })
 })
+
+describe('rename', () => {
+  it('stays off the menu until a row asks to start the field', () => {
+    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
+    expect(screen.queryByTestId('rename-agent-item')).not.toBeInTheDocument()
+  })
+
+  it('calls onRenameRequest from the owner rename item', async () => {
+    const onRenameRequest = vi.fn()
+    render(
+      <AgentContextMenu agent={AGENT} onRenameRequest={onRenameRequest}>
+        <span>row</span>
+      </AgentContextMenu>,
+    )
+
+    await userEvent.click(screen.getByTestId('rename-agent-item'))
+    expect(onRenameRequest).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/agents/agent-context-menu.test.tsx
+++ b/src/renderer/components/agents/agent-context-menu.test.tsx
@@ -17,8 +17,9 @@ vi.mock('@renderer/hooks/use-agents', () => ({
 vi.mock('./agent-settings-dialog', () => ({ AgentSettingsDialog: () => null }))
 vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }))
 vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }))
+const { mockCanAdminAgent } = vi.hoisted(() => ({ mockCanAdminAgent: vi.fn(() => true) }))
 vi.mock('@renderer/context/user-context', () => ({
-  useUser: () => ({ canAdminAgent: () => true, isAuthMode: false }),
+  useUser: () => ({ canAdminAgent: mockCanAdminAgent, isAuthMode: false }),
 }))
 
 const { mockUserSettings, mockUpdateSettings } = vi.hoisted(() => ({
@@ -96,6 +97,7 @@ function drive(target: 'local' | 'cloud') {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockCanAdminAgent.mockReturnValue(true)
   mockApiFetch.mockResolvedValue({ ok: true, json: async () => ({ path: '/srv/agents/sales' }) })
   mockUserSettings.mockReturnValue({ agentFolders: [], agentFolderAssignments: {} })
   mockUseAgents.mockReturnValue({ data: ALL_AGENTS, isLoading: false, error: null })
@@ -342,5 +344,15 @@ describe('rename', () => {
 
     await userEvent.click(screen.getByTestId('rename-agent-item'))
     expect(onRenameRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides rename from a member who cannot admin the agent', () => {
+    mockCanAdminAgent.mockReturnValue(false)
+    render(
+      <AgentContextMenu agent={AGENT} onRenameRequest={vi.fn()}>
+        <span>row</span>
+      </AgentContextMenu>,
+    )
+    expect(screen.queryByTestId('rename-agent-item')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -29,7 +29,7 @@ import { useUser } from '@renderer/context/user-context'
 import { AgentSettingsDialog } from './agent-settings-dialog'
 import { apiFetch } from '@renderer/lib/api'
 import { canUseHostFeatures } from '@renderer/lib/host-features'
-import { Settings, FolderOpen, Copy, Trash2, LogOut, Move, FolderInput } from 'lucide-react'
+import { Settings, FolderOpen, Copy, Trash2, LogOut, Move, FolderInput, Pencil } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Input } from '@renderer/components/ui/input'
 import { useUserSettings, useUpdateUserSettings, type UserSettingsData } from '@renderer/hooks/use-user-settings'
@@ -55,6 +55,7 @@ interface AgentContextMenuProps {
   onArrange?: () => void
   /** Let an explicit mobile arrange gesture own touch holds. */
   disableTouchLongPress?: boolean
+  onRenameRequest?: () => void
 }
 
 export function AgentContextMenu({
@@ -63,6 +64,7 @@ export function AgentContextMenu({
   additionalOptions,
   onArrange,
   disableTouchLongPress,
+  onRenameRequest,
 }: AgentContextMenuProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showLeaveDialog, setShowLeaveDialog] = useState(false)
@@ -241,6 +243,15 @@ export function AgentContextMenu({
           )}
           {additionalOptions}
           {(onArrange || additionalOptions) && <ContextMenuSeparator />}
+          {isOwner && onRenameRequest && (
+            <ContextMenuItem
+              data-testid="rename-agent-item"
+              onClick={onRenameRequest}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              Rename Agent
+            </ContextMenuItem>
+          )}
           <ContextMenuSub>
             <ContextMenuSubTrigger data-testid="move-agent-to-folder-trigger">
               <FolderInput className="h-4 w-4 mr-2" />

--- a/src/renderer/components/layout/agent-folder-block.test.tsx
+++ b/src/renderer/components/layout/agent-folder-block.test.tsx
@@ -296,6 +296,7 @@ describe('AgentFolderBlock', () => {
   it('opens straight into rename mode for a freshly created folder', () => {
     renderBlock({ initialRenaming: true })
     expect(screen.getByTestId('folder-name-input')).toBeInTheDocument()
+    expect(screen.getByLabelText('Create folder')).toBeInTheDocument()
   })
 
   it('deletes on request', async () => {

--- a/src/renderer/components/layout/agent-folder-block.tsx
+++ b/src/renderer/components/layout/agent-folder-block.tsx
@@ -16,68 +16,12 @@ import {
   ContextMenuTrigger,
 } from '@renderer/components/ui/context-menu'
 import { SidebarMenuButton } from '@renderer/components/ui/sidebar'
+import { InlineRenameInput } from '@renderer/components/ui/inline-rename-input'
 import {
   containerIdForFolder,
   sortableIdForFolder,
   type AgentFolder,
 } from '@renderer/lib/agent-folders'
-
-/**
- * Inline rename for a folder. Mirrors the dashboard rename in `app-sidebar.tsx`
- * — commit on Enter or blur, abandon on Escape — but writes to user settings
- * through the caller rather than hitting an API of its own.
- */
-function FolderNameInput({
-  currentName,
-  onCommit,
-  onDone,
-}: {
-  currentName: string
-  onCommit: (name: string) => void
-  onDone: () => void
-}) {
-  const [value, setValue] = useState(currentName)
-  const inputRef = React.useRef<HTMLInputElement>(null)
-  const settledRef = React.useRef(false)
-
-  React.useEffect(() => {
-    inputRef.current?.select()
-  }, [])
-
-  const submit = () => {
-    if (settledRef.current) return
-    settledRef.current = true
-    const trimmed = value.trim()
-    if (trimmed && trimmed !== currentName) onCommit(trimmed)
-    onDone()
-  }
-
-  const cancel = () => {
-    if (settledRef.current) return
-    settledRef.current = true
-    onDone()
-  }
-
-  return (
-    <input
-      ref={inputRef}
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onKeyDown={(e) => {
-        e.stopPropagation()
-        if (e.key === 'Enter') submit()
-        if (e.key === 'Escape') cancel()
-      }}
-      onBlur={submit}
-      onClick={(e) => e.stopPropagation()}
-      onPointerDown={(e) => e.stopPropagation()}
-      autoFocus
-      aria-label="Folder name"
-      data-testid="folder-name-input"
-      className="w-full bg-background border border-input rounded px-1 py-0 text-[13px] outline-none focus:ring-1 focus:ring-ring"
-    />
-  )
-}
 
 /**
  * The folder header's interactive row. Memoized because the block around it
@@ -200,7 +144,7 @@ export function AgentFolderBlock({
   /** Mount straight into rename mode — used by the just-created folder. */
   initialRenaming?: boolean
   onToggle: () => void
-  onRename: (name: string) => void
+  onRename: (name: string) => void | Promise<unknown>
   onRenameEnd?: () => void
   onDelete: () => void
   /** Rendered as a hover + on the default folder's header row. */
@@ -275,9 +219,13 @@ export function AgentFolderBlock({
         // control nested in a <button> is invalid markup, and clicking it would
         // land on the button and toggle the folder shut mid-edit.
         <div className="flex h-8 items-center rounded-md px-2">
-          <FolderNameInput
+          <InlineRenameInput
             currentName={folder.name}
-            onCommit={onRename}
+            noun="folder"
+            ariaLabel={initialRenaming ? 'Create folder' : 'Folder name'}
+            testId="folder-name-input"
+            className="text-[13px]"
+            onSave={onRename}
             onDone={() => {
               setIsRenaming(false)
               onRenameEnd?.()

--- a/src/renderer/components/layout/agent-header.test.tsx
+++ b/src/renderer/components/layout/agent-header.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@renderer/hooks/use-sessions', () => ({
       invokedByAgentSlug: mocks.invokedByAgentSlug,
     },
   }),
+  useUpdateSessionName: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 
 vi.mock('@renderer/hooks/use-scheduled-tasks', () => ({

--- a/src/renderer/components/layout/agent-header.tsx
+++ b/src/renderer/components/layout/agent-header.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react'
 import { Power, Square, Clock, Loader2, Zap, MoreVertical } from 'lucide-react'
 import { AppLink } from '@renderer/components/ui/app-link'
 import { useRouteLocation } from '@renderer/router/use-route-location'
 import { useAgent, type useStartAgent, type useStopAgent } from '@renderer/hooks/use-agents'
-import { useSessions, useSession } from '@renderer/hooks/use-sessions'
+import { useSessions, useSession, useUpdateSessionName } from '@renderer/hooks/use-sessions'
+import { InlineRenameInput } from '@renderer/components/ui/inline-rename-input'
 import { useScheduledTask } from '@renderer/hooks/use-scheduled-tasks'
 import { useWebhookTrigger } from '@renderer/hooks/use-webhook-triggers'
 import { useConnectedAccounts } from '@renderer/hooks/use-connected-accounts'
@@ -46,6 +48,8 @@ function BreadcrumbSeparator() {
  */
 export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHeaderProps) {
   const { view } = useRouteLocation()
+  const [isRenamingSession, setIsRenamingSession] = useState(false)
+  const updateSessionName = useUpdateSessionName()
   const sessionId = view.kind === 'session' ? view.id : null
   const scheduledTaskId = view.kind === 'task' ? view.id : null
   const webhookTriggerId = view.kind === 'webhook' ? view.id : null
@@ -187,19 +191,33 @@ export function AgentHeader({ slug, isViewOnly, startAgent, stopAgent }: AgentHe
         {sessionId && session?.agentSlug === agent?.slug && (
           <>
             <BreadcrumbSeparator />
-            <SessionContextMenu
-              sessionId={sessionId}
-              sessionName={session?.name || 'Session'}
-              agentSlug={slug}
-              sessionIsLive={!!session?.isActive || !!session?.isAwaitingInput}
-            >
-              <span
-                className="text-sm font-light text-foreground cursor-context-menu app-no-drag"
-                data-testid="session-breadcrumb"
+            {isRenamingSession ? (
+              <div className="min-w-[8rem] max-w-xs">
+                <InlineRenameInput
+                  currentName={session?.name || 'Session'}
+                  noun="session"
+                  ariaLabel="Session name"
+                  testId="session-breadcrumb"
+                  onSave={(name) => updateSessionName.mutateAsync({ sessionId, agentSlug: slug, name })}
+                  onDone={() => setIsRenamingSession(false)}
+                />
+              </div>
+            ) : (
+              <SessionContextMenu
+                sessionId={sessionId}
+                sessionName={session?.name || 'Session'}
+                agentSlug={slug}
+                sessionIsLive={!!session?.isActive || !!session?.isAwaitingInput}
+                onRenameRequest={() => setIsRenamingSession(true)}
               >
-                {session?.name || 'Loading...'}
-              </span>
-            </SessionContextMenu>
+                <span
+                  className="text-sm font-light text-foreground cursor-context-menu app-no-drag"
+                  data-testid="session-breadcrumb"
+                >
+                  {session?.name || 'Loading...'}
+                </span>
+              </SessionContextMenu>
+            )}
           </>
         )}
         {dashboardSlug && (

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -33,6 +33,7 @@ const mockUseAgents = vi.fn()
 vi.mock('@renderer/hooks/use-agents', () => ({
   useAgents: () => mockUseAgents(),
   useDeleteAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
   // Resolve the route param to the canonical id the way the real hook does,
   // using the mocked params + agents so active-state tests behave faithfully.
   useRouteAgentId: () => {

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -55,6 +55,7 @@ const mockUseSessions = vi.fn()
 vi.mock('@renderer/hooks/use-sessions', () => ({
   useSessions: (slug: string | null) => mockUseSessions(slug),
   useCreateSession: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateSessionName: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 
 vi.mock('@renderer/hooks/use-message-stream', () => ({

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -49,7 +49,7 @@ import {
   type FirewallFixUiState,
 } from '@renderer/components/runtime/runtime-status-banners'
 import { useFirewallStatus, useFixFirewall } from '@renderer/hooks/use-firewall-status'
-import { useAgents, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
+import { useAgents, useRouteAgentId, useUpdateAgent, type ApiAgent } from '@renderer/hooks/use-agents'
 import { useSessions, useUpdateSessionName, type ApiSession } from '@renderer/hooks/use-sessions'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useSettings } from '@renderer/hooks/use-settings'
@@ -500,6 +500,8 @@ const AgentMenuItemInner = React.forwardRef<
   }
 
   const { ref: hintRef, hint } = useCmdHintTarget()
+  const [isRenaming, setIsRenaming] = useState(false)
+  const updateAgent = useUpdateAgent()
 
   return (
     <Collapsible asChild open={isOpen && !isDragActive} onOpenChange={setIsOpen}>
@@ -510,26 +512,41 @@ const AgentMenuItemInner = React.forwardRef<
           item that also contains CollapsibleContent below.
         */}
         <div className="relative">
-          <AgentContextMenu agent={agent}>
-            <SidebarMenuButton
-              asChild
-              isActive={isSelected}
-              className="justify-between pl-7"
+          {isRenaming ? (
+            <div
+              className="flex h-8 items-center rounded-md px-2 pl-7"
               data-testid={`agent-item-${agent.slug}`}
             >
-              <AppLink ref={hintRef} to="/agents/$slug" params={{ slug: agent.displaySlug }}>
-                <span className="flex items-center gap-1.5 min-w-0">
-                  <span className="truncate text-[13px] font-normal text-sidebar-foreground">{agent.name}</span>
-                  {isShared && <Users className="h-3 w-3 shrink-0 text-muted-foreground" />}
-                </span>
-                {hint !== null ? (
-                  <CmdHintBadge hint={hint} />
-                ) : (
-                  <AgentRowIndicator agent={agent} sessions={sessions} isOpen={isOpen} />
-                )}
-              </AppLink>
-            </SidebarMenuButton>
-          </AgentContextMenu>
+              <InlineRenameInput
+                currentName={agent.name}
+                noun="agent"
+                ariaLabel="Agent name"
+                onSave={(name) => updateAgent.mutateAsync({ slug: agent.slug, name })}
+                onDone={() => setIsRenaming(false)}
+              />
+            </div>
+          ) : (
+            <AgentContextMenu agent={agent} onRenameRequest={() => setIsRenaming(true)}>
+              <SidebarMenuButton
+                asChild
+                isActive={isSelected}
+                className="justify-between pl-7"
+                data-testid={`agent-item-${agent.slug}`}
+              >
+                <AppLink ref={hintRef} to="/agents/$slug" params={{ slug: agent.displaySlug }}>
+                  <span className="flex items-center gap-1.5 min-w-0">
+                    <span className="truncate text-[13px] font-normal text-sidebar-foreground">{agent.name}</span>
+                    {isShared && <Users className="h-3 w-3 shrink-0 text-muted-foreground" />}
+                  </span>
+                  {hint !== null ? (
+                    <CmdHintBadge hint={hint} />
+                  ) : (
+                    <AgentRowIndicator agent={agent} sessions={sessions} isOpen={isOpen} />
+                  )}
+                </AppLink>
+              </SidebarMenuButton>
+            </AgentContextMenu>
+          )}
           {/*
             Sibling chevron button overlays its slot in the row so the row stays a
             single <button> (no nested interactive controls). Only rendered when

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -50,7 +50,7 @@ import {
 } from '@renderer/components/runtime/runtime-status-banners'
 import { useFirewallStatus, useFixFirewall } from '@renderer/hooks/use-firewall-status'
 import { useAgents, useRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
-import { useSessions, type ApiSession } from '@renderer/hooks/use-sessions'
+import { useSessions, useUpdateSessionName, type ApiSession } from '@renderer/hooks/use-sessions'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
@@ -63,6 +63,7 @@ import { SIDEBAR_TREE_CONNECTORS } from '@renderer/components/ui/tree-connectors
 import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
 import { SessionContextMenu } from '@renderer/components/sessions/session-context-menu'
 import { DashboardContextMenu } from '@renderer/components/dashboards/dashboard-context-menu'
+import { InlineRenameInput } from '@renderer/components/ui/inline-rename-input'
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams, useRouterState } from '@tanstack/react-router'
 import { apiFetch } from '@renderer/lib/api'
@@ -200,62 +201,81 @@ function SessionSubItem({
   // redundant — the session clearly isn't asleep).
   const showPendingWake = !!session.pendingWakeAt && !isWorking && !isAwaitingInput
   const { ref: hintRef, hint } = useCmdHintTarget()
+  const [isRenaming, setIsRenaming] = useState(false)
+  const updateSessionName = useUpdateSessionName()
 
   return (
     <SidebarMenuSubItem>
-      <SessionContextMenu
-        sessionId={session.id}
-        sessionName={session.name}
-        agentSlug={agentSlug}
-        // Same condition `hasUnread` above gates the dot on — no point
-        // offering "Mark as Unread" where the dot would be suppressed.
-        sessionIsLive={!!session.isActive || !!session.isAwaitingInput}
-      >
-        <SidebarMenuSubButton
-          asChild
-          isActive={isSelected}
+      {isRenaming ? (
+        <div
+          className="flex h-8 items-center rounded-md px-2"
+          data-testid={`session-item-${session.id}`}
         >
-          <AppLink
-            ref={hintRef}
-            to="/agents/$slug/sessions/$sessionId"
-            params={{ slug: agentSlug, sessionId: session.id }}
-            className="flex items-center gap-2 w-full"
-            data-testid={`session-item-${session.id}`}
+          <InlineRenameInput
+            currentName={session.name}
+            noun="session"
+            ariaLabel="Session name"
+            testId={`session-name-${session.id}`}
+            onSave={(name) => updateSessionName.mutateAsync({ sessionId: session.id, agentSlug, name })}
+            onDone={() => setIsRenaming(false)}
+          />
+        </div>
+      ) : (
+        <SessionContextMenu
+          sessionId={session.id}
+          sessionName={session.name}
+          agentSlug={agentSlug}
+          // Same condition `hasUnread` above gates the dot on — no point
+          // offering "Mark as Unread" where the dot would be suppressed.
+          sessionIsLive={!!session.isActive || !!session.isAwaitingInput}
+          onRenameRequest={() => setIsRenaming(true)}
+        >
+          <SidebarMenuSubButton
+            asChild
+            isActive={isSelected}
           >
-            <HoverScrollText
-              className="flex-1 text-left"
-              data-testid={`session-name-${session.id}`}
-              hoverTarget="parent"
+            <AppLink
+              ref={hintRef}
+              to="/agents/$slug/sessions/$sessionId"
+              params={{ slug: agentSlug, sessionId: session.id }}
+              className="flex items-center gap-2 w-full"
+              data-testid={`session-item-${session.id}`}
             >
-              {session.name}
-            </HoverScrollText>
-            {hint !== null ? (
-              <CmdHintBadge hint={hint} />
-            ) : (
-              <span className="flex items-center justify-center gap-1 min-w-4 shrink-0">
-                {showPendingWake && (
-                  <span
-                    className="flex items-center"
-                    role="img"
-                    aria-label="scheduled to resume"
-                    title={`Resumes ${formatDistanceToNow(new Date(session.pendingWakeAt!), { addSuffix: true })}`}
-                    data-testid={`session-pending-wake-${session.id}`}
-                  >
-                    <MoonStar className="h-3 w-3 text-muted-foreground" />
-                  </span>
-                )}
-                {isAwaitingInput ? (
-                  <AwaitingDot />
-                ) : isWorking ? (
-                  <WorkingDots />
-                ) : hasUnread ? (
-                  <span className="h-1.5 w-1.5 rounded-full bg-blue-500" role="img" aria-label="unread notifications" />
-                ) : null}
-              </span>
-            )}
-          </AppLink>
-        </SidebarMenuSubButton>
-      </SessionContextMenu>
+              <HoverScrollText
+                className="flex-1 text-left"
+                data-testid={`session-name-${session.id}`}
+                hoverTarget="parent"
+              >
+                {session.name}
+              </HoverScrollText>
+              {hint !== null ? (
+                <CmdHintBadge hint={hint} />
+              ) : (
+                <span className="flex items-center justify-center gap-1 min-w-4 shrink-0">
+                  {showPendingWake && (
+                    <span
+                      className="flex items-center"
+                      role="img"
+                      aria-label="scheduled to resume"
+                      title={`Resumes ${formatDistanceToNow(new Date(session.pendingWakeAt!), { addSuffix: true })}`}
+                      data-testid={`session-pending-wake-${session.id}`}
+                    >
+                      <MoonStar className="h-3 w-3 text-muted-foreground" />
+                    </span>
+                  )}
+                  {isAwaitingInput ? (
+                    <AwaitingDot />
+                  ) : isWorking ? (
+                    <WorkingDots />
+                  ) : hasUnread ? (
+                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500" role="img" aria-label="unread notifications" />
+                  ) : null}
+                </span>
+              )}
+            </AppLink>
+          </SidebarMenuSubButton>
+        </SessionContextMenu>
+      )}
     </SidebarMenuSubItem>
   )
 }
@@ -273,112 +293,63 @@ function DashboardSubItem({
   const isSelected = routeAgentId === agentSlug && routeDashSlug === artifact.slug
   const [isRenaming, setIsRenaming] = useState(false)
   const { ref: hintRef, hint } = useCmdHintTarget()
+  const queryClient = useQueryClient()
 
   const handleDoubleClick = () => {
     openDashboardExternal(agentSlug, artifact.slug, artifact.name)
   }
 
+  const saveName = async (name: string) => {
+    const res = await apiFetch(`/api/agents/${agentSlug}/artifacts/${artifact.slug}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    })
+    if (!res.ok) throw new Error('Failed to rename dashboard')
+    queryClient.invalidateQueries({ queryKey: ['artifacts', agentSlug] })
+    queryClient.invalidateQueries({ queryKey: ['agents'] })
+  }
+
   return (
     <SidebarMenuSubItem>
-      <DashboardContextMenu
-        artifactSlug={artifact.slug}
-        artifactName={artifact.name}
-        agentSlug={agentSlug}
-        onRenameRequest={() => setIsRenaming(true)}
-      >
-        <SidebarMenuSubButton
-          asChild
-          isActive={isSelected}
-          title={`${artifact.description || artifact.name} (double-click to open in new window)`}
+      {isRenaming ? (
+        <div className="flex h-8 items-center gap-2 rounded-md px-2">
+          <SquareMousePointer className="!h-3.5 !w-3.5 shrink-0" />
+          <InlineRenameInput
+            currentName={artifact.name}
+            noun="dashboard"
+            ariaLabel="Dashboard name"
+            onSave={saveName}
+            onDone={() => setIsRenaming(false)}
+          />
+        </div>
+      ) : (
+        <DashboardContextMenu
+          artifactSlug={artifact.slug}
+          artifactName={artifact.name}
+          agentSlug={agentSlug}
+          onRenameRequest={() => setIsRenaming(true)}
         >
-          <AppLink
-            ref={hintRef}
-            to="/agents/$slug/dashboards/$dashSlug"
-            params={{ slug: agentSlug, dashSlug: artifact.slug }}
-            onDoubleClick={handleDoubleClick}
-            className="flex items-center gap-2 w-full"
+          <SidebarMenuSubButton
+            asChild
+            isActive={isSelected}
+            title={`${artifact.description || artifact.name} (double-click to open in new window)`}
           >
-            <SquareMousePointer className="!h-3.5 !w-3.5 shrink-0" />
-            {isRenaming ? (
-              <InlineRenameInput
-                agentSlug={agentSlug}
-                artifactSlug={artifact.slug}
-                currentName={artifact.name}
-                onDone={() => setIsRenaming(false)}
-              />
-            ) : (
+            <AppLink
+              ref={hintRef}
+              to="/agents/$slug/dashboards/$dashSlug"
+              params={{ slug: agentSlug, dashSlug: artifact.slug }}
+              onDoubleClick={handleDoubleClick}
+              className="flex items-center gap-2 w-full"
+            >
+              <SquareMousePointer className="!h-3.5 !w-3.5 shrink-0" />
               <span className="truncate">{artifact.name}</span>
-            )}
-            {hint !== null && <CmdHintBadge hint={hint} className="ml-auto" />}
-          </AppLink>
-        </SidebarMenuSubButton>
-      </DashboardContextMenu>
+              {hint !== null && <CmdHintBadge hint={hint} className="ml-auto" />}
+            </AppLink>
+          </SidebarMenuSubButton>
+        </DashboardContextMenu>
+      )}
     </SidebarMenuSubItem>
-  )
-}
-
-function InlineRenameInput({
-  agentSlug,
-  artifactSlug,
-  currentName,
-  onDone,
-}: {
-  agentSlug: string
-  artifactSlug: string
-  currentName: string
-  onDone: () => void
-}) {
-  const [value, setValue] = useState(currentName)
-  const queryClient = useQueryClient()
-  const inputRef = React.useRef<HTMLInputElement>(null)
-  const cancelledRef = React.useRef(false)
-  const submittedRef = React.useRef(false)
-
-  React.useEffect(() => {
-    inputRef.current?.select()
-  }, [])
-
-  const submit = async () => {
-    if (submittedRef.current || cancelledRef.current) return
-    submittedRef.current = true
-    const trimmed = value.trim()
-    if (trimmed && trimmed !== currentName) {
-      try {
-        const res = await apiFetch(`/api/agents/${agentSlug}/artifacts/${artifactSlug}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: trimmed }),
-        })
-        if (res.ok) {
-          queryClient.invalidateQueries({ queryKey: ['artifacts', agentSlug] })
-        }
-      } catch (error) {
-        console.error('Failed to rename dashboard:', error)
-      }
-    }
-    onDone()
-  }
-
-  const cancel = () => {
-    cancelledRef.current = true
-    onDone()
-  }
-
-  return (
-    <input
-      ref={inputRef}
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onKeyDown={(e) => {
-        e.stopPropagation()
-        if (e.key === 'Enter') submit()
-        if (e.key === 'Escape') cancel()
-      }}
-      onBlur={submit}
-      onClick={(e) => e.stopPropagation()}
-      autoFocus
-      className="w-full bg-background border border-input rounded px-1 py-0 text-sm outline-none focus:ring-1 focus:ring-ring"
-    />
   )
 }
 
@@ -1306,7 +1277,7 @@ export function AppSidebar() {
   }, [updateSettings])
 
   const handleRenameFolder = useCallback((folderId: string, name: string) => {
-    updateSettings.mutate((current) => ({
+    return updateSettings.mutateAsync((current) => ({
       agentFolders: sanitizeFolders(current?.agentFolders).map((f) =>
         f.id === folderId ? { ...f, name } : f
       ),

--- a/src/renderer/components/sessions/related-sessions.tsx
+++ b/src/renderer/components/sessions/related-sessions.tsx
@@ -4,7 +4,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-indicators'
 import { HighlightMatch } from '@renderer/components/ui/highlight-match'
 import { Button } from '@renderer/components/ui/button'
-import { Input } from '@renderer/components/ui/input'
+import { InlineRenameInput } from '@renderer/components/ui/inline-rename-input'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 import {
   Select,
@@ -23,14 +23,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@renderer/components/ui/dialog'
 import { useRouteLocation } from '@renderer/router/use-route-location'
 import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
@@ -173,9 +165,8 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
   const deleteSession = useDeleteSession()
   const updateSessionName = useUpdateSessionName()
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
-  const [showRenameDialog, setShowRenameDialog] = useState(false)
+  const [isRenaming, setIsRenaming] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
-  const [newName, setNewName] = useState(session.name)
 
   const handleDelete = async () => {
     if (!agentSlug) return
@@ -194,21 +185,6 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
     }
   }
 
-  const handleRename = async () => {
-    if (!agentSlug) return
-    const trimmed = newName.trim()
-    if (!trimmed || trimmed === session.name) {
-      setShowRenameDialog(false)
-      return
-    }
-    try {
-      await updateSessionName.mutateAsync({ sessionId: session.id, agentSlug, name: trimmed })
-      setShowRenameDialog(false)
-    } catch (error) {
-      console.error('Failed to rename session:', error)
-    }
-  }
-
   const handleCopyRawLog = async () => {
     if (!agentSlug) return
     try {
@@ -219,6 +195,20 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
     } catch (error) {
       console.error('Failed to copy raw log:', error)
     }
+  }
+
+  if (isRenaming && agentSlug) {
+    return (
+      <div className="w-full py-3 px-1">
+        <InlineRenameInput
+          currentName={session.name}
+          noun="session"
+          ariaLabel="Session name"
+          onSave={(name) => updateSessionName.mutateAsync({ sessionId: session.id, agentSlug, name })}
+          onDone={() => setIsRenaming(false)}
+        />
+      </div>
+    )
   }
 
   return (
@@ -293,8 +283,7 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
                   className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-muted transition-colors"
                   onClick={(e) => {
                     e.stopPropagation()
-                    setNewName(session.name)
-                    setShowRenameDialog(true)
+                    setIsRenaming(true)
                   }}
                 >
                   <Pencil className="h-3.5 w-3.5" />
@@ -349,33 +338,6 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
-      <Dialog open={showRenameDialog} onOpenChange={setShowRenameDialog}>
-        <DialogContent className="overflow-hidden">
-          <DialogHeader>
-            <DialogTitle>Rename Session</DialogTitle>
-            <DialogDescription>
-              Enter a new name for this session.
-            </DialogDescription>
-          </DialogHeader>
-          <form onSubmit={(e) => { e.preventDefault(); handleRename() }}>
-            <Input
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              placeholder="Session name"
-              autoFocus
-            />
-            <DialogFooter className="mt-4">
-              <Button type="button" variant="outline" onClick={() => setShowRenameDialog(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={updateSessionName.isPending || !newName.trim()}>
-                {updateSessionName.isPending ? 'Renaming...' : 'Rename'}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
     </>
   )
 }

--- a/src/renderer/components/sessions/session-context-menu.test.tsx
+++ b/src/renderer/components/sessions/session-context-menu.test.tsx
@@ -48,21 +48,10 @@ vi.mock('@renderer/components/ui/alert-dialog', () => ({
   AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
-vi.mock('@renderer/components/ui/dialog', () => ({
-  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <>{children}</> : null,
-  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}))
-
 const mockSetMarkedUnread = vi.fn().mockResolvedValue({ success: true })
 
 vi.mock('@renderer/hooks/use-sessions', () => ({
   useDeleteSession: () => ({ mutateAsync: vi.fn() }),
-  useUpdateSessionName: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useSetSessionMarkedUnread: () => ({ mutateAsync: mockSetMarkedUnread, isPending: false }),
 }))
 
@@ -225,6 +214,23 @@ describe('SessionContextMenu mark as unread', () => {
 
     expect(screen.queryByTestId('rename-session-item')).not.toBeInTheDocument()
     expect(screen.getByTestId('mark-unread-session-item')).toBeInTheDocument()
+  })
+
+  it('calls onRenameRequest from the owner rename item', () => {
+    const onRenameRequest = vi.fn()
+    render(
+      <SessionContextMenu
+        sessionId="session-9"
+        sessionName="Session Nine"
+        agentSlug="agent-2"
+        onRenameRequest={onRenameRequest}
+      >
+        <button type="button">Session Nine</button>
+      </SessionContextMenu>,
+    )
+
+    fireEvent.click(screen.getByTestId('rename-session-item'))
+    expect(onRenameRequest).toHaveBeenCalledTimes(1)
   })
 
   // A mark is scoped to the acting user, so it raises a dot on their sidebar

--- a/src/renderer/components/sessions/session-context-menu.tsx
+++ b/src/renderer/components/sessions/session-context-menu.tsx
@@ -17,17 +17,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@renderer/components/ui/alert-dialog'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@renderer/components/ui/dialog'
-import { Button } from '@renderer/components/ui/button'
-import { Input } from '@renderer/components/ui/input'
-import { useDeleteSession, useUpdateSessionName, useSetSessionMarkedUnread } from '@renderer/hooks/use-sessions'
+import { useDeleteSession, useSetSessionMarkedUnread } from '@renderer/hooks/use-sessions'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { Trash2, ClipboardCopy, Pencil, MessageSquareDot } from 'lucide-react'
@@ -56,6 +46,7 @@ interface SessionContextMenuProps {
    * silent no-op.
    */
   sessionIsLive?: boolean
+  onRenameRequest?: () => void
   children: React.ReactNode
 }
 
@@ -64,17 +55,14 @@ export function SessionContextMenu({
   sessionName,
   agentSlug,
   sessionIsLive = false,
+  onRenameRequest,
   children,
 }: SessionContextMenuProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
-  const [showRenameDialog, setShowRenameDialog] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
-  const [newName, setNewName] = useState(sessionName)
   const [usage, setUsage] = useState<UsageState>({ status: 'idle' })
-  const renameInputRef = useRef<HTMLInputElement>(null)
   const usageRequestRef = useRef(0)
   const deleteSession = useDeleteSession()
-  const updateSessionName = useUpdateSessionName()
   const setSessionMarkedUnread = useSetSessionMarkedUnread()
   const navigate = useNavigate()
   // strict:false → undefined when the menu is opened off the session route
@@ -96,20 +84,6 @@ export function SessionContextMenu({
       console.error('Failed to delete session:', error)
     } finally {
       setIsDeleting(false)
-    }
-  }
-
-  const handleRename = async () => {
-    const trimmed = newName.trim()
-    if (!trimmed || trimmed === sessionName) {
-      setShowRenameDialog(false)
-      return
-    }
-    try {
-      await updateSessionName.mutateAsync({ sessionId, agentSlug, name: trimmed })
-      setShowRenameDialog(false)
-    } catch (error) {
-      console.error('Failed to rename session:', error)
     }
   }
 
@@ -163,13 +137,10 @@ export function SessionContextMenu({
           {children}
         </ContextMenuTrigger>
         <ContextMenuContent>
-          {isOwner && (
+          {isOwner && onRenameRequest && (
             <ContextMenuItem
               data-testid="rename-session-item"
-              onClick={() => {
-                setNewName(sessionName)
-                setShowRenameDialog(true)
-              }}
+              onClick={onRenameRequest}
             >
               <Pencil className="h-4 w-4 mr-2" />
               Rename Session
@@ -251,34 +222,6 @@ export function SessionContextMenu({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
-      <Dialog open={showRenameDialog} onOpenChange={setShowRenameDialog}>
-        <DialogContent className="overflow-hidden">
-          <DialogHeader>
-            <DialogTitle>Rename Session</DialogTitle>
-            <DialogDescription>
-              Enter a new name for this session.
-            </DialogDescription>
-          </DialogHeader>
-          <form onSubmit={(e) => { e.preventDefault(); handleRename() }}>
-            <Input
-              ref={renameInputRef}
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              placeholder="Session name"
-              autoFocus
-            />
-            <DialogFooter className="mt-4">
-              <Button type="button" variant="outline" onClick={() => setShowRenameDialog(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={updateSessionName.isPending || !newName.trim()}>
-                {updateSessionName.isPending ? 'Renaming...' : 'Rename'}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
     </>
   )
 }

--- a/src/renderer/components/ui/alert-dialog.tsx
+++ b/src/renderer/components/ui/alert-dialog.tsx
@@ -13,12 +13,17 @@ const AlertDialogPortal = AlertDialogPrimitive.Portal
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+>(({ className, onPointerDown, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
       "fixed inset-0 z-50 bg-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
+    onPointerDown={(e) => {
+      // Portals leave the DOM, but React still bubbles to sortable ancestors.
+      e.stopPropagation()
+      onPointerDown?.(e)
+    }}
     {...props}
     ref={ref}
   />
@@ -28,7 +33,7 @@ AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, onPointerDown, ...props }, ref) => (
   <AlertDialogPortal>
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
@@ -37,6 +42,10 @@ const AlertDialogContent = React.forwardRef<
         "fixed left-[50%] top-[50%] z-50 grid [&>*]:min-w-0 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
+      onPointerDown={(e) => {
+        e.stopPropagation()
+        onPointerDown?.(e)
+      }}
       {...props}
     />
   </AlertDialogPortal>

--- a/src/renderer/components/ui/dialog.tsx
+++ b/src/renderer/components/ui/dialog.tsx
@@ -12,13 +12,18 @@ const DialogClose = DialogPrimitive.Close
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+>(({ className, onPointerDown, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
       'fixed inset-0 z-50 bg-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
+    onPointerDown={(e) => {
+      // Portals leave the DOM, but React still bubbles to sortable ancestors.
+      e.stopPropagation()
+      onPointerDown?.(e)
+    }}
     {...props}
   />
 ))
@@ -30,7 +35,7 @@ const DialogContent = React.forwardRef<
     /** Omit the top-right X close button (e.g. when the dialog has its own Cancel). */
     hideClose?: boolean
   }
->(({ className, children, onKeyDown, hideClose, ...props }, ref) => (
+>(({ className, children, onKeyDown, onPointerDown, hideClose, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -39,6 +44,10 @@ const DialogContent = React.forwardRef<
         'fixed left-[50%] top-[50%] z-50 grid [&>*]:min-w-0 w-full max-w-lg max-h-[90vh] overflow-y-scroll translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
+      onPointerDown={(e) => {
+        e.stopPropagation()
+        onPointerDown?.(e)
+      }}
       onKeyDown={(e) => {
         onKeyDown?.(e)
         e.stopPropagation()

--- a/src/renderer/components/ui/inline-rename-input.test.tsx
+++ b/src/renderer/components/ui/inline-rename-input.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import type { ComponentProps } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
+import { InlineRenameInput } from './inline-rename-input'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}))
+
+function renderField(overrides: Partial<ComponentProps<typeof InlineRenameInput>> = {}) {
+  const onSave = overrides.onSave ?? vi.fn().mockResolvedValue(undefined)
+  const onDone = overrides.onDone ?? vi.fn()
+  render(
+    <>
+      <InlineRenameInput
+        currentName="New Session"
+        noun="session"
+        ariaLabel="Session name"
+        testId="name-input"
+        onSave={onSave}
+        onDone={onDone}
+        {...overrides}
+      />
+      <button type="button" data-testid="other">Other</button>
+    </>,
+  )
+  return { onSave, onDone }
+}
+
+describe('InlineRenameInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('selects the current name on mount so typing replaces it', () => {
+    renderField()
+    const input = screen.getByTestId('name-input') as HTMLInputElement
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe('New Session'.length)
+  })
+
+  it('saves a trimmed name on Enter', async () => {
+    const user = userEvent.setup()
+    const { onSave, onDone } = renderField()
+    await user.clear(screen.getByTestId('name-input'))
+    await user.type(screen.getByTestId('name-input'), '  Q3 plan  {Enter}')
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith('Q3 plan'))
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  it('saves on leave', async () => {
+    const user = userEvent.setup()
+    const { onSave } = renderField()
+    await user.clear(screen.getByTestId('name-input'))
+    await user.type(screen.getByTestId('name-input'), 'Q3 plan')
+    await user.tab()
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith('Q3 plan'))
+  })
+
+  it('abandons on Escape without saving', async () => {
+    const user = userEvent.setup()
+    const { onSave, onDone } = renderField()
+    await user.type(screen.getByTestId('name-input'), ' changed')
+    await user.keyboard('{Escape}')
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  it('treats an unchanged or blank name as a cancel', async () => {
+    const user = userEvent.setup()
+    const { onSave, onDone } = renderField()
+    await user.type(screen.getByTestId('name-input'), '{Enter}')
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  it('treats a name edited back to the snapshot as a cancel', async () => {
+    const user = userEvent.setup()
+    const { onSave, onDone } = renderField()
+    await user.type(screen.getByTestId('name-input'), ' extra')
+    await user.clear(screen.getByTestId('name-input'))
+    await user.type(screen.getByTestId('name-input'), 'New Session{Enter}')
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  it('keeps the typed name when currentName updates while editing', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const onDone = vi.fn()
+    const { rerender } = render(
+      <InlineRenameInput
+        currentName="New Session"
+        noun="session"
+        ariaLabel="Session name"
+        testId="name-input"
+        onSave={onSave}
+        onDone={onDone}
+      />,
+    )
+    await user.clear(screen.getByTestId('name-input'))
+    await user.type(screen.getByTestId('name-input'), 'Quarterly numbers')
+    rerender(
+      <InlineRenameInput
+        currentName="Reviewing the Q3 spreadsheet"
+        noun="session"
+        ariaLabel="Session name"
+        testId="name-input"
+        onSave={onSave}
+        onDone={onDone}
+      />,
+    )
+    expect(screen.getByTestId('name-input')).toHaveValue('Quarterly numbers')
+  })
+
+  it('stays open with a toast when save fails', async () => {
+    const user = userEvent.setup()
+    const error = new Error('Nope')
+    const { onSave, onDone } = renderField({
+      onSave: vi.fn().mockRejectedValue(error),
+    })
+    await user.clear(screen.getByTestId('name-input'))
+    await user.type(screen.getByTestId('name-input'), 'Q3 plan{Enter}')
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+    expect(onDone).not.toHaveBeenCalled()
+    expect(screen.getByTestId('name-input')).toHaveValue('Q3 plan')
+    expect(toast.error).toHaveBeenCalledWith('Failed to rename session', {
+      description: 'Nope',
+    })
+  })
+
+  it('locks the field while save is in flight and holds the leaving click', async () => {
+    const user = userEvent.setup()
+    let resolveSave: (() => void) | undefined
+    const otherClick = vi.fn()
+    const onSave = vi.fn(() => new Promise<void>((resolve) => { resolveSave = resolve }))
+    const onDone = vi.fn()
+    render(
+      <>
+        <InlineRenameInput
+          currentName="New Session"
+          noun="session"
+          ariaLabel="Session name"
+          testId="name-input"
+          onSave={onSave}
+          onDone={onDone}
+        />
+        <button type="button" data-testid="other" onClick={otherClick}>Other</button>
+      </>,
+    )
+    await user.clear(screen.getByTestId('name-input'))
+    await user.type(screen.getByTestId('name-input'), 'Q3 plan')
+    await user.click(screen.getByTestId('other'))
+    expect(onSave).toHaveBeenCalled()
+    expect(screen.getByTestId('name-input')).toBeDisabled()
+    expect(otherClick).not.toHaveBeenCalled()
+    expect(onDone).not.toHaveBeenCalled()
+    resolveSave?.()
+    await waitFor(() => expect(onDone).toHaveBeenCalled())
+    await waitFor(() => expect(otherClick).toHaveBeenCalled())
+  })
+
+  it('drops the held click when save fails', async () => {
+    const user = userEvent.setup()
+    const otherClick = vi.fn()
+    render(
+      <>
+        <InlineRenameInput
+          currentName="New Session"
+          noun="session"
+          ariaLabel="Session name"
+          testId="name-input"
+          onSave={vi.fn().mockRejectedValue(new Error('Nope'))}
+          onDone={vi.fn()}
+        />
+        <button type="button" data-testid="other" onClick={otherClick}>Other</button>
+      </>,
+    )
+    await user.clear(screen.getByTestId('name-input'))
+    await user.type(screen.getByTestId('name-input'), 'Q3 plan')
+    await user.click(screen.getByTestId('other'))
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(otherClick).not.toHaveBeenCalled()
+    expect(screen.getByTestId('name-input')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/ui/inline-rename-input.tsx
+++ b/src/renderer/components/ui/inline-rename-input.tsx
@@ -17,7 +17,7 @@ export function InlineRenameInput({
   onDone,
 }: {
   currentName: string
-  noun: 'session' | 'dashboard' | 'folder'
+  noun: 'session' | 'dashboard' | 'folder' | 'agent'
   ariaLabel: string
   testId?: string
   className?: string

--- a/src/renderer/components/ui/inline-rename-input.tsx
+++ b/src/renderer/components/ui/inline-rename-input.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { cn } from '@shared/lib/utils/cn'
+
+/**
+ * In-place rename for a sidebar (or list) name. Snapshots the name on mount,
+ * commits on Enter or leave, abandons on Escape, and stays open with a toast
+ * when save fails. A click that caused the leave is held until save succeeds.
+ */
+export function InlineRenameInput({
+  currentName,
+  noun,
+  ariaLabel,
+  testId,
+  className,
+  onSave,
+  onDone,
+}: {
+  currentName: string
+  noun: 'session' | 'dashboard' | 'folder'
+  ariaLabel: string
+  testId?: string
+  className?: string
+  onSave: (name: string) => void | Promise<unknown>
+  onDone: () => void
+}) {
+  const snapshot = useRef(currentName)
+  const [value, setValue] = useState(currentName)
+  const [isPending, setIsPending] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const settledRef = useRef(false)
+  const pendingRef = useRef(false)
+  const queuedClickRef = useRef<Element | null>(null)
+  const swallowLeaveClickRef = useRef(false)
+  const generationRef = useRef(0)
+
+  useEffect(() => {
+    inputRef.current?.select()
+  }, [])
+
+  useEffect(() => {
+    const onClickCapture = (event: MouseEvent) => {
+      if (!pendingRef.current && !swallowLeaveClickRef.current) return
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (inputRef.current?.contains(target)) return
+      event.preventDefault()
+      event.stopPropagation()
+      if (swallowLeaveClickRef.current) {
+        swallowLeaveClickRef.current = false
+        return
+      }
+      queuedClickRef.current =
+        target instanceof Element
+          ? target.closest('a, button, [role="button"], [role="link"]') ?? target
+          : null
+    }
+    document.addEventListener('click', onClickCapture, true)
+    return () => document.removeEventListener('click', onClickCapture, true)
+  }, [])
+
+  const close = () => {
+    settledRef.current = true
+    pendingRef.current = false
+    const queued = queuedClickRef.current
+    queuedClickRef.current = null
+    onDone()
+    if (queued instanceof HTMLElement) {
+      queueMicrotask(() => queued.click())
+    }
+  }
+
+  const submit = async () => {
+    if (settledRef.current || pendingRef.current) return
+    const trimmed = value.trim()
+    if (!trimmed || trimmed === snapshot.current) {
+      close()
+      return
+    }
+
+    const generation = ++generationRef.current
+    pendingRef.current = true
+    setIsPending(true)
+    try {
+      await onSave(trimmed)
+      if (generationRef.current === generation) close()
+    } catch (error) {
+      console.error(`Failed to rename ${noun}:`, error)
+      toast.error(`Failed to rename ${noun}`, {
+        description: error instanceof Error ? error.message : 'Please try again.',
+      })
+      if (generationRef.current === generation) {
+        pendingRef.current = false
+        queuedClickRef.current = null
+        swallowLeaveClickRef.current = true
+        setIsPending(false)
+      }
+    }
+  }
+
+  const cancel = () => {
+    if (pendingRef.current) return
+    close()
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={(e) => {
+        e.stopPropagation()
+        if (e.key === 'Enter') void submit()
+        if (e.key === 'Escape') cancel()
+      }}
+      onBlur={() => { void submit() }}
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      autoFocus
+      disabled={isPending}
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className={cn(
+        'w-full bg-background border border-input rounded px-1 py-0 text-sm outline-none focus:ring-1 focus:ring-ring disabled:opacity-60',
+        className,
+      )}
+    />
+  )
+}

--- a/src/renderer/hooks/use-sessions.marked-unread.test.tsx
+++ b/src/renderer/hooks/use-sessions.marked-unread.test.tsx
@@ -10,7 +10,7 @@ import { createElement, type ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { clearSessionUnreadInCache, useSetSessionMarkedUnread } from './use-sessions'
+import { clearSessionUnreadInCache, useSetSessionMarkedUnread, useUpdateSessionName } from './use-sessions'
 import type { ApiSession } from '@shared/lib/types/api'
 
 const mockApiFetch = vi.fn()
@@ -45,6 +45,32 @@ function renderMutation() {
   const { result } = renderHook(() => useSetSessionMarkedUnread(), { wrapper })
   return { result, invalidate }
 }
+
+describe('useUpdateSessionName invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('refetches the session list and the singular leaf the header reads', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'sess-1', agentSlug: 'agent-1', name: 'Renamed' }),
+    })
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+    const { result } = renderHook(() => useUpdateSessionName(), { wrapper })
+
+    result.current.mutate({ sessionId: 'sess-1', agentSlug: 'agent-1', name: 'Renamed' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['sessions', 'agent-1'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['session', 'sess-1', 'agent-1'] })
+  })
+})
 
 describe('useSetSessionMarkedUnread invalidation', () => {
   beforeEach(() => {

--- a/src/renderer/hooks/use-sessions.ts
+++ b/src/renderer/hooks/use-sessions.ts
@@ -152,9 +152,10 @@ export function useUpdateSessionName() {
       return res.json() as Promise<ApiSession>
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['sessions', resolveAgentSlugFromCache(queryClient, variables.agentSlug)],
-      })
+      const slug = resolveAgentSlugFromCache(queryClient, variables.agentSlug)
+      queryClient.invalidateQueries({ queryKey: ['sessions', slug] })
+      // The header crumb and document title read the singular leaf, not the list.
+      queryClient.invalidateQueries({ queryKey: ['session', variables.sessionId, slug] })
     },
   })
 }


### PR DESCRIPTION
Sessions, dashboards, folders, and agents now rename in place on the row instead of through a dialog. The field replaces the link so a double-click cannot open the dashboard and a text drag cannot pick up the agent. Enter or click-away saves, Escape discards, and a failed write stays in the field with a toast.

Closes https://linear.app/datawizz/issue/SUP-685/one-rename-dialog-for-sessions-dashboards-and-folders

- Right-click Rename, or a new folder mounts already editing
- The field replaces the row and selects the current name
- Enter or click away: empty or unchanged closes with no write, otherwise the write runs with the field locked
- Success closes the field and replays the click that left
- Failure keeps the field open, toasts, and drops that click
- Escape closes if nothing is in flight
- A dialog opened from the row does not start an agent drag

Out of scope: file preview, the home-title click-to-edit, scheduled-task titles, the Settings name field.
