### PR TITLE
Align Agent Home session ordering with sidebar

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -260,6 +260,40 @@ describe('AgentHome', () => {
     expect(screen.getByText('Test Agent')).toBeInTheDocument()
   })
 
+  it('orders sessions by last activity rather than creation time', () => {
+    mockSessionsData = [
+      {
+        id: 'newer-created',
+        agentSlug: testAgent.slug,
+        name: 'Newer created session',
+        createdAt: new Date('2026-08-25T12:00:00.000Z'),
+        lastActivityAt: new Date('2026-08-25T12:00:00.000Z'),
+        messageCount: 1,
+      },
+      {
+        id: 'recently-active',
+        agentSlug: testAgent.slug,
+        name: 'Recently active session',
+        createdAt: new Date('2026-08-24T12:00:00.000Z'),
+        lastActivityAt: new Date('2026-08-26T12:00:00.000Z'),
+        messageCount: 2,
+      },
+    ]
+
+    renderWithProviders(
+      <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
+    )
+
+    const sessionRows = screen.getAllByRole('button')
+      .filter((row) => row.textContent?.includes('session'))
+      .map((row) => row.textContent)
+
+    expect(sessionRows).toEqual([
+      expect.stringContaining('Recently active session'),
+      expect.stringContaining('Newer created session'),
+    ])
+  })
+
   it('keeps the non-owner layout full-width below the desktop breakpoint', () => {
     renderWithProviders(
       <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -144,6 +144,9 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
       id: s.id,
       name: s.name,
       createdAt: typeof s.createdAt === 'string' ? s.createdAt : new Date(s.createdAt).toISOString(),
+      lastActivityAt: typeof s.lastActivityAt === 'string'
+        ? s.lastActivityAt
+        : new Date(s.lastActivityAt).toISOString(),
       isActive: s.isActive,
       isAwaitingInput: s.isAwaitingInput,
       hasUnreadNotifications: s.hasUnreadNotifications,

--- a/src/renderer/components/sessions/related-sessions.tsx
+++ b/src/renderer/components/sessions/related-sessions.tsx
@@ -41,6 +41,7 @@ interface SessionItem {
   id: string
   name: string
   createdAt: string
+  lastActivityAt?: string
   isActive?: boolean
   isAwaitingInput?: boolean
   hasUnreadNotifications?: boolean
@@ -80,7 +81,8 @@ export function RelatedSessions({ sessions, formatDate, className, showIcon = tr
   const sorted = useMemo(() => {
     const copy = [...filtered]
     copy.sort((a, b) => {
-      const diff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      const diff = new Date(b.lastActivityAt ?? b.createdAt).getTime()
+        - new Date(a.lastActivityAt ?? a.createdAt).getTime()
       return sortOrder === 'newest' ? diff : -diff
     })
     return copy

--- a/src/renderer/components/sessions/related-sessions.tsx
+++ b/src/renderer/components/sessions/related-sessions.tsx
@@ -36,6 +36,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
 import { useDeleteSession, useUpdateSessionName } from '@renderer/hooks/use-sessions'
 import { apiFetch } from '@renderer/lib/api'
+import { sortSessionsByActivity, type SessionSortOrder } from '@shared/lib/session-ordering'
 
 interface SessionItem {
   id: string
@@ -63,7 +64,7 @@ interface RelatedSessionsProps {
   pageSize?: number
 }
 
-export type SortOrder = 'newest' | 'oldest'
+export type SortOrder = SessionSortOrder
 
 const DEFAULT_PAGE_SIZE = 10
 
@@ -78,15 +79,7 @@ export function RelatedSessions({ sessions, formatDate, className, showIcon = tr
     return sessions.filter((s) => s.name.toLowerCase().includes(q))
   }, [sessions, searchQuery])
 
-  const sorted = useMemo(() => {
-    const copy = [...filtered]
-    copy.sort((a, b) => {
-      const diff = new Date(b.lastActivityAt ?? b.createdAt).getTime()
-        - new Date(a.lastActivityAt ?? a.createdAt).getTime()
-      return sortOrder === 'newest' ? diff : -diff
-    })
-    return copy
-  }, [filtered, sortOrder])
+  const sorted = useMemo(() => sortSessionsByActivity(filtered, sortOrder), [filtered, sortOrder])
 
   // Reset page when search query changes
   const prevQuery = useRef(searchQuery)

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -38,6 +38,10 @@ import {
   type TransformedItem,
 } from '@shared/lib/utils/message-transform'
 import { findDeltaWindowStart } from '@shared/lib/messages-delta'
+import {
+  sortSessionsByActivity,
+  type SessionActivityFields,
+} from '@shared/lib/session-ordering'
 import { replaceInlineMediaWithRefs } from './session-media'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
 import { isHiddenAutomatedSession } from './session-visibility'
@@ -755,19 +759,6 @@ export interface ListSessionsOptions {
   limit?: number
 }
 
-type SessionOrderFields = {
-  id: string
-  createdAt: Date
-  lastActivityAt?: Date | null
-}
-
-function sessionActivityTimestamp(session: SessionOrderFields): number {
-  const lastActivity = session.lastActivityAt?.getTime()
-  if (Number.isFinite(lastActivity)) return lastActivity!
-  const created = session.createdAt.getTime()
-  return Number.isFinite(created) ? created : Number.NEGATIVE_INFINITY
-}
-
 /**
  * Return a deterministically ordered copy of a session list.
  *
@@ -775,25 +766,14 @@ function sessionActivityTimestamp(session: SessionOrderFields): number {
  * and aggregate agent responses. In particular, callers must visibility-filter
  * before invoking this helper and applying a limit.
  */
-export function sortSessionsNewestFirst<T extends SessionOrderFields>(
+export function sortSessionsNewestFirst<T extends SessionActivityFields>(
   sessions: readonly T[],
   sortBy: SessionSortBy = 'last_activity_at',
 ): T[] {
-  return [...sessions].sort((a, b) => {
-    let aTimestamp: number
-    let bTimestamp: number
-    switch (sortBy) {
-      case 'last_activity_at':
-        aTimestamp = sessionActivityTimestamp(a)
-        bTimestamp = sessionActivityTimestamp(b)
-        break
-    }
-    if (aTimestamp < bTimestamp) return 1
-    if (aTimestamp > bTimestamp) return -1
-    if (a.id < b.id) return -1
-    if (a.id > b.id) return 1
-    return 0
-  })
+  switch (sortBy) {
+    case 'last_activity_at':
+      return sortSessionsByActivity(sessions, 'newest')
+  }
 }
 
 /**

--- a/src/shared/lib/session-ordering.test.ts
+++ b/src/shared/lib/session-ordering.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { sortSessionsByActivity } from './session-ordering'
+
+describe('sortSessionsByActivity', () => {
+  const sessions = [
+    {
+      id: 'newer-created',
+      createdAt: '2026-08-25T12:00:00.000Z',
+      lastActivityAt: '2026-08-25T12:00:00.000Z',
+    },
+    {
+      id: 'created-fallback',
+      createdAt: '2026-08-24T12:00:00.000Z',
+      lastActivityAt: 'invalid',
+    },
+    {
+      id: 'recently-active',
+      createdAt: '2026-08-23T12:00:00.000Z',
+      lastActivityAt: '2026-08-26T12:00:00.000Z',
+    },
+  ]
+
+  it('orders newest activity first without mutating the input', () => {
+    const originalIds = sessions.map(({ id }) => id)
+
+    expect(sortSessionsByActivity(sessions).map(({ id }) => id))
+      .toEqual(['recently-active', 'newer-created', 'created-fallback'])
+    expect(sessions.map(({ id }) => id)).toEqual(originalIds)
+  })
+
+  it('supports oldest activity first', () => {
+    expect(sortSessionsByActivity(sessions, 'oldest').map(({ id }) => id))
+      .toEqual(['created-fallback', 'newer-created', 'recently-active'])
+  })
+
+  it('accepts Date values and breaks equal timestamps by id', () => {
+    const tied = sortSessionsByActivity([
+      { id: 'z-session', createdAt: new Date('2026-08-26T12:00:00.000Z') },
+      { id: 'a-session', createdAt: new Date('2026-08-26T12:00:00.000Z') },
+    ])
+
+    expect(tied.map(({ id }) => id)).toEqual(['a-session', 'z-session'])
+  })
+})

--- a/src/shared/lib/session-ordering.ts
+++ b/src/shared/lib/session-ordering.ts
@@ -1,0 +1,40 @@
+export type SessionSortOrder = 'newest' | 'oldest'
+
+export type SessionActivityFields = {
+  id: string
+  createdAt: Date | string
+  lastActivityAt?: Date | string | null
+}
+
+function dateTimestamp(value: Date | string | null | undefined): number {
+  if (value == null) return Number.NaN
+  return value instanceof Date ? value.getTime() : new Date(value).getTime()
+}
+
+function sessionActivityTimestamp(session: SessionActivityFields): number {
+  const lastActivity = dateTimestamp(session.lastActivityAt)
+  if (Number.isFinite(lastActivity)) return lastActivity
+  const created = dateTimestamp(session.createdAt)
+  return Number.isFinite(created) ? created : Number.NEGATIVE_INFINITY
+}
+
+/**
+ * Return a deterministically activity-ordered copy of a session list.
+ *
+ * Shared by the API and renderer so the sidebar and page lists cannot drift
+ * on timestamp fallback or tie-breaking behavior.
+ */
+export function sortSessionsByActivity<T extends SessionActivityFields>(
+  sessions: readonly T[],
+  order: SessionSortOrder = 'newest',
+): T[] {
+  return [...sessions].sort((a, b) => {
+    const aTimestamp = sessionActivityTimestamp(a)
+    const bTimestamp = sessionActivityTimestamp(b)
+    if (aTimestamp < bTimestamp) return order === 'newest' ? 1 : -1
+    if (aTimestamp > bTimestamp) return order === 'newest' ? -1 : 1
+    if (a.id < b.id) return -1
+    if (a.id > b.id) return 1
+    return 0
+  })
+}


### PR DESCRIPTION
## Summary

- centralize deterministic session activity ordering in a pure shared sorter used by the API/sidebar path and renderer lists
- sort Agent Home sessions by last activity while keeping displayed creation dates unchanged
- fall back to creation time and share deterministic tie-breaking across consumers
- add regression coverage for resumed sessions and the shared sorter contract

## Testing

- `npm run test:run -- src/shared/lib/session-ordering.test.ts src/renderer/components/agents/agent-home/agent-home.test.tsx src/shared/lib/services/session-service.test.ts`
- `npm run typecheck`
- `npx eslint src/shared/lib/session-ordering.ts src/shared/lib/session-ordering.test.ts src/shared/lib/services/session-service.ts src/renderer/components/sessions/related-sessions.tsx`