### PR TITLE
feat(analytics): stamp origin on session_created/message_sent to separate onboarding auto-sends

### DIFF
--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -121,7 +121,7 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
         onMessageFailed?.(localId)
         throw error
       }
-      track('message_sent')
+      track('message_sent', { origin: 'user' })
     }, [onMessageSent, onMessageUuidAssigned, onMessageFailed, sendMessage, sessionId, agentSlug, track, composerOptions, isActive, isWaitingBackground]),
     submitDisabled: sendMessage.isPending || isOffline || !isRuntimeReady,
     draftKey: `session:${sessionId}`,

--- a/src/renderer/hooks/use-sessions.ts
+++ b/src/renderer/hooks/use-sessions.ts
@@ -94,6 +94,9 @@ export function useCreateSession() {
       model?: string
       // Provenance for sessions confirmed via a dashboard's dispatch dialog.
       dashboardDispatch?: SessionDashboardDispatch
+      // Analytics-only: distinguishes auto-started sessions (template onboarding)
+      // from user-typed ones. Not sent to the server.
+      origin?: 'user' | 'onboarding'
     }) => {
       const res = await apiFetch(`/api/agents/${data.agentSlug}/sessions`, {
         method: 'POST',
@@ -112,8 +115,9 @@ export function useCreateSession() {
       return res.json() as Promise<ApiSession & { initialMessageUuid: string }>
     },
     onSuccess: (_, variables) => {
-      track('session_created')
-      track('message_sent')
+      const origin = variables.origin ?? 'user'
+      track('session_created', { origin })
+      track('message_sent', { origin })
       queryClient.invalidateQueries({
         queryKey: ['sessions', resolveAgentSlugFromCache(queryClient, variables.agentSlug)],
       })

--- a/src/renderer/hooks/use-start-onboarding-session.ts
+++ b/src/renderer/hooks/use-start-onboarding-session.ts
@@ -25,6 +25,7 @@ export function useStartOnboardingSession() {
         const session = await createSession.mutateAsync({
           agentSlug,
           message: firstPrompt?.trim() || ONBOARDING_MESSAGE,
+          origin: 'onboarding',
         })
         void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: agentSlug, sessionId: session.id } })
       } catch {


### PR DESCRIPTION
## What

Adds an `origin` event property (`user` | `onboarding`) to the client `session_created` and `message_sent` analytics events.

## Why

Installing an agent template that has an onboarding skill auto-starts a session via `useStartOnboardingSession` → `useCreateSession`, which fires `session_created` + `message_sent` with **zero user typing** (the synthetic "This agent was just set up from a template…" message, or the template's `first_prompt` since #887). Those events carried no properties at all, so synthetic onboarding sends were indistinguishable from real user messages in Amplitude — every template-with-onboarding install inflated `message_sent`/`session_created` by 1 and polluted engagement funnels.

## How

- `useCreateSession` accepts an analytics-only `origin` field (never sent to the server) and stamps it on both `onSuccess` events, defaulting to `user`.
- `useStartOnboardingSession` passes `origin: 'onboarding'`. All other `useCreateSession` callers (agent home composer, quick dispatch, create-agent form, dashboard dispatch) are user-typed and use the default.
- The in-session emitter in `message-input.tsx` stamps `origin: 'user'` so after rollout `(none)` cleanly means "pre-rollout client" (same convention as `agent_created.has_template_prompt`, #797).

No new event names; `origin` is not a reserved wrapper property.

## Testing

- `tsc --noEmit` clean.
- `vitest run` on the touched suites (use-sessions, create-agent-form, create-agent-form.handoff, quick-dispatch): 51/51 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
