### PR TITLE
Stop a CDN caching authorized workspace files

### DIFF
--- a/src/api/cache-headers.test.ts
+++ b/src/api/cache-headers.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import app from './index'
+
+/**
+ * The `/api/*` default is uncacheable (see middleware/default-cache-control),
+ * which is only safe if the handful of routes that genuinely want a CDN copy
+ * keep theirs. These are public, auth-free, immutable-per-deploy bundles that
+ * every dashboard iframe pulls, so losing their caching would be a silent
+ * bandwidth regression rather than a visible failure — assert it against the
+ * real app rather than a stand-in router, since registration order is what
+ * decides whether the middleware sees a route's own header at all.
+ */
+describe('public API bundles stay CDN-cacheable', () => {
+  it.each([
+    ['/api/stt/speech-recognition-polyfill.js', 'public, max-age=3600'],
+    ['/api/llm/anthropic-polyfill.js', 'public, max-age=3600'],
+    ['/api/llm/anthropic-sdk.js', 'public, max-age=86400'],
+  ])('%s keeps %s', async (path, expected) => {
+    const res = await app.request(path)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe(expected)
+  })
+})

--- a/src/api/dashboard-runtime.test.ts
+++ b/src/api/dashboard-runtime.test.ts
@@ -285,6 +285,30 @@ describe('dashboard response scoping', () => {
     )
   })
 
