### PR TITLE
chore(deps): bump lucide-react to 1.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "fflate": "^0.8.2",
         "jsdom": "^28.1.0",
-        "lucide-react": "^0.446.0",
+        "lucide-react": "^1.40.0",
         "markdown-it": "^14.3.0",
         "p-limit": "^3.1.0",
         "postcss": "^8.4.0",
@@ -18747,13 +18747,13 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.446.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.446.0.tgz",
-      "integrity": "sha512-BU7gy8MfBMqvEdDPH79VhOXSEgyG8TSPOKWaExWGCQVqnGH7wGgDngPbofu+KdtVjPQBWbEmnfMTq90CTiiDRg==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.40.0.tgz",
+      "integrity": "sha512-MaG+8WnOXkDWz9XeElj7TnQ890tTZUB0a36i03aRRCKGWE6e7jJpmdCvtxxuxcjjdqyN6m4sL6qlHVuSUDtYgg==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/luxon": {

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "fflate": "^0.8.2",
     "jsdom": "^28.1.0",
-    "lucide-react": "^0.446.0",
+    "lucide-react": "^1.40.0",
     "markdown-it": "^14.3.0",
     "p-limit": "^3.1.0",
     "postcss": "^8.4.0",


### PR DESCRIPTION
## Summary

Bumps `lucide-react` from 0.446 to 1.40. This brings `file-braces`, `file-play`, and the centered `file-code` that the file-type icon PR stacked on this one builds on.

No call sites change here. Every existing icon import still resolves (typecheck is clean), and the renderer test suites pass.

Bottom of a five-PR stack: this → file-type icons → delivery rows → drawer restyle → upload chips.

## Test plan

- [x] `npm run typecheck`
- [x] Renderer unit suites
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
