### PR TITLE
feat(analytics): track session fork outcomes (session_forked / session_fork_failed)

### DIFF
--- a/src/renderer/hooks/use-sessions.fork.test.ts
+++ b/src/renderer/hooks/use-sessions.fork.test.ts
@@ -12,6 +12,11 @@ vi.mock('@renderer/lib/api', () => ({
   apiJson: vi.fn(),
 }))
 
+const mockTrack = vi.fn()
+vi.mock('@renderer/context/analytics-context', () => ({
+  useAnalyticsTracking: () => ({ track: mockTrack }),
+}))
+
 let queryClient: QueryClient
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -22,6 +27,7 @@ function wrapper({ children }: { children: ReactNode }) {
 describe('useForkSession', () => {
   beforeEach(() => {
     mockApiFetch.mockReset()
+    mockTrack.mockReset()
   })
 
   it('seeds the fork cache and draft on success', async () => {
@@ -41,6 +47,8 @@ describe('useForkSession', () => {
     expect(queryClient.getQueryData(['session', 'fork-1', 'agent-a'])).toEqual(
       expect.objectContaining({ id: 'fork-1', agentSlug: 'agent-a' }),
     )
+    expect(mockTrack).toHaveBeenCalledWith('session_forked')
+    expect(mockTrack).not.toHaveBeenCalledWith('session_fork_failed', expect.anything())
   })
 
   it('throws the server error text', async () => {
@@ -52,5 +60,7 @@ describe('useForkSession', () => {
     await expect(
       result.current.mutateAsync({ sessionId: 'src-1', agentSlug: 'agent-a' }),
     ).rejects.toThrow('Session is currently running')
+    expect(mockTrack).toHaveBeenCalledWith('session_fork_failed', { reason: 'Session is currently running' })
+    expect(mockTrack).not.toHaveBeenCalledWith('session_forked')
   })
 })

--- a/src/renderer/hooks/use-sessions.ts
+++ b/src/renderer/hooks/use-sessions.ts
@@ -266,6 +266,7 @@ export function useClearSessionUnread() {
 export function useForkSession() {
   const queryClient = useQueryClient()
   const draftsStore = useDraftsStore()
+  const { track } = useAnalyticsTracking()
 
   return useMutation({
     mutationFn: async ({ sessionId, agentSlug }: { sessionId: string; agentSlug: string }) => {
@@ -284,7 +285,11 @@ export function useForkSession() {
       return res.json() as Promise<ApiSession>
     },
     onMutate: ({ sessionId }) => ({ draft: snapshotSessionDraft(draftsStore, sessionId) }),
+    onError: (error) => {
+      track('session_fork_failed', { reason: error instanceof Error ? error.message : 'unknown' })
+    },
     onSuccess: (fork, variables, context) => {
+      track('session_forked')
       queryClient.setQueryData(['session', fork.id, fork.agentSlug], fork)
       seedSessionDraft(draftsStore, fork.id, context.draft)
       queryClient.invalidateQueries({


### PR DESCRIPTION
## What

Adds analytics for the new Fork Session action (#894 / SUP-247): `session_forked` on success and its failure twin `session_fork_failed { reason }` on error, both emitted from `useForkSession` so every entry point (sidebar / header context menus) is covered.

## Why

Fork Session shipped in 0.5.16 with zero instrumentation. A fork creates a brand-new session **without** going through `useCreateSession`, so it emits neither `session_created` nor `message_sent` — forked sessions are invisible in Amplitude and will show up as a growing unexplained gap between Supabase/agent-container session rows and `session_created`. Adoption of the feature and its refusal rate (`session_busy` while streaming, not-found, 500) are currently unmeasurable.

## How

- `useForkSession` takes `track` from `useAnalyticsTracking()` (same pattern as `useCreateSession`).
- `onSuccess` → `track('session_forked')`.
- `onError` → `track('session_fork_failed', { reason })`, where `reason` is the server's fixed error string (`Session is currently running`, `Session not found`, `Failed to fork session`) — no user content.
- Literal event names, no reserved wrapper props, failure twin added with the success event (analytics gotchas B1/B2/B6).
- Test: `use-sessions.fork.test.ts` mocks `analytics-context` (as `use-sessions.seeding.test.tsx` already does) and asserts both events.

## Notes

- All `SessionContextMenu` render sites (`app-sidebar.tsx`, `agent-header.tsx`) sit under `AnalyticsProvider` (`App.tsx:33`), so the hook is safe.
- The audit checkout has no `node_modules`; CI is the verification for vitest/tsc on this PR.
- Catalog rows for both events are being added in `analytics-tracking-catalogue.csv` (analytics-docs) alongside this PR.

Found by the 2026-09-02 weekly analytics audit.
