### PR TITLE
fix(sessions): never show "transcript not found" over a live session's first turn

### DIFF
--- a/e2e/helpers/onboarding-session.ts
+++ b/e2e/helpers/onboarding-session.ts
@@ -1,0 +1,75 @@
+import { expect, type Page } from '@playwright/test'
+
+export const ONBOARDING_MESSAGE =
+  'This agent was just set up from a template. Please run the agent-onboarding skill to help me configure it.'
+
+const NOT_FOUND_SELECTOR = '[data-testid="session-transcript-not-found"]'
+
+declare global {
+  interface Window {
+    __e2eTranscriptNotFoundSeen?: boolean
+  }
+}
+
+/**
+ * Start recording whether the "Session transcript not found" card is ever
+ * mounted. Call this BEFORE the action that opens the onboarding session (the
+ * install / import click): the card can show for a few hundred ms and be gone
+ * again by the time a locator looks, so a Playwright assertion after the fact
+ * would race past it. The observer lives in the document, so it survives the
+ * in-app navigation into the session but not a full page load.
+ */
+export async function armTranscriptNotFoundWatch(page: Page) {
+  await page.evaluate((selector) => {
+    window.__e2eTranscriptNotFoundSeen = !!document.querySelector(selector)
+    // React reuses the loading placeholder's <div> for the card (same element
+    // type, same slot), so the card can arrive as an ATTRIBUTE change on an
+    // existing node plus children inserted under it — never as an added node
+    // carrying the test id. Check all three shapes, and the live document.
+    const observer = new MutationObserver((mutations) => {
+      if (document.querySelector(selector)) {
+        window.__e2eTranscriptNotFoundSeen = true
+        return
+      }
+      for (const mutation of mutations) {
+        const target = mutation.target instanceof HTMLElement ? mutation.target : null
+        if (target?.matches(selector) || target?.closest(selector)) {
+          window.__e2eTranscriptNotFoundSeen = true
+          return
+        }
+        for (const node of mutation.addedNodes) {
+          if (!(node instanceof HTMLElement)) continue
+          if (node.matches(selector) || node.querySelector(selector)) {
+            window.__e2eTranscriptNotFoundSeen = true
+            return
+          }
+        }
+      }
+    })
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-testid'],
+    })
+  }, NOT_FOUND_SELECTOR)
+}
+
+/**
+ * The onboarding session opens BEFORE the container has written its transcript
+ * (the mock holds the first line back for ~1.5 s, like a cold agent does). Wait
+ * for the onboarding prompt to land, then check the card never showed in the
+ * meantime — the whole point of that window is that the user sees an agent
+ * working, never a missing session. Requires `armTranscriptNotFoundWatch`.
+ */
+export async function expectOnboardingSessionToOpenCleanly(page: Page, timeoutMs = 20_000) {
+  await expect(page).toHaveURL(/\/agents\/[^/]+\/sessions\//, { timeout: timeoutMs })
+  await expect(page.locator('[data-testid="message-list"]')).toBeVisible({ timeout: timeoutMs })
+  await expect(
+    page.locator('[data-testid="message-user"]').filter({ hasText: ONBOARDING_MESSAGE }),
+  ).toBeVisible({ timeout: timeoutMs })
+
+  const seen = await page.evaluate(() => window.__e2eTranscriptNotFoundSeen)
+  expect(seen, 'armTranscriptNotFoundWatch must be called before opening the session').toBeDefined()
+  expect(seen, '"Session transcript not found" must never show while the onboarding session starts').toBe(false)
+}

--- a/e2e/specs/agent-import.spec.ts
+++ b/e2e/specs/agent-import.spec.ts
@@ -6,9 +6,11 @@ import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
 import { buildAgentTemplateZip } from '../helpers/agent-template-zip'
-
-const ONBOARDING_MESSAGE =
-  'This agent was just set up from a template. Please run the agent-onboarding skill to help me configure it.'
+import {
+  ONBOARDING_MESSAGE,
+  armTranscriptNotFoundWatch,
+  expectOnboardingSessionToOpenCleanly,
+} from '../helpers/onboarding-session'
 
 /**
  * Covers the AgentHome → import → onboarding-session flow refactored to use
@@ -58,14 +60,14 @@ test.describe('Agent Import Onboarding', () => {
     // Upload the fixture zip into the dialog's hidden file input, then submit.
     await dialog.locator('input[type="file"]').setInputFiles(zipPath)
     await expect(dialog.getByText('with-onboarding.zip')).toBeVisible()
+    await armTranscriptNotFoundWatch(page)
     await dialog.locator('button[type="submit"]').click()
 
     // Dialog closes, then `useStartOnboardingSession` creates the onboarding
-    // session and `selectSession` routes to it — the message list renders.
+    // session and `selectSession` routes to it — the message list renders,
+    // and the first user message in it is the onboarding prompt.
     await expect(dialog).not.toBeVisible({ timeout: 15000 })
-    await expect(sessionPage.getMessageList()).toBeVisible({ timeout: 15000 })
-
-    // The first user message in the new session is the onboarding prompt.
+    await expectOnboardingSessionToOpenCleanly(page)
     await sessionPage.expectUserMessage(ONBOARDING_MESSAGE)
 
     // The imported agent is now selected in the sidebar.
@@ -87,6 +89,7 @@ test.describe('Agent Import Onboarding', () => {
     await expect(dialog).toBeVisible()
 
     await dialog.locator('input[type="file"]').setInputFiles(zipPath)
+    await armTranscriptNotFoundWatch(page)
     await dialog.locator('button[type="submit"]').click()
 
     // MockContainerClient delays onboarding session creation by 2 s —
@@ -97,7 +100,7 @@ test.describe('Agent Import Onboarding', () => {
 
     // After the delay resolves, the dialog disappears and the session appears.
     await expect(setupDialog).not.toBeVisible({ timeout: 15000 })
-    await expect(sessionPage.getMessageList()).toBeVisible({ timeout: 15000 })
+    await expectOnboardingSessionToOpenCleanly(page)
     await sessionPage.expectUserMessage(ONBOARDING_MESSAGE)
   })
 

--- a/e2e/specs/template-onboarding.spec.ts
+++ b/e2e/specs/template-onboarding.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import {
+  armTranscriptNotFoundWatch,
+  expectOnboardingSessionToOpenCleanly,
+} from '../helpers/onboarding-session'
+
+/**
+ * Discover → install a marketplace template that ships the agent-onboarding
+ * skill → the onboarding session opens and runs. The seeded public skillset
+ * (e2e/setup-e2e-data.js) carries one such template.
+ */
+test.describe('Template install with onboarding skill', () => {
+  test('installing the template opens a working onboarding session, never a missing one', async ({ page }) => {
+    const appPage = new AppPage(page)
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+
+    await page.goto('/explore/github-com-skillfulagents-public-skillset/e2e-onboarding-template')
+    await expect(page.getByTestId('template-detail-view')).toBeVisible()
+    await armTranscriptNotFoundWatch(page)
+    await page.getByTestId('template-detail-install').click()
+
+    // Install progress, then the "Setting up your agent…" card while the
+    // session is created (the mock holds createSession for 2 s).
+    const install = page.getByTestId('template-install-status')
+    const setup = page.getByTestId('onboarding-setup-dialog')
+    await expect(install.or(setup).first()).toBeVisible({ timeout: 15_000 })
+    await expect(setup).toBeVisible({ timeout: 15_000 })
+    await expect(setup).toBeHidden({ timeout: 15_000 })
+
+    await expectOnboardingSessionToOpenCleanly(page)
+
+    const sidebar = page.locator('[data-testid="app-sidebar"]')
+    await expect(sidebar.getByText('E2E Onboarding Template', { exact: true }).first()).toBeVisible()
+  })
+})

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -3845,6 +3845,46 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
   })
 
