### PR TITLE
Read the E2E mock recorder through one shared helper

### DIFF
--- a/e2e/helpers/mock-recorder.ts
+++ b/e2e/helpers/mock-recorder.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Reader for `.e2e-mock-recorder.jsonl` — the JSONL file MockContainerClient
+ * appends to under the active data dir, and the only way a spec can see the
+ * runtime options the renderer actually sent through the full API path (there
+ * is deliberately no HTTP endpoint that returns them).
+ *
+ * Seven specs grew their own copy of this and drifted: some guarded the parse,
+ * some did not, and the ones that did not turn a routine partial write into a
+ * SyntaxError. Three traps are baked in here so nobody has to rediscover them:
+ *
+ *  1. The app appends WHILE a spec polls, so the final line can be read
+ *     half-written. Unparseable lines are skipped, not thrown on — the next
+ *     poll sees the complete line.
+ *  2. The file is shared across workers and tests, so it never starts empty.
+ *     A predicate MUST filter on something test-unique (a generated agent
+ *     slug, a unique initial message) rather than assume isolation.
+ *  3. The path has to be derived the way the Playwright config derives the
+ *     data dir, including any per-project subdirectory. Handling only the
+ *     SUPERAGENT_DATA_DIR branch or only the fallback passes locally and fails
+ *     in CI, or the reverse, depending on which one sets the variable.
+ */
+
+const RECORDER_FILENAME = '.e2e-mock-recorder.jsonl'
+
+/** The fields every recorder consumer relies on; specs narrow this further. */
+export interface MockRecordBase {
+  type: string
+  agentSlug?: string
+}
+
+export interface MockRecorderOptions {
+  /**
+   * Data dir to use when SUPERAGENT_DATA_DIR is unset — i.e. the same default
+   * the spec's Playwright config falls back to. Defaults to the main suite's.
+   */
+  defaultDataDir?: string
+  /**
+   * Per-project subdirectory beneath the data dir, for configs that give each
+   * project its own (the auth suite does). Omit when the config does not.
+   */
+  subdir?: string
+}
+
+export interface WaitForRecordOptions {
+  timeoutMs?: number
+  /** Named in the timeout message, e.g. "container_start for agent-7". */
+  label?: string
+}
+
+export interface MockRecorder<T extends MockRecordBase> {
+  /** Absolute path to the JSONL file, for diagnostics. */
+  readonly file: string
+  /** Every record written so far; skips a torn final line. */
+  read(): T[]
+  /** Poll until one record matches, or throw with the tail of what was seen. */
+  waitFor(predicate: (record: T) => boolean, options?: WaitForRecordOptions): Promise<T>
+}
+
+export function mockRecorder<T extends MockRecordBase>(
+  options: MockRecorderOptions = {},
+): MockRecorder<T> {
+  const { defaultDataDir = '.e2e-data', subdir } = options
+  // `path.resolve` lets SUPERAGENT_DATA_DIR be absolute or relative to cwd.
+  const base = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? defaultDataDir)
+  const file = path.join(subdir ? path.join(base, subdir) : base, RECORDER_FILENAME)
+
+  const read = (): T[] => {
+    if (!fs.existsSync(file)) return []
+    return fs
+      .readFileSync(file, 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line) as T]
+        } catch {
+          // Trap 1: a partially-written final line. Drop it and let the next
+          // poll read it whole.
+          return []
+        }
+      })
+  }
+
+  const waitFor = async (
+    predicate: (record: T) => boolean,
+    { timeoutMs = 12000, label }: WaitForRecordOptions = {},
+  ): Promise<T> => {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      const found = read().find(predicate)
+      if (found) return found
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+    const subject = label ? ` for ${label}` : ''
+    throw new Error(
+      `Timed out after ${timeoutMs}ms waiting for a mock record${subject}. `
+      + `Last records seen: ${JSON.stringify(read().slice(-10), null, 2)}`,
+    )
+  }
+
+  return { file, read, waitFor }
+}

--- a/e2e/specs/agent-default-model.spec.ts
+++ b/e2e/specs/agent-default-model.spec.ts
@@ -1,11 +1,7 @@
 import { test, expect } from '@playwright/test'
