### PR TITLE
fix(skillsets): recover stale validation caches

### DIFF
--- a/src/shared/lib/services/skillset-service.test.ts
+++ b/src/shared/lib/services/skillset-service.test.ts
@@ -1260,6 +1260,71 @@ Instructions here`
   // ============================================================================
 
   describe('validateSkillsetUrl', () => {
+    function mockCloneWritingIndex(getIndex: () => unknown, cloneCalls: string[]) {
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === '--version') {
+          return { stdout: 'git version 2.44.0\n', stderr: '' }
+        }
+        if (cmd === 'git' && args[0] === 'clone') {
+          const dest = args[4]
+          cloneCalls.push(dest)
+          fs.mkdirSync(path.join(dest, '.git'), { recursive: true })
+          fs.writeFileSync(
+            path.join(dest, 'index.json'),
+            JSON.stringify(getIndex()),
+            'utf-8',
+          )
+        }
+        return { stdout: '', stderr: '' }
+      })
+    }
+
+    it('drops a newly cloned invalid cache so retry reads the corrected remote', async () => {
+      const url = 'https://github.com/TestOrg/stale-validation'
+      const repoDir = getSkillsetRepoDir(urlToSkillsetId(url))
+      const correctedIndex = buildIndex({ skillset_name: 'Corrected Skillset' })
+      let remoteIndex: unknown = { skills: [] }
+      const cloneCalls: string[] = []
+      mockCloneWritingIndex(() => remoteIndex, cloneCalls)
+
+      await expect(validateSkillsetUrl(url)).rejects.toThrow(
+        /skillset_name.*expected string.*received undefined/i,
+      )
+      expect(fs.existsSync(repoDir)).toBe(false)
+
+      remoteIndex = correctedIndex
+      await expect(validateSkillsetUrl(url)).resolves.toEqual(correctedIndex)
+      expect(cloneCalls).toEqual([repoDir, repoDir])
+    })
+
+    it('re-clones a malformed cache left by an older build on the first retry', async () => {
+      const url = 'https://github.com/TestOrg/legacy-stale-validation'
+      const repoDir = getSkillsetRepoDir(urlToSkillsetId(url))
+      await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true })
+      await fs.promises.writeFile(
+        path.join(repoDir, 'index.json'),
+        JSON.stringify({ skills: [] }),
+        'utf-8',
+      )
+
+      const correctedIndex = buildIndex({ skillset_name: 'Corrected Skillset' })
+      const cloneCalls: string[] = []
+      mockCloneWritingIndex(() => correctedIndex, cloneCalls)
+
+      await expect(validateSkillsetUrl(url)).resolves.toEqual(correctedIndex)
+      expect(cloneCalls).toEqual([repoDir])
+    })
+
+    it('keeps the zero-network fast path for an already valid cache', async () => {
+      const url = 'https://github.com/TestOrg/valid-validation-cache'
+      const index = buildIndex()
+      await createSkillsetCache(urlToSkillsetId(url), index)
+      mockExecFileAsNoOp()
+
+      await expect(validateSkillsetUrl(url)).resolves.toEqual(index)
+      expect(mockExecFile).not.toHaveBeenCalled()
+    })
+
     it('throws helpful error with install link when git is not installed', async () => {
       mockExecFile.mockImplementation((cmd: string) => {
         if (cmd === 'git') {

--- a/src/shared/lib/services/skillset-service.ts
+++ b/src/shared/lib/services/skillset-service.ts
@@ -823,8 +823,32 @@ export async function validateSkillsetUrl(
     }
   }
 
+  // A failed validation must not poison every retry with the same cached
+  // index. Keep the fast path for a healthy cache (the add flow validates
+  // twice), but discard malformed caches so the next attempt observes the
+  // current remote. If the bad cache predates this validation call, re-clone
+  // once immediately so users upgrading from an affected build recover on
+  // their first retry.
+  const cacheWasReady = await isCacheReady(
+    getSkillsetRepoDirForRef(ref),
+    provider,
+  )
   const repoDir = await ensureSkillsetCached(ref)
-  return readIndexJson(repoDir)
+  try {
+    return await readIndexJson(repoDir)
+  } catch (error) {
+    await removeSkillsetCache(ref)
+    if (!cacheWasReady) throw error
+  }
+
+  const freshRepoDir = await ensureSkillsetCached(ref)
+  try {
+    return await readIndexJson(freshRepoDir)
+  } catch (error) {
+    // Do not leave a freshly confirmed-invalid remote cached either.
+    await removeSkillsetCache(ref)
+    throw error
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- discard malformed caches created by failed skillset URL validation
- re-clone a malformed cache that predates the current validation call, recovering users affected by older builds on their first retry
- preserve the zero-network fast path when the cached index is valid

## Root cause

Validation treated any cache containing a Git directory as ready. A failed import therefore left an invalid index cached, and every retry parsed that stale clone instead of the corrected repository.

## Verification

- skillset service suite: 181 passed
- focused validateSkillsetUrl tests: 5 passed
- TypeScript typecheck: passed
- lint: 0 errors; 39 pre-existing warnings
- real Git reproduction: initial invalid import fails, corrected remote succeeds on the next retry without manual cache clearing

Linear: https://linear.app/datawizz/issue/SUP-747/skillset-import-retries-validate-a-stale-cached-indexjson