### PR TITLE
Surface CLI spawn errno and auto-replace microVMs that can't launch sessions

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -106,7 +106,15 @@ app.post('/sessions', async (c) => {
     return c.json(session, 201);
   } catch (error: any) {
     console.error('Error creating session:', error);
-    return c.json({ error: error.message || 'Failed to create session' }, 500);
+    // The Agent SDK attaches the spawn errno (`code`) and a failure class
+    // (`errorClass`, e.g. 'executable_launch_failed') to CLI launch errors.
+    // Forward both: the message alone hides the errno behind the SDK's canned
+    // libc-mismatch guess, and the host keys auto-recovery off errorClass.
+    return c.json({
+      error: error.message || 'Failed to create session',
+      ...(typeof error.code === 'string' && { code: error.code }),
+      ...(typeof error.errorClass === 'string' && { errorClass: error.errorClass }),
+    }, 500);
   }
 });
 

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -1249,6 +1249,8 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       if (!response.ok) {
         // Try to get more details from response body
         let errorDetail = ''
+        let containerErrorCode: string | undefined
+        let containerErrorClass: string | undefined
         try {
           const errorBody = await response.text()
           if (errorBody) {
@@ -1256,6 +1258,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
             try {
               const parsed = JSON.parse(errorBody)
               errorDetail = parsed.error || errorBody
+              // Spawn errno + failure class forwarded by the container for
+              // CLI launch failures (see the POST /sessions handler).
+              if (typeof parsed.code === 'string') containerErrorCode = parsed.code
+              if (typeof parsed.errorClass === 'string') containerErrorClass = parsed.errorClass
             } catch {
               errorDetail = errorBody
             }
@@ -1271,7 +1277,16 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           )
         }
 
-        throw new Error(`Failed to create session: ${errorDetail || response.statusText}`)
+        // Fold the errno into the message so telemetry shows the real spawn
+        // failure (the SDK's message is a canned libc guess), and attach both
+        // fields for programmatic checks (microVM launch-failure auto-replace).
+        const diagnostic = [containerErrorClass, containerErrorCode].filter(Boolean).join(' ')
+        throw Object.assign(
+          new Error(
+            `Failed to create session: ${errorDetail || response.statusText}${diagnostic ? ` [${diagnostic}]` : ''}`,
+          ),
+          { containerErrorCode, containerErrorClass },
+        )
       }
 
       return response.json()

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -800,6 +800,71 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     superCreate.mockRestore()
   })
 