-import * as fs from 'fs'
-import * as path from 'path'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
-
-const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
-const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+import { mockRecorder } from '../helpers/mock-recorder'
 
 interface MockRecord {
   type: 'sendMessage' | 'createSession'
@@ -18,27 +14,11 @@ interface MockRecord {
   timestamp: string
 }
 
-function readRecords(): MockRecord[] {
-  if (!fs.existsSync(RECORDER_FILE)) return []
-  const lines = fs.readFileSync(RECORDER_FILE, 'utf-8').trim().split('\n').filter(Boolean)
-  return lines.map((l) => JSON.parse(l) as MockRecord)
-}
+// Predicates below filter on a test-unique attribute (agentSlug or unique
+// content) — see the helper's note on the recorder file being shared across
+// workers and tests.
+const recorder = mockRecorder<MockRecord>()
 
-// The recorder file is shared across Playwright workers, so callers must
-// filter by a test-unique attribute (unique message content) — never truncate
-// the file or assume it's empty at start.
-async function waitForRecord(
-  predicate: (r: MockRecord) => boolean,
-  timeoutMs = 10000
-): Promise<MockRecord> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const found = readRecords().find(predicate)
-    if (found) return found
-    await new Promise((r) => setTimeout(r, 100))
-  }
-  throw new Error(`Timed out waiting for matching record. Records seen: ${JSON.stringify(readRecords(), null, 2)}`)
-}
 
 // Distinct from the global default (Opus) so adoption is observable.
 const HAIKU_PINNED = 'claude-haiku-4-5'
@@ -95,8 +75,7 @@ test.describe('Per-agent default model', () => {
     await page.locator('[data-testid="home-send-button"]').click()
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
 
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === initialMessage
     )
     expect(record.model).toBe(HAIKU_PINNED)
     expect(record.effort).toBe('high')
@@ -120,8 +99,7 @@ test.describe('Per-agent default model', () => {
     await page.locator('[data-testid="home-message-input"]').fill(resetMessage)
     await page.locator('[data-testid="home-send-button"]').click()
 
-    const resetRecord = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === resetMessage
+    const resetRecord = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === resetMessage
     )
     expect(resetRecord.model).toBe('claude-opus-5')
   })

--- a/e2e/specs/agent-secrets.spec.ts
+++ b/e2e/specs/agent-secrets.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect, type Locator } from '@playwright/test'
-import * as fs from 'fs'
-import * as path from 'path'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
+import { mockRecorder } from '../helpers/mock-recorder'
 
 /**
  * Agent secrets (the hardened `.env` store) end-to-end.
@@ -15,9 +14,6 @@ import { AgentPage } from '../pages/agent.page'
  * across a reload (the read side of the hardened store).
  */
 
-const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
-const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
-
 interface MockRecord {
   type: 'sendMessage' | 'createSession'
   agentSlug: string
@@ -26,38 +22,9 @@ interface MockRecord {
   timestamp: string
 }
 
-function readRecords(): MockRecord[] {
-  if (!fs.existsSync(RECORDER_FILE)) return []
-  return fs
-    .readFileSync(RECORDER_FILE, 'utf-8')
-    .trim()
-    .split('\n')
-    .filter(Boolean)
-    .flatMap((line) => {
-      try {
-        return [JSON.parse(line) as MockRecord]
-      } catch {
-        // The app appends to this file while the test polls it. Ignore a
-        // partially-written final line and retry on the next pass.
-        return []
-      }
-    })
-}
-
-/**
- * Wait for a matching record. The recorder file is shared across workers/tests,
- * so the predicate MUST filter by a test-unique attribute (here: the unique
- * initialMessage) — never assume the file starts empty.
- */
-async function waitForRecord(predicate: (r: MockRecord) => boolean, timeoutMs = 12000): Promise<MockRecord> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const found = readRecords().find(predicate)
-    if (found) return found
-    await new Promise((r) => setTimeout(r, 100))
-  }
-  throw new Error(`Timed out waiting for record. Seen: ${JSON.stringify(readRecords().slice(-10), null, 2)}`)
-}
+// Predicates below filter on the unique initialMessage — see the helper's note
+// on the recorder file being shared across workers.
+const recorder = mockRecorder<MockRecord>()
 
 test.describe('Agent Secrets (reach the container & persist)', () => {
   let appPage: AppPage
@@ -125,8 +92,7 @@ test.describe('Agent Secrets (reach the container & persist)', () => {
 
     // 5. The mock container recorded the env var name it received — assert the
     //    UI-added secret made it all the way through.
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === sessionMessage
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === sessionMessage
     )
     expect(record.availableEnvVars ?? []).toContain(expectedEnvVar)
   })
@@ -161,8 +127,7 @@ test.describe('Agent Secrets (reach the container & persist)', () => {
     await page.locator('[data-testid="home-send-button"]').click()
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
 
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === sessionMessage
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === sessionMessage
     )
     expect(record.availableEnvVars ?? []).not.toContain(expectedEnvVar)
   })

