### PR TITLE
Hold the reading line through anchor relocations and unmount dips

### DIFF
--- a/e2e/specs/turn-end-jump.spec.ts
+++ b/e2e/specs/turn-end-jump.spec.ts
@@ -1,0 +1,102 @@
+import { writeFileSync } from 'node:fs'
+import { test, expect, type Page } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+// Regression for the send/turn-end reading-line jumps: content mounting
+// ABOVE the anchored turn (the previous turn's summary header at
+// materialization; the persisted swap + header at turn end) used to slide
+// the reading line down the screen in a single frame (~120px) because the
+// reserve math kept stale anchor coordinates. Samples the last user
+// message's viewport position every frame across a short turn and bounds
+// its frame-to-frame movement.
+
+declare global {
+  interface Window {
+    __rec2?: Array<Record<string, number | string>>
+  }
+}
+
+function installRecorder(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+    const rec: NonNullable<Window['__rec2']> = []
+    window.__rec2 = rec
+    const sample = () => {
+      const spacer = el.querySelector<HTMLElement>('[data-testid="turn-anchor-spacer"]')
+      const clearance = el.querySelector<HTMLElement>('[data-testid="live-edge-clearance"]')
+      const userMsgs = el.querySelectorAll<HTMLElement>('[data-testid="message-user"]')
+      const lastUser = userMsgs[userMsgs.length - 1]
+      const pill = [...document.querySelectorAll('button')].some(
+        (b) => b.textContent?.includes('Scroll to bottom') && b.offsetParent !== null,
+      )
+      rec.push({
+        t: Math.round(performance.now()),
+        scrollTop: Math.round(el.scrollTop),
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        spacer: spacer ? Math.round(Number.parseFloat(spacer.style.height || '0')) : -1,
+        clearance: clearance ? Math.round(clearance.getBoundingClientRect().height) : -1,
+        userTopInViewport: lastUser ? Math.round(lastUser.getBoundingClientRect().top) : -1,
+        pill: pill ? 1 : 0,
+        userCount: userMsgs.length,
+      })
+      requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  })
+}
+
+test.describe('turn end jump recorder', () => {
+  test('records send-through-idle geometry', async ({ page }, testInfo) => {
+    test.setTimeout(120000)
+    const appPage = new AppPage(page)
+    const agentPage = new AgentPage(page)
+    const sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await agentPage.createAgent(`Turn End ${testInfo.workerIndex}-${Date.now()}`)
+
+    // A first short turn so the NEXT send has a previous turn to finalize
+    // (the "Worked for Ns" header mount is part of the 00:02 jump).
+    await sessionPage.sendMessage('hello there')
+    await sessionPage.waitForUserMessageCount(1)
+    await expect(sessionPage.getStopButton()).toBeHidden({ timeout: 30000 })
+
+    await installRecorder(page)
+    await sessionPage.sendMessage('thanks')
+    await sessionPage.waitForUserMessageCount(2)
+    await expect(sessionPage.getStopButton()).toBeHidden({ timeout: 30000 })
+    // Ride out the post-turn settling: keep recording until ~90 more frames
+    // (≈1.5s) have accumulated after the turn ended.
+    const framesAtIdle = await page.evaluate(() => window.__rec2?.length ?? 0)
+    await expect
+      .poll(() => page.evaluate(() => window.__rec2?.length ?? 0), { timeout: 15000 })
+      .toBeGreaterThan(framesAtIdle + 90)
+
+    const rec = await page.evaluate(() => window.__rec2)
+    writeFileSync(testInfo.outputPath('turn-end-recorder.json'), JSON.stringify(rec))
+    console.log(`[recorder] samples=${rec?.length} -> ${testInfo.outputPath('turn-end-recorder.json')}`)
+
+    expect(rec).toBeTruthy()
+    expect(rec!.length).toBeGreaterThan(50)
+    // The reading line may travel smoothly (the send glide moves it ~15px a
+    // frame) but must never teleport. Pre-fix this measured +116 at
+    // materialization and +120 at turn end.
+    let maxFrameJump = 0
+    for (let i = 1; i < rec!.length; i++) {
+      // A frame where a user row mounts or unmounts legitimately changes
+      // which element is "the last user message" — only positional jumps of
+      // a stable set count.
+      if (rec![i].userCount !== rec![i - 1].userCount) continue
+      const a = rec![i - 1].userTopInViewport as number
+      const b = rec![i].userTopInViewport as number
+      if (a >= 0 && b >= 0) maxFrameJump = Math.max(maxFrameJump, Math.abs(b - a))
+    }
+    expect(maxFrameJump).toBeLessThan(60)
+    // Zero input in this test: the pill must never appear.
+    expect(rec!.every((f) => f.pill === 0)).toBe(true)
+  })
+})

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -374,6 +374,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
         isUser && 'flex-row-reverse !my-6'
       )}
       data-testid={isUser ? 'message-user' : isAssistant ? 'message-assistant' : undefined}
