### PR TITLE
Close the browser preview drawer when the window is closed externally (SUP-710)

### DIFF
--- a/agent-container/src/browser-liveness.test.ts
+++ b/agent-container/src/browser-liveness.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  PAGE_TARGET_RECHECK_MS,
+  confirmNoPagesLeft,
+  readTabSources,
+  recheckPageTarget,
+} from './browser-liveness'
+
+describe('recheckPageTarget', () => {
+  it('waits before looking again, so a tab that lags browser_open is still found', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const findTarget = vi.fn().mockResolvedValue({ id: 'page-1' })
+
+    const target = await recheckPageTarget(findTarget, sleep)
+
+    expect(sleep).toHaveBeenCalledWith(PAGE_TARGET_RECHECK_MS)
+    expect(sleep.mock.invocationCallOrder[0]).toBeLessThan(findTarget.mock.invocationCallOrder[0])
+    expect(target).toEqual({ id: 'page-1' })
+  })
+
+  it('reports no target when the second look also finds none', async () => {
+    const findTarget = vi.fn().mockResolvedValue(null)
+
+    expect(await recheckPageTarget(findTarget, async () => {})).toBeNull()
+    expect(findTarget).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats an unreachable CDP endpoint as no target rather than throwing', async () => {
+    const findTarget = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
+
+    await expect(recheckPageTarget(findTarget, async () => {})).resolves.toBeNull()
+  })
+})
+
+describe('readTabSources', () => {
+  it('does not ask the daemon for tabs when Chrome reports no page', async () => {
+    // Asking would MAKE one: agent-browser opens about:blank so it has
+    // something to report, resurrecting the window the user just closed.
+    const listDaemonTabs = vi.fn().mockResolvedValue([{ tabId: 't2', url: 'about:blank' }])
+
+    const result = await readTabSources(async () => [], listDaemonTabs)
+
+    expect(listDaemonTabs).not.toHaveBeenCalled()
+    expect(result).toEqual({ allTargets: [], daemonTabs: [] })
+  })
+
+  it('reconciles both sources while Chrome still has a page', async () => {
+    const listDaemonTabs = vi.fn().mockResolvedValue([{ tabId: 't1', url: 'https://example.com/' }])
+
+    const result = await readTabSources(
+      async () => [{ id: 'A', url: 'https://example.com/' }],
+      listDaemonTabs,
+    )
+
+    expect(listDaemonTabs).toHaveBeenCalledTimes(1)
+    expect(result.allTargets).toHaveLength(1)
+    expect(result.daemonTabs).toHaveLength(1)
+  })
+})
+
+describe('confirmNoPagesLeft', () => {
+  it('confirms the close when Chrome answers with no page', async () => {
+    expect(await confirmNoPagesLeft(async () => [])).toBe(true)
+  })
+
+  it('does not confirm when a page turned up after all', async () => {
+    expect(await confirmNoPagesLeft(async () => [{ id: 'late-page' }])).toBe(false)
+  })
+
+  it('does not confirm when Chrome cannot be reached', async () => {
+    // A transient outage fails the lenient lookups the same way a closed
+    // browser does — without this, a network blip tears down a live browser.
+    const strict = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
+
+    expect(await confirmNoPagesLeft(strict)).toBe(false)
+  })
+})

