### PR TITLE
Classify Safari compositor rollbacks by engine activity, not position history

### DIFF
--- a/e2e/specs/thinking-collapse-reading-line.spec.ts
+++ b/e2e/specs/thinking-collapse-reading-line.spec.ts
@@ -1,0 +1,308 @@
+import { writeFileSync } from 'node:fs'
+import { test, expect, type Page } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+// Matches the 'think long passes' mock scenario: three thinking blocks, each
+// overfilling the card's max-height (max-h-64 ≈ 256px body), so each pass
+// ending collapses the card by its full body height.
+const PROMPT = 'think long passes please'
+
+// A reader who scrolled up LESS than the collapse height is inside the clamp
+// zone: when the card body unmounts, scrollHeight shrinks below their
+// scrollTop and the browser drags them along. overflow-anchor is disabled on
+// the list, so no engine — ours or the browser's — holds the line today.
+const ESCAPE_WHEEL_PX = 120
+
+declare global {
+  interface Window {
+    __rlrec?: {
+      frames: Array<Record<string, number>>
+    }
+  }
+}
+
+// Per-frame viewport-relative top of the last user row — the reading line a
+// scrolled-up reader is visually holding. A stable hold keeps it constant;
+// the clamp shows up as one large frame-over-frame delta at collapse time.
+function installRecorder(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+    const rec: NonNullable<Window['__rlrec']> = { frames: [] }
+    window.__rlrec = rec
+    // Wheel input moves the viewport legitimately — tag frames near a wheel so
+    // the jump metric only judges motion the user did not cause.
+    let lastWheelT = -Infinity
+    el.addEventListener('wheel', () => { lastWheelT = performance.now() }, { passive: true })
+    const sample = () => {
+      const anchors = el.querySelectorAll<HTMLElement>('[data-turn-anchor-id]')
+      let anchorTop = NaN
+      for (let i = anchors.length - 1; i >= 0; i--) {
+        const r = anchors[i].getBoundingClientRect()
+        if (r.height > 0) {
+          anchorTop = r.top
+          break
+        }
+      }
+      const pillVisible = [...document.querySelectorAll('button')].some(
+        (b) => b.textContent?.includes('Scroll to bottom') && b.offsetParent !== null,
+      )
+      rec.frames.push({
+        t: performance.now(),
+        wheelRecent: performance.now() - lastWheelT < 150 ? 1 : 0,
+        anchorTop,
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        openBodies: document.querySelectorAll('[data-testid="thinking-block-body"]').length,
+        cards: document.querySelectorAll('[data-testid="thinking-block"]').length,
+        pill: pillVisible ? 1 : 0,
+      })
+      requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  })
+}
+
+test.describe('Reading line through a thinking-card collapse (escaped reader)', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await agentPage.createAgent(`ReadingLine Agent ${testInfo.workerIndex}-${Date.now()}`)
+  })
+
+  // KNOWN FAILING — documents the outstanding escaped-reader bug: a reader
+  // scrolled up less than the card-body height sits in the clamp zone, and the
+  // collapse drags them (~110-210px, BOTH engines; overflow-anchor is disabled
+  // and the reserve only guards positions above the anchor). Fix direction:
+  // grow the bottom spacer to absorb mid-turn shrinks. Un-fixme when built.
+  test.fixme('holds a scrolled-up reader through the collapse clamp', async ({ page }, testInfo) => {
+    test.setTimeout(240000)
+
+    // Real scroll range first, so the collapse clamps against a distant
+    // maximum instead of degenerating to scrollTop 0.
+    await sessionPage.sendMessage('stream a long story please')
+    await sessionPage.waitForUserMessageCount(1)
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')
+            return el ? el.scrollHeight - el.clientHeight : 0
+          }),
+        { timeout: 60000 },
+      )
+      .toBeGreaterThan(1500)
+    await expect(sessionPage.getStopButton()).toBeHidden({ timeout: 30000 })
+
+    await sessionPage.sendMessage(PROMPT)
+    await sessionPage.waitForUserMessageCount(2)
+    await expect(page.getByTestId('message-list')).toBeVisible()
+
+    // Wait for the THIRD pass to stream: by then the send-time turn reserve is
+    // consumed (two full cards + chips grew past it), matching the deep-turn
+    // shape in the field where the spacer can no longer absorb the shrink.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => ({
+            cards: document.querySelectorAll('[data-testid="thinking-block"]').length,
+            open: document.querySelectorAll('[data-testid="thinking-block-body"]').length,
+            bodyH:
+              document.querySelector<HTMLElement>('[data-testid="thinking-block-body"]')
+                ?.offsetHeight ?? 0,
+          })),
+        { timeout: 60000 },
+      )
+      .toMatchObject({ cards: 3, open: 1 })
+    // Let the live body reach its max height so the collapse is full-size.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              document.querySelector<HTMLElement>('[data-testid="thinking-block-body"]')
+                ?.offsetHeight ?? 0,
+          ),
+        { timeout: 30000 },
+      )
+      .toBeGreaterThan(200)
+
+    await installRecorder(page)
+
+    // Escape with real input — a small scroll up, like a reader peeking at the
+    // streaming thinking text. Lands INSIDE the clamp zone (< card body height).
+    // Wheel over the TOP of the list: the live card's body is its own scroller,
+    // and a wheel over it scrolls the card's interior, not the transcript.
+    const list = page.getByTestId('message-list')
+    const box = (await list.boundingBox())!
+    await page.mouse.move(box.x + box.width / 2, box.y + 60)
+    await page.mouse.wheel(0, -ESCAPE_WHEEL_PX)
+    await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeVisible({
+      timeout: 5000,
+    })
+
+    // Ride out the pass-3 collapse and the turn end.
+    await expect(page.getByText('Done with all long thinking passes')).toBeVisible({
+      timeout: 60000,
+    })
+    // A few settle frames past the collapse.
+    const framesNow = await page.evaluate(() => window.__rlrec?.frames.length ?? 0)
+    await expect
+      .poll(() => page.evaluate(() => window.__rlrec?.frames.length ?? 0), { timeout: 10000 })
+      .toBeGreaterThan(framesNow + 30)
+
+    const rec = await page.evaluate(() => window.__rlrec!)
+    writeFileSync(testInfo.outputPath('reading-line-recorder.json'), JSON.stringify(rec))
+    console.log(
+      `[recorder] frames=${rec.frames.length} -> ${testInfo.outputPath('reading-line-recorder.json')}`,
+    )
+
+    // The reading line must hold: no single frame may displace the reader's
+    // reference row by more than a text-reflow's worth. The collapse clamp
+    // fails this by ~(card body − distanceFromBottom) pixels in one frame.
+    let maxJump = 0
+    let jumpAt = -1
+    for (let i = 1; i < rec.frames.length; i++) {
+      const a = rec.frames[i - 1]
+      const b = rec.frames[i]
+      if (!Number.isFinite(a.anchorTop) || !Number.isFinite(b.anchorTop)) continue
+      if (a.wheelRecent || b.wheelRecent) continue
+      const d = Math.abs(b.anchorTop - a.anchorTop)
+      if (d > maxJump) {
+        maxJump = d
+        jumpAt = i
+      }
+    }
+    console.log(
+      `[reading-line] maxJump=${maxJump.toFixed(1)}px at frame ${jumpAt} ` +
+        `(openBodies ${rec.frames[jumpAt - 1]?.openBodies}→${rec.frames[jumpAt]?.openBodies}, ` +
+        `scrollTop ${rec.frames[jumpAt - 1]?.scrollTop}→${rec.frames[jumpAt]?.scrollTop})`,
+    )
+    expect(maxJump).toBeLessThan(40)
+  })
+
+  // The field report: the user touches NOTHING. The app is following the
+  // stream, a big thinking card collapses, and following silently dies — the
+  // scroll-to-bottom pill appears and the viewport is left stranded above the
+  // live edge. Zero input for the whole turn; following must survive every
+  // collapse (three pass-end collapses plus the turn-end persisted swap).
+  test('hands off: following survives every thinking-card collapse', async ({ page }, testInfo) => {
+    test.setTimeout(240000)
+
+    await sessionPage.sendMessage('stream a long story please')
+    await sessionPage.waitForUserMessageCount(1)
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')
+            return el ? el.scrollHeight - el.clientHeight : 0
+          }),
+        { timeout: 60000 },
+      )
+      .toBeGreaterThan(1500)
+    await expect(sessionPage.getStopButton()).toBeHidden({ timeout: 30000 })
+
+    await sessionPage.sendMessage(PROMPT)
+    await sessionPage.waitForUserMessageCount(2)
+    await expect(page.getByTestId('message-list')).toBeVisible()
+    await installRecorder(page)
+
+    await expect(page.getByText('Done with all long thinking passes')).toBeVisible({
+      timeout: 120000,
+    })
+    // Settle frames past the turn end.
+    const framesNow = await page.evaluate(() => window.__rlrec?.frames.length ?? 0)
+    await expect
+      .poll(() => page.evaluate(() => window.__rlrec?.frames.length ?? 0), { timeout: 10000 })
+      .toBeGreaterThan(framesNow + 30)
+
+    const rec = await page.evaluate(() => window.__rlrec!)
+    writeFileSync(testInfo.outputPath('handsoff-recorder.json'), JSON.stringify(rec))
+
+    const pillFrames = rec.frames.filter((f) => f.pill === 1)
+    const firstPill = rec.frames.findIndex((f) => f.pill === 1)
+    const ctx = firstPill > 0 ? rec.frames[firstPill] : null
+    console.log(
+      `[hands-off] frames=${rec.frames.length} pillFrames=${pillFrames.length}` +
+        (ctx
+          ? ` firstPill@${firstPill} (scrollTop=${ctx.scrollTop} scrollHeight=${ctx.scrollHeight} openBodies=${ctx.openBodies} cards=${ctx.cards})`
+          : ''),
+    )
+
+    const final = await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+      return el.scrollHeight - el.scrollTop - el.clientHeight
+    })
+    console.log(`[hands-off] final distanceFromBottom=${final}`)
+
+    // Following must never have disengaged.
+    expect(pillFrames.length).toBe(0)
+    expect(final).toBeLessThan(90)
+  })
+
+  // Same hands-off shape but a DEEP turn: eight passes, running well past the
+  // send-time reserve — closer to the long real turns where follow-loss is
+  // reported in the field.
+  test('hands off marathon: following survives a deep multi-pass turn', async ({ page }, testInfo) => {
+    test.setTimeout(240000)
+
+    await sessionPage.sendMessage('stream a long story please')
+    await sessionPage.waitForUserMessageCount(1)
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')
+            return el ? el.scrollHeight - el.clientHeight : 0
+          }),
+        { timeout: 60000 },
+      )
+      .toBeGreaterThan(1500)
+    await expect(sessionPage.getStopButton()).toBeHidden({ timeout: 30000 })
+
+    await sessionPage.sendMessage('think a marathon please')
+    await sessionPage.waitForUserMessageCount(2)
+    await expect(page.getByTestId('message-list')).toBeVisible()
+    await installRecorder(page)
+
+    await expect(page.getByText('Done with the marathon of thinking passes')).toBeVisible({
+      timeout: 120000,
+    })
+    const framesNow = await page.evaluate(() => window.__rlrec?.frames.length ?? 0)
+    await expect
+      .poll(() => page.evaluate(() => window.__rlrec?.frames.length ?? 0), { timeout: 10000 })
+      .toBeGreaterThan(framesNow + 30)
+
+    const rec = await page.evaluate(() => window.__rlrec!)
+    writeFileSync(testInfo.outputPath('marathon-recorder.json'), JSON.stringify(rec))
+
+    const pillFrames = rec.frames.filter((f) => f.pill === 1)
+    const firstPill = rec.frames.findIndex((f) => f.pill === 1)
+    const ctx = firstPill > 0 ? rec.frames[firstPill] : null
+    console.log(
+      `[marathon] frames=${rec.frames.length} pillFrames=${pillFrames.length}` +
+        (ctx
+          ? ` firstPill@${firstPill} (scrollTop=${ctx.scrollTop} scrollHeight=${ctx.scrollHeight} openBodies=${ctx.openBodies} cards=${ctx.cards})`
+          : ''),
+    )
+    const final = await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+      return el.scrollHeight - el.scrollTop - el.clientHeight
+    })
+    console.log(`[marathon] final distanceFromBottom=${final}`)
+
+    expect(pillFrames.length).toBe(0)
+    expect(final).toBeLessThan(90)
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -88,7 +88,7 @@ export default defineConfig({
     // explicitly with --project=web-webkit (needs `npx playwright install webkit`).
     {
       name: 'web-webkit',
-      testMatch: '**/safari-follow.spec.ts',
+      testMatch: ['**/safari-follow.spec.ts', '**/thinking-collapse-reading-line.spec.ts'],
       use: { ...devices['Desktop Safari'] },
     },
   ],

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2969,6 +2969,34 @@ describe('MessageList', () => {
       expect(geometry.scrollTop).toBe(899)
     })
 
+    it('converges back when a rollback lands between recorded positions', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el) // baseline at the live edge (699 joins the trail)
+
+      // Convergence writes 899; the trail now holds 699 and 899.
+      geometry.setNaturalScrollHeight(1500)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1500)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(899))
+
+      // WebKit reverts to the bottom of a stale layout snapshot — a value we
+      // never wrote, falling BETWEEN the recorded positions. It is still the
+      // engine's own motion coming back: following must survive and converge.
+      geometry.setScrollTop(780)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(899)
+    })
+
     it('releases follow when an input-less scroll lands off the recently-held trail', async () => {
       installFakeResizeObserver()
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
@@ -2978,9 +3006,15 @@ describe('MessageList', () => {
       fireEvent.scroll(el) // baseline at the live edge
 
       // A programmatic jump (app code, an extension, a test driving
-      // scrollTo) carries no input evidence either — but it lands where the
-      // scroller has NOT recently been. That is an escape, not a rollback:
-      // follow must release, and nothing may yank the reader back down.
+      // scrollTo) carries no input evidence either — but it arrives while the
+      // engine is QUIET (no writes for a while) and lands where the scroller
+      // has not recently been. That is an escape, not a rollback: follow must
+      // release, and nothing may yank the reader back down. First age out the
+      // mount pin so the engine-activity window is genuinely closed, as it is
+      // whenever such jumps happen in reality.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 450))
+      })
       geometry.setScrollTop(150)
       fireEvent.scroll(el)
       await act(async () => {

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -72,14 +72,40 @@ const ESCAPE_MIN_DISTANCE_PX = 24
 // rollbacks to the same committed position after large thinking-card
 // collapses, WebKit only).
 const INPUT_EVIDENCE_WINDOW_MS = 500
-// A rollback, by definition, lands on a position the scroller recently held.
-// An evidence-less upward move is only read as one when it does; landing
-// anywhere else with no input behind it is a programmatic jump (scrollTo
-// from app code, an extension, tests) and releases following like any other
-// escape.
+// A rollback, by definition, lands somewhere the scroller recently traveled.
+// NOT necessarily on a position we ever wrote: WebKit reverts to the bottom
+// of a stale layout snapshot, which falls BETWEEN our recorded positions
+// (reproduced by thinking-collapse-reading-line.spec.ts 'hands off marathon'
+// — deterministic zero-input snaps to the same never-written value). So an
+// evidence-less upward move reads as a rollback when it lands on a recorded
+// position OR inside a small segment between two consecutive ones — the
+// creep path the viewport actually traversed. Landing outside that path with
+// no input behind it is a programmatic jump (scrollTo from app code, an
+// extension, tests) and releases following like any other escape. Segments
+// wider than the cap are real discontinuities (the initial pin, an escape
+// jump) — the viewport never held their interior, so they don't absorb.
 const ROLLBACK_TRAIL_MS = 2000
-const ROLLBACK_TRAIL_MAX = 40
+// Count cap is only a runaway backstop; retention is time-based (entries age
+// out of classification at ROLLBACK_TRAIL_MS and are evicted as they record).
+const ROLLBACK_TRAIL_MAX = 256
 const ROLLBACK_TRAIL_TOLERANCE_PX = 2
+const ROLLBACK_TRAIL_SEGMENT_MAX_PX = 500
+// The trail alone cannot decide: WebKit's compositor may revert to a snapshot
+// OLDER than any bounded history when the main thread is busy (reproduced —
+// zero-input snaps landing past the trail's oldest entry). While the engine
+// is the one moving the viewport (a live glide, or any programmatic write
+// this recently), an evidence-less upward stable landing is its own motion
+// coming back, wherever it lands. Programmatic jumps from outside the engine
+// (find-in-page, extensions, tests) are only distinguishable when the engine
+// is quiet — which is when they actually happen. Two guards keep an outside
+// jump from being eaten by coincidence (a mount-settle pin racing a test's
+// scrollTo(0) by ~90ms was real): the window is a couple of frames, and the
+// write-window path only accepts reverts of plausible size — a rollback
+// undoes recently composited creep (tens to hundreds of px), while outside
+// jumps travel the transcript. A live glide is exempt from the cap: WebKit
+// has been seen reverting a multi-thousand-px chase mid-flight.
+const ENGINE_WRITE_ROLLBACK_WINDOW_MS = 150
+const ROLLBACK_REVERT_CAP_PX = 1200
 // How long the scrolling tree gets to settle before convergence re-pins
 // after an engine-caused upward scroll.
 const ENGINE_SCROLL_SETTLE_MS = 150
@@ -215,8 +241,9 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   const lastUserScrollUpAtRef = useRef(0)
   // Positions the scroller has recently held — every observed scroll event
   // and every engine write funnels through rememberPosition. Consulted only
-  // to separate compositor rollbacks (land ON the trail) from programmatic
-  // jumps (land off it) when an upward move has no input evidence.
+  // to separate compositor rollbacks (land on the recently traveled path)
+  // from programmatic jumps (land off it) when an upward move has no input
+  // evidence.
   const positionTrailRef = useRef<Array<{ scrollTop: number; at: number }>>([])
 
   // Interaction tracking. A drag (a press that moved), a press on the
@@ -254,17 +281,29 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   // viewport after the larger slice renders so the content under the user doesn't jump.
   const prevScrollHeightRef = useRef<number | null>(null)
 
+  // Stamped by every engine-authored scrollTop write; consulted by the
+  // rollback classifier — see ENGINE_WRITE_ROLLBACK_WINDOW_MS.
+  const engineWroteAtRef = useRef(0)
+  const writeScrollTop = useCallback((el: HTMLElement, top: number) => {
+    engineWroteAtRef.current = performance.now()
+    el.scrollTop = top
+  }, [])
+
   const rememberPosition = useCallback(() => {
     const el = scrollRef.current
     if (!el) return
     const trail = positionTrailRef.current
+    const now = performance.now()
     const latest = trail[trail.length - 1]
     if (latest && Math.abs(latest.scrollTop - el.scrollTop) <= ROLLBACK_TRAIL_TOLERANCE_PX) {
-      latest.scrollTop = el.scrollTop
-      latest.at = performance.now()
+      // Deduplicate write echoes without sliding the entry along a slow creep
+      // — the anchored position is what keeps the traversal history.
+      latest.at = now
     } else {
-      trail.push({ scrollTop: el.scrollTop, at: performance.now() })
-      if (trail.length > ROLLBACK_TRAIL_MAX) trail.shift()
+      trail.push({ scrollTop: el.scrollTop, at: now })
+      while (trail.length > ROLLBACK_TRAIL_MAX || (trail.length && now - trail[0].at > ROLLBACK_TRAIL_MS)) {
+        trail.shift()
+      }
     }
     baselineRef.current = {
       scrollTop: el.scrollTop,
@@ -301,7 +340,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     if (!el) return
     glideRef.current?.cancel()
     if (prefersReducedMotion()) {
-      el.scrollTop = liveEdgeTarget(el)
+      writeScrollTop(el, liveEdgeTarget(el))
       rememberPosition()
       return
     }
@@ -331,18 +370,18 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       last = now
       const remaining = target - el.scrollTop
       if (Math.abs(remaining) <= 1 || now - startedAt >= GLIDE_MAX_MS) {
-        el.scrollTop = target
+        writeScrollTop(el, target)
         rememberPosition()
         glideRef.current = null
         return
       }
-      el.scrollTop = el.scrollTop + remaining * (1 - Math.exp((-dt / 1000) * GLIDE_RATE_PER_S))
+      writeScrollTop(el, el.scrollTop + remaining * (1 - Math.exp((-dt / 1000) * GLIDE_RATE_PER_S)))
       handle.top = el.scrollTop
       rememberPosition()
       frameId = requestAnimationFrame(step)
     }
     frameId = requestAnimationFrame(step)
-  }, [rememberPosition])
+  }, [rememberPosition, writeScrollTop])
 
   // Re-assert the live edge. Convergence, not classification: called after
   // every content/viewport resize and every reserve sync while following, so
@@ -382,7 +421,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       glideRef.current.cancel()
     }
     if (prefersReducedMotion() || gap > FOLLOW_GLIDE_MAX_GAP_PX) {
-      el.scrollTop = target
+      writeScrollTop(el, target)
       rememberPosition()
     } else {
       // Convergence itself is animated: the chase re-targets every frame,
@@ -391,7 +430,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       // chase alive across ticks.
       glideToLiveEdge('follow')
     }
-  }, [glideToLiveEdge, rememberPosition, selectionInProgress])
+  }, [glideToLiveEdge, rememberPosition, selectionInProgress, writeScrollTop])
   useLayoutEffect(() => {
     pinRetryRef.current = pinToLiveEdge
   }, [pinToLiveEdge])
