### PR TITLE
fix(sessions): clear the unread dot optimistically on open

### DIFF
--- a/src/renderer/components/layout/session-view.test.tsx
+++ b/src/renderer/components/layout/session-view.test.tsx
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   markRead: vi.fn(),
   setMarkedUnread: vi.fn(),
+  // Reports whether a dot was actually showing; defaults to the common no-op open.
+  clearUnread: vi.fn(() => false),
 }))
 
 vi.mock('@tanstack/react-router', () => ({
@@ -29,6 +31,7 @@ vi.mock('@renderer/hooks/use-sessions', () => ({
   // Opening a session clears any "mark as unread" flag alongside the
   // notification read-marking below.
   useSetSessionMarkedUnread: () => ({ mutate: mocks.setMarkedUnread }),
+  useClearSessionUnread: () => mocks.clearUnread,
 }))
 
 vi.mock('@renderer/hooks/use-notifications', () => ({
@@ -62,9 +65,47 @@ vi.mock('@renderer/context/workflow-context', () => ({
   WorkflowProvider: ({ children }: { children: ReactNode }) => children,
 }))
 
+describe('SessionView unread clearing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.clearUnread.mockReturnValue(false)
+  })
+
+  it('takes the dot down in the caches on mount and writes through immediately', () => {
+    mocks.clearUnread.mockReturnValue(true)
+    render(<SessionView agentSlug="target-agent" sessionId="x-session" />)
+
+    expect(mocks.clearUnread).toHaveBeenCalledWith('target-agent', 'x-session')
+    // A dot that was actually showing must not be able to come back on the next
+    // refetch, so its write does not wait out the quick-navigation debounce.
+    expect(mocks.markRead).toHaveBeenCalledWith('x-session')
+    expect(mocks.setMarkedUnread).toHaveBeenCalledWith({
+      sessionId: 'x-session',
+      agentSlug: 'target-agent',
+      markedUnread: false,
+    })
+  })
+
+  it('keeps the debounce for an open with no dot showing', () => {
+    vi.useFakeTimers()
+    try {
+      render(<SessionView agentSlug="target-agent" sessionId="x-session" />)
+
+      expect(mocks.markRead).not.toHaveBeenCalled()
+      expect(mocks.setMarkedUnread).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(1000)
+      expect(mocks.markRead).toHaveBeenCalledWith('x-session')
+      expect(mocks.setMarkedUnread).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
 describe('SessionView x-agent provenance', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.clearUnread.mockReturnValue(false)
   })
 
   it('shows the Back bar and returns to Called from Other Agents', () => {

--- a/src/renderer/components/layout/session-view.tsx
+++ b/src/renderer/components/layout/session-view.tsx
@@ -3,7 +3,7 @@ import { FilePreviewProvider } from '@renderer/context/file-preview-context'
 import { WorkflowProvider } from '@renderer/context/workflow-context'
 import { ChevronLeft, CalendarClock, GitFork, Zap } from 'lucide-react'
 import { useEffect } from 'react'
-import { useSession, useSetSessionMarkedUnread } from '@renderer/hooks/use-sessions'
+import { useSession, useSetSessionMarkedUnread, useClearSessionUnread } from '@renderer/hooks/use-sessions'
 import { HttpError } from '@renderer/lib/api'
 import { SessionNotFound } from '@renderer/router/route-fallbacks'
 import { useNavigate } from '@tanstack/react-router'
@@ -37,6 +37,7 @@ export function SessionView({ agentSlug, sessionId }: SessionViewProps) {
   const { data: session, error: sessionError } = useSession(sessionId, agentSlug)
   const markSessionNotificationsRead = useMarkSessionNotificationsRead()
   const setSessionMarkedUnread = useSetSessionMarkedUnread()
+  const clearSessionUnread = useClearSessionUnread()
   const {
     getPendingMessages,
     onMessageSent,
@@ -54,15 +55,26 @@ export function SessionView({ agentSlug, sessionId }: SessionViewProps) {
 
   // Auto-mark notifications as read when viewing a session
   useEffect(() => {
-    // Small delay to avoid marking as read on quick navigation
-    const timeout = setTimeout(() => {
+    const clearWrites = () => {
       markSessionNotificationsRead.mutate(sessionId)
       // "Mark as unread" survives until the session is *reopened*, so it clears
       // here and deliberately not in the visibilitychange handler below —
       // otherwise marking the session you're looking at would be undone by the
       // next window refocus.
       setSessionMarkedUnread.mutate({ sessionId, agentSlug, markedUnread: false })
-    }, 1000)
+    }
+    // Take the dot down in the caches right away — waiting for the write plus
+    // the session-list refetch is what made clicking a dotted session feel like
+    // it lagged. A session that was actually dotted also writes immediately
+    // rather than on the debounce below: the optimistic state has to match what
+    // the server will report, or the next refetch puts the dot back.
+    if (clearSessionUnread(agentSlug, sessionId)) {
+      clearWrites()
+      return
+    }
+    // Nothing was showing, so the writes are a no-op for the dot — keep them on
+    // a small delay to avoid marking as read on quick navigation.
+    const timeout = setTimeout(clearWrites, 1000)
     return () => clearTimeout(timeout)
   }, [sessionId]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/renderer/hooks/use-sessions.marked-unread.test.tsx
+++ b/src/renderer/hooks/use-sessions.marked-unread.test.tsx
@@ -10,7 +10,8 @@ import { createElement, type ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useSetSessionMarkedUnread } from './use-sessions'
+import { clearSessionUnreadInCache, useSetSessionMarkedUnread } from './use-sessions'
+import type { ApiSession } from '@shared/lib/types/api'
 
 const mockApiFetch = vi.fn()
 vi.mock('@renderer/lib/api', () => ({
@@ -87,5 +88,81 @@ describe('useSetSessionMarkedUnread invalidation', () => {
     expect(mockApiFetch).toHaveBeenLastCalledWith('/api/agents/agent-1/sessions/sess-1/unread', {
       method: 'DELETE',
     })
+  })
+})
+
+/**
+ * The dot is rendered straight out of the caches, so opening a session takes it
+ * down there first and lets the write and its refetch land afterwards.
+ */
+describe('clearSessionUnreadInCache', () => {
+  function session(id: string, hasUnreadNotifications: boolean): ApiSession {
+    return {
+      id,
+      agentSlug: 'agent-1',
+      name: id,
+      createdAt: new Date(0),
+      lastActivityAt: new Date(0),
+      messageCount: 1,
+      hasUnreadNotifications,
+    }
+  }
+
+  function seed() {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(['sessions', 'agent-1'], [session('sess-1', true), session('sess-2', false)])
+    queryClient.setQueryData(['sessions', 'agent-1', 'notable', 25], [session('sess-1', true)])
+    queryClient.setQueryData(['session', 'sess-1', 'agent-1'], session('sess-1', true))
+    queryClient.setQueryData(['agents'], [{ slug: 'agent-1', hasUnreadNotifications: true }])
+    queryClient.setQueryData(['agents', 'agent-1'], { slug: 'agent-1', hasUnreadNotifications: true })
+    return queryClient
+  }
+
+  function unreadIds(queryClient: QueryClient, key: unknown[]) {
+    return (queryClient.getQueryData(key) as ApiSession[]).filter((s) => s.hasUnreadNotifications).map((s) => s.id)
+  }
+
+  it('clears the dot in the full list, the notable slice and the session entry', () => {
+    const queryClient = seed()
+
+    expect(clearSessionUnreadInCache(queryClient, 'agent-1', 'sess-1')).toBe(true)
+    expect(unreadIds(queryClient, ['sessions', 'agent-1'])).toEqual([])
+    expect(unreadIds(queryClient, ['sessions', 'agent-1', 'notable', 25])).toEqual([])
+    expect((queryClient.getQueryData(['session', 'sess-1', 'agent-1']) as ApiSession).hasUnreadNotifications).toBe(false)
+  })
+
+  it('rolls the agent indicator down only once no other session is unread', () => {
+    const queryClient = seed()
+    queryClient.setQueryData(['sessions', 'agent-1'], [session('sess-1', true), session('sess-2', true)])
+
+    clearSessionUnreadInCache(queryClient, 'agent-1', 'sess-1')
+    expect(queryClient.getQueryData(['agents'])).toEqual([{ slug: 'agent-1', hasUnreadNotifications: true }])
+
+    clearSessionUnreadInCache(queryClient, 'agent-1', 'sess-2')
+    expect(queryClient.getQueryData(['agents'])).toEqual([{ slug: 'agent-1', hasUnreadNotifications: false }])
+    expect(queryClient.getQueryData(['agents', 'agent-1'])).toEqual({
+      slug: 'agent-1',
+      hasUnreadNotifications: false,
+    })
+  })
+
+  it('reports the no-op open and leaves the caches untouched', () => {
+    const queryClient = seed()
+    const before = queryClient.getQueryData(['sessions', 'agent-1'])
+
+    expect(clearSessionUnreadInCache(queryClient, 'agent-1', 'sess-2')).toBe(false)
+    expect(queryClient.getQueryData(['sessions', 'agent-1'])).toBe(before)
+    expect(queryClient.getQueryData(['agents'])).toEqual([{ slug: 'agent-1', hasUnreadNotifications: true }])
+  })
+
+  it('leaves list entries that carry no unread flag alone', () => {
+    const queryClient = seed()
+    // Automation slices live under the same prefix with a different shape.
+    queryClient.setQueryData(['sessions', 'agent-1', 'completed-one-time'], [{ id: 'sess-1', taskId: 'task-1' }])
+
+    clearSessionUnreadInCache(queryClient, 'agent-1', 'sess-1')
+    expect(queryClient.getQueryData(['sessions', 'agent-1', 'completed-one-time'])).toEqual([
+      { id: 'sess-1', taskId: 'task-1' },
+    ])
   })
 })

--- a/src/renderer/hooks/use-sessions.ts
+++ b/src/renderer/hooks/use-sessions.ts
@@ -1,4 +1,5 @@
 import { apiFetch, apiJson } from '@renderer/lib/api'
+import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useAgents, resolveRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
@@ -192,4 +193,79 @@ export function useSetSessionMarkedUnread() {
       queryClient.invalidateQueries({ queryKey: ['agents'] })
     },
   })
+}
+
+/**
+ * Drop a session's unread dot from every cache that renders it: the agent's
+ * session lists (full list and notable slice), the single-session entry, and
+ * the agent-level rollup — which only comes down once no OTHER cached session
+ * of that agent is still unread. The server write follows on its own; clearing
+ * the caches up front is what makes opening a session feel instant instead of
+ * holding the dot for a roundtrip plus a session-list refetch.
+ *
+ * Returns whether a dot was actually showing, so a caller can tell a real
+ * clear from the no-op that every other session open performs.
+ */
+export function clearSessionUnreadInCache(
+  queryClient: QueryClient,
+  agentSlug: string,
+  sessionId: string,
+): boolean {
+  const resolvedSlug = resolveAgentSlugFromCache(queryClient, agentSlug)
+  let cleared = false
+
+  // Everything under the prefix: the full list, the notable slice, and the
+  // automation slices (whose entries carry no unread flag, so they no-op).
+  queryClient.setQueriesData<unknown>({ queryKey: ['sessions', resolvedSlug] }, (data: unknown) => {
+    if (!Array.isArray(data)) return data
+    let changed = false
+    const next = data.map((entry) => {
+      const session = entry as ApiSession | null
+      if (!session || session.id !== sessionId || !session.hasUnreadNotifications) return entry
+      changed = true
+      return { ...session, hasUnreadNotifications: false }
+    })
+    if (!changed) return data
+    cleared = true
+    return next
+  })
+
+  queryClient.setQueryData<ApiSession>(['session', sessionId, resolvedSlug], (session) => {
+    if (!session?.hasUnreadNotifications) return session
+    cleared = true
+    return { ...session, hasUnreadNotifications: false }
+  })
+
+  if (!cleared) return false
+
+  const anotherSessionIsUnread = queryClient
+    .getQueriesData<unknown>({ queryKey: ['sessions', resolvedSlug] })
+    .some(([, data]) =>
+      Array.isArray(data) &&
+      data.some((entry) => (entry as ApiSession | null)?.hasUnreadNotifications),
+    )
+  if (!anotherSessionIsUnread) {
+    queryClient.setQueryData<ApiAgent[]>(['agents'], (agents) =>
+      Array.isArray(agents)
+        ? agents.map((agent) =>
+            agent.slug === resolvedSlug && agent.hasUnreadNotifications
+              ? { ...agent, hasUnreadNotifications: false }
+              : agent,
+          )
+        : agents,
+    )
+    queryClient.setQueryData<ApiAgent>(['agents', resolvedSlug], (agent) =>
+      agent?.hasUnreadNotifications ? { ...agent, hasUnreadNotifications: false } : agent,
+    )
+  }
+  return true
+}
+
+/** Hook form of {@link clearSessionUnreadInCache}, bound to the active client. */
+export function useClearSessionUnread() {
+  const queryClient = useQueryClient()
+  return useCallback(
+    (agentSlug: string, sessionId: string) => clearSessionUnreadInCache(queryClient, agentSlug, sessionId),
+    [queryClient],
+  )
 }


### PR DESCRIPTION
Clicking a session that carries a blue dot held the dot for a visible beat before it cleared.

## Why it lagged

`SessionView`'s mount effect waited out a 1s debounce, fired the two clear writes (`read-by-session` + `DELETE .../unread`), and only then did the `onSuccess` invalidation's session-list refetch take the dot down. Every one of those steps was in front of a purely visual change.

## What changed

`clearSessionUnreadInCache()` (new, in `use-sessions.ts`) drops the flag from every cache the dot actually renders from, on mount:

- all lists under `['sessions', resolvedSlug]` — the full list and the notable slice
- the `['session', id, slug]` entry
- the agent-level rollup in `['agents']` / `['agents', slug]`, which only comes down once no **other** cached session of that agent is still unread

It returns whether a dot was really showing. `SessionView` uses that: a session that was actually dotted writes through immediately instead of on the debounce, because the optimistic state has to match what the server will report — otherwise navigating away inside the second leaves the server flag set and the next refetch puts the dot back. The no-op clear every other session open performs keeps the existing 1s quick-navigation debounce, so nothing changes for the common case the debounce was added for.

Entries under the same query prefix that aren't `ApiSession` (e.g. `['sessions', slug, 'completed-one-time']`) are untouched — the updater only rewrites items whose `id` matches *and* that carry a truthy `hasUnreadNotifications`.

## Still costs a roundtrip

A cold deep-link straight to a session URL: the sessions list isn't cached yet at mount, so there's nothing to patch. The dot appears with the list and clears on the existing path. Clicking a session from the sidebar or the home graph — the reported case — is fully covered, since those lists are already in cache.

## Testing

- 6 new unit tests: cache patching across the three list shapes, agent-rollup gating on other unread sessions, the no-op report leaving caches identical, foreign entry shapes left alone, and the immediate-vs-debounced write split in `SessionView`.
- `npx tsc --noEmit` clean, `npx eslint` clean on the changed files, 540 renderer tests pass.

https://claude.ai/code/session_01N23asUUWTsUZz7RQ27rRcq