--- a/agent-container/src/browser-liveness.ts
+++ b/agent-container/src/browser-liveness.ts
@@ -1,0 +1,75 @@
+/**
+ * Detecting that the browser went away without anyone telling us.
+ *
+ * The host notices Chrome *quitting* (the process dies) and posts
+ * /browser/notify-closed. It cannot notice Chrome losing its last *window*:
+ * on macOS the app stays alive with zero pages, so the process check keeps
+ * passing while the screencast has nothing left to stream. Both cases surface
+ * the same way here — the CDP target list has no page in it.
+ */
+
+/** How long to wait before taking a second look for a page target. */
+export const PAGE_TARGET_RECHECK_MS = 750;
+
+/**
+ * A screencast connect that finds no page target usually means the browser is
+ * gone, but a tab can be missing for a moment right after browser_open —
+ * Chrome creates the target slightly after the daemon reports success. Look
+ * once more before tearing the browser down. Resolves to the target the second
+ * look found, or null when the browser really has no page left.
+ */
+export async function recheckPageTarget<T>(
+  findTarget: () => Promise<T | null>,
+  sleep: (ms: number) => Promise<unknown>,
+): Promise<T | null> {
+  await sleep(PAGE_TARGET_RECHECK_MS);
+  try {
+    return await findTarget();
+  } catch {
+    // Can't reach Chrome — no target to report. Whether that means the
+    // browser is closed is confirmNoPagesLeft's call, not ours.
+    return null;
+  }
+}
+
+/**
+ * Read the two tab sources the viewer reconciles: Chrome's own page targets,
+ * and agent-browser's view of them.
+ *
+ * The guard is not an optimisation. Asking agent-browser for a tab list when
+ * the browser has no page MAKES one — the daemon opens about:blank so it has
+ * something to report. A 2s poll doing that resurrects the window the user
+ * just closed, and hands the close detector a phantom tab to recover onto.
+ * Chrome's target list is the authority on whether any page exists; when it
+ * says none, there is nothing for the daemon to reconcile.
+ */
+export async function readTabSources<Target, DaemonTab>(
+  listPageTargets: () => Promise<Target[]>,
+  listDaemonTabs: () => Promise<DaemonTab[]>,
+): Promise<{ allTargets: Target[]; daemonTabs: DaemonTab[] }> {
+  const allTargets = await listPageTargets();
+  if (allTargets.length === 0) return { allTargets, daemonTabs: [] };
+  return { allTargets, daemonTabs: await listDaemonTabs() };
+}
+
+/**
+ * Only Chrome itself can testify that it has no pages left.
+ *
+ * The lenient target lookups above swallow every network failure into "no
+ * targets", which reads exactly like a closed browser — but an unreachable
+ * endpoint proves nothing. A dead Chrome process is the host watcher's case
+ * (it posts /browser/notify-closed), and a transient container↔host outage
+ * fails both lookups at once, 750ms being no de-correlation at all. Tearing
+ * down on that would orphan a live browser we just lost the address of.
+ * So the close verdict needs an answered request whose answer held no page;
+ * anything else resolves false and leaves the state alone.
+ */
+export async function confirmNoPagesLeft(
+  listPageTargetsStrict: () => Promise<readonly unknown[]>,
+): Promise<boolean> {
+  try {
+    return (await listPageTargetsStrict()).length === 0;
+  } catch {
+    return false;
+  }
+}

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -656,6 +656,13 @@ import {
   resolveBrowserRuntimeLocation,
   shouldRefuseImplicitHostLoopback,
 } from './browser-location';
+import { confirmNoPagesLeft, readTabSources, recheckPageTarget } from './browser-liveness';
+
+// Bumped each time /browser/open succeeds. External-close detection spans real
+// time (two target lookups 750ms apart, then a confirmation request); a browser
+// opened during that span must not be torn down by a verdict formed against the
+// one before it. Detection snapshots this before looking and re-compares last.
+let browserOpenGeneration = 0;
 
 // Proxy object so existing code can read `browserState.active` etc. without changes.
 // Writes must go through _setBrowserState() to keep the canonical module state in sync.
@@ -1165,6 +1172,7 @@ app.post('/browser/open', async (c) => {
       }
     }
 
+    browserOpenGeneration++;
     _setBrowserState({ active: true, sessionId: body.sessionId, cdpUrl: cdpUrl || null, location });
     tabManager.resetTabCount();
     resetUrlTracking();
@@ -1252,15 +1260,32 @@ app.post('/browser/release', async (c) => {
   }
 });
 