+      data-turn-anchor-id={isUser ? message.id : undefined}
     >
       {/* Message content */}
       <div

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2445,7 +2445,7 @@ describe('MessageList', () => {
       let naturalScrollHeight = 1300
       let scrollTop = 700
       let clientHeight = 600
-      const anchorDocumentTop = 1200
+      let anchorDocumentTop = 1200
       const spacerHeight = () => Number.parseFloat(
         (el.querySelector('[data-testid="turn-anchor-spacer"]') as HTMLElement | null)?.style.height || '0',
       ) || 0
@@ -2502,6 +2502,7 @@ describe('MessageList', () => {
         setScrollTop(value: number) { scrollTop = value },
         setNaturalScrollHeight(value: number) { naturalScrollHeight = value },
         setClientHeight(value: number) { clientHeight = value },
+        setAnchorDocumentTop(value: number) { anchorDocumentTop = value },
       }
     }
 
@@ -2526,6 +2527,69 @@ describe('MessageList', () => {
       expect(anchor.getBoundingClientRect().top).toBe(101)
       expect(geometry.scrollTop).toBe(1099)
       expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+    })
+
+    it('holds the reading line when content mounts above the anchored turn', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(1099)
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+
+      // The previous turn finalizes: its summary header mounts ABOVE the
+      // anchor, sliding the reading line 120px down the document.
+      geometry.setAnchorDocumentTop(1320)
+      geometry.setNaturalScrollHeight(1420)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1420)
+      })
+
+      // The pin carried the viewport to the moved reading line; the reserve
+      // did not shrink and nothing dragged the anchor back down the screen.
+      await waitFor(() => expect(geometry.scrollTop).toBe(1219))
+      const anchor = screen.getByText('What changed?').closest('[data-turn-anchor-id]') as HTMLElement
+      expect(anchor.getBoundingClientRect().top).toBe(101)
+      expect(screen.getByTestId('turn-anchor-spacer')).toHaveStyle({ height: '400px' })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+    })
+
+    it('leaves an escaped reader alone when content mounts above the anchored turn', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+
+      rerender(
+        <MessageList sessionId="s-1" agentSlug="agent-1" pendingUserMessages={[pending]} />,
+      )
+      expect(geometry.scrollTop).toBe(1099)
+
+      // The reader escapes upward while the reserve still holds.
+      fireEvent.scroll(el)
+      fireEvent.wheel(el, { deltaY: -40 })
+      geometry.setScrollTop(300)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5))
+      })
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+
+      // Above-anchor growth must not move their viewport.
+      geometry.setAnchorDocumentTop(1320)
+      geometry.setNaturalScrollHeight(1420)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1420)
+      })
+      expect(geometry.scrollTop).toBe(300)
     })
 
     it('re-engages following and returns to the reading line when a send follows an escape', async () => {

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -193,7 +193,14 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   const contentBodyRef = useRef<HTMLDivElement>(null)
   const bottomSpacerRef = useRef<HTMLDivElement>(null)
   const bottomSpacerHeightRef = useRef(0)
-  const anchoredTurnRef = useRef<{ localId: string; scrollTop: number } | null>(null)
+  const anchoredTurnRef = useRef<{
+    localId: string
+    /** Server id adopted at materialization — the persisted row carries it as the anchor tag after the ghost unmounts. */
+    uuid?: string
+    scrollTop: number
+    /** The anchor element's document top at capture; re-measured every reserve sync to catch above-anchor layout shifts. */
+    anchorTop: number
+  } | null>(null)
 
   // Following state lives in a ref (the single source of truth — handlers and
   // observers read it without stale-closure risk); the state mirror only
@@ -232,7 +239,12 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   // re-computed each frame) target, used only for explicit trips. Its first
   // write is deferred a frame so a commit landing between the send effect and
   // the glide's start still sees the pre-glide viewport.
-  const glideRef = useRef<{ kind: 'trip' | 'follow'; cancel: () => void } | null>(null)
+  const glideRef = useRef<{
+    kind: 'trip' | 'follow'
+    /** The glide's last written scrollTop — the reference for undoing external clamps mid-flight. */
+    top?: number
+    cancel: () => void
+  } | null>(null)
 
   // How many trailing (visible) messages to render. Grows on scroll-up and while
   // the user is scrolled up during streaming. Starts at BASE_WINDOW; the component
@@ -298,6 +310,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     let startedAt = 0
     const handle = {
       kind,
+      top: undefined as number | undefined,
       cancel: () => {
         cancelAnimationFrame(frameId)
         if (glideRef.current === handle) glideRef.current = null
@@ -324,6 +337,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
         return
       }
       el.scrollTop = el.scrollTop + remaining * (1 - Math.exp((-dt / 1000) * GLIDE_RATE_PER_S))
+      handle.top = el.scrollTop
       rememberPosition()
       frameId = requestAnimationFrame(step)
     }
@@ -449,6 +463,50 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     const el = scrollRef.current
     const anchoredTurn = anchoredTurnRef.current
     if (!el || !anchoredTurn) return
+    // Two layout artifacts around materialization and turn end displace the
+    // reading line in a single frame, and both land while the send trip
+    // glide owns the viewport (so the pin cannot cover them). Correct them
+    // here — this sync runs in the same layout effect as the content commit,
+    // before paint.
+    const interactionOwns =
+      pointerDragRef.current || pointerOnScrollbarRef.current || touchActiveRef.current
+    const mayAdjustViewport =
+      followingRef.current && !interactionOwns && !selectionInProgress()
+    // Content mounting ABOVE the anchor (a finished turn's summary header)
+    // slides the reading line down the document while the stored coordinates
+    // stay put. Move the coordinates with the re-measured element — otherwise
+    // the spacer math below shrinks the reserve by the same amount — and
+    // carry the viewport along so the line keeps its place on screen.
+    // During the ghost→persisted handover both forms can briefly carry the
+    // anchor tag, and the ghost's emptied wrapper lingers at the OLD
+    // position — measuring it reads zero drift while the real row mounted
+    // lower. Prefer the last tagged element that actually has height.
+    const findAnchor = (id: string) => {
+      const matches = contentBodyRef.current?.querySelectorAll<HTMLElement>(
+        `[data-turn-anchor-id="${CSS.escape(id)}"]`,
+      )
+      if (!matches?.length) return null
+      for (let i = matches.length - 1; i >= 0; i--) {
+        if (matches[i].getBoundingClientRect().height > 0) return matches[i]
+      }
+      return matches[0]
+    }
+    const anchorEl =
+      (anchoredTurn.uuid ? findAnchor(anchoredTurn.uuid) : null) ??
+      findAnchor(anchoredTurn.localId)
+    if (anchorEl) {
+      const anchorTop =
+        anchorEl.getBoundingClientRect().top - el.getBoundingClientRect().top + el.scrollTop
+      const drift = anchorTop - anchoredTurn.anchorTop
+      if (Math.abs(drift) > 1) {
+        anchoredTurn.anchorTop = anchorTop
+        anchoredTurn.scrollTop = Math.max(0, anchorTop - TURN_ANCHOR_TOP)
+        if (mayAdjustViewport) {
+          el.scrollTop = Math.min(Math.max(0, el.scrollTop + drift), liveEdgeTarget(el))
+          rememberPosition()
+        }
+      }
+    }
     const naturalScrollHeight = el.scrollHeight - bottomSpacerHeightRef.current
     const requiredSpacer = Math.max(
       0,
@@ -467,10 +525,32 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     // spacer write above re-inflates the scroll range — and nothing else moves
     // it back until content grows again, so the held turn would visibly sag.
     // The anchored reading line IS the live-edge target while the reserve
-    // holds; the pin puts the viewport back on it (and carries its own
-    // guards for gestures and the send glide).
-    pinToLiveEdge()
-  }, [setBottomSpacerHeight, pinToLiveEdge])
+    // holds. With no input evidence and no glide in flight the sag can only
+    // be such an artifact: snap it closed here, in the same layout pass, so
+    // it never paints. Otherwise the pin covers it with its own guards.
+    const inputBacked =
+      pointerDownRef.current ||
+      touchActiveRef.current ||
+      performance.now() - lastInputAtRef.current < INPUT_EVIDENCE_WINDOW_MS
+    const glide = glideRef.current
+    if (mayAdjustViewport && glide?.top != null && el.scrollTop < glide.top - 1) {
+      // A transient unmount dip (a streamed block swapped for its persisted
+      // row) clamped the viewport below a mid-flight glide's own last write.
+      // The spacer write above has just re-inflated the scroll range — put
+      // the viewport straight back so the dip never paints; the glide then
+      // resumes from where it actually was.
+      el.scrollTop = Math.min(glide.top, liveEdgeTarget(el))
+      rememberPosition()
+    } else if (mayAdjustViewport && !inputBacked && !glide) {
+      const target = liveEdgeTarget(el)
+      if (el.scrollTop < target) {
+        el.scrollTop = target
+        rememberPosition()
+      }
+    } else {
+      pinToLiveEdge()
+    }
+  }, [setBottomSpacerHeight, pinToLiveEdge, rememberPosition, selectionInProgress])
 
   // Pin the viewport to the live edge before first paint — without this,
   // opening a session flashes the top of the transcript for a frame. Guarded
