### PR TITLE
Sidebar folders: overlay drop animation + new-folder placement

### DIFF
--- a/e2e/specs/agent-folders.spec.ts
+++ b/e2e/specs/agent-folders.spec.ts
@@ -570,8 +570,12 @@ test.describe('agent folders in the left nav', () => {
       throw new Error('drag never engaged')
     }
 
-    // A freshly created folder lands last, so Edges starts at the bottom.
-    expect((await folders()).at(-1)).toBe(edgesId)
+    // A freshly created folder mounts directly above the default folder — in
+    // view next to the + that made it, not below the scroll fold.
+    {
+      const order = await folders()
+      expect(order.indexOf(edgesId)).toBe(order.indexOf('agent-folder-root') - 1)
+    }
 
     // ── The natural "make it first" gesture: drop in the space ABOVE the
     // first block. There used to be nothing droppable there, so the drag

--- a/src/renderer/components/layout/agent-folder-block.test.tsx
+++ b/src/renderer/components/layout/agent-folder-block.test.tsx
@@ -3,16 +3,27 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-const { mockUseSortable, mockUseDroppable } = vi.hoisted(() => ({
+const { mockUseSortable, mockUseDroppable, mockDefaultKeyframes } = vi.hoisted(() => ({
   mockUseSortable: vi.fn(),
   mockUseDroppable: vi.fn(),
+  mockDefaultKeyframes: vi.fn(() => [] as Keyframe[]),
 }))
 
 vi.mock('@dnd-kit/sortable', () => ({
   useSortable: (args: unknown) => mockUseSortable(args),
 }))
-vi.mock('@dnd-kit/core', () => ({ useDroppable: (args: unknown) => mockUseDroppable(args) }))
-vi.mock('@dnd-kit/utilities', () => ({ CSS: { Transform: { toString: () => '' } } }))
+vi.mock('@dnd-kit/core', () => ({
+  useDroppable: (args: unknown) => mockUseDroppable(args),
+  defaultDropAnimation: { duration: 250, easing: 'ease', keyframes: mockDefaultKeyframes },
+}))
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Transform: {
+      toString: (t: { x: number; y: number; scaleX: number; scaleY: number } | null) =>
+        t ? `translate3d(${t.x}px, ${t.y}px, 0) scaleX(${t.scaleX}) scaleY(${t.scaleY})` : '',
+    },
+  },
+}))
 
 // Radix context menus never open in jsdom without a real pointer; render the
 // items inline so the folder actions are reachable.
@@ -31,7 +42,8 @@ vi.mock('@renderer/components/ui/sidebar', () => ({
   ),
 }))
 
-import { AgentDragOverlayRow, AgentFolderBlock } from './agent-folder-block'
+import { AgentDragOverlayRow, AgentFolderBlock, overlayDropKeyframes } from './agent-folder-block'
+import type { DropAnimationKeyframeResolver } from '@dnd-kit/core'
 
 const FOLDER = { id: 'f1', name: 'Work' }
 
@@ -392,5 +404,44 @@ describe('AgentDragOverlayRow', () => {
   it('names what is being dragged', () => {
     render(<AgentDragOverlayRow label="Sales" isFolder={false} />)
     expect(screen.getByText('Sales')).toBeInTheDocument()
+  })
+})
+
+describe('overlayDropKeyframes', () => {
+  const RECT = { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 }
+
+  function dropParams(activeRect: Partial<typeof RECT>) {
+    return {
+      active: { id: 'a1', data: { current: undefined }, node: document.createElement('div'), rect: { ...RECT, ...activeRect } },
+      dragOverlay: { node: document.createElement('div'), rect: { ...RECT, top: 530, left: 17, width: 240, height: 36 } },
+      draggableNodes: new Map(),
+      droppableContainers: new Map(),
+      measuringConfiguration: {},
+      transform: {
+        initial: { x: 4, y: 260, scaleX: 1, scaleY: 1 },
+        final: { x: -13, y: -530, scaleX: 1, scaleY: 1 },
+      },
+    } as unknown as Parameters<DropAnimationKeyframeResolver>[0]
+  }
+
+  it('fades out where it was dropped when the landing spot is hidden', () => {
+    // A row filed into a collapsed folder sits in the folder's hidden body,
+    // which measures 0×0 at the viewport origin — the default keyframes
+    // would fly the overlay to the window's top-left corner.
+    const frames = overlayDropKeyframes(dropParams({ width: 0, height: 0 }))
+    expect(frames).toHaveLength(2)
+    expect(frames[1].transform).toBe(frames[0].transform)
+    expect(frames[0].transform).toContain('translate3d(4px, 260px')
+    expect(frames[0].opacity).toBe(1)
+    expect(frames[1].opacity).toBe(0)
+    expect(mockDefaultKeyframes).not.toHaveBeenCalled()
+  })
+
+  it('keeps the stock flight to a visible landing spot', () => {
+    const stockFrames = [{ transform: 'from' }, { transform: 'to' }]
+    mockDefaultKeyframes.mockReturnValueOnce(stockFrames)
+    const params = dropParams({ width: 240, height: 32, top: 700, left: 17 })
+    expect(overlayDropKeyframes(params)).toBe(stockFrames)
+    expect(mockDefaultKeyframes).toHaveBeenCalledWith(params)
   })
 })

