### PR TITLE
Show the cloud deployment version in the sidebar footer (SUP-701)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@types/react-file-icon": "^1.0.4",
+        "@types/semver": "^7.8.0",
         "@types/web-push": "^3.6.4",
         "@types/ws": "^8.5.12",
         "@types/yauzl": "^2.10.3",
@@ -11012,6 +11013,13 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-file-icon": "^1.0.4",
+    "@types/semver": "^7.8.0",
     "@types/web-push": "^3.6.4",
     "@types/ws": "^8.5.12",
     "@types/yauzl": "^2.10.3",

--- a/src/api/routes/runtime-status.ts
+++ b/src/api/routes/runtime-status.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { Authenticated } from '../middleware/auth'
 import { containerManager } from '@shared/lib/container/container-manager'
+import { APP_VERSION } from '@shared/lib/config/version'
 import { getActiveLlmProvider } from '@shared/lib/llm-provider'
 import { getServicesInitError } from '@shared/lib/startup'
 
@@ -15,6 +16,7 @@ runtimeStatus.get('/', (c) => {
     hasRunningAgents: containerManager.hasRunningAgents(),
     apiKeyConfigured: getActiveLlmProvider().getApiKeyStatus().isConfigured,
     servicesInitError: getServicesInitError(),
+    appVersion: APP_VERSION,
   })
 })
 

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -79,8 +79,11 @@ vi.mock('@renderer/hooks/use-user-settings', () => ({
   useUpdateUserSettings: () => ({ mutate: mockUpdateSettings }),
 }))
 