@@ -406,10 +445,10 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     glideRef.current?.cancel()
     const el = scrollRef.current
     if (el) {
-      el.scrollTop = liveEdgeTarget(el)
+      writeScrollTop(el, liveEdgeTarget(el))
       rememberPosition()
     }
-  }, [glideToLiveEdge, rememberPosition])
+  }, [glideToLiveEdge, rememberPosition, writeScrollTop])
 
   // Visible messages the trailing window slices. Derived values in the
   // component still compute over the FULL message list, so turn boundaries /
@@ -502,7 +541,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
         anchoredTurn.anchorTop = anchorTop
         anchoredTurn.scrollTop = Math.max(0, anchorTop - TURN_ANCHOR_TOP)
         if (mayAdjustViewport) {
-          el.scrollTop = Math.min(Math.max(0, el.scrollTop + drift), liveEdgeTarget(el))
+          writeScrollTop(el, Math.min(Math.max(0, el.scrollTop + drift), liveEdgeTarget(el)))
           rememberPosition()
         }
       }
@@ -539,18 +578,18 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       // The spacer write above has just re-inflated the scroll range — put
       // the viewport straight back so the dip never paints; the glide then
       // resumes from where it actually was.
-      el.scrollTop = Math.min(glide.top, liveEdgeTarget(el))
+      writeScrollTop(el, Math.min(glide.top, liveEdgeTarget(el)))
       rememberPosition()
     } else if (mayAdjustViewport && !inputBacked && !glide) {
       const target = liveEdgeTarget(el)
       if (el.scrollTop < target) {
-        el.scrollTop = target
+        writeScrollTop(el, target)
         rememberPosition()
       }
     } else {
       pinToLiveEdge()
     }
