### PR TITLE
perf(agents): overlap the independent reads behind the agents list (SUP-658, 3/3)

### DIFF
--- a/perf/agents-home.big.perf.ts
+++ b/perf/agents-home.big.perf.ts
@@ -7,12 +7,14 @@
 import { defineHomeScenarios } from './home-scenarios'
 
 // Cold reads still stat every transcript once to build the summary; warm
-// reads (the iOS poll) and the sessions page come from the cache.
+// reads (the iOS poll) and the sessions page come from the cache. Wall is
+// bounded by the per-agent critical path: the agent list, artifact lookups
+// and per-request DB reads overlap.
 defineHomeScenarios('big', {
   agentsCold: { totalOps: 5021, ops: { stat: 5009 }, wallMs: 10_400 },
-  agentsWarm: { totalOps: 15, ops: { stat: 4 }, wallMs: 280 },
+  agentsWarm: { totalOps: 15, ops: { stat: 4 }, wallMs: 110 },
   homeCold: { totalOps: 5028, ops: { stat: 5010 }, wallMs: 10_500 },
-  homeWarm: { totalOps: 22, ops: { stat: 5 }, wallMs: 290 },
-  sessionsPage: { totalOps: 3, ops: { stat: 2 }, wallMs: 110 },
+  homeWarm: { totalOps: 22, ops: { stat: 5 }, wallMs: 260 },
+  sessionsPage: { totalOps: 3, ops: { stat: 2 }, wallMs: 100 },
   sessionsNotable: { totalOps: 1, ops: { stat: 1 }, wallMs: 40 },
 })

--- a/perf/agents-home.small.perf.ts
+++ b/perf/agents-home.small.perf.ts
@@ -7,12 +7,14 @@
 import { defineHomeScenarios } from './home-scenarios'
 
 // Cold reads still stat every transcript once to build the summary; warm
-// reads (the iOS poll) and the sessions page come from the cache.
+// reads (the iOS poll) and the sessions page come from the cache. Wall is
+// bounded by the per-agent critical path, not the agent count: the agent
+// list, artifact lookups and per-request DB reads overlap.
 defineHomeScenarios('small', {
-  agentsCold: { totalOps: 317, ops: { stat: 275 }, wallMs: 320 },
-  agentsWarm: { totalOps: 52, ops: { stat: 15 }, wallMs: 290 },
-  homeCold: { totalOps: 352, ops: { stat: 280 }, wallMs: 450 },
-  homeWarm: { totalOps: 87, ops: { stat: 20 }, wallMs: 320 },
+  agentsCold: { totalOps: 317, ops: { stat: 275 }, wallMs: 240 },
+  agentsWarm: { totalOps: 52, ops: { stat: 15 }, wallMs: 110 },
+  homeCold: { totalOps: 352, ops: { stat: 280 }, wallMs: 370 },
+  homeWarm: { totalOps: 87, ops: { stat: 20 }, wallMs: 240 },
   sessionsPage: { totalOps: 3, ops: { stat: 2 }, wallMs: 70 },
   sessionsNotable: { totalOps: 1, ops: { stat: 1 }, wallMs: 40 },
 })

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1893,13 +1893,17 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
       return c.json(ordered.slice(0, resultLimit))
     }
 
