### PR TITLE
Connections: add an All tab to the Add New Connection dialog

### DIFF
--- a/src/renderer/components/connections/connections-list.tsx
+++ b/src/renderer/components/connections/connections-list.tsx
@@ -81,7 +81,6 @@ export function NewIntegrationButton() {
       <IntegrationDirectoryDialog
         open={open}
         onOpenChange={setOpen}
-        initialTab="apis"
         onApiConnected={setNewApi}
         onMcpConnected={setNewMcp}
       />

--- a/src/renderer/components/connections/integration-directory-dialog.tsx
+++ b/src/renderer/components/connections/integration-directory-dialog.tsx
@@ -24,8 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@renderer/components/ui/select'
-import { HighlightMatch } from '@renderer/components/ui/highlight-match'
-import { Loader2, Plus, Search } from 'lucide-react'
+import { ArrowRight, Loader2, Plus, Search, SearchX } from 'lucide-react'
 import { IntegrationList, IntegrationRow } from './integration-row'
 import { mcpDraftSchema, type McpDraft, type McpAuthType } from './mcp-draft-schema'
 import {
@@ -43,7 +42,120 @@ import type { Provider } from '@shared/lib/account-providers/service-catalog'
 import { COMMON_MCP_SERVERS, type CommonMcpServer } from '@shared/lib/mcp/common-servers'
 import { OAuthFlowCancel } from './oauth-flow-cancel'
 
-export type DirectoryTab = 'apis' | 'mcps'
+export type DirectoryTab = 'all' | 'apis' | 'mcps'
+
+const SEARCH_PLACEHOLDER: Record<DirectoryTab, string> = {
+  all: 'Search all connections...',
+  apis: 'Search APIs...',
+  mcps: 'Search MCP servers...',
+}
+
+function useProviders() {
+  return useQuery<{ providers: Provider[] }>({
+    queryKey: ['providers'],
+    queryFn: async () => {
+      const res = await apiFetch('/api/providers')
+      if (!res.ok) throw new Error('Failed to fetch providers')
+      return res.json()
+    },
+  })
+}
+
+function filterProviders(providers: Provider[] | undefined, filter: string): Provider[] {
+  const list = Array.isArray(providers) ? providers : []
+  const q = filter.trim().toLowerCase()
+  if (!q) return list
+  return list.filter((p) =>
+    p.displayName.toLowerCase().includes(q) ||
+    p.slug.toLowerCase().includes(q) ||
+    p.description.toLowerCase().includes(q)
+  )
+}
+
+function filterMcpServers(filter: string): readonly CommonMcpServer[] {
+  const q = filter.trim().toLowerCase()
+  if (!q) return COMMON_MCP_SERVERS
+  return COMMON_MCP_SERVERS.filter((s) =>
+    s.displayName.toLowerCase().includes(q) ||
+    s.slug.toLowerCase().includes(q) ||
+    s.description.toLowerCase().includes(q) ||
+    s.category.toLowerCase().includes(q)
+  )
+}
+
+// Shown under a scoped tab's empty state when the *other* directory has hits,
+// so a search on APIs/MCPs can't dead-end on a service that does exist.
+function CrossDirectoryHint({ count, noun, query, onSeeAll }: {
+  count: number
+  noun: string
+  query: string
+  onSeeAll: () => void
+}) {
+  if (count === 0) return null
+  // Rendered as the chin of DirectoryEmptyState — the parent owns the border
+  // radius and clips this strip, so no rounding of its own.
+  return (
+    <button
+      type="button"
+      onClick={onSeeAll}
+      data-testid="directory-see-all"
+      className="relative -mt-3 flex w-full items-center justify-between gap-2 rounded-b-lg bg-[#E5F2FF] px-3 pb-2 pt-5 text-left text-[11px] text-[#0A7CFF] transition-opacity hover:opacity-80"
+    >
+      <span className="truncate">{`${count} ${noun}${count === 1 ? ' matches' : 's match'} \u201C${query}\u201D.`}</span>
+      <span className="flex items-center gap-1 font-medium shrink-0">
+        View
+        <ArrowRight className="h-3 w-3" />
+      </span>
+    </button>
+  )
+}
+
+// Browse-time footer note. Hidden while a search is active — there the empty
+// chips already carry the "nothing here, try this instead" message.
+function DirectoryFooterNote({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={cn('rounded-lg bg-[#E5F2FF] px-3 py-2.5 text-[11px] text-[#0A7CFF]', className)}>
+      {children}
+    </div>
+  )
+}
+
+// A section with no matches keeps a card-shaped slot, greyed out. It renders as
+// a grid cell and mirrors a connection card's icon square + name + subtitle
+// structure exactly, so it matches on both width and height by construction.
+function DirectoryEmptyState({ noun, query, chin }: { noun: string; query: string; chin?: ReactNode }) {
+  return (
+    <div className="relative">
+      {/* bg-background under the muted tint keeps this layer opaque, so the
+          chin tucked behind it can't bleed through. */}
+      <div className="relative z-10 rounded-lg border bg-background shadow-sm">
+        <div className="flex items-center gap-3 rounded-lg bg-muted/50 p-3">
+          <div className="h-7 w-7 rounded-md bg-muted flex items-center justify-center shrink-0">
+            <SearchX className="h-4 w-4 text-muted-foreground/60" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium truncate">{`No ${noun} matches`}</div>
+            <div className="text-[11px] text-muted-foreground mt-0.5 truncate">
+              {`Ask your agent about other ways to connect ${query}.`}
+            </div>
+          </div>
+        </div>
+      </div>
+      {chin}
+    </div>
+  )
+}
+
+// Section header for the combined "All" tab, sized a clear step above the
+// card names underneath it.
+function DirectorySectionHeading({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="px-1 pt-2 space-y-0.5">
+      <h3 className="text-xs font-medium">{title}</h3>
+      <p className="text-[11px] text-muted-foreground">{description}</p>
+    </div>
+  )
+}
 
 export interface NewApiConnection {
   accountId: string
@@ -64,7 +176,7 @@ interface IntegrationDirectoryDialogProps {
   onMcpConnected?: (connection: NewMcpConnection) => void
 }
 
-export function IntegrationDirectoryDialog({ open, onOpenChange, initialTab = 'apis', onApiConnected, onMcpConnected }: IntegrationDirectoryDialogProps) {
+export function IntegrationDirectoryDialog({ open, onOpenChange, initialTab = 'all', onApiConnected, onMcpConnected }: IntegrationDirectoryDialogProps) {
   const [tab, setTab] = useState<DirectoryTab>(initialTab)
   const [filter, setFilter] = useState('')
   const prevOpen = useRef(open)
@@ -79,10 +191,11 @@ export function IntegrationDirectoryDialog({ open, onOpenChange, initialTab = 'a
     prevOpen.current = open
   }, [open, initialTab])
 
-  const handleTabChange = (v: string) => {
-    setTab(v as DirectoryTab)
-    setFilter('')
-  }
+  // The query survives a tab switch — CrossDirectoryHint hands it to the All
+  // tab, and clearing it there would throw away what the user just typed.
+  const handleTabChange = (v: string) => setTab(v as DirectoryTab)
+
+  const seeAllForFilter = useCallback(() => setTab('all'), [])
 
   const close = useCallback(() => onOpenChange(false), [onOpenChange])
 
@@ -109,24 +222,33 @@ export function IntegrationDirectoryDialog({ open, onOpenChange, initialTab = 'a
         <Tabs value={tab} onValueChange={handleTabChange} className="flex flex-col gap-4 mt-4 min-h-[50vh]">
           <div className="flex items-center gap-2">
             <TabsList>
+              <TabsTrigger value="all" data-testid="directory-tab-all">All</TabsTrigger>
               <TabsTrigger value="apis" data-testid="directory-tab-apis">APIs</TabsTrigger>
               <TabsTrigger value="mcps" data-testid="directory-tab-mcps">MCPs</TabsTrigger>
             </TabsList>
             <div className="relative ml-auto w-56">
               <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
-                placeholder={tab === 'apis' ? 'Search APIs...' : 'Search MCP servers...'}
+                placeholder={SEARCH_PLACEHOLDER[tab]}
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
                 className="pl-8"
               />
             </div>
           </div>
+          <TabsContent value="all" className="mt-0">
+            <AllPanel
+              filter={filter}
+              onApiConnected={handleApiConnected}
+              onMcpConnected={handleMcpConnected}
+              fallbackClose={close}
+            />
+          </TabsContent>
           <TabsContent value="apis" className="mt-0">
-            <ApisPanel filter={filter} onConnected={handleApiConnected} fallbackClose={close} />
+            <ApisPanel filter={filter} onConnected={handleApiConnected} fallbackClose={close} onSeeAll={seeAllForFilter} />
           </TabsContent>
           <TabsContent value="mcps" className="mt-0">
-            <McpsPanel filter={filter} onConnected={handleMcpConnected} fallbackClose={close} />
+            <McpsPanel filter={filter} onConnected={handleMcpConnected} fallbackClose={close} onSeeAll={seeAllForFilter} />
           </TabsContent>
         </Tabs>
       </DialogContent>
@@ -134,17 +256,35 @@ export function IntegrationDirectoryDialog({ open, onOpenChange, initialTab = 'a
   )
 }
 
+// --- All panel ---
+
+// Renders both directories in one scroll area. Each panel keeps its own
+// connect/OAuth state; only the section chrome and scrolling move up here.
+function AllPanel({ filter, onApiConnected, onMcpConnected, fallbackClose }: {
+  filter: string
+  onApiConnected: (connection: NewApiConnection) => void
+  onMcpConnected: (connection: NewMcpConnection) => void
+  fallbackClose: () => void
+}) {
+  // Both sections always render, each carrying its own empty state, so a search
+  // shows what each directory has to say rather than silently dropping one.
+  return (
+    <div className="max-h-[50vh] overflow-y-auto pr-1 space-y-5">
+      <ApisPanel embedded filter={filter} onConnected={onApiConnected} fallbackClose={fallbackClose} />
+      <McpsPanel embedded filter={filter} onConnected={onMcpConnected} fallbackClose={fallbackClose} />
+      {!filter.trim() && (
+        <DirectoryFooterNote>
+          Don&apos;t see what you&apos;re looking for? Add any MCP server by URL, or ask your agent about connecting to a specific service.
+        </DirectoryFooterNote>
+      )}
+    </div>
+  )
+}
+
 // --- APIs panel ---
 
-function ApisPanel({ filter, onConnected, fallbackClose }: { filter: string; onConnected: (connection: NewApiConnection) => void; fallbackClose: () => void }) {
-  const { data: providersData, isLoading } = useQuery<{ providers: Provider[] }>({
-    queryKey: ['providers'],
-    queryFn: async () => {
-      const res = await apiFetch('/api/providers')
-      if (!res.ok) throw new Error('Failed to fetch providers')
-      return res.json()
-    },
-  })
+function ApisPanel({ filter, onConnected, fallbackClose, embedded = false, onSeeAll }: { filter: string; onConnected: (connection: NewApiConnection) => void; fallbackClose: () => void; embedded?: boolean; onSeeAll?: () => void }) {
+  const { data: providersData, isLoading } = useProviders()
   const initiateConnection = useInitiateConnection()
   const invalidateAccounts = useInvalidateConnectedAccounts()
 
@@ -228,16 +368,8 @@ function ApisPanel({ filter, onConnected, fallbackClose }: { filter: string; onC
     return () => window.removeEventListener('message', handleMessage)
   }, [connecting, invalidateAccounts, onConnected, fallbackClose])
 
-  const filtered = useMemo(() => {
-    const providers = Array.isArray(providersData?.providers) ? providersData.providers : []
-    if (!filter.trim()) return providers
-    const q = filter.toLowerCase()
-    return providers.filter((p) =>
-      p.displayName.toLowerCase().includes(q) ||
-      p.slug.toLowerCase().includes(q) ||
-      p.description.toLowerCase().includes(q)
-    )
-  }, [providersData, filter])
+  const filtered = useMemo(() => filterProviders(providersData?.providers, filter), [providersData, filter])
+  const mcpMatchCount = useMemo(() => filterMcpServers(filter).length, [filter])
 
   const handleConnect = async (slug: string) => {
     setConnecting(slug)
@@ -262,6 +394,12 @@ function ApisPanel({ filter, onConnected, fallbackClose }: { filter: string; onC
 
   return (
     <div className="space-y-3">
+      {embedded && (
+        <DirectorySectionHeading
+          title="APIs"
+          description="The most reliable and robust connections — check here first."
+        />
+      )}
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
           {error}
@@ -273,9 +411,17 @@ function ApisPanel({ filter, onConnected, fallbackClose }: { filter: string; onC
           Loading APIs...
         </div>
       ) : filtered.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No APIs match your search.</p>
+        <IntegrationList variant="grid">
+          <DirectoryEmptyState
+            noun="API"
+            query={filter.trim()}
+            chin={onSeeAll && (
+              <CrossDirectoryHint count={mcpMatchCount} noun="MCP server" query={filter.trim()} onSeeAll={onSeeAll} />
+            )}
+          />
+        </IntegrationList>
       ) : (
-        <div className="max-h-[50vh] overflow-y-auto pr-1">
+        <div className={cn(!embedded && 'max-h-[50vh] overflow-y-auto pr-1')}>
           <IntegrationList variant="grid">
             {filtered.map((provider) => {
               const pending = connecting === provider.slug
@@ -285,7 +431,7 @@ function ApisPanel({ filter, onConnected, fallbackClose }: { filter: string; onC
                   boxed
                   iconSlug={provider.slug}
                   iconFallback="oauth"
-                  name={<HighlightMatch text={provider.displayName} query={filter} />}
+                  name={provider.displayName}
                   subtitle={provider.description}
                   right={
                     <div className="flex items-center gap-2">
@@ -314,9 +460,11 @@ function ApisPanel({ filter, onConnected, fallbackClose }: { filter: string; onC
                 />
               )
             })}
-            <div className="col-span-2 rounded-lg bg-muted/50 px-3 py-2.5 text-[11px] text-muted-foreground">
-              Don&apos;t see the API you&apos;re looking for? Check MCPs or ask your agent about connecting to a specific service.
-            </div>
+            {!embedded && !filter.trim() && (
+              <DirectoryFooterNote className="col-span-2">
+                Don&apos;t see the API you&apos;re looking for? Check MCPs or ask your agent about connecting to a specific service.
+              </DirectoryFooterNote>
+            )}
           </IntegrationList>
         </div>
       )}
@@ -334,7 +482,7 @@ type DraftState = Omit<McpDraft, 'authType' | 'token' | 'clientName' | 'clientId
   clientSecret: string
 }
 
-function McpsPanel({ filter, onConnected, fallbackClose }: { filter: string; onConnected: (connection: NewMcpConnection) => void; fallbackClose: () => void }) {
+function McpsPanel({ filter, onConnected, fallbackClose, embedded = false, onSeeAll }: { filter: string; onConnected: (connection: NewMcpConnection) => void; fallbackClose: () => void; embedded?: boolean; onSeeAll?: () => void }) {
   const addMcp = useAddRemoteMcp()
   const initiateOAuth = useInitiateMcpOAuth()
   const invalidateRemoteMcps = useInvalidateRemoteMcps()
@@ -393,25 +541,10 @@ function McpsPanel({ filter, onConnected, fallbackClose }: { filter: string; onC
     }
   })
 
-  const filtered = useMemo(() => {
-    if (!filter.trim()) return COMMON_MCP_SERVERS
-    const q = filter.toLowerCase()
-    return COMMON_MCP_SERVERS.filter((s) =>
-      s.displayName.toLowerCase().includes(q) ||
-      s.slug.toLowerCase().includes(q) ||
-      s.description.toLowerCase().includes(q) ||
-      s.category.toLowerCase().includes(q)
-    )
-  }, [filter])
-
-  const grouped = useMemo(() => {
-    const map: Record<string, CommonMcpServer[]> = {}
-    for (const s of filtered) {
-      if (!map[s.category]) map[s.category] = []
-      map[s.category].push(s)
-    }
-    return map
-  }, [filtered])
+  const filtered = useMemo(() => filterMcpServers(filter), [filter])
+  // Cached under the same key ApisPanel uses — only needed to size the hint.
+  const { data: providersData } = useProviders()
+  const apiMatchCount = useMemo(() => filterProviders(providersData?.providers, filter).length, [providersData, filter])
 
   const handlePickServer = (server: CommonMcpServer) => {
     setError(null)
@@ -680,49 +813,57 @@ function McpsPanel({ filter, onConnected, fallbackClose }: { filter: string; onC
     )
   }
 
+  const searching = filter.trim().length > 0
+  const customCard = renderMcpCard(
+    'custom',
+    undefined,
+    'blocks',
+    'Custom MCP',
+    'Add any MCP server by URL',
+    handlePickCustom,
+    'Add a custom MCP server',
+  )
+
   return (
     <div className="space-y-3">
+      {embedded && (
+        <DirectorySectionHeading
+          title="MCPs"
+          description="Wider coverage for everything else, including servers you run yourself."
+        />
+      )}
       {error && !draft && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
           {error}
         </div>
       )}
-      <div className="space-y-4 max-h-[50vh] overflow-y-auto pr-1">
+      <div className={cn('space-y-4', !embedded && 'max-h-[50vh] overflow-y-auto pr-1')}>
         <IntegrationList variant="grid">
-          {renderMcpCard(
-            'custom',
-            undefined,
-            'blocks',
-            'Custom MCP',
-            'Add any MCP server by URL',
-            handlePickCustom,
-            'Add a custom MCP server',
+          {filtered.length === 0 && (
+            <DirectoryEmptyState
+              noun="MCP"
+              query={filter.trim()}
+              chin={onSeeAll && (
+                <CrossDirectoryHint count={apiMatchCount} noun="API" query={filter.trim()} onSeeAll={onSeeAll} />
+              )}
+            />
           )}
+          {/* Browsing, Custom MCP leads as the entry point; searching, it
+              trails the real matches as the "none of these?" fallback. */}
+          {!searching && customCard}
+          {filtered.map((server) =>
+            renderMcpCard(
+              server.slug,
+              server.slug,
+              'mcp',
+              server.displayName,
+              server.description,
+              () => handlePickServer(server),
+              `Connect ${server.displayName}`,
+            ),
+          )}
+          {searching && customCard}
         </IntegrationList>
-        {Object.keys(grouped).length === 0 ? (
-          <p className="text-sm text-muted-foreground">No MCP servers match your search.</p>
-        ) : (
-          Object.entries(grouped).map(([category, servers]) => (
-            <div key={category} className="space-y-1.5">
-              <p className="text-[11px] uppercase tracking-wide font-medium text-muted-foreground px-1">
-                {category}
-              </p>
-              <IntegrationList variant="grid">
-                {servers.map((server) =>
-                  renderMcpCard(
-                    server.slug,
-                    server.slug,
-                    'mcp',
-                    <HighlightMatch text={server.displayName} query={filter} />,
-                    server.description,
-                    () => handlePickServer(server),
-                    `Connect ${server.displayName}`,
-                  ),
-                )}
-              </IntegrationList>
-            </div>
-          ))
-        )}
       </div>
     </div>
   )

--- a/src/renderer/components/connections/new-integration-button.test.tsx
+++ b/src/renderer/components/connections/new-integration-button.test.tsx
@@ -135,6 +135,94 @@ afterEach(() => {
   capturedMcpOAuthCallback = null
 })
 
+describe('NewIntegrationButton — All tab', () => {
+  it('opens on the All tab showing both APIs and MCP servers', async () => {
+    window.electronAPI = undefined
+
+    renderWithProviders(<NewIntegrationButton />)
+    await userEvent.click(screen.getByTestId('connections-add-button'))
+
+    expect(screen.getByTestId('directory-tab-all')).toHaveAttribute('data-state', 'active')
+    await waitFor(() => expect(screen.getByTestId('directory-connect-api-slack')).toBeInTheDocument())
+    expect(screen.getByTestId('directory-connect-mcp-linear')).toBeInTheDocument()
+    expect(screen.getByTestId('directory-connect-mcp-custom')).toBeInTheDocument()
+  })
+
+  it('keeps both sections when the search only matches one of them', async () => {
+    window.electronAPI = undefined
+
+    renderWithProviders(<NewIntegrationButton />)
+    await userEvent.click(screen.getByTestId('connections-add-button'))
+    await waitFor(() => expect(screen.getByTestId('directory-connect-api-slack')).toBeInTheDocument())
+
+    await userEvent.type(screen.getByPlaceholderText('Search all connections...'), 'linear')
+
+    // The APIs section stays put and says so itself rather than disappearing.
+    await waitFor(() => expect(screen.getByText('No API matches')).toBeInTheDocument())
+    expect(screen.getByRole('heading', { name: 'APIs' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'MCPs' })).toBeInTheDocument()
+    expect(screen.queryByTestId('directory-connect-api-slack')).not.toBeInTheDocument()
+
+    // While searching, Custom MCP trails the real hits instead of leading.
+    const cards = screen.getAllByTestId(/^directory-connect-mcp-/)
+    expect(cards[0]).toHaveAttribute('data-testid', 'directory-connect-mcp-linear')
+    expect(cards.at(-1)).toHaveAttribute('data-testid', 'directory-connect-mcp-custom')
+  })
+
+  it('shows both empty states when nothing matches', async () => {
+    window.electronAPI = undefined
+
+    renderWithProviders(<NewIntegrationButton />)
+    await userEvent.click(screen.getByTestId('connections-add-button'))
+    await waitFor(() => expect(screen.getByTestId('directory-connect-api-slack')).toBeInTheDocument())
+
+    await userEvent.type(screen.getByPlaceholderText('Search all connections...'), 'zzzznope')
+
+    await waitFor(() => expect(screen.getByText('No API matches')).toBeInTheDocument())
+    expect(screen.getByText('No MCP matches')).toBeInTheDocument()
+    // The browse-time footer note steps aside once a search is running.
+    expect(screen.queryByText(/Don't see what you're looking for/)).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'APIs' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'MCPs' })).toBeInTheDocument()
+  })
+})
+
+describe('NewIntegrationButton — cross-directory search hint', () => {
+  it('offers a jump to All when the scoped tab finds nothing but the other one does', async () => {
+    window.electronAPI = undefined
+
+    renderWithProviders(<NewIntegrationButton />)
+    await userEvent.click(screen.getByTestId('connections-add-button'))
+    await userEvent.click(screen.getByTestId('directory-tab-apis'))
+    await waitFor(() => expect(screen.getByTestId('directory-connect-api-slack')).toBeInTheDocument())
+
+    await userEvent.type(screen.getByPlaceholderText('Search APIs...'), 'linear')
+
+    await waitFor(() => expect(screen.getByText('No API matches')).toBeInTheDocument())
+    expect(screen.getByText(/1 MCP server matches/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('directory-see-all'))
+
+    // Lands on All with the query carried over, not discarded.
+    expect(screen.getByTestId('directory-tab-all')).toHaveAttribute('data-state', 'active')
+    expect(screen.getByPlaceholderText('Search all connections...')).toHaveValue('linear')
+    await waitFor(() => expect(screen.getByTestId('directory-connect-mcp-linear')).toBeInTheDocument())
+  })
+
+  it('omits the hint when neither directory matches', async () => {
+    window.electronAPI = undefined
+
+    renderWithProviders(<NewIntegrationButton />)
+    await userEvent.click(screen.getByTestId('connections-add-button'))
+    await userEvent.click(screen.getByTestId('directory-tab-mcps'))
+
+    await userEvent.type(screen.getByPlaceholderText('Search MCP servers...'), 'zzzznope')
+
+    await waitFor(() => expect(screen.getByText('No MCP matches')).toBeInTheDocument())
+    expect(screen.queryByTestId('directory-see-all')).not.toBeInTheDocument()
+  })
+})
+
 describe('NewIntegrationButton — post-OAuth policy editor', () => {
   it('opens ScopePolicyEditor after Electron IPC OAuth callback', async () => {
     const unsubscribe = vi.fn()


### PR DESCRIPTION
## What

The **Add New Connection** dialog now opens on a combined **All** tab listing both directories in one scroll area — an APIs section over an MCPs section, each with a short line on when to reach for it. The APIs and MCPs tabs are unchanged and still scope to their own directory.

## Search behaviour

Search stays **scoped to the selected tab**. Clicking *MCPs* is an explicit narrowing, and surfacing a Gmail API there would make the tab meaningless.

The cost of scoping is a dead end: on *APIs*, typing "granola" returns nothing and reads as "Granola isn't available" when it exists one tab over. So a scoped search that finds nothing while the other directory has hits now shows a callout tucked behind the empty-state card — "1 MCP server matches "granola" · View →" — that jumps to **All** and carries the query with it. The query also survives a tab switch now, which it previously did not; otherwise that jump would discard what the user just typed.

On the All tab, **both sections always render while searching**, each with its own card-shaped empty state, rather than one silently disappearing.

## Also in here

- MCP **category grouping removed** in favour of a flat grid. Note `filterMcpServers` still matches on `category`, so "crm"/"payments" style queries keep working — but a query can now match for a reason that isn't visible. One line to drop if that's not wanted.
- **Custom MCP** leads when browsing (entry point into a ~185-item list) and trails the matches when searching (it isn't a match).
- **Search-term highlighting removed** from result names. `HighlightMatch` itself stays — still used by the policy editors, search dialog, and related sessions.
- Shared `useProviders` / `filterProviders` / `filterMcpServers` helpers so the panels share one `['providers']` query and one filter definition.

## Worth a look

The footer note and the cross-directory callout use hardcoded `#0A7CFF` / `#E5F2FF`, unlike everything else in the file, which goes through tokens. **They won't invert in dark mode.** Happy to add a `dark:` variant or promote them to CSS variables — just wasn't sure whether this pairing is meant to be reused.

## Testing

- 5 new tests in `new-integration-button.test.tsx` covering the default tab, both-sections-on-search, the combined empty states, the callout's jump-with-query, and no-callout-when-nothing-matches. Full connections suite: 66/66.
- Typecheck and lint clean on all touched files.
- Verified in the browser preview through the "hide a section / jump to All" flow; later styling passes (header sizing, the empty-state card, the chin) were verified structurally and in the user's live Electron app, not by screenshot on my end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)