### PR TITLE
Add a copy-contents action to the file preview header

### DIFF
--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -503,8 +503,39 @@ test.describe('File Preview', () => {
     await expect(markdown(page).getByRole('heading', { name: 'Report Content' })).toBeVisible({ timeout: 5000 })
     await expect(page.locator('img[alt="chart.png"]')).not.toBeVisible()
 
+    await expect(page.getByTestId('file-preview-copy')).toBeVisible()
+
     // Switch forward to the image tab again → image renderer returns.
     await fileTab(page, 'chart.png').click()
     await expect(page.locator('img[alt="chart.png"]')).toBeVisible({ timeout: 5000 })
+
+    // A PNG has nothing copyable, so the header drops the action.
+    await expect(page.getByTestId('file-preview-copy')).toHaveCount(0)
+  })
+
+  test('copies the open text file from the preview header', async ({ page }) => {
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    await agentPage.createAgent(`CopyFile ${Date.now()}`)
+    const agentSlug = await getLatestAgentSlug(page)
+    seedWorkspaceFile(agentSlug, 'output/report.md', '# Test Report\n\nThis is a test with **bold** text.')
+
+    await sessionPage.sendMessage('deliver file')
+    await sessionPage.waitForResponse(15000)
+    const filePill = getFilePill(page, 'report.md').first()
+    await expect(filePill).toBeVisible({ timeout: 10000 })
+    await filePill.click()
+    await expect(markdown(page).getByRole('heading', { name: 'Test Report' })).toBeVisible({ timeout: 10000 })
+
+    const header = page.getByTestId('file-preview-header')
+    await header.getByTestId('file-preview-copy').click()
+
+    // The real gate: a browser only honours the write while the click's user
+    // gesture is live, so this fails if the handler awaits a fetch first.
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe('# Test Report\n\nThis is a test with **bold** text.')
+
+    await expect(page.getByText('Copied contents of “report.md”')).toBeVisible()
+    await expect(header.getByTestId('file-preview-copied-icon')).toBeVisible()
+    await expect(header.getByTestId('file-preview-copy-icon')).toBeVisible({ timeout: 5000 })
   })
 })

--- a/src/renderer/components/file-preview/copy-file-button.test.tsx
+++ b/src/renderer/components/file-preview/copy-file-button.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
+import { CopyFileButton } from './copy-file-button'
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const FILE_URL = 'http://localhost/api/agents/a/files/notes.md?inline=true'
+
+let queryClient: QueryClient
+let writeText: ReturnType<typeof vi.fn>
+
+function renderButton() {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CopyFileButton fileUrl={FILE_URL} displayName="notes.md" />
+    </QueryClientProvider>,
+  )
+}
+
+function clickCopy() {
+  fireEvent.click(screen.getByRole('button', { name: 'Copy file contents' }))
+}
+
+beforeEach(() => {
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('CopyFileButton', () => {
+  it('copies the text the renderer already loaded without refetching', async () => {
+    queryClient.setQueryData(['file-content', FILE_URL], { text: '# Notes', truncated: false })
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    renderButton()
+
+    clickCopy()
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('# Notes'))
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(toast.success).toHaveBeenCalledWith('Copied contents of “notes.md”')
+  })
+
+  it('shows a check mark for a few seconds, then goes back to the copy icon', async () => {
+    vi.useFakeTimers()
+    queryClient.setQueryData(['file-content', FILE_URL], { text: '# Notes', truncated: false })
+    renderButton()
+
+    expect(screen.getByTestId('file-preview-copy-icon')).toBeInTheDocument()
+
+    clickCopy()
+    await act(() => vi.advanceTimersByTimeAsync(0))
+    expect(screen.getByTestId('file-preview-copied-icon')).toBeInTheDocument()
+
+    await act(() => vi.advanceTimersByTimeAsync(2000))
+    expect(screen.getByTestId('file-preview-copy-icon')).toBeInTheDocument()
+  })
+
+  it('fetches the file when the renderer has not cached it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('plain body', { status: 200 })))
+    renderButton()
+
+    clickCopy()
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('plain body'))
+  })
+
+  it('refuses to put binary content on the clipboard', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('PNG\u0000data', { status: 200 })))
+    renderButton()
+
+    clickCopy()
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Could not copy file contents', {
+      description: '“notes.md” is not a text file',
+    }))
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed load instead of silently confirming', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 404 })))
+    renderButton()
+
+    clickCopy()
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('file-preview-copied-icon')).not.toBeInTheDocument()
+  })
+
+  it('says so when the preview only holds part of a huge file', async () => {
+    queryClient.setQueryData(['file-content', FILE_URL], { text: 'partial', truncated: true })
+    renderButton()
+
+    clickCopy()
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(
+      'Copied the first 5,000,000 characters of “notes.md”',
+    ))
+  })
+})

