### PR TITLE
Allow dropping files onto sidebar agents and sessions

### DIFF
--- a/e2e/specs/sidebar-file-drop.spec.ts
+++ b/e2e/specs/sidebar-file-drop.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, type Locator, type TestInfo } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import {
+  createAgent,
+  createSession,
+  getAgentItem,
+  uniqueName,
+  type TestAgent,
+  type TestSession,
+} from '../helpers/agents'
+
+async function dispatchFileDrag(
+  target: Locator,
+  eventType: 'dragenter' | 'drop',
+  fileName: string,
+) {
+  await target.evaluate((element, { eventType, fileName }) => {
+    const dataTransfer = new DataTransfer()
+    dataTransfer.items.add(new File(['sidebar drop'], fileName, { type: 'text/plain' }))
+    element.dispatchEvent(new DragEvent(eventType, {
+      bubbles: true,
+      cancelable: true,
+      dataTransfer,
+    }))
+  }, { eventType, fileName })
+}
+
+function attachmentPreview(page: import('@playwright/test').Page, fileName: string) {
+  return page.getByTestId('attachment-preview').filter({ hasText: fileName })
+}
+
+test.describe('Sidebar file drop', () => {
+  let agent: TestAgent
+
+  test.beforeEach(async ({ page, request }, testInfo: TestInfo) => {
+    agent = await createAgent(request, uniqueName(testInfo, 'Sidebar Drop Agent'))
+
+    const appPage = new AppPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+  })
+
+  test('dropping a file on an agent row opens its home composer with the attachment', async ({ page }) => {
+    const fileName = 'agent-sidebar-drop.txt'
+    const row = getAgentItem(page, agent).locator('xpath=..')
+    await expect(row).toBeVisible()
+
+    await dispatchFileDrag(row, 'dragenter', fileName)
+    await expect(row).toHaveAttribute('data-file-drop-active', '')
+
+    await dispatchFileDrag(row, 'drop', fileName)
+
+    await expect(page).toHaveURL(/\/agents\/[^/]+$/)
+    await expect(page.getByTestId('agent-breadcrumb')).toHaveText(agent.name)
+    await expect(page.getByTestId('home-message-input')).toBeVisible()
+    await expect(attachmentPreview(page, fileName)).toBeVisible()
+  })
+
+  test('dropping a file on a session row opens its composer with the attachment', async ({ page, request }) => {
+    const session: TestSession = await createSession(request, agent, 'Create a session for sidebar drop coverage')
+    const fileName = 'session-sidebar-drop.txt'
+    await page.reload()
+    await new AppPage(page).waitForAgentsLoaded()
+    await new AgentPage(page).expandAgent(agent.name)
+
+    const row = page.getByTestId(`session-item-${session.id}`).locator('xpath=ancestor::li[1]')
+    await expect(row).toBeVisible({ timeout: 15000 })
+
+    await dispatchFileDrag(row, 'dragenter', fileName)
+    await expect(row).toHaveAttribute('data-file-drop-active', '')
+
+    await dispatchFileDrag(row, 'drop', fileName)
+
+    await expect(page).toHaveURL(new RegExp(`/agents/${agent.slug}/sessions/${session.id}$`))
+    await expect(page.getByTestId('message-input')).toBeVisible()
+    await expect(attachmentPreview(page, fileName)).toBeVisible()
+  })
+})

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { cloneElement, isValidElement, type ReactElement } from 'react'
-import { act, screen } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { pointerWithin } from '@dnd-kit/core'
 import { AppSidebar } from './app-sidebar'
@@ -17,6 +17,8 @@ vi.stubGlobal('__RENDER_TRACKING__', false)
 const mockIsElectron = vi.hoisted(() => vi.fn(() => false))
 const mockGetPlatform = vi.hoisted(() => vi.fn(() => 'web'))
 const mockOpenDashboardExternal = vi.hoisted(() => vi.fn())
