### PR TITLE
Key the session registries by agent, and delete the ownership index

### DIFF
--- a/src/api/routes/activity.test.ts
+++ b/src/api/routes/activity.test.ts
@@ -66,16 +66,16 @@ describe('activity API', () => {
     await createApp().request('http://localhost/api/activity/agents/agent-a')
 
     const { isSessionLive } = mockGetAgentActivityStats.mock.calls[0][1] as {
-      isSessionLive: (sessionId: string) => boolean
+      isSessionLive: (agentSlug: string, sessionId: string) => boolean
     }
     mockIsSessionActive.mockReturnValue(true)
-    expect(isSessionLive('session-1')).toBe(true)
-    expect(mockIsSessionActive).toHaveBeenCalledWith('session-1')
+    expect(isSessionLive('agent-one', 'session-1')).toBe(true)
+    expect(mockIsSessionActive).toHaveBeenCalledWith('agent-one', 'session-1')
 
     // An idle-but-still-subscribed session is NOT live — a persisted
     // 'running' for it must downgrade instead of pulsing forever.
     mockIsSessionActive.mockReturnValue(false)
-    expect(isSessionLive('session-1')).toBe(false)
+    expect(isSessionLive('agent-one', 'session-1')).toBe(false)
   })
 
   it.each([

--- a/src/api/routes/activity.ts
+++ b/src/api/routes/activity.ts
@@ -21,7 +21,8 @@ activityRouter.use('*', Authenticated())
 // some connection-loss paths, but isSessionActive is true only while a turn is
 // actually processing — a persisted 'running' with an inactive session is a
 // dead or stopped run and must downgrade to failed instead of pulsing forever.
-const isSessionLive = (sessionId: string) => messagePersister.isSessionActive(sessionId)
+const isSessionLive = (agentSlug: string, sessionId: string) =>
+  messagePersister.isSessionActive(agentSlug, sessionId)
 
 activityRouter.get('/agents/:id', ResolveAgent(), AgentRead(), async (c) => {
   try {

--- a/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
+++ b/src/api/routes/agents-owner-acl-rollback.sup207.test.ts
@@ -178,7 +178,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: vi.fn(), listSessionsFromSummary: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
-  sessionExists: vi.fn().mockResolvedValue(true), sessionBelongsToAgent: vi.fn().mockResolvedValue(true), reserveSessionOwnership: vi.fn().mockResolvedValue(undefined), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  sessionExists: vi.fn().mockResolvedValue(true), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
 }))

--- a/src/api/routes/agents.delete-ordering.sup208.test.ts
+++ b/src/api/routes/agents.delete-ordering.sup208.test.ts
@@ -167,7 +167,7 @@ vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: vi.fn(), listSessionsFromSummary: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
-  sessionExists: vi.fn().mockResolvedValue(true), sessionBelongsToAgent: vi.fn().mockResolvedValue(true), reserveSessionOwnership: vi.fn().mockResolvedValue(undefined), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  sessionExists: vi.fn().mockResolvedValue(true), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
 }))

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -323,8 +323,6 @@ vi.mock('@shared/lib/services/session-service', async (importOriginal) => {
   getSession: vi.fn(),
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),
-  sessionBelongsToAgent: vi.fn().mockResolvedValue(true),
-  reserveSessionOwnership: vi.fn().mockResolvedValue(undefined),
   sessionIsKnown: vi.fn().mockResolvedValue(true),
   isSessionRegistered: vi.fn().mockResolvedValue(false),
   updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
@@ -595,7 +593,7 @@ import {
   importSkillFromZip,
 } from '@shared/lib/services/skillset-service'
 import { getAgent, getAgentWithStatus, listAgentsWithStatus } from '@shared/lib/services/agent-service'
-import { listSessionsFromSummary, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionMessagesDelta, getSessionSummary, sessionExists, sessionBelongsToAgent, reserveSessionOwnership, sessionIsKnown, isSessionRegistered, deleteSession, getSession, getSessionMetadata, updateSessionName, registerSession, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { listSessionsFromSummary, listSessionsByIds, getSessionMessagesWithCompact, getSessionMessagesPage, getSessionMessagesDelta, getSessionSummary, sessionExists, sessionIsKnown, isSessionRegistered, deleteSession, getSession, getSessionMetadata, updateSessionName, registerSession, readSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
 import { listCompletedOneTimeTasks, listPendingScheduledTasks, listPendingWakesByAgent } from '@shared/lib/services/scheduled-task-service'
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
@@ -623,7 +621,6 @@ function createApp() {
 
 beforeEach(() => {
   mockAuthorizedAgentRole = 'owner'
-  vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
   vi.mocked(sessionIsKnown).mockResolvedValue(true)
 })
 
@@ -3674,7 +3671,7 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
     expect(updateSessionMetadata).toHaveBeenCalledWith('test-agent', 'sess-1', {
       model: 'claude-haiku-4-5',
     })
-    expect(messagePersister.broadcastSessionUpdate).toHaveBeenCalledWith('sess-1')
+    expect(messagePersister.broadcastSessionUpdate).toHaveBeenCalledWith('test-agent', 'sess-1')
     expect(messagePersister.broadcastGlobal).toHaveBeenCalledWith({
       type: 'session_updated',
       sessionId: 'sess-1',
@@ -3711,7 +3708,7 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
       effort: 'high',
     })
     expect(res.status).toBe(201)
-    expect(messagePersister.broadcastSessionUpdate).toHaveBeenCalledWith('sess-1')
+    expect(messagePersister.broadcastSessionUpdate).toHaveBeenCalledWith('test-agent', 'sess-1')
     expect(messagePersister.broadcastGlobal).toHaveBeenCalledWith({
       type: 'session_updated',
       sessionId: 'sess-1',
@@ -3756,7 +3753,7 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
 
     // The dispatch guard runs first so a message sent during an open request
     // (e.g. AskUserQuestion) cancels it instead of deadlocking behind it.
-    expect(messagePersister.cancelAwaitingInput).toHaveBeenCalledWith('sess-1', 'test-agent')
+    expect(messagePersister.cancelAwaitingInput).toHaveBeenCalledWith('test-agent', 'sess-1')
     const cancelOrder = vi.mocked(messagePersister.cancelAwaitingInput).mock.invocationCallOrder[0]
     const sendOrder = mockSendMessage.mock.invocationCallOrder[0]
     expect(cancelOrder).toBeLessThan(sendOrder)
@@ -3771,7 +3768,7 @@ describe('message author attribution — POST /:id/sessions/:sessionId/messages'
 
     const response = postJson(app, URL, { content: 'take it from here' })
     await vi.waitFor(() => {
-      expect(messagePersister.promoteAutomatedSession).toHaveBeenCalledWith('sess-1', 'test-agent')
+      expect(messagePersister.promoteAutomatedSession).toHaveBeenCalledWith('test-agent', 'sess-1')
     })
     expect(mockSendMessage).not.toHaveBeenCalled()
 
@@ -3917,7 +3914,6 @@ describe('GET /:id/sessions/:sessionId/messages pagination', () => {
     vi.clearAllMocks()
     app = createApp()
     vi.mocked(sessionExists).mockResolvedValue(true)
-    vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
   })
 
   afterEach(() => {
@@ -4232,7 +4228,6 @@ describe('GET /:id/sessions/:sessionId/messages forward delta (?after=)', () => 
     vi.clearAllMocks()
     app = createApp()
     vi.mocked(sessionExists).mockResolvedValue(true)
-    vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
   })
 
   it('answers a delta envelope and forwards after + abort signal to the reader', async () => {
@@ -4333,7 +4328,6 @@ describe('GET /:id/sessions/:sessionId/media/:ref', () => {
     vi.clearAllMocks()
     app = createApp()
     vi.mocked(sessionExists).mockResolvedValue(true)
-    vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
     vi.mocked(decodeMediaRef).mockReturnValue({ v: 1, u: 'u-1', o: 10, s: 100, l: 200, h: 'fp' })
     vi.mocked(openMediaBlob).mockResolvedValue({
       stream: Readable.from([image]),
@@ -4385,7 +4379,7 @@ describe('GET /:id/sessions/:sessionId/media/:ref', () => {
   })
 
   it('404s for a session the agent does not own', async () => {
-    vi.mocked(sessionBelongsToAgent).mockResolvedValue(false)
+    vi.mocked(sessionIsKnown).mockResolvedValue(false)
     const res = await getReq(app, `/api/agents/test-agent/sessions/sess-1/media/${REF}`)
     expect(res.status).toBe(404)
     expect(openMediaBlob).not.toHaveBeenCalled()
@@ -4748,11 +4742,7 @@ describe('browser credential broker routes', () => {
     const [resolvePath, resolveOptions] = mockContainerFetch.mock.calls[2]
     expect(resolvePath).toBe('/inputs/tool-credential/resolve')
     expect(JSON.parse(resolveOptions.body)).toEqual({ value: 'credentials_filled' })
-    expect(messagePersister.completeInputRequest).toHaveBeenCalledWith(
-      'sess-1',
-      'tool-credential',
-      'answered',
-    )
+    expect(messagePersister.completeInputRequest).toHaveBeenCalledWith('test-agent', 'sess-1', 'tool-credential', 'answered', )
   })
 
   it('claims the request before retrieval so a concurrent Done cannot settle it', async () => {
@@ -5006,11 +4996,7 @@ describe('decision routes settle their request immediately', () => {
     parkOpen(body.toolUseId as string, kind)
     const res = await postJson(app, url, body)
     expect(res.status).toBe(200)
-    expect(messagePersister.completeInputRequest).toHaveBeenCalledWith(
-      'sess-1',
-      body.toolUseId,
-      outcome,
-    )
+    expect(messagePersister.completeInputRequest).toHaveBeenCalledWith('test-agent', 'sess-1', body.toolUseId, outcome, )
   })
 
   it('a failed container reject does NOT settle the request', async () => {
@@ -5416,11 +5402,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }],
-    )
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith('test-agent', 'sess-1', [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }], )
   })
 
   it('a trailing QUEUED user message does not end the turn scan', async () => {
@@ -5438,11 +5420,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
     ])
 
     await getReq(app, URL)
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }],
-    )
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith('test-agent', 'sess-1', [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }], )
   })
 
   it('does not recover when a later user message started a fresh turn', async () => {
@@ -5495,11 +5473,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
       'User declined the request',
     )
     expect(toolCalls.find((t) => t.id === 'tool-open')?.result).toBeUndefined()
-    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-      'sess-1',
-      'test-agent',
-      [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }],
-    )
+    expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith('test-agent', 'sess-1', [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }], )
   })
 
   it('does not recover for an inactive session', async () => {
@@ -5532,7 +5506,6 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
       } as unknown as Awaited<ReturnType<typeof getSessionMessagesPage>>)
 
     beforeEach(() => {
-      vi.mocked(sessionBelongsToAgent).mockResolvedValue(true)
     })
 
     afterEach(() => {
@@ -5563,11 +5536,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
 
       const res = await getReq(app, `${URL}?limit=50`)
       expect(res.status).toBe(200)
-      expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-        'sess-1',
-        'test-agent',
-        [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }],
-      )
+      expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith('test-agent', 'sess-1', [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }], )
     })
 
     it('a trailing QUEUED user message does not end the turn scan', async () => {
@@ -5584,11 +5553,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
       ])
 
       await getReq(app, `${URL}?limit=50`)
-      expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-        'sess-1',
-        'test-agent',
-        [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }],
-      )
+      expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith('test-agent', 'sess-1', [{ toolUseId: 'tool-q', toolName: 'mcp__user-input__request_secret' }], )
     })
 
     it('does not recover when a later user message started a fresh turn', async () => {
@@ -5655,11 +5620,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
         'User declined the request',
       )
       expect(toolCalls.find((t) => t.id === 'tool-open')?.result).toBeUndefined()
-      expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-        'sess-1',
-        'test-agent',
-        [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }],
-      )
+      expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith('test-agent', 'sess-1', [{ toolUseId: 'tool-open', toolName: 'AskUserQuestion' }], )
     })
 
     it('recovers from a forward-delta window too', async () => {
@@ -5681,11 +5642,7 @@ describe('awaiting-input recovery — GET /:id/sessions/:sessionId/messages', ()
 
       const res = await getReq(app, `${URL}?after=m1`)
       expect(res.status).toBe(200)
-      expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith(
-        'sess-1',
-        'test-agent',
-        [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }],
-      )
+      expect(messagePersister.recoverSessionAwaitingInput).toHaveBeenCalledWith('test-agent', 'sess-1', [{ toolUseId: 'tool-q', toolName: 'AskUserQuestion' }], )
     })
   })
 })
@@ -5711,7 +5668,7 @@ describe('user message SSE broadcast — POST /:id/sessions/:sessionId/messages'
     const res = await postJson(app, URL, { content: 'hello everyone' })
     expect(res.status).toBe(201)
 
-    expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith('sess-1', {
+    expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith('test-agent', 'sess-1', {
       type: 'user_message',
       content: 'hello everyone',
       sender: { id: 'test-user-id', name: 'Test User' },
@@ -5727,7 +5684,7 @@ describe('user message SSE broadcast — POST /:id/sessions/:sessionId/messages'
     const res = await postJson(app, URL, { content: 'queued message' })
     expect(res.status).toBe(201)
 
-    expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith('sess-1', expect.objectContaining({
+    expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith('test-agent', 'sess-1', expect.objectContaining({
       type: 'user_message',
       queued: true,
     }))
@@ -5741,7 +5698,7 @@ describe('user message SSE broadcast — POST /:id/sessions/:sessionId/messages'
     expect(res.status).toBe(201)
     const body = await res.json()
     expect(body.queued).toBe(true)
-    expect(messagePersister.coalesceIfRecovering).toHaveBeenCalledWith('sess-1', {
+    expect(messagePersister.coalesceIfRecovering).toHaveBeenCalledWith('test-agent', 'sess-1', {
       uuid: expect.any(String),
       text: 'keep going',
     })
@@ -5797,7 +5754,7 @@ describe('cancel queued message — DELETE /:id/sessions/:sessionId/queued-messa
     const res = await deleteReq(app, URL)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ cancelled: true })
-    expect(messagePersister.dropCoalescedUserMessage).toHaveBeenCalledWith('sess-1', UUID)
+    expect(messagePersister.dropCoalescedUserMessage).toHaveBeenCalledWith('test-agent', 'sess-1', UUID)
     expect(mockCancelQueuedMessage).not.toHaveBeenCalled()
   })
 })
@@ -5817,7 +5774,7 @@ describe('typing indicator — POST /:id/sessions/:sessionId/typing', () => {
     const res = await postJson(app, URL, {})
     expect(res.status).toBe(200)
 
-    expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith('sess-1', {
+    expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith('test-agent', 'sess-1', {
       type: 'user_typing',
       sender: { id: 'test-user-id', name: 'Test User' },
     })
@@ -5913,10 +5870,10 @@ describe('GET /api/agents/:id/scheduled-tasks/completed-sessions', () => {
       },
     ])
     vi.mocked(messagePersister.isSessionActive).mockImplementation(
-      (sessionId: string) => sessionId === 'running-session',
+      (_agentSlug: string, sessionId: string) => sessionId === 'running-session',
     )
     vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
-      (sessionId: string) => sessionId === 'legacy-session',
+      (_agentSlug: string, sessionId: string) => sessionId === 'legacy-session',
     )
 
     const res = await getReq(createApp(), URL)
@@ -6017,10 +5974,10 @@ describe('GET /api/agents (enriched summary)', () => {
       ['agent-1', new Set(['settled-visible'])],
     ]))
     vi.mocked(messagePersister.isSessionActive).mockImplementation(
-      (id: string) => id === 'settled-visible',
+      (_agentSlug: string, id: string) => id === 'settled-visible',
     )
     vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
-      (id: string) => id === 'settled-visible',
+      (_agentSlug: string, id: string) => id === 'settled-visible',
     )
     vi.mocked(messagePersister.getActiveSessionIdsForAgent)
       .mockReturnValue(['settled-visible'])
@@ -6108,7 +6065,7 @@ describe('GET /api/agents (enriched summary)', () => {
 
     expect(body[0].latestVisibleSession.messageTail.messages[0].toolCalls[0].result)
       .toBe('User provided input')
-    expect(messagePersister.getSettledInputRequests).toHaveBeenCalledWith('latest-visible')
+    expect(messagePersister.getSettledInputRequests).toHaveBeenCalledWith('agent-1', 'latest-visible')
   })
 
   it('reports unread and pending attention on an older visible session', async () => {
@@ -6121,7 +6078,7 @@ describe('GET /api/agents (enriched summary)', () => {
       ['agent-1', new Set(['older-visible'])],
     ]))
     vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
-      (id: string) => id === 'older-visible',
+      (_agentSlug: string, id: string) => id === 'older-visible',
     )
     vi.mocked(messagePersister.getActiveSessionIdsForAgent)
       .mockReturnValue(['older-visible'])
@@ -6158,7 +6115,7 @@ describe('GET /api/agents (enriched summary)', () => {
       ['agent-1', new Set(['hidden-scheduled'])],
     ]))
     vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
-      (id: string) => id === 'hidden-scheduled',
+      (_agentSlug: string, id: string) => id === 'hidden-scheduled',
     )
     vi.mocked(messagePersister.getActiveSessionIdsForAgent)
       .mockReturnValue(['hidden-scheduled'])
@@ -6650,7 +6607,7 @@ describe('GET /api/agents (enriched summary)', () => {
     const body = await res.json()
 
     expect(body[0].hasActiveSessions).toBe(true)
-    expect(messagePersister.isSessionActive).toHaveBeenCalledWith('sess-active')
+    expect(messagePersister.isSessionActive).toHaveBeenCalledWith('agent-1', 'sess-active')
   })
 
   it('detects sessions awaiting input', async () => {
@@ -8142,16 +8099,6 @@ describe('session model/effort resolution — POST /:id/sessions', () => {
     expect(await res.json()).toMatchObject({ model: 'haiku', effort: 'high', speed: 'fast' })
   })
 
-  it('reserves ownership before publishing global lifecycle state', async () => {
-    const res = await postJson(app, SESSIONS_URL, { message: 'hello' })
-
-    expect(res.status).toBe(201)
-    expect(reserveSessionOwnership).toHaveBeenCalledWith('test-agent', 'session-123')
-    expect(vi.mocked(reserveSessionOwnership).mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(messagePersister.markSessionActive).mock.invocationCallOrder[0],
-    )
-  })
-
   it('explicit per-session model/effort win over agent preference defaults', async () => {
     vi.mocked(readJsonFileStrict).mockResolvedValue({
       defaultModel: 'haiku',
@@ -8369,10 +8316,10 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
     ])
     vi.mocked(getSessionIdsWithUnreadNotifications).mockResolvedValue(new Set(['s-both', 's-unread']))
     vi.mocked(messagePersister.isSessionActive).mockImplementation(
-      (id: string) => id === 's-live' || id === 's-awaiting' || id === 's-both',
+      (_agentSlug: string, id: string) => id === 's-live' || id === 's-awaiting' || id === 's-both',
     )
     vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
-      (id: string) => id === 's-awaiting',
+      (_agentSlug: string, id: string) => id === 's-awaiting',
     )
     vi.mocked(listSessionsByIds).mockImplementation(async (_slug, ids) =>
       ids.map((id) => sessionInfo(id, '2026-01-02T10:00:00Z')),
@@ -8395,7 +8342,7 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
       sessionInfo('s-idle-newest', '2026-01-02T12:00:00Z'),
       sessionInfo('s-live-older', '2026-01-02T09:00:00Z'),
     ])
-    vi.mocked(messagePersister.isSessionActive).mockImplementation((id: string) => id === 's-live-older')
+    vi.mocked(messagePersister.isSessionActive).mockImplementation((_agentSlug: string, id: string) => id === 's-live-older')
 
     const res = await getReq(app, `${NOTABLE_URL}&limit=1`)
     const body = await res.json()
@@ -8411,7 +8358,7 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
       sessionInfo('s-unread-newer', '2026-01-02T12:00:00Z'),
     ])
     vi.mocked(messagePersister.isSessionActive).mockImplementation(
-      (id: string) => id === 's-live-older',
+      (_agentSlug: string, id: string) => id === 's-live-older',
     )
 
     const res = await getReq(
@@ -8461,12 +8408,12 @@ describe('notable sessions fast path — GET /:id/sessions?notable=true', () => 
       sessionInfo('s-live', '2026-01-02T10:00:00Z'),
       sessionInfo('s-idle', '2026-01-02T11:00:00Z'),
     ])
-    vi.mocked(messagePersister.isSessionActive).mockImplementation((id: string) => id === 's-live')
+    vi.mocked(messagePersister.isSessionActive).mockImplementation((_agentSlug: string, id: string) => id === 's-live')
     // Agent-level reviews are already folded into the persister's derived
     // awaiting projection (they flag every active session of the agent) —
     // the route adds no special-case of its own anymore.
     vi.mocked(messagePersister.isSessionAwaitingInput).mockImplementation(
-      (id: string) => id === 's-live',
+      (_agentSlug: string, id: string) => id === 's-live',
     )
 
     const res = await getReq(app, NOTABLE_URL)
@@ -8763,9 +8710,7 @@ describe('POST /:id/sessions/:sessionId/run-script — once-grants are single-us
 
     expect(res.status).toBe(200)
     expect(mockExec).toHaveBeenCalledTimes(1)
-    expect(messagePersister.completeInputRequest).toHaveBeenCalledWith(
-      'sess-1', 'tool-once-1', 'answered',
-    )
+    expect(messagePersister.completeInputRequest).toHaveBeenCalledWith('test-agent', 'sess-1', 'tool-once-1', 'answered', )
 
     // The next request_script_run must prompt again, not auto-execute.
     expect(
@@ -8825,10 +8770,6 @@ describe('cross-agent session scoping', () => {
       async (agentSlug: string, sessionId: string) =>
         agentSlug === ATTACKER && sessionId === OWN_SESSION,
     )
-    vi.mocked(sessionBelongsToAgent).mockImplementation(
-      async (agentSlug: string, sessionId: string) =>
-        agentSlug === ATTACKER && sessionId === OWN_SESSION,
-    )
     vi.mocked(sessionExists).mockImplementation(
       async (agentSlug: string, sessionId: string) =>
         agentSlug === ATTACKER && sessionId === OWN_SESSION,
@@ -8852,14 +8793,31 @@ describe('cross-agent session scoping', () => {
   }
 
   describe('GET /sessions/:sessionId/messages', () => {
-    it('rejects a foreign id even if a same-named transcript exists locally', async () => {
-      vi.mocked(sessionExists).mockResolvedValue(true)
-
+    it('rejects an id this agent has no session for', async () => {
       const res = await app.request(url(VICTIM_SESSION, '/messages'))
 
       expect(res.status).toBe(404)
       expect(messagePersister.getSettledInputRequests).not.toHaveBeenCalled()
       expect(messagePersister.recoverSessionAwaitingInput).not.toHaveBeenCalled()
+    })
+
+    it('reads this agent’s own session even when another agent uses the same id', async () => {
+      // A same-named transcript in THIS agent's directory is this agent's
+      // session, and every registry the read then reaches is keyed by agent
+      // AND session — so it resolves inside this agent's own namespace and the
+      // other agent's session is untouched. Proven end to end, against real
+      // routes and a real persister, in session-scope.integration.test.ts
+      // ("a forged transcript does not buy access…").
+      vi.mocked(sessionIsKnown).mockResolvedValue(true)
+      vi.mocked(sessionExists).mockResolvedValue(true)
+
+      const res = await app.request(url(VICTIM_SESSION, '/messages'))
+
+      expect(res.status).toBe(200)
+      expect(messagePersister.getSettledInputRequests).toHaveBeenCalledWith(
+        ATTACKER,
+        VICTIM_SESSION,
+      )
     })
   })
 
@@ -8906,7 +8864,7 @@ describe('cross-agent session scoping', () => {
       const res = await postJson(app, url(OWN_SESSION, '/interrupt'), {})
 
       expect(res.status).toBe(200)
-      expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith(OWN_SESSION)
+      expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith(ATTACKER, OWN_SESSION)
     })
 
     it('still marks the caller’s own session interrupted when the container throws', async () => {
@@ -8915,7 +8873,7 @@ describe('cross-agent session scoping', () => {
       const res = await postJson(app, url(OWN_SESSION, '/interrupt'), {})
 
       expect(res.status).toBe(200)
-      expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith(OWN_SESSION)
+      expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith(ATTACKER, OWN_SESSION)
     })
   })
 
@@ -8975,10 +8933,7 @@ describe('cross-agent session scoping', () => {
       const res = await postJson(app, url(OWN_SESSION, '/typing'), {})
 
       expect(res.status).toBe(200)
-      expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith(
-        OWN_SESSION,
-        expect.objectContaining({ type: 'user_typing' }),
-      )
+      expect(messagePersister.broadcastSessionEvent).toHaveBeenCalledWith(ATTACKER, OWN_SESSION, expect.objectContaining({ type: 'user_typing' }), )
     })
   })
 
@@ -9037,7 +8992,7 @@ describe('cross-agent session scoping', () => {
       const res = await deleteReq(app, url(OWN_SESSION))
 
       expect(res.status).toBe(204)
-      expect(messagePersister.unsubscribeFromSession).toHaveBeenCalledWith(OWN_SESSION)
+      expect(messagePersister.unsubscribeFromSession).toHaveBeenCalledWith(ATTACKER, OWN_SESSION)
       expect(deleteSession).toHaveBeenCalledWith(ATTACKER, OWN_SESSION)
     })
   })

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -4492,7 +4492,7 @@ describe('DELETE /:id/sessions/:sessionId', () => {
     const res = await deleteReq(app, URL)
 
     expect(res.status).toBe(204)
-    expect(deleteSessionUnreadMarks).toHaveBeenCalledWith(['sess-1'])
+    expect(deleteSessionUnreadMarks).toHaveBeenCalledWith('test-agent', ['sess-1'])
   })
 
   it('deletes a dangling session whose transcript JSONL is gone (no getSession gate)', async () => {
@@ -8469,7 +8469,7 @@ describe('mark as unread — /:id/sessions/:sessionId/unread', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(vi.mocked(clearSessionUnread)).toHaveBeenCalledWith('sess-1', 'test-user-id')
+    expect(vi.mocked(clearSessionUnread)).toHaveBeenCalledWith('test-agent', 'sess-1', 'test-user-id')
     expect(vi.mocked(markSessionUnread)).not.toHaveBeenCalled()
   })
 

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -324,6 +324,7 @@ vi.mock('@shared/lib/services/session-service', async (importOriginal) => {
   getSessionMetadata: vi.fn(),
   sessionExists: vi.fn().mockResolvedValue(true),
   sessionIsKnown: vi.fn().mockResolvedValue(true),
+  sessionFileRealPathWithinAgent: vi.fn().mockReturnValue(true),
   isSessionRegistered: vi.fn().mockResolvedValue(false),
   updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(),
@@ -332,6 +333,14 @@ vi.mock('@shared/lib/services/session-service', async (importOriginal) => {
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
   readSessionMetadata: vi.fn(() => Promise.resolve({})),
   }
+})
+
+// Keep the pure path helpers real; stub only the symlink-resolving one, which
+// would otherwise hit the mocked fs. Route-level containment is proven in
+// session-scope.integration.test.ts against the real filesystem.
+vi.mock('@shared/lib/utils/path-safety', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/lib/utils/path-safety')>()
+  return { ...actual, isRealPathWithinDir: vi.fn().mockReturnValue(true) }
 })
 
 const mockLoadSessionUsageTotals = vi.fn()

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2538,6 +2538,13 @@ agents.get('/:id/sessions/:sessionId/raw-log', AgentRead(), async (c) => {
     const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
+    // Ownership + containment first: this route opens the transcript by path
+    // directly, so without the gate a traversal-shaped id throws into the
+    // catch (500, not 404) and a planted symlink is followed to another
+    // agent's transcript. sessionExists is non-throwing and symlink-aware.
+    if (!(await sessionExists(agentSlug, sessionId))) {
+      return c.json({ error: 'Session log not found' }, 404)
+    }
 
     const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -71,8 +71,6 @@ import {
   getSession,
   getSessionMetadata,
   sessionExists,
-  sessionBelongsToAgent,
-  reserveSessionOwnership,
   sessionIsKnown,
   isSessionRegistered,
   updateSessionMetadata,
@@ -516,7 +514,7 @@ function getAttentionOutsideLatest(
       ...messagePersister.getActiveSessionIdsForAgent(agentSlug),
     ])
     for (const sessionId of candidateIds) {
-      if (!messagePersister.isSessionAwaitingInput(sessionId)) continue
+      if (!messagePersister.isSessionAwaitingInput(agentSlug, sessionId)) continue
       observedPendingInput = true
       if (countsOutside(sessionId)) {
         hasPendingInput = true
@@ -580,8 +578,8 @@ async function getLatestVisibleSessionTail(
   return {
     session: {
       ...session,
-      isActive: messagePersister.isSessionActive(session.id),
-      isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id),
+      isActive: messagePersister.isSessionActive(agentSlug, session.id),
+      isAwaitingInput: messagePersister.isSessionAwaitingInput(agentSlug, session.id),
       hasUnreadNotifications: unreadSessionIds.has(session.id),
     },
     messageTail,
@@ -724,11 +722,11 @@ async function enrichAgentsWithSummary(
       let hasUnreadNotifications = false
       const hasAgentLevelReviews = reviewManager.getPendingReviewsForAgent(agent.slug).length > 0
       for (const sessionId of sessionSummary.sessionIds) {
-        const isActive = messagePersister.isSessionActive(sessionId)
+        const isActive = messagePersister.isSessionActive(agent.slug, sessionId)
         if (isActive) {
           hasActiveSessions = true
         }
-        if (messagePersister.isSessionAwaitingInput(sessionId)) {
+        if (messagePersister.isSessionAwaitingInput(agent.slug, sessionId)) {
           hasSessionsAwaitingInput = true
         }
         if (unreadSessionIds.has(sessionId) && !isHiddenAutomatedSession(sessionMetadata[sessionId])) {
@@ -1264,7 +1262,7 @@ Respond with ONLY the session name, nothing else. No quotes, no explanation.`,
       : message.trim().split(/\s+/).slice(0, 6).join(' ').substring(0, 60)
     if (finalName) {
       await updateSessionName(agentSlug, sessionId, finalName)
-      messagePersister.broadcastSessionUpdate(sessionId)
+      messagePersister.broadcastSessionUpdate(agentSlug, sessionId)
     }
   } catch (error) {
     console.error('Failed to update session name:', error)
@@ -1914,13 +1912,13 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
         { excludeAutomated: true },
       )
       const enriched = infos.map((session) => {
-        const isActive = messagePersister.isSessionActive(session.id)
+        const isActive = messagePersister.isSessionActive(slug, session.id)
         return {
           ...session,
           isActive,
           // The awaiting projection already counts agent-scoped reviews
           // against every active session of the agent — no review special-case.
-          isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id),
+          isAwaitingInput: messagePersister.isSessionAwaitingInput(slug, session.id),
           hasUnreadNotifications: unreadIds.has(session.id) || markedUnreadIds.has(session.id),
         }
       })
@@ -1953,14 +1951,14 @@ agents.get('/:id/sessions', AgentRead(), async (c) => {
     ])
     const wakesBySession = new Map(pendingWakes.map((w) => [w.resumeSessionId!, w]))
     const sessionsWithStatus = sessionList.map((session) => {
-      const isActive = messagePersister.isSessionActive(session.id)
+      const isActive = messagePersister.isSessionActive(slug, session.id)
       const wake = wakesBySession.get(session.id)
       return {
         ...session,
         isActive,
         // The awaiting projection already counts agent-scoped reviews against
         // every active session of the agent — no review special-case.
-        isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id),
+        isAwaitingInput: messagePersister.isSessionAwaitingInput(slug, session.id),
         hasUnreadNotifications:
           unreadSessionIds.has(session.id) || markedUnreadSessionIds.has(session.id),
         ...(wake
@@ -2060,11 +2058,6 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     })
     const sessionId = containerSession.id
 
-    // Claim the globally keyed id before any lifecycle state becomes visible.
-    // Metadata registration below is intentionally later so stream attachment
-    // still wins the race with early container output.
-    await reserveSessionOwnership(slug, sessionId)
-
     // Runtime choices are SESSION state once the first turn starts, including
     // inherited defaults. Persist the effective values, not merely explicit
     // overrides, so changing an agent/app default later cannot silently change
@@ -2099,9 +2092,9 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
     let lifecycleStarted = false
     let sessionRegistered = false
     try {
-      messagePersister.markSessionActive(sessionId, slug)
+      messagePersister.markSessionActive(slug, sessionId)
       lifecycleStarted = true
-      await messagePersister.subscribeToSession(sessionId, client, sessionId, slug)
+      await messagePersister.subscribeToSession(slug, sessionId, client, sessionId)
 
       // Record author for initial message after we know the sessionId
       if (isAuthMode()) {
@@ -2118,13 +2111,13 @@ agents.post('/:id/sessions', AgentUser(), async (c) => {
       sessionRegistered = true
     } catch (error) {
       if (lifecycleStarted && !sessionRegistered) {
-        messagePersister.unsubscribeFromSession(sessionId)
+        messagePersister.unsubscribeFromSession(slug, sessionId)
       }
       throw error
     }
     // Store slash commands from container's init event (captured during session creation)
     if (containerSession.slashCommands && containerSession.slashCommands.length > 0) {
-      messagePersister.setSlashCommands(sessionId, containerSession.slashCommands)
+      messagePersister.setSlashCommands(slug, sessionId, containerSession.slashCommands)
       updateSessionMetadata(slug, sessionId, { slashCommands: containerSession.slashCommands }).catch(console.error)
     }
 
@@ -2178,7 +2171,7 @@ async function annotateAndRecoverMessages(
 ): Promise<void> {
   await resolveInterruptedSubagents(transformed, agentSlug, sessionId)
 
-  const settledRequests = messagePersister.getSettledInputRequests(sessionId)
+  const settledRequests = messagePersister.getSettledInputRequests(agentSlug, sessionId)
   if (settledRequests.size > 0) {
     for (const item of transformed) {
       if (item.type !== 'assistant') continue
@@ -2193,10 +2186,10 @@ async function annotateAndRecoverMessages(
     }
   }
 
-  if (messagePersister.isSessionActive(sessionId)) {
+  if (messagePersister.isSessionActive(agentSlug, sessionId)) {
     const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
     if (unresolvedRequests.length > 0) {
-      messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
+      messagePersister.recoverSessionAwaitingInput(agentSlug, sessionId, unresolvedRequests)
     }
   }
 
@@ -2256,10 +2249,7 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     // No JSONL transcript on disk — e.g. it was deleted by the CLI's retention
     // cleanup while the metadata entry lingers in the nav. Signal this distinctly
     // from an empty (but present) transcript so the UI can show a clear message.
-    if (
-      !(await sessionBelongsToAgent(agentSlug, sessionId)) ||
-      !(await sessionExists(agentSlug, sessionId))
-    ) {
+    if (!(await sessionExists(agentSlug, sessionId))) {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
@@ -2345,7 +2335,7 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     // history consumer — the client's refresh fallback, the transcript card,
     // and the recovery scan below — sees a completed call instead of
     // resurrecting a decided one.
-    const settledRequests = messagePersister.getSettledInputRequests(sessionId)
+    const settledRequests = messagePersister.getSettledInputRequests(agentSlug, sessionId)
     if (settledRequests.size > 0) {
       for (const item of transformed) {
         if (item.type !== 'assistant') continue
@@ -2360,13 +2350,13 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
       }
     }
 
-    if (messagePersister.isSessionActive(sessionId)) {
+    if (messagePersister.isSessionActive(agentSlug, sessionId)) {
       const unresolvedRequests = getUnresolvedBlockingInputRequests(transformed)
       if (unresolvedRequests.length > 0) {
         // If the request-specific stream event was missed, persisted messages are
         // the fallback source of truth. A stale transcript can briefly re-assert
         // awaiting input, but the next stream result/idle event clears it.
-        messagePersister.recoverSessionAwaitingInput(sessionId, agentSlug, unresolvedRequests)
+        messagePersister.recoverSessionAwaitingInput(agentSlug, sessionId, unresolvedRequests)
       }
     }
 
@@ -2443,7 +2433,7 @@ agents.get('/:id/sessions/:sessionId/media/:ref', AgentRead(), async (c) => {
     // would 404 — telling the client the image is gone when the truth is that
     // this machine could not look. openMediaBlob distinguishes the two, and a
     // genuinely missing transcript surfaces there as 410.
-    if (!(await sessionBelongsToAgent(agentSlug, sessionId))) {
+    if (!(await sessionIsKnown(agentSlug, sessionId))) {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
@@ -2632,7 +2622,7 @@ async function persistAndBroadcastUserMessage(
     userId,
   })
   const user = c.get('user' as never) as { id: string; name: string }
-  messagePersister.broadcastSessionEvent(args.sessionId, {
+  messagePersister.broadcastSessionEvent(args.agentSlug, args.sessionId, {
     type: 'user_message',
     content: args.content,
     sender: { id: user.id, name: user.name },
@@ -2673,7 +2663,7 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     // a person has joined the session. This must precede sendMessage: a fast
     // turn can settle immediately, and completion notification visibility is
     // decided from the host-side promotedToInteractive marker.
-    await messagePersister.promoteAutomatedSession(sessionId, agentSlug)
+    await messagePersister.promoteAutomatedSession(agentSlug, sessionId)
 
     // Server-generated message uuid (never client-supplied — the uuid keys the
     // messageAuthor attribution row, so a client-chosen value could collide
@@ -2683,7 +2673,7 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     const messageUuid = randomUUID()
     const text = content.trim()
 
-    if (messagePersister.coalesceIfRecovering(sessionId, { uuid: messageUuid, text })) {
+    if (messagePersister.coalesceIfRecovering(agentSlug, sessionId, { uuid: messageUuid, text })) {
       await persistAndBroadcastUserMessage(c, {
         messageUuid,
         sessionId,
@@ -2704,8 +2694,8 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
       info = containerManager.getCachedInfo(agentSlug)
     }
 
-    if (!messagePersister.isSubscribed(sessionId)) {
-      await messagePersister.subscribeToSession(sessionId, client, sessionId, agentSlug)
+    if (!messagePersister.isSubscribed(agentSlug, sessionId)) {
+      await messagePersister.subscribeToSession(agentSlug, sessionId, client, sessionId)
     }
 
     // If the session is awaiting user input (an open AskUserQuestion / secret / file
@@ -2713,13 +2703,13 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
     // turn instead of deadlocking behind the blocked tool. No-op when not awaiting.
     // Runs before the wasQueued capture so its state changes (interrupt for subagent
     // requests) are reflected in the queue-vs-fresh-turn decision below.
-    await messagePersister.cancelAwaitingInput(sessionId, agentSlug)
+    await messagePersister.cancelAwaitingInput(agentSlug, sessionId)
 
     // Captured before markSessionActive: a message sent while the agent is
     // mid-turn is queued by the agent loop rather than starting a new turn.
-    const wasQueued = messagePersister.isSessionActive(sessionId)
+    const wasQueued = messagePersister.isSessionActive(agentSlug, sessionId)
 
-    messagePersister.markSessionActive(sessionId, agentSlug)
+    messagePersister.markSessionActive(agentSlug, sessionId)
 
     // A mid-turn send must not carry model/effort/speed: the container treats a
     // parameter change as interrupt/restart of the in-flight query. The
@@ -2772,7 +2762,7 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
           // Other windows/devices may already have seeded their composer from
           // the previous session metadata. Tell both the local session stream
           // and the global event stream to refresh before their next send.
-          messagePersister.broadcastSessionUpdate(sessionId)
+          messagePersister.broadcastSessionUpdate(agentSlug, sessionId)
           messagePersister.broadcastGlobal({ type: 'session_updated', sessionId, agentSlug })
         }
       } catch (error) {
@@ -2803,7 +2793,7 @@ agents.delete('/:id/sessions/:sessionId/queued-messages/:uuid', AgentUser(), asy
       return c.json({ error: 'Session not found' }, 404)
     }
 
-    if (messagePersister.dropCoalescedUserMessage(sessionId, uuidParam.data)) {
+    if (messagePersister.dropCoalescedUserMessage(agentSlug, sessionId, uuidParam.data)) {
       return c.json({ cancelled: true })
     }
 
@@ -2829,7 +2819,7 @@ agents.post('/:id/sessions/:sessionId/typing', AgentUser(), async (c) => {
     return c.json({ error: 'Session not found' }, 404)
   }
 
-  messagePersister.broadcastSessionEvent(sessionId, {
+  messagePersister.broadcastSessionEvent(getAgentId(c), sessionId, {
     type: 'user_typing',
     sender: { id: user.id, name: user.name },
   })
@@ -2850,7 +2840,7 @@ agents.get('/:id/sessions/:sessionId', AgentRead(), async (c) => {
       return c.json({ error: 'Session not found' }, 404)
     }
 
-    const isActive = messagePersister.isSessionActive(sessionId)
+    const isActive = messagePersister.isSessionActive(agentSlug, sessionId)
     const metadata = await getSessionMetadata(agentSlug, sessionId)
     const pendingWake = await getPendingWakeForSession(agentSlug, sessionId)
     const invokingAgent = metadata?.invokedByAgentSlug
@@ -2869,7 +2859,7 @@ agents.get('/:id/sessions/:sessionId', AgentRead(), async (c) => {
       // condition the session lists use (the breadcrumb context menu hides
       // "Mark as Unread" while a session is working or awaiting input, since
       // no list renders an unread dot in that state).
-      isAwaitingInput: messagePersister.isSessionAwaitingInput(sessionId),
+      isAwaitingInput: messagePersister.isSessionAwaitingInput(agentSlug, sessionId),
       lastUsage: metadata?.lastUsage,
       scheduledTaskId: metadata?.scheduledTaskId,
       scheduledTaskName: metadata?.scheduledTaskName,
@@ -2992,16 +2982,15 @@ agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
     // exactly the "transcript OR metadata entry exists" condition that
     // deleteSession itself reports success for.
     if (
-      !(await sessionBelongsToAgent(agentSlug, sessionId)) ||
-      (!(await sessionExists(agentSlug, sessionId)) &&
-        !(await isSessionRegistered(agentSlug, sessionId)))
+      !(await sessionExists(agentSlug, sessionId)) &&
+      !(await isSessionRegistered(agentSlug, sessionId))
     ) {
       return c.json({ error: 'Session not found' }, 404)
     }
 
     // Before the delete, so an in-flight append can't recreate the transcript
     // just after it is unlinked.
-    messagePersister.unsubscribeFromSession(sessionId)
+    messagePersister.unsubscribeFromSession(agentSlug, sessionId)
 
     // deleteSession is the authority for existence here: it removes the JSONL
     // transcript and/or a lingering metadata entry and returns false only when
@@ -3054,7 +3043,7 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
 
     try {
       // Subscribe FIRST to avoid missing any broadcasts
-      unsubscribe = messagePersister.addSSEClient(sessionId, async (data) => {
+      unsubscribe = messagePersister.addSSEClient(agentSlug, sessionId, async (data) => {
         try {
           await stream.writeSSE({
             data: JSON.stringify(data),
@@ -3066,21 +3055,21 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
       })
 
       // Send initial connection message (include slash commands for late-joining clients)
-      const isActive = messagePersister.isSessionActive(sessionId)
-      let slashCommands = messagePersister.getSlashCommands(sessionId)
+      const isActive = messagePersister.isSessionActive(agentSlug, sessionId)
+      let slashCommands = messagePersister.getSlashCommands(agentSlug, sessionId)
       // Fall back to persisted metadata (e.g. after container restart)
       if (slashCommands.length === 0) {
         const meta = await getSessionMetadata(agentSlug, sessionId)
         if (meta?.slashCommands && meta.slashCommands.length > 0) {
           const repaired = repairLegacySlashCommands(meta.slashCommands)
           slashCommands = repaired.commands
-          messagePersister.setSlashCommands(sessionId, slashCommands)
+          messagePersister.setSlashCommands(agentSlug, sessionId, slashCommands)
           if (repaired.changed) {
             updateSessionMetadata(agentSlug, sessionId, { slashCommands }).catch(console.error)
           }
         }
       }
-      const backgroundTasks = messagePersister.getActiveBackgroundTasks(sessionId)
+      const backgroundTasks = messagePersister.getActiveBackgroundTasks(agentSlug, sessionId)
       await stream.writeSSE({
         data: JSON.stringify({
           type: 'connected',
@@ -3106,7 +3095,7 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
       // Keep-alive ping every 30 seconds
       pingInterval = setInterval(async () => {
         try {
-          const currentIsActive = messagePersister.isSessionActive(sessionId)
+          const currentIsActive = messagePersister.isSessionActive(agentSlug, sessionId)
           await stream.writeSSE({
             data: JSON.stringify({ type: 'ping', isActive: currentIsActive }),
             event: 'message',
@@ -3151,7 +3140,7 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
     // This handles the case where container crashed/restarted but UI still shows active
     if (info.status !== 'running') {
       console.log(`[Agents] Container not running for ${agentSlug}, marking session ${sessionId} as interrupted locally`)
-      await messagePersister.markSessionInterrupted(sessionId)
+      await messagePersister.markSessionInterrupted(agentSlug, sessionId)
       reviewManager.denyAllForAgent(agentSlug)
       return c.json({ success: true, note: 'Container not running, session marked inactive' })
     }
@@ -3165,7 +3154,7 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
       console.log(`[Agents] Container interrupt returned false for session ${sessionId}, marking as interrupted locally`)
     }
 
-    await messagePersister.markSessionInterrupted(sessionId)
+    await messagePersister.markSessionInterrupted(agentSlug, sessionId)
     reviewManager.denyAllForAgent(agentSlug)
 
     return c.json({ success: true })
@@ -3174,7 +3163,7 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
     // Even on error, try to mark session as interrupted to fix UI state.
     // Ownership was established above, so this reaches only the caller's session.
     try {
-      await messagePersister.markSessionInterrupted(sessionId)
+      await messagePersister.markSessionInterrupted(agentSlug, sessionId)
       reviewManager.denyAllForAgent(agentSlug)
       return c.json({ success: true, note: 'Error during interrupt, but session marked inactive' })
     } catch {
@@ -3325,7 +3314,7 @@ agents.post('/:id/sessions/:sessionId/provide-secret', AgentUser(), async (c) =>
         return c.json({ error: 'Failed to reject secret request' }, 500)
       }
 
-      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
+      messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'secret', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -3390,7 +3379,7 @@ agents.post('/:id/sessions/:sessionId/provide-secret', AgentUser(), async (c) =>
       return c.json({ error: 'Secret saved but failed to notify agent' }, 500)
     }
     console.log(`[provide-secret] Request ${toolUseId} resolved successfully`)
-    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
+    messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'answered')
 
     return c.json({ success: true, saved: true })
   } catch (error) {
@@ -3438,7 +3427,7 @@ agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), a
         return c.json({ error: 'Failed to reject request' }, 500)
       }
 
-      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
+      messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'connected_account', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -3545,7 +3534,7 @@ agents.post('/:id/sessions/:sessionId/provide-connected-account', AgentUser(), a
     console.log(
       `[provide-connected-account] Request ${toolUseId} resolved successfully`
     )
-    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
+    messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'answered')
 
     return c.json({
       success: true,
@@ -3596,7 +3585,7 @@ agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) =
         return c.json({ error: 'Failed to reject question request' }, 500)
       }
 
-      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
+      messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'question', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -3628,7 +3617,7 @@ agents.post('/:id/sessions/:sessionId/answer-question', AgentUser(), async (c) =
       return c.json({ error: 'Failed to submit answers' }, 500)
     }
     console.log(`[answer-question] Request ${toolUseId} resolved successfully`)
-    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
+    messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'answered')
 
     return c.json({ success: true })
   } catch (error) {
@@ -3679,7 +3668,7 @@ agents.post('/:id/sessions/:sessionId/capability-review', AgentUser(), async (c)
         return c.json({ error: 'Failed to reject capability launch' }, 500)
       }
 
-      messagePersister.completeCapabilityReview(sessionId, toolUseId, 'declined')
+      messagePersister.completeCapabilityReview(agentSlug, sessionId, toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'capability_review', capability, withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -3708,9 +3697,9 @@ agents.post('/:id/sessions/:sessionId/capability-review', AgentUser(), async (c)
     // Mirror the container's grant so later launches in this session don't
     // produce review cards nothing is waiting on.
     if (scope === 'session') {
-      messagePersister.grantSessionCapability(sessionId, capability)
+      messagePersister.grantSessionCapability(agentSlug, sessionId, capability)
     }
-    messagePersister.completeCapabilityReview(sessionId, toolUseId, 'answered')
+    messagePersister.completeCapabilityReview(agentSlug, sessionId, toolUseId, 'answered')
 
     trackServerEvent('capability_launch_approved', { capability, scope })
     return c.json({ success: true })
@@ -3970,7 +3959,7 @@ agents.post(
     )
     const requestSettled = resolveResponse.ok
     if (requestSettled) {
-      messagePersister.completeInputRequest(sessionId, body.toolUseId, 'answered')
+      messagePersister.completeInputRequest(agentSlug, sessionId, body.toolUseId, 'answered')
     } else {
       console.error('[autofill-browser-credential] Credentials filled but browser input could not be resolved')
     }
@@ -4035,7 +4024,7 @@ agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), asyn
       }
 
       const sessionId = c.req.param('sessionId')
-      messagePersister.completeInputRequest(sessionId, toolUseId, 'declined')
+      messagePersister.completeInputRequest(agentSlug, sessionId, toolUseId, 'declined')
 
       // Interrupt the session so the user can chat directly with the agent
       try {
@@ -4043,7 +4032,7 @@ agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), asyn
       } catch (e) {
         console.error(`[complete-browser-input] Failed to interrupt session: ${e}`)
       }
-      await messagePersister.markSessionInterrupted(sessionId)
+      await messagePersister.markSessionInterrupted(agentSlug, sessionId)
 
       trackServerEvent('request_declined', { type: 'browser_input', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
@@ -4071,7 +4060,7 @@ agents.post('/:id/sessions/:sessionId/complete-browser-input', AgentUser(), asyn
       return c.json({ error: 'Failed to complete browser input request' }, 500)
     }
 
-    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
+    messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'answered')
     return c.json({ success: true })
   } catch (error) {
     console.error('Failed to complete browser input:', error)
@@ -4121,7 +4110,7 @@ agents.post('/:id/sessions/:sessionId/run-script', AgentUser(), async (c) => {
         return c.json({ error: 'Failed to reject script run request' }, 500)
       }
 
-      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
+      messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'script_run', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -4213,7 +4202,7 @@ agents.post('/:id/sessions/:sessionId/run-script', AgentUser(), async (c) => {
       return c.json({ error: 'Failed to resolve script run request' }, 500)
     }
 
-    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
+    messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'answered')
     trackServerEvent('script_executed', { scriptType, exitCode })
     return c.json({ success: true })
   } catch (error) {
@@ -4270,7 +4259,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
         return c.json({ error: 'Failed to reject computer use request' }, 500)
       }
 
-      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId, 'declined')
+      messagePersister.clearPendingComputerUseRequest(agentSlug, sessionId, toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'computer_use', method, withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -4293,7 +4282,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
       if (!resolveResponse.ok) {
         return c.json({ error: 'Failed to resolve computer use request' }, 500)
       }
-      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId, 'answered')
+      messagePersister.clearPendingComputerUseRequest(agentSlug, sessionId, toolUseId, 'answered')
       return c.json({ success: true })
     }
 
@@ -4328,7 +4317,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
       ).catch(() => {})
       // The user approved but execution blew up — the wait was consumed by a
       // system failure, not a user decision.
-      messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId, 'invalidated')
+      messagePersister.clearPendingComputerUseRequest(agentSlug, sessionId, toolUseId, 'invalidated')
       return c.json({ success: true, error: errorMsg })
     }
 
@@ -4341,17 +4330,17 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
       if (targetApp) {
         computerUsePermissionManager.setGrabbedApp(agentSlug, targetApp)
         // Broadcast immediately with app name, then resolve icon async
-        messagePersister.broadcastSessionEvent(sessionId, { type: 'computer_use_grab_changed', app: targetApp })
+        messagePersister.broadcastSessionEvent(agentSlug, sessionId, { type: 'computer_use_grab_changed', app: targetApp })
         const { getAppIconBase64 } = await import('@shared/lib/computer-use/app-icon')
         getAppIconBase64(targetApp).then((icon) => {
           if (icon) {
-            messagePersister.broadcastSessionEvent(sessionId, { type: 'computer_use_grab_changed', app: targetApp, appIcon: icon })
+            messagePersister.broadcastSessionEvent(agentSlug, sessionId, { type: 'computer_use_grab_changed', app: targetApp, appIcon: icon })
           }
         }).catch(() => {})
       }
     } else if (method === 'ungrab' || method === 'quit') {
       computerUsePermissionManager.clearGrabbedApp(agentSlug)
-      messagePersister.broadcastSessionEvent(sessionId, { type: 'computer_use_grab_changed', app: null })
+      messagePersister.broadcastSessionEvent(agentSlug, sessionId, { type: 'computer_use_grab_changed', app: null })
     }
 
     // Consume "once" grant after use
@@ -4381,7 +4370,7 @@ agents.post('/:id/sessions/:sessionId/computer-use', AgentUser(), async (c) => {
       return c.json({ error: 'Failed to resolve computer use request' }, 500)
     }
 
-    messagePersister.clearPendingComputerUseRequest(sessionId, toolUseId, 'answered')
+    messagePersister.clearPendingComputerUseRequest(agentSlug, sessionId, toolUseId, 'answered')
     trackServerEvent('computer_use_executed', { method, permissionLevel, grantType })
     return c.json({ success: true })
   } catch (error) {
@@ -4414,7 +4403,7 @@ agents.post('/:id/sessions/:sessionId/computer-use/revoke', AgentUser(), async (
     }
 
     // Broadcast to UI
-    messagePersister.broadcastSessionEvent(sessionId, { type: 'computer_use_grab_changed', app: null })
+    messagePersister.broadcastSessionEvent(agentSlug, sessionId, { type: 'computer_use_grab_changed', app: null })
 
     return c.json({ success: true, revoked: appName || true })
   } catch (error) {
@@ -4469,14 +4458,14 @@ agents.get('/:id/scheduled-tasks/completed-sessions', AgentRead(), async (c) => 
         // restart, or during the tiny idle-event/metadata-write race, the same
         // inactive run is settled. This mirrors activity-stats semantics.
         return metadata[sessionId]?.automationStatus !== 'running'
-          || !messagePersister.isSessionActive(sessionId)
+          || !messagePersister.isSessionActive(slug, sessionId)
       })
 
     const sessions = await listSessionsByIds(slug, completedSessionIds)
     const sessionsWithStatus = sessions.map((session) => ({
       ...session,
-      isActive: messagePersister.isSessionActive(session.id),
-      isAwaitingInput: messagePersister.isSessionAwaitingInput(session.id),
+      isActive: messagePersister.isSessionActive(slug, session.id),
+      isAwaitingInput: messagePersister.isSessionAwaitingInput(slug, session.id),
     }))
     sessionsWithStatus.sort(
       (a, b) => b.lastActivityAt.getTime() - a.lastActivityAt.getTime()
@@ -5119,7 +5108,7 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
         console.error('Failed to reject remote MCP request:', await rejectResponse.text())
         return c.json({ error: 'Failed to decline the request in container' }, 502)
       }
-      messagePersister.completeInputRequest(c.req.param('sessionId'), body.toolUseId, 'declined')
+      messagePersister.completeInputRequest(getAgentId(c), c.req.param('sessionId'), body.toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'remote_mcp', withReason: !!body.declineReason })
       return c.json({ success: true, status: 'declined' })
     }
@@ -5192,7 +5181,7 @@ agents.post('/:id/sessions/:sessionId/provide-remote-mcp', AgentUser(), async (c
       return c.json({ error: 'Failed to resolve the request in container' }, 502)
     }
 
-    messagePersister.completeInputRequest(c.req.param('sessionId'), body.toolUseId, 'answered')
+    messagePersister.completeInputRequest(getAgentId(c), c.req.param('sessionId'), body.toolUseId, 'answered')
     return c.json({ success: true, status: 'provided' })
   } catch (error) {
     console.error('Failed to provide remote MCP:', error)
@@ -6476,7 +6465,7 @@ agents.post('/:id/sessions/:sessionId/provide-file', AgentUser(), async (c) => {
         return c.json({ error: 'Failed to reject file request' }, 500)
       }
 
-      messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'declined')
+      messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'declined')
       trackServerEvent('request_declined', { type: 'file', withReason: !!declineReason })
       return c.json({ success: true, declined: true })
     }
@@ -6508,7 +6497,7 @@ agents.post('/:id/sessions/:sessionId/provide-file', AgentUser(), async (c) => {
       return c.json({ error: 'Failed to notify agent of uploaded file' }, 500)
     }
     console.log(`[provide-file] Request ${toolUseId} resolved successfully`)
-    messagePersister.completeInputRequest(c.req.param('sessionId'), toolUseId, 'answered')
+    messagePersister.completeInputRequest(agentSlug, c.req.param('sessionId'), toolUseId, 'answered')
 
     return c.json({ success: true, filePath })
   } catch (error) {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2961,7 +2961,7 @@ async function setUnreadFlag(c: Context, sessionId: string, markedUnread: boolea
     const userId = getCurrentUserId(c)
     const changed = markedUnread
       ? await markSessionUnread(agentSlug, sessionId, userId)
-      : await clearSessionUnread(sessionId, userId)
+      : await clearSessionUnread(agentSlug, sessionId, userId)
     return c.json({ success: true, markedUnread, changed })
   } catch (error) {
     console.error('Failed to update session unread flag:', error)
@@ -3027,7 +3027,7 @@ agents.delete('/:id/sessions/:sessionId', AgentAdmin(), async (c) => {
     await deleteNotificationsBySessionIds([sessionId])
     // A mark left behind would be an unreachable row: nothing lists the
     // session any more, so nothing could ever clear it.
-    await deleteSessionUnreadMarks([sessionId])
+    await deleteSessionUnreadMarks(agentSlug, [sessionId])
 
     return c.body(null, 204)
   } catch (error) {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -545,6 +545,18 @@ async function getLatestVisibleSessionTail(
   sessionMetadata: SessionMetadataMap,
   signal?: AbortSignal,
 ): Promise<NonNullable<ApiAgent['latestVisibleSession']>> {
+  // KNOWN RESIDUAL (accepted, out of scope): `session` comes from the listing,
+  // which drops symlinked transcripts by dirent type but still readdir's THROUGH
+  // a symlinked ancestor directory (e.g. an agent that replaced its own
+  // `-workspace` with a link to another agent's). This read would then follow
+  // that link and surface a stranger's tail on the agent's own home card. It is
+  // NOT gated with the realpath check the direct content routes use, because
+  // that costs an fs op on the exactly-pinned home/agents perf budgets. The
+  // vector is narrow (self-destructive: it breaks the attacker's own agent, and
+  // exposes only the latest tail via their own home). Direct-id content routes
+  // (messages, media, raw-log, usage, single-session, subagent) ARE covered by
+  // sessionFileRealPathWithinAgent; closing this path means gating the read here
+  // and re-recording those budgets.
   signal?.throwIfAborted()
   // Read first, check existence only if the read came back empty: the page
   // reader answers a missing transcript with an empty page, so the common

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -72,6 +72,7 @@ import {
   getSessionMetadata,
   sessionExists,
   sessionIsKnown,
+  sessionFileRealPathWithinAgent,
   isSessionRegistered,
   updateSessionMetadata,
   deleteSession,
@@ -189,7 +190,7 @@ import { getConfiguredLlmClient, createSummarizerText } from '@shared/lib/llm-pr
 import { resolveActiveProviderModel } from '@shared/lib/llm-provider'
 import { revokeProxyToken } from '@shared/lib/proxy/token-store'
 import { getAgentWorkspaceDir } from '@shared/lib/utils/file-storage'
-import { isPathWithinDir, sanitizeUploadFilename } from '@shared/lib/utils/path-safety'
+import { isPathWithinDir, isRealPathWithinDir, sanitizeUploadFilename } from '@shared/lib/utils/path-safety'
 import { AGENT_PACKAGE_EXTENSION, SKILL_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
 import { readAgentPreferences, updateAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { agentPreferencesUpdateSchema } from '@shared/lib/types/agent-preferences'
@@ -2433,7 +2434,16 @@ agents.get('/:id/sessions/:sessionId/media/:ref', AgentRead(), async (c) => {
     // would 404 — telling the client the image is gone when the truth is that
     // this machine could not look. openMediaBlob distinguishes the two, and a
     // genuinely missing transcript surfaces there as 410.
-    if (!(await sessionIsKnown(agentSlug, sessionId))) {
+    // sessionIsKnown is satisfied by a metadata entry alone, and openMediaBlob
+    // below opens the transcript by path — so a planted symlink whose metadata
+    // the agent also forged would be FOLLOWED to another agent's transcript.
+    // The realpath guard (unlike sessionIsKnown) refuses that link while still
+    // admitting a legitimately deleted transcript, whose bytes are gone and
+    // which openMediaBlob answers with a 410.
+    if (
+      !(await sessionIsKnown(agentSlug, sessionId)) ||
+      !sessionFileRealPathWithinAgent(agentSlug, sessionId)
+    ) {
       return c.json({ error: 'Session transcript not found' }, 404)
     }
 
@@ -2514,6 +2524,18 @@ agents.get('/:id/sessions/:sessionId/subagent/:agentId/messages', AgentRead(), a
 
     const sessionsDir = getAgentSessionsDir(agentSlug)
     const subagentJsonlPath = path.join(sessionsDir, sessionId, 'subagents', `agent-${subagentId}.jsonl`)
+
+    // sessionId and subagentId are unvalidated URL segments spliced into a
+    // path, so keep the read inside this agent's own session tree: reject a
+    // traversal id lexically, and a symlinked component that resolves out of
+    // the tree via the real path. Without this the route reads an arbitrary
+    // file (another agent's transcript, or anything a planted link points at).
+    if (
+      !isPathWithinDir(sessionsDir, subagentJsonlPath) ||
+      !isRealPathWithinDir(sessionsDir, subagentJsonlPath)
+    ) {
+      return c.json({ error: 'Subagent transcript not found' }, 404)
+    }
 
     const entries = await readJsonlFile(subagentJsonlPath) as any[]
     const messageEntries = entries.filter(

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2526,13 +2526,15 @@ agents.get('/:id/sessions/:sessionId/subagent/:agentId/messages', AgentRead(), a
     const subagentJsonlPath = path.join(sessionsDir, sessionId, 'subagents', `agent-${subagentId}.jsonl`)
 
     // sessionId and subagentId are unvalidated URL segments spliced into a
-    // path, so keep the read inside this agent's own session tree: reject a
+    // path, so keep the read inside this agent's own workspace: reject a
     // traversal id lexically, and a symlinked component that resolves out of
-    // the tree via the real path. Without this the route reads an arbitrary
-    // file (another agent's transcript, or anything a planted link points at).
+    // the tree via the real path. The realpath check is anchored on the
+    // WORKSPACE (the bind-mount point the container can't replace), not the
+    // attacker-writable session dir — a symlinked `-workspace` would otherwise
+    // resolve base and candidate to the same escaped location and pass.
     if (
       !isPathWithinDir(sessionsDir, subagentJsonlPath) ||
-      !isRealPathWithinDir(sessionsDir, subagentJsonlPath)
+      !isRealPathWithinDir(getAgentWorkspaceDir(agentSlug), subagentJsonlPath)
     ) {
       return c.json({ error: 'Subagent transcript not found' }, 404)
     }

--- a/src/api/routes/home-card-health.test.ts
+++ b/src/api/routes/home-card-health.test.ts
@@ -62,11 +62,11 @@ describe('home card health API', () => {
     })
 
     const { isSessionLive } = mockBuildHomeCardHealth.mock.calls[0][0] as {
-      isSessionLive: (sessionId: string) => boolean
+      isSessionLive: (agentSlug: string, sessionId: string) => boolean
     }
     mockIsSessionActive.mockReturnValue(true)
-    expect(isSessionLive('session-1')).toBe(true)
-    expect(mockIsSessionActive).toHaveBeenCalledWith('session-1')
+    expect(isSessionLive('agent-one', 'session-1')).toBe(true)
+    expect(mockIsSessionActive).toHaveBeenCalledWith('agent-one', 'session-1')
   })
 
   it('returns a sanitized error when the batch build fails', async () => {

--- a/src/api/routes/home-card-health.ts
+++ b/src/api/routes/home-card-health.ts
@@ -18,7 +18,8 @@ homeCardHealth.get('/', async (c) => {
       agentSlugs,
       days: parseActivityDays(c.req.query('days')),
       tzOffsetMinutes: parseActivityTzOffset(c.req.query('tz')),
-      isSessionLive: (sessionId) => messagePersister.isSessionActive(sessionId),
+      isSessionLive: (agentSlug: string, sessionId: string) =>
+        messagePersister.isSessionActive(agentSlug, sessionId),
     }))
   } catch (error) {
     console.error('Failed to build home card health:', error)

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -198,7 +198,7 @@ describe('scheduled-tasks route', () => {
       { id: 'session-active', name: 'Active session' },
       { id: 'session-idle', name: 'Idle session' },
     ])
-    mockMessagePersister.isSessionActive.mockImplementation((sessionId: string) => sessionId === 'session-active')
+    mockMessagePersister.isSessionActive.mockImplementation((_agentSlug: string, sessionId: string) => sessionId === 'session-active')
     mockCreateSession.mockResolvedValue({ id: 'container-session-1' })
     mockEnsureRunning.mockResolvedValue({ createSession: mockCreateSession })
     mockGetSecretEnvVars.mockResolvedValue(['GITHUB_TOKEN'])
@@ -257,12 +257,12 @@ describe('scheduled-tasks route', () => {
       scheduledTaskName: 'Daily report',
     })
     expect(mockMessagePersister.subscribeToSession).toHaveBeenCalledWith(
+      'agent-one',
       'container-session-1',
       { createSession: mockCreateSession },
       'container-session-1',
-      'agent-one',
     )
-    expect(mockMessagePersister.markSessionActive).toHaveBeenCalledWith('container-session-1', 'agent-one')
+    expect(mockMessagePersister.markSessionActive).toHaveBeenCalledWith('agent-one', 'container-session-1')
     expect(mockRecordManualExecution).toHaveBeenCalledWith('task-1', 'container-session-1')
     expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
   })

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -69,7 +69,7 @@ scheduledTasksRouter.get('/:taskId/sessions', TaskAgentRole('viewer'), async (c)
     const sessions = await getSessionsByScheduledTask(task!.agentSlug, task!.id)
     const sessionsWithStatus = sessions.map((session) => ({
       ...session,
-      isActive: messagePersister.isSessionActive(session.id),
+      isActive: messagePersister.isSessionActive(task!.agentSlug, session.id),
     }))
     return c.json(sessionsWithStatus)
   } catch (error) {
@@ -97,7 +97,7 @@ scheduledTasksRouter.delete('/:taskId', TaskAgentRole('user'), async (c) => {
         sessionId: task!.resumeSessionId,
         agentSlug: task!.agentSlug,
       })
-      messagePersister.broadcastSessionUpdate(task!.resumeSessionId)
+      messagePersister.broadcastSessionUpdate(task!.agentSlug, task!.resumeSessionId)
     }
 
     return c.body(null, 204)
@@ -335,8 +335,8 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
       scheduledTaskName: task.name || undefined,
     })
 
-    await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug)
-    messagePersister.markSessionActive(sessionId, task.agentSlug)
+    await messagePersister.subscribeToSession(task.agentSlug, sessionId, client, sessionId)
+    messagePersister.markSessionActive(task.agentSlug, sessionId)
 
     if (task.isRecurring) {
       // Recurring: keep schedule, just record the manual execution

--- a/src/api/routes/security-repro.test.ts
+++ b/src/api/routes/security-repro.test.ts
@@ -249,7 +249,7 @@ vi.mock('@shared/lib/services/agent-service', () => ({
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: vi.fn(), updateSessionName: vi.fn(), registerSession: vi.fn(),
   getSessionMessagesWithCompact: vi.fn(), getSession: vi.fn(), getSessionMetadata: vi.fn(),
-  sessionExists: vi.fn().mockResolvedValue(true), sessionBelongsToAgent: vi.fn().mockResolvedValue(true), reserveSessionOwnership: vi.fn().mockResolvedValue(undefined), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+  sessionExists: vi.fn().mockResolvedValue(true), updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
   deleteSession: vi.fn(), removeMessage: vi.fn(), removeToolCall: vi.fn(),
   getSessionSummary: vi.fn().mockResolvedValue({ sessionIds: [], sessionCount: 0, lastActivityAt: null }),
 }))

--- a/src/api/routes/session-scope.integration.test.ts
+++ b/src/api/routes/session-scope.integration.test.ts
@@ -1,10 +1,10 @@
 /**
  * Cross-agent session scoping — REAL services, REAL filesystem.
  *
- * `agents.test.ts` already covers this surface, but it mocks `sessionIsKnown`
- * and `sessionBelongsToAgent`. Those tests prove the routes CALL a gate and
- * honour its answer; they cannot prove the gate is right, and they would stay
- * green if the mechanism behind it were replaced with a broken one.
+ * `agents.test.ts` already covers this surface, but it mocks `sessionIsKnown`.
+ * Those tests prove the routes CALL a gate and honour its answer; they cannot
+ * prove the gate is right, and they would stay green if the mechanism behind
+ * it were replaced with a broken one.
  *
  * This file closes that gap. The session service, the file-storage paths and
  * the message persister are all real, over a real temp data dir. Only the
@@ -281,21 +281,21 @@ beforeEach(async () => {
   writeTranscript(ATTACKER, attackerSession)
 
   // The victim's session is LIVE: subscribed and streaming.
-  await messagePersister.subscribeToSession(victimSession, makeMockClient(), victimSession, VICTIM)
-  await messagePersister.subscribeToSession(attackerSession, makeMockClient(), attackerSession, ATTACKER)
-  messagePersister.markSessionActive(victimSession, VICTIM)
+  await messagePersister.subscribeToSession(VICTIM, victimSession, makeMockClient(), victimSession)
+  await messagePersister.subscribeToSession(ATTACKER, attackerSession, makeMockClient(), attackerSession)
+  messagePersister.markSessionActive(VICTIM, victimSession)
 
   victimEvents = []
   attackerEvents = []
-  cleanupVictimSse = messagePersister.addSSEClient(victimSession, (d) => { victimEvents.push(d) })
-  cleanupAttackerSse = messagePersister.addSSEClient(attackerSession, (d) => { attackerEvents.push(d) })
+  cleanupVictimSse = messagePersister.addSSEClient(VICTIM, victimSession, (d) => { victimEvents.push(d) })
+  cleanupAttackerSse = messagePersister.addSSEClient(ATTACKER, attackerSession, (d) => { attackerEvents.push(d) })
 })
 
 afterEach(() => {
   cleanupVictimSse?.()
   cleanupAttackerSse?.()
-  messagePersister.unsubscribeFromSession(victimSession)
-  messagePersister.unsubscribeFromSession(attackerSession)
+  messagePersister.unsubscribeFromSession(VICTIM, victimSession)
+  messagePersister.unsubscribeFromSession(ATTACKER, attackerSession)
   realFs.rmSync(tmpDir, { recursive: true, force: true })
   if (previousDataDir === undefined) delete process.env.SUPERAGENT_DATA_DIR
   else process.env.SUPERAGENT_DATA_DIR = previousDataDir
@@ -306,8 +306,8 @@ afterEach(() => {
  * Note what it does NOT mention: status codes, ownership indexes, map keys.
  */
 function expectVictimUntouched(): void {
-  expect(messagePersister.isSessionActive(victimSession)).toBe(true)
-  expect(messagePersister.isSubscribed(victimSession)).toBe(true)
+  expect(messagePersister.isSessionActive(VICTIM, victimSession)).toBe(true)
+  expect(messagePersister.isSubscribed(VICTIM, victimSession)).toBe(true)
   expect(victimEvents).toEqual([])
 }
 

--- a/src/api/routes/session-scope.integration.test.ts
+++ b/src/api/routes/session-scope.integration.test.ts
@@ -391,6 +391,49 @@ describe('a forged transcript does not buy access to another agent’s live sess
   })
 })
 
+describe('a symlink forged in the attacker’s workspace resolves to the victim’s file', () => {
+  // Sharper than the plain forged file: a symlink named after the victim's
+  // session, planted in the attacker's own bind-mounted directory, RESOLVES to
+  // the victim's real transcript. A containment check that compares only path
+  // strings treats it as the attacker's own session. There is no benign
+  // reading of this id — it points at a file the attacker does not own — so
+  // here every gated route MUST refuse it (404), not merely leave the victim
+  // untouched.
+  beforeEach(() => {
+    const attackerDir = getAgentSessionsDir(ATTACKER)
+    realFs.mkdirSync(attackerDir, { recursive: true })
+    const link = path.join(attackerDir, `${victimSession}.jsonl`)
+    realFs.rmSync(link, { force: true })
+    realFs.symlinkSync(path.join(getAgentSessionsDir(VICTIM), `${victimSession}.jsonl`), link)
+  })
+
+  it('the messages listing refuses the id', async () => {
+    const res = await app().request(url(ATTACKER, victimSession, '/messages'), { method: 'GET' })
+    expect(res.status).toBe(404)
+    expectVictimUntouched()
+  })
+
+  it('the single-session read refuses the id', async () => {
+    const res = await app().request(url(ATTACKER, victimSession), { method: 'GET' })
+    expect(res.status).toBe(404)
+    expectVictimUntouched()
+  })
+
+  it('interrupt refuses the id', async () => {
+    const res = await post(url(ATTACKER, victimSession, '/interrupt'))
+    expect(res.status).toBe(404)
+    expect(mockInterruptSession).not.toHaveBeenCalled()
+    expectVictimUntouched()
+  })
+
+  it('delete refuses the id and leaves the victim’s real transcript', async () => {
+    const res = await app().request(url(ATTACKER, victimSession), { method: 'DELETE' })
+    expect(res.status).toBe(404)
+    expect(await sessionExists(VICTIM, victimSession)).toBe(true)
+    expectVictimUntouched()
+  })
+})
+
 describe('scoping does not over-block the caller’s own session', () => {
   it('interrupts its own session', async () => {
     const res = await post(url(ATTACKER, attackerSession, '/interrupt'))

--- a/src/api/routes/session-scope.integration.test.ts
+++ b/src/api/routes/session-scope.integration.test.ts
@@ -432,6 +432,40 @@ describe('a symlink forged in the attacker’s workspace resolves to the victim�
     expect(await sessionExists(VICTIM, victimSession)).toBe(true)
     expectVictimUntouched()
   })
+
+  it('media refuses the id even when the attacker also forges its metadata', async () => {
+    // The metadata makes sessionIsKnown pass (it is satisfied by a metadata
+    // entry alone), so only the media route's realpath guard stands between the
+    // request and openMediaBlob following the link into the victim's transcript.
+    await registerSession(ATTACKER, victimSession, 'Forged')
+    const res = await app().request(url(ATTACKER, victimSession, '/media/anyref'), { method: 'GET' })
+    expect(res.status).toBe(404)
+    expectVictimUntouched()
+  })
+})
+
+describe('the subagent-messages route stays inside the agent’s own tree', () => {
+  it('refuses a traversal-shaped session id', async () => {
+    const res = await app().request(
+      `http://localhost/api/agents/${ATTACKER}/sessions/..%2F..%2F${VICTIM}%2Fworkspace/subagent/x/messages`,
+      { method: 'GET' },
+    )
+    expect(res.status).toBe(404)
+    expectVictimUntouched()
+  })
+
+  it('refuses a traversal-shaped subagent id that escapes the session tree', async () => {
+    // Enough `..` to climb out of the agent's session directory entirely (the
+    // `agent-` filename prefix absorbs the first one). Without the guard this
+    // reads an arbitrary file off disk.
+    const escape = Array(10).fill('..').join('%2F')
+    const res = await app().request(
+      `http://localhost/api/agents/${ATTACKER}/sessions/${attackerSession}/subagent/${escape}%2Fetc%2Fpasswd/messages`,
+      { method: 'GET' },
+    )
+    expect(res.status).toBe(404)
+    expectVictimUntouched()
+  })
 })
 
 describe('scoping does not over-block the caller’s own session', () => {

--- a/src/api/routes/webhook-triggers.ts
+++ b/src/api/routes/webhook-triggers.ts
@@ -54,7 +54,7 @@ webhookTriggersRouter.get('/:triggerId/sessions', TriggerAgentRole('viewer'), as
     const sessions = await getSessionsByWebhookTrigger(trigger!.agentSlug, trigger!.id)
     const sessionsWithStatus = sessions.map((session) => ({
       ...session,
-      isActive: messagePersister.isSessionActive(session.id),
+      isActive: messagePersister.isSessionActive(trigger!.agentSlug, session.id),
     }))
     return c.json(sessionsWithStatus)
   } catch (error) {

--- a/src/api/routes/x-agent-chat.test.ts
+++ b/src/api/routes/x-agent-chat.test.ts
@@ -366,7 +366,7 @@ describe('x-agent chat route', () => {
     const { error } = await res.json() as { error: string }
     expect(error).toContain('chat chat-1 (General)')
     expect(error).toContain('delivered to that chat automatically')
-    expect(mockGetChatIntegrationSessionBySessionId).toHaveBeenCalledWith('caller-session')
+    expect(mockGetChatIntegrationSessionBySessionId).toHaveBeenCalledWith('agent-one', 'caller-session')
     expect(connector.sendMessage).not.toHaveBeenCalled()
   })
 

--- a/src/api/routes/x-agent-chat.ts
+++ b/src/api/routes/x-agent-chat.ts
@@ -251,7 +251,7 @@ xAgentChat.post('/send', async (c) => {
     // session is rotated out, its SSE forwarding is torn down, so an outbound
     // send is the only remaining delivery path.
     if (session_id) {
-      const callerChatSession = getChatIntegrationSessionBySessionId(session_id)
+      const callerChatSession = getChatIntegrationSessionBySessionId(callerSlug, session_id)
       if (
         callerChatSession
         && !callerChatSession.archivedAt

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -80,7 +80,6 @@ const mockRegisterSession = vi.fn(async (..._args: unknown[]) => {})
 const mockUpdateSessionMetadata = vi.fn(async (..._args: unknown[]) => {})
 const mockGetSessionMetadata = vi.fn(async (..._args: unknown[]): Promise<unknown> => null)
 const mockSessionIsKnown = vi.fn(async (..._args: unknown[]) => true)
-const mockReserveSessionOwnership = vi.fn(async (..._args: unknown[]) => {})
 vi.mock('@shared/lib/services/session-service', () => ({
   listSessions: (...args: unknown[]) => mockListSessions(...args),
   getSessionMessagesWithCompact: (...args: unknown[]) => mockGetTranscript(...args),
@@ -97,7 +96,6 @@ vi.mock('@shared/lib/services/session-service', () => ({
     return null
   },
   registerSession: (...args: unknown[]) => mockRegisterSession(...args),
-  reserveSessionOwnership: (...args: unknown[]) => mockReserveSessionOwnership(...args),
   updateSessionMetadata: (...args: unknown[]) => mockUpdateSessionMetadata(...args),
   getSessionMetadata: (...args: unknown[]) => mockGetSessionMetadata(...args),
   sessionIsKnown: (...args: unknown[]) => mockSessionIsKnown(...args),
@@ -134,24 +132,24 @@ function waitForIdleTimeoutError(): Error {
 // callers mark/observe the session active before waiting, so "inactive" means
 // the turn already finished.
 function expectBoundedSyncWait(sessionId: string): void {
-  expect(mockWaitForIdle).toHaveBeenCalledWith(sessionId, {
+  expect(mockWaitForIdle).toHaveBeenCalledWith('target-agent', sessionId, {
     timeoutMs: expect.any(Number),
     requireActiveFirst: false,
   })
-  const opts = mockWaitForIdle.mock.calls.at(-1)?.[1] as { timeoutMs: number }
+  const opts = mockWaitForIdle.mock.calls.at(-1)?.[2] as { timeoutMs: number }
   expect(opts.timeoutMs).toBeGreaterThan(0)
   expect(opts.timeoutMs).toBeLessThanOrEqual(120_000)
 }
-const mockIsSessionActive = vi.fn((_sessionId?: string): boolean => false)
-const mockIsSessionAwaitingInput = vi.fn((_sessionId?: string): boolean => false)
+const mockIsSessionActive = vi.fn((_agentSlug?: string, _sessionId?: string): boolean => false)
+const mockIsSessionAwaitingInput = vi.fn((_agentSlug?: string, _sessionId?: string): boolean => false)
 const mockWaitForIdle = vi.fn(async (..._args: unknown[]) => {})
 const mockSubscribeToSession = vi.fn()
 const mockMarkSessionActive = vi.fn()
 const mockBroadcastGlobal = vi.fn()
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
-    isSessionActive: (sessionId?: string) => mockIsSessionActive(sessionId),
-    isSessionAwaitingInput: (sessionId?: string) => mockIsSessionAwaitingInput(sessionId),
+    isSessionActive: (agentSlug?: string, sessionId?: string) => mockIsSessionActive(agentSlug, sessionId),
+    isSessionAwaitingInput: (agentSlug: string, sessionId?: string,) => mockIsSessionAwaitingInput(agentSlug, sessionId),
     waitForIdle: (...args: unknown[]) => mockWaitForIdle(...args),
     isSubscribed: vi.fn(() => false),
     subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
@@ -552,10 +550,10 @@ describe('/invoke', () => {
       }),
     )
     expect(mockCreateSession.mock.calls[0][0]).not.toHaveProperty('initialMessageUuid')
-    expect(mockReserveSessionOwnership).toHaveBeenCalledWith(TARGET_SLUG, 'new-sess-id')
-    expect(mockReserveSessionOwnership.mock.invocationCallOrder[0]).toBeLessThan(
-      mockMarkSessionActive.mock.invocationCallOrder[0],
-    )
+    // The id no longer needs claiming: markSessionActive creates the state
+    // under a key that already carries the target agent, so it cannot collide
+    // with another agent's session of the same id.
+    expect(mockMarkSessionActive).toHaveBeenCalledWith(TARGET_SLUG, 'new-sess-id')
     expect(mockRegisterSession).toHaveBeenCalledWith(
       TARGET_SLUG,
       'new-sess-id',
@@ -1468,7 +1466,7 @@ describe('/get-sessions', () => {
       { id: 'sess-1', name: 'S1', createdAt: new Date(), lastActivityAt: new Date(), messageCount: 3 },
       { id: 'sess-2', name: 'S2', createdAt: new Date(), lastActivityAt: new Date(), messageCount: 0 },
     ])
-    mockIsSessionActive.mockImplementation((id?: string) => id === 'sess-1')
+    mockIsSessionActive.mockImplementation((_agentSlug?: string, id?: string) => id === 'sess-1')
     const res = await authedFetch('/x-agent/get-sessions', { slug: TARGET_SLUG })
     const body = await res.json()
     expect(body.sessions).toHaveLength(2)

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -33,7 +33,6 @@ import {
   findLastSessionEntry,
   getSessionMetadata,
   registerSession,
-  reserveSessionOwnership,
   sessionIsKnown,
 } from '@shared/lib/services/session-service'
 import { containerManager } from '@shared/lib/container/container-manager'
@@ -379,7 +378,7 @@ xAgent.post('/get-sessions', zValidator('json', getSessionsBodySchema), async (c
       createdAt: s.createdAt,
       lastActivityAt: s.lastActivityAt,
       messageCount: s.messageCount,
-      isRunning: messagePersister.isSessionActive(s.id),
+      isRunning: messagePersister.isSessionActive(targetSlug, s.id),
     })),
     total: allSessions.length,
     offset,
@@ -522,6 +521,7 @@ function isWaitForIdleTimeout(error: unknown): boolean {
  * finished — resolving immediately is correct, not a startup race.
  */
 async function waitForTurnWithinBudget(
+  targetSlug: string,
   sessionId: string,
   deadline: number,
 ): Promise<'completed' | 'timeout'> {
@@ -530,10 +530,10 @@ async function waitForTurnWithinBudget(
     // Pre-wait work can eat the whole budget; if the turn already finished
     // during it, that's a completion — reporting 'timeout' here would label a
     // finished turn 'running' and make the caller poll for a result it has.
-    return messagePersister.isSessionActive(sessionId) ? 'timeout' : 'completed'
+    return messagePersister.isSessionActive(targetSlug, sessionId) ? 'timeout' : 'completed'
   }
   try {
-    await messagePersister.waitForIdle(sessionId, {
+    await messagePersister.waitForIdle(targetSlug, sessionId, {
       timeoutMs: remainingMs,
       requireActiveFirst: false,
     })
@@ -621,7 +621,7 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
     return c.json({ error: 'Session not found' }, 404)
   }
 
-  if (sync && messagePersister.isSessionActive(sessionId)) {
+  if (sync && messagePersister.isSessionActive(targetSlug, sessionId)) {
     // Last reply flushed before we started waiting — used below to detect that
     // the turn we waited out has actually reached the transcript file.
     const boundaryEntry = await findLastSessionEntry(targetSlug, sessionId, isReturnableAssistantEntry)
@@ -631,7 +631,7 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
       // repeat, not an unbounded wait — an unbounded wait would outlive the
       // container's 300s fetch header timeout and surface as a retry-inducing
       // network error. Other failures stay hard errors.
-      const outcome = await waitForTurnWithinBudget(sessionId, syncDeadline)
+      const outcome = await waitForTurnWithinBudget(targetSlug, sessionId, syncDeadline)
       // The turn's 'result' event clears isActive before its final assistant
       // entry hits the JSONL file. When the turn we observed running has ended
       // — the wait said so, or it timed out and the turn ended in the gap
@@ -645,7 +645,7 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
       // poll budget on sessions that are simply idle. A session that went idle
       // just before the isSessionActive check above keeps plain read-what's-
       // flushed semantics.
-      if (outcome === 'completed' || !messagePersister.isSessionActive(sessionId)) {
+      if (outcome === 'completed' || !messagePersister.isSessionActive(targetSlug, sessionId)) {
         await readLastAssistantMessage(targetSlug, sessionId, boundaryEntry?.uuid)
       }
     } catch (error) {
@@ -655,8 +655,8 @@ xAgent.post('/get-transcript', zValidator('json', getTranscriptBodySchema), asyn
     }
   }
 
-  const isAwaiting = messagePersister.isSessionAwaitingInput(sessionId)
-  const isActive = messagePersister.isSessionActive(sessionId)
+  const isAwaiting = messagePersister.isSessionAwaitingInput(targetSlug, sessionId)
+  const isActive = messagePersister.isSessionActive(targetSlug, sessionId)
   const status: 'running' | 'idle' | 'awaiting_input' = isAwaiting
     ? 'awaiting_input'
     : isActive
@@ -771,7 +771,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         if (!(await sessionIsKnown(targetSlug, existingSessionId))) {
           return c.json({ error: 'Session not found' }, 404)
         }
-        if (messagePersister.isSessionActive(existingSessionId)) {
+        if (messagePersister.isSessionActive(targetSlug, existingSessionId)) {
           return c.json({ error: 'Target session is currently running' }, 409)
         }
         stage = 'ensure_running'
@@ -783,9 +783,9 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
           ? await findLastSessionEntry(targetSlug, existingSessionId, isReturnableAssistantEntry)
           : null
         stage = 'subscribe'
-        if (!messagePersister.isSubscribed(existingSessionId)) {
+        if (!messagePersister.isSubscribed(targetSlug, existingSessionId)) {
           await subscribeWithTimeout(
-            messagePersister.subscribeToSession(existingSessionId, client, existingSessionId, targetSlug),
+            messagePersister.subscribeToSession(targetSlug, existingSessionId, client, existingSessionId),
           )
         }
         // Checked AFTER every unbounded pre-send await (container startup and
@@ -800,7 +800,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
           })
           return c.json({ error: deliveryCutoffError() }, 504)
         }
-        messagePersister.markSessionActive(existingSessionId, targetSlug)
+        messagePersister.markSessionActive(targetSlug, existingSessionId)
         stage = 'send_message'
         let messageUuid: string | undefined
         if (isAuthMode() && attributedUserId) {
@@ -828,7 +828,7 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
           stage = 'wait_for_idle'
           let outcome: 'completed' | 'timeout'
           try {
-            outcome = await waitForTurnWithinBudget(existingSessionId, syncDeadline)
+            outcome = await waitForTurnWithinBudget(targetSlug, existingSessionId, syncDeadline)
           } catch (error) {
             return c.json({
               sessionId: existingSessionId,
@@ -926,9 +926,8 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
       }
       const containerSession = created
       const newSessionId = containerSession.id
-      await reserveSessionOwnership(targetSlug, newSessionId)
       // Mark active before any await so waitForIdle sees state if result arrives early.
-      messagePersister.markSessionActive(newSessionId, targetSlug)
+      messagePersister.markSessionActive(targetSlug, newSessionId)
 
       const authorRecorded = initialMessageUuid && attributedUserId
         ? await insertMessageAuthorBestEffort({
@@ -976,14 +975,14 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         if (authorRecorded && initialMessageUuid) {
           await deleteMessageAuthorBestEffort(initialMessageUuid)
         }
-        messagePersister.unsubscribeFromSession(newSessionId)
+        messagePersister.unsubscribeFromSession(targetSlug, newSessionId)
         return c.json({ error: `Failed to register invoked session: ${message}` }, 500)
       }
 
       stage = 'subscribe'
       try {
         await subscribeWithTimeout(
-          messagePersister.subscribeToSession(newSessionId, client, newSessionId, targetSlug),
+          messagePersister.subscribeToSession(targetSlug, newSessionId, client, newSessionId),
         )
       } catch (subscribeErr) {
         const message = subscribeErr instanceof Error ? subscribeErr.message : String(subscribeErr)
@@ -1010,18 +1009,18 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
         if (authorRecorded && initialMessageUuid) {
           await deleteMessageAuthorBestEffort(initialMessageUuid)
         }
-        messagePersister.unsubscribeFromSession(newSessionId)
+        messagePersister.unsubscribeFromSession(targetSlug, newSessionId)
         return c.json({ error: `Failed to attach to invoked session: ${message}` }, 500)
       }
       if (containerSession.slashCommands && containerSession.slashCommands.length > 0) {
-        messagePersister.setSlashCommands(newSessionId, containerSession.slashCommands)
+        messagePersister.setSlashCommands(targetSlug, newSessionId, containerSession.slashCommands)
       }
 
       if (sync) {
         stage = 'wait_for_idle'
         let outcome: 'completed' | 'timeout'
         try {
-          outcome = await waitForTurnWithinBudget(newSessionId, syncDeadline)
+          outcome = await waitForTurnWithinBudget(targetSlug, newSessionId, syncDeadline)
         } catch (error) {
           return c.json({
             sessionId: newSessionId,

--- a/src/shared/lib/chat-integrations/chat-integration-manager-archived-restore.sup233.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-archived-restore.sup233.test.ts
@@ -139,7 +139,7 @@ describe('SUP-233 reconnect restore ignores archived sessions', () => {
     // Drives connectIntegration -> restore loop.
     await chatIntegrationManager.addIntegration(integrationId)
 
-    const subscribedSessionIds = addSSEClient.mock.calls.map((c) => c[0])
+    const subscribedSessionIds = addSSEClient.mock.calls.map((c) => c[1])
     expect(subscribedSessionIds).toContain('active-agent-session')
     expect(subscribedSessionIds).not.toContain('archived-agent-session')
   })

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1622,7 +1622,7 @@ class ChatIntegrationManager {
     // If we know the sessionId, send only to the chat session that owns it
     if (sessionId) {
       try {
-        const chatSession = getChatIntegrationSessionBySessionId(sessionId)
+        const chatSession = getChatIntegrationSessionBySessionId(agentSlug, sessionId)
         if (chatSession) {
           const key = `${chatSession.integrationId}:${chatSession.externalChatId}`
           const managed = this.chatSessions.get(key)

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -698,18 +698,19 @@ class ChatIntegrationManager {
   private subscribeChatSession(integrationId: string, chatId: string, sessionId: string): void {
     const session = this.getOrCreateChatSession(integrationId, chatId)
     if (!session) return
+    const agentSlug = session.integration.agentSlug
 
     // Clean up any previous subscription + its indicator tick
     session.sseUnsubscribe?.()
     stopIndicatorTick(session)
 
-    const unsubscribe = messagePersister.addSSEClient(sessionId, (event: unknown) => {
+    const unsubscribe = messagePersister.addSSEClient(agentSlug, sessionId, (event: unknown) => {
       // Wake on a BUSY snapshot: an event means something changed, so re-arm the tick if the
       // session is now busy (and it had slept), painting immediately on a cold arm. A non-busy
       // event is ignored — it must NOT arm a tick that nothing would sleep, nor cancel a pending
       // sleep. Synchronous and BEFORE the serialization queue, so a backed-up handler can't
       // delay the wake. The tick — not this — keeps painting.
-      armIndicatorIfBusy(session, sessionId, messagePersister.getSessionActivity(sessionId))
+      armIndicatorIfBusy(session, sessionId, messagePersister.getSessionActivity(agentSlug, sessionId))
       // Serialize SSE event processing per chat session to prevent race conditions
       // (e.g. session_idle arriving while stream_delta's sendStreamingUpdate is still in-flight)
       this.enqueueSSEEvent(integrationId, chatId, event, sessionId)
@@ -722,7 +723,7 @@ class ChatIntegrationManager {
     // this snapshot is what arms the tick; we never depend on a future event to start it. The
     // tick is alive for the subscription, not the turn.
     session.sessionId = sessionId
-    const coldActivity = messagePersister.getSessionActivity(sessionId)
+    const coldActivity = messagePersister.getSessionActivity(agentSlug, sessionId)
     armIndicatorIfBusy(session, sessionId, coldActivity)
     if (!BUSY_ACTIVITIES.has(coldActivity)) clearIndicator(session)
   }
@@ -751,7 +752,7 @@ class ChatIntegrationManager {
     for (const session of this.chatSessions.values()) {
       const sessionId = session.sessionId
       if (!sessionId || session.indicatorTickTimer) continue
-      armIndicatorIfBusy(session, sessionId, messagePersister.getSessionActivity(sessionId))
+      armIndicatorIfBusy(session, sessionId, messagePersister.getSessionActivity(session.integration.agentSlug, sessionId))
     }
 
     await this.reconcileIntegrations({ force: false })
@@ -1051,8 +1052,8 @@ class ChatIntegrationManager {
     // Hoisted so the catch can reuse it for self-heal without re-downloading.
     let messageText = ''
     try {
-      if (!messagePersister.isSubscribed(sessionId)) {
-        await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug)
+      if (!messagePersister.isSubscribed(integration.agentSlug, sessionId)) {
+        await messagePersister.subscribeToSession(integration.agentSlug, sessionId, client, sessionId)
       }
 
       // Ensure SSE → chat forwarding is active (may have been torn down by reconnect)
@@ -1099,7 +1100,7 @@ class ChatIntegrationManager {
       if (consumed) return
 
       await client.sendMessage(sessionId, messageText)
-      messagePersister.markSessionActive(sessionId, integration.agentSlug)
+      messagePersister.markSessionActive(integration.agentSlug, sessionId)
       const now = Date.now()
       const lastTouch = this.lastSessionTouch.get(chatSession.id) ?? 0
       if (now - lastTouch > 60_000) {
@@ -1222,8 +1223,8 @@ class ChatIntegrationManager {
       displayName,
     })
 
-    await messagePersister.subscribeToSession(sessionId, client, sessionId, integration.agentSlug)
-    messagePersister.markSessionActive(sessionId, integration.agentSlug)
+    await messagePersister.subscribeToSession(integration.agentSlug, sessionId, client, sessionId)
+    messagePersister.markSessionActive(integration.agentSlug, sessionId)
     this.subscribeChatSession(integration.id, chatId, sessionId)
   }
 
@@ -1761,7 +1762,7 @@ class ChatIntegrationManager {
           // Settle immediately — parallel tool calls hold the transcript
           // tool_result until every sibling resolves. The registry entry's
           // scope supplies the session.
-          messagePersister.completeInputRequest(undefined, toolUseId, 'answered')
+          messagePersister.completeInputRequest(undefined, undefined, toolUseId, 'answered')
         }
         return
       }
@@ -1779,7 +1780,7 @@ class ChatIntegrationManager {
         console.error(`[ChatIntegrationManager] Failed to resolve input ${toolUseId}:`, text)
         reportError(new Error(`Resolve input failed: ${resolveResponse.status}`), 'resolve-input', { integrationId, toolUseId, status: resolveResponse.status })
       } else {
-        messagePersister.completeInputRequest(undefined, toolUseId, 'answered')
+        messagePersister.completeInputRequest(undefined, undefined, toolUseId, 'answered')
       }
     } catch (err) {
       console.error(`[ChatIntegrationManager] Failed to handle interactive response:`, err)
@@ -1930,7 +1931,7 @@ export function startIndicatorTick(managed: ManagedConnector, sessionId: string)
   cancelIndicatorSleep(managed)
   if (managed.indicatorTickTimer) return false
   managed.indicatorTickTimer = setInterval(() => {
-    const activity = messagePersister.getSessionActivity(sessionId)
+    const activity = messagePersister.getSessionActivity(managed.integration.agentSlug, sessionId)
     reconcileIndicator(managed, activity)
     // The tick owns its own sleep: a busy read keeps it awake (cancel any pending stop), the
     // first of a sustained non-busy run starts the debounce. scheduleIndicatorSleep is arm-once,
@@ -1993,7 +1994,7 @@ export function scheduleIndicatorSleep(managed: ManagedConnector): void {
   if (!sessionId) return
   managed.sleepTimer = setTimeout(() => {
     managed.sleepTimer = null
-    if (!BUSY_ACTIVITIES.has(messagePersister.getSessionActivity(sessionId))) {
+    if (!BUSY_ACTIVITIES.has(messagePersister.getSessionActivity(managed.integration.agentSlug, sessionId))) {
       // Clear before stopping: stopIndicatorTick only drops timers, so stopping a tick that
       // is somehow still showing a draft would strand it. Clearing first makes the guard
       // self-defending regardless of how the caller left indicatorShown.

--- a/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
+++ b/src/shared/lib/chat-integrations/perpetual-thinking.repro.test.ts
@@ -3,7 +3,7 @@
  *
  * The indicator is a self-healing projection of the agent's activity:
  *  - The manager owns a per-session TICK (alive for the SSE subscription, not a
- *    turn). Each tick reads `messagePersister.getSessionActivity(sessionId)` and
+ *    turn). Each tick reads `messagePersister.getSessionActivity(agentSlug, sessionId)` and
  *    reconciles the connector. The tick is the ONLY thing that PAINTS, and the
  *    self-healing backstop — a stuck or wrong indicator self-corrects within one
  *    tick because the tick re-reads reality every interval.

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
@@ -13,8 +13,8 @@
  */
 
 interface AwaitingInputPersister {
-  isSessionAwaitingInput(sessionId: string): boolean
-  cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void>
+  isSessionAwaitingInput(agentSlug: string, sessionId: string): boolean
+  cancelAwaitingInput(agentSlug: string, sessionId: string): Promise<void>
 }
 
 /**
@@ -60,7 +60,7 @@ export async function consumeOrCancelAwaitingInput(opts: {
   // only on a confirmed live resolve; a non-text message, a multi-question card, or any other
   // awaiting type falls through to cancel.
   const isPlainText = !!messageText.trim() && !hasFiles
-  if (isPlainText && persister.isSessionAwaitingInput(sessionId)) {
+  if (isPlainText && persister.isSessionAwaitingInput(agentSlug, sessionId)) {
     // Recovered stubs are excluded the same way they are excluded from the
     // wire: they carry no renderable payload, so no card was ever posted and
     // there is nothing in this chat for the text to answer.
@@ -76,7 +76,7 @@ export async function consumeOrCancelAwaitingInput(opts: {
   // Not an answer: cancel the pending request so the message starts a fresh turn instead of
   // deadlocking behind the blocked tool (no-op when not awaiting), and strip the now-abandoned
   // card so it does not keep showing live buttons.
-  await persister.cancelAwaitingInput(sessionId, agentSlug)
+  await persister.cancelAwaitingInput(agentSlug, sessionId)
   await connector.dismissOpenCards(chatId)
   return false
 }

--- a/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
+++ b/src/shared/lib/chat-integrations/resolve-awaiting-input.ts
@@ -25,7 +25,7 @@ interface AwaitingInputPersister {
  * already settled.
  */
 interface OpenRequestRegistry {
-  getOpenRequestsForSession(sessionId: string): Array<{
+  getOpenRequestsForSession(agentSlug: string, sessionId: string): Array<{
     id: string
     kind: string
     payload: unknown
@@ -65,7 +65,7 @@ export async function consumeOrCancelAwaitingInput(opts: {
     // wire: they carry no renderable payload, so no card was ever posted and
     // there is nothing in this chat for the text to answer.
     const pendingQuestion = registry
-      .getOpenRequestsForSession(sessionId)
+      .getOpenRequestsForSession(agentSlug, sessionId)
       .find((r) => r.kind === 'question' && (r.payload as { recovered?: unknown }).recovered !== true)
     if (pendingQuestion) {
       const answered = await connector.answerOpenQuestionWithText(chatId, pendingQuestion.id, answerText ?? messageText)

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -124,10 +124,10 @@ class ContainerManager {
       takeCoalescedUserMessages: (id) => messagePersister.takeCoalescedUserMessages(agentId, id),
       isSessionRecovering: (id) => messagePersister.isSessionRecovering(agentId, id),
       isSubscribed: (id) => messagePersister.isSubscribed(agentId, id),
-      subscribeToSession: (sessionId, client, containerSessionId, agentSlug) =>
-        // Recovery only ever resubscribes THIS agent's sessions; the deps
-        // interface still carries the slug, and it must agree with agentId.
-        messagePersister.subscribeToSession(agentSlug ?? agentId, sessionId, client, containerSessionId),
+      subscribeToSession: (sessionId, client, containerSessionId) =>
+        // Recovery only ever resubscribes THIS agent's sessions, so the slug is
+        // agentId — never a value the caller could disagree with.
+        messagePersister.subscribeToSession(agentId, sessionId, client, containerSessionId),
       restrictToSessionIds,
       syncAgentStatus: async () => {
         try {

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -119,13 +119,15 @@ class ContainerManager {
       ensureRunning: () => this.ensureRunning(agentId),
       snapshotMidTurnSessions: (slug, restrict) => messagePersister.snapshotMidTurnSessions(slug, restrict),
       consumeLastFatal: (slug) => messagePersister.consumeLastFatal(slug),
-      settleRecoveringSessions: (ids) => messagePersister.settleRecoveringSessions(ids),
-      markRecovered: (ids) => messagePersister.markRecovered(ids),
-      takeCoalescedUserMessages: (id) => messagePersister.takeCoalescedUserMessages(id),
-      isSessionRecovering: (id) => messagePersister.isSessionRecovering(id),
-      isSubscribed: (id) => messagePersister.isSubscribed(id),
+      settleRecoveringSessions: (ids) => messagePersister.settleRecoveringSessions(agentId, ids),
+      markRecovered: (ids) => messagePersister.markRecovered(agentId, ids),
+      takeCoalescedUserMessages: (id) => messagePersister.takeCoalescedUserMessages(agentId, id),
+      isSessionRecovering: (id) => messagePersister.isSessionRecovering(agentId, id),
+      isSubscribed: (id) => messagePersister.isSubscribed(agentId, id),
       subscribeToSession: (sessionId, client, containerSessionId, agentSlug) =>
-        messagePersister.subscribeToSession(sessionId, client, containerSessionId, agentSlug),
+        // Recovery only ever resubscribes THIS agent's sessions; the deps
+        // interface still carries the slug, and it must agree with agentId.
+        messagePersister.subscribeToSession(agentSlug ?? agentId, sessionId, client, containerSessionId),
       restrictToSessionIds,
       syncAgentStatus: async () => {
         try {

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -333,7 +333,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
   const cardsFor = (kind: string) =>
     sseEvents.filter((e) => e.type === 'user_request_created' && e.request?.kind === kind)
   const openStreamRequestIds = () =>
-    userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'stream')
+    userInputRequestManager.getStoreIdsForSession(AGENT_SLUG, SESSION_ID, 'stream')
 
   function simulateToolUse(toolName: string, toolId: string, input: Record<string, unknown>) {
     mockClient._sendMessage({
@@ -914,7 +914,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         )
         expect(
           userInputRequestManager
-            .getOpenRequestsForSession(SESSION_ID)
+            .getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)
             .some((r) => r.id === 'side-sr-auto' && r.autoApproved === true)
         ).toBe(true)
 
@@ -981,11 +981,11 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
         await vi.waitFor(() => {
           expect(
-            userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+            userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID).map((r) => r.id)
           ).toContain(toolId)
         })
         const entry = userInputRequestManager
-          .getOpenRequestsForSession(SESSION_ID)
+          .getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)
           .find((r) => r.id === toolId)!
         expect(entry.kind, kindCase.label).toBe(kindCase.kind)
         expect(entry.scope).toEqual({ agentSlug: AGENT_SLUG, sessionId: SESSION_ID })
@@ -994,7 +994,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
         sendToolResult(toolId)
         expect(
-          userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+          userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID).map((r) => r.id)
         ).not.toContain(toolId)
         expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
           id: toolId,
@@ -1007,7 +1007,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
     it('a stray main-path tool_result cannot evict the registry\'s computer-use entry (store-scoped resolve)', () => {
       simulateToolUse('mcp__computer-use__computer_click', 'shadow-cu-1', { x: 1, y: 2 })
-      expect(userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'computer_use')).toEqual([
+      expect(userInputRequestManager.getStoreIdsForSession(AGENT_SLUG, SESSION_ID, 'computer_use')).toEqual([
         'shadow-cu-1',
       ])
 
@@ -1015,12 +1015,12 @@ describe('pending user-input request lifecycle (characterization)', () => {
       // untouched. The registry mirrors the STORE, not the tool_result — if it
       // settled here, the inline parity assert would blow up this test.
       sendToolResult('shadow-cu-1')
-      expect(userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'computer_use')).toEqual([
+      expect(userInputRequestManager.getStoreIdsForSession(AGENT_SLUG, SESSION_ID, 'computer_use')).toEqual([
         'shadow-cu-1',
       ])
 
       messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'shadow-cu-1')
-      expect(userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'computer_use')).toEqual([])
+      expect(userInputRequestManager.getStoreIdsForSession(AGENT_SLUG, SESSION_ID, 'computer_use')).toEqual([])
       expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-cu-1',
         kind: 'computer_use',
@@ -1038,17 +1038,17 @@ describe('pending user-input request lifecycle (characterization)', () => {
         questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
       })
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
-      expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(true)
+      expect(userInputRequestManager.isSessionAwaiting(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The first tool_result settles one request; the second card is still
       // parked, so bit and projection both stay on — the persister's status
       // IS the projection now.
       sendToolResult('shadow-par-1')
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
-      expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(true)
+      expect(userInputRequestManager.isSessionAwaiting(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       sendToolResult('shadow-par-2')
-      expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
+      expect(userInputRequestManager.isSessionAwaiting(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(userInputRequestManager.stats.mismatches).toBe(0)
     })
@@ -1064,16 +1064,16 @@ describe('pending user-input request lifecycle (characterization)', () => {
       simulateToolUse('Workflow', 'shadow-cap-1', { script: 'export const meta = {}' })
       await vi.waitFor(() => {
         expect(
-          userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+          userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID).map((r) => r.id)
         ).toContain('shadow-cap-1')
       })
       expect(
-        userInputRequestManager.getOpenRequestsForSession(SESSION_ID)[0].kind
+        userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)[0].kind
       ).toBe('capability_review')
 
       messagePersister.completeCapabilityReview(AGENT_SLUG, SESSION_ID, 'shadow-cap-1')
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
-      expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
+      expect(userInputRequestManager.isSessionAwaiting(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(userInputRequestManager.stats.mismatches).toBe(0)
     })
@@ -1089,7 +1089,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       simulateToolUse('Workflow', 'shadow-out-1', { script: 'export const meta = {}' })
       await vi.waitFor(() => {
         expect(
-          userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+          userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID).map((r) => r.id)
         ).toContain('shadow-out-1')
       })
       messagePersister.completeCapabilityReview(AGENT_SLUG, SESSION_ID, 'shadow-out-1', 'declined')
@@ -1124,10 +1124,10 @@ describe('pending user-input request lifecycle (characterization)', () => {
         reason: 'Need it',
       })
       simulateToolUse('mcp__computer-use__computer_click', 'shadow-drop-2', { x: 1, y: 2 })
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(2)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(2)
 
       messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
       expect(
         userInputRequestManager.stats.recentResolutions.slice(-2).map((r) => r.outcome)
       ).toEqual(['invalidated', 'invalidated'])
@@ -1261,7 +1261,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         openStreamRequestIds()
       ).toEqual(['resub-secret-1'])
       expect(
-        userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
+        userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID).map((r) => r.id)
       ).toContain('resub-secret-1')
       messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
@@ -1311,7 +1311,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       simulateToolUse('AskUserQuestion', 'par-question-1', {
         questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
       })
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(2)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(2)
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       messagePersister.completeInputRequest(AGENT_SLUG, SESSION_ID, 'par-secret-1', 'declined')
@@ -1319,7 +1319,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       // Registry and replay store both drop the declined ask NOW — a reload
       // must not resurrect it. The surviving question keeps the light on.
       expect(
-        userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id),
+        userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID).map((r) => r.id),
       ).toEqual(['par-question-1'])
       expect(openStreamRequestIds()).toEqual(
         ['par-question-1'],
@@ -1379,7 +1379,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       // supplies the session.
       messagePersister.completeInputRequest(AGENT_SLUG, undefined, 'par-solo-1', 'answered')
 
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
   })
@@ -1412,7 +1412,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
     it('a subagent that dies with a parked request invalidates it everywhere', async () => {
       sendSidechainToolUse('parent-dead-1', 'side-orphan-1')
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(1)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
 
       // The subagent finishes WITHOUT a tool_result for the parked ask
       // (killed, errored, or torn down) — sidechain 'result' is its terminal
@@ -1423,7 +1423,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         subtype: 'success',
       })
 
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(openStreamRequestIds()).toHaveLength(0)
       expect(
@@ -1468,7 +1468,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       })
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(
-        userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id),
+        userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID).map((r) => r.id),
       ).toEqual(['side-script-1'])
 
       mockClient._sendMessage({
@@ -1477,7 +1477,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         subtype: 'success',
       })
 
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(
         userInputRequestManager.stats.recentResolutions.find((r) => r.id === 'side-script-1')
@@ -1488,7 +1488,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
     it("a sibling subagent's death leaves another subagent's parked request open", () => {
       sendSidechainToolUse('parent-alive-1', 'side-kept-1')
       sendSidechainToolUse('parent-dying-1', 'side-dropped-1')
-      expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(2)
+      expect(userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)).toHaveLength(2)
 
       mockClient._sendMessage({
         type: 'result',
@@ -1496,7 +1496,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         subtype: 'success',
       })
 
-      const open = userInputRequestManager.getOpenRequestsForSession(SESSION_ID)
+      const open = userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID)
       expect(open.map((r) => r.id)).toEqual(['side-kept-1'])
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
@@ -1512,7 +1512,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         subtype: 'success',
       })
       expect(
-        userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id),
+        userInputRequestManager.getOpenRequestsForSession(AGENT_SLUG, SESSION_ID).map((r) => r.id),
       ).toEqual(['main-secret-1'])
       expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })

--- a/src/shared/lib/container/message-persister.request-lifecycle.test.ts
+++ b/src/shared/lib/container/message-persister.request-lifecycle.test.ts
@@ -304,15 +304,15 @@ describe('pending user-input request lifecycle (characterization)', () => {
     userInputRequestManager.reset()
 
     mockClient = createMockClient()
-    await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+    await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
     // Requests park mid-turn: production always has markSessionActive before
     // any request event arrives, and the derived awaiting projection is gated
     // on an active turn (an inactive session is never awaiting).
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const events: any[] = []
-    sseCleanup = messagePersister.addSSEClient(SESSION_ID, (data) => {
+    sseCleanup = messagePersister.addSSEClient(AGENT_SLUG, SESSION_ID, (data) => {
       events.push(data)
     })
     sseEvents = events
@@ -322,7 +322,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
     if (originalE2eMock === undefined) delete process.env.E2E_MOCK
     else process.env.E2E_MOCK = originalE2eMock
     sseCleanup()
-    messagePersister.unsubscribeFromSession(SESSION_ID)
+    messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
     vi.clearAllMocks()
     mockCheckPermission.mockReturnValue('prompt_needed')
   })
@@ -385,7 +385,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         expect(cards).toHaveLength(1)
         expect(cards[0].request.id).toBe('tool-open-1')
 
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(true)
         expect(
           openStreamRequestIds()
@@ -400,11 +400,11 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
       it('resolves: the tool_result drops the replay entry and clears awaiting', () => {
         simulateToolUse(toolName, 'tool-resolve-1', input)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
         sendToolResult('tool-resolve-1')
 
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
         expect(openStreamRequestIds()).toHaveLength(0)
       })
 
@@ -426,11 +426,11 @@ describe('pending user-input request lifecycle (characterization)', () => {
         // while the second card is parked. (This was the pinned parallel-
         // request split-brain before the flip: the imperative clear dropped
         // the bit on the first tool_result.)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         expect(openStreamRequestIds()).toHaveLength(1)
 
         sendToolResult('tool-par-2')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
         expect(openStreamRequestIds()).toHaveLength(0)
       })
     }
@@ -479,9 +479,9 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(cards[0].request.id).toBe('cu-open-1')
       expect(cards[0].request.autoApproved).toBe(false)
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(
-        messagePersister.getPendingComputerUseRequests(SESSION_ID).map((r) => r.toolUseId)
+        messagePersister.getPendingComputerUseRequests(AGENT_SLUG, SESSION_ID).map((r) => r.toolUseId)
       ).toContain('cu-open-1')
       expect(openStreamRequestIds()).toHaveLength(0)
 
@@ -494,7 +494,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
     it('a tool_result alone does NOT drop the parked entry — and awaiting stays on with it', () => {
       simulateToolUse(TOOL, 'cu-clear-1', { x: 1, y: 2 })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The computer-use store is cleared only via the decision route's
       // explicit call, so the entry survives a stray tool_result. Derived
@@ -503,13 +503,13 @@ describe('pending user-input request lifecycle (characterization)', () => {
       // without consulting this store.)
       sendToolResult('cu-clear-1')
       expect(
-        messagePersister.getPendingComputerUseRequests(SESSION_ID).map((r) => r.toolUseId)
+        messagePersister.getPendingComputerUseRequests(AGENT_SLUG, SESSION_ID).map((r) => r.toolUseId)
       ).toContain('cu-clear-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
-      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-1')
-      expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'cu-clear-1')
+      expect(messagePersister.getPendingComputerUseRequests(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('the route clear flips awaiting and broadcasts when it was the last blocking wait', () => {
@@ -520,18 +520,18 @@ describe('pending user-input request lifecycle (characterization)', () => {
       })
       try {
         simulateToolUse(TOOL, 'cu-clear-2', { x: 1, y: 2 })
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
         // The route clear applies the shared waiting-light rule: with both
         // stores empty and no external blocker, the bit flips AND the wire
         // says input was provided — together, atomically. (Before the unified
         // dispatch change it broadcast without flipping the bit, leaving the
         // wire and the bit disagreeing until the tool_result landed.)
-        messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-2')
+        messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'cu-clear-2')
         expect(
           globalEvents.filter((e) => e.type === 'session_input_provided')
         ).toHaveLength(1)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       } finally {
         cleanup()
       }
@@ -543,13 +543,13 @@ describe('pending user-input request lifecycle (characterization)', () => {
         reason: 'Need it',
       })
       simulateToolUse(TOOL, 'cu-clear-3', { x: 1, y: 2 })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Clearing the computer-use entry must NOT flip awaiting: the secret
       // is still parked on the other store.
-      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'cu-clear-3')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
-      expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
+      messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'cu-clear-3')
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(messagePersister.getPendingComputerUseRequests(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
     })
   })
 
@@ -573,7 +573,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       await vi.waitFor(() => {
         expect(cardsFor('capability_review')).toHaveLength(1)
       })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(
         openStreamRequestIds()
       ).toContain('wf-lifecycle-1')
@@ -591,7 +591,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         expect(openStreamRequestIds()).toHaveLength(1)
       })
 
-      messagePersister.completeCapabilityReview(SESSION_ID, 'wf-lifecycle-2')
+      messagePersister.completeCapabilityReview(AGENT_SLUG, SESSION_ID, 'wf-lifecycle-2')
 
       expect(openStreamRequestIds()).toHaveLength(0)
       expect(
@@ -602,7 +602,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       // Derived awaiting: settling the review settles the wait. (Before the
       // flip this door emptied its store and broadcast but left the bit stuck
       // until later stream traffic cleared it — a pinned split-brain.)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
   })
 
@@ -637,40 +637,40 @@ describe('pending user-input request lifecycle (characterization)', () => {
         reason: 'Need it',
       })
       simulateToolUse('mcp__computer-use__computer_click', 'mix-cu-1', { x: 1, y: 2 })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The secret resolves, but the cu entry AND the review are still open.
       sendToolResult('mix-secret-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The cu entry resolves, but the review is still open.
-      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'mix-cu-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'mix-cu-1')
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The review settles — nothing is open anymore.
       userInputRequestManager.resolve('mix-review-1', 'answered')
       messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('the agent-wide sync cannot clear awaiting while a review remains open', () => {
       parkAgentReview('mix-review-2')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Before the derived flip, the agent-level clear door trusted its
       // caller to verify no reviews remained — a caller that forgot cleared
       // awaiting under a live review. The projection makes that impossible:
       // sync recomputes from the registry, and the review is still in it.
       messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // A stray tool_result on the session doesn't drop it either.
       sendToolResult('unknown-tool-id')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       userInputRequestManager.resolve('mix-review-2', 'declined')
       messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
   })
 
@@ -795,7 +795,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
         const cards = cardsFor(kind)
         expect(cards).toHaveLength(surfacesToday ? 1 : 0)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(surfacesToday)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(surfacesToday)
       })
 
       it('complete sidechain assistant message: card broadcast and awaiting match the matrix', () => {
@@ -803,7 +803,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
         const cards = cardsFor(kind)
         expect(cards).toHaveLength(surfacesToday ? 1 : 0)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(surfacesToday)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(surfacesToday)
       })
     }
   )
@@ -871,14 +871,14 @@ describe('pending user-input request lifecycle (characterization)', () => {
         'parent-res',
         'complete'
       )
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       sseEvents.length = 0
 
       sendSidechainToolResult('side-res-1', 'parent-res')
 
       expect(sseEvents.filter((e) => e.type === 'tool_result')).toHaveLength(1)
       expect(openStreamRequestIds()).toHaveLength(0)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('the sidechain resolve applies the both-stores rule: a parked computer-use keeps awaiting on', () => {
@@ -890,14 +890,14 @@ describe('pending user-input request lifecycle (characterization)', () => {
         'complete'
       )
       simulateToolUse('mcp__computer-use__computer_click', 'side-cu-1', { x: 1, y: 2 })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       sendSidechainToolResult('side-q-1', 'parent-mix')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Clearing the last computer-use entry now flips the light (shared rule).
-      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'side-cu-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'side-cu-1')
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('an auto-approved script replay entry does not keep awaiting on after the last real ask resolves', async () => {
@@ -926,12 +926,12 @@ describe('pending user-input request lifecycle (characterization)', () => {
           'parent-auto',
           'complete'
         )
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
         // The auto-approved script's replay entry is still tracked, but it is
         // not a real wait — resolving the secret must clear awaiting.
         sendSidechainToolResult('side-real-1', 'parent-auto')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       } finally {
         vi.unstubAllGlobals()
       }
@@ -953,17 +953,17 @@ describe('pending user-input request lifecycle (characterization)', () => {
         'parent-blk',
         'complete'
       )
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The subagent's ask resolves, but the review is still parked — the
       // waiting light must stay on.
       sendSidechainToolResult('side-blk-1', 'parent-blk')
       expect(openStreamRequestIds()).toHaveLength(0)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       userInputRequestManager.resolve('side-review-1', 'answered')
       messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
   })
 
@@ -1019,7 +1019,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         'shadow-cu-1',
       ])
 
-      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-cu-1')
+      messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'shadow-cu-1')
       expect(userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'computer_use')).toEqual([])
       expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-cu-1',
@@ -1037,19 +1037,19 @@ describe('pending user-input request lifecycle (characterization)', () => {
       simulateToolUse('AskUserQuestion', 'shadow-par-2', {
         questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
       })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(true)
 
       // The first tool_result settles one request; the second card is still
       // parked, so bit and projection both stay on — the persister's status
       // IS the projection now.
       sendToolResult('shadow-par-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(true)
 
       sendToolResult('shadow-par-2')
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(userInputRequestManager.stats.mismatches).toBe(0)
     })
 
@@ -1071,10 +1071,10 @@ describe('pending user-input request lifecycle (characterization)', () => {
         userInputRequestManager.getOpenRequestsForSession(SESSION_ID)[0].kind
       ).toBe('capability_review')
 
-      messagePersister.completeCapabilityReview(SESSION_ID, 'shadow-cap-1')
+      messagePersister.completeCapabilityReview(AGENT_SLUG, SESSION_ID, 'shadow-cap-1')
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
       expect(userInputRequestManager.isSessionAwaiting(SESSION_ID, AGENT_SLUG)).toBe(false)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(userInputRequestManager.stats.mismatches).toBe(0)
     })
 
@@ -1092,7 +1092,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
           userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
         ).toContain('shadow-out-1')
       })
-      messagePersister.completeCapabilityReview(SESSION_ID, 'shadow-out-1', 'declined')
+      messagePersister.completeCapabilityReview(AGENT_SLUG, SESSION_ID, 'shadow-out-1', 'declined')
       expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-out-1',
         kind: 'capability_review',
@@ -1101,7 +1101,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
       // Computer use denied, then a second one consumed by an execution failure.
       simulateToolUse('mcp__computer-use__computer_click', 'shadow-out-2', { x: 1, y: 2 })
-      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-out-2', 'declined')
+      messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'shadow-out-2', 'declined')
       expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-out-2',
         kind: 'computer_use',
@@ -1109,7 +1109,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       })
 
       simulateToolUse('mcp__computer-use__computer_click', 'shadow-out-3', { x: 3, y: 4 })
-      messagePersister.clearPendingComputerUseRequest(SESSION_ID, 'shadow-out-3', 'invalidated')
+      messagePersister.clearPendingComputerUseRequest(AGENT_SLUG, SESSION_ID, 'shadow-out-3', 'invalidated')
       expect(userInputRequestManager.stats.recentResolutions.at(-1)).toMatchObject({
         id: 'shadow-out-3',
         kind: 'computer_use',
@@ -1126,7 +1126,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       simulateToolUse('mcp__computer-use__computer_click', 'shadow-drop-2', { x: 1, y: 2 })
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(2)
 
-      messagePersister.unsubscribeFromSession(SESSION_ID)
+      messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
       expect(
         userInputRequestManager.stats.recentResolutions.slice(-2).map((r) => r.outcome)
@@ -1155,10 +1155,10 @@ describe('pending user-input request lifecycle (characterization)', () => {
     }
 
     it('cancelAwaitingInput rejects recovered entries on the container despite the wire filter', async () => {
-      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
+      messagePersister.recoverSessionAwaitingInput(AGENT_SLUG, SESSION_ID, [
         { toolUseId: 'rec-cancel-1', toolName: 'AskUserQuestion' },
       ])
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       // A recovered synthetic is a real wait in the registry but carries no
       // renderable payload, so no card event goes out for it — clients render
       // it from the transcript that triggered the recovery.
@@ -1168,13 +1168,13 @@ describe('pending user-input request lifecycle (characterization)', () => {
       // The container-side cleanup still has to happen on cancel: the
       // recovered ask is exactly the one whose container pending may still be
       // live, and a late answer must not land on the abandoned turn.
-      await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+      await messagePersister.cancelAwaitingInput(AGENT_SLUG, SESSION_ID)
 
       const rejectedUrls = mockContainerClientFetch.mock.calls
         .map((call) => call[0])
         .filter((url): url is string => typeof url === 'string' && url.endsWith('/reject'))
       expect(rejectedUrls).toContain('/inputs/rec-cancel-1/reject')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('a clean success mid-turn re-derives awaiting instead of blind-clearing it', () => {
@@ -1192,20 +1192,20 @@ describe('pending user-input request lifecycle (characterization)', () => {
           session_state_events: true,
         })
         parkAgentReview('boundary-review-1')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
         mockClient._sendMessage({ type: 'result', subtype: 'success', num_turns: 1 })
 
         // Still active (the runtime owns idle) and the review is still open —
         // the session keeps reading awaiting, and no falling edge fires.
-        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         expect(globalEvents.filter((e) => e.type === 'session_input_provided')).toHaveLength(0)
 
         // The review settles → the falling edge fires now, not never.
         userInputRequestManager.resolve('boundary-review-1', 'answered')
         messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
         expect(globalEvents.filter((e) => e.type === 'session_input_provided')).toHaveLength(1)
       } finally {
         cleanup()
@@ -1221,12 +1221,12 @@ describe('pending user-input request lifecycle (characterization)', () => {
       try {
         // End the current turn (result-driven idle — no authority announced).
         mockClient._sendMessage({ type: 'result', subtype: 'success', num_turns: 1 })
-        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
 
         // A review parks while the session is idle: an inactive session never
         // reads awaiting.
         parkAgentReview('boundary-review-2')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
 
         // The runtime starts the next (queued) turn itself — no POST, no
         // markSessionActive. The self-heal must sync the projection too.
@@ -1235,8 +1235,8 @@ describe('pending user-input request lifecycle (characterization)', () => {
           subtype: 'session_state_changed',
           state: 'running',
         })
-        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         expect(globalEvents.filter((e) => e.type === 'session_awaiting_input')).toHaveLength(1)
       } finally {
         cleanup()
@@ -1248,12 +1248,12 @@ describe('pending user-input request lifecycle (characterization)', () => {
         secretName: 'API_KEY',
         reason: 'Need it',
       })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Reattach the stream (reconnect of an in-flight session). Only the
       // transport may turn over — the wait itself is still parked.
       const secondClient = createMockClient()
-      await messagePersister.subscribeToSession(SESSION_ID, secondClient, SESSION_ID, AGENT_SLUG)
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, secondClient, SESSION_ID)
 
       // Replay store, registry entry, and cache all still agree, so a later
       // sync must NOT clear the genuinely parked ask.
@@ -1264,7 +1264,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
         userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id)
       ).toContain('resub-secret-1')
       messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The parked ask resolves over the NEW transport and settles normally.
       secondClient._sendMessage({
@@ -1275,21 +1275,21 @@ describe('pending user-input request lifecycle (characterization)', () => {
           ],
         },
       })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(openStreamRequestIds()).toHaveLength(0)
     })
 
     it('the markSessionIdle revert clears the awaiting cache an agent review had set', () => {
       parkAgentReview('boundary-review-3')
       // markSessionActive's trailing sync picks up the open review.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The optimistic send fails → revert. An inactive session is never
       // awaiting, review or not — the cache resets with isActive.
-      messagePersister.markSessionIdle(SESSION_ID)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      messagePersister.markSessionIdle(AGENT_SLUG, SESSION_ID)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
   })
 
@@ -1312,9 +1312,9 @@ describe('pending user-input request lifecycle (characterization)', () => {
         questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
       })
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(2)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
-      messagePersister.completeInputRequest(SESSION_ID, 'par-secret-1', 'declined')
+      messagePersister.completeInputRequest(AGENT_SLUG, SESSION_ID, 'par-secret-1', 'declined')
 
       // Registry and replay store both drop the declined ask NOW — a reload
       // must not resurrect it. The surviving question keeps the light on.
@@ -1324,7 +1324,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(openStreamRequestIds()).toEqual(
         ['par-question-1'],
       )
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(
         userInputRequestManager.stats.recentResolutions.find((r) => r.id === 'par-secret-1')
           ?.outcome,
@@ -1346,7 +1346,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       ).toHaveLength(1)
 
       sendToolResult('par-question-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('the settled outcome is stamped for the messages route until the turn boundary clears it', () => {
@@ -1357,15 +1357,15 @@ describe('pending user-input request lifecycle (characterization)', () => {
         secretName: 'API_KEY',
         reason: 'Need it',
       })
-      messagePersister.completeInputRequest(SESSION_ID, 'par-stamp-1', 'declined')
-      expect(messagePersister.getSettledInputRequests(SESSION_ID).get('par-stamp-1')).toBe(
+      messagePersister.completeInputRequest(AGENT_SLUG, SESSION_ID, 'par-stamp-1', 'declined')
+      expect(messagePersister.getSettledInputRequests(AGENT_SLUG, SESSION_ID).get('par-stamp-1')).toBe(
         'declined',
       )
 
       // The turn boundary lands the real results in the transcript — the
       // stamp expires with it.
       mockClient._sendMessage({ type: 'result', subtype: 'success', num_turns: 1 })
-      expect(messagePersister.getSettledInputRequests(SESSION_ID).size).toBe(0)
+      expect(messagePersister.getSettledInputRequests(AGENT_SLUG, SESSION_ID).size).toBe(0)
     })
 
     it('settling the last parked ask clears awaiting, and callers without a sessionId derive it', () => {
@@ -1373,14 +1373,14 @@ describe('pending user-input request lifecycle (characterization)', () => {
         secretName: 'API_KEY',
         reason: 'Need it',
       })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Chat connectors know only the toolUseId — the registry entry's scope
       // supplies the session.
-      messagePersister.completeInputRequest(undefined, 'par-solo-1', 'answered')
+      messagePersister.completeInputRequest(AGENT_SLUG, undefined, 'par-solo-1', 'answered')
 
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
   })
 
@@ -1411,7 +1411,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
     it('a subagent that dies with a parked request invalidates it everywhere', async () => {
       sendSidechainToolUse('parent-dead-1', 'side-orphan-1')
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(1)
 
       // The subagent finishes WITHOUT a tool_result for the parked ask
@@ -1424,7 +1424,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       })
 
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(openStreamRequestIds()).toHaveLength(0)
       expect(
         userInputRequestManager.stats.recentResolutions.find((r) => r.id === 'side-orphan-1')
@@ -1466,7 +1466,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
           ],
         },
       })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(
         userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id),
       ).toEqual(['side-script-1'])
@@ -1478,7 +1478,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       })
 
       expect(userInputRequestManager.getOpenRequestsForSession(SESSION_ID)).toHaveLength(0)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(
         userInputRequestManager.stats.recentResolutions.find((r) => r.id === 'side-script-1')
           ?.outcome,
@@ -1498,7 +1498,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
       const open = userInputRequestManager.getOpenRequestsForSession(SESSION_ID)
       expect(open.map((r) => r.id)).toEqual(['side-kept-1'])
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it("a main-agent request has no parent linkage and survives subagent completions", () => {
@@ -1514,7 +1514,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(
         userInputRequestManager.getOpenRequestsForSession(SESSION_ID).map((r) => r.id),
       ).toEqual(['main-secret-1'])
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
   })
 
@@ -1619,12 +1619,17 @@ describe('pending user-input request lifecycle (characterization)', () => {
       expect(resolved[0].outcome).toBe('declined')
     })
 
-    it('a request without a verified agentSlug never reaches the global stream (fail closed)', () => {
+    it('a request without a verified agentSlug reaches no stream at all (fail closed)', () => {
       // The global-stream ACL filter forwards events without a top-level
       // agentSlug to EVERY authenticated user. The scope schema types the
       // slug as optional, so the broadcast boundary must fail closed rather
-      // than trust that every registration path populated it. The session
-      // stream still gets the event — its subscribers are AgentRead-gated.
+      // than trust that every registration path populated it.
+      //
+      // The session stream used to still receive it, because it was addressed
+      // by session id alone. It is addressed by agent AND session now, so a
+      // request that names no agent cannot be routed to a session stream
+      // either — strictly more closed than before, and the reason a slugless
+      // registration is a bug to find rather than a delivery to preserve.
       userInputRequestManager.register({
         id: 'wire-noslug-1',
         kind: 'secret',
@@ -1646,19 +1651,19 @@ describe('pending user-input request lifecycle (characterization)', () => {
 
       expect(createdFor(globalEvents, 'wire-noslug-1')).toHaveLength(0)
       expect(createdFor(globalEvents, 'wire-noslug-2')).toHaveLength(0)
-      expect(createdFor(sseEvents, 'wire-noslug-1')).toHaveLength(1)
-      expect(createdFor(sseEvents, 'wire-noslug-2')).toHaveLength(1)
+      expect(createdFor(sseEvents, 'wire-noslug-1')).toHaveLength(0)
+      expect(createdFor(sseEvents, 'wire-noslug-2')).toHaveLength(0)
 
       userInputRequestManager.resolve('wire-noslug-1', 'answered')
       expect(resolvedFor(globalEvents, 'wire-noslug-1')).toHaveLength(0)
-      expect(resolvedFor(sseEvents, 'wire-noslug-1')).toHaveLength(1)
+      expect(resolvedFor(sseEvents, 'wire-noslug-1')).toHaveLength(0)
     })
 
     it('recovery synthetics never hit the wire — the transcript renders those cards', () => {
-      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
+      messagePersister.recoverSessionAwaitingInput(AGENT_SLUG, SESSION_ID, [
         { toolUseId: 'wire-recovered-1', toolName: 'AskUserQuestion' },
       ])
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(createdFor(globalEvents, 'wire-recovered-1')).toHaveLength(0)
       expect(createdFor(sseEvents, 'wire-recovered-1')).toHaveLength(0)
     })
@@ -1669,7 +1674,7 @@ describe('pending user-input request lifecycle (characterization)', () => {
       // the real registration forever: clients never receive a renderable
       // user_request_created and the snapshot serves a stub the card guards
       // drop.
-      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
+      messagePersister.recoverSessionAwaitingInput(AGENT_SLUG, SESSION_ID, [
         { toolUseId: 'wire-upgrade-1', toolName: 'mcp__user-input__request_secret' },
       ])
       expect(createdFor(globalEvents, 'wire-upgrade-1')).toHaveLength(0)

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -293,7 +293,7 @@ describe('MessagePersister', () => {
   const requestCards = (kind: string) =>
     sseEvents.filter((e) => e.type === 'user_request_created' && e.request?.kind === kind)
   const openStreamRequestIds = () =>
-    userInputRequestManager.getStoreIdsForSession(SESSION_ID, 'stream')
+    userInputRequestManager.getStoreIdsForSession(AGENT_SLUG, SESSION_ID, 'stream')
 
   beforeEach(async () => {
     mockClient = createMockClient()

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -182,7 +182,7 @@ vi.mock('./container-manager', () => ({
 }))
 
 // Import after mocks are set up
-import { messagePersister, redactStreamedToolInput, WaitForIdleTimeoutError } from './message-persister'
+import { messagePersister, redactStreamedToolInput, sessionKeyOf, WaitForIdleTimeoutError } from './message-persister'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { finalizeAutomationStatus, getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
@@ -272,9 +272,9 @@ function createMockClient(): ContainerClient & {
 }
 
 // Helper to collect SSE events from a session
-function collectSSEEvents(sessionId: string): { events: any[]; cleanup: () => void } {
+function collectSSEEvents(agentSlug: string, sessionId: string): { events: any[]; cleanup: () => void } {
   const events: any[] = []
-  const cleanup = messagePersister.addSSEClient(sessionId, (data) => {
+  const cleanup = messagePersister.addSSEClient(agentSlug, sessionId, (data) => {
     events.push(data)
   })
   return { events, cleanup }
@@ -297,16 +297,16 @@ describe('MessagePersister', () => {
 
   beforeEach(async () => {
     mockClient = createMockClient()
-    await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+    await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
 
-    const sse = collectSSEEvents(SESSION_ID)
+    const sse = collectSSEEvents(AGENT_SLUG, SESSION_ID)
     sseEvents = sse.events
     sseCleanup = sse.cleanup
   })
 
   afterEach(() => {
     sseCleanup()
-    messagePersister.unsubscribeFromSession(SESSION_ID)
+    messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
     vi.clearAllMocks()
   })
 
@@ -330,7 +330,7 @@ describe('MessagePersister', () => {
       // every cache-backed list until the first complete assistant frame.
       vi.useFakeTimers({ now: new Date('2026-08-07T18:30:00.000Z') })
       try {
-        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       } finally {
         vi.useRealTimers()
       }
@@ -344,25 +344,25 @@ describe('MessagePersister', () => {
     })
 
     it('re-marking an active session for a queued message records again', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       expect(mockRecordProvisionalSessionActivity).toHaveBeenCalledTimes(2)
     })
 
     it('reverts the send record when the send is rolled back before reaching the container', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       const mark = mockRecordProvisionalSessionActivity.mock.results[0]!.value
 
-      messagePersister.markSessionIdle(SESSION_ID)
+      messagePersister.markSessionIdle(AGENT_SLUG, SESSION_ID)
 
       expect(mockRevertSessionActivity).toHaveBeenCalledTimes(1)
       expect(mockRevertSessionActivity).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, mark)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('does not revert once the container has answered the send', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._messageCallback!({
         type: 'message',
         content: { type: 'assistant', message: { role: 'assistant', content: 'working' } },
@@ -370,7 +370,7 @@ describe('MessagePersister', () => {
         sessionId: SESSION_ID,
       })
 
-      messagePersister.markSessionIdle(SESSION_ID)
+      messagePersister.markSessionIdle(AGENT_SLUG, SESSION_ID)
 
       expect(mockRevertSessionActivity).not.toHaveBeenCalled()
     })
@@ -390,7 +390,7 @@ describe('MessagePersister', () => {
     })
 
     it('refreshes a session that finished while detached from its transcript mtime, not the replay time', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockRecordSessionActivity.mockClear()
       mockStat.mockResolvedValueOnce({ mtimeMs: 1_754_600_000_000, size: 4096 })
 
@@ -421,7 +421,7 @@ describe('MessagePersister', () => {
   describe('completion notification response selection', () => {
     it('passes only the newest merged textual assistant response at authoritative idle', async () => {
       mockStat.mockResolvedValueOnce({ size: 12_345 })
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system',
         subtype: 'capabilities',
@@ -541,7 +541,7 @@ describe('MessagePersister', () => {
           resolveStat = resolve
         }),
       )
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'assistant',
         uuid: 'final-entry',
@@ -566,7 +566,7 @@ describe('MessagePersister', () => {
     })
 
     it('does not reuse working text when the newest assistant item is tool-only', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'assistant',
         uuid: 'working-entry',
@@ -604,7 +604,7 @@ describe('MessagePersister', () => {
     })
 
     it('does not reuse the prior answer when a queued turn produces no assistant item', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system',
         subtype: 'capabilities',
@@ -621,7 +621,7 @@ describe('MessagePersister', () => {
 
       // The second request is queued before turn A's result. It then ends with
       // no assistant frame (for example, a prompt hook blocks it).
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'result',
         subtype: 'success',
@@ -683,17 +683,17 @@ describe('MessagePersister', () => {
         },
       },
     ])('does not consume the queued-turn guard on $label results', ({ result }) => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system',
         subtype: 'capabilities',
         session_state_events: true,
       })
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       mockClient._sendMessage(result)
 
-      const state = (messagePersister as any).streamingStates.get(SESSION_ID)
+      const state = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
       expect(state.queuedTurnCount).toBe(1)
       expect(state.resetAssistantBeforeNextTurnOutput).toBe(false)
 
@@ -710,7 +710,7 @@ describe('MessagePersister', () => {
     })
 
     it('settles a self-healed running event followed by idle without a new result', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system',
         subtype: 'capabilities',
@@ -749,7 +749,7 @@ describe('MessagePersister', () => {
         state: 'idle',
       })
 
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
       expect(notificationManager.triggerSessionComplete).toHaveBeenCalledWith(
         SESSION_ID,
@@ -759,7 +759,7 @@ describe('MessagePersister', () => {
     })
 
     it('does not notify for a modern success-subtype error result', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system',
         subtype: 'capabilities',
@@ -784,7 +784,7 @@ describe('MessagePersister', () => {
     })
 
     it('does not notify when a legacy turn exits for resume', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'assistant',
         uuid: 'resume-answer',
@@ -878,7 +878,7 @@ describe('MessagePersister', () => {
     it('settles a session whose blocked first turn ended before the socket attached', async () => {
       // The wedge signature: the route marked the session active, but no live
       // turn frames ever arrived (they fired into the WS attach gap).
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
       sendCapabilities()
 
@@ -901,20 +901,20 @@ describe('MessagePersister', () => {
       })
 
       expect(mockAppendInformationalEntry).toHaveBeenCalledTimes(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(sseEvents.some((e) => e.type === 'session_idle')).toBe(true)
     })
 
     it('ignores replayed frames when the live copies were already processed', () => {
       // A full live turn settles the session…
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sendCapabilities()
       mockClient._sendMessage({
         type: 'result', subtype: 'success', is_error: false, duration_ms: 100, num_turns: 1,
         usage: { input_tokens: 0, output_tokens: 0 },
       })
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
       sseEvents.length = 0
       vi.clearAllMocks()
 
@@ -1108,15 +1108,15 @@ describe('MessagePersister', () => {
     })
 
     it('leaves "compacting" via getSessionActivity when compaction completes (no stale "Compacting…")', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID) // active → 'working'
       mockClient._sendMessage({ type: 'system', subtype: 'status', status: 'compacting', session_id: SESSION_ID, uuid: 's1' })
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('compacting')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('compacting')
 
       // The compact-summary user message clears isCompacting (state.isCompacting was true).
       mockClient._sendMessage({ type: 'user', session_id: SESSION_ID, uuid: 'summary-1' })
 
       // The pull projection must immediately leave 'compacting' (the tick re-reads it).
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('working')
     })
   })
 
@@ -1413,7 +1413,7 @@ describe('MessagePersister', () => {
         })
 
         expect(sseEvents.filter(e => e.type === 'subagent_completed')).toHaveLength(1)
-        expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
+        expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
         expect(userInputRequestManager.getOpenRequest('blocked-bg-child-request')).toBeNull()
       } finally {
         userInputRequestManager.resolve('blocked-bg-child-request', 'cancelled')
@@ -1480,7 +1480,7 @@ describe('MessagePersister', () => {
       })
 
       expect(sseEvents.filter(e => e.type === 'subagent_completed')).toHaveLength(0)
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toEqual([
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toEqual([
         expect.objectContaining({ taskId: 'agent-resumed', isSubagent: true }),
       ])
 
@@ -1514,7 +1514,7 @@ describe('MessagePersister', () => {
     // background-bash-premature-idle capture shape; replace with a real workflow capture
     // fixture when one is available.)
     it('treats a local_workflow as a background task and survives a premature idle', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       // Make session_state_changed the idle authority (matches the container handshake).
       mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
       sseEvents.length = 0
@@ -1572,7 +1572,7 @@ describe('MessagePersister', () => {
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
       expect(sseEvents.some(e => e.type === 'session_idle')).toBe(false)
       expect(sseEvents.some(e => e.type === 'background_task_completed')).toBe(false)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Workflow settles → its terminal clears the background task exactly once.
       mockClient._sendMessage({
@@ -1675,7 +1675,7 @@ describe('MessagePersister', () => {
       sseEvents.length = 0
 
       // Interrupt the session
-      await messagePersister.markSessionInterrupted(SESSION_ID)
+      await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID)
 
       // Now tool_result should NOT trigger subagent_completed since state was cleared
       mockClient._sendMessage({
@@ -1705,7 +1705,7 @@ describe('MessagePersister', () => {
       })
 
       // Mark session active first
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       sseEvents.length = 0
 
@@ -2325,8 +2325,8 @@ describe('MessagePersister', () => {
     })
 
     it('skips messages after session is interrupted (except result)', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-      await messagePersister.markSessionInterrupted(SESSION_ID)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID)
 
       sseEvents.length = 0
 
@@ -2486,20 +2486,20 @@ describe('MessagePersister', () => {
 
   describe('markSessionIdle', () => {
     it('flips an active session back to idle and broadcasts session_idle', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
       sseEvents.length = 0
 
-      messagePersister.markSessionIdle(SESSION_ID)
+      messagePersister.markSessionIdle(AGENT_SLUG, SESSION_ID)
 
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(sseEvents.filter((e) => e.type === 'session_idle')).toHaveLength(1)
     })
 
     it('is a no-op on an already-idle session', () => {
       sseEvents.length = 0
 
-      messagePersister.markSessionIdle(SESSION_ID)
+      messagePersister.markSessionIdle(AGENT_SLUG, SESSION_ID)
 
       expect(sseEvents).toHaveLength(0)
     })
@@ -2658,11 +2658,11 @@ describe('MessagePersister', () => {
 
   describe('slash commands', () => {
     it('getSlashCommands returns empty array for unknown session', () => {
-      expect(messagePersister.getSlashCommands('nonexistent')).toEqual([])
+      expect(messagePersister.getSlashCommands(AGENT_SLUG, 'nonexistent')).toEqual([])
     })
 
     it('getSlashCommands returns empty array initially', () => {
-      expect(messagePersister.getSlashCommands(SESSION_ID)).toEqual([])
+      expect(messagePersister.getSlashCommands(AGENT_SLUG, SESSION_ID)).toEqual([])
     })
 
     it('setSlashCommands stores and getSlashCommands retrieves', () => {
@@ -2670,16 +2670,16 @@ describe('MessagePersister', () => {
         { name: 'compact', description: 'Clear history', argumentHint: '<instructions>' },
         { name: 'review', description: 'Review code', argumentHint: '' },
       ]
-      messagePersister.setSlashCommands(SESSION_ID, commands)
-      expect(messagePersister.getSlashCommands(SESSION_ID)).toEqual(commands)
+      messagePersister.setSlashCommands(AGENT_SLUG, SESSION_ID, commands)
+      expect(messagePersister.getSlashCommands(AGENT_SLUG, SESSION_ID)).toEqual(commands)
     })
 
     it('setSlashCommands is a no-op for unknown session', () => {
       // Should not throw
-      messagePersister.setSlashCommands('nonexistent', [
+      messagePersister.setSlashCommands(AGENT_SLUG, 'nonexistent', [
         { name: 'test', description: '', argumentHint: '' },
       ])
-      expect(messagePersister.getSlashCommands('nonexistent')).toEqual([])
+      expect(messagePersister.getSlashCommands(AGENT_SLUG, 'nonexistent')).toEqual([])
     })
 
     it('captures slash commands from init event as fallback when none are set', () => {
@@ -2702,7 +2702,7 @@ describe('MessagePersister', () => {
       ])
 
       // Should be retrievable via accessor
-      const stored = messagePersister.getSlashCommands(SESSION_ID)
+      const stored = messagePersister.getSlashCommands(AGENT_SLUG, SESSION_ID)
       expect(stored).toHaveLength(3)
       expect(stored[0].name).toBe('compact')
     })
@@ -2712,7 +2712,7 @@ describe('MessagePersister', () => {
       const richCommands = [
         { name: 'Order Canvas Print', description: 'Order a framed canvas', argumentHint: '<image>' },
       ]
-      messagePersister.setSlashCommands(SESSION_ID, richCommands)
+      messagePersister.setSlashCommands(AGENT_SLUG, SESSION_ID, richCommands)
 
       sseEvents.length = 0
 
@@ -2724,7 +2724,7 @@ describe('MessagePersister', () => {
         slash_commands: ['order-canvas-print', 'review'],
       })
 
-      const stored = messagePersister.getSlashCommands(SESSION_ID)
+      const stored = messagePersister.getSlashCommands(AGENT_SLUG, SESSION_ID)
       expect(stored).toEqual([
         { name: 'order-canvas-print', description: 'Order a framed canvas', argumentHint: '<image>' },
         { name: 'review', description: '', argumentHint: '' },
@@ -2738,7 +2738,7 @@ describe('MessagePersister', () => {
       const commands = [
         { name: 'cost', description: 'Show cost', argumentHint: '' },
       ]
-      messagePersister.setSlashCommands(SESSION_ID, commands)
+      messagePersister.setSlashCommands(AGENT_SLUG, SESSION_ID, commands)
 
       sseEvents.length = 0
 
@@ -3226,7 +3226,7 @@ describe('MessagePersister', () => {
       // Requests park mid-turn: production always has markSessionActive before
       // a request event arrives, and the derived awaiting projection is gated
       // on an active turn (an inactive session is never awaiting).
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     })
 
     // Helper to collect global notification events
@@ -3261,7 +3261,7 @@ describe('MessagePersister', () => {
     }
 
     it('isSessionAwaitingInput returns false initially', () => {
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('sets isAwaitingInput after request_secret tool fires', () => {
@@ -3270,32 +3270,32 @@ describe('MessagePersister', () => {
         reason: 'Need it',
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('preserves initial-turn active and awaiting flags across stream subscription', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       simulateToolUse('mcp__user-input__request_secret', 'tool-1', {
         secretName: 'API_KEY',
         reason: 'Need it',
       })
 
-      await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
 
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(true)
     })
 
     it('recovers awaiting input for an active session from persisted request fallback', () => {
       const { events: globalEvents, cleanup: globalCleanup } = collectGlobalEvents()
 
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-      messagePersister.recoverSessionAwaitingInput(SESSION_ID, AGENT_SLUG, [
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      messagePersister.recoverSessionAwaitingInput(AGENT_SLUG, SESSION_ID, [
         { toolUseId: 'recovered-1', toolName: 'mcp__user-input__request_secret' },
       ])
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_SLUG)).toBe(true)
 
       const awaitingEvents = globalEvents.filter(e => e.type === 'session_awaiting_input')
@@ -3316,7 +3316,7 @@ describe('MessagePersister', () => {
           ],
         },
       })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
 
       globalCleanup()
     })
@@ -3324,11 +3324,11 @@ describe('MessagePersister', () => {
     it('does not recover awaiting input for an inactive session', () => {
       // A session with no active turn (here: no streaming state at all — the
       // post-restart shape this fallback exists for) must not be recovered.
-      messagePersister.recoverSessionAwaitingInput('inactive-session-1', AGENT_SLUG, [
+      messagePersister.recoverSessionAwaitingInput(AGENT_SLUG, 'inactive-session-1', [
         { toolUseId: 'recovered-2', toolName: 'mcp__user-input__request_secret' },
       ])
 
-      expect(messagePersister.isSessionAwaitingInput('inactive-session-1')).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, 'inactive-session-1')).toBe(false)
     })
 
     it('sets isAwaitingInput after AskUserQuestion tool fires', () => {
@@ -3336,7 +3336,7 @@ describe('MessagePersister', () => {
         questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('sets isAwaitingInput after request_connected_account tool fires', () => {
@@ -3345,7 +3345,7 @@ describe('MessagePersister', () => {
         reason: 'Need access',
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('sets isAwaitingInput after request_file tool fires', () => {
@@ -3353,7 +3353,7 @@ describe('MessagePersister', () => {
         description: 'Upload a CSV',
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('sets isAwaitingInput after request_remote_mcp tool fires', () => {
@@ -3361,7 +3361,7 @@ describe('MessagePersister', () => {
         url: 'https://example.com/mcp',
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('sets isAwaitingInput after request_browser_input tool fires', () => {
@@ -3370,7 +3370,7 @@ describe('MessagePersister', () => {
         requirements: ['Enter credentials'],
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     // A background subagent's request_browser_input must flip the SAME awaiting
@@ -3412,7 +3412,7 @@ describe('MessagePersister', () => {
         const cards = requestCards('browser_input')
         expect(cards).toHaveLength(1)
         expect(cards[0].request.id).toBe('sub-tool-1')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
       })
 
       it('sets isAwaitingInput when a subagent complete assistant message carries request_browser_input', () => {
@@ -3433,7 +3433,7 @@ describe('MessagePersister', () => {
           },
         })
 
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         const awaiting = globalEvents.filter(e => e.type === 'session_awaiting_input')
         expect(awaiting).toHaveLength(1)
         expect(awaiting[0].sessionId).toBe(SESSION_ID)
@@ -3467,7 +3467,7 @@ describe('MessagePersister', () => {
         const { events: globalEvents, cleanup } = collectGlobalEvents()
 
         sendSidechainBrowserInputRequest('agent-tool-3', 'sub-tool-3')
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         expect(openStreamRequestIds()).toHaveLength(1)
 
         sseEvents.length = 0
@@ -3486,7 +3486,7 @@ describe('MessagePersister', () => {
           },
         })
 
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
         expect(openStreamRequestIds()).toHaveLength(0)
         // Same broadcast the main path uses — other windows drop their card copy off it
         const results = sseEvents.filter(e => e.type === 'tool_result')
@@ -3511,7 +3511,7 @@ describe('MessagePersister', () => {
           },
         })
 
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         expect(openStreamRequestIds()).toHaveLength(1)
       })
 
@@ -3534,7 +3534,7 @@ describe('MessagePersister', () => {
           },
         })
 
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         expect(openStreamRequestIds()).toEqual(['main-q-1'])
       })
     })
@@ -3546,7 +3546,7 @@ describe('MessagePersister', () => {
         prompt: 'Do something',
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('does NOT set isAwaitingInput for deliver_file tool', () => {
@@ -3555,13 +3555,13 @@ describe('MessagePersister', () => {
         description: 'Results',
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('does NOT set isAwaitingInput for non-user-input tools', () => {
       simulateToolUse('Bash', 'tool-1', { command: 'ls' })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('broadcasts session_awaiting_input globally when status transitions', () => {
@@ -3594,10 +3594,10 @@ describe('MessagePersister', () => {
     })
 
     it('clears isAwaitingInput when tool result arrives (user message)', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       simulateToolUse('mcp__user-input__request_secret', 'tool-1', { secretName: 'KEY' })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Simulate tool result arriving as a user message
       mockClient._sendMessage({
@@ -3609,11 +3609,11 @@ describe('MessagePersister', () => {
         },
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('keeps isAwaitingInput on tool result while a parked review is open', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       // A parked proxy/x-agent review keeps the agent awaiting even as an
       // unrelated tool result lands. The review lives outside the stream maps
@@ -3632,7 +3632,7 @@ describe('MessagePersister', () => {
 
       try {
         simulateToolUse('mcp__user-input__request_secret', 'tool-1', { secretName: 'KEY' })
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
         // User answers the secret; its tool result arrives while the review is still up.
         mockClient._sendMessage({
@@ -3645,19 +3645,19 @@ describe('MessagePersister', () => {
         })
 
         // Must stay awaiting — the review is still open.
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
         // Once the review resolves, the agent-wide sync settles the session.
         userInputRequestManager.resolve('blocker-review-1', 'answered')
         messagePersister.syncAgentSessionsAwaiting(AGENT_SLUG)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       } finally {
         userInputRequestManager.resolve('blocker-review-1', 'cancelled')
       }
     })
 
     it('broadcasts session_input_provided globally when input is received', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       simulateToolUse('mcp__user-input__request_secret', 'tool-1', { secretName: 'KEY' })
 
@@ -3682,10 +3682,10 @@ describe('MessagePersister', () => {
     })
 
     it('clears isAwaitingInput when session goes idle (result event)', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       simulateToolUse('mcp__user-input__request_secret', 'tool-1', { secretName: 'KEY' })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Simulate session completing
       mockClient._sendMessage({
@@ -3693,32 +3693,32 @@ describe('MessagePersister', () => {
         subtype: 'success',
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('clears isAwaitingInput when session is interrupted', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       simulateToolUse('mcp__user-input__request_secret', 'tool-1', { secretName: 'KEY' })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
-      await messagePersister.markSessionInterrupted(SESSION_ID)
+      await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID)
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('clears isAwaitingInput when new user message starts (markSessionActive)', () => {
       simulateToolUse('mcp__user-input__request_secret', 'tool-1', { secretName: 'KEY' })
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // New message starts a new turn
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('returns false for unknown session IDs', () => {
-      expect(messagePersister.isSessionAwaitingInput('nonexistent-session')).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, 'nonexistent-session')).toBe(false)
     })
 
     // ------------------------------------------------------------------
@@ -3736,14 +3736,14 @@ describe('MessagePersister', () => {
         mockContainerClientFetch.mock.calls.find((c) => c[0] === `/sessions/${SESSION_ID}/interrupt`)
 
       it('interrupts a top-level AskUserQuestion BEFORE cleanup-rejecting it (aborted turn cannot resume into a filler reply)', async () => {
-        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
         simulateToolUse('AskUserQuestion', 'q-1', {
           questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
         })
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         mockContainerClientFetch.mockClear()
 
-        await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+        await messagePersister.cancelAwaitingInput(AGENT_SLUG, SESSION_ID)
 
         const calls = mockContainerClientFetch.mock.calls
         const interruptIdx = calls.findIndex((c) => c[0] === `/sessions/${SESSION_ID}/interrupt`)
@@ -3754,86 +3754,86 @@ describe('MessagePersister', () => {
         expect(interruptIdx).toBeGreaterThanOrEqual(0)
         expect(rejectIdx).toBeGreaterThan(interruptIdx)
         // markSessionInterrupted ran, clearing the awaiting state.
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       })
 
       it('rejects AND interrupts for a subagent browser_input request', async () => {
-        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
         simulateToolUse('mcp__user-input__request_browser_input', 'bi-1', {
           message: 'Please log in',
           requirements: ['Enter credentials'],
         })
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         mockContainerClientFetch.mockClear()
 
-        await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+        await messagePersister.cancelAwaitingInput(AGENT_SLUG, SESSION_ID)
 
         expect(rejectCallFor('bi-1')).toBeDefined()
         expect(interruptCall()).toBeDefined()
         // The interrupt path marks the session interrupted (awaiting cleared).
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       })
 
       it('sweeps the pending computer-use entries and interrupts', async () => {
         vi.stubEnv('E2E_MOCK', 'true') // skip the host platform gate so the request goes pending
         try {
-          messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+          messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
           simulateToolUse('mcp__computer-use__computer_click', 'cu-1', { ref: 'win:1' })
-          expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
-          expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(1)
+          expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
+          expect(messagePersister.getPendingComputerUseRequests(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
           mockContainerClientFetch.mockClear()
 
-          await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+          await messagePersister.cancelAwaitingInput(AGENT_SLUG, SESSION_ID)
 
           expect(rejectCallFor('cu-1')).toBeDefined()
           expect(interruptCall()).toBeDefined()
           // Host-side computer_use bookkeeping is cleared too (session_idle only clears
           // pendingInputRequests), so a reconnect can't replay a phantom approval card.
-          expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
+          expect(messagePersister.getPendingComputerUseRequests(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
         } finally {
           vi.unstubAllEnvs()
         }
       })
 
       it('rejects every pending request when several are open', async () => {
-        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
         simulateToolUse('mcp__user-input__request_secret', 's-1', { secretName: 'KEY1' })
         simulateToolUse('mcp__user-input__request_file', 'f-1', { description: 'CSV' })
         mockContainerClientFetch.mockClear()
 
-        await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+        await messagePersister.cancelAwaitingInput(AGENT_SLUG, SESSION_ID)
 
         expect(rejectCallFor('s-1')).toBeDefined()
         expect(rejectCallFor('f-1')).toBeDefined()
       })
 
       it('is a no-op when the session is not awaiting input', async () => {
-        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
         mockContainerClientFetch.mockClear()
 
-        await messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)
+        await messagePersister.cancelAwaitingInput(AGENT_SLUG, SESSION_ID)
 
         expect(mockContainerClientFetch).not.toHaveBeenCalled()
       })
 
       it('swallows reject/interrupt failures so a best-effort cancel never throws', async () => {
-        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
         simulateToolUse('mcp__user-input__request_browser_input', 'bi-err', {
           message: 'Please log in',
           requirements: ['Enter credentials'],
         })
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
         mockContainerClientFetch.mockClear()
         mockContainerClientFetch.mockRejectedValue(new Error('container unreachable'))
         try {
           // Must resolve, not reject — a failed cancel must never block the incoming message.
-          await expect(messagePersister.cancelAwaitingInput(SESSION_ID, AGENT_SLUG)).resolves.toBeUndefined()
+          await expect(messagePersister.cancelAwaitingInput(AGENT_SLUG, SESSION_ID)).resolves.toBeUndefined()
           // Both container calls were attempted (and rejected): the interrupt + the cleanup reject.
           expect(rejectCallFor('bi-err')).toBeDefined()
           expect(interruptCall()).toBeDefined()
           // The interrupt fetch rejected, but markSessionInterrupted runs right after the swallowed
           // interrupt, so the cancel still clears the awaiting state.
-          expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+          expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
         } finally {
           mockContainerClientFetch.mockImplementation(() => Promise.resolve({ ok: true }))
         }
@@ -3849,15 +3849,15 @@ describe('MessagePersister', () => {
     it('projects the streaming-state flags onto an activity label', () => {
       // helper sets the three lifecycle flags on the session's streaming state
       const setFlags = (a: boolean, aw: boolean, s: boolean) => {
-        const st = (messagePersister as any).streamingStates.get(SESSION_ID)
+        const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
         st.isActive = a; st.isAwaitingInput = aw; st.isStreaming = s
       }
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // ensures a state exists
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID) // ensures a state exists
 
-      setFlags(true, false, false);  expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')   // nothing more specific
-      setFlags(true, false, true);   expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('streaming') // assistant text owns the surface
-      setFlags(true, true, false);   expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('awaiting')  // waiting on the user
-      setFlags(false, false, false); expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('idle')      // not active
+      setFlags(true, false, false);  expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('working')   // nothing more specific
+      setFlags(true, false, true);   expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('streaming') // assistant text owns the surface
+      setFlags(true, true, false);   expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('awaiting')  // waiting on the user
+      setFlags(false, false, false); expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('idle')      // not active
     })
 
     it('honors the busy precedence (compacting > retrying > thinking > streaming), even with isStreaming set', () => {
@@ -3865,34 +3865,34 @@ describe('MessagePersister', () => {
       // states must still win, so chat shows "Compacting…/Retrying…/Thinking…" like the
       // app rather than dishonestly yielding to 'streaming'. As each clears, the next
       // down the ladder shows, and once all clear, streamed text owns the surface.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-      const st = (messagePersister as any).streamingStates.get(SESSION_ID)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
       st.isActive = true; st.isAwaitingInput = false; st.currentToolUse = null
       st.isStreaming = true
 
       st.isCompacting = true; st.isRetrying = true; st.currentThinking = true
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('compacting')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('compacting')
       st.isCompacting = false
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('retrying')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('retrying')
       st.isRetrying = false
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('thinking')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('thinking')
       st.currentThinking = false
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('streaming')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('streaming')
     })
 
     it('a new turn (markSessionActive) clears a stale isCompacting/currentThinking from an abnormally-ended prior turn', () => {
       // The desktop app resets these on session_active/idle/error; chat must too, or a
       // turn that ended mid-compaction (error/interrupt before the compact summary)
       // wedges the next turn's label to "Compacting…". The state object is reused across turns.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-      const st = (messagePersister as any).streamingStates.get(SESSION_ID)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
       st.isActive = false; st.isCompacting = true; st.currentThinking = true; st.isRetrying = true
 
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // next user message
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID) // next user message
       expect(st.isCompacting).toBe(false)
       expect(st.currentThinking).toBe(false)
       expect(st.isRetrying).toBe(false)
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('working')
     })
 
     it('keeps a running turn intact when a queued message re-marks an ALREADY-active session', () => {
@@ -3900,7 +3900,7 @@ describe('MessagePersister', () => {
       // turn boundary, so everything that turn is still doing survives. Driven with
       // the real frames, since the bug was that markSessionActive wiped exactly the
       // state those frames had just established. (SUP-736)
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start', message: { id: 'msg_1' } } })
       mockClient._sendMessage({
         type: 'stream_event',
@@ -3912,21 +3912,21 @@ describe('MessagePersister', () => {
       mockClient._sendMessage({
         type: 'system', subtype: 'status', status: 'compacting', session_id: SESSION_ID, uuid: 's1',
       })
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('compacting')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('compacting')
       sseEvents.length = 0
 
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // queued mid-turn
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID) // queued mid-turn
 
       // The app is told which of the two meanings this session_active carries.
       expect(sseEvents.find(e => e.type === 'session_active')).toMatchObject({ queuedMidTurn: true })
       // Chat's label walks back down the real ladder as each state ends, instead of
       // dropping straight to "Working…" the moment the message was queued.
-      const st = (messagePersister as any).streamingStates.get(SESSION_ID)
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('compacting')
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('compacting')
       st.isCompacting = false
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('retrying')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('retrying')
       st.isRetrying = false
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('thinking')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('thinking')
 
       // And the open thinking block still closes under the id the app opened it
       // with — a nulled message id/block index would have re-keyed it to undefined.
@@ -3935,7 +3935,7 @@ describe('MessagePersister', () => {
     })
 
     it('is idle for an unknown session', () => {
-      expect(messagePersister.getSessionActivity('nope')).toBe('idle')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, 'nope')).toBe('idle')
     })
   })
 
@@ -3999,7 +3999,7 @@ describe('MessagePersister', () => {
       // The decision route calls this on approve AND reject. Waiting for the
       // launched Workflow's tool_result would leave the card up for the whole
       // (possibly minutes-long) run.
-      messagePersister.completeCapabilityReview(SESSION_ID, 'wf-1')
+      messagePersister.completeCapabilityReview(AGENT_SLUG, SESSION_ID, 'wf-1')
 
       expect(openStreamRequestIds()).toHaveLength(0)
       const resolved = sseEvents.filter(e => e.type === 'user_request_resolved')
@@ -4008,7 +4008,7 @@ describe('MessagePersister', () => {
     })
 
     it('a session-scope grant in the host mirror suppresses review cards without a container query', async () => {
-      messagePersister.grantSessionCapability(SESSION_ID, 'workflows')
+      messagePersister.grantSessionCapability(AGENT_SLUG, SESSION_ID, 'workflows')
       simulateToolUse('Workflow', 'wf-2', { script: 'export const meta = {}' })
 
       await flush()
@@ -4027,7 +4027,7 @@ describe('MessagePersister', () => {
       simulateToolUse('Workflow', 'wf-3', { script: 'export const meta = {}' })
 
       await vi.waitFor(() => {
-        expect(messagePersister.hasSessionCapabilityGrant(SESSION_ID, 'workflows')).toBe(true)
+        expect(messagePersister.hasSessionCapabilityGrant(AGENT_SLUG, SESSION_ID, 'workflows')).toBe(true)
       })
       expect(requestCards('capability_review')).toHaveLength(0)
     })
@@ -4123,7 +4123,7 @@ describe('MessagePersister', () => {
     beforeEach(() => {
       // Promotion fires on the awaiting rising edge, which requires an active
       // turn — as in production, where the automated send marks active first.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     })
 
     function collectGlobalEvents(): { events: any[]; cleanup: () => void } {
@@ -4331,7 +4331,7 @@ describe('MessagePersister', () => {
     })
 
     it('defers success past open background work and persists only at the settled idle', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
       mockClient._sendMessage({
         type: 'system', subtype: 'task_started', task_type: 'local_workflow',
@@ -4367,7 +4367,7 @@ describe('MessagePersister', () => {
     })
 
     it('lets a later failure win over an earlier unsettled success', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
 
       // First (merged-turn) result succeeds but the runtime never goes idle —
@@ -4466,12 +4466,12 @@ describe('MessagePersister', () => {
     // shape, then let the async subscribe-time resolution land.
     async function resubscribeWithMetadata(meta: Record<string, unknown> | null) {
       vi.mocked(getSessionMetadata).mockResolvedValue(meta as never)
-      await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
       await new Promise((resolve) => setTimeout(resolve, 0))
     }
 
     function settleSession() {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       // State-events authority: the runtime's own idle proves the queue drained.
       mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
       mockClient._sendMessage({
@@ -4486,8 +4486,8 @@ describe('MessagePersister', () => {
 
       settleSession()
 
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
       const lastSubscription = vi.mocked(mockClient.subscribeToStream).mock.results.at(-1)!
         .value as { unsubscribe: ReturnType<typeof vi.fn> }
       expect(lastSubscription.unsubscribe).toHaveBeenCalled()
@@ -4496,7 +4496,7 @@ describe('MessagePersister', () => {
     it('releases the stream when a scheduled session settles with an error', async () => {
       await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
 
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true })
       mockClient._sendMessage({
         type: 'result', subtype: 'error_during_execution', is_error: true, duration_ms: 100, num_turns: 1,
@@ -4504,8 +4504,8 @@ describe('MessagePersister', () => {
       })
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
 
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('releases the stream when a webhook session settles', async () => {
@@ -4513,7 +4513,7 @@ describe('MessagePersister', () => {
 
       settleSession()
 
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('releases the stream when an x-agent session settles', async () => {
@@ -4521,7 +4521,7 @@ describe('MessagePersister', () => {
 
       settleSession()
 
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('keeps the stream for an interactive session', async () => {
@@ -4529,8 +4529,8 @@ describe('MessagePersister', () => {
 
       settleSession()
 
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('keeps the stream for a promoted automation session', async () => {
@@ -4538,17 +4538,17 @@ describe('MessagePersister', () => {
 
       settleSession()
 
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('keeps the stream when a scheduled session is promoted mid-run', async () => {
       await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
 
-      await messagePersister.promoteAutomatedSession(SESSION_ID, AGENT_SLUG)
+      await messagePersister.promoteAutomatedSession(AGENT_SLUG, SESSION_ID)
 
       settleSession()
 
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('does not let a stale subscribe-time metadata read undo a promotion', async () => {
@@ -4563,14 +4563,14 @@ describe('MessagePersister', () => {
         return Promise.resolve(unpromoted as never)
       })
 
-      await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
-      await messagePersister.promoteAutomatedSession(SESSION_ID, AGENT_SLUG)
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      await messagePersister.promoteAutomatedSession(AGENT_SLUG, SESSION_ID)
       resolveSubscribeMeta!(unpromoted)
       await new Promise((resolve) => setTimeout(resolve, 0))
 
       settleSession()
 
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('does not release on a legacy result-driven idle (no state-events authority)', async () => {
@@ -4579,29 +4579,29 @@ describe('MessagePersister', () => {
       // on this stream, so the release must not fire.
       await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
 
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'result', subtype: 'success', is_error: false, duration_ms: 100, num_turns: 1,
         usage: { input_tokens: 1, output_tokens: 1 },
       })
 
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('a released session re-subscribes cleanly for a later wake', async () => {
       await resubscribeWithMetadata({ isScheduledExecution: true, scheduledTaskId: 'task-1' })
       settleSession()
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
 
       // The wake path checks isSubscribed and re-subscribes on demand.
-      await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(true)
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // And the resumed run releases again at its own settle.
       await new Promise((resolve) => setTimeout(resolve, 0))
       settleSession()
-      expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
   })
 
@@ -4613,7 +4613,7 @@ describe('MessagePersister', () => {
     beforeEach(() => {
       // Awaiting is derived and gated on an active turn — mark active as the
       // real message send would before any request event arrives.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     })
 
     // Use existing simulateToolUse helper (already defined above in awaiting input tests)
@@ -4754,7 +4754,7 @@ describe('MessagePersister', () => {
         scriptType: 'shell',
       })
 
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('does NOT set isAwaitingInput when use_host_shell is auto-approved', () => {
@@ -4769,7 +4769,7 @@ describe('MessagePersister', () => {
 
       // Auto-approved scripts must not flip the global awaiting-input flag — that's
       // what drives the orange agent-status indicator.
-      expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       vi.unstubAllGlobals()
     })
   })
@@ -4833,8 +4833,8 @@ describe('MessagePersister', () => {
           },
         })
 
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
-        expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
+        expect(messagePersister.getPendingComputerUseRequests(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
         expect(triggerSpy).not.toHaveBeenCalled()
 
         const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
@@ -4881,8 +4881,8 @@ describe('MessagePersister', () => {
           })
         })
 
-        expect(messagePersister.getPendingComputerUseRequests(SESSION_ID)).toHaveLength(0)
-        expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+        expect(messagePersister.getPendingComputerUseRequests(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
+        expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
       } finally {
         if (originalE2eMock === undefined) delete process.env.E2E_MOCK
         else process.env.E2E_MOCK = originalE2eMock
@@ -4897,7 +4897,7 @@ describe('MessagePersister', () => {
 
   describe('API error code tracking', () => {
     it('captures error code from assistant message and includes it in session_error', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
 
       // SDK sends assistant message with error field (e.g., auth failure)
@@ -4926,7 +4926,7 @@ describe('MessagePersister', () => {
     })
 
     it('classifies a success-subtype result with is_error as an error turn (modern shape)', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
 
       // The modern SDK dead-turn shape: subtype stays 'success', the error is
@@ -4950,11 +4950,11 @@ describe('MessagePersister', () => {
       expect(errorEvents[0].terminalReason).toBe('api_error')
       expect(errorEvents[0].apiErrorStatus).toBe(404)
       expect(errorEvents[0].apiErrorCode).toBeNull()
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('broadcasts session_error with null apiErrorCode when no assistant error preceded', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
 
       // Error result without a preceding assistant message error
@@ -4974,7 +4974,7 @@ describe('MessagePersister', () => {
     })
 
     it('clears lastApiErrorCode on new user message', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       // First turn: assistant with error
       mockClient._sendMessage({
@@ -4994,7 +4994,7 @@ describe('MessagePersister', () => {
       })
 
       // New user message clears the error code
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
 
       // Second turn: different error without assistant error field
@@ -5014,7 +5014,7 @@ describe('MessagePersister', () => {
     })
 
     it('broadcasts stream_api_error when text was already streaming', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       // Simulate SDK streaming text before the error
       mockClient._sendMessage({
@@ -5043,7 +5043,7 @@ describe('MessagePersister', () => {
     })
 
     it('broadcasts stream_delta with apiErrorCode when no text was streaming', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
 
       // Complete assistant message with error (no prior streaming)
@@ -6446,46 +6446,46 @@ describe('MessagePersister', () => {
     const WAIT_SESSION = 'wait-session'
 
     afterEach(() => {
-      messagePersister.unsubscribeFromSession(WAIT_SESSION)
+      messagePersister.unsubscribeFromSession(AGENT_SLUG, WAIT_SESSION)
     })
 
     it('rejects with "session never became active" when state never appears (requireActiveFirst default)', async () => {
       await expect(
-        messagePersister.waitForIdle(WAIT_SESSION, { observeMs: 100 }),
+        messagePersister.waitForIdle(AGENT_SLUG, WAIT_SESSION, { observeMs: 100 }),
       ).rejects.toThrow(/never became active/)
     })
 
     it('resolves immediately for missing state when requireActiveFirst=false', async () => {
       await expect(
-        messagePersister.waitForIdle(WAIT_SESSION, { requireActiveFirst: false }),
+        messagePersister.waitForIdle(AGENT_SLUG, WAIT_SESSION, { requireActiveFirst: false }),
       ).resolves.toBeUndefined()
     })
 
     it('rejects with "aborted" when the abort signal fires mid-wait', async () => {
       // Caller cancellation (e.g. HTTP client disconnect) must propagate through
       // waitForIdle so we don't keep polling after no one's listening.
-      messagePersister.markSessionActive(WAIT_SESSION, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, WAIT_SESSION)
       const ctrl = new AbortController()
-      const promise = messagePersister.waitForIdle(WAIT_SESSION, { signal: ctrl.signal })
+      const promise = messagePersister.waitForIdle(AGENT_SLUG, WAIT_SESSION, { signal: ctrl.signal })
       setTimeout(() => ctrl.abort(), 30)
       await expect(promise).rejects.toThrow(/aborted/)
     })
 
     it('rejects synchronously when signal is already aborted', async () => {
-      messagePersister.markSessionActive(WAIT_SESSION, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, WAIT_SESSION)
       const ctrl = new AbortController()
       ctrl.abort()
       await expect(
-        messagePersister.waitForIdle(WAIT_SESSION, { signal: ctrl.signal }),
+        messagePersister.waitForIdle(AGENT_SLUG, WAIT_SESSION, { signal: ctrl.signal }),
       ).rejects.toThrow(/aborted/)
     })
 
     it('rejects with timeout when an active session never goes idle', async () => {
       // Once the session is active, observeMs no longer applies — timeoutMs is
       // the stop-gap. Verifies the timeout branch (not the never-active branch).
-      messagePersister.markSessionActive(WAIT_SESSION, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, WAIT_SESSION)
       const err: unknown = await messagePersister
-        .waitForIdle(WAIT_SESSION, { timeoutMs: 200 })
+        .waitForIdle(AGENT_SLUG, WAIT_SESSION, { timeoutMs: 200 })
         .then(() => null, (e: unknown) => e)
       expect(err).toBeInstanceOf(WaitForIdleTimeoutError)
       // The x-agent routes distinguish timeout from other failures by error
@@ -6497,14 +6497,14 @@ describe('MessagePersister', () => {
 
     it('resolves once an active session goes idle (and preserves isActive across subscribe)', async () => {
       // Mirror the x-agent sync-invoke pattern: markSessionActive *before* subscribe
-      messagePersister.markSessionActive(WAIT_SESSION, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, WAIT_SESSION)
       const client = createMockClient()
-      await messagePersister.subscribeToSession(WAIT_SESSION, client, WAIT_SESSION, AGENT_SLUG)
+      await messagePersister.subscribeToSession(AGENT_SLUG, WAIT_SESSION, client, WAIT_SESSION)
       // Without preservation, isActive would have been wiped here and waitForIdle
       // would reject "never became active" instead of waiting for the result event.
-      expect(messagePersister.isSessionActive(WAIT_SESSION)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, WAIT_SESSION)).toBe(true)
 
-      const promise = messagePersister.waitForIdle(WAIT_SESSION, { observeMs: 1000 })
+      const promise = messagePersister.waitForIdle(AGENT_SLUG, WAIT_SESSION, { observeMs: 1000 })
       setTimeout(() => client._sendMessage({ type: 'result', subtype: 'success' }), 50)
       await expect(promise).resolves.toBeUndefined()
     })
@@ -6518,33 +6518,33 @@ describe('MessagePersister', () => {
     const PRESERVE_SESSION = 'preserve-session'
 
     afterEach(() => {
-      messagePersister.unsubscribeFromSession(PRESERVE_SESSION)
+      messagePersister.unsubscribeFromSession(AGENT_SLUG, PRESERVE_SESSION)
     })
 
     it('preserves isActive=true from prior state when (re-)subscribing', async () => {
       // Caller marks active before subscribing (x-agent sync invoke pattern)
-      messagePersister.markSessionActive(PRESERVE_SESSION, AGENT_SLUG)
-      expect(messagePersister.isSessionActive(PRESERVE_SESSION)).toBe(true)
+      messagePersister.markSessionActive(AGENT_SLUG, PRESERVE_SESSION)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, PRESERVE_SESSION)).toBe(true)
 
       const client = createMockClient()
-      await messagePersister.subscribeToSession(PRESERVE_SESSION, client, PRESERVE_SESSION, AGENT_SLUG)
+      await messagePersister.subscribeToSession(AGENT_SLUG, PRESERVE_SESSION, client, PRESERVE_SESSION)
 
       // Without preservation, isActive would be reset to false here
-      expect(messagePersister.isSessionActive(PRESERVE_SESSION)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, PRESERVE_SESSION)).toBe(true)
     })
 
     it('defaults isActive=false when subscribing fresh (no prior state)', async () => {
       const client = createMockClient()
-      await messagePersister.subscribeToSession(PRESERVE_SESSION, client, PRESERVE_SESSION, AGENT_SLUG)
-      expect(messagePersister.isSessionActive(PRESERVE_SESSION)).toBe(false)
+      await messagePersister.subscribeToSession(AGENT_SLUG, PRESERVE_SESSION, client, PRESERVE_SESSION)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, PRESERVE_SESSION)).toBe(false)
     })
 
     it('concurrent subscribeToSession calls share the in-flight subscription (no double-init)', async () => {
       const client = createMockClient()
       const subscribeSpy = client.subscribeToStream as ReturnType<typeof vi.fn>
       // Fire two concurrent subscribes for the same session before either resolves
-      const p1 = messagePersister.subscribeToSession(PRESERVE_SESSION, client, PRESERVE_SESSION, AGENT_SLUG)
-      const p2 = messagePersister.subscribeToSession(PRESERVE_SESSION, client, PRESERVE_SESSION, AGENT_SLUG)
+      const p1 = messagePersister.subscribeToSession(AGENT_SLUG, PRESERVE_SESSION, client, PRESERVE_SESSION)
+      const p2 = messagePersister.subscribeToSession(AGENT_SLUG, PRESERVE_SESSION, client, PRESERVE_SESSION)
       await Promise.all([p1, p2])
       // Underlying transport subscription must only happen once
       expect(subscribeSpy).toHaveBeenCalledTimes(1)
@@ -6557,7 +6557,7 @@ describe('MessagePersister', () => {
 
   describe('background Bash task tracking', () => {
     it('detects backgroundTaskId from tool_use_result and broadcasts start event', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
 
       mockClient._sendMessage({
@@ -6579,7 +6579,7 @@ describe('MessagePersister', () => {
     })
 
     it('keeps isActive true when result arrives with pending background tasks', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       // Inject a background task
       mockClient._sendMessage({
@@ -6595,11 +6595,11 @@ describe('MessagePersister', () => {
       })
 
       // Session should still be active
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('broadcasts session_waiting_background instead of session_idle when bg tasks pending', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       mockClient._sendMessage({
         type: 'user',
@@ -6623,7 +6623,7 @@ describe('MessagePersister', () => {
     })
 
     it('clears background task on system task-completion and goes idle', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       // Start background task
       mockClient._sendMessage({
@@ -6637,7 +6637,7 @@ describe('MessagePersister', () => {
         type: 'result',
         subtype: 'success',
       })
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       sseEvents.length = 0
 
@@ -6661,7 +6661,7 @@ describe('MessagePersister', () => {
         subtype: 'success',
       })
 
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
     })
 
@@ -6671,7 +6671,7 @@ describe('MessagePersister', () => {
       // `task_updated` patch rather than a matching `task_notification`. The persister
       // must clear it from that signal or the session stays pinned in
       // session_waiting_background forever. See background-bash-busy-completion fixture.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       mockClient._sendMessage({
         type: 'user',
@@ -6681,7 +6681,7 @@ describe('MessagePersister', () => {
 
       // Agent turn ends with the bg task still pending → stays active.
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       sseEvents.length = 0
 
@@ -6699,13 +6699,13 @@ describe('MessagePersister', () => {
 
       // Next result should now go idle rather than re-emit session_waiting_background.
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
       expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
     })
 
     it('ignores task_updated for non-terminal status or untracked task', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'user',
         tool_use_result: { backgroundTaskId: 'bg-x' },
@@ -6723,7 +6723,7 @@ describe('MessagePersister', () => {
       })
 
       expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID).map(t => t.taskId)).toContain('bg-x')
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID).map(t => t.taskId)).toContain('bg-x')
     })
 
     it('session_state_changed idle keeps a still-running bg task tracked (no premature phantom-clear)', () => {
@@ -6737,7 +6737,7 @@ describe('MessagePersister', () => {
       // activeBackgroundTasks only ever holds local_bash tasks, and those always get a
       // later terminal signal — so the old "missed signal → phantom" premise never
       // holds. See the background-bash-premature-idle replay fixture (real capture).
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'user',
         tool_use_result: { backgroundTaskId: 'bg-running' },
@@ -6745,7 +6745,7 @@ describe('MessagePersister', () => {
       })
       // Turn ends with the task still tracked → session stays active (waiting).
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       sseEvents.length = 0
 
@@ -6754,10 +6754,10 @@ describe('MessagePersister', () => {
 
       // Not cleared, not finalized — surfaced as waiting-on-background instead.
       expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID).map(t => t.taskId)).toContain('bg-running')
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID).map(t => t.taskId)).toContain('bg-running')
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(0)
       expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The real terminal signal (task_updated{completed}) then clears it...
       sseEvents.length = 0
@@ -6765,17 +6765,17 @@ describe('MessagePersister', () => {
         type: 'system', subtype: 'task_updated', task_id: 'bg-running', patch: { status: 'completed' },
       })
       expect(sseEvents.filter(e => e.type === 'background_task_completed').map(e => e.taskId)).toContain('bg-running')
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
 
       // ...and the subsequent, truly-settled idle finalizes the session.
       sseEvents.length = 0
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('backstop: session_state_changed idle is a no-op with no pending tasks (no spurious idle)', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
       expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
@@ -6783,7 +6783,7 @@ describe('MessagePersister', () => {
     })
 
     it('backstop: session_state_changed running does not clear pending tasks', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'user',
         tool_use_result: { backgroundTaskId: 'bg-keep' },
@@ -6792,11 +6792,11 @@ describe('MessagePersister', () => {
       sseEvents.length = 0
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'running' })
       expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID).map(t => t.taskId)).toContain('bg-keep')
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID).map(t => t.taskId)).toContain('bg-keep')
     })
 
     it('background_tasks_changed self-heals a task whose terminal signal never arrives', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'user',
         tool_use_result: { backgroundTaskId: 'bg-lost' },
@@ -6810,7 +6810,7 @@ describe('MessagePersister', () => {
       // snapshot the task would pin the session in waiting-background forever.
       mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [] })
       expect(sseEvents.filter(e => e.type === 'background_task_completed').map(e => e.taskId)).toEqual(['bg-lost'])
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
 
       // A late terminal signal for the already-cleared task no-ops.
       sseEvents.length = 0
@@ -6822,14 +6822,14 @@ describe('MessagePersister', () => {
       // The settled idle now finalizes.
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('background_tasks_changed announcing an unregistered task blocks idle (union gate)', () => {
       // The snapshot LEADS per-task signals: it can announce a task before the
       // registration metadata (task_started / tool-result) arrives. An idle in
       // that window must not finalize even though the incremental map is empty.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       // Mid-turn: the SDK announces the task (registration metadata not seen).
       mockClient._sendMessage({
         type: 'system',
@@ -6844,14 +6844,14 @@ describe('MessagePersister', () => {
       const waiting = sseEvents.filter(e => e.type === 'session_waiting_background')
       expect(waiting).toHaveLength(1)
       expect(waiting[0].backgroundTaskCount).toBe(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The task finishes: empty snapshot, then the settled idle finalizes.
       sseEvents.length = 0
       mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [] })
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     // ------------------------------------------------------------------
@@ -6871,7 +6871,7 @@ describe('MessagePersister', () => {
       // removal frame is the one that never comes. A background subagent settles
       // via task_notification carrying its agentId as task_id — the incremental
       // map clears, but the stale snapshot id keeps the union non-zero.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       // Background subagent launch: the ack registers it in the incremental map.
       mockClient._sendMessage({
@@ -6895,7 +6895,7 @@ describe('MessagePersister', () => {
       // Turn ends while it runs → waiting, as designed.
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       sseEvents.length = 0
 
@@ -6908,7 +6908,7 @@ describe('MessagePersister', () => {
         status: 'completed',
         summary: 'Agent finished',
       })
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
 
       // The wake turn's result + idle must now finalize the session.
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
@@ -6916,7 +6916,7 @@ describe('MessagePersister', () => {
 
       expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('Stop drains the snapshot so later turns still settle', () => {
@@ -6925,7 +6925,7 @@ describe('MessagePersister', () => {
       // that id. If Stop clears only the incremental map, every subsequent turn
       // in the session ends in waiting-background instead of idle — the session
       // reads "Working…" at the end of every turn, permanently.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'user',
         tool_use_result: { backgroundTaskId: 'bg-download' },
@@ -6937,18 +6937,18 @@ describe('MessagePersister', () => {
         tasks: [{ task_id: 'bg-download', task_type: 'local_bash', description: 'yt-dlp' }],
       })
 
-      return messagePersister.markSessionInterrupted(SESSION_ID).then(() => {
-        expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
+      return messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID).then(() => {
+        expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
 
         // A brand-new turn, with no background work at all.
-        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
         sseEvents.length = 0
         mockClient._sendMessage({ type: 'result', subtype: 'success' })
         mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
 
         expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
         expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
-        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
       })
     })
 
@@ -6957,7 +6957,7 @@ describe('MessagePersister', () => {
       // so ids from the previous process can never be retired by the SDK. The
       // container announces the replacement (idle eviction + --resume, crash,
       // MCP-injection restart) and the host must reset to the empty set.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system',
         subtype: 'background_tasks_changed',
@@ -6965,19 +6965,19 @@ describe('MessagePersister', () => {
       })
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // The CLI process is replaced; its background tasks died with it.
       mockClient._sendMessage({ type: 'system', subtype: 'process_restarted' })
 
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
 
       expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('a capabilities handshake naming a new process instance drops the stale snapshot', () => {
@@ -6987,7 +6987,7 @@ describe('MessagePersister', () => {
       // session is published and before the socket subscribes. The host state
       // survives that reconnect, so the handshake has to carry the process
       // identity and the host has to notice it changed.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-1',
       })
@@ -6998,21 +6998,21 @@ describe('MessagePersister', () => {
       })
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Reconnect after the process was replaced behind our back.
       mockClient._sendMessage({
         type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-2',
       })
 
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
 
       expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(0)
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('a reattach to the SAME process instance keeps running tasks tracked', () => {
@@ -7020,7 +7020,7 @@ describe('MessagePersister', () => {
       // "saw a handshake": an SSE/WebSocket reattach mid-job is the same live
       // CLI with the same tasks still running. Resetting there would drop the
       // indicator and un-gate auto-sleep on real work.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-1',
       })
@@ -7043,11 +7043,11 @@ describe('MessagePersister', () => {
       })
 
       expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID).map(t => t.taskId)).toContain('bg-live')
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID).map(t => t.taskId)).toContain('bg-live')
 
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(0)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('keeps process identity in sync across an interrupt-driven restart', () => {
@@ -7059,12 +7059,12 @@ describe('MessagePersister', () => {
       // name and mistakes it for a restart, dropping background tasks that are
       // genuinely running: a live indicator lost and auto-sleep un-gated
       // mid-job, the exact failure the union gate exists to prevent.
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-A',
       })
 
-      return messagePersister.markSessionInterrupted(SESSION_ID).then(() => {
+      return messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID).then(() => {
         // The container restarts the CLI in response, while we're still flagged
         // interrupted.
         mockClient._sendMessage({
@@ -7072,7 +7072,7 @@ describe('MessagePersister', () => {
         })
 
         // New turn on the new process, with real background work.
-        messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
         mockClient._sendMessage({
           type: 'user',
           tool_use_result: { backgroundTaskId: 'bg-live' },
@@ -7093,16 +7093,16 @@ describe('MessagePersister', () => {
         })
 
         expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
-        expect(messagePersister.getActiveBackgroundTasks(SESSION_ID).map(t => t.taskId)).toContain('bg-live')
+        expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID).map(t => t.taskId)).toContain('bg-live')
 
         mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
         expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(0)
-        expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
       })
     })
 
     it('forwards command_lifecycle frames to SSE and drops malformed ones', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
 
       mockClient._sendMessage({ type: 'command_lifecycle', command_uuid: 'u1', state: 'queued' })
@@ -7121,7 +7121,7 @@ describe('MessagePersister', () => {
     })
 
     it('ignores a malformed background_tasks_changed frame instead of clearing running tasks', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       mockClient._sendMessage({
         type: 'user',
         tool_use_result: { backgroundTaskId: 'bg-safe' },
@@ -7136,11 +7136,11 @@ describe('MessagePersister', () => {
       mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [{ nope: true }] })
 
       expect(sseEvents.filter(e => e.type === 'background_task_completed')).toHaveLength(0)
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID).map(t => t.taskId)).toContain('bg-safe')
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID).map(t => t.taskId)).toContain('bg-safe')
     })
 
     it('tracks multiple concurrent background tasks', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       mockClient._sendMessage({
         type: 'user',
@@ -7153,7 +7153,7 @@ describe('MessagePersister', () => {
         message: { content: [{ type: 'tool_result', tool_use_id: 'tool-2', content: 'Running' }] },
       })
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(2)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(2)
 
       // Complete first task via system message
       mockClient._sendMessage({
@@ -7163,12 +7163,12 @@ describe('MessagePersister', () => {
         status: 'completed',
       })
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)[0].taskId).toBe('bg-2')
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)[0].taskId).toBe('bg-2')
     })
 
     it('clears background tasks on session interrupt', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       mockClient._sendMessage({
         type: 'user',
@@ -7176,16 +7176,16 @@ describe('MessagePersister', () => {
         message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
       })
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
 
-      await messagePersister.markSessionInterrupted(SESSION_ID)
+      await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID)
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(0)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(0)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
     it('does not duplicate background task on repeated tool_use_result', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       // Same backgroundTaskId twice
       mockClient._sendMessage({
@@ -7199,11 +7199,11 @@ describe('MessagePersister', () => {
         message: { content: [{ type: 'tool_result', tool_use_id: 'tool-2', content: 'Running' }] },
       })
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
     })
 
     it('preserves background tasks across re-subscribe', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       mockClient._sendMessage({
         type: 'user',
@@ -7211,25 +7211,25 @@ describe('MessagePersister', () => {
         message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
       })
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
 
       // Re-subscribe (simulates reconnection)
       const newClient = createMockClient()
-      await messagePersister.subscribeToSession(SESSION_ID, newClient, SESSION_ID, AGENT_SLUG)
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, newClient, SESSION_ID)
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
-      expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
       // Clean up the new subscription
-      messagePersister.unsubscribeFromSession(SESSION_ID)
+      messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
     })
 
     it('returns empty array for unknown session', () => {
-      expect(messagePersister.getActiveBackgroundTasks('nonexistent')).toEqual([])
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, 'nonexistent')).toEqual([])
     })
 
     it('ignores system messages with task_id that do not match active bg tasks', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       mockClient._sendMessage({
         type: 'user',
@@ -7237,7 +7237,7 @@ describe('MessagePersister', () => {
         message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
       })
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
 
       // System message with non-matching task_id
       mockClient._sendMessage({
@@ -7248,11 +7248,11 @@ describe('MessagePersister', () => {
       })
 
       // Should NOT have cleared our task
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
     })
 
     it('also detects snake_case background_task_id', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       sseEvents.length = 0
 
       mockClient._sendMessage({
@@ -7261,8 +7261,8 @@ describe('MessagePersister', () => {
         message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
       })
 
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)).toHaveLength(1)
-      expect(messagePersister.getActiveBackgroundTasks(SESSION_ID)[0].taskId).toBe('snake-1')
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toHaveLength(1)
+      expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)[0].taskId).toBe('snake-1')
     })
   })
 
@@ -7275,9 +7275,9 @@ describe('MessagePersister', () => {
     // machinery in the pull-projection refactor); getSessionActivity is the sole
     // source of truth and must never broadcast a session_activity SSE event.
     it('does not broadcast session_activity on markSessionActive', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       expect(sseEvents.filter((e) => e.type === 'session_activity')).toHaveLength(0)
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('working')
     })
 
     // Iddo (review): message_start must NOT optimistically project 'streaming' before
@@ -7288,7 +7288,7 @@ describe('MessagePersister', () => {
     // per tool-first assistant message in an agentic turn. 'streaming' is deferred to the
     // first text token instead.
     it('keeps a tool-first message on "working" without flipping through "streaming"', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID) // active → 'working'
 
       mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
       mockClient._sendMessage({
@@ -7296,21 +7296,21 @@ describe('MessagePersister', () => {
         event: { type: 'content_block_start', content_block: { type: 'tool_use', id: 't1', name: 'Bash' } },
       })
 
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('working')
     })
 
     it('projects "streaming" only when real text starts (first text_delta), not at message_start', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID) // active → 'working'
       mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
       // No content yet: the agent is honestly 'working', not optimistically 'streaming'.
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('working')
 
       mockClient._sendMessage({
         type: 'stream_event',
         event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hello' } },
       })
       // The first token yields the reply surface to the streamed text.
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('streaming')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('streaming')
     })
 
     // Regression: a mid-stream error must NOT emit a spurious busy activity right
@@ -7319,21 +7319,21 @@ describe('MessagePersister', () => {
     // streaming just cleared" snapshot would briefly read 'working' and race
     // connectors (Slack's async reaction add/remove) into a stuck indicator.
     it('broadcasts no session_activity and settles to idle on a mid-stream error result', () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID) // active → 'working'
       mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
       mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } } }) // → 'streaming'
 
       mockClient._sendMessage({ type: 'result', subtype: 'error', error: 'boom' })
 
       expect(sseEvents.filter(e => e.type === 'session_activity')).toHaveLength(0)
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('idle')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('idle')
     })
 
     // Same invariant for the connection-closed → markSessionInactive terminal
     // path: finalizeIdle's single non-busy emit covers the settle; clearing
     // streaming/awaiting must not emit a busy activity first.
     it('broadcasts no session_activity and settles to idle when markSessionInactive finalizes a streaming session', async () => {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG) // active → 'working'
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID) // active → 'working'
       mockClient._sendMessage({ type: 'stream_event', event: { type: 'message_start' } })
       mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } } }) // → 'streaming'
 
@@ -7348,7 +7348,7 @@ describe('MessagePersister', () => {
       await new Promise((r) => setTimeout(r, 0))
 
       expect(sseEvents.filter(e => e.type === 'session_activity')).toHaveLength(0)
-      expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('idle')
+      expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('idle')
     })
   })
 })
@@ -7362,7 +7362,7 @@ describe('MessagePersister.handleConnectionClosed re-subscribe', () => {
   const AGENT_SLUG = 'reconnect-agent'
 
   afterEach(() => {
-    messagePersister.unsubscribeFromSession(SESSION_ID)
+    messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
     vi.clearAllMocks()
   })
 
@@ -7408,8 +7408,8 @@ describe('MessagePersister.handleConnectionClosed re-subscribe', () => {
     process.on('unhandledRejection', onUnhandled)
 
     try {
-      await messagePersister.subscribeToSession(SESSION_ID, client, SESSION_ID, AGENT_SLUG)
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, client, SESSION_ID)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       // Simulate the WebSocket dropping — the container synthesizes this message.
       callback!({
@@ -7464,20 +7464,20 @@ describe('MessagePersister connection lost mid-turn', () => {
 
   beforeEach(async () => {
     mockClient = createMockClient()
-    await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
-    const sse = collectSSEEvents(SESSION_ID)
+    await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+    const sse = collectSSEEvents(AGENT_SLUG, SESSION_ID)
     sseEvents = sse.events
     sseCleanup = sse.cleanup
   })
 
   afterEach(() => {
     sseCleanup()
-    messagePersister.unsubscribeFromSession(SESSION_ID)
+    messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
     vi.clearAllMocks()
   })
 
   it('broadcasts session_error (not session_idle) when the connection drops mid-turn', async () => {
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     sseEvents.length = 0
 
     await dropConnection()
@@ -7490,8 +7490,8 @@ describe('MessagePersister connection lost mid-turn', () => {
     expect(errors[0].isActive).toBe(false)
     expect(sseEvents.filter((e) => e.type === 'session_idle')).toHaveLength(0)
     // The session still settles: no longer active, activity reads idle.
-    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
-    expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('idle')
+    expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+    expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('idle')
   })
 
   it('also announces the mid-turn death on the global stream (sidebar/notifications)', async () => {
@@ -7500,7 +7500,7 @@ describe('MessagePersister connection lost mid-turn', () => {
       globalEvents.push(data)
     })
     try {
-      messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
       await dropConnection()
 
@@ -7525,8 +7525,8 @@ describe('MessagePersister connection lost mid-turn', () => {
   })
 
   it('does not report an error when the connection drops after a user interrupt', async () => {
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    await messagePersister.markSessionInterrupted(SESSION_ID)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+    await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID)
     sseEvents.length = 0
 
     await dropConnection()
@@ -7542,91 +7542,91 @@ describe('MessagePersister mid-turn recovery snapshot', () => {
 
   beforeEach(async () => {
     mockClient = createMockClient()
-    await messagePersister.subscribeToSession(SESSION_ID, mockClient, SESSION_ID, AGENT_SLUG)
+    await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
   })
 
   afterEach(() => {
-    messagePersister.unsubscribeFromSession(SESSION_ID)
+    messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
     vi.clearAllMocks()
   })
 
   it('snapshots active sessions and skips session_error while they are recovering', () => {
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     expect(messagePersister.snapshotMidTurnSessions(AGENT_SLUG)).toEqual([SESSION_ID])
-    expect(messagePersister.isSessionRecovering(SESSION_ID)).toBe(true)
-    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
 
     messagePersister.markAllSessionsInactiveForAgent(AGENT_SLUG)
-    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
-    expect(messagePersister.isSessionRecovering(SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(true)
   })
 
   it('snapshots only the requested session ids', async () => {
     const otherId = 'recover-session-2'
-    await messagePersister.subscribeToSession(otherId, mockClient, otherId, AGENT_SLUG)
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    messagePersister.markSessionActive(otherId, AGENT_SLUG)
+    await messagePersister.subscribeToSession(AGENT_SLUG, otherId, mockClient, otherId)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+    messagePersister.markSessionActive(AGENT_SLUG, otherId)
 
     expect(messagePersister.snapshotMidTurnSessions(AGENT_SLUG, [SESSION_ID])).toEqual([SESSION_ID])
-    expect(messagePersister.isSessionRecovering(SESSION_ID)).toBe(true)
-    expect(messagePersister.isSessionRecovering(otherId)).toBe(false)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, otherId)).toBe(false)
 
-    messagePersister.unsubscribeFromSession(otherId)
+    messagePersister.unsubscribeFromSession(AGENT_SLUG, otherId)
   })
 
   it('settles recovering sessions when the agent is stopped', () => {
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     messagePersister.snapshotMidTurnSessions(AGENT_SLUG)
     messagePersister.markAllSessionsInactiveForAgent(AGENT_SLUG, { settleRecovering: true })
-    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
-    expect(messagePersister.isSessionRecovering(SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(false)
   })
 
   it('does not snapshot idle or interrupted sessions', async () => {
     expect(messagePersister.snapshotMidTurnSessions(AGENT_SLUG)).toEqual([])
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    await messagePersister.markSessionInterrupted(SESSION_ID)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+    await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID)
     expect(messagePersister.snapshotMidTurnSessions(AGENT_SLUG)).toEqual([])
   })
 
   it('coalesces user text while recovering and keeps each message uuid', () => {
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     messagePersister.snapshotMidTurnSessions(AGENT_SLUG)
-    expect(messagePersister.coalesceIfRecovering(SESSION_ID, { uuid: 'u1', text: 'first' })).toBe(true)
-    expect(messagePersister.coalesceIfRecovering(SESSION_ID, { uuid: 'u2', text: 'second' })).toBe(true)
-    expect(messagePersister.takeCoalescedUserMessages(SESSION_ID)).toEqual([
+    expect(messagePersister.coalesceIfRecovering(AGENT_SLUG, SESSION_ID, { uuid: 'u1', text: 'first' })).toBe(true)
+    expect(messagePersister.coalesceIfRecovering(AGENT_SLUG, SESSION_ID, { uuid: 'u2', text: 'second' })).toBe(true)
+    expect(messagePersister.takeCoalescedUserMessages(AGENT_SLUG, SESSION_ID)).toEqual([
       { uuid: 'u1', text: 'first' },
       { uuid: 'u2', text: 'second' },
     ])
-    expect(messagePersister.coalesceIfRecovering('other', { uuid: 'u3', text: 'nope' })).toBe(false)
+    expect(messagePersister.coalesceIfRecovering(AGENT_SLUG, 'other', { uuid: 'u3', text: 'nope' })).toBe(false)
   })
 
   it('drops a coalesced user message by uuid', () => {
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     messagePersister.snapshotMidTurnSessions(AGENT_SLUG)
-    messagePersister.coalesceIfRecovering(SESSION_ID, { uuid: 'u1', text: 'first' })
-    messagePersister.coalesceIfRecovering(SESSION_ID, { uuid: 'u2', text: 'second' })
-    expect(messagePersister.dropCoalescedUserMessage(SESSION_ID, 'u1')).toBe(true)
-    expect(messagePersister.takeCoalescedUserMessages(SESSION_ID)).toEqual([{ uuid: 'u2', text: 'second' }])
+    messagePersister.coalesceIfRecovering(AGENT_SLUG, SESSION_ID, { uuid: 'u1', text: 'first' })
+    messagePersister.coalesceIfRecovering(AGENT_SLUG, SESSION_ID, { uuid: 'u2', text: 'second' })
+    expect(messagePersister.dropCoalescedUserMessage(AGENT_SLUG, SESSION_ID, 'u1')).toBe(true)
+    expect(messagePersister.takeCoalescedUserMessages(AGENT_SLUG, SESSION_ID)).toEqual([{ uuid: 'u2', text: 'second' }])
   })
 
   it('does not log coalesced message content when settling', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     messagePersister.snapshotMidTurnSessions(AGENT_SLUG)
-    messagePersister.coalesceIfRecovering(SESSION_ID, { uuid: 'u1', text: 'secret user text' })
-    messagePersister.settleRecoveringSessions([SESSION_ID])
+    messagePersister.coalesceIfRecovering(AGENT_SLUG, SESSION_ID, { uuid: 'u1', text: 'secret user text' })
+    messagePersister.settleRecoveringSessions(AGENT_SLUG, [SESSION_ID])
     expect(warn).toHaveBeenCalled()
     expect(warn.mock.calls.flat().join(' ')).not.toContain('secret user text')
     warn.mockRestore()
   })
 
   it('settles recovering sessions as connection_lost and writes automation status', () => {
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
     messagePersister.snapshotMidTurnSessions(AGENT_SLUG)
-    messagePersister.settleRecoveringSessions([SESSION_ID])
-    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
-    expect(messagePersister.isSessionRecovering(SESSION_ID)).toBe(false)
+    messagePersister.settleRecoveringSessions(AGENT_SLUG, [SESSION_ID])
+    expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(false)
     expect(finalizeAutomationStatus).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID, 'failed')
   })
 
@@ -7634,7 +7634,7 @@ describe('MessagePersister mid-turn recovery snapshot', () => {
     const onDeath = vi.fn()
     messagePersister.setUnexpectedDeathCallback(onDeath)
     mockClient.onFatalResult = vi.fn(() => 'defer_for_recovery' as const)
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
     mockClient._sendMessage({
       type: 'result',
@@ -7643,8 +7643,8 @@ describe('MessagePersister mid-turn recovery snapshot', () => {
       error: 'The agent process was killed due to running out of memory.',
     })
 
-    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
-    expect(messagePersister.isSessionRecovering(SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(false)
     expect(onDeath).toHaveBeenCalledWith(AGENT_SLUG)
     expect(messagePersister.consumeLastFatal(AGENT_SLUG)).toBe('oom_sigkill')
     messagePersister.setUnexpectedDeathCallback(null)
@@ -7653,7 +7653,7 @@ describe('MessagePersister mid-turn recovery snapshot', () => {
   it('does not snapshot a fatal SIGKILL when no recovery callback is registered', async () => {
     messagePersister.setUnexpectedDeathCallback(null)
     mockClient.onFatalResult = vi.fn(() => 'defer_for_recovery' as const)
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
 
     mockClient._sendMessage({
       type: 'result',
@@ -7662,18 +7662,18 @@ describe('MessagePersister mid-turn recovery snapshot', () => {
       error: 'The agent process was killed due to running out of memory.',
     })
 
-    expect(messagePersister.isSessionRecovering(SESSION_ID)).toBe(false)
-    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
   })
 
   it('does not settle mid-turn on connection_closed when recovery is registered', async () => {
     const otherId = 'recover-session-2'
     const otherClient = createMockClient()
-    await messagePersister.subscribeToSession(otherId, otherClient, otherId, AGENT_SLUG)
+    await messagePersister.subscribeToSession(AGENT_SLUG, otherId, otherClient, otherId)
     const onDeath = vi.fn()
     messagePersister.setUnexpectedDeathCallback(onDeath)
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
-    messagePersister.markSessionActive(otherId, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+    messagePersister.markSessionActive(AGENT_SLUG, otherId)
 
     mockClient._messageCallback!({
       type: 'connection_closed',
@@ -7685,15 +7685,15 @@ describe('MessagePersister mid-turn recovery snapshot', () => {
 
     expect(onDeath).toHaveBeenCalledWith(AGENT_SLUG, SESSION_ID)
     expect(onDeath).toHaveBeenCalledTimes(1)
-    expect(messagePersister.isSessionActive(SESSION_ID)).toBe(true)
-    expect(messagePersister.isSessionActive(otherId)).toBe(true)
-    expect(messagePersister.isSessionRecovering(SESSION_ID)).toBe(false)
-    expect(messagePersister.isSessionRecovering(otherId)).toBe(false)
+    expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionActive(AGENT_SLUG, otherId)).toBe(true)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionRecovering(AGENT_SLUG, otherId)).toBe(false)
     // Dead transport is detached so recovery's isSubscribed gate resubscribes.
-    expect(messagePersister.isSubscribed(SESSION_ID)).toBe(false)
-    expect(messagePersister.isSubscribed(otherId)).toBe(true)
+    expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+    expect(messagePersister.isSubscribed(AGENT_SLUG, otherId)).toBe(true)
     messagePersister.setUnexpectedDeathCallback(null)
-    messagePersister.unsubscribeFromSession(otherId)
+    messagePersister.unsubscribeFromSession(AGENT_SLUG, otherId)
   })
 })
 
@@ -7727,22 +7727,22 @@ describe('cross-agent isolation', () => {
     clientA1 = createMockClient()
     clientA2 = createMockClient()
     clientB1 = createMockClient()
-    await messagePersister.subscribeToSession(SESSION_A1, clientA1, SESSION_A1, AGENT_A)
-    await messagePersister.subscribeToSession(SESSION_A2, clientA2, SESSION_A2, AGENT_A)
-    await messagePersister.subscribeToSession(SESSION_B1, clientB1, SESSION_B1, AGENT_B)
+    await messagePersister.subscribeToSession(AGENT_A, SESSION_A1, clientA1, SESSION_A1)
+    await messagePersister.subscribeToSession(AGENT_A, SESSION_A2, clientA2, SESSION_A2)
+    await messagePersister.subscribeToSession(AGENT_B, SESSION_B1, clientB1, SESSION_B1)
   })
 
   afterEach(() => {
     for (const id of [SESSION_A1, SESSION_A2, SESSION_B1]) {
-      messagePersister.unsubscribeFromSession(id)
+      messagePersister.unsubscribeFromSession(id === SESSION_B1 ? AGENT_B : AGENT_A, id)
     }
     vi.clearAllMocks()
   })
 
   describe('agent-scoped queries', () => {
     it('reports active sessions only for the agent that owns them', () => {
-      messagePersister.markSessionActive(SESSION_A1, AGENT_A)
-      messagePersister.markSessionActive(SESSION_B1, AGENT_B)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A1)
+      messagePersister.markSessionActive(AGENT_B, SESSION_B1)
 
       expect(messagePersister.getActiveSessionIdsForAgent(AGENT_A)).toEqual([SESSION_A1])
       expect(messagePersister.getActiveSessionIdsForAgent(AGENT_B)).toEqual([SESSION_B1])
@@ -7752,56 +7752,56 @@ describe('cross-agent isolation', () => {
     })
 
     it('reports awaiting-input only for the agent that owns the session', () => {
-      messagePersister.markSessionActive(SESSION_A1, AGENT_A)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A1)
 
       expect(messagePersister.hasSessionsAwaitingInputForAgent(AGENT_B)).toBe(false)
     })
 
     it('stopping one agent’s container leaves the other agent’s sessions alone', () => {
-      messagePersister.markSessionActive(SESSION_A1, AGENT_A)
-      messagePersister.markSessionActive(SESSION_A2, AGENT_A)
-      messagePersister.markSessionActive(SESSION_B1, AGENT_B)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A1)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A2)
+      messagePersister.markSessionActive(AGENT_B, SESSION_B1)
 
       messagePersister.markAllSessionsInactiveForAgent(AGENT_A)
 
-      expect(messagePersister.isSessionActive(SESSION_A1)).toBe(false)
-      expect(messagePersister.isSessionActive(SESSION_A2)).toBe(false)
-      expect(messagePersister.isSessionActive(SESSION_B1)).toBe(true)
-      expect(messagePersister.isSubscribed(SESSION_B1)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_A, SESSION_A1)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_A, SESSION_A2)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_B, SESSION_B1)).toBe(true)
+      expect(messagePersister.isSubscribed(AGENT_B, SESSION_B1)).toBe(true)
     })
 
     it('snapshots mid-turn sessions only for the named agent', () => {
-      messagePersister.markSessionActive(SESSION_A1, AGENT_A)
-      messagePersister.markSessionActive(SESSION_B1, AGENT_B)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A1)
+      messagePersister.markSessionActive(AGENT_B, SESSION_B1)
 
       expect(messagePersister.snapshotMidTurnSessions(AGENT_A)).toEqual([SESSION_A1])
-      expect(messagePersister.isSessionRecovering(SESSION_B1)).toBe(false)
+      expect(messagePersister.isSessionRecovering(AGENT_B, SESSION_B1)).toBe(false)
     })
 
     it('honours the restrict list within an agent', () => {
-      messagePersister.markSessionActive(SESSION_A1, AGENT_A)
-      messagePersister.markSessionActive(SESSION_A2, AGENT_A)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A1)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A2)
 
       expect(messagePersister.snapshotMidTurnSessions(AGENT_A, [SESSION_A2])).toEqual([SESSION_A2])
-      expect(messagePersister.isSessionRecovering(SESSION_A1)).toBe(false)
-      expect(messagePersister.isSessionRecovering(SESSION_A2)).toBe(true)
+      expect(messagePersister.isSessionRecovering(AGENT_A, SESSION_A1)).toBe(false)
+      expect(messagePersister.isSessionRecovering(AGENT_A, SESSION_A2)).toBe(true)
     })
 
     it('never snapshots another agent’s session even when it is named in the restrict list', () => {
-      messagePersister.markSessionActive(SESSION_A1, AGENT_A)
-      messagePersister.markSessionActive(SESSION_B1, AGENT_B)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A1)
+      messagePersister.markSessionActive(AGENT_B, SESSION_B1)
 
       expect(messagePersister.snapshotMidTurnSessions(AGENT_A, [SESSION_B1])).toEqual([])
-      expect(messagePersister.isSessionRecovering(SESSION_B1)).toBe(false)
+      expect(messagePersister.isSessionRecovering(AGENT_B, SESSION_B1)).toBe(false)
     })
   })
 
   describe('per-session state does not bleed', () => {
     it('delivers SSE events only to the subscribers of that session', () => {
-      const a1 = collectSSEEvents(SESSION_A1)
-      const b1 = collectSSEEvents(SESSION_B1)
+      const a1 = collectSSEEvents(AGENT_A, SESSION_A1)
+      const b1 = collectSSEEvents(AGENT_B, SESSION_B1)
       try {
-        messagePersister.broadcastSessionEvent(SESSION_B1, { type: 'user_typing' })
+        messagePersister.broadcastSessionEvent(AGENT_B, SESSION_B1, { type: 'user_typing' })
 
         expect(b1.events).toContainEqual(expect.objectContaining({ type: 'user_typing' }))
         expect(a1.events).toEqual([])
@@ -7812,35 +7812,35 @@ describe('cross-agent isolation', () => {
     })
 
     it('interrupting one session does not settle another agent’s session', async () => {
-      messagePersister.markSessionActive(SESSION_A1, AGENT_A)
-      messagePersister.markSessionActive(SESSION_B1, AGENT_B)
+      messagePersister.markSessionActive(AGENT_A, SESSION_A1)
+      messagePersister.markSessionActive(AGENT_B, SESSION_B1)
 
-      await messagePersister.markSessionInterrupted(SESSION_A1)
+      await messagePersister.markSessionInterrupted(AGENT_A, SESSION_A1)
 
-      expect(messagePersister.isSessionActive(SESSION_A1)).toBe(false)
-      expect(messagePersister.isSessionActive(SESSION_B1)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_A, SESSION_A1)).toBe(false)
+      expect(messagePersister.isSessionActive(AGENT_B, SESSION_B1)).toBe(true)
     })
 
     it('unsubscribing one session leaves the other agent’s subscription intact', () => {
-      messagePersister.unsubscribeFromSession(SESSION_A1)
+      messagePersister.unsubscribeFromSession(AGENT_A, SESSION_A1)
 
-      expect(messagePersister.isSubscribed(SESSION_A1)).toBe(false)
-      expect(messagePersister.isSubscribed(SESSION_B1)).toBe(true)
+      expect(messagePersister.isSubscribed(AGENT_A, SESSION_A1)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_B, SESSION_B1)).toBe(true)
     })
 
     it('keeps slash commands per session', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      messagePersister.setSlashCommands(SESSION_A1, [{ name: 'alpha-only' }] as any)
+      messagePersister.setSlashCommands(AGENT_A, SESSION_A1, [{ name: 'alpha-only' }] as any)
 
-      expect(messagePersister.getSlashCommands(SESSION_A1)).toEqual([{ name: 'alpha-only' }])
-      expect(messagePersister.getSlashCommands(SESSION_B1)).toEqual([])
+      expect(messagePersister.getSlashCommands(AGENT_A, SESSION_A1)).toEqual([{ name: 'alpha-only' }])
+      expect(messagePersister.getSlashCommands(AGENT_B, SESSION_B1)).toEqual([])
     })
 
     it('keeps capability grants per session', () => {
-      messagePersister.grantSessionCapability(SESSION_A1, 'subagents')
+      messagePersister.grantSessionCapability(AGENT_A, SESSION_A1, 'subagents')
 
-      expect(messagePersister.hasSessionCapabilityGrant(SESSION_A1, 'subagents')).toBe(true)
-      expect(messagePersister.hasSessionCapabilityGrant(SESSION_B1, 'subagents')).toBe(false)
+      expect(messagePersister.hasSessionCapabilityGrant(AGENT_A, SESSION_A1, 'subagents')).toBe(true)
+      expect(messagePersister.hasSessionCapabilityGrant(AGENT_B, SESSION_B1, 'subagents')).toBe(false)
     })
 
     it('attributes a streamed frame to the agent that owns the session', () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -470,15 +470,18 @@ class MessagePersister {
             outcome: transition.outcome,
             scope: request.scope,
           }
-    // Fail closed: the schema types scope.agentSlug as optional (and '' is
-    // possible), and the ACL filter forwards slug-less events to EVERY
-    // authenticated user — so a request without a verified slug must never
-    // reach the global stream. Its session stream still gets it: those
-    // subscribers are AgentRead-gated per session.
-    if (request.scope.agentSlug) {
-      this.broadcastGlobal(event)
-    }
-    if (request.scope.agentSlug && request.scope.sessionId) {
+    // Fail closed on a missing slug. The schema types scope.agentSlug as
+    // optional (and '' is possible), and the global-stream ACL filter forwards
+    // slug-less events to EVERY authenticated user, so such a request must not
+    // reach the global stream. It must not reach the per-session stream either:
+    // the session key is (agent, session), so without a slug there is no key to
+    // deliver to — and the awaiting projection likewise ignores a slug-less
+    // request (isSessionAwaiting matches on the agent), so it cannot strand a
+    // session either. Every real registration path sets a slug; a slug-less one
+    // is inert by construction.
+    if (!request.scope.agentSlug) return
+    this.broadcastGlobal(event)
+    if (request.scope.sessionId) {
       this.broadcastToSSE(request.scope.agentSlug, request.scope.sessionId, event)
     }
   }
@@ -3651,11 +3654,6 @@ class MessagePersister {
     agentSlug: string
   ): void {
     ;(async () => {
-      if (!agentSlug) {
-        // Without an agentSlug we can't reach the container to resolve/reject.
-        console.error('[MessagePersister] Schedule task missing agentSlug')
-        return
-      }
 
       // Parse the tool input
       let input: {
@@ -3775,11 +3773,6 @@ class MessagePersister {
     agentSlug: string
   ): void {
     ;(async () => {
-      if (!agentSlug) {
-        console.error('[MessagePersister] Schedule resume missing agentSlug')
-        return
-      }
-
       let input: { wakeTime?: string; note?: string; timezone?: string }
       try {
         input = JSON.parse(toolInput)
@@ -3980,11 +3973,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error('[MessagePersister] cancel_scheduled_task missing agentSlug')
-          return
-        }
-
         let input: { task_id: string }
         try {
           input = JSON.parse(toolInput)
@@ -4050,11 +4038,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error(`[MessagePersister] ${action}_scheduled_task missing agentSlug`)
-          return
-        }
-
         let input: { task_id: string }
         try {
           input = JSON.parse(toolInput)
@@ -4169,11 +4152,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error('[MessagePersister] get_available_triggers missing agentSlug')
-          return
-        }
-
         if (!isPlatformComposioActive()) {
           await this.rejectContainerInput(agentSlug, toolUseId, 'Webhook triggers are only available with platform Composio')
           return
@@ -4231,11 +4209,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error('[MessagePersister] setup_trigger missing agentSlug')
-          return
-        }
-
         if (!isPlatformComposioActive()) {
           await this.rejectContainerInput(agentSlug, toolUseId, 'Webhook triggers are only available with platform Composio')
           return
@@ -4374,11 +4347,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error('[MessagePersister] create_webhook_endpoint missing agentSlug')
-          return
-        }
-
         // Gate on platform auth, not Composio mode: custom endpoints live on
         // the platform proxy and must keep working when the user brings their
         // own Composio key (mirrors the teardown gate in
@@ -4514,11 +4482,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error('[MessagePersister] update_webhook_endpoint missing agentSlug')
-          return
-        }
-
         // Gate on platform auth, not Composio mode: custom endpoints live on
         // the platform proxy and must keep working when the user brings their
         // own Composio key (mirrors the teardown gate in
@@ -4620,11 +4583,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error('[MessagePersister] inspect_webhook_events missing agentSlug')
-          return
-        }
-
         if (!getPlatformAccessToken()) {
           await this.rejectContainerInput(agentSlug, toolUseId, 'Custom webhook endpoints are only available when connected to the platform')
           return
@@ -4707,11 +4665,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error('[MessagePersister] list_triggers missing agentSlug')
-          return
-        }
-
         const triggers = await listActiveWebhookTriggers(agentSlug)
         const formatted = triggers.length === 0
           ? 'No active webhook triggers for this agent.'
@@ -4741,11 +4694,6 @@ ${continuation}`
   ): void {
     ;(async () => {
       try {
-        if (!agentSlug) {
-          console.error('[MessagePersister] cancel_trigger missing agentSlug')
-          return
-        }
-
         let input: { trigger_id: string }
         try {
           input = JSON.parse(toolInput)

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -645,7 +645,7 @@ class MessagePersister {
     }
     this.streamingStates.delete(key)
     // Shadow registry (Phase 2): every session-scoped entry dies with the state.
-    userInputRequestManager.dropSessionRequests(sessionId, 'invalidated')
+    userInputRequestManager.dropSessionRequests(agentSlug, sessionId, 'invalidated')
     this.containerClients.delete(key)
     // Safe to drop: the container's persisted grants are authoritative, so a
     // resubscribed session repopulates this on the next launch with one GET.
@@ -831,10 +831,7 @@ class MessagePersister {
   // and the lifecycle tests' view of what is still parked.
   getPendingComputerUseRequests(agentSlug: string, sessionId: string): Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> {
     return userInputRequestManager
-      .getOpenRequestsForSession(sessionId)
-      // The request store is keyed by session id alone, so scope it to the
-      // asking agent here the way every other registry read is scoped.
-      .filter((r) => r.scope.agentSlug === agentSlug)
+      .getOpenRequestsForSession(agentSlug, sessionId)
       // Auto-approved requests are registered only for the decision gate —
       // nothing may treat a command that is already executing as parked.
       .filter((r) => r.kind === 'computer_use' && !r.autoApproved)
@@ -970,7 +967,7 @@ class MessagePersister {
     // INCLUDED — they are exactly the ones whose container-side pending may
     // still be live (the host missed the original delivery), so skipping them
     // would leave an abandoned request for a late click to land on.
-    const inputRequestIds = userInputRequestManager.getStoreIdsForSession(sessionId, 'stream')
+    const inputRequestIds = userInputRequestManager.getStoreIdsForSession(agentSlug, sessionId, 'stream')
     const computerUseIds = this.getPendingComputerUseRequests(agentSlug, sessionId).map((r) => r.toolUseId)
 
     // Interrupt FIRST: abort the parked query so it can never resume into a filler reply.
@@ -1451,7 +1448,7 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state) return
     const derived =
-      state.isActive && userInputRequestManager.isSessionAwaiting(sessionId, state.agentSlug)
+      state.isActive && userInputRequestManager.isSessionAwaiting(agentSlug, sessionId)
     if (derived === state.isAwaitingInput) return
     state.isAwaitingInput = derived
     if (derived) {
@@ -1707,6 +1704,7 @@ class MessagePersister {
         state.settledInputRequests.clear()
         // A new turn supersedes parked asks; an idle boundary cancels them.
         userInputRequestManager.clearSessionStreamRequests(
+          agentSlug,
           sessionId,
           evt.type === 'session_active' ? 'superseded' : 'cancelled',
         )
@@ -1718,7 +1716,7 @@ class MessagePersister {
           // awaiting was an imperative bit, but the derived projection would
           // read them as a live wait and flag the fresh turn as awaiting.
           // (Idle keeps them so a still-parked approval survives a reconnect.)
-          for (const id of userInputRequestManager.getStoreIdsForSession(sessionId, 'computer_use')) {
+          for (const id of userInputRequestManager.getStoreIdsForSession(agentSlug, sessionId, 'computer_use')) {
             userInputRequestManager.resolveIfInStore(id, 'computer_use', 'superseded')
           }
         }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -110,6 +110,47 @@ type StreamRequestKind = Exclude<
   'computer_use' | 'proxy_review' | 'x_agent_review' | 'account_reauth_required' | 'mcp_reauth_required'
 >
 
+// ---------------------------------------------------------------------------
+// Session keys
+//
+// A session id is unique within its agent, NOT across the install: it arrives
+// from the container, and an agent can write any id it likes into its own
+// bind-mounted workspace. Keying a process-global registry by the id alone
+// therefore lets one agent's request address another agent's live session
+// (SUP-479). Every registry below is keyed by agent AND session.
+//
+// The key is branded so this cannot silently regress: passing a bare
+// `sessionId` where a `SessionKey` is expected is a compile error, which is
+// the only reason a string-keyed refactor of this size is checkable at all.
+// ---------------------------------------------------------------------------
+declare const sessionKeyBrand: unique symbol
+type SessionKey = string & { readonly [sessionKeyBrand]: true }
+
+const SESSION_KEY_SEPARATOR = '\u0000'
+
+export function sessionKeyOf(agentSlug: string, sessionId: string): SessionKey {
+  return `${agentSlug}${SESSION_KEY_SEPARATOR}${sessionId}` as SessionKey
+}
+
+/**
+ * Everything a handler needs about the session it is working on, resolved once
+ * at the entry point instead of re-looked-up by id at each hop.
+ *
+ * Handlers destructure `sessionId` out of this, so their bodies keep using the
+ * bare id for the things that are genuinely id-shaped — SSE payloads, disk
+ * paths, service calls — while every registry lookup goes through `key`.
+ */
+interface SessionCtx {
+  readonly key: SessionKey
+  readonly agentSlug: string
+  readonly sessionId: string
+}
+
+function sessionCtx(agentSlug: string, sessionId: string): SessionCtx {
+  return { key: sessionKeyOf(agentSlug, sessionId), agentSlug, sessionId }
+}
+
+
 // Tracks streaming state for SSE broadcasts
 // In the file-based model, messages are stored in JSONL files by the Claude SDK.
 // This class only handles SSE streaming updates to the frontend, not persistence.
@@ -126,7 +167,8 @@ interface StreamingState {
   isRecovering: boolean // Mid-turn death claimed for resume; skip session_error until resume fails
   coalescedUserMessages?: CoalescedUserMessage[] // User texts sent while recovering; delivered with their uuids
   isCompacting: boolean // True while compaction is in progress, cleared on compact completion
-  agentSlug?: string // The agent slug for this session
+  agentSlug: string // The agent that owns this session; half of its registry key
+  sessionId: string // The bare id, for payloads and disk paths
   notAutomationSession?: boolean // Cached "not a cron/webhook session" verdict; skips the automation-status metadata write on later results
   // Unpromoted cron/webhook session: release its container stream when the
   // session settles. Resolved from session metadata at subscribe time so the
@@ -306,20 +348,20 @@ export class WaitForIdleTimeoutError extends Error {
 
 // TODO this file is too big, this class is HUGE. Needs breaking up
 class MessagePersister {
-  private streamingStates: Map<string, StreamingState> = new Map()
+  private streamingStates: Map<SessionKey, StreamingState> = new Map()
   // "Allow for this session" capability grants, keyed by sessionId. Display
   // bookkeeping ONLY — enforcement lives in the container (which persists its
   // copy with the session). Once granted, launches auto-allow container-side
   // with no pending entry, so we must stop broadcasting review cards for them.
-  private sessionCapabilityGrants: Map<string, Set<'subagents' | 'workflows'>> = new Map()
-  private subscriptions: Map<string, () => void> = new Map()
-  private sseClients: Map<string, Set<(data: unknown) => void>> = new Map()
+  private sessionCapabilityGrants: Map<SessionKey, Set<'subagents' | 'workflows'>> = new Map()
+  private subscriptions: Map<SessionKey, () => void> = new Map()
+  private sseClients: Map<SessionKey, Set<(data: unknown) => void>> = new Map()
   // Per-run journal tailers driving the live workflow drawer, keyed `${sessionId}::${runId}`
-  private workflowTailers: Map<string, WorkflowJournalTailer> = new Map()
+  private workflowTailers: Map<`${SessionKey}::${string}`, WorkflowJournalTailer> = new Map()
   // Global notification subscribers (e.g., Electron main process)
   private globalNotificationClients: Set<(data: unknown) => void> = new Set()
   // Track container clients per session for reconnection
-  private containerClients: Map<string, ContainerClient> = new Map()
+  private containerClients: Map<SessionKey, ContainerClient> = new Map()
   // Callback to request stopping a container (registered by container-manager)
   private onStopContainerRequested: ((agentSlug: string) => void) | null = null
   private onUnexpectedDeathRequested: ((agentSlug: string, sessionId?: string) => void) | null = null
@@ -330,7 +372,7 @@ class MessagePersister {
   // In-flight subscribe promises, keyed by sessionId. Concurrent
   // subscribeToSession() calls for the same session share the underlying
   // promise so we don't double-install listeners or double-tear-down state.
-  private subscribingNow: Map<string, Promise<void>> = new Map()
+  private subscribingNow: Map<SessionKey, Promise<void>> = new Map()
 
   constructor() {
     // Unified wire: every registry transition — no matter which of the many
@@ -436,8 +478,8 @@ class MessagePersister {
     if (request.scope.agentSlug) {
       this.broadcastGlobal(event)
     }
-    if (request.scope.sessionId) {
-      this.broadcastToSSE(request.scope.sessionId, event)
+    if (request.scope.agentSlug && request.scope.sessionId) {
+      this.broadcastToSSE(request.scope.agentSlug, request.scope.sessionId, event)
     }
   }
 
@@ -447,27 +489,28 @@ class MessagePersister {
   // subscription instead of racing each other (which would re-init state and
   // leak listeners).
   async subscribeToSession(
+    agentSlug: string,
     sessionId: string,
     client: ContainerClient,
     containerSessionId: string,
-    agentSlug?: string
   ): Promise<void> {
-    const inFlight = this.subscribingNow.get(sessionId)
+    const ctx = sessionCtx(agentSlug, sessionId)
+    const inFlight = this.subscribingNow.get(ctx.key)
     if (inFlight) return inFlight
-    const promise = this.doSubscribeToSession(sessionId, client, containerSessionId, agentSlug)
+    const promise = this.doSubscribeToSession(ctx, client, containerSessionId)
       .finally(() => {
-        this.subscribingNow.delete(sessionId)
+        this.subscribingNow.delete(ctx.key)
       })
-    this.subscribingNow.set(sessionId, promise)
+    this.subscribingNow.set(ctx.key, promise)
     return promise
   }
 
   private async doSubscribeToSession(
-    sessionId: string,
+    ctx: SessionCtx,
     client: ContainerClient,
     containerSessionId: string,
-    agentSlug?: string
   ): Promise<void> {
+    const { agentSlug, sessionId } = ctx
     // Preserve session-lifecycle state across (re-)subscribe so callers that
     // markSessionActive *before* subscribing (e.g. x-agent sync invoke) and
     // SSE reconnects of in-flight sessions don't lose their "currently busy"
@@ -475,7 +518,7 @@ class MessagePersister {
     // over too: the awaiting cache is only meaningful while its source of
     // truth survives — recreating them empty would let the next sync clear a
     // genuinely parked wait.
-    const prior = this.streamingStates.get(sessionId)
+    const prior = this.streamingStates.get(ctx.key)
     const priorIsActive = prior?.isActive ?? false
     const priorIsAwaitingInput = prior?.isAwaitingInput ?? false
     const priorBackgroundTasks = prior?.activeBackgroundTasks ?? new Map()
@@ -484,14 +527,15 @@ class MessagePersister {
     // Detach only the transport if already subscribed. NOT unsubscribeFromSession:
     // that is a full teardown — it drops the session's registry entries, which
     // must outlive a transport reattach for the same live session.
-    const existingUnsubscribe = this.subscriptions.get(sessionId)
+    const existingUnsubscribe = this.subscriptions.get(ctx.key)
     if (existingUnsubscribe) {
       existingUnsubscribe()
-      this.subscriptions.delete(sessionId)
+      this.subscriptions.delete(ctx.key)
     }
 
     // Initialize state
-    this.streamingStates.set(sessionId, {
+    this.streamingStates.set(ctx.key, {
+      sessionId,
       currentText: '',
       isStreaming: false,
       currentToolUse: null,
@@ -539,20 +583,20 @@ class MessagePersister {
       promotedToInteractive: prior?.promotedToInteractive ?? false,
     })
 
-    this.resolveReleaseStreamOnSettle(sessionId, agentSlug)
+    this.resolveReleaseStreamOnSettle(ctx)
 
     // Store container client for reconnection checks
-    this.containerClients.set(sessionId, client)
+    this.containerClients.set(ctx.key, client)
 
     // Subscribe to the container's message stream
     const { unsubscribe, ready } = client.subscribeToStream(
       containerSessionId,
-      (message) => this.handleMessage(sessionId, message)
+      (message) => this.handleMessage(ctx, message)
     )
 
-    this.subscriptions.set(sessionId, unsubscribe)
+    this.subscriptions.set(ctx.key, unsubscribe)
 
-    if (this.capture && agentSlug) {
+    if (this.capture) {
       const subagentsDir = path.join(getAgentSessionsDir(agentSlug), sessionId, 'subagents')
       await this.capture.snapshotSubagentsDir(sessionId, subagentsDir, 'subscribe')
       await this.capture.recordNote(sessionId, 'subscribe', { agentSlug, containerSessionId })
@@ -567,13 +611,13 @@ class MessagePersister {
   // the verdict lands well before finalizeIdle consumes it, and an unresolved
   // read just means the stream is kept (the pre-fix behavior). Automation
   // paths register metadata before subscribing, so the read can't miss them.
-  private resolveReleaseStreamOnSettle(sessionId: string, agentSlug?: string): void {
-    if (!agentSlug) return
-    const stateRef = this.streamingStates.get(sessionId)
+  private resolveReleaseStreamOnSettle(ctx: SessionCtx): void {
+    const { agentSlug, sessionId } = ctx
+    const stateRef = this.streamingStates.get(ctx.key)
     void getSessionMetadata(agentSlug, sessionId)
       .then((meta) => {
         // A resubscribe replaced the state and kicked off its own resolution.
-        const current = this.streamingStates.get(sessionId)
+        const current = this.streamingStates.get(ctx.key)
         if (!current || current !== stateRef) return
         // Promote wins: its marker is set synchronously, this read may be stale.
         if (current.promotedToInteractive) return
@@ -592,25 +636,26 @@ class MessagePersister {
   }
 
   // Unsubscribe from a session
-  unsubscribeFromSession(sessionId: string): void {
-    const unsubscribe = this.subscriptions.get(sessionId)
+  unsubscribeFromSession(agentSlug: string, sessionId: string): void {
+    const key = sessionKeyOf(agentSlug, sessionId)
+    const unsubscribe = this.subscriptions.get(key)
     if (unsubscribe) {
       unsubscribe()
-      this.subscriptions.delete(sessionId)
+      this.subscriptions.delete(key)
     }
-    this.streamingStates.delete(sessionId)
+    this.streamingStates.delete(key)
     // Shadow registry (Phase 2): every session-scoped entry dies with the state.
     userInputRequestManager.dropSessionRequests(sessionId, 'invalidated')
-    this.containerClients.delete(sessionId)
+    this.containerClients.delete(key)
     // Safe to drop: the container's persisted grants are authoritative, so a
     // resubscribed session repopulates this on the next launch with one GET.
-    this.sessionCapabilityGrants.delete(sessionId)
+    this.sessionCapabilityGrants.delete(key)
   }
 
   // Single idle finalizer — flips state and broadcasts to session + global
   // listeners. Used by the result handler (legacy result-driven idle), the
   // session_state_changed handler (authoritative idle), and markSessionInactive.
-  private finalizeIdle(sessionId: string, state: StreamingState): void {
+  private finalizeIdle(agentSlug: string, sessionId: string, state: StreamingState): void {
     // The session is truly settled: persist the automation outcome for a turn
     // that ended in a clean success. (Failures were already persisted at their
     // result — an error ends the turn immediately. Interrupts never set the
@@ -626,26 +671,27 @@ class MessagePersister {
     // — e.g. the markSessionIdle revert after markSessionActive's sync picked
     // up an open agent-scoped review.
     state.isAwaitingInput = false
-    this.broadcastToSSE(sessionId, { type: 'session_idle', isActive: false })
+    this.broadcastToSSE(agentSlug, sessionId, { type: 'session_idle', isActive: false })
     this.broadcastGlobal({
       type: 'session_idle',
       sessionId,
       agentSlug: state.agentSlug,
       isActive: false,
     })
-    this.maybeReleaseSettledAutomationStream(sessionId, state)
+    this.maybeReleaseSettledAutomationStream(state)
   }
 
   // Tear down a settled automation stream. Sync: an async gap races the wake path's isSubscribed check.
   // Gated on stateEventsAuthority so a legacy idle can't drop a queued turn's stream.
-  private maybeReleaseSettledAutomationStream(sessionId: string, state: StreamingState): void {
+  private maybeReleaseSettledAutomationStream(state: StreamingState): void {
+    const { agentSlug, sessionId } = state
     if (
       state.releaseStreamOnSettle &&
       state.stateEventsAuthority &&
-      this.subscriptions.has(sessionId)
+      this.subscriptions.has(sessionKeyOf(agentSlug, sessionId))
     ) {
       console.log(`[MessagePersister] Releasing settled automation stream for session ${sessionId}`)
-      this.unsubscribeFromSession(sessionId)
+      this.unsubscribeFromSession(agentSlug, sessionId)
     }
   }
 
@@ -653,8 +699,8 @@ class MessagePersister {
   // before reaching the container (e.g. a scheduled wake delivery error). The
   // session never actually started a turn, so flip it back to idle rather than
   // leaving a phantom "working" state until some later retry succeeds.
-  markSessionIdle(sessionId: string): void {
-    const state = this.streamingStates.get(sessionId)
+  markSessionIdle(agentSlug: string, sessionId: string): void {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state?.isActive) return
     // The send never happened, so the recency it was credited with is undone
     // too (a no-op if a frame has arrived since — then the turn was real).
@@ -662,12 +708,12 @@ class MessagePersister {
       revertSessionActivity(state.agentSlug, sessionId, state.provisionalActivity)
     }
     state.provisionalActivity = null
-    this.finalizeIdle(sessionId, state)
+    this.finalizeIdle(agentSlug, sessionId, state)
   }
 
   // Check if a session is currently active (processing user request)
-  isSessionActive(sessionId: string): boolean {
-    const state = this.streamingStates.get(sessionId)
+  isSessionActive(agentSlug: string, sessionId: string): boolean {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     return state?.isActive ?? false
   }
 
@@ -683,8 +729,7 @@ class MessagePersister {
   // that explicitly want "resolve if idle now" semantics.
   // observeMs (default 2000): how long to wait for the session to become active before
   // giving up with an error (only when requireActiveFirst=true).
-  waitForIdle(
-    sessionId: string,
+  waitForIdle(agentSlug: string, sessionId: string,
     opts?: {
       timeoutMs?: number
       signal?: AbortSignal
@@ -717,7 +762,7 @@ class MessagePersister {
       }
 
       const tick = () => {
-        const state = this.streamingStates.get(sessionId)
+        const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
         if (state?.isActive) everActive = true
 
         if (!state || !state.isActive) {
@@ -747,8 +792,8 @@ class MessagePersister {
   }
 
   // Check if a session is waiting for user input
-  isSessionAwaitingInput(sessionId: string): boolean {
-    const state = this.streamingStates.get(sessionId)
+  isSessionAwaitingInput(agentSlug: string, sessionId: string): boolean {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     return state?.isAwaitingInput ?? false
   }
 
@@ -776,17 +821,20 @@ class MessagePersister {
 
   // Public snapshot of the activity — the chat manager's per-session tick samples it
   // each interval, and the subscribe-time reconcile reads it for a cold start.
-  getSessionActivity(sessionId: string): SessionActivity {
-    const state = this.streamingStates.get(sessionId)
+  getSessionActivity(agentSlug: string, sessionId: string): SessionActivity {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     return state ? this.computeActivity(state) : 'idle'
   }
 
   // Open computer-use approvals for a session, projected out of the registry.
   // Drives the turn-cancel sweep (which must reject each one on the container)
   // and the lifecycle tests' view of what is still parked.
-  getPendingComputerUseRequests(sessionId: string): Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> {
+  getPendingComputerUseRequests(agentSlug: string, sessionId: string): Array<{ toolUseId: string; method: string; params: Record<string, unknown>; permissionLevel: string; appName?: string; agentSlug?: string }> {
     return userInputRequestManager
       .getOpenRequestsForSession(sessionId)
+      // The request store is keyed by session id alone, so scope it to the
+      // asking agent here the way every other registry read is scoped.
+      .filter((r) => r.scope.agentSlug === agentSlug)
       // Auto-approved requests are registered only for the decision gate —
       // nothing may treat a command that is already executing as parked.
       .filter((r) => r.kind === 'computer_use' && !r.autoApproved)
@@ -811,21 +859,21 @@ class MessagePersister {
   // Requests a decision route settled while their transcript tool_result is
   // still held back by parallel siblings. The messages route stamps these
   // outcomes onto the transcript.
-  getSettledInputRequests(sessionId: string): Map<string, UserInputRequestOutcome> {
-    return this.streamingStates.get(sessionId)?.settledInputRequests ?? new Map()
+  getSettledInputRequests(agentSlug: string, sessionId: string): Map<string, UserInputRequestOutcome> {
+    return this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))?.settledInputRequests ?? new Map()
   }
 
   // Record an "Allow for this session" capability grant (decision route calls
   // this when the user picks session scope) so later launches in the session
   // don't produce review cards the container will never wait on.
-  grantSessionCapability(sessionId: string, capability: 'subagents' | 'workflows'): void {
-    const grants = this.sessionCapabilityGrants.get(sessionId) ?? new Set()
+  grantSessionCapability(agentSlug: string, sessionId: string, capability: 'subagents' | 'workflows'): void {
+    const grants = this.sessionCapabilityGrants.get(sessionKeyOf(agentSlug, sessionId)) ?? new Set()
     grants.add(capability)
-    this.sessionCapabilityGrants.set(sessionId, grants)
+    this.sessionCapabilityGrants.set(sessionKeyOf(agentSlug, sessionId), grants)
   }
 
-  hasSessionCapabilityGrant(sessionId: string, capability: 'subagents' | 'workflows'): boolean {
-    return this.sessionCapabilityGrants.get(sessionId)?.has(capability) ?? false
+  hasSessionCapabilityGrant(agentSlug: string, sessionId: string, capability: 'subagents' | 'workflows'): boolean {
+    return this.sessionCapabilityGrants.get(sessionKeyOf(agentSlug, sessionId))?.has(capability) ?? false
   }
 
   // Drop a decided capability review from the reconnect-replay store and tell live
@@ -834,14 +882,15 @@ class MessagePersister {
   // minutes before its result arrives, and until then a refresh would replay (and
   // other connected clients would keep) a stale approval card.
   completeCapabilityReview(
+    agentSlug: string,
     sessionId: string,
     toolUseId: string,
     outcome: UserInputRequestOutcome = 'answered',
   ): void {
-    const state = this.streamingStates.get(sessionId)
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state) return
     userInputRequestManager.resolveIfInStore(toolUseId, 'stream', outcome)
-    this.syncSessionAwaiting(sessionId)
+    this.syncSessionAwaiting(agentSlug, sessionId)
   }
 
   // Settle a stream-store request the moment its decision succeeds. The
@@ -854,14 +903,16 @@ class MessagePersister {
   // the toolUseId (chat connectors) pass sessionId undefined — the registry
   // entry's scope supplies it.
   completeInputRequest(
+    agentSlug: string | undefined,
     sessionId: string | undefined,
     toolUseId: string,
     outcome: UserInputRequestOutcome,
   ): void {
-    const scopeSessionId =
-      sessionId ?? userInputRequestManager.getOpenRequest(toolUseId)?.scope.sessionId
-    if (!scopeSessionId) return
-    const state = this.streamingStates.get(scopeSessionId)
+    const scope = userInputRequestManager.getOpenRequest(toolUseId)?.scope
+    const scopeSessionId = sessionId ?? scope?.sessionId
+    const scopeAgentSlug = agentSlug ?? scope?.agentSlug
+    if (!scopeSessionId || !scopeAgentSlug) return
+    const state = this.streamingStates.get(sessionKeyOf(scopeAgentSlug, scopeSessionId))
     const settled = userInputRequestManager.resolveIfInStore(toolUseId, 'stream', outcome)
     if (state && settled) {
       state.settledInputRequests.set(toolUseId, outcome)
@@ -871,24 +922,25 @@ class MessagePersister {
       // removed its card optimistically; every other tab drops it off this
       // event. Card removal is idempotent, so the later real tool_result
       // broadcasting again is harmless.
-      this.broadcastToSSE(scopeSessionId, {
+      this.broadcastToSSE(scopeAgentSlug, scopeSessionId, {
         type: 'tool_result',
         toolUseId,
         result: outcome === 'answered' ? 'User provided input' : 'User declined the request',
         isError: outcome !== 'answered',
       })
     }
-    this.syncSessionAwaiting(scopeSessionId)
+    this.syncSessionAwaiting(scopeAgentSlug, scopeSessionId)
   }
 
   // Clear a pending computer use request (after approval/rejection)
   clearPendingComputerUseRequest(
+    agentSlug: string,
     sessionId: string,
     toolUseId: string,
     outcome: UserInputRequestOutcome = 'answered',
   ): void {
     userInputRequestManager.resolveIfInStore(toolUseId, 'computer_use', outcome)
-    this.syncSessionAwaiting(sessionId)
+    this.syncSessionAwaiting(agentSlug, sessionId)
   }
 
   // When a new message arrives while the session is awaiting user input, cancel the
@@ -909,8 +961,8 @@ class MessagePersister {
   // idempotent when sends are serialized — the chat path serializes per chat via messageQueues;
   // the app send route does not, so two truly concurrent sends there can both pass it.)
   // Interrupt/reject failures are swallowed: a best-effort cancel must never block the message.
-  async cancelAwaitingInput(sessionId: string, agentSlug: string): Promise<void> {
-    if (!this.isSessionAwaitingInput(sessionId)) return
+  async cancelAwaitingInput(agentSlug: string, sessionId: string): Promise<void> {
+    if (!this.isSessionAwaitingInput(agentSlug, sessionId)) return
 
     // Snapshot the pending ids of both stores before interrupting: the stream
     // store is cleared by markSessionInterrupted's session_idle, and computer
@@ -919,13 +971,13 @@ class MessagePersister {
     // still be live (the host missed the original delivery), so skipping them
     // would leave an abandoned request for a late click to land on.
     const inputRequestIds = userInputRequestManager.getStoreIdsForSession(sessionId, 'stream')
-    const computerUseIds = this.getPendingComputerUseRequests(sessionId).map((r) => r.toolUseId)
+    const computerUseIds = this.getPendingComputerUseRequests(agentSlug, sessionId).map((r) => r.toolUseId)
 
     // Interrupt FIRST: abort the parked query so it can never resume into a filler reply.
     await this.interruptContainerSession(agentSlug, sessionId).catch(
       (e) => console.error(`[MessagePersister] cancelAwaitingInput interrupt failed for ${sessionId}:`, e),
     )
-    await this.markSessionInterrupted(sessionId)
+    await this.markSessionInterrupted(agentSlug, sessionId)
 
     // Clear the host-side computer_use bookkeeping explicitly — session_idle only clears
     // the stream store, so a leftover entry would replay a phantom approval card on reconnect.
@@ -944,20 +996,20 @@ class MessagePersister {
   }
 
   // Get available slash commands for a session
-  getSlashCommands(sessionId: string): SlashCommandInfo[] {
-    return this.streamingStates.get(sessionId)?.slashCommands ?? []
+  getSlashCommands(agentSlug: string, sessionId: string): SlashCommandInfo[] {
+    return this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))?.slashCommands ?? []
   }
 
   // Set slash commands for a session (from container session creation response)
-  setSlashCommands(sessionId: string, commands: SlashCommandInfo[]): void {
-    const state = this.streamingStates.get(sessionId)
+  setSlashCommands(agentSlug: string, sessionId: string, commands: SlashCommandInfo[]): void {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (state) {
       state.slashCommands = commands
     }
   }
 
-  getActiveBackgroundTasks(sessionId: string): Array<{ taskId: string; startedAt: number; isWorkflow?: boolean; isSubagent?: boolean }> {
-    const state = this.streamingStates.get(sessionId)
+  getActiveBackgroundTasks(agentSlug: string, sessionId: string): Array<{ taskId: string; startedAt: number; isWorkflow?: boolean; isSubagent?: boolean }> {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state) return []
     return Array.from(state.activeBackgroundTasks.entries()).map(([taskId, info]) => ({
       taskId,
@@ -968,8 +1020,8 @@ class MessagePersister {
   }
 
   // Check if a session has an active subscription
-  isSubscribed(sessionId: string): boolean {
-    return this.subscriptions.has(sessionId)
+  isSubscribed(agentSlug: string, sessionId: string): boolean {
+    return this.subscriptions.has(sessionKeyOf(agentSlug, sessionId))
   }
 
   // Check if any session for a given agent is currently active (processing)
@@ -988,9 +1040,9 @@ class MessagePersister {
   // agents.ts that lights up `isActive && hasAgentLevelReviews`.
   getActiveSessionIdsForAgent(agentSlug: string): string[] {
     const ids: string[] = []
-    for (const [sessionId, state] of this.streamingStates) {
+    for (const state of this.streamingStates.values()) {
       if (state.agentSlug === agentSlug && state.isActive) {
-        ids.push(sessionId)
+        ids.push(state.sessionId)
       }
     }
     return ids
@@ -1011,21 +1063,22 @@ class MessagePersister {
     agentSlug: string,
     options?: { settleRecovering?: boolean },
   ): void {
-    for (const [sessionId, state] of this.streamingStates) {
+    for (const state of this.streamingStates.values()) {
       if (state.agentSlug === agentSlug) {
+        const { sessionId } = state
         if (state.isRecovering) {
           if (options?.settleRecovering) {
-            this.settleRecoveringSessions([sessionId])
+            this.settleRecoveringSessions(agentSlug, [sessionId])
           } else {
-            this.detachSessionTransport(sessionId)
+            this.detachSessionTransport(agentSlug, sessionId)
           }
           continue
         }
         if (state.isActive) {
           console.log(`[MessagePersister] Marking session ${sessionId} inactive (container stopped)`)
-          this.markSessionInactive(sessionId, state)
+          this.markSessionInactive(agentSlug, sessionId, state)
         }
-        this.detachSessionTransport(sessionId)
+        this.detachSessionTransport(agentSlug, sessionId)
       }
     }
   }
@@ -1033,22 +1086,22 @@ class MessagePersister {
   snapshotMidTurnSessions(agentSlug: string, restrictToSessionIds?: string[]): string[] {
     const restrict = restrictToSessionIds ? new Set(restrictToSessionIds) : null
     const ids: string[] = []
-    for (const [sessionId, state] of this.streamingStates) {
-      if (restrict && !restrict.has(sessionId)) continue
+    for (const state of this.streamingStates.values()) {
+      if (restrict && !restrict.has(state.sessionId)) continue
       if (state.agentSlug === agentSlug && state.isActive && !state.isInterrupted) {
         state.isRecovering = true
-        ids.push(sessionId)
+        ids.push(state.sessionId)
       }
     }
     return ids
   }
 
-  isSessionRecovering(sessionId: string): boolean {
-    return this.streamingStates.get(sessionId)?.isRecovering === true
+  isSessionRecovering(agentSlug: string, sessionId: string): boolean {
+    return this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))?.isRecovering === true
   }
 
-  coalesceIfRecovering(sessionId: string, message: CoalescedUserMessage): boolean {
-    const state = this.streamingStates.get(sessionId)
+  coalesceIfRecovering(agentSlug: string, sessionId: string, message: CoalescedUserMessage): boolean {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state?.isRecovering) return false
     const text = message.text.trim()
     if (!text) return true
@@ -1059,16 +1112,16 @@ class MessagePersister {
     return true
   }
 
-  takeCoalescedUserMessages(sessionId: string): CoalescedUserMessage[] {
-    const state = this.streamingStates.get(sessionId)
+  takeCoalescedUserMessages(agentSlug: string, sessionId: string): CoalescedUserMessage[] {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     const messages = state?.coalescedUserMessages
     if (!state || !messages?.length) return []
     state.coalescedUserMessages = undefined
     return messages
   }
 
-  dropCoalescedUserMessage(sessionId: string, uuid: string): boolean {
-    const state = this.streamingStates.get(sessionId)
+  dropCoalescedUserMessage(agentSlug: string, sessionId: string, uuid: string): boolean {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state?.coalescedUserMessages) return false
     const next = state.coalescedUserMessages.filter((message) => message.uuid !== uuid)
     if (next.length === state.coalescedUserMessages.length) return false
@@ -1076,18 +1129,18 @@ class MessagePersister {
     return true
   }
 
-  markRecovered(sessionIds: string[]): void {
+  markRecovered(agentSlug: string, sessionIds: string[]): void {
     for (const sessionId of sessionIds) {
-      const state = this.streamingStates.get(sessionId)
+      const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
       if (!state) continue
       state.isRecovering = false
       state.coalescedUserMessages = undefined
     }
   }
 
-  settleRecoveringSessions(sessionIds: string[]): void {
+  settleRecoveringSessions(agentSlug: string, sessionIds: string[]): void {
     for (const sessionId of sessionIds) {
-      const state = this.streamingStates.get(sessionId)
+      const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
       if (!state) continue
       state.isRecovering = false
       const dropped = state.coalescedUserMessages
@@ -1103,9 +1156,9 @@ class MessagePersister {
       }
       state.coalescedUserMessages = undefined
       if (state.isActive && !state.isInterrupted) {
-        this.markSessionInactive(sessionId, state)
+        this.markSessionInactive(agentSlug, sessionId, state)
       }
-      this.detachSessionTransport(sessionId)
+      this.detachSessionTransport(agentSlug, sessionId)
     }
   }
 
@@ -1119,13 +1172,13 @@ class MessagePersister {
     this.lastFatalByAgent.set(agentSlug, kind)
   }
 
-  private detachSessionTransport(sessionId: string): void {
-    const unsubscribe = this.subscriptions.get(sessionId)
+  private detachSessionTransport(agentSlug: string, sessionId: string): void {
+    const unsubscribe = this.subscriptions.get(sessionKeyOf(agentSlug, sessionId))
     if (unsubscribe) {
       unsubscribe()
-      this.subscriptions.delete(sessionId)
+      this.subscriptions.delete(sessionKeyOf(agentSlug, sessionId))
     }
-    this.containerClients.delete(sessionId)
+    this.containerClients.delete(sessionKeyOf(agentSlug, sessionId))
   }
 
   // Broadcast to global notification clients only (e.g., sidebar updates, Electron main process)
@@ -1165,8 +1218,8 @@ class MessagePersister {
   }
 
   // Mark a session as interrupted (not active)
-  async markSessionInterrupted(sessionId: string): Promise<void> {
-    const state = this.streamingStates.get(sessionId)
+  async markSessionInterrupted(agentSlug: string, sessionId: string): Promise<void> {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
 
     // Set interrupted flag FIRST to prevent race conditions with incoming events
     if (state) {
@@ -1187,14 +1240,13 @@ class MessagePersister {
       state.bgTasksSnapshot = null
       state.isRecovering = false
       state.coalescedUserMessages = undefined
-      this.stopAllWorkflowTailers(sessionId)
+      this.stopAllWorkflowTailers(agentSlug, sessionId)
     }
 
     // Broadcast to session-specific clients
-    this.broadcastToSSE(sessionId, { type: 'session_idle', isActive: false })
+    this.broadcastToSSE(agentSlug, sessionId, { type: 'session_idle', isActive: false })
 
     // Also broadcast globally so sidebar updates regardless of which session is being viewed
-    const agentSlug = state?.agentSlug
     if (agentSlug) {
       this.broadcastGlobal({
         type: 'session_idle',
@@ -1206,25 +1258,25 @@ class MessagePersister {
   }
 
   // Add SSE client for real-time updates
-  addSSEClient(sessionId: string, callback: (data: unknown) => void): () => void {
-    let clients = this.sseClients.get(sessionId)
+  addSSEClient(agentSlug: string, sessionId: string, callback: (data: unknown) => void): () => void {
+    let clients = this.sseClients.get(sessionKeyOf(agentSlug, sessionId))
     if (!clients) {
       clients = new Set()
-      this.sseClients.set(sessionId, clients)
+      this.sseClients.set(sessionKeyOf(agentSlug, sessionId), clients)
     }
     clients.add(callback)
 
     return () => {
       clients?.delete(callback)
       if (clients?.size === 0) {
-        this.sseClients.delete(sessionId)
+        this.sseClients.delete(sessionKeyOf(agentSlug, sessionId))
       }
     }
   }
 
   // Public method to broadcast session metadata updates (e.g., name change)
-  broadcastSessionUpdate(sessionId: string): void {
-    this.broadcastToSSE(sessionId, { type: 'session_updated' })
+  broadcastSessionUpdate(agentSlug: string, sessionId: string): void {
+    this.broadcastToSSE(agentSlug, sessionId, { type: 'session_updated' })
   }
 
   private resetSessionCompleteResponse(state: StreamingState): void {
@@ -1265,10 +1317,11 @@ class MessagePersister {
   }
 
   // Mark session as active (when user sends a message)
-  markSessionActive(sessionId: string, agentSlug?: string): void {
-    let state = this.streamingStates.get(sessionId)
+  markSessionActive(agentSlug: string, sessionId: string): void {
+    let state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state) {
       state = {
+        sessionId,
         currentText: '',
         isStreaming: false,
         currentToolUse: null,
@@ -1303,8 +1356,8 @@ class MessagePersister {
       provisionalActivity: null,
         isRetrying: false,
       }
-      this.streamingStates.set(sessionId, state)
-      if (this.capture && agentSlug) {
+      this.streamingStates.set(sessionKeyOf(agentSlug, sessionId), state)
+      if (this.capture) {
         const subagentsDir = path.join(getAgentSessionsDir(agentSlug), sessionId, 'subagents')
         this.capture.snapshotSubagentsDir(sessionId, subagentsDir, 'state-created').catch(() => {})
         this.capture.recordNote(sessionId, 'state_created', { agentSlug }).catch(() => {})
@@ -1369,7 +1422,7 @@ class MessagePersister {
     // message accepted into a running turn rather than a new one, so it can keep the
     // turn-scoped state (compaction, thinking, running subagents) that a real turn
     // boundary would clear.
-    this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true, queuedMidTurn: wasActive })
+    this.broadcastToSSE(agentSlug, sessionId, { type: 'session_active', isActive: true, queuedMidTurn: wasActive })
 
     // Also broadcast globally so sidebar updates regardless of which session is being viewed
     this.broadcastGlobal({
@@ -1384,7 +1437,7 @@ class MessagePersister {
     // survive a new message — an agent-scoped proxy/x-agent review. Syncing
     // makes a session that joins mid-review show awaiting immediately (the
     // review used to mark only the sessions active at request time).
-    this.syncSessionAwaiting(sessionId)
+    this.syncSessionAwaiting(agentSlug, sessionId)
   }
 
   // Recompute the derived awaiting projection for a session and broadcast on
@@ -1394,8 +1447,8 @@ class MessagePersister {
   // it directly, alongside isActive, without broadcasting). An inactive
   // session is never awaiting: its parked requests died with the turn, even
   // when a stale entry (or an agent-scoped review) is still open.
-  private syncSessionAwaiting(sessionId: string): void {
-    const state = this.streamingStates.get(sessionId)
+  private syncSessionAwaiting(agentSlug: string, sessionId: string): void {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state) return
     const derived =
       state.isActive && userInputRequestManager.isSessionAwaiting(sessionId, state.agentSlug)
@@ -1408,7 +1461,7 @@ class MessagePersister {
         agentSlug: state.agentSlug,
       })
       if (state.agentSlug) {
-        this.promoteAutomatedSession(sessionId, state.agentSlug).catch((err) => {
+        this.promoteAutomatedSession(state.agentSlug, sessionId).catch((err) => {
           console.error('[MessagePersister] Failed to promote automated session:', err)
         })
       }
@@ -1426,8 +1479,8 @@ class MessagePersister {
   // opens or settles. Replaces the registerAwaitingBlockerSource predicate and
   // the mark/clear pair ReviewManager used to drive imperatively.
   syncAgentSessionsAwaiting(agentSlug: string): void {
-    for (const [sessionId, state] of this.streamingStates) {
-      if (state.agentSlug === agentSlug) this.syncSessionAwaiting(sessionId)
+    for (const state of this.streamingStates.values()) {
+      if (state.agentSlug === agentSlug) this.syncSessionAwaiting(agentSlug, state.sessionId)
     }
   }
 
@@ -1465,7 +1518,7 @@ class MessagePersister {
     toolName: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string,
   ): void {
     // A recovered stub does NOT dedupe: transcript recovery can synthesize a
@@ -1495,7 +1548,7 @@ class MessagePersister {
     // The handler above already broadcast the request event, which registered
     // it — the sync just picks the new entry up.
     if (isBlockingUserInputToolName(toolName)) {
-      this.syncSessionAwaiting(sessionId)
+      this.syncSessionAwaiting(agentSlug, sessionId)
     }
   }
 
@@ -1521,11 +1574,11 @@ class MessagePersister {
   // place. Resolution needs no special path — their tool_result (or the next
   // turn boundary) clears them like any other stream-store entry.
   recoverSessionAwaitingInput(
+    agentSlug: string,
     sessionId: string,
-    agentSlug: string | undefined,
     unresolved: Array<{ toolUseId: string; toolName: string }>,
   ): void {
-    const state = this.streamingStates.get(sessionId)
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (!state?.isActive) return
     if (agentSlug && !state.agentSlug) {
       state.agentSlug = agentSlug
@@ -1541,7 +1594,7 @@ class MessagePersister {
         { agentSlug: state.agentSlug },
       )
     }
-    this.syncSessionAwaiting(sessionId)
+    this.syncSessionAwaiting(agentSlug, sessionId)
   }
 
   // Promote an automated session (cron/webhook/chat/x-agent) to a regular
@@ -1549,7 +1602,7 @@ class MessagePersister {
   // Public: the notification manager promotes on session_waiting so blocked
   // automations surface in session lists instead of accruing unread rows
   // nothing displays.
-  async promoteAutomatedSession(sessionId: string, agentSlug: string): Promise<void> {
+  async promoteAutomatedSession(agentSlug: string, sessionId: string): Promise<void> {
     const meta = await getSessionMetadata(agentSlug, sessionId)
     if (!isHiddenAutomatedSession(meta)) return
 
@@ -1559,7 +1612,7 @@ class MessagePersister {
 
     // Promoted sessions behave interactive from here on — keep their stream
     // alive across settles like any other interactive session.
-    const state = this.streamingStates.get(sessionId)
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (state) {
       state.promotedToInteractive = true
       state.releaseStreamOnSettle = false
@@ -1604,6 +1657,7 @@ class MessagePersister {
    * transcript JSONL (reload-safe), then nudge clients to refetch.
    */
   private handleInformational(
+    agentSlug: string,
     sessionId: string,
     state: StreamingState,
     content: { uuid?: string; content?: string; level?: string; prevent_continuation?: boolean },
@@ -1625,7 +1679,7 @@ class MessagePersister {
     })
       .then(() => {
         // The banner lives in the transcript now — refetch materializes it.
-        this.broadcastToSSE(sessionId, { type: 'messages_updated' })
+        this.broadcastToSSE(agentSlug, sessionId, { type: 'messages_updated' })
       })
       .catch((err) => {
         console.error('[MessagePersister] Failed to persist informational banner:', err)
@@ -1633,19 +1687,20 @@ class MessagePersister {
   }
 
   // Broadcast an arbitrary event to all SSE clients for a session (public)
-  broadcastSessionEvent(sessionId: string, data: unknown): void {
-    this.broadcastToSSE(sessionId, data)
+  broadcastSessionEvent(agentSlug: string, sessionId: string, data: unknown): void {
+    this.broadcastToSSE(agentSlug, sessionId, data)
   }
 
   // Broadcast to SSE clients
-  private broadcastToSSE(sessionId: string, data: unknown): void {
+  private broadcastToSSE(agentSlug: string, sessionId: string, data: unknown): void {
+    const key = sessionKeyOf(agentSlug, sessionId)
     this.capture?.recordOutput(sessionId, data)
     // Turn boundaries settle whatever the last turn left parked. That is the
     // only request bookkeeping on the broadcast path — registration itself
     // lives in the per-kind handlers.
     const evt = data as { type?: string } | null
     if (evt && (evt.type === 'session_active' || evt.type === 'session_idle')) {
-      const state = this.streamingStates.get(sessionId)
+      const state = this.streamingStates.get(key)
       if (state) {
         // The turn boundary lands the held-back sibling results in the
         // transcript — the settled-outcome stamps are no longer needed.
@@ -1669,7 +1724,7 @@ class MessagePersister {
         }
       }
     }
-    const clients = this.sseClients.get(sessionId)
+    const clients = this.sseClients.get(key)
     if (clients) {
       clients.forEach((callback) => {
         try {
@@ -1683,11 +1738,12 @@ class MessagePersister {
 
   // Handle incoming message from container
   private handleMessage(
-    sessionId: string,
+    ctx: SessionCtx,
     message: StreamMessage
   ): void {
+    const { agentSlug, sessionId } = ctx
     this.capture?.recordInput(sessionId, message)
-    const state = this.streamingStates.get(sessionId)
+    const state = this.streamingStates.get(ctx.key)
     if (!state) return
 
     // Skip processing if session was interrupted (prevents race conditions)
@@ -1721,7 +1777,7 @@ class MessagePersister {
     if (content.type === 'system') {
       const taskId = content.task_id as string | undefined
       if (taskId && content.status) {
-        this.clearBackgroundTask(sessionId, state, taskId)
+        this.clearBackgroundTask(agentSlug, sessionId, state, taskId)
       }
     }
 
@@ -1818,17 +1874,17 @@ class MessagePersister {
           // If the SDK already streamed text, just send the code. Otherwise also send the text.
           const hasStreamedText = state.currentText.length > 0
           if (hasStreamedText) {
-            this.broadcastToSSE(sessionId, { type: 'stream_api_error', apiErrorCode: content.error })
+            this.broadcastToSSE(agentSlug, sessionId, { type: 'stream_api_error', apiErrorCode: content.error })
           } else {
             const errorText = this.extractAssistantText(content)
             if (errorText) {
-              this.broadcastToSSE(sessionId, { type: 'stream_delta', text: errorText, apiErrorCode: content.error })
+              this.broadcastToSSE(agentSlug, sessionId, { type: 'stream_delta', text: errorText, apiErrorCode: content.error })
             }
           }
         }
         // Clear currentText since the message is now persisted
         state.currentText = ''
-        this.broadcastToSSE(sessionId, { type: 'messages_updated' })
+        this.broadcastToSSE(agentSlug, sessionId, { type: 'messages_updated' })
         // Broadcast context usage from the assistant message's usage field
         const assistantUsage = content.message?.usage
         if (assistantUsage) {
@@ -1918,7 +1974,7 @@ class MessagePersister {
                       .map((p: { text?: string }) => p.text || '')
                       .join('')
                   }
-                  this.broadcastSubagentCompleted(sessionId, state, block.tool_use_id, resultText)
+                  this.broadcastSubagentCompleted(agentSlug, sessionId, state, block.tool_use_id, resultText)
                 }
               }
             }
@@ -1932,7 +1988,7 @@ class MessagePersister {
           if (bgId && typeof bgId === 'string' && !state.activeBackgroundTasks.has(bgId)) {
             const startedAt = Date.now()
             state.activeBackgroundTasks.set(bgId, { startedAt })
-            this.broadcastToSSE(sessionId, {
+            this.broadcastToSSE(agentSlug, sessionId, {
               type: 'background_task_started',
               taskId: bgId,
               startedAt,
@@ -1955,18 +2011,18 @@ class MessagePersister {
         if (state.isCompacting || content.isCompactSummary) {
           state.isCompacting = false
           // Compaction complete — broadcast so frontend transitions from spinner to boundary
-          this.broadcastToSSE(sessionId, { type: 'compact_complete' })
-          this.broadcastToSSE(sessionId, { type: 'messages_updated' })
+          this.broadcastToSSE(agentSlug, sessionId, { type: 'compact_complete' })
+          this.broadcastToSSE(agentSlug, sessionId, { type: 'messages_updated' })
           break
         }
         // Tool results come as 'user' type messages. handleToolResults settles
         // each answered request in the registry and recomputes awaiting from
         // what actually remains open — answering one of several parallel
         // requests no longer drops the waiting light while siblings are parked.
-        this.handleToolResults(sessionId, content)
+        this.handleToolResults(agentSlug, sessionId, content)
         // Broadcast refresh so frontend can detect the persisted user message
         // and clear the optimistic pending copy promptly.
-        this.broadcastToSSE(sessionId, { type: 'messages_updated' })
+        this.broadcastToSSE(agentSlug, sessionId, { type: 'messages_updated' })
         break
 
       case 'system':
@@ -1980,7 +2036,7 @@ class MessagePersister {
               state.slashCommands,
             )
           }
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'stream_start',
             slashCommands: state.slashCommands.length > 0 ? state.slashCommands : undefined,
           })
@@ -1988,7 +2044,7 @@ class MessagePersister {
           // Prefer the SDK's explicit compacting status when available.
           if (content.status === 'compacting' && !state.isCompacting) {
             state.isCompacting = true
-            this.broadcastToSSE(sessionId, { type: 'compact_start' })
+            this.broadcastToSSE(agentSlug, sessionId, { type: 'compact_start' })
           }
           if (content.status === 'requesting') {
             // The CLI is composing the next model request — the moment it
@@ -1996,18 +2052,18 @@ class MessagePersister {
             // here are persisted as queued_command attachments with no stream
             // event of their own, so broadcast a refetch to materialize their
             // ghosts promptly.
-            this.broadcastToSSE(sessionId, { type: 'messages_updated' })
+            this.broadcastToSSE(agentSlug, sessionId, { type: 'messages_updated' })
           }
         } else if (content.subtype === 'compact_boundary') {
           // Fallback for SDK paths that surface compaction via boundary without an earlier status.
           if (!state.isCompacting) {
             state.isCompacting = true
-            this.broadcastToSSE(sessionId, { type: 'compact_start' })
+            this.broadcastToSSE(agentSlug, sessionId, { type: 'compact_start' })
           }
         } else if (content.subtype === 'api_retry') {
           // API retry in progress — broadcast details so the UI can show retry state
           state.isRetrying = true
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'api_retry',
             attempt: content.attempt,
             maxRetries: content.max_retries,
@@ -2045,7 +2101,7 @@ class MessagePersister {
             if (isResumedSubagent && agentId) {
               this.registerBackgroundSubagent(sessionId, state, agentId, toolUseId)
             }
-            this.broadcastToSSE(sessionId, {
+            this.broadcastToSSE(agentSlug, sessionId, {
               type: 'subagent_started',
               parentToolId: toolUseId,
               taskId: agentId,
@@ -2072,7 +2128,7 @@ class MessagePersister {
                 toolUseId,
                 workflowName: typeof content.workflow_name === 'string' ? content.workflow_name : undefined,
               })
-              this.broadcastToSSE(sessionId, { type: 'background_task_started', taskId: workflowTaskId, startedAt, isWorkflow: true })
+              this.broadcastToSSE(agentSlug, sessionId, { type: 'background_task_started', taskId: workflowTaskId, startedAt, isWorkflow: true })
               this.broadcastGlobal({ type: 'background_task_started', sessionId, agentSlug: state.agentSlug, taskId: workflowTaskId })
               // NOTE: we do NOT emit workflow_started or start the journal tailer yet — the
               // real on-disk runId (`wf_…`, the name of the subagents/workflows/<runId> dir)
@@ -2084,7 +2140,7 @@ class MessagePersister {
           // Subagent progress with usage stats (description intentionally omitted —
           // task_progress.description can change to reflect current action, but the
           // header should keep the original task description from task_started)
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'subagent_progress',
             parentToolId: content.tool_use_id,
             summary: content.summary,
@@ -2095,7 +2151,7 @@ class MessagePersister {
           // A dynamic workflow's task_progress carries a full live snapshot of its agent
           // tree in `workflow_progress[]` (per-agent state incl. failed, tokens, toolCalls,
           // current tool) plus cumulative `usage`. Forward it for the drawer's live view.
-          this.emitWorkflowProgress(sessionId, content, state)
+          this.emitWorkflowProgress(agentSlug, sessionId, content, state)
         } else if (content.subtype === 'task_updated') {
           // Background task state change. When a backgrounded Bash command completes
           // while the agent is still busy (a foreground tool was in flight when it
@@ -2112,7 +2168,7 @@ class MessagePersister {
           // Unconditional on map membership, same reason as the task_notification
           // path above: the id may only exist in the snapshot.
           if (taskId && isTerminal) {
-            this.clearBackgroundTask(sessionId, state, taskId)
+            this.clearBackgroundTask(agentSlug, sessionId, state, taskId)
           }
           // A background *subagent* (task_type 'local_agent') settles via a
           // task_updated whose task_id equals the subagent's agentId. The busy
@@ -2126,7 +2182,7 @@ class MessagePersister {
           if (taskId && isTerminal) {
             for (const [parentToolId, sub] of state.activeSubagents) {
               if ((sub.isBackground || sub.isResumed) && sub.agentId === taskId) {
-                this.broadcastSubagentCompleted(sessionId, state, parentToolId)
+                this.broadcastSubagentCompleted(agentSlug, sessionId, state, parentToolId)
                 break
               }
             }
@@ -2149,7 +2205,7 @@ class MessagePersister {
             (status === 'completed' || status === 'failed' || status === 'killed')
           ) {
             const summary = typeof content.summary === 'string' ? content.summary : undefined
-            this.broadcastSubagentCompleted(sessionId, state, toolUseId!, summary)
+            this.broadcastSubagentCompleted(agentSlug, sessionId, state, toolUseId!, summary)
           }
         } else if (content.subtype === 'process_restarted') {
           // Container-synthesized, live: the session's CLI process was replaced
@@ -2205,12 +2261,12 @@ class MessagePersister {
                 // alive and surface it as waiting-on-background; the per-task
                 // terminal signal (task_notification / task_updated) clears each
                 // task, and the subsequent, truly-settled idle finalizes.
-                this.broadcastToSSE(sessionId, {
+                this.broadcastToSSE(agentSlug, sessionId, {
                   type: 'session_waiting_background',
                   backgroundTaskCount: openBackgroundWork,
                 })
               } else {
-                this.finalizeIdle(sessionId, state)
+                this.finalizeIdle(agentSlug, sessionId, state)
                 // Completion notification at the real end of the work. Skip
                 // resume-exits: the session is pausing for a resume, not done.
                 if (state.lastResultSubtype === 'success' && state.agentSlug) {
@@ -2227,7 +2283,7 @@ class MessagePersister {
               }
             } else if (!state.isActive && state.lastResultSubtype !== null) {
               // Error path already cleared isActive, so finalizeIdle never ran.
-              this.maybeReleaseSettledAutomationStream(sessionId, state)
+              this.maybeReleaseSettledAutomationStream(state)
             }
           } else if (content.state === 'running' && !state.isActive) {
             // The runtime started a turn we didn't initiate via POST (e.g. a
@@ -2240,7 +2296,7 @@ class MessagePersister {
             // running → idle pair without another result; clearing the guard
             // here would leave isActive stuck until disconnect. The response
             // reset above keeps any duplicate completion notification generic.
-            this.broadcastToSSE(sessionId, { type: 'session_active', isActive: true })
+            this.broadcastToSSE(agentSlug, sessionId, { type: 'session_active', isActive: true })
             this.broadcastGlobal({
               type: 'session_active',
               sessionId,
@@ -2252,7 +2308,7 @@ class MessagePersister {
             // this picks up only waits that survive a new turn — an
             // agent-scoped review that was already parked when the runtime
             // started this one.
-            this.syncSessionAwaiting(sessionId)
+            this.syncSessionAwaiting(agentSlug, sessionId)
           }
         } else if (content.subtype === 'background_tasks_changed') {
           // Authoritative full snapshot of the session's live background tasks
@@ -2272,18 +2328,18 @@ class MessagePersister {
                 console.log(
                   `[MessagePersister] background_tasks_changed: clearing ${taskId} (no longer in SDK snapshot)`
                 )
-                this.clearBackgroundTask(sessionId, state, taskId)
+                this.clearBackgroundTask(agentSlug, sessionId, state, taskId)
               }
             }
           }
         } else if (content.subtype === 'memory_recall') {
           // Memory recall — agent is reading memory files
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'memory_recall',
             memoryPaths: content.memory_paths || [],
           })
         } else if (content.subtype === 'informational') {
-          this.handleInformational(sessionId, state, content)
+          this.handleInformational(agentSlug, sessionId, state, content)
         }
         break
 
@@ -2295,7 +2351,7 @@ class MessagePersister {
         // dropped (nothing downstream can act without a uuid).
         const lifecycle = parseCommandLifecycle(content)
         if (lifecycle) {
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'command_lifecycle',
             commandUuid: lifecycle.commandUuid,
             state: lifecycle.state,
@@ -2343,7 +2399,7 @@ class MessagePersister {
           inferOomSigkillFatal(content) &&
           state.agentSlug &&
           this.onUnexpectedDeathRequested &&
-          this.containerClients.get(sessionId)?.onFatalResult('oom_sigkill') === 'defer_for_recovery'
+          this.containerClients.get(sessionKeyOf(agentSlug, sessionId))?.onFatalResult('oom_sigkill') === 'defer_for_recovery'
         ) {
           this.recordLastFatal(state.agentSlug, 'oom_sigkill')
           this.onUnexpectedDeathRequested?.(state.agentSlug)
@@ -2353,7 +2409,7 @@ class MessagePersister {
           state.isActive = false
           state.isAwaitingInput = false
         } else if (state.stateEventsAuthority || this.openBackgroundWorkCount(state) > 0) {
-          this.syncSessionAwaiting(sessionId)
+          this.syncSessionAwaiting(agentSlug, sessionId)
         } else {
           state.isAwaitingInput = false // finalizeIdle below settles the turn
         }
@@ -2396,7 +2452,7 @@ class MessagePersister {
         // with a continuation turn moments later. turn_output_complete still
         // fires so partially-streamed text reconciles against the transcript.
         if (classification.isInterrupt) {
-          this.broadcastToSSE(sessionId, { type: 'turn_output_complete' })
+          this.broadcastToSSE(agentSlug, sessionId, { type: 'turn_output_complete' })
           break
         }
 
@@ -2414,7 +2470,7 @@ class MessagePersister {
             apiErrorCode ? `(${apiErrorCode})` : '',
             terminalReason ? `[${terminalReason}]` : ''
           )
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'session_error',
             error: errorMessage,
             apiErrorCode,
@@ -2446,13 +2502,13 @@ class MessagePersister {
         // transcript (the JSONL write can lag the stream) — otherwise a
         // follow-up turn's stream_start can wipe the streaming bubble before
         // its persisted copy is fetched and the final message blinks out.
-        this.broadcastToSSE(sessionId, { type: 'turn_output_complete' })
+        this.broadcastToSSE(agentSlug, sessionId, { type: 'turn_output_complete' })
 
         // UI hint: background tasks outlive the turn output.
         {
           const openBackgroundWork = this.openBackgroundWorkCount(state)
           if (openBackgroundWork > 0) {
-            this.broadcastToSSE(sessionId, {
+            this.broadcastToSSE(agentSlug, sessionId, {
               type: 'session_waiting_background',
               backgroundTaskCount: openBackgroundWork,
             })
@@ -2472,7 +2528,7 @@ class MessagePersister {
         if (this.openBackgroundWorkCount(state) > 0) {
           break
         }
-        this.finalizeIdle(sessionId, state)
+        this.finalizeIdle(agentSlug, sessionId, state)
         // Trigger session complete notification. Whether to *show* an OS
         // notification (vs just creating the DB record) is the renderer's
         // call — it knows about window focus, per-user viewing, and the
@@ -2494,7 +2550,7 @@ class MessagePersister {
 
       case 'browser_active':
         // Browser state changed — forward to SSE clients
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'browser_active',
           active: content.active,
         })
@@ -2507,7 +2563,7 @@ class MessagePersister {
         // everywhere instead of leaving it dangling until reconnect cleanup.
         if (typeof content.toolUseId === 'string') {
           if (userInputRequestManager.getOpenRequest(content.toolUseId)) {
-            this.completeCapabilityReview(sessionId, content.toolUseId, 'cancelled')
+            this.completeCapabilityReview(agentSlug, sessionId, content.toolUseId, 'cancelled')
           } else {
             // No card yet — handleCapabilityReviewTool is still awaiting its
             // container grant lookup. Tombstone the id so the handler drops
@@ -2541,19 +2597,20 @@ class MessagePersister {
 
   // Handle connection closed - check container and mark inactive if session is done
   private handleConnectionClosed(sessionId: string, state: StreamingState): void {
+    const { agentSlug } = state
     const diedMidTurn = state.isActive && !state.isInterrupted
     if (diedMidTurn && this.onUnexpectedDeathRequested && state.agentSlug) {
       // The socket is gone; detach so isSubscribed reports the truth and the
       // recovery orchestrator's ignore/recover paths actually resubscribe.
-      this.detachSessionTransport(sessionId)
+      this.detachSessionTransport(agentSlug, sessionId)
       this.onUnexpectedDeathRequested(state.agentSlug, sessionId)
       return
     }
 
-    const client = this.containerClients.get(sessionId)
+    const client = this.containerClients.get(sessionKeyOf(agentSlug, sessionId))
     if (!client) {
       // No client reference, assume session is done
-      this.markSessionInactive(sessionId, state)
+      this.markSessionInactive(agentSlug, sessionId, state)
       return
     }
 
@@ -2563,7 +2620,7 @@ class MessagePersister {
         if (!containerSession) {
           // Session doesn't exist in container anymore
           console.log(`[MessagePersister] Session ${sessionId} not found in container, marking inactive`)
-          this.markSessionInactive(sessionId, state)
+          this.markSessionInactive(agentSlug, sessionId, state)
           return
         }
 
@@ -2575,9 +2632,9 @@ class MessagePersister {
           console.log(`[MessagePersister] Session ${sessionId} still running, re-subscribing`)
           const { unsubscribe, ready } = client.subscribeToStream(
             sessionId,
-            (message) => this.handleMessage(sessionId, message)
+            (message) => this.handleMessage(sessionCtx(agentSlug, sessionId), message)
           )
-          this.subscriptions.set(sessionId, unsubscribe)
+          this.subscriptions.set(sessionKeyOf(agentSlug, sessionId), unsubscribe)
           // Defense-in-depth: we don't await the re-subscribe here, so attach a
           // handler to the `ready` promise. A failed reconnect routes a
           // synthesized connection_closed message through the callback above;
@@ -2588,18 +2645,18 @@ class MessagePersister {
         } else {
           // Session finished
           console.log(`[MessagePersister] Session ${sessionId} not running in container, marking inactive`)
-          this.markSessionInactive(sessionId, state)
+          this.markSessionInactive(agentSlug, sessionId, state)
         }
       })
       .catch((error) => {
         // Can't reach container, assume session is done
         console.error(`[MessagePersister] Failed to check container for session ${sessionId}:`, error)
-        this.markSessionInactive(sessionId, state)
+        this.markSessionInactive(agentSlug, sessionId, state)
       })
   }
 
   // Mark a session as inactive and broadcast the update
-  private markSessionInactive(sessionId: string, state: StreamingState): void {
+  private markSessionInactive(agentSlug: string, sessionId: string, state: StreamingState): void {
     // A session that was mid-turn (user message sent, no result yet) and not
     // deliberately interrupted didn't finish — its runtime vanished (container
     // crash, guest OOM kill of the agent process, VM death). Surface that as an
@@ -2616,7 +2673,7 @@ class MessagePersister {
     // The runtime is gone; its background tasks went with it (same reasoning as
     // markSessionInterrupted).
     state.bgTasksSnapshot = null
-    this.stopAllWorkflowTailers(sessionId)
+    this.stopAllWorkflowTailers(agentSlug, sessionId)
     if (diedMidTurn) {
       // Mirror the result-error path: settle isActive BEFORE broadcasting so
       // the terminal transition is a single non-busy emit (an intermediate
@@ -2629,7 +2686,7 @@ class MessagePersister {
         'The container may have crashed or run out of memory.'
       console.error(`[MessagePersister] Session ${sessionId} died mid-turn (connection lost)`)
       this.persistAutomationStatus(sessionId, state, 'failed')
-      this.broadcastToSSE(sessionId, {
+      this.broadcastToSSE(agentSlug, sessionId, {
         type: 'session_error',
         error: errorMessage,
         apiErrorCode: null,
@@ -2651,11 +2708,12 @@ class MessagePersister {
     // Don't emit here first: clearing streaming while isActive is still true
     // would read working=true and emit a spurious working(true)→(false) pair
     // that races connectors into a stuck indicator.
-    this.finalizeIdle(sessionId, state)
+    this.finalizeIdle(agentSlug, sessionId, state)
   }
 
   // Handle sidechain (subagent) messages — filter them out of main streaming state
   private handleSidechainMessage(sessionId: string, content: any, state: StreamingState): void {
+    const { agentSlug } = state
     const parentToolId = content.parent_tool_use_id as string
 
     // Look up or create the subagent entry for this parent tool
@@ -2677,7 +2735,7 @@ class MessagePersister {
     const messageAgentId = content.agentId as string | undefined
     if (messageAgentId && !sub.agentId) {
       sub.agentId = messageAgentId
-      this.broadcastToSSE(sessionId, {
+      this.broadcastToSSE(agentSlug, sessionId, {
         type: 'subagent_updated',
         parentToolId,
         agentId: sub.agentId,
@@ -2697,7 +2755,7 @@ class MessagePersister {
 
     // Sidechain 'result' means the background subagent has finished execution
     if (content.type === 'result') {
-      this.broadcastSubagentCompleted(sessionId, state, parentToolId)
+      this.broadcastSubagentCompleted(agentSlug, sessionId, state, parentToolId)
       return
     }
 
@@ -2730,13 +2788,13 @@ class MessagePersister {
               : newText
             if (delta) {
               if (!newText.startsWith(sub.currentText)) {
-                this.broadcastToSSE(sessionId, {
+                this.broadcastToSSE(agentSlug, sessionId, {
                   type: 'subagent_stream_start',
                   parentToolId,
                   agentId: sub.agentId,
                 })
               }
-              this.broadcastToSSE(sessionId, {
+              this.broadcastToSSE(agentSlug, sessionId, {
                 type: 'subagent_stream_delta',
                 parentToolId,
                 agentId: sub.agentId,
@@ -2773,7 +2831,7 @@ class MessagePersister {
           }
         }
       }
-      this.broadcastToSSE(sessionId, {
+      this.broadcastToSSE(agentSlug, sessionId, {
         type: 'subagent_updated',
         parentToolId,
         agentId: sub.agentId,
@@ -2787,6 +2845,7 @@ class MessagePersister {
     agentId: string,
     toolUseId: string,
   ): void {
+    const { agentSlug } = state
     if (state.activeBackgroundTasks.has(agentId)) return
 
     const startedAt = Date.now()
@@ -2798,7 +2857,7 @@ class MessagePersister {
     // isSubagent lets the renderer skip these in the generic
     // "N background processes" row — the named subagent row
     // already represents this work in the activity tray.
-    this.broadcastToSSE(sessionId, {
+    this.broadcastToSSE(agentSlug, sessionId, {
       type: 'background_task_started',
       taskId: agentId,
       startedAt,
@@ -2861,13 +2920,14 @@ class MessagePersister {
   // ever retire the ids we hold and they would pin the session "working" for the
   // rest of its life. Mirrors SessionSettlementTracker.resetBackgroundTasks.
   private dropProcessLocalBackgroundState(sessionId: string, state: StreamingState): void {
+    const { agentSlug } = state
     for (const taskId of [...state.activeBackgroundTasks.keys()]) {
-      this.clearBackgroundTask(sessionId, state, taskId)
+      this.clearBackgroundTask(agentSlug, sessionId, state, taskId)
     }
     state.bgTasksSnapshot = null
   }
 
-  private clearBackgroundTask(sessionId: string, state: StreamingState, taskId: string): boolean {
+  private clearBackgroundTask(agentSlug: string, sessionId: string, state: StreamingState, taskId: string): boolean {
     // Retire the id from the level set too. A terminal per-task signal normally
     // trails the snapshot that already dropped the task and this is a no-op; if
     // that removal frame never arrives, the freshest information has to win or
@@ -2876,12 +2936,12 @@ class MessagePersister {
     const info = state.activeBackgroundTasks.get(taskId)
     if (!info) return false
     state.activeBackgroundTasks.delete(taskId)
-    this.broadcastToSSE(sessionId, { type: 'background_task_completed', taskId })
+    this.broadcastToSSE(agentSlug, sessionId, { type: 'background_task_completed', taskId })
     this.broadcastGlobal({ type: 'background_task_completed', sessionId, agentSlug: state.agentSlug, taskId })
     // Use the real on-disk runId (learned from the tool result), NOT the task_id.
     if (info.isWorkflow && info.runId) {
-      this.broadcastToSSE(sessionId, { type: 'workflow_completed', runId: info.runId })
-      this.stopWorkflowTailer(sessionId, info.runId)
+      this.broadcastToSSE(agentSlug, sessionId, { type: 'workflow_completed', runId: info.runId })
+      this.stopWorkflowTailer(agentSlug, sessionId, info.runId)
     }
     return true
   }
@@ -2892,6 +2952,7 @@ class MessagePersister {
   // it's the only correct key for the tree route + journal tailer. We match it back to the
   // workflow background task by the launching tool_use_id and fire workflow_started here.
   private wireWorkflowFromToolResult(sessionId: string, content: any, state: StreamingState): void {
+    const { agentSlug } = state
     const tur = content?.tool_use_result as { taskType?: string; runId?: string } | undefined
     let runId = tur?.taskType === 'local_workflow' && typeof tur.runId === 'string' ? tur.runId : undefined
     // tool_use_id is on the tool_result block inside the user message.
@@ -2914,14 +2975,14 @@ class MessagePersister {
     for (const [, info] of state.activeBackgroundTasks) {
       if (info.isWorkflow && info.toolUseId === toolUseId && !info.runId) {
         info.runId = runId
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'workflow_started',
           toolUseId,
           runId,
           name: info.workflowName,
           startedAt: info.startedAt,
         })
-        this.startWorkflowTailer(sessionId, state.agentSlug, runId)
+        this.startWorkflowTailer(agentSlug, sessionId, runId)
         break
       }
     }
@@ -2930,7 +2991,7 @@ class MessagePersister {
   // Forward the rich live snapshot in a workflow's task_progress.workflow_progress[] to
   // the drawer: per-agent state (incl. failed/killed) + tokens + toolCalls + current tool,
   // plus the workflow's cumulative usage. Resolves runId via the launching tool_use_id.
-  private emitWorkflowProgress(sessionId: string, content: any, state: StreamingState): void {
+  private emitWorkflowProgress(agentSlug: string, sessionId: string, content: any, state: StreamingState): void {
     const wp = content?.workflow_progress
     const toolUseId = content?.tool_use_id as string | undefined
     if (!Array.isArray(wp) || !toolUseId) return
@@ -2958,7 +3019,7 @@ class MessagePersister {
       }))
       .filter((a: { agentId?: string }) => typeof a.agentId === 'string')
     const u = content.usage as { total_tokens?: number; tool_uses?: number; duration_ms?: number } | undefined
-    this.broadcastToSSE(sessionId, {
+    this.broadcastToSSE(agentSlug, sessionId, {
       type: 'workflow_progress',
       runId,
       agents,
@@ -2968,22 +3029,21 @@ class MessagePersister {
     })
   }
 
-  private startWorkflowTailer(sessionId: string, agentSlug: string | undefined, runId: string): void {
-    if (!agentSlug) return // can't resolve the workspace dir without a slug
-    const key = `${sessionId}::${runId}`
+  private startWorkflowTailer(agentSlug: string, sessionId: string, runId: string): void {
+    const key = `${sessionKeyOf(agentSlug, sessionId)}::${runId}` as const
     if (this.workflowTailers.has(key)) return
     const tailer = new WorkflowJournalTailer({
       sessionsDir: getAgentSessionsDir(agentSlug),
       sessionId,
       runId,
-      emit: (update) => this.broadcastToSSE(sessionId, update),
+      emit: (update) => this.broadcastToSSE(agentSlug, sessionId, update),
     })
     this.workflowTailers.set(key, tailer)
     tailer.start()
   }
 
-  private stopWorkflowTailer(sessionId: string, runId: string): void {
-    const key = `${sessionId}::${runId}`
+  private stopWorkflowTailer(agentSlug: string, sessionId: string, runId: string): void {
+    const key = `${sessionKeyOf(agentSlug, sessionId)}::${runId}` as const
     const tailer = this.workflowTailers.get(key)
     if (tailer) {
       tailer.stop()
@@ -2991,8 +3051,8 @@ class MessagePersister {
     }
   }
 
-  private stopAllWorkflowTailers(sessionId: string): void {
-    const prefix = `${sessionId}::`
+  private stopAllWorkflowTailers(agentSlug: string, sessionId: string): void {
+    const prefix = `${sessionKeyOf(agentSlug, sessionId)}::`
     for (const [key, tailer] of this.workflowTailers) {
       if (key.startsWith(prefix)) {
         tailer.stop()
@@ -3001,15 +3061,15 @@ class MessagePersister {
     }
   }
 
-  private broadcastSubagentCompleted(sessionId: string, state: StreamingState, parentToolId: string, resultText?: string): void {
+  private broadcastSubagentCompleted(agentSlug: string, sessionId: string, state: StreamingState, parentToolId: string, resultText?: string): void {
     const sub = state.activeSubagents.get(parentToolId)
     // Broadcast a final subagent_updated so the frontend refetches subagent messages
-    this.broadcastToSSE(sessionId, {
+    this.broadcastToSSE(agentSlug, sessionId, {
       type: 'subagent_updated',
       parentToolId,
       agentId: sub?.agentId ?? null,
     })
-    this.broadcastToSSE(sessionId, {
+    this.broadcastToSSE(agentSlug, sessionId, {
       type: 'subagent_completed',
       parentToolId,
       agentId: sub?.agentId ?? null,
@@ -3033,6 +3093,7 @@ class MessagePersister {
     state: StreamingState,
     parentToolId: string,
   ): void {
+    const { agentSlug } = state
     const orphaned = userInputRequestManager.resolveRequestsByParent(parentToolId, 'invalidated')
     if (orphaned.length === 0) return
     for (const request of orphaned) {
@@ -3049,7 +3110,7 @@ class MessagePersister {
         )
       }
     }
-    this.syncSessionAwaiting(sessionId)
+    this.syncSessionAwaiting(agentSlug, sessionId)
   }
 
   // Handle subagent stream events — mirrors handleStreamEvent but with subagent_ prefixed SSE events
@@ -3059,6 +3120,7 @@ class MessagePersister {
     state: StreamingState,
     parentToolId: string
   ): void {
+    const { agentSlug } = state
     const sub = state.activeSubagents.get(parentToolId)
     if (!sub) return
 
@@ -3067,7 +3129,7 @@ class MessagePersister {
         sub.currentText = ''
         sub.currentToolUse = null
         sub.currentToolInput = ''
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'subagent_stream_start',
           parentToolId,
           agentId: sub.agentId,
@@ -3081,7 +3143,7 @@ class MessagePersister {
             name: event.content_block.name!,
           }
           sub.currentToolInput = ''
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'subagent_tool_use_start',
             parentToolId,
             agentId: sub.agentId,
@@ -3095,7 +3157,7 @@ class MessagePersister {
       case 'content_block_delta':
         if (event.delta?.type === 'text_delta' && event.delta.text) {
           sub.currentText += event.delta.text
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'subagent_stream_delta',
             parentToolId,
             agentId: sub.agentId,
@@ -3104,7 +3166,7 @@ class MessagePersister {
         } else if (event.delta?.type === 'input_json_delta') {
           const partialJson = event.delta.partial_json || ''
           sub.currentToolInput += partialJson
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'subagent_tool_use_streaming',
             parentToolId,
             agentId: sub.agentId,
@@ -3162,7 +3224,7 @@ class MessagePersister {
             )
           }
 
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'subagent_tool_use_ready',
             parentToolId,
             agentId: sub.agentId,
@@ -3187,6 +3249,7 @@ class MessagePersister {
     event: { type: string; index?: number; message?: { id?: string }; content_block?: { type: string; id?: string; name?: string }; delta?: { type: string; text?: string; partial_json?: string; thinking?: string }; usage?: { input_tokens?: number; output_tokens?: number; cache_creation_input_tokens?: number; cache_read_input_tokens?: number } },
     state: StreamingState
   ): void {
+    const { agentSlug } = state
     switch (event.type) {
       case 'message_start':
         state.currentText = ''
@@ -3198,7 +3261,7 @@ class MessagePersister {
         state.isRetrying = false // the response is flowing now, so any retry resolved
         // 'streaming' is deferred to the first text token (set above) so a message that
         // opens with a tool call stays 'working' instead of flipping streaming→working.
-        this.broadcastToSSE(sessionId, { type: 'stream_start' })
+        this.broadcastToSSE(agentSlug, sessionId, { type: 'stream_start' })
         break
 
       case 'content_block_start':
@@ -3209,7 +3272,7 @@ class MessagePersister {
             name: event.content_block.name!,
           }
           state.currentToolInput = '' // Reset input accumulator
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'tool_use_start',
             toolId: event.content_block.id,
             toolName: event.content_block.name,
@@ -3221,7 +3284,7 @@ class MessagePersister {
           // `display: 'summarized'`; without it newer models omit the text).
           state.currentThinking = true
           state.currentThinkingBlockIndex = Number.isInteger(event.index) ? event.index! : null
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'thinking_start',
             thinkingId: makeThinkingBlockId(
               state.currentAssistantMessageId,
@@ -3234,7 +3297,7 @@ class MessagePersister {
       case 'content_block_delta':
         if (event.delta?.type === 'text_delta' && event.delta.text) {
           state.currentText += event.delta.text
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'stream_delta',
             text: event.delta.text,
           })
@@ -3246,7 +3309,7 @@ class MessagePersister {
           // recover the index from the delta itself when available.
           if (Number.isInteger(event.index)) state.currentThinkingBlockIndex = event.index!
           // Stream summarized reasoning text so the UI can accumulate it for "View thinking"
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'thinking_delta',
             thinkingId: makeThinkingBlockId(
               state.currentAssistantMessageId,
@@ -3258,7 +3321,7 @@ class MessagePersister {
           // Tool input is being streamed - accumulate and broadcast
           const partialJson = event.delta.partial_json || ''
           state.currentToolInput += partialJson
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'tool_use_streaming',
             toolId: state.currentToolUse?.id,
             toolName: state.currentToolUse?.name,
@@ -3274,7 +3337,7 @@ class MessagePersister {
         // Thinking block finished streaming — flip back to "Working"
         if (state.currentThinking) {
           state.currentThinking = false
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'thinking_stop',
             thinkingId: makeThinkingBlockId(
               state.currentAssistantMessageId,
@@ -3466,7 +3529,7 @@ class MessagePersister {
             })
           }
 
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'tool_use_ready',
             toolId: state.currentToolUse.id,
             toolName: state.currentToolUse.name,
@@ -3495,7 +3558,7 @@ class MessagePersister {
         // Defensive: ensure thinking state is cleared if a stop was missed
         if (state.currentThinking) {
           state.currentThinking = false
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'thinking_stop',
             thinkingId: makeThinkingBlockId(
               state.currentAssistantMessageId,
@@ -3514,7 +3577,7 @@ class MessagePersister {
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string
   ): void {
     try {
@@ -3549,7 +3612,7 @@ class MessagePersister {
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string
   ): void {
     try {
@@ -3587,7 +3650,7 @@ class MessagePersister {
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       if (!agentSlug) {
@@ -3661,7 +3724,7 @@ class MessagePersister {
       // a real success failed and retry into a duplicate schedule.
       try {
         // Broadcast the scheduled task created event to session-specific SSE clients
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'scheduled_task_created',
           toolUseId,
           taskId,
@@ -3711,7 +3774,7 @@ class MessagePersister {
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       if (!agentSlug) {
@@ -3765,7 +3828,7 @@ class MessagePersister {
 
       // Persisted — everything past here is best-effort delivery.
       try {
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'scheduled_task_created',
           toolUseId,
           taskId,
@@ -3782,7 +3845,7 @@ class MessagePersister {
         })
         // The pending wake is session-level state (badges, resume banner) —
         // nudge session lists to refetch.
-        this.broadcastToSSE(sessionId, { type: 'session_updated' })
+        this.broadcastToSSE(agentSlug, sessionId, { type: 'session_updated' })
         this.broadcastGlobal({ type: 'session_updated', sessionId, agentSlug })
 
         const parsed = validateScheduleExpression('at', scheduleExpression, timezone)
@@ -3879,7 +3942,7 @@ ${continuation}`
     _sessionId: string,
     toolUseId: string,
     _toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -3915,7 +3978,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -3952,7 +4015,7 @@ ${continuation}`
         }
 
         // Broadcast so the scheduled task list updates in the UI
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'scheduled_task_cancelled',
           toolUseId,
           taskId: input.task_id,
@@ -3985,7 +4048,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -4027,7 +4090,7 @@ ${continuation}`
         }
 
         // Broadcast so the scheduled task list updates in the UI
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'scheduled_task_updated',
           toolUseId,
           taskId: input.task_id,
@@ -4104,7 +4167,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -4166,7 +4229,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -4262,7 +4325,7 @@ ${continuation}`
         }
 
         // 3. Broadcast events
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'webhook_trigger_created',
           toolUseId,
           triggerId,
@@ -4309,7 +4372,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -4394,7 +4457,7 @@ ${continuation}`
         }
 
         // 3. Broadcast events (same shape as Composio trigger creation)
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'webhook_trigger_created',
           toolUseId,
           triggerId,
@@ -4449,7 +4512,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -4555,7 +4618,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -4642,7 +4705,7 @@ ${continuation}`
     _sessionId: string,
     toolUseId: string,
     _toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -4676,7 +4739,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): void {
     ;(async () => {
       try {
@@ -4707,7 +4770,7 @@ ${continuation}`
         }
 
         // Broadcast events
-        this.broadcastToSSE(sessionId, {
+        this.broadcastToSSE(agentSlug, sessionId, {
           type: 'webhook_trigger_cancelled',
           toolUseId,
           triggerId: input.trigger_id,
@@ -4739,7 +4802,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string
   ): void {
     try {
@@ -4780,18 +4843,18 @@ ${continuation}`
     toolUseId: string,
     toolName: string,
     toolInput: string,
-    agentSlug?: string
+    agentSlug: string
   ): Promise<void> {
     try {
       const capability = toolName === 'Workflow' ? 'workflows' : 'subagents'
       if (getAgentCapabilitySettings()[capability] !== 'review') return
-      if (this.hasSessionCapabilityGrant(sessionId, capability)) return
+      if (this.hasSessionCapabilityGrant(agentSlug, sessionId, capability)) return
 
       // The in-memory mirror above is only a fast path — the container's
       // persisted grants are authoritative. A fresh host process against a
       // live granted session would otherwise render a phantom review card
       // while the container runs the launch without waiting.
-      const client = this.containerClients.get(sessionId)
+      const client = this.containerClients.get(sessionKeyOf(agentSlug, sessionId))
       if (client) {
         try {
           const response = await client.fetch(
@@ -4801,7 +4864,7 @@ ${continuation}`
           if (response.ok) {
             const { grants } = sessionCapabilityGrantsResponseSchema.parse(await response.json())
             if (grants.includes(capability)) {
-              this.grantSessionCapability(sessionId, capability)
+              this.grantSessionCapability(agentSlug, sessionId, capability)
               return
             }
           }
@@ -4817,7 +4880,7 @@ ${continuation}`
       // Its completeCapabilityReview found nothing to delete, so consume the
       // tombstone here: broadcasting now would resurrect an unanswerable card
       // and re-mark the session as awaiting input.
-      if (this.streamingStates.get(sessionId)?.cancelledCapabilityReviews.delete(toolUseId)) {
+      if (this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))?.cancelledCapabilityReviews.delete(toolUseId)) {
         return
       }
 
@@ -4835,7 +4898,7 @@ ${continuation}`
         { capability, toolName, input },
         { agentSlug },
       )
-      this.syncSessionAwaiting(sessionId)
+      this.syncSessionAwaiting(agentSlug, sessionId)
     } catch (error) {
       console.error('[MessagePersister] Error handling capability review:', error)
     }
@@ -4846,7 +4909,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string
   ): void {
     try {
@@ -4880,7 +4943,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string
   ): void {
     try {
@@ -4921,7 +4984,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string
   ): void {
     try {
@@ -4955,7 +5018,7 @@ ${continuation}`
       // Capture it when the request opens so credential discovery does not
       // need a separate browser roundtrip later. Fill still re-checks the live
       // origin immediately before the password crosses the host boundary.
-      const client = this.containerClients.get(sessionId)
+      const client = this.containerClients.get(sessionKeyOf(agentSlug, sessionId))
       if (client) {
         void client.fetch(
           `/browser/credential-context?sessionId=${encodeURIComponent(sessionId)}`,
@@ -4979,7 +5042,7 @@ ${continuation}`
       // handler) covers SUBAGENT-originated requests, whose sidechain paths
       // bypass that handler — without this the orange awaiting-input status
       // never flips and the agent shows "working" while parked on the user.
-      this.syncSessionAwaiting(sessionId)
+      this.syncSessionAwaiting(agentSlug, sessionId)
     } catch (error) {
       console.error('[MessagePersister] Error handling browser input request:', error)
     }
@@ -5005,7 +5068,7 @@ ${continuation}`
     sessionId: string,
     toolUseId: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string
   ): void {
     try {
@@ -5059,7 +5122,7 @@ ${continuation}`
       // Only flip the global "awaiting input" status (which drives the orange agent-status
       // pill in the sidebar / tray) when the user actually has to respond.
       if (!autoApproved) {
-        this.syncSessionAwaiting(sessionId)
+        this.syncSessionAwaiting(agentSlug, sessionId)
       }
     } catch (error) {
       console.error('[MessagePersister] Error handling script run request:', error)
@@ -5074,7 +5137,7 @@ ${continuation}`
     toolUseId: string,
     toolName: string,
     toolInput: string,
-    agentSlug?: string,
+    agentSlug: string,
     parentToolUseId?: string,
   ): Promise<void> {
     try {
@@ -5149,7 +5212,7 @@ ${continuation}`
         parentToolUseId,
         payload: { method, params, permissionLevel, appName },
       })
-      this.syncSessionAwaiting(sessionId)
+      this.syncSessionAwaiting(agentSlug, sessionId)
     } catch (error) {
       console.error('[MessagePersister] Error handling computer use request:', error)
     }
@@ -5228,18 +5291,18 @@ ${continuation}`
         if (method === 'grab' || method === 'launch') {
           const targetApp = appName || (params.name as string) || (params.app as string)
           if (targetApp) {
-            this.broadcastToSSE(sessionId, { type: 'computer_use_grab_changed', app: targetApp })
+            this.broadcastToSSE(agentSlug, sessionId, { type: 'computer_use_grab_changed', app: targetApp })
             // Resolve icon async and send update
             import('@shared/lib/computer-use/app-icon').then(({ getAppIconBase64 }) =>
               getAppIconBase64(targetApp).then((icon) => {
                 if (icon) {
-                  this.broadcastToSSE(sessionId, { type: 'computer_use_grab_changed', app: targetApp, appIcon: icon })
+                  this.broadcastToSSE(agentSlug, sessionId, { type: 'computer_use_grab_changed', app: targetApp, appIcon: icon })
                 }
               })
             ).catch(() => {})
           }
         } else if (method === 'ungrab' || method === 'quit') {
-          this.broadcastToSSE(sessionId, { type: 'computer_use_grab_changed', app: null })
+          this.broadcastToSSE(agentSlug, sessionId, { type: 'computer_use_grab_changed', app: null })
         }
       })
       .catch((err: Error) => {
@@ -5265,6 +5328,7 @@ ${continuation}`
     state: StreamingState,
     usage: { input_tokens?: number; output_tokens?: number; cache_creation_input_tokens?: number; cache_read_input_tokens?: number }
   ): void {
+    const { agentSlug } = state
     const contextUsage: SessionUsage = {
       inputTokens: usage.input_tokens ?? 0,
       outputTokens: usage.output_tokens ?? 0,
@@ -5273,7 +5337,7 @@ ${continuation}`
       contextWindow: state.lastContextWindow,
     }
     state.lastAssistantUsage = contextUsage
-    this.broadcastToSSE(sessionId, { type: 'context_usage', ...contextUsage })
+    this.broadcastToSSE(agentSlug, sessionId, { type: 'context_usage', ...contextUsage })
   }
 
   // Extract contextWindow from SDK result event, then persist the last assistant
@@ -5284,6 +5348,7 @@ ${continuation}`
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     content: any
   ): void {
+    const { agentSlug } = state
     try {
       // contextWindow precedence: catalog (non-Claude) > SDK-reported > 200K default.
       // The SDK always reports a number, but for non-Claude models it's a generic
@@ -5312,7 +5377,7 @@ ${continuation}`
         }
 
         // Re-broadcast with the correct contextWindow
-        this.broadcastToSSE(sessionId, { type: 'context_usage', ...lastUsage })
+        this.broadcastToSSE(agentSlug, sessionId, { type: 'context_usage', ...lastUsage })
 
         // Persist to session metadata (fire-and-forget)
         if (state.agentSlug) {
@@ -5338,6 +5403,7 @@ ${continuation}`
     state: StreamingState,
     content: { message?: { content?: Array<{ type: string; tool_use_id?: string; content?: unknown; is_error?: boolean }> } }
   ): void {
+    const { agentSlug } = state
     const blocks = content.message?.content
     if (!Array.isArray(blocks)) return
     for (const block of blocks) {
@@ -5350,24 +5416,25 @@ ${continuation}`
       if (!settled) continue
       // Same broadcast the main path emits — the resolving tab already removed
       // its card optimistically; every other tab drops it off this event.
-      this.broadcastToSSE(sessionId, {
+      this.broadcastToSSE(agentSlug, sessionId, {
         type: 'tool_result',
         toolUseId: block.tool_use_id,
         result: block.content,
         isError: block.is_error || false,
       })
     }
-    this.syncSessionAwaiting(sessionId)
+    this.syncSessionAwaiting(agentSlug, sessionId)
   }
 
   private handleToolResults(
+    agentSlug: string,
     sessionId: string,
     content: { message?: { content?: Array<{ type: string; tool_use_id?: string; content?: unknown; is_error?: boolean }> } }
   ): void {
     try {
       const messageContent = content.message?.content || []
 
-      const state = this.streamingStates.get(sessionId)
+      const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
       for (const block of messageContent) {
         if (block.type === 'tool_result' && block.tool_use_id) {
           // A resolved user-input request must not be replayed to a client that
@@ -5382,7 +5449,7 @@ ${continuation}`
           }
 
           // Broadcast update to SSE clients
-          this.broadcastToSSE(sessionId, {
+          this.broadcastToSSE(agentSlug, sessionId, {
             type: 'tool_result',
             toolUseId: block.tool_use_id,
             result: block.content,
@@ -5395,7 +5462,7 @@ ${continuation}`
           const pendingDeliver = state?.pendingDeliverFiles.get(block.tool_use_id)
           if (pendingDeliver) {
             state!.pendingDeliverFiles.delete(block.tool_use_id)
-            this.broadcastToSSE(sessionId, {
+            this.broadcastToSSE(agentSlug, sessionId, {
               type: 'tool_result_ready',
               toolName: 'mcp__user-input__deliver_file',
               toolUseId: block.tool_use_id,
@@ -5406,7 +5473,7 @@ ${continuation}`
           }
         }
       }
-      this.syncSessionAwaiting(sessionId)
+      this.syncSessionAwaiting(agentSlug, sessionId)
     } catch (error) {
       console.error('Failed to handle tool results:', error)
     }

--- a/src/shared/lib/container/queued-message-idle-replay.test.ts
+++ b/src/shared/lib/container/queued-message-idle-replay.test.ts
@@ -140,14 +140,14 @@ async function setUpReplay(entries: FixtureEntry[], sessionId: string, agentSlug
   const { client, send } = createReplayClient()
 
   const sseEvents: Array<Record<string, unknown>> = []
-  const cleanup = messagePersister.addSSEClient(sessionId, (data) => {
+  const cleanup = messagePersister.addSSEClient(agentSlug, sessionId, (data) => {
     sseEvents.push(data as Record<string, unknown>)
   })
 
-  await messagePersister.subscribeToSession(sessionId, client, sessionId, agentSlug)
+  await messagePersister.subscribeToSession(agentSlug, sessionId, client, sessionId)
   // The POST /messages route marks the session active when the first user
   // message is sent.
-  messagePersister.markSessionActive(sessionId, agentSlug)
+  messagePersister.markSessionActive(agentSlug, sessionId)
 
   const firstResultIdx = entries.findIndex((e) => e.message.content?.type === 'result')
   const sendRange = async (from: number, to: number) => {
@@ -180,7 +180,7 @@ describe('queued-message-during-final-response replay (real capture, session d6c
     // Replay turn 1 up to (but not including) its result. The queued POST
     // landed mid-stream — the route re-marks the session active (no-op).
     await sendRange(0, firstResultIdx)
-    messagePersister.markSessionActive(sessionId, agentSlug)
+    messagePersister.markSessionActive(agentSlug, sessionId)
 
     // Deliver turn 1's result. In the real capture the CLI emits NO state
     // event here — the queued message keeps the runtime going, and the
@@ -189,7 +189,7 @@ describe('queued-message-during-final-response replay (real capture, session d6c
 
     // THE BUG: the legacy result-driven path finalized idle here.
     expect(countIdle(sseEvents)).toBe(0)
-    expect(messagePersister.isSessionActive(sessionId)).toBe(true)
+    expect(messagePersister.isSessionActive(agentSlug, sessionId)).toBe(true)
     // The premature completion notification was part of the same bug.
     expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
     // The turn's output is still announced so the renderer can reconcile the
@@ -201,7 +201,7 @@ describe('queued-message-during-final-response replay (real capture, session d6c
 
     // Exactly one idle, at the authoritative session_state_changed:'idle'.
     expect(countIdle(sseEvents)).toBe(1)
-    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(messagePersister.isSessionActive(agentSlug, sessionId)).toBe(false)
     expect(notificationManager.triggerSessionComplete).toHaveBeenCalledTimes(1)
     expect(notificationManager.triggerSessionComplete).toHaveBeenCalledWith(
       sessionId,
@@ -214,7 +214,7 @@ describe('queued-message-during-final-response replay (real capture, session d6c
     )
 
     cleanup()
-    messagePersister.unsubscribeFromSession(sessionId)
+    messagePersister.unsubscribeFromSession(agentSlug, sessionId)
   })
 
   it('legacy containers (no capabilities hello, no state events) keep result-driven idle', async () => {
@@ -234,7 +234,7 @@ describe('queued-message-during-final-response replay (real capture, session d6c
     // pre-state-events behavior — premature for queued messages, but the
     // session is never left stuck).
     expect(countIdle(sseEvents)).toBeGreaterThanOrEqual(1)
-    expect(messagePersister.isSessionActive(sessionId)).toBe(false)
+    expect(messagePersister.isSessionActive(agentSlug, sessionId)).toBe(false)
     expect(notificationManager.triggerSessionComplete).toHaveBeenLastCalledWith(
       sessionId,
       agentSlug,
@@ -246,6 +246,6 @@ describe('queued-message-during-final-response replay (real capture, session d6c
     )
 
     cleanup()
-    messagePersister.unsubscribeFromSession(sessionId)
+    messagePersister.unsubscribeFromSession(agentSlug, sessionId)
   })
 })

--- a/src/shared/lib/container/runtime-recovery.ts
+++ b/src/shared/lib/container/runtime-recovery.ts
@@ -24,7 +24,6 @@ export type RuntimeRecoveryDeps = {
     sessionId: string,
     client: ContainerClient,
     containerSessionId: string,
-    agentSlug: string,
   ) => Promise<void>
   syncAgentStatus?: () => Promise<void>
   // One-session connection_closed. Omitted = every mid-turn session on the agent.
@@ -259,7 +258,7 @@ async function resubscribeSessions(
   for (const sessionId of sessionIds) {
     if (deps.isStopping() || deps.isSubscribed(sessionId)) continue
     try {
-      await deps.subscribeToSession(sessionId, client, sessionId, deps.agentId)
+      await deps.subscribeToSession(sessionId, client, sessionId)
     } catch (error) {
       captureException(error, {
         tags: { area: 'container', op: 'runtime.resubscribe' },
@@ -303,7 +302,7 @@ async function resumeSessions(
     if (!deps.isSessionRecovering(sessionId)) continue
     try {
       if (!deps.isSubscribed(sessionId)) {
-        await deps.subscribeToSession(sessionId, client, sessionId, deps.agentId)
+        await deps.subscribeToSession(sessionId, client, sessionId)
       }
       await client.sendMessage(sessionId, plan.resumePrompt, randomUUID(), { shouldQuery: true })
       const coalesced = deps.takeCoalescedUserMessages(sessionId)

--- a/src/shared/lib/container/sdk206-fixtures-replay.test.ts
+++ b/src/shared/lib/container/sdk206-fixtures-replay.test.ts
@@ -182,16 +182,16 @@ async function replayTracked(fixtureName: string): Promise<{
   const { client, send } = createReplayClient()
 
   const sseEvents: Array<Record<string, unknown>> = []
-  const cleanup = messagePersister.addSSEClient(meta.sessionId, (data) => {
+  const cleanup = messagePersister.addSSEClient(meta.agentSlug, meta.sessionId, (data) => {
     sseEvents.push(data as Record<string, unknown>)
   })
 
   // The turn-starting user message predates the capture window; the idle
   // handler's gates are keyed on isActive.
   if (meta.startActive) {
-    messagePersister.markSessionActive(meta.sessionId, meta.agentSlug)
+    messagePersister.markSessionActive(meta.agentSlug, meta.sessionId)
   }
-  await messagePersister.subscribeToSession(meta.sessionId, client, meta.sessionId, meta.agentSlug)
+  await messagePersister.subscribeToSession(meta.agentSlug, meta.sessionId, client, meta.sessionId)
 
   const timeline: ReplaySnapshot[] = []
   for (let i = 0; i < streamEntries.length; i++) {
@@ -206,7 +206,7 @@ async function replayTracked(fixtureName: string): Promise<{
       type: c['type'] as string | undefined,
       subtype: c['subtype'] as string | undefined,
       state: c['state'] as string | undefined,
-      isActive: messagePersister.isSessionActive(meta.sessionId),
+      isActive: messagePersister.isSessionActive(meta.agentSlug, meta.sessionId),
       bgStartedIds: sseEvents.filter((e) => e['type'] === 'background_task_started').map((e) => e['taskId'] as string),
       bgCompletedIds: sseEvents.filter((e) => e['type'] === 'background_task_completed').map((e) => e['taskId'] as string),
       sessionIdleCount: sseEvents.filter((e) => e['type'] === 'session_idle').length,
@@ -216,7 +216,7 @@ async function replayTracked(fixtureName: string): Promise<{
 
   await new Promise((r) => setTimeout(r, 50))
   cleanup()
-  messagePersister.unsubscribeFromSession(meta.sessionId)
+  messagePersister.unsubscribeFromSession(meta.agentSlug, meta.sessionId)
 
   return { meta, streamEntries, sseEvents, timeline }
 }

--- a/src/shared/lib/container/subagent-routing-replay.test.ts
+++ b/src/shared/lib/container/subagent-routing-replay.test.ts
@@ -184,12 +184,12 @@ describe('subagent routing replay — sequential subagents across state reset', 
     const { client, send } = createReplayClient()
 
     // Collect SSE events
-    const cleanup = messagePersister.addSSEClient(meta.sessionId, (data) => {
+    const cleanup = messagePersister.addSSEClient(meta.agentSlug, meta.sessionId, (data) => {
       sseEvents.push(data as Record<string, unknown>)
     })
 
     // Subscribe (mirrors what happens on app launch / session resume)
-    await messagePersister.subscribeToSession(meta.sessionId, client, meta.sessionId, meta.agentSlug)
+    await messagePersister.subscribeToSession(meta.agentSlug, meta.sessionId, client, meta.sessionId)
 
     // Replay the captured stream
     for (const entry of streamEntries) {
@@ -202,7 +202,7 @@ describe('subagent routing replay — sequential subagents across state reset', 
     await new Promise((r) => setTimeout(r, 100))
 
     cleanup()
-    messagePersister.unsubscribeFromSession(meta.sessionId)
+    messagePersister.unsubscribeFromSession(meta.agentSlug, meta.sessionId)
 
     // ----- Assertions -----
 

--- a/src/shared/lib/container/subagent-task-events-replay.test.ts
+++ b/src/shared/lib/container/subagent-task-events-replay.test.ts
@@ -195,11 +195,11 @@ async function replayFixture(fixtureName: string): Promise<{
   const { client, send } = createReplayClient()
 
   const sseEvents: Array<Record<string, unknown>> = []
-  const cleanup = messagePersister.addSSEClient(meta.sessionId, (data) => {
+  const cleanup = messagePersister.addSSEClient(meta.agentSlug, meta.sessionId, (data) => {
     sseEvents.push(data as Record<string, unknown>)
   })
 
-  await messagePersister.subscribeToSession(meta.sessionId, client, meta.sessionId, meta.agentSlug)
+  await messagePersister.subscribeToSession(meta.agentSlug, meta.sessionId, client, meta.sessionId)
 
   // Replay
   for (const entry of streamEntries) {
@@ -211,7 +211,7 @@ async function replayFixture(fixtureName: string): Promise<{
   await new Promise((r) => setTimeout(r, 200))
 
   cleanup()
-  messagePersister.unsubscribeFromSession(meta.sessionId)
+  messagePersister.unsubscribeFromSession(meta.agentSlug, meta.sessionId)
 
   // Clean up tmpDir
   await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
@@ -261,16 +261,16 @@ async function replayFixtureTracked(fixtureName: string): Promise<{
   const { client, send } = createReplayClient()
 
   const sseEvents: Array<Record<string, unknown>> = []
-  const cleanup = messagePersister.addSSEClient(meta.sessionId, (data) => {
+  const cleanup = messagePersister.addSSEClient(meta.agentSlug, meta.sessionId, (data) => {
     sseEvents.push(data as Record<string, unknown>)
   })
 
   // The real turn was kicked off by a user message before the capture window, so
   // mark active first; subscribeToSession preserves the prior isActive.
   if (meta.startActive) {
-    messagePersister.markSessionActive(meta.sessionId, meta.agentSlug)
+    messagePersister.markSessionActive(meta.agentSlug, meta.sessionId)
   }
-  await messagePersister.subscribeToSession(meta.sessionId, client, meta.sessionId, meta.agentSlug)
+  await messagePersister.subscribeToSession(meta.agentSlug, meta.sessionId, client, meta.sessionId)
 
   const timeline: ReplaySnapshot[] = []
   for (let i = 0; i < streamEntries.length; i++) {
@@ -289,7 +289,7 @@ async function replayFixtureTracked(fixtureName: string): Promise<{
       status: c['status'] as string | undefined,
       patchStatus: (c['patch'] as { status?: string } | undefined)?.status,
       taskType: c['task_type'] as string | undefined,
-      isActive: messagePersister.isSessionActive(meta.sessionId),
+      isActive: messagePersister.isSessionActive(meta.agentSlug, meta.sessionId),
       bgCompletedIds: sseEvents
         .filter((e) => e['type'] === 'background_task_completed')
         .map((e) => e['taskId'] as string),
@@ -302,7 +302,7 @@ async function replayFixtureTracked(fixtureName: string): Promise<{
 
   await new Promise((r) => setTimeout(r, 50))
   cleanup()
-  messagePersister.unsubscribeFromSession(meta.sessionId)
+  messagePersister.unsubscribeFromSession(meta.agentSlug, meta.sessionId)
 
   return { meta, sseEvents, timeline }
 }

--- a/src/shared/lib/db/migrations/0038_session_unread_marks_agent_pk.sql
+++ b/src/shared/lib/db/migrations/0038_session_unread_marks_agent_pk.sql
@@ -1,0 +1,23 @@
+-- Session ids are unique only WITHIN an agent (import/clone gives two agents
+-- the same id), so the mark's identity is (agent, session, user), not
+-- (session, user). Under the old PK a second agent's mark for a shared id was
+-- swallowed by the INSERT ... ON CONFLICT DO NOTHING, and a clear/delete on the
+-- bare id crossed agents. SQLite cannot alter a primary key in place, so
+-- rebuild the table. agent_slug is already NOT NULL, so every existing row
+-- carries into the wider key unchanged.
+CREATE TABLE `session_unread_marks_new` (
+	`session_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`agent_slug` text NOT NULL,
+	`marked_at` integer NOT NULL,
+	PRIMARY KEY(`agent_slug`, `session_id`, `user_id`)
+);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `session_unread_marks_new` (`session_id`, `user_id`, `agent_slug`, `marked_at`)
+	SELECT `session_id`, `user_id`, `agent_slug`, `marked_at` FROM `session_unread_marks`;
+--> statement-breakpoint
+DROP TABLE `session_unread_marks`;
+--> statement-breakpoint
+ALTER TABLE `session_unread_marks_new` RENAME TO `session_unread_marks`;
+--> statement-breakpoint
+CREATE INDEX `session_unread_marks_agent_slug_user_idx` ON `session_unread_marks` (`agent_slug`,`user_id`);

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1787774911000,
       "tag": "0037_session_unread_marks",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1787774912000,
+      "tag": "0038_session_unread_marks_agent_pk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -312,7 +312,10 @@ export const sessionUnreadMarks = sqliteTable('session_unread_marks', {
   agentSlug: text('agent_slug').notNull(),
   markedAt: integer('marked_at', { mode: 'timestamp_ms' }).notNull(),
 }, (table) => ({
-  pk: primaryKey({ columns: [table.sessionId, table.userId] }),
+  // A session id is unique only within an agent, so the mark's identity
+  // includes the agent — otherwise two agents sharing an id (import/clone)
+  // collide on insert and cross each other on clear/delete.
+  pk: primaryKey({ columns: [table.agentSlug, table.sessionId, table.userId] }),
   // The projections read "marks for this agent, for me".
   agentSlugUserIdx: index('session_unread_marks_agent_slug_user_idx').on(table.agentSlug, table.userId),
 }))

--- a/src/shared/lib/notifications/notification-manager.test.ts
+++ b/src/shared/lib/notifications/notification-manager.test.ts
@@ -369,7 +369,7 @@ describe('session_waiting promotes automated sessions to interactive', () => {
   it('triggerSessionWaitingInput promotes before creating the notification', async () => {
     await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'secret')
 
-    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('sess-1', 'agent-x')
+    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('agent-x', 'sess-1')
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
     expect(mockPromoteAutomatedSession.mock.invocationCallOrder[0]).toBeLessThan(
       mockCreateNotification.mock.invocationCallOrder[0],
@@ -379,7 +379,7 @@ describe('session_waiting promotes automated sessions to interactive', () => {
   it('triggerSessionApiReviewWaiting promotes too — the proxy-review path was the original gap', async () => {
     await notificationManager.triggerSessionApiReviewWaiting('sess-1', 'agent-x', 'review-1', 'Allow?')
 
-    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('sess-1', 'agent-x')
+    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('agent-x', 'sess-1')
     expect(mockCreateNotification).toHaveBeenCalledTimes(1)
   })
 
@@ -404,7 +404,7 @@ describe('session_waiting promotes automated sessions to interactive', () => {
       },
     })
     await notificationManager.triggerSessionWaitingInput('sess-1', 'agent-x', 'secret')
-    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('sess-1', 'agent-x')
+    expect(mockPromoteAutomatedSession).toHaveBeenCalledWith('agent-x', 'sess-1')
     expect(mockCreateNotification).not.toHaveBeenCalled()
   })
 })

--- a/src/shared/lib/notifications/notification-manager.ts
+++ b/src/shared/lib/notifications/notification-manager.ts
@@ -129,7 +129,7 @@ class NotificationManager {
     // and before the settings check: visibility isn't a notification pref.
     if (type === 'session_waiting') {
       try {
-        await messagePersister.promoteAutomatedSession(sessionId, agentSlug)
+        await messagePersister.promoteAutomatedSession(agentSlug, sessionId)
       } catch (error) {
         console.error('[NotificationManager] Failed to promote automated session:', error)
       }

--- a/src/shared/lib/proxy/proxy-review-session-awaiting.test.ts
+++ b/src/shared/lib/proxy/proxy-review-session-awaiting.test.ts
@@ -30,7 +30,7 @@ describe('proxy review session awaiting', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     manager = new ReviewManager()
-    messagePersister.markSessionActive(SESSION_ID, AGENT_SLUG)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
   })
 
   afterEach(() => {
@@ -41,8 +41,8 @@ describe('proxy review session awaiting', () => {
   it('marks activity awaiting while a review is pending', async () => {
     const promise = manager.requestReview(reviewDetails())
     expect(manager.getPendingReviewsForAgent(AGENT_SLUG)).toHaveLength(1)
-    expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
-    expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('awaiting')
+    expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
+    expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('awaiting')
 
     const id = manager.getPendingReviewsForAgent(AGENT_SLUG)[0].id
     manager.submitDecision(id, 'deny', AGENT_SLUG)
@@ -51,12 +51,12 @@ describe('proxy review session awaiting', () => {
 
   it('clears awaiting on allow when nothing else is waiting', async () => {
     const promise = manager.requestReview(reviewDetails())
-    expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('awaiting')
+    expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('awaiting')
     const id = manager.getPendingReviewsForAgent(AGENT_SLUG)[0].id
     manager.submitDecision(id, 'allow', AGENT_SLUG)
     await promise
-    expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
-    expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('working')
+    expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
+    expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('working')
   })
 
   it('clears awaiting on timeout and announces the settlement', async () => {
@@ -66,11 +66,11 @@ describe('proxy review session awaiting', () => {
     })
 
     const promise = manager.requestReview(reviewDetails())
-    expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('awaiting')
+    expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('awaiting')
 
     vi.advanceTimersByTime(5 * 60 * 1000)
     await expect(promise).rejects.toThrow('Review timeout')
-    expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
 
     const resolved = globalEvents.filter(
       (e) => e.type === 'user_request_resolved' && e.outcome === 'timeout',
@@ -85,15 +85,15 @@ describe('proxy review session awaiting', () => {
     const [r1, r2] = manager.getPendingReviewsForAgent(AGENT_SLUG)
     manager.submitDecision(r1.id, 'allow', AGENT_SLUG)
     await p1
-    expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('awaiting')
+    expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('awaiting')
     manager.submitDecision(r2.id, 'deny', AGENT_SLUG)
     await p2.catch(() => {})
-    expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(false)
+    expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(false)
   })
 
   it('does not clear awaiting when a blocking input request is still open', async () => {
     const promise = manager.requestReview(reviewDetails())
-    expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
+    expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
 
     // Park a secret request the way the persister's handlers do — awaiting
     // derives from the registry entry.
@@ -110,8 +110,8 @@ describe('proxy review session awaiting', () => {
     manager.submitDecision(id, 'deny', AGENT_SLUG)
     await promise.catch(() => {})
 
-    expect(messagePersister.isSessionAwaitingInput(SESSION_ID)).toBe(true)
-    expect(messagePersister.getSessionActivity(SESSION_ID)).toBe('awaiting')
+    expect(messagePersister.isSessionAwaitingInput(AGENT_SLUG, SESSION_ID)).toBe(true)
+    expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('awaiting')
 
     userInputRequestManager.resolve('secret-1', 'cancelled')
   })

--- a/src/shared/lib/proxy/review-manager.test.ts
+++ b/src/shared/lib/proxy/review-manager.test.ts
@@ -718,7 +718,7 @@ describe('ReviewManager shadow registry write-through (Phase 2)', () => {
     // The agent-scoped entry drives the derived projection for every session
     // of the agent — the seam that replaces registerAwaitingBlockerSource.
     expect(userInputRequestManager.isAgentAwaiting('shadow-agent')).toBe(true)
-    expect(userInputRequestManager.isSessionAwaiting('any-session', 'shadow-agent')).toBe(true)
+    expect(userInputRequestManager.isSessionAwaiting('shadow-agent', 'any-session')).toBe(true)
   })
 
   it('an x-agent review registers as x_agent_review', () => {
@@ -885,7 +885,7 @@ describe('ReviewManager as registry adapter (Phase 5)', () => {
       payload: { secretName: 'API_KEY' },
     })
     expect(manager.submitDecision('stream-tool-1', 'allow')).toBe(false)
-    expect(userInputRequestManager.getOpenRequestsForSession('session-1')).toHaveLength(1)
+    expect(userInputRequestManager.getOpenRequestsForSession('adapter-agent', 'session-1')).toHaveLength(1)
   })
 
   it('SECURITY: expectedAgentSlug still gates registry-only entries', () => {

--- a/src/shared/lib/scheduler/session-auto-delete-monitor.test.ts
+++ b/src/shared/lib/scheduler/session-auto-delete-monitor.test.ts
@@ -13,7 +13,7 @@ const mockDeleteSessionsBatch = vi.fn()
 const mockReadAgentPreferences = vi.fn()
 const mockGetSettings = vi.fn()
 const mockIsAuthMode = vi.fn(() => false)
-const mockIsSessionActive = vi.fn((_id: string) => false)
+const mockIsSessionActive = vi.fn((_agentSlug: string, _id: string) => false)
 const mockUnsubscribeFromSession = vi.fn()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockDbDelete = vi.fn((..._args: any[]) => ({ where: vi.fn(() => ({ changes: 0 })) }))
@@ -42,8 +42,8 @@ vi.mock('@shared/lib/auth/mode', () => ({
 
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
-    isSessionActive: (id: string) => mockIsSessionActive(id),
-    unsubscribeFromSession: (id: string) => mockUnsubscribeFromSession(id),
+    isSessionActive: (agentSlug: string, id: string) => mockIsSessionActive(agentSlug, id),
+    unsubscribeFromSession: (agentSlug: string, id: string) => mockUnsubscribeFromSession(agentSlug, id),
   },
 }))
 
@@ -241,7 +241,7 @@ describe('SessionAutoDeleteMonitor', () => {
     mockListSessions.mockResolvedValue([oldActive, oldInactive])
     mockReadSessionMetadata.mockResolvedValue({})
     mockIsSessionActive.mockImplementation(
-      (id: string) => id === 'active'
+      (_agentSlug: string, id: string) => id === 'active'
     )
 
     await startAndTrigger()
@@ -312,8 +312,8 @@ describe('SessionAutoDeleteMonitor', () => {
 
     await startAndTrigger()
 
-    expect(mockUnsubscribeFromSession).toHaveBeenCalledWith('old1')
-    expect(mockUnsubscribeFromSession).toHaveBeenCalledWith('old2')
+    expect(mockUnsubscribeFromSession).toHaveBeenCalledWith('test-agent', 'old1')
+    expect(mockUnsubscribeFromSession).toHaveBeenCalledWith('test-agent', 'old2')
   })
 
   it('only cleans up DB records for actually-deleted sessions', async () => {
@@ -332,8 +332,8 @@ describe('SessionAutoDeleteMonitor', () => {
     await startAndTrigger()
 
     expect(mockDbDelete).toHaveBeenCalled()
-    expect(mockUnsubscribeFromSession).toHaveBeenCalledWith('ok')
-    expect(mockUnsubscribeFromSession).not.toHaveBeenCalledWith('failed')
+    expect(mockUnsubscribeFromSession).toHaveBeenCalledWith('test-agent', 'ok')
+    expect(mockUnsubscribeFromSession).not.toHaveBeenCalledWith('test-agent', 'failed')
   })
 
   it('cleans notifications but not messageAuthor when not in auth mode', async () => {

--- a/src/shared/lib/scheduler/session-auto-delete-monitor.ts
+++ b/src/shared/lib/scheduler/session-auto-delete-monitor.ts
@@ -107,7 +107,7 @@ class SessionAutoDeleteMonitor {
       .filter((s) => {
         if (s.lastActivityAt.getTime() >= cutoff) return false
         if (metadata[s.id]?.starred) return false
-        if (messagePersister.isSessionActive(s.id)) return false
+        if (messagePersister.isSessionActive(agentSlug, s.id)) return false
         if (pendingWakeSessionIds.has(s.id)) return false
         return true
       })
@@ -118,7 +118,7 @@ class SessionAutoDeleteMonitor {
     const deletedIds = await deleteSessionsBatch(agentSlug, toDelete)
 
     for (const sessionId of deletedIds) {
-      messagePersister.unsubscribeFromSession(sessionId)
+      messagePersister.unsubscribeFromSession(agentSlug, sessionId)
     }
 
     if (isAuthMode() && deletedIds.length > 0) {

--- a/src/shared/lib/scheduler/session-auto-delete-monitor.ts
+++ b/src/shared/lib/scheduler/session-auto-delete-monitor.ts
@@ -141,7 +141,7 @@ class SessionAutoDeleteMonitor {
     try {
       await deleteNotificationsBySessionIds(deletedIds)
       // Same rule for "mark as unread" marks — see deleteSessionUnreadMarks.
-      await deleteSessionUnreadMarks(deletedIds)
+      await deleteSessionUnreadMarks(agentSlug, deletedIds)
     } catch (error) {
       console.error(
         `[SessionAutoDeleteMonitor] Failed to clean notification records for ${agentSlug}:`,

--- a/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
@@ -206,7 +206,7 @@ describe('TaskScheduler session wake (resume) branch', () => {
     expect(typeof uuid).toBe('string')
     expect(options).toEqual({ shouldQuery: true })
 
-    expect(mockMarkSessionActive).toHaveBeenCalledWith('sleeping-session-1', 'agent-one')
+    expect(mockMarkSessionActive).toHaveBeenCalledWith('agent-one', 'sleeping-session-1')
     expect(mockMarkTaskExecuted).toHaveBeenCalledWith('wake-task-1', 'sleeping-session-1')
   })
 
@@ -216,12 +216,7 @@ describe('TaskScheduler session wake (resume) branch', () => {
 
     await taskScheduler.triggerExecution()
 
-    expect(mockSubscribeToSession).toHaveBeenCalledWith(
-      'sleeping-session-1',
-      expect.anything(),
-      'sleeping-session-1',
-      'agent-one'
-    )
+    expect(mockSubscribeToSession).toHaveBeenCalledWith('agent-one', 'sleeping-session-1', expect.anything(), 'sleeping-session-1')
   })
 
   it('does not re-subscribe an already-subscribed session', async () => {
@@ -239,7 +234,7 @@ describe('TaskScheduler session wake (resume) branch', () => {
 
     await taskScheduler.triggerExecution()
 
-    expect(mockCancelAwaitingInput).toHaveBeenCalledWith('sleeping-session-1', 'agent-one')
+    expect(mockCancelAwaitingInput).toHaveBeenCalledWith('agent-one', 'sleeping-session-1')
     expect(mockCancelAwaitingInput.mock.invocationCallOrder[0]).toBeLessThan(
       mockSendMessage.mock.invocationCallOrder[0]
     )
@@ -336,7 +331,7 @@ describe('TaskScheduler session wake (resume) branch', () => {
     expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
     // The optimistic active flag is reverted — a failed delivery must not
     // leave the session looking busy until the retry lands.
-    expect(mockMarkSessionIdle).toHaveBeenCalledWith('sleeping-session-1')
+    expect(mockMarkSessionIdle).toHaveBeenCalledWith('agent-one', 'sleeping-session-1')
   })
 
   it('fails a wake once it has been retrying past the retry window', async () => {

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -251,13 +251,8 @@ class TaskScheduler {
     })
 
     // Subscribe to the session for SSE updates
-    await messagePersister.subscribeToSession(
-      sessionId,
-      client,
-      sessionId,
-      task.agentSlug
-    )
-    messagePersister.markSessionActive(sessionId, task.agentSlug)
+    await messagePersister.subscribeToSession(task.agentSlug, sessionId, client, sessionId)
+    messagePersister.markSessionActive(task.agentSlug, sessionId)
 
     console.log(
       `[TaskScheduler] Task ${task.id} started, session: ${sessionId}`

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -386,13 +386,8 @@ class TriggerManager {
       automationStatus: 'running',
     })
 
-    await messagePersister.subscribeToSession(
-      sessionId,
-      client,
-      sessionId,
-      trigger.agentSlug
-    )
-    messagePersister.markSessionActive(sessionId, trigger.agentSlug)
+    await messagePersister.subscribeToSession(trigger.agentSlug, sessionId, client, sessionId)
+    messagePersister.markSessionActive(trigger.agentSlug, sessionId)
 
     // Update trigger tracking
     await markTriggerFired(trigger.id, sessionId)

--- a/src/shared/lib/scheduler/wake-delivery.test.ts
+++ b/src/shared/lib/scheduler/wake-delivery.test.ts
@@ -211,8 +211,8 @@ describe('deliverSessionWake', () => {
       'container is restarting'
     )
 
-    expect(mockMarkSessionActive).toHaveBeenCalledWith('sleeping-session-1', 'agent-one')
-    expect(mockMarkSessionIdle).toHaveBeenCalledWith('sleeping-session-1')
+    expect(mockMarkSessionActive).toHaveBeenCalledWith('agent-one', 'sleeping-session-1')
+    expect(mockMarkSessionIdle).toHaveBeenCalledWith('agent-one', 'sleeping-session-1')
     expect(mockMarkTaskExecuted).not.toHaveBeenCalled()
     expect(mockUpdateSessionMetadata).not.toHaveBeenCalled()
   })

--- a/src/shared/lib/scheduler/wake-delivery.ts
+++ b/src/shared/lib/scheduler/wake-delivery.ts
@@ -99,16 +99,16 @@ export async function deliverSessionWake(
     // resumes it from the container's session descriptor.
     const client = await containerManager.ensureRunning(task.agentSlug)
 
-    if (!messagePersister.isSubscribed(sessionId)) {
-      await messagePersister.subscribeToSession(sessionId, client, sessionId, task.agentSlug)
+    if (!messagePersister.isSubscribed(task.agentSlug, sessionId)) {
+      await messagePersister.subscribeToSession(task.agentSlug, sessionId, client, sessionId)
     }
 
     // If the session went to sleep with a blocking user-input request still
     // open (agent asked, nobody answered), cancel it so the wake message
     // starts a fresh turn instead of deadlocking behind the blocked tool.
-    await messagePersister.cancelAwaitingInput(sessionId, task.agentSlug)
+    await messagePersister.cancelAwaitingInput(task.agentSlug, sessionId)
 
-    messagePersister.markSessionActive(sessionId, task.agentSlug)
+    messagePersister.markSessionActive(task.agentSlug, sessionId)
     try {
       await client.sendMessage(sessionId, buildWakeMessage(task, trigger), randomUUID(), {
         shouldQuery: true,
@@ -116,7 +116,7 @@ export async function deliverSessionWake(
     } catch (error) {
       // The turn never started — clear the optimistic active flag so the UI
       // doesn't show a phantom "working" session while the wake awaits retry.
-      messagePersister.markSessionIdle(sessionId)
+      messagePersister.markSessionIdle(task.agentSlug, sessionId)
       throw error
     }
 
@@ -142,7 +142,7 @@ export async function deliverSessionWake(
       sessionId,
       agentSlug: task.agentSlug,
     })
-    messagePersister.broadcastSessionUpdate(sessionId)
+    messagePersister.broadcastSessionUpdate(task.agentSlug, sessionId)
 
     return { outcome: 'delivered', sessionId }
   } finally {

--- a/src/shared/lib/services/activity-stats-service.test.ts
+++ b/src/shared/lib/services/activity-stats-service.test.ts
@@ -381,7 +381,7 @@ describe('activity stats data pathways', () => {
       days: 1,
       now: NOW,
       cronSlots: 2,
-      isSessionLive: (sessionId) => sessionId === 'cron-live',
+      isSessionLive: (_agentSlug, sessionId) => sessionId === 'cron-live',
     })
 
     expect(result.cronByTaskId['cron-a']).toEqual([

--- a/src/shared/lib/services/activity-stats-service.ts
+++ b/src/shared/lib/services/activity-stats-service.ts
@@ -45,7 +45,7 @@ export interface ActivityStatsOptions {
    * app quit mid-run) — it is reported as failed instead of pulsing forever.
    * Defaults to trusting the persisted status when no probe is supplied.
    */
-  isSessionLive?: (sessionId: string) => boolean
+  isSessionLive?: (agentSlug: string, sessionId: string) => boolean
 }
 
 export type ConnectionStatsOptions = ActivityStatsOptions
@@ -91,6 +91,7 @@ function pushEvent(
 }
 
 function webhookEvents(
+  agentSlug: string,
   metadata: SessionMetadataMap,
   options: ActivityStatsOptions,
 ): Map<string, DailyActivityEvent[]> {
@@ -105,7 +106,7 @@ function webhookEvents(
     // tracking and count as succeeded.
     let status = normalizeAutomationStatus(meta.automationStatus)
     if (status === 'running') {
-      if (!options.isSessionLive || options.isSessionLive(sessionId)) continue
+      if (!options.isSessionLive || options.isSessionLive(agentSlug, sessionId)) continue
       status = 'failed'
     }
     const createdAt = new Date(meta.createdAt)
@@ -128,6 +129,7 @@ function webhookEvents(
  * charts cannot drift while avoiding connection/audit queries entirely.
  */
 export function buildAutomationActivityStats(
+  agentSlug: string,
   tasks: AutomationTaskInput[],
   triggers: AutomationTriggerInput[],
   metadata: SessionMetadataMap,
@@ -145,7 +147,7 @@ export function buildAutomationActivityStats(
   for (const [sessionId, meta] of Object.entries(metadata)) {
     if (!meta.scheduledTaskId) continue
     let status = normalizeAutomationStatus(meta.automationStatus)
-    if (status === 'running' && options.isSessionLive && !options.isSessionLive(sessionId)) {
+    if (status === 'running' && options.isSessionLive && !options.isSessionLive(agentSlug, sessionId)) {
       status = 'failed'
     }
     const sessions = sessionsByTaskId.get(meta.scheduledTaskId) ?? []
@@ -167,7 +169,7 @@ export function buildAutomationActivityStats(
   const webhookIds = triggers.map((trigger) => trigger.id)
   const webhookByTriggerId = dailyEventsById(
     webhookIds,
-    webhookEvents(metadata, { ...options, tzOffsetMinutes }),
+    webhookEvents(agentSlug, metadata, { ...options, tzOffsetMinutes }),
     { ...options, now, tzOffsetMinutes },
   )
 
@@ -297,6 +299,7 @@ export async function getAgentActivityStats(
   ])
 
   const { cronByTaskId, webhookByTriggerId } = buildAutomationActivityStats(
+    agentSlug,
     tasks,
     triggers,
     metadata,

--- a/src/shared/lib/services/agent-import-sessions.test.ts
+++ b/src/shared/lib/services/agent-import-sessions.test.ts
@@ -5,15 +5,11 @@
  * the new agent's workspace. From the user's point of view the imported agent
  * has those sessions, and opening it should list them.
  *
- * The tests marked `it.fails` are RED on main. They describe the behaviour the
- * product is supposed to have; the host-owned session ownership index does not
- * know about ids that arrive by any route other than session creation, so a
- * restored session is present on disk but filtered out of every listing.
- *
- * `it.fails` (rather than a plain failing test) keeps CI honest in both
- * directions: the suite is green while the bug exists, and it goes RED the
- * moment the bug is fixed without someone flipping these to `it`. The follow-up
- * that removes the ownership index flips them.
+ * These were `it.fails` when the suite landed: the host-owned session ownership
+ * index did not know about ids arriving by any route other than session
+ * creation, so a restored session sat on disk and was filtered out of every
+ * listing. Removing that index — a listing is now a read of the agent's own
+ * directory — is what turned them green, so they are plain `it` here.
  *
  * Everything here is real: the template service, the session service, the
  * file-storage paths and the filesystem. Only agent creation is stubbed, so a
@@ -120,7 +116,7 @@ function archiveWithSession(sessionId: string, name = 'Restored session'): Promi
 }
 
 describe('full `.agent` import restores its sessions', () => {
-  it.fails('lists a restored session on the imported agent', async () => {
+  it('lists a restored session on the imported agent', async () => {
     const sessionId = crypto.randomUUID()
     nextAgentIs('imported-agent')
 
@@ -135,7 +131,7 @@ describe('full `.agent` import restores its sessions', () => {
     ])
   })
 
-  it.fails('treats a restored session as a session of the imported agent', async () => {
+  it('treats a restored session as a session of the imported agent', async () => {
     const sessionId = crypto.randomUUID()
     nextAgentIs('known-agent')
 
@@ -144,7 +140,7 @@ describe('full `.agent` import restores its sessions', () => {
     expect(await sessionIsKnown('known-agent', sessionId)).toBe(true)
   })
 
-  it.fails('restores the sessions again after the imported agent is deleted', async () => {
+  it('restores the sessions again after the imported agent is deleted', async () => {
     // Export once, import, throw the agent away, import the same archive again.
     // Nothing about the archive changed, so the second import must behave
     // exactly like the first.
@@ -165,7 +161,7 @@ describe('full `.agent` import restores its sessions', () => {
     ])
   })
 
-  it.fails('gives each agent its own copy when one archive is imported twice', async () => {
+  it('gives each agent its own copy when one archive is imported twice', async () => {
     // Importing the same export twice is how an agent gets cloned. The two
     // copies genuinely share session ids — they are copies of the same
     // transcripts — and each agent has to list its own.

--- a/src/shared/lib/services/agent-service.ts
+++ b/src/shared/lib/services/agent-service.ts
@@ -162,8 +162,8 @@ export async function getAgentWithStatus(
   let hasActiveSessions = false
   let hasSessionsAwaitingInput = false
   for (const sessionId of sessionSummary.sessionIds) {
-    if (messagePersister.isSessionActive(sessionId)) hasActiveSessions = true
-    if (messagePersister.isSessionAwaitingInput(sessionId)) hasSessionsAwaitingInput = true
+    if (messagePersister.isSessionActive(slug, sessionId)) hasActiveSessions = true
+    if (messagePersister.isSessionAwaitingInput(slug, sessionId)) hasSessionsAwaitingInput = true
   }
   if (!hasActiveSessions) {
     hasActiveSessions = messagePersister.hasActiveSessionsForAgent(slug)

--- a/src/shared/lib/services/chat-integration-session-service.test.ts
+++ b/src/shared/lib/services/chat-integration-session-service.test.ts
@@ -25,6 +25,7 @@ import {
   createChatIntegrationSession,
   getChatIntegrationSession,
   getChatIntegrationSessionById,
+  getChatIntegrationSessionBySessionId,
   touchChatIntegrationSession,
   archiveChatIntegrationSession,
   resolveActiveSession,
@@ -51,6 +52,35 @@ describe('chat-integration-session-service', () => {
   afterEach(async () => {
     testSqlite?.close()
     await fs.promises.rm(testDir, { recursive: true, force: true })
+  })
+
+  describe('getChatIntegrationSessionBySessionId', () => {
+    // A session id is unique only within an agent. If two agents' integrations
+    // each have a chat session with the same id, the lookup must return the
+    // one owned by the asking agent — otherwise an approval card for one agent
+    // is routed into a different agent's channel.
+    it('returns the asking agent’s session, not another agent’s same-id session', () => {
+      const otherIntegrationId = createChatIntegration({
+        agentSlug: 'other-agent',
+        provider: 'telegram',
+        config: { botToken: 'other-token' },
+      })
+      createChatIntegrationSession({ integrationId, externalChatId: 'chat-mine', sessionId: 'shared-session' })
+      createChatIntegrationSession({ integrationId: otherIntegrationId, externalChatId: 'chat-theirs', sessionId: 'shared-session' })
+
+      const mine = getChatIntegrationSessionBySessionId('test-agent', 'shared-session')
+      expect(mine?.externalChatId).toBe('chat-mine')
+      expect(mine?.integrationId).toBe(integrationId)
+
+      const theirs = getChatIntegrationSessionBySessionId('other-agent', 'shared-session')
+      expect(theirs?.externalChatId).toBe('chat-theirs')
+      expect(theirs?.integrationId).toBe(otherIntegrationId)
+    })
+
+    it('returns null when the id belongs to a different agent', () => {
+      createChatIntegrationSession({ integrationId, externalChatId: 'chat-1', sessionId: 'sess-1' })
+      expect(getChatIntegrationSessionBySessionId('some-stranger', 'sess-1')).toBeNull()
+    })
   })
 
   describe('touchChatIntegrationSession', () => {

--- a/src/shared/lib/services/chat-integration-session-service.ts
+++ b/src/shared/lib/services/chat-integration-session-service.ts
@@ -6,7 +6,7 @@
 
 import { eq, and, isNull, desc } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
-import { chatIntegrationSessions } from '@shared/lib/db/schema'
+import { chatIntegrationSessions, chatIntegrations } from '@shared/lib/db/schema'
 import type { ChatIntegrationSession, NewChatIntegrationSession } from '@shared/lib/db/schema'
 
 export type { ChatIntegrationSession, NewChatIntegrationSession }
@@ -37,11 +37,27 @@ export function getChatIntegrationSessionById(id: string): ChatIntegrationSessio
   return results[0] || null
 }
 
-export function getChatIntegrationSessionBySessionId(sessionId: string): ChatIntegrationSession | null {
+/**
+ * The chat session for `sessionId` that belongs to `agentSlug`.
+ *
+ * A session id is unique only within an agent — import/clone gives two agents
+ * the same id — so a bare-id lookup could return another agent's chat session,
+ * routing one agent's approval card into a different agent's channel. Joining
+ * to the owning integration and filtering on its agent keeps the answer inside
+ * the asking agent.
+ */
+export function getChatIntegrationSessionBySessionId(
+  agentSlug: string,
+  sessionId: string,
+): ChatIntegrationSession | null {
   const results = db.select().from(chatIntegrationSessions)
-    .where(eq(chatIntegrationSessions.sessionId, sessionId))
+    .innerJoin(chatIntegrations, eq(chatIntegrationSessions.integrationId, chatIntegrations.id))
+    .where(and(
+      eq(chatIntegrationSessions.sessionId, sessionId),
+      eq(chatIntegrations.agentSlug, agentSlug),
+    ))
     .all()
-  return results[0] || null
+  return results[0]?.chat_integration_sessions ?? null
 }
 
 export function listChatIntegrationSessions(integrationId: string): ChatIntegrationSession[] {

--- a/src/shared/lib/services/home-card-health-service.ts
+++ b/src/shared/lib/services/home-card-health-service.ts
@@ -107,6 +107,7 @@ export async function buildHomeCardHealth(
     [...agentsWithCharts].map((agentSlug) =>
       limit(async () => {
         const activity = buildAutomationActivityStats(
+          agentSlug,
           cronsByAgent.get(agentSlug) ?? [],
           webhooksByAgent.get(agentSlug) ?? [],
           await readSessionMetadata(agentSlug),

--- a/src/shared/lib/services/session-service.listing.test.ts
+++ b/src/shared/lib/services/session-service.listing.test.ts
@@ -19,7 +19,6 @@ import {
   listSessions,
   listSessionsFromSummary,
   getSessionMessagesPage,
-  reserveSessionOwnership,
 } from './session-service'
 
 // Both implementations must satisfy the same contract: listSessions stats
@@ -190,37 +189,31 @@ describe.each([
     expect(noMeta.createdAt).toEqual(expected)
   })
 
-  it('excludes transcripts and registrations owned by another agent', async () => {
+  it('lists only what is in this agent\u2019s own directory', async () => {
+    // A listing is a directory read, not an ownership lookup: agent-b's
+    // sessions are in agent-b's directory and can never appear here, and an id
+    // that also exists under another agent is simply a different session.
     await writeTranscript('agent-a', 'own', { activityAt: '2026-01-01T00:00:00.000Z' })
     await fs.promises.mkdir(sessionsDir('agent-b'), { recursive: true })
-    // Reserve first: the ownership index is built from disk on first use, so a
-    // later foreign file in agent-a's directory is unowned by agent-a.
-    // (The reservation also invalidates agent-b's summary, not agent-a's; the
-    // summary-backed listing must still build agent-a's map after the foreign
-    // file lands, which it does because the first read is cold.)
-    await reserveSessionOwnership('agent-b', 'foreign-transcript')
-    await reserveSessionOwnership('agent-b', 'foreign-pending')
-    await writeTranscript('agent-a', 'foreign-transcript', { activityAt: '2026-01-09T00:00:00.000Z' })
-    await writeMetadata('agent-a', {
-      'foreign-pending': { name: 'Forged', createdAt: '2026-01-10T00:00:00.000Z' },
-    })
+    await writeTranscript('agent-b', 'b-only', { activityAt: '2026-01-09T00:00:00.000Z' })
+    await writeTranscript('agent-b', 'shared-id', { activityAt: '2026-01-09T00:00:00.000Z' })
+    await writeTranscript('agent-a', 'shared-id', { activityAt: '2026-01-10T00:00:00.000Z' })
 
     const sessions = await list('agent-a', {
       excludeAutomated: true,
       sortBy: 'last_activity_at',
     })
 
-    expect(ids(sessions)).toEqual(['own'])
+    expect(ids(sessions).sort()).toEqual(['own', 'shared-id'])
   })
 
-  it('applies limit after ownership and visibility filtering on transcript-backed sessions', async () => {
+  it('applies limit after visibility filtering on transcript-backed sessions', async () => {
     await writeTranscript('agent-a', 'visible-1', { activityAt: '2026-01-01T00:00:00.000Z' })
     await writeTranscript('agent-a', 'visible-2', { activityAt: '2026-01-02T00:00:00.000Z' })
     await writeTranscript('agent-a', 'hidden-3', { activityAt: '2026-01-03T00:00:00.000Z' })
     await writeTranscript('agent-a', 'empty-4', { entries: [] })
     await fs.promises.mkdir(sessionsDir('agent-b'), { recursive: true })
-    await reserveSessionOwnership('agent-b', 'foreign-5')
-    await writeTranscript('agent-a', 'foreign-5', { activityAt: '2026-01-05T00:00:00.000Z' })
+    await writeTranscript('agent-b', 'foreign-5', { activityAt: '2026-01-05T00:00:00.000Z' })
     await writeMetadata('agent-a', {
       'hidden-3': { isScheduledExecution: true, scheduledTaskId: 't' },
     })
@@ -258,8 +251,7 @@ describe.each([
       'pending-hidden-jan8': { createdAt: '2026-01-08T00:00:00.000Z', invokedByAgentSlug: 'x' },
     })
     await fs.promises.mkdir(sessionsDir('agent-b'), { recursive: true })
-    await reserveSessionOwnership('agent-b', 'foreign-jan7')
-    await writeTranscript('agent-a', 'foreign-jan7', { activityAt: '2026-01-07T00:00:00.000Z' })
+    await writeTranscript('agent-b', 'foreign-jan7', { activityAt: '2026-01-07T00:00:00.000Z' })
     // registered-empty-jan2 is an existing (empty) file; pin its activity too.
     const jan2 = new Date('2026-01-02T00:00:00.000Z')
     await fs.promises.utimes(transcriptPath('agent-a', 'registered-empty-jan2'), jan2, jan2)

--- a/src/shared/lib/services/session-service.ownership.test.ts
+++ b/src/shared/lib/services/session-service.ownership.test.ts
@@ -31,12 +31,6 @@ function makeAgent(slug: string): void {
 function writeTranscript(slug: string, sessionId: string): void {
   fs.writeFileSync(path.join(sessionsDir(slug), `${sessionId}.jsonl`), '{}\n')
 }
-function writeMetadata(slug: string, metadata: Record<string, unknown>): void {
-  fs.writeFileSync(
-    path.join(workspaceDir(slug), 'session-metadata.json'),
-    JSON.stringify(metadata),
-  )
-}
 
 beforeEach(() => {
   tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'session-own-')))
@@ -133,72 +127,59 @@ describe('sessionIsKnown', () => {
     expect(await sessionIsKnown('agent-a', 'b-registered')).toBe(false)
   })
 
-  it('rejects a forged duplicate transcript in an agent-writable workspace', async () => {
+  // A forged transcript is no longer refused HERE, and that is the point of
+  // the change this file was rewritten for. `sessionIsKnown` answers "is this
+  // a session of this agent" from this agent's own directory, so an agent that
+  // writes a file named after someone else's session gets `true` — for its own,
+  // empty, same-named session. What that buys the forger is nothing: every
+  // registry it could then reach is keyed by agent AND session, so it lands in
+  // the forger's own namespace.
+  //
+  // The property that used to be enforced here is now proven where it actually
+  // matters, end to end, against real routes and a real persister:
+  //   src/api/routes/session-scope.integration.test.ts
+  //     — "a forged transcript does not buy access to another agent's live session"
+  //   src/shared/lib/container/message-persister.test.ts
+  //     — "cross-agent isolation"
+  //   e2e/auth/specs/session-scope-roles.spec.ts
+  it('answers for this agent\u2019s own directory, so a forged id names only the forger\u2019s own session', async () => {
     const { sessionIsKnown } = await importService()
     makeAgent('agent-a')
     makeAgent('agent-b')
     writeTranscript('agent-b', 'victim-session')
 
-    // Initialize and persist the host-owned owner before the attacker writes a
-    // same-named file into its own bind-mounted workspace.
     expect(await sessionIsKnown('agent-b', 'victim-session')).toBe(true)
+    expect(await sessionIsKnown('agent-a', 'victim-session')).toBe(false)
+
     writeTranscript('agent-a', 'victim-session')
 
-    expect(await sessionIsKnown('agent-a', 'victim-session')).toBe(false)
+    // Both are now true, and they are two different sessions.
+    expect(await sessionIsKnown('agent-a', 'victim-session')).toBe(true)
     expect(await sessionIsKnown('agent-b', 'victim-session')).toBe(true)
-    expect(
-      JSON.parse(fs.readFileSync(path.join(tmpDir, 'session-ownership.json'), 'utf-8')),
-    ).toEqual({ 'victim-session': 'agent-b' })
   })
 
-  it('fails closed when duplicate transcripts predate ownership migration', async () => {
-    const { sessionIsKnown } = await importService()
-    makeAgent('agent-a')
-    makeAgent('agent-b')
-    writeTranscript('agent-a', 'duplicate-session')
-    writeTranscript('agent-b', 'duplicate-session')
+  it('lets two agents hold the same session id', async () => {
+    // The legitimate version of the case above: one exported agent imported
+    // twice. Both copies carry the same transcript ids and both must work.
+    const { registerSession, sessionIsKnown } = await importService()
+    makeAgent('clone-one')
+    makeAgent('clone-two')
+    await registerSession('clone-one', 'shared-session', 'Copy')
+    await registerSession('clone-two', 'shared-session', 'Copy')
 
-    expect(await sessionIsKnown('agent-a', 'duplicate-session')).toBe(false)
-    expect(await sessionIsKnown('agent-b', 'duplicate-session')).toBe(false)
-    expect(
-      JSON.parse(fs.readFileSync(path.join(tmpDir, 'session-ownership.json'), 'utf-8')),
-    ).toEqual({ 'duplicate-session': null })
+    expect(await sessionIsKnown('clone-one', 'shared-session')).toBe(true)
+    expect(await sessionIsKnown('clone-two', 'shared-session')).toBe(true)
   })
 
-  it('rejects forged metadata for a session registered to another agent', async () => {
+  it('keeps a session of another agent out, by transcript or by metadata', async () => {
     const { registerSession, sessionIsKnown } = await importService()
     makeAgent('agent-a')
     makeAgent('agent-b')
-    await registerSession('agent-b', 'victim-session', 'Victim')
-    writeMetadata('agent-a', {
-      'victim-session': { name: 'Forged', createdAt: new Date().toISOString() },
-    })
+    writeTranscript('agent-b', 'b-on-disk')
+    await registerSession('agent-b', 'b-registered', 'B')
 
-    expect(await sessionIsKnown('agent-a', 'victim-session')).toBe(false)
-    expect(await sessionIsKnown('agent-b', 'victim-session')).toBe(true)
-  })
-
-  it('does not discover forged ids after the one-time legacy migration', async () => {
-    const { sessionIsKnown } = await importService()
-    makeAgent('agent-a')
-
-    expect(await sessionIsKnown('agent-a', 'missing-before-migration')).toBe(false)
-    writeTranscript('agent-a', 'forged-after-migration')
-
-    expect(await sessionIsKnown('agent-a', 'forged-after-migration')).toBe(false)
-  })
-
-  it('reserves a new id before either workspace contains its transcript', async () => {
-    const { reserveSessionOwnership, sessionIsKnown } = await importService()
-    makeAgent('agent-a')
-    makeAgent('agent-b')
-
-    await reserveSessionOwnership('agent-b', 'future-session')
-    writeTranscript('agent-a', 'future-session')
-    writeTranscript('agent-b', 'future-session')
-
-    expect(await sessionIsKnown('agent-a', 'future-session')).toBe(false)
-    expect(await sessionIsKnown('agent-b', 'future-session')).toBe(true)
+    expect(await sessionIsKnown('agent-a', 'b-on-disk')).toBe(false)
+    expect(await sessionIsKnown('agent-a', 'b-registered')).toBe(false)
   })
 
   it('rejects an unknown session id', async () => {

--- a/src/shared/lib/services/session-service.ownership.test.ts
+++ b/src/shared/lib/services/session-service.ownership.test.ts
@@ -216,4 +216,35 @@ describe('sessionIsKnown', () => {
 
     await expect(sessionIsKnown('agent-a', '../../../etc/passwd')).resolves.toBe(false)
   })
+
+  it('rejects a symlink whose real target is another agent’s transcript', async () => {
+    const { sessionIsKnown } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    writeTranscript('agent-b', 'b-session')
+
+    // The agent plants a link in its OWN directory, named after a session it
+    // does not own, pointing at the victim's real transcript. Lexical
+    // containment passes (the link's path is local); real-path containment must
+    // not.
+    fs.symlinkSync(
+      path.join(sessionsDir('agent-b'), 'b-session.jsonl'),
+      path.join(sessionsDir('agent-a'), 'stolen.jsonl'),
+    )
+
+    await expect(sessionIsKnown('agent-a', 'stolen')).resolves.toBe(false)
+  })
+
+  it('removeLegacySessionOwnershipIndex deletes a stale index and is a no-op when absent', async () => {
+    const { removeLegacySessionOwnershipIndex } = await importService()
+    // The index lived one directory above the agents dir — i.e. the data dir.
+    const legacyPath = path.join(tmpDir, 'session-ownership.json')
+    fs.writeFileSync(legacyPath, JSON.stringify({ 'some-session': 'agent-a' }))
+
+    await removeLegacySessionOwnershipIndex()
+    expect(fs.existsSync(legacyPath)).toBe(false)
+
+    // Idempotent: a second call with the file already gone must not throw.
+    await expect(removeLegacySessionOwnershipIndex()).resolves.toBeUndefined()
+  })
 })

--- a/src/shared/lib/services/session-service.ownership.test.ts
+++ b/src/shared/lib/services/session-service.ownership.test.ts
@@ -254,6 +254,25 @@ describe('sessionIsKnown', () => {
     expect((await listSessions('agent-a')).map((s) => s.id)).toEqual(['real'])
   })
 
+  it('rejects a session reached through a symlinked -workspace ancestor', async () => {
+    const { sessionIsKnown, sessionExists } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    writeTranscript('agent-b', 'victim')
+
+    // The attacker replaces its OWN -workspace directory with a symlink to the
+    // victim's. Every id then resolves into the victim's dir. Anchoring the
+    // containment on the attacker's session dir would pass (base and candidate
+    // both resolve through the same link); anchoring on the workspace catches
+    // it, because the workspace is the bind-mount point the container can't
+    // replace.
+    fs.rmSync(sessionsDir('agent-a'), { recursive: true, force: true })
+    fs.symlinkSync(sessionsDir('agent-b'), sessionsDir('agent-a'))
+
+    await expect(sessionExists('agent-a', 'victim')).resolves.toBe(false)
+    await expect(sessionIsKnown('agent-a', 'victim')).resolves.toBe(false)
+  })
+
   it('removeLegacySessionOwnershipIndex deletes a stale index and is a no-op when absent', async () => {
     const { removeLegacySessionOwnershipIndex } = await importService()
     // The index lived one directory above the agents dir — i.e. the data dir.

--- a/src/shared/lib/services/session-service.ownership.test.ts
+++ b/src/shared/lib/services/session-service.ownership.test.ts
@@ -235,6 +235,25 @@ describe('sessionIsKnown', () => {
     await expect(sessionIsKnown('agent-a', 'stolen')).resolves.toBe(false)
   })
 
+  it('excludes a symlinked transcript from the listing and the summary', async () => {
+    const { getSessionSummary, listSessions } = await importService()
+    makeAgent('agent-a')
+    makeAgent('agent-b')
+    writeTranscript('agent-a', 'real')
+    writeTranscript('agent-b', 'victim')
+
+    // A link in agent-a's own dir, named like a session, pointing at agent-b's
+    // transcript. It must never enter a listing — the home-card tail reads the
+    // latest listed session's CONTENT, so a listed link would leak it.
+    fs.symlinkSync(
+      path.join(sessionsDir('agent-b'), 'victim.jsonl'),
+      path.join(sessionsDir('agent-a'), 'stolen.jsonl'),
+    )
+
+    expect((await getSessionSummary('agent-a')).sessionIds).toEqual(['real'])
+    expect((await listSessions('agent-a')).map((s) => s.id)).toEqual(['real'])
+  })
+
   it('removeLegacySessionOwnershipIndex deletes a stale index and is a no-op when absent', async () => {
     const { removeLegacySessionOwnershipIndex } = await importService()
     // The index lived one directory above the agents dir — i.e. the data dir.

--- a/src/shared/lib/services/session-service.summary-cache.test.ts
+++ b/src/shared/lib/services/session-service.summary-cache.test.ts
@@ -28,7 +28,6 @@ import {
   deleteSession,
   getSessionSummary,
   registerSession,
-  reserveSessionOwnership,
 } from './session-service'
 import { recordSessionActivity } from './session-summary-cache'
 import { appendInformationalEntry } from './session-transcript-append'
@@ -97,13 +96,12 @@ describe('getSessionSummary cache', () => {
     expect(statProbe.paths.filter((file) => file.endsWith('.jsonl'))).toHaveLength(2)
   })
 
-  it('reconciles unchanged directory contents when ownership is newly reserved', async () => {
+  it('reconciles a transcript that appears in the directory after a warm read', async () => {
     await createSession('session-a', '2026-01-01T00:00:00.000Z')
-    await fs.promises.mkdir(sessionsDir(), { recursive: true })
-    await fs.promises.writeFile(transcriptPath('session-b'), '{}\n')
     expect((await getSessionSummary(agentSlug)).sessionIds).toEqual(['session-a'])
 
-    await reserveSessionOwnership(agentSlug, 'session-b')
+    await fs.promises.mkdir(sessionsDir(), { recursive: true })
+    await fs.promises.writeFile(transcriptPath('session-b'), '{}\n')
     const summary = await getSessionSummary(agentSlug)
 
     expect(summary.sessionIds.sort()).toEqual(['session-a', 'session-b'])

--- a/src/shared/lib/services/session-service.summary-cache.test.ts
+++ b/src/shared/lib/services/session-service.summary-cache.test.ts
@@ -102,6 +102,12 @@ describe('getSessionSummary cache', () => {
 
     await fs.promises.mkdir(sessionsDir(), { recursive: true })
     await fs.promises.writeFile(transcriptPath('session-b'), '{}\n')
+    // Advance the directory mtime explicitly. The cache reconciles when the dir
+    // mtime changes; on a filesystem with coarse mtime resolution the write and
+    // the preceding warm read can share a tick, so the write alone would not
+    // trip the reconcile. (Mirrors the structural-add test above.)
+    const changedAt = new Date('2030-01-01T00:00:00.000Z')
+    await fs.promises.utimes(sessionsDir(), changedAt, changedAt)
     const summary = await getSessionSummary(agentSlug)
 
     expect(summary.sessionIds.sort()).toEqual(['session-a', 'session-b'])
@@ -173,6 +179,10 @@ describe('getSessionSummary cache', () => {
     await getSessionSummary(agentSlug)
 
     await deleteSession(agentSlug, 'session-b')
+    // Coarse-mtime filesystems may not advance the dir mtime on the unlink
+    // within the same tick as the warm read; force it so the reconcile fires.
+    const changedAt = new Date('2030-01-01T00:00:00.000Z')
+    await fs.promises.utimes(sessionsDir(), changedAt, changedAt)
     const summary = await getSessionSummary(agentSlug)
 
     expect(summary.sessionIds).toEqual(['session-a'])

--- a/src/shared/lib/services/session-service.summary-listing.test.ts
+++ b/src/shared/lib/services/session-service.summary-listing.test.ts
@@ -282,6 +282,10 @@ describe('listSessionsFromSummary', () => {
     await getSessionSummary(agentSlug)
 
     await deleteSession(agentSlug, 'session-b')
+    // Coarse-mtime filesystems may not advance the dir mtime on the unlink
+    // within the same tick as the warm read; force it so the reconcile fires.
+    const changedAt = new Date('2030-01-01T00:00:00.000Z')
+    await fs.promises.utimes(sessionsDir(), changedAt, changedAt)
 
     expect(ids(await listSessionsFromSummary(agentSlug))).toEqual(['session-a'])
   })

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -55,6 +55,7 @@ import {
   ContentBlock,
 } from '@shared/lib/types/agent'
 import { captureException } from '@shared/lib/error-reporting'
+import { isRealPathWithinDir } from '@shared/lib/utils/path-safety'
 import {
   getSessionSummaryCacheSlot,
   applyActivity,
@@ -83,12 +84,20 @@ import {
 // path, a separator) is not one of its sessions, and must not reach a registry
 // or the filesystem.
 function sessionIdIsWithinAgent(agentSlug: string, sessionId: string): boolean {
+  let jsonlPath: string
   try {
-    getSessionJsonlPath(agentSlug, sessionId)
-    return true
+    jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   } catch {
     return false
   }
+  // Lexical containment (the getSessionJsonlPath above) is not enough. The
+  // agent's session directory is bind-mounted read/write into its container,
+  // so the agent can plant a symlink named after ANOTHER agent's session that
+  // resolves to that agent's transcript — a name that looks local but escapes
+  // on read. The id is this agent's only if its real path stays inside the
+  // agent's real session directory. This is what the deleted ownership index
+  // also enforced, without a second source of truth to keep in step.
+  return isRealPathWithinDir(getAgentSessionsDir(agentSlug), jsonlPath)
 }
 
 // ============================================================================
@@ -1903,12 +1912,19 @@ export async function updateSessionName(
 }
 
 /**
- * Check if a session exists
+ * Whether this agent has a transcript on disk for `sessionId`.
+ *
+ * Never throws, and never answers true for an id that is not this agent's:
+ * `sessionIdIsWithinAgent` rejects a traversal-shaped id (which would
+ * otherwise throw out of `getSessionJsonlPath` into the caller's `catch` and,
+ * on the routes that gate delete/interrupt on this, answer 500 instead of a
+ * clean 404) and a symlink whose real target escapes the agent's directory.
  */
 export async function sessionExists(
   agentSlug: string,
   sessionId: string
 ): Promise<boolean> {
+  if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return false
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   return fileExists(jsonlPath)
 }

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -100,6 +100,27 @@ function sessionIdIsWithinAgent(agentSlug: string, sessionId: string): boolean {
   return isRealPathWithinDir(getAgentSessionsDir(agentSlug), jsonlPath)
 }
 
+/**
+ * Delete the legacy session-ownership.json index that earlier builds kept one
+ * directory above all workspaces. This build derives ownership structurally
+ * (agent-keyed registries + containment) and never writes it, so a leftover
+ * file is dead — but a ROLLBACK to a build that reads it would find the stale
+ * copy, skip its first-read discovery migration, and treat every session
+ * created under this build as unowned (filtered from listings, 404 on open).
+ * Removing it on startup makes a rollback self-heal by re-running discovery.
+ *
+ * Best-effort and idempotent: a missing file (the common case after the first
+ * boot) is success, and any error is swallowed so it can never block startup.
+ */
+export async function removeLegacySessionOwnershipIndex(): Promise<void> {
+  const legacyPath = path.join(path.dirname(getAgentsDir()), 'session-ownership.json')
+  try {
+    await fs.promises.rm(legacyPath, { force: true })
+  } catch (error) {
+    console.warn('[session-service] Failed to remove legacy session-ownership index:', error)
+  }
+}
+
 // ============================================================================
 // Session Metadata (custom names, starred status)
 // ============================================================================

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -8,7 +8,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import pLimit from 'p-limit'
-import { z } from 'zod'
 import {
   getAgentsDir,
   getAgentSessionsDir,
@@ -59,177 +58,37 @@ import { captureException } from '@shared/lib/error-reporting'
 import {
   getSessionSummaryCacheSlot,
   applyActivity,
-  invalidateSessionSummaryCache,
   recordSessionActivity,
-  removeSessionFromSummaryCache,
   type SessionActivityEntry,
   SESSION_SUMMARY_CACHE_TTL_MS,
   type SessionSummaryCacheValue,
 } from './session-summary-cache'
 
-// Session transcripts and metadata live inside the agent workspace, which is
-// bind-mounted read/write into its container. They are therefore evidence that
-// a session exists, but NOT authoritative proof of which agent owns a globally
-// keyed session id: an agent can create arbitrary files in its own workspace.
+// A session id is unique within its agent, not across the install: it comes
+// from the container, and an agent can write any id it likes into its own
+// bind-mounted workspace. That used to matter because the process-global
+// registries (the message persister above all) were keyed by session id ALONE,
+// so a forged transcript let one agent's request address another agent's live
+// session (SUP-479). It was answered with a host-owned ownership index kept
+// outside every workspace.
 //
-// Keep the ownership index one directory above all workspaces so containers
-// cannot forge it. `null` is a fail-closed tombstone for a duplicate id found
-// during legacy migration; it must never be claimed implicitly by either agent.
-const sessionOwnershipMapSchema = z.record(z.string(), z.string().nullable())
-type SessionOwnershipMap = z.infer<typeof sessionOwnershipMapSchema>
-const sessionOwnershipByPath = new Map<string, Promise<SessionOwnershipMap>>()
-
-function getSessionOwnershipPath(): string {
-  return path.join(path.dirname(getAgentsDir()), 'session-ownership.json')
-}
-
-async function candidateSessionIdsForAgent(agentSlug: string): Promise<Set<string>> {
-  const ids = new Set(Object.keys(await readSessionMetadata(agentSlug)))
-  const sessionsDir = getAgentSessionsDir(agentSlug)
-  try {
-    const files = await fs.promises.readdir(sessionsDir)
-    for (const file of files) {
-      if (file.endsWith('.jsonl')) ids.add(file.slice(0, -'.jsonl'.length))
-    }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-  }
-  return new Set([...ids].filter((sessionId) => {
-    try {
-      getSessionJsonlPath(agentSlug, sessionId)
-      return true
-    } catch {
-      return false
-    }
-  }))
-}
-
-async function discoverSessionOwners(): Promise<SessionOwnershipMap> {
-  const discovered = Object.create(null) as SessionOwnershipMap
-  for (const agentSlug of await listDirectories(getAgentsDir())) {
-    const ids = await candidateSessionIdsForAgent(agentSlug)
-    for (const id of ids) {
-      if (!Object.hasOwn(discovered, id)) {
-        discovered[id] = agentSlug
-      } else if (discovered[id] !== agentSlug) {
-        discovered[id] = null
-      }
-    }
-  }
-  return discovered
-}
-
-async function loadSessionOwnershipMap(): Promise<SessionOwnershipMap> {
-  const ownershipPath = getSessionOwnershipPath()
-  const cached = sessionOwnershipByPath.get(ownershipPath)
-  if (cached) return cached
-
-  const loading = withFileLock(ownershipPath, async () => {
-    const existed = await fileExists(ownershipPath)
-    const stored = await readJsonFileStrict(ownershipPath, sessionOwnershipMapSchema, {})
-    if (existed) {
-      return Object.assign(Object.create(null) as SessionOwnershipMap, stored)
-    }
-
-    const migrated = await discoverSessionOwners()
-    await ensureDirectory(path.dirname(ownershipPath))
-    await writeJsonFileAtomic(ownershipPath, migrated)
-    return migrated
-  })
-  sessionOwnershipByPath.set(ownershipPath, loading)
-  try {
-    return await loading
-  } catch (error) {
-    if (sessionOwnershipByPath.get(ownershipPath) === loading) {
-      sessionOwnershipByPath.delete(ownershipPath)
-    }
-    throw error
-  }
-}
-
-async function mutateSessionOwnership(
-  mutator: (owners: SessionOwnershipMap) => boolean,
-): Promise<void> {
-  const ownershipPath = getSessionOwnershipPath()
-  const owners = await loadSessionOwnershipMap()
-  await withFileLock(ownershipPath, async () => {
-    const next = Object.assign(Object.create(null) as SessionOwnershipMap, owners)
-    if (!mutator(next)) return
-    await writeJsonFileAtomic(ownershipPath, next)
-    for (const sessionId of Object.keys(owners)) delete owners[sessionId]
-    Object.assign(owners, next)
-  })
-}
-
-async function claimSessionOwnership(agentSlug: string, sessionId: string): Promise<boolean> {
-  // Apply the same containment check used by transcript operations before an
-  // externally produced id can become a durable registry key.
-  getSessionJsonlPath(agentSlug, sessionId)
-  let newlyClaimed = false
-  await mutateSessionOwnership((owners) => {
-    if (!Object.hasOwn(owners, sessionId)) {
-      owners[sessionId] = agentSlug
-      newlyClaimed = true
-      return true
-    }
-    if (owners[sessionId] !== agentSlug) {
-      throw new Error(`Session ${sessionId} is already owned by another agent`)
-    }
-    return false
-  })
-  if (newlyClaimed) invalidateSessionSummaryCache(agentSlug)
-  return newlyClaimed
-}
-
-async function releaseSessionOwnership(agentSlug: string, sessionIds: string[]): Promise<void> {
-  const released: string[] = []
-  await mutateSessionOwnership((owners) => {
-    let changed = false
-    for (const sessionId of sessionIds) {
-      if (owners[sessionId] === agentSlug) {
-        delete owners[sessionId]
-        released.push(sessionId)
-        changed = true
-      }
-    }
-    return changed
-  })
-  for (const sessionId of released) removeSessionFromSummaryCache(agentSlug, sessionId)
-}
-
-async function resolveSessionOwner(sessionId: string): Promise<string | null | undefined> {
-  const owners = await loadSessionOwnershipMap()
-  return Object.hasOwn(owners, sessionId) ? owners[sessionId] : undefined
-}
-
-/**
- * Reserve a newly allocated session id before exposing it through any
- * process-global lifecycle registry. Registration calls this again
- * idempotently when it persists the display metadata.
- */
-export async function reserveSessionOwnership(
-  agentSlug: string,
-  sessionId: string,
-): Promise<void> {
-  await claimSessionOwnership(agentSlug, sessionId)
-}
-
-/**
- * Authoritative ownership check for registries keyed by session id alone.
- * Unlike transcript/metadata existence, this cannot be forged from inside an
- * agent container because the ownership file is outside its mounted workspace.
- */
-export async function sessionBelongsToAgent(
-  agentSlug: string,
-  sessionId: string,
-): Promise<boolean> {
-  // Validate the externally supplied id before considering a registry entry.
+// Those registries are now keyed by agent AND session, so the same forged file
+// resolves to an empty slot in the forging agent's OWN namespace and reaches
+// nothing. There is no ownership question left to answer, and no second source
+// of truth to keep in step with imports, clones or deletes — which is what the
+// index kept getting wrong.
+//
+// What remains is containment, which the index also enforced: an id that
+// cannot name a file under this agent's session directory (`..`, an absolute
+// path, a separator) is not one of its sessions, and must not reach a registry
+// or the filesystem.
+function sessionIdIsWithinAgent(agentSlug: string, sessionId: string): boolean {
   try {
     getSessionJsonlPath(agentSlug, sessionId)
+    return true
   } catch {
     return false
   }
-  return (await resolveSessionOwner(sessionId)) === agentSlug
 }
 
 // ============================================================================
@@ -382,19 +241,16 @@ export async function registerSession(
   name?: string,
   initialMetadata?: Partial<SessionMetadata>,
 ): Promise<void> {
-  const newlyClaimed = await claimSessionOwnership(agentSlug, sessionId)
-  try {
-    await mutateSessionMetadata(agentSlug, (metadata) => {
-      metadata[sessionId] = {
-        ...initialMetadata,
-        name: name || 'New Session',
-        createdAt: new Date().toISOString(),
-      }
-    })
-  } catch (error) {
-    if (newlyClaimed) await releaseSessionOwnership(agentSlug, [sessionId]).catch(() => {})
-    throw error
-  }
+  // Containment is checked here for the same reason transcript writes check
+  // it: an externally supplied id must not become a durable metadata key.
+  getSessionJsonlPath(agentSlug, sessionId)
+  await mutateSessionMetadata(agentSlug, (metadata) => {
+    metadata[sessionId] = {
+      ...initialMetadata,
+      name: name || 'New Session',
+      createdAt: new Date().toISOString(),
+    }
+  })
 }
 
 /**
@@ -672,7 +528,7 @@ async function buildSessionActivityMap(
       const stat = await statTranscriptForSummary(path.join(sessionsDir, file))
       if (!stat) return null
       const sessionId = path.basename(file, '.jsonl')
-      if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
+      if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return null
       return {
         sessionId,
         entry: { mtimeMs: stat.mtimeMs, birthtimeMs: stat.birthtimeMs, size: stat.size },
@@ -839,7 +695,7 @@ export async function listSessions(
       const { sessionId, stat } = result
       processedSessionIds.add(sessionId)
 
-      if (!(await sessionBelongsToAgent(agentSlug, sessionId))) continue
+      if (!sessionIdIsWithinAgent(agentSlug, sessionId)) continue
 
       // Skip empty JSONL files that aren't registered in metadata
       // These are typically created by Claude SDK for subagent directories
@@ -867,7 +723,7 @@ export async function listSessions(
   // (newly created sessions where the agent hasn't streamed yet)
   for (const [sessionId, sessionMeta] of Object.entries(metadata)) {
     if (!processedSessionIds.has(sessionId) && sessionMeta.createdAt) {
-      if (!(await sessionBelongsToAgent(agentSlug, sessionId))) continue
+      if (!sessionIdIsWithinAgent(agentSlug, sessionId)) continue
       // Skip scheduled/webhook sessions when requested
       if (options?.excludeAutomated && isAutomated(sessionId)) {
         continue
@@ -900,7 +756,8 @@ export async function listSessions(
  * exactly the fidelity of the agent card's lastActivityAt.
  *
  * Applies the same rules as listSessions: ownership (the cache is built
- * through sessionBelongsToAgent; metadata-only sessions are checked here),
+ * a read of this agent's own session directory; metadata-only sessions are
+ * checked here),
  * unregistered empty transcripts skipped, visibility filtered BEFORE ordering
  * and limit.
  */
@@ -934,7 +791,7 @@ export async function listSessionsFromSummary(
   // Registered sessions whose agent has not streamed yet (no transcript).
   for (const [sessionId, sessionMeta] of Object.entries(metadata)) {
     if (activity.has(sessionId) || !sessionMeta.createdAt) continue
-    if (!(await sessionBelongsToAgent(agentSlug, sessionId))) continue
+    if (!sessionIdIsWithinAgent(agentSlug, sessionId)) continue
     if (options?.excludeAutomated && isAutomated(sessionId)) continue
     sessions.push(emptySessionFromMetadata(sessionId, agentSlug, sessionMeta))
   }
@@ -963,7 +820,7 @@ export async function listSessionsByIds(
   const sessions = await Promise.all(
     [...new Set(sessionIds)].map((sessionId) =>
       limit(async (): Promise<SessionInfo | null> => {
-        if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
+        if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return null
         if (options?.excludeAutomated && isAutomated(sessionId)) return null
         const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
         try {
@@ -997,7 +854,7 @@ export async function getSession(
   agentSlug: string,
   sessionId: string
 ): Promise<SessionInfo | null> {
-  if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return null
+  if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return null
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   const metadata = await getSessionMetadata(agentSlug, sessionId)
 
@@ -1985,7 +1842,6 @@ export async function deleteSession(
   })
 
   const deleted = jsonlExisted || hadMetadata
-  if (deleted) await releaseSessionOwnership(agentSlug, [sessionId])
   return deleted
 }
 
@@ -2030,7 +1886,6 @@ export async function deleteSessionsBatch(
       }
       return changed
     })
-    await releaseSessionOwnership(agentSlug, deleted)
   }
 
   return deleted
@@ -2085,7 +1940,7 @@ export async function sessionIsKnown(
   agentSlug: string,
   sessionId: string
 ): Promise<boolean> {
-  if (!(await sessionBelongsToAgent(agentSlug, sessionId))) return false
+  if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return false
   try {
     if (await sessionExists(agentSlug, sessionId)) return true
     const metadata = await getSessionMetadata(agentSlug, sessionId)

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -11,6 +11,7 @@ import pLimit from 'p-limit'
 import {
   getAgentsDir,
   getAgentSessionsDir,
+  getAgentWorkspaceDir,
   getAgentSessionMetadataPath,
   getSessionJsonlPath,
   listDirectories,
@@ -107,13 +108,20 @@ function sessionIdPathWithinAgent(agentSlug: string, sessionId: string): boolean
 }
 
 // Lexical containment PLUS symlink resolution: the id names a file whose REAL
-// location is inside the agent's real session directory. The agent's dir is
-// bind-mounted read/write into its container, so it can plant a symlink named
-// after another agent's session that resolves to that agent's transcript — a
-// name that looks local but escapes on read. Use this on every gate that goes
-// on to serve or act on the transcript (never in a listing loop): it costs a
-// realpath, but a session that fails it must not be readable. This is what the
-// deleted ownership index also enforced, without a second source of truth.
+// location is inside this agent's own workspace. The workspace is bind-mounted
+// read/write into the container, so the agent can plant a symlink — named after
+// another agent's session, OR replacing a whole directory like `-workspace` —
+// that resolves to another agent's transcript: a name that looks local but
+// escapes on read. Use this on every gate that goes on to serve or act on the
+// transcript (never in a listing loop): it costs a realpath, but a session that
+// fails it must not be readable. This is what the deleted ownership index also
+// enforced, without a second source of truth.
+//
+// Containment is anchored on the WORKSPACE, not the session directory: the
+// session dir (and every dir under the workspace) is attacker-writable, so a
+// symlinked `-workspace` would make base and candidate realpath to the SAME
+// escaped location and pass. The workspace is the bind-mount point itself,
+// which the container cannot replace, so it is the trustworthy boundary.
 export function sessionFileRealPathWithinAgent(agentSlug: string, sessionId: string): boolean {
   let jsonlPath: string
   try {
@@ -121,7 +129,7 @@ export function sessionFileRealPathWithinAgent(agentSlug: string, sessionId: str
   } catch {
     return false
   }
-  return isRealPathWithinDir(getAgentSessionsDir(agentSlug), jsonlPath)
+  return isRealPathWithinDir(getAgentWorkspaceDir(agentSlug), jsonlPath)
 }
 
 /**

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -114,7 +114,7 @@ function sessionIdPathWithinAgent(agentSlug: string, sessionId: string): boolean
 // on to serve or act on the transcript (never in a listing loop): it costs a
 // realpath, but a session that fails it must not be readable. This is what the
 // deleted ownership index also enforced, without a second source of truth.
-function sessionFileRealPathWithinAgent(agentSlug: string, sessionId: string): boolean {
+export function sessionFileRealPathWithinAgent(agentSlug: string, sessionId: string): boolean {
   let jsonlPath: string
   try {
     jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
@@ -567,6 +567,29 @@ async function statTranscriptForSummary(filePath: string): Promise<fs.Stats | nu
   }
 }
 
+/**
+ * Names of the `.jsonl` transcript files directly in `sessionsDir`, EXCLUDING
+ * symlinks.
+ *
+ * A real session transcript is always a regular file the container wrote; a
+ * symlink named like a session is an escape attempt — it resolves to another
+ * agent's transcript (the dir is bind-mounted read/write into the container).
+ * Dropping it here keeps it out of every listing consumer at once, including
+ * the home-card tail that goes on to READ the latest session's content — so a
+ * planted link can never surface a stranger's messages through a listing.
+ *
+ * The symlink test reads the dirent type that `readdir` already returns, so it
+ * adds no syscall over a plain `readdir` — this stays on the perf hot path.
+ * (Direct id access that bypasses the listing is caught separately by the
+ * realpath gate in {@link sessionFileRealPathWithinAgent}.)
+ */
+async function readSessionTranscriptNames(sessionsDir: string): Promise<string[]> {
+  const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true })
+  return entries
+    .filter((e) => e.name.endsWith('.jsonl') && !e.isSymbolicLink())
+    .map((e) => e.name)
+}
+
 async function buildSessionActivityMap(
   agentSlug: string,
   sessionsDir: string,
@@ -574,8 +597,7 @@ async function buildSessionActivityMap(
 ): Promise<Map<string, SessionActivityEntry>> {
   if (directoryMtimeMs === null) return new Map()
 
-  const files = await fs.promises.readdir(sessionsDir)
-  const jsonlFiles = files.filter((file) => file.endsWith('.jsonl'))
+  const jsonlFiles = await readSessionTranscriptNames(sessionsDir)
   const limit = pLimit(10)
   const stats = await Promise.all(
     jsonlFiles.map((file) => limit(async () => {
@@ -726,8 +748,7 @@ export async function listSessions(
 
   // First, process sessions with JSONL files
   if (await directoryExists(sessionsDir)) {
-    const files = await fs.promises.readdir(sessionsDir)
-    const jsonlFiles = files.filter((f) => f.endsWith('.jsonl'))
+    const jsonlFiles = await readSessionTranscriptNames(sessionsDir)
 
     const limit = pLimit(10)
     const statResults = await Promise.all(

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -83,20 +83,39 @@ import {
 // cannot name a file under this agent's session directory (`..`, an absolute
 // path, a separator) is not one of its sessions, and must not reach a registry
 // or the filesystem.
+// Lexical containment only: `sessionId` names a file under this agent's session
+// directory (no `..`, absolute path, or separator). Deliberately touches no
+// filesystem — it runs once per transcript in the listing/summary hot loops,
+// whose op budget is pinned exactly by the perf suite. It is enough to reject a
+// traversal-shaped id; the SYMLINK escape (a link inside the agent's own dir
+// resolving to another agent's transcript) is caught on the content/action
+// gates instead — see {@link sessionFileResolvesWithinAgent} — because those
+// are the paths that actually read or mutate the file, and they are off the
+// listing hot path.
 function sessionIdIsWithinAgent(agentSlug: string, sessionId: string): boolean {
+  try {
+    getSessionJsonlPath(agentSlug, sessionId)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Lexical containment PLUS symlink resolution: the id names a file whose REAL
+// location is inside the agent's real session directory. The agent's dir is
+// bind-mounted read/write into its container, so it can plant a symlink named
+// after another agent's session that resolves to that agent's transcript — a
+// name that looks local but escapes on read. Use this on every gate that goes
+// on to serve or act on the transcript (never in a listing loop): it costs a
+// realpath, but a session that fails it must not be readable. This is what the
+// deleted ownership index also enforced, without a second source of truth.
+function sessionFileResolvesWithinAgent(agentSlug: string, sessionId: string): boolean {
   let jsonlPath: string
   try {
     jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   } catch {
     return false
   }
-  // Lexical containment (the getSessionJsonlPath above) is not enough. The
-  // agent's session directory is bind-mounted read/write into its container,
-  // so the agent can plant a symlink named after ANOTHER agent's session that
-  // resolves to that agent's transcript — a name that looks local but escapes
-  // on read. The id is this agent's only if its real path stays inside the
-  // agent's real session directory. This is what the deleted ownership index
-  // also enforced, without a second source of truth to keep in step.
   return isRealPathWithinDir(getAgentSessionsDir(agentSlug), jsonlPath)
 }
 
@@ -884,7 +903,10 @@ export async function getSession(
   agentSlug: string,
   sessionId: string
 ): Promise<SessionInfo | null> {
-  if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return null
+  // Content-serving path (the single-session route reads this): symlink-aware,
+  // so a planted link to another agent's transcript resolves to null, not that
+  // agent's session summary.
+  if (!sessionFileResolvesWithinAgent(agentSlug, sessionId)) return null
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   const metadata = await getSessionMetadata(agentSlug, sessionId)
 
@@ -1945,7 +1967,7 @@ export async function sessionExists(
   agentSlug: string,
   sessionId: string
 ): Promise<boolean> {
-  if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return false
+  if (!sessionFileResolvesWithinAgent(agentSlug, sessionId)) return false
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   return fileExists(jsonlPath)
 }

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -83,16 +83,21 @@ import {
 // cannot name a file under this agent's session directory (`..`, an absolute
 // path, a separator) is not one of its sessions, and must not reach a registry
 // or the filesystem.
+// Path-shape validation, NOT an existence or ownership check: it answers true
+// for any well-formed id whether or not a session by that name exists — callers
+// that need "does this session exist / is it really this agent's" must use
+// sessionExists / sessionIsKnown, which layer those on top.
+//
 // Lexical containment only: `sessionId` names a file under this agent's session
 // directory (no `..`, absolute path, or separator). Deliberately touches no
 // filesystem — it runs once per transcript in the listing/summary hot loops,
 // whose op budget is pinned exactly by the perf suite. It is enough to reject a
 // traversal-shaped id; the SYMLINK escape (a link inside the agent's own dir
 // resolving to another agent's transcript) is caught on the content/action
-// gates instead — see {@link sessionFileResolvesWithinAgent} — because those
+// gates instead — see {@link sessionFileRealPathWithinAgent} — because those
 // are the paths that actually read or mutate the file, and they are off the
 // listing hot path.
-function sessionIdIsWithinAgent(agentSlug: string, sessionId: string): boolean {
+function sessionIdPathWithinAgent(agentSlug: string, sessionId: string): boolean {
   try {
     getSessionJsonlPath(agentSlug, sessionId)
     return true
@@ -109,7 +114,7 @@ function sessionIdIsWithinAgent(agentSlug: string, sessionId: string): boolean {
 // on to serve or act on the transcript (never in a listing loop): it costs a
 // realpath, but a session that fails it must not be readable. This is what the
 // deleted ownership index also enforced, without a second source of truth.
-function sessionFileResolvesWithinAgent(agentSlug: string, sessionId: string): boolean {
+function sessionFileRealPathWithinAgent(agentSlug: string, sessionId: string): boolean {
   let jsonlPath: string
   try {
     jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
@@ -577,7 +582,7 @@ async function buildSessionActivityMap(
       const stat = await statTranscriptForSummary(path.join(sessionsDir, file))
       if (!stat) return null
       const sessionId = path.basename(file, '.jsonl')
-      if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return null
+      if (!sessionIdPathWithinAgent(agentSlug, sessionId)) return null
       return {
         sessionId,
         entry: { mtimeMs: stat.mtimeMs, birthtimeMs: stat.birthtimeMs, size: stat.size },
@@ -744,7 +749,7 @@ export async function listSessions(
       const { sessionId, stat } = result
       processedSessionIds.add(sessionId)
 
-      if (!sessionIdIsWithinAgent(agentSlug, sessionId)) continue
+      if (!sessionIdPathWithinAgent(agentSlug, sessionId)) continue
 
       // Skip empty JSONL files that aren't registered in metadata
       // These are typically created by Claude SDK for subagent directories
@@ -772,7 +777,7 @@ export async function listSessions(
   // (newly created sessions where the agent hasn't streamed yet)
   for (const [sessionId, sessionMeta] of Object.entries(metadata)) {
     if (!processedSessionIds.has(sessionId) && sessionMeta.createdAt) {
-      if (!sessionIdIsWithinAgent(agentSlug, sessionId)) continue
+      if (!sessionIdPathWithinAgent(agentSlug, sessionId)) continue
       // Skip scheduled/webhook sessions when requested
       if (options?.excludeAutomated && isAutomated(sessionId)) {
         continue
@@ -840,7 +845,7 @@ export async function listSessionsFromSummary(
   // Registered sessions whose agent has not streamed yet (no transcript).
   for (const [sessionId, sessionMeta] of Object.entries(metadata)) {
     if (activity.has(sessionId) || !sessionMeta.createdAt) continue
-    if (!sessionIdIsWithinAgent(agentSlug, sessionId)) continue
+    if (!sessionIdPathWithinAgent(agentSlug, sessionId)) continue
     if (options?.excludeAutomated && isAutomated(sessionId)) continue
     sessions.push(emptySessionFromMetadata(sessionId, agentSlug, sessionMeta))
   }
@@ -869,7 +874,7 @@ export async function listSessionsByIds(
   const sessions = await Promise.all(
     [...new Set(sessionIds)].map((sessionId) =>
       limit(async (): Promise<SessionInfo | null> => {
-        if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return null
+        if (!sessionIdPathWithinAgent(agentSlug, sessionId)) return null
         if (options?.excludeAutomated && isAutomated(sessionId)) return null
         const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
         try {
@@ -906,7 +911,7 @@ export async function getSession(
   // Content-serving path (the single-session route reads this): symlink-aware,
   // so a planted link to another agent's transcript resolves to null, not that
   // agent's session summary.
-  if (!sessionFileResolvesWithinAgent(agentSlug, sessionId)) return null
+  if (!sessionFileRealPathWithinAgent(agentSlug, sessionId)) return null
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   const metadata = await getSessionMetadata(agentSlug, sessionId)
 
@@ -1958,7 +1963,7 @@ export async function updateSessionName(
  * Whether this agent has a transcript on disk for `sessionId`.
  *
  * Never throws, and never answers true for an id that is not this agent's:
- * `sessionIdIsWithinAgent` rejects a traversal-shaped id (which would
+ * `sessionFileRealPathWithinAgent` rejects a traversal-shaped id (which would
  * otherwise throw out of `getSessionJsonlPath` into the caller's `catch` and,
  * on the routes that gate delete/interrupt on this, answer 500 instead of a
  * clean 404) and a symlink whose real target escapes the agent's directory.
@@ -1967,7 +1972,7 @@ export async function sessionExists(
   agentSlug: string,
   sessionId: string
 ): Promise<boolean> {
-  if (!sessionFileResolvesWithinAgent(agentSlug, sessionId)) return false
+  if (!sessionFileRealPathWithinAgent(agentSlug, sessionId)) return false
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
   return fileExists(jsonlPath)
 }
@@ -1999,7 +2004,7 @@ export async function sessionIsKnown(
   agentSlug: string,
   sessionId: string
 ): Promise<boolean> {
-  if (!sessionIdIsWithinAgent(agentSlug, sessionId)) return false
+  if (!sessionIdPathWithinAgent(agentSlug, sessionId)) return false
   try {
     if (await sessionExists(agentSlug, sessionId)) return true
     const metadata = await getSessionMetadata(agentSlug, sessionId)

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -590,6 +590,12 @@ async function statTranscriptForSummary(filePath: string): Promise<fs.Stats | nu
  * adds no syscall over a plain `readdir` — this stays on the perf hot path.
  * (Direct id access that bypasses the listing is caught separately by the
  * realpath gate in {@link sessionFileRealPathWithinAgent}.)
+ *
+ * KNOWN RESIDUAL (accepted, out of scope): this drops symlinked ENTRIES, but
+ * `readdir` still follows a symlinked ANCESTOR (an agent that replaced its own
+ * `-workspace` with a link), so such a listing reflects another agent's dir.
+ * Fully closing it needs a per-listing realpath on the perf-pinned path — see
+ * the note in getLatestVisibleSessionTail, the one place it reaches content.
  */
 async function readSessionTranscriptNames(sessionsDir: string): Promise<string[]> {
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true })

--- a/src/shared/lib/services/session-summary-cache.ts
+++ b/src/shared/lib/services/session-summary-cache.ts
@@ -149,15 +149,3 @@ export function applyActivity(entry: SessionActivityEntry, activityAtMs: number)
   entry.mtimeMs = Math.max(entry.mtimeMs, activityAtMs)
   entry.size = Math.max(entry.size, 1)
 }
-
-export function removeSessionFromSummaryCache(agentSlug: string, sessionId: string): void {
-  const slot = sessionSummaryCache.get(getAgentSessionsDir(agentSlug))
-  if (!slot) return
-  slot.value?.activityBySession.delete(sessionId)
-  // A build in flight may have stat'd the file before the unlink; mark it so
-  // the fold-in drops it. Otherwise drop any parked write for it: the next
-  // rebuild will not see the file, and a parked write must not resurrect it
-  // (it never could — pending never creates — but it must not linger either).
-  if (slot.loading) slot.pending.set(sessionId, { deleted: true })
-  else slot.pending.delete(sessionId)
-}

--- a/src/shared/lib/services/session-unread-service.test.ts
+++ b/src/shared/lib/services/session-unread-service.test.ts
@@ -57,7 +57,7 @@ describe('session-unread-service', () => {
 
   it('clears the mark', async () => {
     await markSessionUnread('agent-a', 'sess-1', ALICE)
-    await clearSessionUnread('sess-1', ALICE)
+    await clearSessionUnread('agent-a', 'sess-1', ALICE)
 
     expect(await getSessionIdsMarkedUnread('agent-a', ALICE)).toEqual(new Set())
   })
@@ -70,14 +70,40 @@ describe('session-unread-service', () => {
     expect(await getSessionIdsMarkedUnread('agent-b', ALICE)).toEqual(new Set(['sess-b']))
   })
 
+  // A session id is unique only within an agent — import/clone gives two agents
+  // the same id. Both must be able to hold a mark (the PK includes the agent),
+  // and clearing one must not touch the other.
+  it('two agents hold a mark for the same session id independently', async () => {
+    expect(await markSessionUnread('agent-a', 'shared-id', ALICE)).toBe(true)
+    expect(await markSessionUnread('agent-b', 'shared-id', ALICE)).toBe(true)
+
+    expect(await getSessionIdsMarkedUnread('agent-a', ALICE)).toEqual(new Set(['shared-id']))
+    expect(await getSessionIdsMarkedUnread('agent-b', ALICE)).toEqual(new Set(['shared-id']))
+
+    expect(await clearSessionUnread('agent-b', 'shared-id', ALICE)).toBe(true)
+
+    expect(await getSessionIdsMarkedUnread('agent-a', ALICE)).toEqual(new Set(['shared-id']))
+    expect(await getSessionIdsMarkedUnread('agent-b', ALICE)).toEqual(new Set())
+  })
+
+  it('deleting one agent’s session marks leaves another agent’s identically-named mark', async () => {
+    await markSessionUnread('agent-a', 'shared-id', ALICE)
+    await markSessionUnread('agent-b', 'shared-id', ALICE)
+
+    await deleteSessionUnreadMarks('agent-b', ['shared-id'])
+
+    expect(await getSessionIdsMarkedUnread('agent-a', ALICE)).toEqual(new Set(['shared-id']))
+    expect(await getSessionIdsMarkedUnread('agent-b', ALICE)).toEqual(new Set())
+  })
+
   // The clear fires on every session open and the client skips its cache
   // invalidation when nothing was written — refetching the session list and
   // re-enriching every agent for a no-op is what this return value avoids.
   it('reports whether the write actually changed anything', async () => {
-    expect(await clearSessionUnread('never-marked', ALICE)).toBe(false)
+    expect(await clearSessionUnread('agent-a', 'never-marked', ALICE)).toBe(false)
     expect(await markSessionUnread('agent-a', 'sess-1', ALICE)).toBe(true)
     expect(await markSessionUnread('agent-a', 'sess-1', ALICE)).toBe(false)
-    expect(await clearSessionUnread('sess-1', ALICE)).toBe(true)
+    expect(await clearSessionUnread('agent-a', 'sess-1', ALICE)).toBe(true)
   })
 
   it('keeps the original timestamp when a marked session is re-marked', async () => {
@@ -107,7 +133,7 @@ describe('session-unread-service', () => {
       await markSessionUnread('agent-a', 'sess-1', ALICE)
       await markSessionUnread('agent-a', 'sess-1', BOB)
 
-      expect(await clearSessionUnread('sess-1', BOB)).toBe(true)
+      expect(await clearSessionUnread('agent-a', 'sess-1', BOB)).toBe(true)
 
       expect(await getSessionIdsMarkedUnread('agent-a', ALICE)).toEqual(new Set(['sess-1']))
       expect(await getSessionIdsMarkedUnread('agent-a', BOB)).toEqual(new Set())
@@ -134,7 +160,7 @@ describe('session-unread-service', () => {
     expect(await getSessionIdsMarkedUnreadByAgents(['agent-a'], 'local').then((m) => m.get('agent-a')))
       .toEqual(new Set(['sess-1']))
 
-    expect(await clearSessionUnread('sess-1', 'local')).toBe(true)
+    expect(await clearSessionUnread('agent-a', 'sess-1', 'local')).toBe(true)
     expect(await getSessionIdsMarkedUnread('agent-a', 'local')).toEqual(new Set())
   })
 
@@ -179,7 +205,7 @@ describe('session-unread-service', () => {
     await markSessionUnread('agent-a', 'sess-gone', BOB)
     await markSessionUnread('agent-a', 'sess-kept', ALICE)
 
-    expect(await deleteSessionUnreadMarks(['sess-gone'])).toBe(2)
+    expect(await deleteSessionUnreadMarks('agent-a', ['sess-gone'])).toBe(2)
 
     expect(await getSessionIdsMarkedUnread('agent-a', ALICE)).toEqual(new Set(['sess-kept']))
     expect(await getSessionIdsMarkedUnread('agent-a', BOB)).toEqual(new Set())

--- a/src/shared/lib/services/session-unread-service.ts
+++ b/src/shared/lib/services/session-unread-service.ts
@@ -45,13 +45,28 @@ export async function markSessionUnread(
 }
 
 /**
- * Clear this user's mark, leaving anyone else's alone. Fires on every session
- * open, so the overwhelmingly common case deletes no row and reports false.
+ * Clear this user's mark on ONE agent's session, leaving anyone else's alone.
+ * Fires on every session open, so the overwhelmingly common case deletes no
+ * row and reports false.
+ *
+ * Scoped by agentSlug as well as sessionId: a session id is unique only within
+ * an agent (import/clone gives two agents the same id), so a bare-id delete
+ * would clear the mark on a DIFFERENT agent's identically-named session. The
+ * mark was written with an agentSlug and every reader filters by it, so the
+ * clear must too.
  */
-export async function clearSessionUnread(sessionId: string, userId: string): Promise<boolean> {
+export async function clearSessionUnread(
+  agentSlug: string,
+  sessionId: string,
+  userId: string,
+): Promise<boolean> {
   const result = await db
     .delete(sessionUnreadMarks)
-    .where(and(eq(sessionUnreadMarks.sessionId, sessionId), eq(sessionUnreadMarks.userId, userId)))
+    .where(and(
+      eq(sessionUnreadMarks.agentSlug, agentSlug),
+      eq(sessionUnreadMarks.sessionId, sessionId),
+      eq(sessionUnreadMarks.userId, userId),
+    ))
 
   return (result.changes ?? 0) > 0
 }
@@ -98,16 +113,27 @@ export async function getSessionIdsMarkedUnreadByAgents(
 }
 
 /**
- * Drop every user's marks for deleted sessions, alongside
+ * Drop every user's marks for one agent's deleted sessions, alongside
  * deleteNotificationsBySessionIds — otherwise a mark would outlive its session
  * as an unreachable row.
+ *
+ * Scoped to agentSlug: session ids are unique only within an agent, so a
+ * bare-id delete would also drop a different agent's identically-named
+ * session's marks. Every caller deletes one agent's sessions and holds its
+ * slug.
  */
-export async function deleteSessionUnreadMarks(sessionIds: string[]): Promise<number> {
+export async function deleteSessionUnreadMarks(
+  agentSlug: string,
+  sessionIds: string[],
+): Promise<number> {
   if (sessionIds.length === 0) return 0
 
   const result = await db
     .delete(sessionUnreadMarks)
-    .where(inArray(sessionUnreadMarks.sessionId, sessionIds))
+    .where(and(
+      eq(sessionUnreadMarks.agentSlug, agentSlug),
+      inArray(sessionUnreadMarks.sessionId, sessionIds),
+    ))
 
   return result.changes ?? 0
 }

--- a/src/shared/lib/startup.ts
+++ b/src/shared/lib/startup.ts
@@ -19,6 +19,7 @@ import { platformService } from './services/platform-service'
 import { getActiveProvider, stopAllProviders } from '../../main/host-browser'
 import { startBrowserProfileCleanup, stopBrowserProfileCleanup } from '../../main/host-browser/profile-maintenance'
 import { listAgents } from './services/agent-service'
+import { removeLegacySessionOwnershipIndex } from './services/session-service'
 import { isAuthMode } from './auth/mode'
 import { clearPendingApprovalBans } from './auth/clear-pending-approval-bans'
 import { validateAuthModeStartup } from './auth/startup-validation'
@@ -123,6 +124,16 @@ async function initializeServicesInner() {
 
   // Initialize server-side analytics version
   setServerAnalyticsVersion(APP_VERSION)
+
+  // One-time removal of the legacy session-ownership index. This build derives
+  // ownership structurally, so the file is dead here — but leaving it would
+  // strand every new session's ownership on a rollback to a build that reads
+  // it. Deleting it lets that older build re-run its discovery migration.
+  try {
+    await removeLegacySessionOwnershipIndex()
+  } catch (error) {
+    captureException(error, { tags: { component: 'startup', operation: 'remove-legacy-ownership-index' } })
+  }
 
   // Register account providers (Composio, Nango if configured)
   registerAllAccountProviders()

--- a/src/shared/lib/user-input/request-manager.test.ts
+++ b/src/shared/lib/user-input/request-manager.test.ts
@@ -30,14 +30,14 @@ describe('UserInputRequestManager', () => {
       expect(stored).not.toBeNull()
       expect(stored!.kind).toBe('secret')
       expect(stored!.autoApproved).toBe(false)
-      expect(manager.getOpenRequestsForSession('session-1')).toHaveLength(1)
+      expect(manager.getOpenRequestsForSession('agent-a', 'session-1')).toHaveLength(1)
     })
 
     it('is first-delivery-wins: re-registering an open id returns the original unchanged', () => {
       const first = manager.register(secretRequest({ payload: { secretName: 'FIRST' } }))
       const second = manager.register(secretRequest({ payload: { secretName: 'SECOND' } }))
       expect(second).toBe(first)
-      const open = manager.getOpenRequestsForSession('session-1')
+      const open = manager.getOpenRequestsForSession('agent-a', 'session-1')
       expect(open).toHaveLength(1)
       expect((open[0].payload as { secretName?: string }).secretName).toBe('FIRST')
     })
@@ -188,16 +188,16 @@ describe('UserInputRequestManager', () => {
     })
 
     it('clearSessionStreamRequests wipes only the session\'s stream store (turn-boundary mirror)', () => {
-      manager.clearSessionStreamRequests('session-1', 'cancelled')
-      expect(manager.getOpenRequestsForSession('session-1').map((r) => r.id)).toEqual(['cu-1'])
-      expect(manager.getOpenRequestsForSession('session-2')).toHaveLength(1)
+      manager.clearSessionStreamRequests('agent-a', 'session-1', 'cancelled')
+      expect(manager.getOpenRequestsForSession('agent-a', 'session-1').map((r) => r.id)).toEqual(['cu-1'])
+      expect(manager.getOpenRequestsForSession('agent-a', 'session-2')).toHaveLength(1)
       expect(manager.getAgentScopedRequests('agent-a')).toHaveLength(1)
     })
 
     it('dropSessionRequests removes every session-scoped entry but leaves agent-scoped reviews', () => {
-      manager.dropSessionRequests('session-1')
-      expect(manager.getOpenRequestsForSession('session-1')).toHaveLength(0)
-      expect(manager.getOpenRequestsForSession('session-2')).toHaveLength(1)
+      manager.dropSessionRequests('agent-a', 'session-1')
+      expect(manager.getOpenRequestsForSession('agent-a', 'session-1')).toHaveLength(0)
+      expect(manager.getOpenRequestsForSession('agent-a', 'session-2')).toHaveLength(1)
       expect(manager.getAgentScopedRequests('agent-a')).toHaveLength(1)
     })
   })
@@ -205,17 +205,17 @@ describe('UserInputRequestManager', () => {
   describe('awaiting projection', () => {
     it('a session-scoped blocking request makes the session awaiting', () => {
       manager.register(secretRequest())
-      expect(manager.isSessionAwaiting('session-1')).toBe(true)
-      expect(manager.isSessionAwaiting('session-2')).toBe(false)
+      expect(manager.isSessionAwaiting('agent-a', 'session-1')).toBe(true)
+      expect(manager.isSessionAwaiting('agent-a', 'session-2')).toBe(false)
       manager.resolve('tool-1', 'answered')
-      expect(manager.isSessionAwaiting('session-1')).toBe(false)
+      expect(manager.isSessionAwaiting('agent-a', 'session-1')).toBe(false)
     })
 
     it('auto-approved requests never count as real waits', () => {
       manager.register(
         secretRequest({ id: 'auto-1', kind: 'script_run', autoApproved: true, payload: {} }),
       )
-      expect(manager.isSessionAwaiting('session-1')).toBe(false)
+      expect(manager.isSessionAwaiting('agent-a', 'session-1')).toBe(false)
       expect(manager.isAgentAwaiting('agent-a')).toBe(false)
     })
 
@@ -227,9 +227,53 @@ describe('UserInputRequestManager', () => {
         blocking: true,
         payload: { toolkit: 'slack' },
       })
-      expect(manager.isSessionAwaiting('any-session-of-a', 'agent-a')).toBe(true)
-      expect(manager.isSessionAwaiting('any-session-of-b', 'agent-b')).toBe(false)
+      expect(manager.isSessionAwaiting('agent-a', 'any-session-of-a')).toBe(true)
+      expect(manager.isSessionAwaiting('agent-b', 'any-session-of-b')).toBe(false)
       expect(manager.isAgentAwaiting('agent-a')).toBe(true)
+    })
+  })
+
+  describe('two agents holding the same session id do not cross-talk', () => {
+    // A session id is unique only WITHIN an agent. Import/clone gives each
+    // agent its own copy of the same id, so every session-scoped read and
+    // sweep must match the agent too — otherwise one agent's turn boundary
+    // settles another agent's parked request (the SUP-479 class, reopened at
+    // the request registry once duplicate ids across agents became legal).
+    beforeEach(() => {
+      // Same session id 'shared', one live request under each agent.
+      manager.register(secretRequest({ id: 'a-req', scope: { agentSlug: 'agent-a', sessionId: 'shared' } }))
+      manager.register(secretRequest({ id: 'b-req', scope: { agentSlug: 'agent-b', sessionId: 'shared' } }))
+    })
+
+    it('getOpenRequestsForSession returns only the asking agent’s request', () => {
+      expect(manager.getOpenRequestsForSession('agent-a', 'shared').map((r) => r.id)).toEqual(['a-req'])
+      expect(manager.getOpenRequestsForSession('agent-b', 'shared').map((r) => r.id)).toEqual(['b-req'])
+    })
+
+    it('clearSessionStreamRequests settles only the asking agent’s stream entry', () => {
+      manager.clearSessionStreamRequests('agent-a', 'shared', 'cancelled')
+      expect(manager.getOpenRequest('a-req')).toBeNull()
+      expect(manager.getOpenRequest('b-req')).not.toBeNull()
+    })
+
+    it('dropSessionRequests drops only the asking agent’s entry', () => {
+      manager.dropSessionRequests('agent-a', 'shared')
+      expect(manager.getOpenRequest('a-req')).toBeNull()
+      expect(manager.getOpenRequest('b-req')).not.toBeNull()
+    })
+
+    it('getStoreIdsForSession lists only the asking agent’s ids', () => {
+      expect(manager.getStoreIdsForSession('agent-a', 'shared', 'stream')).toEqual(['a-req'])
+      expect(manager.getStoreIdsForSession('agent-b', 'shared', 'stream')).toEqual(['b-req'])
+    })
+
+    it('isSessionAwaiting is answered per agent, not by the bare id', () => {
+      expect(manager.isSessionAwaiting('agent-a', 'shared')).toBe(true)
+      expect(manager.isSessionAwaiting('agent-b', 'shared')).toBe(true)
+      manager.resolve('a-req', 'answered')
+      // agent-a's wait is settled; agent-b's identically-named session is not.
+      expect(manager.isSessionAwaiting('agent-a', 'shared')).toBe(false)
+      expect(manager.isSessionAwaiting('agent-b', 'shared')).toBe(true)
     })
   })
 
@@ -266,7 +310,7 @@ describe('UserInputRequestManager', () => {
       })
       manager.register(secretRequest({ id: 'clear-1' }))
       manager.register(secretRequest({ id: 'clear-2' }))
-      manager.clearSessionStreamRequests('session-1', 'superseded')
+      manager.clearSessionStreamRequests('agent-a', 'session-1', 'superseded')
       expect(outcomes).toEqual([
         { id: 'clear-1', outcome: 'superseded' },
         { id: 'clear-2', outcome: 'superseded' },
@@ -391,7 +435,7 @@ describe('UserInputRequestManager', () => {
       manager.claimRequest('tool-1')
 
       expect(manager.getOpenRequest('tool-1')).not.toBeNull()
-      expect(manager.isSessionAwaiting('session-1', 'agent-a')).toBe(true)
+      expect(manager.isSessionAwaiting('agent-a', 'session-1')).toBe(true)
       expect(manager.getSnapshotForScope('agent-a', 'session-1')).toHaveLength(1)
       expect(manager.stats.open).toBe(1)
     })

--- a/src/shared/lib/user-input/request-manager.ts
+++ b/src/shared/lib/user-input/request-manager.ts
@@ -156,10 +156,29 @@ export class UserInputRequestManager {
     return this.resolve(id, outcome)
   }
 
+  /**
+   * A request scoped to exactly this (agent, session). Session id is unique
+   * only WITHIN an agent — two agents can legitimately hold the same id (an
+   * import/clone gives each its own copy) — so every session-scoped read and
+   * sweep here must match the agent too, or one agent's turn boundary settles
+   * another's parked request. Agent-scoped reviews (no sessionId) never match.
+   */
+  private isForSession(
+    request: PendingUserInputRequest,
+    agentSlug: string,
+    sessionId: string,
+  ): boolean {
+    return request.scope.agentSlug === agentSlug && request.scope.sessionId === sessionId
+  }
+
   /** Mirror of the turn-boundary `pendingInputRequests.clear()` — stream store only. */
-  clearSessionStreamRequests(sessionId: string, outcome: UserInputRequestOutcome): void {
+  clearSessionStreamRequests(
+    agentSlug: string,
+    sessionId: string,
+    outcome: UserInputRequestOutcome,
+  ): void {
     for (const request of [...this.requests.values()]) {
-      if (request.scope.sessionId !== sessionId) continue
+      if (!this.isForSession(request, agentSlug, sessionId)) continue
       if (storeForKind(request.kind) !== 'stream') continue
       this.resolve(request.id, outcome)
     }
@@ -184,9 +203,13 @@ export class UserInputRequestManager {
   }
 
   /** Mirror of `streamingStates.delete` — every session-scoped entry dies with the state. */
-  dropSessionRequests(sessionId: string, outcome: UserInputRequestOutcome = 'invalidated'): void {
+  dropSessionRequests(
+    agentSlug: string,
+    sessionId: string,
+    outcome: UserInputRequestOutcome = 'invalidated',
+  ): void {
     for (const request of [...this.requests.values()]) {
-      if (request.scope.sessionId !== sessionId) continue
+      if (!this.isForSession(request, agentSlug, sessionId)) continue
       this.resolve(request.id, outcome)
     }
   }
@@ -252,8 +275,8 @@ export class UserInputRequestManager {
     return undefined
   }
 
-  getOpenRequestsForSession(sessionId: string): PendingUserInputRequest[] {
-    return [...this.requests.values()].filter((r) => r.scope.sessionId === sessionId)
+  getOpenRequestsForSession(agentSlug: string, sessionId: string): PendingUserInputRequest[] {
+    return [...this.requests.values()].filter((r) => this.isForSession(r, agentSlug, sessionId))
   }
 
   /** Every open request of a store, across all scopes (e.g. shutdown sweeps). */
@@ -297,9 +320,13 @@ export class UserInputRequestManager {
     })
   }
 
-  getStoreIdsForSession(sessionId: string, store: UserInputRequestStore): string[] {
+  getStoreIdsForSession(
+    agentSlug: string,
+    sessionId: string,
+    store: UserInputRequestStore,
+  ): string[] {
     return [...this.requests.values()]
-      .filter((r) => r.scope.sessionId === sessionId && storeForKind(r.kind) === store)
+      .filter((r) => this.isForSession(r, agentSlug, sessionId) && storeForKind(r.kind) === store)
       .map((r) => r.id)
   }
 
@@ -314,15 +341,11 @@ export class UserInputRequestManager {
    * "awaiting input" — the persister recomputes it after every registry
    * transition and broadcasts on the edges.
    */
-  isSessionAwaiting(sessionId: string, agentSlug?: string): boolean {
+  isSessionAwaiting(agentSlug: string, sessionId: string): boolean {
     for (const request of this.requests.values()) {
       if (!this.isRealWait(request)) continue
-      if (request.scope.sessionId === sessionId) return true
-      if (
-        agentSlug !== undefined &&
-        request.scope.sessionId === undefined &&
-        request.scope.agentSlug === agentSlug
-      ) {
+      if (this.isForSession(request, agentSlug, sessionId)) return true
+      if (request.scope.sessionId === undefined && request.scope.agentSlug === agentSlug) {
         return true
       }
     }

--- a/src/shared/lib/utils/path-safety.test.ts
+++ b/src/shared/lib/utils/path-safety.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
 import path from 'path'
-import { isPathWithinDir, assertPathWithinDir, sanitizeUploadFilename } from './path-safety'
+import { isPathWithinDir, assertPathWithinDir, isRealPathWithinDir, sanitizeUploadFilename } from './path-safety'
 
 // ---------------------------------------------------------------------------
 // Path containment guard (SUP-200 generalization). The motivating bug: a bare
@@ -130,5 +132,60 @@ describe('sanitizeUploadFilename', () => {
   it('preserves a normal filename unchanged', () => {
     expect(sanitizeUploadFilename('report.pdf')).toBe('report.pdf')
     expect(sanitizeUploadFilename('My_File-2.png')).toBe('My_File-2.png')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Symlink-aware containment. isPathWithinDir compares strings; this one follows
+// links, because the base directory here is writable by an untrusted party.
+// ---------------------------------------------------------------------------
+
+describe('isRealPathWithinDir', () => {
+  let tmp: string
+  let base: string
+  let outside: string
+
+  beforeEach(() => {
+    tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'realpath-')))
+    base = path.join(tmp, 'agent', 'sessions')
+    outside = path.join(tmp, 'other-agent', 'sessions')
+    fs.mkdirSync(base, { recursive: true })
+    fs.mkdirSync(outside, { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('accepts a real file inside the base', () => {
+    const f = path.join(base, 'a.jsonl')
+    fs.writeFileSync(f, '{}')
+    expect(isRealPathWithinDir(base, f)).toBe(true)
+  })
+
+  it('accepts a not-yet-created leaf under the base (its name was already validated)', () => {
+    expect(isRealPathWithinDir(base, path.join(base, 'not-written-yet.jsonl'))).toBe(true)
+  })
+
+  it('rejects a symlink whose target escapes the base', () => {
+    const victim = path.join(outside, 'victim.jsonl')
+    fs.writeFileSync(victim, 'secret')
+    const link = path.join(base, 'victim.jsonl')
+    fs.symlinkSync(victim, link)
+    expect(isRealPathWithinDir(base, link)).toBe(false)
+  })
+
+  it('rejects a leaf reached through a symlinked directory that escapes the base', () => {
+    const link = path.join(base, 'linkdir')
+    fs.symlinkSync(outside, link)
+    expect(isRealPathWithinDir(base, path.join(link, 'anything.jsonl'))).toBe(false)
+  })
+
+  it('accepts a symlink that stays inside the base', () => {
+    const real = path.join(base, 'real.jsonl')
+    fs.writeFileSync(real, '{}')
+    const link = path.join(base, 'alias.jsonl')
+    fs.symlinkSync(real, link)
+    expect(isRealPathWithinDir(base, link)).toBe(true)
   })
 })

--- a/src/shared/lib/utils/path-safety.ts
+++ b/src/shared/lib/utils/path-safety.ts
@@ -21,6 +21,7 @@
  *     path on success; throws on escape — for callers that fail the request.
  */
 
+import fs from 'fs'
 import path from 'path'
 
 /**
@@ -57,6 +58,50 @@ export function assertPathWithinDir(
     throw new Error(message)
   }
   return path.resolve(candidate)
+}
+
+/**
+ * Symlink-aware containment: true iff `candidate`'s REAL location is inside
+ * (or equal to) `baseDir`'s real location.
+ *
+ * `isPathWithinDir` compares path STRINGS and never follows a link, so a
+ * symlink planted inside `baseDir` that points outside it passes. When the
+ * base directory is writable by an untrusted party — an agent's bind-mounted
+ * workspace — that is a real escape: a link named after another agent's
+ * session resolves to that agent's transcript while still looking local.
+ *
+ * Resolves symlinks on the deepest EXISTING prefix of `candidate` (a
+ * not-yet-created leaf can't be a link, and its name was already validated by
+ * `isPathWithinDir`), then re-appends the missing tail and re-checks
+ * containment against the real base. Any fs error is treated as "not
+ * contained" — fail closed. Follows links via `fs.existsSync`, so a dangling
+ * link resolves to its (contained) parent and reads as absent downstream.
+ */
+export function isRealPathWithinDir(baseDir: string, candidate: string): boolean {
+  try {
+    const realBase = safeRealpath(baseDir)
+    let existing = path.resolve(candidate)
+    const tail: string[] = []
+    while (!fs.existsSync(existing)) {
+      tail.unshift(path.basename(existing))
+      const parent = path.dirname(existing)
+      if (parent === existing) return false // walked past the root
+      existing = parent
+    }
+    const realExisting = safeRealpath(existing)
+    const realCandidate = tail.length > 0 ? path.join(realExisting, ...tail) : realExisting
+    return isPathWithinDir(realBase, realCandidate)
+  } catch {
+    return false
+  }
+}
+
+function safeRealpath(p: string): string {
+  try {
+    return fs.realpathSync(p)
+  } catch {
+    return path.resolve(p)
+  }
 }
 
 /**


### PR DESCRIPTION
Stacked on #906 — **review that first, and merge it first.** The base of this PR is `test/session-scope-coverage`, so the diff here is only the refactor.

Supersedes #900.

## The bug behind the bug

#900 fixes a real thing: a full `.agent` import restores transcripts and `session-metadata.json`, but the sessions never appear. It fixes it by teaching the import path to write to the session-ownership index.

That index is the problem. `messagePersister`'s registries were keyed by **session id alone**, and a session id is unique within its agent, not across the install — it comes from the container, and an agent can write any id it likes into its own bind-mounted workspace. So a route that had authorized the AGENT in its URL could be handed a session id that addressed a stranger's live session (SUP-479, #635), and interrupt it, post into it, or subscribe to its stream.

#635 answered that with a host-owned `session-ownership.json` kept one directory above every workspace, where a container cannot forge it. It works. But it makes "whose session is this" a **second durable source of truth** that every ingress has to remember to update. Import didn't. Neither will clone, restore, or skillset install — `copyDirectoryFiltered` doesn't exclude `.claude/projects`.

And #900 as it stands makes one case worse: `deleteAgent` never releases ownership (only `deleteSession` does, and #900's own third commit reverted the fix for that), so import → delete → re-import the same archive now fails **permanently** and rolls the new agent back. I confirmed that with a repro test on that branch.

## What this does instead

Removes the question rather than answering it again. Every registry — `streamingStates`, `subscriptions`, `sseClients`, `containerClients`, `subscribingNow`, `sessionCapabilityGrants`, `workflowTailers` — is keyed by **agent AND session**.

A forged transcript then resolves to an empty slot in the forging agent's own namespace and reaches nothing. So `session-ownership.json` goes, and with it the migration, the `null` tombstones, `claimSessionOwnership` / `releaseSessionOwnership` / `reserveSessionOwnership` / `sessionBelongsToAgent`, and the six ownership filters in the listing paths. What survives is containment: an id that cannot name a file under this agent's session directory is still refused.

**221 lines out of `session-service.ts`.**

## Worth a close look

**The key is branded.** `SessionKey` is `string & { [brand]: true }`, so passing a bare session id where a key belongs is a compile error. That is the only reason a string-keyed change of this size is checkable at all — `tsc` enumerated all 851 call sites. Without the brand the map lookups would have kept compiling and failing silently.

**Two strings swapped is not something the compiler can catch.** Five methods changed argument order rather than gaining one. I audited every internal call of every changed method for argument order; that audit found two real bugs (`promoteAutomatedSession`, `completeCapabilityReview`) that typechecked fine, plus a key-vs-id confusion in five registry iterations (`for (const [sessionId, state] of this.streamingStates)` — that binding is a key now).

**`sessionIsKnown` keeps its contract but loses a half.** It still answers "is this a session OF THIS AGENT", from this agent's own directory. A forged id now answers `true` — for the forger's own, empty, same-named session, which is worth nothing. The tests that pinned the old answer are rewritten to say so, each pointing at where the property is now proven end to end.

**A request registered with no `agentSlug` now reaches NO stream.** It used to still reach the session stream, which was addressable by session id alone. Strictly more closed; a slugless registration is a bug to find, not a delivery to preserve.

**`isSessionLive`** (activity stats, home card health) takes the agent it is probing.

## The four red tests turn green

`agent-import-sessions.test.ts` from #906 flips from `it.fails` to `it`: a full import restores its sessions, re-importing after a delete works, and one archive imported twice gives both agents their copy. Listing is a directory read again, so none of that needs import-side code.

## Test plan

- [x] Full unit suite: **10252 passed, 3 failed** — the same 3 that fail on the parent commit (`base-container-client` ×2, `webhook-trigger` cold-start; environment-specific on this machine).
- [x] **`session-scope-roles.spec.ts` passes UNCHANGED — all 11, including the forged transcript.** That suite was written to be mechanism-agnostic, and it is the evidence that the security property survived: the refactor could not edit its own guard.
- [x] Main E2E: 6 failures against 8 on the parent, disjoint sets, all green when re-run in isolation (parallelism flake here).
- [x] `tsc` clean; `eslint` back to the parent's 38 warnings.

## Follow-up, not in this PR

`installAgentFromSkillset` copies a repo directory with `copyDirectoryFiltered`, which doesn't exclude `.claude/projects`. Harmless now — those transcripts are simply that agent's sessions — but a skillset shipping transcripts is still surprising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUAyatXXb6kkA16s4E6xHA


---

## Review fixes (follow-up commits)

A pre-merge review found that the persister rekey was sound, but the *model change* it introduces — duplicate session ids across agents become legal — was inherited by other subsystems still keyed by the bare id. Addressed here:

1. **user-input request registry** — five session-scoped methods (`clearSessionStreamRequests`, `dropSessionRequests`, `getStoreIdsForSession`, `getOpenRequestsForSession`, `isSessionAwaiting`) matched `sessionId` alone, so one agent's turn boundary settled another's parked request (partially reopening SUP-479). Now agent-scoped. New cross-agent unit tests.
2. **Symlink escape** — `sessionIdIsWithinAgent` was purely lexical; a symlink in an agent's bind-mounted dir could resolve to another agent's transcript. Added symlink-aware `isRealPathWithinDir`; the raw-log route (previously ungated) now shares the guard.
3. **500 → 404** — `sessionExists` threw on a traversal-shaped id, giving 500 on the messages/usage/delete routes. It's now non-throwing.
4. **Unread marks** — keyed on `(session, user)`; two agents collided. Widened the PK to include the agent (migration 0038) and scoped `clearSessionUnread` / `deleteSessionUnreadMarks`.
5. **Chat routing** — `getChatIntegrationSessionBySessionId` selected by bare id; an approval card could land in another agent's channel. Now joins the owning integration and filters by agent.
6. **Rollback safety** — the orphaned `session-ownership.json` is now removed on startup, so a rollback re-runs its discovery migration instead of treating new sessions as unowned.

Plus cleanups: removed the recovery deps' derivable `agentSlug` param, a dead cache export, 11 dead `agentSlug` guards, and corrected a stale fail-closed comment.

**Verification:** the CI-gated `session-scope-roles.spec.ts` passes 13/13 on this branch (its symlink + traversal guards were red on the unfixed refactor); full typecheck clean (bar pre-existing semver noise); every touched unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Known residual (accepted, out of scope)

The **listing / home-card tail** has a narrow ancestor-symlink exposure. The listing drops symlinked transcript *entries* by dirent type, but `readdir` still follows a symlinked *ancestor* directory — an agent that replaced its own `-workspace` (or `.claude`/`projects`) with a link to another agent's — and `getLatestVisibleSessionTail` reads that listed content without the realpath gate. So such an agent could surface a stranger's latest-session tail on its *own* home card.

Not fixed here because closing it needs a per-listing/per-card `realpath`, which costs fs ops on the *exactly-pinned* `homeCold`/`agentsCold` perf budgets and would require re-recording them. The vector is also self-limiting: it breaks the attacker's own agent (its real session dir is gone) and exposes only the latest tail via its own home endpoint. **All direct-id content routes** — messages, media, raw-log, usage, single-session, subagent — *are* covered by the workspace-anchored `sessionFileRealPathWithinAgent`. Documented in-code at `getLatestVisibleSessionTail` and `readSessionTranscriptNames`.