-  }, [setBottomSpacerHeight, pinToLiveEdge, rememberPosition, selectionInProgress])
+  }, [setBottomSpacerHeight, pinToLiveEdge, rememberPosition, selectionInProgress, writeScrollTop])
 
   // Pin the viewport to the live edge before first paint — without this,
   // opening a session flashes the top of the transcript for a frame. Guarded
@@ -561,7 +600,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     const el = scrollRef.current
     if (pinnedInitialRef.current || !el) return
     pinnedInitialRef.current = true
-    el.scrollTop = liveEdgeTarget(el)
+    writeScrollTop(el, liveEdgeTarget(el))
     rememberPosition()
   })
 
@@ -588,21 +627,40 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
       // Stable geometry narrows the author to the reader or the engine itself
       // (WebKit's compositor rolling back a programmatic write). Fresh input
       // separates them — and an evidence-less move only reads as a rollback
-      // when it lands on the trail of recently held positions, which a
-      // rollback by definition returns to. Off the trail it is a programmatic
-      // jump and is treated exactly like the reader's.
+      // when it lands where the viewport recently traveled: on a recorded
+      // position, or inside a small segment between two consecutive ones
+      // (rollbacks revert to stale-layout bottoms that fall between our
+      // writes). Off that path it is a programmatic jump and is treated
+      // exactly like the reader's.
       const now = performance.now()
       const inputBacked =
         pointerDownRef.current ||
         touchActiveRef.current ||
         now - lastInputAtRef.current < INPUT_EVIDENCE_WINDOW_MS
