### PR TITLE
fix(test): restore agent-home unit test after the completed-sessions hook

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -102,6 +102,7 @@ vi.mock('@renderer/hooks/use-scheduled-tasks', () => ({
   useScheduledTasks: () => ({ data: [] }),
   useRunScheduledTaskNow: () => ({ mutate: vi.fn(), isPending: false }),
   useCancelScheduledTask: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useCompletedOneTimeSessions: () => ({ data: [] }),
 }))
 
 // The morph one-shots live in NavTransientContext. Controllable so the


### PR DESCRIPTION
Fixes the red `unit-tests` job on `main`.

## What broke

`4c605077e` (#857) added `useCompletedOneTimeSessions` to `use-scheduled-tasks.ts` and called it from `home-triggers.tsx:76`. `agent-home.test.tsx:101` factory-mocks that module and enumerates only three exports, so Vitest throws on access of the new one:

```
Error: [vitest] No "useCompletedOneTimeSessions" export is defined on the
"@renderer/hooks/use-scheduled-tasks" mock.
 ❯ HomeTriggers src/renderer/components/agents/agent-home/home-triggers.tsx:76:43
```

#857 updated the sibling `home-triggers.test.tsx` — `agent-home.test.tsx` is the neighbour that got missed.

**Why only 1 of 32 tests in the file failed:** `AgentHome` renders `HomeTriggers` behind `showRightColumn = isOwner` (`agent-home.tsx:281,548`). `beforeEach` resets `mockCanAdminAgent = false`, and `renames the agent inline for owners` is the only test that flips it to `true` — so it's the only one that mounts the subtree reaching the missing export.

## The fix

One line, matching the shape already used in `home-triggers.test.tsx`:

```ts
  useCompletedOneTimeSessions: () => ({ data: [] }),
```

## Verification

Reproduced the CI red locally on the unpatched file, then confirmed green with the fix:

| | without fix | with fix |
|---|---|---|
| `agent-home.test.tsx` | `1 failed \| 31 passed` (exit 1) | `32 passed` (exit 0) |

- `npm run test:run` — **624 passed \| 6 skipped**, 0 failed (exit 0)
- `npm run typecheck` — exit 0
- `npm run lint` — exit 0

## Note for follow-up (not fixed here)

The same mock still omits `usePauseScheduledTask` and `useResumeScheduledTask`, which `home-triggers.tsx` also imports. They don't throw today only because the mocked `useScheduledTasks` returns `data: []`, so no task rows render to call them. Any test that gives that mock a non-empty list will hit the identical failure. Left alone to keep this PR to the one-line unbreak.

https://claude.ai/code/session_01SjyABVQvQtooFM5dmuDQRV