--- a/src/renderer/components/layout/agent-folder-block.tsx
+++ b/src/renderer/components/layout/agent-folder-block.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react'
 import { ChevronRight, Folder, FolderPlus, Pencil, Trash2 } from 'lucide-react'
 import { useSortable } from '@dnd-kit/sortable'
-import { useDroppable } from '@dnd-kit/core'
+import {
+  defaultDropAnimation,
+  useDroppable,
+  type DropAnimation,
+  type DropAnimationKeyframeResolver,
+} from '@dnd-kit/core'
 import { CSS } from '@dnd-kit/utilities'
 import { cn } from '@shared/lib/utils/cn'
 import {
@@ -343,6 +348,30 @@ export function AgentFolderBlock({
         </div>
     </li>
   )
+}
+
+/**
+ * Where the overlay flies once released. The default keyframes aim at the
+ * dropped row's post-drop rect — but a row filed into a COLLAPSED folder sits
+ * in the folder's `hidden` body, and a hidden node measures 0×0 at the
+ * viewport origin, so the overlay would fly to the window's top-left corner.
+ * A landing spot with no visible rect gets a fade-out in place instead.
+ */
+export const overlayDropKeyframes: DropAnimationKeyframeResolver = (params) => {
+  const { width, height } = params.active.rect
+  if (!width && !height) {
+    const transform = CSS.Transform.toString(params.transform.initial)
+    return [
+      { transform, opacity: 1 },
+      { transform, opacity: 0 },
+    ]
+  }
+  return defaultDropAnimation.keyframes(params)
+}
+
+export const agentDropAnimation: DropAnimation = {
+  ...defaultDropAnimation,
+  keyframes: overlayDropKeyframes,
 }
 
 /** The row that follows the cursor during a drag. */

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -971,7 +971,9 @@ describe('AppSidebar — agent folders', () => {
     expect(patch.agentFolders[1].name).toBe('New Folder 2')
   })
 
-  it('puts a newly created folder at the end of the list', () => {
+  it('renders a folder with no recorded place at the end of the list', () => {
+    // The read-side fallback doubles as the upgrade path for folders stored
+    // before places existed; creation itself now records a place up front.
     mockUserSettings.mockReturnValue({
       agentOrder: ['test-agent', 'other-agent'],
       agentFolders: [FOLDERS[0]],
@@ -980,6 +982,32 @@ describe('AppSidebar — agent folders', () => {
     renderWithProviders(<AppSidebar />)
 
     expect(listOrder()).toEqual(['folder:root', 'test-agent', 'other-agent', 'folder:f1'])
+  })
+
+  it('places a created folder directly above the default folder', async () => {
+    renderWithProviders(<AppSidebar />)
+
+    await userEvent.click(screen.getByTestId('new-folder-button'))
+
+    // Untouched install: no stored places yet, so root's marker is written
+    // too — without one it would default ahead of the new folder (place -1).
+    const fresh = patchWith({ agentFolders: [] })
+    expect(fresh.agentListOrder).toEqual([
+      `agent-folder::${fresh.agentFolders[0].id}`,
+      ROOT,
+    ])
+
+    // A root the user moved off the top stays put; the new folder splices in
+    // just above it and other folders keep their places.
+    const arranged = patchWith({
+      agentFolders: [FOLDERS[0]],
+      agentListOrder: ['agent-folder::f1', ROOT],
+    })
+    expect(arranged.agentListOrder).toEqual([
+      'agent-folder::f1',
+      `agent-folder::${arranged.agentFolders[1].id}`,
+      ROOT,
+    ])
   })
 
   it('still renders folders when the user has no agents at all', () => {

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -280,6 +280,7 @@ vi.mock('@dnd-kit/core', () => ({
   useSensor: vi.fn(),
   useSensors: vi.fn(() => []),
   useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  defaultDropAnimation: { duration: 250, easing: 'ease', keyframes: vi.fn(() => []) },
 }))
 vi.mock('@dnd-kit/sortable', () => ({
   SortableContext: ({ children }: any) => <>{children}</>,

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -107,6 +107,7 @@ import {
   containerIdForFolder,
   buildFolderSections,
   dissolveFolder,
+  ROOT_FOLDER_ID,
   locateAgent,
   moveAgent,
   moveFolder,
@@ -1246,13 +1247,27 @@ export function AppSidebar() {
   // click time would revert whatever folder write was still in flight.
   const handleCreateFolder = useCallback(() => {
     const id = newFolderId()
-    // A folder with no recorded place renders at the end of the list, which is
-    // where the user just asked for it. The row mounts in rename mode, so
-    // creating a folder and naming it is one gesture.
+    // The + lives on the default folder's header, so the new folder goes
+    // directly ABOVE that folder — in view next to the button that made it,
+    // where the row's rename input mounts. Ranking it last put it below the
+    // scroll fold on a long list, which read as the button doing nothing.
     setPendingRenameFolderId(id)
     updateSettings.mutate((current) => {
       const folders = sanitizeFolders(current?.agentFolders)
-      return { agentFolders: [...folders, { id, name: uniqueFolderName(folders) }] }
+      const marker = sortableIdForFolder(id)
+      const rootMarker = sortableIdForFolder(ROOT_FOLDER_ID)
+      const order = (current?.agentListOrder ?? []).filter((key) => key !== marker)
+      const rootIndex = order.indexOf(rootMarker)
+      return {
+        agentFolders: [...folders, { id, name: uniqueFolderName(folders) }],
+        // Splice in just above the default folder wherever the user keeps it;
+        // an untouched install has no stored places yet, so root's marker is
+        // written too — without one it would default ahead (place -1).
+        agentListOrder:
+          rootIndex >= 0
+            ? [...order.slice(0, rootIndex), marker, ...order.slice(rootIndex)]
+            : [marker, rootMarker, ...order],
+      }
     })
   }, [updateSettings])
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -101,7 +101,7 @@ import {
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { SortableAgentMenuItem } from './sortable-agent-item'
 import { SidebarDragProvider, useSidebarDragActive } from './sidebar-drag-context'
-import { AgentDragOverlayRow, AgentFolderBlock } from './agent-folder-block'
+import { AgentDragOverlayRow, AgentFolderBlock, agentDropAnimation } from './agent-folder-block'
 import { applyAgentOrder } from '@renderer/lib/agent-ordering'
 import {
   containerIdForFolder,
@@ -1567,7 +1567,7 @@ export function AppSidebar() {
                           </AgentFolderBlock>
                         ))}
                       </SortableContext>
-                      <DragOverlay>
+                      <DragOverlay dropAnimation={agentDropAnimation}>
                         {activeDrag ? (
                           <AgentDragOverlayRow
                             label={activeDrag.label}


### PR DESCRIPTION
Two small UX fixes for the agent-folders sidebar.

## Drop overlay flew to the top-left on collapsed-folder drops

Dropping an agent onto a **collapsed** folder header filed it correctly, but the drag overlay then animated up and off the top of the sidebar. dnd-kit's default drop animation targets the dropped row's post-drop rect — and a row filed into a collapsed folder sits in the folder's `hidden` body, which measures 0×0 at the viewport origin, so the overlay flew to window (0,0). Drops into expanded folders animated fine, which made it look random.

Fix: `overlayDropKeyframes` — when the landing spot has no visible rect, the overlay fades out where it was released (same 250ms, so the E2E `overlay.toBeHidden()` waits between drags are unaffected); visible landing spots keep the stock flight. Unit test proven red with the guard disabled.

## New folders mounted below the scroll fold

A created folder had no recorded place and ranked last — on a long list it mounted below the fold, so the + looked like it did nothing. The create write now records a place up front: the folder's marker splices in directly **above the default folder's**, wherever the user keeps it, so the row and its rename input appear next to the + that made them. On an untouched install (no stored places yet) the root marker is written too, since a placeless root would otherwise default ahead.

The read-side "placeless folders rank last" fallback is unchanged — it remains the upgrade path, and its unit test now says so.

## Verification

- Unit: 100 tests across `agent-folder-block.test.tsx` / `app-sidebar.test.tsx` (3 new), overlay test proven red without the fix
- E2E: `agent-folders.spec.ts` 5/5 (one assertion updated to the new creation contract)
- `tsc --noEmit` and eslint clean; both fixes exercised live in the Electron dev app

https://claude.ai/code/session_01GfMVM5tkSpdKz3m6atTNWj