### PR TITLE
Show the cloud build on the local-tab sidebar chip (SUP-754)

### DIFF
--- a/src/main/api-target.test.ts
+++ b/src/main/api-target.test.ts
@@ -53,36 +53,39 @@ beforeEach(() => {
 
 describe('resolveApiTargetForRenderer', () => {
   it('serves the local API by default', () => {
-    expect(resolveApiTargetForRenderer(LOCAL, CLOUD)).toEqual({
+    expect(resolveApiTargetForRenderer(LOCAL, CLOUD, CLOUD)).toEqual({
       target: 'local',
       baseUrl: LOCAL,
       fallback: null,
+      cloudBaseUrl: CLOUD,
     })
   })
 
   it('serves the keyed proxy prefix when cloud is stored and reachable', () => {
     settings.value.apiTarget = 'cloud'
-    expect(resolveApiTargetForRenderer(LOCAL, CLOUD)).toEqual({
+    expect(resolveApiTargetForRenderer(LOCAL, CLOUD, CLOUD)).toEqual({
       target: 'cloud',
       baseUrl: CLOUD,
       fallback: null,
+      cloudBaseUrl: CLOUD,
     })
   })
 
   it('degrades to local, with a reason, when the workspace is gone', () => {
     settings.value.apiTarget = 'cloud'
-    expect(resolveApiTargetForRenderer(LOCAL, null)).toEqual({
+    expect(resolveApiTargetForRenderer(LOCAL, null, CLOUD)).toEqual({
       target: 'local',
       baseUrl: LOCAL,
       fallback: 'no-workspace',
+      cloudBaseUrl: CLOUD,
     })
   })
 
   it('gives every renderer the same answer', () => {
     settings.value.apiTarget = 'cloud'
     // The main window and the launcher ask separately; they must not diverge.
-    expect(resolveApiTargetForRenderer(LOCAL, CLOUD)).toEqual(
-      resolveApiTargetForRenderer(LOCAL, CLOUD),
+    expect(resolveApiTargetForRenderer(LOCAL, CLOUD, CLOUD)).toEqual(
+      resolveApiTargetForRenderer(LOCAL, CLOUD, CLOUD),
     )
   })
 })
@@ -90,7 +93,7 @@ describe('resolveApiTargetForRenderer', () => {
 describe('applyPreferredApiTarget', () => {
   it('records the choice for subsequent boots', () => {
     applyPreferredApiTarget('cloud')
-    expect(resolveApiTargetForRenderer(LOCAL, CLOUD).target).toBe('cloud')
+    expect(resolveApiTargetForRenderer(LOCAL, CLOUD, CLOUD).target).toBe('cloud')
   })
 
   it('tears down the launcher so it cannot keep driving the old target', () => {
@@ -102,7 +105,7 @@ describe('applyPreferredApiTarget', () => {
     settings.value.apiTarget = 'cloud'
     applyPreferredApiTarget('local')
 
-    expect(resolveApiTargetForRenderer(LOCAL, CLOUD).target).toBe('local')
+    expect(resolveApiTargetForRenderer(LOCAL, CLOUD, CLOUD).target).toBe('local')
     expect(closeQuickDispatchWindow).toHaveBeenCalled()
   })
 

--- a/src/main/api-target.ts
+++ b/src/main/api-target.ts
@@ -18,20 +18,25 @@ import { refreshAppMenu } from './app-menu'
  */
 
 /**
- * The answer handed to a renderer at boot. `cloudBaseUrl` is null when there is
- * no cloud workspace or no live token for one — which is also the validation
- * step for a stored "cloud" preference, so a disconnected account degrades to a
- * working local app rather than a wall of failures.
+ * The answer handed to a renderer at boot. `cloudBaseUrl` is the reachable
+ * cloud target (null without a workspace or live token) and is also the
+ * validation step for a stored "cloud" preference, so a disconnected account
+ * degrades to a working local app rather than a wall of failures.
+ * `cloudProxyBaseUrl` is the door itself — handed to every window whether or
+ * not a token exists, so a workspace connected mid-session is reachable
+ * without a reload.
  */
 export function resolveApiTargetForRenderer(
   localBaseUrl: string,
   cloudBaseUrl: string | null,
+  cloudProxyBaseUrl: string | null,
 ): ResolvedApiTarget {
   const { target, fallback } = resolveApiTarget(readPreferredApiTarget(), cloudBaseUrl)
   return {
     target,
     baseUrl: target === 'cloud' && cloudBaseUrl ? cloudBaseUrl : localBaseUrl,
     fallback,
+    cloudBaseUrl: cloudProxyBaseUrl,
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -474,15 +474,25 @@ ipcMain.handle('get-api-url', () => {
   return `http://localhost:${actualApiPort}`
 })
 
+/** The cloud proxy door, or null when the proxy is not enabled. */
+function cloudProxyBaseUrl(): string | null {
+  if (!isCloudProxyEnabled()) return null
+  return `http://localhost:${actualApiPort}${CLOUD_PROXY_PREFIX}/${getCloudProxyKey()}`
+}
+
 /** The cloud proxy's base URL, or null when there is no workspace to drive. */
 function cloudApiBaseUrl(): string | null {
-  if (!isCloudProxyEnabled() || !resolveCloudProxyTarget()) return null
-  return `http://localhost:${actualApiPort}${CLOUD_PROXY_PREFIX}/${getCloudProxyKey()}`
+  if (!resolveCloudProxyTarget()) return null
+  return cloudProxyBaseUrl()
 }
 
 /** Which Superagent this app is driving, and the base URL that reaches it. */
 function activeApiTarget() {
-  return resolveApiTargetForRenderer(`http://localhost:${actualApiPort}`, cloudApiBaseUrl())
+  return resolveApiTargetForRenderer(
+    `http://localhost:${actualApiPort}`,
+    cloudApiBaseUrl(),
+    cloudProxyBaseUrl(),
+  )
 }
 
 // Which Superagent this renderer drives, settled in main rather than in the

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -1017,7 +1017,7 @@ describe('footer version in cloud mode', () => {
 
     await userEvent.click(screen.getByTestId('sidebar-version-cloud'))
     expect(mockOpenExternalUrl).toHaveBeenCalledWith(
-      'https://platform.example/dashboard/organizations/org_1?tab=cloud',
+      'https://platform.example/dashboard/organizations/org_1?tab=settings',
     )
   })
 

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -106,8 +106,15 @@ vi.mock('@renderer/hooks/use-user-settings', () => ({
 const mockRuntimeStatus: { runtimeReadiness: { status: string }; appVersion?: string } = {
   runtimeReadiness: { status: 'READY' },
 }
+/** The deployment's own runtime status, read through the cloud proxy on both tabs. */
+const mockCloudRuntimeStatus: { appVersion?: string } = {}
+let mockCloudRuntimeLoading = false
 vi.mock('@renderer/hooks/use-runtime-status', () => ({
   useRuntimeStatus: () => ({ data: mockRuntimeStatus }),
+  useCloudRuntimeStatus: () => ({
+    data: mockCloudRuntimeStatus,
+    isLoading: mockCloudRuntimeLoading,
+  }),
 }))
 
 vi.mock('@renderer/hooks/use-artifacts', () => ({
@@ -186,9 +193,16 @@ vi.mock('@renderer/context/update-status-context', () => ({
   useUpdateStatus: () => mockUpdateStatus,
 }))
 
-const mockPlatformAuth: { platformBaseUrl?: string; orgId?: string } = {}
+const mockPlatformAuth: { platformBaseUrl?: string; orgId?: string; connected?: boolean } = {}
 vi.mock('@renderer/hooks/use-platform-auth', () => ({
-  usePlatformAuthStatus: () => ({ data: mockPlatformAuth }),
+  usePlatformAuthStatus: () => ({ data: mockPlatformAuth, isLoading: false }),
+}))
+
+const mockCloudWorkspaceQuery: { data?: { found: boolean; hasValidToken: boolean }; isLoading: boolean } = {
+  isLoading: false,
+}
+vi.mock('@renderer/hooks/use-cloud-workspace', () => ({
+  useCloudWorkspace: () => mockCloudWorkspaceQuery,
 }))
 
 const mockOpenExternalUrl = vi.fn()
@@ -435,11 +449,16 @@ beforeEach(() => {
   mockUnreadCount.mockReturnValue({ data: { count: 0 } })
   mockUserSettings.mockReturnValue({ setupCompleted: true, agentOrder: [] })
   delete mockRuntimeStatus.appVersion
+  delete mockCloudRuntimeStatus.appVersion
   mockRuntimeStatus.runtimeReadiness = { status: 'READY' }
   mockUpdateStatus.state = 'idle'
   delete mockUpdateStatus.version
   delete mockPlatformAuth.platformBaseUrl
   delete mockPlatformAuth.orgId
+  delete mockPlatformAuth.connected
+  mockCloudWorkspaceQuery.data = undefined
+  mockCloudWorkspaceQuery.isLoading = false
+  mockCloudRuntimeLoading = false
   mockOpenExternalUrl.mockReset()
   mockNavigate.mockReset()
   mockGetItemsFromDataTransfer.mockReset()
@@ -960,13 +979,14 @@ describe('footer version in cloud mode', () => {
   })
 
   afterEach(() => {
-    delete mockRuntimeStatus.appVersion
+    delete mockCloudRuntimeStatus.appVersion
+    mockCloudRuntimeLoading = false
     mockUpdateStatus.state = 'idle'
     delete mockUpdateStatus.version
   })
 
   it('shows one number when desktop and cloud match and no update is waiting', async () => {
-    mockRuntimeStatus.appVersion = desktopVersion
+    mockCloudRuntimeStatus.appVersion = desktopVersion
 
     renderWithProviders(<AppSidebar />)
 
@@ -981,7 +1001,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('shows a quiet pair when they differ and nobody is behind', async () => {
-    mockRuntimeStatus.appVersion = PATCH_AHEAD
+    mockCloudRuntimeStatus.appVersion = PATCH_AHEAD
     mockPlatformAuth.platformBaseUrl = 'https://platform.example'
     mockPlatformAuth.orgId = 'org_1'
 
@@ -1002,7 +1022,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('puts a blue dot on cloud when it is a patch behind', () => {
-    mockRuntimeStatus.appVersion = PATCH_BEHIND
+    mockCloudRuntimeStatus.appVersion = PATCH_BEHIND
 
     renderWithProviders(<AppSidebar />)
 
@@ -1012,7 +1032,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('puts an orange dot on cloud when it is a major or minor behind', () => {
-    mockRuntimeStatus.appVersion = MINOR_BEHIND
+    mockCloudRuntimeStatus.appVersion = MINOR_BEHIND
 
     renderWithProviders(<AppSidebar />)
 
@@ -1021,7 +1041,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('puts an orange dot on desktop when the feed matches a newer cloud', () => {
-    mockRuntimeStatus.appVersion = MINOR_AHEAD
+    mockCloudRuntimeStatus.appVersion = MINOR_AHEAD
     mockUpdateStatus.state = 'available'
     mockUpdateStatus.version = MINOR_AHEAD
 
@@ -1032,7 +1052,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('puts orange dots on both when they match and the feed is a major ahead', () => {
-    mockRuntimeStatus.appVersion = desktopVersion
+    mockCloudRuntimeStatus.appVersion = desktopVersion
     mockUpdateStatus.state = 'available'
     mockUpdateStatus.version = MAJOR_AHEAD
 
@@ -1045,7 +1065,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('keeps one number and a desktop update dot when they match the feed', () => {
-    mockRuntimeStatus.appVersion = desktopVersion
+    mockCloudRuntimeStatus.appVersion = desktopVersion
     mockUpdateStatus.state = 'available'
     mockUpdateStatus.version = desktopVersion
 
@@ -1064,7 +1084,7 @@ describe('footer version in cloud mode', () => {
   })
 
   it('falls back to the desktop number when appVersion is not a version', () => {
-    mockRuntimeStatus.appVersion = 'not-a-version'
+    mockCloudRuntimeStatus.appVersion = 'not-a-version'
 
     renderWithProviders(<AppSidebar />)
 
@@ -1073,13 +1093,76 @@ describe('footer version in cloud mode', () => {
   })
 
   it('does not open the cloud tab when org is missing', async () => {
-    mockRuntimeStatus.appVersion = PATCH_AHEAD
+    mockCloudRuntimeStatus.appVersion = PATCH_AHEAD
     mockPlatformAuth.platformBaseUrl = 'https://platform.example'
 
     renderWithProviders(<AppSidebar />)
 
     await userEvent.click(screen.getByTestId('sidebar-version-cloud'))
     expect(mockOpenExternalUrl).not.toHaveBeenCalled()
+  })
+})
+
+describe('footer version on the local tab', () => {
+  const desktopVersion = APP_VERSION
+
+  beforeEach(() => {
+    _resetApiTargetForTest()
+    setActiveTarget('local', null)
+  })
+
+  afterEach(() => {
+    delete mockCloudRuntimeStatus.appVersion
+    mockCloudRuntimeLoading = false
+    mockUpdateStatus.state = 'idle'
+    delete mockUpdateStatus.version
+  })
+
+  it('shows no chip while the cloud version is still loading', () => {
+    mockCloudRuntimeLoading = true
+    mockCloudRuntimeStatus.appVersion = PATCH_AHEAD
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.queryByTestId('sidebar-version')).not.toBeInTheDocument()
+  })
+
+  it('shows no chip while the workspace check is still in flight', () => {
+    mockIsElectron.mockReturnValue(true)
+    mockPlatformAuth.connected = true
+    mockCloudWorkspaceQuery.isLoading = true
+    mockCloudRuntimeStatus.appVersion = PATCH_AHEAD
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.queryByTestId('sidebar-version')).not.toBeInTheDocument()
+  })
+
+  it('shows the pair when the cloud workspace runs a different build', () => {
+    mockCloudRuntimeStatus.appVersion = PATCH_AHEAD
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-version-desktop')).toHaveTextContent(`${desktopVersion}`)
+    expect(screen.getByTestId('sidebar-version-cloud')).toHaveTextContent(PATCH_AHEAD)
+    expect(screen.queryByLabelText('Desktop update available')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Cloud update available')).not.toBeInTheDocument()
+  })
+
+  it('shows one number when there is no cloud workspace to compare against', () => {
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`${desktopVersion}`)
+    expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
+  })
+
+  it('does not take the cloud number from the active-tab runtime status', () => {
+    mockRuntimeStatus.appVersion = PATCH_AHEAD
+
+    renderWithProviders(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-version')).toHaveTextContent(`${desktopVersion}`)
+    expect(screen.queryByTestId('sidebar-version-cloud')).not.toBeInTheDocument()
   })
 })
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1695,7 +1695,7 @@ export function AppSidebar() {
                   const orgId = platformAuth?.orgId
                   if (!base || !orgId) return
                   void openExternalUrl(
-                    `${base}/dashboard/organizations/${orgId}?tab=cloud`,
+                    `${base}/dashboard/organizations/${orgId}?tab=settings`,
                   )
                 }}
                 className="inline-flex items-center gap-0.5 hover:text-foreground"

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -9,7 +9,6 @@ import { AppLink } from '@renderer/components/ui/app-link'
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { isElectron, getPlatform, openDashboardExternal } from '@renderer/lib/env'
 import { openExternalUrl } from '@renderer/lib/open-external'
-import { targetIsRemote } from '@renderer/lib/api-target'
 import { resolveSidebarVersionState } from '@renderer/components/layout/sidebar-version-state'
 import { TargetSwitcher } from '@renderer/components/layout/target-switcher'
 import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
@@ -54,7 +53,7 @@ import { useSessions, type ApiSession } from '@renderer/hooks/use-sessions'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useSettings } from '@renderer/hooks/use-settings'
 import { useUserSettings, useUpdateUserSettings } from '@renderer/hooks/use-user-settings'
-import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
+import { useCloudRuntimeStatus, useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
 import { useCreateUntitledAgent } from '@renderer/hooks/use-create-untitled-agent'
 import { AgentStatus } from '@renderer/components/agents/agent-status'
@@ -869,12 +868,13 @@ export function AppSidebar() {
   const { data: userSettings } = useUserSettings()
   const updateSettings = useUpdateUserSettings()
   const { data: runtimeStatus } = useRuntimeStatus()
+  const { data: cloudStatus, isLoading: cloudVersionPending } = useCloudRuntimeStatus()
+  const { availabilityPending } = useTargetSwitch()
   const { data: platformAuth } = usePlatformAuthStatus()
-  const isCloud = targetIsRemote()
   const desktopVersion = __APP_VERSION__
   const versionState = resolveSidebarVersionState({
     desktopVersion,
-    cloudVersion: isCloud ? runtimeStatus?.appVersion : undefined,
+    cloudVersion: cloudStatus?.appVersion,
     feedVersion: updateAvailable ? updateStatus.version : undefined,
   })
   const isFullScreen = useFullScreen()
@@ -1665,7 +1665,8 @@ export function AppSidebar() {
             <Settings className="h-4 w-4" />
             <span>Settings</span>
           </SidebarMenuButton>
-          {isCloud && versionState.showPair && versionState.cloudVersion ? (
+          {!cloudVersionPending && !availabilityPending &&
+            (versionState.showPair && versionState.cloudVersion ? (
             <div
               className="flex items-center gap-1.5 px-2 text-xs text-muted-foreground shrink-0"
               data-testid="sidebar-version"
@@ -1716,18 +1717,18 @@ export function AppSidebar() {
               type="button"
               onClick={() => openSettings('general')}
               className="inline-flex items-center gap-1.5 px-2 text-xs text-muted-foreground shrink-0 hover:text-foreground"
-              title={updateAvailable ? `${isCloud ? 'Desktop update available' : 'Update available'}: v${updateStatus.version}` : undefined}
+              title={updateAvailable ? `${versionState.cloudVersion ? 'Desktop update available' : 'Update available'}: v${updateStatus.version}` : undefined}
               data-testid="sidebar-version"
             >
               <span>{versionState.cloudVersion ?? desktopVersion}</span>
               {updateAvailable && (
                 <span
                   className="h-1.5 w-1.5 rounded-full bg-blue-500"
-                  aria-label={isCloud ? 'Desktop update available' : 'Update available'}
+                  aria-label={versionState.cloudVersion ? 'Desktop update available' : 'Update available'}
                 />
               )}
             </button>
-          )}
+          ))}
         </div>
       </SidebarFooter>
 

--- a/src/renderer/hooks/use-runtime-status.test.tsx
+++ b/src/renderer/hooks/use-runtime-status.test.tsx
@@ -10,6 +10,8 @@ const { mockGetApiBaseUrl, mockGetCloudApiBaseUrl, mockUseTargetSwitch } = vi.ho
   mockUseTargetSwitch: vi.fn(() => ({ available: false })),
 }))
 
+// `lib/api` is deliberately NOT mocked: the wrappers are what put the origin on
+// the request, so stubbing them would leave the thing under test untested.
 vi.mock('@renderer/lib/env', () => ({
   getApiBaseUrl: mockGetApiBaseUrl,
   getCloudApiBaseUrl: mockGetCloudApiBaseUrl,
@@ -17,10 +19,8 @@ vi.mock('@renderer/lib/env', () => ({
 vi.mock('@renderer/hooks/use-target-switch', () => ({
   useTargetSwitch: mockUseTargetSwitch,
 }))
-vi.mock('@renderer/lib/api', () => ({
-  handleUnauthorizedResponse: vi.fn(async () => {}),
-}))
 
+import { cloudApiFetch } from '@renderer/lib/api'
 import { useCloudRuntimeStatus, useRuntimeStatus } from './use-runtime-status'
 
 const LOCAL = 'http://localhost:3000'
@@ -75,17 +75,17 @@ describe('useCloudRuntimeStatus', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
-  it('fetches the deployment through the door', async () => {
+  it('fetches the deployment through the door, not this window', async () => {
     mockGetCloudApiBaseUrl.mockReturnValue(DOOR)
     mockUseTargetSwitch.mockReturnValue({ available: true })
     const { result } = renderHook(() => useCloudRuntimeStatus(), { wrapper })
     await waitFor(() => expect(result.current.data?.appVersion).toBe('1.2.3'))
-    expect(fetch).toHaveBeenCalledWith(`${DOOR}/api/runtime-status`)
+    expect(fetch).toHaveBeenCalledWith(`${DOOR}/api/runtime-status`, undefined)
   })
 })
 
-describe('URL-keyed cache', () => {
-  it('keeps the two polls on different keys when the URLs differ', async () => {
+describe('cache keys', () => {
+  it('keeps the two polls apart so neither serves the other its number', async () => {
     mockGetCloudApiBaseUrl.mockReturnValue(DOOR)
     mockUseTargetSwitch.mockReturnValue({ available: true })
     const client = new QueryClient({
@@ -114,5 +114,70 @@ describe('URL-keyed cache', () => {
         ['runtime-status', DOOR],
       ]),
     )
+  })
+
+  it('collapses onto one query when both origins are the same Superagent', async () => {
+    // The cloud tab: this window already drives the deployment, so both getters
+    // return the proxy door. Two entries here would poll it twice every 30s.
+    mockGetApiBaseUrl.mockReturnValue(DOOR)
+    mockGetCloudApiBaseUrl.mockReturnValue(DOOR)
+    mockUseTargetSwitch.mockReturnValue({ available: true })
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    const { result } = renderHook(
+      () => {
+        useRuntimeStatus()
+        return useCloudRuntimeStatus()
+      },
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      },
+    )
+    await waitFor(() => expect(result.current.data?.appVersion).toBe('1.2.3'))
+    expect(client.getQueryCache().getAll()).toHaveLength(1)
+    expect(vi.mocked(fetch).mock.calls).toHaveLength(1)
+  })
+
+  it('still serves the cloud reader when only the local poll is enabled', async () => {
+    // Pins the react-query semantics the collapse above rests on: a query runs
+    // while ANY observer is enabled, and a disabled observer sharing the key
+    // still reads the result. Not a reachable product state — the keys only
+    // match on the cloud tab, where `available` is unconditionally true — but
+    // the collapse is only safe *because* of this, and nothing else asserts it.
+    mockGetApiBaseUrl.mockReturnValue(DOOR)
+    mockGetCloudApiBaseUrl.mockReturnValue(DOOR)
+    mockUseTargetSwitch.mockReturnValue({ available: false })
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    const { result } = renderHook(
+      () => {
+        useRuntimeStatus()
+        return useCloudRuntimeStatus()
+      },
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      },
+    )
+    await waitFor(() => expect(result.current.data?.appVersion).toBe('1.2.3'))
+    expect(vi.mocked(fetch).mock.calls).toHaveLength(1)
+  })
+})
+
+describe('cloudApiFetch', () => {
+  it('refuses to fall back to this window when there is no door', async () => {
+    // The hook gates on the door, so this throw is a backstop. It matters
+    // because the silent alternative answers a question about the deployment
+    // with the laptop's own number, which is indistinguishable in the UI.
+    mockGetCloudApiBaseUrl.mockReturnValue(null)
+    await expect(cloudApiFetch('/api/runtime-status')).rejects.toThrow(
+      'Cloud proxy door is not available',
+    )
+    expect(fetch).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/use-runtime-status.test.tsx
+++ b/src/renderer/hooks/use-runtime-status.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+const { mockGetApiBaseUrl, mockGetCloudApiBaseUrl, mockUseTargetSwitch } = vi.hoisted(() => ({
+  mockGetApiBaseUrl: vi.fn(() => ''),
+  mockGetCloudApiBaseUrl: vi.fn((): string | null => null),
+  mockUseTargetSwitch: vi.fn(() => ({ available: false })),
+}))
+
+vi.mock('@renderer/lib/env', () => ({
+  getApiBaseUrl: mockGetApiBaseUrl,
+  getCloudApiBaseUrl: mockGetCloudApiBaseUrl,
+}))
+vi.mock('@renderer/hooks/use-target-switch', () => ({
+  useTargetSwitch: mockUseTargetSwitch,
+}))
+vi.mock('@renderer/lib/api', () => ({
+  handleUnauthorizedResponse: vi.fn(async () => {}),
+}))
+
+import { useCloudRuntimeStatus, useRuntimeStatus } from './use-runtime-status'
+
+const LOCAL = 'http://localhost:3000'
+const DOOR = 'http://localhost:3000/cloud/KEY123'
+
+const STATUS = {
+  runtimeReadiness: { status: 'READY' },
+  hasRunningAgents: false,
+  apiKeyConfigured: true,
+  servicesInitError: null,
+  appVersion: '1.2.3',
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  mockGetApiBaseUrl.mockReturnValue(LOCAL)
+  mockGetCloudApiBaseUrl.mockReturnValue(null)
+  mockUseTargetSwitch.mockReturnValue({ available: false })
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(STATUS), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    ),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useCloudRuntimeStatus', () => {
+  it('does not fetch when the door is missing', () => {
+    renderHook(() => useCloudRuntimeStatus(), { wrapper })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when a workspace is not reachable', () => {
+    mockGetCloudApiBaseUrl.mockReturnValue(DOOR)
+    mockUseTargetSwitch.mockReturnValue({ available: false })
+    renderHook(() => useCloudRuntimeStatus(), { wrapper })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches the deployment through the door', async () => {
+    mockGetCloudApiBaseUrl.mockReturnValue(DOOR)
+    mockUseTargetSwitch.mockReturnValue({ available: true })
+    const { result } = renderHook(() => useCloudRuntimeStatus(), { wrapper })
+    await waitFor(() => expect(result.current.data?.appVersion).toBe('1.2.3'))
+    expect(fetch).toHaveBeenCalledWith(`${DOOR}/api/runtime-status`)
+  })
+})
+
+describe('URL-keyed cache', () => {
+  it('keeps the two polls on different keys when the URLs differ', async () => {
+    mockGetCloudApiBaseUrl.mockReturnValue(DOOR)
+    mockUseTargetSwitch.mockReturnValue({ available: true })
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    renderHook(
+      () => {
+        useRuntimeStatus()
+        useCloudRuntimeStatus()
+      },
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      },
+    )
+    await waitFor(() => {
+      const urls = vi.mocked(fetch).mock.calls.map((call) => call[0])
+      expect(urls).toContain(`${LOCAL}/api/runtime-status`)
+      expect(urls).toContain(`${DOOR}/api/runtime-status`)
+    })
+    const keys = client.getQueryCache().getAll().map((query) => query.queryKey)
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        ['runtime-status', LOCAL],
+        ['runtime-status', DOOR],
+      ]),
+    )
+  })
+})

--- a/src/renderer/hooks/use-runtime-status.ts
+++ b/src/renderer/hooks/use-runtime-status.ts
@@ -1,5 +1,5 @@
 import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
-import { handleUnauthorizedResponse } from '@renderer/lib/api'
+import { apiFetch, cloudApiFetch } from '@renderer/lib/api'
 import { getApiBaseUrl, getCloudApiBaseUrl } from '@renderer/lib/env'
 import { useQuery } from '@tanstack/react-query'
 import type { RuntimeReadiness } from '@shared/lib/container/types'
@@ -14,36 +14,37 @@ export interface RuntimeStatusResponse {
   appVersion?: string
 }
 
-async function fetchRuntimeStatus(baseUrl: string): Promise<RuntimeStatusResponse> {
-  const res = await fetch(`${baseUrl}/api/runtime-status`)
-  await handleUnauthorizedResponse(res.status, '/api/runtime-status')
+async function readRuntimeStatus(res: Response): Promise<RuntimeStatusResponse> {
   if (!res.ok) throw new Error('Failed to fetch runtime status')
   return res.json()
 }
 
 export function useRuntimeStatus() {
-  const baseUrl = getApiBaseUrl()
   return useQuery<RuntimeStatusResponse>({
-    queryKey: ['runtime-status', baseUrl],
-    queryFn: () => fetchRuntimeStatus(baseUrl),
+    queryKey: ['runtime-status', getApiBaseUrl()],
+    queryFn: async () => readRuntimeStatus(await apiFetch('/api/runtime-status')),
     refetchInterval: 30000,
   })
 }
 
 /**
- * The deployment's runtime status on either tab. Single source for the
- * cloud number. Enabled while the cloud proxy door exists and a workspace
- * is reachable (the same live check that shows the Local/Cloud switcher).
+ * The deployment's runtime status on either tab. Single source for the cloud
+ * number. Enabled while the cloud proxy door exists and a workspace is
+ * reachable (the same live check that shows the Local/Cloud switcher).
+ *
+ * Keyed by origin rather than by a literal, so that on the cloud tab — where
+ * this window already drives the deployment and both origins are the same
+ * string — this collapses onto `useRuntimeStatus`'s query instead of polling
+ * the same server twice every 30 seconds. The origin is a cache key here and
+ * never a URL: both requests are composed by the wrappers above, which is why
+ * this module's entry in the origin characterization inventory says so.
  */
 export function useCloudRuntimeStatus() {
   const door = getCloudApiBaseUrl()
   const { available } = useTargetSwitch()
   return useQuery<RuntimeStatusResponse>({
     queryKey: ['runtime-status', door],
-    queryFn: () => {
-      if (door === null) throw new Error('Cloud proxy door is not available')
-      return fetchRuntimeStatus(door)
-    },
+    queryFn: async () => readRuntimeStatus(await cloudApiFetch('/api/runtime-status')),
     enabled: door !== null && available,
     refetchInterval: 30000,
   })

--- a/src/renderer/hooks/use-runtime-status.ts
+++ b/src/renderer/hooks/use-runtime-status.ts
@@ -1,4 +1,6 @@
-import { apiFetch } from '@renderer/lib/api'
+import { useTargetSwitch } from '@renderer/hooks/use-target-switch'
+import { handleUnauthorizedResponse } from '@renderer/lib/api'
+import { getApiBaseUrl, getCloudApiBaseUrl } from '@renderer/lib/env'
 import { useQuery } from '@tanstack/react-query'
 import type { RuntimeReadiness } from '@shared/lib/container/types'
 
@@ -12,14 +14,37 @@ export interface RuntimeStatusResponse {
   appVersion?: string
 }
 
+async function fetchRuntimeStatus(baseUrl: string): Promise<RuntimeStatusResponse> {
+  const res = await fetch(`${baseUrl}/api/runtime-status`)
+  await handleUnauthorizedResponse(res.status, '/api/runtime-status')
+  if (!res.ok) throw new Error('Failed to fetch runtime status')
+  return res.json()
+}
+
 export function useRuntimeStatus() {
+  const baseUrl = getApiBaseUrl()
   return useQuery<RuntimeStatusResponse>({
-    queryKey: ['runtime-status'],
-    queryFn: async () => {
-      const res = await apiFetch('/api/runtime-status')
-      if (!res.ok) throw new Error('Failed to fetch runtime status')
-      return res.json()
+    queryKey: ['runtime-status', baseUrl],
+    queryFn: () => fetchRuntimeStatus(baseUrl),
+    refetchInterval: 30000,
+  })
+}
+
+/**
+ * The deployment's runtime status on either tab. Single source for the
+ * cloud number. Enabled while the cloud proxy door exists and a workspace
+ * is reachable (the same live check that shows the Local/Cloud switcher).
+ */
+export function useCloudRuntimeStatus() {
+  const door = getCloudApiBaseUrl()
+  const { available } = useTargetSwitch()
+  return useQuery<RuntimeStatusResponse>({
+    queryKey: ['runtime-status', door],
+    queryFn: () => {
+      if (door === null) throw new Error('Cloud proxy door is not available')
+      return fetchRuntimeStatus(door)
     },
+    enabled: door !== null && available,
     refetchInterval: 30000,
   })
 }

--- a/src/renderer/hooks/use-target-switch.test.tsx
+++ b/src/renderer/hooks/use-target-switch.test.tsx
@@ -105,6 +105,37 @@ describe('availability', () => {
     renderHook(() => useTargetSwitch())
     expect(mockUseCloudWorkspace.mock.calls[0][0]).toBe(false)
   })
+
+  it('is pending on local while the workspace check is in flight', () => {
+    setActiveTarget('local', null)
+    mockUseCloudWorkspace.mockReturnValue({ data: undefined, isLoading: true })
+    const { result } = renderHook(() => useTargetSwitch())
+    expect(result.current.availabilityPending).toBe(true)
+    expect(result.current.available).toBe(false)
+  })
+
+  it('is pending on local while platform auth is still loading', () => {
+    setActiveTarget('local', null)
+    mockUsePlatformAuthStatus.mockReturnValue({ data: undefined, isLoading: true })
+    const { result } = renderHook(() => useTargetSwitch())
+    expect(result.current.availabilityPending).toBe(true)
+  })
+
+  it('is not pending once the workspace check says none', () => {
+    setActiveTarget('local', null)
+    mockUseCloudWorkspace.mockReturnValue({ data: { found: false, hasValidToken: false }, isLoading: false })
+    const { result } = renderHook(() => useTargetSwitch())
+    expect(result.current.availabilityPending).toBe(false)
+    expect(result.current.available).toBe(false)
+  })
+
+  it('is not pending in cloud mode', () => {
+    setActiveTarget('cloud', null)
+    mockUseCloudWorkspace.mockReturnValue({ data: undefined, isLoading: true })
+    mockUsePlatformAuthStatus.mockReturnValue({ data: undefined, isLoading: true })
+    const { result } = renderHook(() => useTargetSwitch())
+    expect(result.current.availabilityPending).toBe(false)
+  })
 })
 
 describe('switching', () => {

--- a/src/renderer/hooks/use-target-switch.ts
+++ b/src/renderer/hooks/use-target-switch.ts
@@ -16,7 +16,7 @@ export function useTargetSwitch() {
   const [switching, setSwitching] = useState(false)
   const queryClient = useQueryClient()
 
-  const { data: platform } = usePlatformAuthStatus()
+  const { data: platform, isLoading: platformLoading } = usePlatformAuthStatus()
 
   // Only ask about cloud availability from the LOCAL side. In cloud mode every
   // request goes through the proxy to the deployment, and `getCloudWorkspace`
@@ -24,10 +24,14 @@ export function useTargetSwitch() {
   // "no cloud workspace" about itself, and the control would hide exactly when
   // the user needs it to get back. Being in cloud mode is its own proof.
   const canAsk = isElectron() && current === 'local' && platform?.connected === true
-  const { data: workspace } = useCloudWorkspace(canAsk, platform?.orgId)
+  const { data: workspace, isLoading: workspaceLoading } = useCloudWorkspace(canAsk, platform?.orgId)
 
   const cloudReachable =
     current === 'cloud' || (workspace?.found === true && workspace.hasValidToken === true)
+  // Local cannot treat "not yet asked" as "no workspace": that is the
+  // cloud→local first paint, and it would flash the single-number chip.
+  const availabilityPending =
+    isElectron() && current === 'local' && (platformLoading || (canAsk && workspaceLoading))
 
   const switchTo = useCallback(
     async (target: ApiTarget) => {
@@ -60,6 +64,8 @@ export function useTargetSwitch() {
     switching,
     /** Whether to offer the control at all. */
     available: isElectron() && cloudReachable,
+    /** Local side has not yet settled whether a workspace is reachable. */
+    availabilityPending,
     switchTo,
   }
 }

--- a/src/renderer/lib/api-origin.characterization.test.ts
+++ b/src/renderer/lib/api-origin.characterization.test.ts
@@ -9,6 +9,10 @@
  * `fetch` at all (an `<img src>`, an `EventSource`, a `WebSocket`, an Electron
  * `downloadURL`) and so cannot use the wrapper.
  *
+ * One exception, pinned below and nowhere else: `cloudApiFetch` prepends the
+ * cloud proxy door (`getCloudApiBaseUrl()`) so a local window can read the
+ * deployment's state without switching target. It is the door's only exit.
+ *
  * That invariant is currently upheld by convention alone. Nothing fails if a
  * new call site hardcodes a same-origin `/api/...` path: it works in the
  * browser, it works in Electron dev, and it only breaks where the API is not
@@ -106,6 +110,24 @@ const PINNED_CALL_SITES: Record<string, string> = {
     'third-party Deepgram STT endpoint, not this API — must NOT follow the API origin',
   'lib/stt.ts::OpenaiAdapter.createSocket::WebSocket(url)':
     'third-party OpenAI STT endpoint, not this API — must NOT follow the API origin',
+  // The one sanctioned second origin. Pinned rather than taught to the analysis
+  // above on purpose: making `getCloudApiBaseUrl()` derive an origin would bless
+  // every future use of it, including `${getCloudApiBaseUrl()}/api/x` with no
+  // null check (a same-origin path when the door is absent) and a
+  // `getCloudApiBaseUrl() ?? getApiBaseUrl()` fallback that answers a question
+  // about the deployment with this laptop. One exemption, read once.
+  //
+  // The `${...}` below is the call's argument text quoted verbatim, which is
+  // what makes a pin re-open for review when the call changes — not an
+  // interpolation that lost its backticks.
+  // eslint-disable-next-line no-template-curly-in-string
+  'lib/api.ts::cloudApiFetch::fetch(`${baseUrl}${path}`)':
+    'the cloud proxy door (getCloudApiBaseUrl(), lib/env.ts) — handed to every ' +
+    'window at boot so a local window can read the deployment without ' +
+    'switching target, null-checked here before use. This wrapper is the ' +
+    "door's only exit: a new site that builds a URL from it fails the " +
+    'assertion above and must route through cloudApiFetch or be pinned here ' +
+    'with its own reason.',
   'lib/voice-agent-deepgram.ts::DeepgramVoiceAgentAdapter.connect::WebSocket(url)':
     'third-party Deepgram voice-agent socket — must NOT follow the API origin',
   'lib/voice-agent-openai.ts::OpenAIVoiceAgentAdapter.connect::WebSocket(url)':
@@ -124,12 +146,18 @@ const EXTERNAL_ENDPOINT_MODULES = [
 ]
 
 /**
- * Modules that call `getApiBaseUrl()` directly instead of going through
- * `apiFetch`, and why the wrapper does not fit. Every entry is a URL handed to
- * something that cannot carry a request header.
+ * Modules that read an origin getter directly instead of leaving the URL to
+ * `apiFetch`, and why the wrapper does not fit. Almost every entry is a URL
+ * handed to something that cannot carry a request header; the exception is
+ * called out in its own reason.
  *
  * Growing this list is a real cost: each entry has to be revisited by hand
  * whenever the API origin changes.
+ *
+ * Do not route around this list by re-exporting a getter under another name.
+ * The inventory is what catches the `<img src>` and `<iframe src>` class, which
+ * composes a URL without ever touching a network primitive, so an alias would
+ * leave such a module in no inventory and no pin.
  */
 const DIRECT_BASE_URL_CONSUMERS: Record<string, string> = {
   'lib/api.ts': 'the wrapper itself',
@@ -152,6 +180,11 @@ const DIRECT_BASE_URL_CONSUMERS: Record<string, string> = {
     'EventSource — global notification stream',
   'hooks/use-message-stream.ts': 'EventSource — per-session message stream',
   'hooks/use-browser-stream.ts': 'WebSocket — browser view frames',
+  'hooks/use-runtime-status.ts':
+    'the one entry that is NOT a URL: both origins are read as react-query ' +
+    'cache keys, so the local and cloud polls collapse onto one query on the ' +
+    'cloud tab, where the two are the same string. The requests themselves go ' +
+    'through apiFetch and cloudApiFetch — this module composes no URL.',
 }
 
 // ---------------------------------------------------------------------------
@@ -410,14 +443,32 @@ function allCallSites(): CallSite[] {
   )
 }
 
-/** Modules that reference `getApiBaseUrl` as a value. */
+/**
+ * Modules that reference an origin getter as a value.
+ *
+ * Both getters, not just `getApiBaseUrl`: a module that reads only the cloud
+ * door composes a URL no assertion above would see, because a door handed to an
+ * `<img src>` or an `<iframe src>` is not a network primitive at all. Keying on
+ * one getter would leave that module in no inventory and no pin.
+ *
+ * Deliberately NOT shared with `analyzeOrigin`, which still recognizes
+ * `getApiBaseUrl` alone. The two answer different questions: this one asks who
+ * can see an origin at all, that one asks whether a request provably starts
+ * from this window's API. Teaching `analyzeOrigin` the door would bless every
+ * future use of it — including `${getCloudApiBaseUrl()}/api/x` with no null
+ * check, and a `door ?? local` fallback — which is what the pin on
+ * `cloudApiFetch` above exists to avoid. The scanner suite has a case pinning
+ * that difference; do not unify these two sets.
+ */
+const ORIGIN_GETTERS = new Set(['getApiBaseUrl', 'getCloudApiBaseUrl'])
+
 function directBaseUrlConsumers(): string[] {
   return collectSourceFiles(RENDERER_ROOT)
     .filter((file) => {
       const sourceFile = parseSource(relativeTo(file), fs.readFileSync(file, 'utf-8'))
       let uses = false
       const visit = (node: ts.Node): void => {
-        if (ts.isIdentifier(node) && node.text === 'getApiBaseUrl') uses = true
+        if (ts.isIdentifier(node) && ORIGIN_GETTERS.has(node.text)) uses = true
         ts.forEachChild(node, visit)
       }
       visit(sourceFile)
@@ -549,6 +600,28 @@ describe('scanner', () => {
       }
     `)
     expect(site.derivesOrigin).toBe(true)
+  })
+
+  it('does not treat the cloud door as an origin, so door URLs must be pinned', () => {
+    // The door is a real origin, but only `cloudApiFetch` may prepend it, and
+    // that one call site is pinned by name above. If this ever starts deriving,
+    // both shapes below pass unreviewed: the first is a document-relative
+    // `null/api/x` whenever the proxy is off, and the second answers a question
+    // about the deployment with this laptop.
+    const [bare] = scan(`
+      function load() {
+        return fetch(\`\${getCloudApiBaseUrl()}/api/agents\`)
+      }
+    `)
+    expect(bare.derivesOrigin).toBe(false)
+
+    const [fallback] = scan(`
+      function load() {
+        const base = getCloudApiBaseUrl() ?? getApiBaseUrl()
+        return fetch(\`\${base}/api/agents\`)
+      }
+    `)
+    expect(fallback.derivesOrigin).toBe(false)
   })
 
   it('rejects an identifier that merely happens to be named baseUrl', () => {

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from './env'
+import { getApiBaseUrl, getCloudApiBaseUrl } from './env'
 import { hasInteractiveLogin, isAuthMode } from './auth-mode'
 import { reportCloudSessionRejected } from './cloud-session'
 
@@ -14,6 +14,30 @@ export async function apiFetch(
   init?: RequestInit
 ): Promise<Response> {
   const baseUrl = getApiBaseUrl()
+  const response = await fetch(`${baseUrl}${path}`, init)
+  await handleUnauthorizedResponse(response.status, path)
+  return response
+}
+
+/**
+ * `apiFetch` against the cloud proxy door instead of this window's own API.
+ *
+ * The door is the second sanctioned origin (`getCloudApiBaseUrl()`), handed to
+ * every window at boot so a local window can read the deployment's state
+ * without switching target. Requests still leave over loopback — see
+ * `api/routes/cloud-proxy.ts`.
+ *
+ * Throws when the door is absent rather than falling back to the local origin:
+ * a silent fallback would answer a question about the deployment with this
+ * laptop's answer. Callers gate on `getCloudApiBaseUrl() !== null` first, so
+ * the throw is a backstop rather than a path anything reaches.
+ */
+export async function cloudApiFetch(
+  path: string,
+  init?: RequestInit
+): Promise<Response> {
+  const baseUrl = getCloudApiBaseUrl()
+  if (baseUrl === null) throw new Error('Cloud proxy door is not available')
   const response = await fetch(`${baseUrl}${path}`, init)
   await handleUnauthorizedResponse(response.status, path)
   return response

--- a/src/renderer/lib/env.api-target.test.ts
+++ b/src/renderer/lib/env.api-target.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ResolvedApiTarget } from '@shared/lib/api-target'
 import { _resetApiTargetForTest, getActiveTarget, getTargetFallbackReason } from './api-target'
-import { _resetApiBaseUrlForTest, getApiBaseUrl, initApiBaseUrl } from './env'
+import { _resetApiBaseUrlForTest, getApiBaseUrl, getCloudApiBaseUrl, initApiBaseUrl } from './env'
 
 /**
  * Boot-time target selection: which base URL every call site in the renderer
@@ -25,7 +25,7 @@ function stubWindow(electron?: ElectronStub | null) {
 
 const electron = (overrides: ElectronStub = {}): ElectronStub => ({
   getApiUrl: async () => LOCAL,
-  getApiTarget: async () => ({ target: 'local', baseUrl: LOCAL, fallback: null }),
+  getApiTarget: async () => ({ target: 'local', baseUrl: LOCAL, fallback: null, cloudBaseUrl: CLOUD }),
   ...overrides,
 })
 
@@ -46,18 +46,20 @@ describe('initApiBaseUrl', () => {
     await initApiBaseUrl()
 
     expect(getApiBaseUrl()).toBe(LOCAL)
+    expect(getCloudApiBaseUrl()).toBe(CLOUD)
     expect(getActiveTarget()).toBe('local')
   })
 
   it('uses the keyed proxy prefix when main resolves to cloud', async () => {
     stubWindow(
-      electron({ getApiTarget: async () => ({ target: 'cloud', baseUrl: CLOUD, fallback: null }) }),
+      electron({ getApiTarget: async () => ({ target: 'cloud', baseUrl: CLOUD, fallback: null, cloudBaseUrl: CLOUD }) }),
     )
     await initApiBaseUrl()
 
     // Every call site prefixes this, so this one value is what moves the whole
     // UI to the cloud workspace.
     expect(getApiBaseUrl()).toBe(CLOUD)
+    expect(getCloudApiBaseUrl()).toBe(CLOUD)
     expect(getActiveTarget()).toBe('cloud')
     expect(getTargetFallbackReason()).toBeNull()
   })
@@ -65,12 +67,13 @@ describe('initApiBaseUrl', () => {
   it('carries the reason main denied a stored cloud preference', async () => {
     stubWindow(
       electron({
-        getApiTarget: async () => ({ target: 'local', baseUrl: LOCAL, fallback: 'no-workspace' }),
+        getApiTarget: async () => ({ target: 'local', baseUrl: LOCAL, fallback: 'no-workspace', cloudBaseUrl: CLOUD }),
       }),
     )
     await initApiBaseUrl()
 
     expect(getApiBaseUrl()).toBe(LOCAL)
+    expect(getCloudApiBaseUrl()).toBe(CLOUD)
     expect(getActiveTarget()).toBe('local')
     expect(getTargetFallbackReason()).toBe('no-workspace')
   })
@@ -80,6 +83,7 @@ describe('initApiBaseUrl', () => {
     await initApiBaseUrl()
 
     expect(getApiBaseUrl()).toBe(LOCAL)
+    expect(getCloudApiBaseUrl()).toBeNull()
     expect(getActiveTarget()).toBe('local')
   })
 
@@ -88,6 +92,7 @@ describe('initApiBaseUrl', () => {
     await initApiBaseUrl()
 
     expect(getApiBaseUrl()).toBe(LOCAL)
+    expect(getCloudApiBaseUrl()).toBeNull()
     expect(getActiveTarget()).toBe('local')
   })
 
@@ -96,6 +101,7 @@ describe('initApiBaseUrl', () => {
     await initApiBaseUrl()
 
     expect(getApiBaseUrl()).toBe('')
+    expect(getCloudApiBaseUrl()).toBeNull()
     expect(getActiveTarget()).toBe('local')
   })
 

--- a/src/renderer/lib/env.ts
+++ b/src/renderer/lib/env.ts
@@ -3,6 +3,7 @@ import { setActiveTarget } from './api-target'
 
 // Cache for the API base URL (fetched once from Electron main process)
 let cachedApiBaseUrl: string | null = null
+let cachedCloudApiBaseUrl: string | null = null
 
 /**
  * Initialize the API base URL (call this at app startup in Electron).
@@ -30,6 +31,7 @@ export async function initApiBaseUrl(): Promise<void> {
     const resolved = await window.electronAPI.getApiTarget?.().catch(() => null)
     if (resolved) {
       cachedApiBaseUrl = resolved.baseUrl
+      cachedCloudApiBaseUrl = resolved.cloudBaseUrl
       setActiveTarget(resolved.target, resolved.fallback)
       return
     }
@@ -48,6 +50,7 @@ export async function initApiBaseUrl(): Promise<void> {
 /** Test seam: forgets the resolved base URL so a fresh boot can be simulated. */
 export function _resetApiBaseUrlForTest(): void {
   cachedApiBaseUrl = null
+  cachedCloudApiBaseUrl = null
 }
 
 /**
@@ -62,6 +65,11 @@ export function getApiBaseUrl(): string {
   }
   // Web uses same-origin (Vite dev server proxies to API)
   return ''
+}
+
+/** The cloud proxy door, or null when the proxy is not enabled. */
+export function getCloudApiBaseUrl(): string | null {
+  return cachedCloudApiBaseUrl
 }
 
 /**

--- a/src/shared/lib/api-target.ts
+++ b/src/shared/lib/api-target.ts
@@ -18,6 +18,12 @@ export interface ResolvedApiTarget {
   /** Base URL every call site prefixes — loopback in both cases (see cloud-proxy.ts). */
   baseUrl: string
   fallback: TargetFallbackReason
+  /**
+   * The cloud proxy door, handed to every window so cross-target reads have
+   * one address. Null when the proxy is not enabled (web, auth-mode
+   * deployment).
+   */
+  cloudBaseUrl: string | null
 }
 
 /**


### PR DESCRIPTION
The local tab hid the cloud deployment build whenever the numbers differed. Both tabs now read that number through the same cloud proxy door, and during a Local/Cloud switch the chip stays empty until the live fetch settles so the first paint cannot flash the old single number.

Closes https://linear.app/datawizz/issue/SUP-754/show-the-cloud-build-on-the-local-tab-sidebar-chip

```
boot hands every window the cloud proxy address
  → cloud number is the deployment's runtime status through that door
    asked only while a workspace is reachable
  → desktop number is the build constant
  → hide the chip while the door fetch or the local workspace check is in flight
  → pair when the numbers differ or either is behind, else one number
  → the sidebar does not ask which tab the window is on
```

A failed or omitted version falls back to one number, the same as no workspace. The chip rule, the behind dots, and the updater are unchanged.

### The second origin

No behavior change in this part. Reading the deployment from the local tab means this window talks to two Superagents, and `api-origin.characterization.test.ts` asserts it talks to exactly one. It failed, correctly.

Resolved by exemption, not permission. `cloudApiFetch` is the door's only exit, sits beside `apiFetch` with the same 401 handling, and is pinned as one call site with its reason. Teaching the scanner that `getCloudApiBaseUrl` derives an origin would have been one line and would have blessed every later use of it, including a missing null check, which is a document-relative request whenever the proxy is off, and a `door ?? local` fallback, which answers a question about the deployment with this laptop. A new scanner case fails if anyone tries that.

The module inventory now watches both getters. A door handed to an `<img src>` composes a URL without touching a network primitive, so keying on one getter left such a module in no inventory and no pin.

The runtime status hooks build no URLs. They read the getters as cache keys only, which is why their inventory entry says so, and why the two polls collapse onto one query on the cloud tab where both origins are the same string.

### Also here

The cloud version chip now opens the platform settings tab rather than the Cloud Agents page, which is being retired. Unrelated to SUP-754, carried here because it is the same button. The "Set up cloud agents" button in account settings still opens the old page, as do the platform's own two sidebar links; that one is a provisioning entry point with nowhere to provision from on the settings tab, so it wants a redirect on the platform side instead.
