### PR TITLE
Wait for the catalog instead of a 10s deadline on template handoff

### DIFF
--- a/src/renderer/components/agents/template-install-dialog.closing.test.tsx
+++ b/src/renderer/components/agents/template-install-dialog.closing.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+// The real Dialog keeps its content mounted through the close animation. The
+// stub below renders content unconditionally to reproduce that closing frame,
+// when the parent has already cleared `template`.
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+vi.mock('@renderer/hooks/use-agent-templates', () => ({
+  useInstallAgentFromSkillset: () => ({
+    mutateAsync: () => new Promise(() => {}),
+    reset: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}))
+vi.mock('@renderer/components/ui/dialog', () => {
+  const Passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>
+  return {
+    Dialog: Passthrough,
+    DialogContent: Passthrough,
+    DialogHeader: Passthrough,
+    DialogTitle: Passthrough,
+    DialogDescription: Passthrough,
+  }
+})
+
+import { TemplateInstallDialog } from './template-install-dialog'
+import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
+
+const template: ApiDiscoverableAgent = {
+  skillsetId: 'skillset-1',
+  skillsetName: 'Public',
+  name: 'Research Bot',
+  description: 'Does research',
+  version: '1.0.0',
+  path: 'agents/research-bot/',
+}
+
+describe('TemplateInstallDialog closing frame', () => {
+  it('keeps the last template name while the dialog animates closed', () => {
+    const { rerender } = render(
+      <TemplateInstallDialog template={template} onClose={() => {}} onInstalled={() => {}} />,
+    )
+    expect(screen.getByText('Installing Research Bot')).toBeTruthy()
+
+    rerender(<TemplateInstallDialog template={null} onClose={() => {}} onInstalled={() => {}} />)
+
+    expect(screen.getByText('Installing Research Bot')).toBeTruthy()
+    expect(screen.getByText('From Public')).toBeTruthy()
+    expect(screen.queryByText(/undefined/)).toBeNull()
+  })
+})

--- a/src/renderer/components/agents/template-install-dialog.tsx
+++ b/src/renderer/components/agents/template-install-dialog.tsx
@@ -34,6 +34,11 @@ export function TemplateInstallDialog({ template, onClose, onInstalled }: Templa
   // One install per opening. A re-render must not fire a second one, and the
   // ref (not state) is what makes that true even under StrictMode double-invoke.
   const startedFor = useRef<string | null>(null)
+  // The parent clears `template` on close, but the content stays mounted
+  // through the close animation. Keep showing the last one for that frame.
+  const shownRef = useRef<ApiDiscoverableAgent | null>(null)
+  if (template) shownRef.current = template
+  const shown = shownRef.current
 
   const run = useCallback(
     async (target: ApiDiscoverableAgent) => {
@@ -83,10 +88,10 @@ export function TemplateInstallDialog({ template, onClose, onInstalled }: Templa
       <DialogContent className="max-w-sm" hideClose={phase === 'installing'}>
         <DialogHeader>
           <DialogTitle>
-            {phase === 'error' ? `Couldn't install ${template?.name}` : `Installing ${template?.name}`}
+            {phase === 'error' ? `Couldn't install ${shown?.name}` : `Installing ${shown?.name}`}
           </DialogTitle>
           <DialogDescription>
-            {phase === 'error' ? errorMessage : `From ${template?.skillsetName}`}
+            {phase === 'error' ? errorMessage : `From ${shown?.skillsetName}`}
           </DialogDescription>
         </DialogHeader>
 

--- a/src/renderer/components/signup-handoff-consumer.test.tsx
+++ b/src/renderer/components/signup-handoff-consumer.test.tsx
@@ -10,6 +10,7 @@ const mutateAsync = vi.fn()
 const toastError = vi.fn()
 let mockDiscoverableAgents: ApiDiscoverableAgent[] | undefined
 let mockDiscoverableAgentsFailed = false
+let mockDiscoverableAgentsLoading = false
 let mockSetupCompleted = true
 let mockGlobalSetupCompleted = true
 let mockIsAuthMode = true
@@ -29,7 +30,11 @@ vi.mock('@renderer/hooks/use-agent-templates', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@renderer/hooks/use-agent-templates')>()
   return {
     ...actual,
-    useDiscoverableAgents: () => ({ data: mockDiscoverableAgents, isError: mockDiscoverableAgentsFailed }),
+    useDiscoverableAgents: () => ({
+      data: mockDiscoverableAgents,
+      isError: mockDiscoverableAgentsFailed,
+      isLoading: mockDiscoverableAgentsLoading,
+    }),
   }
 })
 vi.mock('@renderer/hooks/use-complete-template-install', () => ({
@@ -110,6 +115,7 @@ describe('SignupHandoffConsumer', () => {
     vi.clearAllMocks()
     mockDiscoverableAgents = []
     mockDiscoverableAgentsFailed = false
+    mockDiscoverableAgentsLoading = false
     mockSetupCompleted = true
     mockGlobalSetupCompleted = true
     mockIsAuthMode = true
@@ -253,6 +259,28 @@ describe('SignupHandoffConsumer template-only first run', () => {
     await waitFor(() => expect(toastError).toHaveBeenCalledWith("Couldn't load that template", expect.anything()))
     expect(queryByTestId('template-install-dialog')).toBeNull()
     expect(completeInstall).not.toHaveBeenCalled()
+  })
+
+  it('catalog still loading → keeps waiting past any fixed deadline, no toast', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      mockDiscoverableAgents = undefined
+      mockDiscoverableAgentsLoading = true
+      const { queryByTestId } = renderSlugFirstRun()
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(toastError).not.toHaveBeenCalled()
+      expect(queryByTestId('template-install-dialog')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('catalog settled with nothing to show → toast, no dialog', async () => {
+    mockDiscoverableAgents = undefined
+    mockDiscoverableAgentsLoading = false
+    const { queryByTestId } = renderSlugFirstRun()
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Couldn't load that template", expect.anything()))
+    expect(queryByTestId('template-install-dialog')).toBeNull()
   })
 
   it('catalog error → toast, no dialog', async () => {

--- a/src/renderer/components/signup-handoff-consumer.tsx
+++ b/src/renderer/components/signup-handoff-consumer.tsx
@@ -17,8 +17,6 @@ import { lenient } from '@renderer/router/zod-search'
 import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
 import type { ApiDiscoverableAgent } from '@shared/lib/types/api'
 
-export const HANDOFF_TEMPLATE_WAIT_MS = 10000
-
 function toastTemplateNotFound() {
   toast.error("Couldn't load that template", {
     description: 'Pick one from Discover or create your own agent.',
@@ -39,7 +37,11 @@ export function SignupHandoffConsumer() {
   const setupCompleted = userSettings?.setupCompleted
   const settingsReady = userSettings !== undefined
   const updateUserSettings = useUpdateUserSettings()
-  const { data: discoverableAgents, isError: discoverableAgentsFailed } = useDiscoverableAgents()
+  const {
+    data: discoverableAgents,
+    isError: discoverableAgentsFailed,
+    isLoading: discoverableAgentsLoading,
+  } = useDiscoverableAgents()
   const completeInstall = useCompleteTemplateInstall()
   const [template, setTemplate] = useState<ApiDiscoverableAgent | null>(null)
   const resolvedRef = useRef(false)
@@ -86,15 +88,11 @@ export function SignupHandoffConsumer() {
       toastTemplateNotFound()
       return
     }
-    if (!discoverableAgents || discoverableAgents.length === 0) {
-      const timer = setTimeout(() => {
-        if (resolvedRef.current) return
-        resolvedRef.current = true
-        toastTemplateNotFound()
-      }, HANDOFF_TEMPLATE_WAIT_MS)
-      return () => clearTimeout(timer)
-    }
-    const target = discoverableAgents.find(
+    // No deadline: a cold cloud workspace builds the catalog cache on the first
+    // /api/skillsets call, and that can outlast any fixed timer. The hook's
+    // isLoading covers skillsets, the first catalog fetch, and the refresh.
+    if (discoverableAgentsLoading) return
+    const target = discoverableAgents?.find(
       (a) => a.skillsetId === DEFAULT_PUBLIC_SKILLSET.id && slugFromAgentPath(a.path) === slug,
     )
     resolvedRef.current = true
@@ -103,7 +101,7 @@ export function SignupHandoffConsumer() {
       return
     }
     setTemplate(target)
-  }, [canAutoInstallTemplate, discoverableAgents, discoverableAgentsFailed, slug])
+  }, [canAutoInstallTemplate, discoverableAgents, discoverableAgentsFailed, discoverableAgentsLoading, slug])
 
   return (
     <TemplateInstallDialog

--- a/src/renderer/hooks/use-agent-templates.ts
+++ b/src/renderer/hooks/use-agent-templates.ts
@@ -46,7 +46,7 @@ export function isWaitingOnDiscoverableRefresh(
  */
 export function useDiscoverableAgents() {
   const queryClient = useQueryClient()
-  const { data: skillsets } = useSkillsets()
+  const { data: skillsets, isLoading: skillsetsLoading } = useSkillsets()
   const hasSkillsets = !!(skillsets && skillsets.length > 0)
 
   const query = useQuery<ApiDiscoverableAgent[]>({
@@ -95,7 +95,8 @@ export function useDiscoverableAgents() {
 
   return {
     ...query,
-    isLoading: query.isLoading || waitingOnRefresh,
+    // Skillsets gate this query, so their fetch is part of the catalog's load.
+    isLoading: skillsetsLoading || query.isLoading || waitingOnRefresh,
   }
 }
 

--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -894,6 +894,36 @@ Instructions here`
       expect(cloneCalls).toBe(1)
     })
 
+    it('coalesces cold builds that start before the first readiness probe completes', async () => {
+      const config = buildSkillsetConfig()
+      const ref = {
+        skillsetId: config.id,
+        skillsetUrl: config.url,
+        provider: config.provider,
+        providerData: config.providerData,
+      }
+
+      let cloneCalls = 0
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === '--version') {
+          return { stdout: 'git version 2.44.0\n', stderr: '' }
+        }
+        if (cmd === 'git' && args[0] === 'clone') {
+          cloneCalls += 1
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+      // Same tick, no await between them: the second caller arrives while the
+      // first is still inside its readiness probe, before any build is running.
+      const first = ensureSkillsetCached(ref)
+      const second = ensureSkillsetCached(ref)
+
+      const repoDir = getSkillsetRepoDir(config.id)
+      await expect(Promise.all([first, second])).resolves.toEqual([repoDir, repoDir])
+      expect(cloneCalls).toBe(1)
+    })
+
     it('gitPull swallows expected drift errors from fetch+reset without throwing', async () => {
       const skillContent = '# Test Skill\nOriginal content'
       const meta = buildMetadata({ originalContentHash: contentHash(skillContent) })

--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -127,6 +127,7 @@ import {
   getSkillPRInfo,
   getInstalledSkillMetadata,
   getSkillsetRepoDir,
+  ensureSkillsetCached,
   isCacheReady,
   isGitAvailable,
   deleteSkill,
@@ -850,6 +851,47 @@ Instructions here`
 
       await expect(refreshSkillset(ref)).resolves.toEqual(index)
       expect(setUrlCalls).toBe(2)
+    })
+
+    it('coalesces concurrent first-time cache builds for the same cache directory', async () => {
+      const config = buildSkillsetConfig()
+      const ref = {
+        skillsetId: config.id,
+        skillsetUrl: config.url,
+        provider: config.provider,
+        providerData: config.providerData,
+      }
+
+      let cloneCalls = 0
+      let releaseClone!: () => void
+      let notifyCloneStarted!: () => void
+      const cloneStarted = new Promise<void>((resolve) => {
+        notifyCloneStarted = resolve
+      })
+      const cloneCanFinish = new Promise<void>((resolve) => {
+        releaseClone = resolve
+      })
+
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === '--version') {
+          return { stdout: 'git version 2.44.0\n', stderr: '' }
+        }
+        if (cmd === 'git' && args[0] === 'clone') {
+          cloneCalls += 1
+          notifyCloneStarted()
+          return cloneCanFinish.then(() => ({ stdout: '', stderr: '' }))
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+      const first = ensureSkillsetCached(ref)
+      await cloneStarted
+      const second = ensureSkillsetCached(ref)
+      releaseClone()
+
+      const repoDir = getSkillsetRepoDir(config.id)
+      await expect(Promise.all([first, second])).resolves.toEqual([repoDir, repoDir])
+      expect(cloneCalls).toBe(1)
     })
 
     it('gitPull swallows expected drift errors from fetch+reset without throwing', async () => {

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -69,6 +69,7 @@ function getRepoGitEnv(repoDir: string) {
 }
 
 const activeSkillsetRefreshes = new Map<string, Promise<SkillsetIndex>>()
+const activeSkillsetPopulates = new Map<string, Promise<string>>()
 
 // ============================================================================
 // Path Helpers
@@ -704,8 +705,31 @@ export async function ensureSkillsetCached(ref: SkillsetRef): Promise<string> {
   const hostingProvider = getSkillsetProvider(ref.provider)
   const repoDir = getSkillsetRepoDir(hostingProvider.getEffectiveRepoId(ref))
 
+  // The first populate is rm + write in place, so a second caller during it
+  // (reload, second tab, install) would delete files the first is writing.
+  // Coalesce on the directory, like refreshSkillset. Checked before the
+  // readiness probe so the join is synchronous.
+  const inFlight = activeSkillsetPopulates.get(repoDir)
+  if (inFlight) return inFlight
+
   if (await isCacheReady(repoDir, ref.provider)) return repoDir
 
+  const populate = populateSkillsetCache(ref, hostingProvider, repoDir)
+  activeSkillsetPopulates.set(repoDir, populate)
+  try {
+    return await populate
+  } finally {
+    if (activeSkillsetPopulates.get(repoDir) === populate) {
+      activeSkillsetPopulates.delete(repoDir)
+    }
+  }
+}
+
+async function populateSkillsetCache(
+  ref: SkillsetRef,
+  hostingProvider: ReturnType<typeof getSkillsetProvider>,
+  repoDir: string,
+): Promise<string> {
   await ensureDirectory(getSkillsetCacheDir())
 
   const parentDir = path.dirname(repoDir)

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -707,14 +707,16 @@ export async function ensureSkillsetCached(ref: SkillsetRef): Promise<string> {
 
   // The first populate is rm + write in place, so a second caller during it
   // (reload, second tab, install) would delete files the first is writing.
-  // Coalesce on the directory, like refreshSkillset. Checked before the
-  // readiness probe so the join is synchronous.
+  // Coalesce on the directory, like refreshSkillset. The readiness probe runs
+  // inside the stored promise: the map must be set before the first await, or
+  // two cold callers probing at once would both reach the populate.
   const inFlight = activeSkillsetPopulates.get(repoDir)
   if (inFlight) return inFlight
 
-  if (await isCacheReady(repoDir, ref.provider)) return repoDir
-
-  const populate = populateSkillsetCache(ref, hostingProvider, repoDir)
+  const populate = (async () => {
+    if (await isCacheReady(repoDir, ref.provider)) return repoDir
+    return populateSkillsetCache(ref, hostingProvider, repoDir)
+  })()
   activeSkillsetPopulates.set(repoDir, populate)
   try {
     return await populate


### PR DESCRIPTION
The signup handoff consumer gave the discoverable-agents catalog ten seconds before toasting "Couldn't load that template" and abandoning the install. On a fresh cloud workspace the first `/api/skillsets` call builds the catalog cache (zip download plus extract), and that can outlast the window, so the toast fired while the catalog was still on its way. This PR drops the deadline and gates on the hook's `isLoading`, folding the skillsets fetch into it since it gates the catalog query. It also coalesces concurrent first-time cache builds in `ensureSkillsetCached`, which deleted each other's files when a reload or install overlapped the cold build, and latches the last template in `TemplateInstallDialog` so the close animation no longer renders "Installing undefined".

Production 4 files / +44 -9. Tests 3 files / +113.

Resolution now walks the hook's state instead of a clock:

- `useDiscoverableAgents.isLoading` is true while skillsets load, while the first catalog fetch is in flight, or while the first catalog came back empty and the refresh has not settled.
- `signup-handoff-consumer.tsx` returns from its effect while that holds. No timer.
- Catalog error → toast. Loading false with no catalog or no match → toast. Match → install dialog.
- A request that hangs surfaces as `isError` from `apiFetch`, not as a silent wait.

First-time cache build:

- `ensureSkillsetCached` is rm-then-write in place, with no guard. Two cold callers on the same skillset raced.
- A per-directory in-flight map now hands later callers the running promise, the same shape `refreshSkillset` uses ten lines below.
- The map check runs before the async readiness probe, so the join is synchronous and a caller cannot slip past a build that finishes during its probe.

Dialog closing frame:

- Install resolves → `onClose()` clears `template` → Radix animates out with content still mounted.
- The title and subtitle now read from a ref that keeps the last non-null template.

The sibling deadline in `create-agent-form.tsx` (wizard path, non-seeded workspaces) is unchanged here.
