### PR TITLE
feat: point GLM-5.3 Flash catalog pricing at Fireworks

### DIFF
--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -625,7 +625,7 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
   },
   ...MUSE_SPARK_MODELS,
   {
-    // Bare id matches the platform proxy's glm-5.3-flash → cloudflare route.
+    // Bare id matches the platform proxy's glm-5.3-flash → fireworks route.
     id: 'glm-5.3-flash',
     label: 'GLM-5.3 Flash',
     blurb: 'Z.AI GLM, served via Platform',
@@ -638,13 +638,13 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     supportsWebFetch: false,
     supportsImageInput: true,
     contextWindow: 1_048_576,
-    // Cloudflare Workers AI list rates (2026-08-26). Cache write is unpublished,
-    // so cacheCreation mirrors input — same convention as Fireworks/Meta.
+    // Fireworks serverless rates for glm-5p3-flash (2026-08-31). Cache write is
+    // unpublished, so cacheCreation mirrors input — same convention as Kimi/Meta.
     pricing: {
       inputPerMtok: 0.15,
       outputPerMtok: 0.5,
       cacheCreationPerMtok: 0.15,
-      cacheReadPerMtok: 0.03,
+      cacheReadPerMtok: 0.029,
     },
   },
 ]

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -251,7 +251,7 @@ describe('getProviderCatalog', () => {
       supportedSpeeds: ['normal', 'fast'],
       pricing: { inputPerMtok: 3, outputPerMtok: 15, speedMultipliers: { fast: 1.5 } },
     })
-    // Cloudflare Workers AI via the platform proxy. Bare id only.
+    // Fireworks via the platform proxy. Bare id only.
     expect(catalog.find((m) => m.id === 'glm-5.3-flash')).toMatchObject({
       family: 'glm',
       isLatest: true,
@@ -260,7 +260,7 @@ describe('getProviderCatalog', () => {
       supportsWebFetch: false,
       supportsImageInput: true,
       contextWindow: 1_048_576,
-      pricing: { inputPerMtok: 0.15, outputPerMtok: 0.5, cacheReadPerMtok: 0.03 },
+      pricing: { inputPerMtok: 0.15, outputPerMtok: 0.5, cacheReadPerMtok: 0.029 },
     })
     // Platform keys off bare ids, never the OpenRouter vendor-prefixed slugs.
     expect(catalog.some((m) => m.id === 'openai/gpt-5.5')).toBe(false)

--- a/src/shared/lib/services/usage-service.test.ts
+++ b/src/shared/lib/services/usage-service.test.ts
@@ -1285,7 +1285,7 @@ describe('usage-service', () => {
       expect(await costOf('kimi-k3', { speed: 'slow' }, 'platform')).toBeCloseTo(kimiBase, 9)
     })
 
-    it('bills platform GLM-5.3 Flash at Cloudflare list rates with no speed tier', async () => {
+    it('bills platform GLM-5.3 Flash at Fireworks list rates with no speed tier', async () => {
       const glmBase = (100_000 * 0.15 + 1_000 * 0.5) / 1_000_000
       expect(await costOf('glm-5.3-flash', {}, 'platform')).toBeCloseTo(glmBase, 9)
       expect(await costOf('glm-5.3-flash', { speed: 'fast' }, 'platform')).toBeCloseTo(glmBase, 9)


### PR DESCRIPTION
## Summary
- Keep the SuperAgent catalog aligned with the platform proxy: `glm-5.3-flash` now rides Fireworks, not Cloudflare.
- Update cache-read pricing from $0.03 to Fireworks list $0.029 / M. Input/output stay $0.15 / $0.50.

## Why
The proxy is switching this model to Fireworks. Catalog comments and local cost estimates still said Cloudflare.

## Test plan
- [x] Catalog + usage unit tests
- [ ] After the platform PR deploys, pick GLM-5.3 Flash in SuperAgent and confirm a streamed turn works


Made with [Cursor](https://cursor.com)