--- a/src/renderer/components/file-preview/copy-file-button.tsx
+++ b/src/renderer/components/file-preview/copy-file-button.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Check, ClipboardCopy } from 'lucide-react'
+import { Check, Copy } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { copyLazyTextToClipboard, copyTextToClipboard } from '@renderer/lib/clipboard'
@@ -61,7 +61,7 @@ export function CopyFileButton({ fileUrl, displayName }: CopyFileButtonProps) {
     >
       {copied
         ? <Check data-testid="file-preview-copied-icon" className="h-4 w-4 text-green-600 dark:text-green-400" />
-        : <ClipboardCopy data-testid="file-preview-copy-icon" className="h-4 w-4" />}
+        : <Copy data-testid="file-preview-copy-icon" className="h-4 w-4" />}
     </button>
   )
 }

--- a/src/renderer/components/file-preview/copy-file-button.tsx
+++ b/src/renderer/components/file-preview/copy-file-button.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check, ClipboardCopy } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { copyLazyTextToClipboard, copyTextToClipboard } from '@renderer/lib/clipboard'
+import { looksBinary } from './file-types'
+import { MAX_CONTENT_CHARS, type FileContent } from './renderers/use-file-content'
+
+const CONFIRMATION_MS = 2000
+
+interface CopyFileButtonProps {
+  fileUrl: string
+  displayName: string
+}
+
+export function CopyFileButton({ fileUrl, displayName }: CopyFileButtonProps) {
+  const queryClient = useQueryClient()
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => () => clearTimeout(resetTimer.current), [])
+
+  const handleCopy = async () => {
+    // Text renderers load through the same ['file-content', url] query, so for
+    // the file on screen the content is normally already here — writing it
+    // without awaiting anything is the only shape browsers reliably accept from
+    // a click handler.
+    const cached = queryClient.getQueryData<FileContent>(['file-content', fileUrl])
+
+    try {
+      if (cached) {
+        if (looksBinary(cached.text)) throw new Error(`“${displayName}” is not a text file`)
+        await copyTextToClipboard(cached.text)
+      } else {
+        await copyLazyTextToClipboard(() => fetchText(fileUrl, displayName))
+      }
+    } catch (error) {
+      toast.error('Could not copy file contents', {
+        description: error instanceof Error ? error.message : undefined,
+      })
+      return
+    }
+
+    setCopied(true)
+    clearTimeout(resetTimer.current)
+    resetTimer.current = setTimeout(() => setCopied(false), CONFIRMATION_MS)
+
+    toast.success(cached?.truncated
+      ? `Copied the first ${MAX_CONTENT_CHARS.toLocaleString()} characters of “${displayName}”`
+      : `Copied contents of “${displayName}”`)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="p-0.5 rounded hover:bg-muted transition-colors"
+      title="Copy file contents"
+      aria-label="Copy file contents"
+      data-testid="file-preview-copy"
+    >
+      {copied
+        ? <Check data-testid="file-preview-copied-icon" className="h-4 w-4 text-green-600 dark:text-green-400" />
+        : <ClipboardCopy data-testid="file-preview-copy-icon" className="h-4 w-4" />}
+    </button>
+  )
+}
+
+async function fetchText(url: string, displayName: string): Promise<string> {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`Failed to load file: ${response.status}`)
+
+  const text = await response.text()
+  if (looksBinary(text)) throw new Error(`“${displayName}” is not a text file`)
+  return text
+}

