### PR TITLE
feat(messages): show a loading indicator while an older page is fetched

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2378,6 +2378,22 @@ describe('MessageList', () => {
       expect(mockFetchOlder).toHaveBeenCalledOnce()
     })
 
+    it('shows a loading indicator at the top while an older page is in flight', () => {
+      mockMessagesData.data = manyMessages(50)
+      mockMessagesData.hasOlder = true
+      mockMessagesData.isFetchingOlder = true
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getByRole('status')).toHaveTextContent('Loading older messages')
+    })
+
+    it('hides the loading indicator once the older page has landed', () => {
+      mockMessagesData.data = manyMessages(50)
+      mockMessagesData.hasOlder = true
+      mockMessagesData.isFetchingOlder = false
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByText(/Loading older messages/)).not.toBeInTheDocument()
+    })
+
     it('retries fetchOlder after a failed older page instead of wedging scroll-up', () => {
       mockFetchOlder.mockResolvedValue(false)
       mockMessagesData.data = manyMessages(50)

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -1109,11 +1109,20 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
           aria-relevant="additions"
           aria-busy={isStreaming || undefined}
         >
-        {hiddenCount > 0 && (
+        {hiddenCount > 0 ? (
           <div className="flex items-center justify-center py-3 text-xs text-muted-foreground">
             {hiddenCount} earlier {hiddenCount === 1 ? 'message' : 'messages'} hidden — scroll up to load
           </div>
-        )}
+        ) : isFetchingOlder ? (
+          <div
+            className="flex items-center justify-center gap-2 py-3 text-xs text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            Loading older messages…
+          </div>
+        ) : null}
         {windowedMessages.map((item, index) => {
           const turn = completedTurnByItemId.get(item.id)
           const expanded = !!turn && expandedTurnIds.has(turn.id)


### PR DESCRIPTION
## Summary

Scrolling to the top of a long session issued the older-page request with no feedback, so a slow page looked like scrolling had simply stopped. The top-of-list banner slot now shows a small spinner with **"Loading older messages…"** while `isFetchingOlder` is true and no locally hidden messages remain to reveal.

- Reuses the existing banner slot in `message-list.tsx`: the "N earlier messages hidden" text still wins while locally windowed messages remain; otherwise the spinner shows during an in-flight older fetch.
- Marked `role="status"` / `aria-live="polite"` so screen readers announce it.
- Two tests added: the indicator appears while an older fetch is pending, and is absent once it has landed.

Note: this only covers the in-flight state. A session whose older history is unreachable server-side (the `MAX_TAIL_LINES` 50k-line paging cap in `session-service.ts`) still goes silent because the client never issues a request; that is a separate fix.

## Test plan

- [x] `npx vitest run src/renderer/components/messages/message-list.test.tsx` (134 passed)
- [x] typecheck + eslint clean on the two files
- [x] Recorded a Playwright run against the mock E2E server with a 3.5s delayed older page: spinner shows at the top during the fetch, older rows land with scroll position anchored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKyRuLWJTv3B1TdmDcrKMG