-      const rollback =
-        !inputBacked &&
-        positionTrailRef.current.some(
-          (p) =>
-            now - p.at <= ROLLBACK_TRAIL_MS &&
-            Math.abs(p.scrollTop - el.scrollTop) <= ROLLBACK_TRAIL_TOLERANCE_PX,
-        )
+      const trail = positionTrailRef.current
+      let onTrail = false
+      for (let i = 0; i < trail.length && !onTrail; i++) {
+        const p = trail[i]
+        if (now - p.at > ROLLBACK_TRAIL_MS) continue
+        if (Math.abs(p.scrollTop - el.scrollTop) <= ROLLBACK_TRAIL_TOLERANCE_PX) {
+          onTrail = true
+          break
+        }
+        const q = trail[i + 1]
+        if (!q) continue
+        const lo = Math.min(p.scrollTop, q.scrollTop)
+        const hi = Math.max(p.scrollTop, q.scrollTop)
+        onTrail =
+          hi - lo <= ROLLBACK_TRAIL_SEGMENT_MAX_PX && el.scrollTop > lo && el.scrollTop < hi
+      }
+      // While the engine is the one moving the viewport, an evidence-less
+      // upward landing is its own motion coming back wherever it lands — the
+      // compositor can revert to a snapshot older than any bounded trail.
+      const engineActive =
+        glideRef.current != null ||
+        (now - engineWroteAtRef.current < ENGINE_WRITE_ROLLBACK_WINDOW_MS &&
+          upwardDelta <= ROLLBACK_REVERT_CAP_PX)
+      const rollback = !inputBacked && (engineActive || onTrail)
       if (!rollback) {
         lastUserScrollUpAtRef.current = now
         // Blank reserve is one-way. When the reader moves upward, consume the

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -1595,6 +1595,17 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
       15,
       10
     )],
