### PR TITLE
test(zip): deflake the fd-leak assertion in openZipFromFile

### DIFF
--- a/src/shared/lib/utils/zip.test.ts
+++ b/src/shared/lib/utils/zip.test.ts
@@ -186,15 +186,31 @@ describe('openZipFromFile', () => {
 
     // No ZipReader is constructed on this path, so the shared open path must
     // close the underlying file itself; the spy proves close() ran, and the
-    // fd count proves the descriptor was actually released.
+    // fd check proves the descriptor was actually released.
     const closeSpy = vi.spyOn(yauzl.ZipFile.prototype, 'close')
-    const countFds = () =>
-      process.platform === 'win32' ? 0 : fs.readdirSync('/dev/fd').length
+    // Count only descriptors that point at THIS zip, not every fd in the
+    // process. The suite shares one worker, so an unrelated async fs op running
+    // during the await below can open a descriptor and inflate a whole-process
+    // count — a spurious "+1 leak". Matching the file makes the check immune to
+    // that. (SUP-flaky: `expected N to be <= N-1` under load.)
+    const realZipPath = fs.realpathSync(zipPath)
+    const openFdsForZip = () => {
+      if (process.platform === 'win32') return 0
+      let count = 0
+      for (const fd of fs.readdirSync('/dev/fd')) {
+        try {
+          if (fs.readlinkSync(path.join('/dev/fd', fd)) === realZipPath) count++
+        } catch {
+          // fd was closed between readdir and readlink, or isn't a symlink.
+        }
+      }
+      return count
+    }
     try {
-      const fdsBefore = countFds()
       await expect(openZipFromFile(zipPath)).rejects.toThrow(/central directory/i)
       expect(closeSpy).toHaveBeenCalled()
-      expect(countFds()).toBeLessThanOrEqual(fdsBefore)
+      // The descriptor opened for the zip must be released on the error path.
+      expect(openFdsForZip()).toBe(0)
     } finally {
       closeSpy.mockRestore()
     }


### PR DESCRIPTION
## What

`zip.test.ts > openZipFromFile > closes the file when the entry walk fails after a successful open` counts **every** file descriptor in the process (`fs.readdirSync('/dev/fd').length`) before and after the open, and asserts `after <= before`.

The suite shares one vitest worker, so an unrelated async fs op that opens a descriptor during the `await` window inflates the whole-process count by one — a spurious "+1 leak." It fails CI intermittently with `expected 26 to be less than or equal to 25`.

## Fix

Count only descriptors that point at **this** zip file (readlink each `/dev/fd` entry, match the zip's realpath) and assert it is `0` after the error path — proving the specific descriptor was released, independent of anything else the worker is doing. The `close()` spy assertion is unchanged.

## Notes

- Test-only; no production code touched.
- Surfaced on the PR #907/#906 CI (`unit-tests`), but the flake is pre-existing and unrelated to that work — `zip.ts`/`zip.test.ts` are untouched there. Splitting it out so it can land on its own.
- Verified: passes in isolation and under concurrency (run alongside the fs-heavy `session-service`/`agents` suites); tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)