### PR TITLE
fix(proxy): allow the non-API hosts each toolkit actually needs

### DIFF
--- a/src/shared/lib/proxy/allowed-hosts.test.ts
+++ b/src/shared/lib/proxy/allowed-hosts.test.ts
@@ -42,12 +42,45 @@ describe('isHostAllowed', () => {
     expect(isHostAllowed('gmail', 'api.github.com')).toBe(false)
   })
 
-  it('allows github api host for github toolkit', () => {
+  it('allows every github host the toolkit actually needs', () => {
     expect(isHostAllowed('github', 'api.github.com')).toBe(true)
+    // github.com carries the git smart-HTTP transport, which api.github.com
+    // does not serve — blocking it broke authenticated git access.
+    expect(isHostAllowed('github', 'github.com')).toBe(true)
+    expect(isHostAllowed('github', 'raw.githubusercontent.com')).toBe(true)
+    expect(isHostAllowed('github', 'uploads.github.com')).toBe(true)
   })
 
   it('rejects unknown hosts for github toolkit', () => {
-    expect(isHostAllowed('github', 'github.com')).toBe(false)
+    expect(isHostAllowed('github', 'gist.github.com')).toBe(false)
+    expect(isHostAllowed('github', 'evil-github.com')).toBe(false)
+  })
+
+  it('allows the git transport host for bitbucket', () => {
+    expect(isHostAllowed('bitbucket', 'api.bitbucket.org')).toBe(true)
+    expect(isHostAllowed('bitbucket', 'bitbucket.org')).toBe(true)
+  })
+
+  it('allows regional sentry hosts', () => {
+    expect(isHostAllowed('sentry', 'sentry.io')).toBe(true)
+    expect(isHostAllowed('sentry', 'us.sentry.io')).toBe(true)
+    expect(isHostAllowed('sentry', 'de.sentry.io')).toBe(true)
+    expect(isHostAllowed('sentry', 'evil-sentry.io')).toBe(false)
+  })
+
+  it('allows every datadog site host', () => {
+    expect(isHostAllowed('datadog', 'api.datadoghq.com')).toBe(true)
+    expect(isHostAllowed('datadog', 'api.datadoghq.eu')).toBe(true)
+    expect(isHostAllowed('datadog', 'api.ap1.datadoghq.com')).toBe(true)
+    expect(isHostAllowed('datadog', 'api.ddog-gov.com')).toBe(true)
+  })
+
+  it('allows the secondary upload and event hosts', () => {
+    expect(isHostAllowed('pagerduty', 'events.pagerduty.com')).toBe(true)
+    expect(isHostAllowed('linear', 'uploads.linear.app')).toBe(true)
+    expect(isHostAllowed('airtable', 'content.airtable.com')).toBe(true)
+    expect(isHostAllowed('stripe', 'files.stripe.com')).toBe(true)
+    expect(isHostAllowed('twitter', 'upload.twitter.com')).toBe(true)
   })
 
   it('rejects all hosts for unknown toolkit', () => {

--- a/src/shared/lib/proxy/allowed-hosts.ts
+++ b/src/shared/lib/proxy/allowed-hosts.ts
@@ -24,16 +24,41 @@ export const TOOLKIT_ALLOWED_HOSTS: Record<string, string[]> = {
   discord: ['discord.com'],
 
   // Developer Tools
-  github: ['api.github.com'],
+  // api.github.com serves the REST API only. github.com carries the git
+  // smart-HTTP transport and every non-API endpoint, raw.githubusercontent.com
+  // serves file contents, and uploads.github.com is the separate host the
+  // create-release API hands back as `upload_url`. Download hosts (codeload,
+  // release assets) are reached by redirect, which is followed server-side, so
+  // they need no entry — and naming them directly would inject an Authorization
+  // header onto an already-signed URL.
+  github: [
+    'api.github.com',
+    'github.com',
+    'raw.githubusercontent.com',
+    'uploads.github.com',
+  ],
   gitlab: ['gitlab.com'],
-  bitbucket: ['api.bitbucket.org'],
-  sentry: ['sentry.io'],
-  datadog: ['api.datadoghq.com', 'api.us5.datadoghq.com'],
-  pagerduty: ['api.pagerduty.com'],
+  // bitbucket.org carries the git transport; api.bitbucket.org is REST only.
+  bitbucket: ['api.bitbucket.org', 'bitbucket.org'],
+  // Sentry's API host is region-specific (us.sentry.io, de.sentry.io).
+  sentry: ['sentry.io', '*.sentry.io'],
+  // Datadog has one API host per site; a customer is on exactly one of them.
+  datadog: [
+    'api.datadoghq.com',
+    'api.datadoghq.eu',
+    'api.us3.datadoghq.com',
+    'api.us5.datadoghq.com',
+    'api.ap1.datadoghq.com',
+    'api.ap2.datadoghq.com',
+    'api.ddog-gov.com',
+  ],
+  // events.pagerduty.com is the Events API v2 host, separate from the REST API.
+  pagerduty: ['api.pagerduty.com', 'events.pagerduty.com'],
 
   // Project Management
   notion: ['api.notion.com'],
-  linear: ['api.linear.app'],
+  // uploads.linear.app receives the file uploads the API issues URLs for.
+  linear: ['api.linear.app', 'uploads.linear.app'],
   jira: ['*.atlassian.net'],
   confluence: ['*.atlassian.net'],
   asana: ['app.asana.com', 'api.asana.com'],
@@ -49,19 +74,22 @@ export const TOOLKIT_ALLOWED_HOSTS: Record<string, string[]> = {
   intercom: ['api.intercom.io'],
 
   // Cloud Storage & Documents
-  airtable: ['api.airtable.com'],
+  // content.airtable.com hosts uploadAttachment, which api.airtable.com does not.
+  airtable: ['api.airtable.com', 'content.airtable.com'],
   dropbox: ['api.dropboxapi.com', 'content.dropboxapi.com'],
   box: ['api.box.com', 'upload.box.com'],
   docusign: ['*.docusign.net', '*.docusign.com'],
 
   // Social Media
-  twitter: ['api.twitter.com', 'api.x.com'],
+  // upload.twitter.com serves the v1.1 media upload endpoints.
+  twitter: ['api.twitter.com', 'api.x.com', 'upload.twitter.com'],
   linkedin: ['api.linkedin.com'],
   instagram: ['graph.instagram.com', 'graph.facebook.com'],
 
   // E-Commerce & Finance
   shopify: ['*.myshopify.com'],
-  stripe: ['api.stripe.com'],
+  // files.stripe.com is the file create/upload host.
+  stripe: ['api.stripe.com', 'files.stripe.com'],
   quickbooks: [
     'quickbooks.api.intuit.com',
     'sandbox-quickbooks.api.intuit.com',


### PR DESCRIPTION
## The bug

An agent with a GitHub connection can reach `api.github.com` through the proxy, but gets a **403 from our own proxy** for `github.com` — the host that serves the git smart-HTTP transport and every non-API endpoint. The allowlist had `github: ['api.github.com']` and the test explicitly asserted `github.com` was rejected.

Same shape as the `files.slack.com` fix (SUP-303): the API host is not the only host a toolkit needs. Auditing the rest of the list turned up eight more toolkits with the same gap.

## What changed

`src/shared/lib/proxy/allowed-hosts.ts`, each entry commented with why the host is separate from the API host:

| toolkit | added | why |
|---|---|---|
| `github` | `github.com`, `raw.githubusercontent.com`, `uploads.github.com` | git transport; raw file contents; the `upload_url` create-release hands back |
| `bitbucket` | `bitbucket.org` | git transport |
| `sentry` | `*.sentry.io` | region-specific API hosts (`us.`, `de.`) |
| `datadog` | `api.datadoghq.eu`, `api.us3/ap1/ap2.datadoghq.com`, `api.ddog-gov.com` | one API host per site; only us1 + us5 were listed |
| `pagerduty` | `events.pagerduty.com` | Events API v2 |
| `linear` | `uploads.linear.app` | file uploads |
| `airtable` | `content.airtable.com` | `uploadAttachment` |
| `stripe` | `files.stripe.com` | file create/upload |
| `twitter` | `upload.twitter.com` | v1.1 media upload |

Verified live: `github.com/.../info/refs?service=git-upload-pack` → 200, `raw.githubusercontent.com` → 200, and every added host resolves.

## Deliberately not added

`codeload.github.com` and the release-asset hosts. Confirmed those are reached by a 302 from `api.github.com` (`/tarball` → codeload, asset download → `release-assets.githubusercontent.com`), which the server-side fetch follows on its own — so they already work. Naming them directly would inject an `Authorization` header onto an already-signed URL.

## Safety

Scope maps are keyed on path only (`matchScopes(toolkit, method, path)`), so requests to the new hosts land on unmapped paths, return `matched: false`, and fall through to the account/global default — which is `review` (`user-settings-service.ts:148`). They prompt the user rather than passing silently.

## Known limitation, not fixed here

This unblocks plain HTTP against `github.com`. Actual `git clone` through the proxy still won't work:

- `directForward` injects `Authorization: Bearer`, while GitHub's git endpoint wants Basic (our own `github-provider.ts:126` uses `AUTHORIZATION: basic base64(x-access-token:TOKEN)`).
- Composio-managed (redacted-token) connections route through `proxyForward` → `translateProxyBody`, which only accepts JSON or base64 binary and re-envelopes the response — git's `application/x-git-upload-pack-request` POST would be mangled.

Worth a follow-up if agents are expected to clone private repos through the proxy.

## Testing

- `allowed-hosts.test.ts` updated — the old "rejects `github.com`" assertion now covers `gist.github.com` / `evil-github.com`, plus new cases for each toolkit above. 26 tests pass.
- eslint clean on both files.
- `npm run typecheck` reports only two pre-existing `semver` errors in `app-sidebar.test.tsx` / `sidebar-version-state.ts`, unrelated to this change.
- `proxy.test.ts` mocks `allowed-hosts` wholesale, so it is unaffected. `TOOLKIT_ALLOWED_HOSTS` has no other consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzPiyMjbwUALMPBpUDw2dQ
