### PR TITLE
feat(messages): seek older pages by byte offset (uuid:offset cursors)

### DIFF
--- a/src/renderer/hooks/use-messages.test.ts
+++ b/src/renderer/hooks/use-messages.test.ts
@@ -405,6 +405,70 @@ describe('useMessages forward delta', () => {
     expect(inflight[4].url).toContain('cursor=c2')
   })
 
+  it('walks past all-duplicate older pages in one gesture and lands the first page that adds something', async () => {
+    // A transcript whose history was replayed verbatim serves the copy and
+    // then the originals: pages whose every item is already on screen add
+    // nothing, so the fetch keeps walking instead of handing the reader an
+    // empty scroll-up.
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+    await settleInitialPage(wrapper, result, [user('u5'), assistant('a5')])
+
+    const onBeforePrepend = vi.fn()
+    let olderDone: Promise<boolean>
+    act(() => {
+      olderDone = result.current.fetchOlder(onBeforePrepend)
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    expect(inflight[1].url).toContain('cursor=older-cursor')
+    // Duplicates of the trailing page — nothing new.
+    inflight[1].resolve({ messages: [user('u5'), assistant('a5')], nextCursor: 'c2' })
+    await waitFor(() => expect(inflight).toHaveLength(3))
+    expect(inflight[2].url).toContain('cursor=c2')
+    expect(onBeforePrepend).not.toHaveBeenCalled()
+    // Still nothing new (the copy of an item the client also has).
+    inflight[2].resolve({ messages: [assistant('a5')], nextCursor: 'c3' })
+    await waitFor(() => expect(inflight).toHaveLength(4))
+    expect(inflight[3].url).toContain('cursor=c3')
+    inflight[3].resolve({ messages: [user('u4'), assistant('a4'), user('u5')], nextCursor: 'c4' })
+
+    await act(async () => {
+      expect(await olderDone).toBe(true)
+    })
+    expect(onBeforePrepend).toHaveBeenCalledTimes(1)
+    expect(result.current.data?.map((m) => m.id)).toEqual(['u4', 'a4', 'u5', 'a5'])
+    expect(result.current.hasOlder).toBe(true)
+    expect(result.current.isFetchingOlder).toBe(false)
+
+    // The next gesture resumes from the last cursor the walk reached.
+    act(() => {
+      void result.current.fetchOlder()
+    })
+    await waitFor(() => expect(inflight).toHaveLength(5))
+    expect(inflight[4].url).toContain('cursor=c4')
+  })
+
+  it('an all-duplicate terminal page ends older history without a prepend', async () => {
+    const wrapper = createWrapper()
+    const { result } = renderHook(() => useMessages('s1', 'agent-1'), { wrapper })
+    await settleInitialPage(wrapper, result, [user('u1'), assistant('a1')])
+
+    const onBeforePrepend = vi.fn()
+    let olderDone: Promise<boolean>
+    act(() => {
+      olderDone = result.current.fetchOlder(onBeforePrepend)
+    })
+    await waitFor(() => expect(inflight).toHaveLength(2))
+    inflight[1].resolve({ messages: [user('u1')], nextCursor: null })
+    await act(async () => {
+      expect(await olderDone).toBe(false)
+    })
+    expect(onBeforePrepend).not.toHaveBeenCalled()
+    expect(result.current.data?.map((m) => m.id)).toEqual(['u1', 'a1'])
+    expect(result.current.hasOlder).toBe(false)
+    expect(result.current.isFetchingOlder).toBe(false)
+  })
+
   it('drops an item deleted remotely from within the covered range on a periodic full fetch', async () => {
     vi.useFakeTimers({ toFake: ['Date'] })
     try {

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -12,6 +12,12 @@ import { pickDeltaAnchor, mergeDeltaMessages } from '@shared/lib/messages-delta'
 // Re-export for convenience
 export type { ApiMessage, ApiMessageOrBoundary }
 
+// How many consecutive older pages one fetchOlder call walks through when
+// they add nothing visible (all-duplicate pages from a replayed transcript).
+// Bounds a single gesture's work; the cursor still advances, so the next
+// scroll-up resumes from where this one stopped.
+const MAX_EMPTY_OLDER_PAGE_HOPS = 25
+
 /**
  * Thrown when the session's JSONL transcript is absent (HTTP 404) — e.g. it was
  * deleted by the CLI's retention cleanup while the metadata entry lingers in the
@@ -255,24 +261,39 @@ export function useMessages(sessionId: string | null, agentSlug: string | null) 
     olderAbortRef.current = controller
     setIsFetchingOlder(true)
     try {
-      const page = await fetchMessagesPage(agentSlug, sessionId, {
-        limit: MESSAGES_PAGE_OLDER_LIMIT,
-        cursor,
-        signal: controller.signal,
-      })
-      // Older-history state was reset while this page was in flight (resync
-      // or session switch): the response belongs to the previous transcript
-      // generation and must not commit.
-      if (gen !== olderGenRef.current) return false
-      const existing = new Set(older.map((m) => m.id))
-      const prepended = page.messages.filter((m) => !existing.has(m.id) && !deleted.has(m.id))
-      if (prepended.length > 0) onBeforePrepend?.()
+      // Items already on screen: in the older buffer, or in the trailing page
+      // (`data` drops older items that also appear in latest, so those add
+      // nothing visible either). A page consisting only of these is skipped
+      // and the walk continues in the same gesture — a transcript whose
+      // history was replayed verbatim serves the copy and then the
+      // originals, and a bounded hop keeps the reader from having to scroll
+      // once per empty page.
+      const seen = new Set([...older, ...latestMessages].map((m) => m.id))
+      let fresh: ApiMessageOrBoundary[] = []
+      let nextCursor: string | null = cursor
+      for (let hop = 0; hop < MAX_EMPTY_OLDER_PAGE_HOPS && nextCursor; hop++) {
+        const page = await fetchMessagesPage(agentSlug, sessionId, {
+          limit: MESSAGES_PAGE_OLDER_LIMIT,
+          cursor: nextCursor,
+          signal: controller.signal,
+        })
+        // Older-history state was reset while this page was in flight (resync
+        // or session switch): the response belongs to the previous transcript
+        // generation and must not commit.
+        if (gen !== olderGenRef.current) return false
+        const added = page.messages.filter((m) => !seen.has(m.id) && !deleted.has(m.id))
+        for (const m of added) seen.add(m.id)
+        fresh = [...added, ...fresh]
+        nextCursor = page.nextCursor
+        if (added.length > 0) break
+      }
+      if (fresh.length > 0) onBeforePrepend?.()
       setOlder((cur) => {
-        const seen = new Set(cur.map((m) => m.id))
-        return [...page.messages.filter((m) => !seen.has(m.id) && !deleted.has(m.id)), ...cur]
+        const have = new Set(cur.map((m) => m.id))
+        return [...fresh.filter((m) => !have.has(m.id)), ...cur]
       })
-      setOlderCursor(page.nextCursor)
-      return prepended.length > 0
+      setOlderCursor(nextCursor)
+      return fresh.length > 0
     } catch (error) {
       // Rejection caused by our own generation reset (abort) — not an error.
       if (gen !== olderGenRef.current) return false

--- a/src/shared/lib/services/session-page-cursor.test.ts
+++ b/src/shared/lib/services/session-page-cursor.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { parsePageCursor, formatPageCursor } from './session-page-cursor'
+
+describe('page cursor codec', () => {
+  it('round-trips an id with an offset', () => {
+    const cursor = formatPageCursor('5c1f0c9e-8f1e-4d0a-9d2b-3a7b1c2d3e4f', 123456)
+    expect(cursor).toBe('5c1f0c9e-8f1e-4d0a-9d2b-3a7b1c2d3e4f:123456')
+    expect(parsePageCursor(cursor)).toEqual({
+      id: '5c1f0c9e-8f1e-4d0a-9d2b-3a7b1c2d3e4f',
+      offset: 123456,
+    })
+  })
+
+  it('treats a bare uuid as an id-only cursor (legacy clients)', () => {
+    expect(parsePageCursor('5c1f0c9e-8f1e-4d0a-9d2b-3a7b1c2d3e4f')).toEqual({
+      id: '5c1f0c9e-8f1e-4d0a-9d2b-3a7b1c2d3e4f',
+    })
+  })
+
+  it('formats id-only when there is no usable offset', () => {
+    expect(formatPageCursor('abc', undefined)).toBe('abc')
+    expect(formatPageCursor('abc', -1)).toBe('abc')
+    expect(formatPageCursor('abc', 1.5)).toBe('abc')
+    expect(formatPageCursor('abc', 0)).toBe('abc:0')
+  })
+
+  it('does not mistake other colon suffixes for an offset', () => {
+    expect(parsePageCursor('abc:')).toEqual({ id: 'abc:' })
+    expect(parsePageCursor('abc:12x')).toEqual({ id: 'abc:12x' })
+    expect(parsePageCursor('abc:-5')).toEqual({ id: 'abc:-5' })
+    // A digit run too long to be a safe integer is not an offset.
+    expect(parsePageCursor('abc:1234567890123456')).toEqual({ id: 'abc:1234567890123456' })
+    expect(parsePageCursor(':5')).toEqual({ id: ':5' })
+  })
+})

--- a/src/shared/lib/services/session-page-cursor.ts
+++ b/src/shared/lib/services/session-page-cursor.ts
@@ -1,0 +1,35 @@
+/**
+ * Messages page cursor codec.
+ *
+ * A cursor names the page's oldest item by transcript uuid. It may also carry
+ * the byte offset of that item's JSONL line as `uuid:offset`, which lets the
+ * server seek straight to the row instead of re-scanning from EOF on every
+ * page. The offset is a hint: the server validates that the row at that
+ * offset still carries the uuid (transcripts get rewritten by deletion,
+ * retention cleanup and resync) and falls back to the id-only scan when it
+ * does not. A bare uuid is always accepted — older clients, and the client's
+ * own id-only fallbacks, keep working.
+ *
+ * Opaque to the client: it never parses or builds one.
+ */
+export interface PageCursor {
+  id: string
+  /** Byte offset of the id's line start. Absent on legacy id-only cursors. */
+  offset?: number
+}
+
+// Transcript uuids are UUIDv4 (no colon), so a trailing `:digits` is
+// unambiguous. Digits are capped so the offset always parses as a safe
+// integer; a longer run is not treated as an offset.
+const OFFSET_SUFFIX = /^(.+):(\d{1,15})$/
+
+export function parsePageCursor(cursor: string): PageCursor {
+  const m = OFFSET_SUFFIX.exec(cursor)
+  if (!m) return { id: cursor }
+  return { id: m[1]!, offset: Number(m[2]) }
+}
+
+export function formatPageCursor(id: string, offset: number | undefined): string {
+  if (offset === undefined || !Number.isInteger(offset) || offset < 0) return id
+  return `${id}:${offset}`
+}

--- a/src/shared/lib/services/session-service.cursor-offset.test.ts
+++ b/src/shared/lib/services/session-service.cursor-offset.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Offset-carrying page cursors (`uuid:offset`): the server seeks to the
+ * cursor row instead of re-scanning from EOF, which makes every page O(page)
+ * and lifts the id-only reachability cap. These tests pin that the seek path
+ * serves the same pages as the legacy id-only scan, degrades to it when the
+ * offset is stale, and reaches history the id-only walk cannot.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+import { getSessionMessagesPage, getSessionMessagesWithCompact } from './session-service'
+import { parsePageCursor, formatPageCursor } from './session-page-cursor'
+import { readLineAt } from '@shared/lib/utils/file-storage'
+import { transformMessages } from '@shared/lib/utils/message-transform'
+
+const AGENT = 'offset-agent'
+let testDir: string
+let originalDataDir: string | undefined
+
+beforeEach(async () => {
+  testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cursor-offset-'))
+  originalDataDir = process.env.SUPERAGENT_DATA_DIR
+  process.env.SUPERAGENT_DATA_DIR = testDir
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  if (originalDataDir) process.env.SUPERAGENT_DATA_DIR = originalDataDir
+  else delete process.env.SUPERAGENT_DATA_DIR
+  await fs.promises.rm(testDir, { recursive: true, force: true })
+})
+
+function jsonlPath(sessionId: string): string {
+  return path.join(
+    testDir, 'agents', AGENT, 'workspace', '.claude', 'projects', '-workspace', `${sessionId}.jsonl`
+  )
+}
+
+async function writeTranscript(sessionId: string, entries: object[]): Promise<void> {
+  const p = jsonlPath(sessionId)
+  await fs.promises.mkdir(path.dirname(p), { recursive: true })
+  await fs.promises.writeFile(p, entries.map((e) => JSON.stringify(e)).join('\n') + '\n')
+}
+
+const ts = (s: number) => new Date(Date.UTC(2026, 0, 1) + s * 1000).toISOString()
+
+/** Plain user/assistant alternation. */
+function simpleThread(turns: number): object[] {
+  const rows: object[] = []
+  for (let i = 0; i < turns; i++) {
+    rows.push({ type: 'user', uuid: `u-${i}`, timestamp: ts(i * 2), sessionId: 's', parentUuid: null, message: { role: 'user', content: `q${i}` } })
+    rows.push({ type: 'assistant', uuid: `a-${i}`, timestamp: ts(i * 2 + 1), sessionId: 's', parentUuid: `u-${i}`, message: { id: `msg-${i}`, role: 'assistant', content: [{ type: 'text', text: `a${i}` }] } })
+  }
+  return rows
+}
+
+/** Every shape the scanner special-cases: multi-entry assistant groups with
+ * interleaved tool results, meta rows, queued commands, compact boundaries
+ * with their summaries, contiguous system runs (recall / boundary /
+ * informational, which the transform reorders), and the odd huge row. */
+function mixedThread(turns: number): object[] {
+  const rows: object[] = []
+  let t = 0
+  for (let i = 0; i < turns; i++) {
+    rows.push({ type: 'user', uuid: `u-${i}`, timestamp: ts(t++), sessionId: 's', parentUuid: null, message: { role: 'user', content: `q${i}` } })
+    if (i % 5 === 3) {
+      rows.push({ type: 'user', uuid: `meta-${i}`, timestamp: ts(t++), sessionId: 's', parentUuid: null, isMeta: true, message: { role: 'user', content: 'meta' } })
+    }
+    rows.push({ type: 'assistant', uuid: `a-${i}-0`, timestamp: ts(t++), sessionId: 's', parentUuid: `u-${i}`, message: { id: `msg-${i}`, role: 'assistant', content: [{ type: 'thinking', thinking: `think ${i}` }, { type: 'text', text: `plan ${i}` }] } })
+    rows.push({ type: 'assistant', uuid: `a-${i}-1`, timestamp: ts(t++), sessionId: 's', parentUuid: `a-${i}-0`, message: { id: `msg-${i}`, role: 'assistant', content: [{ type: 'tool_use', id: `t-${i}`, name: 'Bash', input: { command: `echo ${i}` } }] } })
+    const pad = i % 13 === 6 ? 'y'.repeat(120 * 1024) : `out ${i}`
+    rows.push({ type: 'user', uuid: `r-${i}`, timestamp: ts(t++), sessionId: 's', parentUuid: `a-${i}-1`, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: `t-${i}`, content: pad }] } })
+    rows.push({ type: 'assistant', uuid: `a-${i}-2`, timestamp: ts(t++), sessionId: 's', parentUuid: `r-${i}`, message: { id: `msg-${i}b`, role: 'assistant', content: [{ type: 'text', text: `done ${i}` }] } })
+    if (i % 7 === 2) {
+      rows.push({ type: 'system', uuid: `info-${i}`, subtype: 'informational', content: `Operation stopped by hook: ${i}`, isMeta: false, timestamp: ts(t++) })
+      rows.push({ type: 'system', uuid: `mr-${i}`, subtype: 'memory_recall', content: '', isMeta: false, timestamp: ts(t++), memory_paths: ['MEMORY.md'] })
+    }
+    if (i % 11 === 9) {
+      rows.push({ type: 'system', uuid: `cb-${i}`, subtype: 'compact_boundary', content: '', isMeta: false, timestamp: ts(t++), compactMetadata: { trigger: 'auto', preTokens: 1 } })
+      rows.push({ type: 'user', uuid: `cs-${i}`, timestamp: ts(t++), sessionId: 's', parentUuid: null, isCompactSummary: true, message: { role: 'user', content: `summary ${i}` } })
+    }
+  }
+  return rows
+}
+
+interface Walk {
+  ids: string[]
+  pages: number
+  cursors: string[]
+}
+
+/** Walk from the trailing page to the start. `legacy` strips offsets so every
+ * request takes the id-only path. */
+async function walk(
+  sessionId: string,
+  opts: { first: number; older: number; byteBudget?: number; legacy?: boolean; maxPages?: number }
+): Promise<Walk> {
+  const budget = opts.byteBudget !== undefined ? { byteBudget: opts.byteBudget } : {}
+  let page = await getSessionMessagesPage(AGENT, sessionId, { limit: opts.first, ...budget })
+  const ids = page.messages.map((m) => m.id)
+  const cursors: string[] = []
+  let pages = 1
+  let cursor = page.nextCursor
+  const maxPages = opts.maxPages ?? 5000
+  while (cursor) {
+    if (pages >= maxPages) throw new Error(`walk did not terminate within ${maxPages} pages`)
+    cursors.push(cursor)
+    page = await getSessionMessagesPage(AGENT, sessionId, {
+      limit: opts.older,
+      cursor: opts.legacy ? parsePageCursor(cursor).id : cursor,
+      ...budget,
+    })
+    pages++
+    ids.unshift(...page.messages.map((m) => m.id))
+    cursor = page.nextCursor
+  }
+  return { ids, pages, cursors }
+}
+
+async function fullIds(sessionId: string): Promise<string[]> {
+  const entries = await getSessionMessagesWithCompact(AGENT, sessionId)
+  return transformMessages(entries.filter((m) => !('isMeta' in m && m.isMeta))).map((m) => m.id)
+}
+
+describe('offset cursors — shape', () => {
+  it('the trailing page hands out uuid:offset pointing at its oldest row', async () => {
+    await writeTranscript('shape', simpleThread(20))
+    const page = await getSessionMessagesPage(AGENT, 'shape', { limit: 6 })
+    const cursor = parsePageCursor(page.nextCursor!)
+    expect(cursor.id).toBe(page.messages[0]!.id)
+    expect(cursor.offset).toBeTypeOf('number')
+    const row = JSON.parse((await readLineAt(jsonlPath('shape'), cursor.offset!))!.toString())
+    expect(row.uuid).toBe(cursor.id)
+  })
+
+  it('every cursor in a walk sits strictly deeper in the file than the last', async () => {
+    await writeTranscript('descend', mixedThread(60))
+    const { cursors } = await walk('descend', { first: 5, older: 4, byteBudget: 16 * 1024 })
+    let prev = Number.POSITIVE_INFINITY
+    for (const c of cursors) {
+      const { offset } = parsePageCursor(c)
+      // An id-only cursor is allowed (the progress guard), but an offset must descend.
+      if (offset !== undefined) {
+        expect(offset).toBeLessThan(prev)
+        prev = offset
+      }
+    }
+    expect(cursors.length).toBeGreaterThan(5)
+  })
+
+  it('an id-only request is answered with an offset cursor (clients upgrade transparently)', async () => {
+    await writeTranscript('upgrade', simpleThread(30))
+    const page = await getSessionMessagesPage(AGENT, 'upgrade', { limit: 4, cursor: 'u-20' })
+    expect(page.messages.map((m) => m.id)).toEqual(['u-18', 'a-18', 'u-19', 'a-19'])
+    expect(parsePageCursor(page.nextCursor!)).toEqual({ id: 'u-18', offset: expect.any(Number) })
+  })
+})
+
+describe('offset cursors — equivalence with the id-only scan', () => {
+  const combos: { first: number; older: number; byteBudget?: number }[] = [
+    { first: 7, older: 5 },
+    { first: 3, older: 3, byteBudget: 8 * 1024 },
+    { first: 25, older: 10, byteBudget: 64 * 1024 },
+    { first: 1, older: 1 },
+  ]
+
+  for (const combo of combos) {
+    it(`serves the identical page sequence for limit ${combo.older}, budget ${combo.byteBudget ?? 'default'}`, async () => {
+      await writeTranscript('equiv', mixedThread(80))
+      const full = await fullIds('equiv')
+      const seek = await walk('equiv', combo)
+      const legacy = await walk('equiv', { ...combo, legacy: true })
+      expect(seek.ids).toEqual(legacy.ids)
+      expect(seek.ids).toEqual(full)
+      expect(seek.pages).toBe(legacy.pages)
+    })
+  }
+
+  it('matches on plain threads too', async () => {
+    await writeTranscript('plain', simpleThread(500))
+    const seek = await walk('plain', { first: 30, older: 20 })
+    const legacy = await walk('plain', { first: 30, older: 20, legacy: true })
+    expect(seek.ids).toEqual(legacy.ids)
+    expect(seek.ids).toEqual(await fullIds('plain'))
+  })
+})
+
+describe('offset cursors — reach', () => {
+  it('walks past the id-only line cap to the start of a 60k-line transcript', async () => {
+    const turns = 30_000
+    await writeTranscript('deep', simpleThread(turns))
+    const { ids, pages } = await walk('deep', { first: 300, older: 200 })
+    expect(ids.length).toBe(turns * 2)
+    expect(new Set(ids).size).toBe(turns * 2)
+    expect(ids[0]).toBe('u-0')
+    expect(pages).toBe(1 + Math.ceil((turns * 2 - 300) / 200))
+  }, 120_000)
+
+  it('an id-only cursor deeper than the line cap still ends pagination (legacy contract)', async () => {
+    await writeTranscript('deep-legacy', simpleThread(30_000))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // u-100 is ~59,800 lines below EOF: unreachable without an offset.
+    const page = await getSessionMessagesPage(AGENT, 'deep-legacy', { limit: 10, cursor: 'u-100' })
+    expect(page).toEqual({ messages: [], nextCursor: null })
+    expect(warn.mock.calls.some(([m]) => String(m).includes('not found within'))).toBe(true)
+    // The same row is one seek away with its offset.
+    const rows = simpleThread(30_000)
+    const offset = rows.slice(0, 200).reduce((n, r) => n + JSON.stringify(r).length + 1, 0)
+    const seeked = await getSessionMessagesPage(AGENT, 'deep-legacy', {
+      limit: 10,
+      cursor: formatPageCursor('u-100', offset),
+    })
+    expect(seeked.messages.map((m) => m.id)).toEqual([
+      'u-95', 'a-95', 'u-96', 'a-96', 'u-97', 'a-97', 'u-98', 'a-98', 'u-99', 'a-99',
+    ])
+  }, 120_000)
+})
+
+describe('offset cursors — stale offsets degrade to the id scan', () => {
+  async function expectFallback(sessionId: string, cursor: string) {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const seeked = await getSessionMessagesPage(AGENT, sessionId, { limit: 4, cursor })
+    const legacy = await getSessionMessagesPage(AGENT, sessionId, {
+      limit: 4,
+      cursor: parsePageCursor(cursor).id,
+    })
+    expect(seeked.messages.map((m) => m.id)).toEqual(legacy.messages.map((m) => m.id))
+    expect(seeked.nextCursor).toBe(legacy.nextCursor)
+    expect(warn.mock.calls.some(([m]) => String(m).includes('is stale'))).toBe(true)
+    warn.mockRestore()
+    return seeked
+  }
+
+  it('the row moved because an earlier row was deleted (rewrite)', async () => {
+    const rows = simpleThread(40)
+    await writeTranscript('moved', rows)
+    const page = await getSessionMessagesPage(AGENT, 'moved', { limit: 6 })
+    const cursor = page.nextCursor!
+    // Delete a row well above the cursor: everything below shifts up.
+    const kept = rows.filter((r) => (r as { uuid: string }).uuid !== 'u-3')
+    await writeTranscript('moved', kept)
+    const seeked = await expectFallback('moved', cursor)
+    expect(seeked.messages.length).toBe(4)
+    // And the fallback re-issues a fresh, valid offset.
+    const next = parsePageCursor(seeked.nextCursor!)
+    const row = JSON.parse((await readLineAt(jsonlPath('moved'), next.offset!))!.toString())
+    expect(row.uuid).toBe(next.id)
+  })
+
+  it('the offset lands mid-row', async () => {
+    await writeTranscript('midrow', simpleThread(40))
+    const page = await getSessionMessagesPage(AGENT, 'midrow', { limit: 6 })
+    const { id, offset } = parsePageCursor(page.nextCursor!)
+    await expectFallback('midrow', formatPageCursor(id, offset! + 3))
+  })
+
+  it('the offset points at a different row', async () => {
+    await writeTranscript('other-row', simpleThread(40))
+    const page = await getSessionMessagesPage(AGENT, 'other-row', { limit: 6 })
+    const { id } = parsePageCursor(page.nextCursor!)
+    // Offset of the very first row (u-0), which is not the cursor row.
+    await expectFallback('other-row', formatPageCursor(id, 0))
+  })
+
+  it('the offset is past EOF', async () => {
+    await writeTranscript('past-eof', simpleThread(40))
+    const page = await getSessionMessagesPage(AGENT, 'past-eof', { limit: 6 })
+    const { id } = parsePageCursor(page.nextCursor!)
+    await expectFallback('past-eof', formatPageCursor(id, 50_000_000))
+  })
+
+  it('the row is gone entirely: pagination ends, never serving a newer page', async () => {
+    const rows = simpleThread(40)
+    await writeTranscript('gone', rows)
+    const page = await getSessionMessagesPage(AGENT, 'gone', { limit: 6 })
+    const cursor = page.nextCursor!
+    const { id } = parsePageCursor(cursor)
+    await writeTranscript('gone', rows.filter((r) => (r as { uuid: string }).uuid !== id))
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(await getSessionMessagesPage(AGENT, 'gone', { limit: 4, cursor })).toEqual({
+      messages: [],
+      nextCursor: null,
+    })
+  })
+
+  it('a missing transcript answers the empty terminal page for an offset cursor', async () => {
+    expect(
+      await getSessionMessagesPage(AGENT, 'nope', { limit: 4, cursor: formatPageCursor('u-1', 10) })
+    ).toEqual({ messages: [], nextCursor: null })
+  })
+})
+
+describe('offset cursors — grace window', () => {
+  it('attaches a tool result that sits above the cursor row, like the id-only scan', async () => {
+    // Cursor on the tool_use's assistant group; its result is the next row up.
+    await writeTranscript('grace', mixedThread(12))
+    const full = await getSessionMessagesPage(AGENT, 'grace', { limit: 200 })
+    const target = full.messages.find((m) => m.id === 'a-8-2')!
+    const idx = full.messages.indexOf(target)
+    const cursorId = full.messages[idx + 1]!.id
+    const offsets = new Map<string, number>()
+    let off = 0
+    for (const r of mixedThread(12)) {
+      offsets.set((r as { uuid: string }).uuid, off)
+      off += JSON.stringify(r).length + 1
+    }
+    const seeked = await getSessionMessagesPage(AGENT, 'grace', {
+      limit: 3,
+      cursor: formatPageCursor(cursorId, offsets.get(cursorId)!),
+    })
+    const legacy = await getSessionMessagesPage(AGENT, 'grace', { limit: 3, cursor: cursorId })
+    expect(seeked.messages).toEqual(legacy.messages)
+    const group = seeked.messages.find((m) => m.type === 'assistant' && 'toolCalls' in m && m.toolCalls.some((t) => t.id === 't-8'))
+    expect(group).toBeDefined()
+    expect((group as { toolCalls: { id: string; result?: unknown }[] }).toolCalls.find((t) => t.id === 't-8')!.result).toBeDefined()
+  })
+})

--- a/src/shared/lib/services/session-service.cursor-offset.test.ts
+++ b/src/shared/lib/services/session-service.cursor-offset.test.ts
@@ -292,6 +292,73 @@ describe('offset cursors — stale offsets degrade to the id scan', () => {
   })
 })
 
