### PR TITLE
perf(sessions): list visible sessions from the summary cache (SUP-658, 2/3)

### DIFF
--- a/perf/agents-home.big.perf.ts
+++ b/perf/agents-home.big.perf.ts
@@ -6,12 +6,13 @@
  */
 import { defineHomeScenarios } from './home-scenarios'
 
-// Baseline recorded on the pre-optimisation code (SUP-658 as shipped).
+// Cold reads still stat every transcript once to build the summary; warm
+// reads (the iOS poll) and the sessions page come from the cache.
 defineHomeScenarios('big', {
   agentsCold: { totalOps: 5021, ops: { stat: 5009 }, wallMs: 10_400 },
   agentsWarm: { totalOps: 15, ops: { stat: 4 }, wallMs: 280 },
-  homeCold: { totalOps: 10037, ops: { stat: 10017 }, wallMs: 10_700 },
-  homeWarm: { totalOps: 5031, ops: { stat: 5012 }, wallMs: 10_700 },
-  sessionsPage: { totalOps: 5009, ops: { stat: 5007 }, wallMs: 10_400 },
+  homeCold: { totalOps: 5028, ops: { stat: 5010 }, wallMs: 10_500 },
+  homeWarm: { totalOps: 22, ops: { stat: 5 }, wallMs: 290 },
+  sessionsPage: { totalOps: 3, ops: { stat: 2 }, wallMs: 110 },
   sessionsNotable: { totalOps: 1, ops: { stat: 1 }, wallMs: 40 },
 })

--- a/perf/agents-home.small.perf.ts
+++ b/perf/agents-home.small.perf.ts
@@ -6,12 +6,13 @@
  */
 import { defineHomeScenarios } from './home-scenarios'
 
-// Baseline recorded on the pre-optimisation code (SUP-658 as shipped).
+// Cold reads still stat every transcript once to build the summary; warm
+// reads (the iOS poll) and the sessions page come from the cache.
 defineHomeScenarios('small', {
   agentsCold: { totalOps: 317, ops: { stat: 275 }, wallMs: 320 },
   agentsWarm: { totalOps: 52, ops: { stat: 15 }, wallMs: 290 },
-  homeCold: { totalOps: 632, ops: { stat: 550 }, wallMs: 520 },
-  homeWarm: { totalOps: 367, ops: { stat: 290 }, wallMs: 500 },
-  sessionsPage: { totalOps: 56, ops: { stat: 54 }, wallMs: 220 },
+  homeCold: { totalOps: 352, ops: { stat: 280 }, wallMs: 450 },
+  homeWarm: { totalOps: 87, ops: { stat: 20 }, wallMs: 320 },
+  sessionsPage: { totalOps: 3, ops: { stat: 2 }, wallMs: 70 },
   sessionsNotable: { totalOps: 1, ops: { stat: 1 }, wallMs: 40 },
 })

