### PR TITLE
Cap audit log prune at a max batch count per run

### DIFF
--- a/src/shared/lib/services/api-log-auto-delete.test.ts
+++ b/src/shared/lib/services/api-log-auto-delete.test.ts
@@ -68,4 +68,23 @@ describe('pruneExpiredApiLogsForAgent', () => {
     expect(tables.proxy).toEqual([])
     expect(tables.mcp).toEqual([])
   })
+
+  it('stops at maxBatches even if the db keeps reporting deletions', async () => {
+    let runs = 0
+    const neverEmptyDb: ApiLogAutoDeleteDb = {
+      prepare() {
+        return {
+          run() {
+            runs++
+            return { changes: 2 }
+          },
+        }
+      },
+    }
+
+    const result = await pruneExpiredApiLogsForAgent(neverEmptyDb, 'agent-a', 1_000, 2, 3)
+
+    expect(runs).toBe(6)
+    expect(result).toEqual({ proxyDeleted: 6, mcpDeleted: 6 })
+  })
 })

--- a/src/shared/lib/services/api-log-auto-delete.ts
+++ b/src/shared/lib/services/api-log-auto-delete.ts
@@ -1,4 +1,7 @@
 export const API_LOG_PRUNE_BATCH_SIZE = 5_000
+// Caps a single prune run at maxBatches * batchSize rows per table; anything
+// beyond that is picked up by the monitor's next cycle.
+export const API_LOG_PRUNE_MAX_BATCHES = 200
 
 const PRUNE_TABLES = ['proxy_audit_log', 'mcp_audit_log'] as const
 
@@ -19,13 +22,14 @@ export async function pruneExpiredApiLogsForAgent(
   agentSlug: string,
   cutoffMs: number,
   batchSize = API_LOG_PRUNE_BATCH_SIZE,
+  maxBatches = API_LOG_PRUNE_MAX_BATCHES,
 ): Promise<{ proxyDeleted: number; mcpDeleted: number }> {
   let proxyDeleted = 0
   let mcpDeleted = 0
 
   for (const table of PRUNE_TABLES) {
     const stmt = db.prepare(pruneSql(table))
-    for (;;) {
+    for (let batch = 0; batch < maxBatches; batch++) {
       const { changes } = stmt.run(agentSlug, cutoffMs, batchSize)
       if (changes === 0) break
       if (table === 'proxy_audit_log') proxyDeleted += changes


### PR DESCRIPTION
Follow-up to #893. The batch-delete loop in `pruneExpiredApiLogsForAgent` was an unbounded `for (;;)`; this bounds it with a new `API_LOG_PRUNE_MAX_BATCHES = 200`.

- At the 5,000-row batch size that caps a single run at 1M rows per table per agent — enough to never matter in practice, but finite if a driver misbehaves or the backlog is enormous.
- The monitor re-runs every 4h with a fixed cutoff, so anything past the cap drains on the next cycle; no rows are stranded.
- `maxBatches` is an optional param alongside `batchSize`, and a new test stubs a DB that always reports deletions and asserts the loop stops after exactly `maxBatches` runs per table.

https://claude.ai/code/session_01LC6kZ35rhMUUpcJuCpiyHw