### PR TITLE
Keep a running turn's status alive when a message is queued (SUP-736)

### DIFF
--- a/e2e/specs/message-queueing.spec.ts
+++ b/e2e/specs/message-queueing.spec.ts
@@ -69,6 +69,44 @@ test.describe('Message queueing while agent is working', () => {
     ).toBeVisible({ timeout: 15000 })
   })
 
+  test('a message queued during compaction keeps the compacting status and sits below the boundary', async ({ page }) => {
+    // The mock holds compaction open for 10s and delays pickup to 8s, so this
+    // one runs longer than the default per-test budget.
+    test.setTimeout(60000)
+    // SUP-736: queueing a follow-up is not a turn boundary. The compaction it
+    // lands during is still running, so both the live compact line and the
+    // "Compacting..." status must survive it, with the ghost below the line —
+    // the queued message is picked up on the far side of the boundary.
+    await sessionPage.sendMessage('please compact slowly for this test')
+
+    const compactingLine = page.getByText('Compacting conversation...')
+    await expect(compactingLine).toBeVisible({ timeout: 15000 })
+    await expect(sessionPage.getActivityIndicator()).toContainText('Compacting', { timeout: 15000 })
+
+    // 'pickup after turn' selects the mock's long pickup window, so the ghost is
+    // still a ghost while the assertions below run.
+    await sessionPage.typeMessage('queued while compacting, pickup after turn')
+    await sessionPage.getSendButton().click()
+
+    const ghost = page.locator('[data-testid="queued-user-message"]')
+    await expect(ghost).toBeVisible({ timeout: 5000 })
+
+    await expect(compactingLine).toBeVisible()
+    await expect(sessionPage.getActivityIndicator()).toContainText('Compacting')
+
+    const lineBox = await compactingLine.boundingBox()
+    const ghostBox = await ghost.boundingBox()
+    expect(lineBox!.y).toBeLessThan(ghostBox!.y)
+
+    // Compaction finishes on its own, and only then does the live line go away.
+    // (The persisted boundary it becomes is inside the completed turn, which
+    // collapses behind its summary once the session is idle.)
+    await expect(compactingLine).not.toBeAttached({ timeout: 25000 })
+    await expect(
+      sessionPage.getAssistantMessages().filter({ hasText: 'Compacted the conversation.' })
+    ).toBeVisible({ timeout: 15000 })
+  })
+
   test('a queued message can be cancelled before pickup', async ({ page }) => {
     await sessionPage.sendMessage('please work slowly for the cancel test')
     await expect(sessionPage.getStopButton()).toBeVisible({ timeout: 10000 })

--- a/e2e/specs/message-queueing.spec.ts
+++ b/e2e/specs/message-queueing.spec.ts
@@ -77,6 +77,19 @@ test.describe('Message queueing while agent is working', () => {
     // lands during is still running, so both the live compact line and the
     // "Compacting..." status must survive it, with the ghost below the line —
     // the queued message is picked up on the far side of the boundary.
+
+    // Settle a first turn before starting the one that compacts. compact_start
+    // is a one-shot broadcast and the connected frame carries no compaction
+    // snapshot, so a client that subscribes late never learns compaction began.
+    // The first message is what creates the session and navigates to it — under
+    // CI load that hand-off outran the mock's compacting status and the whole
+    // compaction came and went before the stream was listening.
+    await sessionPage.sendMessage('hello there')
+    await expect(
+      sessionPage.getAssistantMessages().filter({ hasText: 'This is a mock response from the E2E test container.' })
+    ).toBeVisible({ timeout: 15000 })
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 15000 })
+
     await sessionPage.sendMessage('please compact slowly for this test')
 
     const compactingLine = page.getByText('Compacting conversation...')

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -1049,6 +1049,26 @@ describe('MessageList', () => {
     expect(text.indexOf('StreamingBash')).toBeLessThan(text.indexOf('Queued msg'))
   })
 
+  it('renders the live compact line above the queued ghosts', () => {
+    // A message queued during compaction is picked up on the far side of the
+    // boundary, so it reads below the compact line, not above it. (SUP-736)
+    mockMessagesData.data = [createUserMessage({ content: { text: '/compact' } })]
+    mockStreamState.isActive = true
+    mockStreamState.isCompacting = true
+
+    const { container } = renderWithProviders(
+      <MessageList
+        sessionId="s-1"
+        agentSlug="agent-1"
+        pendingUserMessages={[{ localId: 'q1', uuid: 'q1', text: 'Queued msg', sentAt: Date.now(), queued: true }]}
+      />
+    )
+
+    const text = container.textContent || ''
+    expect(text.indexOf('Compacting conversation...')).toBeGreaterThan(-1)
+    expect(text.indexOf('Compacting conversation...')).toBeLessThan(text.indexOf('Queued msg'))
+  })
+
   it('does not close the turn at a persisted queued message (no elapsed divider mid-turn)', () => {
     mockStreamState.isActive = true
     mockMessagesData.data = [

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -1346,6 +1346,13 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
           <DeliveredFiles files={turnDeliveredFiles.get(deferredElapsedMessageId)!} agentSlug={agentSlug} />
         )}
 
+        {/* Real-time compacting indicator. Above the queued ghosts: a message
+            queued during compaction is picked up on the far side of the
+            boundary, so it belongs below the compact line, not above it. */}
+        {isCompacting && (
+          <CompactBoundaryItem isCompacting />
+        )}
+
         {/* Queued ghosts — waiting for the agent loop to pick them up, so they
             always sit below the current turn's streaming output and tools. */}
         {visiblePeerMessages.filter((p) => p.queued).map(renderPeerGhost)}
@@ -1365,11 +1372,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
               </span>
             </div>
           </div>
-        )}
-
-        {/* Real-time compacting indicator */}
-        {isCompacting && (
-          <CompactBoundaryItem isCompacting />
         )}
 
         {/* Pending interactive requests render in the composer slot — see SessionChatColumn. */}

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -399,6 +399,146 @@ describe('useMessageStream', () => {
     expect(result.current.isCompacting).toBe(false)
   })
 
+  it('keeps compacting through a mid-turn session_active (queued message)', async () => {
+    // Queueing a message during a manual /compact re-broadcasts session_active for
+    // the SAME turn. Compaction is still running, so the label and its boundary line
+    // must survive it — a genuinely new turn still clears the flag. (SUP-736)
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      MockEventSource.instances[0].simulateMessage({ type: 'compact_start' })
+    })
+    expect(result.current.isCompacting).toBe(true)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: true })
+    })
+    expect(result.current.isCompacting).toBe(true)
+    expect(result.current.isActive).toBe(true)
+
+    // A genuinely new turn still clears a compaction the previous turn left behind.
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: false })
+    })
+    expect(result.current.isCompacting).toBe(false)
+  })
+
+  it('keeps the retry state and elapsed clock through a mid-turn session_active', async () => {
+    // The turn is one API retry deep and N seconds in; queueing a follow-up neither
+    // resolved the retry nor restarted the clock, so neither may be reset. (SUP-736)
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: false })
+      MockEventSource.instances[0].simulateMessage({ type: 'api_retry', attempt: 2, maxRetries: 5, delayMs: 1000 })
+    })
+    const startedAt = result.current.activeStartTime
+    expect(result.current.apiRetry?.attempt).toBe(2)
+    expect(startedAt).not.toBeNull()
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: true })
+    })
+    expect(result.current.apiRetry?.attempt).toBe(2)
+    expect(result.current.activeStartTime).toBe(startedAt)
+
+    // A new turn resets both: fresh clock, no inherited retry.
+    const later = vi.spyOn(Date, 'now').mockReturnValue(startedAt! + 60_000)
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: false })
+    })
+    later.mockRestore()
+    expect(result.current.apiRetry).toBeNull()
+    expect(result.current.activeStartTime).toBe(startedAt! + 60_000)
+  })
+
+  it('clears message-scoped state on a mid-turn session_active', async () => {
+    // The other half of the rule: what ANY accepted message invalidates is cleared
+    // on both paths — a queued message resumes work parked on background tasks.
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: false })
+      MockEventSource.instances[0].simulateMessage({ type: 'session_waiting_background' })
+    })
+    expect(result.current.isWaitingBackground).toBe(true)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: true })
+    })
+    expect(result.current.isWaitingBackground).toBe(false)
+  })
+
+  it('keeps live thinking and running subagents through a mid-turn session_active', async () => {
+    // Same turn, so the open thinking block keeps accumulating and the Task blocks
+    // still running stay on screen — a queued follow-up must not blank them. (SUP-736)
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      MockEventSource.instances[0].simulateMessage({ type: 'thinking_start', thinkingId: 'msg_1:0' })
+      MockEventSource.instances[0].simulateMessage({ type: 'thinking_delta', thinkingId: 'msg_1:0', text: 'weighing it' })
+      MockEventSource.instances[0].simulateMessage({
+        type: 'subagent_started',
+        parentToolId: 'tool-1',
+        agentId: 'sub-1',
+        subagentType: 'Explore',
+        description: 'search',
+      })
+    })
+    expect(result.current.isThinking).toBe(true)
+    expect(result.current.activeSubagents).toHaveLength(1)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: true })
+    })
+    expect(result.current.isThinking).toBe(true)
+    expect(result.current.thinkingBlocks[0]?.text).toBe('weighing it')
+    expect(result.current.activeSubagents).toHaveLength(1)
+
+    // A genuinely new turn still starts from a clean slate.
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true, queuedMidTurn: false })
+    })
+    expect(result.current.isThinking).toBe(false)
+    expect(result.current.thinkingBlocks).toHaveLength(0)
+    expect(result.current.activeSubagents).toHaveLength(0)
+  })
+
+  it('treats a session_active with no queuedMidTurn flag as a new turn', async () => {
+    // An older remote deployment sends no flag. Only the explicit flag preserves
+    // turn state — the isActive we hold can be stale-true after a dropped idle.
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      MockEventSource.instances[0].simulateMessage({ type: 'compact_start' })
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active', isActive: true })
+    })
+    expect(result.current.isCompacting).toBe(false)
+  })
+
   it('handles error recovery — resets streaming but preserves isActive', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -476,29 +476,42 @@ function getOrCreateEventSource(
       else if (data.type === 'session_active') {
         // Session became active - user sent a message
         if (data.sessionId && data.sessionId !== sessionId) return
-        // Reset thinking stream for the new turn
-        sessionThinking.delete(sessionId)
+        // This frame carries TWO meanings: a genuinely new turn, and a
+        // queued/steering message accepted into a turn that is already running
+        // (`queuedMidTurn`). Deciding reset-vs-preserve field by field produced a
+        // long tail of bugs — queueing a follow-up blanked the running turn's
+        // whole status surface (SUP-736) — so the rule is encoded once, as two
+        // named groups, instead:
+        //
+        //   message-scoped — invalidated by ANY accepted message.
+        //   turn-scoped    — only a real turn boundary ends these. Mid-turn the
+        //                    compaction, thinking blocks, subagents, retry and
+        //                    elapsed clock all belong to the turn still running.
+        //
+        // Everything else carries over from the state we already hold, so state
+        // added to StreamState later survives a mid-turn pickup by default —
+        // opting it out is an explicit line in the turn-scoped group.
+        const queuedMidTurn = data.queuedMidTurn === true
+        // The thinking stream lives outside StreamState but is turn-scoped too.
+        if (!queuedMidTurn) sessionThinking.delete(sessionId)
         streamStates.set(sessionId, {
+          ...(current ?? EMPTY_STREAM_STATE),
           isActive: true,
-          isStreaming: current?.isStreaming ?? false,
-          streamingMessage: current?.streamingMessage ?? null,
-          streamingToolUses: current?.streamingToolUses ?? [],
-          error: null, // Clear any previous error when starting new request
+          // Message-scoped: a new message clears the last error, ends whatever
+          // typing indicator it belongs to, and resumes work that was parked on
+          // background tasks.
+          error: null,
           apiErrorCode: null,
-          browserActive: current?.browserActive ?? false,
-          computerUseApp: current?.computerUseApp ?? null,
-          computerUseAppIcon: current?.computerUseAppIcon ?? null,
-          activeStartTime: Date.now(),
-          isCompacting: false,
-          contextUsage: current?.contextUsage ?? null,
-          activeSubagents: [],
-          completedSubagents: null,
           typingUser: null,
-          peerUserMessages: current?.peerUserMessages ?? [],
-          apiRetry: null,
-          backgroundTasks: current?.backgroundTasks ?? [],
           isWaitingBackground: false,
-          discardedCommandUuids: current?.discardedCommandUuids ?? [],
+          // Turn-scoped: a new turn only.
+          ...(queuedMidTurn ? {} : {
+            activeStartTime: Date.now(),
+            isCompacting: false,
+            activeSubagents: [],
+            completedSubagents: null,
+            apiRetry: null,
+          }),
         })
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
       }

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3886,12 +3886,52 @@ describe('MessagePersister', () => {
       // wedges the next turn's label to "Compacting…". The state object is reused across turns.
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
       const st = (messagePersister as any).streamingStates.get(SESSION_ID)
-      st.isActive = false; st.isCompacting = true; st.currentThinking = true
+      st.isActive = false; st.isCompacting = true; st.currentThinking = true; st.isRetrying = true
 
       messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // next user message
       expect(st.isCompacting).toBe(false)
       expect(st.currentThinking).toBe(false)
+      expect(st.isRetrying).toBe(false)
       expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+    })
+
+    it('keeps a running turn intact when a queued message re-marks an ALREADY-active session', () => {
+      // Queueing a message mid-turn accepts it into the RUNNING turn — it is not a
+      // turn boundary, so everything that turn is still doing survives. Driven with
+      // the real frames, since the bug was that markSessionActive wiped exactly the
+      // state those frames had just established. (SUP-736)
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start', message: { id: 'msg_1' } } })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } },
+      })
+      mockClient._sendMessage({
+        type: 'system', subtype: 'api_retry', attempt: 2, max_retries: 5, session_id: SESSION_ID, uuid: 'r1',
+      })
+      mockClient._sendMessage({
+        type: 'system', subtype: 'status', status: 'compacting', session_id: SESSION_ID, uuid: 's1',
+      })
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('compacting')
+      sseEvents.length = 0
+
+      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // queued mid-turn
+
+      // The app is told which of the two meanings this session_active carries.
+      expect(sseEvents.find(e => e.type === 'session_active')).toMatchObject({ queuedMidTurn: true })
+      // Chat's label walks back down the real ladder as each state ends, instead of
+      // dropping straight to "Working…" the moment the message was queued.
+      const st = (messagePersister as any).streamingStates.get(SESSION_ID)
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('compacting')
+      st.isCompacting = false
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('retrying')
+      st.isRetrying = false
+      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('thinking')
+
+      // And the open thinking block still closes under the id the app opened it
+      // with — a nulled message id/block index would have re-keyed it to undefined.
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_stop', index: 0 } })
+      expect(sseEvents.find(e => e.type === 'thinking_stop')).toMatchObject({ thinkingId: 'msg_1:0' })
     })
 
     it('is idle for an unknown session', () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1310,34 +1310,44 @@ class MessagePersister {
         this.capture.recordNote(sessionId, 'state_created', { agentSlug }).catch(() => {})
       }
     }
