### PR TITLE
feat(models): add Muse Spark 1.3 and 1.3c to the platform catalog

### DIFF
--- a/src/renderer/components/messages/model-family-list.test.tsx
+++ b/src/renderer/components/messages/model-family-list.test.tsx
@@ -38,6 +38,8 @@ describe('familyDisplayName', () => {
     expect(familyDisplayName('sonnet')).toBe('Sonnet')
     expect(familyDisplayName('gpt')).toBe('GPT')
     expect(familyDisplayName('glm')).toBe('GLM')
+    expect(familyDisplayName('muse')).toBe('Muse Spark')
+    expect(familyDisplayName('muse-contributor')).toBe('Muse Spark Contributor')
   })
 })
 
@@ -212,6 +214,35 @@ describe('ModelFamilyList', () => {
     expect(onPick).toHaveBeenLastCalledWith('gpt-5.6-luna')
   })
 
+  it('renders the Muse Spark tiers as two lineage rows with version chips', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    // Mirrors the platform catalog: authored oldest→newest per family.
+    const museCatalog: ModelDefinition[] = [
+      { id: 'muse-spark-1.2', label: 'Muse Spark 1.2', family: 'muse', icon: 'meta', supportedEfforts: STD },
+      { id: 'muse-spark-1.3', label: 'Muse Spark 1.3', family: 'muse', isLatest: true, isDefault: true, icon: 'meta', supportedEfforts: STD },
+      { id: 'muse-spark-1.2-contributor', label: 'Muse Spark Contributor 1.2', family: 'muse-contributor', icon: 'meta', supportedEfforts: STD, dataUsedForProductImprovement: true },
+      { id: 'muse-spark-1.3-contributor', label: 'Muse Spark Contributor 1.3', family: 'muse-contributor', isLatest: true, icon: 'meta', supportedEfforts: STD, dataUsedForProductImprovement: true },
+    ]
+    render(<ModelFamilyList catalog={museCatalog} value="muse-spark-1.3" onPick={onPick} />)
+    // One row per tier…
+    const standard = screen.getByTestId('model-family-muse')
+    const contributor = screen.getByTestId('model-family-muse-contributor')
+    expect(standard).toHaveTextContent('Muse Spark')
+    expect(contributor).toHaveTextContent('Muse Spark Contributor')
+    // …each with bare-version chips: the family name is stripped from both.
+    expect(screen.getByTestId('model-pinned-muse-spark-1.3')).toHaveTextContent('1.3')
+    expect(screen.getByTestId('model-pinned-muse-spark-1.2')).toHaveTextContent('1.2')
+    expect(screen.getByTestId('model-pinned-muse-spark-1.3-contributor')).toHaveTextContent('1.3')
+    expect(screen.getByTestId('model-pinned-muse-spark-1.2-contributor')).toHaveTextContent('1.2')
+    expect(screen.getByTestId('model-pinned-muse-spark-1.3-contributor')).not.toHaveTextContent('Contributor')
+    // Each row picks its own tier's latest; chips pin a version.
+    await user.click(contributor)
+    expect(onPick).toHaveBeenLastCalledWith('muse-spark-1.3-contributor')
+    await user.click(screen.getByTestId('model-pinned-muse-spark-1.2'))
+    expect(onPick).toHaveBeenLastCalledWith('muse-spark-1.2')
+  })
+
   it('offers a per-family "latest" alias row in settings mode', async () => {
     const user = userEvent.setup()
     const onPick = vi.fn()
@@ -361,8 +392,9 @@ describe('ModelFamilyList', () => {
       },
       {
         id: 'muse-spark-1.2-contributor',
-        label: 'Muse Spark 1.2c',
-        family: 'muse',
+        label: 'Muse Spark Contributor 1.2',
+        family: 'muse-contributor',
+        isLatest: true,
         icon: 'meta',
         supportedEfforts: STD,
         dataUsedForProductImprovement: true,

--- a/src/renderer/components/messages/model-family-list.tsx
+++ b/src/renderer/components/messages/model-family-list.tsx
@@ -15,7 +15,12 @@ function capitalize(s: string): string {
 }
 
 // Acronym families that shouldn't be title-cased (e.g. 'gpt' → 'GPT', not 'Gpt').
-const FAMILY_LABELS: Record<string, string> = { gpt: 'GPT', glm: 'GLM' }
+const FAMILY_LABELS: Record<string, string> = {
+  gpt: 'GPT',
+  glm: 'GLM',
+  muse: 'Muse Spark',
+  'muse-contributor': 'Muse Spark Contributor',
+}
 
 /** Display name for a family key, special-casing acronyms. */
 export function familyDisplayName(family: string): string {
@@ -60,7 +65,7 @@ export function vendorDefault(
  * Families outside this set (e.g. 'gpt', where each entry is a distinct tier)
  * keep one row per concrete model.
  */
-const LINEAGE_FAMILIES = new Set(['fable', 'opus', 'sonnet', 'haiku', 'kimi'])
+const LINEAGE_FAMILIES = new Set(['fable', 'opus', 'sonnet', 'haiku', 'kimi', 'muse', 'muse-contributor'])
 
 /** Chip label for a version: its label minus the family prefix ("Opus 4.8" → "4.8"). */
 function versionChipLabel(label: string, familyName: string): string {

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -465,8 +465,9 @@ const MUSE_SPARK_SHARED = {
   contextWindow: 1_000_000,
 } as const
 
-/** Standard-tier rates, identical across muse-spark 1.1 and 1.2. */
+/** Standard-tier rates, identical across muse-spark 1.1, 1.2, and 1.3. */
 const MUSE_SPARK_STANDARD_PRICING = { inputPerMtok: 1.25, outputPerMtok: 4.25 } as const
+const MUSE_SPARK_CONTRIBUTOR_PRICING = { inputPerMtok: 0.1, outputPerMtok: 0.2 } as const
 
 const MUSE_SPARK_MODELS: ModelDefinition[] = [
   {
@@ -481,9 +482,7 @@ const MUSE_SPARK_MODELS: ModelDefinition[] = [
     ...MUSE_SPARK_SHARED,
     id: 'muse-spark-1.2',
     label: 'Muse Spark 1.2',
-    blurb: 'Meta flagship, served via Platform',
-    isLatest: true,
-    isDefault: true,
+    blurb: 'Meta, served via Platform',
     pricing: MUSE_SPARK_STANDARD_PRICING,
   },
   {
@@ -496,7 +495,24 @@ const MUSE_SPARK_MODELS: ModelDefinition[] = [
     id: 'muse-spark-1.2-contributor',
     label: 'Muse Spark 1.2c',
     blurb: 'Meta contributor tier, served via Platform',
-    pricing: { inputPerMtok: 0.1, outputPerMtok: 0.2 },
+    pricing: MUSE_SPARK_CONTRIBUTOR_PRICING,
+    dataUsedForProductImprovement: true,
+  },
+  {
+    ...MUSE_SPARK_SHARED,
+    id: 'muse-spark-1.3',
+    label: 'Muse Spark 1.3',
+    blurb: 'Meta flagship, served via Platform',
+    isLatest: true,
+    isDefault: true,
+    pricing: MUSE_SPARK_STANDARD_PRICING,
+  },
+  {
+    ...MUSE_SPARK_SHARED,
+    id: 'muse-spark-1.3-contributor',
+    label: 'Muse Spark 1.3c',
+    blurb: 'Meta contributor tier, served via Platform',
+    pricing: MUSE_SPARK_CONTRIBUTOR_PRICING,
     dataUsedForProductImprovement: true,
   },
 ]

--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -454,9 +454,13 @@ const PLATFORM_RESPONSES_WEB = { supportsWebSearch: true, supportsWebFetch: fals
  *
  * The `meta` icon key follows the one-brand-icon-per-vendor convention the
  * catalog test enforces; the mark lives at `public/model-icons/meta.svg`.
+ *
+ * Two families, one per billing tier, so the picker shows two version rows
+ * ("Muse Spark" and "Muse Spark Contributor") the way it does for Opus and
+ * Fable, rather than one flat row per release. Each family is also a bare
+ * alias (`muse`, `muse-contributor`) that rides upgrades to its isLatest id.
  */
 const MUSE_SPARK_SHARED = {
-  family: 'muse',
   icon: 'meta',
   supportedEfforts: NON_CLAUDE_EFFORTS,
   supportsWebSearch: false,
@@ -466,54 +470,62 @@ const MUSE_SPARK_SHARED = {
 } as const
 
 /** Standard-tier rates, identical across muse-spark 1.1, 1.2, and 1.3. */
-const MUSE_SPARK_STANDARD_PRICING = { inputPerMtok: 1.25, outputPerMtok: 4.25 } as const
-const MUSE_SPARK_CONTRIBUTOR_PRICING = { inputPerMtok: 0.1, outputPerMtok: 0.2 } as const
+const MUSE_SPARK_STANDARD = {
+  ...MUSE_SPARK_SHARED,
+  family: 'muse',
+  pricing: { inputPerMtok: 1.25, outputPerMtok: 4.25 },
+} as const
+
+/**
+ * Meta's discounted tier, ~12x cheaper in exchange for data use: Meta uses
+ * Contributor prompts and outputs to improve its products, and has not
+ * clarified whether that is training-only. Anything touching customer data,
+ * PII, or secrets belongs on the standard tier — which is what
+ * `dataUsedForProductImprovement` puts in front of the user at pick time.
+ */
+const MUSE_SPARK_CONTRIBUTOR = {
+  ...MUSE_SPARK_SHARED,
+  family: 'muse-contributor',
+  pricing: { inputPerMtok: 0.1, outputPerMtok: 0.2 },
+  dataUsedForProductImprovement: true,
+} as const
 
 const MUSE_SPARK_MODELS: ModelDefinition[] = [
   {
-    ...MUSE_SPARK_SHARED,
+    ...MUSE_SPARK_STANDARD,
     id: 'muse-spark-1.1',
     label: 'Muse Spark 1.1',
     blurb: 'Meta, served via Platform',
-    pricing: MUSE_SPARK_STANDARD_PRICING,
   },
   {
     // Bare id matches the platform proxy's muse-spark-* → meta route.
-    ...MUSE_SPARK_SHARED,
+    ...MUSE_SPARK_STANDARD,
     id: 'muse-spark-1.2',
     label: 'Muse Spark 1.2',
     blurb: 'Meta, served via Platform',
-    pricing: MUSE_SPARK_STANDARD_PRICING,
   },
   {
-    // Meta's discounted tier, ~12x cheaper in exchange for data use: Meta uses
-    // Contributor prompts and outputs to improve its products, and has not
-    // clarified whether that is training-only. Anything touching customer
-    // data, PII, or secrets belongs on the standard tier above — which is what
-    // `dataUsedForProductImprovement` puts in front of the user at pick time.
-    ...MUSE_SPARK_SHARED,
-    id: 'muse-spark-1.2-contributor',
-    label: 'Muse Spark 1.2c',
-    blurb: 'Meta contributor tier, served via Platform',
-    pricing: MUSE_SPARK_CONTRIBUTOR_PRICING,
-    dataUsedForProductImprovement: true,
-  },
-  {
-    ...MUSE_SPARK_SHARED,
+    ...MUSE_SPARK_STANDARD,
     id: 'muse-spark-1.3',
     label: 'Muse Spark 1.3',
     blurb: 'Meta flagship, served via Platform',
     isLatest: true,
     isDefault: true,
-    pricing: MUSE_SPARK_STANDARD_PRICING,
+  },
+  // Labels carry the full family name so the picker's version chips strip to
+  // the bare version ("1.3"), matching the standard row beside them.
+  {
+    ...MUSE_SPARK_CONTRIBUTOR,
+    id: 'muse-spark-1.2-contributor',
+    label: 'Muse Spark Contributor 1.2',
+    blurb: 'Meta contributor tier, served via Platform',
   },
   {
-    ...MUSE_SPARK_SHARED,
+    ...MUSE_SPARK_CONTRIBUTOR,
     id: 'muse-spark-1.3-contributor',
-    label: 'Muse Spark 1.3c',
+    label: 'Muse Spark Contributor 1.3',
     blurb: 'Meta contributor tier, served via Platform',
-    pricing: MUSE_SPARK_CONTRIBUTOR_PRICING,
-    dataUsedForProductImprovement: true,
+    isLatest: true,
   },
 ]
 

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -61,7 +61,7 @@ describe('getProviderCatalog', () => {
       ['openai', 'gpt-5.6-sol'],
       ['xai', 'grok-4.6'],
       ['kimi', 'kimi-k3'],
-      ['meta', 'muse-spark-1.2'],
+      ['meta', 'muse-spark-1.3'],
       ['zai', 'glm-5.3-flash'],
     ])
   })


### PR DESCRIPTION
## Summary
- Meta released Muse Spark 1.3 on the same platform-proxy route and prices as 1.2. The picker still treated 1.2 as the Meta flagship, so a new agent would not see 1.3.
- Add `muse-spark-1.3` and `muse-spark-1.3-contributor` to the platform catalog, mark 1.3 as latest/default, and keep 1.1 / 1.2 / 1.2c selectable.

Depends on the proxy allowlist in SkillfulAgents/platform#381. Without that deploy, picking 1.3 is rejected as an unsupported Meta model.

## Test plan
- [x] `npx vitest run src/shared/lib/llm-provider/model-catalog.test.ts src/renderer/components/messages/model-family-list.test.tsx`
- [ ] On a platform-provider workspace, Meta tab shows Muse Spark 1.3 as latest
- [ ] 1.3c still shows the product-improvement warning; standard 1.3 does not
- [ ] After platform#381 is deployed, a send on 1.3 completes instead of `unsupported_model`


Made with [Cursor](https://cursor.com)