### PR TITLE
feat(renderer): restyle the file drawer header and tabs

### DIFF
--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -447,7 +447,8 @@ test.describe('File Preview', () => {
       // right-side panel control with a left-side close button.
       const viewportWidth = page.viewportSize()!.width
       await expect(async () => {
-        for (const control of [header.getByTitle('Close file preview'), header.getByTitle('Download file')]) {
+        const title = page.getByTestId('file-preview-title')
+        for (const control of [header.getByTitle('Close file preview'), title.getByLabel('Download file')]) {
           await expect(control).toBeVisible()
           const box = await control.boundingBox()
           expect(box).not.toBeNull()

--- a/e2e/specs/file-preview.spec.ts
+++ b/e2e/specs/file-preview.spec.ts
@@ -514,7 +514,7 @@ test.describe('File Preview', () => {
     await expect(page.getByTestId('file-preview-copy')).toHaveCount(0)
   })
 
-  test('copies the open text file from the preview header', async ({ page }) => {
+  test('copies the open text file from the title row', async ({ page }) => {
     await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
     await agentPage.createAgent(`CopyFile ${Date.now()}`)
     const agentSlug = await getLatestAgentSlug(page)
@@ -527,8 +527,9 @@ test.describe('File Preview', () => {
     await filePill.click()
     await expect(markdown(page).getByRole('heading', { name: 'Test Report' })).toBeVisible({ timeout: 10000 })
 
-    const header = page.getByTestId('file-preview-header')
-    await header.getByTestId('file-preview-copy').click()
+    // The per-file actions live with the filename, not in the panel header.
+    const titleRow = page.getByTestId('file-preview-title')
+    await titleRow.getByTestId('file-preview-copy').click()
 
     // The real gate: a browser only honours the write while the click's user
     // gesture is live, so this fails if the handler awaits a fetch first.
@@ -536,7 +537,7 @@ test.describe('File Preview', () => {
       .toBe('# Test Report\n\nThis is a test with **bold** text.')
 
     await expect(page.getByText('Copied contents of “report.md”')).toBeVisible()
-    await expect(header.getByTestId('file-preview-copied-icon')).toBeVisible()
-    await expect(header.getByTestId('file-preview-copy-icon')).toBeVisible({ timeout: 5000 })
+    await expect(titleRow.getByTestId('file-preview-copied-icon')).toBeVisible()
+    await expect(titleRow.getByTestId('file-preview-copy-icon')).toBeVisible({ timeout: 5000 })
   })
 })

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -668,6 +668,10 @@ async function getReq(app: Hono, url: string): Promise<Response> {
   return app.request(`http://localhost${url}`, { method: 'GET' })
 }
 
+async function headReq(app: Hono, url: string, headers?: HeadersInit): Promise<Response> {
+  return app.request(`http://localhost${url}`, { method: 'HEAD', headers })
+}
+
 async function postFormData(app: Hono, url: string, body: FormData): Promise<Response> {
   return app.request(`http://localhost${url}`, {
     method: 'POST',
@@ -2240,6 +2244,50 @@ describe('path traversal security — GET /:id/files/*', () => {
 
     expect(res.status).toBe(400)
     expect(mockCreateReadStream).not.toHaveBeenCalled()
+  })
+
+  // Hono has no HEAD routing: it answers a HEAD by running this GET handler and
+  // throwing the body away. A stream opened here is never read and never
+  // closed, so every HEAD of a file past the stream's 64KB high-water mark
+  // leaked a descriptor — and the drawer sends one HEAD per file it opens, for
+  // the size beside the filename.
+  describe('HEAD', () => {
+    it('answers with the size and no file descriptor opened', async () => {
+      mockFsStat.mockResolvedValueOnce({ isFile: () => true, size: 5_242_880 })
+
+      const res = await headReq(app, '/api/agents/test-agent/files/out/render.mp4?inline=true')
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-length')).toBe('5242880')
+      expect(res.headers.get('accept-ranges')).toBe('bytes')
+      expect(res.headers.get('content-type')).toBe('video/mp4')
+      expect(mockCreateReadStream).not.toHaveBeenCalled()
+    })
+
+    it('answers a ranged HEAD with the range headers and still opens nothing', async () => {
+      mockFsStat.mockResolvedValueOnce({ isFile: () => true, size: 1000 })
+
+      const res = await headReq(app, '/api/agents/test-agent/files/out/render.mp4', { range: 'bytes=0-99' })
+
+      expect(res.status).toBe(206)
+      expect(res.headers.get('content-range')).toBe('bytes 0-99/1000')
+      expect(res.headers.get('content-length')).toBe('100')
+      expect(mockCreateReadStream).not.toHaveBeenCalled()
+    })
+
+    it('still 404s a missing file', async () => {
+      mockFsStat.mockResolvedValueOnce(null)
+      const res = await headReq(app, '/api/agents/test-agent/files/gone.txt')
+      expect(res.status).toBe(404)
+    })
+
+    it('leaves the GET streaming the body', async () => {
+      mockFsStat.mockResolvedValueOnce({ isFile: () => true, size: 100 })
+      mockCreateReadStream.mockReturnValueOnce({ pipe: vi.fn() })
+
+      await getReq(app, '/api/agents/test-agent/files/out/render.mp4')
+      expect(mockCreateReadStream).toHaveBeenCalled()
+    })
   })
 
   // Note: path traversal with ../ in URLs (e.g. /files/../../etc/passwd) is typically

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -6522,12 +6522,22 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
 
     // Advertise range support so media players (e.g. <video>) can seek. When the
     // client requests a byte range, serve just that slice as 206 Partial
-    // Content; otherwise stream the whole file. Only the stream we actually
-    // return is opened, so we never leak a dangling read descriptor.
+    // Content; otherwise stream the whole file.
     c.header('Accept-Ranges', 'bytes')
     const size = stat.size
     const rangeHeader = c.req.header('range')
     const parsedRange = rangeHeader ? parseByteRange(rangeHeader, size) : null
+
+    // Hono has no HEAD routing: its dispatcher answers a HEAD by running the
+    // GET handler and dropping the body (`new Response(null, await dispatch(…,
+    // 'GET'))`). A stream opened below would therefore be constructed, never
+    // read and never closed — Node's stream only closes its descriptor once the
+    // consumer drains or destroys it, so every HEAD of a file past the 64KB
+    // high-water mark leaks one fd for the life of the process. The headers are
+    // the entire answer to a HEAD anyway; return before opening anything.
+    // (`c.req.method` is the real method — the dispatcher overrides its routing
+    // key, not the request.)
+    const bodyless = c.req.method === 'HEAD'
 
     if (rangeHeader && !parsedRange) {
       // Unsatisfiable range → 416 with the valid extent so the client can retry.
@@ -6537,14 +6547,16 @@ agents.get('/:id/files/*', AgentRead(), async (c) => {
 
     if (parsedRange) {
       const { start, end } = parsedRange
-      const chunk = Readable.toWeb(fs.createReadStream(canonicalFile, { start, end })) as ReadableStream
       c.header('Content-Range', `bytes ${start}-${end}/${size}`)
       c.header('Content-Length', (end - start + 1).toString())
+      if (bodyless) return c.body(null, 206)
+      const chunk = Readable.toWeb(fs.createReadStream(canonicalFile, { start, end })) as ReadableStream
       return c.body(chunk, 206)
     }
 
-    const webStream = Readable.toWeb(fs.createReadStream(canonicalFile)) as ReadableStream
     c.header('Content-Length', size.toString())
+    if (bodyless) return c.body(null)
+    const webStream = Readable.toWeb(fs.createReadStream(canonicalFile)) as ReadableStream
     return c.body(webStream)
   } catch (error) {
     console.error('Failed to download file:', error)

--- a/src/api/routes/cloud-proxy.test.ts
+++ b/src/api/routes/cloud-proxy.test.ts
@@ -272,6 +272,24 @@ describe('cloud proxy forwarding', () => {
     expect(res.headers.get('content-length')).toBeNull()
   })
 
+  // The drawer reads a workspace file's size from the Content-Length of a HEAD.
+  // A HEAD has no body to re-frame, so the header describes the resource rather
+  // than the transfer — stripping it left every file in a cloud workspace with
+  // no size beside its name.
+  it('keeps Content-Length on a HEAD, where it describes the file', async () => {
+    mockFetch.mockResolvedValue(new Response(null, { headers: { 'content-length': '5242880' } }))
+    const res = await call('/api/agents/a/files/out/render.mp4', { method: 'HEAD' })
+    expect(res.headers.get('content-length')).toBe('5242880')
+  })
+
+  it('still drops Content-Length on a HEAD the upstream declared encoded', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(null, { headers: { 'content-encoding': 'gzip', 'content-length': '999' } }),
+    )
+    const res = await call('/api/agents/a/files/out/render.mp4', { method: 'HEAD' })
+    expect(res.headers.get('content-length')).toBeNull()
+  })
+
   it('passes the upstream status through', async () => {
     mockFetch.mockResolvedValue(new Response('nope', { status: 403 }))
     const res = await call('/api/agents')

--- a/src/api/routes/cloud-proxy.ts
+++ b/src/api/routes/cloud-proxy.ts
@@ -80,17 +80,20 @@ const FORWARDED_REQUEST_HEADERS = [
  * - `set-cookie` / `set-auth-token`: session credentials for the *deployment's*
  *   origin. Landing them on a loopback origin gives the renderer a second,
  *   unmanaged copy of the credential this proxy exists to hold on its behalf.
- * - `content-encoding` / `content-length` / hop-by-hop: we re-frame the body, so
- *   the upstream's framing metadata describes something that no longer exists.
+ * - `content-encoding` / hop-by-hop: we re-frame the body, so the upstream's
+ *   framing metadata describes something that no longer exists.
  * - `access-control-*`: the local server's own CORS middleware answers for this
  *   origin. Two sets of CORS headers is not permissive, it is a rejected
  *   response.
+ *
+ * `content-length` belongs to that first group for the same reason but is not
+ * listed here, because a HEAD is the one case where it does not: see
+ * `buildClientHeaders`.
  */
 const STRIPPED_RESPONSE_HEADERS = new Set([
   'set-cookie',
   'set-auth-token',
   'content-encoding',
-  'content-length',
   'transfer-encoding',
   'connection',
   'keep-alive',
@@ -180,10 +183,27 @@ function buildUpstreamHeaders(request: Request, token: string): Headers {
   return headers
 }
 
-function buildClientHeaders(upstream: { headers: Headers }): Headers {
+/**
+ * `keepContentLength` is for a HEAD, and only a HEAD.
+ *
+ * Content-Length is normally dropped because we hand the caller a re-framed
+ * body: `fetch` may have decoded a `content-encoding` out from under it, and
+ * Node writes its own framing for what we return either way, so the upstream's
+ * number describes bytes that no longer exist.
+ *
+ * A HEAD has no body to re-frame. Its Content-Length describes the *resource*,
+ * and for a workspace file it is the entire answer — the renderer's file-size
+ * hook asks for nothing else, so stripping it is why a cloud workspace showed
+ * every file with no size beside its name. It is still dropped when the
+ * upstream declared a `content-encoding`, where the number counts compressed
+ * bytes rather than the resource.
+ */
+function buildClientHeaders(upstream: { headers: Headers }, keepContentLength = false): Headers {
+  const preserveLength = keepContentLength && !upstream.headers.has('content-encoding')
   const headers = new Headers()
   upstream.headers.forEach((value, name) => {
     const lower = name.toLowerCase()
+    if (lower === 'content-length' && !preserveLength) return
     if (STRIPPED_RESPONSE_HEADERS.has(lower)) return
     if (lower.startsWith('access-control-')) return
     headers.set(name, value)
@@ -213,6 +233,8 @@ function canUsePrefetch(request: Request): boolean {
 }
 
 function fromPrefetch(prefetched: PrefetchedResponse): Response {
+  // Only a GET is ever prefetched (see canUsePrefetch), so there is never a
+  // HEAD's Content-Length to preserve here.
   return new Response(prefetched.body, {
     status: prefetched.status,
     headers: buildClientHeaders({ headers: new Headers(prefetched.headers) }),
@@ -324,7 +346,7 @@ async function forwardRequest(
       } catch (error) {
         return upstreamFailure(request, error)
       }
-      return toClientResponse(upstream)
+      return toClientResponse(upstream, request.method)
     }
     return new Response(rejectionBody, {
       status: 401,
@@ -332,14 +354,14 @@ async function forwardRequest(
     })
   }
 
-  return toClientResponse(upstream)
+  return toClientResponse(upstream, request.method)
 }
 
-function toClientResponse(upstream: Response): Response {
+function toClientResponse(upstream: Response, method: string): Response {
   return new Response(upstream.body, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers: buildClientHeaders(upstream),
+    headers: buildClientHeaders(upstream, method === 'HEAD'),
   })
 }
 

--- a/src/renderer/components/file-preview/copy-file-button.test.tsx
+++ b/src/renderer/components/file-preview/copy-file-button.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { toast } from 'sonner'
+import { TooltipProvider } from '@renderer/components/ui/tooltip'
 import { CopyFileButton } from './copy-file-button'
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
@@ -15,7 +16,10 @@ let writeText: ReturnType<typeof vi.fn>
 function renderButton() {
   return render(
     <QueryClientProvider client={queryClient}>
-      <CopyFileButton fileUrl={FILE_URL} displayName="notes.md" />
+      {/* The button shares the action row's provider rather than carrying one. */}
+      <TooltipProvider>
+        <CopyFileButton fileUrl={FILE_URL} displayName="notes.md" />
+      </TooltipProvider>
     </QueryClientProvider>,
   )
 }

--- a/src/renderer/components/file-preview/copy-file-button.tsx
+++ b/src/renderer/components/file-preview/copy-file-button.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Check, Copy } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { copyLazyTextToClipboard, copyTextToClipboard } from '@renderer/lib/clipboard'
 import { looksBinary } from './file-types'
 import { MAX_CONTENT_CHARS, type FileContent } from './renderers/use-file-content'
@@ -50,19 +51,26 @@ export function CopyFileButton({ fileUrl, displayName }: CopyFileButtonProps) {
       : `Copied contents of “${displayName}”`)
   }
 
+  // Self-contained provider so the button works anywhere it is dropped in.
   return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      className="p-0.5 rounded hover:bg-muted transition-colors"
-      title="Copy file contents"
-      aria-label="Copy file contents"
-      data-testid="file-preview-copy"
-    >
-      {copied
-        ? <Check data-testid="file-preview-copied-icon" className="h-4 w-4 text-green-600 dark:text-green-400" />
-        : <Copy data-testid="file-preview-copy-icon" className="h-4 w-4" />}
-    </button>
+    <TooltipProvider delayDuration={300}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="p-0.5 rounded hover:bg-muted transition-colors"
+          aria-label="Copy file contents"
+          data-testid="file-preview-copy"
+        >
+          {copied
+            ? <Check data-testid="file-preview-copied-icon" className="h-4 w-4 text-green-600 dark:text-green-400" />
+            : <Copy data-testid="file-preview-copy-icon" className="h-4 w-4" />}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{copied ? 'Copied' : 'Copy file contents'}</TooltipContent>
+    </Tooltip>
+    </TooltipProvider>
   )
 }
 

--- a/src/renderer/components/file-preview/copy-file-button.tsx
+++ b/src/renderer/components/file-preview/copy-file-button.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Check, Copy } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { copyLazyTextToClipboard, copyTextToClipboard } from '@renderer/lib/clipboard'
 import { looksBinary } from './file-types'
 import { MAX_CONTENT_CHARS, type FileContent } from './renderers/use-file-content'
@@ -51,9 +51,9 @@ export function CopyFileButton({ fileUrl, displayName }: CopyFileButtonProps) {
       : `Copied contents of “${displayName}”`)
   }
 
-  // Self-contained provider so the button works anywhere it is dropped in.
+  // No provider of its own: it shares the one around the action row, so moving
+  // between these buttons skips the second tooltip's open delay.
   return (
-    <TooltipProvider delayDuration={300}>
     <Tooltip>
       <TooltipTrigger asChild>
         <button
@@ -70,7 +70,6 @@ export function CopyFileButton({ fileUrl, displayName }: CopyFileButtonProps) {
       </TooltipTrigger>
       <TooltipContent>{copied ? 'Copied' : 'Copy file contents'}</TooltipContent>
     </Tooltip>
-    </TooltipProvider>
   )
 }
 

--- a/src/renderer/components/file-preview/file-preview-pagination.integration.test.tsx
+++ b/src/renderer/components/file-preview/file-preview-pagination.integration.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { FilePreviewProvider, useFilePreview } from '@renderer/context/file-preview-context'
 import { FilePreviewTrayContent } from './file-preview-tray-content'
@@ -61,9 +62,11 @@ function PreviewHarness() {
 describe('PDF preview pagination integration', () => {
   it('rerenders the visible PDF page after clicking next', async () => {
     render(
-      <FilePreviewProvider sessionId="test-session">
-        <PreviewHarness />
-      </FilePreviewProvider>,
+      <QueryClientProvider client={new QueryClient()}>
+        <FilePreviewProvider sessionId="test-session">
+          <PreviewHarness />
+        </FilePreviewProvider>
+      </QueryClientProvider>,
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Open PDF' }))

--- a/src/renderer/components/file-preview/file-preview-pagination.integration.test.tsx
+++ b/src/renderer/components/file-preview/file-preview-pagination.integration.test.tsx
@@ -14,6 +14,9 @@ vi.mock('@renderer/router/use-route-location', () => ({
 }))
 
 vi.mock('./file-tab-bar', () => ({ FileTabBar: () => null }))
+// The tray reads the file's size over HEAD; jsdom has no server to answer, and
+// the size is not what this test is about.
+vi.mock('@renderer/hooks/use-file-size', () => ({ useFileSize: () => ({ data: null }) }))
 vi.mock('./comments/comment-bar', () => ({ CommentBar: () => null }))
 vi.mock('react-pdf', () => ({
   pdfjs: { GlobalWorkerOptions: {} },

--- a/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { FilePreviewTrayContent } from './file-preview-tray-content'
 import type { PreviewTab } from '@renderer/context/file-preview-context'
@@ -28,14 +29,16 @@ vi.mock('@renderer/context/file-preview-context', () => ({
   }),
 }))
 
-// The folder header's host-path actions read the user's role; grant it so a
+// The folder title row's host-path actions read the user's role; grant it so a
 // folder tab renders them (their own behaviour is covered in
 // folder-host-actions.test.tsx).
 vi.mock('@renderer/context/user-context', () => ({
   useUser: () => ({ canAdminAgent: () => true }),
 }))
 
-vi.mock('./file-tab-bar', () => ({ FileTabBar: () => null }))
+vi.mock('@renderer/hooks/use-file-size', () => ({ useFileSize: () => ({ data: 12_800 }) }))
+// The drawer's close controls ride in the tab bar's trailing slot; render just that.
+vi.mock('./file-tab-bar', () => ({ FileTabBar: ({ trailing }: { trailing?: ReactNode }) => <div>{trailing}</div> }))
 vi.mock('./renderers/file-renderer', () => ({ FileRenderer: () => <div data-testid="file-renderer" /> }))
 vi.mock('./folder-browser', () => ({ FolderBrowser: () => <div data-testid="folder-browser" /> }))
 vi.mock('./comments/comment-bar', () => ({ CommentBar: () => <div data-testid="comment-bar" /> }))
@@ -60,7 +63,16 @@ describe('FilePreviewTrayContent', () => {
     }]
   })
 
-  it('exposes container-responsive close controls on opposite sides', () => {
+  it('shows the filename with its size, and the file actions, in the title row', () => {
+    renderTray()
+    const title = screen.getByTestId('file-preview-title')
+    expect(title).toHaveTextContent('report.md')
+    expect(screen.getByTestId('file-preview-size')).toHaveTextContent('12.5 KB')
+    expect(title.querySelector('[aria-label="Download file"]')).not.toBeNull()
+    expect(screen.getByTestId('file-preview-header').querySelector('[aria-label="Download file"]')).toBeNull()
+  })
+
+  it('exposes container-responsive close controls after the tabs', () => {
     const onClose = vi.fn()
     renderTray(onClose)
 
@@ -85,10 +97,12 @@ describe('FilePreviewTrayContent', () => {
     }]
     renderTray()
 
-    expect(screen.getByTestId('folder-copy-path')).toBeInTheDocument()
+    // The folder's host actions sit with its name, the same place a file's
+    // copy and download do — not in the panel header.
+    expect(screen.getByTestId('file-preview-title')).toContainElement(screen.getByTestId('folder-copy-path'))
 
     expect(screen.getByTestId('folder-browser')).toBeVisible()
-    expect(screen.queryByTitle('Download file')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Download file')).not.toBeInTheDocument()
     expect(screen.queryByTestId('file-preview-copy')).not.toBeInTheDocument()
     expect(screen.queryByTestId('comment-bar')).not.toBeInTheDocument()
   })
@@ -111,6 +125,6 @@ describe('FilePreviewTrayContent', () => {
     renderTray()
 
     expect(screen.queryByTestId('file-preview-copy')).not.toBeInTheDocument()
-    expect(screen.getByTitle('Download file')).toBeInTheDocument()
+    expect(screen.getByLabelText('Download file')).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/file-preview/file-preview-tray-content.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from 'react'
 import { ArrowDownToLine, PanelRight, X } from 'lucide-react'
 import { useFilePreview } from '@renderer/context/file-preview-context'
 import { CopyFileButton } from './copy-file-button'
@@ -7,8 +8,7 @@ import { FileRenderer } from './renderers/file-renderer'
 import { FolderBrowser } from './folder-browser'
 import { FolderHostActions } from './folder-host-actions'
 import { CommentBar } from './comments/comment-bar'
-import { getApiBaseUrl } from '@renderer/lib/env'
-import { getAgentFileApiPath } from '@renderer/lib/workspace-file-url'
+import { getAgentFileApiPath, getAgentFileUrl } from '@renderer/lib/workspace-file-url'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { cn } from '@shared/lib/utils/cn'
 import { formatFileSize } from '@shared/lib/utils/format-file-size'
@@ -21,26 +21,27 @@ interface FilePreviewTrayContentProps {
 
 export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayContentProps) {
   const { openTabs, activeTabIndex, setActiveTab, setPdfPage, closeTab, comments } = useFilePreview()
+  // The body card squares off its top-left corner only while the active tab sits
+  // directly above it; the strip is the only thing that knows when that is.
+  const [leadingTabFlush, setLeadingTabFlush] = useState(false)
+  const onLeadingTabFlush = useCallback((flush: boolean) => setLeadingTabFlush(flush), [])
 
   const activeTab = openTabs[activeTabIndex]
+  const activeFile = activeTab?.kind === 'file' ? activeTab : null
   // Hooks run before the early return so their order is stable across renders.
   const { data: fileSize } = useFileSize(
-    activeTab?.kind === 'file' ? getAgentFileApiPath(activeTab.agentSlug, activeTab.filePath) : null,
-    activeTab?.kind === 'file' ? activeTab.version : 0,
+    activeFile ? getAgentFileApiPath(activeFile.agentSlug, activeFile.filePath) : null,
+    activeFile?.version ?? 0,
   )
   if (!activeTab) return null
 
-  const baseUrl = getApiBaseUrl()
-  const fileApiPath = activeTab.kind === 'file'
-    ? getAgentFileApiPath(activeTab.agentSlug, activeTab.filePath)
+  const fileUrl = activeFile
+    ? getAgentFileUrl(activeFile.agentSlug, activeFile.filePath, { inline: true, version: activeFile.version })
     : null
-  // `v` is a cache buster, not a server-read param: the route ignores it, but it
-  // keeps a redelivered file from resolving to a URL that a browser or CDN still
-  // holds the previous body for.
-  const versionQuery = activeTab.kind === 'file' && activeTab.version > 0 ? `v=${activeTab.version}` : ''
-  const fileUrl = fileApiPath ? `${baseUrl}${fileApiPath}?inline=true${versionQuery ? `&${versionQuery}` : ''}` : null
-  const downloadUrl = fileApiPath ? `${baseUrl}${fileApiPath}${versionQuery ? `?${versionQuery}` : ''}` : null
-  const activeComments = activeTab.kind === 'file' ? comments.get(activeTab.filePath) || [] : []
+  const downloadUrl = activeFile
+    ? getAgentFileUrl(activeFile.agentSlug, activeFile.filePath, { version: activeFile.version })
+    : null
+  const activeComments = activeFile ? comments.get(activeFile.filePath) || [] : []
 
   return (
     <div className="contents" data-testid="file-preview-tray">
@@ -50,6 +51,7 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
         activeIndex={activeTabIndex}
         onTabClick={setActiveTab}
         onCloseTab={closeTab}
+        onLeadingTabFlush={onLeadingTabFlush}
         trailing={
           // The drawer's own controls. Compact layouts show the close button;
           // wide layouts show the panel-hide button (see globals.css).
@@ -76,23 +78,33 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
 
       {/* File content: a card inset 16px on every side, on the same gray as the tab rail. */}
       <div className="flex flex-1 min-h-0 flex-col bg-muted/60 px-4 pb-4">
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-lg rounded-tl-none border border-black/5 bg-background dark:border-white/5">
+      <div
+        className={cn(
+          'flex flex-1 min-h-0 flex-col overflow-hidden rounded-lg border border-black/5 bg-background dark:border-white/5',
+          // Square only where a tab actually meets the corner. Under an inactive
+          // tab — or a strip scrolled away from its first tab — the square edge
+          // would be a corner cut for no one.
+          leadingTabFlush && 'rounded-tl-none',
+        )}
+      >
         <div className="flex shrink-0 items-center gap-2 px-4 pt-4 pb-2" data-testid="file-preview-title">
           <div className="flex min-w-0 flex-1 items-baseline gap-2">
             <h2 className="truncate text-sm font-medium text-foreground">{activeTab.displayName}</h2>
-            {activeTab.kind === 'file' && typeof fileSize === 'number' && (
+            {activeFile && typeof fileSize === 'number' && (
               <span className="shrink-0 text-xs font-normal text-muted-foreground" data-testid="file-preview-size">
                 {formatFileSize(fileSize)}
               </span>
             )}
           </div>
           {/* A tab's own actions live with its name, not in the panel header —
-              the folder's host actions for the same reason as the file's. */}
+              the folder's host actions for the same reason as the file's. One
+              provider for the row, so moving between them skips the second
+              tooltip's open delay. */}
           <TooltipProvider delayDuration={300}>
           <div className="flex shrink-0 items-center gap-1 text-muted-foreground">
             {activeTab.kind === 'folder' && <FolderHostActions folder={activeTab} />}
-            {fileUrl && activeTab.kind === 'file' && isCopyableTextFile(activeTab.filePath) && (
-              <CopyFileButton fileUrl={fileUrl} displayName={activeTab.displayName} />
+            {fileUrl && activeFile && isCopyableTextFile(activeFile.filePath) && (
+              <CopyFileButton fileUrl={fileUrl} displayName={activeFile.displayName} />
             )}
             {downloadUrl && (
               <Tooltip>
@@ -121,13 +133,13 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
         >
           {activeTab.kind === 'folder' ? (
             <FolderBrowser folder={activeTab} />
-          ) : fileUrl ? (
+          ) : fileUrl && activeFile ? (
             <FileRenderer
-              filePath={activeTab.filePath}
+              filePath={activeFile.filePath}
               fileUrl={fileUrl}
-              agentSlug={activeTab.agentSlug}
-              pdfPage={activeTab.pdfPage}
-              onPdfPageChange={(page) => setPdfPage(activeTab.filePath, page)}
+              agentSlug={activeFile.agentSlug}
+              pdfPage={activeFile.pdfPage}
+              onPdfPageChange={(page) => setPdfPage(activeFile.filePath, page)}
             />
           ) : null}
         </div>
@@ -135,10 +147,10 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
       </div>
 
       {/* Comment bar */}
-      {activeTab.kind === 'file' && (
+      {activeFile && (
         <CommentBar
           comments={activeComments}
-          filePath={activeTab.filePath}
+          filePath={activeFile.filePath}
           sessionId={sessionId}
         />
       )}

--- a/src/renderer/components/file-preview/file-preview-tray-content.tsx
+++ b/src/renderer/components/file-preview/file-preview-tray-content.tsx
@@ -1,4 +1,4 @@
-import { Download, FileText, Folder, PanelRightClose, X } from 'lucide-react'
+import { ArrowDownToLine, PanelRight, X } from 'lucide-react'
 import { useFilePreview } from '@renderer/context/file-preview-context'
 import { CopyFileButton } from './copy-file-button'
 import { FileTabBar } from './file-tab-bar'
@@ -9,7 +9,10 @@ import { FolderHostActions } from './folder-host-actions'
 import { CommentBar } from './comments/comment-bar'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import { getAgentFileApiPath } from '@renderer/lib/workspace-file-url'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { cn } from '@shared/lib/utils/cn'
+import { formatFileSize } from '@shared/lib/utils/format-file-size'
+import { useFileSize } from '@renderer/hooks/use-file-size'
 
 interface FilePreviewTrayContentProps {
   sessionId: string
@@ -20,6 +23,11 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
   const { openTabs, activeTabIndex, setActiveTab, setPdfPage, closeTab, comments } = useFilePreview()
 
   const activeTab = openTabs[activeTabIndex]
+  // Hooks run before the early return so their order is stable across renders.
+  const { data: fileSize } = useFileSize(
+    activeTab?.kind === 'file' ? getAgentFileApiPath(activeTab.agentSlug, activeTab.filePath) : null,
+    activeTab?.kind === 'file' ? activeTab.version : 0,
+  )
   if (!activeTab) return null
 
   const baseUrl = getApiBaseUrl()
@@ -36,73 +44,94 @@ export function FilePreviewTrayContent({ sessionId, onClose }: FilePreviewTrayCo
 
   return (
     <div className="contents" data-testid="file-preview-tray">
-      {/* Header */}
-      <div className="flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground select-none shrink-0" data-testid="file-preview-header">
-        <button
-          className="file-preview-compact-close -ml-1 hidden p-0.5 rounded hover:bg-muted transition-colors"
-          onClick={onClose}
-          title="Close file preview"
-          aria-label="Close file preview"
-        >
-          <X className="h-4 w-4" />
-        </button>
-        {activeTab.kind === 'folder' ? (
-          <Folder className="h-4 w-4 shrink-0" />
-        ) : (
-          <FileText className="h-4 w-4 shrink-0" />
-        )}
-        <span className="flex-1 text-xs truncate font-medium">Files</span>
-        {fileUrl && activeTab.kind === 'file' && isCopyableTextFile(activeTab.filePath) && (
-          <CopyFileButton fileUrl={fileUrl} displayName={activeTab.displayName} />
-        )}
-        {activeTab.kind === 'folder' && <FolderHostActions folder={activeTab} />}
-        {downloadUrl && (
-          <a
-            href={downloadUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="p-0.5 rounded hover:bg-muted transition-colors"
-            title="Download file"
-          >
-            <Download className="h-4 w-4" />
-          </a>
-        )}
-        <button
-          className="file-preview-wide-close inline-flex p-0.5 rounded hover:bg-muted transition-colors"
-          onClick={onClose}
-          title="Hide files panel"
-          aria-label="Hide files panel"
-        >
-          <PanelRightClose className="h-4 w-4" />
-        </button>
-      </div>
-
       {/* File tabs */}
       <FileTabBar
         tabs={openTabs}
         activeIndex={activeTabIndex}
         onTabClick={setActiveTab}
         onCloseTab={closeTab}
+        trailing={
+          // The drawer's own controls. Compact layouts show the close button;
+          // wide layouts show the panel-hide button (see globals.css).
+          <div className="flex items-center gap-1" data-testid="file-preview-header">
+            <button
+              className="file-preview-compact-close hidden p-0.5 rounded hover:bg-muted transition-colors"
+              onClick={onClose}
+              title="Close file preview"
+              aria-label="Close file preview"
+            >
+              <X className="h-4 w-4" />
+            </button>
+            <button
+              className="file-preview-wide-close inline-flex p-0.5 rounded hover:bg-muted transition-colors"
+              onClick={onClose}
+              title="Hide files panel"
+              aria-label="Hide files panel"
+            >
+              <PanelRight className="h-4 w-4" />
+            </button>
+          </div>
+        }
       />
 
-      {/* File content */}
-      <div
-        className={cn(
-          'flex-1 min-h-0',
-          activeTab.kind === 'folder' ? 'overflow-hidden' : 'overflow-auto',
-        )}
-      >
-        {activeTab.kind === 'folder' ? (
-          <FolderBrowser folder={activeTab} />
-        ) : fileUrl ? (
-          <FileRenderer
-            filePath={activeTab.filePath}
-            fileUrl={fileUrl}
-            agentSlug={activeTab.agentSlug}
-            pdfPage={activeTab.pdfPage}
-            onPdfPageChange={(page) => setPdfPage(activeTab.filePath, page)}
-          />
-        ) : null}
+      {/* File content: a card inset 16px on every side, on the same gray as the tab rail. */}
+      <div className="flex flex-1 min-h-0 flex-col bg-muted/60 px-4 pb-4">
+      <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-lg rounded-tl-none border border-black/5 bg-background dark:border-white/5">
+        <div className="flex shrink-0 items-center gap-2 px-4 pt-4 pb-2" data-testid="file-preview-title">
+          <div className="flex min-w-0 flex-1 items-baseline gap-2">
+            <h2 className="truncate text-sm font-medium text-foreground">{activeTab.displayName}</h2>
+            {activeTab.kind === 'file' && typeof fileSize === 'number' && (
+              <span className="shrink-0 text-xs font-normal text-muted-foreground" data-testid="file-preview-size">
+                {formatFileSize(fileSize)}
+              </span>
+            )}
+          </div>
+          {/* A tab's own actions live with its name, not in the panel header —
+              the folder's host actions for the same reason as the file's. */}
+          <TooltipProvider delayDuration={300}>
+          <div className="flex shrink-0 items-center gap-1 text-muted-foreground">
+            {activeTab.kind === 'folder' && <FolderHostActions folder={activeTab} />}
+            {fileUrl && activeTab.kind === 'file' && isCopyableTextFile(activeTab.filePath) && (
+              <CopyFileButton fileUrl={fileUrl} displayName={activeTab.displayName} />
+            )}
+            {downloadUrl && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <a
+                    href={downloadUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-0.5 rounded hover:bg-muted transition-colors"
+                    aria-label="Download file"
+                  >
+                    <ArrowDownToLine className="h-4 w-4" />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent>Download file</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+          </TooltipProvider>
+        </div>
+        <div
+          className={cn(
+            'flex-1 min-h-0',
+            activeTab.kind === 'folder' ? 'overflow-hidden' : 'overflow-auto',
+          )}
+        >
+          {activeTab.kind === 'folder' ? (
+            <FolderBrowser folder={activeTab} />
+          ) : fileUrl ? (
+            <FileRenderer
+              filePath={activeTab.filePath}
+              fileUrl={fileUrl}
+              agentSlug={activeTab.agentSlug}
+              pdfPage={activeTab.pdfPage}
+              onPdfPageChange={(page) => setPdfPage(activeTab.filePath, page)}
+            />
+          ) : null}
+        </div>
+      </div>
       </div>
 
       {/* Comment bar */}

--- a/src/renderer/components/file-preview/file-tab-bar.test.tsx
+++ b/src/renderer/components/file-preview/file-tab-bar.test.tsx
@@ -24,36 +24,55 @@ const tabs: PreviewTab[] = [
   },
 ]
 
+const scrollPositions = new WeakMap<HTMLElement, number>()
+
 /**
- * jsdom has no layout, so give the tab group a fake geometry: `visible` px
- * wide, holding `content` px of tabs. Every tab reports `tabWidth` px.
+ * jsdom has no layout and no scrolling: give the tab group a fake geometry —
+ * `visible` px wide holding `content` px of tabs, each `tabWidth` px — and a
+ * `scrollLeft` that actually moves, so what the tests exercise is the
+ * component's own arithmetic rather than a no-op.
  */
 function fakeLayout({ visible, content, tabWidth }: { visible: number; content: number; tabWidth: number }) {
-  const spies = [
-    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement) {
-      return this.dataset.testid === 'file-tab-group' ? visible : 0
-    }),
-    vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockImplementation(function (this: HTMLElement) {
-      return this.dataset.testid === 'file-tab-group' ? content : 0
-    }),
-    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function (this: HTMLElement) {
-      return this.dataset.testid === 'file-tab' ? tabWidth : 0
-    }),
-    vi.spyOn(HTMLElement.prototype, 'offsetLeft', 'get').mockImplementation(function (this: HTMLElement) {
-      if (this.dataset.testid !== 'file-tab') return 0
-      const siblings = Array.from(this.parentElement?.children ?? [])
-      return siblings.indexOf(this) * (tabWidth + 1)
-    }),
-  ]
-  return () => spies.forEach((s) => s.mockRestore())
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement) {
+    return this.dataset.testid === 'file-tab-group' ? visible : 0
+  })
+  vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockImplementation(function (this: HTMLElement) {
+    return this.dataset.testid === 'file-tab-group' ? content : 0
+  })
+  vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function (this: HTMLElement) {
+    return this.dataset.testid === 'file-tab' ? tabWidth : 0
+  })
+  vi.spyOn(HTMLElement.prototype, 'offsetLeft', 'get').mockImplementation(function (this: HTMLElement) {
+    if (this.dataset.testid !== 'file-tab') return 0
+    const siblings = Array.from(this.parentElement?.children ?? [])
+    return siblings.indexOf(this) * (tabWidth + 1)
+  })
+  vi.spyOn(HTMLElement.prototype, 'scrollLeft', 'get').mockImplementation(function (this: HTMLElement) {
+    return scrollPositions.get(this) ?? 0
+  })
+
+  const max = Math.max(0, content - visible)
+  function scrollTo(this: HTMLElement, options: ScrollToOptions) {
+    scrollPositions.set(this, Math.min(Math.max(options.left ?? 0, 0), max))
+    this.dispatchEvent(new Event('scroll'))
+  }
+  HTMLElement.prototype.scrollTo = scrollTo as HTMLElement['scrollTo']
+  HTMLElement.prototype.scrollBy = function (this: HTMLElement, options: ScrollToOptions) {
+    scrollTo.call(this, { left: (scrollPositions.get(this) ?? 0) + (options.left ?? 0) })
+  } as HTMLElement['scrollBy']
 }
 
-function trackTransform() {
-  return (screen.getByTestId('file-tab-group').firstElementChild as HTMLElement).style.transform
+function scrollLeft() {
+  return screen.getByTestId('file-tab-group').scrollLeft
 }
 
 describe('FileTabBar', () => {
-  afterEach(() => vi.restoreAllMocks())
+  afterEach(() => {
+    vi.restoreAllMocks()
+    // Drop the shadowing assignments so the prototype's own methods return.
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollBy
+  })
 
   it('renders folder and file tabs, marks the active one, and selects by index', async () => {
     const user = userEvent.setup()
@@ -81,6 +100,15 @@ describe('FileTabBar', () => {
     expect(onTabClick).not.toHaveBeenCalled()
   })
 
+  // Every other tab collapses to icon + close; the one the user is reading keeps
+  // room for its name.
+  it('holds a wider floor for the active tab than for the rest', () => {
+    render(<FileTabBar tabs={tabs} activeIndex={1} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
+    const [inactive, active] = screen.getAllByTestId('file-tab')
+    expect(active.className).toContain('min-w-[9.5rem]')
+    expect(inactive.className).toContain('min-w-[4.25rem]')
+  })
+
   it('hides the arrows while every tab fits', () => {
     fakeLayout({ visible: 400, content: 300, tabWidth: 150 })
     render(<FileTabBar tabs={tabs} activeIndex={0} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
@@ -88,7 +116,7 @@ describe('FileTabBar', () => {
     expect(screen.getByTestId('file-tab-bar')).not.toHaveAttribute('data-overflowing')
   })
 
-  it('shows arrows on overflow, slides one tab per click, and disables at each end', () => {
+  it('shows arrows on overflow, scrolls one tab per click, and disables at each end', () => {
     // two 100px tabs in a 120px group: 81px of overflow (100 + 1 gap + 100 - 120)
     fakeLayout({ visible: 120, content: 201, tabWidth: 100 })
     render(<FileTabBar tabs={tabs} activeIndex={0} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
@@ -98,26 +126,87 @@ describe('FileTabBar', () => {
     expect(screen.getByTestId('file-tab-bar')).toHaveAttribute('data-overflowing', 'true')
     expect(earlier).toBeDisabled()
     expect(later).toBeEnabled()
-    expect(trackTransform()).toBe('translateX(-0px)')
+    expect(scrollLeft()).toBe(0)
 
     fireEvent.click(later)
     // one step is a tab width plus the gap, clamped to the overflow
-    expect(trackTransform()).toBe('translateX(-81px)')
+    expect(scrollLeft()).toBe(81)
     expect(later).toBeDisabled()
     expect(earlier).toBeEnabled()
 
     fireEvent.click(earlier)
-    expect(trackTransform()).toBe('translateX(-0px)')
+    expect(scrollLeft()).toBe(0)
     expect(earlier).toBeDisabled()
   })
 
-  it('slides the active tab into view when it is selected off-screen', () => {
+  it('scrolls the active tab into view when it is selected off-screen', () => {
     fakeLayout({ visible: 120, content: 201, tabWidth: 100 })
     const { rerender } = render(<FileTabBar tabs={tabs} activeIndex={0} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
-    expect(trackTransform()).toBe('translateX(-0px)')
+    expect(scrollLeft()).toBe(0)
 
     rerender(<FileTabBar tabs={tabs} activeIndex={1} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
-    // second tab spans 101..201; revealing it in a 120px window means sliding to 81
-    expect(trackTransform()).toBe('translateX(-81px)')
+    // second tab spans 101..201; revealing it in a 120px window means scrolling to 81
+    expect(scrollLeft()).toBe(81)
+  })
+
+  // A clipped tab is still in the tab order, so tabbing to one must bring it
+  // into the strip rather than move focus somewhere invisible.
+  it('scrolls a tab into view when it takes focus without being selected', () => {
+    fakeLayout({ visible: 120, content: 201, tabWidth: 100 })
+    render(<FileTabBar tabs={tabs} activeIndex={0} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
+    expect(scrollLeft()).toBe(0)
+
+    fireEvent.focus(screen.getAllByTestId('file-tab')[1])
+    expect(scrollLeft()).toBe(81)
+  })
+
+  describe('leading-tab flush', () => {
+    it('reports flush while the first tab is active and the strip is unscrolled', () => {
+      fakeLayout({ visible: 400, content: 300, tabWidth: 150 })
+      const onLeadingTabFlush = vi.fn()
+      render(
+        <FileTabBar
+          tabs={tabs}
+          activeIndex={0}
+          onTabClick={vi.fn()}
+          onCloseTab={vi.fn()}
+          onLeadingTabFlush={onLeadingTabFlush}
+        />,
+      )
+      expect(onLeadingTabFlush).toHaveBeenLastCalledWith(true)
+    })
+
+    it('reports not flush when a later tab is active', () => {
+      fakeLayout({ visible: 400, content: 300, tabWidth: 150 })
+      const onLeadingTabFlush = vi.fn()
+      render(
+        <FileTabBar
+          tabs={tabs}
+          activeIndex={1}
+          onTabClick={vi.fn()}
+          onCloseTab={vi.fn()}
+          onLeadingTabFlush={onLeadingTabFlush}
+        />,
+      )
+      expect(onLeadingTabFlush).toHaveBeenLastCalledWith(false)
+    })
+
+    it('reports not flush once the strip is scrolled off its first tab', () => {
+      fakeLayout({ visible: 120, content: 201, tabWidth: 100 })
+      const onLeadingTabFlush = vi.fn()
+      render(
+        <FileTabBar
+          tabs={tabs}
+          activeIndex={0}
+          onTabClick={vi.fn()}
+          onCloseTab={vi.fn()}
+          onLeadingTabFlush={onLeadingTabFlush}
+        />,
+      )
+      expect(onLeadingTabFlush).toHaveBeenLastCalledWith(true)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Later tabs' }))
+      expect(onLeadingTabFlush).toHaveBeenLastCalledWith(false)
+    })
   })
 })

--- a/src/renderer/components/file-preview/file-tab-bar.test.tsx
+++ b/src/renderer/components/file-preview/file-tab-bar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FileTabBar } from './file-tab-bar'
 import type { PreviewTab } from '@renderer/context/file-preview-context'
@@ -24,24 +24,100 @@ const tabs: PreviewTab[] = [
   },
 ]
 
+/**
+ * jsdom has no layout, so give the tab group a fake geometry: `visible` px
+ * wide, holding `content` px of tabs. Every tab reports `tabWidth` px.
+ */
+function fakeLayout({ visible, content, tabWidth }: { visible: number; content: number; tabWidth: number }) {
+  const spies = [
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.dataset.testid === 'file-tab-group' ? visible : 0
+    }),
+    vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.dataset.testid === 'file-tab-group' ? content : 0
+    }),
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.dataset.testid === 'file-tab' ? tabWidth : 0
+    }),
+    vi.spyOn(HTMLElement.prototype, 'offsetLeft', 'get').mockImplementation(function (this: HTMLElement) {
+      if (this.dataset.testid !== 'file-tab') return 0
+      const siblings = Array.from(this.parentElement?.children ?? [])
+      return siblings.indexOf(this) * (tabWidth + 1)
+    }),
+  ]
+  return () => spies.forEach((s) => s.mockRestore())
+}
+
+function trackTransform() {
+  return (screen.getByTestId('file-tab-group').firstElementChild as HTMLElement).style.transform
+}
+
 describe('FileTabBar', () => {
-  it('renders folder and file tabs and closes by discriminated key', async () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders folder and file tabs, marks the active one, and selects by index', async () => {
     const user = userEvent.setup()
+    const onTabClick = vi.fn()
+    render(<FileTabBar tabs={tabs} activeIndex={0} onTabClick={onTabClick} onCloseTab={vi.fn()} />)
+
+    const rendered = screen.getAllByTestId('file-tab')
+    expect(rendered).toHaveLength(2)
+    expect(rendered[0]).toHaveAttribute('data-tab-kind', 'folder')
+    expect(rendered[0]).toHaveAttribute('data-active', 'true')
+    expect(rendered[1]).not.toHaveAttribute('data-active')
+
+    await user.click(rendered[1])
+    expect(onTabClick).toHaveBeenCalledWith(1)
+  })
+
+  it('closes by discriminated key without selecting the tab', async () => {
+    const user = userEvent.setup()
+    const onTabClick = vi.fn()
     const onCloseTab = vi.fn()
-    render(
-      <FileTabBar
-        tabs={tabs}
-        activeIndex={0}
-        onTabClick={vi.fn()}
-        onCloseTab={onCloseTab}
-      />,
-    )
+    render(<FileTabBar tabs={tabs} activeIndex={1} onTabClick={onTabClick} onCloseTab={onCloseTab} />)
 
-    expect(screen.getByTestId('file-tab-bar').children).toHaveLength(2)
-    expect(screen.getAllByTestId('file-tab')[0]).toHaveAttribute('data-tab-kind', 'folder')
-    const folderClose = screen.getAllByTestId('file-tab-close')[0]
-    await user.click(folderClose)
-
+    await user.click(screen.getAllByTestId('file-tab-close')[0])
     expect(onCloseTab).toHaveBeenCalledWith('folder:/workspace/reports')
+    expect(onTabClick).not.toHaveBeenCalled()
+  })
+
+  it('hides the arrows while every tab fits', () => {
+    fakeLayout({ visible: 400, content: 300, tabWidth: 150 })
+    render(<FileTabBar tabs={tabs} activeIndex={0} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
+    expect(screen.queryByTestId('file-tab-arrows')).toBeNull()
+    expect(screen.getByTestId('file-tab-bar')).not.toHaveAttribute('data-overflowing')
+  })
+
+  it('shows arrows on overflow, slides one tab per click, and disables at each end', () => {
+    // two 100px tabs in a 120px group: 81px of overflow (100 + 1 gap + 100 - 120)
+    fakeLayout({ visible: 120, content: 201, tabWidth: 100 })
+    render(<FileTabBar tabs={tabs} activeIndex={0} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
+
+    const earlier = screen.getByRole('button', { name: 'Earlier tabs' })
+    const later = screen.getByRole('button', { name: 'Later tabs' })
+    expect(screen.getByTestId('file-tab-bar')).toHaveAttribute('data-overflowing', 'true')
+    expect(earlier).toBeDisabled()
+    expect(later).toBeEnabled()
+    expect(trackTransform()).toBe('translateX(-0px)')
+
+    fireEvent.click(later)
+    // one step is a tab width plus the gap, clamped to the overflow
+    expect(trackTransform()).toBe('translateX(-81px)')
+    expect(later).toBeDisabled()
+    expect(earlier).toBeEnabled()
+
+    fireEvent.click(earlier)
+    expect(trackTransform()).toBe('translateX(-0px)')
+    expect(earlier).toBeDisabled()
+  })
+
+  it('slides the active tab into view when it is selected off-screen', () => {
+    fakeLayout({ visible: 120, content: 201, tabWidth: 100 })
+    const { rerender } = render(<FileTabBar tabs={tabs} activeIndex={0} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
+    expect(trackTransform()).toBe('translateX(-0px)')
+
+    rerender(<FileTabBar tabs={tabs} activeIndex={1} onTabClick={vi.fn()} onCloseTab={vi.fn()} />)
+    // second tab spans 101..201; revealing it in a 120px window means sliding to 81
+    expect(trackTransform()).toBe('translateX(-81px)')
   })
 })

--- a/src/renderer/components/file-preview/file-tab-bar.tsx
+++ b/src/renderer/components/file-preview/file-tab-bar.tsx
@@ -9,41 +9,54 @@ interface FileTabBarProps {
   activeIndex: number
   onTabClick: (index: number) => void
   onCloseTab: (tabKey: string) => void
+  /**
+   * Whether the active tab's left edge is flush with the strip's left inset —
+   * true only for the first tab, unscrolled. The body card squares off its
+   * top-left corner to meet the tab when it is.
+   */
+  onLeadingTabFlush?: (flush: boolean) => void
   /** Panel-level controls rendered after the last tab, at the strip's right edge (the drawer close). */
   trailing?: ReactNode
 }
 
 const TAB_GAP_PX = 1
+/** Sub-pixel slack: a scroller's scrollLeft rarely lands exactly on its maximum. */
+const EDGE_EPSILON_PX = 1
 
 /**
  * Chrome-style tab strip.
  *
- * Tabs share one 160px basis and shrink in lockstep down to a floor. Past the
- * floor they overflow, and the strip shows a pair of arrows that slide the
- * track one tab at a time. The track is *translated* inside a group that clips
- * only horizontally — not scrolled — because a scroll container also clips
- * vertically, and the active tab hangs 1px over the body card's top border to
- * hide the line beneath it.
+ * Tabs share one 160px basis and shrink in lockstep down to a floor — except
+ * the active one, which keeps enough width to read its own name. Past the floor
+ * they overflow and the strip shows a pair of arrows that scroll it one tab at
+ * a time.
+ *
+ * The strip is a real horizontal scroller, so a trackpad swipe, a touch drag
+ * and the browser's own focus-reveal all work without us reimplementing them.
+ * The reason it originally wasn't one is that the active tab hangs 1px below
+ * the track to cover the body card's top border, and a scroll container clips
+ * that overhang: `pb-px -mb-px` buys the overhang a pixel of padding to live
+ * in, which keeps it visible and keeps the vertical axis from overflowing.
  */
-export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, trailing }: FileTabBarProps) {
+export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, onLeadingTabFlush, trailing }: FileTabBarProps) {
   const groupRef = useRef<HTMLDivElement>(null)
   const trackRef = useRef<HTMLDivElement>(null)
-  const [offset, setOffset] = useState(0)
-  const [maxOffset, setMaxOffset] = useState(0)
+  const [scrollLeft, setScrollLeft] = useState(0)
+  const [maxScroll, setMaxScroll] = useState(0)
 
-  /** How far the track can slide: the content width beyond the visible group. */
+  /** How far the strip can scroll: the content width beyond the visible group. */
   const measure = useCallback(() => {
     const group = groupRef.current
-    if (!group) return 0
-    const max = Math.max(0, group.scrollWidth - group.clientWidth)
-    setMaxOffset(max)
-    setOffset((o) => Math.min(o, max))
-    return max
+    if (!group) return
+    setMaxScroll(Math.max(0, group.scrollWidth - group.clientWidth))
+    setScrollLeft(group.scrollLeft)
   }, [])
 
+  // The active tab is wider than the rest, so selecting one changes the content
+  // width as well as adding or removing a tab does.
   useLayoutEffect(() => {
     measure()
-  }, [measure, tabs.length])
+  }, [measure, tabs.length, activeIndex])
 
   useEffect(() => {
     const group = groupRef.current
@@ -53,32 +66,50 @@ export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, trailing
     return () => observer.disconnect()
   }, [measure])
 
-  // Keep the active tab in view: slide just far enough to reveal it.
-  useLayoutEffect(() => {
+  /** Scroll just far enough to bring a tab fully into the strip. */
+  const reveal = useCallback((index: number) => {
     const group = groupRef.current
-    const tab = trackRef.current?.children[activeIndex] as HTMLElement | undefined
-    if (!group || !tab) return
-    const left = tab.offsetLeft
+    const track = trackRef.current
+    const tab = track?.children[index] as HTMLElement | undefined
+    if (!group || !track || !tab) return
+    // offsetLeft is measured against the positioned strip, not the scroll
+    // content; subtracting the track's own offset puts both on the same axis
+    // as scrollLeft.
+    const left = tab.offsetLeft - track.offsetLeft
     const right = left + tab.offsetWidth
-    setOffset((o) => {
-      if (left < o) return left
-      if (right > o + group.clientWidth) return Math.max(0, right - group.clientWidth)
-      return o
-    })
-  }, [activeIndex, tabs.length, maxOffset])
+    if (left < group.scrollLeft) {
+      group.scrollTo({ left, behavior: 'smooth' })
+    } else if (right > group.scrollLeft + group.clientWidth) {
+      group.scrollTo({ left: right - group.clientWidth, behavior: 'smooth' })
+    }
+  }, [])
 
+  useLayoutEffect(() => {
+    reveal(activeIndex)
+  }, [reveal, activeIndex, tabs.length])
+
+  const atStart = scrollLeft <= EDGE_EPSILON_PX
+  const atEnd = scrollLeft >= maxScroll - EDGE_EPSILON_PX
+  const overflowing = maxScroll > 0
+
+  useEffect(() => {
+    onLeadingTabFlush?.(activeIndex === 0 && atStart)
+  }, [onLeadingTabFlush, activeIndex, atStart])
+
+  /**
+   * One tab's worth of travel. The active tab is deliberately wider than its
+   * neighbours, so a step measured off it would overshoot; sample another.
+   */
   const step = () => {
-    const first = trackRef.current?.children[0] as HTMLElement | undefined
-    return (first?.offsetWidth ?? 160) + TAB_GAP_PX
+    const children = Array.from(trackRef.current?.children ?? []) as HTMLElement[]
+    const sample = children.find((_, index) => index !== activeIndex) ?? children[0]
+    return (sample?.offsetWidth ?? 160) + TAB_GAP_PX
   }
-  const slideLeft = () => setOffset((o) => Math.max(0, o - step()))
-  const slideRight = () => setOffset((o) => Math.min(maxOffset, o + step()))
+  const slide = (direction: -1 | 1) => {
+    groupRef.current?.scrollBy({ left: direction * step(), behavior: 'smooth' })
+  }
 
   if (tabs.length === 0) return null
-
-  const overflowing = maxOffset > 0
-  const atStart = offset <= 0
-  const atEnd = offset >= maxOffset
 
   return (
     <div
@@ -89,18 +120,24 @@ export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, trailing
       data-overflowing={overflowing || undefined}
     >
       {/* Bounded to the space left after the arrows and trailing control.
-          overflow-x-clip (not hidden) keeps the vertical axis visible. */}
-      <div ref={groupRef} className="min-w-0 flex-1 overflow-x-clip" data-testid="file-tab-group">
-        <div
-          ref={trackRef}
-          className="flex w-full items-end gap-px transition-transform duration-200 ease-out"
-          style={{ transform: `translateX(-${offset}px)` }}
-        >
+          pb-px/-mb-px holds the active tab's 1px overhang without letting the
+          vertical axis overflow (see the component comment). */}
+      <div
+        ref={groupRef}
+        onScroll={(e) => setScrollLeft(e.currentTarget.scrollLeft)}
+        className="file-tab-scroller min-w-0 flex-1 -mb-px overflow-x-auto overflow-y-hidden pb-px"
+        data-testid="file-tab-group"
+      >
+        <div ref={trackRef} className="flex w-full items-end gap-px">
           {tabs.map((tab, index) => (
             <button
               key={getPreviewTabKey(tab)}
               type="button"
               onClick={() => onTabClick(index)}
+              // A clipped tab is still in the tab order, and the strip cannot
+              // rely on the browser to reveal it during a smooth scroll of its
+              // own; bring it in explicitly.
+              onFocus={() => reveal(index)}
               data-testid="file-tab"
               data-tab-kind={tab.kind}
               data-file-name={tab.displayName}
@@ -109,10 +146,13 @@ export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, trailing
               className={cn(
                 // Uniform tabs, like Chrome: every tab starts from the same 160px basis
                 // and shrinks in lockstep, down to a floor that still fits icon + close.
-                'group relative flex h-8 flex-[0_1_160px] min-w-[4.25rem] items-center gap-1.5 rounded-t-lg px-3 text-left text-xs transition-colors',
+                'group relative flex h-8 flex-[0_1_160px] items-center gap-1.5 rounded-t-lg px-3 text-left text-xs transition-colors',
                 index === activeIndex
-                  ? 'z-10 -mb-px border border-b-0 border-black/5 bg-background text-foreground shadow-[0_-1px_2px_rgba(0,0,0,0.04)] dark:border-white/5'
-                  : 'text-foreground hover:bg-background/60',
+                  // The one tab whose name the user needs to read is the one
+                  // they are looking at, so it holds a floor wide enough for a
+                  // label while the rest collapse to icon + close.
+                  ? 'z-10 min-w-[9.5rem] -mb-px border border-b-0 border-black/5 bg-background text-foreground shadow-[0_-1px_2px_rgba(0,0,0,0.04)] dark:border-white/5'
+                  : 'min-w-[4.25rem] text-foreground hover:bg-background/60',
                 // hairline separator on the left of inactive tabs that don't touch the active card
                 index > 0 && index !== activeIndex && index - 1 !== activeIndex &&
                   'before:absolute before:left-0 before:top-2 before:bottom-2 before:w-px before:bg-border/60',
@@ -160,7 +200,7 @@ export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, trailing
         <div className="flex h-8 shrink-0 items-center pl-1 text-muted-foreground" data-testid="file-tab-arrows">
           <button
             type="button"
-            onClick={slideLeft}
+            onClick={() => slide(-1)}
             disabled={atStart}
             aria-label="Earlier tabs"
             className="rounded p-0.5 transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
@@ -169,7 +209,7 @@ export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, trailing
           </button>
           <button
             type="button"
-            onClick={slideRight}
+            onClick={() => slide(1)}
             disabled={atEnd}
             aria-label="Later tabs"
             className="rounded p-0.5 transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"

--- a/src/renderer/components/file-preview/file-tab-bar.tsx
+++ b/src/renderer/components/file-preview/file-tab-bar.tsx
@@ -1,4 +1,5 @@
-import { X } from 'lucide-react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { ChevronLeft, ChevronRight, X } from 'lucide-react'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 import { cn } from '@shared/lib/utils/cn'
 import { getPreviewTabKey, type PreviewTab } from '@renderer/context/file-preview-context'
@@ -8,54 +9,178 @@ interface FileTabBarProps {
   activeIndex: number
   onTabClick: (index: number) => void
   onCloseTab: (tabKey: string) => void
+  /** Panel-level controls rendered after the last tab, at the strip's right edge (the drawer close). */
+  trailing?: ReactNode
 }
 
-export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab }: FileTabBarProps) {
+const TAB_GAP_PX = 1
+
+/**
+ * Chrome-style tab strip.
+ *
+ * Tabs share one 160px basis and shrink in lockstep down to a floor. Past the
+ * floor they overflow, and the strip shows a pair of arrows that slide the
+ * track one tab at a time. The track is *translated* inside a group that clips
+ * only horizontally — not scrolled — because a scroll container also clips
+ * vertically, and the active tab hangs 1px over the body card's top border to
+ * hide the line beneath it.
+ */
+export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, trailing }: FileTabBarProps) {
+  const groupRef = useRef<HTMLDivElement>(null)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [offset, setOffset] = useState(0)
+  const [maxOffset, setMaxOffset] = useState(0)
+
+  /** How far the track can slide: the content width beyond the visible group. */
+  const measure = useCallback(() => {
+    const group = groupRef.current
+    if (!group) return 0
+    const max = Math.max(0, group.scrollWidth - group.clientWidth)
+    setMaxOffset(max)
+    setOffset((o) => Math.min(o, max))
+    return max
+  }, [])
+
+  useLayoutEffect(() => {
+    measure()
+  }, [measure, tabs.length])
+
+  useEffect(() => {
+    const group = groupRef.current
+    if (!group || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => measure())
+    observer.observe(group)
+    return () => observer.disconnect()
+  }, [measure])
+
+  // Keep the active tab in view: slide just far enough to reveal it.
+  useLayoutEffect(() => {
+    const group = groupRef.current
+    const tab = trackRef.current?.children[activeIndex] as HTMLElement | undefined
+    if (!group || !tab) return
+    const left = tab.offsetLeft
+    const right = left + tab.offsetWidth
+    setOffset((o) => {
+      if (left < o) return left
+      if (right > o + group.clientWidth) return Math.max(0, right - group.clientWidth)
+      return o
+    })
+  }, [activeIndex, tabs.length, maxOffset])
+
+  const step = () => {
+    const first = trackRef.current?.children[0] as HTMLElement | undefined
+    return (first?.offsetWidth ?? 160) + TAB_GAP_PX
+  }
+  const slideLeft = () => setOffset((o) => Math.max(0, o - step()))
+  const slideRight = () => setOffset((o) => Math.min(maxOffset, o + step()))
+
   if (tabs.length === 0) return null
 
+  const overflowing = maxOffset > 0
+  const atStart = offset <= 0
+  const atEnd = offset >= maxOffset
+
   return (
-    <div className="flex items-center gap-0 border-b border-border/40 shrink-0 overflow-x-auto scrollbar-none" data-testid="file-tab-bar">
-      {tabs.map((tab, index) => (
-        <button
-          key={getPreviewTabKey(tab)}
-          type="button"
-          onClick={() => onTabClick(index)}
-          data-testid="file-tab"
-          data-tab-kind={tab.kind}
-          data-file-name={tab.displayName}
-          data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
-          className={cn(
-            'group flex items-center gap-1.5 px-3 py-1.5 text-xs border-r border-border/30 shrink-0 max-w-[160px] transition-colors',
-            index === activeIndex
-              ? 'bg-background text-foreground border-b-2 border-b-primary'
-              : 'bg-muted/30 text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-          )}
+    <div
+      // pl-4 matches the body card's 16px inset, so the first tab's left edge
+      // is flush with the card's (the card's top-left corner is square for this).
+      className="relative flex items-end bg-muted/60 pl-4 pr-2 pt-1.5 shrink-0"
+      data-testid="file-tab-bar"
+      data-overflowing={overflowing || undefined}
+    >
+      {/* Bounded to the space left after the arrows and trailing control.
+          overflow-x-clip (not hidden) keeps the vertical axis visible. */}
+      <div ref={groupRef} className="min-w-0 flex-1 overflow-x-clip" data-testid="file-tab-group">
+        <div
+          ref={trackRef}
+          className="flex w-full items-end gap-px transition-transform duration-200 ease-out"
+          style={{ transform: `translateX(-${offset}px)` }}
         >
-          <FileTypeIcon filename={tab.displayName} size="sm" folder={tab.kind === 'folder'} />
-          <span className="truncate">{tab.displayName}</span>
-          <span
-            role="button"
-            tabIndex={0}
-            data-testid="file-tab-close"
-            data-file-name={tab.displayName}
-            data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
-            onClick={(e) => {
-              e.stopPropagation()
-              onCloseTab(getPreviewTabKey(tab))
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.stopPropagation()
-                e.preventDefault()
-                onCloseTab(getPreviewTabKey(tab))
-              }
-            }}
-            className="ml-auto p-0.5 rounded hover:bg-muted-foreground/20 opacity-0 group-hover:opacity-100 touch:opacity-100 transition-opacity"
+          {tabs.map((tab, index) => (
+            <button
+              key={getPreviewTabKey(tab)}
+              type="button"
+              onClick={() => onTabClick(index)}
+              data-testid="file-tab"
+              data-tab-kind={tab.kind}
+              data-file-name={tab.displayName}
+              data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
+              data-active={index === activeIndex || undefined}
+              className={cn(
+                // Uniform tabs, like Chrome: every tab starts from the same 160px basis
+                // and shrinks in lockstep, down to a floor that still fits icon + close.
+                'group relative flex h-8 flex-[0_1_160px] min-w-[4.25rem] items-center gap-1.5 rounded-t-lg px-3 text-left text-xs transition-colors',
+                index === activeIndex
+                  ? 'z-10 -mb-px border border-b-0 border-black/5 bg-background text-foreground shadow-[0_-1px_2px_rgba(0,0,0,0.04)] dark:border-white/5'
+                  : 'text-foreground hover:bg-background/60',
+                // hairline separator on the left of inactive tabs that don't touch the active card
+                index > 0 && index !== activeIndex && index - 1 !== activeIndex &&
+                  'before:absolute before:left-0 before:top-2 before:bottom-2 before:w-px before:bg-border/60',
+              )}
+            >
+              {/* Follow the tab's own color so the icon darkens with the label on the
+                  active tab and on hover, instead of the icon's muted default. */}
+              <FileTypeIcon filename={tab.displayName} size="sm" folder={tab.kind === 'folder'} className="text-inherit" />
+              {/* Overflowing names fade out at the right edge instead of ellipsizing, as in Chrome. */}
+              <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap [mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]">
+                {tab.displayName}
+              </span>
+              <span
+                role="button"
+                tabIndex={0}
+                data-testid="file-tab-close"
+                data-file-name={tab.displayName}
+                data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
+                aria-label={`Close ${tab.displayName}`}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onCloseTab(getPreviewTabKey(tab))
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    onCloseTab(getPreviewTabKey(tab))
+                  }
+                }}
+                className={cn(
+                  'ml-auto shrink-0 rounded p-0.5 text-muted-foreground transition-opacity hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100 touch:opacity-100',
+                  // the selected tab keeps its close visible; the rest reveal it on hover
+                  index === activeIndex ? 'opacity-100' : 'opacity-0',
+                )}
+              >
+                <X className="h-3 w-3" />
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {overflowing && (
+        <div className="flex h-8 shrink-0 items-center pl-1 text-muted-foreground" data-testid="file-tab-arrows">
+          <button
+            type="button"
+            onClick={slideLeft}
+            disabled={atStart}
+            aria-label="Earlier tabs"
+            className="rounded p-0.5 transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
           >
-            <X className="h-3 w-3" />
-          </span>
-        </button>
-      ))}
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={slideRight}
+            disabled={atEnd}
+            aria-label="Later tabs"
+            className="rounded p-0.5 transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {/* ml-auto pins it right; pr-1.5 + the strip's pr-2 + the button's p-0.5 puts the icon's edge at 16px, flush with the body card. */}
+      {trailing && <div className="ml-auto flex h-8 shrink-0 items-center pl-1 pr-1.5 text-muted-foreground">{trailing}</div>}
     </div>
   )
 }

--- a/src/renderer/components/file-preview/renderers/unsupported-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/unsupported-renderer.tsx
@@ -1,8 +1,7 @@
 import { ArrowDownToLine } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
-import { getApiBaseUrl } from '@renderer/lib/env'
-import { getAgentFileApiPath } from '@renderer/lib/workspace-file-url'
+import { getAgentFileUrl } from '@renderer/lib/workspace-file-url'
 import { getPathName } from '@shared/lib/utils/workspace-path'
 
 interface UnsupportedRendererProps {
@@ -12,8 +11,7 @@ interface UnsupportedRendererProps {
 
 export function UnsupportedRenderer({ filePath, agentSlug }: UnsupportedRendererProps) {
   const filename = getPathName(filePath)
-  const baseUrl = getApiBaseUrl()
-  const downloadUrl = `${baseUrl}${getAgentFileApiPath(agentSlug, filePath)}`
+  const downloadUrl = getAgentFileUrl(agentSlug, filePath)
 
   return (
     <div className="flex flex-col items-center justify-center gap-4 py-16 px-8 text-center">

--- a/src/renderer/components/file-preview/renderers/unsupported-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/unsupported-renderer.tsx
@@ -1,4 +1,4 @@
-import { Download, FileQuestion } from 'lucide-react'
+import { ArrowDownToLine } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
 import { getApiBaseUrl } from '@renderer/lib/env'
@@ -17,9 +17,6 @@ export function UnsupportedRenderer({ filePath, agentSlug }: UnsupportedRenderer
 
   return (
     <div className="flex flex-col items-center justify-center gap-4 py-16 px-8 text-center">
-      <div className="p-4 rounded-full bg-muted/50">
-        <FileQuestion className="h-10 w-10 text-muted-foreground" />
-      </div>
       <div className="space-y-1">
         <div className="flex items-center gap-2 justify-center">
           <FileTypeIcon filename={filename} size="md" className="text-muted-foreground" />
@@ -31,7 +28,7 @@ export function UnsupportedRenderer({ filePath, agentSlug }: UnsupportedRenderer
       </div>
       <a href={downloadUrl} target="_blank" rel="noopener noreferrer">
         <Button variant="outline" size="sm">
-          <Download className="h-3.5 w-3.5 mr-1.5" />
+          <ArrowDownToLine className="h-3.5 w-3.5 mr-1.5" />
           Download
         </Button>
       </a>

--- a/src/renderer/components/ui/file-delivery-row.tsx
+++ b/src/renderer/components/ui/file-delivery-row.tsx
@@ -3,8 +3,7 @@ import { buttonVariants } from './button'
 import { FileIconTile } from './file-icon-tile'
 import { previewKind } from '@renderer/components/file-preview/file-types'
 import { useFilePreview } from '@renderer/context/file-preview-context'
-import { getApiBaseUrl } from '@renderer/lib/env'
-import { getAgentFileApiPath } from '@renderer/lib/workspace-file-url'
+import { getAgentFileUrl } from '@renderer/lib/workspace-file-url'
 import { cn } from '@shared/lib/utils/cn'
 import { formatFileSize } from '@shared/lib/utils/format-file-size'
 import { getPathName, toWorkspaceRelativePath } from '@shared/lib/utils/workspace-path'
@@ -75,7 +74,7 @@ export function FileDeliveryRow({ filePath, agentSlug, description, sizeBytes, c
         <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" aria-hidden="true" />
       ) : (
         <a
-          href={`${getApiBaseUrl()}${getAgentFileApiPath(agentSlug, filePath)}`}
+          href={getAgentFileUrl(agentSlug, filePath)}
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -322,6 +322,18 @@ html[data-keyboard-open] [data-composer-footer] {
   background-color: rgba(120, 120, 130, .55);
 }
 
+/* The file drawer's tab strip. It scrolls horizontally so a trackpad swipe, a
+   touch drag and the browser's focus reveal work natively, but a scrollbar
+   drawn under the tabs would sit a second, competing affordance next to the
+   arrows that already say the same thing. Hidden, not removed: everything that
+   scrolls the strip still scrolls it. */
+.file-tab-scroller {
+  scrollbar-width: none;
+}
+.file-tab-scroller::-webkit-scrollbar {
+  display: none;
+}
+
 /* Fix Radix ScrollArea viewport using display: table which causes content to expand */
 [data-radix-scroll-area-viewport] {
   display: block !important;

--- a/src/renderer/hooks/use-file-size.ts
+++ b/src/renderer/hooks/use-file-size.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@renderer/lib/api'
+
+/**
+ * Byte size of a workspace file, read from the Content-Length of a HEAD
+ * request against its API path. The file route answers HEAD with the same
+ * headers as GET, so this never downloads the body. `version` is the tab's
+ * cache-busting token: a redelivered file gets a fresh size.
+ */
+export function useFileSize(fileApiPath: string | null, version = 0) {
+  return useQuery<number | null>({
+    queryKey: ['file-size', fileApiPath, version],
+    queryFn: async () => {
+      const res = await apiFetch(`${fileApiPath}?v=${version}`, { method: 'HEAD' })
+      if (!res.ok) return null
+      const length = res.headers.get('content-length')
+      const bytes = length === null ? NaN : Number(length)
+      return Number.isFinite(bytes) ? bytes : null
+    },
+    enabled: fileApiPath !== null,
+    staleTime: 60_000,
+    retry: false,
+  })
+}

--- a/src/renderer/hooks/use-file-size.ts
+++ b/src/renderer/hooks/use-file-size.ts
@@ -3,9 +3,11 @@ import { apiFetch } from '@renderer/lib/api'
 
 /**
  * Byte size of a workspace file, read from the Content-Length of a HEAD
- * request against its API path. The file route answers HEAD with the same
- * headers as GET, so this never downloads the body. `version` is the tab's
- * cache-busting token: a redelivered file gets a fresh size.
+ * request against its API path. The file route answers a HEAD with the same
+ * headers as a GET and no body, and the cloud proxy passes that length through
+ * rather than stripping it as it does for a re-framed body — so this costs one
+ * round trip and no bytes, in either mode. `version` is the tab's cache-busting
+ * token: a redelivered file gets a fresh size.
  */
 export function useFileSize(fileApiPath: string | null, version = 0) {
   return useQuery<number | null>({

--- a/src/renderer/lib/api-origin.characterization.test.ts
+++ b/src/renderer/lib/api-origin.characterization.test.ts
@@ -85,7 +85,7 @@ const PRIMITIVE_CONSTRUCTORS = new Set(['EventSource', 'WebSocket'])
  */
 const PINNED_CALL_SITES: Record<string, string> = {
   'components/file-preview/renderers/use-file-content.ts::useFileContent::fetch(url)':
-    'prebuilt `url` prop; composed by file-preview-tray-content.tsx from getApiBaseUrl()',
+    'prebuilt `url` prop; composed by lib/workspace-file-url.ts from getApiBaseUrl()',
   'components/file-preview/renderers/audio-renderer.tsx::AudioRenderer.decodeWaveform::fetch(url)':
     'prebuilt `url` prop; same origin as use-file-content.ts above',
   'components/file-preview/copy-file-button.tsx::fetchText::fetch(url)':
@@ -145,9 +145,8 @@ const DIRECT_BASE_URL_CONSUMERS: Record<string, string> = {
   'components/ui/model-icon.tsx': '<img src> — model icon asset',
   'components/home/dashboard-card.tsx': '<img src> — dashboard screenshot',
   'components/dashboards/dashboard-view.tsx': '<iframe src> — embedded dashboard',
-  'components/file-preview/file-preview-tray-content.tsx': 'file URL passed to previewers/<img>',
-  'components/file-preview/renderers/unsupported-renderer.tsx': 'download link href',
-  'components/ui/file-delivery-row.tsx': 'download link href on the delivered-file row',
+  'lib/workspace-file-url.ts':
+    'getAgentFileUrl() — the one place a workspace-file URL is composed, for the preview tray\'s previewers/<img>, the unsupported renderer\'s download link and the delivered-file row\'s. None of those can carry a request header, and building the URL once here is what keeps their encoding and cache-busting from drifting apart',
   'components/messages/message-input.tsx': 'fire-and-forget typing ping (deliberately not awaited)',
   'components/notifications/global-notification-handler.tsx':
     'EventSource — global notification stream',

--- a/src/renderer/lib/workspace-file-url.test.ts
+++ b/src/renderer/lib/workspace-file-url.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
-import { encodeWorkspaceFilePath, getAgentFileApiPath } from './workspace-file-url'
+import { describe, expect, it, vi } from 'vitest'
+import { encodeWorkspaceFilePath, getAgentFileApiPath, getAgentFileUrl } from './workspace-file-url'
+
+vi.mock('@renderer/lib/env', () => ({ getApiBaseUrl: () => 'http://api.test' }))
 
 describe('workspace file URLs', () => {
   it('encodes every path segment without encoding separators', () => {
@@ -12,5 +14,30 @@ describe('workspace file URLs', () => {
     expect(getAgentFileApiPath('Agent #1', '/workspace/report.md')).toBe(
       '/api/agents/Agent%20%231/files/report.md',
     )
+  })
+
+  describe('getAgentFileUrl', () => {
+    it('builds a bare download URL by default', () => {
+      expect(getAgentFileUrl('a', '/workspace/output/report.md')).toBe(
+        'http://api.test/api/agents/a/files/output/report.md',
+      )
+    })
+
+    it('asks for inline bytes when told to', () => {
+      expect(getAgentFileUrl('a', '/workspace/report.md', { inline: true })).toBe(
+        'http://api.test/api/agents/a/files/report.md?inline=true',
+      )
+    })
+
+    // Version 0 means the file has never been redelivered, so there is nothing
+    // to bust and no reason to carry a parameter the server ignores.
+    it('omits the cache buster at version 0 and carries it above', () => {
+      expect(getAgentFileUrl('a', '/workspace/report.md', { version: 0 })).toBe(
+        'http://api.test/api/agents/a/files/report.md',
+      )
+      expect(getAgentFileUrl('a', '/workspace/report.md', { inline: true, version: 3 })).toBe(
+        'http://api.test/api/agents/a/files/report.md?inline=true&v=3',
+      )
+    })
   })
 })

--- a/src/renderer/lib/workspace-file-url.ts
+++ b/src/renderer/lib/workspace-file-url.ts
@@ -1,4 +1,5 @@
 import { toWorkspaceRelativePath } from '@shared/lib/utils/workspace-path'
+import { getApiBaseUrl } from '@renderer/lib/env'
 
 /** Convert a container workspace path into safely encoded API path segments. */
 export function encodeWorkspaceFilePath(filePath: string): string {
@@ -11,4 +12,28 @@ export function encodeWorkspaceFilePath(filePath: string): string {
 
 export function getAgentFileApiPath(agentSlug: string, filePath: string): string {
   return `/api/agents/${encodeURIComponent(agentSlug)}/files/${encodeWorkspaceFilePath(filePath)}`
+}
+
+interface AgentFileUrlOptions {
+  /** Ask the route to serve the bytes for display rather than as a download. */
+  inline?: boolean
+  /**
+   * The tab's cache-busting token. `v` is not read by the server: it exists so
+   * a redelivered file does not resolve to a URL a browser or CDN still holds
+   * the previous body for. `0` means "never redelivered" and is left off.
+   */
+  version?: number
+}
+
+/** Absolute URL for a workspace file, for an `<a href>`, an `<img src>` or a fetch. */
+export function getAgentFileUrl(
+  agentSlug: string,
+  filePath: string,
+  { inline = false, version = 0 }: AgentFileUrlOptions = {},
+): string {
+  const params = new URLSearchParams()
+  if (inline) params.set('inline', 'true')
+  if (version > 0) params.set('v', String(version))
+  const query = params.toString()
+  return `${getApiBaseUrl()}${getAgentFileApiPath(agentSlug, filePath)}${query ? `?${query}` : ''}`
 }


### PR DESCRIPTION
## Summary

Stacked on https://github.com/SkillfulAgents/SuperAgent/pull/945 — merge that first.

- **Chrome-style tab strip.** Uniform-width tabs that shrink in lockstep; the active tab is a raised card whose open bottom hides the body's top border; labels fade instead of ellipsizing; per-tab close, always visible on the active tab; overflow arrows slide the row one tab at a time. The track is translated rather than scrolled so the active tab's 1px overhang onto the body is never clipped.
- **Header row removed.** The drawer's close/hide control rides at the right end of the tab strip, aligned with the body card. Icon is `panel-right`.
- **File body is a bordered, rounded card** inset 16px on the tab rail's gray. It's headed by the filename with its byte size (from a HEAD request's Content-Length via a new `useFileSize` hook) and the per-file copy/download actions, with tooltips.
- **No-preview state** drops the question-mark badge; download icons use `arrow-down-to-line`.

## Test plan

- [x] `npm run typecheck`, lint on touched files
- [x] file-preview unit suites (120 passing): tab bar overflow/arrow tests with faked geometry, tray title/size/actions, copy button
- [x] E2E `file-preview.spec.ts` header/title/close assertions updated (not run locally)
- [ ] Visual check in the Electron app: tab strip at 1, 5, and 15 tabs; compact vs wide close control; dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