+    // Re-marking an ALREADY-active session is how a queued/steering message is
+    // accepted mid-turn — it is not a turn boundary. Split the resets the same way
+    // the app's session_active handler does (see use-message-stream.ts): what any
+    // accepted message invalidates, versus what only a real new turn ends. State
+    // that belongs to the running turn must survive the mid-turn path, or the
+    // session's whole reported status collapses to "Working…" the moment a
+    // follow-up is queued (SUP-736).
     const wasActive = state.isActive
     state.isActive = true
+    // Message-scoped: true for a queued message just as much as a new turn.
     state.isInterrupted = false // Reset interrupted flag on new message
     state.isAwaitingInput = false // Reset awaiting input on new message
-    state.isRetrying = false // Reset retry flag on new message
-    // Reset compaction/thinking too, mirroring the app's session_active reset: a
-    // turn that ended mid-compaction/-thinking (error/interrupt before the clearing
-    // event) must not wedge the next turn's label. State is reused across turns.
-    state.isCompacting = false
-    state.currentThinking = false
-    state.currentAssistantMessageId = null
-    state.currentThinkingBlockIndex = null
     state.lastApiErrorCode = null // Clear previous API error on new message
     // Clear the previous turn's result subtype so a late idle from an
     // already-finished (or interrupted) run can't fire a stale "success"
     // completion notification against the turn this message is starting.
     state.lastResultSubtype = null
     state.lastResultCleanSuccess = false
