### PR TITLE
fix(mcp): send the http redirect when the user supplies an OAuth client ID

### DIFF
--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -830,6 +830,56 @@ describe('oauth', () => {
       const url = new URL(result!.authorizationUrl)
       expect(url.searchParams.get('client_id')).toBe('stored-client-id')
     })
+
+    it('sends the http redirect, not the app scheme, when a client ID is supplied', async () => {
+      setupDiscoveryMocks()
+
+      mockDbFrom.mockReturnValue({ where: mockWhere })
+      mockWhere.mockReturnValue({ limit: mockLimit })
+      mockLimit.mockResolvedValue([{ oauthClientId: null, oauthClientSecret: null }])
+      mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
+      // Desktop candidate order: custom app scheme first, http loopback second.
+      const result = await initiateOAuthFlow(
+        'mcp-1',
+        'https://mcp.example.com/mcp',
+        ['superagent://mcp-oauth-callback', 'http://localhost:47891/api/remote-mcps/oauth-callback'],
+        true,
+        undefined,
+        'supplied-client-id'
+      )
+
+      expect(result).not.toBeNull()
+      const url = new URL(result!.authorizationUrl)
+      expect(url.searchParams.get('client_id')).toBe('supplied-client-id')
+      // A hand-registered client_id can only have been paired with an http(s)
+      // redirect in the provider's console, so the app scheme must not be sent.
+      expect(url.searchParams.get('redirect_uri')).toBe(
+        'http://localhost:47891/api/remote-mcps/oauth-callback'
+      )
+    })
+
+    it('keeps the app scheme when a client ID is supplied and no http candidate exists', async () => {
+      setupDiscoveryMocks()
+
+      mockDbFrom.mockReturnValue({ where: mockWhere })
+      mockWhere.mockReturnValue({ limit: mockLimit })
+      mockLimit.mockResolvedValue([{ oauthClientId: null, oauthClientSecret: null }])
+      mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+
+      const result = await initiateOAuthFlow(
+        'mcp-1',
+        'https://mcp.example.com/mcp',
+        ['superagent://mcp-oauth-callback'],
+        true,
+        undefined,
+        'supplied-client-id'
+      )
+
+      expect(result).not.toBeNull()
+      const url = new URL(result!.authorizationUrl)
+      expect(url.searchParams.get('redirect_uri')).toBe('superagent://mcp-oauth-callback')
+    })
   })
 
   // =========================================================================

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -398,6 +398,20 @@ export function validateAndConsumeOAuthErrorResponse(
  * Initiate an OAuth flow for a remote MCP server.
  * Returns the authorization URL to redirect the user to.
  */
+/**
+ * Pick the redirect to send when the caller supplied its own client_id.
+ *
+ * Dynamic registration learns which redirect an authorization server accepts by
+ * trying each candidate, but a supplied client_id skips registration entirely,
+ * so there is nothing to learn it from. A supplied client_id also means the
+ * redirect was registered by hand in the provider's console, and those consoles
+ * take http(s) only — a custom app scheme could never have been registered
+ * there. Prefer the http(s) candidate, which on desktop is the loopback URL.
+ */
+function redirectForSuppliedClient(redirectCandidates: string[], fallback: string): string {
+  return redirectCandidates.find((candidate) => /^https?:/i.test(candidate)) ?? fallback
+}
+
 export async function initiateOAuthFlow(
   mcpId: string,
   mcpUrl: string,
@@ -431,7 +445,8 @@ export async function initiateOAuthFlow(
   let registeredScope: string | undefined
   // Redirect actually used on the authorization + token requests. Defaults to the
   // preferred candidate; dynamic registration may switch it to a fallback the AS
-  // accepts (e.g. an http loopback URL when the custom app scheme is rejected).
+  // accepts (e.g. an http loopback URL when the custom app scheme is rejected),
+  // and a supplied client_id pins it to the http(s) candidate.
   let redirectUri = redirectCandidates[0]
 
   // Check if we already have client credentials stored
@@ -444,6 +459,7 @@ export async function initiateOAuthFlow(
   if (clientIdOverride) {
     clientId = clientIdOverride
     clientSecret = clientSecretOverride || undefined
+    redirectUri = redirectForSuppliedClient(redirectCandidates, redirectUri)
   } else if (metadata.registration_endpoint) {
     // Prefer a fresh dynamic registration over a stored client_id on re-auth: it
     // self-heals which redirect the AS accepts (custom scheme vs http loopback)
@@ -584,12 +600,14 @@ export async function initiateNewServerOAuth(
   let registeredScope: string | undefined
   // Redirect actually used on the authorization + token requests. Defaults to the
   // preferred candidate; dynamic registration may switch it to a fallback the AS
-  // accepts (e.g. an http loopback URL when the custom app scheme is rejected).
+  // accepts (e.g. an http loopback URL when the custom app scheme is rejected),
+  // and a supplied client_id pins it to the http(s) candidate.
   let redirectUri = redirectCandidates[0]
 
   if (clientIdOverride) {
     clientId = clientIdOverride
     clientSecret = clientSecretOverride || undefined
+    redirectUri = redirectForSuppliedClient(redirectCandidates, redirectUri)
   } else if (metadata.registration_endpoint) {
     const registration = await registerDynamicClientWithFallback(
       metadata.registration_endpoint,


### PR DESCRIPTION
Connecting an MCP server with a hand-supplied **Client ID** fails on desktop: the authorization server rejects the `redirect_uri` before the user ever sees a consent screen.

Hit while connecting Meta's official ads MCP (`mcp.facebook.com/ads`), which advertises a `registration_endpoint` and then refuses to honor it — `400 invalid_client_metadata: Dynamic registration is not available for this client` — so a supplied Client ID is the only way in.

## Root cause

`redirectUri` is initialized to `redirectCandidates[0]`, which on desktop is the custom app scheme (`superagent://mcp-oauth-callback`). Only the dynamic-registration branch ever reassigns it — via `registerDynamicClientWithFallback`, which discovers by trial which redirect the server accepts.

The supplied-`client_id` branch **skips registration entirely**, so it falls through with the app scheme still selected and sends that to the authorization endpoint. Providers that require hand-registration (Meta, and web OAuth consoles generally) accept https/loopback only, so this can never succeed.

Both `initiateOAuthFlow` and `initiateNewServerOAuth` carry the identical bug. Both fixed.

## The fix

A supplied `client_id` means the redirect was registered by hand in the provider's console, and those consoles take http(s) only — so the http candidate is the only one that *can* have been registered. Pin to it.

Falls back to the existing behavior when no http candidate exists, so web callers (whose only candidate is already https) are byte-for-byte unaffected.

## Why not a toggle

A user-facing "use loopback redirect" switch was considered and set aside for now:

- The value is inferable, not a preference — the set of providers that accept a custom scheme *and reject* loopback is empty for remote MCP servers (Auth0/Okta take both; Meta takes only https).
- It is not answerable by the person being asked. The answerable version is "which of these two strings did you paste into the console?", which needs both literal URIs on screen — that belongs with the catalog setup-instructions work, not here.
- It would have to persist. `initiateOAuthFlow` re-reads stored credentials on reconnect without reopening the form, so an unpersisted toggle would silently revert on first re-auth and break a working connection. That means a new column on `remote_mcp_servers` plus a hand-written migration.

If a real case turns up, the right shape is a persisted select over the candidate list — never a boolean, and never free text (in auth mode a free-text redirect would let an admin point another user's authorization code at a host they control).

## Known limitation

The desktop loopback is `http://localhost:47891/...` but the port comes from `findAvailablePort(47891)`, so a second instance lands on 47892 while consoles want exact-match URIs. Not addressed here; surfacing the live redirect in the connect UI is the follow-up.

## Verification

- `npx vitest run src/shared/lib/mcp/oauth.test.ts` — 55 passed
- New tests confirmed non-vacuous: reverting the one-line change fails `sends the http redirect, not the app scheme, when a client ID is supplied`, restoring it passes
- `npx tsc --noEmit` clean; `npx eslint` 0 errors

https://claude.ai/code/session_01XHJjtpyMNXx4biqU5c5CEx