### PR TITLE
feat: drop the Models label from the model picker, give vendor tabs the full row

### DIFF
--- a/src/renderer/components/messages/composer-options-popover.test.tsx
+++ b/src/renderer/components/messages/composer-options-popover.test.tsx
@@ -83,8 +83,7 @@ describe('ComposerOptionsPopover', () => {
     const user = userEvent.setup()
     render(<Harness initialModel="claude-sonnet-4-6" />)
     await user.click(screen.getByTestId('composer-options-trigger'))
-    expect(await screen.findByText('Models')).toBeInTheDocument()
-    expect(screen.getByText('Effort')).toBeInTheDocument()
+    expect(await screen.findByText('Effort')).toBeInTheDocument()
     // Flat list: concrete versions are top-level rows, no family headers.
     expect(screen.getByTestId('model-pinned-claude-haiku-4-5')).toBeInTheDocument()
     expect(screen.getByTestId('model-pinned-claude-sonnet-4-6')).toBeInTheDocument()
@@ -122,7 +121,7 @@ describe('ComposerOptionsPopover', () => {
     await user.click(await screen.findByTestId('model-pinned-claude-opus-4-8'))
     expect(setModel).toHaveBeenCalledWith('claude-opus-4-8')
     // Stays open so model + effort can be tuned together.
-    expect(screen.getByText('Models')).toBeInTheDocument()
+    expect(screen.getByTestId('model-pinned-claude-opus-4-8')).toBeInTheDocument()
   })
 
   it('selecting an effort calls setEffort and keeps the popover open', async () => {
@@ -182,7 +181,7 @@ describe('ComposerOptionsPopover', () => {
     render(<Harness catalog={[]} initialModel={undefined} />)
     expect(screen.getByTestId('composer-options-trigger')).toHaveTextContent('High')
     await user.click(screen.getByTestId('composer-options-trigger'))
-    expect(screen.queryByText('Models')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('model-pinned-claude-opus-4-8')).not.toBeInTheDocument()
     expect(await screen.findByText('Effort')).toBeInTheDocument()
   })
 
@@ -195,10 +194,10 @@ describe('ComposerOptionsPopover', () => {
     const user = userEvent.setup()
     render(<Harness initialModel="claude-opus-4-8" />)
     await user.click(screen.getByTestId('composer-options-trigger'))
-    const models = await screen.findByText('Models')
+    const models = await screen.findByTestId('model-pinned-claude-opus-4-8')
     const effort = screen.getByText('Effort')
     const speed = screen.getByText('Speed')
-    // DOM order == visual order (no col-reverse): Models, then Effort, then Speed.
+    // DOM order == visual order (no col-reverse): model rows, then Effort, then Speed.
     expect(models.compareDocumentPosition(effort) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(effort.compareDocumentPosition(speed) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })

--- a/src/renderer/components/messages/composer-options-popover.tsx
+++ b/src/renderer/components/messages/composer-options-popover.tsx
@@ -91,11 +91,9 @@ function ComposerOptionsPopoverImpl({ state, disabled, includeEffort = true, foo
         {selectedModel && (
           <>
             {/* Flat list, no "latest" — per-message picks a concrete version.
-                The "Models" label renders inside, below the vendor tabs.
                 Picks never dismiss: model and effort get tuned together, and the
                 popover closes only on outside click / Escape / trigger toggle. */}
             <ModelFamilyList
-              header="Models"
               catalog={catalog}
               value={model}
               onPick={setModel}

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -192,11 +192,6 @@ interface ModelFamilyListProps {
   /** Called with the value to store: a concrete id, or a bare alias for the "latest" row. */
   onPick: (value: string) => void
   /**
-   * Section label (e.g. "Models") rendered INSIDE the picker, above the vendor
-   * tabs — passed in by the parent so the label and tabs stack as one block.
-   */
-  header?: ReactNode
-  /**
    * Offer a "· latest" row per family that stores the bare alias (rides upgrades).
    * ON for saved-setting selectors; OFF for the per-message composer, where
    * latest-vs-pinned has no meaning — you pick a concrete version to send now.
@@ -418,7 +413,6 @@ export function ModelFamilyList({
   catalog,
   value,
   onPick,
-  header,
   offerLatest = false,
   webProvider,
 }: ModelFamilyListProps) {
@@ -478,70 +472,63 @@ export function ModelFamilyList({
 
   return (
     <div className="flex flex-col gap-0.5">
-      {(header !== undefined || vendors.length > 1) && (
-        // One row: section label left, vendor tabs right. The tab bar is an
-        // icon-only single-select segmented control, mirroring the Appearance
-        // picker in general settings (intentionally not Radix Tabs — see that
-        // comment). Names live in standard-delay tooltips so the bar scales to
-        // many vendors without crowding.
-        <div className="flex items-center justify-between gap-2 pb-1 pl-2 pr-1 pt-1">
-          <span className="min-w-0 truncate text-[11px] font-medium text-muted-foreground/70">
-            {header}
-          </span>
-          {vendors.length > 1 && (
-            <TooltipProvider>
-              <div
-                role="radiogroup"
-                aria-label="Model vendor"
-                className="inline-flex shrink-0 items-center rounded-lg bg-muted p-0.5 text-muted-foreground"
-              >
-                {vendors.map((key) => {
-                  const isActive = key === activeVendor
-                  return (
-                    <Tooltip key={key}>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          role="radio"
-                          aria-checked={isActive}
-                          aria-label={vendorDisplayName(key)}
-                          data-testid={`model-vendor-tab-${key}`}
-                          // A tab click also SELECTS the vendor's declared default —
-                          // without this, single-model tabs (Grok, Kimi) read
-                          // as selected while nothing changed. Skipped when the
-                          // selection already lives on the clicked tab, so
-                          // re-clicking your own tab can't clobber a pinned
-                          // version or bare alias. The pick is provisional:
-                          // picks never dismiss, so the check lands in view
-                          // and any other row is one click away.
-                          onClick={() => {
-                            setPickedVendor(key)
-                            if (resolved && vendorKey(resolved) === key) return
-                            const defaultModel = vendorDefault(catalog, key)
-                            if (defaultModel) {
-                              // The catalog declares a concrete default. Do
-                              // not turn it into a family alias on settings
-                              // surfaces: the family's latest may be a
-                              // different model now or after an upgrade.
-                              onPick(defaultModel.id)
-                            }
-                          }}
-                          className={cn(
-                            'inline-flex h-6 w-8 items-center justify-center rounded-md transition-all hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                            isActive && 'bg-background text-foreground shadow'
-                          )}
-                        >
-                          <ModelIcon icon={key === NO_VENDOR ? undefined : key} className="h-3.5 w-3.5 shrink-0" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent>{vendorDisplayName(key)}</TooltipContent>
-                    </Tooltip>
-                  )
-                })}
-              </div>
-            </TooltipProvider>
-          )}
-        </div>
+      {vendors.length > 1 && (
+        // Full-width icon-only single-select segmented control, mirroring the
+        // Appearance picker in general settings (intentionally not Radix Tabs —
+        // see that comment). No section label beside it: provider catalogs grew
+        // past the point where one fits, so the tabs get the whole row and the
+        // names live in standard-delay tooltips.
+        <TooltipProvider>
+          <div
+            role="radiogroup"
+            aria-label="Model vendor"
+            className="mx-1 my-1 flex items-center rounded-lg bg-muted p-0.5 text-muted-foreground"
+          >
+            {vendors.map((key) => {
+              const isActive = key === activeVendor
+              return (
+                <Tooltip key={key}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={isActive}
+                      aria-label={vendorDisplayName(key)}
+                      data-testid={`model-vendor-tab-${key}`}
+                      // A tab click also SELECTS the vendor's declared default —
+                      // without this, single-model tabs (Grok, Kimi) read
+                      // as selected while nothing changed. Skipped when the
+                      // selection already lives on the clicked tab, so
+                      // re-clicking your own tab can't clobber a pinned
+                      // version or bare alias. The pick is provisional:
+                      // picks never dismiss, so the check lands in view
+                      // and any other row is one click away.
+                      onClick={() => {
+                        setPickedVendor(key)
+                        if (resolved && vendorKey(resolved) === key) return
+                        const defaultModel = vendorDefault(catalog, key)
+                        if (defaultModel) {
+                          // The catalog declares a concrete default. Do
+                          // not turn it into a family alias on settings
+                          // surfaces: the family's latest may be a
+                          // different model now or after an upgrade.
+                          onPick(defaultModel.id)
+                        }
+                      }}
+                      className={cn(
+                        'inline-flex h-6 flex-1 items-center justify-center rounded-md transition-all hover:bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                        isActive && 'bg-background text-foreground shadow'
+                      )}
+                    >
+                      <ModelIcon icon={key === NO_VENDOR ? undefined : key} className="h-3.5 w-3.5 shrink-0" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{vendorDisplayName(key)}</TooltipContent>
+                </Tooltip>
+              )
+            })}
+          </div>
+        </TooltipProvider>
       )}
       {families.map((group) => {
         const familyHasSelection = selectedFamily === group.family

--- a/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
+++ b/src/renderer/components/quick-dispatch/quick-dispatch-menus.tsx
@@ -118,7 +118,7 @@ export function ModelEffortMenu({ state, maxHeight }: { state: ComposerOptionsSt
         {/* webProvider silences the web-tools warning when a configured host
             vendor already makes web tools work on any model — without it this
             picker contradicted the composer's. */}
-        <ModelFamilyList header="Model" catalog={catalog} value={model} onPick={setModel} webProvider={webProvider} />
+        <ModelFamilyList catalog={catalog} value={model} onPick={setModel} webProvider={webProvider} />
       </div>
       <div className="shrink-0 px-1 pb-1 pt-2">
         <EffortSection levels={efforts} value={effort} onChange={setEffort} />

--- a/src/renderer/components/settings/settings-model-select.tsx
+++ b/src/renderer/components/settings/settings-model-select.tsx
@@ -132,7 +132,6 @@ function SettingsModelSelectImpl({
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <ModelFamilyList
-          header="Model"
           catalog={catalog}
           value={model}
           onPick={onModelChange}


### PR DESCRIPTION
## Summary

With the recent provider additions, the "Models"/"Model" section label inline with the vendor tabs was getting squeezed into an ellipsis ("Mo..."). This removes the label and gives the tab bar the full width of the picker.

- **`ModelFamilyList`**: the `header` prop is gone. The old "label left, tabs right" row is now just the vendor segmented control — rendered only when the catalog spans more than one vendor, stretched edge to edge, with each tab switched from fixed `w-8` to `flex-1` so icons distribute evenly. Vendor-name tooltips unchanged.
- **Callers** (composer popover, settings model selector, quick-dispatch menu): dropped their `header=` props. Single-vendor catalogs now render no header row at all (previously a lone label).
- **Tests**: assertions that anchored on the "Models" text now anchor on model-row testids, including the Model → Effort → Speed ordering test.

## Testing

- `npx tsc --noEmit` clean
- eslint clean on touched files
- `composer-options-popover`, `model-family-list`, `settings-model-select` unit tests: 74 passed

https://claude.ai/code/session_01Jd1KVgfmZcUpy725JujB9N