-    // Re-marking an already-active session is how queued/steering messages are
-    // accepted mid-turn. Preserve the current candidate in that case; the next
-    // assistant message group will replace it. A genuinely new turn must never
-    // inherit the prior turn's answer.
-    if (!wasActive) {
+    if (wasActive) {
+      state.queuedTurnCount += 1
+    } else {
+      // Turn-scoped. Compaction/thinking mirror the app's reset: a turn that ended
+      // mid-compaction/-thinking (error/interrupt before the clearing event) must
+      // not wedge the next turn's label — state is reused across turns. Mid-turn
+      // they are still running, and the nulled message id/block index would also
+      // re-key an open thinking block's remaining delta and stop events onto an id
+      // the app never opened. isRetrying likewise: an in-flight API retry outlives
+      // a queued message (message_start clears it when the response flows).
+      state.isCompacting = false
+      state.currentThinking = false
+      state.currentAssistantMessageId = null
+      state.currentThinkingBlockIndex = null
+      state.isRetrying = false
+      // The turn's answer candidate: the next assistant message group replaces it
+      // mid-turn, but a genuinely new turn must never inherit the prior one's.
       this.resetSessionCompleteResponse(state)
       state.queuedTurnCount = 0
       state.resetAssistantBeforeNextTurnOutput = false
-    } else {
-      state.queuedTurnCount += 1
     }
     if (agentSlug) {
       state.agentSlug = agentSlug
@@ -1355,8 +1365,11 @@ class MessagePersister {
       state.provisionalActivity = recordProvisionalSessionActivity(state.agentSlug, sessionId, Date.now())
     }
 
-    // Broadcast to session-specific clients
-    this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true })
+    // Broadcast to session-specific clients. queuedMidTurn tells the app this is a
+    // message accepted into a running turn rather than a new one, so it can keep the
+    // turn-scoped state (compaction, thinking, running subagents) that a real turn
+    // boundary would clear.
+    this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true, queuedMidTurn: wasActive })
 
     // Also broadcast globally so sidebar updates regardless of which session is being viewed
     this.broadcastGlobal({

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -481,6 +481,80 @@ export class SlowWorkScenario implements MockScenario {
 }
 
 /**
+ * Manual /compact with a long compaction window — the send-a-message-while-
+ * compacting case (SUP-736). Holds `status: compacting` open long enough for a
+ * test to queue a follow-up (the busy path in sendMessage takes it as steering),
+ * then writes the boundary + summary pair the transcript renders and settles.
+ *
+ * The compacted command itself is never echoed as a user message: the runtime
+ * persists its effect as the compact boundary instead.
+ */
+export class SlowCompactionScenario implements MockScenario {
+  constructor(private durationMs = 12000) {}
+
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    // Echo the turn-starting message first, so its optimistic ghost materializes
+    // before compaction opens. Order matters: the persister ends compaction at
+    // the first user message that follows the compacting status.
+    setTimeout(() => {
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        message: { content: userMessage },
+        timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'user',
+        content: { type: 'user', message: { content: [{ type: 'text', text: userMessage }] } },
+      })
+    }, 10)
+
+    setTimeout(() => {
+      client.emitStreamMessage(sessionId, {
+        type: 'system',
+        content: { type: 'system', subtype: 'status', status: 'compacting' },
+      })
+    }, 150)
+
+    setTimeout(() => {
+      const summary = 'Summary of the conversation so far.'
+      client.writeJsonlEntry(sessionId, {
+        type: 'system',
+        subtype: 'compact_boundary',
+        content: 'Conversation compacted',
+        compactMetadata: { trigger: 'manual', preTokens: 120000 },
+        timestamp: new Date().toISOString(),
+      })
+      client.writeJsonlEntry(sessionId, {
+        type: 'user',
+        isCompactSummary: true,
+        message: { content: summary },
+        timestamp: new Date().toISOString(),
+      })
+      // The summary on the stream is what ends compaction host-side (the
+      // persister clears isCompacting on the first user message after the
+      // compacting status and broadcasts compact_complete).
+      client.emitStreamMessage(sessionId, {
+        type: 'user',
+        content: {
+          type: 'user',
+          isCompactSummary: true,
+          message: { content: [{ type: 'text', text: summary }] },
+        },
+      })
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'Compacted the conversation.' }] },
+        timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'result',
+        content: { type: 'result', subtype: 'success' },
+      })
+    }, this.durationMs)
+  }
+}
+
+/**
  * API error scenario - simulates an LLM provider error (e.g., auth failure, rate limit).
  * Emits an assistant message with the SDK error code, then a result with error subtype.
  */