-// POST /browser/notify-closed - Host browser was closed externally, clean up state
-app.post('/browser/notify-closed', (c) => {
-  if (browserState.location) {
+/**
+ * Drop every trace of a browser the user closed on us.
+ *
+ * Reached two ways: the host telling us Chrome's process died, and the
+ * screencast finding no page left to stream (macOS keeps Chrome alive after
+ * its last window closes, so only the second one catches that). Until this
+ * runs, /browser/status keeps answering "active" and the viewer keeps
+ * reconnecting to a browser that no longer exists.
+ *
+ * The state reset is synchronous: callers that also close a viewer socket rely
+ * on the status endpoint already answering "inactive" by the time they do.
+ */
+async function handleExternalBrowserClose(
+  reason: string,
+  options: { stopHostBrowser: boolean },
+): Promise<void> {
+  const ownerSessionId = browserState.sessionId;
+  const location = browserState.location;
+
+  if (location) {
     cleanupAgentBrowserDaemon();
     cleanupCdpScreencast();
-    broadcastBrowserEvent(false);
+    broadcastBrowserEvent(false, ownerSessionId);
     _setBrowserState({ active: false, sessionId: null, cdpUrl: null, location: null });
     tabManager.resetTabCount();
-    console.log('[Browser] Browser closed externally, state cleaned up');
+    console.log(`[Browser] Browser closed externally (${reason}), state cleaned up`);
   }
   // Outside the guard: an external close can race the active flag, and a
   // pending browser_input is unanswerable once the browser is gone either way.
@@ -1268,6 +1293,18 @@ app.post('/browser/notify-closed', (c) => {
     'browser_input',
     'The browser was closed before the user completed this request'
   );
+
+  // Only when we detected this ourselves. A host-driven close has already torn
+  // the process down — the window is gone but, on macOS, the app it belonged
+  // to is still running and still holding the profile.
+  if (location && options.stopHostBrowser) {
+    await stopHostBrowserIfNeeded(location);
+  }
+}
+
+// POST /browser/notify-closed - Host browser was closed externally, clean up state
+app.post('/browser/notify-closed', async (c) => {
+  await handleExternalBrowserClose('host reported the process exited', { stopHostBrowser: false });
   return c.json({ success: true });
 });
 
@@ -2208,6 +2245,20 @@ interface BrowserTabInfo {
   active: boolean;
 }
 
+/**
+ * Strict variant of the /json lookup: throws when Chrome cannot be reached or
+ * answers garbage, so confirmNoPagesLeft can tell "answered: no pages" from
+ * "no answer". Remote CDP providers without a /json endpoint land in the
+ * throw path on purpose — a headless provider has no window for the user to
+ * close, and guessing costs a leaked remote session.
+ */
+async function listPageTargetsStrict(): Promise<Array<{ type: string }>> {
+  const res = await fetch(`${getCdpHttpEndpoint()}/json`);
+  if (!res.ok) throw new Error(`CDP /json answered ${res.status}`);
+  const targets = await res.json() as Array<{ type: string }>;
+  return targets.filter(t => t.type === 'page');
+}
+
 /** Get ALL CDP page targets across all strategies */
 async function getAllPageTargets(): Promise<PageTarget[]> {
   // Try Chrome's HTTP /json endpoint first (works for local Chrome)
@@ -2601,13 +2652,34 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
     if (cdpScreencast?.cdpWs !== cdpWs) return;
 
     // Unexpected close — try to recover by switching to agent's active tab
-    findActivePageTarget().then(target => {
+    const generationAtDetection = browserOpenGeneration;
+    findActivePageTarget().then(async target => {
+      if (!target) {
+        target = await recheckPageTarget(() => findActivePageTarget(), sleep);
+      }
       if (target && cdpScreencast?.clientWs === clientWs && clientWs.readyState === WebSocket.OPEN) {
         console.log('[CDP] Recovering from closed target, switching to', target.id);
         cdpScreencast.autoFollow = true;
         switchScreencastTarget(target, clientWs);
         broadcastTabList();
+      } else if (
+        !target &&
+        (await confirmNoPagesLeft(listPageTargetsStrict)) &&
+        browserOpenGeneration === generationAtDetection
+      ) {
+        // The tab we were streaming was the last one — the user closed the
+        // browser. Same ordering rule as the connect path: state first, so the
+        // viewer's status check on the socket close answers "inactive".
+        const cleanup = handleExternalBrowserClose('streamed page closed with no page left', { stopHostBrowser: true });
+        if (clientWs.readyState === WebSocket.OPEN) {
+          clientWs.send(JSON.stringify({ type: 'browser_closed' }));
+          clientWs.close();
+        }
+        await cleanup;
       } else if (clientWs.readyState === WebSocket.OPEN) {
+        // Recovery target lost its viewer, or the close couldn't be confirmed
+        // (endpoint unreachable / a fresh browser_open won the race). Drop the
+        // socket and let the viewer's bounded retry sort out which it was.
         clientWs.close();
       }
     }).catch(() => {
@@ -2678,10 +2750,10 @@ async function broadcastTabList(prefetched?: { allTargets: PageTarget[]; daemonT
   if (clientWs.readyState !== WebSocket.OPEN) return;
 
   try {
-    const { allTargets, daemonTabs } = prefetched ?? {
-      allTargets: await getAllPageTargets(),
-      daemonTabs: await tabManager.queryTabs(),
-    };
+    const { allTargets, daemonTabs } = prefetched ?? await readTabSources(
+      () => getAllPageTargets(),
+      () => tabManager.queryTabs(),
+    );
 
     const claimedTargetIds = new Set<string>();
     let tabs: BrowserTabInfo[] = [];
@@ -2745,11 +2817,13 @@ function notifyBrowserAction() {
     if (!cdpScreencast || cdpScreencast.clientWs !== currentClient) return;
 
     try {
-      // Fetch once and share across both operations
-      const [allTargets, daemonTabs] = await Promise.all([
-        getAllPageTargets(),
-        tabManager.queryTabs(),
-      ]);
+      // Fetch once and share across both operations. Sequential, not
+      // Promise.all: the daemon must not be asked for tabs when Chrome has no
+      // page — see readTabSources.
+      const { allTargets, daemonTabs } = await readTabSources(
+        () => getAllPageTargets(),
+        () => tabManager.queryTabs(),
+      );
 
       // Resolve where the viewer should move. Do not prefer its current target:
       // a stale daemon URL must retain Chrome's MRU fallback for auto-follow.
@@ -2778,13 +2852,36 @@ function handleBrowserStreamConnection(ws: WebSocket) {
   // If there's an existing screencast, close it (single viewer)
   cleanupCdpScreencast();
 
-  findActivePageTarget().then((target) => {
+  const generationAtDetection = browserOpenGeneration;
+  findActivePageTarget().then(async (target) => {
     if (!target) {
-      console.error('[CDP] No active page target found');
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'error', message: 'No browser tab found — the page may still be loading' }));
+      target = await recheckPageTarget(() => findActivePageTarget(), sleep);
+    }
+    if (!target) {
+      if (
+        (await confirmNoPagesLeft(listPageTargetsStrict)) &&
+        browserOpenGeneration === generationAtDetection
+      ) {
+        // No page anywhere in the browser, twice over, and Chrome itself said
+        // so: the user closed it. Reset our state before closing the socket so
+        // the viewer's post-close status check sees "inactive" and stops
+        // reconnecting to a browser that's gone.
+        console.error('[CDP] No page target left — treating the browser as closed');
+        const cleanup = handleExternalBrowserClose('no page target left', { stopHostBrowser: true });
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'browser_closed' }));
+          ws.close();
+        }
+        await cleanup;
+      } else {
+        // Couldn't prove the browser is gone (endpoint unreachable, or a fresh
+        // browser_open landed mid-detection). Answer like the old code and let
+        // the viewer's bounded retry try again once things settle.
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'error', message: 'No browser tab found — the page may still be loading' }));
+        }
+        ws.close();
       }
-      ws.close();
       return;
     }
     connectCdpToTarget(target.id, target.wsUrl, ws, target.requiresSession);

--- a/src/renderer/hooks/use-browser-stream.test.tsx
+++ b/src/renderer/hooks/use-browser-stream.test.tsx
@@ -36,6 +36,7 @@ class FakeWebSocket {
   readyState = FakeWebSocket.CONNECTING
   onopen: (() => void) | null = null
   onclose: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
 
   constructor(public url: string) {
     FakeWebSocket.instances.push(this)
@@ -45,6 +46,10 @@ class FakeWebSocket {
     if (this.readyState !== FakeWebSocket.CONNECTING) return
     this.readyState = FakeWebSocket.OPEN
     this.onopen?.()
+  }
+
+  emit(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) })
   }
 
   close() {
@@ -178,5 +183,84 @@ describe('useBrowserStream reconnect', () => {
     await advanceOneSecondAndOpenNewSockets()
 
     expect(FakeWebSocket.instances).toHaveLength(3)
+  })
+
+  it('closes the tray on browser_closed instead of asking the server again', async () => {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+
+    await settle()
+    act(() => {
+      FakeWebSocket.instances[0].completeHandshake()
+    })
+    await settle()
+
+    // The user closed the browser window: the server says so, then drops us.
+    act(() => {
+      FakeWebSocket.instances[0].emit({ type: 'browser_closed' })
+      FakeWebSocket.instances[0].close()
+    })
+    await settle()
+
+    expect(clearBrowserActive).toHaveBeenCalledWith('s')
+    // The browser is gone — no status probe, and nothing to reconnect to.
+    expect(mockApiFetch).not.toHaveBeenCalled()
+    for (let i = 0; i < 3; i++) {
+      await advanceOneSecondAndOpenNewSockets()
+    }
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
+  it('gives up once a socket has died before opening too many times over', async () => {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+
+    await settle()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    // Every socket dies mid-handshake while /browser/status keeps insisting the
+    // browser is alive — the reconnect loop this bug produced.
+    for (let i = 0; i < 12; i++) {
+      const latest = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+      act(() => {
+        latest.close()
+      })
+      await settle()
+      await act(async () => {
+        vi.advanceTimersByTime(30_000)
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+    }
+
+    // 1 initial + 5 bounded retries, then the tray is dropped.
+    expect(FakeWebSocket.instances).toHaveLength(6)
+    expect(clearBrowserActive).toHaveBeenCalledWith('s')
+  })
+
+  it('forgives an isolated death — the attempt budget resets once a socket opens', async () => {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+
+    await settle()
+
+    // Six separate deaths, each followed by a socket that opens fine. Without
+    // the reset this would exhaust the budget and close a working preview.
+    for (let i = 0; i < 6; i++) {
+      const latest = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+      act(() => {
+        latest.completeHandshake()
+      })
+      await settle()
+      act(() => {
+        latest.close()
+      })
+      await settle()
+      await advanceOneSecondAndOpenNewSockets()
+    }
+
+    expect(FakeWebSocket.instances).toHaveLength(7)
+    expect(clearBrowserActive).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/use-browser-stream.ts
+++ b/src/renderer/hooks/use-browser-stream.ts
@@ -8,6 +8,11 @@ import { useUser } from '@renderer/context/user-context'
 
 const MODIFIER_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta'])
 
+// Reconnect backoff for a socket that keeps dying before it opens.
+const RECONNECT_BASE_MS = 1000
+const MAX_RECONNECT_DELAY_MS = 8000
+const MAX_FAILED_RECONNECTS = 5
+
 interface UseBrowserStreamOptions {
   agentSlug: string
   sessionId: string
@@ -46,6 +51,10 @@ export function useBrowserStream({
 
   // Lifecycle refs for cleanup
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Sockets that died before ever opening, back to back. The stream endpoint
+  // answering "still active" is not proof it can serve us — give up rather than
+  // reconnect at 1Hz forever behind a preview that will never paint.
+  const failedReconnectsRef = useRef(0)
 
   const { requests: pendingBrowserInputRequests, dismiss: dismissBrowserInputRequest } =
     usePendingBrowserInputRequests(sessionId, agentSlug, isActive)
@@ -145,8 +154,12 @@ export function useBrowserStream({
 
     const ws = new WebSocket(wsUrl)
     wsRef.current = ws
+    // Set by a browser_closed frame: the server has already dropped its browser
+    // state, so the close that follows needs no status check and no retry.
+    let browserGone = false
 
     ws.onopen = () => {
+      failedReconnectsRef.current = 0
       setConnected(true)
     }
 
@@ -204,6 +217,11 @@ export function useBrowserStream({
           setViewingTargetId(prev => prev === data.targetId ? prev : data.targetId)
         } else if (data.type === 'selection_result' && data.text) {
           navigator.clipboard.writeText(data.text).catch(() => {})
+        } else if (data.type === 'browser_closed') {
+          // The user closed the browser window. Drop the tray now rather than
+          // waiting on the status round-trip the socket close would trigger.
+          browserGone = true
+          clearBrowserActive(sessionId)
         }
       } catch {
         // Ignore parse errors for binary frames
@@ -214,14 +232,24 @@ export function useBrowserStream({
       if (wsRef.current !== ws) return
       setConnected(false)
       setPageLoading(false)
+      if (browserGone) {
+        clearBrowserActive(sessionId)
+        return
+      }
       apiFetch(`/api/agents/${agentSlug}/browser/status`)
         .then((res) => res.json())
         .then((status: { active?: boolean; sessionId?: string }) => {
           if (wsRef.current !== ws) return
           if (!status.active || status.sessionId !== sessionId) {
             clearBrowserActive(sessionId)
+          } else if (failedReconnectsRef.current >= MAX_FAILED_RECONNECTS) {
+            clearBrowserActive(sessionId)
           } else {
-            reconnectTimerRef.current = setTimeout(() => setReconnectKey(k => k + 1), 1000)
+            const attempt = failedReconnectsRef.current++
+            reconnectTimerRef.current = setTimeout(
+              () => setReconnectKey(k => k + 1),
+              Math.min(RECONNECT_BASE_MS * 2 ** attempt, MAX_RECONNECT_DELAY_MS),
+            )
           }
         })
         .catch(() => {


### PR DESCRIPTION
Fixes SUP-710

## Bug

macOS + Electron: have the agent open the host browser, let the turn end, then close the Chrome **window** (not quit Chrome). The preview drawer stays open, stuck in a 1Hz reconnect loop.

## Root cause

The host's darwin ChromeProvider only detects Chrome *quitting* (PID poll → `/browser/notify-closed`). On macOS the app survives its last window, so nothing ever fired: the container's `browserState` stayed `active` and `/browser/status` kept telling the renderer to reconnect to a browser with nothing left to stream.

A second bug hid underneath: the viewer's 2s tab poll asks the agent-browser daemon for tabs, and when Chrome has zero pages the daemon **opens `about:blank` so it has something to report** — resurrecting the window the user just closed within ~500ms.

## Fix

**Container** (`server.ts` + new `browser-liveness.ts`):
- The two screencast paths (viewer connect finding no page target, and the streamed page's CDP socket closing with no page left) now treat "no page target, rechecked once after 750ms" as an external close: reset browser state, send `{type:'browser_closed'}` to the viewer, and stop the leftover host Chrome still holding the profile.
- Two guards keep the verdict honest:
  - `confirmNoPagesLeft` — teardown requires Chrome *answering* `/json` with zero pages. An unreachable endpoint proves nothing: process death is the host watcher's case, and a transient container↔host outage fails both lookups at once (750ms apart is no de-correlation) — tearing down on that would orphan a live browser.
  - `browserOpenGeneration` — detection spans real time; a `browser_open` landing mid-detection bumps the generation and the stale verdict is discarded instead of killing the fresh browser.
- `readTabSources` — the daemon is only asked for tabs when Chrome's own target list reports ≥1 page, so the poll can no longer resurrect a closed window.

**Renderer** (`use-browser-stream.ts`):
- Handles the `browser_closed` frame: drop the tray immediately, skip the status probe, no reconnect.
- Bounds the reconnect loop as a backstop: exponential backoff from 1s capped at 8s, gives up after 5 consecutive failures, budget resets whenever a socket opens — so no failure mode reconnects forever again.

## Scope

Ticket item 3.1 only. The "inject a message to the agent" nice-to-have (3.2) was deliberately left out to keep this PR small.

## Testing

- `agent-container/src/browser-liveness.test.ts`: recheck delay/ordering, unreachable-endpoint handling, daemon-resurrection guard, and the confirm-close verdict (answered-zero vs late page vs unreachable).
- `src/renderer/hooks/use-browser-stream.test.tsx`: `browser_closed` closes the tray with no status probe and no reconnect; the retry budget gives up at 1+5 sockets; the budget resets after a successful open (six isolated deaths don't kill a working preview).
- Full container suite 918 passed / 8 skipped; root + container typecheck clean; eslint clean on changed files.
- Live-reproduced on macOS: agent opens wsj.com, turn ends, window closed externally → drawer closes instead of looping.

https://claude.ai/code/session_01LAduheyVEzdGbTBWEXPqU6