### PR TITLE
prompt: keep reusable work on /workspace, large temp on /tmp

### DIFF
--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -201,6 +201,16 @@ describe('generateSystemPrompt rendering', () => {
     expect(echoed, 'FAQ should point at the prompt/search tool, not restate slugs').toEqual([])
   })
 
+  it('tells the agent to keep regenerable scratch on /tmp', () => {
+    const out = generateSystemPrompt()
+    expect(out).toContain('## Workspace vs Scratch')
+    expect(out).toContain('A path is **regenerable** when it is fine if it is gone next session')
+    expect(out).toContain('Put that scratch in `/tmp`')
+    expect(out).toContain('A path is **durable** when the user would lose work')
+    expect(out).toContain('Anything you deliver, bookmark, or that the user will open again also goes on `/workspace`')
+    expect(out).toContain('When unsure, prefer `/workspace`')
+  })
+
   it('routes product questions through the complete image-owned FAQ directory', () => {
     const out = generateSystemPrompt()
     const faqDir = join(__dirname, '..', 'docs', 'faqs')

--- a/agent-container/src/system-prompt-vars.test.ts
+++ b/agent-container/src/system-prompt-vars.test.ts
@@ -201,14 +201,13 @@ describe('generateSystemPrompt rendering', () => {
     expect(echoed, 'FAQ should point at the prompt/search tool, not restate slugs').toEqual([])
   })
 
-  it('tells the agent to keep regenerable scratch on /tmp', () => {
+  it('tells the agent to keep reusable work on /workspace and large ephemeral files on /tmp', () => {
     const out = generateSystemPrompt()
-    expect(out).toContain('## Workspace vs Scratch')
-    expect(out).toContain('A path is **regenerable** when it is fine if it is gone next session')
-    expect(out).toContain('Put that scratch in `/tmp`')
-    expect(out).toContain('A path is **durable** when the user would lose work')
-    expect(out).toContain('Anything you deliver, bookmark, or that the user will open again also goes on `/workspace`')
-    expect(out).toContain('When unsure, prefer `/workspace`')
+    expect(out).toContain('## Workspace vs Tmp')
+    expect(out).toContain('Your main working directory is `/workspace`')
+    expect(out).toContain('Store any reusable content / code / files / output in it')
+    expect(out).toContain('`/tmp` is a faster ephemeral location')
+    expect(out).toContain('For large temporary files / installs / temp work-trees')
   })
 
   it('routes product questions through the complete image-owned FAQ directory', () => {

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -533,13 +533,11 @@ Use the `mcp__chat__*` tools to configure or send through external chat platform
 
 `send_chat_message` works outside a chat session too — it is how you reach the user proactively from a scheduled task, a trigger, or any session the user is not watching. Reach for it whenever work finishes (or needs a decision) in a session the user did not start.
 
-## Workspace vs Scratch
+## Workspace vs Tmp
 
-`/workspace` is kept for the next session. `/tmp` is not — it is empty the next time you start.
+Your main working directory is `/workspace`. It persists across restarts and sessions, and the user has access to it. Store any reusable content / code / files / output in it.
 
-A path is **regenerable** when it is fine if it is gone next session: it can be re-downloaded, re-cloned, or rebuilt. Put that scratch in `/tmp` (one-off clones, build output, caches you create). Do not copy regenerable trees into `/workspace` just to keep them.
-
-A path is **durable** when the user would lose work. Keep those on `/workspace`: the user's files, `.claude` (sessions, memory, skills), `.env`, `CLAUDE.md`, and any project they will keep editing across sessions. Anything you deliver, bookmark, or that the user will open again also goes on `/workspace`. When unsure, prefer `/workspace`.
+`/tmp` is a faster ephemeral location, and often faster (non-NFS). For large temporary files / installs / temp work-trees that do not need to be user accessible / survive restart -> use it.
 
 ## File Handling
 

--- a/agent-container/src/system-prompt.md
+++ b/agent-container/src/system-prompt.md
@@ -533,6 +533,14 @@ Use the `mcp__chat__*` tools to configure or send through external chat platform
 
 `send_chat_message` works outside a chat session too — it is how you reach the user proactively from a scheduled task, a trigger, or any session the user is not watching. Reach for it whenever work finishes (or needs a decision) in a session the user did not start.
 
+## Workspace vs Scratch
+
+`/workspace` is kept for the next session. `/tmp` is not — it is empty the next time you start.
+
+A path is **regenerable** when it is fine if it is gone next session: it can be re-downloaded, re-cloned, or rebuilt. Put that scratch in `/tmp` (one-off clones, build output, caches you create). Do not copy regenerable trees into `/workspace` just to keep them.
+
+A path is **durable** when the user would lose work. Keep those on `/workspace`: the user's files, `.claude` (sessions, memory, skills), `.env`, `CLAUDE.md`, and any project they will keep editing across sessions. Anything you deliver, bookmark, or that the user will open again also goes on `/workspace`. When unsure, prefer `/workspace`.
+
 ## File Handling
 
 ### Receiving Files from Users


### PR DESCRIPTION
## Summary

Prompt-only slice of [SUP-691](https://linear.app/datawizz/issue/SUP-691/keep-regenerable-agent-data-on-local-disk-not-s3-files-nfs): tell the agent where to put files it chooses itself.

`/workspace` is the main working directory. It persists across restarts and sessions, and the user can see it — reusable content, code, files, and output go there.

`/tmp` is ephemeral and often faster (non-NFS). Large temporary files, installs, and temp work-trees that do not need to be user-accessible or survive a restart go there.

This does not move runtime-owned paths. A prompt cannot change `BUN_INSTALL_CACHE_DIR`, `AGENT_BROWSER_PROFILE`, or dashboard `bun install` output.

## Test plan

- [x] `agent-container` `system-prompt-vars.test.ts` (50 tests)