### PR TITLE
Reflect MCP defaults across tool permissions

### DIFF
--- a/src/renderer/components/settings/tool-policy-editor.test.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.test.tsx
@@ -111,4 +111,27 @@ describe('ToolPolicyEditor — Save enable/disable', () => {
     toolToggle('search', 'allow').click() // clicking the active option resets to default
     await waitFor(() => expect(screen.getByTestId('tool-policy-save')).toBeDisabled())
   })
+
+  it('shows the MCP default on tools that have no rule of their own', async () => {
+    policiesFixture = [{ toolName: '*', decision: 'allow' }]
+    renderEditor('mcp-5')
+    await waitFor(() => expect(screen.getByTestId('tool-row-search')).toBeInTheDocument())
+
+    expect(toolToggle('search', 'allow')).toHaveAttribute('data-active', 'true')
+    expect(toolToggle('search', 'allow')).toHaveAttribute('data-inherited', 'true')
+    expect(toolToggle('send', 'allow')).toHaveAttribute('data-inherited', 'true')
+  })
+
+  it('keeps an explicit tool rule visible over the MCP default', async () => {
+    policiesFixture = [
+      { toolName: '*', decision: 'allow' },
+      { toolName: 'send', decision: 'block' },
+    ]
+    renderEditor('mcp-6')
+    await waitFor(() => expect(screen.getByTestId('tool-row-send')).toBeInTheDocument())
+
+    expect(toolToggle('send', 'block')).toHaveAttribute('data-active', 'true')
+    expect(toolToggle('send', 'block')).toHaveAttribute('data-inherited', 'false')
+    expect(toolToggle('search', 'allow')).toHaveAttribute('data-inherited', 'true')
+  })
 })

--- a/src/renderer/components/settings/tool-policy-editor.tsx
+++ b/src/renderer/components/settings/tool-policy-editor.tsx
@@ -256,6 +256,7 @@ export function ToolPolicyEditorBody({
                   </div>
                   <PolicyDecisionToggle
                     value={p.decision}
+                    inheritedValue={mcpDefault === 'default' ? undefined : mcpDefault}
                     onChange={(v) => updateToolPolicy(p.toolName, v)}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- display the MCP-level default as inherited on tools without explicit policies
- keep explicit per-tool policies visually authoritative
- add regression coverage for inherited and overridden tool decisions

## Verification
- `npm run test:run -- src/renderer/components/settings/tool-policy-editor.test.tsx` (7 tests passed)
- `npm run typecheck`
- `npx eslint src/renderer/components/settings/tool-policy-editor.tsx src/renderer/components/settings/tool-policy-editor.test.tsx`