### PR TITLE
feat(renderer): stamp agent home sessions with last chat time

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -290,6 +290,33 @@ describe('AgentHome', () => {
     ])
   })
 
+  it('stamps each session with its last activity rather than its creation time', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-08-27T12:00:00.000Z'))
+      mockSessionsData = [
+        {
+          id: 'old-but-active',
+          agentSlug: testAgent.slug,
+          name: 'Old but active session',
+          createdAt: new Date('2026-08-17T12:00:00.000Z'),
+          lastActivityAt: new Date('2026-08-27T11:00:00.000Z'),
+          messageCount: 2,
+        },
+      ]
+
+      renderWithProviders(
+        <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />
+      )
+
+      expect(screen.getByText('Old but active session')).toBeInTheDocument()
+      expect(screen.getByText('about 1 hour ago')).toBeInTheDocument()
+      expect(screen.queryByText('10 days ago')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps the non-owner layout full-width below the desktop breakpoint', () => {
     renderWithProviders(
       <AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -500,7 +500,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                 {sessions.length > 0 ? (
                   <>
                     <div className="flex items-center gap-2">
-                      <h2 className="text-sm font-medium text-muted-foreground flex-1">Sessions</h2>
+                      <h2 className="text-sm font-medium text-muted-foreground flex-1">Recent Sessions</h2>
                       <SortPopover value={sessionSort} onChange={setSessionSort} ariaLabel="Sort sessions" />
                       <Button
                         type="button"

--- a/src/renderer/components/sessions/related-sessions.tsx
+++ b/src/renderer/components/sessions/related-sessions.tsx
@@ -269,7 +269,8 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
           </div>
           {!dateAsTitle && (
             <div className="text-xs text-muted-foreground truncate">
-              {formatDate(session.createdAt)}
+              {/* Match the activity ordering: the stamp is the last chat, not the creation date. */}
+              {formatDate(session.lastActivityAt ?? session.createdAt)}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- The agent home session list already orders by last activity (shared `sortSessionsByActivity`, landed in #880), but each row still printed the creation date, so a recently active old session looked out of place. The row now formats `lastActivityAt` when supplied, falling back to `createdAt`.
- Run history and completed tasks reuse the row but don't pass `lastActivityAt`, so they keep showing the run/creation date.
- Section header renamed from "Sessions" to "Recent Sessions".

## Test plan
- [x] New test: a session created 10 days ago but active an hour ago reads "about 1 hour ago"
- [x] agent-home, completed-tasks, and triggers suites pass; typecheck + lint clean
- [x] Verified by hand in the Electron dev build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
