### PR TITLE
test(e2e): run the home-graph suite isolated from sibling agent churn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,6 +166,7 @@ jobs:
         run: npm run test:e2e:wizard
 
       - name: Run Playwright E2E suites
+        id: web_e2e
         if: ${{ success() || steps.wizard_e2e.outcome == 'failure' }}
         env:
           PORT: '3000'
@@ -174,6 +175,19 @@ jobs:
           PLAYWRIGHT_OUTPUT_DIR: test-results/web
           PLAYWRIGHT_HTML_REPORT: playwright-report/web
         run: npm run test:e2e
+
+      # Own server + fresh data dir: the graph canvas gestures need a board
+      # that holds only this spec's agents and a layout no sibling worker is
+      # re-solving mid-gesture (the previous shared-server arrangement was the
+      # suite's top flake source).
+      - name: Run graph E2E suite
+        if: ${{ success() || steps.wizard_e2e.outcome == 'failure' || steps.web_e2e.outcome == 'failure' }}
+        env:
+          PORT: '3000'
+          SUPERAGENT_DATA_DIR: .e2e-data/graph
+          PLAYWRIGHT_OUTPUT_DIR: test-results/graph
+          PLAYWRIGHT_HTML_REPORT: playwright-report/graph
+        run: npm run test:e2e:graph
 
       - name: Upload Playwright artifacts
         if: always()

--- a/e2e/specs/home-graph.spec.ts
+++ b/e2e/specs/home-graph.spec.ts
@@ -8,7 +8,14 @@
  *
  * Position persistence writes global user settings, so the drag test asserts
  * through the API rather than screen coordinates — screen positions depend on
- * fitView and on how many agents other parallel specs have created.
+ * fitView and on how many agents exist on the board.
+ *
+ * Runs under the dedicated `web-graph` project (test:e2e:graph) on its own
+ * server and data dir, serially: canvas mouse gestures need a still layout,
+ * and on the shared web server sibling specs' agent churn re-solved the graph
+ * under the cursor often enough to make this file the suite's top flake. The
+ * in-test pin/zoom/retry armor below predates that isolation and stays as a
+ * second line of defense against the file's own re-layouts.
  */
 import { test, expect, type Page } from '@playwright/test'
 import { createAgent, uniqueName, type TestAgent } from '../helpers/agents'

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:e2e": "E2E_MOCK=true playwright test --project=web-chromium",
     "test:e2e:web": "E2E_MOCK=true playwright test --project=web-chromium",
     "test:e2e:wizard": "E2E_MOCK=true playwright test --config=playwright.wizard.config.ts",
+    "test:e2e:graph": "E2E_MOCK=true playwright test --project=web-graph",
     "test:e2e:pwa": "E2E_MOCK=true playwright test --config=playwright.pwa.config.ts",
     "test:e2e:a11y": "E2E_MOCK=true E2E_INCLUDE_A11Y=true playwright test e2e/specs/a11y-audit.spec.ts --project=web-chromium",
     "test:e2e:headed": "E2E_MOCK=true playwright test --project=web-chromium --headed",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,6 +25,11 @@ const webTestIgnore = [
   '**/pwa-precache.spec.ts',
   // WebKit-engine regression (async-scroll follow) — runs under the web-webkit project.
   '**/safari-follow.spec.ts',
+  // Canvas mouse gestures need a still layout: sibling specs' agent churn on
+  // the shared server re-solves the graph under the cursor, which made this
+  // the suite's top flake. Runs under the web-graph project on its own server
+  // and data dir (see test:e2e:graph).
+  '**/home-graph.spec.ts',
 ]
 
 if (process.env.E2E_INCLUDE_A11Y !== 'true') {
@@ -90,6 +95,19 @@ export default defineConfig({
       name: 'web-webkit',
       testMatch: ['**/safari-follow.spec.ts', '**/thinking-collapse-reading-line.spec.ts'],
       use: { ...devices['Desktop Safari'] },
+    },
+    // Home connections graph — canvas mouse gestures (hover-fade, edge draw,
+    // node drag) against react-flow. Run with `npm run test:e2e:graph` and a
+    // dedicated SUPERAGENT_DATA_DIR: the only agents on the board are the
+    // spec's own, so the layout stays still and fitView never bottoms out at
+    // minZoom. Not fullyParallel — the file's own tests would otherwise churn
+    // each other's layout from parallel workers, recreating the flake this
+    // project exists to remove.
+    {
+      name: 'web-graph',
+      testMatch: ['**/home-graph.spec.ts'],
+      fullyParallel: false,
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
 


### PR DESCRIPTION
## Why

`home-graph.spec.ts` is the `Tests` workflow's single worst flake: it appears in **19 of the last 22 failed `e2e-tests` runs** (18 hard failures + 12 retry-passes across 9 branches, `main` included). Every observed failure mode traces to the one hazard the spec's own comments fight line by line — all specs share one server, so ~100 sibling agents keep re-solving the graph layout mid-gesture:

- hover lands where a card just was → `data-graph-dimmed` never set, 15s `toPass` exhausted
- fitView bottoms out at minZoom (~0.15) where a port's hit zone is ~3px → edge draw silently never registers (`drawn === false` after 5 armored attempts)
- nodes jump outside the viewport between measure and click → `Element is outside of the viewport`

The in-file pin/zoom/retry armor reduced but could not eliminate this; three consecutive attempts still failed regularly under 6-worker churn.

## What

Remove the hazard instead of adding more armor, following the wizard suite's precedent:

- New `web-graph` Playwright project (same config) that owns `home-graph.spec.ts`; `web-chromium` now ignores it.
- The project is not `fullyParallel`, so the file's own tests can't churn each other's layout either.
- New `npm run test:e2e:graph` script; new CI step in the `e2e-tests` job with a fresh `SUPERAGENT_DATA_DIR` — the board holds only the spec's own agents, nothing re-layouts mid-gesture, ports render at full size.

**Every assertion is unchanged** — same tests, same strictness; the existing armor stays as a second line of defense against the file's own re-layouts.

## Validation

- `--list` confirms the spec moved projects (0 matches in web-chromium, 6 in web-graph).
- Locally: 6/6 green, then **18/18 green with `--repeat-each=3 --retries=0`** in ~20s. The CI step's added wall time is dominated by one server boot.
- typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MPzp6RbSaWiNtcGDQA5dJ