+  it('createSession replaces a live generation on a CLI launch failure (structured errorClass)', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+
+    let runCount = 0
+    sendMock.mockImplementation(async (cmd: { type: string }) => {
+      if (cmd.type === 'Run') {
+        runCount++
+        responses.getState = 'RUNNING'
+        return { microvmId: `mvm-launchfail-${runCount}`, endpoint: 'ep.lambda-microvm.aws' }
+      }
+      if (cmd.type === 'Get') return { state: responses.getState ?? 'RUNNING' }
+      if (cmd.type === 'Terminate') return {}
+      if (cmd.type === 'Token') return { authToken: { 'X-aws-proxy-auth': 'tok' } }
+      return {}
+    })
+    // The VM stays RUNNING throughout — the launch-failure path must replace
+    // it anyway, unlike the unreachable path which requires a dead generation.
+    responses.getState = 'RUNNING'
+
+    const superCreate = vi.spyOn(BaseContainerClient.prototype, 'createSession')
+    superCreate
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Failed to create session: spawn failed [executable_launch_failed ENOENT]'), {
+          containerErrorClass: 'executable_launch_failed',
+          containerErrorCode: 'ENOENT',
+        }),
+      )
+      .mockResolvedValueOnce({ id: 'sess-fresh' } as never)
+
+    await expect(client.createSession({ initialMessage: 'hi' })).resolves.toEqual({ id: 'sess-fresh' })
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(true)
+    expect(runCount).toBe(1)
+    expect(superCreate).toHaveBeenCalledTimes(2)
+    expect(addErrorBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ reason: 'executable_launch_failed' }),
+      }),
+    )
+    superCreate.mockRestore()
+  })
+
+  it('createSession does not replace on a launch-failure-shaped message without the structured errorClass', async () => {
+    const { BaseContainerClient } = await import('./base-container-client')
+    const client = newClient()
+    await client.start()
+    sendMock.mockClear()
+    responses.getState = 'RUNNING'
+
+    const superCreate = vi
+      .spyOn(BaseContainerClient.prototype, 'createSession')
+      .mockRejectedValue(
+        new Error(
+          'Failed to create session: Claude Code native binary at /app/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64/claude exists but failed to launch.',
+        ),
+      )
+
+    await expect(client.createSession({ initialMessage: 'hi' })).rejects.toThrow(/failed to launch/)
+    expect(sendMock.mock.calls.some((c) => c[0].type === 'Terminate')).toBe(false)
+    expect(superCreate).toHaveBeenCalledTimes(1)
+    superCreate.mockRestore()
+  })
+
   it('createSession does not replace on timeout even if the generation later looks dead', async () => {
     const { BaseContainerClient } = await import('./base-container-client')
     const client = newClient()

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -818,6 +818,16 @@ function isUnreachableCreateSessionError(error: unknown): boolean {
   return false
 }
 
+// The CLI spawn failed inside a live container (Agent SDK errorClass
+// 'executable_launch_failed': spawn ENOENT/EACCES/… while the binary is
+// present on disk). Observed on long-lived microVMs that answer HTTP but can
+// no longer start any session — degraded fs/cwd state that only a VM
+// replacement clears, so every scheduled run fails until then.
+function isExecutableLaunchFailureError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return (error as { containerErrorClass?: unknown }).containerErrorClass === 'executable_launch_failed'
+}
+
 function honorMicrovmAutoResume(plan: UnexpectedDeathPlan): UnexpectedDeathPlan {
   if (plan.action === 'recover' && !isAutoResumeOnUnexpectedDeathEnabled(getSettings())) {
     return { action: 'settle' }
@@ -1006,6 +1016,17 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     try {
       return await super.createSession(options)
     } catch (error) {
+      // CLI spawn failure inside a live VM: it answers HTTP but no session can
+      // start, and only a restart clears it. Replace the generation once and
+      // retry instead of failing every run until someone restarts by hand.
+      // Deliberately terminates a VM that may still host older live sessions —
+      // in this state they'd lose their next process restart anyway.
+      if (isExecutableLaunchFailureError(error)) {
+        const liveId = agentStates.get(this.config.agentId)?.microvmId ?? installedId
+        if (liveId === null) throw error
+        await this.replaceGeneration('executable_launch_failed', liveId)
+        return await super.createSession(options)
+      }
       if (!isUnreachableCreateSessionError(error)) throw error
       let deadId = await this.observeDeadGeneration()
       if (deadId === null && installedId !== null && !agentStates.has(this.config.agentId)) {


### PR DESCRIPTION
## Problem

Users hit `Claude Code native binary … exists but failed to launch. This usually means the binary does not match this system's libc` when starting agents (Sentry [ELECTRON-JX](https://datawizz.sentry.io/issues/ELECTRON-JX), [ELECTRON-C5](https://datawizz.sentry.io/issues/ELECTRON-C5) — 57 events / 6 users over 90d, ~70% from one user's recurring scheduled tasks). Restarting the agent container always resolves it.

The libc explanation is the Agent SDK's canned guess: it emits that message for **any** spawn failure with errno in `{ENOENT, EACCES, EPERM, ENOTDIR, ELOOP, ENAMETOOLONG, EROFS}` while the binary exists on disk (a real libc mismatch is ruled out — the Dockerfile already strips musl variants and smoke-tests the binary, and a mismatch would fail deterministically, not intermittently on long-lived VMs). The real errno was being dropped at two boundaries: the container's 500 body kept only `error.message`, and the host rethrew that verbatim. Meanwhile a VM in this state answers HTTP fine, so it failed every scheduled run — for days — until a manual restart.

## Changes

- **agent-container** `POST /sessions`: the error body now forwards the SDK's spawn errno (`code`) and `errorClass` alongside the message.
- **Host** `base-container-client`: parses both, folds them into the thrown message so Sentry titles show e.g. `Failed to create session: … [executable_launch_failed ENOENT]`, and attaches them as `containerErrorCode`/`containerErrorClass` properties.
- **Auto-heal** `LambdaMicroVmRuntimeClient.createSession`: on `errorClass === 'executable_launch_failed'`, replace the live VM generation once (existing `replaceGeneration`/`restartAgent` machinery, same as the `post_create_unreachable` path) and retry. At most one replacement per call. Detection is structured-only — container images are version-locked to the app, so there's no message-matching fallback.

Trade-off noted in a comment: replacement terminates a VM that may still host older live sessions, but in this state no new session can start anyway and a restart is the known remedy.

## Testing

- New tests mirroring the existing replace-retry suite: structured `errorClass` triggers replace+retry on a RUNNING generation; a launch-failure-shaped **message without** the structured field does not.
- Typecheck + lint clean on all touched files. Local vitest for this suite is unreliable on this machine (the pre-existing, already-merged connect-refused tests time out identically), so CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoQ16BDmb3g1Wv8v1pqJDu