### PR TITLE
fix: give markdown-preview code blocks real contrast

### DIFF
--- a/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/markdown-renderer.tsx
@@ -34,13 +34,20 @@ export function MarkdownRenderer({ url, filePath, commentsEnabled = true }: Mark
           <span>Failed to load file</span>
         </div>
       ) : (
-        <div className="prose prose-sm max-w-none min-w-0 break-words dark:prose-invert" data-testid="markdown-renderer">
+        <div
+          className="prose prose-sm max-w-none min-w-0 break-words dark:prose-invert [&_pre_code]:bg-transparent [&_pre_code]:p-0"
+          data-testid="markdown-renderer"
+        >
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             urlTransform={markdownUrlTransform}
             components={{
+              // `prose` colours a code block for its own dark `pre` background
+              // (--tw-prose-pre-code is gray-200). This one is a light tinted
+              // card, so the text colour has to come back to the body colour or
+              // it reads as grey-on-grey. Matches the chat transcript's block.
               pre: ({ children }) => (
-                <pre className="rounded-lg p-3 text-sm overflow-x-auto bg-black/[0.03] dark:bg-white/[0.06]">
+                <pre className="rounded-lg p-3 text-sm overflow-x-auto border border-border/60 bg-black/[0.03] dark:bg-white/[0.06] text-foreground">
                   {children}
                 </pre>
               ),
@@ -49,7 +56,7 @@ export function MarkdownRenderer({ url, filePath, commentsEnabled = true }: Mark
                   return <code className={className}>{children}</code>
                 }
                 return (
-                  <code className="rounded px-1.5 py-0.5 text-sm font-medium bg-black/[0.03] dark:bg-white/[0.06]">
+                  <code className="rounded px-1.5 py-0.5 text-sm font-medium bg-black/[0.03] dark:bg-white/[0.06] text-foreground">
                     {children}
                   </code>
                 )


### PR DESCRIPTION
Fenced code blocks in the markdown file preview rendered as grey-on-grey.

## Cause

`@tailwindcss/typography` styles `pre` for *its own* dark code-block background:

```css
.prose :where(pre) { color: var(--tw-prose-pre-code); background-color: var(--tw-prose-pre-bg); }
.prose :where(pre code) { color: inherit; }
```

In light mode `--tw-prose-pre-code` is `#e5e7eb` (gray-200). `markdown-renderer.tsx` overrode the *background* to a light tint (`bg-black/[0.03]`) but never overrode the colour, so gray-200 text landed on a `#f7f7f7` panel.

## Fix

- `pre` gets `text-foreground` plus a `border-border/60` hairline, matching the chat transcript's `CodeBlock` in `message-item.tsx`, which already did exactly this.
- `[&_pre_code]:bg-transparent [&_pre_code]:p-0` on the container, mirroring `thinking-block-item.tsx` — a fence with no language tag falls through to the inline-code branch, so it was drawing a second pill background and padding *inside* the block.
- Inline `code` gets `text-foreground` so it uses the app token rather than prose's gray-900.

`.text-foreground` sits in the utilities layer and `.prose :where(pre)` in components, at equal specificity, so the override wins the cascade.

## Measured

Compiled the project's real `tailwind.config.ts` + `globals.css` through the Tailwind CLI and computed the contrast against the exact class strings:

| | light | dark |
|---|---|---|
| before | **1.16:1** | 10.01:1 |
| after | **18.48:1** | 14.13:1 |

## Verification caveat

`npm run typecheck` reports 114 pre-existing errors in this worktree, all missing-module / implicit-any failures from uninstalled dependencies — none in the touched file. Lint and an in-app screenshot were not run for the same reason (no `node_modules` on this branch); the numbers above come from the compiled cascade rather than the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)