### PR TITLE
fix: pass catalog context windows to the Claude Agent SDK for non-Claude models

### DIFF
--- a/agent-container/src/claude-code-effort.test.ts
+++ b/agent-container/src/claude-code-effort.test.ts
@@ -351,6 +351,97 @@ describe('ClaudeCodeProcess model handling', () => {
   })
 })
 
+describe('ClaudeCodeProcess model context windows', () => {
+  beforeEach(() => {
+    calls.length = 0
+    setModelCalls.length = 0
+  })
+
+  const windows = { 'grok-4.6': 500_000, 'gpt-5.5': 1_050_000 }
+  const maxContextOf = (call: MockQueryCall): string | undefined =>
+    (call.options.env as Record<string, string | undefined>).CLAUDE_CODE_MAX_CONTEXT_TOKENS
+
+  it('sets CLAUDE_CODE_MAX_CONTEXT_TOKENS from the catalog map for the session model', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-ctx-1',
+      workingDirectory: '/tmp',
+      model: 'grok-4.6',
+      modelContextWindows: windows,
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    expect(maxContextOf(calls[0])).toBe('500000')
+  })
+
+  it('leaves the env var unset for a model without a catalog window', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-ctx-2',
+      workingDirectory: '/tmp',
+      model: 'claude-sonnet-4-6',
+      modelContextWindows: windows,
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    expect(maxContextOf(calls[0])).toBeUndefined()
+  })
+
+  it('lets a user-set custom env var win over the catalog value', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-ctx-3',
+      workingDirectory: '/tmp',
+      model: 'grok-4.6',
+      modelContextWindows: windows,
+      customEnvVars: { CLAUDE_CODE_MAX_CONTEXT_TOKENS: '123456' },
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    expect(maxContextOf(calls[0])).toBe('123456')
+  })
+
+  it('restarts the query (not setModel) when a model switch changes the window', { timeout: 15000 }, async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-ctx-4',
+      workingDirectory: '/tmp',
+      model: 'claude-sonnet-4-6',
+      modelContextWindows: windows,
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+    expect(maxContextOf(calls[0])).toBeUndefined()
+
+    // claude → grok changes the window (unset → 500k); dynamic setModel would
+    // leave the new model running against the old env, so it must re-query.
+    await process.sendMessage('hello', undefined, { model: 'grok-4.6' })
+
+    expect(setModelCalls).toHaveLength(0)
+    expect(calls).toHaveLength(2)
+    expect(calls[1].options.model).toBe('grok-4.6')
+    expect(maxContextOf(calls[1])).toBe('500000')
+  })
+
+  it('still switches dynamically when both models share a window', async () => {
+    const process = new ClaudeCodeProcess({
+      sessionId: 'test-ctx-5',
+      workingDirectory: '/tmp',
+      model: 'claude-sonnet-4-6',
+      modelContextWindows: windows,
+    })
+
+    await process.start()
+    expect(calls).toHaveLength(1)
+
+    // Neither claude id has a catalog window — no env change, setModel is fine.
+    await process.sendMessage('hello', undefined, { model: 'claude-opus-4-7' })
+
+    expect(calls).toHaveLength(1)
+    expect(setModelCalls).toEqual(['claude-opus-4-7'])
+  })
+})
+
 describe('ClaudeCodeProcess model prompt hints', () => {
   beforeEach(() => {
     calls.length = 0

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -56,6 +56,7 @@ import {
 import { createCapabilityGateHook, CAPABILITY_REVIEW_HOOK_TIMEOUT_S } from './capability-gate-hook';
 import {
   buildModelSubagentDefinitions,
+  type ModelContextWindows,
   type SubagentModelDefinition,
 } from './subagent-model-catalog';
 import { mergeCanonicalSlashCommands } from './slash-commands';
@@ -447,6 +448,7 @@ export interface ClaudeCodeProcessOptions {
   browserModel?: string;
   dashboardBuilderModel?: string;
   subagentModels?: SubagentModelDefinition[];
+  modelContextWindows?: ModelContextWindows;
   webSearchProvider?: string;
   webFetchProvider?: string;
   maxOutputTokens?: number;
@@ -472,6 +474,7 @@ export class ClaudeCodeProcess extends EventEmitter {
   private browserModel: string | undefined;
   private dashboardBuilderModel: string | undefined;
   private subagentModels: SubagentModelDefinition[];
+  private modelContextWindows: ModelContextWindows;
   private webSearchProvider: string | undefined;
   private webFetchProvider: string | undefined;
   private maxOutputTokens: number | undefined;
@@ -551,6 +554,7 @@ export class ClaudeCodeProcess extends EventEmitter {
     this.browserModel = options.browserModel;
     this.dashboardBuilderModel = options.dashboardBuilderModel;
     this.subagentModels = options.subagentModels ?? [];
+    this.modelContextWindows = options.modelContextWindows ?? {};
     this.webSearchProvider = options.webSearchProvider;
     this.webFetchProvider = options.webFetchProvider;
     this.maxOutputTokens = options.maxOutputTokens;
@@ -731,6 +735,10 @@ export class ClaudeCodeProcess extends EventEmitter {
     return this.warmHandle !== null;
   }
 
+  private contextWindowForModel(model: string | undefined): number | undefined {
+    return model ? this.modelContextWindows[model] : undefined;
+  }
+
   private buildQueryOptions(): Options {
     const remoteMcpConfigs = this.buildRemoteMcpServers();
     const remoteMcpToolPatterns = Object.keys(remoteMcpConfigs).map(name => `mcp__${name}__*`);
@@ -831,6 +839,15 @@ export class ClaudeCodeProcess extends EventEmitter {
         CLAUDE_CODE_ENABLE_TODO_TOOLS: 'true',
         // Explicit maxOutputTokens setting takes precedence over custom env var
         ...(this.maxOutputTokens && { CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(this.maxOutputTokens) }),
+        // Tell the SDK the real context window for non-Claude models (it
+        // assumes 200k for unknown ids and auto-compacts against that — 40% of
+        // grok's 500k, 19% of gpt-5.x's 1.05M). The SDK only honors this env
+        // var for non-claude-* models, so it never affects Claude sessions. A
+        // user-set custom env var (spread above) deliberately wins.
+        ...(this.contextWindowForModel(this.model) &&
+          !this.customEnvVars?.CLAUDE_CODE_MAX_CONTEXT_TOKENS && {
+            CLAUDE_CODE_MAX_CONTEXT_TOKENS: String(this.contextWindowForModel(this.model)),
+          }),
       }), this.speed),
       mcpServers: {
         'user-input': createUserInputMcpServer(() => this),
@@ -1331,6 +1348,11 @@ export class ClaudeCodeProcess extends EventEmitter {
     // compare ids directly. Switching between two pinned versions of a family
     // (e.g. opus-4-6 -> opus-4-7) is now a real, intentional switch.
     const modelChanged = model !== undefined && model !== this.model;
+    // CLAUDE_CODE_MAX_CONTEXT_TOKENS is baked into the query env, so a switch
+    // that changes the catalog window (e.g. claude → grok) can't use dynamic
+    // setModel — the new model would run against the old window.
+    const contextWindowChanged =
+      modelChanged && this.contextWindowForModel(model) !== this.contextWindowForModel(this.model);
 
     // Capability policies follow the host's CURRENT settings, refreshed on
     // every message so a long-lived session tracks settings changes. Review
@@ -1377,7 +1399,8 @@ export class ClaudeCodeProcess extends EventEmitter {
       effortChanged ||
       speedChanged ||
       capabilityBlockChanged ||
-      runtimeConnectionConfigChanged
+      runtimeConnectionConfigChanged ||
+      contextWindowChanged
     ) {
       // Effort can only be set at query creation time — the SDK has no setEffort
       // facility — so any effort change forces an interrupt + re-query. Speed
@@ -1390,6 +1413,7 @@ export class ClaudeCodeProcess extends EventEmitter {
       if (speedChanged) reasons.push(`speed ${currentSpeed} -> ${speed}`);
       if (capabilityBlockChanged) reasons.push('capability block boundary changed');
       if (runtimeConnectionConfigChanged) reasons.push('runtime connection configuration changed');
+      if (contextWindowChanged) reasons.push('model context window changed');
       if (modelChanged) reasons.push(`model -> ${this.model}`);
       console.log(`[Session ${this.sessionId}] Restarting query (${reasons.join(', ')})`);
       await this.interrupt();

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -16,7 +16,7 @@ import {
   warmProfileKey,
   type WarmProfile,
 } from './warm-profile';
-import { subagentModelCatalogSchema } from './subagent-model-catalog';
+import { modelContextWindowsSchema, subagentModelCatalogSchema } from './subagent-model-catalog';
 
 interface SessionData {
   session: Session;
@@ -214,6 +214,7 @@ export class SessionManager extends EventEmitter {
     const capabilityPolicies = agentCapabilityPoliciesSchema.parse(request.capabilityPolicies);
     const speed = speedLevelSchema.parse(request.speed);
     const subagentModels = subagentModelCatalogSchema.parse(request.subagentModels);
+    const modelContextWindows = modelContextWindowsSchema.parse(request.modelContextWindows);
 
     // Ensure working directory exists
     if (!fs.existsSync(workingDirectory)) {
@@ -230,6 +231,7 @@ export class SessionManager extends EventEmitter {
       speed,
       capabilityPolicies,
       subagentModels,
+      modelContextWindows,
       workingDirectory,
     };
     const sessionProfile = sessionProfileFromRequest(normalized);
@@ -246,6 +248,7 @@ export class SessionManager extends EventEmitter {
         browserModel: request.browserModel,
         dashboardBuilderModel: request.dashboardBuilderModel,
         subagentModels,
+        modelContextWindows,
         webSearchProvider: request.webSearchProvider,
         webFetchProvider: request.webFetchProvider,
         maxOutputTokens: request.maxOutputTokens,
@@ -382,6 +385,7 @@ export class SessionManager extends EventEmitter {
       browserModel: request.browserModel,
       dashboardBuilderModel: request.dashboardBuilderModel,
       subagentModels,
+      modelContextWindows,
       webSearchProvider: request.webSearchProvider,
       webFetchProvider: request.webFetchProvider,
       maxOutputTokens: request.maxOutputTokens,
@@ -478,6 +482,7 @@ export class SessionManager extends EventEmitter {
         browserModel: profile.browserModel,
         dashboardBuilderModel: profile.dashboardBuilderModel,
         subagentModels: profile.subagentModels,
+        modelContextWindows: profile.modelContextWindows,
         webSearchProvider: profile.webSearchProvider,
         webFetchProvider: profile.webFetchProvider,
         maxOutputTokens: profile.maxOutputTokens,
@@ -591,6 +596,7 @@ export class SessionManager extends EventEmitter {
         browserModel: persisted.browserModel,
         dashboardBuilderModel: persisted.dashboardBuilderModel,
         subagentModels: persisted.subagentModels,
+        modelContextWindows: persisted.modelContextWindows,
         webSearchProvider: persisted.webSearchProvider,
         webFetchProvider: persisted.webFetchProvider,
         maxOutputTokens: persisted.maxOutputTokens,

--- a/agent-container/src/session-persistence-schema.ts
+++ b/agent-container/src/session-persistence-schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { agentCapabilityPoliciesSchema, speedLevelSchema } from './capability-policies';
-import { subagentModelCatalogSchema } from './subagent-model-catalog';
+import { modelContextWindowsSchema, subagentModelCatalogSchema } from './subagent-model-catalog';
 
 export const sessionMetadataSchema = z
   .object({
@@ -16,6 +16,7 @@ export const sessionMetadataSchema = z
     browserModel: z.string().optional(),
     dashboardBuilderModel: z.string().optional(),
     subagentModels: subagentModelCatalogSchema,
+    modelContextWindows: modelContextWindowsSchema,
     webSearchProvider: z.string().optional(),
     webFetchProvider: z.string().optional(),
     maxOutputTokens: z.number().optional(),

--- a/agent-container/src/subagent-model-catalog.ts
+++ b/agent-container/src/subagent-model-catalog.ts
@@ -31,6 +31,15 @@ export const subagentModelCatalogSchema = z
 
 export type SubagentModelDefinition = z.infer<typeof subagentModelDefinitionSchema>;
 
+// Model id → catalog context window, host-supplied for every catalog model
+// (subagentModels above only carries isLatest entries). Read at query build to
+// set CLAUDE_CODE_MAX_CONTEXT_TOKENS; the SDK ignores it for claude-* models.
+export const modelContextWindowsSchema = z
+  .record(z.string().min(1), z.number().int().positive())
+  .default({});
+
+export type ModelContextWindows = z.infer<typeof modelContextWindowsSchema>;
+
 function stableHash(value: string): string {
   let hash = 0x811c9dc5;
   for (let index = 0; index < value.length; index++) {

--- a/agent-container/src/types.ts
+++ b/agent-container/src/types.ts
@@ -82,6 +82,7 @@ export interface CreateSessionRequest {
   browserModel?: string; // Model for browser subagent
   dashboardBuilderModel?: string; // Model for the dashboard-builder subagent
   subagentModels?: SubagentModelDefinition[]; // Provider catalog exposed as model-backed subagent types
+  modelContextWindows?: Record<string, number>; // Model id → catalog context window (feeds CLAUDE_CODE_MAX_CONTEXT_TOKENS)
   webSearchProvider?: string; // Active host-side web search vendor id (non-secret); activates mcp__web__search + disables native WebSearch
   webFetchProvider?: string; // Active host-side web fetch vendor id (non-secret); activates mcp__web__web_fetch + disables native WebFetch
   maxOutputTokens?: number; // Max tokens per response (CLAUDE_CODE_MAX_OUTPUT_TOKENS)

--- a/agent-container/src/warm-profile.test.ts
+++ b/agent-container/src/warm-profile.test.ts
@@ -69,6 +69,17 @@ describe('warmProfileKey', () => {
     expect(gpt).not.toBe(grok)
   })
 
+  it('separates profiles whose model context windows differ', () => {
+    const a = warmProfileKey(
+      warmProfileSchema.parse({ ...base, modelContextWindows: { 'grok-4.6': 500_000 } })
+    )
+    const b = warmProfileKey(
+      warmProfileSchema.parse({ ...base, modelContextWindows: { 'grok-4.6': 200_000 } })
+    )
+
+    expect(a).not.toBe(b)
+  })
+
   it('treats an absent field and an explicitly undefined one as the same profile', () => {
     const absent = warmProfileKey(warmProfileSchema.parse({ model: 'm' }))
     const undef = warmProfileKey(warmProfileSchema.parse({ model: 'm', effort: undefined, speed: undefined }))

--- a/agent-container/src/warm-profile.ts
+++ b/agent-container/src/warm-profile.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { z } from 'zod';
 import { agentCapabilityPoliciesSchema, speedLevelSchema } from './capability-policies';
 import type { CreateSessionRequest } from './types';
-import { subagentModelCatalogSchema } from './subagent-model-catalog';
+import { modelContextWindowsSchema, subagentModelCatalogSchema } from './subagent-model-catalog';
 
 /**
  * The subset of a create-session request that a pre-warmed CLI subprocess
@@ -23,6 +23,7 @@ export const warmProfileSchema = z.object({
   browserModel: z.string().optional(),
   dashboardBuilderModel: z.string().optional(),
   subagentModels: subagentModelCatalogSchema,
+  modelContextWindows: modelContextWindowsSchema,
   webSearchProvider: z.string().optional(),
   webFetchProvider: z.string().optional(),
   maxOutputTokens: z.number().optional(),
@@ -70,6 +71,7 @@ function buildProfile(
     browserModel: request.browserModel,
     dashboardBuilderModel: request.dashboardBuilderModel,
     subagentModels: request.subagentModels,
+    modelContextWindows: request.modelContextWindows,
     webSearchProvider: request.webSearchProvider,
     webFetchProvider: request.webFetchProvider,
     maxOutputTokens: request.maxOutputTokens,

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -29,7 +29,7 @@ import type {
 import { getAgentWorkspaceDir } from '@shared/lib/config/data-dir'
 import { getContainerHostUrl, getAppPort } from '@shared/lib/proxy/host-url'
 import { getAgentCapabilitySettings, getSettings } from '@shared/lib/config/settings'
-import { getActiveLlmProvider } from '@shared/lib/llm-provider'
+import { getActiveLlmProvider, getModelContextWindowMap } from '@shared/lib/llm-provider'
 import type { AgentIdentity } from '@shared/lib/llm-provider/base-llm-provider'
 import { readAgentDisplayNameSync } from '@shared/lib/utils/file-storage'
 import { resolveContainerModel, getContainerModelPromptHints } from './resolve-model'
@@ -1191,6 +1191,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     const resolvedDashboardBuilderModel = resolveContainerModel(options.dashboardBuilderModel, 'dashboard')
     const modelPromptHints = getContainerModelPromptHints(resolvedModel)
     const subagentModels = getSubagentModelCatalog(getActiveLlmProvider().id)
+    // Catalog windows for ALL models (not just isLatest like subagentModels):
+    // the container passes the session model's window to the Claude Agent SDK
+    // via CLAUDE_CODE_MAX_CONTEXT_TOKENS, else non-Claude models compact at
+    // the SDK's 200k default (grok: 500k real, gpt-5.x: 1.05M real).
+    const modelContextWindows = getModelContextWindowMap(getActiveLlmProvider().id)
     // The active web vendor id is a non-secret signal (NOT a model, so no resolveContainerModel).
     // Resolved once here from global settings so every session-creation caller inherits it. One
     // stored vendor backs both tools; the two ids sent to the container are the per-tool enablement
@@ -1223,6 +1228,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           browserModel: resolvedBrowserModel,
           dashboardBuilderModel: resolvedDashboardBuilderModel,
           subagentModels,
+          modelContextWindows,
           webSearchProvider,
           webFetchProvider,
           maxOutputTokens: options.maxOutputTokens,

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -27,6 +27,7 @@ export {
   getProviderCatalog,
   getModelDefinition,
   getModelContextWindow,
+  getModelContextWindowMap,
   getModelPromptHints,
   hasVersionSegment,
   resolveModelForProvider,

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -13,6 +13,7 @@ import {
   getProviderCatalog,
   getModelDefinition,
   getModelContextWindow,
+  getModelContextWindowMap,
   getModelPromptHints,
   hasVersionSegment,
   resolveModelForProvider,
@@ -504,6 +505,21 @@ describe('getModelContextWindow', () => {
 
   it('returns undefined for an unknown id', () => {
     expect(getModelContextWindow('nope', 'platform')).toBeUndefined()
+  })
+})
+
+describe('getModelContextWindowMap', () => {
+  it('maps every Platform model that declares a window, non-latest included', () => {
+    const map = getModelContextWindowMap('platform')
+    expect(map['grok-4.6']).toBe(500_000)
+    expect(map['grok-4.5']).toBe(500_000)
+    expect(map['gpt-5.5']).toBe(1_050_000)
+    expect(map['gpt-5.4']).toBe(1_050_000)
+  })
+
+  it('omits Claude models (no catalog window; the SDK supplies theirs)', () => {
+    const map = getModelContextWindowMap('platform')
+    expect(Object.keys(map).some(id => id.startsWith('claude-'))).toBe(false)
   })
 })
 

--- a/src/shared/lib/llm-provider/model-catalog.ts
+++ b/src/shared/lib/llm-provider/model-catalog.ts
@@ -145,6 +145,21 @@ export function getModelContextWindow(
   return getModelDefinition(id, providerId)?.contextWindow
 }
 
+/**
+ * Model id → catalog context window for every entry that declares one.
+ * Sent to the agent container so the Claude Agent SDK can be told the real
+ * window for non-Claude models (it otherwise assumes a 200k default).
+ */
+export function getModelContextWindowMap(
+  providerId: LlmProviderId,
+): Record<string, number> {
+  return Object.fromEntries(
+    getEffectiveCatalog(providerId)
+      .filter(model => model.contextWindow !== undefined)
+      .map(model => [model.id, model.contextWindow as number]),
+  )
+}
+
 /** Static catalog prompt hints for a model, or an empty list if unset. */
 export function getModelPromptHints(
   id: string,


### PR DESCRIPTION
## What's broken

The Claude Agent SDK never learns the real context window for non-Claude models — any model id it doesn't recognize gets a hardcoded 200k default. SuperAgent's catalog has the correct windows (grok 500k, gpt-5.x 1.05M) but only used them for UI display.

Two failure modes, both verified against the real pinned SDK binary with a mock upstream:

- **SDK ≤ 0.3.219 (most production history):** no auto-compaction at all for non-Claude models. ClickHouse shows grok sessions maxing at 499,493/499,519 tokens — pinned at xAI's 500k hard wall, where they die with context-exceeded errors.
- **SDK 0.3.238 (current pin, rolling out in v0.5.10+):** auto-compaction now fires for non-Claude models, but against the 200k default — grok compacts at 40% of real capacity, gpt-5.x at 19%. ClickHouse: grok requests >210k tokens collapsed from ~1000/week to 16 in the week of Aug 30.

`settings.autoCompactWindow` cannot fix this: the SDK clamps it with `Math.min(modelWindow, configured)` (can only shrink) and its schema caps at 1M, below gpt-5.x's 1.05M.

## What changed

- **Host:** new `getModelContextWindowMap(providerId)` builds `{model id → contextWindow}` from the full effective catalog (not just `isLatest`, so pinned older picks like `grok-4.5` are covered). `base-container-client.ts` sends it as `modelContextWindows` in the create-session payload.
- **Container:** zod-validated at the request boundary, part of the warm-profile key, persisted for resume, passed to all three `ClaudeCodeProcess` construction sites. `buildQueryOptions()` sets `CLAUDE_CODE_MAX_CONTEXT_TOKENS` for the session model; a user-set custom env var wins.
- **Model switching:** a switch that changes the window (e.g. claude → grok) takes the interrupt+restart path instead of dynamic `setModel`, because the env var is baked at query creation. Same-window switches keep the dynamic path.

The SDK only honors `CLAUDE_CODE_MAX_CONTEXT_TOKENS` for non-`claude-*` models (verified against the pinned binary), so Claude sessions are unaffected.

## Repro / verification

- E2E harness (mock Anthropic upstream reporting ~199.5k input tokens, real pinned SDK): baseline `grok-4.6` auto-compacts at pre_tokens=199,942; with the env var set to 500000, no compaction and the SDK reports the correct window; `claude-sonnet-4-6` behaves identically with and without the var.
- Unit tests: env var set from map / unset for Claude ids / custom-env precedence / window-change restart vs same-window dynamic switch / warm-profile key separation / catalog map contents.
- Container suite 947 passed; host container-lib suite 1080 passed; host catalog tests 48 passed; lint clean.

Linear: SUP-738

## Test plan

- [x] CI green (typecheck, lint, tests)
- [x] Manual: start a grok session, verify `CLAUDE_CODE_MAX_CONTEXT_TOKENS=500000` in the query env and no compaction below 500k
- [ ] Manual: switch claude → grok mid-session, verify the query restarts and the env var appears

Made with [Cursor](https://cursor.com)