-    const sessionList = await listSessionsFromSummary(slug, {
-      excludeAutomated: true,
-      ...(sortByRaw === undefined ? {} : { sortBy }),
-      ...(resultLimit === undefined ? {} : { limit: resultLimit }),
-    })
-    const unreadSessionIds = await getSessionIdsWithUnreadNotifications(slug)
-    const pendingWakes = await listPendingWakesByAgent(slug)
+    // Independent lookups (filesystem summary, notifications table, scheduled
+    // tasks table) — overlap them rather than paying their latencies in series.
+    const [sessionList, unreadSessionIds, pendingWakes] = await Promise.all([
+      listSessionsFromSummary(slug, {
+        excludeAutomated: true,
+        ...(sortByRaw === undefined ? {} : { sortBy }),
+        ...(resultLimit === undefined ? {} : { limit: resultLimit }),
+      }),
+      getSessionIdsWithUnreadNotifications(slug),
+      listPendingWakesByAgent(slug),
+    ])
     const wakesBySession = new Map(pendingWakes.map((w) => [w.resumeSessionId!, w]))
     const sessionsWithStatus = sessionList.map((session) => {
       const isActive = messagePersister.isSessionActive(session.id)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -7141,7 +7141,10 @@ agents.patch('/:id/x-agent-policies', AgentAdmin(), async (c) => {
     return c.json({ error: 'Cannot set a policy targeting the same agent' }, 400)
   }
   if (targetSlug !== null) {
-    const targetAgent = await getAgent(targetSlug)
+    // The target comes straight from the body, not through ResolveAgent's
+    // charset gate: check the directory first so a malformed slug is a 404
+    // rather than a thrown read (getAgent no longer stats before reading).
+    const targetAgent = (await agentExists(targetSlug)) ? await getAgent(targetSlug) : null
     if (!targetAgent || !(await callerCanSeeAgent(c, targetSlug))) {
       return c.json({ error: 'Agent not found' }, 404)
     }
@@ -7194,7 +7197,12 @@ agents.put('/:id/x-agent-policies/invoke/:target', AgentAdmin(), async (c) => {
   // target must also be VISIBLE to the caller (same anti-topology-leak rule
   // the GET route enforces) — and an invisible target returns the SAME 404 as
   // a nonexistent one, so this can't be used as an agent-existence oracle.
-  const [callerAgent, targetAgent] = await Promise.all([getAgent(slug), getAgent(targetSlug)])
+  // `:target` is a raw path param, not resolved by ResolveAgent, so gate it
+  // on the directory first: a malformed slug must be a 404, not a thrown read.
+  const [callerAgent, targetAgent] = await Promise.all([
+    getAgent(slug),
+    agentExists(targetSlug).then((exists) => (exists ? getAgent(targetSlug) : null)),
+  ])
   if (!callerAgent || !targetAgent || !(await callerCanSeeAgent(c, targetSlug))) {
     return c.json({ error: 'Agent not found' }, 404)
   }

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -7141,10 +7141,7 @@ agents.patch('/:id/x-agent-policies', AgentAdmin(), async (c) => {
     return c.json({ error: 'Cannot set a policy targeting the same agent' }, 400)
   }
   if (targetSlug !== null) {
-    // The target comes straight from the body, not through ResolveAgent's
-    // charset gate: check the directory first so a malformed slug is a 404
-    // rather than a thrown read (getAgent no longer stats before reading).
-    const targetAgent = (await agentExists(targetSlug)) ? await getAgent(targetSlug) : null
+    const targetAgent = await getAgent(targetSlug)
     if (!targetAgent || !(await callerCanSeeAgent(c, targetSlug))) {
       return c.json({ error: 'Agent not found' }, 404)
     }
@@ -7197,12 +7194,7 @@ agents.put('/:id/x-agent-policies/invoke/:target', AgentAdmin(), async (c) => {
   // target must also be VISIBLE to the caller (same anti-topology-leak rule
   // the GET route enforces) — and an invisible target returns the SAME 404 as
   // a nonexistent one, so this can't be used as an agent-existence oracle.
-  // `:target` is a raw path param, not resolved by ResolveAgent, so gate it
-  // on the directory first: a malformed slug must be a 404, not a thrown read.
-  const [callerAgent, targetAgent] = await Promise.all([
-    getAgent(slug),
-    agentExists(targetSlug).then((exists) => (exists ? getAgent(targetSlug) : null)),
-  ])
+  const [callerAgent, targetAgent] = await Promise.all([getAgent(slug), getAgent(targetSlug)])
   if (!callerAgent || !targetAgent || !(await callerCanSeeAgent(c, targetSlug))) {
     return c.json({ error: 'Agent not found' }, 404)
   }

--- a/src/api/routes/x-agent-policies.test.ts
+++ b/src/api/routes/x-agent-policies.test.ts
@@ -125,6 +125,7 @@ vi.mock('@shared/lib/proxy/token-store', () => ({
 // ----------------------------------------------------------------------------
 
 import agentsRouter from './agents'
+import { agentExists } from '@shared/lib/services/agent-service'
 import {
   setPolicy,
   getPolicy,
@@ -289,6 +290,20 @@ describe('PATCH /api/agents/:id/x-agent-policies', () => {
     expect(getPolicy(CALLER, 'invoke', TARGET_B)).toBeNull()
   })
 
+  it('returns 404 for a target with no agent directory without reading it', async () => {
+    // The target slug is raw request input. A slug that is not a directory
+    // (a stray file in the agents dir, a NUL byte, an over-long name) used to
+    // be caught by getAgent's directory check; now the route gates on it.
+    vi.mocked(agentExists).mockResolvedValueOnce(false)
+    mockGetAgent.mockClear()
+
+    const res = await patchPolicy({ operation: 'invoke', targetSlug: 'not-a-directory', decision: 'allow' })
+
+    expect(res.status).toBe(404)
+    expect(mockGetAgent).not.toHaveBeenCalledWith('not-a-directory')
+    expect(getPolicy(CALLER, 'invoke', 'not-a-directory')).toBeNull()
+  })
+
   it('rejects self-targeted and targeted list policies', async () => {
     const self = await patchPolicy({ operation: 'invoke', targetSlug: CALLER, decision: 'allow' })
     const targetedList = await patchPolicy({ operation: 'list', targetSlug: TARGET_A, decision: 'allow' })
@@ -443,6 +458,23 @@ describe('atomic single invoke policy endpoints', () => {
     })
     expect(await res.json()).toMatchObject({ created: false, previousDecision: 'block' })
     expect(getPolicy(CALLER, 'invoke', TARGET_A)?.decision).toBe('allow')
+  })
+
+  it('PUT returns 404 for a target with no agent directory without reading it', async () => {
+    // The caller is read directly; only the raw `:target` goes through the
+    // directory gate, so this single miss is the target's.
+    vi.mocked(agentExists).mockResolvedValueOnce(false)
+    mockGetAgent.mockClear()
+
+    const res = await app.request(invokeUrl(CALLER, 'not-a-directory'), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'allow' }),
+    })
+
+    expect(res.status).toBe(404)
+    expect(mockGetAgent).not.toHaveBeenCalledWith('not-a-directory')
+    expect(getPolicy(CALLER, 'invoke', 'not-a-directory')).toBeNull()
   })
 
   it('PUT rejects targeting the caller itself', async () => {

--- a/src/api/routes/x-agent-policies.test.ts
+++ b/src/api/routes/x-agent-policies.test.ts
@@ -125,7 +125,6 @@ vi.mock('@shared/lib/proxy/token-store', () => ({
 // ----------------------------------------------------------------------------
 
 import agentsRouter from './agents'
-import { agentExists } from '@shared/lib/services/agent-service'
 import {
   setPolicy,
   getPolicy,
@@ -290,18 +289,16 @@ describe('PATCH /api/agents/:id/x-agent-policies', () => {
     expect(getPolicy(CALLER, 'invoke', TARGET_B)).toBeNull()
   })
 
-  it('returns 404 for a target with no agent directory without reading it', async () => {
-    // The target slug is raw request input. A slug that is not a directory
-    // (a stray file in the agents dir, a NUL byte, an over-long name) used to
-    // be caught by getAgent's directory check; now the route gates on it.
-    vi.mocked(agentExists).mockResolvedValueOnce(false)
-    mockGetAgent.mockClear()
+  it('returns 404 for a target that is not an agent', async () => {
+    // The target slug is raw request input; getAgent answers null for
+    // anything that is not an agent directory (see agent-service tests for
+    // the malformed-path cases), and the route turns that into a 404.
+    mockGetAgent.mockImplementation(async (slug: string) => (slug === 'not-an-agent' ? null : { slug, frontmatter: { name: slug }, instructions: '' }))
 
-    const res = await patchPolicy({ operation: 'invoke', targetSlug: 'not-a-directory', decision: 'allow' })
+    const res = await patchPolicy({ operation: 'invoke', targetSlug: 'not-an-agent', decision: 'allow' })
 
     expect(res.status).toBe(404)
-    expect(mockGetAgent).not.toHaveBeenCalledWith('not-a-directory')
-    expect(getPolicy(CALLER, 'invoke', 'not-a-directory')).toBeNull()
+    expect(getPolicy(CALLER, 'invoke', 'not-an-agent')).toBeNull()
   })
 
   it('rejects self-targeted and targeted list policies', async () => {
@@ -460,21 +457,17 @@ describe('atomic single invoke policy endpoints', () => {
     expect(getPolicy(CALLER, 'invoke', TARGET_A)?.decision).toBe('allow')
   })
 
-  it('PUT returns 404 for a target with no agent directory without reading it', async () => {
-    // The caller is read directly; only the raw `:target` goes through the
-    // directory gate, so this single miss is the target's.
-    vi.mocked(agentExists).mockResolvedValueOnce(false)
-    mockGetAgent.mockClear()
+  it('PUT returns 404 for a target that is not an agent', async () => {
+    mockGetAgent.mockImplementation(async (slug: string) => (slug === 'not-an-agent' ? null : { slug, frontmatter: { name: slug }, instructions: '' }))
 
-    const res = await app.request(invokeUrl(CALLER, 'not-a-directory'), {
+    const res = await app.request(invokeUrl(CALLER, 'not-an-agent'), {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ decision: 'allow' }),
     })
 
     expect(res.status).toBe(404)
-    expect(mockGetAgent).not.toHaveBeenCalledWith('not-a-directory')
-    expect(getPolicy(CALLER, 'invoke', 'not-a-directory')).toBeNull()
+    expect(getPolicy(CALLER, 'invoke', 'not-an-agent')).toBeNull()
   })
 
   it('PUT rejects targeting the caller itself', async () => {

--- a/src/shared/lib/services/agent-service.test.ts
+++ b/src/shared/lib/services/agent-service.test.ts
@@ -111,6 +111,28 @@ describe('agent-service', () => {
       expect(agent).toBeNull()
     })
 
+    // Slugs reach getAgent from request bodies and stored policy rows, not
+    // only from ResolveAgent, so "not an agent directory" must be null for
+    // every way a path can fail — not a thrown read.
+    it('returns null when the slug names a regular file in the agents dir', async () => {
+      await fs.promises.mkdir(path.join(testDir, 'agents'), { recursive: true })
+      await fs.promises.writeFile(path.join(testDir, 'agents', 'stray-file'), 'not an agent')
+
+      await expect(getAgent('stray-file')).resolves.toBeNull()
+    })
+
+    it('returns null for a slug that is not a valid path component', async () => {
+      await expect(getAgent('bad\0slug')).resolves.toBeNull()
+      await expect(getAgent('x'.repeat(300))).resolves.toBeNull()
+    })
+
+    it('still surfaces a real read error on an existing agent directory', async () => {
+      // CLAUDE.md is a directory: the agent exists, its config is unreadable.
+      await fs.promises.mkdir(path.join(testDir, 'agents', 'broken', 'workspace', 'CLAUDE.md'), { recursive: true })
+
+      await expect(getAgent('broken')).rejects.toMatchObject({ code: 'EISDIR' })
+    })
+
     it('returns agent config for existing agent', async () => {
       await createTestAgent('test-agent', SAMPLE_CLAUDE_MD)
 

--- a/src/shared/lib/services/agent-service.ts
+++ b/src/shared/lib/services/agent-service.ts
@@ -22,6 +22,7 @@ import {
   generateAgentId,
   displaySlug,
 } from '@shared/lib/utils/file-storage'
+import pLimit from 'p-limit'
 import {
   AgentFrontmatter,
   AgentConfig,
@@ -117,12 +118,9 @@ export async function listAgentSlugs(): Promise<string[]> {
  * Get a single agent by slug
  */
 export async function getAgent(slug: string): Promise<AgentConfig | null> {
-  const agentDir = getAgentDir(slug)
-
-  if (!(await directoryExists(agentDir))) {
-    return null
-  }
-
+  // No directory pre-check: a missing agent surfaces as a missing CLAUDE.md
+  // (readFileOrNull → null), and every stat is a round trip on network
+  // filesystems. This runs once per agent on the auth-mode agents list.
   return parseAgentClaudeMd(slug)
 }
 
@@ -185,14 +183,13 @@ export async function listAgents(): Promise<AgentConfig[]> {
   await ensureDirectory(agentsDir)
 
   const slugs = await listDirectories(agentsDir)
-  const agents: AgentConfig[] = []
 
-  for (const slug of slugs) {
-    const agent = await parseAgentClaudeMd(slug)
-    if (agent) {
-      agents.push(agent)
-    }
-  }
+  // One CLAUDE.md read per agent; concurrent, bounded. Sequential reads made
+  // the agents list cost N round trips before any per-agent summary work
+  // could start.
+  const limit = pLimit(10)
+  const parsed = await Promise.all(slugs.map((slug) => limit(() => parseAgentClaudeMd(slug))))
+  const agents = parsed.filter((agent): agent is AgentConfig => agent !== null)
 
   // Sort by creation date, newest first
   agents.sort((a, b) => {

--- a/src/shared/lib/services/agent-service.ts
+++ b/src/shared/lib/services/agent-service.ts
@@ -118,10 +118,21 @@ export async function listAgentSlugs(): Promise<string[]> {
  * Get a single agent by slug
  */
 export async function getAgent(slug: string): Promise<AgentConfig | null> {
-  // No directory pre-check: a missing agent surfaces as a missing CLAUDE.md
-  // (readFileOrNull → null), and every stat is a round trip on network
-  // filesystems. This runs once per agent on the auth-mode agents list.
-  return parseAgentClaudeMd(slug)
+  // No directory pre-check on the happy path: a missing agent surfaces as a
+  // missing CLAUDE.md (readFileOrNull → null), and every stat is a round trip
+  // on network filesystems. This runs once per agent on the auth-mode list.
+  //
+  // The contract is still "null unless this is an agent directory": slugs
+  // reach here from request bodies and stored policy rows, not only from
+  // ResolveAgent, so a path that is a regular file (ENOTDIR), too long
+  // (ENAMETOOLONG) or malformed (a NUL byte) must be null, not a throw. Only
+  // that failure path pays the stat.
+  try {
+    return await parseAgentClaudeMd(slug)
+  } catch (error) {
+    if (await directoryExists(getAgentDir(slug)).catch(() => false)) throw error
+    return null
+  }
 }
 
 /**

--- a/src/shared/lib/services/artifact-service.test.ts
+++ b/src/shared/lib/services/artifact-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -44,6 +44,52 @@ describe('artifact-service', () => {
   }
 
   describe('listArtifactsFromFilesystem', () => {
+    it('never has more than ten filesystem probes in flight, even with rejected groups', async () => {
+      // 30 artifacts × 3 probes each, a third of them without package.json —
+      // the rejection that frees a per-artifact slot early would let sibling
+      // probes exceed the bound if the limiter wrapped artifacts.
+      for (let i = 0; i < 30; i++) {
+        const slug = `art-${String(i).padStart(2, '0')}`
+        if (i % 3 === 0) {
+          fs.mkdirSync(path.join(testDir, 'agents', 'test-agent', 'workspace', 'artifacts', slug), { recursive: true })
+        } else {
+          createArtifactDir('test-agent', slug, { name: slug })
+        }
+      }
+
+      let inFlight = 0
+      let maxInFlight = 0
+      const track = async <T>(run: () => Promise<T>): Promise<T> => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        try {
+          // Yield so concurrent probes overlap instead of completing in turn.
+          await new Promise((resolve) => setTimeout(resolve, 1))
+          return await run()
+        } finally {
+          inFlight -= 1
+        }
+      }
+      const realReadFile = fs.promises.readFile
+      const realAccess = fs.promises.access
+      const realStat = fs.promises.stat
+      vi.spyOn(fs.promises, 'readFile').mockImplementation(((...args: Parameters<typeof realReadFile>) =>
+        track(() => realReadFile(...args))) as typeof fs.promises.readFile)
+      vi.spyOn(fs.promises, 'access').mockImplementation(((...args: Parameters<typeof realAccess>) =>
+        track(() => realAccess(...args))) as typeof fs.promises.access)
+      vi.spyOn(fs.promises, 'stat').mockImplementation(((...args: Parameters<typeof realStat>) =>
+        track(() => realStat(...args))) as typeof fs.promises.stat)
+
+      try {
+        const result = await listArtifactsFromFilesystem('test-agent')
+        expect(result.map((a) => a.slug)).toHaveLength(20)
+        expect(maxInFlight).toBeLessThanOrEqual(10)
+        expect(maxInFlight).toBeGreaterThan(1)
+      } finally {
+        vi.restoreAllMocks()
+      }
+    })
+
     it('returns empty array when artifacts dir does not exist', async () => {
       // Agent dir exists but no artifacts subdirectory
       const agentDir = path.join(testDir, 'agents', 'test-agent', 'workspace')

--- a/src/shared/lib/services/artifact-service.ts
+++ b/src/shared/lib/services/artifact-service.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
+import pLimit from 'p-limit'
 import { getAgentWorkspaceDir, writeFileAtomic } from '@shared/lib/utils/file-storage'
 import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 
@@ -33,43 +34,46 @@ export async function listArtifactsFromFilesystem(
     return []
   }
 
-  const dashboards: ArtifactInfo[] = []
+  // Three independent lookups per artifact, artifacts independent of each
+  // other: issue them concurrently (bounded) instead of one round trip at a
+  // time — this runs for every agent on every agents-list poll. Result order
+  // follows the directory listing, as before.
+  const limit = pLimit(10)
+  const dashboards = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => limit(async (): Promise<ArtifactInfo | null> => {
+        const artifactDir = path.join(artifactsDir, entry.name)
+        try {
+          const [pkgContent, hasScreenshot, hasNodeModules] = await Promise.all([
+            fs.promises.readFile(path.join(artifactDir, 'package.json'), 'utf-8'),
+            fileExists(path.join(artifactDir, ARTIFACT_SCREENSHOT_FILENAME)),
+            directoryExists(path.join(artifactDir, 'node_modules')),
+          ])
+          const pkg = JSON.parse(pkgContent)
+          const info: ArtifactInfo = {
+            slug: entry.name,
+            name: pkg.name || entry.name,
+            description: pkg.description || '',
+            status: 'stopped',
+            port: 0,
+          }
+          // Only include hasScreenshot when true — keeps the API shape minimal
+          // and avoids spurious `hasScreenshot: false` fields in common responses.
+          if (hasScreenshot) info.hasScreenshot = true
+          // The host can report this before the agent container is running. That
+          // lets the dashboard view explain first-run preparation during container
+          // startup instead of flashing the state only during a fast install.
+          if (!hasNodeModules) info.firstRun = true
+          return info
+        } catch {
+          // No valid package.json, skip
+          return null
+        }
+      })),
+  )
 
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue
-
-    const pkgPath = path.join(artifactsDir, entry.name, 'package.json')
-    try {
-      const pkgContent = await fs.promises.readFile(pkgPath, 'utf-8')
-      const pkg = JSON.parse(pkgContent)
-      const screenshotPath = path.join(
-        artifactsDir,
-        entry.name,
-        ARTIFACT_SCREENSHOT_FILENAME
-      )
-      const hasScreenshot = await fileExists(screenshotPath)
-      const firstRun = !(await directoryExists(path.join(artifactsDir, entry.name, 'node_modules')))
-      const info: ArtifactInfo = {
-        slug: entry.name,
-        name: pkg.name || entry.name,
-        description: pkg.description || '',
-        status: 'stopped',
-        port: 0,
-      }
-      // Only include hasScreenshot when true — keeps the API shape minimal
-      // and avoids spurious `hasScreenshot: false` fields in common responses.
-      if (hasScreenshot) info.hasScreenshot = true
-      // The host can report this before the agent container is running. That
-      // lets the dashboard view explain first-run preparation during container
-      // startup instead of flashing the state only during a fast install.
-      if (firstRun) info.firstRun = true
-      dashboards.push(info)
-    } catch {
-      // No valid package.json, skip
-    }
-  }
-
-  return dashboards
+  return dashboards.filter((info): info is ArtifactInfo => info !== null)
 }
 
 async function fileExists(p: string): Promise<boolean> {

--- a/src/shared/lib/services/artifact-service.ts
+++ b/src/shared/lib/services/artifact-service.ts
@@ -35,20 +35,23 @@ export async function listArtifactsFromFilesystem(
   }
 
   // Three independent lookups per artifact, artifacts independent of each
-  // other: issue them concurrently (bounded) instead of one round trip at a
-  // time — this runs for every agent on every agents-list poll. Result order
-  // follows the directory listing, as before.
+  // other: issue them concurrently instead of one round trip at a time —
+  // this runs for every agent on every agents-list poll. The limiter bounds
+  // individual filesystem probes, not artifacts: wrapping the artifact would
+  // let each slot fan out to three probes, and a missing package.json would
+  // reject the group and free the slot while its two siblings still ran.
+  // Result order follows the directory listing, as before.
   const limit = pLimit(10)
   const dashboards = await Promise.all(
     entries
       .filter((entry) => entry.isDirectory())
-      .map((entry) => limit(async (): Promise<ArtifactInfo | null> => {
+      .map(async (entry): Promise<ArtifactInfo | null> => {
         const artifactDir = path.join(artifactsDir, entry.name)
         try {
           const [pkgContent, hasScreenshot, hasNodeModules] = await Promise.all([
-            fs.promises.readFile(path.join(artifactDir, 'package.json'), 'utf-8'),
-            fileExists(path.join(artifactDir, ARTIFACT_SCREENSHOT_FILENAME)),
-            directoryExists(path.join(artifactDir, 'node_modules')),
+            limit(() => fs.promises.readFile(path.join(artifactDir, 'package.json'), 'utf-8')),
+            limit(() => fileExists(path.join(artifactDir, ARTIFACT_SCREENSHOT_FILENAME))),
+            limit(() => directoryExists(path.join(artifactDir, 'node_modules'))),
           ])
           const pkg = JSON.parse(pkgContent)
           const info: ArtifactInfo = {
@@ -70,7 +73,7 @@ export async function listArtifactsFromFilesystem(
           // No valid package.json, skip
           return null
         }
-      })),
+      }),
   )
 
   return dashboards.filter((info): info is ArtifactInfo => info !== null)


### PR DESCRIPTION
Stacked on #869. Third of three PRs for the SUP-658 iOS home-page path.

## What

The summary-cache listing (#869) removed the O(sessions) stat storm; what remained was **serialised** work — same op count, paid one round trip at a time:

- `listAgents` read each agent's `CLAUDE.md` in a `for … await` loop — N round trips before any per-agent summary work could start. Now bounded concurrent (`pLimit(10)`); ordering is still by `createdAt` (pinned by the 6-agent ordering test from #867).
- `listArtifactsFromFilesystem` did `readFile` + `stat` + `stat` per artifact, sequentially, artifact after artifact. Now the three lookups run together and artifacts run concurrently; the limiter bounds **individual probes** (≤ 10 in flight), so a rejected group cannot free a slot while its siblings still run. Result order still follows the directory listing.
- `getAgent` no longer stats the agent directory before reading `CLAUDE.md` on the happy path. Its contract is unchanged — `null` unless the slug is an agent directory: on a non-ENOENT read failure it checks the directory and returns `null` for a regular file / overlong / malformed slug, and only propagates the error when the directory really exists (an unreadable config). Slugs reach it from request bodies and stored policy rows, not only from `ResolveAgent`, and the policy GET reads every stored target through it, so this matters.
- `GET /:id/sessions` awaited its three independent lookups (summary, notifications table, pending wakes) in series; now `Promise.all` (row enrichment pinned by the unread + pending-wake test from #867).

## Numbers (perf suite, 10 ms simulated latency; op counts unchanged by design)

| scenario | before | after |
|---|---|---|
| small `GET /api/agents`, warm | 148 ms | **53 ms** |
| small `GET /api/agents`, cold | 162 ms | 119 ms |
| small home poll, warm | 158 ms | 118 ms |
| small home poll, cold | 225 ms | 185 ms |
| big `GET /api/agents`, warm | 136 ms | **53 ms** |
| big home poll, warm | 142 ms | 132 ms |

Wall budgets in `perf/agents-home.{small,big}.perf.ts` tightened accordingly.

## Tests

- `agent-service.test.ts`: `getAgent` returns `null` for a regular file in the agents dir, a NUL byte, an overlong slug; still throws `EISDIR` for an existing agent whose `CLAUDE.md` is a directory; `listAgents` ordering with 6 agents.
- `artifact-service.test.ts`: 30 artifacts, a third without `package.json` — never more than ten probes in flight.
- `x-agent-policies.test.ts`: PATCH and PUT 404 a non-agent target.

## Not done here

- The outer `pLimit(5)` in `enrichAgentsWithSummary` is unchanged; with the stat storm gone there's no evidence it's the bottleneck.
- The tail page's backward-scan + forward re-read (2 opens, bytes read twice) is left as is — it's ~10 ops per agent now and the most invasive change of the list; revisit only if the numbers say so.
- The `getAgent` change isn't exercised by the perf suite (non-auth mode); covered by unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
