### PR TITLE
Raise agent template upload limit to 10,000 files

### DIFF
--- a/src/shared/lib/services/agent-template-service.test.ts
+++ b/src/shared/lib/services/agent-template-service.test.ts
@@ -408,31 +408,31 @@ describe('validateAgentTemplate', () => {
   // --------------------------------------------------------------------------
 
   describe('file count limits', () => {
-    it('rejects template with too many files (> 2000)', async () => {
+    it('rejects template with too many files (> 10,000)', async () => {
       const files: Record<string, string> = {
         'CLAUDE.md': MINIMAL_CLAUDE_MD,
       }
-      // Create 2001 actual files (beyond the limit)
-      for (let i = 0; i < 2001; i++) {
+      // 10,000 additional files + CLAUDE.md = 10,001 (beyond the limit)
+      for (let i = 0; i < 10_000; i++) {
         files[`files/file-${i}.txt`] = `content ${i}`
       }
       const result = await validateAgentTemplate(await makeZip(files))
       expect(result.valid).toBe(false)
       expect(result.error).toContain('Too many files')
-      expect(result.error).toContain('max 2000')
+      expect(result.error).toContain('max 10000')
     })
 
     it('accepts template at exactly the file count limit', async () => {
       const files: Record<string, string> = {
         'CLAUDE.md': MINIMAL_CLAUDE_MD,
       }
-      // 1999 additional files + CLAUDE.md = 2000 exactly
-      for (let i = 0; i < 1999; i++) {
+      // 9,999 additional files + CLAUDE.md = 10,000 exactly
+      for (let i = 0; i < 9_999; i++) {
         files[`files/file-${i}.txt`] = `content ${i}`
       }
       const result = await validateAgentTemplate(await makeZip(files))
       expect(result.valid).toBe(true)
-      expect(result.fileCount).toBe(2000)
+      expect(result.fileCount).toBe(10_000)
     })
   })
 
@@ -670,7 +670,7 @@ describe('validateAgentTemplate (full mode)', () => {
     const files: Record<string, string> = {
       'CLAUDE.md': MINIMAL_CLAUDE_MD,
     }
-    for (let i = 0; i < 2001; i++) {
+    for (let i = 0; i < 10_000; i++) {
       files[`.env.${i}`] = `SECRET_${i}=value`
     }
     const result = await validateAgentTemplate(await makeZip(files), 'full')

--- a/src/shared/lib/services/agent-template-service.ts
+++ b/src/shared/lib/services/agent-template-service.ts
@@ -62,7 +62,7 @@ import { pruneInstalledTemplateIfInvalid } from './skillset-reconcile'
 
 const MAX_UNCOMPRESSED_SIZE = 500 * 1024 * 1024 // 500MB
 export const MAX_COMPRESSED_SIZE = 500 * 1024 * 1024 // 500MB
-const MAX_FILE_COUNT = 2000
+const MAX_FILE_COUNT = 10_000
 export const MAX_TEMPLATE_PROMPT_SIZE = 16 * 1024 // 16KB
 
 /** Canonical prompt handoff file, plus a lowercase compatibility spelling. */


### PR DESCRIPTION
## Summary
- raise the agent template upload limit from 2,000 to 10,000 files
- update template and full-package boundary coverage for the new limit

## Testing
- `git diff --check`
- Not run: `npm run test:run -- src/shared/lib/services/agent-template-service.test.ts` (`vitest` is not installed in this worktree)