### PR TITLE
Reload open tabs onto the waking page when the workspace is down

### DIFF
--- a/src/renderer/components/auth/auth-gate.test.tsx
+++ b/src/renderer/components/auth/auth-gate.test.tsx
@@ -39,6 +39,7 @@ vi.mock('./workspace-reconnect', () => ({
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
 import {
   _armWorkspaceUnavailableReloadForTest,
+  _markWorkspaceAsleepForTest,
   _resetWorkspaceUnavailableForTest,
 } from '@renderer/lib/workspace-unavailable'
 import { AuthGate } from './auth-gate'
@@ -178,6 +179,22 @@ describe('which recovery AuthGate offers when there is no session', () => {
 
     expect(queryByTestId('auth-page')).not.toBeInTheDocument()
     expect(getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('overlays the asleep prompt while keeping the app mounted underneath', () => {
+    vi.stubGlobal('__AUTH_MODE__', true)
+    setActiveTarget('local', null)
+    setUser({ ...unauthenticated, isAuthenticated: true })
+    _markWorkspaceAsleepForTest()
+
+    const { getByTestId, getByText } = render(
+      <AuthGate>
+        <div>app</div>
+      </AuthGate>,
+    )
+
+    expect(getByTestId('workspace-asleep-overlay')).toBeInTheDocument()
+    expect(getByText('app')).toBeInTheDocument()
   })
 
   it('offers the login form for a web deployment', () => {

--- a/src/renderer/components/auth/auth-gate.test.tsx
+++ b/src/renderer/components/auth/auth-gate.test.tsx
@@ -165,20 +165,37 @@ describe('which recovery AuthGate offers when there is no session', () => {
     mustChangePassword: false,
   }
 
-  it('holds the loading screen while a workspace-unavailable reload is in flight', () => {
+  it('covers the last surface with the updating overlay while a reload is in flight', () => {
     vi.stubGlobal('__AUTH_MODE__', true)
     setActiveTarget('local', null)
     _armWorkspaceUnavailableReloadForTest()
-    setUser(unauthenticated)
+    setUser({ ...unauthenticated, isAuthenticated: true })
 
-    const { queryByTestId, getByText } = render(
+    const { getByTestId, getByText, queryByTestId } = render(
       <AuthGate>
         <div>app</div>
       </AuthGate>,
     )
 
+    expect(getByTestId('workspace-updating-overlay')).toBeInTheDocument()
+    expect(getByText('app')).toBeInTheDocument()
     expect(queryByTestId('auth-page')).not.toBeInTheDocument()
-    expect(getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('covers AuthPage with the updating overlay when the session drops mid-reload', () => {
+    vi.stubGlobal('__AUTH_MODE__', true)
+    setActiveTarget('local', null)
+    _armWorkspaceUnavailableReloadForTest()
+    setUser(unauthenticated)
+
+    const { getByTestId } = render(
+      <AuthGate>
+        <div>app</div>
+      </AuthGate>,
+    )
+
+    expect(getByTestId('workspace-updating-overlay')).toBeInTheDocument()
+    expect(getByTestId('auth-page')).toBeInTheDocument()
   })
 
   it('overlays the asleep prompt while keeping the app mounted underneath', () => {

--- a/src/renderer/components/auth/auth-gate.test.tsx
+++ b/src/renderer/components/auth/auth-gate.test.tsx
@@ -37,6 +37,10 @@ vi.mock('./workspace-reconnect', () => ({
 }))
 
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
+import {
+  _armWorkspaceUnavailableReloadForTest,
+  _resetWorkspaceUnavailableForTest,
+} from '@renderer/lib/workspace-unavailable'
 import { AuthGate } from './auth-gate'
 
 type UserState = {
@@ -65,6 +69,7 @@ describe('AuthGate cold-stash vs sign-out (wasAuthenticatedRef guard)', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    _resetWorkspaceUnavailableForTest()
   })
 
   it('cold deep-link: stashes the target once the session settles unauthenticated', () => {
@@ -149,6 +154,7 @@ describe('which recovery AuthGate offers when there is no session', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     _resetApiTargetForTest()
+    _resetWorkspaceUnavailableForTest()
   })
 
   const unauthenticated = {
@@ -157,6 +163,22 @@ describe('which recovery AuthGate offers when there is no session', () => {
     isPending: false,
     mustChangePassword: false,
   }
+
+  it('holds the loading screen while a workspace-unavailable reload is in flight', () => {
+    vi.stubGlobal('__AUTH_MODE__', true)
+    setActiveTarget('local', null)
+    _armWorkspaceUnavailableReloadForTest()
+    setUser(unauthenticated)
+
+    const { queryByTestId, getByText } = render(
+      <AuthGate>
+        <div>app</div>
+      </AuthGate>,
+    )
+
+    expect(queryByTestId('auth-page')).not.toBeInTheDocument()
+    expect(getByText('Loading...')).toBeInTheDocument()
+  })
 
   it('offers the login form for a web deployment', () => {
     vi.stubGlobal('__AUTH_MODE__', true)

--- a/src/renderer/components/auth/auth-gate.test.tsx
+++ b/src/renderer/components/auth/auth-gate.test.tsx
@@ -181,20 +181,13 @@ describe('which recovery AuthGate offers when there is no session', () => {
     expect(getByText('Loading...')).toBeInTheDocument()
   })
 
-  it('keeps the app mounted when an asleep response clears the auth session', () => {
+  it('overlays the asleep prompt while keeping the app mounted underneath', () => {
     vi.stubGlobal('__AUTH_MODE__', true)
     setActiveTarget('local', null)
     setUser({ ...unauthenticated, isAuthenticated: true })
+    _markWorkspaceAsleepForTest()
 
-    const { getByTestId, getByText, queryByTestId, rerender } = render(
-      <AuthGate>
-        <div>app</div>
-      </AuthGate>,
-    )
-
-    act(() => _markWorkspaceAsleepForTest())
-    setUser(unauthenticated)
-    rerender(
+    const { getByTestId, getByText } = render(
       <AuthGate>
         <div>app</div>
       </AuthGate>,
@@ -202,7 +195,6 @@ describe('which recovery AuthGate offers when there is no session', () => {
 
     expect(getByTestId('workspace-asleep-overlay')).toBeInTheDocument()
     expect(getByText('app')).toBeInTheDocument()
-    expect(queryByTestId('auth-page')).not.toBeInTheDocument()
   })
 
   it('offers the login form for a web deployment', () => {

--- a/src/renderer/components/auth/auth-gate.test.tsx
+++ b/src/renderer/components/auth/auth-gate.test.tsx
@@ -181,13 +181,20 @@ describe('which recovery AuthGate offers when there is no session', () => {
     expect(getByText('Loading...')).toBeInTheDocument()
   })
 
-  it('overlays the asleep prompt while keeping the app mounted underneath', () => {
+  it('keeps the app mounted when an asleep response clears the auth session', () => {
     vi.stubGlobal('__AUTH_MODE__', true)
     setActiveTarget('local', null)
     setUser({ ...unauthenticated, isAuthenticated: true })
-    _markWorkspaceAsleepForTest()
 
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, queryByTestId, rerender } = render(
+      <AuthGate>
+        <div>app</div>
+      </AuthGate>,
+    )
+
+    act(() => _markWorkspaceAsleepForTest())
+    setUser(unauthenticated)
+    rerender(
       <AuthGate>
         <div>app</div>
       </AuthGate>,
@@ -195,6 +202,7 @@ describe('which recovery AuthGate offers when there is no session', () => {
 
     expect(getByTestId('workspace-asleep-overlay')).toBeInTheDocument()
     expect(getByText('app')).toBeInTheDocument()
+    expect(queryByTestId('auth-page')).not.toBeInTheDocument()
   })
 
   it('offers the login form for a web deployment', () => {

--- a/src/renderer/components/auth/auth-gate.tsx
+++ b/src/renderer/components/auth/auth-gate.tsx
@@ -9,7 +9,7 @@ import {
 } from '@renderer/lib/workspace-unavailable'
 import { AuthPage } from './auth-page'
 import { ForcePasswordChange } from './force-password-change'
-import { WorkspaceAsleepOverlay } from './workspace-asleep'
+import { WorkspaceUnavailableOverlay } from './workspace-asleep'
 import { WorkspaceReconnect } from './workspace-reconnect'
 
 /**
@@ -103,23 +103,24 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     }
   }, [isAuthMode, isPending, isAuthenticated])
 
-  const withAsleepOverlay = (content: React.ReactNode) => (
+  const overlayMode = asleep ? 'asleep' : reloadPending ? 'updating' : null
+  const withUnavailableOverlay = (content: React.ReactNode) => (
     <>
       {content}
-      {asleep && <WorkspaceAsleepOverlay />}
+      {overlayMode && <WorkspaceUnavailableOverlay mode={overlayMode} />}
     </>
   )
 
-  if (!isAuthMode) return withAsleepOverlay(children)
-  if ((isPending && !pendingApproval) || reloadPending) {
-    return withAsleepOverlay(<LoadingScreen />)
+  if (!isAuthMode) return withUnavailableOverlay(children)
+  if (isPending && !pendingApproval) {
+    return withUnavailableOverlay(<LoadingScreen />)
   }
   // A cloud workspace authenticates with a token held by the main process, so
   // there is no password to ask for — offer reconnection instead of a login form.
-  if (!isAuthenticated && targetIsRemote()) return withAsleepOverlay(<WorkspaceReconnect />)
+  if (!isAuthenticated && targetIsRemote()) return withUnavailableOverlay(<WorkspaceReconnect />)
   if (!isAuthenticated || pendingApproval) {
-    return withAsleepOverlay(<AuthPage onPendingApproval={onPendingApproval} />)
+    return withUnavailableOverlay(<AuthPage onPendingApproval={onPendingApproval} />)
   }
-  if (mustChangePassword) return withAsleepOverlay(<ForcePasswordChange />)
-  return withAsleepOverlay(children)
+  if (mustChangePassword) return withUnavailableOverlay(<ForcePasswordChange />)
+  return withUnavailableOverlay(children)
 }

--- a/src/renderer/components/auth/auth-gate.tsx
+++ b/src/renderer/components/auth/auth-gate.tsx
@@ -1,10 +1,15 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
 import { useUser } from '@renderer/context/user-context'
 import { stashRedirectTarget } from '@renderer/lib/api'
 import { targetIsRemote } from '@renderer/lib/api-target'
-import { isWorkspaceUnavailableReloadPending } from '@renderer/lib/workspace-unavailable'
+import {
+  isWorkspaceAsleep,
+  isWorkspaceUnavailableReloadPending,
+  subscribeWorkspaceAsleep,
+} from '@renderer/lib/workspace-unavailable'
 import { AuthPage } from './auth-page'
 import { ForcePasswordChange } from './force-password-change'
+import { WorkspaceAsleepOverlay } from './workspace-asleep'
 import { WorkspaceReconnect } from './workspace-reconnect'
 
 /**
@@ -72,6 +77,7 @@ function useSignalPainted(isPending: boolean): void {
 export function AuthGate({ children }: { children: React.ReactNode }) {
   const { isAuthMode, isAuthenticated, isPending, mustChangePassword } = useUser()
   const [pendingApproval, setPendingApproval] = useState(false)
+  const asleep = useSyncExternalStore(subscribeWorkspaceAsleep, isWorkspaceAsleep)
   useSignalPainted(isPending && !pendingApproval)
 
   const onPendingApproval = useCallback((pending = true) => setPendingApproval(pending), [])
@@ -96,12 +102,25 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     }
   }, [isAuthMode, isPending, isAuthenticated])
 
-  if (!isAuthMode) return <>{children}</>
-  if ((isPending && !pendingApproval) || isWorkspaceUnavailableReloadPending()) return <LoadingScreen />
+  // The overlay sits over whatever the gate resolves to, leaving it mounted so
+  // an asleep workspace never silently discards in-progress renderer state.
+  const withAsleepOverlay = (content: React.ReactNode) => (
+    <>
+      {content}
+      {asleep && <WorkspaceAsleepOverlay />}
+    </>
+  )
+
+  if (!isAuthMode) return withAsleepOverlay(children)
+  if ((isPending && !pendingApproval) || isWorkspaceUnavailableReloadPending()) {
+    return withAsleepOverlay(<LoadingScreen />)
+  }
   // A cloud workspace authenticates with a token held by the main process, so
   // there is no password to ask for — offer reconnection instead of a login form.
-  if (!isAuthenticated && targetIsRemote()) return <WorkspaceReconnect />
-  if (!isAuthenticated || pendingApproval) return <AuthPage onPendingApproval={onPendingApproval} />
-  if (mustChangePassword) return <ForcePasswordChange />
-  return <>{children}</>
+  if (!isAuthenticated && targetIsRemote()) return withAsleepOverlay(<WorkspaceReconnect />)
+  if (!isAuthenticated || pendingApproval) {
+    return withAsleepOverlay(<AuthPage onPendingApproval={onPendingApproval} />)
+  }
+  if (mustChangePassword) return withAsleepOverlay(<ForcePasswordChange />)
+  return withAsleepOverlay(children)
 }

--- a/src/renderer/components/auth/auth-gate.tsx
+++ b/src/renderer/components/auth/auth-gate.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import { useUser } from '@renderer/context/user-context'
 import { stashRedirectTarget } from '@renderer/lib/api'
 import { targetIsRemote } from '@renderer/lib/api-target'
+import { isWorkspaceUnavailableReloadPending } from '@renderer/lib/workspace-unavailable'
 import { AuthPage } from './auth-page'
 import { ForcePasswordChange } from './force-password-change'
 import { WorkspaceReconnect } from './workspace-reconnect'
@@ -96,7 +97,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   }, [isAuthMode, isPending, isAuthenticated])
 
   if (!isAuthMode) return <>{children}</>
-  if (isPending && !pendingApproval) return <LoadingScreen />
+  if ((isPending && !pendingApproval) || isWorkspaceUnavailableReloadPending()) return <LoadingScreen />
   // A cloud workspace authenticates with a token held by the main process, so
   // there is no password to ask for — offer reconnection instead of a login form.
   if (!isAuthenticated && targetIsRemote()) return <WorkspaceReconnect />

--- a/src/renderer/components/auth/auth-gate.tsx
+++ b/src/renderer/components/auth/auth-gate.tsx
@@ -5,7 +5,7 @@ import { targetIsRemote } from '@renderer/lib/api-target'
 import {
   isWorkspaceAsleep,
   isWorkspaceUnavailableReloadPending,
-  subscribeWorkspaceAsleep,
+  subscribeWorkspaceUnavailable,
 } from '@renderer/lib/workspace-unavailable'
 import { AuthPage } from './auth-page'
 import { ForcePasswordChange } from './force-password-change'
@@ -77,7 +77,8 @@ function useSignalPainted(isPending: boolean): void {
 export function AuthGate({ children }: { children: React.ReactNode }) {
   const { isAuthMode, isAuthenticated, isPending, mustChangePassword } = useUser()
   const [pendingApproval, setPendingApproval] = useState(false)
-  const asleep = useSyncExternalStore(subscribeWorkspaceAsleep, isWorkspaceAsleep)
+  const asleep = useSyncExternalStore(subscribeWorkspaceUnavailable, isWorkspaceAsleep)
+  const reloadPending = useSyncExternalStore(subscribeWorkspaceUnavailable, isWorkspaceUnavailableReloadPending)
   useSignalPainted(isPending && !pendingApproval)
 
   const onPendingApproval = useCallback((pending = true) => setPendingApproval(pending), [])
@@ -110,7 +111,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   )
 
   if (!isAuthMode) return withAsleepOverlay(children)
-  if ((isPending && !pendingApproval) || isWorkspaceUnavailableReloadPending()) {
+  if ((isPending && !pendingApproval) || reloadPending) {
     return withAsleepOverlay(<LoadingScreen />)
   }
   // A cloud workspace authenticates with a token held by the main process, so

--- a/src/renderer/components/auth/auth-gate.tsx
+++ b/src/renderer/components/auth/auth-gate.tsx
@@ -102,31 +102,23 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     }
   }, [isAuthMode, isPending, isAuthenticated])
 
-  let content: React.ReactNode
-  if (!isAuthMode) {
-    content = children
-  } else if ((isPending && !pendingApproval) || isWorkspaceUnavailableReloadPending()) {
-    content = <LoadingScreen />
-  } else if (!isAuthenticated && targetIsRemote()) {
-    // A cloud workspace has no interactive login, so offer reconnection.
-    content = <WorkspaceReconnect />
-  } else if (!isAuthenticated || pendingApproval) {
-    content = <AuthPage onPendingApproval={onPendingApproval} />
-  } else if (mustChangePassword) {
-    content = <ForcePasswordChange />
-  } else {
-    content = children
-  }
-
-  // Better Auth clears its session on fetch errors; freeze the last rendered
-  // content while asleep so that transition cannot unmount the app.
-  const visibleContentRef = useRef(content)
-  if (!asleep) visibleContentRef.current = content
-
-  return (
+  const withAsleepOverlay = (content: React.ReactNode) => (
     <>
-      {visibleContentRef.current}
+      {content}
       {asleep && <WorkspaceAsleepOverlay />}
     </>
   )
+
+  if (!isAuthMode) return withAsleepOverlay(children)
+  if ((isPending && !pendingApproval) || isWorkspaceUnavailableReloadPending()) {
+    return withAsleepOverlay(<LoadingScreen />)
+  }
+  // A cloud workspace authenticates with a token held by the main process, so
+  // there is no password to ask for — offer reconnection instead of a login form.
+  if (!isAuthenticated && targetIsRemote()) return withAsleepOverlay(<WorkspaceReconnect />)
+  if (!isAuthenticated || pendingApproval) {
+    return withAsleepOverlay(<AuthPage onPendingApproval={onPendingApproval} />)
+  }
+  if (mustChangePassword) return withAsleepOverlay(<ForcePasswordChange />)
+  return withAsleepOverlay(children)
 }

--- a/src/renderer/components/auth/auth-gate.tsx
+++ b/src/renderer/components/auth/auth-gate.tsx
@@ -102,25 +102,31 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     }
   }, [isAuthMode, isPending, isAuthenticated])
 
-  // The overlay sits over whatever the gate resolves to, leaving it mounted so
-  // an asleep workspace never silently discards in-progress renderer state.
-  const withAsleepOverlay = (content: React.ReactNode) => (
+  let content: React.ReactNode
+  if (!isAuthMode) {
+    content = children
+  } else if ((isPending && !pendingApproval) || isWorkspaceUnavailableReloadPending()) {
+    content = <LoadingScreen />
+  } else if (!isAuthenticated && targetIsRemote()) {
+    // A cloud workspace has no interactive login, so offer reconnection.
+    content = <WorkspaceReconnect />
+  } else if (!isAuthenticated || pendingApproval) {
+    content = <AuthPage onPendingApproval={onPendingApproval} />
+  } else if (mustChangePassword) {
+    content = <ForcePasswordChange />
+  } else {
+    content = children
+  }
+
+  // Better Auth clears its session on fetch errors; freeze the last rendered
+  // content while asleep so that transition cannot unmount the app.
+  const visibleContentRef = useRef(content)
+  if (!asleep) visibleContentRef.current = content
+
+  return (
     <>
-      {content}
+      {visibleContentRef.current}
       {asleep && <WorkspaceAsleepOverlay />}
     </>
   )
-
-  if (!isAuthMode) return withAsleepOverlay(children)
-  if ((isPending && !pendingApproval) || isWorkspaceUnavailableReloadPending()) {
-    return withAsleepOverlay(<LoadingScreen />)
-  }
-  // A cloud workspace authenticates with a token held by the main process, so
-  // there is no password to ask for — offer reconnection instead of a login form.
-  if (!isAuthenticated && targetIsRemote()) return withAsleepOverlay(<WorkspaceReconnect />)
-  if (!isAuthenticated || pendingApproval) {
-    return withAsleepOverlay(<AuthPage onPendingApproval={onPendingApproval} />)
-  }
-  if (mustChangePassword) return withAsleepOverlay(<ForcePasswordChange />)
-  return withAsleepOverlay(children)
 }

--- a/src/renderer/components/auth/auth-page.test.tsx
+++ b/src/renderer/components/auth/auth-page.test.tsx
@@ -44,6 +44,21 @@ describe('AuthPage', () => {
     expect(screen.getByTestId('auth-config-loading')).toHaveTextContent('Loading authentication options...')
   })
 
+  it('keeps the loading state instead of the raw ingress error while the workspace is updating', async () => {
+    apiFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'deployment_unavailable' }),
+    })
+
+    render(<AuthPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-config-loading')).toHaveTextContent('Updating your workspace...')
+    })
+    expect(screen.queryByTestId('auth-config-error')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('signin-submit')).not.toBeInTheDocument()
+  })
+
   it('surfaces auth config fetch errors without rendering fallback auth forms', async () => {
     apiFetch.mockResolvedValue({
       ok: false,

--- a/src/renderer/components/auth/auth-page.tsx
+++ b/src/renderer/components/auth/auth-page.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { signIn, signUp, signOut } from '@renderer/lib/auth-client'
 import { apiFetch, consumeRedirectStash, peekRedirectStash } from '@renderer/lib/api'
+import { isWorkspaceUnavailableError } from '@renderer/lib/workspace-unavailable'
 import { Card, CardContent, CardHeader } from '@renderer/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@renderer/components/ui/tabs'
 import { Input } from '@renderer/components/ui/input'
@@ -406,10 +407,12 @@ export function AuthPage({ onPendingApproval }: { onPendingApproval?: (pending?:
           <h1 className="text-2xl font-medium">Gamut</h1>
         </CardHeader>
         <CardContent className="space-y-4">
-          {isLoading ? (
+          {isLoading || isWorkspaceUnavailableError(error) ? (
             <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground" data-testid="auth-config-loading">
               <Loader2 className="h-4 w-4 animate-spin" />
-              Loading authentication options...
+              {isWorkspaceUnavailableError(error)
+                ? 'Updating your workspace...'
+                : 'Loading authentication options...'}
             </div>
           ) : error ? (
             <Alert variant="destructive" data-testid="auth-config-error">

--- a/src/renderer/components/auth/workspace-asleep.tsx
+++ b/src/renderer/components/auth/workspace-asleep.tsx
@@ -1,34 +1,52 @@
+import { Loader2 } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { Card, CardContent, CardHeader } from '@renderer/components/ui/card'
 
+export type WorkspaceUnavailableOverlayMode = 'asleep' | 'updating'
+
 /**
- * Full-window overlay shown when ingress reports the workspace asleep or
- * errored. Rendered OVER the app (which stays mounted) so nothing typed is
- * lost; the reload is the user's call and lands on the click-to-wake page.
+ * Full-window sheet over the last painted app. Waking covers in-app errors
+ * until the document reload hits the waiting page; sleeping waits for a click.
  */
-export function WorkspaceAsleepOverlay() {
+export function WorkspaceUnavailableOverlay({ mode }: { mode: WorkspaceUnavailableOverlayMode }) {
+  const asleep = mode === 'asleep'
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
-      data-testid="workspace-asleep-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background"
+      data-testid={asleep ? 'workspace-asleep-overlay' : 'workspace-updating-overlay'}
     >
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <h2 className="text-lg font-medium">Your workspace is asleep</h2>
+          <h2 className="text-lg font-medium">
+            {asleep ? 'Your workspace is asleep' : 'Updating your workspace'}
+          </h2>
         </CardHeader>
         <CardContent className="space-y-4 text-center">
-          <p className="text-sm text-muted-foreground">
-            It powered down while idle. Wake it up to keep working — this will reload the page.
-          </p>
-          <Button
-            className="w-full"
-            data-testid="workspace-asleep-reload"
-            onClick={() => window.location.reload()}
-          >
-            Wake it up
-          </Button>
+          {asleep ? (
+            <>
+              <p className="text-sm text-muted-foreground">
+                It powered down while idle. Wake it up to keep working — this will reload the page.
+              </p>
+              <Button
+                className="w-full"
+                data-testid="workspace-asleep-reload"
+                onClick={() => window.location.reload()}
+              >
+                Wake it up
+              </Button>
+            </>
+          ) : (
+            <p className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Getting it ready again…
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>
   )
+}
+
+export function WorkspaceAsleepOverlay() {
+  return <WorkspaceUnavailableOverlay mode="asleep" />
 }

--- a/src/renderer/components/auth/workspace-asleep.tsx
+++ b/src/renderer/components/auth/workspace-asleep.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@renderer/components/ui/button'
+import { Card, CardContent, CardHeader } from '@renderer/components/ui/card'
+
+/**
+ * Full-window overlay shown when ingress reports the workspace asleep or
+ * errored. Rendered OVER the app (which stays mounted) so nothing typed is
+ * lost; the reload is the user's call and lands on the click-to-wake page.
+ */
+export function WorkspaceAsleepOverlay() {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+      data-testid="workspace-asleep-overlay"
+    >
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <h2 className="text-lg font-medium">Your workspace is asleep</h2>
+        </CardHeader>
+        <CardContent className="space-y-4 text-center">
+          <p className="text-sm text-muted-foreground">
+            It powered down while idle. Wake it up to keep working — this will reload the page.
+          </p>
+          <Button
+            className="w-full"
+            data-testid="workspace-asleep-reload"
+            onClick={() => window.location.reload()}
+          >
+            Wake it up
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/renderer/components/auth/workspace-asleep.tsx
+++ b/src/renderer/components/auth/workspace-asleep.tsx
@@ -4,10 +4,7 @@ import { Card, CardContent, CardHeader } from '@renderer/components/ui/card'
 
 export type WorkspaceUnavailableOverlayMode = 'asleep' | 'updating'
 
-/**
- * Full-window sheet over the last painted app. Waking covers in-app errors
- * until the document reload hits the waiting page; sleeping waits for a click.
- */
+/** Waking: cover red errors until reload hits the ingress page. Sleeping: click to wake. */
 export function WorkspaceUnavailableOverlay({ mode }: { mode: WorkspaceUnavailableOverlayMode }) {
   const asleep = mode === 'asleep'
   return (

--- a/src/renderer/components/auth/workspace-asleep.tsx
+++ b/src/renderer/components/auth/workspace-asleep.tsx
@@ -46,7 +46,3 @@ export function WorkspaceUnavailableOverlay({ mode }: { mode: WorkspaceUnavailab
     </div>
   )
 }
-
-export function WorkspaceAsleepOverlay() {
-  return <WorkspaceUnavailableOverlay mode="asleep" />
-}

--- a/src/renderer/lib/api-origin.characterization.test.ts
+++ b/src/renderer/lib/api-origin.characterization.test.ts
@@ -95,6 +95,9 @@ const PINNED_CALL_SITES: Record<string, string> = {
     'prebuilt `src` on a parsed tool-result document: a data: URL for an inline ' +
     'PDF, or the session media URL that parse-tool-result.ts composes from ' +
     'getApiBaseUrl() (the same address the <img> refs load from)',
+  'lib/auth-client.ts::authFetch::fetch(input)':
+    'prebuilt better-auth request URL; its client composes this from the ' +
+    'getApiBaseUrl()-derived baseURL passed during lazy construction',
   // Not third-party — this one IS our API, reached over ws:// instead of http://.
   'hooks/use-browser-stream.ts::useBrowserStream::WebSocket(wsUrl)':
     'the only site that does scheme surgery: it splits getApiBaseUrl() into a ' +

--- a/src/renderer/lib/api.test.ts
+++ b/src/renderer/lib/api.test.ts
@@ -3,7 +3,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // api.ts imports getApiBaseUrl at module load; stub it so the import is inert.
-vi.mock('./env', () => ({ getApiBaseUrl: () => '' }))
+vi.mock('./env', () => ({
+  getApiBaseUrl: () => '',
+  isElectron: () => typeof window !== 'undefined' && !!(window as { electronAPI?: unknown }).electronAPI,
+}))
 
 // apiFetch dynamically import()s ./auth-client on a 401; mock it so signOut is an
 // observable spy and the real better-auth client never loads.
@@ -23,6 +26,10 @@ import {
   markDeliberateSignOut,
   clearDeliberateSignOut,
 } from './api'
+import {
+  _resetWorkspaceUnavailableForTest,
+  _setWorkspaceUnavailableReloadForTest,
+} from './workspace-unavailable'
 
 const KEY = 'superagent.redirect'
 
@@ -287,5 +294,51 @@ describe('apiFetch (init passthrough)', () => {
       '/api/x',
       expect.objectContaining({ signal: controller.signal })
     )
+  })
+})
+
+describe('apiFetch workspace-unavailable reload', () => {
+  const reload = vi.fn()
+
+  beforeEach(() => {
+    _resetWorkspaceUnavailableForTest()
+    _setWorkspaceUnavailableReloadForTest(reload)
+    reload.mockClear()
+    delete (window as { electronAPI?: unknown }).electronAPI
+  })
+
+  afterEach(() => {
+    _resetWorkspaceUnavailableForTest()
+    vi.unstubAllGlobals()
+    delete (window as { electronAPI?: unknown }).electronAPI
+  })
+
+  it('reloads when ingress says the deployment is unavailable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ error: 'deployment_unavailable', state: 'waking' }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    )
+    const res = await apiFetch('/api/auth-config')
+    expect(res.status).toBe(503)
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('does not reload a normal 503', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ error: 'rate_limited' }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    )
+    await apiFetch('/api/x')
+    expect(reload).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -1,6 +1,7 @@
 import { getApiBaseUrl } from './env'
 import { hasInteractiveLogin, isAuthMode } from './auth-mode'
 import { reportCloudSessionRejected } from './cloud-session'
+import { maybeReloadForWorkspaceUnavailable } from './workspace-unavailable'
 
 /**
  * Fetch wrapper that prepends the API base URL.
@@ -15,6 +16,7 @@ export async function apiFetch(
 ): Promise<Response> {
   const baseUrl = getApiBaseUrl()
   const response = await fetch(`${baseUrl}${path}`, init)
+  await maybeReloadForWorkspaceUnavailable(response)
   await handleUnauthorizedResponse(response.status, path)
   return response
 }

--- a/src/renderer/lib/auth-client.test.ts
+++ b/src/renderer/lib/auth-client.test.ts
@@ -7,7 +7,7 @@ vi.unmock('@renderer/lib/auth-client')
 
 const { createAuthClient, baseUrl, remote } = vi.hoisted(() => ({
   remote: { value: false },
-  createAuthClient: vi.fn((_options: { baseURL?: string; fetchOptions?: { credentials?: string } }) => ({
+  createAuthClient: vi.fn((_options: { baseURL?: string; fetchOptions?: { credentials?: string; customFetchImpl?: unknown } }) => ({
     signIn: { email: vi.fn() },
     signUp: { email: vi.fn() },
     signOut: vi.fn(),
@@ -69,6 +69,11 @@ describe('construction timing', () => {
     expect(createAuthClient.mock.calls[0][0]).toMatchObject({
       baseURL: 'http://localhost:3000/cloud/KEY123/api/auth',
     })
+  })
+
+  it('installs a fetch wrapper so a waking ingress reloads the document', () => {
+    useSession()
+    expect(typeof createAuthClient.mock.calls[0][0].fetchOptions?.customFetchImpl).toBe('function')
   })
 
   it('builds only once across many uses', () => {

--- a/src/renderer/lib/auth-client.ts
+++ b/src/renderer/lib/auth-client.ts
@@ -2,6 +2,13 @@ import { createAuthClient } from 'better-auth/react'
 import { adminClient, genericOAuthClient } from 'better-auth/client/plugins'
 import { getApiBaseUrl } from './env'
 import { targetIsRemote } from './api-target'
+import { maybeReloadForWorkspaceUnavailable } from './workspace-unavailable'
+
+async function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const response = await fetch(input, init)
+  await maybeReloadForWorkspaceUnavailable(response)
+  return response
+}
 
 /**
  * The Better Auth client, pointed at whichever API this renderer drives.
@@ -72,7 +79,7 @@ type AuthClient = ReturnType<typeof buildClient>
 function buildClient() {
   return createAuthClient({
     baseURL: resolveBaseUrl(),
-    fetchOptions: { credentials: credentialsMode() },
+    fetchOptions: { credentials: credentialsMode(), customFetchImpl: authFetch },
     plugins: [adminClient(), genericOAuthClient()],
   })
 }

--- a/src/renderer/lib/workspace-unavailable-schema.ts
+++ b/src/renderer/lib/workspace-unavailable-schema.ts
@@ -2,10 +2,15 @@ import { z } from 'zod'
 
 // Fallback contract for ingress workers that predate the header; the header
 // (WORKSPACE_UNAVAILABLE_HEADER) is the primary signal.
+export const workspaceUnavailableStateSchema = z.enum([
+  'waking',
+  'sleeping',
+  'error',
+  'unreachable',
+])
+export type WorkspaceUnavailableState = z.infer<typeof workspaceUnavailableStateSchema>
+
 export const workspaceUnavailableBodySchema = z.object({
-  error: z.union([
-    z.literal('deployment_unavailable'),
-    z.literal('The request could not reach your workspace. Please retry.'),
-  ]),
-  state: z.string().optional(),
+  error: z.literal('deployment_unavailable'),
+  state: workspaceUnavailableStateSchema,
 })

--- a/src/renderer/lib/workspace-unavailable-schema.ts
+++ b/src/renderer/lib/workspace-unavailable-schema.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod'
 
+// Fallback contract for ingress workers that predate the header; the header
+// (WORKSPACE_UNAVAILABLE_HEADER) is the primary signal.
 export const workspaceUnavailableBodySchema = z.object({
   error: z.union([
     z.literal('deployment_unavailable'),
     z.literal('The request could not reach your workspace. Please retry.'),
   ]),
+  state: z.string().optional(),
 })

--- a/src/renderer/lib/workspace-unavailable-schema.ts
+++ b/src/renderer/lib/workspace-unavailable-schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const workspaceUnavailableBodySchema = z.object({
+  error: z.union([
+    z.literal('deployment_unavailable'),
+    z.literal('The request could not reach your workspace. Please retry.'),
+  ]),
+})

--- a/src/renderer/lib/workspace-unavailable.test.ts
+++ b/src/renderer/lib/workspace-unavailable.test.ts
@@ -10,7 +10,7 @@ import {
   isWorkspaceUnavailableError,
   isWorkspaceUnavailableReloadPending,
   maybeReloadForWorkspaceUnavailable,
-  subscribeWorkspaceAsleep,
+  subscribeWorkspaceUnavailable,
 } from './workspace-unavailable'
 
 function jsonResponse(status: number, body: unknown, state?: string): Response {
@@ -134,7 +134,7 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
 
   it('prompts instead of reloading when the workspace is sleeping (header)', async () => {
     const notify = vi.fn()
-    subscribeWorkspaceAsleep(notify)
+    subscribeWorkspaceUnavailable(notify)
     await maybeReloadForWorkspaceUnavailable(
       jsonResponse(503, { error: 'deployment_unavailable', state: 'sleeping' }, 'sleeping'),
     )
@@ -161,10 +161,51 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
 
   it('notifies each asleep listener at most once', async () => {
     const notify = vi.fn()
-    subscribeWorkspaceAsleep(notify)
+    subscribeWorkspaceUnavailable(notify)
     await maybeReloadForWorkspaceUnavailable(jsonResponse(503, {}, 'sleeping'))
     await maybeReloadForWorkspaceUnavailable(jsonResponse(503, {}, 'sleeping'))
     expect(notify).toHaveBeenCalledOnce()
+  })
+
+  it('notifies subscribers when a reload becomes pending', async () => {
+    const notify = vi.fn()
+    subscribeWorkspaceUnavailable(notify)
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, {}, 'waking'))
+    expect(isWorkspaceUnavailableReloadPending()).toBe(true)
+    expect(notify).toHaveBeenCalledOnce()
+  })
+
+  it('clears the asleep prompt when a later request succeeds', async () => {
+    const notify = vi.fn()
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, {}, 'sleeping'))
+    expect(isWorkspaceAsleep()).toBe(true)
+    subscribeWorkspaceUnavailable(notify)
+    await maybeReloadForWorkspaceUnavailable(new Response('ok', { status: 200 }))
+    expect(isWorkspaceAsleep()).toBe(false)
+    expect(notify).toHaveBeenCalledOnce()
+  })
+
+  it('a success without a prior prompt notifies nobody', async () => {
+    const notify = vi.fn()
+    subscribeWorkspaceUnavailable(notify)
+    await maybeReloadForWorkspaceUnavailable(new Response('ok', { status: 200 }))
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('still reloads when sessionStorage is unavailable', async () => {
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('denied')
+    })
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('denied')
+    })
+    try {
+      await maybeReloadForWorkspaceUnavailable(jsonResponse(503, {}, 'waking'))
+      expect(reload).toHaveBeenCalledOnce()
+    } finally {
+      getItem.mockRestore()
+      setItem.mockRestore()
+    }
   })
 })
 

--- a/src/renderer/lib/workspace-unavailable.test.ts
+++ b/src/renderer/lib/workspace-unavailable.test.ts
@@ -25,19 +25,34 @@ function jsonResponse(status: number, body: unknown, state?: string): Response {
 
 describe('workspaceUnavailableBodySchema', () => {
   it('accepts the ingress 503 body', () => {
-    expect(workspaceUnavailableBodySchema.safeParse({ error: 'deployment_unavailable' }).success).toBe(true)
-  })
-
-  it('accepts the ingress 502 body', () => {
     expect(
       workspaceUnavailableBodySchema.safeParse({
-        error: 'The request could not reach your workspace. Please retry.',
+        error: 'deployment_unavailable',
+        state: 'waking',
       }).success,
     ).toBe(true)
   })
 
+  it('rejects the ambiguous legacy 502 body', () => {
+    expect(
+      workspaceUnavailableBodySchema.safeParse({
+        error: 'The request could not reach your workspace. Please retry.',
+      }).success,
+    ).toBe(false)
+  })
+
   it('rejects an unrelated error string', () => {
     expect(workspaceUnavailableBodySchema.safeParse({ error: 'Auth config unavailable' }).success).toBe(false)
+  })
+
+  it('rejects missing or unknown route states', () => {
+    expect(workspaceUnavailableBodySchema.safeParse({ error: 'deployment_unavailable' }).success).toBe(false)
+    expect(
+      workspaceUnavailableBodySchema.safeParse({
+        error: 'deployment_unavailable',
+        state: 'future-state',
+      }).success,
+    ).toBe(false)
   })
 })
 
@@ -64,11 +79,11 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
     expect(await response.json()).toEqual({ error: 'deployment_unavailable', state: 'waking' })
   })
 
-  it('reloads on the ready-route 502 body', async () => {
+  it('does not reload on the ambiguous legacy 502 body', async () => {
     await maybeReloadForWorkspaceUnavailable(
       jsonResponse(502, { error: 'The request could not reach your workspace. Please retry.' }),
     )
-    expect(reload).toHaveBeenCalledOnce()
+    expect(reload).not.toHaveBeenCalled()
   })
 
   it('does not reload other 503s', async () => {
@@ -89,8 +104,9 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
   })
 
   it('does not reload again inside the cooldown', async () => {
-    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, { error: 'deployment_unavailable' }))
-    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, { error: 'deployment_unavailable' }))
+    const unavailable = { error: 'deployment_unavailable', state: 'waking' }
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
     expect(reload).toHaveBeenCalledOnce()
   })
 
@@ -106,6 +122,14 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
   it('reloads on a header-tagged unreachable 502', async () => {
     await maybeReloadForWorkspaceUnavailable(jsonResponse(502, {}, 'unreachable'))
     expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('ignores an unknown header state', async () => {
+    await maybeReloadForWorkspaceUnavailable(
+      jsonResponse(503, { error: 'deployment_unavailable', state: 'waking' }, 'future-state'),
+    )
+    expect(reload).not.toHaveBeenCalled()
+    expect(isWorkspaceAsleep()).toBe(false)
   })
 
   it('prompts instead of reloading when the workspace is sleeping (header)', async () => {

--- a/src/renderer/lib/workspace-unavailable.test.ts
+++ b/src/renderer/lib/workspace-unavailable.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { workspaceUnavailableBodySchema } from './workspace-unavailable-schema'
+import {
+  _resetWorkspaceUnavailableForTest,
+  _setWorkspaceUnavailableReloadForTest,
+  isWorkspaceUnavailableError,
+  isWorkspaceUnavailableReloadPending,
+  maybeReloadForWorkspaceUnavailable,
+} from './workspace-unavailable'
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('workspaceUnavailableBodySchema', () => {
+  it('accepts the ingress 503 body', () => {
+    expect(workspaceUnavailableBodySchema.safeParse({ error: 'deployment_unavailable' }).success).toBe(true)
+  })
+
+  it('accepts the ingress 502 body', () => {
+    expect(
+      workspaceUnavailableBodySchema.safeParse({
+        error: 'The request could not reach your workspace. Please retry.',
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects an unrelated error string', () => {
+    expect(workspaceUnavailableBodySchema.safeParse({ error: 'Auth config unavailable' }).success).toBe(false)
+  })
+})
+
+describe('maybeReloadForWorkspaceUnavailable', () => {
+  const reload = vi.fn()
+
+  beforeEach(() => {
+    _resetWorkspaceUnavailableForTest()
+    _setWorkspaceUnavailableReloadForTest(reload)
+    reload.mockClear()
+    delete (window as { electronAPI?: unknown }).electronAPI
+  })
+
+  afterEach(() => {
+    _resetWorkspaceUnavailableForTest()
+    delete (window as { electronAPI?: unknown }).electronAPI
+  })
+
+  it('reloads the document on deployment_unavailable so the next load hits the waiting page', async () => {
+    const response = jsonResponse(503, { error: 'deployment_unavailable', state: 'waking' })
+    await maybeReloadForWorkspaceUnavailable(response)
+    expect(reload).toHaveBeenCalledOnce()
+    expect(isWorkspaceUnavailableReloadPending()).toBe(true)
+    expect(await response.json()).toEqual({ error: 'deployment_unavailable', state: 'waking' })
+  })
+
+  it('reloads on the ready-route 502 body', async () => {
+    await maybeReloadForWorkspaceUnavailable(
+      jsonResponse(502, { error: 'The request could not reach your workspace. Please retry.' }),
+    )
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('does not reload other 503s', async () => {
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, { error: 'wake_unavailable' }))
+    expect(reload).not.toHaveBeenCalled()
+    expect(isWorkspaceUnavailableReloadPending()).toBe(false)
+  })
+
+  it('does not reload 401s', async () => {
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(401, { error: 'deployment_unavailable' }))
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('does not reload in Electron, where a renderer reload misses the ingress waiting page', async () => {
+    ;(window as { electronAPI?: object }).electronAPI = {}
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, { error: 'deployment_unavailable' }))
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('does not reload again inside the cooldown', async () => {
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, { error: 'deployment_unavailable' }))
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, { error: 'deployment_unavailable' }))
+    expect(reload).toHaveBeenCalledOnce()
+  })
+})
+
+describe('isWorkspaceUnavailableError', () => {
+  it('is true only for the ingress error strings', () => {
+    expect(isWorkspaceUnavailableError('deployment_unavailable')).toBe(true)
+    expect(isWorkspaceUnavailableError('Auth config unavailable')).toBe(false)
+    expect(isWorkspaceUnavailableError(null)).toBe(false)
+  })
+})
+

--- a/src/renderer/lib/workspace-unavailable.test.ts
+++ b/src/renderer/lib/workspace-unavailable.test.ts
@@ -3,17 +3,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { workspaceUnavailableBodySchema } from './workspace-unavailable-schema'
 import {
+  WORKSPACE_UNAVAILABLE_HEADER,
   _resetWorkspaceUnavailableForTest,
   _setWorkspaceUnavailableReloadForTest,
+  isWorkspaceAsleep,
   isWorkspaceUnavailableError,
   isWorkspaceUnavailableReloadPending,
   maybeReloadForWorkspaceUnavailable,
+  subscribeWorkspaceAsleep,
 } from './workspace-unavailable'
 
-function jsonResponse(status: number, body: unknown): Response {
+function jsonResponse(status: number, body: unknown, state?: string): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      'content-type': 'application/json',
+      ...(state ? { [WORKSPACE_UNAVAILABLE_HEADER]: state } : {}),
+    },
   })
 }
 
@@ -86,6 +92,55 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
     await maybeReloadForWorkspaceUnavailable(jsonResponse(503, { error: 'deployment_unavailable' }))
     await maybeReloadForWorkspaceUnavailable(jsonResponse(503, { error: 'deployment_unavailable' }))
     expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('trusts the header without reading the body', async () => {
+    const response = new Response('not json', {
+      status: 503,
+      headers: { [WORKSPACE_UNAVAILABLE_HEADER]: 'waking' },
+    })
+    await maybeReloadForWorkspaceUnavailable(response)
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('reloads on a header-tagged unreachable 502', async () => {
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(502, {}, 'unreachable'))
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('prompts instead of reloading when the workspace is sleeping (header)', async () => {
+    const notify = vi.fn()
+    subscribeWorkspaceAsleep(notify)
+    await maybeReloadForWorkspaceUnavailable(
+      jsonResponse(503, { error: 'deployment_unavailable', state: 'sleeping' }, 'sleeping'),
+    )
+    expect(reload).not.toHaveBeenCalled()
+    expect(isWorkspaceAsleep()).toBe(true)
+    expect(notify).toHaveBeenCalledOnce()
+  })
+
+  it('prompts instead of reloading when the workspace is sleeping (body fallback)', async () => {
+    await maybeReloadForWorkspaceUnavailable(
+      jsonResponse(503, { error: 'deployment_unavailable', state: 'sleeping' }),
+    )
+    expect(reload).not.toHaveBeenCalled()
+    expect(isWorkspaceAsleep()).toBe(true)
+  })
+
+  it('prompts on the error state too', async () => {
+    await maybeReloadForWorkspaceUnavailable(
+      jsonResponse(503, { error: 'deployment_unavailable', state: 'error' }, 'error'),
+    )
+    expect(reload).not.toHaveBeenCalled()
+    expect(isWorkspaceAsleep()).toBe(true)
+  })
+
+  it('notifies each asleep listener at most once', async () => {
+    const notify = vi.fn()
+    subscribeWorkspaceAsleep(notify)
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, {}, 'sleeping'))
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, {}, 'sleeping'))
+    expect(notify).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/renderer/lib/workspace-unavailable.test.ts
+++ b/src/renderer/lib/workspace-unavailable.test.ts
@@ -125,6 +125,22 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
     }
   })
 
+  it('a success cancels the queued reload and drops the overlay', async () => {
+    vi.useFakeTimers()
+    try {
+      const unavailable = { error: 'deployment_unavailable', state: 'waking' }
+      await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
+      await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
+      expect(reload).toHaveBeenCalledOnce()
+      await maybeReloadForWorkspaceUnavailable(new Response('ok', { status: 200 }))
+      expect(isWorkspaceUnavailableReloadPending()).toBe(false)
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(reload).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('trusts the header without reading the body', async () => {
     const response = new Response('not json', {
       status: 503,

--- a/src/renderer/lib/workspace-unavailable.test.ts
+++ b/src/renderer/lib/workspace-unavailable.test.ts
@@ -110,6 +110,21 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
     expect(reload).toHaveBeenCalledOnce()
   })
 
+  it('covers immediately and reloads after the cooldown expires', async () => {
+    vi.useFakeTimers()
+    try {
+      const unavailable = { error: 'deployment_unavailable', state: 'waking' }
+      await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
+      await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
+      expect(reload).toHaveBeenCalledOnce()
+      expect(isWorkspaceUnavailableReloadPending()).toBe(true)
+      await vi.advanceTimersByTimeAsync(15_000)
+      expect(reload).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('trusts the header without reading the body', async () => {
     const response = new Response('not json', {
       status: 503,

--- a/src/renderer/lib/workspace-unavailable.test.ts
+++ b/src/renderer/lib/workspace-unavailable.test.ts
@@ -110,35 +110,25 @@ describe('maybeReloadForWorkspaceUnavailable', () => {
     expect(reload).toHaveBeenCalledOnce()
   })
 
-  it('covers immediately and reloads after the cooldown expires', async () => {
+  it('does not schedule a later reload after the cooldown — ingress waits for ready', async () => {
     vi.useFakeTimers()
     try {
       const unavailable = { error: 'deployment_unavailable', state: 'waking' }
       await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
       await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
       expect(reload).toHaveBeenCalledOnce()
-      expect(isWorkspaceUnavailableReloadPending()).toBe(true)
-      await vi.advanceTimersByTimeAsync(15_000)
-      expect(reload).toHaveBeenCalledTimes(2)
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('a success cancels the queued reload and drops the overlay', async () => {
-    vi.useFakeTimers()
-    try {
-      const unavailable = { error: 'deployment_unavailable', state: 'waking' }
-      await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
-      await maybeReloadForWorkspaceUnavailable(jsonResponse(503, unavailable))
-      expect(reload).toHaveBeenCalledOnce()
-      await maybeReloadForWorkspaceUnavailable(new Response('ok', { status: 200 }))
-      expect(isWorkspaceUnavailableReloadPending()).toBe(false)
       await vi.advanceTimersByTimeAsync(30_000)
       expect(reload).toHaveBeenCalledOnce()
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('a success drops the overlay and does not reload later', async () => {
+    await maybeReloadForWorkspaceUnavailable(jsonResponse(503, {}, 'waking'))
+    expect(isWorkspaceUnavailableReloadPending()).toBe(true)
+    await maybeReloadForWorkspaceUnavailable(new Response('ok', { status: 200 }))
+    expect(isWorkspaceUnavailableReloadPending()).toBe(false)
   })
 
   it('trusts the header without reading the body', async () => {

--- a/src/renderer/lib/workspace-unavailable.ts
+++ b/src/renderer/lib/workspace-unavailable.ts
@@ -1,10 +1,20 @@
 import { isElectron } from './env'
 import { workspaceUnavailableBodySchema } from './workspace-unavailable-schema'
 
+// Set by the ingress on its 502/503 JSON; value is the route state ("waking",
+// "sleeping", "error") or "unreachable" for a dead upstream behind a ready route.
+export const WORKSPACE_UNAVAILABLE_HEADER = 'x-workspace-unavailable'
+
 const RELOAD_KEY = 'superagent.workspace-unavailable-reload'
 const COOLDOWN_MS = 15_000
 
+// sleeping/error mean click-to-wake: reloading would silently drop any typed
+// but unsent state, so those surface a prompt instead of a forced reload.
+const PROMPT_STATES = new Set(['sleeping', 'error'])
+
 let reloadPending = false
+let asleep = false
+const asleepListeners = new Set<() => void>()
 let reloadImpl = (): void => {
   window.location.reload()
 }
@@ -18,8 +28,21 @@ export function isWorkspaceUnavailableReloadPending(): boolean {
   return reloadPending
 }
 
+export function isWorkspaceAsleep(): boolean {
+  return asleep
+}
+
+export function subscribeWorkspaceAsleep(listener: () => void): () => void {
+  asleepListeners.add(listener)
+  return () => {
+    asleepListeners.delete(listener)
+  }
+}
+
 export function _resetWorkspaceUnavailableForTest(): void {
   reloadPending = false
+  asleep = false
+  asleepListeners.clear()
   reloadImpl = () => {
     window.location.reload()
   }
@@ -34,8 +57,17 @@ export function _armWorkspaceUnavailableReloadForTest(): void {
   reloadPending = true
 }
 
+export function _markWorkspaceAsleepForTest(): void {
+  markWorkspaceAsleep()
+}
+
+function markWorkspaceAsleep(): void {
+  if (asleep) return
+  asleep = true
+  for (const listener of asleepListeners) listener()
+}
+
 function reloadForWorkspaceUnavailable(): void {
-  if (isElectron()) return
   const last = Number(sessionStorage.getItem(RELOAD_KEY) ?? 0)
   if (Number.isFinite(last) && Date.now() - last < COOLDOWN_MS) return
   sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
@@ -43,16 +75,34 @@ function reloadForWorkspaceUnavailable(): void {
   reloadImpl()
 }
 
-// Open-tab 502/503 from ingress: reload so the next document request gets the waiting page.
-export async function maybeReloadForWorkspaceUnavailable(response: Response): Promise<void> {
-  if (response.status !== 502 && response.status !== 503) return
-  if (typeof response.clone !== 'function') return
+async function unavailableStateOf(response: Response): Promise<string | null> {
+  const header = response.headers.get(WORKSPACE_UNAVAILABLE_HEADER)
+  if (header) return header
+  // Fallback for ingress deployments that predate the header.
+  if (typeof response.clone !== 'function') return null
   let body: unknown
   try {
     body = await response.clone().json()
   } catch {
+    return null
+  }
+  const parsed = workspaceUnavailableBodySchema.safeParse(body)
+  if (!parsed.success) return null
+  return parsed.data.state ?? 'unreachable'
+}
+
+// Open-tab 502/503 from ingress. Mid-boot states reload so the next document
+// request gets the waiting page; sleeping/error only flag a wake prompt.
+export async function maybeReloadForWorkspaceUnavailable(response: Response): Promise<void> {
+  if (response.status !== 502 && response.status !== 503) return
+  // An Electron renderer loads local assets, so a reload never reaches the
+  // ingress waiting page — WorkspaceReconnect handles this case instead.
+  if (isElectron()) return
+  const state = await unavailableStateOf(response)
+  if (!state) return
+  if (PROMPT_STATES.has(state)) {
+    markWorkspaceAsleep()
     return
   }
-  if (!workspaceUnavailableBodySchema.safeParse(body).success) return
   reloadForWorkspaceUnavailable()
 }

--- a/src/renderer/lib/workspace-unavailable.ts
+++ b/src/renderer/lib/workspace-unavailable.ts
@@ -1,0 +1,58 @@
+import { isElectron } from './env'
+import { workspaceUnavailableBodySchema } from './workspace-unavailable-schema'
+
+const RELOAD_KEY = 'superagent.workspace-unavailable-reload'
+const COOLDOWN_MS = 15_000
+
+let reloadPending = false
+let reloadImpl = (): void => {
+  window.location.reload()
+}
+
+export function isWorkspaceUnavailableError(message: string | null | undefined): boolean {
+  if (!message) return false
+  return workspaceUnavailableBodySchema.safeParse({ error: message }).success
+}
+
+export function isWorkspaceUnavailableReloadPending(): boolean {
+  return reloadPending
+}
+
+export function _resetWorkspaceUnavailableForTest(): void {
+  reloadPending = false
+  reloadImpl = () => {
+    window.location.reload()
+  }
+  sessionStorage.removeItem(RELOAD_KEY)
+}
+
+export function _setWorkspaceUnavailableReloadForTest(fn: () => void): void {
+  reloadImpl = fn
+}
+
+export function _armWorkspaceUnavailableReloadForTest(): void {
+  reloadPending = true
+}
+
+function reloadForWorkspaceUnavailable(): void {
+  if (isElectron()) return
+  const last = Number(sessionStorage.getItem(RELOAD_KEY) ?? 0)
+  if (Number.isFinite(last) && Date.now() - last < COOLDOWN_MS) return
+  sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+  reloadPending = true
+  reloadImpl()
+}
+
+// Open-tab 502/503 from ingress: reload so the next document request gets the waiting page.
+export async function maybeReloadForWorkspaceUnavailable(response: Response): Promise<void> {
+  if (response.status !== 502 && response.status !== 503) return
+  if (typeof response.clone !== 'function') return
+  let body: unknown
+  try {
+    body = await response.clone().json()
+  } catch {
+    return
+  }
+  if (!workspaceUnavailableBodySchema.safeParse(body).success) return
+  reloadForWorkspaceUnavailable()
+}

--- a/src/renderer/lib/workspace-unavailable.ts
+++ b/src/renderer/lib/workspace-unavailable.ts
@@ -19,7 +19,6 @@ const PROMPT_STATES = new Set<WorkspaceUnavailableState>(['sleeping', 'error'])
 let reloadPending = false
 let asleep = false
 const listeners = new Set<() => void>()
-let reloadTimer: ReturnType<typeof setTimeout> | null = null
 let reloadImpl = (): void => {
   window.location.reload()
 }
@@ -52,10 +51,6 @@ export function _resetWorkspaceUnavailableForTest(): void {
   reloadPending = false
   asleep = false
   listeners.clear()
-  if (reloadTimer != null) {
-    clearTimeout(reloadTimer)
-    reloadTimer = null
-  }
   reloadImpl = () => {
     window.location.reload()
   }
@@ -84,12 +79,7 @@ function markWorkspaceAsleep(): void {
   notify()
 }
 
-// The workspace recovered on its own; drop the overlay and any queued reload.
 function clearWorkspaceUnavailable(): void {
-  if (reloadTimer != null) {
-    clearTimeout(reloadTimer)
-    reloadTimer = null
-  }
   if (!asleep && !reloadPending) return
   asleep = false
   reloadPending = false
@@ -114,26 +104,15 @@ function rememberReloadAt(now: number): void {
   }
 }
 
-function armReloadPending(): void {
-  if (reloadPending) return
-  reloadPending = true
-  notify()
-}
-
 function reloadForWorkspaceUnavailable(): void {
-  // Cover first so in-app 502/503 errors never paint over the last surface.
-  armReloadPending()
   const last = lastReloadAt()
   const now = Date.now()
-  if (Number.isFinite(last) && now - last < COOLDOWN_MS) {
-    if (reloadTimer == null) {
-      reloadTimer = setTimeout(() => {
-        reloadTimer = null
-        rememberReloadAt(Date.now())
-        reloadImpl()
-      }, COOLDOWN_MS - (now - last))
-    }
-    return
+  // Loop guard only. Do not sit on this overlay waiting — the ingress waking
+  // page is what polls until the host is ready.
+  if (Number.isFinite(last) && now - last < COOLDOWN_MS) return
+  if (!reloadPending) {
+    reloadPending = true
+    notify()
   }
   rememberReloadAt(now)
   reloadImpl()
@@ -159,11 +138,9 @@ async function unavailableStateOf(response: Response): Promise<WorkspaceUnavaila
   return parsed.data.state
 }
 
-// Open-tab 502/503 from ingress. Mid-boot states reload so the next document
-// request gets the waiting page; sleeping/error only flag a wake prompt.
+// Open-tab 502/503 from ingress. Mid-boot states cover then reload so the next
+// document request gets the waiting page; sleeping/error only flag a wake prompt.
 export async function maybeReloadForWorkspaceUnavailable(response: Response): Promise<void> {
-  // The workspace can wake through another path (another tab, ingress timer);
-  // any success drops the prompt instead of forcing a pointless reload.
   if (response.ok) {
     clearWorkspaceUnavailable()
     return

--- a/src/renderer/lib/workspace-unavailable.ts
+++ b/src/renderer/lib/workspace-unavailable.ts
@@ -84,9 +84,15 @@ function markWorkspaceAsleep(): void {
   notify()
 }
 
-function clearWorkspaceAsleep(): void {
-  if (!asleep) return
+// The workspace recovered on its own; drop the overlay and any queued reload.
+function clearWorkspaceUnavailable(): void {
+  if (reloadTimer != null) {
+    clearTimeout(reloadTimer)
+    reloadTimer = null
+  }
+  if (!asleep && !reloadPending) return
   asleep = false
+  reloadPending = false
   notify()
 }
 
@@ -159,7 +165,7 @@ export async function maybeReloadForWorkspaceUnavailable(response: Response): Pr
   // The workspace can wake through another path (another tab, ingress timer);
   // any success drops the prompt instead of forcing a pointless reload.
   if (response.ok) {
-    clearWorkspaceAsleep()
+    clearWorkspaceUnavailable()
     return
   }
   if (response.status !== 502 && response.status !== 503) return

--- a/src/renderer/lib/workspace-unavailable.ts
+++ b/src/renderer/lib/workspace-unavailable.ts
@@ -18,9 +18,13 @@ const PROMPT_STATES = new Set<WorkspaceUnavailableState>(['sleeping', 'error'])
 
 let reloadPending = false
 let asleep = false
-const asleepListeners = new Set<() => void>()
+const listeners = new Set<() => void>()
 let reloadImpl = (): void => {
   window.location.reload()
+}
+
+function notify(): void {
+  for (const listener of listeners) listener()
 }
 
 export function isWorkspaceUnavailableError(message: string | null | undefined): boolean {
@@ -35,21 +39,26 @@ export function isWorkspaceAsleep(): boolean {
   return asleep
 }
 
-export function subscribeWorkspaceAsleep(listener: () => void): () => void {
-  asleepListeners.add(listener)
+// One store for both flags; snapshots above are the useSyncExternalStore reads.
+export function subscribeWorkspaceUnavailable(listener: () => void): () => void {
+  listeners.add(listener)
   return () => {
-    asleepListeners.delete(listener)
+    listeners.delete(listener)
   }
 }
 
 export function _resetWorkspaceUnavailableForTest(): void {
   reloadPending = false
   asleep = false
-  asleepListeners.clear()
+  listeners.clear()
   reloadImpl = () => {
     window.location.reload()
   }
-  sessionStorage.removeItem(RELOAD_KEY)
+  try {
+    sessionStorage.removeItem(RELOAD_KEY)
+  } catch {
+    // jsdom without storage; nothing to clear.
+  }
 }
 
 export function _setWorkspaceUnavailableReloadForTest(fn: () => void): void {
@@ -67,14 +76,40 @@ export function _markWorkspaceAsleepForTest(): void {
 function markWorkspaceAsleep(): void {
   if (asleep) return
   asleep = true
-  for (const listener of asleepListeners) listener()
+  notify()
+}
+
+function clearWorkspaceAsleep(): void {
+  if (!asleep) return
+  asleep = false
+  notify()
+}
+
+// Some privacy modes throw on any sessionStorage access; a broken cooldown
+// must degrade to "reload anyway", never to an exception out of apiFetch.
+function lastReloadAt(): number {
+  try {
+    return Number(sessionStorage.getItem(RELOAD_KEY) ?? 0)
+  } catch {
+    return 0
+  }
+}
+
+function rememberReloadAt(now: number): void {
+  try {
+    sessionStorage.setItem(RELOAD_KEY, String(now))
+  } catch {
+    // Cooldown persistence is best-effort.
+  }
 }
 
 function reloadForWorkspaceUnavailable(): void {
-  const last = Number(sessionStorage.getItem(RELOAD_KEY) ?? 0)
-  if (Number.isFinite(last) && Date.now() - last < COOLDOWN_MS) return
-  sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+  const last = lastReloadAt()
+  const now = Date.now()
+  if (Number.isFinite(last) && now - last < COOLDOWN_MS) return
+  rememberReloadAt(now)
   reloadPending = true
+  notify()
   reloadImpl()
 }
 
@@ -101,6 +136,12 @@ async function unavailableStateOf(response: Response): Promise<WorkspaceUnavaila
 // Open-tab 502/503 from ingress. Mid-boot states reload so the next document
 // request gets the waiting page; sleeping/error only flag a wake prompt.
 export async function maybeReloadForWorkspaceUnavailable(response: Response): Promise<void> {
+  // The workspace can wake through another path (another tab, ingress timer);
+  // any success drops the prompt instead of forcing a pointless reload.
+  if (response.ok) {
+    clearWorkspaceAsleep()
+    return
+  }
   if (response.status !== 502 && response.status !== 503) return
   // An Electron renderer loads local assets, so a reload never reaches the
   // ingress waiting page — WorkspaceReconnect handles this case instead.

--- a/src/renderer/lib/workspace-unavailable.ts
+++ b/src/renderer/lib/workspace-unavailable.ts
@@ -19,6 +19,7 @@ const PROMPT_STATES = new Set<WorkspaceUnavailableState>(['sleeping', 'error'])
 let reloadPending = false
 let asleep = false
 const listeners = new Set<() => void>()
+let reloadTimer: ReturnType<typeof setTimeout> | null = null
 let reloadImpl = (): void => {
   window.location.reload()
 }
@@ -51,6 +52,10 @@ export function _resetWorkspaceUnavailableForTest(): void {
   reloadPending = false
   asleep = false
   listeners.clear()
+  if (reloadTimer != null) {
+    clearTimeout(reloadTimer)
+    reloadTimer = null
+  }
   reloadImpl = () => {
     window.location.reload()
   }
@@ -103,13 +108,28 @@ function rememberReloadAt(now: number): void {
   }
 }
 
-function reloadForWorkspaceUnavailable(): void {
-  const last = lastReloadAt()
-  const now = Date.now()
-  if (Number.isFinite(last) && now - last < COOLDOWN_MS) return
-  rememberReloadAt(now)
+function armReloadPending(): void {
+  if (reloadPending) return
   reloadPending = true
   notify()
+}
+
+function reloadForWorkspaceUnavailable(): void {
+  // Cover first so in-app 502/503 errors never paint over the last surface.
+  armReloadPending()
+  const last = lastReloadAt()
+  const now = Date.now()
+  if (Number.isFinite(last) && now - last < COOLDOWN_MS) {
+    if (reloadTimer == null) {
+      reloadTimer = setTimeout(() => {
+        reloadTimer = null
+        rememberReloadAt(Date.now())
+        reloadImpl()
+      }, COOLDOWN_MS - (now - last))
+    }
+    return
+  }
+  rememberReloadAt(now)
   reloadImpl()
 }
 

--- a/src/renderer/lib/workspace-unavailable.ts
+++ b/src/renderer/lib/workspace-unavailable.ts
@@ -1,5 +1,9 @@
 import { isElectron } from './env'
-import { workspaceUnavailableBodySchema } from './workspace-unavailable-schema'
+import {
+  workspaceUnavailableBodySchema,
+  workspaceUnavailableStateSchema,
+  type WorkspaceUnavailableState,
+} from './workspace-unavailable-schema'
 
 // Set by the ingress on its 502/503 JSON; value is the route state ("waking",
 // "sleeping", "error") or "unreachable" for a dead upstream behind a ready route.
@@ -10,7 +14,7 @@ const COOLDOWN_MS = 15_000
 
 // sleeping/error mean click-to-wake: reloading would silently drop any typed
 // but unsent state, so those surface a prompt instead of a forced reload.
-const PROMPT_STATES = new Set(['sleeping', 'error'])
+const PROMPT_STATES = new Set<WorkspaceUnavailableState>(['sleeping', 'error'])
 
 let reloadPending = false
 let asleep = false
@@ -20,8 +24,7 @@ let reloadImpl = (): void => {
 }
 
 export function isWorkspaceUnavailableError(message: string | null | undefined): boolean {
-  if (!message) return false
-  return workspaceUnavailableBodySchema.safeParse({ error: message }).success
+  return message === 'deployment_unavailable'
 }
 
 export function isWorkspaceUnavailableReloadPending(): boolean {
@@ -75,10 +78,14 @@ function reloadForWorkspaceUnavailable(): void {
   reloadImpl()
 }
 
-async function unavailableStateOf(response: Response): Promise<string | null> {
+async function unavailableStateOf(response: Response): Promise<WorkspaceUnavailableState | null> {
   const header = response.headers.get(WORKSPACE_UNAVAILABLE_HEADER)
-  if (header) return header
-  // Fallback for ingress deployments that predate the header.
+  if (header) {
+    const parsed = workspaceUnavailableStateSchema.safeParse(header)
+    return parsed.success ? parsed.data : null
+  }
+  // Legacy 502 text also covered app-generated 502s, so only 503 has a safe fallback.
+  if (response.status !== 503) return null
   if (typeof response.clone !== 'function') return null
   let body: unknown
   try {
@@ -88,7 +95,7 @@ async function unavailableStateOf(response: Response): Promise<string | null> {
   }
   const parsed = workspaceUnavailableBodySchema.safeParse(body)
   if (!parsed.success) return null
-  return parsed.data.state ?? 'unreachable'
+  return parsed.data.state
 }
 
 // Open-tab 502/503 from ingress. Mid-boot states reload so the next document


### PR DESCRIPTION
## Summary
- **Bug:** During a host-app upgrade the open tab stays on SuperAgent and paints a login card with `deployment unavailable`. Users think the workspace is broken.
- **Why:** Ingress already has a waking page, but it is HTML for a new page load. An already-open tab only gets JSON `503 deployment_unavailable` / `502` “could not reach your workspace.”
- **Change:** On those two ingress bodies, the web app reloads the document (with a 15s cooldown, Electron skipped) so the next load hits “Getting your workspace ready.” AuthGate/AuthPage stay on loading instead of the red error while that reload is in flight.

## Test plan
- [ ] Unit tests: `workspace-unavailable`, `apiFetch` 503 reload, AuthPage/AuthGate loading (already green locally)
- [ ] Open a session tab, force the org through an upgrade (or flip the Cloudflare route to `waking`)
- [ ] Confirm the open tab reloads into the waking page without showing the red login error
- [ ] Confirm a refresh after the host is back lands on the same session URL
- [ ] Confirm a real `503` that is not `deployment_unavailable` does not reload


Made with [Cursor](https://cursor.com)