### PR TITLE
Widen the WebKit rollback classifier windows to match measured CI timings

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -3050,6 +3050,40 @@ describe('MessageList', () => {
       expect(geometry.scrollTop).toBe(899)
     })
 
+    it('converges back when a rollback lands on seconds-old creep after the engine goes quiet', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el) // baseline at the live edge (699 joins the trail)
+
+      // Convergence writes 899; the trail now holds 699 and 899.
+      geometry.setNaturalScrollHeight(1500)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1500)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(899))
+
+      // The CI-recorded kill shape: the stream pauses at a pass boundary, the
+      // engine's last write goes quiet, and 2+ seconds later WebKit's
+      // compositor reverts to the bottom of a layout snapshot 2.3s stale —
+      // landing on creep the viewport traversed well before, outside both a
+      // frames-scale write window and a too-short trail. It is still the
+      // engine's own motion coming back: following must survive and converge.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 2400))
+      })
+      geometry.setScrollTop(780)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(899)
+    })
+
     it('releases follow when an input-less scroll lands off the recently-held trail', async () => {
       installFakeResizeObserver()
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
@@ -3066,7 +3100,7 @@ describe('MessageList', () => {
       // mount pin so the engine-activity window is genuinely closed, as it is
       // whenever such jumps happen in reality.
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 450))
+        await new Promise((resolve) => setTimeout(resolve, 600))
       })
       geometry.setScrollTop(150)
       fireEvent.scroll(el)

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -84,10 +84,17 @@ const INPUT_EVIDENCE_WINDOW_MS = 500
 // extension, tests) and releases following like any other escape. Segments
 // wider than the cap are real discontinuities (the initial pin, an escape
 // jump) — the viewport never held their interior, so they don't absorb.
-const ROLLBACK_TRAIL_MS = 2000
+// Retention must outlast the snapshots WebKit actually reverts to: on loaded
+// CI runners the compositor has been recorded rolling back to a layout 2.3s
+// stale (landing on creep traversed 2276ms earlier — past a 2000ms trail by
+// a fraction, releasing follow with zero input). Keep several seconds of
+// margin over that measured age.
+const ROLLBACK_TRAIL_MS = 6000
 // Count cap is only a runaway backstop; retention is time-based (entries age
 // out of classification at ROLLBACK_TRAIL_MS and are evicted as they record).
-const ROLLBACK_TRAIL_MAX = 256
+// Sized so steady glide creep (~30 distinct entries/s) cannot flood the
+// retention window out of the cap.
+const ROLLBACK_TRAIL_MAX = 512
 const ROLLBACK_TRAIL_TOLERANCE_PX = 2
 const ROLLBACK_TRAIL_SEGMENT_MAX_PX = 500
 // The trail alone cannot decide: WebKit's compositor may revert to a snapshot
@@ -99,12 +106,15 @@ const ROLLBACK_TRAIL_SEGMENT_MAX_PX = 500
 // (find-in-page, extensions, tests) are only distinguishable when the engine
 // is quiet — which is when they actually happen. Two guards keep an outside
 // jump from being eaten by coincidence (a mount-settle pin racing a test's
-// scrollTo(0) by ~90ms was real): the window is a couple of frames, and the
-// write-window path only accepts reverts of plausible size — a rollback
-// undoes recently composited creep (tens to hundreds of px), while outside
-// jumps travel the transcript. A live glide is exempt from the cap: WebKit
-// has been seen reverting a multi-thousand-px chase mid-flight.
-const ENGINE_WRITE_ROLLBACK_WINDOW_MS = 150
+// scrollTo(0) by ~90ms was real): the window is short, and the write-window
+// path only accepts reverts of plausible size — a rollback undoes recently
+// composited creep (tens to hundreds of px), while outside jumps travel the
+// transcript. A live glide is exempt from the cap: WebKit has been seen
+// reverting a multi-thousand-px chase mid-flight. The window itself must
+// cover the quiet gap between a chase's last settle write and the rollback:
+// recorded at 167ms on loaded CI runners (past a 150ms window by two frames,
+// releasing follow with zero input), so it carries margin over that.
+const ENGINE_WRITE_ROLLBACK_WINDOW_MS = 400
 const ROLLBACK_REVERT_CAP_PX = 1200
 // How long the scrolling tree gets to settle before convergence re-pins
 // after an engine-caused upward scroll.


### PR DESCRIPTION
## Problem

The `e2e-webkit-macos` job has been failing intermittently on main since Aug 28 — three consecutive red runs recently — always in the "hands off marathon" spec, always the same signature: the scroll-to-bottom pill appears mid-stream with zero user input, and the run ends with the viewport stranded 44px above the live edge.

## Root cause

From the failing run's uploaded frame recorder: at a streaming pause between thinking passes, WebKit's compositor rolled the viewport back 137px to the bottom of a layout snapshot **2.3s stale**, **167ms** after the engine's last scroll write. The rollback classifier in `use-message-list-scroll.ts` accepts such zero-input reverts through two windows, and this one missed both by a hair:

- `ENGINE_WRITE_ROLLBACK_WINDOW_MS = 150` — the rollback landed 167ms after the last write (17ms late)
- `ROLLBACK_TRAIL_MS = 2000` — it landed on creep the viewport traversed 2276ms earlier (276ms out)

So the engine's own motion coming back was misclassified as a user escape, and following was released.

## Fix

- `ENGINE_WRITE_ROLLBACK_WINDOW_MS` 150 → **400**: covers the measured quiet gap between a chase's last settle write and the rollback. The 1200px revert cap still keeps genuine outside programmatic jumps releasing follow, and the outside-jump unit test's quiet wait (bumped 450 → 600ms) keeps that contract pinned.
- `ROLLBACK_TRAIL_MS` 2000 → **6000**: trail retention now outlasts the snapshot ages WebKit actually reverts to, with margin.
- `ROLLBACK_TRAIL_MAX` 256 → **512**: so steady glide creep (~30 distinct entries/s) can't flood the longer retention window out of the count cap.

Comments record the measured timings so the margins stay explainable.

## Testing

- New unit regression test with the exact kill shape (engine quiet, rollback landing on seconds-old creep): **fails on the old constants, passes on the new**. All 129 message-list tests pass.
- `--project=web-webkit --repeat-each=3 --retries=0` serial (CI's exact shape): 9 passed, 0 failed; every marathon run `pillFrames=0`, final distance ≤1px.
- Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2uveynJ8sHfK85GCJpdsd