@@ -661,6 +741,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
           anchoredTurnRef.current = {
             localId: newestTurnStart.localId,
             scrollTop: Math.max(0, anchorTop - TURN_ANCHOR_TOP),
+            anchorTop,
           }
         } else {
           anchoredTurnRef.current = null
@@ -685,6 +766,15 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
         syncTurnReserve()
       }
       return
+    }
+
+    // Materialization renames the anchor: the ghost wrapper (tagged with the
+    // localId) unmounts and the persisted row (tagged with the server id)
+    // takes over as the element the reserve sync re-measures against.
+    const anchored = anchoredTurnRef.current
+    if (anchored && !anchored.uuid) {
+      const match = (pendingUserMessages ?? []).find((p) => p.localId === anchored.localId)
+      if (match?.uuid) anchored.uuid = match.uuid
     }
 
     syncTurnReserve()


### PR DESCRIPTION
## Problem

Two visible jumps in every exchange (caught on video, reproduced with a per-frame recorder):

- **On send (~00:02):** the moment the optimistic message materializes, the previous turn's "Worked for Ns" summary header mounts above the reading line — the whole transcript shoves down ~120px in one frame, then the send glide crawls it back.
- **On turn end (~00:03):** the streamed response swaps to its persisted row + this turn's header mounts — same shove, plus the browser clamps `scrollTop` for the instant the streamed block is unmounted, sagging the reading line ~85px.

