### PR TITLE
feat(errors): resume sessions after billing recovery (SUP-725)

### DIFF
--- a/src/api/billing-resume-attempts.test.ts
+++ b/src/api/billing-resume-attempts.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  beginBillingResumeAttempt,
+  finishBillingResumeAttempt,
+  resetBillingResumeAttemptsForTests,
+} from './billing-resume-attempts'
+
+describe('billing resume attempts', () => {
+  beforeEach(() => resetBillingResumeAttemptsForTests())
+
+  it('scopes duplicate attempt ids to their session', () => {
+    expect(beginBillingResumeAttempt('attempt-1', 'session-1', 0)).toEqual({ ok: true })
+    finishBillingResumeAttempt('attempt-1', 'session-1', true, 0)
+
+    expect(beginBillingResumeAttempt('attempt-1', 'session-1', 1)).toEqual({
+      ok: false,
+      duplicate: true,
+    })
+    expect(beginBillingResumeAttempt('attempt-1', 'session-2', 1)).toEqual({ ok: true })
+  })
+
+  it('expires completed attempts after the resume target lifetime', () => {
+    expect(beginBillingResumeAttempt('attempt-1', 'session-1', 0)).toEqual({ ok: true })
+    finishBillingResumeAttempt('attempt-1', 'session-1', true, 0)
+
+    expect(beginBillingResumeAttempt('attempt-1', 'session-1', 30 * 60 * 1000 + 1)).toEqual({
+      ok: true,
+    })
+  })
+
+  it('bounds completed attempt history', () => {
+    for (let i = 0; i <= 1000; i++) {
+      const attemptId = `attempt-${i}`
+      expect(beginBillingResumeAttempt(attemptId, 'session-1', i)).toEqual({ ok: true })
+      finishBillingResumeAttempt(attemptId, 'session-1', true, i)
+    }
+
+    expect(beginBillingResumeAttempt('attempt-0', 'session-1', 1002)).toEqual({ ok: true })
+  })
+})

--- a/src/api/billing-resume-attempts.ts
+++ b/src/api/billing-resume-attempts.ts
@@ -1,0 +1,67 @@
+type AttemptState = 'in_flight' | 'done'
+
+const DONE_TTL_MS = 30 * 60 * 1000
+const MAX_DONE_ATTEMPTS = 1000
+const attempts = new Map<string, { state: AttemptState; expiresAt: number | null }>()
+const sessionsInFlight = new Set<string>()
+
+function key(attemptId: string, sessionId: string): string {
+  return `${sessionId}:${attemptId}`
+}
+
+function pruneDoneAttempts(now: number): void {
+  for (const [attemptKey, attempt] of attempts) {
+    if (attempt.state === 'done' && attempt.expiresAt !== null && attempt.expiresAt <= now) {
+      attempts.delete(attemptKey)
+    }
+  }
+  let doneCount = [...attempts.values()].filter((attempt) => attempt.state === 'done').length
+  if (doneCount <= MAX_DONE_ATTEMPTS) return
+  for (const [attemptKey, attempt] of attempts) {
+    if (attempt.state !== 'done') continue
+    attempts.delete(attemptKey)
+    doneCount--
+    if (doneCount <= MAX_DONE_ATTEMPTS) return
+  }
+}
+
+export function beginBillingResumeAttempt(
+  attemptId: string,
+  sessionId: string,
+  now = Date.now(),
+):
+  | { ok: true }
+  | { ok: false; duplicate: true }
+  | { ok: false; duplicate?: false; reason: 'in_flight' | 'session_busy' } {
+  pruneDoneAttempts(now)
+  const existing = attempts.get(key(attemptId, sessionId))
+  if (existing?.state === 'done') return { ok: false, duplicate: true }
+  if (existing?.state === 'in_flight') return { ok: false, reason: 'in_flight' }
+  if (sessionsInFlight.has(sessionId)) return { ok: false, reason: 'session_busy' }
+  attempts.set(key(attemptId, sessionId), { state: 'in_flight', expiresAt: null })
+  sessionsInFlight.add(sessionId)
+  return { ok: true }
+}
+
+export function finishBillingResumeAttempt(
+  attemptId: string,
+  sessionId: string,
+  success: boolean,
+  now = Date.now(),
+): void {
+  sessionsInFlight.delete(sessionId)
+  if (success) {
+    attempts.set(key(attemptId, sessionId), {
+      state: 'done',
+      expiresAt: now + DONE_TTL_MS,
+    })
+    pruneDoneAttempts(now)
+  } else {
+    attempts.delete(key(attemptId, sessionId))
+  }
+}
+
+export function resetBillingResumeAttemptsForTests(): void {
+  attempts.clear()
+  sessionsInFlight.clear()
+}

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -179,6 +179,9 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     coalesceIfRecovering: vi.fn(() => false),
     dropCoalescedUserMessage: vi.fn(() => false),
     markSessionActive: vi.fn(),
+    markSessionIdle: vi.fn(),
+    tryMarkSessionActiveForBillingResume: vi.fn(() => true),
+    markSessionIdleIfBillingResumeClaimed: vi.fn(),
     markSessionInterrupted: vi.fn(),
     cancelAwaitingInput: vi.fn(),
     completeInputRequest: vi.fn(),
