### PR TITLE
fix(notifications): reopen dead streams so new children keep a composer (SUP-697)

### DIFF
--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, cleanup, waitFor } from '@testing-library/react'
+import { act, render, cleanup, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 // ---------------------------------------------------------------------------
@@ -8,17 +8,24 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 // ---------------------------------------------------------------------------
 
 // Mock EventSource
-class MockEventSource {
+class MockEventSource extends EventTarget {
   static instances: MockEventSource[] = []
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 2
   onmessage: ((event: { data: string }) => void) | null = null
   onopen: (() => void) | null = null
   onerror: (() => void) | null = null
   url: string
+  readyState = MockEventSource.OPEN
   constructor(url: string) {
+    super()
     this.url = url
     MockEventSource.instances.push(this)
   }
-  close() {}
+  close() {
+    this.readyState = MockEventSource.CLOSED
+  }
 }
 
 vi.stubGlobal('EventSource', MockEventSource)
@@ -72,6 +79,7 @@ vi.mock('@renderer/hooks/use-mount-warnings', () => ({
   setMountWarning: vi.fn(),
 }))
 
+import { STREAM_RECONNECT_MS } from '@renderer/lib/stream-liveness'
 import { GlobalNotificationHandler } from './global-notification-handler'
 
 // ---------------------------------------------------------------------------
@@ -886,5 +894,63 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     es.onopen?.()
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+  })
+})
+
+describe('stream healing', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockEventSource.instances = []
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  function renderHandler() {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <GlobalNotificationHandler />
+      </QueryClientProvider>
+    )
+  }
+
+  it('error at readyState 2 reopens and onopen invalidates agents + roles', async () => {
+    renderHandler()
+    expect(MockEventSource.instances).toHaveLength(1)
+
+    const first = getLatestEventSource()
+    first.readyState = MockEventSource.CLOSED
+    await act(async () => {
+      first.dispatchEvent(new Event('error'))
+      await vi.advanceTimersByTimeAsync(STREAM_RECONNECT_MS)
+    })
+
+    expect(MockEventSource.instances).toHaveLength(2)
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    getLatestEventSource().onopen?.()
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+  })
+
+  it('unmount does not reopen after a fatal close', async () => {
+    const { unmount } = renderHandler()
+    expect(MockEventSource.instances).toHaveLength(1)
+
+    const first = getLatestEventSource()
+    first.readyState = MockEventSource.CLOSED
+    unmount()
+    await act(async () => {
+      first.dispatchEvent(new Event('error'))
+      await vi.advanceTimersByTimeAsync(STREAM_RECONNECT_MS)
+    })
+
+    expect(MockEventSource.instances).toHaveLength(1)
   })
 })

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -80,7 +80,7 @@ vi.mock('@renderer/hooks/use-mount-warnings', () => ({
 }))
 
 import { STREAM_RECONNECT_MS } from '@renderer/lib/stream-liveness'
-import { GlobalNotificationHandler } from './global-notification-handler'
+import { GlobalNotificationHandler, isRefetchableAfterOutage } from './global-notification-handler'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -894,6 +894,8 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     es.onopen?.()
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+    // Mount and a browser-handled reconnect are not outages.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ predicate: isRefetchableAfterOutage })
   })
 })
 
@@ -921,22 +923,62 @@ describe('stream healing', () => {
     )
   }
 