+  // A session's transcript is created by the CLI on its first persisted line,
+  // seconds after createSession returns on a cold agent — and the creating
+  // client (an onboarding session has no optimistic ghost to hide behind) has
+  // already opened the session and asked for its messages. A live session with
+  // no file yet is EMPTY, not gone: answer the empty page, never the 404 that
+  // renders "Session transcript not found" over a running turn.
+  describe('live session whose first turn has not written its transcript yet', () => {
+    beforeEach(() => {
+      vi.mocked(sessionExists).mockResolvedValue(false)
+      vi.mocked(sessionIsKnown).mockResolvedValue(true)
+      vi.mocked(messagePersister.isSessionActive).mockReturnValue(true)
+    })
+
+    it('answers an empty page on the paginated path', async () => {
+      const res = await getReq(app, `${URL}?limit=50&media=ref`)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ messages: [], nextCursor: null })
+      expect(getSessionMessagesPage).not.toHaveBeenCalled()
+    })
+
+    it('answers an empty array on the legacy unpaginated path', async () => {
+      const res = await getReq(app, URL)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual([])
+      expect(getSessionMessagesWithCompact).not.toHaveBeenCalled()
+    })
+
+    it('still 404s once the session is no longer live (the retention-deleted case)', async () => {
+      vi.mocked(messagePersister.isSessionActive).mockReturnValue(false)
+      const res = await getReq(app, `${URL}?limit=50`)
+      expect(res.status).toBe(404)
+    })
+
+    it('still 404s for an id that is not a session of this agent', async () => {
+      vi.mocked(sessionIsKnown).mockResolvedValue(false)
+      const res = await getReq(app, `${URL}?limit=50`)
+      expect(res.status).toBe(404)
+    })
+  })
+
   it('does not query messageAuthor in non-auth mode', async () => {
     mockIsAuthMode.mockReturnValue(false)
     mockTransformMessages.mockReturnValue([

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -2278,26 +2278,41 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
     const agentSlug = getAgentId(c)
     const sessionId = c.req.param('sessionId')
 
-    // No JSONL transcript on disk — e.g. it was deleted by the CLI's retention
-    // cleanup while the metadata entry lingers in the nav. Signal this distinctly
-    // from an empty (but present) transcript so the UI can show a clear message.
-    if (!(await sessionExists(agentSlug, sessionId))) {
-      return c.json({ error: 'Session transcript not found' }, 404)
-    }
-
     const rawLimit = c.req.query('limit')
     const rawCursor = c.req.query('cursor')
     const rawAfter = c.req.query('after')
     const rawMedia = c.req.query('media')
-    // `media` selects this branch too: it is only honored on the paginated
-    // path, so leaving it out would silently serve a full inline response to a
-    // client that asked for refs — and skip validating the value at all.
-    if (
+    // `media` selects the paginated branch too: it is only honored there, so
+    // leaving it out would silently serve a full inline response to a client
+    // that asked for refs — and skip validating the value at all.
+    const paginated =
       rawLimit !== undefined ||
       rawCursor !== undefined ||
       rawAfter !== undefined ||
       rawMedia !== undefined
-    ) {
+
+    if (!(await sessionExists(agentSlug, sessionId))) {
+      // A live session whose first turn has not persisted anything yet: the
+      // CLI creates the transcript on its first written line, seconds after
+      // createSession returns on a cold agent, and the creating client has
+      // already navigated in and asked for messages by then. That is an empty
+      // transcript, not a missing one — answer the empty page so the client
+      // keeps showing the running turn and picks the lines up as they land.
+      // (sessionIsKnown keeps the containment guarantee for the id.)
+      if (
+        messagePersister.isSessionActive(agentSlug, sessionId) &&
+        (await sessionIsKnown(agentSlug, sessionId))
+      ) {
+        return paginated ? c.json({ messages: [], nextCursor: null }) : c.json([])
+      }
+      // No JSONL transcript on disk — e.g. it was deleted by the CLI's
+      // retention cleanup while the metadata entry lingers in the nav. Signal
+      // this distinctly from an empty (but present) transcript so the UI can
+      // show a clear message.
+      return c.json({ error: 'Session transcript not found' }, 404)
+    }
+
+    if (paginated) {
       const parsed = messagesListQuerySchema.safeParse({
         ...(rawLimit !== undefined ? { limit: rawLimit } : {}),
         ...(rawCursor !== undefined ? { cursor: rawCursor } : {}),

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -3,6 +3,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { useState } from 'react'
 import { MessageList } from './message-list'
+// Resolves to the mocked module's class below — the one the component's
+// instanceof check sees.
+import { TranscriptNotFoundError } from '@renderer/hooks/use-messages'
 import { useDraft } from '@renderer/context/drafts-context'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import { createUserMessage, createAssistantMessage, createToolCall, createCompactBoundary } from '@renderer/test/factories'
@@ -201,6 +204,39 @@ describe('MessageList', () => {
     )
     expect(screen.getByText('Hi')).toBeInTheDocument()
     expect(screen.getByText('Hello!')).toBeInTheDocument()
+  })
+
+  describe('transcript not found', () => {
+    beforeEach(() => {
+      mockMessagesData.error = new TranscriptNotFoundError()
+    })
+
+    it('shows the not-found card for an idle session with no ghost', () => {
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getByTestId('session-transcript-not-found')).toBeInTheDocument()
+    })
+
+    it('hides it behind the creating client’s optimistic ghost', () => {
+      renderWithProviders(
+        <MessageList
+          sessionId="s-1"
+          agentSlug="agent-1"
+          pendingUserMessages={[{ localId: 'pm-1', uuid: 'pm-1', text: 'First message', sentAt: Date.now() }]}
+        />
+      )
+      expect(screen.queryByTestId('session-transcript-not-found')).not.toBeInTheDocument()
+      expect(screen.getByText('First message')).toBeInTheDocument()
+    })
+
+    // An onboarding session opens with no ghost, before the container has
+    // written its first line. The turn is running, so the transcript is not
+    // yet written rather than gone — render the (empty) live transcript.
+    it('hides it while the session is live, even with no ghost', () => {
+      mockStreamState.isActive = true
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByTestId('session-transcript-not-found')).not.toBeInTheDocument()
+      expect(screen.getByTestId('message-list')).toBeInTheDocument()
+    })
   })
 
   describe('session time flags', () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -1056,11 +1056,18 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
   }
 
   // The transcript file is gone (e.g. removed by the CLI's retention cleanup)
-  // while the session still appears in the nav. Don't show this during the brief
-  // new-session window — the creating client has a pendingUserMessage then.
-  if (error instanceof TranscriptNotFoundError && !hasPendingMessages) {
+  // while the session still appears in the nav. Don't show this during the
+  // new-session window: the composer's client has a pendingUserMessage then,
+  // and every client sees the turn running (an onboarding session opens with
+  // no ghost at all) — a live session's transcript is not yet written, not
+  // gone. The server answers that window with an empty page; this also covers
+  // a server that predates it.
+  if (error instanceof TranscriptNotFoundError && !hasPendingMessages && !isActive) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-2 px-4 text-center">
+      <div
+        className="flex-1 flex flex-col items-center justify-center gap-2 px-4 text-center"
+        data-testid="session-transcript-not-found"
+      >
         <FileX2 className="h-8 w-8 text-muted-foreground" />
         <p className="text-sm font-medium text-foreground">Session transcript not found</p>
         <p className="max-w-sm text-xs text-muted-foreground">

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -559,6 +559,21 @@ export class SlowCompactionScenario implements MockScenario {
 }
 
 /**
+ * A transcript that lands late. The real CLI creates the session's JSONL on
+ * its first persisted line, which for a freshly started agent is seconds after
+ * createSession returns — and by then the client has already navigated into
+ * the session and asked for its messages. Delaying the inner scenario (which
+ * does the writing) reproduces that window instead of racing past it.
+ */
+export class LateTranscriptScenario implements MockScenario {
+  constructor(private inner: MockScenario, private delayMs: number) {}
+
+  execute(sessionId: string, client: MockContainerClient, userMessage: string): void {
+    setTimeout(() => this.inner.execute(sessionId, client, userMessage), this.delayMs)
+  }
+}
+
+/**
  * API error scenario - simulates an LLM provider error (e.g., auth failure, rate limit).
  * Emits an assistant message with the SDK error code, then a result with error subtype.
  */
@@ -1661,6 +1676,12 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     ['work slowly', new SlowWorkScenario()],
     // Long compaction window: queue a message while the session is compacting
     ['compact slowly', new SlowCompactionScenario(10000)],
+    // Onboarding sessions start on a cold agent, so their transcript lands
+    // well after the client has opened the session (see LateTranscriptScenario).
+    ['agent-onboarding', new LateTranscriptScenario(
+      new SimpleTextResponseScenario('Welcome! Let me help you configure this agent.'),
+      1500,
+    )],
     // Long thinking passes: each pass overfills the card's max-height so the
     // card scrolls internally while live, then collapses by its full body
     // height when the pass ends — the shrink-at-the-live-edge shape behind


### PR DESCRIPTION
## Summary

Installing an agent template that ships the `agent-onboarding` skill briefly showed **"Session transcript not found"** in the onboarding session (reported on 0.5.15-rc.1).

**Root cause.** The CLI creates a session's JSONL on its first persisted line, which on a cold agent is seconds after `createSession` returns. The onboarding flow has already navigated into the session by then, the messages route answered 404 for a transcript that did not exist yet, and `MessageList` rendered the not-found card over a running turn. The composer flow hides the same window behind its optimistic ghost message; the onboarding flow creates the session with no ghost, so it was exposed.

**Not a code regression from 0.5.14.** The card and its 404 date to the June retention work, and every file on the onboarding path is unchanged between v0.5.14 and rc.1. It is a latent race that a slow first turn makes visible.

## Changes

- **`GET /:id/sessions/:sessionId/messages`**: when the transcript is absent but the session is active in the persister *and* known to this agent, answer the empty page (`{ messages: [], nextCursor: null }`, or `[]` on the legacy unpaginated path) instead of 404. The 404 stays for the retention-deleted case.
- **`MessageList`**: also suppress the not-found card while the stream reports the turn running. Covers a server that predates the route change during a rolling deploy.
- **Mock container**: onboarding sessions now write their transcript 1.5 s late (`LateTranscriptScenario`), mirroring the cold-agent window so E2E exercises it instead of racing past it.
- **E2E**: new `e2e/specs/template-onboarding.spec.ts` covers Discover → install → onboarding session (there was no main-suite coverage for this). A shared helper arms a `MutationObserver` before the install/import click and fails the test if the card ever mounts; the two existing import-onboarding tests use it too. Verified the assertion fires with both fixes disabled.
- **Unit tests**: route (empty page for a live session; still 404 when idle or for a foreign id) and component guard.

Deliberately **not** included: seeding an optimistic ghost for the onboarding prompt so the window looks identical to a composer send. That needs the pending-message store to survive across `AgentShell` mounts; follow-up.

## Test plan

- [x] `vitest` — `agents.test.ts` and `message-list.test.tsx` in full (601 passed)
- [x] Mock E2E — `template-onboarding.spec.ts` + `agent-import.spec.ts` (5 passed); fails on the new assertion with the fixes disabled
- [x] Wizard config — template onboarding test passes
- [x] Auth suite — `auth-template-handoff` project (3 passed)
- [x] eslint clean on changed files; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SW45feQLMLPbzfpoSLYiMr