+    // A deep turn: eight overfilled passes back-to-back, so the turn runs long
+    // past the send-time reserve — the state where follow-loss is reported in
+    // the field on real long-thinking turns.
+    ['think a marathon', new MultiPassThinkingScenario(
+      Array.from({ length: 8 }, (_, i) =>
+        `Pass ${i + 1}. ${'Working through the problem space step by step, revisiting each constraint and checking the running plan against it before moving on. '.repeat(12)}End of pass ${i + 1}.`,
+      ),
+      'Done with the marathon of thinking passes — here is the answer.',
+      15,
+      10
+    )],
     // Several thinking passes persisted one-by-one — an interruptible thinking turn
     ['think in passes', new MultiPassThinkingScenario(
       [


### PR DESCRIPTION
## Problem

Safari kills live-edge following on long turns — three field recordings, one session, no input in any of them:

- mid-stream during a long thinking turn: one-frame ~134px upward snap, pill appears, follow dead
- 37 minutes into a tool-heavy turn (no thinking collapse anywhere near it): same snap, ~45px
- ~1.5s after turn end, as the turn-finalize reconcile lands: same snap, ~540px

**Mechanism** (pinned via per-frame recorders + engine logs): WebKit's async compositor reverts programmatic scroll writes to the bottom of a **stale layout snapshot** — a scrollTop that may never have been written and is older than any bounded history — and reports it as a genuine upward, size-stable scroll event with zero input. The exact-match position trail from #841 structurally cannot recognize these landings (the deterministic repro lands 26px past the trail's oldest in-window entry), so they read as user escapes and following is released.

Chromium is unaffected — scroll writes commit synchronously there (verified: the kill scenario is 3/3 clean on the **pre-fix** engine under Chromium, while pre-fix WebKit dies 9/9).

## Fix

An evidence-less upward, size-stable landing reads as a rollback when the engine is the one moving the viewport:

- a glide is live — uncapped, WebKit has been seen reverting multi-thousand-px chases mid-flight; or
- a programmatic write landed within the last **150ms** and the revert is **≤1200px** — the size cap is load-bearing: a mount-settle pin racing `message-pagination`'s `scrollTo(0)` by ~90ms re-broke that spec deterministically until the cap separated plausible rollback sizes (45–210px observed) from transcript-scale jumps (17639px); or
- it lands on the position trail, kept as a secondary acceptor — now time-evicted instead of count-flooded, entries no longer slide along a slow creep, and small (≤500px) segments between consecutive entries count as traversed.

All engine writes funnel through a new `writeScrollTop()` that stamps the activity window.

## Repro / new coverage

`e2e/specs/thinking-collapse-reading-line.spec.ts` + a `think a marathon` mock scenario (eight overfilled thinking passes — the **deep turn** is the required ingredient; the existing 3-pass scenario never kills):

- `hands off marathon`: zero input for the whole turn; pre-fix WebKit fails 9/9 with identical single-frame ~175px snaps to the same pixel; post-fix 8/8 clean (`pillFrames=0`)
- `hands off` (3-pass) control
- a `test.fixme` repro documenting the **separate, still-open** escaped-reader collapse-clamp bug (a reader scrolled up less than the card-body height gets dragged ~110–210px on collapse — both engines; fix direction: grow the bottom spacer on mid-turn shrinks)

The `web-webkit` Playwright project's `testMatch` now includes the new spec.

## Validation (all at final constants)

| Suite | Result |
|---|---|
| unit `message-list.test.tsx` (new between-positions rollback test) | 126/126 |
| WebKit `hands off marathon` | 5/5 + 3/3, pillFrames=0 (pre-fix: 0/9) |
| WebKit `safari-follow` rollback soak | 10/10 + 3/3 |
| Chromium transcript-follow / thinking-collapse-follow / turn-end-jump / message-pagination | 9/9 (pagination alone ×4) |
| Chromium marathon, pre-fix engine (engine-specificity control) | 3/3 clean |
| tsc + eslint | clean |

Field recordings are from 0.5.12 (pre-fix); a real-Safari pass on this branch is the remaining sanity check.

https://claude.ai/code/session_01Mek1h1HX7adobTrQj8XsPn