--- a/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { FilePreviewTrayContent } from './file-preview-tray-content'
 import type { PreviewTab } from '@renderer/context/file-preview-context'
@@ -32,6 +33,14 @@ vi.mock('./renderers/file-renderer', () => ({ FileRenderer: () => <div data-test
 vi.mock('./folder-browser', () => ({ FolderBrowser: () => <div data-testid="folder-browser" /> }))
 vi.mock('./comments/comment-bar', () => ({ CommentBar: () => <div data-testid="comment-bar" /> }))
 
+function renderTray(onClose = vi.fn()) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <FilePreviewTrayContent sessionId="test-session" onClose={onClose} />
+    </QueryClientProvider>,
+  )
+}
+
 describe('FilePreviewTrayContent', () => {
   beforeEach(() => {
     mocks.openTabs = [{
@@ -46,12 +55,7 @@ describe('FilePreviewTrayContent', () => {
 
   it('exposes container-responsive close controls on opposite sides', () => {
     const onClose = vi.fn()
-    render(
-      <FilePreviewTrayContent
-        sessionId="test-session"
-        onClose={onClose}
-      />,
-    )
+    renderTray(onClose)
 
     const mobileClose = screen.getByRole('button', { name: 'Close file preview' })
     const desktopClose = screen.getByRole('button', { name: 'Hide files panel' })
@@ -72,15 +76,32 @@ describe('FilePreviewTrayContent', () => {
       expandedPaths: ['/workspace/reports'],
       query: '',
     }]
-    render(
-      <FilePreviewTrayContent
-        sessionId="test-session"
-        onClose={vi.fn()}
-      />,
-    )
+    renderTray()
 
     expect(screen.getByTestId('folder-browser')).toBeVisible()
     expect(screen.queryByTitle('Download file')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('file-preview-copy')).not.toBeInTheDocument()
     expect(screen.queryByTestId('comment-bar')).not.toBeInTheDocument()
+  })
+
+  it('offers copy alongside download when a text file is open', () => {
+    renderTray()
+
+    expect(screen.getByTestId('file-preview-copy')).toBeInTheDocument()
+  })
+
+  it('hides copy for a file whose bytes could not be text', () => {
+    mocks.openTabs = [{
+      kind: 'file',
+      filePath: '/workspace/diagram.png',
+      agentSlug: 'test-agent',
+      displayName: 'diagram.png',
+      version: 0,
+      pdfPage: 1,
+    }]
+    renderTray()
+
+    expect(screen.queryByTestId('file-preview-copy')).not.toBeInTheDocument()
+    expect(screen.getByTitle('Download file')).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/file-preview/file-preview-tray-content.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.tsx
@@ -1,6 +1,8 @@
 import { Download, FileText, Folder, PanelRightClose, X } from 'lucide-react'
 import { useFilePreview } from '@renderer/context/file-preview-context'
+import { CopyFileButton } from './copy-file-button'
 import { FileTabBar } from './file-tab-bar'
+import { isCopyableTextFile } from './file-types'
 import { FileRenderer } from './renderers/file-renderer'
 import { FolderBrowser } from './folder-browser'
 import { CommentBar } from './comments/comment-bar'
@@ -46,6 +48,9 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
           <FileText className="h-4 w-4 shrink-0" />
         )}
         <span className="flex-1 text-xs truncate font-medium">Files</span>
+        {fileUrl && activeTab.kind === 'file' && isCopyableTextFile(activeTab.filePath) && (
+          <CopyFileButton fileUrl={fileUrl} displayName={activeTab.displayName} />
+        )}
         {downloadUrl && (
           <a
             href={downloadUrl}

--- a/src/renderer/components/file-preview/file-types.test.ts
+++ b/src/renderer/components/file-preview/file-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isCopyableTextFile } from './file-types'
+import { isCopyableTextFile, looksBinary } from './file-types'
 
 describe('isCopyableTextFile', () => {
   it.each(['notes.md', 'data.csv', 'config.json', 'index.html', 'icon.svg', 'Dockerfile'])(
@@ -7,8 +7,33 @@ describe('isCopyableTextFile', () => {
     fileName => expect(isCopyableTextFile(fileName)).toBe(true),
   )
 
-  it.each(['photo.png', 'clip.mp4', 'document.pdf', 'archive.zip'])(
+  it.each(['LICENSE', 'Procfile', '.env.production', 'main.zig', 'query.hcl'])(
+    'allows copying %s, which no extension list would have covered',
+    fileName => expect(isCopyableTextFile(fileName)).toBe(true),
+  )
+
+  it.each(['photo.png', 'clip.mp4', 'song.mp3', 'document.pdf', 'archive.zip', 'app.wasm', 'data.sqlite'])(
     'does not allow copying %s',
     fileName => expect(isCopyableTextFile(fileName)).toBe(false),
   )
+})
+
+describe('looksBinary', () => {
+  it.each([
+    ['plain text', 'hello world'],
+    ['an empty file', ''],
+    ['text with the odd decoding artefact', `caf�${'e'.repeat(200)}`],
+  ])('treats %s as text', (_label, text) => expect(looksBinary(text)).toBe(false))
+
+  it('flags a NUL byte, the way git does', () => {
+    expect(looksBinary('ELF\u0000\u0001\u0002')).toBe(true)
+  })
+
+  it('flags content that decoded mostly to replacement characters', () => {
+    expect(looksBinary('�'.repeat(50))).toBe(true)
+  })
+
+  it('only sniffs the head, so a NUL past the sample window is not decisive', () => {
+    expect(looksBinary(`${'a'.repeat(8000)}\u0000`)).toBe(false)
+  })
 })

--- a/src/renderer/components/file-preview/file-types.ts
+++ b/src/renderer/components/file-preview/file-types.ts
@@ -13,15 +13,46 @@ export const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', '
 export const VIDEO_EXTS = new Set(['mp4', 'mov', 'webm', 'm4v', 'ogv'])
 export const AUDIO_EXTS = new Set(['mp3', 'wav', 'm4a', 'aac', 'ogg', 'oga', 'opus', 'flac', 'weba'])
 
-const COPYABLE_TEXT_EXTS = new Set([
-  ...MARKDOWN_EXTS,
-  ...CSV_EXTS,
-  ...TEXT_EXTS,
-  'html',
-  'htm',
-  'svg',
+const BINARY_EXTS = new Set([
+  ...[...IMAGE_EXTS].filter(ext => ext !== 'svg'),
+  ...VIDEO_EXTS,
+  ...AUDIO_EXTS,
+  'pdf', 'zip', 'tar', 'gz', 'tgz', 'bz2', 'xz', '7z', 'rar',
+  'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
+  'exe', 'dll', 'so', 'dylib', 'bin', 'wasm', 'class', 'jar',
+  'db', 'sqlite', 'sqlite3',
+  'woff', 'woff2', 'ttf', 'otf', 'eot',
 ])
 
+/**
+ * An extension can only rule formats *out* — there is no list that covers every
+ * text file an agent might write. So anything not known to be binary is treated
+ * as copyable, which is what lets extensionless files (LICENSE, Procfile) and
+ * unfamiliar code extensions get a copy action at all. `looksBinary` is the
+ * actual guard: it inspects the bytes we fetched before they reach the
+ * clipboard, so a wrong guess here costs an error toast, not garbage.
+ */
 export function isCopyableTextFile(filePath: string): boolean {
-  return COPYABLE_TEXT_EXTS.has(getFileExtension(filePath))
+  return !BINARY_EXTS.has(getFileExtension(filePath))
 }
+
+const BINARY_SNIFF_CHARS = 8000
+const MAX_REPLACEMENT_RATIO = 0.1
+
+/**
+ * Git's heuristic: a NUL byte in the first few KB means binary. Decoding via
+ * `Response.text()` also turns any byte sequence that isn't valid UTF-8 into
+ * U+FFFD, so a high density of those is the second tell.
+ */
+export function looksBinary(text: string): boolean {
+  const sample = text.slice(0, BINARY_SNIFF_CHARS)
+
+  let replacements = 0
+  for (let i = 0; i < sample.length; i++) {
+    const code = sample.charCodeAt(i)
+    if (code === 0x0000) return true
+    if (code === 0xfffd) replacements++
+  }
+  return replacements / sample.length > MAX_REPLACEMENT_RATIO
+}
+

--- a/src/renderer/components/file-preview/folder-file-context-menu.tsx
+++ b/src/renderer/components/file-preview/folder-file-context-menu.tsx
@@ -40,12 +40,13 @@ import { Input } from '@renderer/components/ui/input'
 import { useFilePreview, type FolderTab } from '@renderer/context/file-preview-context'
 import { useUser } from '@renderer/context/user-context'
 import { apiFetch } from '@renderer/lib/api'
+import { copyLazyTextToClipboard } from '@renderer/lib/clipboard'
 import { downloadBlob } from '@renderer/lib/download'
 import { canUseHostFeatures } from '@renderer/lib/host-features'
 import { getAgentFileApiPath } from '@renderer/lib/workspace-file-url'
 import type { FolderEntry } from '@renderer/hooks/use-folder-entries'
 import type { Bookmark } from '@renderer/hooks/use-bookmarks'
-import { isCopyableTextFile } from './file-types'
+import { isCopyableTextFile, looksBinary } from './file-types'
 
 interface FolderEntryContextMenuProps {
   folder: FolderTab
@@ -131,9 +132,13 @@ export function FolderEntryContextMenu({
 
   const handleCopy = async () => {
     try {
-      const response = await apiFetch(`${fileApiPath}?inline=true`)
-      if (!response.ok) throw new Error(await getResponseError(response, 'Failed to copy file'))
-      await navigator.clipboard.writeText(await response.text())
+      await copyLazyTextToClipboard(async () => {
+        const response = await apiFetch(`${fileApiPath}?inline=true`)
+        if (!response.ok) throw new Error(await getResponseError(response, 'Failed to copy file'))
+        const text = await response.text()
+        if (looksBinary(text)) throw new Error(`“${entry.name}” is not a text file`)
+        return text
+      })
       toast.success(`Copied contents of “${entry.name}”`)
     } catch (error) {
       toast.error('Could not copy file contents', {

--- a/src/renderer/lib/api-origin.characterization.test.ts
+++ b/src/renderer/lib/api-origin.characterization.test.ts
@@ -88,6 +88,9 @@ const PINNED_CALL_SITES: Record<string, string> = {
     'prebuilt `url` prop; composed by file-preview-tray-content.tsx from getApiBaseUrl()',
   'components/file-preview/renderers/audio-renderer.tsx::AudioRenderer.decodeWaveform::fetch(url)':
     'prebuilt `url` prop; same origin as use-file-content.ts above',
+  'components/file-preview/copy-file-button.tsx::fetchText::fetch(url)':
+    'the same prebuilt `fileUrl` the renderer loads, refetched only when the ' +
+    'file-content cache is cold; same origin as use-file-content.ts above',
   // Not third-party — this one IS our API, reached over ws:// instead of http://.
   'hooks/use-browser-stream.ts::useBrowserStream::WebSocket(wsUrl)':
     'the only site that does scheme surgery: it splits getApiBaseUrl() into a ' +

--- a/src/renderer/lib/clipboard.test.ts
+++ b/src/renderer/lib/clipboard.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { copyLazyTextToClipboard, copyTextToClipboard } from './clipboard'
+
+function stubClipboard(value: unknown) {
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value })
+}
+
+describe('copyTextToClipboard', () => {
+  afterEach(() => {
+    stubClipboard(undefined)
+    vi.unstubAllGlobals()
+  })
+
+  it('writes through the async clipboard API when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard({ writeText })
+
+    await copyTextToClipboard('hello')
+
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+
+  it('falls back to a selection copy outside secure contexts', async () => {
+    stubClipboard(undefined)
+    const execCommand = vi.fn().mockReturnValue(true)
+    document.execCommand = execCommand
+
+    await copyTextToClipboard('hello')
+
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('reports a blocked selection copy and still cleans up', async () => {
+    stubClipboard(undefined)
+    document.execCommand = vi.fn().mockReturnValue(false)
+
+    await expect(copyTextToClipboard('hello')).rejects.toThrow('blocked')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+})
+
+describe('copyLazyTextToClipboard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ClipboardItem', class {
+      constructor(public readonly items: Record<string, Promise<Blob>>) {}
+    })
+  })
+
+  afterEach(() => {
+    stubClipboard(undefined)
+    vi.unstubAllGlobals()
+  })
+
+  it('hands the pending text to ClipboardItem so the user gesture survives the fetch', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    stubClipboard({ write, writeText: vi.fn() })
+    let resolveText: (text: string) => void = () => {}
+    const loadText = vi.fn(() => new Promise<string>(resolve => { resolveText = resolve }))
+
+    const copying = copyLazyTextToClipboard(loadText)
+    // The write is issued before the text exists — that is the whole point.
+    await vi.waitFor(() => expect(write).toHaveBeenCalled())
+    resolveText('file body')
+    await copying
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+  })
+
+  it('retries with writeText when the engine rejects a promise-valued ClipboardItem', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard({ write: vi.fn().mockRejectedValue(new Error('not implemented')), writeText })
+    const loadText = vi.fn().mockResolvedValue('file body')
+
+    await copyLazyTextToClipboard(loadText)
+
+    expect(writeText).toHaveBeenCalledWith('file body')
+    expect(loadText).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces the loader error rather than the clipboard error', async () => {
+    stubClipboard({ write: vi.fn().mockRejectedValue(new Error('NotAllowedError')), writeText: vi.fn() })
+
+    await expect(
+      copyLazyTextToClipboard(() => Promise.reject(new Error('is not a text file'))),
+    ).rejects.toThrow('is not a text file')
+  })
+})

--- a/src/renderer/lib/clipboard.ts
+++ b/src/renderer/lib/clipboard.ts
@@ -1,0 +1,61 @@
+/**
+ * Browsers only honour a clipboard write while the user gesture that triggered
+ * it is still "live", and awaiting a fetch first spends that gesture — Safari
+ * then rejects the write with a NotAllowedError. Callers that already hold the
+ * text use `copyTextToClipboard`; callers that must load it first use
+ * `copyLazyTextToClipboard`, which hands the pending text to `ClipboardItem` as
+ * a promise so the gesture survives the round trip.
+ */
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+    return
+  }
+  copyViaSelection(text)
+}
+
+export async function copyLazyTextToClipboard(loadText: () => Promise<string>): Promise<void> {
+  const pending = loadText()
+
+  if (typeof ClipboardItem !== 'undefined' && navigator.clipboard?.write) {
+    const blob = pending.then(text => new Blob([text], { type: 'text/plain' }))
+    // An engine that rejects the ClipboardItem never consumes this blob, so its
+    // rejection would surface as an unhandled one. `pending` is re-awaited below,
+    // which is where the failure actually gets reported.
+    blob.catch(() => {})
+
+    try {
+      await navigator.clipboard.write([new ClipboardItem({ 'text/plain': blob })])
+      return
+    } catch {
+      // Promise-valued ClipboardItem is a recent addition; older engines reject
+      // it outright. Retrying below also re-surfaces a `loadText` failure with
+      // its original message instead of the clipboard's generic one.
+    }
+  }
+
+  await copyTextToClipboard(await pending)
+}
+
+/**
+ * navigator.clipboard is undefined outside secure contexts, which is where a
+ * self-hosted workspace served over plain HTTP lands.
+ */
+function copyViaSelection(text: string): void {
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.top = '0'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  try {
+    textarea.select()
+    if (!document.execCommand('copy')) {
+      throw new Error('The browser blocked the clipboard write')
+    }
+  } finally {
+    textarea.remove()
+  }
+}


### PR DESCRIPTION
Adds a one-click "copy file contents" action to the file preview header, next to Download.

Linear: [SUP-709](https://linear.app/datawizz/issue/SUP-709/when-viewing-a-markdown-text-file-in-the-app-offer-a-copy-file-option)

## What changed

- **`copy-file-button.tsx`** — new header action. Shows `ClipboardCopy`, swaps to a green `Check` for 2s on success, and toasts via sonner (`Copied contents of "notes.md"`). Errors surface as `toast.error` with the reason.
- **`lib/clipboard.ts`** — shared `copyTextToClipboard` / `copyLazyTextToClipboard`.
- **`file-types.ts`** — `isCopyableTextFile` inverted to a binary-extension denylist; new `looksBinary` content sniff.
- **`folder-file-context-menu.tsx`** — its existing "Copy contents" item now shares the same helper and binary guard instead of calling `navigator.clipboard.writeText` directly.

## On the three points in the ticket

**1. Generic text detection.** There is no extension list that covers every text file an agent might write, so the extension check now only rules formats *out* (images, video, audio, pdf, archives, office docs, executables, fonts, sqlite). Everything else — including extensionless files like `LICENSE` and `Procfile`, and unfamiliar extensions like `.zig` or `.hcl` — is treated as copyable. The real guard is content-based: `looksBinary` applies git's heuristic (a NUL byte in the first 8 KB) plus a check for content that decoded mostly to U+FFFD replacement characters. A wrong guess therefore costs an error toast, not garbage on the clipboard.

**2. Toast + icon toggle.** Both implemented; the icon reverts after 2s and the timeout is cleared on unmount.

**3. Browser clipboard rules.** This was the fiddly part. A browser only honours a clipboard write while the triggering user gesture is still live, and awaiting a fetch first spends that gesture — Safari then rejects with `NotAllowedError`. Two mitigations:

- The text renderers already load through the `['file-content', url]` react-query key, so for the file on screen the content is normally *already in the cache*. The button reads it from there and writes without awaiting anything — the shape browsers reliably accept.
- When the cache is cold, `copyLazyTextToClipboard` hands the pending text to `ClipboardItem` as a promise, which keeps the gesture alive across the fetch. Engines that reject promise-valued `ClipboardItem` fall back to await-then-`writeText`, and `navigator.clipboard` being absent entirely (non-secure context, e.g. a self-hosted workspace on plain HTTP) falls back to a hidden-textarea `execCommand` copy.

## Tests

- `copy-file-button.test.tsx` — cached-copy without refetch, icon toggle and revert, cold-cache fetch, binary refusal, failed load, truncated-file wording.
- `clipboard.test.ts` — `ClipboardItem` promise path, fallback on rejection (loader called once), `execCommand` path, and that a loader error is surfaced rather than the clipboard's generic one.
- `file-types.test.ts` — extensionless/unknown extensions now copyable, binary ones not; `looksBinary` cases including the 8 KB sample window.
- `file-preview.spec.ts` — new Playwright test asserting the real clipboard actually holds the file text after a click (this is what would catch a gesture regression), plus copy hidden on an image tab.

`npm run test:run` (10,553), `typecheck`, and `lint` pass. `file-preview.spec.ts` passes end-to-end in Chromium.

## Note

I could not open the screenshot attached to the ticket (Linear's uploads host isn't reachable from the agent's proxy), so I placed the button next to the existing Download action in the file-preview header — the app's only file-viewer toolbar. Happy to move it if the screenshot meant somewhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
