### PR TITLE
Add platform GLM-5.3 Flash to the model catalog

### DIFF
--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -624,9 +624,32 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     supportsImageInput: true,
   },
   ...MUSE_SPARK_MODELS,
+  {
+    // Bare id matches the platform proxy's glm-5.3-flash → cloudflare route.
+    id: 'glm-5.3-flash',
+    label: 'GLM-5.3 Flash',
+    blurb: 'Z.AI GLM, served via Platform',
+    family: 'glm',
+    isLatest: true,
+    isDefault: true,
+    icon: 'zai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportsWebSearch: false,
+    supportsWebFetch: false,
+    supportsImageInput: true,
+    contextWindow: 1_048_576,
+    // Cloudflare Workers AI list rates (2026-08-26). Cache write is unpublished,
+    // so cacheCreation mirrors input — same convention as Fireworks/Meta.
+    pricing: {
+      inputPerMtok: 0.15,
+      outputPerMtok: 0.5,
+      cacheCreationPerMtok: 0.15,
+      cacheReadPerMtok: 0.03,
+    },
+  },
 ]
 
-/** Platform — bare Claude models plus the GPT/Grok models the proxy serves. */
+/** Platform — bare Claude models plus the GPT/Grok/Kimi/Muse/GLM models the proxy serves. */
 export const PLATFORM_CATALOG: ModelDefinition[] = [
   ...withPlatformClaudeSpeeds(CLAUDE_BARE_CATALOG),
   ...PLATFORM_EXTRA_MODELS,

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -61,6 +61,7 @@ describe('getProviderCatalog', () => {
       ['xai', 'grok-4.6'],
       ['kimi', 'kimi-k3'],
       ['meta', 'muse-spark-1.2'],
+      ['zai', 'glm-5.3-flash'],
     ])
   })
 
@@ -249,6 +250,17 @@ describe('getProviderCatalog', () => {
       supportsWebFetch: false,
       supportedSpeeds: ['normal', 'fast'],
       pricing: { inputPerMtok: 3, outputPerMtok: 15, speedMultipliers: { fast: 1.5 } },
+    })
+    // Cloudflare Workers AI via the platform proxy. Bare id only.
+    expect(catalog.find((m) => m.id === 'glm-5.3-flash')).toMatchObject({
+      family: 'glm',
+      isLatest: true,
+      icon: 'zai',
+      supportsWebSearch: false,
+      supportsWebFetch: false,
+      supportsImageInput: true,
+      contextWindow: 1_048_576,
+      pricing: { inputPerMtok: 0.15, outputPerMtok: 0.5, cacheReadPerMtok: 0.03 },
     })
     // Platform keys off bare ids, never the OpenRouter vendor-prefixed slugs.
     expect(catalog.some((m) => m.id === 'openai/gpt-5.5')).toBe(false)
@@ -586,14 +598,15 @@ describe('resolveModelForProvider', () => {
     )
   })
 
-  it('resolves Platform GPT/Grok models to bare ids and falls back for unsupported glm', () => {
+  it('resolves Platform GPT/Grok/GLM models to bare ids', () => {
     expect(resolveModelForProvider('gpt', 'platform', 'agent')).toBe('gpt-5.6-sol')
     expect(resolveModelForProvider('gpt-5.4', 'platform', 'agent')).toBe('gpt-5.4')
     expect(resolveModelForProvider('gpt-5.6-luna', 'platform', 'agent')).toBe('gpt-5.6-luna')
     expect(resolveModelForProvider('grok', 'platform', 'agent')).toBe('grok-4.6')
     expect(resolveModelForProvider('grok-4.6', 'platform', 'agent')).toBe('grok-4.6')
     expect(resolveModelForProvider('grok-4.5', 'platform', 'agent')).toBe('grok-4.5')
-    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('grok-4.6')
+    expect(resolveModelForProvider('glm', 'platform', 'agent')).toBe('glm-5.3-flash')
+    expect(resolveModelForProvider('glm-5.3-flash', 'platform', 'agent')).toBe('glm-5.3-flash')
   })
 
   it('resolves the SAME bare alias to each provider concrete id (cross-provider portability)', () => {

--- a/src/shared/lib/services/usage-service.test.ts
+++ b/src/shared/lib/services/usage-service.test.ts
@@ -1285,6 +1285,12 @@ describe('usage-service', () => {
       expect(await costOf('kimi-k3', { speed: 'slow' }, 'platform')).toBeCloseTo(kimiBase, 9)
     })
 
+    it('bills platform GLM-5.3 Flash at Cloudflare list rates with no speed tier', async () => {
+      const glmBase = (100_000 * 0.15 + 1_000 * 0.5) / 1_000_000
+      expect(await costOf('glm-5.3-flash', {}, 'platform')).toBeCloseTo(glmBase, 9)
+      expect(await costOf('glm-5.3-flash', { speed: 'fast' }, 'platform')).toBeCloseTo(glmBase, 9)
+    })
+
     it('prefers the local computation over tier-blind costUSD when a multiplier applies', async () => {
       expect(await costOf('gpt-5.4', { speed: 'fast', costUSD: 9.99 }, 'platform')).toBeCloseTo(
         GPT54_BASE * 2,


### PR DESCRIPTION
## Summary

Platform users could not pick GLM-5.3 Flash. The proxy already routes `glm-5.3-flash` to Cloudflare Workers AI ([platform #347](https://github.com/SkillfulAgents/platform/pull/347)); this adds the matching catalog entry so SuperAgent can select it.

## What changed

- Bare id `glm-5.3-flash` on the platform catalog (family `glm`, latest/default).
- Cloudflare list rates: $0.15 / $0.50 / $0.03 per M (input / output / cached input). No fast tier — Fast in the UI does not change price or routing.
- `glm` alias now resolves to this model instead of falling back to Grok.

## Test plan

- [ ] Platform connected: model picker shows **GLM-5.3 Flash**.
- [ ] Selecting it sends `glm-5.3-flash` (not `z-ai/glm-5.2`).
- [ ] Usage estimate uses the Cloudflare rates above; Fast does not multiply cost.
- [ ] Do not merge until the proxy upstream is live on the environment you will test (staging/prod). Without it, the picker entry 400s.


Made with [Cursor](https://cursor.com)