### PR TITLE
Let an agent owner drop connections other members shared (SUP-702)

### DIFF
--- a/e2e/auth/specs/shared-connections.spec.ts
+++ b/e2e/auth/specs/shared-connections.spec.ts
@@ -27,9 +27,13 @@ import { AppPage } from '../../pages/app.page'
 // Serial narrative — each test builds on state from the previous ones.
 test.describe.configure({ mode: 'serial' })
 
-// Matches the `auth-shared-connections` project's dataDir in playwright.auth.config.ts.
-const DATA_DIR = path.resolve(
-  process.env.SUPERAGENT_DATA_DIR ?? path.join(process.cwd(), '.e2e-data-auth', 'shared-connections'),
+// Mirrors how playwright.auth.config.ts derives this project's dataDir: a base
+// that SUPERAGENT_DATA_DIR overrides, then the per-project subdirectory. Both
+// halves matter — CI sets that env var, a local run usually does not, so a
+// spec that only handles one branch passes in exactly one of the two places.
+const DATA_DIR = path.join(
+  path.resolve(process.env.SUPERAGENT_DATA_DIR ?? path.join(process.cwd(), '.e2e-data-auth')),
+  'shared-connections',
 )
 const RECORDER_FILE = path.join(DATA_DIR, '.e2e-mock-recorder.jsonl')
 
@@ -54,15 +58,22 @@ async function signUp(page: Page, user: typeof owner) {
   await appPage.dismissWizardIfVisible()
 }
 
+// A retry re-runs this whole serial narrative in the same worker, so module
+// state survives and the database still holds the failed attempt's rows.
+// Connection ids are UNIQUE, so they have to be minted per call — a constant
+// seeded once at import time is not enough.
+let accountSeq = 0
+
 /** Create a connected account owned by whoever `page` is signed in as. */
 async function createAccount(
   page: Page,
   displayName: string,
   status: 'active' | 'expired',
 ): Promise<string> {
+  accountSeq += 1
   const res = await page.request.post('/api/connected-accounts', {
     data: {
-      providerConnectionId: `conn-${displayName.replace(/\s+/g, '-').toLowerCase()}`,
+      providerConnectionId: `conn-${accountSeq}-${Date.now().toString(36)}`,
       toolkitSlug: 'github',
       displayName,
       status,
@@ -101,7 +112,7 @@ function readRecords(): Array<{ type: string; agentSlug: string; proxyToken?: st
     .map((line) => JSON.parse(line))
 }
 
-async function waitForProxyToken(slug: string, timeoutMs = 15000): Promise<string> {
+async function waitForProxyToken(slug: string, timeoutMs = 45000): Promise<string> {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
     const found = readRecords().find((r) => r.type === 'container_start' && r.agentSlug === slug)
@@ -256,7 +267,11 @@ test.describe('Shared agent connections', () => {
     expect(policyRes.ok(), `set policy ${policyRes.status()}`).toBeTruthy()
     await assignAccount(user3Page, agentSlug, expiredAccountId)
 
+    // The shared link removed above left the agent empty, so this is the only
+    // one. Asserted rather than assumed: picking the wrong link silently would
+    // make every dismissal check below prove nothing.
     const owned = await listAgentAccounts(user2Page, agentSlug)
+    expect(owned).toHaveLength(1)
     expiredMappingId = (owned[0] as { mappingId: string }).mappingId
 
     // Waking a session starts the mock container, which records the proxy

--- a/e2e/auth/specs/shared-connections.spec.ts
+++ b/e2e/auth/specs/shared-connections.spec.ts
@@ -1,0 +1,368 @@
+/**
+ * Connections another member shared onto an agent, from the agent owner's side.
+ *
+ * Two things used to leave an owner stuck with a connection they did not own:
+ *
+ *  1. The Agent Connections page showed the link as a bare "Shared" row with no
+ *     control on it. The only unlink route was keyed on the ACCOUNT id and
+ *     owner-scoped, and the foreign DTO withholds that id by design — so there
+ *     was no reachable call at all, not merely a hidden button.
+ *  2. When the shared credential expired mid-run, the reauth card blocked every
+ *     session of the agent. Reconnecting belongs to the credential's owner, and
+ *     the card offered nobody else a way out, so the agent sat wedged until the
+ *     five-minute timer fired.
+ *
+ * This narrative proves both against the real server with real users: the owner
+ * can now unlink and dismiss, and — the half that matters as much — a member
+ * holding only `user` on the agent still cannot, and neither path can be aimed
+ * at a different agent by passing its ids to this one's URL.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+import type { Page } from '@playwright/test'
+import { test, expect } from '../fixtures/multi-user.fixture'
+import { AuthPage } from '../pages/auth.page'
+import { AppPage } from '../../pages/app.page'
+
+// Serial narrative — each test builds on state from the previous ones.
+test.describe.configure({ mode: 'serial' })
+
+// Matches the `auth-shared-connections` project's dataDir in playwright.auth.config.ts.
+const DATA_DIR = path.resolve(
+  process.env.SUPERAGENT_DATA_DIR ?? path.join(process.cwd(), '.e2e-data-auth', 'shared-connections'),
+)
+const RECORDER_FILE = path.join(DATA_DIR, '.e2e-mock-recorder.jsonl')
+
+const first = { name: 'Ada Admin', email: 'ada@test.com', password: 'password123' }
+const owner = { name: 'Odette Owner', email: 'odette@test.com', password: 'password123' }
+const member = { name: 'Mel Member', email: 'mel@test.com', password: 'password123' }
+
+let agentSlug = ''
+let otherAgentSlug = ''
+let sharedAccountId = ''
+let sharedMappingId = ''
+let expiredAccountId = ''
+let expiredMappingId = ''
+let proxyToken = ''
+
+async function signUp(page: Page, user: typeof owner) {
+  const authPage = new AuthPage(page)
+  const appPage = new AppPage(page)
+  await authPage.resetToAuthPage()
+  await authPage.signUpOrSignIn(user.name, user.email, user.password)
+  await appPage.waitForAppLoaded()
+  await appPage.dismissWizardIfVisible()
+}
+
+/** Create a connected account owned by whoever `page` is signed in as. */
+async function createAccount(
+  page: Page,
+  displayName: string,
+  status: 'active' | 'expired',
+): Promise<string> {
+  const res = await page.request.post('/api/connected-accounts', {
+    data: {
+      providerConnectionId: `conn-${displayName.replace(/\s+/g, '-').toLowerCase()}`,
+      toolkitSlug: 'github',
+      displayName,
+      status,
+    },
+  })
+  expect(res.ok(), `create account ${res.status()}`).toBeTruthy()
+  const { account } = (await res.json()) as { account: { id: string } }
+  return account.id
+}
+
+async function assignAccount(page: Page, slug: string, accountId: string) {
+  const res = await page.request.post(`/api/agents/${slug}/connected-accounts`, {
+    data: { accountIds: [accountId] },
+  })
+  expect(res.ok(), `assign account ${res.status()}`).toBeTruthy()
+}
+
+type AgentAccount =
+  | { kind: 'connected-account'; toolkitSlug: string; mappingId: string }
+  | { id: string; displayName: string; mappingId: string }
+
+async function listAgentAccounts(page: Page, slug: string): Promise<AgentAccount[]> {
+  const res = await page.request.get(`/api/agents/${slug}/connected-accounts`)
+  expect(res.ok(), `list agent accounts ${res.status()}`).toBeTruthy()
+  const { accounts } = (await res.json()) as { accounts: AgentAccount[] }
+  return accounts
+}
+
+function readRecords(): Array<{ type: string; agentSlug: string; proxyToken?: string }> {
+  if (!fs.existsSync(RECORDER_FILE)) return []
+  return fs
+    .readFileSync(RECORDER_FILE, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+}
+
+async function waitForProxyToken(slug: string, timeoutMs = 15000): Promise<string> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const found = readRecords().find((r) => r.type === 'container_start' && r.agentSlug === slug)
+    if (found?.proxyToken) return found.proxyToken
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`Timed out waiting for the mock container to record a proxy token for ${slug}`)
+}
+
+async function pendingReauthRequestId(page: Page, slug: string, timeoutMs = 15000): Promise<string> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const res = await page.request.get(`/api/agents/${slug}/pending-requests`)
+    if (res.ok()) {
+      const { requests } = (await res.json()) as {
+        requests: Array<{ id: string; kind: string }>
+      }
+      const reauth = requests.find((r) => r.kind === 'account_reauth_required')
+      if (reauth) return reauth.id
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150))
+  }
+  throw new Error('Timed out waiting for an account_reauth_required request')
+}
+
+test.describe('Shared agent connections', () => {
+  test('three users sign up and the owner shares an agent with a member', async ({
+    user1Page,
+    user2Page,
+    user3Page,
+  }) => {
+    // The first account in an auth-mode install is promoted to global admin,
+    // and admins bypass the agent ACL entirely. Burning that promotion on a
+    // user this narrative never acts as is what makes the owner an ORDINARY
+    // agent owner and the member an ordinary member.
+    await signUp(user1Page, first)
+
+    await signUp(user2Page, owner)
+    const agentRes = await user2Page.request.post('/api/agents', { data: { name: 'Shared Agent' } })
+    expect(agentRes.ok()).toBeTruthy()
+    agentSlug = ((await agentRes.json()) as { slug: string }).slug
+
+    const otherRes = await user2Page.request.post('/api/agents', { data: { name: 'Solo Agent' } })
+    expect(otherRes.ok()).toBeTruthy()
+    otherAgentSlug = ((await otherRes.json()) as { slug: string }).slug
+
+    await signUp(user3Page, member)
+
+    const searchRes = await user2Page.request.get(
+      `/api/agents/${agentSlug}/access/search-users?q=${encodeURIComponent(member.email)}`,
+    )
+    expect(searchRes.ok()).toBeTruthy()
+    const found = (await searchRes.json()) as Array<{ id: string; email: string }>
+    const memberId = found.find((u) => u.email === member.email)?.id
+    expect(memberId, 'member is findable from the owner’s access tab').toBeTruthy()
+
+    const grantRes = await user2Page.request.post(`/api/agents/${agentSlug}/access`, {
+      data: { userId: memberId, role: 'user' },
+    })
+    expect(grantRes.status()).toBe(201)
+  })
+
+  test('the member attaches their own connection to the shared agent', async ({ user3Page }) => {
+    sharedAccountId = await createAccount(user3Page, 'Mel GitHub', 'active')
+    await assignAccount(user3Page, agentSlug, sharedAccountId)
+
+    const asMember = await listAgentAccounts(user3Page, agentSlug)
+    expect(asMember).toHaveLength(1)
+    expect(asMember[0]).toMatchObject({ id: sharedAccountId, displayName: 'Mel GitHub' })
+  })
+
+  test('the owner sees the link as an opaque shared row carrying only a link id', async ({
+    user2Page,
+  }) => {
+    const asOwner = await listAgentAccounts(user2Page, agentSlug)
+    expect(asOwner).toHaveLength(1)
+
+    const row = asOwner[0]
+    expect(row).toMatchObject({ kind: 'connected-account', toolkitSlug: 'github' })
+    // Everything that identifies the account or its owner stays withheld; the
+    // link id is the whole of what the owner gets, and it is enough to unlink.
+    expect(row).not.toHaveProperty('id')
+    expect(row).not.toHaveProperty('displayName')
+    expect(JSON.stringify(row)).not.toContain(sharedAccountId)
+
+    sharedMappingId = row.mappingId
+    expect(sharedMappingId).toBeTruthy()
+  })
+
+  test('the account-keyed unlink still refuses to touch another member’s link', async ({
+    user2Page,
+  }) => {
+    // The owner would have to guess the id to try this at all, but the guard
+    // has to stay closed regardless: this route unlinks only accounts the
+    // CALLER owns, whatever their role on the agent.
+    const res = await user2Page.request.delete(
+      `/api/agents/${agentSlug}/connected-accounts/${sharedAccountId}`,
+    )
+    expect(res.status()).toBe(404)
+    expect(await listAgentAccounts(user2Page, agentSlug)).toHaveLength(1)
+  })
+
+  test('a member with only `user` on the agent cannot unlink by link id', async ({ user3Page }) => {
+    const res = await user3Page.request.delete(
+      `/api/agents/${agentSlug}/connected-accounts/mapping/${sharedMappingId}`,
+    )
+    expect(res.status()).toBe(403)
+    expect(await listAgentAccounts(user3Page, agentSlug)).toHaveLength(1)
+  })
+
+  test('the owner cannot aim a link id at a different agent’s URL', async ({ user2Page }) => {
+    // The owner owns both agents, so the ACL lets the call through — only the
+    // route's agent+link match stops it from severing the other agent's link.
+    const res = await user2Page.request.delete(
+      `/api/agents/${otherAgentSlug}/connected-accounts/mapping/${sharedMappingId}`,
+    )
+    expect(res.status()).toBe(404)
+    expect(await listAgentAccounts(user2Page, agentSlug)).toHaveLength(1)
+  })
+
+  test('the owner removes the shared connection from the Connections page', async ({
+    user2Page,
+  }) => {
+    await user2Page.goto(`/agents/${agentSlug}/connections`)
+
+    const removeButton = user2Page.getByTestId(`connection-shared-remove-${sharedMappingId}`)
+    await expect(removeButton).toBeVisible({ timeout: 15000 })
+    await removeButton.click()
+    await user2Page.getByTestId('connection-shared-remove-confirm').click()
+
+    await expect(removeButton).toHaveCount(0)
+    expect(await listAgentAccounts(user2Page, agentSlug)).toHaveLength(0)
+  })
+
+  test('the connection itself survives — only the link died', async ({ user3Page }) => {
+    const res = await user3Page.request.get('/api/connected-accounts')
+    expect(res.ok()).toBeTruthy()
+    const { accounts } = (await res.json()) as { accounts: Array<{ id: string }> }
+    expect(accounts.map((a) => a.id)).toContain(sharedAccountId)
+  })
+
+  test('an expired shared credential parks the agent on a card the owner cannot clear', async ({
+    user2Page,
+    user3Page,
+  }) => {
+    expiredAccountId = await createAccount(user3Page, 'Mel Stale GitHub', 'expired')
+    // Let the request past the policy gate so it reaches the re-auth park,
+    // which is what this test is about.
+    const policyRes = await user3Page.request.put(`/api/policies/scope/${expiredAccountId}`, {
+      data: { policies: [{ scope: '*', decision: 'allow' }] },
+    })
+    expect(policyRes.ok(), `set policy ${policyRes.status()}`).toBeTruthy()
+    await assignAccount(user3Page, agentSlug, expiredAccountId)
+
+    const owned = await listAgentAccounts(user2Page, agentSlug)
+    expiredMappingId = (owned[0] as { mappingId: string }).mappingId
+
+    // Waking a session starts the mock container, which records the proxy
+    // token — the credential a real agent authenticates to the proxy with.
+    const sessionRes = await user2Page.request.post(`/api/agents/${agentSlug}/sessions`, {
+      data: { message: 'use the shared connection' },
+    })
+    expect(sessionRes.ok()).toBeTruthy()
+    proxyToken = await waitForProxyToken(agentSlug)
+  })
+
+  test('the owner dismisses the reauth card and the parked call fails as dismissed', async ({
+    user2Page,
+    user3Page,
+  }) => {
+    // Fire the proxy call the way the container would and leave it hanging.
+    const parked = user2Page.request.fetch(
+      `/api/proxy/${agentSlug}/${expiredAccountId}/api.github.com/user`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        timeout: 60000,
+        failOnStatusCode: false,
+      },
+    )
+
+    const requestId = await pendingReauthRequestId(user2Page, agentSlug)
+
+    // The credential is the member's, so the owner cannot reconnect it. Before
+    // the escape hatch this was the wedge: nothing to press, five minutes to
+    // wait. A cross-agent dismissal still has to bounce.
+    const crossAgent = await user2Page.request.post(
+      `/api/agents/${otherAgentSlug}/reauth-request/${requestId}/dismiss`,
+      { data: {} },
+    )
+    expect(crossAgent.status()).toBe(404)
+
+    const dismissed = await user2Page.request.post(
+      `/api/agents/${agentSlug}/reauth-request/${requestId}/dismiss`,
+      { data: { reason: 'the owner is out today' } },
+    )
+    expect(dismissed.ok(), `dismiss ${dismissed.status()}`).toBeTruthy()
+
+    // The agent learns a person decided this, not that the wait stalled — a
+    // 408 timeout would invite it straight back into the same wall.
+    const response = await parked
+    expect(response.status()).toBe(403)
+    const failure = (await response.json()) as { error: string; message: string }
+    expect(failure.error).toBe('account_reauth_dismissed')
+    // The card's reason box promises the agent hears WHY, so the words the
+    // dismisser typed have to survive all the way onto the parked call.
+    expect(failure.message).toContain('the owner is out today')
+
+    // Card gone: no session of the agent is still held awaiting input.
+    const pending = await user2Page.request.get(`/api/agents/${agentSlug}/pending-requests`)
+    const { requests } = (await pending.json()) as { requests: Array<{ kind: string }> }
+    expect(requests.filter((r) => r.kind === 'account_reauth_required')).toHaveLength(0)
+
+    // Dismissing abandons one call; it never touches the credential itself.
+    const stillThere = await user3Page.request.get('/api/connected-accounts')
+    const { accounts } = (await stillThere.json()) as { accounts: Array<{ id: string }> }
+    expect(accounts.map((a) => a.id)).toContain(expiredAccountId)
+  })
+
+  test('dismissing again is a no-op rather than an error', async ({ user2Page }) => {
+    // A second tab, a double click, or a card revived from a stale snapshot
+    // must not read as a failure to the person pressing it.
+    const res = await user2Page.request.post(
+      `/api/agents/${agentSlug}/reauth-request/${'00000000-0000-4000-8000-000000000000'}/dismiss`,
+      { data: {} },
+    )
+    expect(res.ok()).toBeTruthy()
+    expect(await res.json()).toMatchObject({ alreadySettled: true })
+  })
+
+  test('a member with only `user` on the agent may still dismiss', async ({
+    user2Page,
+    user3Page,
+  }) => {
+    // Unlinking is the owner's; abandoning a call the agent is stuck on is not.
+    // Whoever can put work into the agent can give up on it.
+    const parked = user2Page.request.fetch(
+      `/api/proxy/${agentSlug}/${expiredAccountId}/api.github.com/user`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        timeout: 60000,
+        failOnStatusCode: false,
+      },
+    )
+
+    const requestId = await pendingReauthRequestId(user3Page, agentSlug)
+    const res = await user3Page.request.post(
+      `/api/agents/${agentSlug}/reauth-request/${requestId}/dismiss`,
+      { data: {} },
+    )
+    expect(res.ok(), `member dismiss ${res.status()}`).toBeTruthy()
+
+    expect((await parked).status()).toBe(403)
+  })
+
+  test('the owner can unlink the expired shared credential too', async ({ user2Page }) => {
+    const res = await user2Page.request.delete(
+      `/api/agents/${agentSlug}/connected-accounts/mapping/${expiredMappingId}`,
+    )
+    expect(res.ok(), `unlink ${res.status()}`).toBeTruthy()
+    expect(await listAgentAccounts(user2Page, agentSlug)).toHaveLength(0)
+  })
+})

--- a/e2e/auth/specs/shared-connections.spec.ts
+++ b/e2e/auth/specs/shared-connections.spec.ts
@@ -102,14 +102,26 @@ async function listAgentAccounts(page: Page, slug: string): Promise<AgentAccount
   return accounts
 }
 
-function readRecords(): Array<{ type: string; agentSlug: string; proxyToken?: string }> {
+type MockRecord = { type: string; agentSlug: string; proxyToken?: string }
+
+function readRecords(): MockRecord[] {
   if (!fs.existsSync(RECORDER_FILE)) return []
   return fs
     .readFileSync(RECORDER_FILE, 'utf-8')
     .trim()
     .split('\n')
     .filter(Boolean)
-    .map((line) => JSON.parse(line))
+    .flatMap((line) => {
+      // The server appends to this file while the poll loop below reads it, so
+      // the final line can be half-written. Skip it and let the next tick see
+      // it whole — throwing here would surface a torn write as a SyntaxError
+      // instead of the wait simply continuing.
+      try {
+        return [JSON.parse(line) as MockRecord]
+      } catch {
+        return []
+      }
+    })
 }
 
 async function waitForProxyToken(slug: string, timeoutMs = 45000): Promise<string> {

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -68,6 +68,13 @@ const authProjects = [
     dataDir: path.join(e2eDataDir, 'template-handoff'),
     viteCacheDir: path.join(e2eDataDir, '.vite', 'template-handoff'),
   },
+  {
+    name: 'auth-shared-connections',
+    testMatch: '**/shared-connections.spec.ts',
+    port: e2ePort + 8,
+    dataDir: path.join(e2eDataDir, 'shared-connections'),
+    viteCacheDir: path.join(e2eDataDir, '.vite', 'shared-connections'),
+  },
 ].map((project, index) => ({
   ...project,
   baseURL: index === 0 && process.env.E2E_BASE_URL

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -929,7 +929,11 @@ describe('shared-agent connection projections', () => {
       mappingId: 'own-account-mapping',
     })
     expect(body.accounts[0]).not.toHaveProperty('userId')
-    expect(body.accounts[1]).toEqual({ kind: 'connected-account', toolkitSlug: 'slack' })
+    expect(body.accounts[1]).toEqual({
+      kind: 'connected-account',
+      toolkitSlug: 'slack',
+      mappingId: 'victim-account-mapping',
+    })
     expect(JSON.stringify(body)).not.toContain('victim-account-id')
     expect(JSON.stringify(body)).not.toContain('victim-provider-connection')
     expect(JSON.stringify(body)).not.toContain('Victim Workspace')
@@ -954,7 +958,11 @@ describe('shared-agent connection projections', () => {
     const body = await res.json() as { accounts: Array<Record<string, unknown>> }
 
     expect(res.status).toBe(200)
-    expect(body.accounts[1]).toEqual({ kind: 'connected-account', toolkitSlug: 'slack' })
+    expect(body.accounts[1]).toEqual({
+      kind: 'connected-account',
+      toolkitSlug: 'slack',
+      mappingId: 'victim-account-mapping',
+    })
     expect(JSON.stringify(body)).not.toContain('victim-account-id')
     expect(JSON.stringify(body)).not.toContain('victim-provider-connection')
     expect(JSON.stringify(body)).not.toContain('victim-user-id')
@@ -983,7 +991,7 @@ describe('shared-agent connection projections', () => {
     })
     expect(body.mcps[0]).not.toHaveProperty('userId')
     expect(body.mcps[0]).not.toHaveProperty('accessToken')
-    expect(body.mcps[1]).toEqual({ kind: 'remote-mcp' })
+    expect(body.mcps[1]).toEqual({ kind: 'remote-mcp', mappingId: 'victim-mcp-mapping' })
     expect(JSON.stringify(body)).not.toContain('victim-mcp-id')
     expect(JSON.stringify(body)).not.toContain('Victim private MCP')
     expect(JSON.stringify(body)).not.toContain('victim.example.test')

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -143,6 +143,8 @@ import { markSessionUnread, clearSessionUnread, getSessionIdsMarkedUnread, getSe
 import { isHiddenAutomatedSession } from '@shared/lib/services/session-visibility'
 import { getInboundXAgentDetails } from '@shared/lib/services/inbound-x-agent-service'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
+import { accountReauthManager } from '@shared/lib/proxy/account-reauth-manager'
+import { mcpReauthManager } from '@shared/lib/proxy/mcp-reauth-manager'
 import { isValidApiScope } from '@shared/lib/proxy/scope-matcher'
 import { isLabelDefaultKey } from '@shared/lib/proxy/policy-sentinels'
 import type { ScopeLabel } from '@shared/lib/proxy/scope-metadata'
@@ -4852,6 +4854,53 @@ agents.delete('/:id/connected-accounts/:accountId', AgentUser(), async (c) => {
   }
 })
 
+// DELETE /api/agents/:id/connected-accounts/mapping/:mappingId - Unlink by link id
+//
+// The sibling route above is keyed on the ACCOUNT id and owner-scoped, so it
+// can only ever sever a link to the caller's own account. An agent owner also
+// has to be able to drop a connection another member shared onto the agent —
+// without being handed that account's id, which the foreign DTO deliberately
+// withholds. So this route is keyed on the LINK id instead, and gated on
+// AgentAdmin(): owning the agent is what authorizes it, not owning the account.
+// A `user` on the agent still cannot reach it. Only the mapping row dies; the
+// account itself stays with its owner.
+agents.delete('/:id/connected-accounts/mapping/:mappingId', AgentAdmin(), async (c) => {
+  try {
+    const slug = getAgentId(c)
+    const mappingId = c.req.param('mappingId')
+
+    // Matched on BOTH columns: a link id is an unauthenticated pointer into a
+    // global table, so owning agent A must not unlink agent B's connection by
+    // sending B's mapping id to A's URL.
+    const [found] = await db
+      .select({
+        id: agentConnectedAccounts.id,
+        connectedAccountId: agentConnectedAccounts.connectedAccountId,
+      })
+      .from(agentConnectedAccounts)
+      .where(and(
+        eq(agentConnectedAccounts.id, mappingId),
+        eq(agentConnectedAccounts.agentSlug, slug),
+      ))
+      .limit(1)
+
+    if (!found) {
+      return c.json({ error: 'Account mapping not found' }, 404)
+    }
+
+    await db
+      .delete(agentConnectedAccounts)
+      .where(eq(agentConnectedAccounts.id, found.id))
+
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: found.connectedAccountId, action: 'unassigned', details: { agentSlug: slug } })
+    const liveRefresh = await syncAgentConnectionEnvironment(slug, 'connected-accounts')
+    return c.json({ success: true, liveRefresh })
+  } catch (error) {
+    console.error('Failed to remove account mapping:', error)
+    return c.json({ error: 'Failed to remove account mapping' }, 500)
+  }
+})
+
 // GET /api/agents/:id/remote-mcps - List remote MCP servers assigned to this agent
 agents.get('/:id/remote-mcps', AgentRead(), async (c) => {
   try {
@@ -4961,6 +5010,36 @@ agents.delete('/:id/remote-mcps/:mcpId', AgentUser(), async (c) => {
 
     await db.delete(agentRemoteMcps).where(eq(agentRemoteMcps.id, mapping.id))
     logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: mcpId, action: 'unassigned', details: { agentSlug: slug } })
+    const liveRefresh = await syncAgentConnectionEnvironment(slug, 'remote-mcps')
+    return c.json({ success: true, liveRefresh })
+  } catch (error) {
+    console.error('Failed to remove remote MCP from agent:', error)
+    return c.json({ error: 'Failed to remove remote MCP from agent' }, 500)
+  }
+})
+
+// DELETE /api/agents/:id/remote-mcps/mapping/:mappingId - Unlink by link id
+// The connected-accounts twin above carries the full rationale.
+agents.delete('/:id/remote-mcps/mapping/:mappingId', AgentAdmin(), async (c) => {
+  try {
+    const slug = getAgentId(c)
+    const mappingId = c.req.param('mappingId')
+
+    const [mapping] = await db
+      .select({ id: agentRemoteMcps.id, remoteMcpId: agentRemoteMcps.remoteMcpId })
+      .from(agentRemoteMcps)
+      .where(and(
+        eq(agentRemoteMcps.id, mappingId),
+        eq(agentRemoteMcps.agentSlug, slug),
+      ))
+      .limit(1)
+
+    if (!mapping) {
+      return c.json({ error: 'MCP mapping not found' }, 404)
+    }
+
+    await db.delete(agentRemoteMcps).where(eq(agentRemoteMcps.id, mapping.id))
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: mapping.remoteMcpId, action: 'unassigned', details: { agentSlug: slug } })
     const liveRefresh = await syncAgentConnectionEnvironment(slug, 'remote-mcps')
     return c.json({ success: true, liveRefresh })
   } catch (error) {
@@ -6958,6 +7037,85 @@ agents.get('/:id/pending-requests', AgentRead(), (c) => {
   const agentSlug = getAgentId(c)
   const sessionId = c.req.query('sessionId') || undefined
   return c.json({ requests: userInputRequestManager.getSnapshotForScope(agentSlug, sessionId) })
+})
+
+// =============================================================================
+// Re-authentication endpoints
+// =============================================================================
+
+const MAX_DISMISS_REASON_LENGTH = 500
+
+// POST /api/agents/:id/reauth-request/:requestId/dismiss - Give up on a parked
+// re-authentication card.
+//
+// A reauth card is agent-scoped and blocking: while it is open, every session
+// of the agent sits in awaiting-input. Reconnecting is the owner's privilege,
+// so when the shared credential belongs to someone else, nobody in the room
+// can clear the card and the agent stays stuck until the five-minute timer
+// fires. This is the escape hatch — it fails the parked call with a distinct
+// "dismissed" status (not a timeout) so the agent knows a person decided it.
+//
+// AgentUser(), not AgentAdmin(): anyone who can put work into this agent can
+// abandon a call it is stuck on. Viewers, who cannot, are excluded.
+agents.post('/:id/reauth-request/:requestId/dismiss', AgentUser(), async (c) => {
+  const slug = getAgentId(c)
+  const requestId = c.req.param('requestId')
+  const body = await c.req.json<{ reason?: string }>().catch(() => ({} as { reason?: string }))
+  // Bounded: this text is forwarded into the proxy's error body and written to
+  // the audit log, so it must not be an unbounded write from the composer.
+  const reason = typeof body.reason === 'string' && body.reason.trim()
+    ? body.reason.trim().slice(0, MAX_DISMISS_REASON_LENGTH)
+    : undefined
+
+  const open = userInputRequestManager.getOpenRequest(requestId)
+  if (open) {
+    // A caller-supplied id points into a global, cross-agent registry, so both
+    // the kind and the agent are re-checked against the URL before we settle
+    // anything — the same guard the review routes apply.
+    if (
+      open.scope.agentSlug !== slug ||
+      (open.kind !== 'account_reauth_required' && open.kind !== 'mcp_reauth_required')
+    ) {
+      return c.json({ error: 'Request not found' }, 404)
+    }
+
+    const dismissed = open.kind === 'account_reauth_required'
+      ? accountReauthManager.dismiss(requestId, slug, reason)
+      : mcpReauthManager.dismiss(requestId, slug, reason)
+
+    // An open envelope whose parked group is already gone (every waiter
+    // aborted, but the entry outlived them) would otherwise leave the card —
+    // and the awaiting-input state behind it — on screen forever. Clearing it
+    // is the whole point of this route, so do it rather than report success
+    // and change nothing.
+    if (!dismissed) {
+      userInputRequestManager.resolve(requestId, 'cancelled')
+      messagePersister.syncAgentSessionsAwaiting(slug)
+    }
+
+    // Short form, matching the `type` its sibling decline routes emit
+    // ('secret', 'connected_account') rather than the raw registry kind.
+    const declinedType = open.kind === 'account_reauth_required' ? 'account_reauth' : 'mcp_reauth'
+    trackServerEvent('request_declined', { type: declinedType, withReason: !!reason })
+    return c.json({ success: true })
+  }
+
+  // Settled or unknown. Report on it only through the route that could have
+  // decided it, so settling a request never widens who may read its outcome.
+  const settled = userInputRequestManager.getRecentResolution(requestId)
+  if (settled && (
+    settled.scope.agentSlug !== slug ||
+    (settled.kind !== 'account_reauth_required' && settled.kind !== 'mcp_reauth_required')
+  )) {
+    return c.json({ error: 'Request not found' }, 404)
+  }
+  // 200, not an error: the caller's intent is already satisfied and a stale
+  // card should dismiss itself exactly like a successful one.
+  return c.json({
+    success: true,
+    alreadySettled: true,
+    ...(settled ? { outcome: settled.outcome } : {}),
+  })
 })
 
 // =============================================================================

--- a/src/api/routes/mcp-proxy.ts
+++ b/src/api/routes/mcp-proxy.ts
@@ -4,6 +4,7 @@ import { validateProxyToken } from '@shared/lib/proxy/token-store'
 import { resolveMcpPolicy } from '@shared/lib/proxy/policy-resolver'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
 import { mcpReauthManager } from '@shared/lib/proxy/mcp-reauth-manager'
+import { isReauthDismissed, reauthDismissalReason, withDismissalReason } from '@shared/lib/proxy/reauth-dismissal'
 import { db } from '@shared/lib/db'
 import {
   remoteMcpServers,
@@ -264,6 +265,38 @@ async function tryRefreshToken(mcp: {
 const mcpProxy = new Hono()
 
 // Catch-all route: /api/mcp-proxy/:agentSlug/:mcpId and optional trailing path
+/**
+ * How each way of failing a parked re-auth is reported to the agent. Split out
+ * of the response builder because three parallel ternaries over the same four
+ * cases is a place for them to drift apart.
+ *
+ * `dismissed` is deliberately a 403, not the 408 the timeout returns: a person
+ * decided this, and a timeout reads to an agent as an invitation to retry.
+ */
+const MCP_REAUTH_FAILURES = {
+  timeout: {
+    statusCode: 408,
+    error: 'mcp_reauth_timeout',
+    message: 'The request timed out while waiting for the MCP server to be reconnected.',
+  },
+  dismissed: {
+    statusCode: 403,
+    error: 'mcp_reauth_dismissed',
+    message: 'A user dismissed the reconnection request, so this call was not made. '
+      + 'Do not retry it until the MCP server is reconnected.',
+  },
+  missing: {
+    statusCode: 404,
+    error: 'mcp_reauth_failed',
+    message: 'The MCP server disappeared while re-authenticating.',
+  },
+  inactive: {
+    statusCode: 502,
+    error: 'mcp_reauth_failed',
+    message: 'The MCP server did not become active after re-authentication.',
+  },
+} as const
+
 mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
   const agentSlug = c.req.param('agentSlug')
   const mcpId = c.req.param('mcpId')
@@ -352,7 +385,8 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
 
   type ReauthResult =
     | { ok: true }
-    | { ok: false; reason: 'timeout' | 'missing' | 'inactive' }
+    // See the account proxy for `dismissReason`.
+    | { ok: false; reason: 'timeout' | 'dismissed' | 'missing' | 'inactive'; dismissReason?: string }
 
   const holdForReauth = async (): Promise<ReauthResult> => {
     try {
@@ -362,7 +396,11 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
         mcpName: mcp!.name,
         authType: mcp!.authType,
       }, c.req.raw.signal)
-    } catch {
+    } catch (error) {
+      // See the account proxy: a dismissal is a decision, not a stalled wait.
+      if (isReauthDismissed(error)) {
+        return { ok: false, reason: 'dismissed', dismissReason: reauthDismissalReason(error) }
+      }
       return { ok: false, reason: 'timeout' }
     }
 
@@ -376,16 +414,9 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
   const reauthFailureResponse = async (
     result: Exclude<ReauthResult, { ok: true }>,
   ) => {
-    const statusCode = result.reason === 'timeout'
-      ? 408
-      : result.reason === 'missing'
-        ? 404
-        : 502
-    const message = result.reason === 'timeout'
-      ? 'The request timed out while waiting for the MCP server to be reconnected.'
-      : result.reason === 'missing'
-        ? 'The MCP server disappeared while re-authenticating.'
-        : 'The MCP server did not become active after re-authentication.'
+    const failure = MCP_REAUTH_FAILURES[result.reason]
+    const { statusCode, error } = failure
+    const message = withDismissalReason(failure.message, result.dismissReason)
 
     await logMcpAuditEntry({
       agentSlug,
@@ -399,11 +430,7 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
       matchedTool: toolName ?? undefined,
     })
 
-    return c.json({
-      error: result.reason === 'timeout' ? 'mcp_reauth_timeout' : 'mcp_reauth_failed',
-      message,
-      mcpStatus: 'auth_required',
-    }, statusCode)
+    return c.json({ error, message, mcpStatus: 'auth_required' }, statusCode)
   }
 
   const markAuthRequired = async (errorMessage: string) => {

--- a/src/api/routes/proxy.ts
+++ b/src/api/routes/proxy.ts
@@ -6,6 +6,7 @@ import { matchScopes } from '@shared/lib/proxy/scope-matcher'
 import { resolveApiPolicy } from '@shared/lib/proxy/policy-resolver'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
 import { accountReauthManager } from '@shared/lib/proxy/account-reauth-manager'
+import { isReauthDismissed, reauthDismissalReason, withDismissalReason } from '@shared/lib/proxy/reauth-dismissal'
 import { getAccountProviderByName } from '@shared/lib/account-providers'
 import { attribution, runWithAttribution } from '@shared/lib/platform-attribution'
 import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
@@ -150,7 +151,9 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
 
   type ReauthResult =
     | { ok: true }
-    | { ok: false; reason: 'timeout' | 'missing' | 'inactive' }
+    // `dismissReason` is what the dismisser typed, forwarded so the agent
+    // learns WHY a person cut its call off, not merely that they did.
+    | { ok: false; reason: 'timeout' | 'dismissed' | 'missing' | 'inactive'; dismissReason?: string }
 
   const holdForReauth = async (status: 'expired' | 'revoked'): Promise<ReauthResult> => {
     try {
@@ -160,7 +163,12 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
         toolkit: account!.toolkitSlug,
         accountStatus: status,
       }, c.req.raw.signal)
-    } catch {
+    } catch (error) {
+      // A person pressing Dismiss and a five-minute timer both land here; only
+      // the first should read as a decision the agent must respect.
+      if (isReauthDismissed(error)) {
+        return { ok: false, reason: 'dismissed', dismissReason: reauthDismissalReason(error) }
+      }
       return { ok: false, reason: 'timeout' }
     }
 
@@ -183,6 +191,16 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
         message: 'The request timed out while waiting for the account to be reconnected.',
         accountStatus: status,
       }, 408)
+    }
+
+    if (result.reason === 'dismissed') {
+      const message = withDismissalReason(
+        'A user dismissed the reconnection request, so this call was not made. '
+        + 'Do not retry it until the connection is reconnected.',
+        result.dismissReason,
+      )
+      await auditError(`Account re-authentication dismissed by a user (${status})`, 403)
+      return c.json({ error: 'account_reauth_dismissed', message, accountStatus: status }, 403)
     }
 
     const message = result.reason === 'missing'

--- a/src/renderer/components/agents/agent-home/home-connections.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-connections.test.tsx
@@ -152,11 +152,11 @@ describe('HomeConnections — row navigation', () => {
       const method = init?.method ?? 'GET'
       if (path === '/api/agents/test-agent/connected-accounts' && method === 'GET') {
         return Promise.resolve(jsonResponse({
-          accounts: [{ kind: 'connected-account', toolkitSlug: 'slack' }],
+          accounts: [{ kind: 'connected-account', toolkitSlug: 'slack', mappingId: 'map-a1' }],
         }))
       }
       if (path === '/api/agents/test-agent/remote-mcps' && method === 'GET') {
-        return Promise.resolve(jsonResponse({ mcps: [{ kind: 'remote-mcp' }] }))
+        return Promise.resolve(jsonResponse({ mcps: [{ kind: 'remote-mcp', mappingId: 'map-m1' }] }))
       }
       if (path.startsWith('/api/activity/agents/test-agent?days=14&tz=') && method === 'GET') {
         return Promise.resolve(jsonResponse({

--- a/src/renderer/components/connections/connections-list.test.tsx
+++ b/src/renderer/components/connections/connections-list.test.tsx
@@ -1,16 +1,30 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ConnectionsList } from './connections-list'
 import { renderWithProviders } from '@renderer/test/test-utils'
 
 const mockMutateAsync = vi.fn()
+const mockRemoveSharedAccount = vi.fn()
+const mockRemoveSharedMcp = vi.fn()
+
+// Owner by default (the local-mode answer too); flipped per-test below.
+let canAdminAgent = true
+
+vi.mock('@renderer/context/user-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/context/user-context')>()
+  return {
+    ...actual,
+    useUser: () => ({ ...actual.useUser(), canAdminAgent: () => canAdminAgent }),
+  }
+})
 
 vi.mock('@renderer/hooks/use-connected-accounts', () => ({
   useConnectedAccounts: () => ({ data: { accounts: [] }, isLoading: false }),
   useAgentConnectedAccounts: () => ({
     data: {
-      accounts: [{ kind: 'connected-account', toolkitSlug: 'slack' }],
+      accounts: [{ kind: 'connected-account', toolkitSlug: 'slack', mappingId: 'map-a1' }],
     },
     isLoading: false,
   }),
@@ -24,12 +38,17 @@ vi.mock('@renderer/hooks/use-connected-accounts', () => ({
     isPending: false,
     variables: undefined,
   }),
+  useRemoveAgentAccountMapping: () => ({
+    mutateAsync: mockRemoveSharedAccount,
+    isPending: false,
+    variables: undefined,
+  }),
 }))
 
 vi.mock('@renderer/hooks/use-remote-mcps', () => ({
   useRemoteMcps: () => ({ data: { servers: [] }, isLoading: false }),
   useAgentRemoteMcps: () => ({
-    data: { mcps: [{ kind: 'remote-mcp' }] },
+    data: { mcps: [{ kind: 'remote-mcp', mappingId: 'map-m1' }] },
     isLoading: false,
   }),
   useAssignMcpToAgent: () => ({
@@ -39,6 +58,11 @@ vi.mock('@renderer/hooks/use-remote-mcps', () => ({
   }),
   useRemoveMcpFromAgent: () => ({
     mutateAsync: mockMutateAsync,
+    isPending: false,
+    variables: undefined,
+  }),
+  useRemoveAgentMcpMapping: () => ({
+    mutateAsync: mockRemoveSharedMcp,
     isPending: false,
     variables: undefined,
   }),
@@ -53,17 +77,27 @@ vi.mock('@renderer/hooks/use-oauth-reconnect', () => ({
   }),
 }))
 
+function renderList(detailRowKey: string | null = null, onDetailRowKeyChange = vi.fn()) {
+  return renderWithProviders(
+    <ConnectionsList
+      agentSlug="test-agent"
+      detailRowKey={detailRowKey}
+      detailView="details"
+      onDetailViewChange={vi.fn()}
+      onDetailRowKeyChange={onDetailRowKeyChange}
+    />,
+  )
+}
+
 describe('ConnectionsList shared capabilities', () => {
+  beforeEach(() => {
+    canAdminAgent = true
+    mockRemoveSharedAccount.mockReset().mockResolvedValue(undefined)
+    mockRemoveSharedMcp.mockReset().mockResolvedValue(undefined)
+  })
+
   it('does not expose detail navigation or access controls for foreign links', () => {
-    renderWithProviders(
-      <ConnectionsList
-        agentSlug="test-agent"
-        detailRowKey={null}
-        detailView="details"
-        onDetailViewChange={vi.fn()}
-        onDetailRowKeyChange={vi.fn()}
-      />,
-    )
+    renderList()
 
     expect(screen.getByText('Slack')).toBeInTheDocument()
     expect(screen.getByText('Shared MCP connection')).toBeInTheDocument()
@@ -76,20 +110,57 @@ describe('ConnectionsList shared capabilities', () => {
   it('rejects a synthetic foreign detail key', async () => {
     const onDetailRowKeyChange = vi.fn()
 
-    renderWithProviders(
-      <ConnectionsList
-        agentSlug="test-agent"
-        detailRowKey="foreign-account-slack-0"
-        detailView="details"
-        onDetailViewChange={vi.fn()}
-        onDetailRowKeyChange={onDetailRowKeyChange}
-      />,
-    )
+    renderList('foreign-account-map-a1', onDetailRowKeyChange)
 
     await waitFor(() => {
       expect(onDetailRowKeyChange).toHaveBeenCalledWith(null)
     })
     expect(screen.getByText('Slack')).toBeInTheDocument()
     expect(screen.queryByText('Connection details')).not.toBeInTheDocument()
+  })
+
+  it('lets an agent owner unlink a shared account by its link id', async () => {
+    const user = userEvent.setup()
+    renderList()
+
+    await user.click(screen.getByTestId('connection-shared-remove-map-a1'))
+    // The confirm stands between the click and the mutation on purpose: only
+    // the connection's owner can share it back.
+    expect(mockRemoveSharedAccount).not.toHaveBeenCalled()
+
+    await user.click(screen.getByTestId('connection-shared-remove-confirm'))
+
+    await waitFor(() => {
+      expect(mockRemoveSharedAccount).toHaveBeenCalledWith({
+        agentSlug: 'test-agent',
+        mappingId: 'map-a1',
+      })
+    })
+    expect(mockRemoveSharedMcp).not.toHaveBeenCalled()
+  })
+
+  it('routes a shared MCP row to the MCP unlink hook', async () => {
+    const user = userEvent.setup()
+    renderList()
+
+    await user.click(screen.getByTestId('connection-shared-remove-map-m1'))
+    await user.click(screen.getByTestId('connection-shared-remove-confirm'))
+
+    await waitFor(() => {
+      expect(mockRemoveSharedMcp).toHaveBeenCalledWith({
+        agentSlug: 'test-agent',
+        mappingId: 'map-m1',
+      })
+    })
+    expect(mockRemoveSharedAccount).not.toHaveBeenCalled()
+  })
+
+  it('hides the unlink control from a member who does not own the agent', () => {
+    canAdminAgent = false
+    renderList()
+
+    expect(screen.getAllByText('Shared')).toHaveLength(2)
+    expect(screen.queryByTestId('connection-shared-remove-map-a1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('connection-shared-remove-map-m1')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/connections/connections-list.tsx
+++ b/src/renderer/components/connections/connections-list.tsx
@@ -2,7 +2,17 @@ import { useEffect, useMemo, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { Switch } from '@renderer/components/ui/switch'
 import { Button } from '@renderer/components/ui/button'
-import { ChevronRight, Loader2, Plus } from 'lucide-react'
+import { ChevronRight, Loader2, Plus, X } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@renderer/components/ui/alert-dialog'
 import { IntegrationDirectoryDialog, type NewApiConnection, type NewMcpConnection } from '@renderer/components/connections/integration-directory-dialog'
 import { IntegrationList } from '@renderer/components/connections/integration-row'
 import { ConnectionDetailPage } from '@renderer/components/connections/connection-detail-page'
@@ -16,6 +26,7 @@ import {
   useConnectedAccounts,
   useAgentConnectedAccounts,
   useAssignAccountsToAgent,
+  useRemoveAgentAccountMapping,
   useRemoveAgentConnectedAccount,
 } from '@renderer/hooks/use-connected-accounts'
 import { useOAuthReconnect } from '@renderer/hooks/use-oauth-reconnect'
@@ -23,10 +34,12 @@ import {
   useRemoteMcps,
   useAgentRemoteMcps,
   useAssignMcpToAgent,
+  useRemoveAgentMcpMapping,
   useRemoveMcpFromAgent,
 } from '@renderer/hooks/use-remote-mcps'
 import { buildUnifiedRows, type UnifiedRow } from '@renderer/components/connections/unified-rows'
 import { startViewTransition } from '@renderer/lib/view-transition'
+import { useUser } from '@renderer/context/user-context'
 import {
   isForeignAgentConnectedAccount,
   isForeignAgentRemoteMcp,
@@ -131,6 +144,14 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailView, detailBackLab
   const removeAccount = useRemoveAgentConnectedAccount()
   const assignMcp = useAssignMcpToAgent()
   const removeMcp = useRemoveMcpFromAgent()
+  const removeSharedAccount = useRemoveAgentAccountMapping()
+  const removeSharedMcp = useRemoveAgentMcpMapping()
+  const { canAdminAgent } = useUser()
+  const canRemoveShared = canAdminAgent(agentSlug)
+  // The shared row awaiting confirmation. Unlinking a connection someone else
+  // owns is one-way for the person doing it — only the owner can re-share it —
+  // so it asks first, unlike the reversible grant switch.
+  const [sharedPendingRemoval, setSharedPendingRemoval] = useState<UnifiedRow | null>(null)
   const {
     reconnect: oauthReconnect,
     pendingAccountId,
@@ -252,8 +273,21 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailView, detailBackLab
     }
   }
 
+  const confirmSharedRemoval = async () => {
+    const row = sharedPendingRemoval
+    if (!row?.mappingId) return
+    setSharedPendingRemoval(null)
+    const removal = row.type === 'oauth' ? removeSharedAccount : removeSharedMcp
+    // Caught only to keep the rejection handled — neither hook opts out of the
+    // global error toast, so a failure is reported there and the row stays put.
+    await removal.mutateAsync({ agentSlug, mappingId: row.mappingId }).catch(() => {})
+  }
+
   const isRowPending = (row: UnifiedRow): boolean => {
-    if (row.foreign) return false
+    if (row.foreign) {
+      const removal = row.type === 'oauth' ? removeSharedAccount : removeSharedMcp
+      return removal.isPending && removal.variables?.mappingId === row.mappingId
+    }
 
     if (row.type === 'oauth') {
       if (assignAccounts.isPending && assignAccounts.variables?.accountIds.includes(row.id)) return true
@@ -314,7 +348,32 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailView, detailBackLab
         reconnecting={pendingAccountId === row.id}
         right={
           row.foreign ? (
-            <span className="text-xs text-muted-foreground">Shared</span>
+            <>
+              <span className="text-xs text-muted-foreground">Shared</span>
+              {canRemoveShared && row.mappingId && (
+                pending ? (
+                  <Loader2
+                    className="h-4 w-4 animate-spin text-muted-foreground"
+                    aria-label="Removing shared connection"
+                    data-testid={`connection-shared-remove-${row.mappingId}-pending`}
+                  />
+                ) : (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setSharedPendingRemoval(row)
+                    }}
+                    aria-label={`Remove ${row.name} from this agent`}
+                    data-testid={`connection-shared-remove-${row.mappingId}`}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                )
+              )}
+            </>
           ) : <>
             {/* Slides in on row hover/focus; -ml-2 swallows the flex gap while hidden. */}
             <span
@@ -346,8 +405,38 @@ function AllConnectionsList({ agentSlug, detailRowKey, detailView, detailBackLab
 
   const hasAny = grantedRows.length > 0 || notGrantedRows.length > 0
 
+  const removalDialog = (
+    <AlertDialog
+      open={sharedPendingRemoval !== null}
+      onOpenChange={(open) => { if (!open) setSharedPendingRemoval(null) }}
+    >
+      <AlertDialogContent data-testid="connection-shared-remove-dialog">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Remove {sharedPendingRemoval?.name} from this agent?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            This agent will lose access to the connection immediately. The
+            connection itself stays with the member who shared it — only they
+            can share it back.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => { void confirmSharedRemoval() }}
+            data-testid="connection-shared-remove-confirm"
+          >
+            Remove
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+
   return (
     <div className="space-y-6">
+      {removalDialog}
       {isLoading ? (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/renderer/components/connections/unified-rows.test.ts
+++ b/src/renderer/components/connections/unified-rows.test.ts
@@ -145,30 +145,52 @@ describe('buildUnifiedRows', () => {
     const rows = buildUnifiedRows({
       allAccounts: [],
       allMcps: [],
-      foreignAccounts: [{ kind: 'connected-account', toolkitSlug: 'github' }],
-      foreignMcps: [{ kind: 'remote-mcp' }],
+      foreignAccounts: [{ kind: 'connected-account', toolkitSlug: 'github', mappingId: 'map-a1' }],
+      foreignMcps: [{ kind: 'remote-mcp', mappingId: 'map-m1' }],
     })
 
     expect(rows).toEqual([
       expect.objectContaining({
-        key: 'foreign-account-github-0',
+        key: 'foreign-account-map-a1',
         name: 'GitHub',
         subtitle: 'Connected by another member',
         type: 'oauth',
         granted: true,
         foreign: true,
+        mappingId: 'map-a1',
       }),
       expect.objectContaining({
-        key: 'foreign-mcp-0',
+        key: 'foreign-mcp-map-m1',
         name: 'Shared MCP connection',
         subtitle: 'Connected by another member',
         type: 'mcp',
         granted: true,
         foreign: true,
+        mappingId: 'map-m1',
       }),
     ])
     expect(rows.every((row) => row.date === undefined)).toBe(true)
     expect(rows.every((row) => row.mcpTools === undefined)).toBe(true)
     expect(rows.every((row) => row.mcpErrorMessage === undefined)).toBe(true)
+  })
+
+  it('keys foreign rows on the link id so removing a sibling cannot shift them', () => {
+    const build = (accounts: Array<{ toolkitSlug: string; mappingId: string }>) =>
+      buildUnifiedRows({
+        allAccounts: [],
+        allMcps: [],
+        foreignAccounts: accounts.map((a) => ({ kind: 'connected-account' as const, ...a })),
+      })
+
+    const before = build([
+      { toolkitSlug: 'slack', mappingId: 'map-1' },
+      { toolkitSlug: 'slack', mappingId: 'map-2' },
+    ])
+    const after = build([{ toolkitSlug: 'slack', mappingId: 'map-2' }])
+
+    // Two links to the same toolkit are indistinguishable by name; only the
+    // link id keeps the surviving row pointing at itself after the refetch.
+    expect(before.map((r) => r.key)).toEqual(['foreign-account-map-1', 'foreign-account-map-2'])
+    expect(after.map((r) => r.key)).toEqual(['foreign-account-map-2'])
   })
 })

--- a/src/renderer/components/connections/unified-rows.ts
+++ b/src/renderer/components/connections/unified-rows.ts
@@ -18,8 +18,14 @@ export interface UnifiedRow {
   type: 'oauth' | 'mcp'
   date?: string | number
   granted: boolean
-  /** Opaque link owned by another member; never navigable or mutable. */
+  /**
+   * Opaque link owned by another member: never navigable, and never togglable.
+   * An agent owner can only sever it whole, addressing it by `mappingId` —
+   * which is why that field carries no account identity of its own.
+   */
   foreign?: true
+  /** Set on foreign rows only: the agent↔connection link id. */
+  mappingId?: string
   toolkit?: string
   mcpTools?: Array<{ name: string; description?: string }>
   mcpStatus?: RemoteMcpServer['status']
@@ -50,9 +56,12 @@ export function buildForeignConnectionRows({
   accounts = [],
   mcps = [],
 }: ForeignRowsArgs): UnifiedRow[] {
-  const rows: UnifiedRow[] = accounts.map((account, index) => {
+  const rows: UnifiedRow[] = accounts.map((account) => {
     const provider = getProvider(account.toolkitSlug)
-    const id = `foreign-account-${account.toolkitSlug}-${index}`
+    // Keyed on the link id, not list position: a remove control has to keep
+    // pointing at the same link across the refetch that follows a sibling's
+    // removal, and an index would silently slide onto its neighbour.
+    const id = `foreign-account-${account.mappingId}`
     return {
       key: id,
       id,
@@ -63,11 +72,12 @@ export function buildForeignConnectionRows({
       type: 'oauth',
       granted: true,
       foreign: true,
+      mappingId: account.mappingId,
     }
   })
 
-  mcps.forEach((_mcp, index) => {
-    const id = `foreign-mcp-${index}`
+  for (const mcp of mcps) {
+    const id = `foreign-mcp-${mcp.mappingId}`
     rows.push({
       key: id,
       id,
@@ -77,8 +87,9 @@ export function buildForeignConnectionRows({
       type: 'mcp',
       granted: true,
       foreign: true,
+      mappingId: mcp.mappingId,
     })
-  })
+  }
 
   return rows
 }

--- a/src/renderer/components/messages/account-reauth-request-item.test.tsx
+++ b/src/renderer/components/messages/account-reauth-request-item.test.tsx
@@ -4,8 +4,13 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { AccountReauthRequestItem } from './account-reauth-request-item'
 
 const mockReconnect = vi.fn()
+const mockDismiss = vi.fn()
 let mockPendingAccountId: string | null = null
 let mockOwnedAccountIds = ['account-1', 'account-2', 'account-3']
+
+vi.mock('@renderer/lib/reauth-dismiss', () => ({
+  dismissReauthRequest: (...args: unknown[]) => mockDismiss(...args),
+}))
 
 vi.mock('@renderer/hooks/use-oauth-reconnect', () => ({
   useOAuthReconnect: () => ({
@@ -23,6 +28,7 @@ vi.mock('@renderer/hooks/use-connected-accounts', () => ({
 describe('AccountReauthRequestItem', () => {
   beforeEach(() => {
     mockReconnect.mockReset()
+    mockDismiss.mockReset().mockResolvedValue(undefined)
     mockPendingAccountId = null
     mockOwnedAccountIds = ['account-1', 'account-2', 'account-3']
   })
@@ -87,7 +93,7 @@ describe('AccountReauthRequestItem', () => {
     expect(screen.getByText('Waiting for reconnection')).toBeInTheDocument()
   })
 
-  it('shows a non-actionable card to a member who does not own the account', () => {
+  it('offers a member who does not own the account a way out instead of reconnect', () => {
     mockOwnedAccountIds = []
     render(
       <AccountReauthRequestItem
@@ -100,7 +106,73 @@ describe('AccountReauthRequestItem', () => {
       />,
     )
 
+    // Reconnecting stays the owner's alone, but the card blocks every session
+    // of the agent — so this member must not be left with nothing to press.
     expect(screen.queryByTestId('account-reauth-reconnect-btn')).not.toBeInTheDocument()
+    expect(screen.getByTestId('account-reauth-dismiss-btn')).toBeInTheDocument()
     expect(screen.getByText(/Only the connection owner can reconnect/)).toBeInTheDocument()
+  })
+
+  it('dismisses the parked request and closes the card', async () => {
+    const onComplete = vi.fn()
+    mockOwnedAccountIds = []
+
+    render(
+      <AccountReauthRequestItem
+        proxyRequestId="proxy-5"
+        accountId="account-5"
+        toolkit="gmail"
+        accountStatus="expired"
+        agentSlug="agent-1"
+        onComplete={onComplete}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('account-reauth-dismiss-btn'))
+
+    await waitFor(() => expect(mockDismiss).toHaveBeenCalledWith({
+      agentSlug: 'agent-1',
+      requestId: 'proxy-5',
+      reason: undefined,
+    }))
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce())
+  })
+
+  it('keeps the card open when the dismissal fails', async () => {
+    const onComplete = vi.fn()
+    mockOwnedAccountIds = []
+    mockDismiss.mockRejectedValue(new Error('Request not found'))
+
+    render(
+      <AccountReauthRequestItem
+        proxyRequestId="proxy-6"
+        accountId="account-6"
+        toolkit="gmail"
+        accountStatus="expired"
+        agentSlug="agent-1"
+        onComplete={onComplete}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('account-reauth-dismiss-btn'))
+
+    expect(await screen.findByText(/Request not found/)).toBeInTheDocument()
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('offers no dismissal in read-only mode', () => {
+    render(
+      <AccountReauthRequestItem
+        proxyRequestId="proxy-7"
+        accountId="account-1"
+        toolkit="gmail"
+        accountStatus="expired"
+        agentSlug="agent-1"
+        readOnly
+        onComplete={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByTestId('account-reauth-dismiss-btn')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/messages/account-reauth-request-item.tsx
+++ b/src/renderer/components/messages/account-reauth-request-item.tsx
@@ -4,7 +4,9 @@ import { Button } from '@renderer/components/ui/button'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
 import { useOAuthReconnect } from '@renderer/hooks/use-oauth-reconnect'
 import { useConnectedAccounts } from '@renderer/hooks/use-connected-accounts'
+import { dismissReauthRequest } from '@renderer/lib/reauth-dismiss'
 import { getProvider } from '@shared/lib/account-providers/service-catalog'
+import { DeclineButton } from './decline-button'
 import { RequestItemActions } from './request-item-actions'
 import { RequestItemShell } from './request-item-shell'
 
@@ -30,6 +32,7 @@ export function AccountReauthRequestItem({
   onComplete,
 }: AccountReauthRequestItemProps) {
   const [error, setError] = useState<string | null>(null)
+  const [dismissing, setDismissing] = useState(false)
   const { reconnect, pendingAccountId } = useOAuthReconnect()
   const { data: connectedAccounts } = useConnectedAccounts()
   const isReconnecting = pendingAccountId === accountId
@@ -38,6 +41,10 @@ export function AccountReauthRequestItem({
   const statusLabel = accountStatus === 'expired' ? 'expired' : 'been revoked'
   const ownsAccount = connectedAccounts?.accounts.some((account) => account.id === accountId)
   const canReconnect = !readOnly && ownsAccount === true
+  // Reconnecting is the owner's alone, but the card blocks every session of the
+  // agent — so anyone looking at it needs a way out, or a shared credential
+  // nobody present can fix wedges the agent until the request times out.
+  const canDismiss = !readOnly
 
   const handleReconnect = async () => {
     setError(null)
@@ -49,38 +56,59 @@ export function AccountReauthRequestItem({
     }
   }
 
+  const handleDismiss = async (reason?: string) => {
+    setError(null)
+    setDismissing(true)
+    try {
+      await dismissReauthRequest({ agentSlug, requestId: proxyRequestId, reason })
+      onComplete()
+    } catch (dismissError) {
+      setError(dismissError instanceof Error ? dismissError.message : 'Failed to dismiss the request')
+    } finally {
+      setDismissing(false)
+    }
+  }
+
   return (
     <RequestItemShell
       title={`This request needs ${providerName} access that has ${statusLabel}.`}
       subtitle={ownsAccount === false
-        ? 'Only the connection owner can reconnect it. The request will resume when they do.'
+        ? 'Only the connection owner can reconnect it. Dismiss to let the agent move on without it.'
         : 'Reconnect to continue. The original request will resume automatically.'}
       icon={<ServiceIcon slug={toolkit} fallback="oauth" className="h-4 w-4" />}
       theme="orange"
       sessionId={sessionId}
       agentSlug={agentSlug}
-      readOnly={canReconnect ? false : {}}
+      readOnly={canDismiss ? false : {}}
       waitingText="Waiting for reconnection"
       error={error}
       data-testid="account-reauth-request"
       data-status={accountStatus}
     >
-      {canReconnect && (
+      {canDismiss && (
         <RequestItemActions>
-          <Button
-            type="button"
-            size="xs"
-            onClick={handleReconnect}
-            disabled={isReconnecting}
-            data-testid="account-reauth-reconnect-btn"
-          >
-            {isReconnecting ? (
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-            )}
-            {isReconnecting ? 'Reconnecting…' : 'Reconnect'}
-          </Button>
+          <DeclineButton
+            onDecline={(reason) => { void handleDismiss(reason) }}
+            disabled={dismissing || isReconnecting}
+            label="Dismiss"
+            data-testid="account-reauth-dismiss-btn"
+          />
+          {canReconnect && (
+            <Button
+              type="button"
+              size="xs"
+              onClick={handleReconnect}
+              disabled={isReconnecting || dismissing}
+              data-testid="account-reauth-reconnect-btn"
+            >
+              {isReconnecting ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              {isReconnecting ? 'Reconnecting…' : 'Reconnect'}
+            </Button>
+          )}
         </RequestItemActions>
       )}
       <span className="sr-only">Proxy request {proxyRequestId}</span>

--- a/src/renderer/components/messages/mcp-reauth-request-item.test.tsx
+++ b/src/renderer/components/messages/mcp-reauth-request-item.test.tsx
@@ -8,6 +8,7 @@ const mockInitiateOAuth = vi.fn()
 const mockApiFetch = vi.fn()
 const mockNavigate = vi.fn()
 const mockClose = vi.fn()
+const mockDismiss = vi.fn()
 let oauthComplete: ((result: { success: boolean; error?: string }) => void) | null = null
 let mockCanManage = true
 
@@ -28,6 +29,10 @@ vi.mock('@renderer/lib/api', () => ({
 
 vi.mock('@renderer/lib/oauth-popup', () => ({
   prepareOAuthPopup: () => ({ navigate: mockNavigate, close: mockClose }),
+}))
+
+vi.mock('@renderer/lib/reauth-dismiss', () => ({
+  dismissReauthRequest: (...args: unknown[]) => mockDismiss(...args),
 }))
 
 function renderItem(overrides: Partial<React.ComponentProps<typeof McpReauthRequestItem>> = {}) {
@@ -52,6 +57,7 @@ function renderItem(overrides: Partial<React.ComponentProps<typeof McpReauthRequ
 describe('McpReauthRequestItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockDismiss.mockResolvedValue(undefined)
     oauthComplete = null
     mockCanManage = true
   })
@@ -99,14 +105,41 @@ describe('McpReauthRequestItem', () => {
     renderItem({ readOnly: true })
 
     expect(screen.queryByTestId('mcp-reauth-reconnect-btn')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mcp-reauth-dismiss-btn')).not.toBeInTheDocument()
     expect(screen.getByText('Waiting for reconnection')).toBeInTheDocument()
   })
 
-  it('shows a non-actionable card to a member who cannot manage the MCP', () => {
+  it('offers a member who cannot manage the MCP a way out instead of reconnect', () => {
     mockCanManage = false
     renderItem()
 
     expect(screen.queryByTestId('mcp-reauth-reconnect-btn')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mcp-reauth-dismiss-btn')).toBeInTheDocument()
     expect(screen.getByText(/Only the connection owner or an administrator/)).toBeInTheDocument()
+  })
+
+  it('dismisses the parked request and closes the card', async () => {
+    mockCanManage = false
+    const props = renderItem()
+
+    fireEvent.click(screen.getByTestId('mcp-reauth-dismiss-btn'))
+
+    await waitFor(() => expect(mockDismiss).toHaveBeenCalledWith({
+      agentSlug: 'agent-1',
+      requestId: 'proxy-1',
+      reason: undefined,
+    }))
+    await waitFor(() => expect(props.onComplete).toHaveBeenCalledOnce())
+  })
+
+  it('keeps the card open when the dismissal fails', async () => {
+    mockCanManage = false
+    mockDismiss.mockRejectedValue(new Error('Request not found'))
+    const props = renderItem()
+
+    fireEvent.click(screen.getByTestId('mcp-reauth-dismiss-btn'))
+
+    expect(await screen.findByText(/Request not found/)).toBeInTheDocument()
+    expect(props.onComplete).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/messages/mcp-reauth-request-item.tsx
+++ b/src/renderer/components/messages/mcp-reauth-request-item.tsx
@@ -8,7 +8,9 @@ import { useCanManageRemoteMcp, useInitiateMcpOAuth } from '@renderer/hooks/use-
 import { useMcpOAuthListener } from '@renderer/hooks/use-mcp-oauth-listener'
 import { apiFetch } from '@renderer/lib/api'
 import { prepareOAuthPopup } from '@renderer/lib/oauth-popup'
+import { dismissReauthRequest } from '@renderer/lib/reauth-dismiss'
 import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
+import { DeclineButton } from './decline-button'
 import { RequestItemActions } from './request-item-actions'
 import { RequestItemShell } from './request-item-shell'
 
@@ -37,6 +39,7 @@ export function McpReauthRequestItem({
   const initiateOAuth = useInitiateMcpOAuth()
   const { data: canManage } = useCanManageRemoteMcp(mcpId)
   const [pending, setPending] = useState(false)
+  const [dismissing, setDismissing] = useState(false)
   const [bearerToken, setBearerToken] = useState('')
   const [error, setError] = useState<string | null>(null)
   const popupRef = useRef<ReturnType<typeof prepareOAuthPopup> | null>(null)
@@ -45,6 +48,9 @@ export function McpReauthRequestItem({
     [mcpName],
   )
   const canReconnect = !readOnly && canManage === true
+  // See the account twin: the card blocks every session of the agent, so a
+  // viewer who cannot reconnect still needs a way to let the agent move on.
+  const canDismiss = !readOnly
 
   const finish = () => {
     queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
@@ -68,6 +74,19 @@ export function McpReauthRequestItem({
     popupRef.current?.close()
     popupRef.current = null
   }, [])
+
+  const dismiss = async (reason?: string) => {
+    setError(null)
+    setDismissing(true)
+    try {
+      await dismissReauthRequest({ agentSlug, requestId: proxyRequestId, reason })
+      onComplete()
+    } catch (dismissError) {
+      setError(dismissError instanceof Error ? dismissError.message : 'Failed to dismiss the request')
+    } finally {
+      setDismissing(false)
+    }
+  }
 
   const parseError = async (response: Response, fallback: string) => {
     const body = await response.json().catch(() => ({})) as { error?: unknown }
@@ -126,13 +145,13 @@ export function McpReauthRequestItem({
     <RequestItemShell
       title={`This request needs ${mcpName}, which requires re-authentication.`}
       subtitle={canManage === false
-        ? 'Only the connection owner or an administrator can reconnect it. The request will resume when they do.'
+        ? 'Only the connection owner or an administrator can reconnect it. Dismiss to let the agent move on without it.'
         : 'Reconnect to continue. The original MCP request will resume automatically.'}
       icon={<ServiceIcon slug={serviceSlug} fallback="mcp" className="h-4 w-4" />}
       theme="orange"
       sessionId={sessionId}
       agentSlug={agentSlug}
-      readOnly={canReconnect ? false : {}}
+      readOnly={canDismiss ? false : {}}
       waitingText="Waiting for reconnection"
       error={error}
       data-testid="mcp-reauth-request"
@@ -148,22 +167,30 @@ export function McpReauthRequestItem({
           data-testid="mcp-reauth-token-input"
         />
       )}
-      {canReconnect && (
+      {canDismiss && (
         <RequestItemActions>
-          <Button
-            type="button"
-            size="xs"
-            onClick={() => void reconnect()}
-            disabled={pending || (authType === 'bearer' && !bearerToken.trim())}
-            data-testid="mcp-reauth-reconnect-btn"
-          >
-            {pending ? (
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-            )}
-            {pending ? 'Reconnecting…' : authType === 'none' ? 'Retry' : 'Reconnect'}
-          </Button>
+          <DeclineButton
+            onDecline={(reason) => { void dismiss(reason) }}
+            disabled={pending || dismissing}
+            label="Dismiss"
+            data-testid="mcp-reauth-dismiss-btn"
+          />
+          {canReconnect && (
+            <Button
+              type="button"
+              size="xs"
+              onClick={() => void reconnect()}
+              disabled={pending || dismissing || (authType === 'bearer' && !bearerToken.trim())}
+              data-testid="mcp-reauth-reconnect-btn"
+            >
+              {pending ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              {pending ? 'Reconnecting…' : authType === 'none' ? 'Retry' : 'Reconnect'}
+            </Button>
+          )}
         </RequestItemActions>
       )}
       <span className="sr-only">MCP proxy request {proxyRequestId}</span>

--- a/src/renderer/hooks/use-connected-accounts.ts
+++ b/src/renderer/hooks/use-connected-accounts.ts
@@ -222,6 +222,30 @@ export function useRemoveAgentConnectedAccount() {
 }
 
 /**
+ * Remove a connection from an agent by LINK id rather than account id — the
+ * only handle an agent owner has for a connection another member shared onto
+ * the agent. Server-gated on owning the agent.
+ */
+export function useRemoveAgentAccountMapping() {
+  const queryClient = useQueryClient()
+
+  return useMutation<void, Error, { agentSlug: string; mappingId: string }>({
+    mutationFn: async ({ agentSlug, mappingId }) => {
+      const res = await apiFetch(
+        `/api/agents/${agentSlug}/connected-accounts/mapping/${mappingId}`,
+        { method: 'DELETE' },
+      )
+      if (!res.ok) throw new Error('Failed to remove the shared connection from this agent')
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
+    },
+    onSuccess: () => {
+      // Bare prefix — see useAssignAccountsToAgent: reaches the id-keyed home card too.
+      queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts'] })
+    },
+  })
+}
+
+/**
  * Hook to fetch agent slugs that have a connected account mapped
  */
 export function useAccountAgents(accountId: string) {

--- a/src/renderer/hooks/use-remote-mcps.ts
+++ b/src/renderer/hooks/use-remote-mcps.ts
@@ -235,6 +235,30 @@ export function useRemoveMcpFromAgent() {
 }
 
 /**
+ * Remove a remote MCP from an agent by LINK id — the agent-owner twin of
+ * useRemoveMcpFromAgent, for a server another member shared onto the agent
+ * whose id the owner never sees. Server-gated on owning the agent.
+ */
+export function useRemoveAgentMcpMapping() {
+  const queryClient = useQueryClient()
+
+  return useMutation<void, Error, { agentSlug: string; mappingId: string }>({
+    mutationFn: async ({ agentSlug, mappingId }) => {
+      const res = await apiFetch(
+        `/api/agents/${agentSlug}/remote-mcps/mapping/${mappingId}`,
+        { method: 'DELETE' },
+      )
+      if (!res.ok) throw new Error('Failed to remove the shared connection from this agent')
+      warnIfLiveRefreshFailed(await res.json().catch(() => ({})))
+    },
+    onSuccess: () => {
+      // Bare prefix — see useAssignMcpToAgent: reaches the id-keyed home card too.
+      queryClient.invalidateQueries({ queryKey: ['agent-remote-mcps'] })
+    },
+  })
+}
+
+/**
  * Hook to fetch agent slugs that have an MCP server mapped
  */
 export function useMcpAgents(mcpId: string) {

--- a/src/renderer/lib/reauth-dismiss.ts
+++ b/src/renderer/lib/reauth-dismiss.ts
@@ -1,0 +1,35 @@
+import { apiFetch } from '@renderer/lib/api'
+
+/**
+ * Abandon a parked re-authentication request.
+ *
+ * A reauth card blocks every session of its agent, and only the connection's
+ * owner can clear it by reconnecting — so for a connection someone else shared,
+ * this is the sole way out short of the five-minute timeout. The parked agent
+ * call fails with a "dismissed" status rather than a timeout, so it reads as a
+ * decision rather than an invitation to retry.
+ */
+export async function dismissReauthRequest({
+  agentSlug,
+  requestId,
+  reason,
+}: {
+  agentSlug: string
+  requestId: string
+  reason?: string
+}): Promise<void> {
+  const response = await apiFetch(
+    `/api/agents/${agentSlug}/reauth-request/${requestId}/dismiss`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason }),
+    },
+  )
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({})) as { error?: unknown }
+    throw new Error(
+      typeof body.error === 'string' ? body.error : 'Failed to dismiss the request',
+    )
+  }
+}

--- a/src/shared/lib/agent-connections/public.test.ts
+++ b/src/shared/lib/agent-connections/public.test.ts
@@ -74,11 +74,20 @@ function mcpMapping(overrides: Partial<AgentRemoteMcp> = {}): AgentRemoteMcp {
 }
 
 describe('agent connection DTOs', () => {
-  it('keeps a foreign account marker free of row, owner, and provider identifiers', () => {
+  it('reduces a foreign account to its toolkit and the link id', () => {
     const result = toAgentConnectedAccountDto(accountMapping(), account(), 'viewer-2')
 
-    expect(result).toEqual({ kind: 'connected-account', toolkitSlug: 'github' })
-    expect(JSON.stringify(result)).not.toContain('account-1')
+    // The link id is the handle an agent owner unlinks by. It names the
+    // agent↔account row, so it leaks nothing about the account or its owner —
+    // which is exactly what the assertions below pin.
+    expect(result).toEqual({
+      kind: 'connected-account',
+      toolkitSlug: 'github',
+      mappingId: 'account-mapping-1',
+    })
+    expect(result).not.toHaveProperty('id')
+    expect(result).not.toHaveProperty('displayName')
+    expect(JSON.stringify(result)).not.toContain('"account-1"')
     expect(JSON.stringify(result)).not.toContain('owner-1')
     expect(JSON.stringify(result)).not.toContain('provider-connection-1')
   })
@@ -106,11 +115,13 @@ describe('agent connection DTOs', () => {
     expect(result).toMatchObject({ id: 'account-1', displayName: 'My GitHub' })
   })
 
-  it('uses a fully opaque marker for a foreign MCP', () => {
+  it('reduces a foreign MCP to the link id alone', () => {
     const result = toAgentRemoteMcpDto(mcpMapping(), mcp(), 'viewer-2')
 
-    expect(result).toEqual({ kind: 'remote-mcp' })
-    expect(JSON.stringify(result)).not.toContain('mcp-1')
+    expect(result).toEqual({ kind: 'remote-mcp', mappingId: 'mcp-mapping-1' })
+    expect(result).not.toHaveProperty('id')
+    expect(result).not.toHaveProperty('name')
+    expect(JSON.stringify(result)).not.toContain('"mcp-1"')
     expect(JSON.stringify(result)).not.toContain('private.example.test')
     expect(JSON.stringify(result)).not.toContain('search')
   })

--- a/src/shared/lib/agent-connections/public.ts
+++ b/src/shared/lib/agent-connections/public.ts
@@ -22,10 +22,19 @@ export interface PublicAgentConnectedAccount {
   provider?: Provider
 }
 
-/** Minimal capability marker for a connected account owned by another user. */
+/**
+ * Minimal capability marker for a connected account owned by another user.
+ *
+ * `mappingId` names the agent↔account LINK, never the account: it carries no
+ * owner, provider, or account identity, and the only route that accepts it —
+ * the agent-owner unlink below — re-checks that the link belongs to the agent
+ * in the URL. That is what lets a co-owner drop a shared connection from their
+ * agent without ever learning whose it is.
+ */
 export interface ForeignAgentConnectedAccount {
   kind: 'connected-account'
   toolkitSlug: string
+  mappingId: string
 }
 
 export type AgentConnectedAccountDto = PublicAgentConnectedAccount | ForeignAgentConnectedAccount
@@ -42,9 +51,13 @@ export interface PublicAgentRemoteMcp {
   mappedAt: string
 }
 
-/** Minimal capability marker for a remote MCP owned by another user. */
+/**
+ * Minimal capability marker for a remote MCP owned by another user. See
+ * {@link ForeignAgentConnectedAccount} for why `mappingId` is safe to expose.
+ */
 export interface ForeignAgentRemoteMcp {
   kind: 'remote-mcp'
+  mappingId: string
 }
 
 export type AgentRemoteMcpDto = PublicAgentRemoteMcp | ForeignAgentRemoteMcp
@@ -78,7 +91,11 @@ export function toAgentConnectedAccountDto(
   provider?: Provider,
 ): AgentConnectedAccountDto {
   if (viewerUserId !== null && account.userId !== viewerUserId) {
-    return { kind: 'connected-account', toolkitSlug: account.toolkitSlug }
+    return {
+      kind: 'connected-account',
+      toolkitSlug: account.toolkitSlug,
+      mappingId: mapping.id,
+    }
   }
 
   return {
@@ -103,7 +120,7 @@ export function toAgentRemoteMcpDto(
   viewerUserId: string | null,
 ): AgentRemoteMcpDto {
   if (viewerUserId !== null && mcp.userId !== viewerUserId) {
-    return { kind: 'remote-mcp' }
+    return { kind: 'remote-mcp', mappingId: mapping.id }
   }
 
   return {

--- a/src/shared/lib/proxy/account-reauth-manager.test.ts
+++ b/src/shared/lib/proxy/account-reauth-manager.test.ts
@@ -13,6 +13,7 @@ import {
   AccountReauthManager,
 } from './account-reauth-manager'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import { isReauthDismissed } from './reauth-dismissal'
 
 const DETAILS = {
   agentSlug: 'agent-1',
@@ -113,5 +114,43 @@ describe('AccountReauthManager', () => {
 
     await rejection
     expect(userInputRequestManager.getOpenRequestsForStore('review')).toHaveLength(0)
+  })
+
+  it('clears the card and every parked request when a user dismisses it', async () => {
+    const first = manager.requestReauth(DETAILS)
+    const second = manager.requestReauth(DETAILS)
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+    const rejections = Promise.all([
+      first.catch((error: unknown) => error),
+      second.catch((error: unknown) => error),
+    ])
+
+    expect(manager.dismiss(request.id, 'agent-1', 'nobody here owns it')).toBe(true)
+
+    // The reason reaches the agent through the parked call's failure, and the
+    // failure is flagged so the proxy can call it a dismissal, not a timeout.
+    for (const error of await rejections) {
+      expect(isReauthDismissed(error)).toBe(true)
+      expect((error as Error).message).toContain('nobody here owns it')
+    }
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(0)
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)?.outcome).toBe('cancelled')
+  })
+
+  it('refuses a dismissal aimed at another agent', async () => {
+    const promise = manager.requestReauth(DETAILS)
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+
+    // The id is an unauthenticated pointer into a process-wide map; holding a
+    // role on some other agent must not settle this one's wait.
+    expect(manager.dismiss(request.id, 'agent-2')).toBe(false)
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(1)
+
+    manager.completeAccount('account-1')
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('reports an unknown request id as not dismissed', () => {
+    expect(manager.dismiss('no-such-request', 'agent-1')).toBe(false)
   })
 })

--- a/src/shared/lib/proxy/account-reauth-manager.ts
+++ b/src/shared/lib/proxy/account-reauth-manager.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
+import { ReauthDismissedError, reauthDismissedMessage } from './reauth-dismissal'
 
 export const ACCOUNT_REAUTH_TIMEOUT_MS = 5 * 60 * 1000
 
@@ -205,6 +206,28 @@ export class AccountReauthManager {
 
       messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
     })
+  }
+
+  /**
+   * Give up on one parked card because a person dismissed it. Without this the
+   * only exits are the owner reconnecting or the five-minute timer, so a
+   * shared credential nobody present can reconnect holds every session of the
+   * agent in awaiting-input until it expires.
+   *
+   * Returns false when `entryId` names no live group under `agentSlug` — the
+   * caller decides whether that is a stale card or a cross-agent probe.
+   */
+  dismiss(entryId: string, agentSlug: string, reason?: string): boolean {
+    const group = this.groups.get(entryId)
+    if (!group || group.agentSlug !== agentSlug) return false
+    this.settleGroup(group, 'cancelled', {
+      type: 'reject',
+      error: new ReauthDismissedError(
+        reauthDismissedMessage('Account re-authentication', reason),
+        reason,
+      ),
+    })
+    return true
   }
 
   /** Resume every parked proxy request that uses the reconnected account. */

--- a/src/shared/lib/proxy/mcp-reauth-manager.test.ts
+++ b/src/shared/lib/proxy/mcp-reauth-manager.test.ts
@@ -10,6 +10,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
 
 import { MCP_REAUTH_TIMEOUT_MS, McpReauthManager } from './mcp-reauth-manager'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import { isReauthDismissed } from './reauth-dismissal'
 
 const DETAILS = {
   agentSlug: 'agent-1',
@@ -110,5 +111,30 @@ describe('McpReauthManager', () => {
 
     await rejection
     expect(userInputRequestManager.getOpenRequestsForStore('review')).toHaveLength(0)
+  })
+
+  it('clears the card and the parked request when a user dismisses it', async () => {
+    const promise = manager.requestReauth(DETAILS)
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+    const rejection = promise.catch((error: unknown) => error)
+
+    expect(manager.dismiss(request.id, 'agent-1', 'not my server')).toBe(true)
+
+    const error = await rejection
+    expect(isReauthDismissed(error)).toBe(true)
+    expect((error as Error).message).toContain('not my server')
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(0)
+    expect(userInputRequestManager.stats.recentResolutions.at(-1)?.outcome).toBe('cancelled')
+  })
+
+  it('refuses a dismissal aimed at another agent', async () => {
+    const promise = manager.requestReauth(DETAILS)
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+
+    expect(manager.dismiss(request.id, 'agent-2')).toBe(false)
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(1)
+
+    manager.completeMcp('mcp-1')
+    await expect(promise).resolves.toBeUndefined()
   })
 })

--- a/src/shared/lib/proxy/mcp-reauth-manager.ts
+++ b/src/shared/lib/proxy/mcp-reauth-manager.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
+import { ReauthDismissedError, reauthDismissedMessage } from './reauth-dismissal'
 
 export const MCP_REAUTH_TIMEOUT_MS = 5 * 60 * 1000
 
@@ -193,6 +194,23 @@ export class McpReauthManager {
 
       messagePersister.syncAgentSessionsAwaiting(details.agentSlug)
     })
+  }
+
+  /**
+   * Give up on one parked card because a person dismissed it. The
+   * account-reauth twin carries the full rationale.
+   */
+  dismiss(entryId: string, agentSlug: string, reason?: string): boolean {
+    const group = this.groups.get(entryId)
+    if (!group || group.agentSlug !== agentSlug) return false
+    this.settleGroup(group, 'cancelled', {
+      type: 'reject',
+      error: new ReauthDismissedError(
+        reauthDismissedMessage('MCP re-authentication', reason),
+        reason,
+      ),
+    })
+    return true
   }
 
   /** Resume every parked proxy request that uses the reconnected MCP. */

--- a/src/shared/lib/proxy/reauth-dismissal.ts
+++ b/src/shared/lib/proxy/reauth-dismissal.ts
@@ -1,0 +1,56 @@
+/**
+ * Marker for a re-auth wait that a person deliberately dismissed, as opposed
+ * to one that ran out its timer.
+ *
+ * A parked proxy request could only end one of two ways before this — the
+ * credential came back, or the wait timed out — and both re-auth managers
+ * reject with a plain Error. The proxy routes turn any rejection into a 408
+ * "timed out", which is the wrong story to tell an agent whose user just said
+ * "give up on this one": it invites a retry into the same wall.
+ *
+ * The flag is duck-typed rather than checked with `instanceof` on purpose.
+ * The managers live in shared code that the API bundle and the Electron main
+ * bundle each load through their own module instance, so a class identity does
+ * not survive the crossing; an own-property flag does.
+ */
+export class ReauthDismissedError extends Error {
+  readonly reauthDismissed = true
+  /** What the person typed, if anything. Forwarded to the agent verbatim. */
+  readonly dismissReason?: string
+
+  constructor(message: string, dismissReason?: string) {
+    super(message)
+    this.name = 'ReauthDismissedError'
+    this.dismissReason = dismissReason
+  }
+}
+
+export function isReauthDismissed(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { reauthDismissed?: unknown }).reauthDismissed === true
+  )
+}
+
+/** The dismisser's stated reason, if they gave one. Read alongside {@link isReauthDismissed}. */
+export function reauthDismissalReason(error: unknown): string | undefined {
+  if (!isReauthDismissed(error)) return undefined
+  const reason = (error as { dismissReason?: unknown }).dismissReason
+  return typeof reason === 'string' && reason ? reason : undefined
+}
+
+/** The message the parked agent request is failed with. */
+export function reauthDismissedMessage(subject: string, reason?: string): string {
+  const base = `${subject} was dismissed by a user`
+  return reason ? `${base}: ${reason}` : base
+}
+
+/**
+ * Append the dismisser's own words to the agent-facing explanation. Kept here
+ * so both proxies phrase it identically — the agent reads this as the reason a
+ * tool call it made came back empty.
+ */
+export function withDismissalReason(message: string, reason?: string): string {
+  return reason ? `${message} They said: "${reason}"` : message
+}


### PR DESCRIPTION
The Agent Connections page showed a member's shared connection as a bare "Shared" row with nothing on it. The only unlink route is keyed on the account id and owner-scoped, and the foreign DTO withholds that id by design — so there was no reachable call at all, not merely a hidden button. Separately, when a shared credential expired mid-run the reauth card blocked every session of the agent, with reconnecting reserved to the credential's owner and a five-minute timer as the only exit.

Closes https://linear.app/datawizz/issue/SUP-702

## Unlinking a shared connection

Foreign DTOs now carry the agent-connection **link** id — the join row, which names no account, owner, or provider. New `DELETE /api/agents/:id/{connected-accounts,remote-mcps}/mapping/:mappingId` accept it, gated on `AgentAdmin()`: owning the *agent* authorizes the unlink, not owning the account. Only the mapping row dies; the connection stays with the member who shared it.

- the pre-existing account-keyed route is untouched and still owner-scoped
- a `user` on the agent gets 403
- both routes match on agent **and** link id, so a link id sent to another agent's URL 404s
- foreign row keys moved from `<toolkit>-<index>` to `<mappingId>` — an index key slid onto its neighbour after a sibling was removed
- the ✕ sits behind a confirm: unlinking is one-way for the person doing it, since only the owner can share it back

## The wedge escape hatch

`POST /api/agents/:id/reauth-request/:requestId/dismiss`, gated on `AgentUser()` — whoever can put work into the agent can abandon a call it is stuck on. Both reauth cards render a **Dismiss** action whenever the surface is not view-only; Reconnect stays owner-only. That also restores the Stop-session button, which the read-only shell had been suppressing.

The parked call fails **403 `account_reauth_dismissed`** (or `mcp_reauth_dismissed`) rather than the 408 timeout shape — a timeout reads to an agent as an invitation to retry into the same wall. The dismisser's stated reason travels with it, so the card's "tell your agent why" box is honoured end to end. `isReauthDismissed()` is duck-typed rather than `instanceof`: these managers are loaded through separate module instances by the API and Electron main bundles, and a class identity does not survive that crossing.

## Note on what an owner sees

A shared row renders as the toolkit name (`Slack`, `Gmail`) because the display name is withheld. Two shared Slack accounts therefore look identical — the link ids keep *removal* correct, but the labels don't help an owner choose between them. Left for a follow-up; it needs a disambiguator that still leaks nothing.

Dismissing also leaves no transcript entry — reauth requests are agent-scoped and carry no session id to anchor one to. In practice the agent narrates the 403 in its next message. Deliberately left as is.

## Tests

- **E2E, auth mode** — new `auth-shared-connections` project, 13 tests, three real users against the real server. Covers the opaque row, the `user`-role 403, both cross-agent 404s, removal **through the actual Connections page UI**, the account surviving its link, a real parked proxy call dismissed to 403 with the reason intact, the repeat dismissal returning `alreadySettled`, and a `user`-role member dismissing (the deliberate asymmetry with unlink).
- **Unit** — manager `dismiss` (cross-agent refusal, reason propagation, unknown id), the owner/non-owner split on the connections list, both reauth cards' dismiss/failure/read-only paths, DTO projections.
- Full suite: 10,543 passing. `tsc` and `eslint` clean.

https://claude.ai/code/session_01Y73CeDYiQFXt4fHmEgCJCa
