### PR TITLE
test(auth-e2e): make serial-group retries idempotent against the live server

### DIFF
--- a/e2e/auth/specs/auth-flow.spec.ts
+++ b/e2e/auth/specs/auth-flow.spec.ts
@@ -14,7 +14,10 @@ test.describe.configure({ mode: 'serial' })
 const user1 = { name: 'Alice Admin', email: 'alice@test.com', password: 'password123' }
 const user2 = { name: 'Bob Builder', email: 'bob@test.com', password: 'password123' }
 const user3 = { name: 'Carol Viewer', email: 'carol@test.com', password: 'password123' }
-const agentName = 'Auth Test Agent'
+// Minted per attempt in "user2 creates an agent": a serial-group retry runs
+// against the same live server, so a fixed name would match the failed
+// attempt's leftover agent too and strict-mode every name-based lookup below.
+let agentName = ''
 // Captured once user2 is viewing the agent — used by the cross-tenant deep-link
 // test to prove the loader gates access by URL, not just by sidebar visibility.
 let agentSlug = ''
@@ -122,6 +125,7 @@ test.describe('Auth Flow', () => {
   test('user2 creates an agent', async ({ user2Page }) => {
     const agentPage = new AgentPage(user2Page)
 
+    agentName = test.info().retry === 0 ? 'Auth Test Agent' : `Auth Test Agent R${test.info().retry}`
     await agentPage.createAgent(agentName)
 
     // Verify agent appears in sidebar

--- a/e2e/auth/specs/graph-roles.spec.ts
+++ b/e2e/auth/specs/graph-roles.spec.ts
@@ -16,7 +16,10 @@ test.describe.configure({ mode: 'serial' })
 
 const owner = { name: 'Olivia Owner', email: 'olivia@test.com', password: 'password123' }
 const viewer = { name: 'Vic Viewer', email: 'vic@test.com', password: 'password123' }
-const agentName = 'Graph Roles Agent'
+// Minted per attempt in the first test: a serial-group retry runs against the
+// same live server, so a fixed name would also match the failed attempt's
+// leftover agent and strict-mode the sidebar lookup in openAccessTab.
+let agentName = ''
 let agentSlug = ''
 
 test.describe('Graph role-gated affordances', () => {
@@ -29,6 +32,7 @@ test.describe('Graph role-gated affordances', () => {
     await appPage.waitForAppLoaded()
     await appPage.dismissWizardIfVisible()
 
+    agentName = test.info().retry === 0 ? 'Graph Roles Agent' : `Graph Roles Agent R${test.info().retry}`
     const response = await user1Page.request.post('/api/agents', { data: { name: agentName } })
     expect(response.ok()).toBeTruthy()
     const agent = await response.json() as { slug: string }

--- a/e2e/auth/specs/model-picker-roles.spec.ts
+++ b/e2e/auth/specs/model-picker-roles.spec.ts
@@ -10,7 +10,10 @@ test.describe.configure({ mode: 'serial' })
 
 const admin = { name: 'Ada Admin', email: 'ada@test.com', password: 'password123' }
 const member = { name: 'Mia Member', email: 'mia@test.com', password: 'password123' }
-const agentName = 'Model Picker Agent'
+// Minted per attempt where the agent is created: a serial-group retry runs
+// against the same live server, so a fixed name would also match the failed
+// attempt's leftover agent in the sidebar.
+let agentName = ''
 
 /**
  * Non-admin users must still get a working model picker. The model catalog
@@ -44,6 +47,7 @@ test.describe('Model picker for non-admin users', () => {
     await appPage.dismissWizardIfVisible()
     await userBar.expectUserName(member.name)
 
+    agentName = test.info().retry === 0 ? 'Model Picker Agent' : `Model Picker Agent R${test.info().retry}`
     await agentPage.createAgent(agentName)
     await expect(agentPage.getAgentItem(agentName)).toBeVisible()
   })

--- a/e2e/auth/specs/template-handoff.spec.ts
+++ b/e2e/auth/specs/template-handoff.spec.ts
@@ -30,6 +30,18 @@ test.describe('Signup template handoff', () => {
   })
 
   test('template_slug installs on the workspace with no first-run screen', async ({ user1Page }) => {
+    // The installed agent's name is fixed by the template, so a serial-group
+    // retry (same live server) would install a second copy next to the failed
+    // attempt's and strict-mode the sidebar assertion below. Delete leftovers
+    // first; each attempt then proves a fresh install.
+    const listRes = await user1Page.request.get('/api/agents')
+    expect(listRes.ok()).toBe(true)
+    const existing = await listRes.json() as Array<{ slug: string; name: string }>
+    for (const leftover of existing.filter((a) => a.name === 'E2E Onboarding Template')) {
+      const del = await user1Page.request.delete(`/api/agents/${leftover.slug}`)
+      expect(del.ok(), `delete leftover install ${del.status()}`).toBe(true)
+    }
+
     // Per-user flag, so the PUT must ride the signed-in page's cookies, not the bare request fixture.
     const reset = await user1Page.request.put('/api/user-settings', {
       data: { setupCompleted: false, onboardingProgress: null },
@@ -51,7 +63,10 @@ test.describe('Signup template handoff', () => {
     await expect(user1Page.locator('[data-testid="wizard-container"]')).toHaveCount(0)
     await expect(user1Page.locator('[data-testid="create-agent-prompt"]')).toHaveCount(0)
     await expect(setup).toBeHidden()
-    await expect(sidebar.getByText('E2E Onboarding Template', { exact: true })).toBeVisible()
+    // The sidebar entry appears only after the install finishes writing the
+    // agent — give it the same budget as the install status above, not the 5s
+    // default that flaked on loaded CI runners.
+    await expect(sidebar.getByText('E2E Onboarding Template', { exact: true })).toBeVisible({ timeout: 15_000 })
 
     await expect.poll(async () => {
       const settings = await (await user1Page.request.get('/api/user-settings')).json()

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -86,6 +86,24 @@ function buildAuthServerCommand(dataDir: string, port: number, viteCacheDir: str
   return `SUPERAGENT_DATA_DIR="${dataDir}" AUTH_MODE=true node e2e/setup-e2e-data.js && SUPERAGENT_DATA_DIR="${dataDir}" VITE_CACHE_DIR="${viteCacheDir}" E2E_MOCK=true AUTH_MODE=true ANTHROPIC_API_KEY=sk-ant-e2e-mock PORT=${port} npm run dev:web`
 }
 
+// Each project gets its own dedicated server, and Playwright starts every
+// webServer entry no matter which projects a run selects — nine dev servers
+// for a one-project run, which a laptop cannot bring up inside the 120s
+// budget. Start only the servers the selected projects will actually hit.
+// (CLI-only filter: `--project` never reaches config evaluation any other
+// way; with no flag, all servers start, exactly as before.)
+const selectedProjects = process.argv.flatMap((arg, i) => {
+  if (arg === '--project') return process.argv[i + 1] ? [process.argv[i + 1]] : []
+  if (arg.startsWith('--project=')) return [arg.slice('--project='.length)]
+  return []
+})
+const matchedProjects = authProjects.filter((project) => selectedProjects.includes(project.name))
+// Fall back to all servers when nothing matched exactly — `--project` also
+// accepts glob patterns, and starting every server beats starting none.
+const activeProjects = selectedProjects.length > 0 && matchedProjects.length > 0
+  ? matchedProjects
+  : authProjects
+
 export default defineConfig({
   testDir: './e2e/auth/specs',
   outputDir: playwrightOutputDir,
@@ -106,7 +124,7 @@ export default defineConfig({
     use: { ...devices['Desktop Chrome'], baseURL: project.baseURL },
   })),
 
-  webServer: authProjects.map((project) => ({
+  webServer: activeProjects.map((project) => ({
     command: buildAuthServerCommand(project.dataDir, project.port, project.viteCacheDir),
     url: `${project.baseURL}/api/settings`,
     reuseExistingServer: false,


### PR DESCRIPTION
## Why

CI log mining across the last week's failed `Tests` runs showed the auth E2E job's retries are useless: a serial-group retry reruns the whole narrative against the **same live server**, whose DB still holds the failed attempt's rows. Specs that create agents under a fixed name then collide with their own leftovers — every name-based sidebar lookup resolves to 2–3 elements and strict-mode fails — so a one-off first-attempt timing flake is promoted to a hard job failure. Observed in runs 33443619768 (main), 33328503630, 33442764609, 33446319796.

## What

Following the retry-idempotency patterns already in the suite (`user-onboarding`'s per-attempt invitee email, `auth-settings`' `retryScopedUser`):

- **auth-flow, graph-roles, model-picker-roles**: mint the agent name per attempt (`… R${test.info().retry}` suffix) in the test that creates it, so a retry creates and looks up a name the previous attempt never used. Attempt 0 keeps the original name; assertions stay exactly as strict.
- **template-handoff**: the installed agent's name is fixed by the template, so the install test now deletes the failed attempt's installed copy via the API before re-driving the install, and the sidebar assertion gets the same 15s budget as the install status above it (the 5s default was the original first-attempt flake on loaded runners).
- **playwright.auth.config.ts**: start only the selected `--project`s' dedicated web servers instead of all nine (unchanged when no exact project is named — CI's full-suite run is unaffected).

`session-scope-roles`, `shared-connections`, `user-onboarding`, `auth-settings`, `typing-indicator`, `mobile-pairing` are already retry-idempotent (unique ids or slug-scoped lookups) and are untouched.

## Validation

- `npm run typecheck` + eslint clean.
- Local run of the four touched projects: **44 passed (58s)**, zero flakes.

No assertion was weakened; retries simply stop poisoning themselves, so Playwright's existing `retries: 2` can absorb genuine one-off timing flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MPzp6RbSaWiNtcGDQA5dJ