### PR TITLE
Cut the wait from landing to Setting up your agent (SUP-707)

### DIFF
--- a/perf/skillset-install.perf.ts
+++ b/perf/skillset-install.perf.ts
@@ -1,0 +1,98 @@
+/**
+ * Cold skillset unpack + template install under the NFS shim.
+ * Wall budgets are the onboarding targets at BUDGET_LATENCY_MS (10 ms/op).
+ */
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { afterAll, beforeAll, describe, it } from 'vitest'
+import { createZipBuffer } from '@shared/lib/utils/zip'
+import { extractZipToDir } from '@shared/lib/skillset-provider/public-provider'
+import { expectWithinBudget, measure } from './harness'
+
+const EXTRACT_ENTRIES = 770
+const INSTALL_FILES = 40
+
+function buildExtractZip(): Promise<Buffer> {
+  const files: Record<string, string> = {}
+  for (let i = 0; i < EXTRACT_ENTRIES; i++) {
+    const name = `file-${String(i).padStart(4, '0')}.txt`
+    files[`owner-repo-abc123/${name}`] = `entry-${i}\n`
+  }
+  return createZipBuffer(files)
+}
+
+describe('skillset install', () => {
+  let dataDir: string
+  let extractZip: Buffer
+  let previousDataDir: string | undefined
+  let installAgentFromSkillset: typeof import('@shared/lib/services/agent-template-service').installAgentFromSkillset
+  let getSkillsetRepoDir: typeof import('@shared/lib/services/skillset-service').getSkillsetRepoDir
+
+  beforeAll(async () => {
+    previousDataDir = process.env.SUPERAGENT_DATA_DIR
+    dataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'superagent-perf-skillset-'))
+    process.env.SUPERAGENT_DATA_DIR = dataDir
+    extractZip = await buildExtractZip()
+    ;({ installAgentFromSkillset } = await import('@shared/lib/services/agent-template-service'))
+    ;({ getSkillsetRepoDir } = await import('@shared/lib/services/skillset-service'))
+  })
+
+  afterAll(async () => {
+    if (previousDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = previousDataDir
+    await fs.promises.rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('extracts a 770-entry zip within the catalog budget', async () => {
+    const dest = path.join(dataDir, 'extract-dest')
+    const { measurement } = await measure(() => extractZipToDir(extractZip, dest))
+    expectWithinBudget('skillset extractZipToDir', measurement, {
+      totalOps: 10_000,
+      wallMs: 1500,
+    })
+  })
+
+  it('installs from a seeded cache within the install budget', async () => {
+    const skillsetId = 'perf-skillset'
+    const agentPath = 'agents/perf-template/'
+    const repoDir = getSkillsetRepoDir(skillsetId)
+    const templateDir = path.join(repoDir, 'agents', 'perf-template')
+    await fs.promises.mkdir(templateDir, { recursive: true })
+    await fs.promises.writeFile(
+      path.join(templateDir, 'CLAUDE.md'),
+      '---\nname: Perf Template\n---\n# Perf\n',
+      'utf-8',
+    )
+    for (let i = 0; i < INSTALL_FILES; i++) {
+      await fs.promises.writeFile(
+        path.join(templateDir, `skill-${String(i).padStart(2, '0')}.md`),
+        `# skill ${i}\n`,
+        'utf-8',
+      )
+    }
+    await fs.promises.writeFile(
+      path.join(repoDir, '.skillset-cache-meta.json'),
+      JSON.stringify({ provider: 'public', cachedAt: new Date().toISOString() }),
+      'utf-8',
+    )
+
+    const { measurement } = await measure(() =>
+      installAgentFromSkillset(
+        {
+          skillsetId,
+          skillsetUrl: 'https://github.com/example/perf-skillset',
+          provider: 'public',
+          skillsetName: 'Perf',
+        },
+        agentPath,
+        'Perf Agent',
+        '1.0.0',
+      ),
+    )
+    expectWithinBudget('skillset installAgentFromSkillset', measurement, {
+      totalOps: 10_000,
+      wallMs: 500,
+    })
+  })
+})

--- a/src/renderer/components/agents/create-agent-form.handoff.test.tsx
+++ b/src/renderer/components/agents/create-agent-form.handoff.test.tsx
@@ -143,6 +143,11 @@ vi.mock('@renderer/hooks/use-voice-input', () => ({
   },
 }))
 