--- a/e2e/specs/composer-secret-detection.spec.ts
+++ b/e2e/specs/composer-secret-detection.spec.ts
@@ -1,11 +1,7 @@
 import { expect, test } from '@playwright/test'
-import * as fs from 'fs'
-import * as path from 'path'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
-
-const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
-const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+import { mockRecorder } from '../helpers/mock-recorder'
 
 interface MockRecord {
   type: 'sendMessage' | 'createSession'
@@ -14,28 +10,7 @@ interface MockRecord {
   availableEnvVars?: string[]
 }
 
-function readRecords(): MockRecord[] {
-  if (!fs.existsSync(RECORDER_FILE)) return []
-  const records: MockRecord[] = []
-  for (const line of fs.readFileSync(RECORDER_FILE, 'utf-8').trim().split('\n').filter(Boolean)) {
-    try {
-      records.push(JSON.parse(line) as MockRecord)
-    } catch {
-      // A concurrently-appended final line can be incomplete for a moment.
-    }
-  }
-  return records
-}
-
-async function waitForRecord(predicate: (record: MockRecord) => boolean, timeoutMs = 12_000) {
-  const startedAt = Date.now()
-  while (Date.now() - startedAt < timeoutMs) {
-    const record = readRecords().find(predicate)
-    if (record) return record
-    await new Promise((resolve) => setTimeout(resolve, 100))
-  }
-  throw new Error(`Timed out waiting for mock record. Seen: ${JSON.stringify(readRecords().slice(-10), null, 2)}`)
-}
+const recorder = mockRecorder<MockRecord>()
 
 test.describe('composer secret detection', () => {
   let agentPage: AgentPage
@@ -79,8 +54,7 @@ test.describe('composer secret detection', () => {
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15_000 })
 
     const expectedMessage = `Use this credential:\n[Key saved to .env - ${envVar}]`
-    const record = await waitForRecord(
-      (candidate) => candidate.type === 'createSession' && candidate.initialMessage === expectedMessage
+    const record = await recorder.waitFor((candidate) => candidate.type === 'createSession' && candidate.initialMessage === expectedMessage
     )
     expect(record.initialMessage).not.toContain(rawKey)
     expect(record.availableEnvVars ?? []).toContain(envVar)

--- a/e2e/specs/mcp-policy-enforcement.spec.ts
+++ b/e2e/specs/mcp-policy-enforcement.spec.ts
@@ -1,6 +1,4 @@
 import { test, expect, type APIRequestContext, type TestInfo } from '@playwright/test'
-import * as fs from 'fs'
-import * as path from 'path'
 import { AppPage } from '../pages/app.page'
 import { SessionPage } from '../pages/session.page'
 import {
@@ -15,6 +13,7 @@ import {
 } from '../helpers/agents'
 import { createRemoteMcp, assignRemoteMcpToAgent, type TestRemoteMcp } from '../helpers/connections'
 import { startMockMcpServer, type MockMcpServer } from '../helpers/mock-mcp-server'
+import { mockRecorder } from '../helpers/mock-recorder'
 
 /**
  * MCP tool-policy enforcement — the product's main MCP safety mechanism, which
@@ -35,9 +34,6 @@ import { startMockMcpServer, type MockMcpServer } from '../helpers/mock-mcp-serv
  * the whole file parallel-safe.
  */
 
-const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
-const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
-
 interface MockRecord {
   type: string
   agentSlug: string
@@ -45,27 +41,7 @@ interface MockRecord {
   timestamp: string
 }
 
-function readRecords(): MockRecord[] {
-  if (!fs.existsSync(RECORDER_FILE)) return []
-  return fs
-    .readFileSync(RECORDER_FILE, 'utf-8')
-    .trim()
-    .split('\n')
-    .filter(Boolean)
-    .map((l) => JSON.parse(l) as MockRecord)
-}
-
-// The recorder file is shared across workers, so the predicate MUST filter by
-// a test-unique attribute (the agent slug) — never assume it starts empty.
-async function waitForRecord(predicate: (r: MockRecord) => boolean, timeoutMs = 12000): Promise<MockRecord> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const found = readRecords().find(predicate)
-    if (found) return found
-    await new Promise((r) => setTimeout(r, 100))
-  }
-  throw new Error('Timed out waiting for container_start recorder record')
-}
+const recorder = mockRecorder<MockRecord>()
 
 type PolicyDecision = 'allow' | 'review' | 'block'
 
@@ -96,7 +72,7 @@ test.describe('MCP tool-policy enforcement', () => {
     // Creating a session wakes the (mock) container, which writes its
     // PROXY_TOKEN to the recorder — the credential the proxy expects.
     const session = await createSession(request, agent, `wake ${uniqueName(testInfo, 'mcp')}`)
-    const record = await waitForRecord((r) => r.type === 'container_start' && r.agentSlug === agent.slug)
+    const record = await recorder.waitFor((r) => r.type === 'container_start' && r.agentSlug === agent.slug)
     const proxyToken = record.proxyToken
     expect(proxyToken, 'proxy token exposed to the container').toBeTruthy()
 

--- a/e2e/specs/model-selection.spec.ts
+++ b/e2e/specs/model-selection.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect, type Page } from '@playwright/test'
-import * as fs from 'fs'
-import * as path from 'path'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
-
-const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
-const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+import { mockRecorder } from '../helpers/mock-recorder'
 
 interface MockRecord {
   type: 'sendMessage' | 'createSession'
@@ -19,30 +15,11 @@ interface MockRecord {
   timestamp: string
 }
 
-function readRecords(): MockRecord[] {
-  if (!fs.existsSync(RECORDER_FILE)) return []
-  const lines = fs.readFileSync(RECORDER_FILE, 'utf-8').trim().split('\n').filter(Boolean)
-  return lines.map((l) => JSON.parse(l) as MockRecord)
-}
+// Predicates below filter on a test-unique attribute (agentSlug or unique
+// content) — see the helper's note on the recorder file being shared across
+// workers and tests.
+const recorder = mockRecorder<MockRecord>()
 
-/**
- * Wait for a matching record. The recorder file is shared across Playwright
- * workers and across all tests in this spec, so callers must filter by a
- * test-unique attribute (agentSlug or unique content) — never truncate the
- * file or assume it's empty at start.
- */
-async function waitForRecord(
-  predicate: (r: MockRecord) => boolean,
-  timeoutMs = 10000
-): Promise<MockRecord> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const found = readRecords().find(predicate)
-    if (found) return found
-    await new Promise((r) => setTimeout(r, 100))
-  }
-  throw new Error(`Timed out waiting for matching record. Records seen: ${JSON.stringify(readRecords(), null, 2)}`)
-}
 
 // Composer is a flat list keyed by concrete id; the host resolves the selection
 // to a concrete wire id before the (mock) container records it.
@@ -99,8 +76,7 @@ test.describe('Model selection', () => {
 
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
 
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === initialMessage
     )
     expect(record.model).toBe(OPUS_LATEST)
   })
@@ -120,8 +96,7 @@ test.describe('Model selection', () => {
     await page.locator('[data-testid="home-send-button"]').click()
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
 
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === initialMessage
     )
     expect(record.model).toBe(OPUS_PINNED_OLDER)
   })
@@ -145,8 +120,7 @@ test.describe('Model selection', () => {
 
     await sessionPage.sendMessage(followUp)
 
-    const sendRecord = await waitForRecord(
-      (r) => r.type === 'sendMessage' && r.content === followUp
+    const sendRecord = await recorder.waitFor((r) => r.type === 'sendMessage' && r.content === followUp
     )
     expect(sendRecord.model).toBe(HAIKU)
     expect(sendRecord.effort).toBe('low')
@@ -176,8 +150,7 @@ test.describe('Model selection', () => {
     await page.locator('[data-testid="home-send-button"]').click()
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
 
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === initialMessage
     )
     expect(record.model).toBe(SONNET)
     expect(record.effort).toBe('medium')
@@ -199,8 +172,7 @@ test.describe('Model selection', () => {
     await page.locator('[data-testid="home-message-input"]').fill(followUp)
     await page.locator('[data-testid="home-send-button"]').click()
 
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === followUp
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === followUp
     )
     // Bare 'opus' resolves to its concrete latest id — match family-shape so the
     // test survives future default-version bumps.

--- a/e2e/specs/speed-selection.spec.ts
+++ b/e2e/specs/speed-selection.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect, type Page } from '@playwright/test'
-import * as fs from 'fs'
-import * as path from 'path'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
-
-const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
-const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
+import { mockRecorder } from '../helpers/mock-recorder'
 
 interface MockRecord {
   type: 'sendMessage' | 'createSession'
@@ -20,30 +16,11 @@ interface MockRecord {
   timestamp: string
 }
 
-function readRecords(): MockRecord[] {
-  if (!fs.existsSync(RECORDER_FILE)) return []
-  const lines = fs.readFileSync(RECORDER_FILE, 'utf-8').trim().split('\n').filter(Boolean)
-  return lines.map((l) => JSON.parse(l) as MockRecord)
-}
+// Predicates below filter on a test-unique attribute (agentSlug or unique
+// content) — see the helper's note on the recorder file being shared across
+// workers and tests.
+const recorder = mockRecorder<MockRecord>()
 
-/**
- * Wait for a matching record. The recorder file is shared across Playwright
- * workers and across all tests in this spec, so callers must filter by a
- * test-unique attribute (agentSlug or unique content) — never truncate the
- * file or assume it's empty at start.
- */
-async function waitForRecord(
-  predicate: (r: MockRecord) => boolean,
-  timeoutMs = 10000
-): Promise<MockRecord> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const found = readRecords().find(predicate)
-    if (found) return found
-    await new Promise((r) => setTimeout(r, 100))
-  }
-  throw new Error(`Timed out waiting for matching record. Records seen: ${JSON.stringify(readRecords(), null, 2)}`)
-}
 
 // The E2E seed (setup-e2e-data.js) grants Opus 4.8 a speed choice via a
 // user-level catalog override; every other model keeps the builtin
@@ -103,8 +80,7 @@ test.describe('Speed selection', () => {
     await page.locator('[data-testid="home-send-button"]').click()
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
 
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === initialMessage
     )
     expect(record.speed).toBe('fast')
   })
@@ -120,8 +96,7 @@ test.describe('Speed selection', () => {
     await page.locator('[data-testid="home-send-button"]').click()
     await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: 15000 })
 
-    const record = await waitForRecord(
-      (r) => r.type === 'createSession' && r.initialMessage === initialMessage
+    const record = await recorder.waitFor((r) => r.type === 'createSession' && r.initialMessage === initialMessage
     )
     expect(record.speed).toBeUndefined()
   })
@@ -142,8 +117,7 @@ test.describe('Speed selection', () => {
 
     await sessionPage.sendMessage(followUp)
 
-    const sendRecord = await waitForRecord(
-      (r) => r.type === 'sendMessage' && r.content === followUp
+    const sendRecord = await recorder.waitFor((r) => r.type === 'sendMessage' && r.content === followUp
     )
     expect(sendRecord.speed).toBe('fast')
     expect(sendRecord.model).toBe(OPUS_LATEST)

--- a/e2e/specs/x-agent-transcript-limit.spec.ts
+++ b/e2e/specs/x-agent-transcript-limit.spec.ts
@@ -1,6 +1,5 @@
-import { test, expect, type APIRequestContext, type TestInfo } from '@playwright/test'
-import * as fs from 'fs'
-import * as path from 'path'
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { mockRecorder } from '../helpers/mock-recorder'
 import {
   createAgent,
   createSession,
@@ -15,33 +14,20 @@ import {
  * Host route the container tool calls: limit returns the compacted tail.
  */
 
-const E2E_DATA_DIR = path.resolve(process.cwd(), process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data')
-const RECORDER_FILE = path.join(E2E_DATA_DIR, '.e2e-mock-recorder.jsonl')
-
 interface MockRecord {
   type: string
   agentSlug: string
   proxyToken?: string
 }
 
-function readRecords(): MockRecord[] {
-  if (!fs.existsSync(RECORDER_FILE)) return []
-  return fs
-    .readFileSync(RECORDER_FILE, 'utf-8')
-    .trim()
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as MockRecord)
-}
+const recorder = mockRecorder<MockRecord>()
 
 async function waitForProxyToken(agentSlug: string, timeoutMs = 12000): Promise<string> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const found = readRecords().find((r) => r.type === 'container_start' && r.agentSlug === agentSlug)
-    if (found?.proxyToken) return found.proxyToken
-    await new Promise((r) => setTimeout(r, 100))
-  }
-  throw new Error(`Timed out waiting for proxy token for ${agentSlug}`)
+  const found = await recorder.waitFor(
+    (r) => r.type === 'container_start' && r.agentSlug === agentSlug && !!r.proxyToken,
+    { timeoutMs, label: `container_start with a proxy token for ${agentSlug}` },
+  )
+  return found.proxyToken!
 }
 
 async function allowRead(


### PR DESCRIPTION
Seven specs read `.e2e-mock-recorder.jsonl` — the file `MockContainerClient` appends to, and the only way a spec can see the runtime options the renderer actually sent through the full API path. Each had grown its own copy of the same ~20 lines, and the copies had drifted.

Five parsed each line unguarded. The app appends to that file *while* the specs poll it, so the final line can be read half-written — which turns a routine partial write into a `SyntaxError` thrown out of the poll loop instead of a wait that simply continues on the next tick. A rare flake, and a thoroughly misleading one when it lands.

The two copies that *do* guard the parse are the interesting part: someone already hit this and fixed their own file, and nothing carried that lesson to the other five. That's the argument for a helper over five more try/catches.

## What changed

New `e2e/helpers/mock-recorder.ts` owns reading and polling, and documents the three traps the copies kept rediscovering:

1. **A torn final line** — skipped, not thrown on.
2. **The file is shared across workers and tests**, so it never starts empty. Predicates must filter on something test-unique; the helper says so where the next person will read it.
3. **The path must be derived the way the Playwright config derives it**, including any per-project subdirectory. This one has already bitten once: handling only the `SUPERAGENT_DATA_DIR` branch or only the fallback passes locally and fails in CI (or the reverse), because CI sets that variable and a local run usually does not. The helper takes `defaultDataDir` and `subdir` so both branches are built the same way.

Each spec keeps its own `MockRecord` type — that type documents what the spec cares about, and collapsing them into one union would lose that. The helper is generic over it.

Timeout messages are now uniform and all include the tail of what was actually seen, which the terser copies did not.

## Not in this PR

`e2e/auth/specs/shared-connections.spec.ts` (on #889) has the same shape and an inline guard. It adopts this helper once one of the two lands — kept separate so this PR stays based on `main` and gets a real CI run rather than the reduced one a stacked base gets.

## Tests

All seven converted specs run green locally: 21 tests, `agent-default-model`, `agent-secrets`, `composer-secret-detection`, `mcp-policy-enforcement`, `model-selection`, `speed-selection`, `x-agent-transcript-limit`. `tsc` clean; `eslint` clean on `e2e/` including the five `no-unhandled-throwing-builtins` warnings this removes.

Net 175 lines removed. No production code touched.

https://claude.ai/code/session_01Y73CeDYiQFXt4fHmEgCJCa