+const mockRuntimeStatus: { runtimeReadiness: { status: string }; appVersion?: string } = {
+  runtimeReadiness: { status: 'READY' },
+}
 vi.mock('@renderer/hooks/use-runtime-status', () => ({
-  useRuntimeStatus: () => ({ data: { runtimeReadiness: { status: 'READY' } } }),
+  useRuntimeStatus: () => ({ data: mockRuntimeStatus }),
 }))
 
 vi.mock('@renderer/hooks/use-artifacts', () => ({
@@ -152,6 +155,11 @@ vi.mock('@renderer/context/user-context', () => ({
 vi.mock('@renderer/context/connectivity-context', () => ({
   useIsOnline: () => true,
   ConnectivityProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+const mockUpdateStatus: { state: string; version?: string } = { state: 'idle' }
+vi.mock('@renderer/context/update-status-context', () => ({
+  useUpdateStatus: () => mockUpdateStatus,
 }))
 
 const mockDialogContext = {
@@ -355,6 +363,8 @@ beforeEach(() => {
   mockRoutePathname = '/'
   mockHistorySubscribers = []
   setMockHistoryIndex(0)
+  _resetApiTargetForTest()
+  setActiveTarget('local', null)
   mockUseAgents.mockReturnValue({
     data: [makeAgent(), makeAgent({ slug: 'other-agent', name: 'Other Agent', status: 'stopped', sessionCount: 0 })],
     isLoading: false,
@@ -366,6 +376,10 @@ beforeEach(() => {
   }))
   mockUnreadCount.mockReturnValue({ data: { count: 0 } })
   mockUserSettings.mockReturnValue({ setupCompleted: true, agentOrder: [] })
+  delete mockRuntimeStatus.appVersion
+  mockRuntimeStatus.runtimeReadiness = { status: 'READY' }
+  mockUpdateStatus.state = 'idle'
+  delete mockUpdateStatus.version
 })
 
 describe('AppSidebar — layout & top nav', () => {
@@ -421,6 +435,18 @@ describe('AppSidebar — layout & top nav', () => {
     renderWithProviders(<AppSidebar />)
     expect(screen.getByTestId('settings-button')).toBeInTheDocument()
     expect(screen.getByText('v0.1.0-test')).toBeInTheDocument()
+  })
+
+  it('keeps the local update tooltip and aria-label', () => {
+    mockUpdateStatus.state = 'available'
+    mockUpdateStatus.version = '1.2.3'
+
+    renderWithProviders(<AppSidebar />)
+
+    const label = screen.getByTestId('sidebar-version')
+    expect(label).toHaveTextContent('v0.1.0-test')
+    expect(label.getAttribute('title')).toBe('Update available: v1.2.3')
+    expect(screen.getByLabelText('Update available')).toBeInTheDocument()
   })
 
   it('Home links to the global home route', () => {
@@ -738,6 +764,45 @@ describe('UserMenu action for the current target', () => {
     await userEvent.click(screen.getByTestId('switch-to-local-button'))
 
     expect(mockUserContext.signOut).not.toHaveBeenCalled()
+  })
+})
+
+describe('footer version in cloud mode', () => {
+  beforeEach(() => {
+    _resetApiTargetForTest()
+  })
+
+  afterEach(() => {
+    delete mockRuntimeStatus.appVersion
+    mockUpdateStatus.state = 'idle'
+    delete mockUpdateStatus.version
+  })
+
+  it('shows the deployment version, not the desktop bundle', () => {
+    setActiveTarget('cloud', null)
+    mockRuntimeStatus.appVersion = '9.9.9'
+    mockUpdateStatus.state = 'available'
+    mockUpdateStatus.version = '1.2.3'
+
+    renderWithProviders(<AppSidebar />)
+
+    const label = screen.getByTestId('sidebar-version')
+    expect(screen.getByTestId('sidebar-version-cloud')).toBeInTheDocument()
+    expect(label).toHaveTextContent('v9.9.9')
+    expect(screen.queryByText('v0.1.0-test')).not.toBeInTheDocument()
+    expect(label.getAttribute('title')).toMatch(/^Desktop update/)
+    expect(screen.getByLabelText('Desktop update available')).toBeInTheDocument()
+  })
+
+  it('shows the cloud mark with no number when the deployment omits appVersion', () => {
+    setActiveTarget('cloud', null)
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-version-cloud')).toBeInTheDocument()
+    expect(screen.getByLabelText('Cloud')).toBeInTheDocument()
+    expect(screen.getByTestId('sidebar-version')).not.toHaveTextContent(/v/)
+    expect(screen.queryByText('v0.1.0-test')).not.toBeInTheDocument()
   })
 })
 

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -460,7 +460,7 @@ describe('AppSidebar — layout & top nav', () => {
   it('renders Settings + version in the footer', () => {
     renderWithProviders(<AppSidebar />)
     expect(screen.getByTestId('settings-button')).toBeInTheDocument()
-    expect(screen.getByText(`v${APP_VERSION}`)).toBeInTheDocument()
+    expect(screen.getByText(`${APP_VERSION}`)).toBeInTheDocument()
   })
 
   it('keeps the local update tooltip and aria-label', () => {
@@ -470,7 +470,7 @@ describe('AppSidebar — layout & top nav', () => {
     renderWithProviders(<AppSidebar />)
 
     const label = screen.getByTestId('sidebar-version')
-    expect(label).toHaveTextContent(`v${APP_VERSION}`)
+    expect(label).toHaveTextContent(`${APP_VERSION}`)
     expect(label.getAttribute('title')).toBe('Update available: v1.2.3')
     expect(screen.getByLabelText('Update available')).toBeInTheDocument()
   })
@@ -812,7 +812,7 @@ describe('footer version in cloud mode', () => {
 
     renderWithProviders(<AppSidebar />)
 
-    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`${desktopVersion}`)
     expect(screen.queryByTestId('sidebar-version-desktop')).not.toBeInTheDocument()
     expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Update available')).not.toBeInTheDocument()
@@ -829,8 +829,8 @@ describe('footer version in cloud mode', () => {
 
     renderWithProviders(<AppSidebar />)
 
-    expect(screen.getByTestId('sidebar-version-desktop')).toHaveTextContent(`v${desktopVersion}`)
-    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent('v0.5.15')
+    expect(screen.getByTestId('sidebar-version-desktop')).toHaveTextContent(`${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent('0.5.15')
     expect(screen.queryByLabelText('Desktop update available')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Cloud update available')).not.toBeInTheDocument()
 
@@ -880,8 +880,8 @@ describe('footer version in cloud mode', () => {
 
     renderWithProviders(<AppSidebar />)
 
-    expect(screen.getByTestId('sidebar-version-desktop')).toHaveTextContent(`v${desktopVersion}`)
-    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version-desktop')).toHaveTextContent(`${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent(`${desktopVersion}`)
     expect(screen.getByLabelText('Desktop update available')).toHaveClass('bg-orange-500')
     expect(screen.getByLabelText('Cloud update available')).toHaveClass('bg-orange-500')
   })
@@ -893,7 +893,7 @@ describe('footer version in cloud mode', () => {
 
     renderWithProviders(<AppSidebar />)
 
-    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`${desktopVersion}`)
     expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
     expect(screen.getByLabelText('Desktop update available')).toHaveClass('bg-blue-500')
   })
@@ -901,7 +901,7 @@ describe('footer version in cloud mode', () => {
   it('falls back to the desktop number when the deployment omits appVersion', () => {
     renderWithProviders(<AppSidebar />)
 
-    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`${desktopVersion}`)
     expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
   })
 
@@ -910,7 +910,7 @@ describe('footer version in cloud mode', () => {
 
     renderWithProviders(<AppSidebar />)
 
-    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`${desktopVersion}`)
     expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
   })
 

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -7,11 +7,10 @@ import { pointerWithin } from '@dnd-kit/core'
 import { AppSidebar } from './app-sidebar'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
-
+import { APP_VERSION } from '@shared/lib/config/version'
 // AppLink (the sidebar item links) is stubbed globally in test/setup.ts — no
 // file-level mock needed. DialogContext is mocked below to control settings.
 
-vi.stubGlobal('__APP_VERSION__', '0.1.0-test')
 vi.stubGlobal('__RENDER_TRACKING__', false)
 
 const mockIsElectron = vi.hoisted(() => vi.fn(() => false))
@@ -160,6 +159,16 @@ vi.mock('@renderer/context/connectivity-context', () => ({
 const mockUpdateStatus: { state: string; version?: string } = { state: 'idle' }
 vi.mock('@renderer/context/update-status-context', () => ({
   useUpdateStatus: () => mockUpdateStatus,
+}))
+
+const mockPlatformAuth: { platformBaseUrl?: string; orgId?: string } = {}
+vi.mock('@renderer/hooks/use-platform-auth', () => ({
+  usePlatformAuthStatus: () => ({ data: mockPlatformAuth }),
+}))
+
+const mockOpenExternalUrl = vi.fn()
+vi.mock('@renderer/lib/open-external', () => ({
+  openExternalUrl: (...args: unknown[]) => mockOpenExternalUrl(...args),
 }))
 
 const mockDialogContext = {
@@ -354,8 +363,22 @@ function notifyHistory(actionType: string) {
   mockHistorySubscribers.forEach((subscriber) => subscriber({ action: { type: actionType } }))
 }
 
+const localStorageStore = new Map<string, string>()
+const localStorageStub = {
+  getItem: (key: string) => localStorageStore.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    localStorageStore.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    localStorageStore.delete(key)
+  },
+  clear: () => localStorageStore.clear(),
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
+  localStorageStore.clear()
+  vi.stubGlobal('localStorage', localStorageStub)
   vi.stubGlobal('__WEB__', true)
   mockIsElectron.mockReturnValue(false)
   mockGetPlatform.mockReturnValue('web')
@@ -380,6 +403,9 @@ beforeEach(() => {
   mockRuntimeStatus.runtimeReadiness = { status: 'READY' }
   mockUpdateStatus.state = 'idle'
   delete mockUpdateStatus.version
+  delete mockPlatformAuth.platformBaseUrl
+  delete mockPlatformAuth.orgId
+  mockOpenExternalUrl.mockReset()
 })
 
 describe('AppSidebar — layout & top nav', () => {
@@ -434,7 +460,7 @@ describe('AppSidebar — layout & top nav', () => {
   it('renders Settings + version in the footer', () => {
     renderWithProviders(<AppSidebar />)
     expect(screen.getByTestId('settings-button')).toBeInTheDocument()
-    expect(screen.getByText('v0.1.0-test')).toBeInTheDocument()
+    expect(screen.getByText(`v${APP_VERSION}`)).toBeInTheDocument()
   })
 
   it('keeps the local update tooltip and aria-label', () => {
@@ -444,7 +470,7 @@ describe('AppSidebar — layout & top nav', () => {
     renderWithProviders(<AppSidebar />)
 
     const label = screen.getByTestId('sidebar-version')
-    expect(label).toHaveTextContent('v0.1.0-test')
+    expect(label).toHaveTextContent(`v${APP_VERSION}`)
     expect(label.getAttribute('title')).toBe('Update available: v1.2.3')
     expect(screen.getByLabelText('Update available')).toBeInTheDocument()
   })
@@ -768,8 +794,11 @@ describe('UserMenu action for the current target', () => {
 })
 
 describe('footer version in cloud mode', () => {
+  const desktopVersion = APP_VERSION
+
   beforeEach(() => {
     _resetApiTargetForTest()
+    setActiveTarget('cloud', null)
   })
 
   afterEach(() => {
@@ -778,31 +807,121 @@ describe('footer version in cloud mode', () => {
     delete mockUpdateStatus.version
   })
 
-  it('shows the deployment version, not the desktop bundle', () => {
-    setActiveTarget('cloud', null)
-    mockRuntimeStatus.appVersion = '9.9.9'
-    mockUpdateStatus.state = 'available'
-    mockUpdateStatus.version = '1.2.3'
+  it('shows one number when desktop and cloud match and no update is waiting', async () => {
+    mockRuntimeStatus.appVersion = desktopVersion
 
     renderWithProviders(<AppSidebar />)
 
-    const label = screen.getByTestId('sidebar-version')
-    expect(screen.getByTestId('sidebar-version-cloud')).toBeInTheDocument()
-    expect(label).toHaveTextContent('v9.9.9')
-    expect(screen.queryByText('v0.1.0-test')).not.toBeInTheDocument()
-    expect(label.getAttribute('title')).toMatch(/^Desktop update/)
-    expect(screen.getByLabelText('Desktop update available')).toBeInTheDocument()
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.queryByTestId('sidebar-version-desktop')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Update available')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Desktop update available')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('sidebar-version'))
+    expect(mockDialogContext.openSettings).toHaveBeenCalledWith('general')
   })
 
-  it('shows the cloud mark with no number when the deployment omits appVersion', () => {
-    setActiveTarget('cloud', null)
+  it('shows a quiet pair when they differ and nobody is behind', async () => {
+    mockRuntimeStatus.appVersion = '0.5.15'
+    mockPlatformAuth.platformBaseUrl = 'https://platform.example'
+    mockPlatformAuth.orgId = 'org_1'
 
     renderWithProviders(<AppSidebar />)
 
-    expect(screen.getByTestId('sidebar-version-cloud')).toBeInTheDocument()
-    expect(screen.getByLabelText('Cloud')).toBeInTheDocument()
-    expect(screen.getByTestId('sidebar-version')).not.toHaveTextContent(/v/)
-    expect(screen.queryByText('v0.1.0-test')).not.toBeInTheDocument()
+    expect(screen.getByTestId('sidebar-version-desktop')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent('v0.5.15')
+    expect(screen.queryByLabelText('Desktop update available')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Cloud update available')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('sidebar-version-desktop'))
+    expect(mockDialogContext.openSettings).toHaveBeenCalledWith('general')
+
+    await userEvent.click(screen.getByTestId('sidebar-version-cloud'))
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith(
+      'https://platform.example/dashboard/organizations/org_1?tab=cloud',
+    )
+  })
+
+  it('puts a blue dot on cloud when it is a patch behind', () => {
+    mockRuntimeStatus.appVersion = '0.5.13'
+
+    renderWithProviders(<AppSidebar />)
+
+    const cloudDot = screen.getByLabelText('Cloud update available')
+    expect(cloudDot).toHaveClass('bg-blue-500')
+    expect(screen.queryByLabelText('Desktop update available')).not.toBeInTheDocument()
+  })
+
+  it('puts an orange dot on cloud when it is a major or minor behind', () => {
+    mockRuntimeStatus.appVersion = '0.4.0'
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByLabelText('Cloud update available')).toHaveClass('bg-orange-500')
+    expect(screen.queryByLabelText('Desktop update available')).not.toBeInTheDocument()
+  })
+
+  it('puts an orange dot on desktop when the feed matches a newer cloud', () => {
+    mockRuntimeStatus.appVersion = '0.6.0'
+    mockUpdateStatus.state = 'available'
+    mockUpdateStatus.version = '0.6.0'
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByLabelText('Desktop update available')).toHaveClass('bg-orange-500')
+    expect(screen.queryByLabelText('Cloud update available')).not.toBeInTheDocument()
+  })
+
+  it('puts orange dots on both when they match and the feed is a major ahead', () => {
+    mockRuntimeStatus.appVersion = desktopVersion
+    mockUpdateStatus.state = 'available'
+    mockUpdateStatus.version = '99.0.0'
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-version-desktop')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.getByLabelText('Desktop update available')).toHaveClass('bg-orange-500')
+    expect(screen.getByLabelText('Cloud update available')).toHaveClass('bg-orange-500')
+  })
+
+  it('keeps one number and a desktop update dot when they match the feed', () => {
+    mockRuntimeStatus.appVersion = desktopVersion
+    mockUpdateStatus.state = 'available'
+    mockUpdateStatus.version = desktopVersion
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Desktop update available')).toHaveClass('bg-blue-500')
+  })
+
+  it('falls back to the desktop number when the deployment omits appVersion', () => {
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the desktop number when appVersion is not a version', () => {
+    mockRuntimeStatus.appVersion = 'not-a-version'
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`v${desktopVersion}`)
+    expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
+  })
+
+  it('does not open the cloud tab when org is missing', async () => {
+    mockRuntimeStatus.appVersion = '0.5.15'
+    mockPlatformAuth.platformBaseUrl = 'https://platform.example'
+
+    renderWithProviders(<AppSidebar />)
+
+    await userEvent.click(screen.getByTestId('sidebar-version-cloud'))
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -8,6 +8,7 @@ import { AppSidebar } from './app-sidebar'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
 import { APP_VERSION } from '@shared/lib/config/version'
+import { major, minor, patch } from 'semver'
 // AppLink (the sidebar item links) is stubbed globally in test/setup.ts — no
 // file-level mock needed. DialogContext is mocked below to control settings.
 
@@ -793,6 +794,25 @@ describe('UserMenu action for the current target', () => {
   })
 })
 
+// The footer compares the deployment against `__APP_VERSION__`, which vitest
+// defines as the real package version. Fixtures are therefore derived from it
+// rather than written as literals: a hardcoded `0.5.13` reads as one patch
+// behind today and a whole minor behind once the app ships 0.6.0, silently
+// flipping the dot these tests assert on from blue to orange.
+const MAJOR = major(APP_VERSION)
+const MINOR = minor(APP_VERSION)
+const PATCH = patch(APP_VERSION)
+
+/** One patch ahead: differs from the desktop build, never behind it. */
+const PATCH_AHEAD = `${MAJOR}.${MINOR}.${PATCH + 1}`
+/** One patch behind — a prerelease of x.y.0 when there is no lower patch. */
+const PATCH_BEHIND = PATCH > 0 ? `${MAJOR}.${MINOR}.${PATCH - 1}` : `${MAJOR}.${MINOR}.0-0`
+/** A whole minor behind (a whole major, on an x.0.z build). */
+const MINOR_BEHIND = MINOR > 0 ? `${MAJOR}.${MINOR - 1}.0` : `${MAJOR - 1}.0.0`
+/** A whole minor ahead, and a whole major ahead. */
+const MINOR_AHEAD = `${MAJOR}.${MINOR + 1}.0`
+const MAJOR_AHEAD = `${MAJOR + 1}.0.0`
+
 describe('footer version in cloud mode', () => {
   const desktopVersion = APP_VERSION
 
@@ -823,14 +843,14 @@ describe('footer version in cloud mode', () => {
   })
 
   it('shows a quiet pair when they differ and nobody is behind', async () => {
-    mockRuntimeStatus.appVersion = '0.5.15'
+    mockRuntimeStatus.appVersion = PATCH_AHEAD
     mockPlatformAuth.platformBaseUrl = 'https://platform.example'
     mockPlatformAuth.orgId = 'org_1'
 
     renderWithProviders(<AppSidebar />)
 
     expect(screen.getByTestId('sidebar-version-desktop')).toHaveTextContent(`${desktopVersion}`)
-    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent('0.5.15')
+    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent(PATCH_AHEAD)
     expect(screen.queryByLabelText('Desktop update available')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Cloud update available')).not.toBeInTheDocument()
 
@@ -844,7 +864,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('puts a blue dot on cloud when it is a patch behind', () => {
-    mockRuntimeStatus.appVersion = '0.5.13'
+    mockRuntimeStatus.appVersion = PATCH_BEHIND
 
     renderWithProviders(<AppSidebar />)
 
@@ -854,7 +874,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('puts an orange dot on cloud when it is a major or minor behind', () => {
-    mockRuntimeStatus.appVersion = '0.4.0'
+    mockRuntimeStatus.appVersion = MINOR_BEHIND
 
     renderWithProviders(<AppSidebar />)
 
@@ -863,9 +883,9 @@ describe('footer version in cloud mode', () => {
   })
 
   it('puts an orange dot on desktop when the feed matches a newer cloud', () => {
-    mockRuntimeStatus.appVersion = '0.6.0'
+    mockRuntimeStatus.appVersion = MINOR_AHEAD
     mockUpdateStatus.state = 'available'
-    mockUpdateStatus.version = '0.6.0'
+    mockUpdateStatus.version = MINOR_AHEAD
 
     renderWithProviders(<AppSidebar />)
 
@@ -876,7 +896,7 @@ describe('footer version in cloud mode', () => {
   it('puts orange dots on both when they match and the feed is a major ahead', () => {
     mockRuntimeStatus.appVersion = desktopVersion
     mockUpdateStatus.state = 'available'
-    mockUpdateStatus.version = '99.0.0'
+    mockUpdateStatus.version = MAJOR_AHEAD
 
     renderWithProviders(<AppSidebar />)
 
@@ -915,7 +935,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('does not open the cloud tab when org is missing', async () => {
-    mockRuntimeStatus.appVersion = '0.5.15'
+    mockRuntimeStatus.appVersion = PATCH_AHEAD
     mockPlatformAuth.platformBaseUrl = 'https://platform.example'
 
     renderWithProviders(<AppSidebar />)

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
+import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, Cloud, MoonStar } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { toast } from 'sonner'
 import { cn } from '@shared/lib/utils/cn'
@@ -8,6 +8,7 @@ import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { AppLink } from '@renderer/components/ui/app-link'
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { isElectron, getPlatform, openDashboardExternal } from '@renderer/lib/env'
+import { targetIsRemote } from '@renderer/lib/api-target'
 import { TargetSwitcher } from '@renderer/components/layout/target-switcher'
 import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
 import { hasInteractiveLogin } from '@renderer/lib/auth-mode'
@@ -823,6 +824,7 @@ export function AppSidebar() {
   const { data: userSettings } = useUserSettings()
   const updateSettings = useUpdateUserSettings()
   const { data: runtimeStatus } = useRuntimeStatus()
+  const isCloud = targetIsRemote()
   const isFullScreen = useFullScreen()
 
   // macOS fires `enter-full-screen` only after its ~700ms zoom animation completes;
@@ -1618,13 +1620,23 @@ export function AppSidebar() {
             type="button"
             onClick={() => openSettings('general')}
             className="flex items-center gap-1.5 px-2 text-xs text-muted-foreground shrink-0 hover:text-foreground"
-            title={updateAvailable ? `Update available: v${updateStatus.version}` : undefined}
+            title={updateAvailable ? `${isCloud ? 'Desktop update available' : 'Update available'}: v${updateStatus.version}` : undefined}
             data-testid="sidebar-version"
           >
             {updateAvailable && (
-              <span className="h-2 w-2 rounded-full bg-blue-500" aria-label="Update available" />
+              <span className="h-2 w-2 rounded-full bg-blue-500" aria-label={isCloud ? 'Desktop update available' : 'Update available'} />
             )}
-            <span>v{__APP_VERSION__}</span>
+            {isCloud && (
+              <Cloud
+                className="h-3 w-3"
+                data-testid="sidebar-version-cloud"
+                aria-hidden={runtimeStatus?.appVersion ? true : undefined}
+                aria-label={runtimeStatus?.appVersion ? undefined : 'Cloud'}
+              />
+            )}
+            {isCloud
+              ? runtimeStatus?.appVersion && <span>v{runtimeStatus.appVersion}</span>
+              : <span>v{__APP_VERSION__}</span>}
           </button>
         </div>
       </SidebarFooter>

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Bell, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, Cloud, MoonStar } from 'lucide-react'
+import { Bell, ChevronDown, ChevronLeft, ChevronRight, Cloud, Laptop, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, User, Users, Compass, MoonStar } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { toast } from 'sonner'
 import { cn } from '@shared/lib/utils/cn'
@@ -8,7 +8,9 @@ import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { AppLink } from '@renderer/components/ui/app-link'
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { isElectron, getPlatform, openDashboardExternal } from '@renderer/lib/env'
+import { openExternalUrl } from '@renderer/lib/open-external'
 import { targetIsRemote } from '@renderer/lib/api-target'
+import { resolveSidebarVersionState } from '@renderer/components/layout/sidebar-version-state'
 import { TargetSwitcher } from '@renderer/components/layout/target-switcher'
 import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
 import { hasInteractiveLogin } from '@renderer/lib/auth-mode'
@@ -53,6 +55,7 @@ import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
+import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
 import { useCreateUntitledAgent } from '@renderer/hooks/use-create-untitled-agent'
 import { AgentStatus } from '@renderer/components/agents/agent-status'
 import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-indicators'
@@ -129,6 +132,24 @@ import { useRememberedFlag } from '@renderer/hooks/use-remembered-flag'
 
 /** Set once Explore has been opened, which retires its "New" badge. */
 const EXPLORE_SEEN_KEY = 'explore.seen'
+
+function VersionBehindDot({
+  wayBehind,
+  label,
+}: {
+  wayBehind: boolean
+  label: string
+}) {
+  return (
+    <span
+      className={cn(
+        'ml-0.5 h-1.5 w-1.5 rounded-full',
+        wayBehind ? 'bg-orange-500' : 'bg-blue-500',
+      )}
+      aria-label={label}
+    />
+  )
+}
 
 // 4px-wide thin scrollbar with a muted-foreground/20 thumb. Reused on the
 // agents-list group; pull out as a constant so the call site stays readable.
@@ -824,7 +845,14 @@ export function AppSidebar() {
   const { data: userSettings } = useUserSettings()
   const updateSettings = useUpdateUserSettings()
   const { data: runtimeStatus } = useRuntimeStatus()
+  const { data: platformAuth } = usePlatformAuthStatus()
   const isCloud = targetIsRemote()
+  const desktopVersion = __APP_VERSION__
+  const versionState = resolveSidebarVersionState({
+    desktopVersion,
+    cloudVersion: isCloud ? runtimeStatus?.appVersion : undefined,
+    feedVersion: updateAvailable ? updateStatus.version : undefined,
+  })
   const isFullScreen = useFullScreen()
 
   // macOS fires `enter-full-screen` only after its ~700ms zoom animation completes;
@@ -1616,28 +1644,69 @@ export function AppSidebar() {
             <Settings className="h-4 w-4" />
             <span>Settings</span>
           </SidebarMenuButton>
-          <button
-            type="button"
-            onClick={() => openSettings('general')}
-            className="flex items-center gap-1.5 px-2 text-xs text-muted-foreground shrink-0 hover:text-foreground"
-            title={updateAvailable ? `${isCloud ? 'Desktop update available' : 'Update available'}: v${updateStatus.version}` : undefined}
-            data-testid="sidebar-version"
-          >
-            {updateAvailable && (
-              <span className="h-2 w-2 rounded-full bg-blue-500" aria-label={isCloud ? 'Desktop update available' : 'Update available'} />
-            )}
-            {isCloud && (
-              <Cloud
-                className="h-3 w-3"
+          {isCloud && versionState.showPair && versionState.cloudVersion ? (
+            <div
+              className="flex items-center gap-1.5 px-2 text-xs text-muted-foreground shrink-0"
+              data-testid="sidebar-version"
+            >
+              <button
+                type="button"
+                onClick={() => openSettings('general')}
+                className="inline-flex items-center gap-0.5 hover:text-foreground"
+                title={`Desktop v${versionState.desktopVersion}`}
+                data-testid="sidebar-version-desktop"
+              >
+                <Laptop className="size-3" aria-hidden="true" />
+                v{versionState.desktopVersion}
+                {versionState.desktopBehind && (
+                  <VersionBehindDot
+                    wayBehind={versionState.desktopWayBehind}
+                    label="Desktop update available"
+                  />
+                )}
+              </button>
+              <span className="h-3 w-px bg-border" aria-hidden="true" />
+              <button
+                type="button"
+                onClick={() => {
+                  const base = platformAuth?.platformBaseUrl
+                  const orgId = platformAuth?.orgId
+                  if (!base || !orgId) return
+                  void openExternalUrl(
+                    `${base}/dashboard/organizations/${orgId}?tab=cloud`,
+                  )
+                }}
+                className="inline-flex items-center gap-0.5 hover:text-foreground"
+                title={`Cloud v${versionState.cloudVersion}`}
                 data-testid="sidebar-version-cloud"
-                aria-hidden={runtimeStatus?.appVersion ? true : undefined}
-                aria-label={runtimeStatus?.appVersion ? undefined : 'Cloud'}
-              />
-            )}
-            {isCloud
-              ? runtimeStatus?.appVersion && <span>v{runtimeStatus.appVersion}</span>
-              : <span>v{__APP_VERSION__}</span>}
-          </button>
+              >
+                <Cloud className="size-3" aria-hidden="true" />
+                v{versionState.cloudVersion}
+                {versionState.cloudBehind && (
+                  <VersionBehindDot
+                    wayBehind={versionState.cloudWayBehind}
+                    label="Cloud update available"
+                  />
+                )}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => openSettings('general')}
+              className="inline-flex items-center gap-1.5 px-2 text-xs text-muted-foreground shrink-0 hover:text-foreground"
+              title={updateAvailable ? `${isCloud ? 'Desktop update available' : 'Update available'}: v${updateStatus.version}` : undefined}
+              data-testid="sidebar-version"
+            >
+              <span>v{versionState.cloudVersion ?? desktopVersion}</span>
+              {updateAvailable && (
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-blue-500"
+                  aria-label={isCloud ? 'Desktop update available' : 'Update available'}
+                />
+              )}
+            </button>
+          )}
         </div>
       </SidebarFooter>
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1656,8 +1656,8 @@ export function AppSidebar() {
                 title={`Desktop v${versionState.desktopVersion}`}
                 data-testid="sidebar-version-desktop"
               >
-                <Laptop className="size-3" aria-hidden="true" />
-                v{versionState.desktopVersion}
+                <Laptop className="mr-0.5 size-3" aria-hidden="true" />
+                {versionState.desktopVersion}
                 {versionState.desktopBehind && (
                   <VersionBehindDot
                     wayBehind={versionState.desktopWayBehind}
@@ -1665,7 +1665,7 @@ export function AppSidebar() {
                   />
                 )}
               </button>
-              <span className="h-3 w-px bg-border" aria-hidden="true" />
+              <span className="h-2.5 w-px bg-current opacity-60" aria-hidden="true" />
               <button
                 type="button"
                 onClick={() => {
@@ -1680,8 +1680,8 @@ export function AppSidebar() {
                 title={`Cloud v${versionState.cloudVersion}`}
                 data-testid="sidebar-version-cloud"
               >
-                <Cloud className="size-3" aria-hidden="true" />
-                v{versionState.cloudVersion}
+                <Cloud className="mr-0.5 size-3" aria-hidden="true" />
+                {versionState.cloudVersion}
                 {versionState.cloudBehind && (
                   <VersionBehindDot
                     wayBehind={versionState.cloudWayBehind}
@@ -1698,7 +1698,7 @@ export function AppSidebar() {
               title={updateAvailable ? `${isCloud ? 'Desktop update available' : 'Update available'}: v${updateStatus.version}` : undefined}
               data-testid="sidebar-version"
             >
-              <span>v{versionState.cloudVersion ?? desktopVersion}</span>
+              <span>{versionState.cloudVersion ?? desktopVersion}</span>
               {updateAvailable && (
                 <span
                   className="h-1.5 w-1.5 rounded-full bg-blue-500"

--- a/src/renderer/components/layout/sidebar-version-state.test.ts
+++ b/src/renderer/components/layout/sidebar-version-state.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSidebarVersionState } from './sidebar-version-state'
+
+describe('resolveSidebarVersionState', () => {
+  it('same versions, no feed: one number, nothing behind', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.5.14',
+        cloudVersion: '0.5.14',
+      }),
+    ).toEqual({
+      showPair: false,
+      desktopBehind: false,
+      cloudBehind: false,
+      desktopWayBehind: false,
+      cloudWayBehind: false,
+      desktopVersion: '0.5.14',
+      cloudVersion: '0.5.14',
+    })
+  })
+
+  it('same versions, patch feed newer: pair, both behind, neither way behind', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.5.13',
+        cloudVersion: '0.5.13',
+        feedVersion: '0.5.14',
+      }),
+    ).toMatchObject({
+      showPair: true,
+      desktopBehind: true,
+      cloudBehind: true,
+      desktopWayBehind: false,
+      cloudWayBehind: false,
+    })
+  })
+
+  it('same versions, major feed newer: pair, both way behind', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.5.14',
+        cloudVersion: '0.5.14',
+        feedVersion: '0.6.0',
+      }),
+    ).toMatchObject({
+      showPair: true,
+      desktopBehind: true,
+      cloudBehind: true,
+      desktopWayBehind: true,
+      cloudWayBehind: true,
+    })
+  })
+
+  it('cloud only patch behind: pair, blue on cloud', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.5.14',
+        cloudVersion: '0.5.13',
+      }),
+    ).toMatchObject({
+      showPair: true,
+      desktopBehind: false,
+      cloudBehind: true,
+      desktopWayBehind: false,
+      cloudWayBehind: false,
+    })
+  })
+
+  it('desktop only patch behind: pair, blue on desktop', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.5.13',
+        cloudVersion: '0.5.14',
+        feedVersion: '0.5.14',
+      }),
+    ).toMatchObject({
+      showPair: true,
+      desktopBehind: true,
+      cloudBehind: false,
+      desktopWayBehind: false,
+      cloudWayBehind: false,
+    })
+  })
+
+  it('cloud way behind desktop when desktop is latest', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.6.0',
+        cloudVersion: '0.5.14',
+      }),
+    ).toMatchObject({
+      showPair: true,
+      desktopBehind: false,
+      cloudBehind: true,
+      desktopWayBehind: false,
+      cloudWayBehind: true,
+    })
+  })
+
+  it('desktop way behind when the feed matches a newer cloud', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.5.14',
+        cloudVersion: '0.6.0',
+        feedVersion: '0.6.0',
+      }),
+    ).toMatchObject({
+      showPair: true,
+      desktopBehind: true,
+      cloudBehind: false,
+      desktopWayBehind: true,
+      cloudWayBehind: false,
+    })
+  })
+
+  it('mixed: desktop patch behind, cloud way behind', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.6.0',
+        cloudVersion: '0.5.14',
+        feedVersion: '0.6.1',
+      }),
+    ).toMatchObject({
+      showPair: true,
+      desktopBehind: true,
+      cloudBehind: true,
+      desktopWayBehind: false,
+      cloudWayBehind: true,
+    })
+  })
+
+  it('cloud ahead of desktop with no feed: pair, nobody behind', () => {
+    expect(
+      resolveSidebarVersionState({
+        desktopVersion: '0.5.14',
+        cloudVersion: '0.5.15',
+      }),
+    ).toMatchObject({
+      showPair: true,
+      desktopBehind: false,
+      cloudBehind: false,
+      desktopWayBehind: false,
+      cloudWayBehind: false,
+    })
+  })
+
+  it('rc is behind the matching release, not way behind', () => {
+    const state = resolveSidebarVersionState({
+      desktopVersion: '0.5.12',
+      cloudVersion: '0.5.12-rc.3',
+    })
+    expect(state).toMatchObject({
+      showPair: true,
+      cloudBehind: true,
+      cloudWayBehind: false,
+    })
+  })
+
+  it('rc cloud is not behind a stable desktop that is the latest', () => {
+    const state = resolveSidebarVersionState({
+      desktopVersion: '0.5.12',
+      cloudVersion: '0.5.13-rc.2',
+    })
+    expect(state.desktopBehind).toBe(false)
+    expect(state.cloudBehind).toBe(false)
+    expect(state.showPair).toBe(true)
+  })
+
+  it('missing cloud version: no pair, no cloud side', () => {
+    const state = resolveSidebarVersionState({
+      desktopVersion: '0.5.14',
+    })
+    expect(state.showPair).toBe(false)
+    expect(state.cloudVersion).toBeNull()
+    expect(state.desktopBehind).toBe(false)
+    expect(state.cloudBehind).toBe(false)
+  })
+
+  it('empty cloud version is treated as missing', () => {
+    const state = resolveSidebarVersionState({
+      desktopVersion: '0.5.14',
+      cloudVersion: '',
+    })
+    expect(state.showPair).toBe(false)
+    expect(state.cloudVersion).toBeNull()
+  })
+
+  it('invalid cloud version is treated as missing', () => {
+    const state = resolveSidebarVersionState({
+      desktopVersion: '0.5.14',
+      cloudVersion: 'not-a-version',
+    })
+    expect(state.showPair).toBe(false)
+    expect(state.cloudVersion).toBeNull()
+    expect(state.desktopBehind).toBe(false)
+    expect(state.cloudBehind).toBe(false)
+  })
+
+  it('cloud version with build metadata is treated as missing', () => {
+    const state = resolveSidebarVersionState({
+      desktopVersion: '0.5.14',
+      cloudVersion: '0.5.14+build.1',
+    })
+    expect(state.showPair).toBe(false)
+    expect(state.cloudVersion).toBeNull()
+  })
+})

--- a/src/renderer/components/layout/sidebar-version-state.ts
+++ b/src/renderer/components/layout/sidebar-version-state.ts
@@ -1,0 +1,65 @@
+import { lt, parse } from 'semver'
+
+export interface SidebarVersionState {
+  showPair: boolean
+  desktopBehind: boolean
+  cloudBehind: boolean
+  desktopWayBehind: boolean
+  cloudWayBehind: boolean
+  desktopVersion: string
+  cloudVersion: string | null
+}
+
+/** Core `x.y.z` plus an optional prerelease. Build metadata is rejected. */
+function parseVersion(raw: string) {
+  const parsed = parse(raw.trim())
+  if (!parsed || parsed.build.length > 0) return null
+  return parsed
+}
+
+function isBehind(version: string, latest: string): boolean {
+  const parsed = parseVersion(version)
+  const parsedLatest = parseVersion(latest)
+  if (!parsed || !parsedLatest) return false
+  return lt(parsed, parsedLatest)
+}
+
+function isMajorMinorBehind(version: string, latest: string): boolean {
+  const parsed = parseVersion(version)
+  const parsedLatest = parseVersion(latest)
+  if (!parsed || !parsedLatest) return false
+  return parsed.major < parsedLatest.major || (parsed.major === parsedLatest.major && parsed.minor < parsedLatest.minor)
+}
+
+/**
+ * Decide how the sidebar footer version chip renders in Electron + cloud.
+ * `feedVersion` is the updater's channel latest when it has one (prerelease
+ * setting already applied). When it is omitted, latest is the desktop build.
+ */
+export function resolveSidebarVersionState(input: {
+  desktopVersion: string
+  cloudVersion?: string
+  feedVersion?: string
+}): SidebarVersionState {
+  const desktopVersion = input.desktopVersion
+  const rawCloud = input.cloudVersion || null
+  const cloudVersion = rawCloud && parseVersion(rawCloud) ? rawCloud : null
+  const latest = input.feedVersion || desktopVersion
+
+  const desktopBehind = isBehind(desktopVersion, latest)
+  const cloudBehind = cloudVersion !== null && isBehind(cloudVersion, latest)
+  const desktopWayBehind = isMajorMinorBehind(desktopVersion, latest)
+  const cloudWayBehind = cloudVersion !== null && isMajorMinorBehind(cloudVersion, latest)
+  const anyoneBehind = desktopBehind || cloudBehind
+  const versionsDiffer = cloudVersion !== null && cloudVersion !== desktopVersion
+
+  return {
+    showPair: cloudVersion !== null && (versionsDiffer || anyoneBehind),
+    desktopBehind,
+    cloudBehind,
+    desktopWayBehind,
+    cloudWayBehind,
+    desktopVersion,
+    cloudVersion,
+  }
+}

--- a/src/renderer/hooks/use-runtime-status.ts
+++ b/src/renderer/hooks/use-runtime-status.ts
@@ -8,6 +8,8 @@ export interface RuntimeStatusResponse {
   apiKeyConfigured: boolean
   /** Non-null when background services failed to init and the server runs degraded. */
   servicesInitError: string | null
+  /** Optional because a deployment built before this field omits it. */
+  appVersion?: string
 }
 
 export function useRuntimeStatus() {


### PR DESCRIPTION
The Cloud tab still runs the desktop bundle, so the footer can show both versions. Local stays one number. When the builds differ, or when they match and either is behind the update feed, the pair shows a laptop and a cloud, with a blue or orange dot on the side that is behind.

Closes https://linear.app/datawizz/issue/SUP-701

8 files, +567 / −17.

- Same versions and nobody behind: one number
- Differ, or same and behind the feed: laptop left, cloud right
- Blue dot = patch behind the latest. Orange = major or minor behind
- Latest is the update feed when one exists, else the desktop build
- Left opens Settings. Right opens the platform Cloud tab
- Missing org or platform URL: right click does nothing
- Missing or unreadable cloud version: desktop number only
- Version comes from `GET /api/runtime-status`, not platform discovery
- A desktop GitHub release can read as latest before the cloud image is rollable
- Blue vs orange is color only