@@ -1581,6 +1655,8 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
   static scenarios = new Map<string, MockScenario>([
     // Slow response window for message-queueing tests (send mid-turn → queued)
     ['work slowly', new SlowWorkScenario()],
+    // Long compaction window: queue a message while the session is compacting
+    ['compact slowly', new SlowCompactionScenario(10000)],
     // Long thinking passes: each pass overfills the card's max-height so the
     // card scrolls internally while live, then collapses by its full body
     // height when the pass ends — the shrink-at-the-live-edge shape behind

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -508,12 +508,16 @@ export class SlowCompactionScenario implements MockScenario {
       })
     }, 10)
 
+    // Well clear of the echo above (the persister ends compaction at the first
+    // user message that FOLLOWS the compacting status) and of any subscribe
+    // hand-off: compact_start is one-shot, so a client that is not listening
+    // yet never learns compaction began.
     setTimeout(() => {
       client.emitStreamMessage(sessionId, {
         type: 'system',
         content: { type: 'system', subtype: 'status', status: 'compacting' },
       })
-    }, 150)
+    }, 1000)
 
     setTimeout(() => {
       const summary = 'Summary of the conversation so far.'


### PR DESCRIPTION
Fixes [SUP-736](https://linear.app/datawizz/issue/SUP-736/bug-queue-message-while-compacting-compacting-status-disappears).

**Repro:** send `/compact`, then send another message while it compacts. The compact line disappears and the status flips straight to "Working". The agent did the right thing — the UI just stopped saying so.

## The cause

`session_active` carries two meanings: a genuinely new turn, and a queued/steering message accepted into a turn that is *already running*. Both the renderer handler and `markSessionActive` rebuilt their entire state from that event as if it only ever meant the first — so a queued follow-up cleared everything the running turn was still doing.

Compaction was the reported symptom; thinking blocks, running subagents, the API-retry state and the elapsed clock were all being blanked the same way.

## The fix

Fixed at the shape rather than field by field. The server flags the mid-turn case (`queuedMidTurn`), and both sides split their resets into two named groups:

- **message-scoped** — invalidated by ANY accepted message: last error, typing indicator, waiting-on-background.
- **turn-scoped** — only a real turn boundary ends these: compaction, thinking (plus its block-id parts, which otherwise re-key an open block's remaining `delta`/`stop` events onto an id the app never opened), subagents, API retry, elapsed clock.

Everything else carries over from the state already held, so state added to `StreamState` later **survives a mid-turn pickup by default** — blanking it becomes an explicit line in the turn-scoped group. This trades away TypeScript's exhaustiveness check at that one site, which was the reason the list stayed complete and also the reason it stayed wrong: the only available default was "reset". The other ~14 rebuild sites keep their exhaustive literals; they have a single meaning.

The live compact line also moves above the queued ghosts — a message queued during compaction is picked up on the far side of the boundary, so it reads below the line.

## Coverage

- **Server** (`message-persister.test.ts`): driven with the real frames (`message_start`, a thinking `content_block_start`, `api_retry`, `status: compacting`), then a queued message; asserts the activity ladder walks `compacting → retrying → thinking` instead of collapsing to `working`, that the frame carries `queuedMidTurn`, and that the open thinking block still closes under `msg_1:0`.
- **Renderer** (`use-message-stream.test.ts`): compacting, thinking + subagents, retry + elapsed clock, the message-scoped clears, and an unflagged frame treated as a new turn.
- **View** (`message-list.test.tsx`): the compact line renders above the queued ghost.
- **E2E** (`message-queueing.spec.ts`): the actual repro, using a new `SlowCompactionScenario` that holds compaction open while a message is queued.

Both new behavioural tests and the E2E were confirmed to fail against the pre-fix code (server: `expected 'working' to be 'compacting'`; view: `expected 65 to be less than 42`; E2E: the compact line not visible after queueing).

## Notes for the reviewer

- `queuedMidTurn` is written as a bare object literal on the server and read off a `JSON.parse` on the client — no shared type, so renaming it on one side leaves every test green. Worth closing with a shared frame type, but that touches how all SSE frames are typed, so it isn't in here.
- The server reads "mid-turn" as `state.isActive`, which is also true in the waiting-on-background state (turn finished, background tasks still running). A message sent right then counts as mid-turn, so the previous turn's subagents and clock carry over. Matches what `session_idle` already does with subagents; benign, but not strictly correct.
- `message-queueing.spec.ts` has one **pre-existing** failure — "cancel after pickup flips the ghost to 'Picked up by the agent'". Confirmed failing on `main` at this base commit, unrelated to these changes. The other 5 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PkB2x3sjqi82JU3ttR4V4