+const toastError = vi.fn()
+vi.mock('sonner', () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args), success: vi.fn() },
+}))
+
 vi.mock('@renderer/components/agents/template-install-dialog', () => ({
   TemplateInstallDialog: (props: { template: unknown }) => {
     lastDialogProps = props
@@ -445,6 +450,7 @@ describe('CreateAgentForm signup handoff', () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(6000)
       })
+      expect(toastError).toHaveBeenCalledWith('Could not load templates')
       expect(screen.getByTestId('create-agent-prompt')).toHaveFocus()
 
       // Settled for good — a list that shows up afterwards must not pop the offer.

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -338,6 +338,7 @@ export function CreateAgentForm({ header, onAgentCreated, onNavigateAway, classN
       // also caps how late an offer may appear on a slow list — a dialog opening
       // minutes after landing reads as a glitch, not an offer.
       const timer = setTimeout(() => {
+        toast.error('Could not load templates')
         setHandoffTemplateSlug(null)
         focusComposer()
       }, HANDOFF_TEMPLATE_WAIT_MS)

--- a/src/renderer/hooks/use-agent-templates.loading.test.ts
+++ b/src/renderer/hooks/use-agent-templates.loading.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { isWaitingOnDiscoverableRefresh } from './use-agent-templates'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+const agent = { path: 'agents/research-bot/' } as ApiDiscoverableAgent
+
+describe('isWaitingOnDiscoverableRefresh', () => {
+  it('is loading when the first catalog is empty and refresh is still pending', () => {
+    expect(isWaitingOnDiscoverableRefresh([], 'pending')).toBe(true)
+    expect(isWaitingOnDiscoverableRefresh([], undefined)).toBe(true)
+    expect(isWaitingOnDiscoverableRefresh([], 'idle')).toBe(true)
+  })
+
+  it('is not loading after refresh settles on an empty catalog', () => {
+    expect(isWaitingOnDiscoverableRefresh([], 'done')).toBe(false)
+  })
+
+  it('is not loading when the first catalog already has templates', () => {
+    expect(isWaitingOnDiscoverableRefresh([agent], 'pending')).toBe(false)
+  })
+
+  it('is not loading when the catalog has not arrived yet', () => {
+    expect(isWaitingOnDiscoverableRefresh(undefined, 'pending')).toBe(false)
+  })
+})

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -27,6 +27,16 @@ type ApiAgentTemplateStatus = ApiItemStatus
 // Module-level flag ensures the background refresh fires only once across all
 // component instances that call useDiscoverableAgents().
 let refreshPromise: Promise<void> | null = null
+const DISCOVERABLE_REFRESH_KEY = ['discoverable-agents-refresh'] as const
+type DiscoverableRefreshState = 'idle' | 'pending' | 'done'
+
+/** Empty first catalog + refresh still in flight. Consumers treat this as loading. */
+export function isWaitingOnDiscoverableRefresh(
+  agents: ApiDiscoverableAgent[] | undefined,
+  refreshState: DiscoverableRefreshState | undefined,
+): boolean {
+  return Array.isArray(agents) && agents.length === 0 && refreshState !== 'done'
+}
 
 /**
  * Fetch discoverable agents from skillsets.
@@ -39,7 +49,7 @@ export function useDiscoverableAgents() {
   const { data: skillsets } = useSkillsets()
   const hasSkillsets = !!(skillsets && skillsets.length > 0)
 
-  return useQuery<ApiDiscoverableAgent[]>({
+  const query = useQuery<ApiDiscoverableAgent[]>({
     queryKey: ['discoverable-agents'],
     enabled: hasSkillsets,
     queryFn: async () => {
@@ -50,6 +60,7 @@ export function useDiscoverableAgents() {
 
       // Kick off a single background refresh the first time any component fetches
       if (!refreshPromise) {
+        queryClient.setQueryData(DISCOVERABLE_REFRESH_KEY, 'pending')
         refreshPromise = apiFetch('/api/agents/discoverable-agents?refresh=true')
           .then(async (refreshRes) => {
             if (refreshRes.ok) {
@@ -61,11 +72,31 @@ export function useDiscoverableAgents() {
             }
           })
           .catch(() => { /* ignore background refresh failures */ })
+          .finally(() => {
+            queryClient.setQueryData(DISCOVERABLE_REFRESH_KEY, 'done')
+          })
+      } else {
+        void refreshPromise.finally(() => {
+          queryClient.setQueryData(DISCOVERABLE_REFRESH_KEY, 'done')
+        })
       }
 
       return agents
     },
   })
