### PR TITLE
fix(mcp): fall back when authorize rejects a registered redirect

### DIFF
--- a/src/shared/lib/mcp/mcp-safe-fetch.test.ts
+++ b/src/shared/lib/mcp/mcp-safe-fetch.test.ts
@@ -51,6 +51,25 @@ describe('mcpSafeFetch', () => {
     expect(secondHeaders.get('authorization')).toBeNull()
   })
 
+  it('returns the first response when followRedirects is false', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://cdn.example/mcp' },
+      }),
+    )
+
+    const res = await mcpSafeFetch(
+      'https://public.example/authorize',
+      { method: 'GET' },
+      undefined,
+      { followRedirects: false },
+    )
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('https://cdn.example/mcp')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
   it('refuses a redirect Location that resolves to a private IP', async () => {
     mockFetch.mockResolvedValue(
       new Response(null, {

--- a/src/shared/lib/mcp/mcp-safe-fetch.ts
+++ b/src/shared/lib/mcp/mcp-safe-fetch.ts
@@ -74,11 +74,13 @@ export async function mcpSafeFetch(
   url: string,
   init?: RequestInit,
   policy?: DiscoveryHostPolicy,
+  options?: { followRedirects?: boolean },
 ): Promise<Response> {
   let currentUrl = url
   let currentInit = init
   let response = await pinnedFetch(currentUrl, currentInit, policy)
   let redirects = 0
+  if (options?.followRedirects === false) return response
 
   while (REDIRECT_STATUS.has(response.status) && redirects < MAX_REDIRECTS) {
     const location = response.headers.get('location')

--- a/src/shared/lib/mcp/oauth.test.ts
+++ b/src/shared/lib/mcp/oauth.test.ts
@@ -1063,6 +1063,8 @@ describe('oauth', () => {
       mockFetch.mockResolvedValueOnce(
         new Response(JSON.stringify({ client_id: 'dyn-scheme' }), { status: 201 })
       )
+      // Authorize probe: scheme is also accepted at authorize.
+      mockFetch.mockResolvedValueOnce(new Response('ok', { status: 200 }))
 
       const result = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',
@@ -1081,6 +1083,92 @@ describe('oauth', () => {
         ([reqUrl]) => reqUrl === 'https://auth.example.com/register'
       )
       expect(registerCalls).toHaveLength(1)
+    })
+
+    it.each([
+      {
+        rejection: 'a 4xx response body',
+        response: () =>
+          new Response('Invalid redirect URI.', {
+            status: 400,
+            headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+          }),
+      },
+      {
+        rejection: 'a redirect error parameter',
+        response: () =>
+          new Response(null, {
+            status: 302,
+            headers: {
+              Location:
+                'superagent://mcp-oauth-callback?error=invalid_redirect_uri',
+            },
+          }),
+      },
+    ])(
+      'falls back to the http loopback when authorize rejects the scheme via $rejection',
+      async ({ response }) => {
+        setupNewServerDcrDiscovery()
+        mockFetch.mockResolvedValueOnce(
+          new Response(JSON.stringify({ client_id: 'dyn-scheme' }), { status: 201 })
+        )
+        mockFetch.mockResolvedValueOnce(response())
+        mockFetch.mockResolvedValueOnce(
+          new Response(JSON.stringify({ client_id: 'dyn-loopback' }), { status: 201 })
+        )
+
+        const loopback = 'http://localhost:47891/api/remote-mcps/oauth-callback'
+        const result = await initiateNewServerOAuth(
+          'https://mcp.example.com/mcp',
+          'Canva',
+          ['superagent://mcp-oauth-callback', loopback],
+          true,
+          'user-1'
+        )
+
+        expect(result).not.toBeNull()
+        const url = new URL(result!.authorizationUrl)
+        expect(url.searchParams.get('redirect_uri')).toBe(loopback)
+        expect(url.searchParams.get('client_id')).toBe('dyn-loopback')
+
+        const registerCalls = mockFetch.mock.calls.filter(
+          ([reqUrl]) => reqUrl === 'https://auth.example.com/register'
+        )
+        expect(registerCalls).toHaveLength(2)
+        const authorizeProbes = mockFetch.mock.calls.filter(
+          ([reqUrl]) =>
+            typeof reqUrl === 'string' &&
+            reqUrl.startsWith('https://auth.example.com/authorize')
+        )
+        expect(authorizeProbes).toHaveLength(1)
+        const probed = new URL(authorizeProbes[0][0] as string)
+        expect(probed.searchParams.get('redirect_uri')).toBe(
+          'superagent://mcp-oauth-callback'
+        )
+        expect(probed.searchParams.get('client_id')).toBe('dyn-scheme')
+        expect(probed.searchParams.get('resource')).toBe('https://mcp.example.com')
+      }
+    )
+
+    it('keeps the custom scheme when the authorize probe is inconclusive', async () => {
+      setupNewServerDcrDiscovery()
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ client_id: 'dyn-scheme' }), { status: 201 })
+      )
+      mockFetch.mockRejectedValueOnce(new Error('network down'))
+
+      const result = await initiateNewServerOAuth(
+        'https://mcp.example.com/mcp',
+        'Flaky AS',
+        ['superagent://mcp-oauth-callback', 'http://localhost:47891/api/remote-mcps/oauth-callback'],
+        true,
+        'user-1'
+      )
+
+      expect(result).not.toBeNull()
+      const url = new URL(result!.authorizationUrl)
+      expect(url.searchParams.get('redirect_uri')).toBe('superagent://mcp-oauth-callback')
+      expect(url.searchParams.get('client_id')).toBe('dyn-scheme')
     })
 
     it('uses provided clientId/clientSecret without dynamic registration', async () => {
@@ -1313,6 +1401,7 @@ describe('oauth', () => {
       mockFetch.mockResolvedValueOnce(
         new Response(JSON.stringify({ client_id: 'dyn-scheme' }), { status: 201 })
       )
+      mockFetch.mockResolvedValueOnce(new Response('ok', { status: 200 }))
 
       const initiated = await initiateNewServerOAuth(
         'https://mcp.example.com/mcp',

--- a/src/shared/lib/mcp/oauth.ts
+++ b/src/shared/lib/mcp/oauth.ts
@@ -244,25 +244,106 @@ export async function registerDynamicClient(
   return { clientId: data.client_id, clientSecret: data.client_secret, scope: data.scope }
 }
 
-/**
- * Register a dynamic client, trying each candidate redirect URI in order until
- * one is accepted. Returns the winning redirect URI alongside the credentials.
- *
- * Strict authorization servers (e.g. cal.com) reject any non-http(s) redirect
- * during registration ("only http and https are allowed"), so the caller passes
- * the custom app scheme first and an http loopback URL as the fallback. Whatever
- * the AS accepts is what we must then use on the authorization and token
- * requests — so it is returned here rather than assumed by the caller.
- */
+function isCustomSchemeRedirect(redirectUri: string): boolean {
+  return !/^https?:/i.test(redirectUri)
+}
+
+// 4xx body / Location only — a 200 login page must not match on page text.
+function authorizeResponseRejectsRedirect(
+  status: number,
+  body: string,
+  location: string | null,
+): boolean {
+  if (location) {
+    const query = location.includes('?') ? location.slice(location.indexOf('?') + 1) : ''
+    if (query) {
+      const error = new URLSearchParams(query).get('error')
+      if (error === 'invalid_redirect_uri') return true
+    }
+  }
+  if (status < 400 || status > 499) return false
+  try {
+    const parsed = JSON.parse(body) as { error?: unknown; error_description?: unknown }
+    if (parsed.error === 'invalid_redirect_uri') return true
+    if (
+      typeof parsed.error_description === 'string' &&
+      /invalid redirect uri/i.test(parsed.error_description)
+    ) {
+      return true
+    }
+  } catch {
+    // Not JSON — Canva returns text/plain "Invalid redirect URI."
+  }
+  return /invalid[_\s-]?redirect[_\s-]?uri/i.test(body)
+}
+
+async function authorizeRejectsRedirect(
+  authorizationEndpoint: string,
+  clientId: string,
+  redirectUri: string,
+  resource?: string,
+): Promise<boolean> {
+  let authUrl: URL
+  try {
+    authUrl = new URL(authorizationEndpoint)
+  } catch {
+    return false
+  }
+  const { codeChallenge } = generatePKCE()
+  authUrl.searchParams.set('response_type', 'code')
+  authUrl.searchParams.set('client_id', clientId)
+  authUrl.searchParams.set('redirect_uri', redirectUri)
+  authUrl.searchParams.set('code_challenge', codeChallenge)
+  authUrl.searchParams.set('code_challenge_method', 'S256')
+  authUrl.searchParams.set('state', 'redirect-probe')
+  if (resource) authUrl.searchParams.set('resource', resource)
+
+  try {
+    const res = await mcpSafeFetch(authUrl.toString(), { method: 'GET' }, undefined, {
+      followRedirects: false,
+    })
+    const body = await res.text().catch(() => '')
+    return authorizeResponseRejectsRedirect(res.status, body, res.headers.get('location'))
+  } catch (error) {
+    console.error(
+      `[mcp/oauth] Authorize redirect probe failed for ${redirectUri}; keeping candidate:`,
+      error,
+    )
+    return false
+  }
+}
+
+// Try each redirect until register AND authorize accept it (Canva 400s only at authorize).
 async function registerDynamicClientWithFallback(
   registrationEndpoint: string,
   redirectCandidates: string[],
   clientName: string,
+  authorizationEndpoint: string,
+  resource?: string,
 ): Promise<{ clientId: string; clientSecret?: string; scope?: string; redirectUri: string }> {
   let lastError: McpOAuthSetupError | undefined
-  for (const redirectUri of redirectCandidates) {
+  for (let i = 0; i < redirectCandidates.length; i++) {
+    const redirectUri = redirectCandidates[i]
     try {
       const registration = await registerDynamicClient(registrationEndpoint, redirectUri, clientName)
+      const hasFallback = i < redirectCandidates.length - 1
+      if (hasFallback && isCustomSchemeRedirect(redirectUri)) {
+        const rejected = await authorizeRejectsRedirect(
+          authorizationEndpoint,
+          registration.clientId,
+          redirectUri,
+          resource,
+        )
+        if (rejected) {
+          console.error(
+            `[mcp/oauth] Authorization rejected redirect ${redirectUri}; trying next candidate`,
+          )
+          lastError = new McpOAuthSetupError(
+            'The authorization server rejected the redirect URI',
+          )
+          continue
+        }
+      }
       return { ...registration, redirectUri }
     } catch (error) {
       if (!(error instanceof McpOAuthSetupError)) throw error
@@ -470,6 +551,8 @@ export async function initiateOAuthFlow(
         metadata.registration_endpoint,
         redirectCandidates,
         clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Gamut',
+        metadata.authorization_endpoint,
+        resource,
       )
       clientId = registration.clientId
       clientSecret = registration.clientSecret
@@ -613,6 +696,8 @@ export async function initiateNewServerOAuth(
       metadata.registration_endpoint,
       redirectCandidates,
       clientNameOverride && clientNameOverride.length > 0 ? clientNameOverride : 'Gamut',
+      metadata.authorization_endpoint,
+      resource,
     )
     clientId = registration.clientId
     clientSecret = registration.clientSecret


### PR DESCRIPTION
## Bug

Connecting the Canva MCP server (`https://mcp.canva.com/mcp`) on desktop always failed with Canva's `Invalid redirect URI` page.

**Repro:** Desktop app → Connections → add Canva (MCP) → Connect → browser opens `mcp.canva.com/authorize` with `redirect_uri=superagent://mcp-oauth-callback` → HTTP 400 `Invalid redirect URI.`

**Root cause:** the redirect fallback (custom app scheme → http loopback) only triggered when **dynamic client registration** rejected a candidate (the cal.com case). Canva *accepts* `superagent://` at DCR, then rejects it at **authorize** — the rejection renders in the user's browser, never reaches our callback, so the app had no signal and never tried `localhost` (which Canva allows).

## Change

After a custom-scheme candidate passes DCR and a fallback candidate exists, probe the authorization endpoint server-side (no redirect following). If the response is an invalid-redirect rejection (4xx body / `error=invalid_redirect_uri` in a redirect back), drop the candidate and register the next one. Probe errors fail open (keep the candidate), so flaky networks can't regress servers that worked before.

- `mcp-safe-fetch.ts`: optional `followRedirects: false` so the probe can read the authorize response directly.
- `oauth.ts`: authorize probe + candidate loop in `registerDynamicClientWithFallback`; both initiate paths pass the authorization endpoint and RFC 8707 resource.

## Test plan
- [x] `vitest run src/shared/lib/mcp/` — 72 passed
- [x] `tsc --noEmit` clean for src (pre-existing errors in `tools/` only), `eslint` clean on touched files
- [x] E2E on desktop dev app: Canva Connect → probe rejects `superagent-dev://` → falls back to `http://localhost:<port>/api/remote-mcps/oauth-callback` → Canva login page → OAuth completes, Canva connected
- [x] Servers accepting the custom scheme at authorize keep it (probe accepts, unit-tested)
- [x] cal.com-style DCR rejection fallback unchanged (unit-tested)

## Not fixed here

Cloud deployments: the http fallback is the deployment's public callback URL, which Canva also rejects until it's on their MCP allowlist (waitlist). This PR only unblocks desktop.