### PR TITLE
Let an onboarding skill set the auto-start message via first_prompt

### DIFF
--- a/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
+++ b/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
@@ -99,7 +99,7 @@ vi.mock('@shared/lib/services/agent-template-service', () => ({
   updateAgentFromSkillset: vi.fn(), getAgentTemplateStatus: vi.fn(), getDiscoverableAgents: vi.fn(),
   refreshSkillsetCaches: vi.fn(), getAgentPRInfo: vi.fn(), createAgentPR: vi.fn(),
   getAgentPublishInfo: vi.fn(), publishAgentToSkillset: vi.fn(), refreshAgentTemplates: vi.fn(),
-  hasOnboardingSkill: vi.fn().mockResolvedValue(false),
+  hasOnboardingSkill: vi.fn().mockResolvedValue({ hasOnboarding: false }),
   getAgentTemplatePrompt: (...a: unknown[]) => mockGetAgentTemplatePrompt(...a),
 }))
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -1379,7 +1379,7 @@ describe('POST /api/agents/import-template', () => {
       slug: 'imported-agent',
       name: 'Imported Agent',
     } as any)
-    vi.mocked(hasOnboardingSkill).mockResolvedValue(false)
+    vi.mocked(hasOnboardingSkill).mockResolvedValue({ hasOnboarding: false })
     vi.mocked(getAgentTemplatePrompt).mockResolvedValue(undefined)
   })
 
@@ -1432,7 +1432,7 @@ describe('POST /api/agents/import-template (chunked)', () => {
       slug: 'imported-agent',
       name: 'Imported Agent',
     } as any)
-    vi.mocked(hasOnboardingSkill).mockResolvedValue(false)
+    vi.mocked(hasOnboardingSkill).mockResolvedValue({ hasOnboarding: false })
     vi.mocked(getAgentTemplatePrompt).mockResolvedValue(undefined)
   })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -980,12 +980,17 @@ async function processImport(c: Context, zipBuffer: Buffer, formData: FormData) 
 
   const agent = await importAgentFromTemplate(zipBuffer, nameOverride || undefined, importMode)
   await createOwnerAclOrRollback(c, agent.slug)
-  const [hasOnboarding, templatePrompt] = await Promise.all([
+  const [onboarding, templatePrompt] = await Promise.all([
     hasOnboardingSkill(agent.slug),
     getAgentTemplatePrompt(agent.slug),
   ])
   logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: agent.slug, action: 'imported', details: { name: agent.name } })
-  return c.json({ ...agent, hasOnboarding, templatePrompt }, 201)
+  return c.json({
+    ...agent,
+    hasOnboarding: onboarding.hasOnboarding,
+    templatePrompt,
+    onboardingFirstPrompt: onboarding.firstPrompt,
+  }, 201)
 }
 
 // GET /api/agents/discoverable-agents - List agents available from skillsets
