### PR TITLE
Stay on the workspace for a template-only first run (SUP-711)

### DIFF
--- a/e2e/auth/specs/template-handoff.spec.ts
+++ b/e2e/auth/specs/template-handoff.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * A homepage template pick carried through signup installs on the
+ * cloud-style first run. The workspace stays on screen. Today's install
+ * dialog, then the setup spinner, then the agent. No create screen.
+ *
+ * Serial on a dedicated server (auth-template-handoff project). The admin
+ * signs up, skips the wizard once so the app shell exists, then the test
+ * resets that user's setupCompleted and lands with the slug in the URL.
+ */
+import { test, expect } from '../fixtures/multi-user.fixture'
+import { AuthPage } from '../pages/auth.page'
+import { AppPage } from '../../pages/app.page'
+
+test.describe.configure({ mode: 'serial' })
+
+const admin = { name: 'Handoff Admin', email: 'handoff-admin@test.com', password: 'password123' }
+
+test.describe('Signup template handoff', () => {
+  test('admin signs up and finishes the first-run screen once', async ({ request, user1Page }) => {
+    const authPage = new AuthPage(user1Page)
+    const appPage = new AppPage(user1Page)
+    await user1Page.context().clearCookies()
+    await user1Page.goto('/')
+    await authPage.expectVisible()
+    const config = await (await request.get('/api/auth-config')).json() as { hasUsers: boolean }
+    if (config.hasUsers) await authPage.signIn(admin.email, admin.password)
+    else await authPage.signUpOrSignIn(admin.name, admin.email, admin.password)
+    await appPage.waitForAppLoaded()
+    await appPage.dismissWizardIfVisible()
+  })
+
+  test('template_slug installs on the workspace with no first-run screen', async ({ user1Page }) => {
+    // Per-user flag, so the PUT must ride the signed-in page's cookies, not the bare request fixture.
+    const reset = await user1Page.request.put('/api/user-settings', {
+      data: { setupCompleted: false, onboardingProgress: null },
+    })
+    expect(reset.ok()).toBe(true)
+
+    await user1Page.goto('/?template_slug=e2e-onboarding-template')
+
+    const sidebar = user1Page.locator('[data-testid="app-sidebar"]')
+    await expect(sidebar).toBeVisible()
+    await expect(user1Page.locator('[data-testid="wizard-container"]')).toHaveCount(0)
+    await expect(user1Page.locator('[data-testid="create-agent-prompt"]')).toHaveCount(0)
+
+    const install = user1Page.getByTestId('template-install-status')
+    const setup = user1Page.getByTestId('onboarding-setup-dialog')
+    await expect(install.or(setup).first()).toBeVisible({ timeout: 15_000 })
+
+    await expect(user1Page).toHaveURL(/\/agents\//, { timeout: 30_000 })
+    await expect(user1Page.locator('[data-testid="wizard-container"]')).toHaveCount(0)
+    await expect(user1Page.locator('[data-testid="create-agent-prompt"]')).toHaveCount(0)
+    await expect(setup).toBeHidden()
+    await expect(sidebar.getByText('E2E Onboarding Template', { exact: true })).toBeVisible()
+
+    await expect.poll(async () => {
+      const settings = await (await user1Page.request.get('/api/user-settings')).json()
+      return settings.setupCompleted === true && settings.onboardingProgress === null
+    }).toBe(true)
+  })
+
+  test('reload does not bring the first-run screen back', async ({ user1Page }) => {
+    await user1Page.goto('/')
+    await expect(user1Page.locator('[data-testid="app-sidebar"]')).toBeVisible()
+    await expect(user1Page.locator('[data-testid="wizard-container"]')).toHaveCount(0)
+  })
+})

--- a/e2e/setup-e2e-data.js
+++ b/e2e/setup-e2e-data.js
@@ -93,7 +93,9 @@ execFileSync('git', [...GIT_AUTHOR, 'commit', '-q', '-m', 'seed'], { cwd: SKILLS
 execFileSync('git', ['remote', 'add', 'origin', SKILLSET_FAKE_URL], { cwd: SKILLSET_REPO_DIR, stdio: 'pipe' })
 
 // Seed a public-provider skillset (no .git, uses .skillset-cache-meta.json marker).
-const PUBLIC_SKILLSET_ID = 'e2e-public-skillset'
+// Must equal DEFAULT_PUBLIC_SKILLSET.id (src/shared/lib/skillset-provider/default-public-skillset.ts):
+// the signup template handoff only matches entries from the default public skillset.
+const PUBLIC_SKILLSET_ID = 'github-com-skillfulagents-public-skillset'
 const PUBLIC_SKILLSET_DIR = path.join(resolvedDir, 'skillset-cache', PUBLIC_SKILLSET_ID)
 fs.rmSync(PUBLIC_SKILLSET_DIR, { recursive: true, force: true })
 fs.mkdirSync(PUBLIC_SKILLSET_DIR, { recursive: true })

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -61,6 +61,13 @@ const authProjects = [
     dataDir: path.join(e2eDataDir, 'mobile-pairing'),
     viteCacheDir: path.join(e2eDataDir, '.vite', 'mobile-pairing'),
   },
+  {
+    name: 'auth-template-handoff',
+    testMatch: '**/template-handoff.spec.ts',
+    port: e2ePort + 7,
+    dataDir: path.join(e2eDataDir, 'template-handoff'),
+    viteCacheDir: path.join(e2eDataDir, '.vite', 'template-handoff'),
+  },
 ].map((project, index) => ({
   ...project,
   baseURL: index === 0 && process.env.E2E_BASE_URL

--- a/src/renderer/components/layout/route-layouts.tsx
+++ b/src/renderer/components/layout/route-layouts.tsx
@@ -1,4 +1,4 @@
-import { lazyRouteComponent, Outlet } from '@tanstack/react-router'
+import { lazyRouteComponent, Outlet, useRouterState } from '@tanstack/react-router'
 import { Suspense, useCallback, useState, useEffect, useRef } from 'react'
 import { DialogProvider } from '@renderer/context/dialog-context'
 import { UpdateStatusProvider } from '@renderer/context/update-status-context'
@@ -24,6 +24,8 @@ import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { useDocumentTitle } from '@renderer/hooks/use-document-title'
 import { setRendererErrorReportingEnabled, setRendererErrorReportingUser } from '@renderer/lib/error-reporting'
+import { homeSearchSchema } from '@renderer/router/search-schemas'
+import { lenient } from '@renderer/router/zod-search'
 
 const SearchDialog = lazyRouteComponent(
   () => import('@renderer/components/search/search-dialog'),
@@ -55,7 +57,15 @@ export function RootLayout() {
   const { isAuthMode, isAdmin, user } = useUser()
   const { open: searchOpen } = useSearch()
   const { identify } = useAnalyticsTracking()
+  const search = useRouterState({
+    select: (s) => s.location.search as Record<string, unknown>,
+  })
+  const { prompt, template_slug } = lenient(homeSearchSchema)(search)
   const hasAutoOpened = useRef(false)
+  // Latched from the URL on first sighting so stripping the params cannot
+  // reopen the create screen mid-install.
+  const templateHandoffArmed = useRef(false)
+  if (template_slug && !prompt) templateHandoffArmed.current = true
 
   useEffect(() => {
     identify()
@@ -121,6 +131,7 @@ export function RootLayout() {
       openWizard()
     } else if (globalSettings.setupCompleted) {
       hasAutoOpened.current = true
+      if (templateHandoffArmed.current) return
       setWizardAgentOnly(true)
       openWizard()
     }

--- a/src/renderer/components/signup-handoff-consumer.test.tsx
+++ b/src/renderer/components/signup-handoff-consumer.test.tsx
@@ -2,6 +2,47 @@
 
 import { render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+const completeInstall = vi.fn()
+const mutateAsync = vi.fn()
+const toastError = vi.fn()
+let mockDiscoverableAgents: ApiDiscoverableAgent[] | undefined
+let mockDiscoverableAgentsFailed = false
+let mockSetupCompleted = true
+
+vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => toastError(...args) } }))
+vi.mock('@renderer/hooks/use-user-settings', () => ({
+  useUserSettings: () => ({ data: { setupCompleted: mockSetupCompleted } }),
+  useUpdateUserSettings: () => ({ mutateAsync }),
+}))
+vi.mock('@renderer/hooks/use-agent-templates', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/hooks/use-agent-templates')>()
+  return {
+    ...actual,
+    useDiscoverableAgents: () => ({ data: mockDiscoverableAgents, isError: mockDiscoverableAgentsFailed }),
+  }
+})
+vi.mock('@renderer/hooks/use-complete-template-install', () => ({
+  useCompleteTemplateInstall: () => completeInstall,
+}))
+vi.mock('@renderer/components/agents/template-install-dialog', () => ({
+  TemplateInstallDialog: ({
+    template,
+    onInstalled,
+  }: {
+    template: ApiDiscoverableAgent | null
+    onInstalled: (agent: { slug: string }) => void | Promise<void>
+  }) => {
+    if (!template) return null
+    return (
+      <button type="button" data-testid="template-install-dialog" onClick={() => void onInstalled({ slug: 'seo-agent' })}>
+        {template.name}
+      </button>
+    )
+  },
+}))
 import {
   createMemoryHistory,
   createRootRoute,
@@ -47,9 +88,23 @@ function makeRouter(initialEntry: string) {
   })
 }
 
+const match: ApiDiscoverableAgent = {
+  skillsetId: DEFAULT_PUBLIC_SKILLSET.id,
+  skillsetName: 'Public',
+  name: 'SEO Agent',
+  description: 'seo',
+  version: '1.0.0',
+  path: 'agents/seo-agent/',
+}
+
 describe('SignupHandoffConsumer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockDiscoverableAgents = []
+    mockDiscoverableAgentsFailed = false
+    mockSetupCompleted = true
+    completeInstall.mockResolvedValue(undefined)
+    mutateAsync.mockResolvedValue({})
   })
 
   it('moves prompt+model into the one-shot and strips those keys from the URL', async () => {
@@ -101,7 +156,7 @@ describe('SignupHandoffConsumer', () => {
     })
   })
 
-  it('slug-only URL moves template_slug into the one-shot', async () => {
+  it('slug-only URL is stripped and not left in the one-shot', async () => {
     const router = makeRouter('/?template_slug=research-agent')
     const { getByTestId } = render(
       <NavTransientProvider>
@@ -110,10 +165,9 @@ describe('SignupHandoffConsumer', () => {
     )
 
     await waitFor(() => {
-      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
-        template_slug: 'research-agent',
-      })
+      expect((router.state.location.search as { template_slug?: string }).template_slug).toBeUndefined()
     })
+    expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toBeNull()
   })
 
   it('is a no-op when neither handoff param is present', async () => {
@@ -146,5 +200,92 @@ describe('SignupHandoffConsumer', () => {
         prompt: 'x'.repeat(400),
       })
     })
+  })
+})
+
+function renderSlugFirstRun(slug = 'seo-agent') {
+  mockSetupCompleted = false
+  const router = makeRouter(`/?template_slug=${slug}`)
+  return render(
+    <NavTransientProvider>
+      <RouterProvider router={router} />
+    </NavTransientProvider>,
+  )
+}
+
+describe('SignupHandoffConsumer template-only first run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDiscoverableAgents = undefined
+    mockDiscoverableAgentsFailed = false
+    mockSetupCompleted = false
+    completeInstall.mockResolvedValue(undefined)
+    mutateAsync.mockResolvedValue({})
+  })
+
+  it('match → opens the install dialog; complete then writes setupCompleted', async () => {
+    mockDiscoverableAgents = [match]
+    const { getByTestId } = renderSlugFirstRun()
+    await waitFor(() => expect(getByTestId('template-install-dialog')).toHaveTextContent('SEO Agent'))
+    getByTestId('template-install-dialog').click()
+    await waitFor(() => expect(completeInstall).toHaveBeenCalledWith({ slug: 'seo-agent' }))
+    expect(mutateAsync).toHaveBeenCalledWith({ setupCompleted: true, onboardingProgress: null })
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('populated, no match → toast, no dialog', async () => {
+    mockDiscoverableAgents = [{ ...match, path: 'agents/other/' }]
+    const { queryByTestId } = renderSlugFirstRun()
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Couldn't load that template", expect.anything()))
+    expect(queryByTestId('template-install-dialog')).toBeNull()
+    expect(completeInstall).not.toHaveBeenCalled()
+  })
+
+  it('catalog error → toast, no dialog', async () => {
+    mockDiscoverableAgentsFailed = true
+    renderSlugFirstRun()
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    expect(completeInstall).not.toHaveBeenCalled()
+  })
+
+  it('setup write fails after install → toast, agent already handed off', async () => {
+    mockDiscoverableAgents = [match]
+    mutateAsync.mockRejectedValue(new Error('PUT failed'))
+    const { getByTestId } = renderSlugFirstRun()
+    await waitFor(() => expect(getByTestId('template-install-dialog')).toBeInTheDocument())
+    getByTestId('template-install-dialog').click()
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Agent installed, but setup status could not be saved.', expect.anything()))
+    expect(completeInstall).toHaveBeenCalled()
+  })
+
+  it('prompt + slug first-run → no install, one-shot keeps both', async () => {
+    mockDiscoverableAgents = [match]
+    const router = makeRouter('/?prompt=hello&template_slug=seo-agent')
+    const { getByTestId, queryByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={router} />
+      </NavTransientProvider>,
+    )
+    await waitFor(() => {
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        prompt: 'hello',
+        template_slug: 'seo-agent',
+      })
+    })
+    expect(queryByTestId('template-install-dialog')).toBeNull()
+    expect(completeInstall).not.toHaveBeenCalled()
+  })
+
+  it('already finished first-run → no install', async () => {
+    mockSetupCompleted = true
+    mockDiscoverableAgents = [match]
+    const { queryByTestId } = render(
+      <NavTransientProvider>
+        <RouterProvider router={makeRouter('/?template_slug=seo-agent')} />
+      </NavTransientProvider>,
+    )
+    await waitFor(() => expect(queryByTestId('home')).toBeTruthy())
+    expect(queryByTestId('template-install-dialog')).toBeNull()
+    expect(completeInstall).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/signup-handoff-consumer.test.tsx
+++ b/src/renderer/components/signup-handoff-consumer.test.tsx
@@ -11,8 +11,16 @@ const toastError = vi.fn()
 let mockDiscoverableAgents: ApiDiscoverableAgent[] | undefined
 let mockDiscoverableAgentsFailed = false
 let mockSetupCompleted = true
+let mockGlobalSetupCompleted = true
+let mockIsAuthMode = true
 
 vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => toastError(...args) } }))
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({ isAuthMode: mockIsAuthMode }),
+}))
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => ({ data: { setupCompleted: mockGlobalSetupCompleted } }),
+}))
 vi.mock('@renderer/hooks/use-user-settings', () => ({
   useUserSettings: () => ({ data: { setupCompleted: mockSetupCompleted } }),
   useUpdateUserSettings: () => ({ mutateAsync }),
@@ -103,6 +111,8 @@ describe('SignupHandoffConsumer', () => {
     mockDiscoverableAgents = []
     mockDiscoverableAgentsFailed = false
     mockSetupCompleted = true
+    mockGlobalSetupCompleted = true
+    mockIsAuthMode = true
     completeInstall.mockResolvedValue(undefined)
     mutateAsync.mockResolvedValue({})
   })
@@ -156,7 +166,7 @@ describe('SignupHandoffConsumer', () => {
     })
   })
 
-  it('slug-only URL is stripped and not left in the one-shot', async () => {
+  it('completed first-run keeps a slug-only handoff after stripping the URL', async () => {
     const router = makeRouter('/?template_slug=research-agent')
     const { getByTestId } = render(
       <NavTransientProvider>
@@ -167,7 +177,9 @@ describe('SignupHandoffConsumer', () => {
     await waitFor(() => {
       expect((router.state.location.search as { template_slug?: string }).template_slug).toBeUndefined()
     })
-    expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toBeNull()
+    expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+      template_slug: 'research-agent',
+    })
   })
 
   it('is a no-op when neither handoff param is present', async () => {
@@ -219,6 +231,8 @@ describe('SignupHandoffConsumer template-only first run', () => {
     mockDiscoverableAgents = undefined
     mockDiscoverableAgentsFailed = false
     mockSetupCompleted = false
+    mockGlobalSetupCompleted = true
+    mockIsAuthMode = true
     completeInstall.mockResolvedValue(undefined)
     mutateAsync.mockResolvedValue({})
   })
@@ -285,6 +299,32 @@ describe('SignupHandoffConsumer template-only first run', () => {
       </NavTransientProvider>,
     )
     await waitFor(() => expect(queryByTestId('home')).toBeTruthy())
+    expect(queryByTestId('template-install-dialog')).toBeNull()
+    expect(completeInstall).not.toHaveBeenCalled()
+  })
+
+  it('global setup incomplete → leaves the handoff for the full wizard', async () => {
+    mockGlobalSetupCompleted = false
+    mockDiscoverableAgents = [match]
+    const { getByTestId, queryByTestId } = renderSlugFirstRun()
+    await waitFor(() => {
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        template_slug: 'seo-agent',
+      })
+    })
+    expect(queryByTestId('template-install-dialog')).toBeNull()
+    expect(completeInstall).not.toHaveBeenCalled()
+  })
+
+  it('local first run → leaves the handoff for the full wizard', async () => {
+    mockIsAuthMode = false
+    mockDiscoverableAgents = [match]
+    const { getByTestId, queryByTestId } = renderSlugFirstRun()
+    await waitFor(() => {
+      expect(JSON.parse(getByTestId('handoff').textContent ?? 'null')).toEqual({
+        template_slug: 'seo-agent',
+      })
+    })
     expect(queryByTestId('template-install-dialog')).toBeNull()
     expect(completeInstall).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/signup-handoff-consumer.tsx
+++ b/src/renderer/components/signup-handoff-consumer.tsx
@@ -1,12 +1,27 @@
 // Always-mounted (route-layouts, above the wizard branch): moves the marketing
 // signup handoff from the URL into the in-memory one-shot, then strips the
-// params. One effect, one shot.
-import { useEffect } from 'react'
+// params. A template-only first run also starts today's install here, because
+// the create form never mounts on that path.
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
-
+import { toast } from 'sonner'
+import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
 import { useNavTransient } from '@renderer/context/nav-transient-context'
+import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
+import { useCompleteTemplateInstall } from '@renderer/hooks/use-complete-template-install'
+import { useUpdateUserSettings, useUserSettings } from '@renderer/hooks/use-user-settings'
 import { homeSearchSchema } from '@renderer/router/search-schemas'
 import { lenient } from '@renderer/router/zod-search'
+import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+export const HANDOFF_TEMPLATE_WAIT_MS = 10000
+
+function toastTemplateNotFound() {
+  toast.error("Couldn't load that template", {
+    description: 'Pick one from Discover or create your own agent.',
+  })
+}
 
 export function SignupHandoffConsumer() {
   // location.search is raw parseSearch output (router-core) — not route-validated.
@@ -16,8 +31,22 @@ export function SignupHandoffConsumer() {
   })
   const navigate = useNavigate()
   const { setSignupHandoff } = useNavTransient()
+  const { data: userSettings } = useUserSettings()
+  const setupCompleted = userSettings?.setupCompleted
+  const settingsReady = userSettings !== undefined
+  const updateUserSettings = useUpdateUserSettings()
+  const { data: discoverableAgents, isError: discoverableAgentsFailed } = useDiscoverableAgents()
+  const completeInstall = useCompleteTemplateInstall()
+  const [template, setTemplate] = useState<ApiDiscoverableAgent | null>(null)
+  const resolvedRef = useRef(false)
+  const slugRef = useRef<string | null>(null)
 
   const { prompt, model, template_slug } = lenient(homeSearchSchema)(search)
+  if (!slugRef.current && template_slug && !prompt) {
+    slugRef.current = template_slug
+  }
+  const slug = slugRef.current
+
   useEffect(() => {
     if (!prompt && !model && !template_slug) return
     setSignupHandoff({ prompt, model, template_slug })
@@ -36,5 +65,52 @@ export function SignupHandoffConsumer() {
     })
   }, [prompt, model, template_slug, setSignupHandoff, navigate])
 
-  return null
+  useEffect(() => {
+    if (slug) setSignupHandoff(null)
+  }, [slug, setSignupHandoff])
+
+  useEffect(() => {
+    if (!slug || resolvedRef.current) return
+    if (!settingsReady || setupCompleted) return
+    if (discoverableAgentsFailed) {
+      resolvedRef.current = true
+      toastTemplateNotFound()
+      return
+    }
+    if (!discoverableAgents || discoverableAgents.length === 0) {
+      const timer = setTimeout(() => {
+        if (resolvedRef.current) return
+        resolvedRef.current = true
+        toastTemplateNotFound()
+      }, HANDOFF_TEMPLATE_WAIT_MS)
+      return () => clearTimeout(timer)
+    }
+    const target = discoverableAgents.find(
+      (a) => a.skillsetId === DEFAULT_PUBLIC_SKILLSET.id && slugFromAgentPath(a.path) === slug,
+    )
+    resolvedRef.current = true
+    if (!target) {
+      toastTemplateNotFound()
+      return
+    }
+    setTemplate(target)
+  }, [discoverableAgents, discoverableAgentsFailed, slug, settingsReady, setupCompleted])
+
+  return (
+    <TemplateInstallDialog
+      template={template}
+      onClose={() => setTemplate(null)}
+      onInstalled={async (agent) => {
+        try {
+          await completeInstall(agent)
+          await updateUserSettings.mutateAsync({ setupCompleted: true, onboardingProgress: null })
+        } catch (error) {
+          console.error('Template installed but setup finish failed:', error)
+          toast.error('Agent installed, but setup status could not be saved.', {
+            description: error instanceof Error ? error.message : 'Please try again from Settings.',
+          })
+        }
+      }}
+    />
+  )
 }

--- a/src/renderer/components/signup-handoff-consumer.tsx
+++ b/src/renderer/components/signup-handoff-consumer.tsx
@@ -7,8 +7,10 @@ import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { TemplateInstallDialog } from '@renderer/components/agents/template-install-dialog'
 import { useNavTransient } from '@renderer/context/nav-transient-context'
+import { useUser } from '@renderer/context/user-context'
 import { useDiscoverableAgents, slugFromAgentPath } from '@renderer/hooks/use-agent-templates'
 import { useCompleteTemplateInstall } from '@renderer/hooks/use-complete-template-install'
+import { useSettings } from '@renderer/hooks/use-settings'
 import { useUpdateUserSettings, useUserSettings } from '@renderer/hooks/use-user-settings'
 import { homeSearchSchema } from '@renderer/router/search-schemas'
 import { lenient } from '@renderer/router/zod-search'
@@ -31,7 +33,9 @@ export function SignupHandoffConsumer() {
   })
   const navigate = useNavigate()
   const { setSignupHandoff } = useNavTransient()
+  const { isAuthMode } = useUser()
   const { data: userSettings } = useUserSettings()
+  const { data: globalSettings } = useSettings()
   const setupCompleted = userSettings?.setupCompleted
   const settingsReady = userSettings !== undefined
   const updateUserSettings = useUpdateUserSettings()
@@ -46,6 +50,11 @@ export function SignupHandoffConsumer() {
     slugRef.current = template_slug
   }
   const slug = slugRef.current
+  // RootLayout skips the create wizard only for an auth user's agent-only
+  // first run. Full/local setup still needs the wizard, whose create step owns
+  // the existing handoff flow.
+  const canAutoInstallTemplate =
+    isAuthMode && globalSettings?.setupCompleted === true && settingsReady && !setupCompleted
 
   useEffect(() => {
     if (!prompt && !model && !template_slug) return
@@ -66,12 +75,12 @@ export function SignupHandoffConsumer() {
   }, [prompt, model, template_slug, setSignupHandoff, navigate])
 
   useEffect(() => {
-    if (slug) setSignupHandoff(null)
-  }, [slug, setSignupHandoff])
+    if (slug && canAutoInstallTemplate) setSignupHandoff(null)
+  }, [slug, canAutoInstallTemplate, setSignupHandoff])
 
   useEffect(() => {
     if (!slug || resolvedRef.current) return
-    if (!settingsReady || setupCompleted) return
+    if (!canAutoInstallTemplate) return
     if (discoverableAgentsFailed) {
       resolvedRef.current = true
       toastTemplateNotFound()
@@ -94,7 +103,7 @@ export function SignupHandoffConsumer() {
       return
     }
     setTemplate(target)
-  }, [discoverableAgents, discoverableAgentsFailed, slug, settingsReady, setupCompleted])
+  }, [canAutoInstallTemplate, discoverableAgents, discoverableAgentsFailed, slug])
 
   return (
     <TemplateInstallDialog

--- a/src/renderer/components/signup-handoff.smoke.test.tsx
+++ b/src/renderer/components/signup-handoff.smoke.test.tsx
@@ -6,6 +6,13 @@
 import { render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('@renderer/context/user-context', () => ({
+  useUser: () => ({ isAuthMode: true }),
+}))
+vi.mock('@renderer/hooks/use-settings', () => ({
+  useSettings: () => ({ data: { setupCompleted: true } }),
+}))
+
 vi.mock('@renderer/hooks/use-user-settings', () => ({
   useUserSettings: () => ({ data: { setupCompleted: true } }),
   useUpdateUserSettings: () => ({ mutateAsync: vi.fn() }),

--- a/src/renderer/components/signup-handoff.smoke.test.tsx
+++ b/src/renderer/components/signup-handoff.smoke.test.tsx
@@ -5,6 +5,24 @@
  */
 import { render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/hooks/use-user-settings', () => ({
+  useUserSettings: () => ({ data: { setupCompleted: true } }),
+  useUpdateUserSettings: () => ({ mutateAsync: vi.fn() }),
+}))
+vi.mock('@renderer/hooks/use-agent-templates', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/hooks/use-agent-templates')>()
+  return {
+    ...actual,
+    useDiscoverableAgents: () => ({ data: [], isError: false }),
+  }
+})
+vi.mock('@renderer/hooks/use-complete-template-install', () => ({
+  useCompleteTemplateInstall: () => vi.fn(),
+}))
+vi.mock('@renderer/components/agents/template-install-dialog', () => ({
+  TemplateInstallDialog: () => null,
+}))
 import {
   createMemoryHistory,
   createRootRoute,


### PR DESCRIPTION
When signup lands with a template slug and no prompt, the first-run create screen no longer replaces the workspace. The install dialog and setup spinner that already exist run on that workspace, then first-run is marked done. Prompt landings and already-finished first runs stay as they are.

Closes https://linear.app/datawizz/issue/SUP-711

2 production files, about 90 lines.

After landing with a slug and no prompt, first-run not done:

- stay on the workspace
- wait for the catalog, up to 10 seconds if it is empty
- match the public skillset and slug
- install dialog, then setup spinner, then the agent
- mark first-run done
- catalog error, empty for 10s, or no match: toast and stay
- install ok, settings write fails: toast, agent stays

Prompt present: first-run create screen.
Already finished first-run: no auto-install.
