### PR TITLE
fix(renderer): mark read-only skillsets in publish pickers

### DIFF
--- a/src/renderer/components/agents/agent-share-popover.tsx
+++ b/src/renderer/components/agents/agent-share-popover.tsx
@@ -37,7 +37,7 @@ import {
   useHostExportStatus,
 } from '@renderer/hooks/use-agent-templates'
 import { AgentTemplatePublishPanel } from '@renderer/components/agents/agent-template-publish-panel'
-import { useSkillsets } from '@renderer/hooks/use-skillsets'
+import { usePublishableSkillsets } from '@renderer/hooks/use-skillsets'
 import { ActivityOrb } from '@renderer/components/messages/activity-orb'
 import { ArrowDownToLine, ArrowRight, Check, LibraryBig, Loader2, Lock, User, X } from 'lucide-react'
 import type { AgentRole } from '@shared/lib/types/agent'
@@ -110,8 +110,10 @@ function UserAvatar({ name, className }: { name: string; className?: string }) {
 export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverProps) {
   const queryClient = useQueryClient()
   const { user, isAuthMode } = useUser()
-  const { data: skillsets } = useSkillsets()
-  const publishAvailable = !!skillsets?.some((ss) => ss.publishMode !== 'none')
+  const { data: publishableSkillsets } = usePublishableSkillsets()
+  // undefined while loading — treat as available so the default tab doesn't
+  // land on Export and stick there once the Publish tab appears.
+  const publishAvailable = publishableSkillsets === undefined || publishableSkillsets.length > 0
   const [open, setOpen] = useState(false)
   const [tab, setTab] = useState<'share' | 'publish' | 'export'>(isAuthMode ? 'share' : 'publish')
   const visibleTab = tab === 'publish' && !publishAvailable

--- a/src/renderer/components/agents/agent-share-popover.tsx
+++ b/src/renderer/components/agents/agent-share-popover.tsx
@@ -37,7 +37,6 @@ import {
   useHostExportStatus,
 } from '@renderer/hooks/use-agent-templates'
 import { AgentTemplatePublishPanel } from '@renderer/components/agents/agent-template-publish-panel'
-import { usePublishableSkillsets } from '@renderer/hooks/use-skillsets'
 import { ActivityOrb } from '@renderer/components/messages/activity-orb'
 import { ArrowDownToLine, ArrowRight, Check, LibraryBig, Loader2, Lock, User, X } from 'lucide-react'
 import type { AgentRole } from '@shared/lib/types/agent'
@@ -110,15 +109,8 @@ function UserAvatar({ name, className }: { name: string; className?: string }) {
 export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverProps) {
   const queryClient = useQueryClient()
   const { user, isAuthMode } = useUser()
-  const { data: publishableSkillsets } = usePublishableSkillsets()
-  // undefined while loading — treat as available so the default tab doesn't
-  // land on Export and stick there once the Publish tab appears.
-  const publishAvailable = publishableSkillsets === undefined || publishableSkillsets.length > 0
   const [open, setOpen] = useState(false)
   const [tab, setTab] = useState<'share' | 'publish' | 'export'>(isAuthMode ? 'share' : 'publish')
-  const visibleTab = tab === 'publish' && !publishAvailable
-    ? (isAuthMode ? 'share' : 'export')
-    : tab
   const [searchQuery, setSearchQuery] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [selectedUsers, setSelectedUsers] = useState<SearchUser[]>([])
@@ -155,7 +147,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
     // lands on Share with the invite input focused.
     setPublishFlowOpen(false)
     setExportChoice('template')
-    setTab(isAuthMode ? 'share' : publishAvailable ? 'publish' : 'export')
+    setTab(isAuthMode ? 'share' : 'publish')
   }
 
   const invalidateAccess = () => {
@@ -398,7 +390,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
         onOpenAutoFocus={(e) => {
           e.preventDefault()
           // Defer past Radix's FocusScope so it can't reclaim focus after us.
-          if (isAuthMode && visibleTab === 'share') {
+          if (isAuthMode && tab === 'share') {
             setTimeout(() => searchInputRef.current?.focus(), 0)
           }
         }}
@@ -407,13 +399,13 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
         {/* Tab bar — Share only exists in auth mode (no ACL without auth).
             The publish flow replaces it with its own back navigation. Same
             segmented Tabs control as the connection directory's APIs/MCPs. */}
-        {!(visibleTab === 'publish' && publishFlowOpen) && (
-          <Tabs value={visibleTab} onValueChange={(v) => setTab(v as typeof tab)}>
+        {!(tab === 'publish' && publishFlowOpen) && (
+          <Tabs value={tab} onValueChange={(v) => setTab(v as typeof tab)}>
             <div className="px-3 pt-3">
               <TabsList className="h-8">
                 {([
                   ...(isAuthMode ? [{ id: 'share', label: 'Invite' } as const] : []),
-                  ...(publishAvailable ? [{ id: 'publish', label: 'Publish' } as const] : []),
+                  { id: 'publish', label: 'Publish' } as const,
                   { id: 'export', label: 'Export' } as const,
                 ]).map((t) => (
                   <TabsTrigger
@@ -430,7 +422,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
           </Tabs>
         )}
 
-        {visibleTab === 'publish' && (
+        {tab === 'publish' && (
           /* ── Publish pane: skillset publishing, flow inline in the popover ── */
           publishFlowOpen ? (
             <AgentTemplatePublishPanel
@@ -454,10 +446,10 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
                 <div className="space-y-4">
                   {/* Hero (Notion "Publish to web"-style) */}
                   <div className="space-y-1 pt-2 text-center">
-                    <p className="text-sm font-medium">Publish to a Library</p>
+                    <p className="text-sm font-medium">Publish to a Skillset</p>
                     <p className="text-xs text-muted-foreground">
                       <span className="block">
-                        Libraries are shared collections of agent templates and skills.
+                        Skillsets are shared collections of agent templates and skills.
                       </span>
                       <span className="block">
                         Publish this agent so teammates can install their own copy.
@@ -465,7 +457,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
                     </p>
                   </div>
 
-                  {/* Diagram: the agent card rises to the cloud library, which
+                  {/* Diagram: the agent card rises to the cloud skillset, which
                       fans out to clustered teammates ready to run their copy. */}
                   {/* Fixed 416x224 coordinate system: user centers sit on a
                       75px radius around the cloud center (208,116) at 0° and
@@ -496,14 +488,14 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
                         </marker>
                       </defs>
                       {([
-                        // [x1, y1, x2, y2, arrowhead] — only the card→library
+                        // [x1, y1, x2, y2, arrowhead] — only the card→skillset
                         // line keeps its head; the radial spokes are plain.
-                        [208, 168, 208, 147, true], // agent card up to the library
-                        [208, 86, 208, 65, false], // library → top teammate
-                        [185, 97, 169, 83, false], // library → upper-left
-                        [231, 97, 247, 83, false], // library → upper-right
-                        [178, 119, 157, 120, false], // library → lower-left
-                        [238, 119, 259, 120, false], // library → lower-right
+                        [208, 168, 208, 147, true], // agent card up to the skillset
+                        [208, 86, 208, 65, false], // skillset → top teammate
+                        [185, 97, 169, 83, false], // skillset → upper-left
+                        [231, 97, 247, 83, false], // skillset → upper-right
+                        [178, 119, 157, 120, false], // skillset → lower-left
+                        [238, 119, 259, 120, false], // skillset → lower-right
                       ] as const).map(([x1, y1, x2, y2, arrowhead]) => (
                         <line
                           key={`${x1}-${y1}`}
@@ -520,7 +512,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
                       ))}
                     </svg>
 
-                    {/* Teammates, all 75px from the library center (5th on top) */}
+                    {/* Teammates, all 75px from the skillset center (5th on top) */}
                     <div className="absolute left-1/2 top-[23px] flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border bg-background shadow-sm">
                       <User className="h-4 w-4 text-muted-foreground" />
                     </div>
@@ -537,7 +529,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
                       <User className="h-4 w-4 text-muted-foreground" />
                     </div>
 
-                    {/* The library in the cloud */}
+                    {/* The skillset in the cloud */}
                     <div className="absolute left-1/2 top-[92px] flex h-12 w-12 -translate-x-1/2 items-center justify-center rounded-xl border bg-background shadow-md">
                       <LibraryBig className="h-5 w-5 text-foreground/70" />
                     </div>
@@ -561,7 +553,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
                     <ArrowRight className="h-4 w-4" />
                   </Button>
 
-                  {/* What publishing to a library actually means */}
+                  {/* What publishing to a skillset actually means */}
                   <div className="space-y-2 text-xs text-muted-foreground">
                     <p className="flex items-start gap-2">
                       <Lock className="mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -573,14 +565,14 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
               ) : (
                 <p className="px-2 py-4 text-center text-sm text-muted-foreground">
                   Publishing isn&apos;t available — this agent is already linked to a
-                  library or can&apos;t be republished from this workspace.
+                  skillset or can&apos;t be republished from this workspace.
                 </p>
               )}
             </div>
           )
         )}
 
-        {visibleTab === 'export' && (
+        {tab === 'export' && (
           /* ── Export pane: template + full-agent downloads ── */
           <div className="space-y-3 p-3" data-testid="agent-export-pane">
             <div role="radiogroup" aria-label="Export type" className="-mx-2 space-y-1">
@@ -649,7 +641,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
           </div>
         )}
 
-        {visibleTab === 'share' && (
+        {tab === 'share' && (
           <>
         {/* Invite row: chip box + batch role + Add */}
         <div className="space-y-2 px-3 pb-4 pt-5">

--- a/src/renderer/components/agents/agent-share-popover.tsx
+++ b/src/renderer/components/agents/agent-share-popover.tsx
@@ -37,6 +37,7 @@ import {
   useHostExportStatus,
 } from '@renderer/hooks/use-agent-templates'
 import { AgentTemplatePublishPanel } from '@renderer/components/agents/agent-template-publish-panel'
+import { useSkillsets } from '@renderer/hooks/use-skillsets'
 import { ActivityOrb } from '@renderer/components/messages/activity-orb'
 import { ArrowDownToLine, ArrowRight, Check, LibraryBig, Loader2, Lock, User, X } from 'lucide-react'
 import type { AgentRole } from '@shared/lib/types/agent'
@@ -109,8 +110,13 @@ function UserAvatar({ name, className }: { name: string; className?: string }) {
 export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverProps) {
   const queryClient = useQueryClient()
   const { user, isAuthMode } = useUser()
+  const { data: skillsets } = useSkillsets()
+  const publishAvailable = !!skillsets?.some((ss) => ss.publishMode !== 'none')
   const [open, setOpen] = useState(false)
   const [tab, setTab] = useState<'share' | 'publish' | 'export'>(isAuthMode ? 'share' : 'publish')
+  const visibleTab = tab === 'publish' && !publishAvailable
+    ? (isAuthMode ? 'share' : 'export')
+    : tab
   const [searchQuery, setSearchQuery] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [selectedUsers, setSelectedUsers] = useState<SearchUser[]>([])
@@ -147,7 +153,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
     // lands on Share with the invite input focused.
     setPublishFlowOpen(false)
     setExportChoice('template')
-    setTab(isAuthMode ? 'share' : 'publish')
+    setTab(isAuthMode ? 'share' : publishAvailable ? 'publish' : 'export')
   }
 
   const invalidateAccess = () => {
@@ -390,7 +396,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
         onOpenAutoFocus={(e) => {
           e.preventDefault()
           // Defer past Radix's FocusScope so it can't reclaim focus after us.
-          if (isAuthMode && tab === 'share') {
+          if (isAuthMode && visibleTab === 'share') {
             setTimeout(() => searchInputRef.current?.focus(), 0)
           }
         }}
@@ -399,13 +405,13 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
         {/* Tab bar — Share only exists in auth mode (no ACL without auth).
             The publish flow replaces it with its own back navigation. Same
             segmented Tabs control as the connection directory's APIs/MCPs. */}
-        {!(tab === 'publish' && publishFlowOpen) && (
-          <Tabs value={tab} onValueChange={(v) => setTab(v as typeof tab)}>
+        {!(visibleTab === 'publish' && publishFlowOpen) && (
+          <Tabs value={visibleTab} onValueChange={(v) => setTab(v as typeof tab)}>
             <div className="px-3 pt-3">
               <TabsList className="h-8">
                 {([
                   ...(isAuthMode ? [{ id: 'share', label: 'Invite' } as const] : []),
-                  { id: 'publish', label: 'Publish' } as const,
+                  ...(publishAvailable ? [{ id: 'publish', label: 'Publish' } as const] : []),
                   { id: 'export', label: 'Export' } as const,
                 ]).map((t) => (
                   <TabsTrigger
@@ -422,7 +428,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
           </Tabs>
         )}
 
-        {tab === 'publish' && (
+        {visibleTab === 'publish' && (
           /* ── Publish pane: skillset publishing, flow inline in the popover ── */
           publishFlowOpen ? (
             <AgentTemplatePublishPanel
@@ -572,7 +578,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
           )
         )}
 
-        {tab === 'export' && (
+        {visibleTab === 'export' && (
           /* ── Export pane: template + full-agent downloads ── */
           <div className="space-y-3 p-3" data-testid="agent-export-pane">
             <div role="radiogroup" aria-label="Export type" className="-mx-2 space-y-1">
@@ -641,7 +647,7 @@ export function AgentSharePopover({ agentSlug, agentName }: AgentSharePopoverPro
           </div>
         )}
 
-        {tab === 'share' && (
+        {visibleTab === 'share' && (
           <>
         {/* Invite row: chip box + batch role + Add */}
         <div className="space-y-2 px-3 pb-4 pt-5">

--- a/src/renderer/components/agents/agent-template-publish-panel.test.tsx
+++ b/src/renderer/components/agents/agent-template-publish-panel.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ApiSkillsetConfig } from '@shared/lib/types/api'
+
+let skillsets: ApiSkillsetConfig[] | undefined = []
+
+vi.mock('@renderer/hooks/use-skillsets', () => ({
+  useSkillsets: () => ({ data: skillsets }),
+}))
+
+vi.mock('@renderer/hooks/use-agent-templates', () => ({
+  useAgentTemplatePublishInfo: () => ({ data: undefined, isLoading: false, error: null }),
+  usePublishAgentTemplate: () => ({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}))
+
+import { AgentTemplatePublishPanel } from './agent-template-publish-panel'
+
+function skillset(over: Partial<ApiSkillsetConfig> = {}): ApiSkillsetConfig {
+  return {
+    id: 'github-skillset',
+    url: 'https://github.com/org/team-skillset',
+    name: 'Team Skillset',
+    description: 'Writable GitHub skillset',
+    skillCount: 1,
+    agentCount: 0,
+    addedAt: '2026-01-01',
+    showUrl: true,
+    publishMode: 'pull_request',
+    ...over,
+  }
+}
+
+async function goToPicker(user: ReturnType<typeof userEvent.setup>) {
+  render(<AgentTemplatePublishPanel agentSlug="test-agent" onBack={vi.fn()} />)
+  await user.type(screen.getByLabelText('Title'), 'Add agent')
+  await user.type(screen.getByLabelText('Description'), 'A new agent template')
+  await user.click(screen.getByTestId('publish-flow-submit'))
+}
+
+beforeEach(() => {
+  skillsets = [
+    skillset({
+      id: 'public-skillset',
+      name: 'Gamut Public Skillset',
+      description: 'Default public skillset',
+      publishMode: 'none',
+    }),
+    skillset(),
+  ]
+})
+
+describe('AgentTemplatePublishPanel', () => {
+  it('lists a read-only skillset as Read only and keeps the writable one selected', async () => {
+    const user = userEvent.setup()
+    await goToPicker(user)
+
+    expect(screen.getByText('Choose a skillset')).toBeInTheDocument()
+    expect(screen.queryByText(/library/i)).not.toBeInTheDocument()
+
+    const readOnly = screen.getByTestId('publish-skillset-option-public-skillset')
+    expect(readOnly).toHaveTextContent('Read only')
+    expect(readOnly).toBeDisabled()
+    expect(readOnly).toHaveAttribute('aria-checked', 'false')
+
+    expect(screen.getByTestId('publish-skillset-option-github-skillset')).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    expect(screen.getByTestId('publish-flow-publish')).toBeEnabled()
+  })
+
+  it('disables Publish when every skillset is read only', async () => {
+    skillsets = [
+      skillset({
+        id: 'public-skillset',
+        name: 'Gamut Public Skillset',
+        publishMode: 'none',
+      }),
+    ]
+    const user = userEvent.setup()
+    await goToPicker(user)
+
+    expect(screen.getByTestId('publish-skillset-option-public-skillset')).toBeDisabled()
+    expect(screen.getByTestId('publish-flow-publish')).toBeDisabled()
+  })
+})

--- a/src/renderer/components/agents/agent-template-publish-panel.tsx
+++ b/src/renderer/components/agents/agent-template-publish-panel.tsx
@@ -6,7 +6,7 @@ import { Label } from '@renderer/components/ui/label'
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { ArrowRight, ArrowUpFromLine, Check, Loader2, ExternalLink, AlertTriangle, ChevronLeft } from 'lucide-react'
 import { useAgentTemplatePublishInfo, usePublishAgentTemplate } from '@renderer/hooks/use-agent-templates'
-import { useSkillsets } from '@renderer/hooks/use-skillsets'
+import { usePublishableSkillsets } from '@renderer/hooks/use-skillsets'
 
 interface AgentTemplatePublishPanelProps {
   agentSlug: string
@@ -22,8 +22,7 @@ interface AgentTemplatePublishPanelProps {
  */
 export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePublishPanelProps) {
   const [step, setStep] = useState<'form' | 'pick'>('form')
-  const { data: allSkillsets } = useSkillsets()
-  const skillsets = allSkillsets?.filter((ss) => ss.publishMode !== 'none')
+  const { data: skillsets } = usePublishableSkillsets()
 
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')

--- a/src/renderer/components/agents/agent-template-publish-panel.tsx
+++ b/src/renderer/components/agents/agent-template-publish-panel.tsx
@@ -6,7 +6,9 @@ import { Label } from '@renderer/components/ui/label'
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { ArrowRight, ArrowUpFromLine, Check, Loader2, ExternalLink, AlertTriangle, ChevronLeft } from 'lucide-react'
 import { useAgentTemplatePublishInfo, usePublishAgentTemplate } from '@renderer/hooks/use-agent-templates'
-import { usePublishableSkillsets } from '@renderer/hooks/use-skillsets'
+import { useSkillsets } from '@renderer/hooks/use-skillsets'
+import { isSkillsetPublishable } from '@renderer/lib/skillset-publish-ui'
+import { cn } from '@shared/lib/utils'
 
 interface AgentTemplatePublishPanelProps {
   agentSlug: string
@@ -16,13 +18,13 @@ interface AgentTemplatePublishPanelProps {
 
 /**
  * Inline publish flow for the agent share popover's Publish tab:
- * title/description/version form first, then choosing a library as the final,
- * committing step — clicking a library publishes to it. State resets by
+ * title/description/version form first, then choosing a skillset as the final,
+ * committing step — clicking a writable skillset selects it. State resets by
  * unmounting when the user navigates back.
  */
 export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePublishPanelProps) {
   const [step, setStep] = useState<'form' | 'pick'>('form')
-  const { data: skillsets } = usePublishableSkillsets()
+  const { data: skillsets } = useSkillsets()
 
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
@@ -30,13 +32,13 @@ export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePu
   const [selectedSkillsetId, setSelectedSkillsetId] = useState<string | null>(null)
   const [publishResult, setPublishResult] = useState<{ prUrl?: string; successMessage: string } | null>(null)
 
-  // Selection defaults to the first library, mirroring the Export tab's
-  // preselected radio pattern.
-  const firstSkillsetId = skillsets?.[0]?.id ?? null
-  const selectedId = selectedSkillsetId ?? firstSkillsetId
+  // Selection defaults to the first writable skillset, mirroring the Export
+  // tab's preselected radio pattern. Read-only skillsets stay listed.
+  const firstWritableId = skillsets?.find((ss) => isSkillsetPublishable(ss.publishMode))?.id ?? null
+  const selectedId = selectedSkillsetId ?? firstWritableId
 
   // Suggested title/body/version derive from the agent's CLAUDE.md (see
-  // getAgentPublishInfo); the fetch targets the currently selected library so
+  // getAgentPublishInfo); the fetch targets the currently selected skillset so
   // its publish preconditions are checked before the final Publish click.
   const {
     data: publishInfo,
@@ -96,7 +98,7 @@ export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePu
           <ChevronLeft className="h-4 w-4" />
         </Button>
         <p className="text-sm font-medium">
-          {publishResult ? 'Published' : step === 'form' ? 'Publish details' : 'Choose a library'}
+          {publishResult ? 'Published' : step === 'form' ? 'Publish details' : 'Choose a skillset'}
         </p>
       </div>
 
@@ -131,8 +133,8 @@ export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePu
             if (title.trim() && body.trim()) setStep('pick')
           }}
         >
-          {/* Suggestion fetch failure (e.g. the library's publish
-              preconditions fail) — the form stays usable; the library picker
+          {/* Suggestion fetch failure (e.g. the skillset's publish
+              preconditions fail) — the form stays usable; the skillset picker
               and final Publish surface their own errors. */}
           {infoError && (
             <Alert variant="destructive">
@@ -207,12 +209,13 @@ export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePu
         </form>
       ) : !skillsets || skillsets.length === 0 ? (
         <p className="py-6 text-center text-sm text-muted-foreground">
-          No libraries connected. Add one in Settings first.
+          No skillsets configured. Add a skillset in Settings first.
         </p>
       ) : (
         <div className="space-y-3">
-          <div role="radiogroup" aria-label="Library" className="-mx-2 space-y-1">
+          <div role="radiogroup" aria-label="Skillset" className="-mx-2 space-y-1">
             {skillsets.map((ss) => {
+              const publishable = isSkillsetPublishable(ss.publishMode)
               const isSelected = selectedId === ss.id
               return (
                 <button
@@ -220,12 +223,21 @@ export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePu
                   type="button"
                   role="radio"
                   aria-checked={isSelected}
-                  className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-left hover:bg-accent"
+                  disabled={!publishable}
+                  className={cn(
+                    'flex w-full items-center gap-3 rounded-md px-2 py-2 text-left',
+                    publishable ? 'hover:bg-accent' : 'cursor-not-allowed opacity-70',
+                  )}
                   onClick={() => setSelectedSkillsetId(ss.id)}
                   data-testid={`publish-skillset-option-${ss.id}`}
                 >
                   <span className="min-w-0 flex-1">
-                    <p className="text-[11px]">{ss.name}</p>
+                    <p className="text-[11px]">
+                      {ss.name}
+                      {!publishable && (
+                        <span className="ml-1.5 font-medium text-muted-foreground">Read only</span>
+                      )}
+                    </p>
                     <p className="mt-0.5 line-clamp-2 text-[11px] text-muted-foreground">
                       {ss.description}
                     </p>
@@ -242,6 +254,7 @@ export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePu
           <Button
             className="w-full gap-1.5"
             onClick={() => void handlePublish()}
+            disabled={!selectedId}
             data-testid="publish-flow-publish"
           >
             {publishAgent.isPending ? (

--- a/src/renderer/components/agents/agent-template-publish-panel.tsx
+++ b/src/renderer/components/agents/agent-template-publish-panel.tsx
@@ -22,7 +22,8 @@ interface AgentTemplatePublishPanelProps {
  */
 export function AgentTemplatePublishPanel({ agentSlug, onBack }: AgentTemplatePublishPanelProps) {
   const [step, setStep] = useState<'form' | 'pick'>('form')
-  const { data: skillsets } = useSkillsets()
+  const { data: allSkillsets } = useSkillsets()
+  const skillsets = allSkillsets?.filter((ss) => ss.publishMode !== 'none')
 
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')

--- a/src/renderer/components/agents/skill-publish-dialog.test.tsx
+++ b/src/renderer/components/agents/skill-publish-dialog.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { ApiSkillsetConfig } from '@shared/lib/types/api'
+
+let skillsets: ApiSkillsetConfig[] | undefined = []
+
+vi.mock('@renderer/hooks/use-skillsets', () => ({
+  useSkillsets: () => ({ data: skillsets }),
+}))
+
+vi.mock('@renderer/hooks/use-agent-skills', () => ({
+  useSkillPublishInfo: () => ({ data: undefined, isLoading: false, error: null }),
+  usePublishSkill: () => ({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@renderer/components/ui/dialog', () => {
+  const Passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>
+  return {
+    Dialog: Passthrough,
+    DialogContent: Passthrough,
+    DialogHeader: Passthrough,
+    DialogTitle: Passthrough,
+    DialogDescription: Passthrough,
+    DialogFooter: Passthrough,
+  }
+})
+
+import { SkillPublishDialog } from './skill-publish-dialog'
+
+function skillset(over: Partial<ApiSkillsetConfig> = {}): ApiSkillsetConfig {
+  return {
+    id: 'github-skillset',
+    url: 'https://github.com/org/team-skillset',
+    name: 'Team Skillset',
+    description: 'Writable GitHub skillset',
+    skillCount: 1,
+    agentCount: 0,
+    addedAt: '2026-01-01',
+    showUrl: true,
+    publishMode: 'pull_request',
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  skillsets = [
+    skillset({
+      id: 'public-skillset',
+      name: 'Gamut Public Skillset',
+      description: 'Default public skillset',
+      publishMode: 'none',
+    }),
+    skillset(),
+  ]
+})
+
+describe('SkillPublishDialog', () => {
+  it('lists a read-only skillset as Read only and does not open the publish form', async () => {
+    const user = userEvent.setup()
+    render(
+      <SkillPublishDialog
+        open
+        onOpenChange={vi.fn()}
+        agentSlug="test-agent"
+        skillDir="my-skill"
+        skillStatus={{ type: 'local' }}
+        onOpenReview={vi.fn()}
+      />,
+    )
+
+    const readOnly = screen.getByTestId('publish-skillset-option-public-skillset')
+    expect(readOnly).toHaveTextContent('Read only')
+    expect(readOnly).toBeDisabled()
+
+    await user.click(readOnly)
+    expect(screen.queryByLabelText('PR Title')).not.toBeInTheDocument()
+  })
+
+  it('opens the publish form when a writable skillset is chosen', async () => {
+    const user = userEvent.setup()
+    render(
+      <SkillPublishDialog
+        open
+        onOpenChange={vi.fn()}
+        agentSlug="test-agent"
+        skillDir="my-skill"
+        skillStatus={{ type: 'local' }}
+        onOpenReview={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByTestId('publish-skillset-option-github-skillset'))
+    expect(screen.getByLabelText('PR Title')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/agents/skill-publish-dialog.tsx
+++ b/src/renderer/components/agents/skill-publish-dialog.tsx
@@ -14,8 +14,9 @@ import { Label } from '@renderer/components/ui/label'
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { Loader2, ExternalLink, AlertTriangle, ChevronLeft } from 'lucide-react'
 import { useSkillPublishInfo, usePublishSkill } from '@renderer/hooks/use-agent-skills'
-import { usePublishableSkillsets } from '@renderer/hooks/use-skillsets'
-import { getPublishDialogCopy } from '@renderer/lib/skillset-publish-ui'
+import { useSkillsets } from '@renderer/hooks/use-skillsets'
+import { getPublishDialogCopy, isSkillsetPublishable } from '@renderer/lib/skillset-publish-ui'
+import { cn } from '@shared/lib/utils'
 import type { ApiSkillsetConfig, ApiItemStatus } from '@shared/lib/types/api'
 
 interface SkillPublishDialogProps {
@@ -38,7 +39,7 @@ export function SkillPublishDialog({
   const canPublish = skillStatus.type === 'local'
   const [step, setStep] = useState<'pick' | 'form'>('pick')
   const [selectedSkillset, setSelectedSkillset] = useState<ApiSkillsetConfig | null>(null)
-  const { data: skillsets } = usePublishableSkillsets()
+  const { data: skillsets } = useSkillsets()
 
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
@@ -138,19 +139,36 @@ export function SkillPublishDialog({
                 </p>
               ) : (
                 <div className="space-y-2">
-                  {skillsets.map((ss) => (
-                    <button
-                      key={ss.id}
-                      type="button"
-                      className="w-full text-left p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors"
-                      onClick={() => handleSkillsetSelect(ss)}
-                    >
-                      <p className="text-sm font-medium">{ss.name}</p>
-                      <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
-                        {ss.description}
-                      </p>
-                    </button>
-                  ))}
+                  {skillsets.map((ss) => {
+                    const publishable = isSkillsetPublishable(ss.publishMode)
+                    return (
+                      <button
+                        key={ss.id}
+                        type="button"
+                        disabled={!publishable}
+                        className={cn(
+                          'w-full text-left p-3 rounded-lg transition-colors',
+                          publishable
+                            ? 'bg-muted/50 hover:bg-muted'
+                            : 'cursor-not-allowed bg-muted/30 opacity-70',
+                        )}
+                        onClick={() => handleSkillsetSelect(ss)}
+                        data-testid={`publish-skillset-option-${ss.id}`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-medium">{ss.name}</p>
+                          {!publishable && (
+                            <span className="text-2xs font-medium text-muted-foreground">
+                              Read only
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                          {ss.description}
+                        </p>
+                      </button>
+                    )
+                  })}
                 </div>
               )}
             </div>

--- a/src/renderer/components/agents/skill-publish-dialog.tsx
+++ b/src/renderer/components/agents/skill-publish-dialog.tsx
@@ -38,7 +38,8 @@ export function SkillPublishDialog({
   const canPublish = skillStatus.type === 'local'
   const [step, setStep] = useState<'pick' | 'form'>('pick')
   const [selectedSkillset, setSelectedSkillset] = useState<ApiSkillsetConfig | null>(null)
-  const { data: skillsets } = useSkillsets()
+  const { data: allSkillsets } = useSkillsets()
+  const skillsets = allSkillsets?.filter((ss) => ss.publishMode !== 'none')
 
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')

--- a/src/renderer/components/agents/skill-publish-dialog.tsx
+++ b/src/renderer/components/agents/skill-publish-dialog.tsx
@@ -14,7 +14,7 @@ import { Label } from '@renderer/components/ui/label'
 import { Alert, AlertDescription } from '@renderer/components/ui/alert'
 import { Loader2, ExternalLink, AlertTriangle, ChevronLeft } from 'lucide-react'
 import { useSkillPublishInfo, usePublishSkill } from '@renderer/hooks/use-agent-skills'
-import { useSkillsets } from '@renderer/hooks/use-skillsets'
+import { usePublishableSkillsets } from '@renderer/hooks/use-skillsets'
 import { getPublishDialogCopy } from '@renderer/lib/skillset-publish-ui'
 import type { ApiSkillsetConfig, ApiItemStatus } from '@shared/lib/types/api'
 
@@ -38,8 +38,7 @@ export function SkillPublishDialog({
   const canPublish = skillStatus.type === 'local'
   const [step, setStep] = useState<'pick' | 'form'>('pick')
   const [selectedSkillset, setSelectedSkillset] = useState<ApiSkillsetConfig | null>(null)
-  const { data: allSkillsets } = useSkillsets()
-  const skillsets = allSkillsets?.filter((ss) => ss.publishMode !== 'none')
+  const { data: skillsets } = usePublishableSkillsets()
 
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')

--- a/src/renderer/hooks/use-skillsets.ts
+++ b/src/renderer/hooks/use-skillsets.ts
@@ -99,6 +99,20 @@ export function useRemoveSkillset() {
 }
 
 /**
+ * Skillsets that accept publishes (excludes read-only ones, e.g. the public
+ * default library). `data` stays undefined while the list is loading so
+ * callers can distinguish "unknown" from "none available".
+ */
+export function usePublishableSkillsets() {
+  const query = useSkillsets()
+  const data = useMemo(
+    () => query.data?.filter((ss) => ss.publishMode !== 'none'),
+    [query.data],
+  )
+  return { ...query, data }
+}
+
+/**
  * Look up the publishMode for a skillset by its ID.
  * Falls back to 'pull_request' if the skillset is unknown (e.g. removed).
  */

--- a/src/renderer/hooks/use-skillsets.ts
+++ b/src/renderer/hooks/use-skillsets.ts
@@ -99,20 +99,6 @@ export function useRemoveSkillset() {
 }
 
 /**
- * Skillsets that accept publishes (excludes read-only ones, e.g. the public
- * default library). `data` stays undefined while the list is loading so
- * callers can distinguish "unknown" from "none available".
- */
-export function usePublishableSkillsets() {
-  const query = useSkillsets()
-  const data = useMemo(
-    () => query.data?.filter((ss) => ss.publishMode !== 'none'),
-    [query.data],
-  )
-  return { ...query, data }
-}
-
-/**
  * Look up the publishMode for a skillset by its ID.
  * Falls back to 'pull_request' if the skillset is unknown (e.g. removed).
  */

--- a/src/renderer/lib/skillset-publish-ui.ts
+++ b/src/renderer/lib/skillset-publish-ui.ts
@@ -18,6 +18,10 @@ type SubmitDialogCopy = {
   pendingButton: string
 }
 
+export function isSkillsetPublishable(mode: PublishMode): boolean {
+  return mode !== 'none'
+}
+
 export function isPullRequestPublishMode(mode: PublishMode): boolean {
   return mode === 'pull_request'
 }


### PR DESCRIPTION
## Summary
- The default connected skillset is `SkillfulAgents/public-skillset` (shown as **Gamut Public Skillset**). It is already read-only (`publishMode: none`), but Publish still listed it as a destination you could pick.
- Skill and agent publish pickers still list every connected skillset. Read-only ones are visible and labeled **Read only**, and cannot be selected.
- Publish copy uses **skillset**, not library.

## Test plan
- [ ] With only the default Gamut skillset connected, open skill Publish and agent Share → Publish: it appears as **Read only** and cannot be selected
- [ ] Add a GitHub skillset and confirm it is selectable in both pickers
- [ ] Settings → Skillsets still lists the default Gamut skillset (install/browse unchanged)