+  it('narrows an upstream public asset directive to the requesting browser', () => {
+    // Artifact assets keep CDN-cacheable extensions under an authorized path, so
+    // a shared cache must never store one — but the upstream's own freshness is
+    // still honoured for the browser.
+    const upstream = new Headers({ 'cache-control': 'public, max-age=31536000, immutable' })
+
+    expect(dashboardResponseHeaders(upstream, basePath).get('cache-control'))
+      .toBe('private, max-age=31536000, immutable')
+  })
+
+  it('revalidates a proxied asset the dashboard server said nothing about', () => {
+    expect(dashboardResponseHeaders(new Headers(), basePath).get('cache-control'))
+      .toBe('private, no-cache')
+  })
+
+  it('revalidates when narrowing leaves no freshness directive behind', () => {
+    // `public` alone is a common dashboard-server default. Reduced to a bare
+    // `private` it states no expiry, so the browser invents one from
+    // Last-Modified and reuses a bundle the agent has since rebuilt.
+    const upstream = new Headers({ 'cache-control': 'public' })
+
+    expect(dashboardResponseHeaders(upstream, basePath).get('cache-control')).toBe('private, no-cache')
+  })
+
   it('invalidates representation headers when HTML was injected', () => {
     const upstream = new Headers({
       'cache-control': 'public, max-age=31536000, immutable',
@@ -296,7 +320,7 @@ describe('dashboard response scoping', () => {
     })
     const result = dashboardResponseHeaders(upstream, basePath, { transformedHtml: true })
 
-    expect(result.get('cache-control')).toBe('no-cache')
+    expect(result.get('cache-control')).toBe('private, no-cache')
     expect(result.has('content-encoding')).toBe(false)
     expect(result.has('content-length')).toBe(false)
     expect(result.has('etag')).toBe(false)

--- a/src/api/dashboard-runtime.ts
+++ b/src/api/dashboard-runtime.ts
@@ -222,6 +222,28 @@ function getSetCookieValues(headers: Headers): string[] {
 }
 
 /** Copy upstream headers while applying browser-visible dashboard scoping. */
+/**
+ * Force a proxied dashboard response into the requesting browser's cache only.
+ * Artifact assets are served under an AgentRead-authorized path but keep the
+ * extensions a CDN caches by default (.js, .css, .png), so passing an upstream
+ * `public` directive through would let a shared cache hand one agent's dashboard
+ * to whoever asks next. Upstream freshness is preserved — only its audience is
+ * narrowed; an upstream that said nothing gets revalidated every time, because a
+ * dashboard is rebuilt in place under unchanging asset names.
+ */
+function privatizeCacheControl(upstreamValue: string | null): string {
+  if (!upstreamValue?.trim()) return 'private, no-cache'
+  const directives = upstreamValue
+    .split(',')
+    .map(directive => directive.trim())
+    .filter(directive => directive && directive.toLowerCase() !== 'public' && directive.toLowerCase() !== 'private')
+  // A bare `public` leaves nothing behind, and `private` alone states no
+  // freshness at all — which a browser answers by inventing its own from
+  // Last-Modified, reusing a bundle the agent has since rebuilt in place.
+  if (directives.length === 0) return 'private, no-cache'
+  return ['private', ...directives].join(', ')
+}
+
 export function dashboardResponseHeaders(
   upstream: Headers,
   basePath: string,
@@ -242,13 +264,17 @@ export function dashboardResponseHeaders(
     headers.append('set-cookie', rewriteDashboardCookiePath(cookie, basePath))
   }
 
+  headers.set('cache-control', privatizeCacheControl(upstream.get('cache-control')))
+
   if (options?.transformedHtml) {
     // fetch transparently decodes upstream bodies; all representation metadata
     // must describe the injected bytes rather than the dashboard's old body.
     headers.delete('content-encoding')
     headers.delete('content-length')
     headers.delete('etag')
-    headers.set('cache-control', 'no-cache')
+    // The injected HTML is not the upstream body, so no upstream freshness
+    // claim applies to it.
+    headers.set('cache-control', 'private, no-cache')
   }
 
   return headers

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -52,6 +52,7 @@ import { getAuthSettings } from '@shared/lib/auth/auth-settings'
 import { getPublicAuthProviders } from '@shared/lib/auth/provider-config'
 import { LocalModeAuth, isContainerFacingPath } from './middleware/local-mode-auth'
 import { armAbortSignal } from './middleware/arm-abort-signal'
+import { defaultCacheControl } from './middleware/default-cache-control'
 
 const app = new Hono()
 
@@ -65,6 +66,15 @@ app.use('*', armAbortSignal)
 // Enable CORS for all routes
 const trustedOrigins = process.env.TRUSTED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean)
 app.use('*', cors(trustedOrigins?.length ? { origin: trustedOrigins } : undefined))
+
+// Uncacheable unless a route opts in — see the middleware for why an absent
+// Cache-Control is the wrong default behind a CDN. Scoped to '*' rather than
+// '/api/*' because the authorized mounts that sit outside /api (the Platform SSO
+// launcher on /auth, the cloud proxy on /cloud) need the default just as much,
+// and a default that only covers most of the surface is how this bug got here.
+// Routes that set their own header — including the static web build's — are
+// left untouched.
+app.use('*', defaultCacheControl)
 
 // Local mode: localhost IP restriction for all API endpoints (except container-facing endpoints)
 if (!isAuthMode()) {

--- a/src/api/middleware/default-cache-control.test.ts
+++ b/src/api/middleware/default-cache-control.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { Hono } from 'hono'
+import { streamSSE } from 'hono/streaming'
+import { defaultCacheControl } from './default-cache-control'
+
+function createApp() {
+  const app = new Hono()
+  app.use('/api/*', defaultCacheControl)
+  return app
+}
+
+describe('defaultCacheControl', () => {
+  it('marks a route that makes no caching claim uncacheable', async () => {
+    const app = createApp()
+    app.get('/api/agents', c => c.json({ agents: [] }))
+
+    const res = await app.request('/api/agents')
+
+    expect(res.headers.get('cache-control')).toBe('private, no-store')
+  })
+
+  it('leaves a route that opted into caching alone', async () => {
+    const app = createApp()
+    app.get('/api/llm/anthropic-sdk.js', c =>
+      c.body('bundle', 200, { 'Cache-Control': 'public, max-age=86400' }))
+
+    const res = await app.request('/api/llm/anthropic-sdk.js')
+
+    expect(res.headers.get('cache-control')).toBe('public, max-age=86400')
+  })
+
+  it('leaves an SSE stream own no-cache in place', async () => {
+    const app = createApp()
+    app.get('/api/notifications/stream', c => streamSSE(c, async (stream) => {
+      await stream.writeSSE({ data: 'hello' })
+    }))
+
+    const res = await app.request('/api/notifications/stream')
+
+    expect(res.headers.get('cache-control')).toBe('no-cache')
+  })
+
+  it('covers a response a handler built itself rather than through the context', async () => {
+    const app = createApp()
+    app.get('/api/agents/a/files/out.mp4', () => new Response('bytes', { status: 206 }))
+
+    const res = await app.request('/api/agents/a/files/out.mp4')
+
+    expect(res.status).toBe(206)
+    expect(res.headers.get('cache-control')).toBe('private, no-store')
+  })
+})

--- a/src/api/middleware/default-cache-control.ts
+++ b/src/api/middleware/default-cache-control.ts
@@ -1,0 +1,25 @@
+import type { MiddlewareHandler } from 'hono'
+
+/** What an API response falls back to when its route makes no caching claim. */
+export const DEFAULT_API_CACHE_CONTROL = 'private, no-store'
+
+/**
+ * Give every API response a Cache-Control unless its route already set one.
+ *
+ * An absent Cache-Control is not a neutral choice once a CDN sits in front of a
+ * deployment: it falls back to its own extension-based TTL, which is how
+ * redelivered workspace files (.mp4, .png) came back stale from the edge — and,
+ * worse, how a per-user authorized body ends up in a shared cache that answers
+ * the next request without our auth ever running. Almost every API response is
+ * per-user and mutable, so uncacheable is the right default.
+ *
+ * Routes that genuinely want caching set their own header and are left
+ * untouched: the public polyfill bundles, hashed-name model icons, immutable
+ * session media, and SSE endpoints (Hono's streamSSE sets no-cache itself).
+ */
+export const defaultCacheControl: MiddlewareHandler = async (c, next) => {
+  await next()
+  if (!c.res.headers.has('cache-control')) {
+    c.res.headers.set('cache-control', DEFAULT_API_CACHE_CONTROL)
+  }
+}

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -2201,6 +2201,17 @@ describe('path traversal security — GET /:id/files/*', () => {
     expect(res.status).not.toBe(400)
   })
 
+  it('marks workspace files uncacheable so a CDN cannot serve a stale or cross-user body', async () => {
+    mockFsStat.mockResolvedValueOnce({ isFile: () => true, size: 100 })
+    mockCreateReadStream.mockReturnValueOnce({ pipe: vi.fn() })
+
+    const res = await getReq(app, '/api/agents/test-agent/files/out/render.mp4?inline=true')
+
+    // Without this, Cloudflare applies its own extension-based default TTL and
+    // serves the previous render of a file the agent has since rewritten.
+    expect(res.headers.get('cache-control')).toBe('private, no-store, max-age=0')
+  })
+
   it('rejects a workspace symlink whose real path escapes the workspace', async () => {
     mockFsRealpath
       .mockResolvedValueOnce('/mock/workspace')
@@ -7325,7 +7336,9 @@ describe('GET /:id/artifacts/:slug/screenshot.png', () => {
     const res = await getReq(app, '/api/agents/my-agent/artifacts/my-dash/screenshot.png')
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('image/png')
-    expect(res.headers.get('cache-control')).toContain('max-age=60')
+    // Brief freshness, but private: a shared cache holding this authorized .png
+    // would serve one agent's dashboard thumbnail to anyone with the URL.
+    expect(res.headers.get('cache-control')).toBe('private, max-age=60, must-revalidate')
 
     // Read path should be rooted at the agent workspace/artifacts/<slug>.
     const readPath = mockFsReadFile.mock.calls[0][0] as string

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -6409,6 +6409,21 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
       c.header('Content-Type', 'application/octet-stream')
     }
 
+    // Workspace files are mutable (the agent rewrites and redelivers them) and
+    // per-user authorized. Without an explicit directive an intermediary CDN
+    // applies its own default TTL by file extension — Cloudflare was serving
+    // 4-hour-old .mp4 renders as cf-cache-status: HIT, and a shared cache holding
+    // an authorized response is a leak as well as a staleness bug. `private`
+    // keeps it out of shared caches, `no-store` out of the browser's too.
+    //
+    // `no-store` over `no-cache` is deliberate, and it is the strict choice: it
+    // costs re-fetches (a seek past the media element's buffer below, an inline
+    // markdown image on remount) to buy an unconditional guarantee that no cache
+    // anywhere holds these bytes. Reclaiming those bytes means serving a
+    // validator — an mtime/size ETag plus If-None-Match → 304 — which is worth
+    // doing, but not as an unvalidated rider on a leak fix.
+    c.header('Cache-Control', 'private, no-store, max-age=0')
+
     // Advertise range support so media players (e.g. <video>) can seek. When the
     // client requests a byte range, serve just that slice as 206 Partial
     // Content; otherwise stream the whole file. Only the stream we actually
@@ -6638,8 +6653,11 @@ agents.get('/:id/artifacts/:artifactSlug/screenshot.png', AgentRead(), async (c)
       status: 200,
       headers: {
         'content-type': 'image/png',
-        // Screenshots are overwritten on every restart, so cache briefly.
-        'cache-control': 'public, max-age=60, must-revalidate',
+        // Screenshots are overwritten on every restart, so cache briefly — and
+        // `private`, never `public`: this is an AgentRead-authorized .png, an
+        // extension a CDN caches by default, so a shared-cache copy would be
+        // served to anyone with the URL without our auth ever running.
+        'cache-control': 'private, max-age=60, must-revalidate',
       },
     })
   } catch (error: any) {

--- a/src/api/routes/settings.ts
+++ b/src/api/routes/settings.ts
@@ -144,7 +144,10 @@ async function serveUploadedModelIcon(c: Context) {
     const iconsDir = getModelIconsDataDir()
     const filePath = assertPathWithinDir(iconsDir, path.join(iconsDir, fileName), 'Invalid model icon filename')
     const bytes = await fs.promises.readFile(filePath)
-    c.header('Cache-Control', 'public, max-age=31536000, immutable')
+    // Names are minted as randomUUID().ext, so a name really does address one
+    // immutable body — but the route is authenticated, so keep the year-long
+    // entry out of shared caches and in the requesting browser only.
+    c.header('Cache-Control', 'private, max-age=31536000, immutable')
     c.header('Content-Security-Policy', "default-src 'none'; img-src data:; style-src 'unsafe-inline'")
     c.header('Content-Type', mimeType)
     c.header('X-Content-Type-Options', 'nosniff')

--- a/src/renderer/components/file-preview/file-preview-tray-content.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.tsx
@@ -25,9 +25,12 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
   const fileApiPath = activeTab.kind === 'file'
     ? getAgentFileApiPath(activeTab.agentSlug, activeTab.filePath)
     : null
-  const versionParam = activeTab.kind === 'file' && activeTab.version > 0 ? `&v=${activeTab.version}` : ''
-  const fileUrl = fileApiPath ? `${baseUrl}${fileApiPath}?inline=true${versionParam}` : null
-  const downloadUrl = fileApiPath ? `${baseUrl}${fileApiPath}` : null
+  // `v` is a cache buster, not a server-read param: the route ignores it, but it
+  // keeps a redelivered file from resolving to a URL that a browser or CDN still
+  // holds the previous body for.
+  const versionQuery = activeTab.kind === 'file' && activeTab.version > 0 ? `v=${activeTab.version}` : ''
+  const fileUrl = fileApiPath ? `${baseUrl}${fileApiPath}?inline=true${versionQuery ? `&${versionQuery}` : ''}` : null
+  const downloadUrl = fileApiPath ? `${baseUrl}${fileApiPath}${versionQuery ? `?${versionQuery}` : ''}` : null
   const activeComments = activeTab.kind === 'file' ? comments.get(activeTab.filePath) || [] : []
 
   return (

--- a/src/renderer/context/file-preview-context.test.tsx
+++ b/src/renderer/context/file-preview-context.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { createElement, type ReactNode } from 'react'
-import { FilePreviewProvider, useFilePreview } from './file-preview-context'
+import { FilePreviewProvider, useFilePreview, type FileTab } from './file-preview-context'
 
 // Mock the route-derived location — FilePreviewProvider reads useRouteLocation and
 // watches view.kind/view.id for session changes.
@@ -37,9 +37,9 @@ describe('FilePreviewContext', () => {
         kind: 'file',
         filePath: '/workspace/report.md',
         displayName: 'report.md',
-        version: 0,
         pdfPage: 1,
       })
+      expect((result.current.openTabs[0] as FileTab).version).toBeGreaterThan(0)
       expect(result.current.isOpen).toBe(true)
       expect(result.current.activeTabIndex).toBe(0)
     })
@@ -57,13 +57,24 @@ describe('FilePreviewContext', () => {
     it('bumps version on re-delivery of same file', () => {
       const { result } = renderHook(() => useFilePreview(), { wrapper })
       act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
-      expect(result.current.openTabs[0]).toMatchObject({ version: 0 })
+      const first = (result.current.openTabs[0] as FileTab).version
 
       act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
-      expect(result.current.openTabs[0]).toMatchObject({ version: 1 })
+      const second = (result.current.openTabs[0] as FileTab).version
+      expect(second).toBeGreaterThan(first)
 
       act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
-      expect(result.current.openTabs[0]).toMatchObject({ version: 2 })
+      expect((result.current.openTabs[0] as FileTab).version).toBeGreaterThan(second)
+    })
+
+    it('seeds the version from the clock so a reload never reuses a cached file URL', () => {
+      const start = Date.now()
+      const { result } = renderHook(() => useFilePreview(), { wrapper })
+      act(() => result.current.openFile('/workspace/report.md', 'agent-1'))
+
+      // A session-local counter would restart at 0 after a reload and resolve to
+      // a URL an intermediary may still hold the previous body for.
+      expect((result.current.openTabs[0] as FileTab).version).toBeGreaterThanOrEqual(start)
     })
   })
 
@@ -132,8 +143,8 @@ describe('FilePreviewContext', () => {
       expect(result.current.openTabs[1]).toMatchObject({
         filePath: newPath,
         displayName: 'new.md',
-        version: 1,
       })
+      expect((result.current.openTabs[1] as FileTab).version).toBeGreaterThan(0)
       expect(result.current.comments.get(oldPath)).toBeUndefined()
       expect(result.current.comments.get(newPath)?.[0]).toMatchObject({
         filePath: newPath,
@@ -180,8 +191,8 @@ describe('FilePreviewContext', () => {
       expect(result.current.openTabs[1]).toMatchObject({
         filePath: `${newPath}/notes.md`,
         displayName: 'notes.md',
-        version: 1,
       })
+      expect((result.current.openTabs[1] as FileTab).version).toBeGreaterThan(0)
       expect(result.current.openTabs[2]).toMatchObject({
         rootPath: newPath,
         displayName: 'archive',

--- a/src/renderer/context/file-preview-context.tsx
+++ b/src/renderer/context/file-preview-context.tsx
@@ -7,6 +7,12 @@ export interface FileTab {
   agentSlug: string
   displayName: string
   description?: string
+  /**
+   * Cache-busting token for this tab's file URL, bumped every time the file is
+   * (re)delivered or renamed. Seeded from the clock rather than 0 so a reload
+   * never reuses a URL an intermediary may still be serving a stale body for —
+   * the agent rewrites these files in place, so path alone is not an identity.
+   */
   version: number
   /** 1-based page currently shown when this tab contains a PDF. */
   pdfPage: number
@@ -80,6 +86,14 @@ interface FilePreviewContextType {
 
 const FilePreviewContext = createContext<FilePreviewContextType | null>(null)
 
+let lastFileVersion = 0
+
+/** Strictly increasing cache-busting token; clock-seeded, monotonic within a session. */
+function nextFileVersion(): number {
+  lastFileVersion = Math.max(Date.now(), lastFileVersion + 1)
+  return lastFileVersion
+}
+
 function getDisplayName(filePath: string): string {
   const normalized = filePath.replace(/\/+$/, '')
   return normalized.split('/').pop() || normalized
@@ -129,6 +143,9 @@ export function FilePreviewProvider({
   }, [sessionId])
 
   const openFile = useCallback((filePath: string, agentSlug: string, description?: string) => {
+    // Minted outside the updater: React may invoke an updater more than once per
+    // commit, and a token that changes between passes is a different file URL.
+    const version = nextFileVersion()
     setOpenTabs(prev => {
       const existingIndex = prev.findIndex(tab => tab.kind === 'file' && tab.filePath === filePath)
       if (existingIndex >= 0) {
@@ -136,7 +153,7 @@ export function FilePreviewProvider({
         setIsOpen(true)
         const next = [...prev]
         const existing = next[existingIndex] as FileTab
-        next[existingIndex] = { ...existing, version: existing.version + 1 }
+        next[existingIndex] = { ...existing, version }
         return next
       }
       const newTab: FileTab = {
@@ -145,7 +162,7 @@ export function FilePreviewProvider({
         agentSlug,
         displayName: getDisplayName(filePath),
         description,
-        version: 0,
+        version,
         pdfPage: 1,
       }
       const next = [...prev, newTab]
@@ -203,13 +220,14 @@ export function FilePreviewProvider({
   }, [])
 
   const renameFilePath = useCallback((oldPath: string, newPath: string) => {
+    const version = nextFileVersion()
     setOpenTabs(prev => prev.map(tab => {
       if (tab.kind === 'file' && tab.filePath === oldPath) {
         return {
           ...tab,
           filePath: newPath,
           displayName: getDisplayName(newPath),
-          version: tab.version + 1,
+          version,
         }
       }
       if (tab.kind === 'folder' && tab.selectedPath === oldPath) {
@@ -264,12 +282,13 @@ export function FilePreviewProvider({
   }, [closeTab])
 
   const renameDirectoryPath = useCallback((oldPath: string, newPath: string) => {
+    const version = nextFileVersion()
     setOpenTabs(prev => prev.map(tab => {
       if (tab.kind === 'file') {
         const filePath = replacePathPrefix(tab.filePath, oldPath, newPath)
         return filePath === tab.filePath
           ? tab
-          : { ...tab, filePath, displayName: getDisplayName(filePath), version: tab.version + 1 }
+          : { ...tab, filePath, displayName: getDisplayName(filePath), version }
       }
 
       const rootPath = replacePathPrefix(tab.rootPath, oldPath, newPath)


### PR DESCRIPTION
## The bug

A file the agent redelivered kept previewing as its **previous** version on a cloud deployment — deliver, play, ask for changes, click the new file, see the old one.

The workspace file route sent no `Cache-Control` at all, so Cloudflare applied its own extension-based default. Observed on `datawizz.ongamut.so`:

```
GET /api/agents/…/files/…/multimodel-hclaim-nomusic-master.mp4?inline=true
Cache-Control: max-age=14400     ← not ours; CF's default browser TTL
cf-cache-status: HIT
Age: 2204
```

Staleness was the visible half. The other half: this route is `AgentRead()`-authorized, so a `HIT` means the edge served workspace bytes **without our auth running at all**.

## The fix

An absent `Cache-Control` isn't a neutral choice behind a CDN, so this doesn't just patch the one route.

| Route | Was | Now | Why |
|---|---|---|---|
| `/:id/files/*` | *(nothing)* | `private, no-store, max-age=0` | The reported bug |
| `/:id/artifacts/:slug/*` (proxy) | upstream's, passed through | narrowed to `private` | Dashboard assets are `.js`/`.css`/`.png` under an authorized path; upstream `public` invited the same leak |
| `/:id/artifacts/:slug/screenshot.png` | `public, max-age=60` | `private, max-age=60` | Authorized `.png`, CDN-cacheable extension |
| `/api/settings/model-icons/:file` | `public, …, immutable` | `private, …, immutable` | Authenticated; names are `randomUUID().ext` so the year is fine, `public` wasn't |
| everything else | *(nothing)* | `private, no-store` | New middleware default |

The default middleware only writes when a route set no header, so opt-ins are untouched — the public polyfill bundles, hashed model icons, immutable session media, and SSE (Hono's `streamSSE` sets its own `no-cache`). It's mounted at `'*'` rather than `/api/*` because two authorized mounts sit outside `/api`: the Platform SSO launcher on `/auth` (a GET returning 302 with a PKCE `Set-Cookie`) and the cloud proxy on `/cloud`.

**Belt and suspenders in the preview.** The `?v=` cache buster was a session-local counter starting at `0`, so a page reload regenerated the *same* URL an intermediary already held a body for. It's now a clock-seeded monotonic token, minted outside the `setState` updaters (React may run those more than once per commit). Applied to the download link too, which had no buster at all.

## Deliberate: `no-store`, not `no-cache`

`no-store` costs re-fetches — a video seek past the media element's buffer, an inline markdown image on remount (`markdown-url-transform.ts` rewrites those to this route). `private, no-cache` plus an mtime/size ETag and `If-None-Match` → 304 would reclaim the bytes and is worth doing, but it needs 304 and `If-Range` handling threaded through the byte-range path that serves these videos. Not a good unvalidated rider on a leak fix; the trade-off and the follow-up are written into the comment above the header.

## Cloudflare side

Already applied on the zone (belt and suspenders — the origin headers now stand on their own):
- Cache Rule: `starts_with(http.request.uri.path, "/api/agents/")` → **Bypass cache**
- Verified **Browser Cache TTL** is *Respect Existing Headers*, and no Page Rule forces *Cache Everything* on `/api/*`
- Purged the cached objects for the hostname

## Testing

- 1808 tests pass across `src/api`, `src/web`, and the file-preview code; typecheck and lint clean apart from two pre-existing `semver` `TS7016` errors from `1c53502b`.
- `src/api/cache-headers.test.ts` asserts the three public bundles against the **real** app — registration order decides whether the middleware ever sees a route's own header, which a stand-in router can't catch.
- Mount semantics verified empirically: `src/web/server.ts` registers the static build *after* mounting the API app, and a sub-app's `'*'` middleware does reach those later routes without clobbering `public, max-age=31536000, immutable` on `/assets/*` or `no-cache` on `index.html`.

Review findings from `/code-review` addressed in-branch: the bare-`private` gap in `privatizeCacheControl` (a `public`-only upstream reduced to no freshness directive at all, which browsers answer with heuristic caching), the `/auth` + `/cloud` coverage hole, and the impure `nextFileVersion()` calls inside state updaters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoM5EWWgCQMxqKnGpjdQ8j
