### PR TITLE
Add API and MCP audit log auto-delete

### DIFF
--- a/agent-container/src/file-hooks/agent-preferences-hook.ts
+++ b/agent-container/src/file-hooks/agent-preferences-hook.ts
@@ -4,6 +4,7 @@ import { FileHook, type FileHookReadResult, type FileHookWriteResult } from './f
 // Keep in sync with src/shared/lib/types/agent-preferences.ts
 const agentPreferencesSchema = z.object({
   autoDeleteInactiveDays: z.number().int().positive().optional(),
+  apiLogAutoDeleteDays: z.number().int().nonnegative().optional(),
   defaultModel: z.string().trim().min(1).optional(),
   defaultEffort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
   defaultSpeed: z.enum(['slow', 'normal', 'fast']).optional(),
@@ -15,6 +16,7 @@ const READ_HINT = `This is the agent preferences file. It stores per-agent setti
 
 Format: a JSON object with optional fields:
 - "autoDeleteInactiveDays" (positive integer, optional): Automatically delete sessions inactive for this many days. Starred sessions are preserved.
+- "apiLogAutoDeleteDays" (non-negative integer, optional): Automatically delete API / MCP audit log rows older than this many days. 0 means Never.
 - "defaultModel" (string, optional): Default model for this agent's new sessions — a concrete model id or a bare family alias. Per-session and per-trigger picks still win.
 - "defaultEffort" (one of "low" | "medium" | "high" | "xhigh" | "max", optional): Default reasoning effort for this agent's new sessions.
 - "defaultSpeed" (one of "slow" | "normal" | "fast", optional): Default processing speed for this agent's new sessions. Only speeds the model's serving path supports take effect.

--- a/src/renderer/components/agents/settings/general-tab.tsx
+++ b/src/renderer/components/agents/settings/general-tab.tsx
@@ -254,7 +254,7 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
         <div className="space-y-0.5">
           <Label>API Log Auto-Delete</Label>
           <p className="text-xs text-muted-foreground">
-            Override the app-wide default for this agent's API and MCP request logs.
+            Override the app-wide default for this agent. Applies to API and MCP request logs.
           </p>
         </div>
         <AgentApiLogAutoDeleteSelect

--- a/src/renderer/components/agents/settings/general-tab.tsx
+++ b/src/renderer/components/agents/settings/general-tab.tsx
@@ -5,6 +5,7 @@ import { Input } from '@renderer/components/ui/input'
 import { Label } from '@renderer/components/ui/label'
 import { Button } from '@renderer/components/ui/button'
 import { AgentAutoDeleteSelect } from '@renderer/components/settings/auto-delete-select'
+import { AgentApiLogAutoDeleteSelect } from '@renderer/components/settings/api-log-auto-delete-select'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -245,6 +246,22 @@ export function GeneralTab({ name, agentSlug, onNameChange, onDialogClose }: Gen
           appDefault={settings?.app?.autoDeleteInactiveDays}
           onChange={(days) => {
             updatePrefs.mutate({ autoDeleteInactiveDays: days })
+          }}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="space-y-0.5">
+          <Label>API Log Auto-Delete</Label>
+          <p className="text-xs text-muted-foreground">
+            Override the app-wide default for this agent's API and MCP request logs.
+          </p>
+        </div>
+        <AgentApiLogAutoDeleteSelect
+          value={agentPrefs?.apiLogAutoDeleteDays}
+          appDefault={settings?.app?.apiLogAutoDeleteDays}
+          onChange={(days) => {
+            updatePrefs.mutate({ apiLogAutoDeleteDays: days })
           }}
         />
       </div>

--- a/src/renderer/components/settings/api-log-auto-delete-select.tsx
+++ b/src/renderer/components/settings/api-log-auto-delete-select.tsx
@@ -1,0 +1,97 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/components/ui/select'
+import {
+  API_LOG_AUTO_DELETE_DAY_OPTIONS,
+  DEFAULT_API_LOG_AUTO_DELETE_DAYS,
+} from '@shared/lib/config/api-log-auto-delete'
+
+export function formatApiLogAutoDeleteLabel(days: number | undefined): string {
+  if (days === 0) return 'never'
+  if (days && days > 0) return `${days} days`
+  return `${DEFAULT_API_LOG_AUTO_DELETE_DAYS} days`
+}
+
+// Custom values (e.g. written by the agent via the preferences file hook) are
+// valid but not in the preset list; render them so the trigger isn't blank.
+function isCustomValue(days: number | undefined): days is number {
+  return (
+    days !== undefined &&
+    days > 0 &&
+    !API_LOG_AUTO_DELETE_DAY_OPTIONS.some((o) => o === days)
+  )
+}
+
+interface ApiLogAutoDeleteSelectProps {
+  value: number | undefined
+  onChange: (days: number) => void
+  disabled?: boolean
+}
+
+export function ApiLogAutoDeleteSelect({ value, onChange, disabled }: ApiLogAutoDeleteSelectProps) {
+  return (
+    <Select
+      value={(value ?? DEFAULT_API_LOG_AUTO_DELETE_DAYS).toString()}
+      onValueChange={(val) => onChange(parseInt(val, 10))}
+      disabled={disabled}
+    >
+      <SelectTrigger className="h-8 w-[140px]" aria-label="API log auto-delete">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="0">Never</SelectItem>
+        {API_LOG_AUTO_DELETE_DAY_OPTIONS.map((days) => (
+          <SelectItem key={days} value={days.toString()}>
+            {days} days
+          </SelectItem>
+        ))}
+        {isCustomValue(value) && (
+          <SelectItem value={value.toString()}>{value} days</SelectItem>
+        )}
+      </SelectContent>
+    </Select>
+  )
+}
+
+interface AgentApiLogAutoDeleteSelectProps {
+  value: number | undefined
+  appDefault: number | undefined
+  onChange: (days: number | null) => void
+}
+
+export function AgentApiLogAutoDeleteSelect({
+  value,
+  appDefault,
+  onChange,
+}: AgentApiLogAutoDeleteSelectProps) {
+  return (
+    <Select
+      value={value === undefined ? 'default' : value.toString()}
+      onValueChange={(val) => {
+        onChange(val === 'default' ? null : parseInt(val, 10))
+      }}
+    >
+      <SelectTrigger className="w-48" aria-label="API log auto-delete">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="default">
+          App default ({formatApiLogAutoDeleteLabel(appDefault)})
+        </SelectItem>
+        <SelectItem value="0">Never</SelectItem>
+        {API_LOG_AUTO_DELETE_DAY_OPTIONS.map((days) => (
+          <SelectItem key={days} value={days.toString()}>
+            {days} days
+          </SelectItem>
+        ))}
+        {isCustomValue(value) && (
+          <SelectItem value={value.toString()}>{value} days</SelectItem>
+        )}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/src/renderer/components/settings/general-tab.tsx
+++ b/src/renderer/components/settings/general-tab.tsx
@@ -16,6 +16,7 @@ import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useUpdateStatus } from '@renderer/context/update-status-context'
 import { ShortcutsSection } from './shortcuts-section'
 import { AutoDeleteSelect } from './auto-delete-select'
+import { ApiLogAutoDeleteSelect } from './api-log-auto-delete-select'
 import { applyWebFavicon, getWebFaviconHref } from '@renderer/lib/favicon'
 import {
   Wand2,
@@ -374,8 +375,8 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
         </div>
       )}
 
-      {/* Telemetry toggles are desktop-only; Session Auto-Delete is a
-          server-wide retention setting, so in auth mode it is admin-only. */}
+      {/* Telemetry toggles are desktop-only; retention controls are
+          server-wide, so in auth mode they are admin-only. */}
       {showAdminFeatures && (
         <div className="space-y-2">
           <h3 className={SECTION_HEADING}>Privacy</h3>
@@ -422,6 +423,18 @@ export function GeneralTab({ onOpenWizard }: GeneralTabProps) {
                   value={globalSettings?.app?.autoDeleteInactiveDays}
                   onChange={(days) => {
                     updateGlobalSettings.mutate({ app: { autoDeleteInactiveDays: days } })
+                  }}
+                />
+              }
+            />
+            <SettingRow
+              name="API Log Auto-Delete"
+              subtitle="Automatically delete API and MCP request logs older than this."
+              right={
+                <ApiLogAutoDeleteSelect
+                  value={globalSettings?.app?.apiLogAutoDeleteDays}
+                  onChange={(days) => {
+                    updateGlobalSettings.mutate({ app: { apiLogAutoDeleteDays: days } })
                   }}
                 />
               }

--- a/src/shared/lib/config/api-log-auto-delete.test.ts
+++ b/src/shared/lib/config/api-log-auto-delete.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_API_LOG_AUTO_DELETE_DAYS,
+  resolveApiLogAutoDeleteDays,
+} from './api-log-auto-delete'
+
+describe('resolveApiLogAutoDeleteDays', () => {
+  it('uses the agent override when set, including Never (0)', () => {
+    expect(resolveApiLogAutoDeleteDays(90, 30)).toBe(90)
+    expect(resolveApiLogAutoDeleteDays(0, 30)).toBe(0)
+  })
+
+  it('uses the app setting when the agent has no override', () => {
+    expect(resolveApiLogAutoDeleteDays(undefined, 60)).toBe(60)
+    expect(resolveApiLogAutoDeleteDays(undefined, 0)).toBe(0)
+  })
+
+  it('falls back to 30 days when neither is set', () => {
+    expect(resolveApiLogAutoDeleteDays(undefined, undefined)).toBe(
+      DEFAULT_API_LOG_AUTO_DELETE_DAYS,
+    )
+    expect(DEFAULT_API_LOG_AUTO_DELETE_DAYS).toBe(30)
+  })
+})

--- a/src/shared/lib/config/api-log-auto-delete.ts
+++ b/src/shared/lib/config/api-log-auto-delete.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_API_LOG_AUTO_DELETE_DAYS = 30
+
+export const API_LOG_AUTO_DELETE_DAY_OPTIONS = [30, 60, 90] as const
+
+/** 0 = Never (keep forever). Unset app+agent falls back to 30. */
+export function resolveApiLogAutoDeleteDays(
+  agentDays: number | undefined,
+  appDays: number | undefined,
+): number {
+  if (agentDays !== undefined) return agentDays
+  if (appDays !== undefined) return appDays
+  return DEFAULT_API_LOG_AUTO_DELETE_DAYS
+}

--- a/src/shared/lib/config/settings-patch.test.ts
+++ b/src/shared/lib/config/settings-patch.test.ts
@@ -85,6 +85,24 @@ describe('settingsPatchSchema', () => {
     ).toBe(false)
   })
 
+  it('accepts API log auto-delete including Never (0)', () => {
+    expect(
+      settingsPatchSchema.safeParse({ app: { apiLogAutoDeleteDays: 0 } }).success,
+    ).toBe(true)
+    expect(
+      settingsPatchSchema.safeParse({ app: { apiLogAutoDeleteDays: 60 } }).success,
+    ).toBe(true)
+  })
+
+  it('rejects negative or fractional API log auto-delete', () => {
+    expect(
+      settingsPatchSchema.safeParse({ app: { apiLogAutoDeleteDays: -5 } }).success,
+    ).toBe(false)
+    expect(
+      settingsPatchSchema.safeParse({ app: { apiLogAutoDeleteDays: 3.7 } }).success,
+    ).toBe(false)
+  })
+
   it('accepts null and empty-string clear semantics', () => {
     expect(
       settingsPatchSchema.safeParse({

--- a/src/shared/lib/config/settings-patch.ts
+++ b/src/shared/lib/config/settings-patch.ts
@@ -77,6 +77,7 @@ export const appSettingsPatchSchema = z.object({
   warmStartOnType: z.boolean(),
   autoResumeOnUnexpectedDeath: z.boolean(),
   autoDeleteInactiveDays: z.number(),
+  apiLogAutoDeleteDays: z.number().int().nonnegative(),
   setupCompleted: z.boolean(),
   accountProvider: z.enum(['composio', 'nango']),
   hostBrowserProvider: z.enum(['chrome', 'browserbase', 'platform']).nullable(),

--- a/src/shared/lib/config/settings.test.ts
+++ b/src/shared/lib/config/settings.test.ts
@@ -380,6 +380,30 @@ describe('loadSettings', () => {
       expect(result.app?.autoDeleteInactiveDays).toBeUndefined()
     })
 
+    it('defaults app.apiLogAutoDeleteDays to 30 when not set', () => {
+      mockSettingsFile(JSON.stringify({}))
+
+      const result = loadSettings()
+
+      expect(result.app?.apiLogAutoDeleteDays).toBe(30)
+    })
+
+    it('preserves app.apiLogAutoDeleteDays = 0 (Never)', () => {
+      mockSettingsFile(JSON.stringify({ app: { apiLogAutoDeleteDays: 0 } }))
+
+      const result = loadSettings()
+
+      expect(result.app?.apiLogAutoDeleteDays).toBe(0)
+    })
+
+    it('preserves app.apiLogAutoDeleteDays = 90', () => {
+      mockSettingsFile(JSON.stringify({ app: { apiLogAutoDeleteDays: 90 } }))
+
+      const result = loadSettings()
+
+      expect(result.app?.apiLogAutoDeleteDays).toBe(90)
+    })
+
     it('preserves customEnvVars as-is', () => {
       const envVars = { MY_VAR: 'hello', ANOTHER: 'world' }
       mockSettingsFile(JSON.stringify({ customEnvVars: envVars }))
@@ -1368,6 +1392,7 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.app?.autoSleepTimeoutMinutes).toBe(30)
     expect(DEFAULT_SETTINGS.app?.warmStartOnType).toBe(true)
     expect(DEFAULT_SETTINGS.app?.autoResumeOnUnexpectedDeath).toBe(true)
+    expect(DEFAULT_SETTINGS.app?.apiLogAutoDeleteDays).toBe(30)
     expect(isAutoResumeOnUnexpectedDeathEnabled(undefined)).toBe(true)
     expect(isAutoResumeOnUnexpectedDeathEnabled({ app: {} })).toBe(true)
     expect(isAutoResumeOnUnexpectedDeathEnabled({ app: { autoResumeOnUnexpectedDeath: false } })).toBe(false)

--- a/src/shared/lib/config/settings.ts
+++ b/src/shared/lib/config/settings.ts
@@ -12,6 +12,7 @@ import { captureException } from '@shared/lib/error-reporting'
 import { persistedSettingsSchema } from './settings-schema'
 import { coerceApiTarget, type ApiTarget } from '@shared/lib/api-target'
 import { DEFAULT_GLOBAL_DISPATCH_SHORTCUT } from './shortcuts'
+import { DEFAULT_API_LOG_AUTO_DELETE_DAYS } from './api-log-auto-delete'
 import type { SkillsetConfig, SkillsetCredential } from '@shared/lib/types/skillset'
 import { DEFAULT_PUBLIC_SKILLSET } from '@shared/lib/skillset-provider/default-public-skillset'
 import type { ComputerUseSettings } from '@shared/lib/computer-use/types'
@@ -111,6 +112,8 @@ export interface AppPreferences {
   /** MicroVM-only. Resume mid-turn sessions after unexpected VM death. Default on. */
   autoResumeOnUnexpectedDeath?: boolean
   autoDeleteInactiveDays?: number
+  /** Days after which API / MCP audit log rows are deleted. 0 = Never. Default 30. */
+  apiLogAutoDeleteDays?: number
   setupCompleted?: boolean
   accountProvider?: AccountProviderType
   hostBrowserProvider?: HostBrowserProviderId
@@ -440,6 +443,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     autoSleepTimeoutMinutes: 30,
     warmStartOnType: true,
     autoResumeOnUnexpectedDeath: true,
+    apiLogAutoDeleteDays: DEFAULT_API_LOG_AUTO_DELETE_DAYS,
     globalDispatchShortcut: DEFAULT_GLOBAL_DISPATCH_SHORTCUT,
     notifications: {
       enabled: true,

--- a/src/shared/lib/scheduler/api-log-auto-delete-monitor.test.ts
+++ b/src/shared/lib/scheduler/api-log-auto-delete-monitor.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentConfig } from '@shared/lib/types/agent'
+
+const mockListAgents = vi.fn()
+const mockReadAgentPreferences = vi.fn()
+const mockGetSettings = vi.fn()
+const mockPrune = vi.fn()
+
+vi.mock('@shared/lib/services/agent-service', () => ({
+  listAgents: () => mockListAgents(),
+}))
+
+vi.mock('@shared/lib/services/agent-preferences-service', () => ({
+  readAgentPreferences: (slug: string) => mockReadAgentPreferences(slug),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => mockGetSettings(),
+}))
+
+vi.mock('@shared/lib/services/api-log-auto-delete', () => ({
+  pruneExpiredApiLogsForAgent: (...args: unknown[]) => mockPrune(...args),
+}))
+
+vi.mock('@shared/lib/db', () => ({
+  sqlite: { prepare: vi.fn() },
+}))
+
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: vi.fn(),
+}))
+
+import { apiLogAutoDeleteMonitor } from './api-log-auto-delete-monitor'
+
+function makeAgent(slug: string): AgentConfig {
+  return {
+    slug,
+    frontmatter: { name: slug, createdAt: '2026-01-01T00:00:00Z' },
+    instructions: '',
+  }
+}
+
+describe('ApiLogAutoDeleteMonitor', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    mockGetSettings.mockReturnValue({ app: { apiLogAutoDeleteDays: 30 } })
+    mockListAgents.mockResolvedValue([])
+    mockReadAgentPreferences.mockResolvedValue({})
+    mockPrune.mockResolvedValue({ proxyDeleted: 0, mcpDeleted: 0 })
+  })
+
+  afterEach(() => {
+    apiLogAutoDeleteMonitor.stop()
+    vi.useRealTimers()
+  })
+
+  async function startAndTrigger() {
+    await apiLogAutoDeleteMonitor.start()
+    await vi.advanceTimersByTimeAsync(30_000)
+  }
+
+  it('does not run cleanup immediately on start', async () => {
+    mockListAgents.mockResolvedValue([makeAgent('agent-1')])
+    await apiLogAutoDeleteMonitor.start()
+    expect(mockListAgents).not.toHaveBeenCalled()
+  })
+
+  it('runs cleanup after the startup delay', async () => {
+    await startAndTrigger()
+    expect(mockListAgents).toHaveBeenCalledOnce()
+  })
+
+  it('defaults to 30 days when the app setting is unset', async () => {
+    mockGetSettings.mockReturnValue({ app: {} })
+    mockListAgents.mockResolvedValue([makeAgent('test-agent')])
+
+    await startAndTrigger()
+
+    expect(mockPrune).toHaveBeenCalledOnce()
+    expect(mockPrune.mock.calls[0][1]).toBe('test-agent')
+    expect(mockPrune.mock.calls[0][2]).toBe(Date.now() - 30 * 86_400_000)
+  })
+
+  it('skips prune when the effective setting is Never (0)', async () => {
+    mockGetSettings.mockReturnValue({ app: { apiLogAutoDeleteDays: 0 } })
+    mockListAgents.mockResolvedValue([makeAgent('test-agent')])
+
+    await startAndTrigger()
+
+    expect(mockPrune).not.toHaveBeenCalled()
+  })
+
+  it('uses the per-agent override over the app default', async () => {
+    mockGetSettings.mockReturnValue({ app: { apiLogAutoDeleteDays: 30 } })
+    mockListAgents.mockResolvedValue([makeAgent('test-agent')])
+    mockReadAgentPreferences.mockResolvedValue({ apiLogAutoDeleteDays: 90 })
+
+    await startAndTrigger()
+
+    expect(mockPrune).toHaveBeenCalledOnce()
+    expect(mockPrune.mock.calls[0][1]).toBe('test-agent')
+    expect(mockPrune.mock.calls[0][2]).toBe(Date.now() - 90 * 86_400_000)
+  })
+
+  it('honors Never on the agent even when the app default is 30', async () => {
+    mockGetSettings.mockReturnValue({ app: { apiLogAutoDeleteDays: 30 } })
+    mockListAgents.mockResolvedValue([makeAgent('test-agent')])
+    mockReadAgentPreferences.mockResolvedValue({ apiLogAutoDeleteDays: 0 })
+
+    await startAndTrigger()
+
+    expect(mockPrune).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/lib/scheduler/api-log-auto-delete-monitor.ts
+++ b/src/shared/lib/scheduler/api-log-auto-delete-monitor.ts
@@ -1,0 +1,113 @@
+import { listAgents } from '@shared/lib/services/agent-service'
+import { readAgentPreferences } from '@shared/lib/services/agent-preferences-service'
+import { getSettings } from '@shared/lib/config/settings'
+import { resolveApiLogAutoDeleteDays } from '@shared/lib/config/api-log-auto-delete'
+import { pruneExpiredApiLogsForAgent } from '@shared/lib/services/api-log-auto-delete'
+import { sqlite } from '@shared/lib/db'
+import { captureException } from '@shared/lib/error-reporting'
+
+class ApiLogAutoDeleteMonitor {
+  private intervalId: NodeJS.Timeout | null = null
+  private startupTimeoutId: NodeJS.Timeout | null = null
+  private isRunning = false
+  private isProcessing = false
+  private pollIntervalMs = 4 * 60 * 60 * 1000
+  private startupDelayMs = 30_000
+
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      console.log('[ApiLogAutoDeleteMonitor] Already running')
+      return
+    }
+
+    this.isRunning = true
+    console.log('[ApiLogAutoDeleteMonitor] Starting monitor...')
+
+    this.startupTimeoutId = setTimeout(() => {
+      this.startupTimeoutId = null
+      this.cleanupAllAgents().catch((error) => {
+        console.error('[ApiLogAutoDeleteMonitor] Error in initial cleanup:', error)
+        captureException(error, { tags: { area: 'api-log-auto-delete', op: 'initial-cleanup' } })
+      })
+
+      this.intervalId = setInterval(() => {
+        this.cleanupAllAgents().catch((error) => {
+          console.error('[ApiLogAutoDeleteMonitor] Error in cleanup cycle:', error)
+          captureException(error, { tags: { area: 'api-log-auto-delete', op: 'cleanup-cycle' } })
+        })
+      }, this.pollIntervalMs)
+    }, this.startupDelayMs)
+
+    console.log(
+      `[ApiLogAutoDeleteMonitor] Monitor started, first run in ${this.startupDelayMs / 1000}s, then every ${this.pollIntervalMs / 3_600_000}h`,
+    )
+  }
+
+  stop(): void {
+    if (this.startupTimeoutId) {
+      clearTimeout(this.startupTimeoutId)
+      this.startupTimeoutId = null
+    }
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+    }
+    this.isRunning = false
+    console.log('[ApiLogAutoDeleteMonitor] Monitor stopped')
+  }
+
+  private async cleanupAllAgents(): Promise<void> {
+    if (this.isProcessing) return
+    this.isProcessing = true
+
+    try {
+      const appDays = getSettings().app?.apiLogAutoDeleteDays
+      const agents = await listAgents()
+
+      for (const agent of agents) {
+        try {
+          const agentPrefs = await readAgentPreferences(agent.slug)
+          const effectiveDays = resolveApiLogAutoDeleteDays(
+            agentPrefs.apiLogAutoDeleteDays,
+            appDays,
+          )
+          if (effectiveDays <= 0) continue
+
+          const cutoff = Date.now() - effectiveDays * 86_400_000
+          const { proxyDeleted, mcpDeleted } = await pruneExpiredApiLogsForAgent(
+            sqlite,
+            agent.slug,
+            cutoff,
+          )
+          if (proxyDeleted + mcpDeleted === 0) continue
+
+          console.log(
+            `[ApiLogAutoDeleteMonitor] Deleted ${proxyDeleted} proxy / ${mcpDeleted} MCP audit rows for ${agent.slug} (older than ${effectiveDays} days)`,
+          )
+        } catch (error) {
+          console.error(
+            `[ApiLogAutoDeleteMonitor] Error cleaning agent ${agent.slug}:`,
+            error,
+          )
+          captureException(error, {
+            tags: { area: 'api-log-auto-delete', op: 'cleanup-agent' },
+            extra: { agentSlug: agent.slug },
+          })
+        }
+      }
+    } finally {
+      this.isProcessing = false
+    }
+  }
+}
+
+const globalForMonitor = globalThis as unknown as {
+  apiLogAutoDeleteMonitor: ApiLogAutoDeleteMonitor | undefined
+}
+
+export const apiLogAutoDeleteMonitor =
+  globalForMonitor.apiLogAutoDeleteMonitor ?? new ApiLogAutoDeleteMonitor()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForMonitor.apiLogAutoDeleteMonitor = apiLogAutoDeleteMonitor
+}

--- a/src/shared/lib/services/activity-stats-service.ts
+++ b/src/shared/lib/services/activity-stats-service.ts
@@ -174,10 +174,8 @@ export function buildAutomationActivityStats(
   return { cronByTaskId, webhookByTriggerId }
 }
 
-// Audit tables grow with every proxied call and have no time-based retention,
-// so the per-day/outcome rollup happens in SQL — the app only ever
-// materializes at most (connections × days × 2) aggregate rows, never the raw
-// request log.
+// Audit tables are pruned by auto-delete, but the per-day/outcome rollup still
+// happens in SQL so the app never materializes the raw request log.
 function auditDayExpr(createdAt: SQLiteColumn, tzOffsetMinutes: number): SQL<string> {
   return sql<string>`date((${createdAt} / 1000) - ${tzOffsetMinutes * 60}, 'unixepoch')`
 }

--- a/src/shared/lib/services/agent-preferences-service.test.ts
+++ b/src/shared/lib/services/agent-preferences-service.test.ts
@@ -84,6 +84,21 @@ describe('agent-preferences-service', () => {
       ).toThrow()
     })
 
+    it('accepts apiLogAutoDeleteDays 0 (Never) and 30', () => {
+      expect(agentPreferencesSchema.parse({ apiLogAutoDeleteDays: 0 })).toEqual({
+        apiLogAutoDeleteDays: 0,
+      })
+      expect(agentPreferencesSchema.parse({ apiLogAutoDeleteDays: 30 })).toEqual({
+        apiLogAutoDeleteDays: 30,
+      })
+    })
+
+    it('rejects negative apiLogAutoDeleteDays', () => {
+      expect(() =>
+        agentPreferencesSchema.parse({ apiLogAutoDeleteDays: -1 })
+      ).toThrow()
+    })
+
     it('rejects negative numbers', () => {
       expect(() =>
         agentPreferencesSchema.parse({ autoDeleteInactiveDays: -5 })
@@ -246,6 +261,14 @@ describe('agent-preferences-service', () => {
 
       const content = JSON.parse(await readPrefsFile('test-agent'))
       expect(content).toEqual({ autoDeleteInactiveDays: 30 })
+    })
+
+    it('persists apiLogAutoDeleteDays = 0 (Never)', async () => {
+      await createWorkspaceDir('test-agent')
+      const result = await updateAgentPreferences('test-agent', {
+        apiLogAutoDeleteDays: 0,
+      })
+      expect(result).toEqual({ apiLogAutoDeleteDays: 0 })
     })
 
     it('merges with existing preferences', async () => {

--- a/src/shared/lib/services/api-log-auto-delete.test.ts
+++ b/src/shared/lib/services/api-log-auto-delete.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { pruneExpiredApiLogsForAgent, type ApiLogAutoDeleteDb } from './api-log-auto-delete'
+
+interface Row {
+  id: string
+  agentSlug: string
+  createdAt: number
+}
+
+function fakeDb(tables: { proxy: Row[]; mcp: Row[] }): ApiLogAutoDeleteDb {
+  return {
+    prepare(sql: string) {
+      const table = sql.includes('proxy_audit_log') ? tables.proxy : tables.mcp
+      return {
+        run(agentSlug: unknown, cutoffMs: unknown, limit: unknown) {
+          const slug = String(agentSlug)
+          const cutoff = Number(cutoffMs)
+          const batch = Number(limit)
+          const matches = table.filter(
+            (row) => row.agentSlug === slug && row.createdAt < cutoff,
+          )
+          const toDelete = new Set(matches.slice(0, batch).map((row) => row.id))
+          const remaining = table.filter((row) => !toDelete.has(row.id))
+          table.length = 0
+          table.push(...remaining)
+          return { changes: toDelete.size }
+        },
+      }
+    },
+  }
+}
+
+describe('pruneExpiredApiLogsForAgent', () => {
+  it('deletes only rows older than the cutoff for that agent', async () => {
+    const cutoff = Date.UTC(2026, 7, 1)
+    const tables = {
+      proxy: [
+        { id: 'p-old', agentSlug: 'agent-a', createdAt: cutoff - 1 },
+        { id: 'p-new', agentSlug: 'agent-a', createdAt: cutoff },
+        { id: 'p-other', agentSlug: 'agent-b', createdAt: cutoff - 1 },
+      ],
+      mcp: [
+        { id: 'm-old', agentSlug: 'agent-a', createdAt: cutoff - 1 },
+        { id: 'm-new', agentSlug: 'agent-a', createdAt: cutoff + 1 },
+      ],
+    }
+
+    const result = await pruneExpiredApiLogsForAgent(fakeDb(tables), 'agent-a', cutoff)
+
+    expect(result).toEqual({ proxyDeleted: 1, mcpDeleted: 1 })
+    expect(tables.proxy.map((row) => row.id)).toEqual(['p-new', 'p-other'])
+    expect(tables.mcp.map((row) => row.id)).toEqual(['m-new'])
+  })
+
+  it('batches deletes until the cutoff window is empty', async () => {
+    const tables = {
+      proxy: [
+        { id: 'p1', agentSlug: 'agent-a', createdAt: 1 },
+        { id: 'p2', agentSlug: 'agent-a', createdAt: 2 },
+        { id: 'p3', agentSlug: 'agent-a', createdAt: 3 },
+      ],
+      mcp: [{ id: 'm1', agentSlug: 'agent-a', createdAt: 1 }],
+    }
+
+    const result = await pruneExpiredApiLogsForAgent(fakeDb(tables), 'agent-a', 1_000, 2)
+
+    expect(result).toEqual({ proxyDeleted: 3, mcpDeleted: 1 })
+    expect(tables.proxy).toEqual([])
+    expect(tables.mcp).toEqual([])
+  })
+})

--- a/src/shared/lib/services/api-log-auto-delete.ts
+++ b/src/shared/lib/services/api-log-auto-delete.ts
@@ -1,0 +1,38 @@
+export const API_LOG_PRUNE_BATCH_SIZE = 5_000
+
+const PRUNE_TABLES = ['proxy_audit_log', 'mcp_audit_log'] as const
+
+type PruneTable = (typeof PRUNE_TABLES)[number]
+
+export interface ApiLogAutoDeleteDb {
+  prepare(sql: string): {
+    run(...params: unknown[]): { changes: number }
+  }
+}
+
+function pruneSql(table: PruneTable): string {
+  return `DELETE FROM ${table} WHERE id IN (SELECT id FROM ${table} WHERE agent_slug = ? AND created_at < ? LIMIT ?)`
+}
+
+export async function pruneExpiredApiLogsForAgent(
+  db: ApiLogAutoDeleteDb,
+  agentSlug: string,
+  cutoffMs: number,
+  batchSize = API_LOG_PRUNE_BATCH_SIZE,
+): Promise<{ proxyDeleted: number; mcpDeleted: number }> {
+  let proxyDeleted = 0
+  let mcpDeleted = 0
+
+  for (const table of PRUNE_TABLES) {
+    const stmt = db.prepare(pruneSql(table))
+    for (;;) {
+      const { changes } = stmt.run(agentSlug, cutoffMs, batchSize)
+      if (changes === 0) break
+      if (table === 'proxy_audit_log') proxyDeleted += changes
+      else mcpDeleted += changes
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+  }
+
+  return { proxyDeleted, mcpDeleted }
+}

--- a/src/shared/lib/startup.post-bind.test.ts
+++ b/src/shared/lib/startup.post-bind.test.ts
@@ -100,6 +100,9 @@ vi.mock('./scheduler/auto-sleep-monitor', () => ({
 vi.mock('./scheduler/session-auto-delete-monitor', () => ({
   sessionAutoDeleteMonitor: { start: () => Promise.resolve(), stop: vi.fn() },
 }))
+vi.mock('./scheduler/api-log-auto-delete-monitor', () => ({
+  apiLogAutoDeleteMonitor: { start: () => Promise.resolve(), stop: vi.fn() },
+}))
 vi.mock('./scheduler/account-sync-service', () => ({
   accountSyncService: { start: () => Promise.resolve(), stop: vi.fn() },
 }))

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -13,6 +13,7 @@ import { captureException } from './error-reporting'
 import { registerAllAccountProviders } from './account-providers/register'
 import { autoSleepMonitor } from './scheduler/auto-sleep-monitor'
 import { sessionAutoDeleteMonitor } from './scheduler/session-auto-delete-monitor'
+import { apiLogAutoDeleteMonitor } from './scheduler/api-log-auto-delete-monitor'
 import { accountSyncService } from './scheduler/account-sync-service'
 import { platformService } from './services/platform-service'
 import { getActiveProvider, stopAllProviders } from '../../main/host-browser'
@@ -249,6 +250,10 @@ async function initializeServicesInner() {
     console.error('Failed to start session auto-delete monitor:', error)
   })
 
+  apiLogAutoDeleteMonitor.start().catch((error) => {
+    console.error('Failed to start API log auto-delete monitor:', error)
+  })
+
   // Start account sync service (deferred — syncs OAuth account status with remote providers)
   accountSyncService.start().catch((error) => {
     console.error('Failed to start account sync service:', error)
@@ -288,6 +293,7 @@ export async function shutdownServices() {
   platformNotificationsManager.stop()
   autoSleepMonitor.stop()
   sessionAutoDeleteMonitor.stop()
+  apiLogAutoDeleteMonitor.stop()
   accountSyncService.stop()
   platformService.stop()
   containerManager.stopStatusSync()

--- a/src/shared/lib/types/agent-preferences.ts
+++ b/src/shared/lib/types/agent-preferences.ts
@@ -4,6 +4,8 @@ import { EFFORT_LEVELS, SPEED_LEVELS } from '@shared/lib/container/types'
 // Keep in sync with agent-container/src/file-hooks/agent-preferences-hook.ts
 export const agentPreferencesSchema = z.object({
   autoDeleteInactiveDays: z.number().int().positive().optional(),
+  /** Days after which this agent's API / MCP audit rows are deleted. 0 = Never. */
+  apiLogAutoDeleteDays: z.number().int().nonnegative().optional(),
   /** Default model for new sessions — a concrete id (pinned) or a bare family alias (latest). Overrides the global default; per-session/trigger picks still win. */
   defaultModel: z.string().trim().min(1).optional(),
   /** Default effort for new sessions. Overrides the global default; per-session/trigger picks still win. */
@@ -20,6 +22,7 @@ export type AgentPreferences = z.infer<typeof agentPreferencesSchema>
  */
 export const agentPreferencesUpdateSchema = z.object({
   autoDeleteInactiveDays: z.number().int().positive().nullish(),
+  apiLogAutoDeleteDays: z.number().int().nonnegative().nullish(),
   defaultModel: z.string().trim().min(1).nullish(),
   defaultEffort: z.enum(EFFORT_LEVELS).nullish(),
   defaultSpeed: z.enum(SPEED_LEVELS).nullish(),


### PR DESCRIPTION
## Summary

API and MCP audit tables grow with every proxied call and had no cutoff. This adds a retention setting (default 30 days) so old rows get pruned. `0` means keep forever.

App Settings sets the default. An agent can override it on its General tab.

## What changed

- Background monitor starts with the other retention jobs and deletes expired `proxy_audit_log` / `mcp_audit_log` rows in batches.
- App setting `apiLogAutoDeleteDays` (30 / 60 / 90 / Never).
- Per-agent override in agent preferences, same options.

## Test plan

- [ ] Settings → General → Privacy: **API Log Auto-Delete** is 30 by default; changing it persists.
- [ ] Agent → Settings → General: override and "Use app default" both work; `0` saves as Never.
- [ ] After the first cleanup (or a test hook), rows older than the cutoff are gone; newer rows stay.
- [ ] Auth mode: only admins see the app-wide control (same as session auto-delete).


Made with [Cursor](https://cursor.com)