### PR TITLE
fix: keep MicroVM start/stop in sync with the host port cache

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -326,7 +326,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   protected handleConnectionError(): void {
     // The port may have changed if the container was restarted out from under
     // us — force the next fetch() to re-resolve it from the runtime.
-    this.cachedRunningPort = null
+    this.rememberRunningPort(null)
     if (this.config.onConnectionError) {
       this.config.onConnectionError()
     }
@@ -683,7 +683,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const info = await this.getInfo()
     if (info.status === 'running') {
       console.log(`Container ${this.getContainerName()} is already running on port ${info.port}`)
-      this.cachedRunningPort = info.port
+      this.rememberRunningPort(info.port)
       return info
     }
 
@@ -855,7 +855,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       }
 
       console.log(`Container ${containerName} is now running on port ${port}`)
-      this.cachedRunningPort = port
+      this.rememberRunningPort(port)
       return { status: 'running', port }
     } catch (error: any) {
       // Only capture if not already captured (health check errors are captured
@@ -896,7 +896,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   async stop(options?: StopOptions): Promise<StopResult> {
-    this.cachedRunningPort = null
+    this.rememberRunningPort(null)
     let forceStopUsed = false
     const stopTimeoutMs = options?.stopTimeoutMs ?? 10_000
     const killTimeoutMs = options?.killTimeoutMs ?? 5_000
@@ -1102,6 +1102,12 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   // re-resolve, which is exactly the pre-cache behavior.
   private cachedRunningPort: number | null = null
 
+  // Subclasses that override start()/stop() must report the live proxy port
+  // here, or the next request talks to a dead 127.0.0.1:<port>.
+  protected rememberRunningPort(port: number | null): void {
+    this.cachedRunningPort = port
+  }
+
   private async getPortOrThrow(): Promise<number> {
     if (this.cachedRunningPort !== null) return this.cachedRunningPort
     const info = await this.getInfo()
@@ -1111,7 +1117,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       this.handleConnectionError()
       throw new Error('Container is not running')
     }
-    this.cachedRunningPort = info.port
+    this.rememberRunningPort(info.port)
     return info.port
   }
 

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -505,6 +505,56 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
   })
 
+  // ---- base port cache sync (start/stop are fully overridden here, so the
+  // cache must be kept in sync by hand — a stale entry after auto-sleep
+  // terminate sent the first post-idle request to a dead loopback port) ----
+
+  it('start() primes the port cache: requests hit the proxy port with no runtime inspect', async () => {
+    const client = newClient()
+    const info = await client.start()
+    sendMock.mockClear()
+    vi.mocked(fetch).mockClear()
+
+    await client.fetch('/health')
+
+    expect(String(vi.mocked(fetch).mock.calls[0][0])).toBe(`http://127.0.0.1:${info.port}/health`)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Get')).toBe(false)
+  })
+
+  it('stop() clears the cached port so the next request re-resolves instead of hitting the dead proxy', async () => {
+    const client = newClient()
+    await client.start()
+    await client.fetch('/health')
+    await client.stop()
+
+    // With a stale cache this would "succeed" against the terminated
+    // generation's loopback port; it must re-resolve and see the agent gone.
+    await expect(client.fetch('/health')).rejects.toThrow('Container is not running')
+  })
+
+  it('stopSync() clears the cached port like stop()', async () => {
+    const client = newClient()
+    await client.start()
+    await client.fetch('/health')
+    client.stopSync()
+
+    await expect(client.fetch('/health')).rejects.toThrow('Container is not running')
+  })
+
+  it('a restart re-primes the cache with the new generation proxy port', async () => {
+    const client = newClient()
+    await client.start()
+    await client.stop()
+    const second = await client.start()
+
+    sendMock.mockClear()
+    vi.mocked(fetch).mockClear()
+    await client.fetch('/health')
+
+    expect(String(vi.mocked(fetch).mock.calls[0][0])).toBe(`http://127.0.0.1:${second.port}/health`)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Get')).toBe(false)
+  })
+
   it('start is a no-op when the agent is already running', async () => {
     const client = newClient()
     await client.start()

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -919,7 +919,10 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
 
   async start(options?: StartOptions): Promise<ContainerInfo> {
     const info = await this.getInfoFromRuntime()
-    if (info.status === 'running') return info
+    if (info.status === 'running') {
+      this.rememberRunningPort(info.port)
+      return info
+    }
 
     const config = getMicrovmRuntimeConfig()
     // Full env exceeds the 4096-byte payload cap, so stash it host-side and pass the
@@ -977,6 +980,8 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     this.cleanupLocal()
     if (hasEnv) setBootstrapEnv(this.config.agentId, env)
     agentStates.set(this.config.agentId, { microvmId: run.microvmId, endpoint: run.endpoint, proxy, proxyPort })
+    // start()/stop() are overridden — report the proxy port to the base cache.
+    this.rememberRunningPort(proxyPort)
 
     try {
       await this.waitForRunning(config.region, run.microvmId, 300_000)
@@ -1241,6 +1246,9 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     state?.proxy.stop()
     agentStates.delete(this.config.agentId)
     clearBootstrapEnv(this.config.agentId)
+    // stop(), stopSync(), teardown, and getInfo's CAS drops all funnel through
+    // here — the base port cache must not outlive the local proxy.
+    this.rememberRunningPort(null)
   }
 
   // Compare-and-swap cleanup: only drop state if it still points at observedId.


### PR DESCRIPTION
## Summary
- `v0.5.10` / `#831` added `cachedRunningPort` so host requests skip a runtime inspect. Docker `start`/`stop` write and clear it. The cloud MicroVM client overrides both and never touched the cache, so after auto-sleep terminate the first send still talked to the old `127.0.0.1:<port>`. Instant retry worked because that failure finally cleared the cache.
- Repro: first message after ~30 minutes idle on cloud → 500 (`ECONNREFUSED` on the subscribe WebSocket). Send again immediately → 201.
- This PR only syncs the cache. `start()` reports the new `proxyPort`; `cleanupLocal()` (used by `stop` / `stopSync` / teardown) clears it. A protected `rememberRunningPort()` lets the subclass write the private field. No route change, no same-call retry.

## Test plan
- [x] `npx vitest run src/shared/lib/container/base-container-client.test.ts src/shared/lib/container/lambda-microvm-runtime.test.ts` (175 passed)
- [x] Cloud: idle an agent past auto-sleep, send one message — first send should succeed without a manual retry


Made with [Cursor](https://cursor.com)