### PR TITLE
fix(e2e): stop folder leftovers from starving the cmd-hint slots

### DIFF
--- a/e2e/specs/agent-folders.spec.ts
+++ b/e2e/specs/agent-folders.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Locator, type Page } from '@playwright/test'
+import { test, expect, type APIRequestContext, type Locator, type Page } from '@playwright/test'
 import { createAgent, uniqueName } from '../helpers/agents'
 
 // Every test here mutates ONE user's settings row (folders are a per-user
@@ -199,8 +199,53 @@ async function dragRowOnto(
   throw lastError instanceof Error ? lastError : new Error(String(lastError))
 }
 
+/**
+ * Folders this file created and has not yet removed. Folders are per-user
+ * settings, so anything left behind outlives the test and — because a new
+ * folder mounts above "Your Agents" — sits ahead of every unfiled agent for
+ * every later spec in the run (the ⌘-hint numbering, for one, only has nine
+ * slots). `removeCreatedFolders` clears them after each test.
+ */
+const createdFolderNames = new Set<string>()
+
+interface FolderSettings {
+  agentFolders?: Array<{ id: string; name: string }>
+  agentFolderAssignments?: Record<string, string>
+  agentListOrder?: string[]
+  collapsedAgentFolders?: string[]
+}
+
+async function removeCreatedFolders(request: APIRequestContext) {
+  if (createdFolderNames.size === 0) return
+  const response = await request.get('/api/user-settings')
+  expect(response.ok()).toBeTruthy()
+  const settings = await response.json() as FolderSettings
+  const doomed = new Set(
+    (settings.agentFolders ?? [])
+      .filter((folder) => createdFolderNames.has(folder.name))
+      .map((folder) => folder.id)
+  )
+  createdFolderNames.clear()
+  if (doomed.size === 0) return
+
+  const update = await request.put('/api/user-settings', {
+    data: {
+      agentFolders: (settings.agentFolders ?? []).filter((folder) => !doomed.has(folder.id)),
+      agentFolderAssignments: Object.fromEntries(
+        Object.entries(settings.agentFolderAssignments ?? {}).filter(([, id]) => !doomed.has(id))
+      ),
+      agentListOrder: (settings.agentListOrder ?? []).filter(
+        (id) => !doomed.has(id.replace(/^agent-folder::/, ''))
+      ),
+      collapsedAgentFolders: (settings.collapsedAgentFolders ?? []).filter((id) => !doomed.has(id)),
+    },
+  })
+  expect(update.ok()).toBeTruthy()
+}
+
 /** Create a folder from the + on the "Your Agents" folder header. */
 async function createFolder(page: Page, name: string): Promise<Locator> {
+  createdFolderNames.add(name)
   await page.getByTestId('new-folder-button').click()
   // The freshly created row mounts straight into rename mode.
   const input = page.getByTestId('folder-name-input')
@@ -249,6 +294,10 @@ test.describe('agent folders in the left nav', () => {
   // rows being dragged between on screen at the same time, which a pointer
   // gesture needs and dnd-kit's auto-scroll cannot be driven into reliably.
   test.use({ viewport: { width: 1280, height: 1800 } })
+
+  test.afterEach(async ({ request }) => {
+    await removeCreatedFolders(request)
+  })
 
   test('files an agent by drag, keeps it across a reload, and releases it on delete', async ({
     page,
@@ -538,12 +587,14 @@ test.describe('agent folders in the left nav', () => {
     const overlay = page.getByTestId('agent-drag-overlay')
     await expect(page.getByTestId('agent-folder-root')).toBeVisible()
 
+    // Edges needs a folder above it to be dropped above, and one to be dropped
+    // below; the anchor is that neighbour. Every step still works on the
+    // CURRENT top-level order rather than assuming who the neighbours are.
+    await createFolder(page, uniqueName(testInfo, 'Anchor'))
     const folderName = uniqueName(testInfo, 'Edges')
     const folderRow = await createFolder(page, folderName)
     const edgesId = `agent-folder-${await folderIdOf(folderRow)}`
 
-    // Repeat runs accumulate earlier folders, so every step works on the
-    // CURRENT top-level order rather than assuming who the neighbours are.
     const folders = async () =>
       (await listOrder(page)).filter((id) => id.startsWith('agent-folder-'))
     const indicatorFor = (testId: string) =>

--- a/e2e/specs/cmd-hint-navigation.spec.ts
+++ b/e2e/specs/cmd-hint-navigation.spec.ts
@@ -26,17 +26,47 @@ test.describe.configure({ mode: 'serial' })
 
 const HINT_BADGES = '[data-testid^="cmd-hint-"]'
 
+/**
+ * Move `agents` to the front of agentOrder, keeping everything else in its
+ * stored order. The folder spec arranges agents by drag in another worker and
+ * asserts the arrangement survives a reload — rebuilding the order from the
+ * agents API would scramble it out from under that test.
+ */
 async function pinAgentsFirst(request: APIRequestContext, agents: TestAgent[]) {
   const listResponse = await request.get('/api/agents')
   expect(listResponse.ok()).toBeTruthy()
   const all = await listResponse.json() as TestAgent[]
 
+  const settingsResponse = await request.get('/api/user-settings')
+  expect(settingsResponse.ok()).toBeTruthy()
+  const settings = await settingsResponse.json() as { agentOrder?: string[] }
+
   const pinned = agents.map((agent) => agent.slug)
-  const rest = all.map((agent) => agent.slug).filter((slug) => !pinned.includes(slug))
+  const seen = new Set(pinned)
+  const rest = [...(settings.agentOrder ?? []), ...all.map((agent) => agent.slug)].filter((slug) => {
+    if (seen.has(slug)) return false
+    seen.add(slug)
+    return true
+  })
   const response = await request.put('/api/user-settings', {
     data: { agentOrder: [...pinned, ...rest] },
   })
   expect(response.ok()).toBeTruthy()
+}
+
+/**
+ * Hide every folder body except "Your Agents" in THIS page only. agentOrder
+ * ranks the unfiled group, but folders render above it, so agents left inside
+ * an expanded folder by the folder spec (which may be mid-run in another
+ * worker) would take hint slots ahead of the pin. The overlay skips rows with
+ * no client rects, and a stylesheet touches no shared settings — collapsing
+ * the folders for real would hide the rows the folder spec is dragging.
+ */
+async function hideOtherFolders(page: Page) {
+  await page.addStyleTag({
+    content:
+      '[data-container-id^="agent-section::"]:not([data-container-id="agent-section::root"]) { display: none !important; }',
+  })
 }
 
 function hintNumber(testId: string | null): number {
@@ -52,16 +82,19 @@ async function holdModifierForHints(page: Page) {
 }
 
 test.describe('Cmd-hold sidebar navigation hints', () => {
+  let page: Page
   let appPage: AppPage
   let agentPage: AgentPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page: fixturePage }) => {
+    page = fixturePage
     appPage = new AppPage(page)
     agentPage = new AgentPage(page)
   })
 
   async function loadApp() {
     await appPage.goto()
+    await hideOtherFolders(page)
     await appPage.waitForAgentsLoaded()
   }
 


### PR DESCRIPTION
## Why main is red

`e2e-tests` has hard-failed `cmd-hint-navigation.spec.ts:130` in 5 of the last 6 runs. Since #859 a new folder mounts directly above "Your Agents", so agents that `agent-folders.spec.ts` leaves inside expanded folders now render ahead of every unfiled agent — including the one cmd-hint pins first via `agentOrder`. With 6 workers the pinned agent lands in hint slot 8–10, its sessions get no badge, and because the folders persist every retry fails the same way.

## Changes

**`cmd-hint-navigation.spec.ts`**
- `loadApp()` injects a page-local stylesheet hiding every folder body except "Your Agents". The overlay skips rows with no client rects, and nothing shared is written, so folder drags in another worker are unaffected.
- `pinAgentsFirst` preserves the stored `agentOrder` instead of rebuilding it from `/api/agents`. That rewrite was a pre-existing cross-worker race that scrambled the unfiled order under the folder spec's "arrangement survives reload" assertion.

**`agent-folders.spec.ts`**
- `afterEach` deletes the folders each test created (plus assignments / list-order / collapsed entries) so they stop accumulating for the rest of the run.
- The reorder test creates its own anchor folder rather than relying on leftovers to have something to drop above.

## Verification
- typecheck + eslint clean
- Both specs together, 2 workers, `--retries=0`: 9/9 × 3 consecutive runs

Not addressed here: the other occasional hard-fails on main (`home-graph`, `session-long-sleep`, `capability-review`) are pre-existing flakes, and the `ZodError` on `grants` in `message-persister.ts` seen in the server log looks like a real bug worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