@@ -1034,12 +1039,17 @@ agents.post('/install-from-skillset', async (c) => {
     )
 
     await createOwnerAclOrRollback(c, agent.slug)
-    const [hasOnboarding, templatePrompt] = await Promise.all([
+    const [onboarding, templatePrompt] = await Promise.all([
       hasOnboardingSkill(agent.slug),
       getAgentTemplatePrompt(agent.slug),
     ])
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent', objectId: agent.slug, action: 'imported', details: { name: agent.name, skillsetId } })
-    return c.json({ ...agent, hasOnboarding, templatePrompt }, 201)
+    return c.json({
+      ...agent,
+      hasOnboarding: onboarding.hasOnboarding,
+      templatePrompt,
+      onboardingFirstPrompt: onboarding.firstPrompt,
+    }, 201)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to install agent from skillset'
     console.error('Failed to install agent from skillset:', error)

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -263,6 +263,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
         agentSlug: imported.slug,
         hasOnboarding: imported.hasOnboarding,
         templatePrompt: imported.templatePrompt,
+        onboardingFirstPrompt: imported.onboardingFirstPrompt,
         noteProgrammaticChange,
         openAgent: () => {
           void navigate({ to: '/agents/$slug', params: { slug: imported.slug } })

--- a/src/renderer/components/agents/create-agent-form.tsx
+++ b/src/renderer/components/agents/create-agent-form.tsx
@@ -220,6 +220,7 @@ export function CreateAgentForm({ header, onAgentCreated, onNavigateAway, classN
         agentSlug: agent.slug,
         hasOnboarding: agent.hasOnboarding,
         templatePrompt: agent.templatePrompt,
+        onboardingFirstPrompt: agent.onboardingFirstPrompt,
         openAgent: () => { void navigate({ to: '/agents/$slug', params: { slug: agent.displaySlug } }) },
         startOnboardingSession,
       })

--- a/src/renderer/components/package-import-handler.tsx
+++ b/src/renderer/components/package-import-handler.tsx
@@ -130,7 +130,7 @@ export function PackageImportHandler() {
         const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, result.slug, result.templatePrompt)
         void navigate({ to: '/agents/$slug', params: { slug: result.displaySlug } })
         if (!hasTemplatePrompt && result.hasOnboarding) {
-          await startOnboardingSession(result.slug)
+          await startOnboardingSession(result.slug, result.onboardingFirstPrompt)
         }
       } catch {
         // Error surfaces in the dialog via importTemplate.error

--- a/src/renderer/hooks/use-complete-template-install.ts
+++ b/src/renderer/hooks/use-complete-template-install.ts
@@ -33,6 +33,7 @@ export function useCompleteTemplateInstall() {
         agentSlug: agent.slug,
         hasOnboarding: agent.hasOnboarding,
         templatePrompt: agent.templatePrompt,
+        onboardingFirstPrompt: agent.onboardingFirstPrompt,
         openAgent: () => { void navigate({ to: '/agents/$slug', params: { slug: agent.slug } }) },
         startOnboardingSession,
       })

--- a/src/renderer/hooks/use-start-onboarding-session.ts
+++ b/src/renderer/hooks/use-start-onboarding-session.ts
@@ -19,12 +19,12 @@ export function useStartOnboardingSession() {
   const navigate = useNavigate()
 
   return useCallback(
-    async (agentSlug: string) => {
+    async (agentSlug: string, firstPrompt?: string) => {
       setOnboarding(true)
       try {
         const session = await createSession.mutateAsync({
           agentSlug,
-          message: ONBOARDING_MESSAGE,
+          message: firstPrompt?.trim() || ONBOARDING_MESSAGE,
         })
         void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: agentSlug, sessionId: session.id } })
       } catch {

--- a/src/renderer/lib/agent-template-handoff.test.ts
+++ b/src/renderer/lib/agent-template-handoff.test.ts
@@ -45,6 +45,21 @@ describe('completeAgentTemplateHandoff', () => {
     })
 
     expect(order).toEqual(['open', 'onboarding'])
-    expect(startOnboardingSession).toHaveBeenCalledWith('new-agent')
+    expect(startOnboardingSession).toHaveBeenCalledWith('new-agent', undefined)
+  })
+
+  it('passes the onboarding first_prompt through when starting the session', async () => {
+    const startOnboardingSession = vi.fn()
+
+    await completeAgentTemplateHandoff({
+      draftsStore: { set: vi.fn() as Pick<DraftsStore, 'set'>['set'] },
+      agentSlug: 'new-agent',
+      hasOnboarding: true,
+      onboardingFirstPrompt: 'Walk me through HubSpot',
+      openAgent: vi.fn(),
+      startOnboardingSession,
+    })
+
+    expect(startOnboardingSession).toHaveBeenCalledWith('new-agent', 'Walk me through HubSpot')
   })
 })

--- a/src/renderer/lib/agent-template-handoff.ts
+++ b/src/renderer/lib/agent-template-handoff.ts
@@ -6,10 +6,11 @@ interface CompleteAgentTemplateHandoffOptions {
   agentSlug: string
   hasOnboarding?: boolean
   templatePrompt?: string
+  onboardingFirstPrompt?: string
   /** Update a surviving composer's baseline before its draft changes. */
   noteProgrammaticChange?: (prompt: string) => void
   openAgent: () => void | Promise<void>
-  startOnboardingSession: (agentSlug: string) => void | Promise<void>
+  startOnboardingSession: (agentSlug: string, firstPrompt?: string) => void | Promise<void>
 }
 
 /**
@@ -21,6 +22,7 @@ export async function completeAgentTemplateHandoff({
   agentSlug,
   hasOnboarding,
   templatePrompt,
+  onboardingFirstPrompt,
   noteProgrammaticChange,
   openAgent,
   startOnboardingSession,
@@ -29,6 +31,6 @@ export async function completeAgentTemplateHandoff({
   const hasTemplatePrompt = seedAgentTemplatePrompt(draftsStore, agentSlug, templatePrompt)
   await openAgent()
   if (!hasTemplatePrompt && hasOnboarding) {
-    await startOnboardingSession(agentSlug)
+    await startOnboardingSession(agentSlug, onboardingFirstPrompt)
   }
 }

--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -1738,21 +1738,59 @@ describe('hasOnboardingSkill', () => {
     fs.mkdirSync(path.dirname(skillPath), { recursive: true })
     fs.writeFileSync(skillPath, '# Onboarding Skill')
 
-    const result = await hasOnboardingSkill('test-agent')
-    expect(result).toBe(true)
+    await expect(hasOnboardingSkill('test-agent')).resolves.toEqual({ hasOnboarding: true })
   })
 
   it('returns false when agent-onboarding directory does not exist', async () => {
     const workspaceDir = path.join(testDir, 'agents', 'test-agent', 'workspace')
     fs.mkdirSync(workspaceDir, { recursive: true })
 
-    const result = await hasOnboardingSkill('test-agent')
-    expect(result).toBe(false)
+    await expect(hasOnboardingSkill('test-agent')).resolves.toEqual({ hasOnboarding: false })
   })
 
   it('returns false when workspace does not exist', async () => {
-    const result = await hasOnboardingSkill('nonexistent-agent')
-    expect(result).toBe(false)
+    await expect(hasOnboardingSkill('nonexistent-agent')).resolves.toEqual({ hasOnboarding: false })
+  })
+
+  it('reads first_prompt from the onboarding skill frontmatter', async () => {
+    const skillPath = path.join(testDir, 'agents', 'test-agent', 'workspace', '.claude', 'skills', 'agent-onboarding', 'SKILL.md')
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true })
+    fs.writeFileSync(skillPath, '---\nname: agent-onboarding\nfirst_prompt: Walk me through HubSpot\n---\n\nOnboard.\n')
+
+    await expect(hasOnboardingSkill('test-agent')).resolves.toEqual({
+      hasOnboarding: true,
+      firstPrompt: 'Walk me through HubSpot',
+    })
+  })
+
+  it('treats a blank first_prompt as absent', async () => {
+    const skillPath = path.join(testDir, 'agents', 'test-agent', 'workspace', '.claude', 'skills', 'agent-onboarding', 'SKILL.md')
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true })
+    fs.writeFileSync(skillPath, '---\nname: agent-onboarding\nfirst_prompt:   \n---\n\nOnboard.\n')
+
+    await expect(hasOnboardingSkill('test-agent')).resolves.toEqual({ hasOnboarding: true })
+  })
+
+  it('treats a YAML block-scalar first_prompt as absent', async () => {
+    const skillPath = path.join(testDir, 'agents', 'test-agent', 'workspace', '.claude', 'skills', 'agent-onboarding', 'SKILL.md')
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true })
+    fs.writeFileSync(skillPath, '---\nname: agent-onboarding\nfirst_prompt: |\n---\n\nOnboard.\n')
+
+    await expect(hasOnboardingSkill('test-agent')).resolves.toEqual({ hasOnboarding: true })
+  })
+
+  it('still reads first_prompt when the skill body is larger than the prompt limit', async () => {
+    const skillPath = path.join(testDir, 'agents', 'test-agent', 'workspace', '.claude', 'skills', 'agent-onboarding', 'SKILL.md')
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true })
+    fs.writeFileSync(
+      skillPath,
+      `---\nname: agent-onboarding\nfirst_prompt: Walk me through HubSpot\n---\n\n${'x'.repeat(MAX_TEMPLATE_PROMPT_SIZE + 1)}\n`,
+    )
+
+    await expect(hasOnboardingSkill('test-agent')).resolves.toEqual({
+      hasOnboarding: true,
+      firstPrompt: 'Walk me through HubSpot',
+    })
   })
 })
 

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -66,6 +66,9 @@ export const MAX_COMPRESSED_SIZE = 500 * 1024 * 1024 // 500MB
 const MAX_FILE_COUNT = 2000
 export const MAX_TEMPLATE_PROMPT_SIZE = 16 * 1024 // 16KB
 
+/** Bytes of SKILL.md to read for frontmatter. The skill body may be larger. */
+const ONBOARDING_SKILL_READ_LIMIT = MAX_TEMPLATE_PROMPT_SIZE + 16 * 1024
+
 /** Canonical prompt handoff file, plus a lowercase compatibility spelling. */
 const TEMPLATE_PROMPT_FILE_NAMES = ['PROMPT.md', 'prompt.md'] as const
 
@@ -764,17 +767,57 @@ export async function getInstalledAgentMetadata(
 }
 
 /**
- * Check if an agent has an onboarding skill (`.claude/skills/agent-onboarding/SKILL.md`).
+ * Probe the onboarding skill (`.claude/skills/agent-onboarding/SKILL.md`).
+ * `firstPrompt` is the optional `first_prompt` frontmatter field.
  */
-export async function hasOnboardingSkill(agentSlug: string): Promise<boolean> {
-  const workspaceDir = getAgentWorkspaceDir(agentSlug)
-  const onboardingPath = path.join(workspaceDir, '.claude', 'skills', 'agent-onboarding', 'SKILL.md')
+export async function hasOnboardingSkill(agentSlug: string): Promise<{
+  hasOnboarding: boolean
+  firstPrompt?: string
+}> {
+  const onboardingPath = path.join(
+    getAgentWorkspaceDir(agentSlug),
+    '.claude',
+    'skills',
+    'agent-onboarding',
+    'SKILL.md',
+  )
+  let handle: Awaited<ReturnType<typeof fs.promises.open>> | undefined
   try {
-    await fs.promises.access(onboardingPath)
-    return true
+    handle = await fs.promises.open(onboardingPath, 'r')
+    const stats = await handle.stat()
+    if (!stats.isFile()) return { hasOnboarding: false }
+    if (stats.size === 0) return { hasOnboarding: true }
+
+    // Frontmatter is at the top. Do not load a 500MB skill body into the heap.
+    const readLen = Math.min(stats.size, ONBOARDING_SKILL_READ_LIMIT)
+    const buffer = Buffer.alloc(readLen)
+    let bytesRead = 0
+    while (bytesRead < buffer.length) {
+      const result = await handle.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead)
+      if (result.bytesRead === 0) break
+      bytesRead += result.bytesRead
+    }
+    const content = buffer.subarray(0, bytesRead).toString('utf8')
+    const firstPrompt = onboardingFirstPromptFromValue(
+      parseMarkdownWithFrontmatter(content).frontmatter.first_prompt,
+    )
+    return firstPrompt ? { hasOnboarding: true, firstPrompt } : { hasOnboarding: true }
   } catch {
-    return false
+    return { hasOnboarding: false }
+  } finally {
+    await handle?.close().catch(() => undefined)
   }
+}
+
+/** Flat YAML turns `first_prompt: |` into the string `|`. That is not a kickoff. */
+const YAML_BLOCK_SCALAR_MARKER = /^[|>][-+]?$/
+
+function onboardingFirstPromptFromValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > MAX_TEMPLATE_PROMPT_SIZE) return undefined
+  if (YAML_BLOCK_SCALAR_MARKER.test(trimmed)) return undefined
+  return trimmed
 }
 
 /**

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -46,6 +46,8 @@ export interface ApiAgentTemplateInstallResult extends ApiAgent {
   hasOnboarding?: boolean
   /** Optional root PROMPT.md contents to prefill on the new agent's home page. */
   templatePrompt?: string
+  /** Optional `first_prompt` from the onboarding skill frontmatter. */
+  onboardingFirstPrompt?: string
 }
 
 export interface ApiAgentDashboard {


### PR DESCRIPTION
Template authors set the first message of the auto-started onboarding session by adding `first_prompt` to the agent-onboarding skill frontmatter. Missing, blank, oversized, or YAML `|` / `>` values still send today's default kickoff. A root PROMPT.md still wins and seeds the composer instead of starting a session.

13 files, +139 / −26.

```
PROMPT.md present → seed composer, no auto-start
else if onboarding skill exists → auto-start
  usable first_prompt → use it
  else → existing default
else → open empty home
```

SKILL.md is read as a frontmatter-sized prefix, not the whole file.
