### PR TITLE
Fold compact boundaries into completed turn work

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -643,6 +643,39 @@ describe('MessageList', () => {
     expect(screen.queryByText('Hidden intermediate work.')).not.toBeInTheDocument()
   })
 
+  it('folds a mid-turn compact boundary into collapsed work', () => {
+    mockMessagesData.data = [
+      createUserMessage({
+        content: { text: 'Do the long-running work' },
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      }),
+      createAssistantMessage({
+        content: { text: 'Working before compaction.' },
+        createdAt: new Date('2025-01-01T00:00:10Z'),
+        toolCalls: [createToolCall({ name: 'Bash' })],
+      }),
+      createCompactBoundary({
+        summary: 'Summary of the early work.',
+        createdAt: new Date('2025-01-01T00:00:20Z'),
+      }),
+      createAssistantMessage({
+        content: { text: 'Final answer after compaction.' },
+        createdAt: new Date('2025-01-01T00:00:30Z'),
+      }),
+    ]
+
+    renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+
+    expect(screen.getByText('Final answer after compaction.')).toBeInTheDocument()
+    expect(screen.queryByText('Working before compaction.')).not.toBeInTheDocument()
+    expect(screen.queryByText('Compacted')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('turn-summary'))
+
+    expect(screen.getByText('Working before compaction.')).toBeInTheDocument()
+    expect(screen.getByText('Compacted')).toBeInTheDocument()
+  })
+
   it('keeps a cancelled terminal tool call visible without an empty disclosure row', () => {
     mockMessagesData.data = [
       createUserMessage({

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -1124,14 +1124,11 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
           const isAssistantItem = item.type === 'assistant'
           const isAnswerMessage =
             !!turn && isAssistantItem && turn.answerMessageIds.has(item.id)
-          const hideItem =
-            collapsed &&
-            isAssistantItem &&
-            !isAnswerMessage
-          const isRevealedWorkItem =
-            expanded &&
-            isAssistantItem &&
-            !isAnswerMessage
+          const isFoldedWorkItem =
+            (isAssistantItem && !isAnswerMessage) ||
+            item.type === 'compact_boundary'
+          const hideItem = collapsed && isFoldedWorkItem
+          const isRevealedWorkItem = expanded && isFoldedWorkItem
 
           let renderedItem: ReactNode = null
           if (!hideItem) {
@@ -1179,15 +1176,19 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
                   )}
                 </>
               )
-              renderedItem = isRevealedWorkItem ? (
-                <div
-                  className={TURN_WORK_REVEAL_CLASS}
-                  data-testid="turn-work-detail"
-                >
-                  {messageItem}
-                </div>
-              ) : messageItem
+              renderedItem = messageItem
             }
+          }
+
+          if (renderedItem && isRevealedWorkItem) {
+            renderedItem = (
+              <div
+                className={TURN_WORK_REVEAL_CLASS}
+                data-testid="turn-work-detail"
+              >
+                {renderedItem}
+              </div>
+            )
           }
 
           return (


### PR DESCRIPTION
## Summary

- fold mid-turn compact-boundary markers into the completed turn disclosure
- reveal compact boundaries with the rest of the work when the summary is expanded
- add a regression test covering the reported collapsed-conversation layout

## Test plan

- npm test -- --run src/renderer/components/messages/message-list.test.tsx
- npm run typecheck
- ./node_modules/.bin/eslint src/renderer/components/messages/message-list.tsx src/renderer/components/messages/message-list.test.tsx