Both are one root cause: the turn reserve stores the anchor as **frozen document coordinates**. When the anchor's real position moves (content mounting above it; the ghost's row materializing elsewhere), the spacer math re-inflates the error and drags the reading line off its screen position. The working-indicator/inset path was suspected but is *not* involved — the recorder shows the spacer already compensates that correctly.

## Fix (all inside the reserve sync, which runs in the content commit's layout effect — before paint)

- The anchored turn now records its **element** (`anchorTop` + the server id adopted at materialization; persisted user rows carry `data-turn-anchor-id`). Every sync re-measures it and moves the stored coordinates with any drift, carrying the viewport along (capped at the live-edge target so it can never double-count with the pin).
- Anchor lookup prefers the **last tagged element with real height** — during the ghost→persisted handover the emptied ghost wrapper lingers at the old position and otherwise reads zero drift.
- **Transient unmount dips** are restored in the same layout pass: against the glide's own last written position when a trip glide is mid-flight (the clamp's scroll echo refreshes the shared baseline before the sync can see it, so the glide keeps its own reference), or straight to the reading line when idle with no input evidence. Ordering matters: the restore runs **after** the spacer write re-inflates the scroll range — before it, the restore caps at the dipped maximum.

## Regression coverage

- New `e2e/specs/turn-end-jump.spec.ts`: rides a full send→turn-end cycle with a per-frame recorder and asserts the reading line never moves more than 60px in a single frame (pre-fix: 116–148px), and the scroll-to-bottom pill never appears. Recorder JSON is kept as a test artifact.
- Unit: two new tests (reading line held through above-anchor mounts; escaped readers left alone), the turn-geometry mock gained a movable anchor position.

## Verification

- Unit 125/125 · Chromium follow + pagination + new spec, 2× serial, retries off: 28/28
- WebKit (real compositor) `safari-follow` soak: **10/10**, zero pill frames — the rollback protection is untouched by the sync changes
- Typecheck + lint clean · validated by eye in the Electron dev build

https://claude.ai/code/session_01FvbUHCM3TA1DFDzWwWvYYT