+describe('partial history replay before a compaction', () => {
+  // Reproduces a real transcript shape (datawizz session d9d97dab): the CLI
+  // re-appended a handful of rows verbatim — including ONE tool_use row of a
+  // multi-row assistant message — right before a compact boundary. When a
+  // page boundary lands on that replayed row it stands alone and becomes the
+  // cursor; the next, deeper window holds the original, the uuid dedupe keeps
+  // that, and it merges into its group under the group's own id. The old
+  // code reported the cursor "vanished" and ended pagination mid-transcript.
+  function replayedThread(): object[] {
+    const rows: object[] = []
+    let t = 0
+    const pad = 'z'.repeat(3 * 1024)
+    const turn = (i: number) => {
+      rows.push({ type: 'user', uuid: `u-${i}`, timestamp: ts(t++), sessionId: 's', parentUuid: null, message: { role: 'user', content: `q${i} ${pad}` } })
+      rows.push({ type: 'assistant', uuid: `a-${i}-0`, timestamp: ts(t++), sessionId: 's', parentUuid: `u-${i}`, message: { id: `msg-${i}`, role: 'assistant', content: [{ type: 'text', text: `plan ${i}` }] } })
+      rows.push({ type: 'assistant', uuid: `a-${i}-1`, timestamp: ts(t++), sessionId: 's', parentUuid: `a-${i}-0`, message: { id: `msg-${i}`, role: 'assistant', content: [{ type: 'tool_use', id: `t-${i}-1`, name: 'Bash', input: { command: `one ${i}` } }] } })
+      rows.push({ type: 'assistant', uuid: `a-${i}-2`, timestamp: ts(t++), sessionId: 's', parentUuid: `a-${i}-1`, message: { id: `msg-${i}`, role: 'assistant', content: [{ type: 'tool_use', id: `t-${i}-2`, name: 'Bash', input: { command: `two ${i}` } }] } })
+      rows.push({ type: 'user', uuid: `r-${i}-2`, timestamp: ts(t++), sessionId: 's', parentUuid: `a-${i}-2`, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: `t-${i}-2`, content: `out two ${i} ${pad}` }] } })
+      rows.push({ type: 'user', uuid: `r-${i}-1`, timestamp: ts(t++), sessionId: 's', parentUuid: `a-${i}-1`, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: `t-${i}-1`, content: `out one ${i} ${pad}` }] } })
+    }
+    for (let i = 0; i < 12; i++) turn(i)
+    // Replay: the second tool_use row of turn 8 and its result, verbatim.
+    const copy = (uuid: string) => rows.find((r) => (r as { uuid: string }).uuid === uuid)!
+    rows.push(copy('r-6-1'), copy('a-8-2'), copy('r-8-2'))
+    rows.push({ type: 'system', uuid: 'cb', subtype: 'compact_boundary', content: '', isMeta: false, timestamp: ts(t++), compactMetadata: { trigger: 'auto', preTokens: 1 } })
+    rows.push({ type: 'user', uuid: 'cs', timestamp: ts(t++), sessionId: 's', parentUuid: 'cb', isCompactSummary: true, message: { role: 'user', content: 'summary' } })
+    for (let i = 12; i < 16; i++) turn(i)
+    return rows
+  }
+
+  it('offset cursors page through the replayed row and reach the start', async () => {
+    await writeTranscript('replay', replayedThread())
+    const full = await fullIds('replay')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // The failure needs a page whose oldest item is the replayed row (first:
+    // 10 is exactly the items from the copy to EOF) followed by an older
+    // page wide enough to reach the original row. Sweep around that.
+    for (const first of [2, 6, 10, 11, 14]) {
+      for (const older of [3, 8, 60]) {
+        for (const byteBudget of [16 * 1024, 64 * 1024, 256 * 1024, undefined]) {
+          const seek = await walk('replay', { first, older, ...(byteBudget ? { byteBudget } : {}) })
+          const missing = full.filter((id) => !seek.ids.includes(id))
+          expect(missing, `first ${first} older ${older} budget ${byteBudget}`).toEqual([])
+          expect(seek.ids[0]).toBe(full[0])
+        }
+      }
+    }
+    expect(warn.mock.calls.some(([m]) => String(m).includes('vanished'))).toBe(false)
+  })
+
+  it('id-only cursors no longer end pagination on the replayed row', async () => {
+    await writeTranscript('replay-legacy', replayedThread())
+    const full = await fullIds('replay-legacy')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const byteBudget of [4 * 1024, 8 * 1024, 16 * 1024]) {
+      for (const older of [1, 2, 3]) {
+        const legacy = await walk('replay-legacy', { first: 2, older, byteBudget, legacy: true })
+        // The legacy scan anchors on the deepest occurrence, so the rows
+        // between the original and the replayed copy can be skipped — but the
+        // walk must reach the start of the transcript.
+        expect(legacy.ids[0], `budget ${byteBudget} limit ${older}`).toBe(full[0])
+      }
+    }
+    expect(warn.mock.calls.some(([m]) => String(m).includes('vanished'))).toBe(false)
+  })
+})
+
 describe('offset cursors — grace window', () => {
   it('attaches a tool result that sits above the cursor row, like the id-only scan', async () => {
     // Cursor on the tool_use's assistant group; its result is the next row up.

--- a/src/shared/lib/services/session-service.page-cost.test.ts
+++ b/src/shared/lib/services/session-service.page-cost.test.ts
@@ -28,6 +28,9 @@ import * as path from 'path'
 import * as os from 'os'
 
 import { getSessionMessagesPage } from './session-service'
+import { parsePageCursor } from './session-page-cursor'
+
+const cursorId = (cursor: string | null) => (cursor === null ? null : parsePageCursor(cursor).id)
 
 const KB = 1024
 const MB = 1024 * KB
@@ -191,7 +194,7 @@ describe('messages page read cost — bounded window', () => {
     // back short with a cursor rather than growing the window to fit.
     expect(page.messages.length).toBeGreaterThan(0)
     expect(page.messages.length).toBeLessThan(2000)
-    expect(page.nextCursor).toBe(page.messages[0]!.id)
+    expect(cursorId(page.nextCursor)).toBe(page.messages[0]!.id)
     // The window is capped at 2x the budget and is covered twice — once by the
     // scan, once by the read.
     expect(account.bytes).toBeLessThan(byteBudget * 4)
@@ -236,6 +239,26 @@ describe('messages page read cost — cursor pages', () => {
     expect(page.messages).toHaveLength(5)
     // The window here is a handful of rows, so the whole cost is the scan.
     expect(account.bytes).toBeLessThan(size + CHUNK_SLACK)
+  })
+
+  it('seeks an offset cursor at the very start without traversing the transcript', async () => {
+    const size = await writeTranscript('seek-cursor', thread(600, 2600))
+    expect(size).toBeGreaterThan(1 * MB)
+    // Learn the offset the way a client does: from a page the server served.
+    const { page: upgrade } = await costOf('seek-cursor', { limit: 1, cursor: 'u-6' })
+    expect(parsePageCursor(upgrade.nextCursor!)).toEqual({ id: 'a-5', offset: expect.any(Number) })
+    const { page: seeded } = await costOf('seek-cursor', { limit: 1, cursor: upgrade.nextCursor! })
+    const cursor = seeded.nextCursor!
+    expect(parsePageCursor(cursor)).toEqual({ id: 'u-5', offset: expect.any(Number) })
+
+    const { account, page } = await costOf('seek-cursor', { limit: 10, cursor })
+
+    expect(page.messages.map((m) => m.id)).toEqual(['u-0', 'a-0', 'u-1', 'a-1', 'u-2', 'a-2', 'u-3', 'a-3', 'u-4', 'a-4'])
+    // The probe reads the cursor row, the grace lookup reads ahead up to
+    // CURSOR_GRACE, and the window is a handful of rows: nowhere near the
+    // 1MB+ of history above.
+    expect(account.bytes).toBeLessThan(CURSOR_GRACE + 4 * CHUNK_SLACK)
+    expect(account.bytes).toBeLessThan(size / 2)
   })
 
   it('gives up on a vanished cursor after one traversal, with no window read', async () => {

--- a/src/shared/lib/services/session-service.test.ts
+++ b/src/shared/lib/services/session-service.test.ts
@@ -35,6 +35,9 @@ import {
   getSessionForScheduledExecution,
   getSessionsByWebhookTrigger,
 } from './session-service'
+import { parsePageCursor } from './session-page-cursor'
+
+const cursorId = (cursor: string | null) => (cursor === null ? null : parsePageCursor(cursor).id)
 
 describe('session-service', () => {
   let testDir: string
@@ -934,7 +937,7 @@ describe('session-service', () => {
 
       const page = await getSessionMessagesPage('test-agent', 'page-session', { limit: 5 })
       expect(page.messages.map((m) => m.id)).toEqual(['a-7', 'u-8', 'a-8', 'u-9', 'a-9'])
-      expect(page.nextCursor).toBe('a-7')
+      expect(cursorId(page.nextCursor)).toBe('a-7')
     })
 
     it('returns the page before a cursor', async () => {
@@ -945,7 +948,7 @@ describe('session-service', () => {
         cursor: 'a-7',
       })
       expect(page.messages.map((m) => m.id)).toEqual(['u-5', 'a-5', 'u-6', 'a-6', 'u-7'])
-      expect(page.nextCursor).toBe('u-5')
+      expect(cursorId(page.nextCursor)).toBe('u-5')
     })
 
     it('returns no cursor on the oldest page', async () => {
@@ -970,7 +973,7 @@ describe('session-service', () => {
       const page = await getSessionMessagesPage('test-agent', 'page-session', { limit: 4 })
       expect(page.messages.map((m) => m.id)).toEqual(['u-18', 'a-18', 'u-19', 'a-19'])
       expect(page.messages.some((m) => m.id === 'huge-prefix')).toBe(false)
-      expect(page.nextCursor).toBe('u-18')
+      expect(cursorId(page.nextCursor)).toBe('u-18')
     })
 
     it('does not use a mid-merge assistant uuid as the page cursor', async () => {
@@ -1027,7 +1030,7 @@ describe('session-service', () => {
       const first = await getSessionMessagesPage('test-agent', 'page-session', { limit: 5 })
       expect(first.messages.map((m) => m.id)).not.toContain('X-1')
       expect(first.messages[0]?.id).toBe('X-0')
-      expect(first.nextCursor).toBe('X-0')
+      expect(cursorId(first.nextCursor)).toBe('X-0')
       expect(first.messages.find((m) => m.id === 'X-0')).toMatchObject({
         type: 'assistant',
         content: { text: 'leading' },
@@ -1098,7 +1101,7 @@ describe('session-service', () => {
         signal: controller.signal,
       })
       expect(page.messages.map((m) => m.id)).toEqual(['a-7', 'u-8', 'a-8', 'u-9', 'a-9'])
-      expect(page.nextCursor).toBe('a-7')
+      expect(cursorId(page.nextCursor)).toBe('a-7')
     })
 
     it('byte budget truncates a page short and cursor paging walks the remainder', async () => {
@@ -1112,7 +1115,7 @@ describe('session-service', () => {
       })
       expect(first.messages.length).toBeGreaterThan(0)
       expect(first.messages.length).toBeLessThan(20)
-      expect(first.nextCursor).toBe(first.messages[0]!.id)
+      expect(cursorId(first.nextCursor)).toBe(first.messages[0]!.id)
 
       const collected = [...first.messages.map((m) => m.id)]
       let cursor = first.nextCursor
@@ -1152,7 +1155,7 @@ describe('session-service', () => {
       // The budget floor guarantees at least one servable item beyond the
       // sacrificial head — the giant trailing item must not become an empty page.
       expect(page.messages.map((m) => m.id)).toEqual(['a-giant'])
-      expect(page.nextCursor).toBe('a-giant')
+      expect(cursorId(page.nextCursor)).toBe('a-giant')
 
       const older = await getSessionMessagesPage('test-agent', 'page-session', {
         limit: 5,
@@ -1224,11 +1227,41 @@ describe('session-service', () => {
       expect(queued).toMatchObject({ type: 'user', queued: true, content: { text: 'steer' } })
     })
 
-    it('terminates and returns each item once when history is replayed verbatim', async () => {
+    it('terminates and covers every item when history is replayed verbatim', async () => {
       // Session resume can re-append prior history to the transcript with the
-      // SAME uuids. The transform canonicalizes duplicates to their oldest
-      // occurrence; cursor resolution must do the same, or paging anchors on
-      // the newest copy and cycles over the same pages forever.
+      // SAME uuids. Paging must never cycle: each cursor the server hands out
+      // sits strictly deeper in the file than the last, so the walk ends at
+      // the file start. Offset cursors seek instead of re-scanning from EOF,
+      // so they serve the replayed copy and then the originals (the client
+      // dedupes by id and skips all-duplicate pages); every item is served,
+      // and the walk is bounded by the file's row count.
+      const six = makeThread(3)
+      await createSessionFile('test-agent', 'page-session', [...six, ...six])
+
+      const first = await getSessionMessagesPage('test-agent', 'page-session', { limit: 3 })
+      const collected = [...first.messages.map((m) => m.id)]
+      let cursor = first.nextCursor
+      let pages = 0
+      for (let i = 0; i < 10 && cursor; i++) {
+        const page = await getSessionMessagesPage('test-agent', 'page-session', {
+          limit: 3,
+          cursor,
+        })
+        pages++
+        // No page repeats an item within itself.
+        expect(new Set(page.messages.map((m) => m.id)).size).toBe(page.messages.length)
+        collected.unshift(...page.messages.map((m) => m.id))
+        cursor = page.nextCursor
+      }
+
+      expect(cursor).toBeNull()
+      expect(pages).toBeLessThanOrEqual(4)
+      expect([...new Set(collected)].sort()).toEqual(['a-0', 'a-1', 'a-2', 'u-0', 'u-1', 'u-2'])
+    })
+
+    it('id-only cursors still anchor on the deepest replayed occurrence', async () => {
+      // Legacy shape (bare uuid): the EOF-down scan re-anchors on the deepest
+      // duplicate, so the walk serves each item exactly once.
       const six = makeThread(3)
       await createSessionFile('test-agent', 'page-session', [...six, ...six])
 
@@ -1238,7 +1271,7 @@ describe('session-service', () => {
       for (let i = 0; i < 10 && cursor; i++) {
         const page = await getSessionMessagesPage('test-agent', 'page-session', {
           limit: 3,
-          cursor,
+          cursor: cursorId(cursor)!,
         })
         collected.unshift(...page.messages.map((m) => m.id))
         cursor = page.nextCursor

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -25,6 +25,8 @@ import {
   streamJsonlFile,
   readJsonlTailLines,
   iterateJsonlLinesBackward,
+  readLineAt,
+  findLineStartAtOrAfter,
   parseJsonl,
   streamFileLines,
   parseJsonlLine,
@@ -43,6 +45,7 @@ import {
   type SessionActivityFields,
 } from '@shared/lib/session-ordering'
 import { replaceInlineMediaWithRefs } from './session-media'
+import { parsePageCursor, formatPageCursor } from './session-page-cursor'
 import { sessionMetadataMapSchema } from './session-metadata-schema'
 import { isHiddenAutomatedSession } from './session-visibility'
 import {
@@ -1023,9 +1026,12 @@ export interface SessionMessagesPage {
   nextCursor: string | null
 }
 
-// Hard bound on how deep paging can reach: every cursor request re-scans from
-// EOF, so history beyond this many raw JSONL lines is unreachable (walk is
-// O(depth²)). Lifting it needs an offset-carrying cursor that seeks instead.
+// Hard bound on how many raw JSONL lines one index scan walks. For the
+// trailing page and for offset-carrying cursors (`uuid:offset`, the shape the
+// server hands out) the scan starts at the cursor's own row, so the bound
+// only caps a single page window and history stays reachable at any depth.
+// A legacy id-only cursor still re-scans from EOF to locate the row, so for
+// it this remains the reachability limit (walk is O(depth²)).
 const MAX_TAIL_LINES = 50_000
 // Soft cap on the raw bytes a single page window may materialize. A window
 // that hits it is served short with a nextCursor, and the client's existing
@@ -1059,8 +1065,23 @@ const MESSAGES_PAGE_HARD_CAP_FACTOR = 2
 // trailing page (whose window always ends at EOF).
 const CURSOR_WINDOW_GRACE_BYTES = 512 * 1024
 
-function pageCursor(messages: TransformedItem[], hasOlder: boolean): string | null {
-  return hasOlder && messages[0] ? messages[0].id : null
+/** Next cursor for a page: its oldest item's id, carrying that row's byte
+ * offset when known so the next request seeks instead of scanning from EOF.
+ * The offset must lie strictly below the request's own cursor row — display
+ * reordering can put a system row from the grace region (above the cursor)
+ * first, and an offset at or above the cursor would let paging climb; such a
+ * cursor goes out id-only so the legacy scan decides. */
+function pageCursor(
+  messages: TransformedItem[],
+  hasOlder: boolean,
+  offsets: Map<string, number>,
+  requestOffset: number | undefined
+): string | null {
+  const first = messages[0]
+  if (!hasOlder || !first) return null
+  const offset = offsets.get(first.id)
+  const descends = requestOffset === undefined || (offset !== undefined && offset < requestOffset)
+  return formatPageCursor(first.id, descends ? offset : undefined)
 }
 
 /** Tail-window read + parse + transform shared by the page and delta readers.
@@ -1204,6 +1225,10 @@ interface PageWindowScan {
    * dropping them would lose data (an empty page behind a huge tool-result
    * run, a trailing system item swallowed by display reordering). */
   dropHead: boolean
+  /** Offset-mode only: the row at the cursor's offset no longer carries the
+   * cursor's uuid (transcript rewritten since the cursor was issued). Nothing
+   * was scanned; the caller retries with the id-only scan. */
+  stale?: true
 }
 
 /** Smallest recorded line-start offset at or past the grace distance, so the
@@ -1281,11 +1306,51 @@ function classifyExtensionRow(
  * items entirely. */
 async function scanMessagesPageWindow(
   jsonlPath: string,
-  opts: { limit: number; cursor?: string; byteBudget: number; signal?: AbortSignal }
+  opts: {
+    limit: number
+    cursor?: string
+    /** Byte offset of the cursor row's line start (from a `uuid:offset`
+     * cursor). Validated before use; the scan then starts at that row instead
+     * of EOF and stops once the window settles — it does not walk on to the
+     * file start looking for a deeper replayed duplicate of the cursor row
+     * (a whole-history replay is served again page by page and deduplicated
+     * by id on the client, at the cost of some all-duplicate pages, instead
+     * of an O(file) scan per page). */
+    cursorOffset?: number
+    byteBudget: number
+    signal?: AbortSignal
+  }
 ): Promise<PageWindowScan> {
-  const { limit, cursor, byteBudget, signal } = opts
+  const { limit, cursor, cursorOffset, byteBudget, signal } = opts
   const hardCap = byteBudget * MESSAGES_PAGE_HARD_CAP_FACTOR
   const cursorNeedle = cursor !== undefined ? Buffer.from(JSON.stringify(cursor)) : null
+  const stale = (): PageWindowScan => ({
+    found: false,
+    startOffset: 0,
+    endOffset: undefined,
+    reachedStart: false,
+    dropHead: true,
+    stale: true,
+  })
+  // Offset mode: confirm the row at the offset is the cursor row, then place
+  // the scan's start just below it and the grace end just above it — the two
+  // things the EOF-down walk otherwise learns on the way to the cursor.
+  let scanEnd: number | undefined
+  let seekGraceEnd: number | undefined
+  if (cursorOffset !== undefined && cursor !== undefined) {
+    const row = await readLineAt(jsonlPath, cursorOffset, signal)
+    const parsed = row !== undefined ? parseJsonlLine<JsonlEntry>(row) : undefined
+    const normalized = parsed !== undefined ? normalizeQueuedCommandEntry(parsed) : undefined
+    if (normalized === undefined || (normalized as { uuid?: string }).uuid !== cursor) {
+      return stale()
+    }
+    scanEnd = cursorOffset + row!.length + 1
+    seekGraceEnd = await findLineStartAtOrAfter(
+      jsonlPath,
+      scanEnd + CURSOR_WINDOW_GRACE_BYTES,
+      signal
+    )
+  }
   // Items needed below the cursor (or below EOF): the page plus the head
   // item that slicing sacrifices when the window start may cut it.
   const targetItems = limit + 1
@@ -1325,7 +1390,9 @@ async function scanMessagesPageWindow(
   // the same span collapse away and must not count as display items.
   let boundaryCountedSinceAnchor = false
 
-  for await (const { line, offset } of iterateJsonlLinesBackward(jsonlPath, signal)) {
+  for await (const { line, offset } of iterateJsonlLinesBackward(jsonlPath, signal, {
+    end: scanEnd,
+  })) {
     linesScanned++
     if (linesScanned > MAX_TAIL_LINES) {
       // Same reachability contract as the old tail reader: history deeper
@@ -1354,7 +1421,11 @@ async function scanMessagesPageWindow(
         suppressUntilAnchorRow = normalized.type === 'system'
         boundaryCountedSinceAnchor = false
         startOffset = offset
-        endOffset = graceEndOffset(lineOffsets!, offset + line.length + 1)
+        // In offset mode the lines above the seek point were never scanned,
+        // so a grace target beyond them falls back to the forward-located
+        // line start (a superset window: it sits ≥ the target, within one
+        // row of it).
+        endOffset = graceEndOffset(lineOffsets!, offset + line.length + 1) ?? seekGraceEnd
         continue
       }
       // A quoted-id byte match inside content or parentUuid parses to a
@@ -1379,7 +1450,9 @@ async function scanMessagesPageWindow(
         continue
       }
       mode = 'settled'
-      if (!cursorNeedle) break
+      // Id-only cursors keep walking to the file start so a deeper replayed
+      // duplicate of the cursor row can re-anchor; offset mode stops here.
+      if (!cursorNeedle || cursorOffset !== undefined) break
       continue
     }
 
@@ -1471,6 +1544,10 @@ async function scanMessagesPageWindow(
   }
 
   if (!anchored) {
+    // Offset mode yields the validated cursor row first, so not anchoring
+    // means the file changed between the probe and the walk (a rewrite race,
+    // or it shrank): let the id-only scan decide against the current layout.
+    if (cursorOffset !== undefined) return stale()
     // Cursor never found: vanished id, or deeper than the line cap.
     return {
       found: false,
@@ -1498,8 +1575,15 @@ async function readEntriesRange(
   endOffset: number | undefined,
   signal?: AbortSignal,
   media?: boolean
-): Promise<(JsonlMessageEntry | JsonlSystemEntry)[]> {
+): Promise<{
+  entries: (JsonlMessageEntry | JsonlSystemEntry)[]
+  /** Line-start offset per entry uuid — the deepest (first in file order)
+   * occurrence wins, matching the transform's dedupe. Feeds the offset half
+   * of the page's `uuid:offset` next cursor. */
+  offsets: Map<string, number>
+}> {
   const entries: (JsonlMessageEntry | JsonlSystemEntry)[] = []
+  const offsets = new Map<string, number>()
   // Rows arrive in file order from a line-boundary start, so accumulating
   // their lengths reproduces each row's absolute offset — what media refs
   // address into. The +1 is the newline the reader strips.
@@ -1527,9 +1611,11 @@ async function readEntriesRange(
         replaceInlineMediaWithRefs(normalized, { line, lineOffset: offset })
       }
       entries.push(normalized)
+      const uuid = (normalized as { uuid?: string }).uuid
+      if (uuid && !offsets.has(uuid)) offsets.set(uuid, offset)
     }
   }
-  return entries
+  return { entries, offsets }
 }
 
 /** Trailing (or `cursor`-before) display page.
@@ -1555,8 +1641,13 @@ export async function getSessionMessagesPage(
   }
 ): Promise<SessionMessagesPage> {
   const jsonlPath = getSessionJsonlPath(agentSlug, sessionId)
-  const { limit, cursor, signal } = opts
+  const { limit, signal } = opts
   const byteBudget = opts.byteBudget ?? MESSAGES_PAGE_BYTE_BUDGET
+  // `uuid:offset` seeks; a bare uuid (older clients, the client's own id-only
+  // fallbacks) scans from EOF as before.
+  const parsedCursor = opts.cursor !== undefined ? parsePageCursor(opts.cursor) : undefined
+  const cursor = parsedCursor?.id
+  let cursorOffset = parsedCursor?.offset
 
   // No existence pre-check: a registered session that has not streamed yet
   // has no transcript and pages as empty, and a stat before every read is a
@@ -1565,9 +1656,29 @@ export async function getSessionMessagesPage(
   // the ENOENT is answered with the same empty terminal page.
   let scan: PageWindowScan
   let entries: (JsonlMessageEntry | JsonlSystemEntry)[]
+  let offsets: Map<string, number>
   try {
-    scan = await scanMessagesPageWindow(jsonlPath, { limit, cursor, byteBudget, signal })
+    scan = await scanMessagesPageWindow(jsonlPath, {
+      limit,
+      cursor,
+      cursorOffset,
+      byteBudget,
+      signal,
+    })
     signal?.throwIfAborted()
+    if (scan.stale) {
+      // The transcript was rewritten under the cursor (deletion, retention,
+      // resync): the offset no longer names the cursor row. Degrade to the
+      // id-only scan, which resolves the row against the current layout or
+      // ends pagination if it is gone.
+      console.warn(
+        `getSessionMessagesPage: cursor offset ${cursorOffset} for ${cursor} is stale in ` +
+        `session ${sessionId}; falling back to the id scan`
+      )
+      cursorOffset = undefined
+      scan = await scanMessagesPageWindow(jsonlPath, { limit, cursor, byteBudget, signal })
+      signal?.throwIfAborted()
+    }
     if (!scan.found) {
       // Vanished id (or cursor deeper than MAX_TAIL_LINES): terminate paging.
       // Never point the client at a newer message — it would loop on
@@ -1580,13 +1691,13 @@ export async function getSessionMessagesPage(
       }
       return { messages: [], nextCursor: null }
     }
-    entries = await readEntriesRange(
+    ;({ entries, offsets } = await readEntriesRange(
       jsonlPath,
       scan.startOffset,
       scan.endOffset,
       signal,
       opts.media === 'ref'
-    )
+    ))
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return { messages: [], nextCursor: null }
@@ -1621,7 +1732,7 @@ export async function getSessionMessagesPage(
         `scan cap below cursor ${cursor}; deeper history is unreachable`
       )
     }
-    return { messages, nextCursor: pageCursor(messages, hasOlder) }
+    return { messages, nextCursor: pageCursor(messages, hasOlder, offsets, cursorOffset) }
   }
 
   const usable = dropHead ? transformed.slice(1) : transformed
@@ -1633,7 +1744,7 @@ export async function getSessionMessagesPage(
       `hard cap before a complete display item; serving an empty page`
     )
   }
-  return { messages, nextCursor: pageCursor(messages, hasOlder) }
+  return { messages, nextCursor: pageCursor(messages, hasOlder, offsets, cursorOffset) }
 }
 
 export interface SessionMessagesDelta {

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -1229,6 +1229,11 @@ interface PageWindowScan {
    * cursor's uuid (transcript rewritten since the cursor was issued). Nothing
    * was scanned; the caller retries with the id-only scan. */
   stale?: true
+  /** Cursor pages: line-start offset of the row the scan anchored on (the
+   * cursor row in offset mode; the deepest occurrence of the uuid in id-only
+   * mode). Lets the page be split by row position when the cursor's item id
+   * does not survive the deeper window's transform. */
+  anchorOffset?: number
 }
 
 /** Smallest recorded line-start offset at or past the grace distance, so the
@@ -1371,6 +1376,7 @@ async function scanMessagesPageWindow(
   let displayCount = 0
   let windowBytes = 0
   let startOffset = 0
+  let anchorOffset: number | undefined
   let hitLineCap = false
   // Conservative default: with nothing counted, treat the head as partial.
   let deepestCountedIsGroup = true
@@ -1402,7 +1408,14 @@ async function scanMessagesPageWindow(
     }
     lineOffsets?.push(offset)
 
-    if (cursorNeedle && line.includes(cursorNeedle)) {
+    // Offset mode anchors exactly once, on the validated row the walk starts
+    // from: a deeper occurrence of the same uuid is a replayed row's
+    // original and must be counted as an ordinary row, not re-anchored on
+    // (re-anchoring would move the page split below the original and skip
+    // everything between it and the copy). Id-only mode has no way to tell
+    // which occurrence issued the cursor and keeps the deepest.
+    const mayAnchor = cursorNeedle !== null && !(cursorOffset !== undefined && anchored)
+    if (mayAnchor && line.includes(cursorNeedle!)) {
       const parsed = parseJsonlLine<JsonlEntry>(line)
       const normalized = parsed !== undefined ? normalizeQueuedCommandEntry(parsed) : undefined
       if (normalized !== undefined && (normalized as { uuid?: string }).uuid === cursor) {
@@ -1421,6 +1434,7 @@ async function scanMessagesPageWindow(
         suppressUntilAnchorRow = normalized.type === 'system'
         boundaryCountedSinceAnchor = false
         startOffset = offset
+        anchorOffset = offset
         // In offset mode the lines above the seek point were never scanned,
         // so a grace target beyond them falls back to the forward-located
         // line start (a superset window: it sits ≥ the target, within one
@@ -1563,6 +1577,7 @@ async function scanMessagesPageWindow(
     endOffset,
     reachedStart: startOffset === 0,
     dropHead: deepestCountedIsGroup,
+    anchorOffset,
   }
 }
 
@@ -1711,20 +1726,40 @@ export async function getSessionMessagesPage(
 
   if (cursor) {
     const idx = transformed.findIndex((item) => item.id === cursor)
-    if (idx === -1) {
-      // The index scan located the cursor's line but the transform of the
-      // materialized window disagrees — a concurrent rewrite between the two
-      // passes, or a replayed duplicate id. Terminate like a vanished cursor
-      // rather than serving a mislabeled page.
+    let messages: TransformedItem[]
+    let hasOlder: boolean
+    if (idx !== -1) {
+      const start = Math.max(dropHead ? 1 : 0, idx - limit)
+      messages = transformed.slice(start, idx)
+      hasOlder = messages.length > 0 && (!reachedStart || start > 0)
+    } else if (scan.anchorOffset !== undefined) {
+      // The index scan located the cursor's row but its item id does not
+      // survive this window's transform. Seen with a partial history replay
+      // (the CLI re-appends a few rows verbatim just before a compaction): in
+      // the page that issued the cursor the replayed assistant row stood
+      // alone and got its own id; here the window also holds the original,
+      // the uuid dedupe keeps that, and it merges into a multi-row group
+      // under the group's own id. Ending pagination here is what made
+      // scroll-up go dead mid-conversation. The row position is still
+      // authoritative: serve every item whose rows sit below the cursor row
+      // — every one of them is display-before whatever the previous page
+      // started with. Items above it were served by that page; a system
+      // row the transform reorders across the boundary may repeat, which
+      // the client's id dedupe absorbs.
+      const cursorRow = scan.anchorOffset
+      const kept = transformed.filter((item) => (offsets.get(item.id) ?? Infinity) < cursorRow)
+      const usable = dropHead ? kept.slice(1) : kept
+      messages = usable.slice(-limit)
+      hasOlder = messages.length > 0 && (!reachedStart || usable.length > messages.length)
+    } else {
+      // A concurrent rewrite between the two passes. Terminate like a vanished
+      // cursor rather than serving a mislabeled page.
       console.warn(
         `getSessionMessagesPage: cursor ${cursor} vanished between scan and ` +
         `read for session ${sessionId}; ending pagination`
       )
       return { messages: [], nextCursor: null }
     }
-    const start = Math.max(dropHead ? 1 : 0, idx - limit)
-    const messages = transformed.slice(start, idx)
-    const hasOlder = messages.length > 0 && (!reachedStart || start > 0)
     // Sequential walks end here when a cap truncates the page to empty.
     if (messages.length === 0 && !reachedStart) {
       console.warn(

--- a/src/shared/lib/utils/file-storage.offset-reads.test.ts
+++ b/src/shared/lib/utils/file-storage.offset-reads.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import {
+  iterateJsonlLinesBackward,
+  readLineAt,
+  findLineStartAtOrAfter,
+} from './file-storage'
+
+let dir: string
+beforeEach(async () => {
+  dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'offset-reads-'))
+})
+afterEach(async () => {
+  await fs.promises.rm(dir, { recursive: true, force: true })
+})
+
+async function write(name: string, content: string): Promise<string> {
+  const p = path.join(dir, name)
+  await fs.promises.writeFile(p, content)
+  return p
+}
+
+async function collect(p: string, end?: number) {
+  const out: { line: string; offset: number }[] = []
+  for await (const { line, offset } of iterateJsonlLinesBackward(p, undefined, { end })) {
+    out.push({ line: line.toString(), offset })
+  }
+  return out
+}
+
+describe('iterateJsonlLinesBackward with an end offset', () => {
+  it('starts at the given line boundary and walks down to the file start', async () => {
+    const p = await write('a.jsonl', 'aaa\nbbbb\ncc\nd\n')
+    // Boundaries: aaa@0, bbbb@4, cc@9, d@12. End just after "bbbb\n" (=9).
+    expect(await collect(p, 9)).toEqual([
+      { line: 'bbbb', offset: 4 },
+      { line: 'aaa', offset: 0 },
+    ])
+  })
+
+  it('an end beyond EOF is clamped to EOF; end 0 yields nothing', async () => {
+    const p = await write('b.jsonl', 'x\ny\n')
+    expect(await collect(p, 10_000)).toEqual(await collect(p))
+    expect(await collect(p, 0)).toEqual([])
+  })
+
+  it('an end at EOF of a file without a trailing newline yields the last row whole', async () => {
+    const p = await write('c.jsonl', 'x\nlast')
+    expect(await collect(p, 6)).toEqual([
+      { line: 'last', offset: 2 },
+      { line: 'x', offset: 0 },
+    ])
+  })
+
+  it('walks a row that spans several read chunks when the end is set', async () => {
+    const big = 'q'.repeat(200 * 1024)
+    const p = await write('d.jsonl', `head\n${big}\ntail\n`)
+    const rows = await collect(p, 5 + big.length + 1)
+    expect(rows.map((r) => r.offset)).toEqual([5, 0])
+    expect(rows[0]!.line.length).toBe(big.length)
+  })
+})
+
+describe('readLineAt', () => {
+  it('returns the row starting at a line boundary, without the newline', async () => {
+    const p = await write('e.jsonl', 'aaa\nbbbb\ncc\n')
+    expect((await readLineAt(p, 4))?.toString()).toBe('bbbb')
+    expect((await readLineAt(p, 0))?.toString()).toBe('aaa')
+    expect((await readLineAt(p, 9))?.toString()).toBe('cc')
+  })
+
+  it('returns the last row of a file without a trailing newline', async () => {
+    const p = await write('f.jsonl', 'aaa\nend')
+    expect((await readLineAt(p, 4))?.toString()).toBe('end')
+  })
+
+  it('returns undefined at or past EOF, and the tail of a row for a mid-row offset', async () => {
+    const p = await write('g.jsonl', 'aaa\nbbbb\n')
+    expect(await readLineAt(p, 9)).toBeUndefined()
+    expect(await readLineAt(p, 500)).toBeUndefined()
+    expect((await readLineAt(p, 6))?.toString()).toBe('bb')
+  })
+
+  it('reads only one row of a large file', async () => {
+    const rows = Array.from({ length: 2000 }, (_, i) => `{"i":${i},"pad":"${'p'.repeat(500)}"}`)
+    const p = await write('h.jsonl', rows.join('\n') + '\n')
+    const offset = rows.slice(0, 700).reduce((n, r) => n + r.length + 1, 0)
+    expect((await readLineAt(p, offset))?.toString()).toBe(rows[700])
+  })
+})
+
+describe('findLineStartAtOrAfter', () => {
+  it('returns the target itself when it is a line boundary', async () => {
+    const p = await write('i.jsonl', 'aaa\nbbbb\ncc\n')
+    expect(await findLineStartAtOrAfter(p, 4)).toBe(4)
+    expect(await findLineStartAtOrAfter(p, 9)).toBe(9)
+    expect(await findLineStartAtOrAfter(p, 0)).toBe(0)
+    expect(await findLineStartAtOrAfter(p, -3)).toBe(0)
+  })
+
+  it('rounds a mid-row target up to the next line start', async () => {
+    const p = await write('j.jsonl', 'aaa\nbbbb\ncc\n')
+    expect(await findLineStartAtOrAfter(p, 1)).toBe(4)
+    expect(await findLineStartAtOrAfter(p, 6)).toBe(9)
+  })
+
+  it('answers EOF for a target inside the final row, and undefined past the last newline', async () => {
+    const p = await write('k.jsonl', 'aaa\nbbbb\ncc\n')
+    // Inside "cc\n": the newline at 11 → line start 12 == EOF.
+    expect(await findLineStartAtOrAfter(p, 10)).toBe(12)
+    expect(await findLineStartAtOrAfter(p, 12)).toBe(12)
+    expect(await findLineStartAtOrAfter(p, 13)).toBeUndefined()
+    const q = await write('l.jsonl', 'aaa\nnoeol')
+    expect(await findLineStartAtOrAfter(q, 5)).toBeUndefined()
+  })
+
+  it('crosses read chunks to find a newline behind a huge row', async () => {
+    const big = 'q'.repeat(300 * 1024)
+    const p = await write('m.jsonl', `head\n${big}\ntail\n`)
+    expect(await findLineStartAtOrAfter(p, 6)).toBe(5 + big.length + 1)
+  })
+
+  it('answers undefined for a missing file', async () => {
+    expect(await findLineStartAtOrAfter(path.join(dir, 'nope.jsonl'), 5)).toBeUndefined()
+  })
+})

--- a/src/shared/lib/utils/file-storage.ts
+++ b/src/shared/lib/utils/file-storage.ts
@@ -502,10 +502,17 @@ export async function readJsonlTailLines(
  *
  * Missing file yields nothing. `signal` aborts between chunk reads (throws the
  * abort reason), same contract as readJsonlTailLines.
+ *
+ * `opts.end` starts the walk at that byte position instead of EOF (clamped to
+ * the file size): the first line yielded is the one ending just below it. It
+ * must be a line boundary — the byte after a `\n`, or EOF — so a caller that
+ * knows where a row ends (an offset-carrying page cursor) skips everything
+ * above it. An `end` inside a row would yield that row's truncated head.
  */
 export async function* iterateJsonlLinesBackward(
   filePath: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  opts?: { end?: number }
 ): AsyncGenerator<{ line: Buffer; offset: number }> {
   signal?.throwIfAborted()
   let fileHandle: fs.promises.FileHandle
@@ -518,7 +525,7 @@ export async function* iterateJsonlLinesBackward(
 
   try {
     const stat = await fileHandle.stat()
-    let pos = stat.size
+    let pos = opts?.end === undefined ? stat.size : Math.max(0, Math.min(opts.end, stat.size))
     // Fragments (in file order) of the line whose start lies in a chunk not
     // yet read — the bytes below the lowest newline processed so far. Kept as
     // an array and concatenated ONCE at the line boundary: re-concatenating
@@ -576,6 +583,63 @@ export async function* iterateJsonlLinesBackward(
       carryBytes = 0
       yield { line: firstLine, offset: 0 }
     }
+  } finally {
+    await fileHandle.close()
+  }
+}
+
+/**
+ * The single raw line that STARTS at byte `offset` (newline excluded), or
+ * undefined when `offset` is at or past EOF. Reads only that line's bytes plus
+ * chunk slack. `offset` must be a line boundary — a mid-row offset returns the
+ * row's tail, which a JSONL consumer rejects as malformed (the property an
+ * offset-carrying page cursor's validation relies on).
+ */
+export async function readLineAt(
+  filePath: string,
+  offset: number,
+  signal?: AbortSignal
+): Promise<Buffer | undefined> {
+  for await (const line of streamFileLines(filePath, { start: offset }, signal)) {
+    return line
+  }
+  return undefined
+}
+
+/**
+ * Smallest line-start offset at or past `target` — the byte after the first
+ * `\n` at or beyond `target - 1` — or undefined when no newline lies there
+ * (the region runs to EOF, read to EOF). `target` ≤ 0 answers 0. Reads
+ * forward from `target` in chunks, so the cost is the distance to the next
+ * newline, not the file. Missing file answers undefined.
+ */
+export async function findLineStartAtOrAfter(
+  filePath: string,
+  target: number,
+  signal?: AbortSignal
+): Promise<number | undefined> {
+  signal?.throwIfAborted()
+  if (target <= 0) return 0
+  let fileHandle: fs.promises.FileHandle
+  try {
+    fileHandle = await fs.promises.open(filePath, 'r')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  }
+  try {
+    const { size } = await fileHandle.stat()
+    let pos = target - 1
+    while (pos < size) {
+      signal?.throwIfAborted()
+      const buf = Buffer.allocUnsafe(Math.min(TAIL_READ_CHUNK, size - pos))
+      const filled = await readFileRangeFully(fileHandle, buf, pos, signal)
+      if (filled === 0) return undefined
+      const idx = buf.subarray(0, filled).indexOf(NEWLINE_BYTE)
+      if (idx !== -1) return pos + idx + 1
+      pos += filled
+    }
+    return undefined
   } finally {
     await fileHandle.close()
   }


### PR DESCRIPTION
## Summary

Scrolling up in a long session could go dead mid-conversation. Two causes, both fixed here:

1. **Cursor id vanishing across windows (the reported bug, reproduced on real data).** The CLI can re-append a handful of rows verbatim right before a compaction, including one `tool_use` row of a multi-row assistant message. In the page that issued the cursor the replayed row stood alone and got its own item id; in the next, deeper window the uuid dedupe kept the original, which merged into its group under the group's own id. `getSessionMessagesPage` reported the cursor "vanished between scan and read" and ended pagination, leaving the list topped by an assistant tool call right above a "Compacted" marker. Reproduced on datawizz session `d9d97dab` at a 256KB budget: the legacy walk ended 73 items short.
2. **Depth cap.** Every older-page request re-scanned the transcript backwards from EOF (O(depth²)), and a 50k-line cap made deeper history unreachable.

### Changes

- **`uuid:offset` cursors.** Page cursors carry the cursor row's byte offset. The server validates that the row at the offset still carries the uuid (transcripts are rewritten by deletion/retention/resync), starts the backward index scan at that row, and locates the grace window with a short forward read. Each page costs O(page) reads; the line cap only bounds a single window. A bare uuid (older clients, the client's own id-only fallbacks) takes the old EOF-down scan; a stale offset logs a warning and degrades to it. Any id-only request is answered with an offset cursor, so clients upgrade transparently.
- **Cursor resolution by row position.** The scan reports the offset of the row it anchored on. When the cursor's item id is absent from the transformed window, the page is every item whose rows sit below that row (dropHead and limit applied as for the trailing page) instead of ending pagination. Offset mode anchors exactly once, on the validated row: a deeper occurrence of the same uuid is a replayed row's original and is counted as an ordinary row (re-anchoring on it would skip everything between original and copy). Id-only mode keeps its "deepest occurrence" anchor.
- **Progress guard.** A next cursor only carries an offset when it sits strictly below the request's own cursor row; otherwise it goes out id-only.
- **Client.** `fetchOlder` walks past pages that add nothing visible within one gesture (bounded to 25 hops), so replayed pages never cost the reader a scroll each. This also closes a latent wedge where a page of items already in the trailing page fired the scroll-anchor guard without growing the list.
- **Reader helpers** (`file-storage.ts`): `iterateJsonlLinesBackward` takes `opts.end`; `readLineAt`; `findLineStartAtOrAfter`.

## Validation

- **Real SuperAgent data:** legacy and seek walks over the 120 largest transcripts in the datawizz data dir (up to 47MB), each at the default and a 256KB budget, compared against the whole-file transform. Seek walks cover every item on all 120 (one cosmetic duplicate on the replay case: the replayed tool call shows standalone and inside its group). Legacy walks reach the start on all 120; on the replay case the small-budget legacy walk skips 3 items (deepest-anchor limitation) where it previously ended 73 short. No "vanished" warnings.
- **Real CLI data:** the same comparison on 21 Claude Code transcripts (up to 29MB / 1,877 items), identical item sequences in both modes.
- **Regression test** reproduces the partial-replay-before-compaction shape and sweeps first/older/budget combinations in both modes; confirmed to fail without the fix.
- **Equivalence** on synthetic mixed-shape transcripts (merge groups with interleaved tool results, meta/queued rows, compact boundaries + summaries, reordered system runs, 120KB rows) at four page/budget combinations.
- **Reach:** a 60k-line transcript pages to its first row with offset cursors; an id-only cursor at that depth still ends pagination (legacy contract pinned).
- **Stale offsets:** moved row, mid-row offset, other row, past EOF, vanished row, missing transcript — each falls back to exactly the id-only page and re-issues a valid offset.
- **Cost:** offset cursor at the very start of a 1MB+ transcript reads under `CURSOR_GRACE + 4 × chunk slack`.
- **Client:** hook tests for the multi-hop walk and an all-duplicate terminal page.
- Related suites: 83 files, 2385 tests pass. Typecheck and eslint clean.

## Notes for review
- `pageCursor` returns id-only when the offset would not descend; the 50k-line cap and its warning remain for legacy cursors only.
- Duplicate uuids are rare in practice: across 5,251 datawizz transcripts, 2 files had 9 duplicate rows total, all just before a compaction. There is no full-history replay in this data.
- The Zod cursor schema (`max(200)`) already accommodates the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