--- a/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
+++ b/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
@@ -176,7 +176,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
 }))
 
 vi.mock('@shared/lib/services/session-service', () => ({
-  listSessions: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
+  listSessions: vi.fn(), listSessionsFromSummary: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true), sessionBelongsToAgent: vi.fn().mockResolvedValue(true), reserveSessionOwnership: vi.fn().mockResolvedValue(undefined), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),

--- a/src/api/routes/agents.delete-ordering.sup208.test.ts
+++ b/src/api/routes/agents.delete-ordering.sup208.test.ts
@@ -165,7 +165,7 @@ vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
 }))
 
 vi.mock('@shared/lib/services/session-service', () => ({
-  listSessions: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
+  listSessions: vi.fn(), listSessionsFromSummary: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true), sessionBelongsToAgent: vi.fn().mockResolvedValue(true), reserveSessionOwnership: vi.fn().mockResolvedValue(undefined), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -311,6 +311,7 @@ vi.mock('@shared/lib/services/session-service', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@shared/lib/services/session-service')>()
   return {
   listSessions: vi.fn(),
+  listSessionsFromSummary: vi.fn(),
   listSessionsByIds: vi.fn(),
   sortSessionsNewestFirst: actual.sortSessionsNewestFirst,
   SESSIONS_LIST_MAX_LIMIT: actual.SESSIONS_LIST_MAX_LIMIT,
@@ -586,7 +587,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessions, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionMessagesDelta, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, getSessionMetadata, updateSessionName, registerSession, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessionsFromSummary, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionMessagesDelta, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, getSessionMetadata, updateSessionName, registerSession, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { listCompletedOneTimeTasks, listPendingScheduledTasks, listPendingWakesByAgent } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -5948,7 +5949,7 @@ describe('GET /api/agents (enriched summary)', () => {
       sessionCount: 0,
       lastActivityAt: null,
     })
-    vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([])
     vi.mocked(readSessionMetadata).mockResolvedValue({})
     vi.mocked(sessionExists).mockResolvedValue(true)
     vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map())
@@ -5978,13 +5979,13 @@ describe('GET /api/agents (enriched summary)', () => {
 
     expect(body[0]).not.toHaveProperty('latestVisibleSession')
     expect(body[0]).not.toHaveProperty('attentionOutsideLatest')
-    expect(listSessions).not.toHaveBeenCalled()
+    expect(listSessionsFromSummary).not.toHaveBeenCalled()
     expect(getSessionMessagesPage).not.toHaveBeenCalled()
   })
 
   it('returns the latest tail and excludes attention on that session', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('settled-visible')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('settled-visible')])
     vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([
       ['agent-1', new Set(['settled-visible'])],
     ]))
@@ -6034,7 +6035,8 @@ describe('GET /api/agents (enriched summary)', () => {
       hasUnreadNotification: false,
       hasPendingInput: false,
     })
-    expect(listSessions).toHaveBeenCalledWith('agent-1', {
+    expect(listSessionsFromSummary).toHaveBeenCalledWith('agent-1', {
+      metadata: {},
       excludeAutomated: true,
       sortBy: 'last_activity_at',
     })
@@ -6053,7 +6055,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('annotates the tail like a transcript page read', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('latest-visible')])
     vi.mocked(getSessionMessagesPage).mockResolvedValue({
       messages: [
         {
@@ -6084,7 +6086,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('reports unread and pending attention on an older visible session', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([
       sessionInfo('latest-visible'),
       sessionInfo('older-visible'),
     ])
@@ -6119,7 +6121,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('ignores unread and pending attention from hidden automation', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('latest-visible')])
     vi.mocked(readSessionMetadata).mockResolvedValue({
       'hidden-scheduled': {
         isScheduledExecution: true,
@@ -6157,7 +6159,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('counts promoted automation as visible outside attention', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([
       sessionInfo('latest-visible'),
       sessionInfo('promoted-scheduled'),
     ])
@@ -6200,7 +6202,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('counts unattributed unread and agent-scoped pending attention as outside', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('latest-visible')])
     vi.mocked(getUnreadNotificationsByAgents).mockResolvedValue(new Map([
       ['agent-1', new Set(['unknown-session'])],
     ]))
@@ -6228,7 +6230,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('treats an unattributable positive pending-input aggregate as outside', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('latest-visible')])
     vi.mocked(messagePersister.hasSessionsAwaitingInputForAgent).mockReturnValue(true)
 
     const res = await getReq(
@@ -6246,7 +6248,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('returns null when an agent has no visible session and skips transcript work', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([])
 
     const res = await getReq(
       app,
@@ -6265,9 +6267,9 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('returns null and reports a latest visible session with neither transcript nor registration', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('missing-transcript')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('missing-transcript')])
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({ messages: [], nextCursor: null })
     vi.mocked(sessionExists).mockResolvedValue(false)
-    vi.mocked(sessionIsKnown).mockResolvedValue(false)
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     try {
@@ -6283,7 +6285,7 @@ describe('GET /api/agents (enriched summary)', () => {
         hasUnreadNotification: false,
         hasPendingInput: false,
       })
-      expect(getSessionMessagesPage).not.toHaveBeenCalled()
+      expect(sessionExists).toHaveBeenCalledWith('agent-1', 'missing-transcript')
       expect(consoleError).toHaveBeenCalledWith(
         'Failed to fetch latest visible session tail for agent agent-1:',
         expect.objectContaining({
@@ -6297,7 +6299,11 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('serves a registered session with an empty tail before its first transcript write', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('registered-pending')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('registered-pending')])
+    vi.mocked(readSessionMetadata).mockResolvedValue({
+      'registered-pending': { name: 'Pending', createdAt: '2026-01-01T11:00:00.000Z' },
+    })
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({ messages: [], nextCursor: null })
     vi.mocked(sessionExists).mockResolvedValue(false)
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
@@ -6317,8 +6323,13 @@ describe('GET /api/agents (enriched summary)', () => {
         hasUnreadNotification: false,
         hasPendingInput: false,
       })
-      expect(sessionIsKnown).toHaveBeenCalledWith('agent-1', 'registered-pending')
-      expect(getSessionMessagesPage).not.toHaveBeenCalled()
+      expect(getSessionMessagesPage).toHaveBeenCalledWith(
+        'agent-1',
+        'registered-pending',
+        expect.any(Object),
+      )
+      // Registration is answered from the metadata map; no existence stat.
+      expect(sessionExists).not.toHaveBeenCalled()
       expect(consoleError).not.toHaveBeenCalled()
     } finally {
       consoleError.mockRestore()
@@ -6327,7 +6338,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('returns null attention instead of false when visible-session selection fails', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockRejectedValue(new Error('visibility unavailable'))
+    vi.mocked(listSessionsFromSummary).mockRejectedValue(new Error('visibility unavailable'))
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     try {
@@ -6352,7 +6363,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
   it('keeps the latest tail but returns null when attention computation fails', async () => {
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent])
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('latest-visible')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('latest-visible')])
     const attentionRead = vi
       .spyOn(userInputRequestManager, 'getOpenRequestsForAgent')
       .mockImplementationOnce(() => {
@@ -6383,7 +6394,7 @@ describe('GET /api/agents (enriched summary)', () => {
   it('hydrates every agent in one collection response without legacy full-transcript reads', async () => {
     const agent2 = { ...baseAgent, slug: 'agent-2', name: 'Agent Two' }
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent, agent2])
-    vi.mocked(listSessions).mockImplementation(async (slug) => [
+    vi.mocked(listSessionsFromSummary).mockImplementation(async (slug) => [
       sessionInfo('session-' + slug, slug),
     ])
     vi.mocked(getSessionMessagesPage).mockImplementation(async (_slug, sessionId) => ({
@@ -6407,7 +6418,7 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(body.map((agent: { latestVisibleSession: { session: { id: string } } }) =>
       agent.latestVisibleSession.session.id,
     )).toEqual(['session-agent-1', 'session-agent-2'])
-    expect(listSessions).toHaveBeenCalledTimes(2)
+    expect(listSessionsFromSummary).toHaveBeenCalledTimes(2)
     expect(getSessionMessagesPage).toHaveBeenCalledTimes(2)
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
@@ -6415,7 +6426,7 @@ describe('GET /api/agents (enriched summary)', () => {
   it('isolates a missing or corrupt transcript to its agent', async () => {
     const agent2 = { ...baseAgent, slug: 'agent-2', name: 'Agent Two' }
     vi.mocked(listAgentsWithStatus).mockResolvedValue([baseAgent, agent2])
-    vi.mocked(listSessions).mockImplementation(async (slug) => [
+    vi.mocked(listSessionsFromSummary).mockImplementation(async (slug) => [
       sessionInfo('session-' + slug, slug),
     ])
     vi.mocked(getSessionMessagesPage).mockImplementation(async (slug) => {
@@ -6465,7 +6476,7 @@ describe('GET /api/agents (enriched summary)', () => {
       where: vi.fn().mockResolvedValue([{ agentSlug: 'agent-1' }]),
     })
     vi.mocked(getAgentWithStatus).mockResolvedValue(baseAgent)
-    vi.mocked(listSessions).mockResolvedValue([sessionInfo('visible-session')])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([sessionInfo('visible-session')])
     vi.mocked(getSessionMessagesPage).mockResolvedValue({
       messages: [],
       nextCursor: null,
@@ -6480,8 +6491,8 @@ describe('GET /api/agents (enriched summary)', () => {
 
     expect(body).toHaveLength(1)
     expect(body[0].slug).toBe('agent-1')
-    expect(listSessions).toHaveBeenCalledTimes(1)
-    expect(listSessions).toHaveBeenCalledWith('agent-1', expect.any(Object))
+    expect(listSessionsFromSummary).toHaveBeenCalledTimes(1)
+    expect(listSessionsFromSummary).toHaveBeenCalledWith('agent-1', expect.any(Object))
     expect(getSessionMessagesPage).toHaveBeenCalledWith(
       'agent-1',
       'visible-session',
@@ -6499,7 +6510,7 @@ describe('GET /api/agents (enriched summary)', () => {
     expect(await res.json()).toEqual({ error: 'Invalid agent list query' })
     expect(listAgentsWithStatus).not.toHaveBeenCalled()
     expect(getSessionSummary).not.toHaveBeenCalled()
-    expect(listSessions).not.toHaveBeenCalled()
+    expect(listSessionsFromSummary).not.toHaveBeenCalled()
   })
 
   it('returns enriched agents with summary fields', async () => {
@@ -8064,11 +8075,11 @@ describe('sessions list query contract — GET /:id/sessions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     app = createApp()
-    vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([])
   })
 
   it('preserves the full visible-list behavior when no query is supplied', async () => {
-    vi.mocked(listSessions).mockResolvedValue([
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([
       sessionInfo('newer-visible', '2026-01-02T00:00:00Z'),
       sessionInfo('older-visible', '2026-01-01T00:00:00Z'),
     ])
@@ -8081,7 +8092,7 @@ describe('sessions list query contract — GET /:id/sessions', () => {
       'newer-visible',
       'older-visible',
     ])
-    expect(listSessions).toHaveBeenCalledWith('test-agent', {
+    expect(listSessionsFromSummary).toHaveBeenCalledWith('test-agent', {
       excludeAutomated: true,
     })
   })
@@ -8090,7 +8101,7 @@ describe('sessions list query contract — GET /:id/sessions', () => {
     // The three lookups feeding this projection are independent; whichever
     // order (or concurrency) the route runs them in, every row must still
     // pick up its own unread flag and wake details.
-    vi.mocked(listSessions).mockResolvedValue([
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([
       sessionInfo('s-waking', '2026-01-02T00:00:00Z'),
       sessionInfo('s-unread', '2026-01-01T00:00:00Z'),
       sessionInfo('s-plain', '2025-12-31T00:00:00Z'),
@@ -8125,7 +8136,7 @@ describe('sessions list query contract — GET /:id/sessions', () => {
   })
 
   it('forwards deterministic activity ordering and limit to the visibility-safe service', async () => {
-    vi.mocked(listSessions).mockResolvedValue([
+    vi.mocked(listSessionsFromSummary).mockResolvedValue([
       sessionInfo('newest-visible', '2026-01-03T00:00:00Z'),
     ])
 
@@ -8137,7 +8148,7 @@ describe('sessions list query contract — GET /:id/sessions', () => {
     expect(res.status).toBe(200)
     expect((await res.json()).map((session: { id: string }) => session.id))
       .toEqual(['newest-visible'])
-    expect(listSessions).toHaveBeenCalledWith('test-agent', {
+    expect(listSessionsFromSummary).toHaveBeenCalledWith('test-agent', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
       limit: 1,
@@ -8148,7 +8159,7 @@ describe('sessions list query contract — GET /:id/sessions', () => {
     const res = await getReq(app, URL + '?limit=1000')
 
     expect(res.status).toBe(200)
-    expect(listSessions).toHaveBeenCalledWith('test-agent', {
+    expect(listSessionsFromSummary).toHaveBeenCalledWith('test-agent', {
       excludeAutomated: true,
       limit: 100,
     })
@@ -8158,7 +8169,7 @@ describe('sessions list query contract — GET /:id/sessions', () => {
     const res = await getReq(app, URL + '?notable=false&limit=2')
 
     expect(res.status).toBe(200)
-    expect(listSessions).toHaveBeenCalledWith('test-agent', {
+    expect(listSessionsFromSummary).toHaveBeenCalledWith('test-agent', {
       excludeAutomated: true,
       limit: 2,
     })
@@ -8179,7 +8190,7 @@ describe('sessions list query contract — GET /:id/sessions', () => {
 
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ error: 'Invalid sessions query' })
-    expect(listSessions).not.toHaveBeenCalled()
+    expect(listSessionsFromSummary).not.toHaveBeenCalled()
     expect(listSessionsByIds).not.toHaveBeenCalled()
   })
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -56,7 +56,7 @@ import type {
   UserInputRequestScope,
 } from '@shared/lib/user-input/request-schema'
 import {
-  listSessions,
+  listSessionsFromSummary,
   listSessionsByIds,
   sortSessionsNewestFirst,
   SESSIONS_LIST_MAX_LIMIT,
@@ -531,28 +531,34 @@ async function getLatestVisibleSessionTail(
   agentSlug: string,
   session: SessionInfo,
   unreadSessionIds: Set<string>,
+  sessionMetadata: SessionMetadataMap,
   signal?: AbortSignal,
 ): Promise<NonNullable<ApiAgent['latestVisibleSession']>> {
+  signal?.throwIfAborted()
+  // Read first, check existence only if the read came back empty: the page
+  // reader answers a missing transcript with an empty page, so the common
+  // case (a transcript with messages) costs no stat at all.
+  const messageTail = await getSessionMessagesPage(agentSlug, session.id, {
+    limit: LATEST_VISIBLE_SESSION_TAIL_LIMIT,
+    byteBudget: LATEST_VISIBLE_SESSION_TAIL_BYTE_BUDGET,
+    media: 'ref',
+    signal,
+  })
   signal?.throwIfAborted()
   // A registered session with no transcript yet (created, nothing streamed) is
   // a normal state and serves an empty tail. Only an id with neither a
   // transcript nor a registration — a session that vanished after listing —
-  // is an error.
-  const transcriptExists = await sessionExists(agentSlug, session.id)
-  if (!transcriptExists && !(await sessionIsKnown(agentSlug, session.id))) {
+  // is an error. Registration is answered from the metadata map already in
+  // hand; the stat runs only for an unregistered empty tail.
+  if (
+    messageTail.messages.length === 0 &&
+    !(Object.hasOwn(sessionMetadata, session.id) && sessionMetadata[session.id]?.createdAt) &&
+    !(await sessionExists(agentSlug, session.id))
+  ) {
     throw new Error(
       'Latest visible session transcript not found for ' + agentSlug + '/' + session.id,
     )
   }
-  const messageTail = transcriptExists
-    ? await getSessionMessagesPage(agentSlug, session.id, {
-        limit: LATEST_VISIBLE_SESSION_TAIL_LIMIT,
-        byteBudget: LATEST_VISIBLE_SESSION_TAIL_BYTE_BUDGET,
-        media: 'ref',
-        signal,
-      })
-    : { messages: [], nextCursor: null }
-  signal?.throwIfAborted()
   // Same treatment as the transcript page endpoint, so the tail matches what
   // opening the session shows. Must run before the session flags below so
   // recovered awaiting-input state is reflected in them.
@@ -582,11 +588,16 @@ async function getVisibleSessionExpansion(
   signal?: AbortSignal,
 ): Promise<AgentVisibleSessionExpansion> {
   let visibleSessions: SessionInfo[]
+  let sessionMetadata: SessionMetadataMap
   try {
     // Keep the complete visibility-filtered snapshot: its first item selects
     // latest, while the remaining metadata-only items answer the two attention
-    // booleans without loading older transcripts.
-    visibleSessions = await listSessions(agentSlug, {
+    // booleans without loading older transcripts. Built from the summary
+    // cache with the metadata map the caller already read, so a warm poll
+    // costs one directory stat per agent instead of one stat per transcript.
+    sessionMetadata = await sessionMetadataPromise
+    visibleSessions = await listSessionsFromSummary(agentSlug, {
+      metadata: sessionMetadata,
       excludeAutomated: true,
       sortBy: 'last_activity_at',
     })
@@ -601,25 +612,26 @@ async function getVisibleSessionExpansion(
   }
 
   const latestSession = visibleSessions[0]
-  const attentionOutsideLatestPromise = sessionMetadataPromise
-    .then((sessionMetadata) => getAttentionOutsideLatest(
+  let attentionOutsideLatest: ApiAgent['attentionOutsideLatest']
+  try {
+    attentionOutsideLatest = getAttentionOutsideLatest(
       agentSlug,
       visibleSessions,
       unreadSessionIds,
       sessionMetadata,
-    ))
-    .catch((error): null => {
-      if (signal?.aborted) throw error
-      console.error('Failed to compute attention outside latest for agent ' + agentSlug + ':', error)
-      captureException(error, {
-        tags: { component: 'agents', operation: 'attention-outside-latest' },
-        extra: { agentSlug },
-      })
-      return null
+    )
+  } catch (error) {
+    if (signal?.aborted) throw error
+    console.error('Failed to compute attention outside latest for agent ' + agentSlug + ':', error)
+    captureException(error, {
+      tags: { component: 'agents', operation: 'attention-outside-latest' },
+      extra: { agentSlug },
     })
+    attentionOutsideLatest = null
+  }
 
-  const latestVisibleSessionPromise = latestSession
-    ? getLatestVisibleSessionTail(agentSlug, latestSession, unreadSessionIds, signal)
+  const latestVisibleSession = latestSession
+    ? await getLatestVisibleSessionTail(agentSlug, latestSession, unreadSessionIds, sessionMetadata, signal)
         .catch((error): null => {
           if (signal?.aborted) throw error
           // Attention still excludes this session as latest, so on this path
@@ -634,12 +646,8 @@ async function getVisibleSessionExpansion(
           })
           return null
         })
-    : Promise.resolve(null)
+    : null
 
-  const [latestVisibleSession, attentionOutsideLatest] = await Promise.all([
-    latestVisibleSessionPromise,
-    attentionOutsideLatestPromise,
-  ])
   return { latestVisibleSession, attentionOutsideLatest }
 }
 
@@ -1885,7 +1893,7 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
       return c.json(ordered.slice(0, resultLimit))
     }
 
-    const sessionList = await listSessions(slug, {
+    const sessionList = await listSessionsFromSummary(slug, {
       excludeAutomated: true,
       ...(sortByRaw === undefined ? {} : { sortBy }),
       ...(resultLimit === undefined ? {} : { limit: resultLimit }),

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -40,6 +40,8 @@ vi.mock('@shared/lib/services/session-service', () => ({
 }))
 vi.mock('@shared/lib/services/session-summary-cache', () => ({
   recordSessionActivity: vi.fn(),
+  recordProvisionalSessionActivity: vi.fn(() => ({ recordedAtMs: 0, previous: null })),
+  revertSessionActivity: vi.fn(),
 }))
 vi.mock('@shared/lib/services/session-transcript-append', () => ({
   appendInformationalEntry: vi.fn(() => Promise.resolve()),

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -29,8 +29,16 @@ vi.mock('@shared/lib/services/session-service', () => ({
   finalizeAutomationStatus: vi.fn(() => Promise.resolve('updated')),
 }))
 const mockRecordSessionActivity = vi.fn()
+const mockRecordProvisionalSessionActivity = vi.fn((_slug: string, _id: string, at: number) => ({
+  recordedAtMs: at,
+  previous: { mtimeMs: at - 60_000, size: 10 },
+}))
+const mockRevertSessionActivity = vi.fn()
 vi.mock('@shared/lib/services/session-summary-cache', () => ({
   recordSessionActivity: (...args: unknown[]) => mockRecordSessionActivity(...args),
+  recordProvisionalSessionActivity: (...args: unknown[]) =>
+    mockRecordProvisionalSessionActivity(...(args as [string, string, number])),
+  revertSessionActivity: (...args: unknown[]) => mockRevertSessionActivity(...args),
 }))
 const mockAppendInformationalEntry = vi.fn((..._args: unknown[]) => Promise.resolve())
 vi.mock('@shared/lib/services/session-transcript-append', () => ({
@@ -327,11 +335,11 @@ describe('MessagePersister', () => {
         vi.useRealTimers()
       }
 
-      expect(mockRecordSessionActivity).toHaveBeenCalledTimes(1)
-      expect(mockRecordSessionActivity).toHaveBeenCalledWith(
+      expect(mockRecordProvisionalSessionActivity).toHaveBeenCalledTimes(1)
+      expect(mockRecordProvisionalSessionActivity).toHaveBeenCalledWith(
         AGENT_SLUG,
         SESSION_ID,
-        new Date('2026-08-07T18:30:00.000Z'),
+        Date.parse('2026-08-07T18:30:00.000Z'),
       )
     })
 
@@ -339,7 +347,32 @@ describe('MessagePersister', () => {
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
 
-      expect(mockRecordSessionActivity).toHaveBeenCalledTimes(2)
+      expect(mockRecordProvisionalSessionActivity).toHaveBeenCalledTimes(2)
+    })
+
+    it('reverts the send record when the send is rolled back before reaching the container', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      const mark = mockRecordProvisionalSessionActivity.mock.results[0]!.value
+
+      messagePersister.markSessionIdle(SESSION_ID)
+
+      expect(mockRevertSessionActivity).toHaveBeenCalledTimes(1)
+      expect(mockRevertSessionActivity).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, mark)
+      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    })
+
+    it('does not revert once the container has answered the send', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._messageCallback!({
+        type: 'message',
+        content: { type: 'assistant', message: { role: 'assistant', content: 'working' } },
+        timestamp: new Date('2026-08-07T18:31:00.000Z'),
+        sessionId: SESSION_ID,
+      })
+
+      messagePersister.markSessionIdle(SESSION_ID)
+
+      expect(mockRevertSessionActivity).not.toHaveBeenCalled()
     })
 
     it('ignores replayed catch-up frames whose host timestamp is arrival time', () => {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -389,6 +389,23 @@ describe('MessagePersister', () => {
       expect(mockRecordSessionActivity).not.toHaveBeenCalled()
     })
 
+    it('refreshes a session that finished while detached from its transcript mtime, not the replay time', async () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockRecordSessionActivity.mockClear()
+      mockStat.mockResolvedValueOnce({ mtimeMs: 1_754_600_000_000, size: 4096 })
+
+      mockClient._messageCallback!({
+        type: 'message',
+        content: { type: 'result', subtype: 'success', replayed: true },
+        timestamp: new Date('2026-08-07T20:00:00.000Z'),
+        sessionId: SESSION_ID,
+      })
+      await vi.waitFor(() => expect(mockRecordSessionActivity).toHaveBeenCalled())
+
+      expect(mockStat).toHaveBeenCalledWith(expect.stringContaining(`${SESSION_ID}.jsonl`))
+      expect(mockRecordSessionActivity).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, 1_754_600_000_000)
+    })
+
     it('does not attribute a sidechain transcript frame to the parent session', () => {
       mockClient._messageCallback!({
         type: 'message',

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -316,6 +316,32 @@ describe('MessagePersister', () => {
       expect(mockRecordSessionActivity).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, timestamp)
     })
 
+    it('records the session as active the moment a message is sent to it', () => {
+      // The CLI appends the user entry as the turn starts but the SDK never
+      // echoes it, so without this the session would keep its old place in
+      // every cache-backed list until the first complete assistant frame.
+      vi.useFakeTimers({ now: new Date('2026-08-07T18:30:00.000Z') })
+      try {
+        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      expect(mockRecordSessionActivity).toHaveBeenCalledTimes(1)
+      expect(mockRecordSessionActivity).toHaveBeenCalledWith(
+        AGENT_SLUG,
+        SESSION_ID,
+        new Date('2026-08-07T18:30:00.000Z'),
+      )
+    })
+
+    it('re-marking an active session for a queued message records again', () => {
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+
+      expect(mockRecordSessionActivity).toHaveBeenCalledTimes(2)
+    })
+
     it('ignores replayed catch-up frames whose host timestamp is arrival time', () => {
       // On the wire, SDK result frames carry no timestamp field, so the host
       // stamps Date.now() at arrival — a reconnect replay recorded here would

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1312,6 +1312,16 @@ class MessagePersister {
       state.agentSlug = agentSlug
     }
 
+    // The user's message is appended to the transcript by the CLI as the turn
+    // starts, but the SDK does not echo it back, so nothing else records it:
+    // the first frame the persister sees is the first complete assistant
+    // message, which can be tens of seconds out. Session lists and the
+    // latest-visible-session pick read the summary cache, so bump it here —
+    // the session must move to the top the moment it is sent to.
+    if (state.agentSlug) {
+      recordSessionActivity(state.agentSlug, sessionId, new Date())
+    }
+
     // Broadcast to session-specific clients
     this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true })
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -67,7 +67,12 @@ import { eq } from 'drizzle-orm'
 import { resolveTimezoneForAgent } from '@shared/lib/services/timezone-resolver'
 import { getFrequencyWarning, getScheduleCountWarning, validateScheduleExpression } from '@shared/lib/services/schedule-parser'
 import { finalizeAutomationStatus, getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
-import { recordSessionActivity } from '@shared/lib/services/session-summary-cache'
+import {
+  recordProvisionalSessionActivity,
+  recordSessionActivity,
+  revertSessionActivity,
+  type SessionActivityMark,
+} from '@shared/lib/services/session-summary-cache'
 import { isHiddenAutomatedSession } from '@shared/lib/services/session-visibility'
 import { appendInformationalEntry } from '@shared/lib/services/session-transcript-append'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
@@ -136,6 +141,11 @@ interface StreamingState {
   // the session running and a later turn can still fail — so the automation
   // outcome is persisted as succeeded only when the session truly settles.
   lastResultCleanSuccess: boolean
+  // The summary-cache write made optimistically by markSessionActive, kept
+  // until the container confirms the turn (first frame) or the send is
+  // rolled back (markSessionIdle), so a failed send cannot leave the session
+  // ranked as if it had just been used.
+  provisionalActivity: SessionActivityMark | null
   lastContextWindow: number // Last known context window size (default 200k)
   lastAssistantUsage: SessionUsage | null // Per-call usage from most recent assistant message
   completedSubagentIds: Set<string> // completed agentIds; a new task_started with the same ID is a resumed run
@@ -521,6 +531,7 @@ class MessagePersister {
       stateEventsAuthority: prior?.stateEventsAuthority ?? false,
       lastResultSubtype: null,
       lastResultCleanSuccess: false,
+      provisionalActivity: null,
       isRetrying: false,
       // Carried over so a transport reattach mid-run doesn't lose the verdict
       // before the refresh below lands.
@@ -645,6 +656,12 @@ class MessagePersister {
   markSessionIdle(sessionId: string): void {
     const state = this.streamingStates.get(sessionId)
     if (!state?.isActive) return
+    // The send never happened, so the recency it was credited with is undone
+    // too (a no-op if a frame has arrived since — then the turn was real).
+    if (state.provisionalActivity && state.agentSlug) {
+      revertSessionActivity(state.agentSlug, sessionId, state.provisionalActivity)
+    }
+    state.provisionalActivity = null
     this.finalizeIdle(sessionId, state)
   }
 
@@ -1270,6 +1287,7 @@ class MessagePersister {
         stateEventsAuthority: false,
         lastResultSubtype: null,
       lastResultCleanSuccess: false,
+      provisionalActivity: null,
         isRetrying: false,
       }
       this.streamingStates.set(sessionId, state)
@@ -1318,8 +1336,10 @@ class MessagePersister {
     // message, which can be tens of seconds out. Session lists and the
     // latest-visible-session pick read the summary cache, so bump it here —
     // the session must move to the top the moment it is sent to.
+    // Provisional until the container answers: markSessionIdle reverts it if
+    // the send never got there.
     if (state.agentSlug) {
-      recordSessionActivity(state.agentSlug, sessionId, new Date())
+      state.provisionalActivity = recordProvisionalSessionActivity(state.agentSlug, sessionId, Date.now())
     }
 
     // Broadcast to session-specific clients
@@ -1703,6 +1723,8 @@ class MessagePersister {
       (content.type === 'assistant' || content.type === 'user' || content.type === 'result')
     ) {
       recordSessionActivity(state.agentSlug, sessionId, message.timestamp)
+      // The turn is real; the optimistic send record no longer needs undoing.
+      state.provisionalActivity = null
     }
 
     // Container late-join catch-up: the runtime replays the last turn's

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1251,6 +1251,19 @@ class MessagePersister {
     }
   }
 
+  // Refresh one session's summary entry from its transcript's real mtime.
+  // Fire-and-forget: a failed stat leaves the TTL reconciliation to repair it.
+  private refreshSessionActivityFromDisk(agentSlug: string, sessionId: string): void {
+    void (async () => {
+      try {
+        const stat = await fs.promises.stat(getSessionJsonlPath(agentSlug, sessionId))
+        if (stat) recordSessionActivity(agentSlug, sessionId, stat.mtimeMs)
+      } catch {
+        // Missing or unreadable: the TTL reconciliation repairs it.
+      }
+    })()
+  }
+
   // Mark session as active (when user sends a message)
   markSessionActive(sessionId: string, agentSlug?: string): void {
     let state = this.streamingStates.get(sessionId)
@@ -1736,6 +1749,15 @@ class MessagePersister {
     // copies, and replaying them would re-fire terminal broadcasts.
     if (content.replayed && !state.isActive) {
       return
+    }
+
+    // This session missed its turn end (still active, now told by replay that
+    // it finished), so nothing recorded that activity. The replay's arrival
+    // time is not when it happened; the transcript's mtime is. One stat of
+    // that file puts the session in its right place now instead of at the
+    // next TTL rebuild.
+    if (content.replayed && content.type === 'result' && state.agentSlug) {
+      this.refreshSessionActivityFromDisk(state.agentSlug, sessionId)
     }
 
     switch (content.type) {

--- a/src/shared/lib/services/session-service.listing.test.ts
+++ b/src/shared/lib/services/session-service.listing.test.ts
@@ -17,11 +17,19 @@ import * as os from 'os'
 import { SAMPLE_JSONL_ENTRIES, toJsonl } from './__fixtures__/test-data'
 import {
   listSessions,
+  listSessionsFromSummary,
   getSessionMessagesPage,
   reserveSessionOwnership,
 } from './session-service'
 
-describe('listSessions visible-list contract', () => {
+// Both implementations must satisfy the same contract: listSessions stats
+// every transcript; listSessionsFromSummary reads the summary cache. Each
+// test seeds its own temp dir, so the cache starts cold and is built from the
+// same directory state the stat-based listing sees.
+describe.each([
+  ['listSessions', listSessions],
+  ['listSessionsFromSummary', listSessionsFromSummary],
+] as const)('%s visible-list contract', (_name, list) => {
   let testDir: string
   let originalEnv: string | undefined
 
@@ -78,7 +86,7 @@ describe('listSessions visible-list contract', () => {
       'registered-empty': { name: 'Just created', createdAt: '2026-01-02T00:00:00.000Z' },
     })
 
-    const sessions = await listSessions('agent-a', {
+    const sessions = await list('agent-a', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
     })
@@ -101,7 +109,7 @@ describe('listSessions visible-list contract', () => {
       'x-agent-new': { invokedByAgentSlug: 'caller' },
     })
 
-    const latest = await listSessions('agent-a', {
+    const latest = await list('agent-a', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
       limit: 1,
@@ -121,7 +129,7 @@ describe('listSessions visible-list contract', () => {
       },
     })
 
-    const latest = await listSessions('agent-a', {
+    const latest = await list('agent-a', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
       limit: 1,
@@ -136,7 +144,7 @@ describe('listSessions visible-list contract', () => {
       'pending-new': { name: 'Pending', createdAt: '2026-01-03T00:00:00.000Z' },
     })
 
-    const sessions = await listSessions('agent-a', {
+    const sessions = await list('agent-a', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
     })
@@ -153,7 +161,7 @@ describe('listSessions visible-list contract', () => {
     await writeTranscript('agent-a', 'c-newest', { activityAt: '2026-01-03T00:00:00.000Z' })
     await writeTranscript('agent-a', 'b-middle', { activityAt: '2026-01-02T00:00:00.000Z' })
 
-    const sessions = await listSessions('agent-a', { sortBy: 'last_activity_at' })
+    const sessions = await list('agent-a', { sortBy: 'last_activity_at' })
 
     expect(ids(sessions)).toEqual(['c-newest', 'b-middle', 'a-oldest'])
     expect(sessions.map((s) => s.lastActivityAt.toISOString())).toEqual([
@@ -170,7 +178,7 @@ describe('listSessions visible-list contract', () => {
       'with-meta': { createdAt: '2025-12-25T00:00:00.000Z' },
     })
 
-    const sessions = await listSessions('agent-a')
+    const sessions = await list('agent-a')
     const withMeta = sessions.find((s) => s.id === 'with-meta')!
     const noMeta = sessions.find((s) => s.id === 'no-meta')!
 
@@ -187,6 +195,9 @@ describe('listSessions visible-list contract', () => {
     await fs.promises.mkdir(sessionsDir('agent-b'), { recursive: true })
     // Reserve first: the ownership index is built from disk on first use, so a
     // later foreign file in agent-a's directory is unowned by agent-a.
+    // (The reservation also invalidates agent-b's summary, not agent-a's; the
+    // summary-backed listing must still build agent-a's map after the foreign
+    // file lands, which it does because the first read is cold.)
     await reserveSessionOwnership('agent-b', 'foreign-transcript')
     await reserveSessionOwnership('agent-b', 'foreign-pending')
     await writeTranscript('agent-a', 'foreign-transcript', { activityAt: '2026-01-09T00:00:00.000Z' })
@@ -194,7 +205,7 @@ describe('listSessions visible-list contract', () => {
       'foreign-pending': { name: 'Forged', createdAt: '2026-01-10T00:00:00.000Z' },
     })
 
-    const sessions = await listSessions('agent-a', {
+    const sessions = await list('agent-a', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
     })
@@ -214,7 +225,7 @@ describe('listSessions visible-list contract', () => {
       'hidden-3': { isScheduledExecution: true, scheduledTaskId: 't' },
     })
 
-    const sessions = await listSessions('agent-a', {
+    const sessions = await list('agent-a', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
       limit: 2,
@@ -253,7 +264,7 @@ describe('listSessions visible-list contract', () => {
     const jan2 = new Date('2026-01-02T00:00:00.000Z')
     await fs.promises.utimes(transcriptPath('agent-a', 'registered-empty-jan2'), jan2, jan2)
 
-    const visible = await listSessions('agent-a', {
+    const visible = await list('agent-a', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
     })
@@ -266,7 +277,7 @@ describe('listSessions visible-list contract', () => {
       'visible-jan1',
     ])
 
-    const everything = await listSessions('agent-a', { sortBy: 'last_activity_at' })
+    const everything = await list('agent-a', { sortBy: 'last_activity_at' })
     expect(ids(everything)).toEqual([
       'pending-hidden-jan8',
       'hidden-jan6',

--- a/src/shared/lib/services/session-service.summary-listing.test.ts
+++ b/src/shared/lib/services/session-service.summary-listing.test.ts
@@ -9,7 +9,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as path from 'path'
 import * as os from 'os'
 
-const statProbe = vi.hoisted(() => ({ paths: [] as string[] }))
+const statProbe = vi.hoisted(() => ({
+  paths: [] as string[],
+  /** Inject `times` consecutive failures with `code` for stats of `path`. */
+  failures: new Map<string, { code: string; times: number }>(),
+}))
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>()
@@ -18,7 +22,13 @@ vi.mock('fs', async (importOriginal) => {
     promises: {
       ...actual.promises,
       stat: (async (...args: Parameters<typeof actual.promises.stat>) => {
-        statProbe.paths.push(String(args[0]))
+        const target = String(args[0])
+        statProbe.paths.push(target)
+        const failure = statProbe.failures.get(target)
+        if (failure && failure.times > 0) {
+          failure.times -= 1
+          throw Object.assign(new Error(`${failure.code}: injected`), { code: failure.code })
+        }
         return actual.promises.stat(...args)
       }) as typeof actual.promises.stat,
     },
@@ -33,7 +43,12 @@ import {
   readSessionMetadata,
   registerSession,
 } from './session-service'
-import { recordSessionActivity } from './session-summary-cache'
+import {
+  SESSION_SUMMARY_CACHE_TTL_MS,
+  recordProvisionalSessionActivity,
+  recordSessionActivity,
+  revertSessionActivity,
+} from './session-summary-cache'
 
 describe('listSessionsFromSummary', () => {
   let testRoot: string
@@ -50,9 +65,11 @@ describe('listSessionsFromSummary', () => {
     process.env.SUPERAGENT_DATA_DIR = testRoot
     await fs.promises.mkdir(sessionsDir(), { recursive: true })
     statProbe.paths.length = 0
+    statProbe.failures.clear()
   })
 
   afterEach(async () => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
     if (priorDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
     else process.env.SUPERAGENT_DATA_DIR = priorDataDir
@@ -114,6 +131,122 @@ describe('listSessionsFromSummary', () => {
     expect(ids(sessions)).toEqual(['session-a', 'session-b'])
     expect(sessions[0]!.lastActivityAt).toEqual(new Date('2026-01-03T00:00:00.000Z'))
     expect(transcriptStats()).toEqual([])
+  })
+
+  it('keeps activity recorded while the cache is cold: the first build folds it in', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    // Nothing has read the summary yet (fresh process, or invalidated). The
+    // send is recorded before the CLI touches the transcript.
+    recordSessionActivity(agentSlug, 'session-a', new Date('2026-01-03T00:00:00.000Z'))
+
+    const sessions = await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })
+
+    expect(ids(sessions)).toEqual(['session-a', 'session-b'])
+    expect(sessions[0]!.lastActivityAt).toEqual(new Date('2026-01-03T00:00:00.000Z'))
+  })
+
+  it('keeps activity recorded against an expired cache across the TTL rebuild', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+    statProbe.paths.length = 0
+
+    // Real time moves past the TTL; the next read will rebuild from stats,
+    // which do not carry the send yet.
+    vi.useFakeTimers({ now: Date.now() + SESSION_SUMMARY_CACHE_TTL_MS + 1, toFake: ['Date'] })
+    recordSessionActivity(agentSlug, 'session-a', Date.now())
+    const recordedAt = Date.now()
+
+    const sessions = await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })
+
+    expect(ids(sessions)).toEqual(['session-a', 'session-b'])
+    expect(sessions[0]!.lastActivityAt.getTime()).toBe(recordedAt)
+    // ...and the rebuild happened (every transcript stat'd), so this was not
+    // just the stale value surviving.
+    expect(transcriptStats().length).toBe(2)
+  })
+
+  it('a rolled-back provisional send restores the previous order', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    const mark = recordProvisionalSessionActivity(agentSlug, 'session-a', new Date('2026-01-03T00:00:00.000Z'))
+    expect(ids(await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })))
+      .toEqual(['session-a', 'session-b'])
+
+    revertSessionActivity(agentSlug, 'session-a', mark)
+
+    const sessions = await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })
+    expect(ids(sessions)).toEqual(['session-b', 'session-a'])
+    expect(sessions[1]!.lastActivityAt).toEqual(new Date('2026-01-01T00:00:00.000Z'))
+  })
+
+  it('a rollback never erases activity recorded after the mark', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    const mark = recordProvisionalSessionActivity(agentSlug, 'session-a', new Date('2026-01-03T00:00:00.000Z'))
+    recordSessionActivity(agentSlug, 'session-a', new Date('2026-01-04T00:00:00.000Z'))
+    revertSessionActivity(agentSlug, 'session-a', mark)
+
+    const sessions = await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })
+    expect(ids(sessions)).toEqual(['session-a', 'session-b'])
+    expect(sessions[0]!.lastActivityAt).toEqual(new Date('2026-01-04T00:00:00.000Z'))
+  })
+
+  it('a rollback of a send recorded against a cold cache forces a re-stat', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+
+    const mark = recordProvisionalSessionActivity(agentSlug, 'session-a', new Date('2026-01-03T00:00:00.000Z'))
+    expect(ids(await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })))
+      .toEqual(['session-a', 'session-b'])
+
+    revertSessionActivity(agentSlug, 'session-a', mark)
+
+    expect(ids(await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })))
+      .toEqual(['session-b', 'session-a'])
+  })
+
+  it('does not cache a transient stat failure as absence', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+
+    // ESTALE on both the stat and its retry: the build fails and nothing is
+    // cached — the alternative is a session hidden until the next TTL.
+    statProbe.failures.set(transcriptPath('session-b'), { code: 'ESTALE', times: 2 })
+    await expect(listSessionsFromSummary(agentSlug)).rejects.toMatchObject({ code: 'ESTALE' })
+
+    // The filesystem recovers; the next read is complete.
+    expect(ids(await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })))
+      .toEqual(['session-b', 'session-a'])
+  })
+
+  it('absorbs a single transient stat failure with one retry', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    statProbe.failures.set(transcriptPath('session-b'), { code: 'EIO', times: 1 })
+
+    expect(ids(await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })))
+      .toEqual(['session-b', 'session-a'])
+  })
+
+  it('still drops a transcript deleted between readdir and stat', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    statProbe.failures.set(transcriptPath('session-b'), { code: 'ENOENT', times: 5 })
+
+    // No throw, no retry storm; session-b is no longer backed by its
+    // transcript and falls through to the metadata-only branch, ranked by
+    // its registration time rather than the file's mtime.
+    const sessions = await listSessionsFromSummary(agentSlug)
+    expect(ids(sessions).sort()).toEqual(['session-a', 'session-b'])
+    expect(sessions.find((s) => s.id === 'session-b')!.lastActivityAt)
+      .not.toEqual(new Date('2026-01-02T00:00:00.000Z'))
+    expect(statProbe.paths.filter((p) => p === transcriptPath('session-b'))).toHaveLength(1)
   })
 
   it('treats an unregistered empty transcript as a session once activity is recorded for it', async () => {

--- a/src/shared/lib/services/session-service.summary-listing.test.ts
+++ b/src/shared/lib/services/session-service.summary-listing.test.ts
@@ -1,0 +1,173 @@
+/**
+ * listSessionsFromSummary's cost and cache-coherence properties — what makes
+ * it safe to put on the per-poll request path. The contract it shares with
+ * listSessions (visibility, ownership, ordering) lives in
+ * session-service.listing.test.ts; this file pins what is specific to reading
+ * from the summary cache.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as path from 'path'
+import * as os from 'os'
+
+const statProbe = vi.hoisted(() => ({ paths: [] as string[] }))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      stat: (async (...args: Parameters<typeof actual.promises.stat>) => {
+        statProbe.paths.push(String(args[0]))
+        return actual.promises.stat(...args)
+      }) as typeof actual.promises.stat,
+    },
+  }
+})
+
+import * as fs from 'fs'
+import {
+  deleteSession,
+  getSessionSummary,
+  listSessionsFromSummary,
+  readSessionMetadata,
+  registerSession,
+} from './session-service'
+import { recordSessionActivity } from './session-summary-cache'
+
+describe('listSessionsFromSummary', () => {
+  let testRoot: string
+  let priorDataDir: string | undefined
+  const agentSlug = 'summary-listing-agent'
+
+  const workspaceDir = () => path.join(testRoot, 'agents', agentSlug, 'workspace')
+  const sessionsDir = () => path.join(workspaceDir(), '.claude', 'projects', '-workspace')
+  const transcriptPath = (sessionId: string) => path.join(sessionsDir(), `${sessionId}.jsonl`)
+
+  beforeEach(async () => {
+    testRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'session-summary-listing-'))
+    priorDataDir = process.env.SUPERAGENT_DATA_DIR
+    process.env.SUPERAGENT_DATA_DIR = testRoot
+    await fs.promises.mkdir(sessionsDir(), { recursive: true })
+    statProbe.paths.length = 0
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    if (priorDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = priorDataDir
+    await fs.promises.rm(testRoot, { recursive: true, force: true })
+  })
+
+  async function createSession(
+    sessionId: string,
+    activityAt: string,
+    content = '{"type":"user","uuid":"u","message":{"role":"user","content":"hi"}}\n',
+  ): Promise<void> {
+    await registerSession(agentSlug, sessionId, sessionId)
+    await fs.promises.writeFile(transcriptPath(sessionId), content)
+    const timestamp = new Date(activityAt)
+    await fs.promises.utimes(transcriptPath(sessionId), timestamp, timestamp)
+  }
+
+  const ids = (sessions: { id: string }[]) => sessions.map((s) => s.id)
+  const transcriptStats = () => statProbe.paths.filter((file) => file.endsWith('.jsonl'))
+
+  it('lists from a warm cache with one directory stat and no transcript stats', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+    statProbe.paths.length = 0
+
+    const sessions = await listSessionsFromSummary(agentSlug, {
+      excludeAutomated: true,
+      sortBy: 'last_activity_at',
+    })
+
+    expect(ids(sessions)).toEqual(['session-b', 'session-a'])
+    expect(statProbe.paths).toEqual([sessionsDir()])
+  })
+
+  it('does not re-read metadata when the caller passes the map', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+    const metadata = await readSessionMetadata(agentSlug)
+    const readFile = vi.spyOn(fs.promises, 'readFile')
+
+    const sessions = await listSessionsFromSummary(agentSlug, { metadata, excludeAutomated: true })
+
+    expect(ids(sessions)).toEqual(['session-a'])
+    expect(readFile).not.toHaveBeenCalled()
+  })
+
+  it('reorders on recorded activity without touching the filesystem', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    // The persister reports a write to the older session; no stat happens.
+    recordSessionActivity(agentSlug, 'session-a', new Date('2026-01-03T00:00:00.000Z'))
+    statProbe.paths.length = 0
+
+    const sessions = await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })
+
+    expect(ids(sessions)).toEqual(['session-a', 'session-b'])
+    expect(sessions[0]!.lastActivityAt).toEqual(new Date('2026-01-03T00:00:00.000Z'))
+    expect(transcriptStats()).toEqual([])
+  })
+
+  it('treats an unregistered empty transcript as a session once activity is recorded for it', async () => {
+    // Cached as size 0 with no registration → an SDK artifact, hidden...
+    await fs.promises.writeFile(transcriptPath('became-real'), '')
+    await createSession('anchor', '2026-01-01T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+    expect(ids(await listSessionsFromSummary(agentSlug))).toEqual(['anchor'])
+
+    // ...until the stream reports a write to it: bytes now exist, and
+    // ownership was already established at build time.
+    recordSessionActivity(agentSlug, 'became-real', new Date('2026-01-05T00:00:00.000Z'))
+
+    expect(ids(await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })))
+      .toEqual(['became-real', 'anchor'])
+  })
+
+  it('picks up a transcript added after the cache was built', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    // registerSession claims ownership, which invalidates the summary; the
+    // new file also bumps the directory mtime. Either alone would do.
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+
+    const sessions = await listSessionsFromSummary(agentSlug, { sortBy: 'last_activity_at' })
+    expect(ids(sessions)).toEqual(['session-b', 'session-a'])
+  })
+
+  it('drops a deleted session immediately', async () => {
+    await createSession('session-a', '2026-01-01T00:00:00.000Z')
+    await createSession('session-b', '2026-01-02T00:00:00.000Z')
+    await getSessionSummary(agentSlug)
+
+    await deleteSession(agentSlug, 'session-b')
+
+    expect(ids(await listSessionsFromSummary(agentSlug))).toEqual(['session-a'])
+  })
+
+  it('includes registered sessions with no transcript and orders them by createdAt', async () => {
+    await createSession('session-a', '2026-01-02T00:00:00.000Z')
+    await registerSession(agentSlug, 'pending-newer', 'Pending')
+    await getSessionSummary(agentSlug)
+    const metadata = await readSessionMetadata(agentSlug)
+    // registerSession stamps createdAt = now, newer than session-a's activity.
+    expect(metadata['pending-newer']?.createdAt).toBeDefined()
+    statProbe.paths.length = 0
+
+    const sessions = await listSessionsFromSummary(agentSlug, {
+      metadata,
+      sortBy: 'last_activity_at',
+    })
+
+    expect(ids(sessions)).toEqual(['pending-newer', 'session-a'])
+    expect(transcriptStats()).toEqual([])
+  })
+})

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -54,9 +54,11 @@ import {
 import { captureException } from '@shared/lib/error-reporting'
 import {
   getSessionSummaryCacheSlot,
+  applyActivity,
   invalidateSessionSummaryCache,
   recordSessionActivity,
   removeSessionFromSummaryCache,
+  type SessionActivityEntry,
   SESSION_SUMMARY_CACHE_TTL_MS,
   type SessionSummaryCacheValue,
 } from './session-summary-cache'
@@ -569,10 +571,11 @@ function emptySessionFromMetadata(
 // network filesystems like S3 Files / EFS used by the k8s / microVM runtime.
 function resolveSessionCreatedAt(
   meta: SessionMetadata | undefined,
-  stat: { birthtimeMs: number; birthtime: Date; mtimeMs: number },
+  stat: { birthtimeMs: number; mtimeMs: number },
 ): Date {
   if (meta?.createdAt) return new Date(meta.createdAt)
-  if (stat.birthtimeMs > 0) return stat.birthtime
+  // Same rounding Node applies when it derives stat.birthtime from the ns value.
+  if (stat.birthtimeMs > 0) return new Date(Math.round(stat.birthtimeMs))
   return new Date(stat.mtimeMs)
 }
 
@@ -580,15 +583,15 @@ function resolveSessionCreatedAt(
 // Session Operations
 // ============================================================================
 
-function summaryFromActivityMap(activityBySession: Map<string, number>): {
+function summaryFromActivityMap(activityBySession: ReadonlyMap<string, SessionActivityEntry>): {
   sessionIds: string[]
   sessionCount: number
   lastActivityAt: Date | null
 } {
   const sessionIds = [...activityBySession.keys()]
   let latestMs: number | null = null
-  for (const activityAtMs of activityBySession.values()) {
-    if (latestMs === null || activityAtMs > latestMs) latestMs = activityAtMs
+  for (const { mtimeMs } of activityBySession.values()) {
+    if (latestMs === null || mtimeMs > latestMs) latestMs = mtimeMs
   }
   return {
     sessionIds,
@@ -611,7 +614,7 @@ async function buildSessionActivityMap(
   agentSlug: string,
   sessionsDir: string,
   directoryMtimeMs: number | null,
-): Promise<Map<string, number>> {
+): Promise<Map<string, SessionActivityEntry>> {
   if (directoryMtimeMs === null) return new Map()
 
   const files = await fs.promises.readdir(sessionsDir)
@@ -625,28 +628,30 @@ async function buildSessionActivityMap(
       if (!stat) return null
       const sessionId = path.basename(file, '.jsonl')
       if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
-      return { sessionId, mtimeMs: stat.mtimeMs }
+      return {
+        sessionId,
+        entry: { mtimeMs: stat.mtimeMs, birthtimeMs: stat.birthtimeMs, size: stat.size },
+      }
     })),
   )
 
-  const activityBySession = new Map<string, number>()
-  for (const entry of stats) {
-    if (entry) activityBySession.set(entry.sessionId, entry.mtimeMs)
+  const activityBySession = new Map<string, SessionActivityEntry>()
+  for (const result of stats) {
+    if (result) activityBySession.set(result.sessionId, result.entry)
   }
   return activityBySession
 }
 
 /**
- * Lightweight session summary from filesystem stats only (no JSONL parsing).
- * Returns session IDs, count, and latest activity time. The first read (and
- * structural/TTL reconciliation) stats every transcript; warm reads validate
- * the directory with one stat and use stream-maintained per-session mtimes.
+ * The per-agent activity map behind {@link getSessionSummary} and
+ * {@link listSessionsFromSummary}: one entry per owned transcript on disk.
+ * The first read (and structural/TTL reconciliation) stats every transcript;
+ * warm reads validate the directory with one stat and use stream-maintained
+ * per-session entries. Callers must treat the returned map as read-only.
  */
-export async function getSessionSummary(agentSlug: string): Promise<{
-  sessionIds: string[]
-  sessionCount: number
-  lastActivityAt: Date | null
-}> {
+async function loadSessionActivityMap(
+  agentSlug: string,
+): Promise<ReadonlyMap<string, SessionActivityEntry>> {
   const sessionsDir = getAgentSessionsDir(agentSlug)
   const slot = getSessionSummaryCacheSlot(sessionsDir)
   const directoryMtimeMs = await getSessionsDirectoryMtime(sessionsDir)
@@ -656,7 +661,7 @@ export async function getSessionSummary(agentSlug: string): Promise<{
     slot.value.directoryMtimeMs === directoryMtimeMs &&
     now - slot.value.builtAtMs < SESSION_SUMMARY_CACHE_TTL_MS
   ) {
-    return summaryFromActivityMap(slot.value.activityBySession)
+    return slot.value.activityBySession
   }
 
   if (slot.loading) {
@@ -666,9 +671,9 @@ export async function getSessionSummary(agentSlug: string): Promise<{
       loaded.directoryMtimeMs === directoryMtimeMs &&
       Date.now() - loaded.builtAtMs < SESSION_SUMMARY_CACHE_TTL_MS
     ) {
-      return summaryFromActivityMap(loaded.activityBySession)
+      return loaded.activityBySession
     }
-    return getSessionSummary(agentSlug)
+    return loadSessionActivityMap(agentSlug)
   }
 
   const revision = slot.revision
@@ -681,11 +686,9 @@ export async function getSessionSummary(agentSlug: string): Promise<{
       for (const [sessionId, mutation] of slot.pending) {
         if (mutation.deleted) {
           activityBySession.delete(sessionId)
-        } else if (mutation.activityAtMs !== undefined && activityBySession.has(sessionId)) {
-          activityBySession.set(
-            sessionId,
-            Math.max(activityBySession.get(sessionId)!, mutation.activityAtMs),
-          )
+        } else if (mutation.activityAtMs !== undefined) {
+          const entry = activityBySession.get(sessionId)
+          if (entry) applyActivity(entry, mutation.activityAtMs)
         }
       }
       slot.pending.clear()
@@ -700,11 +703,24 @@ export async function getSessionSummary(agentSlug: string): Promise<{
   slot.loading = loading
   try {
     const loaded = await loading
-    if (slot.value !== loaded) return getSessionSummary(agentSlug)
-    return summaryFromActivityMap(loaded.activityBySession)
+    if (slot.value !== loaded) return loadSessionActivityMap(agentSlug)
+    return loaded.activityBySession
   } finally {
     if (slot.loading === loading) slot.loading = undefined
   }
+}
+
+/**
+ * Lightweight session summary from filesystem stats only (no JSONL parsing).
+ * Returns session IDs, count, and latest activity time. Warm reads cost one
+ * directory stat; see {@link loadSessionActivityMap}.
+ */
+export async function getSessionSummary(agentSlug: string): Promise<{
+  sessionIds: string[]
+  sessionCount: number
+  lastActivityAt: Date | null
+}> {
+  return summaryFromActivityMap(await loadSessionActivityMap(agentSlug))
 }
 
 export type SessionSortBy = 'last_activity_at'
@@ -847,6 +863,63 @@ export async function listSessions(
   return options?.limit === undefined
     ? ordered
     : ordered.slice(0, options.limit)
+}
+
+/**
+ * The same visible list as {@link listSessions}, built from the session summary
+ * cache instead of a stat of every transcript.
+ *
+ * Warm cost is one directory stat (the cache validation) plus the metadata
+ * read — or nothing beyond the directory stat when the caller passes the map
+ * it already holds. This is what request-path consumers should use: the
+ * agents list hydrates every agent per poll, and on network filesystems each
+ * transcript stat is a round trip. Freshness is that of the summary cache —
+ * structural changes (new/deleted transcripts, ownership claims) reconcile via
+ * directory mtime and invalidation, appends via recordSessionActivity — i.e.
+ * exactly the fidelity of the agent card's lastActivityAt.
+ *
+ * Applies the same rules as listSessions: ownership (the cache is built
+ * through sessionBelongsToAgent; metadata-only sessions are checked here),
+ * unregistered empty transcripts skipped, visibility filtered BEFORE ordering
+ * and limit.
+ */
+export async function listSessionsFromSummary(
+  agentSlug: string,
+  options?: ListSessionsOptions & { metadata?: SessionMetadataMap },
+): Promise<SessionInfo[]> {
+  const metadata = options?.metadata ?? (await readSessionMetadata(agentSlug))
+  const activity = await loadSessionActivityMap(agentSlug)
+  const metaFor = (sessionId: string): SessionMetadata | undefined =>
+    Object.hasOwn(metadata, sessionId) ? metadata[sessionId] : undefined
+  const isAutomated = (sessionId: string) => isHiddenAutomatedSession(metaFor(sessionId))
+
+  const sessions: SessionInfo[] = []
+  for (const [sessionId, entry] of activity) {
+    const meta = metaFor(sessionId)
+    // Same rule as listSessions: an unregistered empty JSONL is an SDK
+    // subagent artifact, not a session.
+    if (entry.size === 0 && !meta) continue
+    if (options?.excludeAutomated && isAutomated(sessionId)) continue
+    sessions.push({
+      id: sessionId,
+      agentSlug,
+      name: meta?.name || 'New Session',
+      createdAt: resolveSessionCreatedAt(meta, entry),
+      lastActivityAt: new Date(entry.mtimeMs),
+      messageCount: 0,
+    })
+  }
+
+  // Registered sessions whose agent has not streamed yet (no transcript).
+  for (const [sessionId, sessionMeta] of Object.entries(metadata)) {
+    if (activity.has(sessionId) || !sessionMeta.createdAt) continue
+    if (!(await sessionBelongsToAgent(agentSlug, sessionId))) continue
+    if (options?.excludeAutomated && isAutomated(sessionId)) continue
+    sessions.push(emptySessionFromMetadata(sessionId, agentSlug, sessionMeta))
+  }
+
+  const ordered = sortSessionsNewestFirst(sessions, options?.sortBy)
+  return options?.limit === undefined ? ordered : ordered.slice(0, options.limit)
 }
 
 /**
@@ -1511,35 +1584,44 @@ export async function getSessionMessagesPage(
   }
 ): Promise<SessionMessagesPage> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
-  if (!(await fileExists(jsonlPath))) {
-    return { messages: [], nextCursor: null }
-  }
-
   const { limit, cursor, signal } = opts
   const byteBudget = opts.byteBudget ?? MESSAGES_PAGE_BYTE_BUDGET
 
-  const scan = await scanMessagesPageWindow(jsonlPath, { limit, cursor, byteBudget, signal })
-  signal?.throwIfAborted()
-  if (!scan.found) {
-    // Vanished id (or cursor deeper than MAX_TAIL_LINES): terminate paging.
-    // Never point the client at a newer message — it would loop on
-    // already-loaded pages.
-    if (!scan.reachedStart) {
-      console.warn(
-        `getSessionMessagesPage: cursor ${cursor} not found within ` +
-        `${MAX_TAIL_LINES} tail lines of session ${sessionId}; ending pagination`
-      )
+  // No existence pre-check: a registered session that has not streamed yet
+  // has no transcript and pages as empty, and a stat before every read is a
+  // wasted round trip on network filesystems. The backward scan yields
+  // nothing for a missing file; the forward read then fails to open it and
+  // the ENOENT is answered with the same empty terminal page.
+  let scan: PageWindowScan
+  let entries: (JsonlMessageEntry | JsonlSystemEntry)[]
+  try {
+    scan = await scanMessagesPageWindow(jsonlPath, { limit, cursor, byteBudget, signal })
+    signal?.throwIfAborted()
+    if (!scan.found) {
+      // Vanished id (or cursor deeper than MAX_TAIL_LINES): terminate paging.
+      // Never point the client at a newer message — it would loop on
+      // already-loaded pages.
+      if (!scan.reachedStart) {
+        console.warn(
+          `getSessionMessagesPage: cursor ${cursor} not found within ` +
+          `${MAX_TAIL_LINES} tail lines of session ${sessionId}; ending pagination`
+        )
+      }
+      return { messages: [], nextCursor: null }
     }
-    return { messages: [], nextCursor: null }
+    entries = await readEntriesRange(
+      jsonlPath,
+      scan.startOffset,
+      scan.endOffset,
+      signal,
+      opts.media === 'ref'
+    )
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { messages: [], nextCursor: null }
+    }
+    throw error
   }
-
-  const entries = await readEntriesRange(
-    jsonlPath,
-    scan.startOffset,
-    scan.endOffset,
-    signal,
-    opts.media === 'ref'
-  )
   signal?.throwIfAborted()
   const transformed = transformMessages(entries)
   const reachedStart = scan.reachedStart

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -610,6 +610,30 @@ async function getSessionsDirectoryMtime(sessionsDir: string): Promise<number | 
   }
 }
 
+/**
+ * Stat one transcript for the summary build. A file deleted between readdir
+ * and stat (deleteSession racing a scan) is not an error — it drops out of
+ * the build. Anything else is: the build's result is cached for minutes, so
+ * treating a transient network-filesystem failure (ESTALE, EIO, a timeout)
+ * as "no such session" would hide or misorder that session until the next
+ * reconciliation. Retry once, then let the build fail; nothing is cached and
+ * the next read rebuilds.
+ */
+async function statTranscriptForSummary(filePath: string): Promise<fs.Stats | null> {
+  const isMissing = (error: unknown) => (error as NodeJS.ErrnoException)?.code === 'ENOENT'
+  try {
+    return await fs.promises.stat(filePath)
+  } catch (error) {
+    if (isMissing(error)) return null
+    try {
+      return await fs.promises.stat(filePath)
+    } catch (retryError) {
+      if (isMissing(retryError)) return null
+      throw retryError
+    }
+  }
+}
+
 async function buildSessionActivityMap(
   agentSlug: string,
   sessionsDir: string,
@@ -622,9 +646,7 @@ async function buildSessionActivityMap(
   const limit = pLimit(10)
   const stats = await Promise.all(
     jsonlFiles.map((file) => limit(async () => {
-      // A transcript deleted between readdir and stat (deleteSession racing a
-      // scan) just drops out of this build instead of failing the whole scan.
-      const stat = await fs.promises.stat(path.join(sessionsDir, file)).catch(() => null)
+      const stat = await statTranscriptForSummary(path.join(sessionsDir, file))
       if (!stat) return null
       const sessionId = path.basename(file, '.jsonl')
       if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null

--- a/src/shared/lib/services/session-summary-cache.ts
+++ b/src/shared/lib/services/session-summary-cache.ts
@@ -2,11 +2,23 @@ import { getAgentSessionsDir } from '@shared/lib/utils/file-storage'
 
 export const SESSION_SUMMARY_CACHE_TTL_MS = 5 * 60 * 1000
 
+/**
+ * What one transcript stat contributed to the summary. Kept per session so
+ * consumers that list sessions (not just count them) can apply the same rules
+ * a fresh stat would — empty unregistered files are SDK artifacts, createdAt
+ * falls back to birthtime — without touching the transcript again.
+ */
+export interface SessionActivityEntry {
+  mtimeMs: number
+  birthtimeMs: number
+  size: number
+}
+
 export interface SessionSummaryCacheValue {
   directoryMtimeMs: number | null
   builtAtMs: number
   revision: number
-  activityBySession: Map<string, number>
+  activityBySession: Map<string, SessionActivityEntry>
 }
 
 export interface SessionSummaryCacheSlot {
@@ -53,9 +65,9 @@ export function recordSessionActivity(
   const slot = sessionSummaryCache.get(getAgentSessionsDir(agentSlug))
   if (!slot) return
 
-  const cachedActivity = slot.value?.activityBySession.get(sessionId)
-  if (cachedActivity !== undefined) {
-    slot.value!.activityBySession.set(sessionId, Math.max(cachedActivity, activityAtMs))
+  const cached = slot.value?.activityBySession.get(sessionId)
+  if (cached !== undefined) {
+    applyActivity(cached, activityAtMs)
   }
   if (slot.loading) {
     const pending = slot.pending.get(sessionId)
@@ -65,6 +77,16 @@ export function recordSessionActivity(
       })
     }
   }
+}
+
+/**
+ * Fold a recorded write into a cached entry. A write also proves the
+ * transcript is no longer empty, so a file that was a zero-byte placeholder
+ * at build time stops being classified as an SDK artifact once it streams.
+ */
+export function applyActivity(entry: SessionActivityEntry, activityAtMs: number): void {
+  entry.mtimeMs = Math.max(entry.mtimeMs, activityAtMs)
+  entry.size = Math.max(entry.size, 1)
 }
 
 export function removeSessionFromSummaryCache(agentSlug: string, sessionId: string): void {

--- a/src/shared/lib/services/session-summary-cache.ts
+++ b/src/shared/lib/services/session-summary-cache.ts
@@ -51,9 +51,17 @@ export function invalidateSessionSummaryCache(agentSlug: string): void {
 }
 
 /**
- * Advance a warm per-agent summary from an authoritative transcript write.
+ * Advance a per-agent summary from an authoritative transcript write.
  * This never creates a session in the summary: structural additions are
  * reconciled from the directory, preserving the ownership/filesystem gates.
+ *
+ * The write is applied to the cached value if there is one AND parked in the
+ * slot's pending map regardless, because the cached value may be about to be
+ * replaced: a cold slot, an expired one, or a build already in flight all
+ * rebuild from real stats, and the transcript may not carry the write yet
+ * (a send is recorded before the CLI appends the user entry). Every rebuild
+ * folds pending in and clears it, so nothing is lost and nothing accumulates
+ * beyond one entry per session.
  */
 export function recordSessionActivity(
   agentSlug: string,
@@ -62,21 +70,74 @@ export function recordSessionActivity(
 ): void {
   const activityAtMs = activityAt instanceof Date ? activityAt.getTime() : activityAt
   if (!Number.isFinite(activityAtMs)) return
-  const slot = sessionSummaryCache.get(getAgentSessionsDir(agentSlug))
-  if (!slot) return
+  const slot = getSessionSummaryCacheSlot(getAgentSessionsDir(agentSlug))
 
   const cached = slot.value?.activityBySession.get(sessionId)
   if (cached !== undefined) {
     applyActivity(cached, activityAtMs)
   }
-  if (slot.loading) {
-    const pending = slot.pending.get(sessionId)
-    if (!pending?.deleted) {
-      slot.pending.set(sessionId, {
-        activityAtMs: Math.max(pending?.activityAtMs ?? -Infinity, activityAtMs),
-      })
-    }
+  const pending = slot.pending.get(sessionId)
+  if (!pending?.deleted) {
+    slot.pending.set(sessionId, {
+      activityAtMs: Math.max(pending?.activityAtMs ?? -Infinity, activityAtMs),
+    })
   }
+}
+
+/** What {@link revertSessionActivity} needs to undo one recorded write. */
+export interface SessionActivityMark {
+  recordedAtMs: number
+  /** The cached entry as it was before the record; null if there was none. */
+  previous: { mtimeMs: number; size: number } | null
+}
+
+/**
+ * Record a write that may still be rolled back — an optimistic send that has
+ * not reached the container yet. Returns the mark to hand back to
+ * {@link revertSessionActivity} if the send fails.
+ */
+export function recordProvisionalSessionActivity(
+  agentSlug: string,
+  sessionId: string,
+  activityAt: Date | number = Date.now(),
+): SessionActivityMark {
+  const recordedAtMs = activityAt instanceof Date ? activityAt.getTime() : activityAt
+  const slot = getSessionSummaryCacheSlot(getAgentSessionsDir(agentSlug))
+  const cached = slot.value?.activityBySession.get(sessionId)
+  const previous = cached ? { mtimeMs: cached.mtimeMs, size: cached.size } : null
+  recordSessionActivity(agentSlug, sessionId, recordedAtMs)
+  return { recordedAtMs, previous }
+}
+
+/**
+ * Undo a provisional record whose send never happened. A no-op if anything
+ * newer was recorded since (the entry's mtime moved past the mark), so a
+ * late rollback can never erase real activity.
+ */
+export function revertSessionActivity(
+  agentSlug: string,
+  sessionId: string,
+  mark: SessionActivityMark,
+): void {
+  const slot = sessionSummaryCache.get(getAgentSessionsDir(agentSlug))
+  if (!slot) return
+
+  const pending = slot.pending.get(sessionId)
+  if (pending && !pending.deleted && pending.activityAtMs === mark.recordedAtMs) {
+    slot.pending.delete(sessionId)
+  }
+  const cached = slot.value?.activityBySession.get(sessionId)
+  if (cached === undefined || cached.mtimeMs !== mark.recordedAtMs) return
+  if (mark.previous) {
+    cached.mtimeMs = mark.previous.mtimeMs
+    cached.size = mark.previous.size
+    return
+  }
+  // The entry did not exist when the mark was taken (cold/expired cache) and
+  // a rebuild has since folded the provisional write into fresh stats. The
+  // pre-write mtime is unknown here, so make the next read re-stat.
+  slot.revision++
+  slot.value = undefined
 }
 
 /**
@@ -93,5 +154,10 @@ export function removeSessionFromSummaryCache(agentSlug: string, sessionId: stri
   const slot = sessionSummaryCache.get(getAgentSessionsDir(agentSlug))
   if (!slot) return
   slot.value?.activityBySession.delete(sessionId)
+  // A build in flight may have stat'd the file before the unlink; mark it so
+  // the fold-in drops it. Otherwise drop any parked write for it: the next
+  // rebuild will not see the file, and a parked write must not resurrect it
+  // (it never could — pending never creates — but it must not linger either).
   if (slot.loading) slot.pending.set(sessionId, { deleted: true })
+  else slot.pending.delete(sessionId)
 }


### PR DESCRIPTION
Stacked on #867 (coverage + perf suite). Second of three PRs for the SUP-658 iOS home-page path.

## Problem

`GET /api/agents?include_latest_visible_session_tail=true` selects each agent's latest visible session through `listSessions`, which readdirs and **stats every transcript in the agent's directory on every request** — on NFS-class volumes that is one round trip per session, per agent, per poll. `GET /api/agents/:id/sessions?limit=20` did the same to return 20 rows. On top of that, `session-metadata.json` was read 2–3× per agent and the chosen transcript stat'd three more times before it was read.

## Change

- **Summary cache learns size + birthtime.** `SessionActivityEntry = { mtimeMs, birthtimeMs, size }` instead of a bare mtime, so a consumer can apply `listSessions`' rules without touching the file: an unregistered empty JSONL is an SDK subagent artifact; `createdAt` = metadata → birthtime → mtime. A recorded write (`recordSessionActivity`) marks the entry non-empty.
- **`listSessionsFromSummary()`** — the same visible list as `listSessions`, built from that cache plus the metadata map (callers that already hold it pass it in). Warm cost: one directory stat. Freshness is the summary cache's — the same fidelity the agent card's `lastActivityAt` already has (structural changes reconcile via dir mtime + invalidation on ownership claims/deletes, appends via `recordSessionActivity`, 5-min TTL backstop).
- `getVisibleSessionExpansion` and the non-notable `GET /:id/sessions` path use it. The expansion threads its metadata map through, so it's read once per agent.
- `getSessionMessagesPage` no longer stats before reading; ENOENT from the read is the empty terminal page. `getLatestVisibleSessionTail` reads first and checks existence only if the page came back empty for an unregistered session — the common case costs no stat.

`listSessions` (stat-everything) is unchanged and still used by non-request-path callers.

## Cache coherence fixes from review (commits 2 and 3)

- **Record activity on send.** The persister bumped the cache only on complete assistant/tool/result frames; nothing recorded the send itself, and the SDK does not echo the user prompt. With a live stat the session moved to the top the moment the CLI appended the user entry; with the cache it stayed put — and the iOS card kept the previous session's tail — until the first complete assistant message. `markSessionActive`, the one hook every send path goes through, now records.
- **Sends survive cold/expired caches.** `recordSessionActivity` used to drop a write when no cache existed, and a write against an expired cache was applied to the value the next read threw away — so a send during a TTL rebuild was lost for a full TTL. Writes are now always parked in the slot's pending map and folded into every rebuild.
- **Failed sends are undone.** The send record is provisional: it carries the entry's previous state, the persister keeps it until the first frame confirms the turn, and the wake-delivery rollback (`markSessionIdle`) reverts it. A revert is a no-op once anything newer was recorded.
- **Stat errors are never cached as absence.** The summary build swallowed every stat error, so a transient ESTALE/EIO hid a session for up to five minutes. Only ENOENT (deleteSession racing a scan) is skipped; anything else is retried once, then fails the build so nothing is cached and the next read rebuilds.

## Numbers (perf suite, 10 ms simulated latency per fs op)

| scenario | before | after |
|---|---|---|
| big (1 × 5000 sessions) home poll, warm cache | 5031 ops / ~5.3 s | **22 ops / ~140 ms** |
| big home poll, cold cache | 10037 ops | 5028 ops (one stat pass instead of two) |
| big `sessions?sort_by=last_activity_at&limit=20` | 5009 ops / ~5.2 s | **3 ops / ~50 ms** |
| small (5 × 50) home poll, warm cache | 367 ops / ~255 ms | 87 ops / ~160 ms |
| small home poll, cold | 632 ops | 352 ops |

Budgets in `perf/agents-home.{small,big}.perf.ts` are tightened to these in this diff.

## Tests

- `session-service.listing.test.ts` (from #867) now runs the whole visible-list contract against **both** `listSessions` and `listSessionsFromSummary`.
- `session-service.summary-listing.test.ts` pins cache-specific properties: warm read = one directory stat and no transcript stats; passing the metadata map skips the read; recorded activity reorders without a stat; a size-0 artifact becomes a session once it streams; adds/deletes reconcile; metadata-only sessions order by `createdAt`; a write recorded cold or across the TTL boundary survives the rebuild; a rolled-back provisional send restores the previous order, never erases newer activity, and forces a re-stat when taken cold; ESTALE is not cached, a single EIO is absorbed by the retry, ENOENT still drops the file.
- `message-persister.test.ts`: `markSessionActive` records provisionally with the send time; re-marks record again; `markSessionIdle` reverts only while no frame has arrived.
- Route tests: the three mock factories gain the new export; the vanished-session and registered-not-yet-streamed cases are rewritten to express state through the page read + metadata map (and assert no existence stat in the registered case).
- Perf suite's end-to-end correctness assertions (latest visible id per agent, artifacts excluded, tail non-empty) pass on the real filesystem.

## Reviewer notes

- The `/sessions` list is now as fresh as the summary cache rather than a live stat. Every host-side mutation keeps that cache coherent (sends, complete frames, informational appends, rewrites, deletes, ownership claims), and a session that finished while the host WebSocket was detached is refreshed from its transcript mtime when the replay arrives (commit 4). The 5-minute TTL is the backstop for writes the host never observed at all.
- `base-container-client.test.ts` › `isHealthy` has 2 failures locally that reproduce on `main` in this environment (global `fetch` stub) — unrelated to this diff; CI should tell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
