### PR TITLE
feat(renderer): show session status glyph in the tab title while hidden

### DIFF
--- a/src/renderer/hooks/use-document-title.test.tsx
+++ b/src/renderer/hooks/use-document-title.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AppLocation } from '@renderer/router/route-state'
 
 const DOT = ' \u00b7 '
@@ -11,7 +11,10 @@ const mocks = vi.hoisted(() => ({
   routeLocation: { selectedAgentSlug: null, view: { kind: 'home' } } as AppLocation,
   routerMatches: [] as Array<{ params: Record<string, string | undefined>; fullPath?: string }>,
   agent: undefined as { name?: string; dashboards?: Array<{ slug: string; name: string }> } | undefined,
-  session: undefined as { name?: string } | undefined,
+  session: undefined as
+    | { name?: string; isActive?: boolean; isAwaitingInput?: boolean; hasUnreadNotifications?: boolean }
+    | undefined,
+  isStreaming: false,
 }))
 
 vi.mock('@renderer/router/use-route-location', () => ({
@@ -32,7 +35,30 @@ vi.mock('@renderer/hooks/use-sessions', () => ({
   useSession: () => ({ data: mocks.session }),
 }))
 
-import { getDocumentTitle, useDocumentTitle } from './use-document-title'
+vi.mock('@renderer/hooks/use-message-stream', () => ({
+  useMessageStream: () => ({ isStreaming: mocks.isStreaming }),
+}))
+
+import {
+  applyTitleIndicator,
+  getDocumentTitle,
+  getTitleIndicator,
+  isTitleIndicatorAnimated,
+  TITLE_INDICATOR_FRAME_MS,
+  useDocumentTitle,
+} from './use-document-title'
+
+const AWAITING = ['\u25c6', '\u25c7'] // ◆ ◇
+const WORKING = ['\u25d0', '\u25d1'] // ◐ ◑
+const UNREAD = '\u25cf' // ●
+
+function setTabHidden(hidden: boolean) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => (hidden ? 'hidden' : 'visible'),
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
 
 function DocumentTitleHarness() {
   useDocumentTitle()
@@ -99,6 +125,31 @@ describe('getDocumentTitle', () => {
   })
 })
 
+describe('getTitleIndicator', () => {
+  it('prioritises awaiting over working over unread and cycles frames', () => {
+    expect(getTitleIndicator({}, 0)).toBeNull()
+    expect(getTitleIndicator({ hasUnreadNotifications: true }, 0)).toBe(UNREAD)
+    expect(getTitleIndicator({ hasUnreadNotifications: true }, 1)).toBe(UNREAD)
+    expect(getTitleIndicator({ isActive: true, hasUnreadNotifications: true }, 0)).toBe(WORKING[0])
+    expect(getTitleIndicator({ isStreaming: true }, 1)).toBe(WORKING[1])
+    expect(getTitleIndicator({ isActive: true, isAwaitingInput: true }, 0)).toBe(AWAITING[0])
+    expect(getTitleIndicator({ isAwaitingInput: true }, 3)).toBe(AWAITING[1])
+  })
+
+  it('only animates the working and awaiting states', () => {
+    expect(isTitleIndicatorAnimated({})).toBe(false)
+    expect(isTitleIndicatorAnimated({ hasUnreadNotifications: true })).toBe(false)
+    expect(isTitleIndicatorAnimated({ isActive: true })).toBe(true)
+    expect(isTitleIndicatorAnimated({ isStreaming: true })).toBe(true)
+    expect(isTitleIndicatorAnimated({ isAwaitingInput: true })).toBe(true)
+  })
+
+  it('prefixes the title with the glyph', () => {
+    expect(applyTitleIndicator('Launch Plan', null)).toBe('Launch Plan')
+    expect(applyTitleIndicator('Launch Plan', UNREAD)).toBe(`${UNREAD} Launch Plan`)
+  })
+})
+
 describe('useDocumentTitle', () => {
   beforeEach(() => {
     document.title = 'Old Title'
@@ -106,6 +157,12 @@ describe('useDocumentTitle', () => {
     mocks.routerMatches = [{ params: {}, fullPath: '/' }]
     mocks.agent = undefined
     mocks.session = undefined
+    mocks.isStreaming = false
+    setTabHidden(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('applies the current route title and updates on navigation', async () => {
@@ -141,5 +198,89 @@ describe('useDocumentTitle', () => {
     render(<DocumentTitleHarness />)
 
     await waitFor(() => expect(document.title).toBe(`Settings${DASH}Connections`))
+  })
+
+  describe('hidden-tab status indicator', () => {
+    const sessionTitle = `Launch Plan${DASH}Agent One`
+
+    function openSession(session: NonNullable<typeof mocks.session>) {
+      mocks.routeLocation = location({ kind: 'session', id: 'session-1' }, 'agent-one')
+      mocks.routerMatches = [
+        { params: { slug: 'agent-one' }, fullPath: '/agents/$slug' },
+        { params: { sessionId: 'session-1' }, fullPath: '/agents/$slug/sessions/$sessionId' },
+      ]
+      mocks.agent = { name: 'Agent One' }
+      mocks.session = { name: 'Launch Plan', ...session }
+    }
+
+    it('shows nothing while the tab is visible, even with something to report', async () => {
+      openSession({ isAwaitingInput: true, hasUnreadNotifications: true })
+      render(<DocumentTitleHarness />)
+      await waitFor(() => expect(document.title).toBe(sessionTitle))
+    })
+
+    it('prefixes the unread dot only while hidden and drops it on return', async () => {
+      openSession({ hasUnreadNotifications: true })
+      render(<DocumentTitleHarness />)
+      await waitFor(() => expect(document.title).toBe(sessionTitle))
+
+      act(() => setTabHidden(true))
+      await waitFor(() => expect(document.title).toBe(`${UNREAD} ${sessionTitle}`))
+
+      act(() => setTabHidden(false))
+      await waitFor(() => expect(document.title).toBe(sessionTitle))
+    })
+
+    it('animates the working glyph once per second while hidden', async () => {
+      vi.useFakeTimers()
+      openSession({ isActive: true })
+      render(<DocumentTitleHarness />)
+      act(() => setTabHidden(true))
+      expect(document.title).toBe(`${WORKING[0]} ${sessionTitle}`)
+
+      act(() => vi.advanceTimersByTime(TITLE_INDICATOR_FRAME_MS))
+      expect(document.title).toBe(`${WORKING[1]} ${sessionTitle}`)
+
+      act(() => vi.advanceTimersByTime(TITLE_INDICATOR_FRAME_MS))
+      expect(document.title).toBe(`${WORKING[0]} ${sessionTitle}`)
+    })
+
+    it('switches to the awaiting blink and back to the dot as the session settles', async () => {
+      vi.useFakeTimers()
+      openSession({ isActive: true, isAwaitingInput: true })
+      const { rerender } = render(<DocumentTitleHarness />)
+      act(() => setTabHidden(true))
+      expect(document.title).toBe(`${AWAITING[0]} ${sessionTitle}`)
+
+      act(() => vi.advanceTimersByTime(TITLE_INDICATOR_FRAME_MS))
+      expect(document.title).toBe(`${AWAITING[1]} ${sessionTitle}`)
+
+      // Turn finished while we were away: the completion notification is unread.
+      mocks.session = { name: 'Launch Plan', isActive: false, isAwaitingInput: false, hasUnreadNotifications: true }
+      rerender(<DocumentTitleHarness />)
+      expect(document.title).toBe(`${UNREAD} ${sessionTitle}`)
+
+      // Idle state holds no timer, so time passing changes nothing.
+      act(() => vi.advanceTimersByTime(TITLE_INDICATOR_FRAME_MS * 3))
+      expect(document.title).toBe(`${UNREAD} ${sessionTitle}`)
+    })
+
+    it('treats a live stream as working before the active echo lands', async () => {
+      openSession({ isActive: false })
+      mocks.isStreaming = true
+      render(<DocumentTitleHarness />)
+      act(() => setTabHidden(true))
+      await waitFor(() => expect(document.title).toBe(`${WORKING[0]} ${sessionTitle}`))
+    })
+
+    it('never decorates non-session views', async () => {
+      mocks.routeLocation = location({ kind: 'home' }, 'agent-one')
+      mocks.routerMatches = [{ params: { slug: 'agent-one' }, fullPath: '/agents/$slug' }]
+      mocks.agent = { name: 'Agent One' }
+      mocks.session = { name: 'Stale', isAwaitingInput: true }
+      render(<DocumentTitleHarness />)
+      act(() => setTabHidden(true))
+      await waitFor(() => expect(document.title).toBe(`Agent One${DOT}Gamut`))
+    })
   })
 })

--- a/src/renderer/hooks/use-document-title.ts
+++ b/src/renderer/hooks/use-document-title.ts
@@ -1,6 +1,7 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useRouterState } from '@tanstack/react-router'
 import { useAgent } from '@renderer/hooks/use-agents'
+import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useSession } from '@renderer/hooks/use-sessions'
 import { useRouteLocation } from '@renderer/router/use-route-location'
 import { settingsTabSchema, type SettingsTab } from '@renderer/router/search-schemas'
@@ -9,6 +10,44 @@ import type { AppLocation, AgentView } from '@renderer/router/route-state'
 const APP_TITLE = 'Gamut'
 const BRAND_SEPARATOR = ' \u00b7 '
 const VIEW_SEPARATOR = ' \u2014 '
+
+// Tab-title status indicator, shown only while the tab is hidden so a user
+// with many tabs open can read session state off the tab strip. Geometric
+// shapes rather than emoji: they render monochrome and single-width in every
+// browser's tab strip, and none has an emoji presentation Chrome would
+// colorize. Priority mirrors the sidebar session row (app-sidebar.tsx):
+// awaiting > working > unread.
+const AWAITING_FRAMES = ['\u25c6', '\u25c7'] // ◆ ◇ — blink
+const WORKING_FRAMES = ['\u25d0', '\u25d1'] // ◐ ◑ — spin
+const UNREAD_GLYPH = '\u25cf' // ●
+// Browsers clamp timers in hidden tabs to once per second (and to once per
+// minute after ~5 min), so anything faster would be silently throttled.
+export const TITLE_INDICATOR_FRAME_MS = 1000
+
+export interface TitleIndicatorFlags {
+  isActive?: boolean
+  isAwaitingInput?: boolean
+  hasUnreadNotifications?: boolean
+  /** Session-view stream state; the `session_active` echo can lag stream start by a tick. */
+  isStreaming?: boolean
+}
+
+/** Whether the indicator for these flags cycles frames (needs a timer). */
+export function isTitleIndicatorAnimated(flags: TitleIndicatorFlags): boolean {
+  return !!(flags.isAwaitingInput || flags.isActive || flags.isStreaming)
+}
+
+export function getTitleIndicator(flags: TitleIndicatorFlags, frame: number): string | null {
+  const step = Math.abs(frame) % 2
+  if (flags.isAwaitingInput) return AWAITING_FRAMES[step]
+  if (flags.isActive || flags.isStreaming) return WORKING_FRAMES[step]
+  if (flags.hasUnreadNotifications) return UNREAD_GLYPH
+  return null
+}
+
+export function applyTitleIndicator(title: string, indicator: string | null): string {
+  return indicator ? `${indicator} ${title}` : title
+}
 
 const SETTINGS_TAB_TITLES = {
   profile: 'Profile & Login',
@@ -152,6 +191,40 @@ function useSettingsTitleState(): SettingsTitleState {
   })
 }
 
+function useTabHidden(): boolean {
+  const [hidden, setHidden] = useState(
+    () => typeof document !== 'undefined' && document.visibilityState === 'hidden',
+  )
+  useEffect(() => {
+    const onVisibilityChange = () => setHidden(document.visibilityState === 'hidden')
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange)
+  }, [])
+  return hidden
+}
+
+/**
+ * Indicator glyph for the session on screen, or null when the tab is visible
+ * or the session has nothing to report. The frame timer only runs while the
+ * tab is hidden AND the state animates, so a visible tab or an idle session
+ * costs nothing.
+ */
+function useHiddenTabIndicator(flags: TitleIndicatorFlags | null): string | null {
+  const hidden = useTabHidden()
+  const animated = hidden && flags !== null && isTitleIndicatorAnimated(flags)
+  const [frame, setFrame] = useState(0)
+
+  useEffect(() => {
+    if (!animated) return
+    setFrame(0)
+    const timer = setInterval(() => setFrame((f) => f + 1), TITLE_INDICATOR_FRAME_MS)
+    return () => clearInterval(timer)
+  }, [animated])
+
+  if (!hidden || flags === null) return null
+  return getTitleIndicator(flags, frame)
+}
+
 export function useDocumentTitle() {
   const location = useRouteLocation()
   const settings = useSettingsTitleState()
@@ -160,6 +233,7 @@ export function useDocumentTitle() {
 
   const { data: agent } = useAgent(agentSlug)
   const { data: session } = useSession(sessionId, agentSlug)
+  const { isStreaming } = useMessageStream(sessionId, agentSlug)
 
   const dashboardName = useMemo(() => {
     if (location.view.kind !== 'dashboard') return null
@@ -181,8 +255,22 @@ export function useDocumentTitle() {
     [agent?.name, agentSlug, dashboardName, location, session?.name, settings.isSettingsRoute, settings.tab],
   )
 
+  const indicatorFlags = useMemo<TitleIndicatorFlags | null>(
+    () =>
+      sessionId && session
+        ? {
+            isActive: session.isActive,
+            isAwaitingInput: session.isAwaitingInput,
+            hasUnreadNotifications: session.hasUnreadNotifications,
+            isStreaming,
+          }
+        : null,
+    [isStreaming, session, sessionId],
+  )
+  const indicator = useHiddenTabIndicator(indicatorFlags)
+
   useEffect(() => {
     if (typeof document === 'undefined') return
-    document.title = title
-  }, [title])
+    document.title = applyTitleIndicator(title, indicator)
+  }, [indicator, title])
 }


### PR DESCRIPTION
## Summary

With many tabs open it's hard to tell at a glance what each agent is doing. This prefixes the `<title>` with a unicode glyph **only while the tab is hidden**, so the tab strip doubles as a status board:

| State | Glyph |
|---|---|
| Awaiting input | `◆` / `◇` blink |
| Working (active or streaming) | `◐` / `◑` spin |
| Done with an unread notification | `●` |
| Tab visible | none |

Geometric shapes rather than emoji: they render monochrome and single-width in every browser tab strip.

## How it hooks in

No new tracking system. `useDocumentTitle` already subscribes to the on-screen session, which carries the same three flags the sidebar dots read (`isActive`, `isAwaitingInput`, `hasUnreadNotifications`, kept fresh by the SSE lifecycle echo). The glyph is a pure function of those, the ref-counted `useMessageStream` state (so a stream counts as working before the `session_active` echo lands), and `document.visibilityState`.

- Priority mirrors `app-sidebar.tsx`: awaiting > working > unread.
- The 1s frame timer runs only while hidden **and** animating. A visible tab, non-session view, or idle session holds no timer.
- The `●` clears on return for free: `session-view.tsx` already marks notifications read on `visibilitychange`.

## Scope / known limits

- Session view only. Agent-level flags for other views are a possible follow-up.
- Gated on `document.hidden`, not `hasFocus()`. Alt-tabbing to another app with the tab still on screen shows nothing.
- Browsers throttle hidden-tab timers to 1/s (and 1/min after ~5 min), so the animation may freeze on one frame. A frozen `◐` still reads as working.

## Testing

- 7 new unit cases in `use-document-title.test.tsx` (pure priority/frame logic, hidden vs visible, animation under fake timers, awaiting → unread transition, streaming-as-working, non-session views untouched). 14/14 pass.
- `npm run typecheck` and eslint clean.
- Manually verified in a web dev instance against a real container: working spin, awaiting blink, and unread dot on return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5WngPhHo8XA23fNcFiEXJ