+
+  const { data: refreshState } = useQuery<DiscoverableRefreshState>({
+    queryKey: DISCOVERABLE_REFRESH_KEY,
+    queryFn: () => 'idle',
+    enabled: false,
+    staleTime: Infinity,
+  })
+  const waitingOnRefresh = isWaitingOnDiscoverableRefresh(query.data, refreshState)
+
+  return {
+    ...query,
+    isLoading: query.isLoading || waitingOnRefresh,
+  }
 }
 
 export function useHostExportStatus() {

--- a/src/shared/lib/config/data-dir.test.ts
+++ b/src/shared/lib/config/data-dir.test.ts
@@ -1,17 +1,20 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import os from 'os'
 import path from 'path'
-import { getDataDir, getDatabasePath } from './data-dir'
+import { getCacheDir, getDataDir, getDatabasePath } from './data-dir'
 
 describe('getDataDir / getDatabasePath', () => {
   const prevDataDir = process.env.SUPERAGENT_DATA_DIR
   const prevDbPath = process.env.SUPERAGENT_DB_PATH
+  const prevCacheDir = process.env.SUPERAGENT_CACHE_DIR
 
   afterEach(() => {
     if (prevDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
     else process.env.SUPERAGENT_DATA_DIR = prevDataDir
     if (prevDbPath === undefined) delete process.env.SUPERAGENT_DB_PATH
     else process.env.SUPERAGENT_DB_PATH = prevDbPath
+    if (prevCacheDir === undefined) delete process.env.SUPERAGENT_CACHE_DIR
+    else process.env.SUPERAGENT_CACHE_DIR = prevCacheDir
   })
 
   it('defaults DB path to ~/.superagent/superagent.db', () => {
@@ -39,5 +42,18 @@ describe('getDataDir / getDatabasePath', () => {
     delete process.env.SUPERAGENT_DATA_DIR
     process.env.SUPERAGENT_DB_PATH = 'relative/superagent.db'
     expect(getDatabasePath()).toBe(path.resolve('relative/superagent.db'))
+  })
+
+  it('defaults cache dir to getDataDir()/skillset-cache', () => {
+    delete process.env.SUPERAGENT_DATA_DIR
+    delete process.env.SUPERAGENT_CACHE_DIR
+    expect(getCacheDir()).toBe(path.join(os.homedir(), '.superagent', 'skillset-cache'))
+  })
+
+  it('uses SUPERAGENT_CACHE_DIR when set', () => {
+    process.env.SUPERAGENT_DATA_DIR = '/tmp/sa-data'
+    process.env.SUPERAGENT_CACHE_DIR = '/tmp/sa-cache'
+    expect(getCacheDir()).toBe(path.resolve('/tmp/sa-cache'))
+    expect(getDataDir()).toBe(path.resolve('/tmp/sa-data'))
   })
 })

--- a/src/shared/lib/config/data-dir.ts
+++ b/src/shared/lib/config/data-dir.ts
@@ -33,6 +33,19 @@ export function getDatabasePath(): string {
 }
 
 /**
+ * Regenerable cache directory (skillset zip unpack, etc.).
+ * SUPERAGENT_CACHE_DIR overrides the default ($SUPERAGENT_DATA_DIR/skillset-cache).
+ * Desktop is unchanged when the env is unset.
+ */
+export function getCacheDir(): string {
+  const envCacheDir = process.env.SUPERAGENT_CACHE_DIR
+  if (envCacheDir) {
+    return path.resolve(envCacheDir)
+  }
+  return path.join(getDataDir(), 'skillset-cache')
+}
+
+/**
  * Get the path to the agents data directory.
  * This is where agent workspaces are stored.
  */

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import crypto from 'crypto'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -1262,6 +1263,35 @@ describe('computeAgentTemplateHash', () => {
     const hash2 = await computeAgentTemplateHash(dir)
     expect(hash1).toBe(hash2)
     expect(hash1).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('digest is byte-identical to the serial implementation on a fixture tree', async () => {
+    const files: Record<string, string> = {
+      'CLAUDE.md': MINIMAL_CLAUDE_MD,
+      'a.txt': 'a-content',
+      'b.txt': 'b-content',
+      'c.txt': 'c-content',
+      'd.txt': 'd-content',
+      'e.txt': 'e-content',
+      'f.txt': 'f-content',
+      'g.txt': 'g-content',
+      'h.txt': 'h-content',
+      'i.txt': 'i-content',
+      'sub/m.txt': 'm-content',
+      'sub/z.txt': 'z-content',
+    }
+    const dir = createDir({
+      ...files,
+      '.env': 'SECRET=nope',
+      'uploads/skip.pdf': 'pdf',
+    })
+
+    const serial = crypto.createHash('sha256')
+    for (const relativePath of Object.keys(files).sort()) {
+      serial.update(relativePath)
+      serial.update(files[relativePath])
+    }
+    expect(await computeAgentTemplateHash(dir)).toBe(serial.digest('hex'))
   })
 })
 

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -9,6 +9,7 @@ import crypto from 'crypto'
 import path from 'path'
 import fs from 'fs'
 import { Readable } from 'stream'
+import pLimit from 'p-limit'
 import archiver from 'archiver'
 import {
   openZipFromBuffer,
@@ -890,17 +891,22 @@ export async function computeAgentTemplateHash(workspaceDir: string): Promise<st
   const files = await walkTemplateFiles(workspaceDir)
   files.sort() // Ensure deterministic order
 
-  const hash = crypto.createHash('sha256')
-
-  for (const relativePath of files) {
-    const fullPath = path.join(workspaceDir, relativePath)
+  const limit = pLimit(8)
+  const contents = new Map<string, string>()
+  await Promise.all(files.map((relativePath) => limit(async () => {
     try {
-      const content = await fs.promises.readFile(fullPath, 'utf-8')
-      hash.update(relativePath)
-      hash.update(content)
+      contents.set(relativePath, await fs.promises.readFile(path.join(workspaceDir, relativePath), 'utf-8'))
     } catch {
       // Skip unreadable files
     }
+  })))
+
+  const hash = crypto.createHash('sha256')
+  for (const relativePath of files) {
+    const content = contents.get(relativePath)
+    if (content === undefined) continue
+    hash.update(relativePath)
+    hash.update(content)
   }
 
   return hash.digest('hex')

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -12,7 +12,7 @@ import crypto from 'crypto'
 import path from 'path'
 import fs from 'fs'
 import yaml from 'js-yaml'
-import { getDataDir } from '@shared/lib/config/data-dir'
+import { getCacheDir } from '@shared/lib/config/data-dir'
 import { getEffectiveModels } from '@shared/lib/config/settings'
 import { getConfiguredLlmClient, createSummarizerText } from '@shared/lib/llm-provider/helpers'
 import { resolveActiveProviderModel } from '@shared/lib/llm-provider'
@@ -75,7 +75,7 @@ const activeSkillsetRefreshes = new Map<string, Promise<SkillsetIndex>>()
 // ============================================================================
 
 function getSkillsetCacheDir(): string {
-  return path.join(getDataDir(), 'skillset-cache')
+  return getCacheDir()
 }
 
 export function getSkillsetRepoDir(skillsetId: string): string {

--- a/src/shared/lib/skillset-provider/public-provider.test.ts
+++ b/src/shared/lib/skillset-provider/public-provider.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { createZipBuffer } from '@shared/lib/utils/zip'
+import { createZipBuffer, ZipExtractionSizeError } from '@shared/lib/utils/zip'
 
 vi.mock('@shared/lib/utils/retry', async () => {
   const actual = await vi.importActual<typeof import('@shared/lib/utils/retry')>(
@@ -19,7 +19,7 @@ vi.mock('@shared/lib/error-reporting', () => ({
 }))
 
 import { NonRetryableError } from '@shared/lib/utils/retry'
-import { PublicSkillsetProvider } from './public-provider'
+import { extractZipToDir, PublicSkillsetProvider } from './public-provider'
 
 const provider = new PublicSkillsetProvider()
 
@@ -263,6 +263,44 @@ describe('PublicSkillsetProvider.populateCache', () => {
     await provider.populateCache(destDir, makeRef('https://github.com/Org/repo'))
 
     expect(JSON.parse(await fs.promises.readFile(path.join(destDir, 'index.json'), 'utf-8'))).toEqual({ flat: true })
+  })
+})
+
+describe('extractZipToDir size cap', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'public-provider-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rejects before writing when declared sizes exceed the cap', async () => {
+    const destDir = path.join(tmpDir, 'cache')
+    const zipBuffer = await buildTestZip({
+      'a.txt': 'aaaa',
+      'b.txt': 'bbbb',
+      'c.txt': 'cccc',
+    })
+
+    await expect(extractZipToDir(zipBuffer, destDir, 10)).rejects.toBeInstanceOf(ZipExtractionSizeError)
+    expect(fs.existsSync(path.join(destDir, 'a.txt'))).toBe(false)
+    expect(fs.existsSync(path.join(destDir, 'b.txt'))).toBe(false)
+    expect(fs.existsSync(path.join(destDir, 'c.txt'))).toBe(false)
+  })
+
+  it('extracts when declared sizes fit under the cap', async () => {
+    const destDir = path.join(tmpDir, 'cache')
+    const zipBuffer = await buildTestZip({
+      'a.txt': 'aaaa',
+      'b.txt': 'bbbb',
+    })
+
+    await extractZipToDir(zipBuffer, destDir, 100)
+    expect(await fs.promises.readFile(path.join(destDir, 'a.txt'), 'utf-8')).toBe('aaaa')
+    expect(await fs.promises.readFile(path.join(destDir, 'b.txt'), 'utf-8')).toBe('bbbb')
   })
 })
 

--- a/src/shared/lib/skillset-provider/public-provider.ts
+++ b/src/shared/lib/skillset-provider/public-provider.ts
@@ -1,7 +1,8 @@
 import path from 'path'
 import fs from 'fs'
+import pLimit from 'p-limit'
 import { ensureDirectory } from '@shared/lib/utils/file-storage'
-import { openZipFromBuffer, detectZipPrefix } from '@shared/lib/utils/zip'
+import { openZipFromBuffer, detectZipPrefix, ZipExtractionSizeError } from '@shared/lib/utils/zip'
 import { validateSafeCloneUrl } from '@shared/lib/utils/url-safety'
 import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 import { withRetry, NonRetryableError } from '@shared/lib/utils/retry'
@@ -41,7 +42,9 @@ export class PublicSkillsetProvider extends BaseSkillsetProvider {
       throw new Error('Public skillset provider requires a URL')
     }
     const zipballUrl = buildZipballUrl(ref.skillsetUrl)
-    await downloadAndExtract(zipballUrl, cacheDir, ref.skillsetUrl)
+    const zipBuffer = await downloadZip(zipballUrl, ref.skillsetUrl)
+    await extractZipToDir(zipBuffer, cacheDir)
+    await writeCacheMeta(cacheDir, ref.skillsetUrl)
   }
 
   override async refreshCache(cacheDir: string, ref: SkillsetProviderRef): Promise<void> {
@@ -80,16 +83,12 @@ function buildZipballUrl(repoUrl: string): string {
   return `https://api.github.com/repos/${owner}/${repo}/zipball`
 }
 
-async function downloadAndExtract(
-  zipballUrl: string,
-  destDir: string,
-  originalUrl: string,
-): Promise<void> {
+async function downloadZip(zipballUrl: string, originalUrl: string): Promise<Buffer> {
   validateSafeCloneUrl(zipballUrl, {
     allowedHostPrefixes: ['https://api.github.com'],
   })
 
-  const zipBuffer = await withRetry(async () => {
+  return withRetry(async () => {
     const response = await fetch(zipballUrl, {
       headers: {
         'Accept': 'application/vnd.github+json',
@@ -119,15 +118,20 @@ async function downloadAndExtract(
     }
     return Buffer.from(await response.arrayBuffer())
   }, 3, 1000)
+}
 
+export async function extractZipToDir(
+  zipBuffer: Buffer,
+  destDir: string,
+  maxBytes = 500 * 1024 * 1024,
+): Promise<void> {
   const reader = await openZipFromBuffer(zipBuffer)
   try {
     const stripPrefix = detectZipPrefix(reader.entries)
 
     await ensureDirectory(destDir)
 
-    const MAX_SKILLSET_SIZE = 500 * 1024 * 1024
-    let totalExtracted = 0
+    const jobs: Array<{ fileName: string; destPath: string; uncompressedSize: number }> = []
     for (const entry of reader.entries) {
       if (entry.isDirectory) continue
 
@@ -141,18 +145,25 @@ async function downloadAndExtract(
       const destPath = path.resolve(destDir, entryName)
       if (!isPathWithinDir(destDir, destPath)) continue
 
-      await ensureDirectory(path.dirname(destPath))
-      const bytesWritten = await reader.extractEntry(
-        entry.fileName,
-        destPath,
-        MAX_SKILLSET_SIZE - totalExtracted,
-      )
-      totalExtracted += bytesWritten
+      jobs.push({ fileName: entry.fileName, destPath, uncompressedSize: entry.uncompressedSize })
     }
+
+    const declared = jobs.reduce((sum, job) => sum + job.uncompressedSize, 0)
+    if (declared > maxBytes) {
+      throw new ZipExtractionSizeError(maxBytes, declared)
+    }
+
+    const limit = pLimit(8)
+    await Promise.all(jobs.map((job) => limit(async () => {
+      await ensureDirectory(path.dirname(job.destPath))
+      await reader.extractEntry(job.fileName, job.destPath, job.uncompressedSize)
+    })))
   } finally {
     reader.close()
   }
+}
 
+async function writeCacheMeta(destDir: string, originalUrl: string): Promise<void> {
   await fs.promises.writeFile(
     path.join(destDir, CACHE_META_FILENAME),
     JSON.stringify({

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { Transform } from 'stream'
 import type { ZodType } from 'zod'
+import pLimit from 'p-limit'
 import { getDataDir } from '@shared/lib/config/data-dir'
 import { assertPathWithinDir } from '@shared/lib/utils/path-safety'
 
@@ -843,6 +844,16 @@ export async function copyDirectoryFiltered(
   dest: string,
   extraExclusions?: string[],
 ): Promise<void> {
+  const limit = pLimit(8)
+  await copyDirectoryFilteredLimited(src, dest, extraExclusions, limit)
+}
+
+async function copyDirectoryFilteredLimited(
+  src: string,
+  dest: string,
+  extraExclusions: string[] | undefined,
+  limit: ReturnType<typeof pLimit>,
+): Promise<void> {
   await ensureDirectory(dest)
   const entries = await fs.promises.readdir(src, { withFileTypes: true })
 
@@ -850,6 +861,7 @@ export async function copyDirectoryFiltered(
     ? new Set([...DEFAULT_COPY_EXCLUDED, ...extraExclusions])
     : DEFAULT_COPY_EXCLUDED
 
+  const tasks: Promise<void>[] = []
   for (const entry of entries) {
     if (excluded.has(entry.name)) continue
 
@@ -857,11 +869,12 @@ export async function copyDirectoryFiltered(
     const destPath = path.join(dest, entry.name)
 
     if (entry.isDirectory()) {
-      await copyDirectoryFiltered(srcPath, destPath, extraExclusions)
+      tasks.push(copyDirectoryFilteredLimited(srcPath, destPath, extraExclusions, limit))
     } else {
-      await fs.promises.copyFile(srcPath, destPath)
+      tasks.push(limit(() => fs.promises.copyFile(srcPath, destPath)))
     }
   }
+  await Promise.all(tasks)
 }
 
 /**


### PR DESCRIPTION
After signup, landing waits on the template catalog and install before Setting up your agent can start. On cold cloud that dead air is serial NFS work, so this unpacks, copies, and hashes eight-wide and lets the cache leave the data volume when SUPERAGENT_CACHE_DIR is set. The roster stays loading until that first refresh finishes, and a toast fires if templates never arrive.

Closes https://linear.app/datawizz/issue/SUP-707

7 production files, about 60 lines. 5 test files plus a perf harness.

After landing:
- catalog not ready → wait here
- match found → Installing {name}
- install done → Setting up your agent...

First catalog fetch:
- list empty and refresh not finished → keep loading
- list empty and refresh finished → show empty
- 10s and still nothing → toast Could not load templates

Zip unpack:
- sum declared sizes first
- over 500 MB → refuse, no files written
- otherwise write eight at a time

Template install:
- copy eight at a time
- read eight at a time, hash in today's sorted order

Cache location:
- env unset → same path as today, under the data dir
- env set → that directory
- later pin this onto local disk to cut the remaining NFS hops
- this PR is safe without that pin

Not in this PR:
- the Setting up your agent modal staying up (container start)
- changing which files go into the hash, or the digest bytes