-  it('error at readyState 2 reopens and onopen invalidates agents + roles', async () => {
+  async function killLatest() {
+    const es = getLatestEventSource()
+    es.readyState = MockEventSource.CLOSED
+    await act(async () => {
+      es.dispatchEvent(new Event('error'))
+    })
+  }
+
+  async function advance(ms: number) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms)
+    })
+  }
+
+  it('error at readyState 2 reopens and the reopen refetches everything mounted except LLM-backed queries', async () => {
     renderHandler()
     expect(MockEventSource.instances).toHaveLength(1)
 
-    const first = getLatestEventSource()
-    first.readyState = MockEventSource.CLOSED
-    await act(async () => {
-      first.dispatchEvent(new Event('error'))
-      await vi.advanceTimersByTimeAsync(STREAM_RECONNECT_MS)
-    })
+    await killLatest()
+    await advance(STREAM_RECONNECT_MS)
 
     expect(MockEventSource.instances).toHaveLength(2)
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
     getLatestEventSource().onopen?.()
+    expect(invalidateSpy).toHaveBeenCalledWith({ predicate: isRefetchableAfterOutage })
+    expect(isRefetchableAfterOutage({ queryKey: ['sessions', 'a1'] })).toBe(true)
+    for (const key of ['agent-template-publish-info', 'agent-template-pr-info', 'skill-publish-info', 'skill-pr-info']) {
+      expect(isRefetchableAfterOutage({ queryKey: [key, 'a1'] })).toBe(false)
+    }
+
+    // A later transient reconnect on the same stream is not an outage.
+    invalidateSpy.mockClear()
+    getLatestEventSource().onopen?.()
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ predicate: isRefetchableAfterOutage })
+  })
+
+  it('reopen delay doubles per consecutive fatal close and resets on open', async () => {
+    renderHandler()
+
+    await killLatest()
+    await advance(STREAM_RECONNECT_MS)
+    expect(MockEventSource.instances).toHaveLength(2)
+
+    // Second consecutive fatal close: 2s, not 1s.
+    await killLatest()
+    await advance(STREAM_RECONNECT_MS)
+    expect(MockEventSource.instances).toHaveLength(2)
+    await advance(STREAM_RECONNECT_MS)
+    expect(MockEventSource.instances).toHaveLength(3)
+
+    // A successful open resets the ladder to 1s.
+    getLatestEventSource().onopen?.()
+    await killLatest()
+    await advance(STREAM_RECONNECT_MS)
+    expect(MockEventSource.instances).toHaveLength(4)
   })
 
   it('unmount does not reopen after a fatal close', async () => {

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -10,7 +10,7 @@
  * - Scheduled task updates - updates task list
  */
 
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { getApiBaseUrl, isElectron } from '@renderer/lib/env'
 import { apiFetch } from '@renderer/lib/api'
@@ -46,6 +46,7 @@ import {
   USER_ACTIONABLE_NOTIFICATION_TYPES,
 } from '@shared/lib/notifications/notification-preferences'
 import { useRenderTracker } from '@renderer/lib/perf'
+import { STREAM_RECONNECT_MS, watchStreamLiveness } from '@renderer/lib/stream-liveness'
 
 // Optimistic status echo per session lifecycle event. Deliberately exhaustive
 // with NO fallback: an event type added to the lifecycle case group without a
@@ -92,6 +93,9 @@ export function GlobalNotificationHandler() {
   userSettingsRef.current = userSettings
   const canAccessAgentRef = useRef(canAccessAgent)
   canAccessAgentRef.current = canAccessAgent
+  const [reconnectKey, setReconnectKey] = useState(0)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const streamRef = useRef<EventSource | null>(null)
 
   // Sync dock badge count with unread notifications (macOS Electron only)
   useEffect(() => {
@@ -227,6 +231,7 @@ export function GlobalNotificationHandler() {
     const baseUrl = getApiBaseUrl()
     const url = `${baseUrl}/api/notifications/stream`
     const es = new EventSource(url)
+    streamRef.current = es
 
     es.onmessage = (event) => {
       try {
@@ -562,13 +567,27 @@ export function GlobalNotificationHandler() {
     }
 
     es.onerror = () => {
-      // EventSource will auto-reconnect; onopen above catches up.
+      // Network errors reconnect in the browser. Fatal close is the watcher.
     }
 
+    const disposeLiveness = watchStreamLiveness(es, () => {
+      if (streamRef.current !== es) return
+      es.close()
+      reconnectTimerRef.current = setTimeout(() => {
+        reconnectTimerRef.current = null
+        if (streamRef.current !== es) return
+        setReconnectKey((k) => k + 1)
+      }, STREAM_RECONNECT_MS)
+    })
+
     return () => {
+      disposeLiveness()
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+      if (streamRef.current === es) streamRef.current = null
       es.close()
     }
-  }, [queryClient, navigate])
+  }, [queryClient, navigate, reconnectKey])
 
   return null
 }

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -46,7 +46,20 @@ import {
   USER_ACTIONABLE_NOTIFICATION_TYPES,
 } from '@shared/lib/notifications/notification-preferences'
 import { useRenderTracker } from '@renderer/lib/perf'
-import { STREAM_RECONNECT_MS, watchStreamLiveness } from '@renderer/lib/stream-liveness'
+import { reconnectDelayMs, watchStreamLiveness } from '@renderer/lib/stream-liveness'
+
+// Queries whose fetch runs an LLM completion server-side. Everything else is
+// refetched wholesale after the stream comes back from a fatal close.
+const EXPENSIVE_QUERY_KEYS = new Set<unknown>([
+  'agent-template-publish-info',
+  'agent-template-pr-info',
+  'skill-publish-info',
+  'skill-pr-info',
+])
+
+export function isRefetchableAfterOutage(query: { queryKey: readonly unknown[] }): boolean {
+  return !EXPENSIVE_QUERY_KEYS.has(query.queryKey[0])
+}
 
 // Optimistic status echo per session lifecycle event. Deliberately exhaustive
 // with NO fallback: an event type added to the lifecycle case group without a
@@ -95,6 +108,8 @@ export function GlobalNotificationHandler() {
   canAccessAgentRef.current = canAccessAgent
   const [reconnectKey, setReconnectKey] = useState(0)
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const reconnectAttemptRef = useRef(0)
+  const wasDeadRef = useRef(false)
   const streamRef = useRef<EventSource | null>(null)
 
   // Sync dock badge count with unread notifications (macOS Electron only)
@@ -562,6 +577,14 @@ export function GlobalNotificationHandler() {
     // Catch up anything missed while the stream was down, including the
     // window before the first successful connect.
     es.onopen = () => {
+      reconnectAttemptRef.current = 0
+      if (wasDeadRef.current) {
+        // The dead window can be arbitrarily long, and every family this
+        // stream feeds may have moved in it. Refetch what is mounted.
+        wasDeadRef.current = false
+        queryClient.invalidateQueries({ predicate: isRefetchableAfterOutage })
+        return
+      }
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
     }
@@ -573,11 +596,14 @@ export function GlobalNotificationHandler() {
     const disposeLiveness = watchStreamLiveness(es, () => {
       if (streamRef.current !== es) return
       es.close()
+      wasDeadRef.current = true
+      const delay = reconnectDelayMs(reconnectAttemptRef.current)
+      reconnectAttemptRef.current += 1
       reconnectTimerRef.current = setTimeout(() => {
         reconnectTimerRef.current = null
         if (streamRef.current !== es) return
         setReconnectKey((k) => k + 1)
-      }, STREAM_RECONNECT_MS)
+      }, delay)
     })
 
     return () => {

--- a/src/renderer/lib/stream-liveness.test.ts
+++ b/src/renderer/lib/stream-liveness.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { watchStreamLiveness } from './stream-liveness'
+
+class FakeEventSource extends EventTarget {
+  readyState = 0
+}
+
+describe('watchStreamLiveness', () => {
+  beforeEach(() => {
+    vi.stubGlobal('EventSource', { CONNECTING: 0, OPEN: 1, CLOSED: 2 })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('calls onDead once for error at readyState 2', () => {
+    const es = new FakeEventSource()
+    es.readyState = EventSource.CLOSED
+    const onDead = vi.fn()
+    watchStreamLiveness(es, onDead)
+
+    es.dispatchEvent(new Event('error'))
+    es.dispatchEvent(new Event('error'))
+
+    expect(onDead).toHaveBeenCalledOnce()
+  })
+
+  it('does not call onDead for error at readyState 0', () => {
+    const es = new FakeEventSource()
+    es.readyState = EventSource.CONNECTING
+    const onDead = vi.fn()
+    watchStreamLiveness(es, onDead)
+
+    es.dispatchEvent(new Event('error'))
+
+    expect(onDead).not.toHaveBeenCalled()
+  })
+
+  it('does not call onDead after dispose', () => {
+    const es = new FakeEventSource()
+    es.readyState = EventSource.CLOSED
+    const onDead = vi.fn()
+    const dispose = watchStreamLiveness(es, onDead)
+
+    dispose()
+    es.dispatchEvent(new Event('error'))
+
+    expect(onDead).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/stream-liveness.test.ts
+++ b/src/renderer/lib/stream-liveness.test.ts
@@ -1,10 +1,25 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { watchStreamLiveness } from './stream-liveness'
+import {
+  STREAM_RECONNECT_MAX_MS,
+  STREAM_RECONNECT_MS,
+  reconnectDelayMs,
+  watchStreamLiveness,
+} from './stream-liveness'
 
 class FakeEventSource extends EventTarget {
   readyState = 0
 }
+
+describe('reconnectDelayMs', () => {
+  it('doubles from the base and caps', () => {
+    expect(reconnectDelayMs(0)).toBe(STREAM_RECONNECT_MS)
+    expect(reconnectDelayMs(1)).toBe(STREAM_RECONNECT_MS * 2)
+    expect(reconnectDelayMs(4)).toBe(STREAM_RECONNECT_MS * 16)
+    expect(reconnectDelayMs(5)).toBe(STREAM_RECONNECT_MAX_MS)
+    expect(reconnectDelayMs(40)).toBe(STREAM_RECONNECT_MAX_MS)
+  })
+})
 
 describe('watchStreamLiveness', () => {
   beforeEach(() => {

--- a/src/renderer/lib/stream-liveness.ts
+++ b/src/renderer/lib/stream-liveness.ts
@@ -1,4 +1,11 @@
 export const STREAM_RECONNECT_MS = 1_000
+export const STREAM_RECONNECT_MAX_MS = 30_000
+
+// Wait before the n-th reopen (n starts at 0): 1s, 2s, 4s ... capped at 30s.
+// A down backend gets a bounded trickle instead of a request per second.
+export function reconnectDelayMs(attempt: number): number {
+  return Math.min(STREAM_RECONNECT_MS * 2 ** attempt, STREAM_RECONNECT_MAX_MS)
+}
 
 export function watchStreamLiveness(
   es: EventTarget & { readyState: number },

--- a/src/renderer/lib/stream-liveness.ts
+++ b/src/renderer/lib/stream-liveness.ts
@@ -1,0 +1,24 @@
+export const STREAM_RECONNECT_MS = 1_000
+
+export function watchStreamLiveness(
+  es: EventTarget & { readyState: number },
+  onDead: () => void,
+): () => void {
+  let disposed = false
+
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    es.removeEventListener('error', onError)
+  }
+
+  const onError = () => {
+    if (disposed) return
+    if (es.readyState !== EventSource.CLOSED) return
+    dispose()
+    onDead()
+  }
+
+  es.addEventListener('error', onError)
+  return dispose
+}


### PR DESCRIPTION
When another agent creates a child, a dead notification stream means the create announce never arrives, so the child lists but stays read-only until reload. The browser closes EventSource for good on a non-200 or non-event-stream reply, which is the Electron cloud-proxy 502 that started this. This PR reopens that wire after a fatal close.

Closes https://linear.app/datawizz/issue/SUP-697/reopen-dead-notification-streams-so-agent-created-children-keep-a

2 production files. Tests are extra.

```
stream dies (fatal close)
  → reopen
  → onopen refetches agents + rights
  → later agent_created still lands
```

The live red vs green on 2026-08-26 was that bug: kill the wire, create via `POST /api/x-agent/create`, open the child without reload. Red stayed view-only. Green had a composer.

Human `POST /api/agents` still does not announce. That path is out of scope.