@@ -618,6 +621,9 @@ import { listCompletedOneTimeTasks, listPendingScheduledTasks, listPendingWakesB
 import { listArtifactsFromFilesystem } from '@shared/lib/services/artifact-service'
 import { deleteNotificationsBySessionIds, getSessionIdsWithUnreadNotifications, getUnreadNotificationsByAgents } from '@shared/lib/services/notification-service'
 import { markSessionUnread, clearSessionUnread, getSessionIdsMarkedUnread, getSessionIdsMarkedUnreadByAgents, deleteSessionUnreadMarks } from '@shared/lib/services/session-unread-service'
+import { resetBillingResumeAttemptsForTests } from '../billing-resume-attempts'
+import * as llmProvider from '@shared/lib/llm-provider'
+import { BILLING_RESUME_SYSTEM_PROMPT } from '@shared/lib/llm-provider/paywall-cta'
 import { messagePersister } from '@shared/lib/container/message-persister'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
@@ -3601,6 +3607,116 @@ describe('folder upload — POST /:id/upload-folder', () => {
 // ============================================================================
 // Message Author Attribution Tests
 // ============================================================================
+
+describe('POST /:id/sessions/:sessionId/resume-after-billing', () => {
+  const URL = '/api/agents/test-agent/sessions/sess-1/resume-after-billing'
+  const ATTEMPT = '550e8400-e29b-41d4-a716-446655440000'
+  let providerSpy: ReturnType<typeof vi.spyOn>
+
+  function paywallPage(text = 'API Error: 402 Workspace has insufficient balance. Top up to continue.') {
+    return {
+      messages: [{
+        id: 'asst-1',
+        type: 'assistant' as const,
+        content: { text },
+        toolCalls: [],
+        createdAt: new Date(),
+        apiError: 'unknown',
+      }],
+      nextCursor: null,
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetBillingResumeAttemptsForTests()
+    vi.mocked(containerManager.ensureRunning).mockResolvedValue(
+      containerManager.getClient('test-agent'),
+    )
+    vi.mocked(messagePersister.isSessionActive).mockReturnValue(false)
+    vi.mocked(messagePersister.tryMarkSessionActiveForBillingResume).mockReturnValue(true)
+    vi.mocked(getSessionMessagesPage).mockResolvedValue(paywallPage() as never)
+    mockSendMessage.mockResolvedValue(undefined)
+    providerSpy = vi.spyOn(llmProvider, 'getActiveLlmProvider').mockReturnValue({
+      parseSpecializedError: (_status: number | undefined, body: unknown) => {
+        const text = typeof body === 'string' ? body : ''
+        if (!text.includes('insufficient balance')) return null
+        return { severity: 'error', icon: 'circle-dollar-sign', message: text, paywall: {} }
+      },
+      parseErrorResponse: () => ({ severity: 'error', icon: 'info', message: 'x' }),
+    } as unknown as ReturnType<typeof llmProvider.getActiveLlmProvider>)
+  })
+
+  afterEach(() => {
+    providerSpy.mockRestore()
+    resetBillingResumeAttemptsForTests()
+    mockSendMessage.mockReset()
+    mockSendMessage.mockResolvedValue(undefined)
+  })
+
+  it('sends a fixed hidden continuation without creating a user message', async () => {
+    const res = await postJson(createApp(), URL, { attemptId: ATTEMPT })
+    expect(res.status).toBe(202)
+    expect(await res.json()).toEqual({ resumed: true })
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'sess-1',
+      BILLING_RESUME_SYSTEM_PROMPT,
+      expect.any(String),
+      { shouldQuery: true },
+    )
+    expect(mockSendMessage.mock.calls[0][1]).not.toMatch(/billing|payment|credit/i)
+    expect(mockDbInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('rejects a session whose latest assistant is not a paywall', async () => {
+    vi.mocked(getSessionMessagesPage).mockResolvedValue({
+      messages: [{
+        id: 'asst-1',
+        type: 'assistant',
+        content: { text: 'hello' },
+        toolCalls: [],
+        createdAt: new Date(),
+      }],
+      nextCursor: null,
+    } as never)
+    const res = await postJson(createApp(), URL, { attemptId: ATTEMPT })
+    expect(res.status).toBe(409)
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  it('replays a completed attempt id without sending again', async () => {
+    expect((await postJson(createApp(), URL, { attemptId: ATTEMPT })).status).toBe(202)
+    mockSendMessage.mockClear()
+    const res = await postJson(createApp(), URL, { attemptId: ATTEMPT })
+    expect(res.status).toBe(202)
+    expect(await res.json()).toEqual({ resumed: true, duplicate: true })
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  it('rejects when a normal send wins the final activity claim', async () => {
+    vi.mocked(messagePersister.tryMarkSessionActiveForBillingResume).mockReturnValueOnce(false)
+
+    const res = await postJson(createApp(), URL, { attemptId: ATTEMPT })
+
+    expect(res.status).toBe(409)
+    expect(mockSendMessage).not.toHaveBeenCalled()
+    expect(messagePersister.markSessionIdleIfBillingResumeClaimed).not.toHaveBeenCalled()
+  })
+
+  it('only rolls back activity still owned by the failed resume', async () => {
+    mockSendMessage.mockRejectedValueOnce(new Error('send failed'))
+
+    const res = await postJson(createApp(), URL, { attemptId: ATTEMPT })
+
+    expect(res.status).toBe(500)
+    expect(messagePersister.markSessionIdleIfBillingResumeClaimed).toHaveBeenCalledWith(
+      'test-agent',
+      'sess-1',
+      ATTEMPT,
+    )
+    expect(messagePersister.markSessionIdle).not.toHaveBeenCalled()
+  })
+})
 
 describe('message author attribution — POST /:id/sessions/:sessionId/messages', () => {
   let app: ReturnType<typeof createApp>

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -29,6 +29,16 @@ import {
 } from '@shared/lib/services/agent-service'
 import { containerManager } from '@shared/lib/container/container-manager'
 import {
+  beginBillingResumeAttempt,
+  finishBillingResumeAttempt,
+} from '../billing-resume-attempts'
+import {
+  latestHiddenContinuationIsResume,
+  latestVisibleAssistantHasPaywall,
+  resumeAfterBillingBodySchema,
+} from '@shared/lib/llm-provider/billing-resume'
+import { BILLING_RESUME_SYSTEM_PROMPT } from '@shared/lib/llm-provider/paywall-cta'
+import {
   syncAgentConnectionEnvironment,
   updateConnectedAccountsEnvironment,
   updateRemoteMcpEnvironment,
@@ -2859,6 +2869,67 @@ agents.post('/:id/sessions/:sessionId/messages', AgentUser(), async (c) => {
   } catch (error) {
     console.error('Failed to send message:', error)
     return c.json({ error: 'Failed to send message' }, 500)
+  }
+})
+
+// Resume a turn interrupted by a billing 402. The prompt is fixed and hidden
+// from the transcript UI; callers cannot use this route to inject content.
+agents.post('/:id/sessions/:sessionId/resume-after-billing', AgentUser(), async (c) => {
+  const agentSlug = getAgentId(c)
+  const sessionId = c.req.param('sessionId')
+  if (!(await sessionIsKnown(agentSlug, sessionId))) {
+    return c.json({ error: 'Session not found' }, 404)
+  }
+
+  const parsed = resumeAfterBillingBodySchema.safeParse(await c.req.json().catch(() => ({})))
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid resume request' }, 400)
+  }
+  const { attemptId } = parsed.data
+
+  const claim = beginBillingResumeAttempt(attemptId, sessionId)
+  if (!claim.ok && claim.duplicate) {
+    return c.json({ resumed: true, duplicate: true }, 202)
+  }
+  if (!claim.ok) {
+    return c.json({ error: 'Resume already in progress' }, 409)
+  }
+
+  if (messagePersister.isSessionActive(agentSlug, sessionId)) {
+    finishBillingResumeAttempt(attemptId, sessionId, false)
+    return c.json({ error: 'Session is already active' }, 409)
+  }
+
+  try {
+    const page = await getSessionMessagesPage(agentSlug, sessionId, { limit: 20 })
+    attachProviderErrorPresentations(page.messages)
+    if (latestHiddenContinuationIsResume(page.messages)) {
+      finishBillingResumeAttempt(attemptId, sessionId, false)
+      return c.json({ resumed: true, duplicate: true }, 202)
+    }
+    if (!latestVisibleAssistantHasPaywall(page.messages)) {
+      finishBillingResumeAttempt(attemptId, sessionId, false)
+      return c.json({ error: 'Session is not waiting on billing' }, 409)
+    }
+
+    const client = await containerManager.ensureRunning(agentSlug)
+    if (!messagePersister.isSubscribed(agentSlug, sessionId)) {
+      await messagePersister.subscribeToSession(agentSlug, sessionId, client, sessionId)
+    }
+    if (!messagePersister.tryMarkSessionActiveForBillingResume(agentSlug, sessionId, attemptId)) {
+      finishBillingResumeAttempt(attemptId, sessionId, false)
+      return c.json({ error: 'Session is already active' }, 409)
+    }
+    await client.sendMessage(sessionId, BILLING_RESUME_SYSTEM_PROMPT, randomUUID(), {
+      shouldQuery: true,
+    })
+    finishBillingResumeAttempt(attemptId, sessionId, true)
+    return c.json({ resumed: true }, 202)
+  } catch (error) {
+    finishBillingResumeAttempt(attemptId, sessionId, false)
+    messagePersister.markSessionIdleIfBillingResumeClaimed(agentSlug, sessionId, attemptId)
+    console.error('Failed to resume after billing:', error)
+    return c.json({ error: 'Failed to resume after billing' }, 500)
   }
 })
 

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -273,6 +273,7 @@ export function AgentActivityIndicator({
           <ProviderErrorCard
             message={error}
             presentation={errorPresentation ?? undefined}
+            resumeTarget={{ agentSlug, sessionId }}
           />
         ) : (
           <ActivityErrorCard message={error} />

--- a/src/renderer/components/messages/session-thread.tsx
+++ b/src/renderer/components/messages/session-thread.tsx
@@ -150,6 +150,11 @@ export function SessionThread({
                 rawMessage={paywall.source.message}
                 paywallCta={paywall.cta}
                 paywallLoading={paywall.loading}
+                resumeTarget={{
+                  agentSlug,
+                  sessionId,
+                  initialAllowed: paywall.billingAccessAllowed,
+                }}
               />
             </div>
           )}

--- a/src/renderer/components/ui/paywall-actions.tsx
+++ b/src/renderer/components/ui/paywall-actions.tsx
@@ -3,22 +3,38 @@ import { Loader2 } from 'lucide-react'
 
 import {
   buildTopupHandoffUrl,
+  isArmablePaywallCta,
   type PaywallCta,
 } from '@shared/lib/llm-provider/paywall-cta'
 import { Button } from '@renderer/components/ui/button'
+import {
+  rememberBillingResumeTarget,
+  type BillingResumeTarget,
+} from '@renderer/lib/billing-resume-target'
+
+export type PaywallResumeTarget = Pick<BillingResumeTarget, 'agentSlug' | 'sessionId'> & {
+  initialAllowed?: boolean
+}
 import { openExternalUrl } from '@renderer/lib/open-external'
 
 function stopCardToggle(event: MouseEvent) {
   event.stopPropagation()
 }
 
+function armResume(resumeTarget?: PaywallResumeTarget): void {
+  if (!resumeTarget) return
+  rememberBillingResumeTarget(resumeTarget)
+}
+
 function ExternalCtaButton({
   href,
   disabled,
+  onOpen,
   children,
 }: {
   href: string | null
   disabled?: boolean
+  onOpen?: () => void
   children: ReactNode
 }) {
   return (
@@ -28,6 +44,7 @@ function ExternalCtaButton({
       onClick={(event) => {
         stopCardToggle(event)
         if (!href) return
+        onOpen?.()
         void openExternalUrl(href)
       }}
     >
@@ -46,9 +63,11 @@ const CTA_LABELS = {
 export function PaywallActions({
   cta,
   loading,
+  resumeTarget,
 }: {
   cta: PaywallCta | null
   loading: boolean
+  resumeTarget?: PaywallResumeTarget
 }) {
   if (loading) {
     return (
@@ -69,6 +88,8 @@ export function PaywallActions({
     )
   }
 
+  const arm = isArmablePaywallCta(cta.kind) ? () => armResume(resumeTarget) : undefined
+
   if (cta.kind === 'topup') {
     const handoffHref = buildTopupHandoffUrl(cta.href, window.electronAPI?.desktopProtocol)
     return (
@@ -79,6 +100,7 @@ export function PaywallActions({
           onClick={(event) => {
             stopCardToggle(event)
             if (!handoffHref) return
+            arm?.()
             void openExternalUrl(handoffHref)
           }}
         >
@@ -90,7 +112,7 @@ export function PaywallActions({
 
   return (
     <div data-testid="paywall-actions">
-      <ExternalCtaButton href={cta.href}>{CTA_LABELS[cta.kind]}</ExternalCtaButton>
+      <ExternalCtaButton href={cta.href} onOpen={arm}>{CTA_LABELS[cta.kind]}</ExternalCtaButton>
     </div>
   )
 }

--- a/src/renderer/components/ui/provider-error-card.test.tsx
+++ b/src/renderer/components/ui/provider-error-card.test.tsx
@@ -4,6 +4,10 @@ import { fireEvent, render, screen } from '@testing-library/react'
 
 import { parsePlatformErrorResponse } from '@shared/lib/llm-provider/platform-error-presentation'
 import { resolvePresentationMarkdown } from '@shared/lib/llm-provider/error-presentation'
+import {
+  getBillingResumeTarget,
+  resetBillingResumeTargetForTests,
+} from '@renderer/lib/billing-resume-target'
 
 import { ProviderErrorCard, ProviderErrorView } from './provider-error-card'
 
@@ -39,8 +43,10 @@ vi.mock('@renderer/hooks/use-billing-info', () => ({
 
 const SPEND_CAP =
   'API Error: Request rejected (429) · A spend cap for this workspace was reached. It resets within 30 days. Ask a workspace admin to raise it.'
+const RESUME_TARGET = { agentSlug: 'agent-1', sessionId: 'session-1' }
 
 beforeEach(() => {
+  resetBillingResumeTargetForTests()
   platformAuth.connected = true
   platformAuth.orgId = 'org_123'
   platformAuth.role = 'owner'
@@ -202,6 +208,7 @@ describe('ProviderErrorView', () => {
           kind: 'topup',
           href: 'https://platform.example.com/dashboard/organizations/org_123?tab=billing',
         }}
+        resumeTarget={RESUME_TARGET}
       />,
     )
 
@@ -212,6 +219,7 @@ describe('ProviderErrorView', () => {
     expect(openExternal).toHaveBeenCalledWith(
       'https://platform.example.com/dashboard/organizations/org_123?tab=billing&intent=topup&return_app=superagent%3A%2F%2Fbilling-updated',
     )
+    expect(getBillingResumeTarget()).toMatchObject(RESUME_TARGET)
   })
 
   it('renders a Go to billing button when the role is unknown', () => {

--- a/src/renderer/components/ui/provider-error-card.tsx
+++ b/src/renderer/components/ui/provider-error-card.tsx
@@ -8,7 +8,7 @@ import type { PaywallCta } from '@shared/lib/llm-provider/paywall-cta'
 
 import { HomeEmptyClouds } from '@renderer/components/home/home-empty-clouds'
 import { RequestError } from '@renderer/components/messages/request-error'
-import { PaywallActions } from '@renderer/components/ui/paywall-actions'
+import { PaywallActions, type PaywallResumeTarget } from '@renderer/components/ui/paywall-actions'
 import { usePaywallCta } from '@renderer/hooks/use-paywall-cta'
 import { useResolvedErrorPresentation } from '@renderer/hooks/use-provider-error-presentation'
 import { markdownUrlTransform } from '@renderer/lib/markdown-url-transform'
@@ -94,11 +94,13 @@ function PaywallCard({
   presentation,
   cta,
   loading,
+  resumeTarget,
   'data-testid': testId,
 }: {
   presentation: ProviderErrorPresentation
   cta: PaywallCta | null
   loading: boolean
+  resumeTarget?: PaywallResumeTarget
   'data-testid'?: string
 }) {
   const message = splitPaywallMessage(presentation.message)
@@ -131,7 +133,7 @@ function PaywallCard({
             </p>
           )}
         </div>
-        <PaywallActions cta={cta} loading={loading} />
+        <PaywallActions cta={cta} loading={loading} resumeTarget={resumeTarget} />
       </div>
     </div>
   )
@@ -142,12 +144,14 @@ export function ProviderErrorView({
   rawMessage,
   paywallCta = null,
   paywallLoading = false,
+  resumeTarget,
   'data-testid': testId,
 }: {
   presentation: ProviderErrorPresentation
   rawMessage?: string
   paywallCta?: PaywallCta | null
   paywallLoading?: boolean
+  resumeTarget?: PaywallResumeTarget
   'data-testid'?: string
 }) {
   if (presentation.paywall) {
@@ -156,6 +160,7 @@ export function ProviderErrorView({
         presentation={presentation}
         cta={paywallCta}
         loading={paywallLoading}
+        resumeTarget={resumeTarget}
         data-testid={testId}
       />
     )
@@ -193,10 +198,12 @@ export function ProviderErrorView({
 export function ProviderErrorCard({
   message,
   presentation,
+  resumeTarget,
   'data-testid': testId,
 }: {
   message: string
   presentation?: ProviderErrorPresentation
+  resumeTarget?: PaywallResumeTarget
   'data-testid'?: string
 }) {
   const base = useMemo(
@@ -211,6 +218,7 @@ export function ProviderErrorCard({
       rawMessage={message}
       paywallCta={paywall.cta}
       paywallLoading={paywall.loading}
+      resumeTarget={resumeTarget}
       data-testid={testId}
     />
   )

--- a/src/renderer/hooks/use-billing-updated.test.tsx
+++ b/src/renderer/hooks/use-billing-updated.test.tsx
@@ -5,11 +5,58 @@ import type { ReactNode } from 'react'
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  resetBillingRecoveryForTests,
+  setBillingRecoveryDelaysForTests,
+} from '@renderer/lib/billing-recovery'
 import { useBillingUpdatedListener } from './use-billing-updated'
 
-function wrapper(client: QueryClient) {
+const target = {
+  agentSlug: 'agent-1',
+  sessionId: 'session-1',
+  attemptId: '550e8400-e29b-41d4-a716-446655440000',
+  initialAllowed: false,
+  createdAt: Date.now(),
+  expiresAt: Date.now() + 60_000,
+}
+const mockApiFetch = vi.fn()
+const mockGetTarget = vi.fn()
+const mockClearTarget = vi.fn()
+const mockClearPaywallError = vi.fn()
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}))
+vi.mock('@renderer/lib/billing-resume-target', () => ({
+  getBillingResumeTarget: () => mockGetTarget(),
+  clearBillingResumeTarget: (...args: unknown[]) => mockClearTarget(...args),
+}))
+vi.mock('@renderer/hooks/use-message-stream', () => ({
+  clearPaywallError: (...args: unknown[]) => mockClearPaywallError(...args),
+  clearPaywallErrors: vi.fn(),
+}))
+vi.mock('@renderer/lib/error-reporting', () => ({
+  captureRendererException: vi.fn(),
+}))
+
+function wrapper(
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return React.createElement(QueryClientProvider, { client }, children)
+  }
+}
+
+function billingResponse(access: { allowed: boolean; reason: 'current_pool' | 'insufficient_balance' }) {
+  return {
+    connected: true,
+    billing: {
+      configured: true,
+      subscription: { status: 'active', paymentStatus: 'current', currentPeriodEnd: null },
+      seat: { balanceCents: 100, startingBalanceCents: 100 },
+      orgPool: { poolBalanceCents: 0 },
+      access,
+    },
   }
 }
 
@@ -17,7 +64,21 @@ describe('useBillingUpdatedListener', () => {
   let billingUpdated: (() => void) | undefined
 
   beforeEach(() => {
+    vi.clearAllMocks()
+    resetBillingRecoveryForTests()
+    setBillingRecoveryDelaysForTests([0])
     billingUpdated = undefined
+    mockGetTarget.mockReturnValue(target)
+    mockApiFetch.mockImplementation(async (url: string) => {
+      if (url === '/api/platform-auth/billing') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => billingResponse({ allowed: true, reason: 'current_pool' }),
+        }
+      }
+      return { ok: true, status: 202, json: async () => ({ resumed: true }) }
+    })
     window.electronAPI = {
       onBillingUpdated: (callback) => {
         billingUpdated = callback
@@ -27,22 +88,44 @@ describe('useBillingUpdatedListener', () => {
     } as typeof window.electronAPI
   })
 
-  it('refreshes the active billing query after the dashboard handoff', async () => {
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    const invalidate = vi.spyOn(client, 'invalidateQueries').mockResolvedValue()
-    renderHook(() => useBillingUpdatedListener(), { wrapper: wrapper(client) })
-
+  it('continues the armed session after the KV gate allows', async () => {
+    renderHook(() => useBillingUpdatedListener(), { wrapper: wrapper() })
     act(() => billingUpdated?.())
 
     await waitFor(() => {
-      expect(invalidate).toHaveBeenCalledWith({
-        queryKey: ['platform-billing'],
-        refetchType: 'active',
-      })
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        '/api/agents/agent-1/sessions/session-1/resume-after-billing',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ attemptId: target.attemptId }),
+        }),
+      )
     })
+    expect(mockClearTarget).toHaveBeenCalledWith(target)
+    expect(mockClearPaywallError).toHaveBeenCalledWith('session-1')
   })
 
-  it('coalesces deep-link, focus, and visibility signals', async () => {
+  it('does not resume from a positive balance while the gate stays denied', async () => {
+    mockApiFetch.mockImplementation(async (url: string) => ({
+      ok: true,
+      status: 200,
+      json: async () => url === '/api/platform-auth/billing'
+        ? billingResponse({ allowed: false, reason: 'insufficient_balance' })
+        : { resumed: true },
+    }))
+    renderHook(() => useBillingUpdatedListener(), { wrapper: wrapper() })
+    act(() => billingUpdated?.())
+
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalledWith('/api/platform-auth/billing'))
+    expect(mockApiFetch).not.toHaveBeenCalledWith(
+      '/api/agents/agent-1/sessions/session-1/resume-after-billing',
+      expect.anything(),
+    )
+    expect(mockClearPaywallError).not.toHaveBeenCalled()
+  })
+
+  it('coalesces billing lifecycle signals without a resume target', async () => {
+    mockGetTarget.mockReturnValue(null)
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const invalidate = vi.spyOn(client, 'invalidateQueries').mockResolvedValue()
     renderHook(() => useBillingUpdatedListener(), { wrapper: wrapper(client) })
@@ -53,6 +136,13 @@ describe('useBillingUpdatedListener', () => {
       document.dispatchEvent(new Event('visibilitychange'))
     })
 
-    await waitFor(() => expect(invalidate).toHaveBeenCalledTimes(1))
+    await waitFor(() => {
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: ['platform-billing'],
+        refetchType: 'active',
+      })
+    })
+    expect(invalidate).toHaveBeenCalledTimes(1)
+    expect(mockApiFetch).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/use-billing-updated.ts
+++ b/src/renderer/hooks/use-billing-updated.ts
@@ -1,23 +1,76 @@
 import { useEffect } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { type QueryClient, useQueryClient } from '@tanstack/react-query'
 
+import { apiFetch } from '@renderer/lib/api'
+import { recoverAfterBillingEvent } from '@renderer/lib/billing-recovery'
+import {
+  clearBillingResumeTarget,
+  getBillingResumeTarget,
+  type BillingResumeTarget,
+} from '@renderer/lib/billing-resume-target'
 import { captureRendererException } from '@renderer/lib/error-reporting'
+import { clearPaywallError } from '@renderer/hooks/use-message-stream'
+import type { BillingInfoResponse } from '@renderer/hooks/use-billing-info'
+
+async function refreshBilling(queryClient: QueryClient): Promise<BillingInfoResponse> {
+  const res = await apiFetch('/api/platform-auth/billing')
+  if (!res.ok) throw new Error(`Billing refresh failed (${res.status})`)
+  const snapshot = await res.json() as BillingInfoResponse
+  queryClient.setQueryData(['platform-billing'], snapshot)
+  return snapshot
+}
+
+async function requestResume(target: BillingResumeTarget): Promise<boolean> {
+  const res = await apiFetch(
+    `/api/agents/${encodeURIComponent(target.agentSlug)}/sessions/${encodeURIComponent(target.sessionId)}/resume-after-billing`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ attemptId: target.attemptId }),
+    },
+  )
+  if (res.ok) {
+    clearBillingResumeTarget(target)
+    clearPaywallError(target.sessionId)
+    return true
+  }
+  if (res.status === 409) {
+    const body = await res.json().catch(() => ({})) as { duplicate?: boolean }
+    if (body.duplicate) {
+      clearBillingResumeTarget(target)
+      clearPaywallError(target.sessionId)
+      return true
+    }
+  }
+  throw new Error(`Resume request failed (${res.status})`)
+}
 
 export function useBillingUpdatedListener(): void {
   const queryClient = useQueryClient()
 
   useEffect(() => {
     const reportRefreshError = (error: unknown) => {
-      console.warn('[BillingUpdated] billing refresh failed:', error)
+      const target = getBillingResumeTarget()
+      console.warn('[BillingUpdated] billing refresh or continuation failed:', error)
       captureRendererException(error, {
-        tags: { area: 'paywall', op: 'refresh-after-update' },
+        tags: { area: 'paywall', op: 'resume-after-update' },
+        extra: target
+          ? { agentSlug: target.agentSlug, sessionId: target.sessionId, attemptId: target.attemptId }
+          : undefined,
       })
     }
 
     const run = () => {
-      void queryClient.invalidateQueries({
-        queryKey: ['platform-billing'],
-        refetchType: 'active',
+      if (!getBillingResumeTarget()) {
+        void queryClient.invalidateQueries({
+          queryKey: ['platform-billing'],
+          refetchType: 'active',
+        }).catch(reportRefreshError)
+        return
+      }
+      void recoverAfterBillingEvent({
+        refresh: () => refreshBilling(queryClient),
+        resume: requestResume,
       }).catch(reportRefreshError)
     }
 

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -273,6 +273,40 @@ describe('useMessageStream', () => {
     expect(result.current.apiErrorCode).toBe('authentication_failed')
   })
 
+  it('clears only a server-authored paywall', async () => {
+    const { useMessageStream, clearPaywallErrors } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'session_error',
+        error: 'API Error: 402 Workspace has insufficient balance. Top up to continue.',
+        apiErrorCode: 'unknown',
+        errorPresentation: {
+          severity: 'error',
+          icon: 'info',
+          message: '**You need more usage credit to continue**',
+          paywall: {},
+        },
+      })
+    })
+    act(() => clearPaywallErrors())
+    expect(result.current.error).toBeNull()
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'session_error',
+        error: 'API Error: 402 Workspace has insufficient balance. Top up to continue.',
+        apiErrorCode: 'unknown',
+      })
+    })
+    act(() => clearPaywallErrors())
+    expect(result.current.error).toContain('insufficient balance')
+  })
+
   it('sets apiErrorCode from stream_api_error event', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -1375,6 +1375,23 @@ export function consumeDiscardedCommand(sessionId: string, uuid: string): void {
   }
 }
 
+export function clearPaywallError(sessionId: string): void {
+  const state = streamStates.get(sessionId)
+  if (!state) return
+  if (!state.errorPresentation?.paywall) return
+  streamStates.set(sessionId, {
+    ...state,
+    error: null,
+    apiErrorCode: null,
+    errorPresentation: null,
+  })
+  streamListeners.get(sessionId)?.forEach((listener) => listener())
+}
+
+export function clearPaywallErrors(): void {
+  for (const sessionId of streamStates.keys()) clearPaywallError(sessionId)
+}
+
 export function removePeerUserMessage(sessionId: string, uuid: string): void {
   const current = streamStates.get(sessionId)
   if (current && current.peerUserMessages.some((p) => p.uuid === uuid)) {

--- a/src/renderer/lib/billing-recovery.test.ts
+++ b/src/renderer/lib/billing-recovery.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getBillingResumeTarget,
+  rememberBillingResumeTarget,
+  resetBillingResumeTargetForTests,
+} from './billing-resume-target'
+import {
+  decideBillingResume,
+  recoverAfterBillingEvent,
+  resetBillingRecoveryForTests,
+} from './billing-recovery'
+import type { BillingInfoResponse } from '@renderer/hooks/use-billing-info'
+
+function snapshot(access?: { allowed: boolean; reason: 'current_pool' | 'insufficient_balance' }): BillingInfoResponse {
+  return {
+    connected: true,
+    billing: {
+      configured: true,
+      subscription: { status: 'active', paymentStatus: 'current', currentPeriodEnd: null },
+      seat: { balanceCents: 5000, startingBalanceCents: 5000 },
+      orgPool: { poolBalanceCents: 99999 },
+      access,
+    },
+  }
+}
+
+const target = {
+  initialAllowed: false,
+  expiresAt: Date.parse('2026-09-01T12:30:00.000Z'),
+}
+
+beforeEach(() => {
+  resetBillingResumeTargetForTests()
+  resetBillingRecoveryForTests()
+})
+
+afterEach(() => {
+  resetBillingResumeTargetForTests()
+  resetBillingRecoveryForTests()
+})
+
+describe('decideBillingResume', () => {
+  it('resumes only after a denied gate becomes allowed before expiry', () => {
+    const now = Date.parse('2026-09-01T12:00:00.000Z')
+    expect(decideBillingResume(
+      snapshot({ allowed: false, reason: 'insufficient_balance' }),
+      target,
+      now,
+    )).toBe('wait')
+    expect(decideBillingResume(
+      snapshot({ allowed: true, reason: 'current_pool' }),
+      target,
+      now,
+    )).toBe('resume')
+    expect(decideBillingResume(snapshot(), target, now)).toBe('abort')
+    expect(decideBillingResume(
+      snapshot({ allowed: true, reason: 'current_pool' }),
+      { ...target, initialAllowed: true },
+      now,
+    )).toBe('abort')
+    expect(decideBillingResume(
+      snapshot({ allowed: true, reason: 'current_pool' }),
+      target,
+      Date.parse('2026-09-01T12:31:00.000Z'),
+    )).toBe('abort')
+  })
+})
+
+describe('recoverAfterBillingEvent', () => {
+  it('polls a stale denied gate until it allows, then resumes once', async () => {
+    rememberBillingResumeTarget({ agentSlug: 'agent-1', sessionId: 'session-1' })
+    const refresh = vi.fn()
+      .mockResolvedValueOnce(snapshot({ allowed: false, reason: 'insufficient_balance' }))
+      .mockResolvedValueOnce(snapshot({ allowed: true, reason: 'current_pool' }))
+    const resume = vi.fn().mockResolvedValue(true)
+
+    await expect(recoverAfterBillingEvent({
+      refresh,
+      resume,
+      sleep: async () => {},
+      delays: [0, 0],
+    })).resolves.toBe('resumed')
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not resume checkout cancel (gate stays denied)', async () => {
+    rememberBillingResumeTarget({ agentSlug: 'agent-1', sessionId: 'session-1' })
+    const resume = vi.fn()
+    await expect(recoverAfterBillingEvent({
+      refresh: async () => snapshot({ allowed: false, reason: 'insufficient_balance' }),
+      resume,
+      sleep: async () => {},
+      delays: [0, 0, 0],
+    })).resolves.toBe('waiting')
+    expect(resume).not.toHaveBeenCalled()
+  })
+
+  it('does not resume from a stale allowed snapshot', async () => {
+    rememberBillingResumeTarget({ agentSlug: 'agent-1', sessionId: 'session-1' })
+    const staleAllowed = { ...snapshot({ allowed: true, reason: 'current_pool' }), stale: true }
+    const resume = vi.fn().mockResolvedValue(true)
+
+    await expect(recoverAfterBillingEvent({
+      refresh: vi.fn()
+        .mockResolvedValueOnce(staleAllowed)
+        .mockResolvedValueOnce(snapshot({ allowed: true, reason: 'current_pool' })),
+      resume,
+      sleep: async () => {},
+      delays: [0, 0],
+    })).resolves.toBe('resumed')
+
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears a terminal target when access is unavailable', async () => {
+    rememberBillingResumeTarget({ agentSlug: 'agent-1', sessionId: 'session-1' })
+
+    await expect(recoverAfterBillingEvent({
+      refresh: async () => snapshot(),
+      resume: vi.fn(),
+      delays: [0],
+    })).resolves.toBe('aborted')
+
+    expect(getBillingResumeTarget()).toBeNull()
+  })
+})

--- a/src/renderer/lib/billing-recovery.ts
+++ b/src/renderer/lib/billing-recovery.ts
@@ -1,0 +1,67 @@
+import type { BillingInfoResponse } from '@renderer/hooks/use-billing-info'
+import {
+  clearBillingResumeTarget,
+  getBillingResumeTarget,
+  type BillingResumeTarget,
+} from '@renderer/lib/billing-resume-target'
+
+export const BILLING_GATE_POLL_DELAYS_MS = [0, 500, 1000, 2000, 4000, 8000] as const
+
+export type RecoveryOutcome = 'resumed' | 'waiting' | 'aborted' | 'idle'
+
+let inFlight = false
+let testDelays: readonly number[] | null = null
+
+export function resetBillingRecoveryForTests(): void {
+  inFlight = false
+  testDelays = null
+}
+
+export function setBillingRecoveryDelaysForTests(delays: readonly number[] | null): void {
+  testDelays = delays
+}
+
+export function decideBillingResume(
+  snapshot: BillingInfoResponse,
+  target: Pick<BillingResumeTarget, 'initialAllowed' | 'expiresAt'>,
+  now = Date.now(),
+): 'resume' | 'wait' | 'abort' {
+  if (now > target.expiresAt) return 'abort'
+  if (snapshot.stale) return 'wait'
+  const access = snapshot.billing?.access
+  if (!access) return 'abort'
+  if (access.allowed && !target.initialAllowed) return 'resume'
+  if (access.allowed) return 'abort'
+  return 'wait'
+}
+
+export async function recoverAfterBillingEvent(opts: {
+  refresh: () => Promise<BillingInfoResponse>
+  resume: (target: BillingResumeTarget) => Promise<boolean>
+  sleep?: (ms: number) => Promise<void>
+  delays?: readonly number[]
+  now?: () => number
+}): Promise<RecoveryOutcome> {
+  if (inFlight) return 'idle'
+  const target = getBillingResumeTarget()
+  if (!target) return 'idle'
+
+  inFlight = true
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)))
+  const delays = opts.delays ?? testDelays ?? BILLING_GATE_POLL_DELAYS_MS
+  const now = opts.now ?? Date.now
+  try {
+    for (const delay of delays) {
+      if (delay > 0) await sleep(delay)
+      const decision = decideBillingResume(await opts.refresh(), target, now())
+      if (decision === 'resume') return (await opts.resume(target)) ? 'resumed' : 'waiting'
+      if (decision === 'abort') {
+        clearBillingResumeTarget(target)
+        return 'aborted'
+      }
+    }
+    return 'waiting'
+  } finally {
+    inFlight = false
+  }
+}

--- a/src/renderer/lib/billing-resume-target.test.ts
+++ b/src/renderer/lib/billing-resume-target.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getBillingResumeTarget,
+  rememberBillingResumeTarget,
+  resetBillingResumeTargetForTests,
+} from './billing-resume-target'
+
+beforeEach(() => {
+  resetBillingResumeTargetForTests()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-09-01T12:00:00.000Z'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  resetBillingResumeTargetForTests()
+})
+
+describe('billing resume target', () => {
+  it('keeps one initiating session and drops expired or malformed records', () => {
+    rememberBillingResumeTarget({ agentSlug: 'agent-1', sessionId: 'session-1' })
+    const second = rememberBillingResumeTarget({ agentSlug: 'agent-2', sessionId: 'session-2' })
+    expect(getBillingResumeTarget()).toEqual(second)
+
+    vi.setSystemTime(new Date('2026-09-01T12:31:00.000Z'))
+    expect(getBillingResumeTarget()).toBeNull()
+
+    sessionStorage.setItem('superagent.billing-resume', '{not-json')
+    expect(getBillingResumeTarget()).toBeNull()
+  })
+})

--- a/src/renderer/lib/billing-resume-target.ts
+++ b/src/renderer/lib/billing-resume-target.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod'
+
+const STORAGE_KEY = 'superagent.billing-resume'
+const TTL_MS = 30 * 60 * 1000
+
+export const billingResumeTargetSchema = z.object({
+  agentSlug: z.string().min(1),
+  sessionId: z.string().min(1),
+  attemptId: z.string().uuid(),
+  initialAllowed: z.boolean(),
+  createdAt: z.number(),
+  expiresAt: z.number(),
+})
+
+export type BillingResumeTarget = z.infer<typeof billingResumeTargetSchema>
+
+let memoryTarget: BillingResumeTarget | null = null
+
+function storage(): Storage | undefined {
+  try {
+    return sessionStorage
+  } catch {
+    return undefined
+  }
+}
+
+function persist(target: BillingResumeTarget | null): void {
+  memoryTarget = target
+  const session = storage()
+  if (!session) return
+  try {
+    if (!target) session.removeItem(STORAGE_KEY)
+    else session.setItem(STORAGE_KEY, JSON.stringify(target))
+  } catch {
+    // Restricted storage still keeps the in-memory copy for this tab.
+  }
+}
+
+function readStored(): BillingResumeTarget | null {
+  const session = storage()
+  if (session) {
+    try {
+      const raw = session.getItem(STORAGE_KEY)
+      if (raw != null) {
+        const parsed = billingResumeTargetSchema.safeParse(JSON.parse(raw))
+        if (parsed.success) return parsed.data
+        session.removeItem(STORAGE_KEY)
+      }
+    } catch {
+      session.removeItem(STORAGE_KEY)
+    }
+  }
+  return memoryTarget
+}
+
+export function rememberBillingResumeTarget(input: {
+  agentSlug: string
+  sessionId: string
+  initialAllowed?: boolean
+}): BillingResumeTarget {
+  const now = Date.now()
+  const target: BillingResumeTarget = {
+    agentSlug: input.agentSlug,
+    sessionId: input.sessionId,
+    attemptId: crypto.randomUUID(),
+    initialAllowed: input.initialAllowed ?? false,
+    createdAt: now,
+    expiresAt: now + TTL_MS,
+  }
+  persist(target)
+  return target
+}
+
+export function getBillingResumeTarget(): BillingResumeTarget | null {
+  const target = readStored()
+  if (!target) return null
+  if (Date.now() > target.expiresAt) {
+    persist(null)
+    return null
+  }
+  return target
+}
+
+export function clearBillingResumeTarget(
+  target?: Pick<BillingResumeTarget, 'agentSlug' | 'sessionId'> | Pick<BillingResumeTarget, 'attemptId'>,
+): void {
+  const current = readStored()
+  if (!current) return
+  if (!target) {
+    persist(null)
+    return
+  }
+  if ('attemptId' in target && target.attemptId === current.attemptId) {
+    persist(null)
+    return
+  }
+  if (
+    'agentSlug' in target
+    && target.agentSlug === current.agentSlug
+    && target.sessionId === current.sessionId
+  ) {
+    persist(null)
+  }
+}
+
+export function resetBillingResumeTargetForTests(): void {
+  memoryTarget = null
+  storage()?.removeItem(STORAGE_KEY)
+}

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2503,6 +2503,36 @@ describe('MessagePersister', () => {
 
       expect(sseEvents).toHaveLength(0)
     })
+    it('only rolls back the billing resume that still owns the active claim', () => {
+      expect(
+        messagePersister.tryMarkSessionActiveForBillingResume(
+          AGENT_SLUG,
+          SESSION_ID,
+          'resume-1',
+        ),
+      ).toBe(true)
+
+      messagePersister.markSessionIdleIfBillingResumeClaimed(AGENT_SLUG, SESSION_ID, 'other-resume')
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+
+      messagePersister.markSessionIdleIfBillingResumeClaimed(AGENT_SLUG, SESSION_ID, 'resume-1')
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+    })
+
+    it('does not roll back after a normal send takes over the active session', () => {
+      expect(
+        messagePersister.tryMarkSessionActiveForBillingResume(
+          AGENT_SLUG,
+          SESSION_ID,
+          'resume-1',
+        ),
+      ).toBe(true)
+
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      messagePersister.markSessionIdleIfBillingResumeClaimed(AGENT_SLUG, SESSION_ID, 'resume-1')
+
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+    })
   })
 
   // ============================================================================

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -189,6 +189,7 @@ interface StreamingState {
   // rolled back (markSessionIdle), so a failed send cannot leave the session
   // ranked as if it had just been used.
   provisionalActivity: SessionActivityMark | null
+  billingResumeClaimId?: string | null
   lastContextWindow: number // Last known context window size (default 200k)
   lastAssistantUsage: SessionUsage | null // Per-call usage from most recent assistant message
   completedSubagentIds: Set<string> // completed agentIds; a new task_started with the same ID is a resumed run
@@ -713,6 +714,17 @@ class MessagePersister {
     }
     state.provisionalActivity = null
     this.finalizeIdle(agentSlug, sessionId, state)
+  }
+
+  markSessionIdleIfBillingResumeClaimed(
+    agentSlug: string,
+    sessionId: string,
+    claimId: string,
+  ): void {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
+    if (state?.billingResumeClaimId !== claimId) return
+    state.billingResumeClaimId = null
+    this.markSessionIdle(agentSlug, sessionId)
   }
 
   // Check if a session is currently active (processing user request)
@@ -1364,6 +1376,7 @@ class MessagePersister {
         this.capture.recordNote(sessionId, 'state_created', { agentSlug }).catch(() => {})
       }
     }
+    state.billingResumeClaimId = null
     // Re-marking an ALREADY-active session is how a queued/steering message is
     // accepted mid-turn — it is not a turn boundary. Split the resets the same way
     // the app's session_active handler does (see use-message-stream.ts): what any
@@ -1439,6 +1452,19 @@ class MessagePersister {
     // makes a session that joins mid-review show awaiting immediately (the
     // review used to mark only the sessions active at request time).
     this.syncSessionAwaiting(agentSlug, sessionId)
+  }
+
+  tryMarkSessionActiveForBillingResume(
+    agentSlug: string,
+    sessionId: string,
+    claimId: string,
+  ): boolean {
+    if (this.isSessionActive(agentSlug, sessionId)) return false
+    this.markSessionActive(agentSlug, sessionId)
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
+    if (!state?.isActive) return false
+    state.billingResumeClaimId = claimId
+    return true
   }
 
   // Recompute the derived awaiting projection for a session and broadcast on
@@ -1825,6 +1851,7 @@ class MessagePersister {
       recordSessionActivity(state.agentSlug, sessionId, message.timestamp)
       // The turn is real; the optimistic send record no longer needs undoing.
       state.provisionalActivity = null
+      state.billingResumeClaimId = null
     }
 
     // Container late-join catch-up: the runtime replays the last turn's

--- a/src/shared/lib/llm-provider/billing-resume.test.ts
+++ b/src/shared/lib/llm-provider/billing-resume.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { BILLING_RESUME_SYSTEM_PROMPT } from './paywall-cta'
+import {
+  latestHiddenContinuationIsResume,
+  latestVisibleAssistantHasPaywall,
+  resumeAfterBillingBodySchema,
+} from './billing-resume'
+import type { TransformedItem } from '@shared/lib/utils/message-transform'
+
+function assistant(text: string, paywall = false): TransformedItem {
+  return {
+    id: 'asst-1',
+    type: 'assistant',
+    content: { text },
+    toolCalls: [],
+    createdAt: new Date(),
+    apiError: 'unknown',
+    errorPresentation: paywall
+      ? { severity: 'error', icon: 'info', message: text, paywall: {} }
+      : undefined,
+  }
+}
+
+function user(text: string): TransformedItem {
+  return {
+    id: 'user-1',
+    type: 'user',
+    content: { text },
+    toolCalls: [],
+    createdAt: new Date(),
+  }
+}
+
+describe('resumeAfterBillingBodySchema', () => {
+  it('requires a uuid attempt id', () => {
+    expect(resumeAfterBillingBodySchema.safeParse({}).success).toBe(false)
+    expect(resumeAfterBillingBodySchema.safeParse({ attemptId: 'not-a-uuid' }).success).toBe(false)
+    expect(resumeAfterBillingBodySchema.safeParse({
+      attemptId: '550e8400-e29b-41d4-a716-446655440000',
+    }).success).toBe(true)
+  })
+})
+
+describe('latestVisibleAssistantHasPaywall', () => {
+  it('trusts only a platform-authored paywall on the newest assistant', () => {
+    expect(latestVisibleAssistantHasPaywall([
+      user('hello'),
+      assistant('API Error: 402 Workspace has insufficient balance.', false),
+    ])).toBe(false)
+    expect(latestVisibleAssistantHasPaywall([
+      user('hello'),
+      assistant('API Error: 402 Workspace has insufficient balance.', true),
+    ])).toBe(true)
+  })
+})
+
+describe('latestHiddenContinuationIsResume', () => {
+  it('detects the hidden continuation as the newest user turn', () => {
+    expect(latestHiddenContinuationIsResume([
+      assistant('blocked', true),
+      user(BILLING_RESUME_SYSTEM_PROMPT),
+    ])).toBe(true)
+    expect(latestHiddenContinuationIsResume([
+      assistant('blocked', true),
+      user('please keep going'),
+    ])).toBe(false)
+  })
+})

--- a/src/shared/lib/llm-provider/billing-resume.ts
+++ b/src/shared/lib/llm-provider/billing-resume.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+import { BILLING_RESUME_SYSTEM_PROMPT } from '@shared/lib/llm-provider/paywall-cta'
+import type { TransformedItem } from '@shared/lib/utils/message-transform'
+
+export const resumeAfterBillingBodySchema = z.object({
+  attemptId: z.string().uuid(),
+})
+
+export function latestVisibleAssistantHasPaywall(items: TransformedItem[]): boolean {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i]
+    if (!item || item.type !== 'assistant') continue
+    return Boolean(item.errorPresentation?.paywall)
+  }
+  return false
+}
+
+export function latestHiddenContinuationIsResume(items: TransformedItem[]): boolean {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i]
+    if (!item || item.type !== 'user') continue
+    const text = item.content.text
+    if (text.startsWith('[SYSTEM] ')) {
+      return text === BILLING_RESUME_SYSTEM_PROMPT
+    }
+    return false
+  }
+  return false
+}

--- a/src/shared/lib/llm-provider/paywall-cta.ts
+++ b/src/shared/lib/llm-provider/paywall-cta.ts
@@ -1,4 +1,6 @@
 export const ORG_BILLING_PATH = '/dashboard/organizations/{orgId}?tab=billing'
+export const BILLING_RESUME_SYSTEM_PROMPT =
+  '[SYSTEM] Continue the interrupted request from where you stopped. Do not repeat work that was already completed.'
 
 export type PaywallCta =
   | { kind: 'subscribe'; href: string | null }
@@ -43,6 +45,9 @@ export function buildTopupHandoffUrl(
 const ACTIVE_SUBSCRIPTION = new Set(['active', 'trialing', 'cancellation_scheduled'])
 const UNRESOLVED_SUBSCRIPTION = new Set(['past_due', 'blocked', 'payment_failed'])
 const PAYMENT_NEEDS_ATTENTION = new Set(['past_due', 'blocked', 'payment_failed'])
+export function isArmablePaywallCta(kind: PaywallCta['kind']): boolean {
+  return kind === 'subscribe' || kind === 'add_card' || kind === 'topup' || kind === 'manage_payment'
+}
 
 // CLI 402s drop `subscription_required`. The billing snapshot still knows
 // whether this org needs a plan vs usage credit.


### PR DESCRIPTION
## Why

The base paywall PR restores the composer after billing recovers, but the user must manually retry the interrupted request. This stacked PR continues that exact session automatically.

## What changed

- Arm one initiating session when the user opens a write billing CTA.
- Poll the proxy-provided `access.allowed` gate after deep-link/focus return; stale or missing gate data never authorizes continuation.
- Send one fixed hidden continuation through an authenticated, agent-scoped API route.
- Scope and bound deduplication records and atomically claim session activity so a concurrent real user send wins safely.
- Clear terminal targets and coalesce deep-link/focus/visibility refresh signals.

Stacked on [the Paywall UI PR](https://github.com/SkillfulAgents/SuperAgent/pull/914). Review only the diff against `feat/sup-725-in-app-paywall`.

## Test plan

- [x] Focused paywall/recovery suite: 1,055 tests
- [x] Manual staging: subscribe restores access and continues the interrupted session
- [x] Manual staging: top-up restores access and continues the interrupted session
- [ ] Cancel checkout leaves the gate denied and does not continue
- [ ] Two sessions: only the session that opened billing continues
- [ ] Repeated hand-back signals produce one continuation

Made with [Cursor](https://cursor.com)