+const mockNavigate = vi.hoisted(() => vi.fn())
+const mockGetItemsFromDataTransfer = vi.hoisted(() => vi.fn())
 
 vi.mock('@renderer/lib/env', () => ({
   isElectron: mockIsElectron,
@@ -27,6 +29,11 @@ vi.mock('@renderer/lib/env', () => ({
 
 vi.mock('@renderer/lib/api', () => ({
   apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })),
+}))
+
+vi.mock('@renderer/lib/file-utils', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@renderer/lib/file-utils')>(),
+  getItemsFromDataTransfer: mockGetItemsFromDataTransfer,
 }))
 
 const mockUseAgents = vi.fn()
@@ -128,7 +135,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   return {
     ...actual,
     useRouter: () => ({ history: mockHistory }),
-    useNavigate: () => () => {},
+    useNavigate: () => mockNavigate,
     useParams: () => mockRouteParams,
     useRouterState: (opts?: { select?: (s: { location: { pathname: string } }) => unknown }) =>
       opts?.select ? opts.select({ location: { pathname: mockRoutePathname } }) : undefined,
@@ -254,14 +261,14 @@ vi.mock('@renderer/components/ui/sidebar', () => ({
     asChild && isValidElement(children)
       ? cloneElement(children as ReactElement, { 'data-active': isActive ? 'true' : 'false', ...props })
       : <button onClick={onClick} data-active={isActive ? 'true' : 'false'} {...props}>{children}</button>,
-  SidebarMenuItem: ({ children, onMouseEnter }: any) => <li onMouseEnter={onMouseEnter}>{children}</li>,
+  SidebarMenuItem: ({ children, ...props }: any) => <li {...props}>{children}</li>,
   SidebarMenuSkeleton: () => <div data-testid="skeleton" />,
   SidebarMenuSub: ({ children }: any) => <ul>{children}</ul>,
   SidebarMenuSubButton: ({ children, isActive, asChild, ...props }: any) =>
     asChild && isValidElement(children)
       ? cloneElement(children as ReactElement, { 'data-active': isActive ? 'true' : 'false', ...props })
       : <div data-active={isActive ? 'true' : 'false'} {...props}>{children}</div>,
-  SidebarMenuSubItem: ({ children }: any) => <li>{children}</li>,
+  SidebarMenuSubItem: ({ children, ...props }: any) => <li {...props}>{children}</li>,
   SidebarRail: () => null,
   useSidebar: () => ({ setOpenMobile: vi.fn() }),
 }))
@@ -407,6 +414,9 @@ beforeEach(() => {
   delete mockPlatformAuth.platformBaseUrl
   delete mockPlatformAuth.orgId
   mockOpenExternalUrl.mockReset()
+  mockNavigate.mockReset()
+  mockGetItemsFromDataTransfer.mockReset()
+  mockGetItemsFromDataTransfer.mockResolvedValue({ files: [], folders: [] })
 })
 
 describe('AppSidebar — layout & top nav', () => {
@@ -617,6 +627,66 @@ describe('AppSidebar — agent rows', () => {
     renderWithProviders(<AppSidebar />)
     const agentRow = screen.getByTestId('agent-item-test-agent').closest('li')!
     expect(agentRow.querySelector('[aria-label="Expand"]')).toBeNull()
+  })
+
+  it('accepts file drops on an agent row and navigates to its home composer', async () => {
+    const file = new File(['agent'], 'agent.txt', { type: 'text/plain' })
+    mockGetItemsFromDataTransfer.mockResolvedValue({ files: [{ file }], folders: [] })
+    renderWithProviders(<AppSidebar />)
+
+    const row = screen.getByTestId('agent-item-test-agent')
+    const target = row.parentElement!
+    const dataTransfer = { types: ['Files'], items: [{ kind: 'file' }] } as unknown as DataTransfer
+
+    fireEvent.dragEnter(target, { dataTransfer })
+    expect(target).toHaveAttribute('data-file-drop-active', '')
+
+    fireEvent.drop(target, { dataTransfer })
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/agents/$slug',
+        params: { slug: 'test-agent' },
+      })
+    })
+    expect(target).not.toHaveAttribute('data-file-drop-active')
+  })
+
+  it('accepts file drops on a session row and navigates to its composer', async () => {
+    const file = new File(['session'], 'session.txt', { type: 'text/plain' })
+    mockGetItemsFromDataTransfer.mockResolvedValue({ files: [{ file }], folders: [] })
+    mockRouteParams = { slug: 'test-agent' }
+    renderWithProviders(<AppSidebar />)
+
+    const row = screen.getByTestId('session-item-session-1')
+    const dataTransfer = { types: ['Files'], items: [{ kind: 'file' }] } as unknown as DataTransfer
+
+    const target = row.closest('li')!
+    fireEvent.dragEnter(target, { dataTransfer })
+    expect(target).toHaveAttribute('data-file-drop-active', '')
+
+    fireEvent.drop(target, { dataTransfer })
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/agents/$slug/sessions/$sessionId',
+        params: { slug: 'test-agent', sessionId: 'session-1' },
+      })
+    })
+  })
+
+  it('ignores non-file drags used by ordinary links and sidebar sorting', () => {
+    renderWithProviders(<AppSidebar />)
+    const row = screen.getByTestId('agent-item-test-agent')
+    const target = row.parentElement!
+    const preventDefault = vi.fn()
+    const dataTransfer = { types: ['text/plain'], items: [] } as unknown as DataTransfer
+
+    fireEvent.dragOver(target, { dataTransfer, preventDefault })
+
+    expect(target).not.toHaveAttribute('data-file-drop-active')
+    expect(mockGetItemsFromDataTransfer).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -19,6 +19,12 @@ const mockGetPlatform = vi.hoisted(() => vi.fn(() => 'web'))
 const mockOpenDashboardExternal = vi.hoisted(() => vi.fn())
 const mockNavigate = vi.hoisted(() => vi.fn())
 const mockGetItemsFromDataTransfer = vi.hoisted(() => vi.fn())
+const mockToastError = vi.hoisted(() => vi.fn())
+
+vi.mock('sonner', async (importOriginal) => ({
+  ...await importOriginal<typeof import('sonner')>(),
+  toast: { error: mockToastError },
+}))
 
 vi.mock('@renderer/lib/env', () => ({
   isElectron: mockIsElectron,
@@ -417,6 +423,7 @@ beforeEach(() => {
   mockNavigate.mockReset()
   mockGetItemsFromDataTransfer.mockReset()
   mockGetItemsFromDataTransfer.mockResolvedValue({ files: [], folders: [] })
+  mockToastError.mockReset()
 })
 
 describe('AppSidebar — layout & top nav', () => {
@@ -673,6 +680,44 @@ describe('AppSidebar — agent rows', () => {
         params: { slug: 'test-agent', sessionId: 'session-1' },
       })
     })
+  })
+
+  it('refuses file drops on a session awaiting input, which has no composer mounted', async () => {
+    const file = new File(['session'], 'session.txt', { type: 'text/plain' })
+    mockGetItemsFromDataTransfer.mockResolvedValue({ files: [{ file }], folders: [] })
+    mockUseSessions.mockImplementation((slug: string | null) => ({
+      data: slug === 'test-agent' ? [makeSession({ isAwaitingInput: true })] : [],
+      isLoading: false,
+    }))
+    mockRouteParams = { slug: 'test-agent' }
+    renderWithProviders(<AppSidebar />)
+
+    const target = screen.getByTestId('session-item-session-1').closest('li')!
+    const dataTransfer = { types: ['Files'], items: [{ kind: 'file' }] } as unknown as DataTransfer
+
+    fireEvent.dragEnter(target, { dataTransfer })
+    expect(target).not.toHaveAttribute('data-file-drop-active')
+
+    fireEvent.drop(target, { dataTransfer })
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    expect(mockGetItemsFromDataTransfer).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('reports a failure to read the dropped files instead of failing silently', async () => {
+    mockGetItemsFromDataTransfer.mockRejectedValue(new Error('unreadable directory'))
+    renderWithProviders(<AppSidebar />)
+
+    const target = screen.getByTestId('agent-item-test-agent').parentElement!
+    const dataTransfer = { types: ['Files'], items: [{ kind: 'file' }] } as unknown as DataTransfer
+
+    fireEvent.drop(target, { dataTransfer })
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Couldn't read the dropped files")
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('ignores non-file drags used by ordinary links and sidebar sorting', () => {

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -129,6 +129,7 @@ import { useRenderTracker } from '@renderer/lib/perf'
 import { useDiscoverableAgents } from '@renderer/hooks/use-agent-templates'
 import { useSkillsets } from '@renderer/hooks/use-skillsets'
 import { useRememberedFlag } from '@renderer/hooks/use-remembered-flag'
+import { useSidebarFileDrop } from './use-sidebar-file-drop'
 
 /** Set once Explore has been opened, which retires its "New" badge. */
 const EXPLORE_SEEN_KEY = 'explore.seen'
@@ -167,6 +168,8 @@ const THIN_SCROLLBAR =
 // toggle with inline options, ~0 with these hoisted.
 const POINTER_SENSOR_OPTIONS = { activationConstraint: { distance: 5 } }
 const KEYBOARD_SENSOR_OPTIONS = { coordinateGetter: sortableKeyboardCoordinates }
+const SIDEBAR_FILE_DROP_CUE =
+  'data-[file-drop-active]:bg-sidebar-accent data-[file-drop-active]:ring-1 data-[file-drop-active]:ring-sidebar-ring'
 
 /** The user-settings fields that together describe the left-nav tree. */
 type AgentTreeSettings = ReturnType<typeof sectionsToSettings>
@@ -200,9 +203,17 @@ function SessionSubItem({
   // redundant — the session clearly isn't asleep).
   const showPendingWake = !!session.pendingWakeAt && !isWorking && !isAwaitingInput
   const { ref: hintRef, hint } = useCmdHintTarget()
+  const dragHandlers = useSidebarFileDrop({
+    kind: 'session',
+    agentSlug,
+    sessionId: session.id,
+  })
 
   return (
-    <SidebarMenuSubItem>
+    <SidebarMenuSubItem
+      {...dragHandlers}
+      className={cn('rounded-md', SIDEBAR_FILE_DROP_CUE)}
+    >
       <SessionContextMenu
         sessionId={session.id}
         sessionName={session.name}
@@ -529,6 +540,11 @@ const AgentMenuItemInner = React.forwardRef<
   }
 
   const { ref: hintRef, hint } = useCmdHintTarget()
+  const dragHandlers = useSidebarFileDrop({
+    kind: 'agent',
+    agentSlug: agent.slug,
+    displaySlug: agent.displaySlug,
+  })
 
   return (
     <Collapsible asChild open={isOpen && !isDragActive} onOpenChange={setIsOpen}>
@@ -538,7 +554,10 @@ const AgentMenuItemInner = React.forwardRef<
           chevron tracks the row height, not the (potentially expanded) menu
           item that also contains CollapsibleContent below.
         */}
-        <div className="relative">
+        <div
+          className={cn('relative rounded-md', SIDEBAR_FILE_DROP_CUE)}
+          {...dragHandlers}
+        >
           <AgentContextMenu agent={agent}>
             <SidebarMenuButton
               asChild

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -207,6 +207,9 @@ function SessionSubItem({
     kind: 'session',
     agentSlug,
     sessionId: session.id,
+    // No composer is mounted behind a pending request, so a drop would be
+    // swallowed and then resurface once the request is answered.
+    disabled: isAwaitingInput,
   })
 
   return (

--- a/src/renderer/components/layout/use-sidebar-file-drop.ts
+++ b/src/renderer/components/layout/use-sidebar-file-drop.ts
@@ -1,0 +1,80 @@
+import { useCallback, type DragEventHandler } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import { getItemsFromDataTransfer } from '@renderer/lib/file-utils'
+import { pendingAttachmentDropKey } from '@renderer/lib/pending-attachment-drop'
+
+type SidebarFileDropTarget =
+  | { kind: 'agent'; agentSlug: string; displaySlug: string }
+  | { kind: 'session'; agentSlug: string; sessionId: string }
+
+function containsFiles(dataTransfer: DataTransfer): boolean {
+  return dataTransfer.types.includes('Files')
+}
+
+function setFileDropActive(element: HTMLElement, active: boolean): void {
+  element.toggleAttribute('data-file-drop-active', active)
+}
+
+export function useSidebarFileDrop(target: SidebarFileDropTarget): {
+  onDragEnter: DragEventHandler<HTMLElement>
+  onDragOver: DragEventHandler<HTMLElement>
+  onDragLeave: DragEventHandler<HTMLElement>
+  onDrop: DragEventHandler<HTMLElement>
+} {
+  const navigate = useNavigate()
+  const store = useDraftsStore()
+
+  const handleDragEnter = useCallback<DragEventHandler<HTMLElement>>((event) => {
+    if (!containsFiles(event.dataTransfer)) return
+    event.preventDefault()
+    event.stopPropagation()
+    setFileDropActive(event.currentTarget, true)
+  }, [])
+
+  const handleDragOver = useCallback<DragEventHandler<HTMLElement>>((event) => {
+    if (!containsFiles(event.dataTransfer)) return
+    event.preventDefault()
+    event.stopPropagation()
+    event.dataTransfer.dropEffect = 'copy'
+  }, [])
+
+  const handleDragLeave = useCallback<DragEventHandler<HTMLElement>>((event) => {
+    if (!containsFiles(event.dataTransfer)) return
+    event.preventDefault()
+    event.stopPropagation()
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      setFileDropActive(event.currentTarget, false)
+    }
+  }, [])
+
+  const handleDrop = useCallback<DragEventHandler<HTMLElement>>((event) => {
+    if (!containsFiles(event.dataTransfer)) return
+    event.preventDefault()
+    event.stopPropagation()
+    setFileDropActive(event.currentTarget, false)
+
+    void getItemsFromDataTransfer(event.dataTransfer).then((items) => {
+      if (items.files.length === 0 && items.folders.length === 0) return
+
+      if (target.kind === 'agent') {
+        store.set(pendingAttachmentDropKey(`agent:${target.agentSlug}`), items)
+        void navigate({ to: '/agents/$slug', params: { slug: target.displaySlug } })
+        return
+      }
+
+      store.set(pendingAttachmentDropKey(`session:${target.sessionId}`), items)
+      void navigate({
+        to: '/agents/$slug/sessions/$sessionId',
+        params: { slug: target.agentSlug, sessionId: target.sessionId },
+      })
+    })
+  }, [target, store, navigate])
+
+  return {
+    onDragEnter: handleDragEnter,
+    onDragOver: handleDragOver,
+    onDragLeave: handleDragLeave,
+    onDrop: handleDrop,
+  }
+}

--- a/src/renderer/components/layout/use-sidebar-file-drop.ts
+++ b/src/renderer/components/layout/use-sidebar-file-drop.ts
@@ -1,12 +1,21 @@
 import { useCallback, type DragEventHandler } from 'react'
 import { useNavigate } from '@tanstack/react-router'
+import { toast } from 'sonner'
 import { useDraftsStore } from '@renderer/context/drafts-context'
 import { getItemsFromDataTransfer } from '@renderer/lib/file-utils'
-import { pendingAttachmentDropKey } from '@renderer/lib/pending-attachment-drop'
+import { setPendingAttachmentDrop } from '@renderer/lib/pending-attachment-drop'
 
-type SidebarFileDropTarget =
+type SidebarFileDropTarget = (
   | { kind: 'agent'; agentSlug: string; displaySlug: string }
   | { kind: 'session'; agentSlug: string; sessionId: string }
+) & {
+  /**
+   * Refuse drops (no cue, "not allowed" cursor, explanatory toast). Set for
+   * sessions awaiting input: those render the pending-request stack instead of
+   * the composer, so there is nothing mounted to receive the attachment.
+   */
+  disabled?: boolean
+}
 
 function containsFiles(dataTransfer: DataTransfer): boolean {
   return dataTransfer.types.includes('Files')
@@ -24,20 +33,28 @@ export function useSidebarFileDrop(target: SidebarFileDropTarget): {
 } {
   const navigate = useNavigate()
   const store = useDraftsStore()
+  // Callers pass `target` as an object literal, so depend on its fields instead —
+  // an unstable object dep would rebuild every handler on every sidebar render.
+  const { kind, agentSlug, disabled = false } = target
+  const displaySlug = target.kind === 'agent' ? target.displaySlug : undefined
+  const sessionId = target.kind === 'session' ? target.sessionId : undefined
 
   const handleDragEnter = useCallback<DragEventHandler<HTMLElement>>((event) => {
     if (!containsFiles(event.dataTransfer)) return
     event.preventDefault()
     event.stopPropagation()
+    if (disabled) return
     setFileDropActive(event.currentTarget, true)
-  }, [])
+  }, [disabled])
 
   const handleDragOver = useCallback<DragEventHandler<HTMLElement>>((event) => {
     if (!containsFiles(event.dataTransfer)) return
+    // Claim the event either way: without preventDefault the browser handles the
+    // drop itself and navigates the window to the dropped file.
     event.preventDefault()
     event.stopPropagation()
-    event.dataTransfer.dropEffect = 'copy'
-  }, [])
+    event.dataTransfer.dropEffect = disabled ? 'none' : 'copy'
+  }, [disabled])
 
   const handleDragLeave = useCallback<DragEventHandler<HTMLElement>>((event) => {
     if (!containsFiles(event.dataTransfer)) return
@@ -54,22 +71,33 @@ export function useSidebarFileDrop(target: SidebarFileDropTarget): {
     event.stopPropagation()
     setFileDropActive(event.currentTarget, false)
 
-    void getItemsFromDataTransfer(event.dataTransfer).then((items) => {
+    if (disabled) {
+      toast.error("Can't attach files while this session is awaiting a reply", {
+        description: 'Answer the pending request first, then drop the files.',
+      })
+      return
+    }
+
+    getItemsFromDataTransfer(event.dataTransfer).then((items) => {
       if (items.files.length === 0 && items.folders.length === 0) return
 
-      if (target.kind === 'agent') {
-        store.set(pendingAttachmentDropKey(`agent:${target.agentSlug}`), items)
-        void navigate({ to: '/agents/$slug', params: { slug: target.displaySlug } })
+      if (kind === 'agent') {
+        setPendingAttachmentDrop(store, `agent:${agentSlug}`, items)
+        void navigate({ to: '/agents/$slug', params: { slug: displaySlug! } })
         return
       }
 
-      store.set(pendingAttachmentDropKey(`session:${target.sessionId}`), items)
+      setPendingAttachmentDrop(store, `session:${sessionId}`, items)
       void navigate({
         to: '/agents/$slug/sessions/$sessionId',
-        params: { slug: target.agentSlug, sessionId: target.sessionId },
+        params: { slug: agentSlug, sessionId: sessionId! },
       })
+    }).catch(() => {
+      // Reading a dropped directory can fail (unreadable entry, file removed
+      // mid-drag). The cue is already cleared, so say so rather than vanishing.
+      toast.error("Couldn't read the dropped files")
     })
-  }, [target, store, navigate])
+  }, [kind, agentSlug, displaySlug, sessionId, disabled, store, navigate])
 
   return {
     onDragEnter: handleDragEnter,

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -7,6 +7,8 @@ import { renderWithProviders } from '@renderer/test/test-utils'
 import { useDraft } from '@renderer/context/drafts-context'
 import { useEffect } from 'react'
 import { setMarkdownComposerSelection } from './markdown-composer-editor'
+import { pendingAttachmentDropKey } from '@renderer/lib/pending-attachment-drop'
+import type { DataTransferResult } from '@renderer/lib/file-utils'
 
 // Mock hooks
 const mockSendMessage = {
@@ -1000,6 +1002,31 @@ describe('MessageInput', () => {
       useEffect(() => { setDraft(value) }, [setDraft, value])
       return null
     }
+
+    function AttachmentDropSeeder({ sessionId, value }: { sessionId: string; value: DataTransferResult }) {
+      const [, setPending] = useDraft<DataTransferResult>(pendingAttachmentDropKey(`session:${sessionId}`))
+      useEffect(() => { setPending(value) }, [setPending, value])
+      return null
+    }
+
+    it('drains sidebar-dropped files into the current session composer', async () => {
+      const file = new File(['dropped'], 'dropped.txt', { type: 'text/plain' })
+      const value = { files: [{ file }], folders: [] }
+      renderWithProviders(
+        <>
+          <MessageInput sessionId="s-1" agentSlug="agent-1" />
+          <AttachmentDropSeeder sessionId="s-1" value={value} />
+        </>
+      )
+
+      await waitFor(() => {
+        expect(mockUploadFile.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({
+          sessionId: 's-1',
+          agentSlug: 'agent-1',
+          file,
+        }))
+      })
+    })
 
     it('restores the draft when re-mounted in the same provider', async () => {
       const { rerender } = renderWithProviders(

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from '@renderer/test/test-utils'
 import { useDraft } from '@renderer/context/drafts-context'
 import { useEffect } from 'react'
 import { setMarkdownComposerSelection } from './markdown-composer-editor'
-import { pendingAttachmentDropKey } from '@renderer/lib/pending-attachment-drop'
+import { pendingAttachmentDropKey, type PendingAttachmentDrop } from '@renderer/lib/pending-attachment-drop'
 import type { DataTransferResult } from '@renderer/lib/file-utils'
 
 // Mock hooks
@@ -1004,8 +1004,8 @@ describe('MessageInput', () => {
     }
 
     function AttachmentDropSeeder({ sessionId, value }: { sessionId: string; value: DataTransferResult }) {
-      const [, setPending] = useDraft<DataTransferResult>(pendingAttachmentDropKey(`session:${sessionId}`))
-      useEffect(() => { setPending(value) }, [setPending, value])
+      const [, setPending] = useDraft<PendingAttachmentDrop>(pendingAttachmentDropKey(`session:${sessionId}`))
+      useEffect(() => { setPending({ items: value, droppedAt: Date.now() }) }, [setPending, value])
       return null
     }
 

--- a/src/renderer/hooks/use-attachments.ts
+++ b/src/renderer/hooks/use-attachments.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { type Attachment, type UploadState } from '@renderer/components/messages/attachment-preview'
-import { getItemsFromDataTransfer, getFolderFromDirectoryInput, type FileWithPath, type FolderGroup } from '@renderer/lib/file-utils'
+import { getItemsFromDataTransfer, getFolderFromDirectoryInput, type DataTransferResult, type FileWithPath, type FolderGroup } from '@renderer/lib/file-utils'
 
 // 500 MB max folder size for in-browser zip upload (no Electron fs.cp available)
 const MAX_WEB_FOLDER_SIZE = 500 * 1024 * 1024
@@ -27,6 +27,8 @@ export function useAttachments(options?: UseAttachmentsOptions) {
   const [isDragOver, setIsDragOver] = useState(false)
   const onAddedRef = useRef(options?.onAttachmentsAdded)
   onAddedRef.current = options?.onAttachmentsAdded
+  const onFoldersReceivedRef = useRef(options?.onFoldersReceived)
+  onFoldersReceivedRef.current = options?.onFoldersReceived
 
   const addFiles = useCallback((files: FileWithPath[]) => {
     const newAttachments: Attachment[] = files.map(({ file }) => {
@@ -124,6 +126,16 @@ export function useAttachments(options?: UseAttachmentsOptions) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const addItems = useCallback(({ files, folders }: DataTransferResult) => {
+    if (files.length > 0) addFiles(files)
+    if (folders.length === 0) return
+    if (onFoldersReceivedRef.current) {
+      onFoldersReceivedRef.current(folders)
+    } else {
+      addFolders(folders)
+    }
+  }, [addFiles, addFolders])
+
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -141,17 +153,9 @@ export function useAttachments(options?: UseAttachmentsOptions) {
     e.stopPropagation()
     setIsDragOver(false)
     if (e.dataTransfer.items.length > 0) {
-      const { files, folders } = await getItemsFromDataTransfer(e.dataTransfer)
-      if (files.length > 0) addFiles(files)
-      if (folders.length > 0) {
-        if (options?.onFoldersReceived) {
-          options.onFoldersReceived(folders)
-        } else {
-          addFolders(folders)
-        }
-      }
+      addItems(await getItemsFromDataTransfer(e.dataTransfer))
     }
-  }, [addFiles, addFolders, options])
+  }, [addItems])
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
@@ -179,6 +183,7 @@ export function useAttachments(options?: UseAttachmentsOptions) {
     isDragOver,
     addFiles,
     addFolders,
+    addItems,
     addMounts,
     updateAttachment,
     setAttachmentError,

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -10,6 +10,7 @@ import { type FolderGroup } from '@renderer/lib/file-utils'
 import { canUseHostFeatures } from '@renderer/lib/host-features'
 import { attachmentStatus, type Attachment, type MountAttachment } from '@renderer/components/messages/attachment-preview'
 import type { UploadProgress } from '@renderer/lib/upload'
+import { usePendingAttachmentDrop } from '@renderer/lib/pending-attachment-drop'
 import {
   findPotentialSecrets,
   replaceSecuredSecrets,
@@ -135,7 +136,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
   const canOfferMount = canUseHostFeatures()
 
   const handleFoldersReceived = useCallback((folders: FolderGroup[]) => {
-    setPendingFolders(folders)
+    setPendingFolders((current) => [...current, ...folders])
     setShowMountDialog(true)
   }, [])
 
@@ -147,6 +148,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     isDragOver,
     addFiles,
     addFolders: addFoldersDirectly,
+    addItems,
     addMounts,
     updateAttachment,
     setAttachmentError,
@@ -163,6 +165,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     },
   })
   attachmentsRef.current = attachments
+  usePendingAttachmentDrop(draftKey, addItems)
 
   const queue = useUploadQueue({
     agentSlug,

--- a/src/renderer/lib/pending-attachment-drop.test.tsx
+++ b/src/renderer/lib/pending-attachment-drop.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { DraftsProvider, useDraftsStore, type DraftsStore } from '@renderer/context/drafts-context'
+import { pendingAttachmentDropKey, usePendingAttachmentDrop } from './pending-attachment-drop'
+import type { DataTransferResult } from './file-utils'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <DraftsProvider>{children}</DraftsProvider>
+}
+
+describe('pending attachment drops', () => {
+  it('namespaces drops by composer draft key', () => {
+    expect(pendingAttachmentDropKey('agent:agent-1')).toBe('pending-attachment-drop:agent:agent-1')
+    expect(pendingAttachmentDropKey('session:session-1')).toBe('pending-attachment-drop:session:session-1')
+  })
+
+  it('reactively drains a drop exactly once', async () => {
+    const addItems = vi.fn()
+    let store: DraftsStore | undefined
+    const draftKey = 'session:session-1'
+    const key = pendingAttachmentDropKey(draftKey)
+    const dropped: DataTransferResult = {
+      files: [{ file: new File(['hello'], 'hello.txt', { type: 'text/plain' }) }],
+      folders: [],
+    }
+
+    renderHook(() => {
+      store = useDraftsStore()
+      usePendingAttachmentDrop(draftKey, addItems)
+    }, { wrapper })
+
+    act(() => store!.set(key, dropped))
+
+    await waitFor(() => expect(addItems).toHaveBeenCalledWith(dropped))
+    expect(store!.get(key)).toBeUndefined()
+
+    await act(async () => {})
+    expect(addItems).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/lib/pending-attachment-drop.test.tsx
+++ b/src/renderer/lib/pending-attachment-drop.test.tsx
@@ -3,7 +3,12 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { type ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { DraftsProvider, useDraftsStore, type DraftsStore } from '@renderer/context/drafts-context'
-import { pendingAttachmentDropKey, usePendingAttachmentDrop } from './pending-attachment-drop'
+import {
+  PENDING_ATTACHMENT_DROP_TTL_MS,
+  pendingAttachmentDropKey,
+  setPendingAttachmentDrop,
+  usePendingAttachmentDrop,
+} from './pending-attachment-drop'
 import type { DataTransferResult } from './file-utils'
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -31,12 +36,36 @@ describe('pending attachment drops', () => {
       usePendingAttachmentDrop(draftKey, addItems)
     }, { wrapper })
 
-    act(() => store!.set(key, dropped))
+    act(() => setPendingAttachmentDrop(store!, draftKey, dropped))
 
     await waitFor(() => expect(addItems).toHaveBeenCalledWith(dropped))
     expect(store!.get(key)).toBeUndefined()
 
     await act(async () => {})
     expect(addItems).toHaveBeenCalledTimes(1)
+  })
+
+  it('discards a drop whose composer never mounted in time', async () => {
+    const addItems = vi.fn()
+    let store: DraftsStore | undefined
+    const draftKey = 'session:session-1'
+    const key = pendingAttachmentDropKey(draftKey)
+
+    // A drop written before the composer existed — e.g. the target route errored
+    // out, or the user navigated away again — must not attach itself on a later,
+    // unrelated visit. `null` stands in for "no composer mounted yet".
+    const { rerender } = renderHook(({ key }: { key: string | null }) => {
+      store = useDraftsStore()
+      usePendingAttachmentDrop(key, addItems)
+    }, { wrapper, initialProps: { key: null as string | null } })
+
+    act(() => setPendingAttachmentDrop(store!, draftKey, { files: [], folders: [] }))
+    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + PENDING_ATTACHMENT_DROP_TTL_MS + 1)
+
+    rerender({ key: draftKey })
+    await act(async () => {})
+    expect(addItems).not.toHaveBeenCalled()
+    expect(store!.get(key)).toBeUndefined()
+    vi.restoreAllMocks()
   })
 })

--- a/src/renderer/lib/pending-attachment-drop.ts
+++ b/src/renderer/lib/pending-attachment-drop.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react'
+import { useDraftsStore } from '@renderer/context/drafts-context'
+import type { DataTransferResult } from './file-utils'
+
+export const pendingAttachmentDropKey = (draftKey: string) =>
+  `pending-attachment-drop:${draftKey}`
+
+export function usePendingAttachmentDrop(
+  draftKey: string | null | undefined,
+  addItems: (items: DataTransferResult) => void,
+): void {
+  const store = useDraftsStore()
+  const addItemsRef = useRef(addItems)
+  addItemsRef.current = addItems
+  const key = draftKey ? pendingAttachmentDropKey(draftKey) : undefined
+
+  useEffect(() => {
+    if (!key) return
+
+    const drain = () => {
+      const pending = store.get<DataTransferResult>(key)
+      if (!pending) return
+      store.set(key, undefined)
+      addItemsRef.current(pending)
+    }
+
+    drain()
+    return store.subscribe(key, drain)
+  }, [key, store])
+}

--- a/src/renderer/lib/pending-attachment-drop.ts
+++ b/src/renderer/lib/pending-attachment-drop.ts
@@ -1,9 +1,35 @@
 import { useEffect, useRef } from 'react'
-import { useDraftsStore } from '@renderer/context/drafts-context'
+import { useDraftsStore, type DraftsStore } from '@renderer/context/drafts-context'
 import type { DataTransferResult } from './file-utils'
+
+/**
+ * How long a sidebar drop waits for its composer to mount. The composer normally
+ * mounts a frame after the navigation, so anything older than this means it never
+ * rendered at all (route error, user navigated away again). Discarding those keeps
+ * live File handles out of the app-lifetime drafts store and stops a forgotten drop
+ * from suddenly attaching itself on an unrelated later visit.
+ */
+export const PENDING_ATTACHMENT_DROP_TTL_MS = 30_000
+
+export interface PendingAttachmentDrop {
+  items: DataTransferResult
+  droppedAt: number
+}
 
 export const pendingAttachmentDropKey = (draftKey: string) =>
   `pending-attachment-drop:${draftKey}`
+
+/** Hand a drop to the composer owning `draftKey`, to drain when it next mounts. */
+export function setPendingAttachmentDrop(
+  store: Pick<DraftsStore, 'set'>,
+  draftKey: string,
+  items: DataTransferResult,
+): void {
+  store.set<PendingAttachmentDrop>(pendingAttachmentDropKey(draftKey), {
+    items,
+    droppedAt: Date.now(),
+  })
+}
 
 export function usePendingAttachmentDrop(
   draftKey: string | null | undefined,
@@ -18,10 +44,11 @@ export function usePendingAttachmentDrop(
     if (!key) return
 
     const drain = () => {
-      const pending = store.get<DataTransferResult>(key)
+      const pending = store.get<PendingAttachmentDrop>(key)
       if (!pending) return
       store.set(key, undefined)
-      addItemsRef.current(pending)
+      if (Date.now() - pending.droppedAt > PENDING_ATTACHMENT_DROP_TTL_MS) return
+      addItemsRef.current(pending.items)
     }
 
     drain()


### PR DESCRIPTION
## Summary

- accept native file drops on agent and session rows without affecting pointer-based sidebar sorting
- navigate to the dropped-on destination and reactively hand files or folders to its composer
- show a subtle row-level drop cue and reuse the existing attachment upload/mount pipeline
- cover agent, session, non-file drag, same-composer handoff, and reorder regression behavior

## Verification

- `npm run test:run` — 642 files passed, 10,627 tests passed
- `npm run typecheck`
- `npm run lint` — 0 errors, 38 pre-existing warnings
- Playwright: sidebar file drop — 2 passed
- Playwright: existing agent folder/reorder suite — 5 passed

Linear: https://linear.app/datawizz/issue/SUP-735/allow-dropping-files-onto-sessions-agents-in-side-bar

Closes SUP-735
