### PR TITLE
Fix container port scan missing loopback-only listeners

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -665,18 +665,25 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     return usedPorts
   }
 
-  private isPortAvailable(port: number): Promise<boolean> {
-    return new Promise((resolve) => {
-      const server = net.createServer()
-      server.once('error', () => resolve(false))
-      server.once('listening', () => {
-        server.close()
-        resolve(true)
+  private async isPortAvailable(port: number): Promise<boolean> {
+    // Probe BOTH addresses. 0.0.0.0 matches docker/nerdctl's publish address
+    // (a 127.0.0.1-only bind would miss a conflict from a process already on
+    // 0.0.0.0:<port>) — but the converse also bites: a process holding ONLY
+    // 127.0.0.1:<port> (a Lima VM port-forward from another Superagent
+    // instance) does not block a wildcard publish, yet it shadows the
+    // loopback address this client actually connects to, so every request
+    // lands in the other instance's container.
+    const bindsOn = (host: string) =>
+      new Promise<boolean>((resolve) => {
+        const server = net.createServer()
+        server.once('error', () => resolve(false))
+        server.once('listening', () => {
+          server.close()
+          resolve(true)
+        })
+        server.listen(port, host)
       })
-      // Bind 0.0.0.0 to match docker/nerdctl's publish address — a 127.0.0.1
-      // bind would miss a conflict from a process already on 0.0.0.0:<port>.
-      server.listen(port, '0.0.0.0')
-    })
+    return (await bindsOn('0.0.0.0')) && (await bindsOn('127.0.0.1'))
   }
 
   async start(options?: StartOptions): Promise<ContainerInfo> {


### PR DESCRIPTION
## Problem

`isPortAvailable` in `BaseContainerClient` probes only a `0.0.0.0` bind. That misses listeners bound **only to loopback**:

- Instance A (Lima runtime) holds `127.0.0.1:4000` via the VM port-forward.
- Instance B (docker runtime) scans for a port: the `0.0.0.0:4000` bind **succeeds** (loopback-only listeners don't block it), so B publishes its container on `*:4000`.
- B then connects to `127.0.0.1:4000` — which routes to **A's Lima forward**, not B's container. Every request lands in the wrong instance's container and fails with 401 (foreign host token). Nothing in the logs points at ports.

Hit this for real while running two instances side-by-side with different container runtimes; it cost a long debugging session because the auth layer is where it surfaces.

## Fix

Probe **both** `0.0.0.0` and `127.0.0.1` and require the port to be free on each. The wildcard probe still catches processes on `0.0.0.0:<port>` (the original concern); the loopback probe catches the shadowing case above.

## Testing

- Reproduced the shadow: with Lima holding `127.0.0.1:4000`, the scan previously returned 4000; with this fix it skips to 4001 and the container is reachable end-to-end.
- `npx tsc --noEmit` and eslint clean.

https://claude.ai/code/session_01FvbUHCM3TA1DFDzWwWvYYT
