### PR TITLE
Agent menu edits: folder destinations only, session labels, reliable sidebar Export Agent

### DIFF
--- a/.qagent/features/agent-settings.md
+++ b/.qagent/features/agent-settings.md
@@ -17,7 +17,7 @@ three-dot button on the agent home header.
 - **Rename Agent** (`data-testid='rename-agent-item'`) - owners only. From the agent home it puts the inline title into edit mode; elsewhere it opens a rename dialog (`data-testid='rename-agent-dialog'`).
 - **Export Agent** (`data-testid='export-agent-item'`) - owners only. Opens the Share popover on its Export pane; from a menu away from the agent home it navigates there first.
 - **Agent Directory** (`data-testid='open-agent-directory-item'`) - owners only. Opens the workspace folder panel (the same one the agent home's "Agent Directory" row opens); from a menu away from the agent home it navigates there first.
-- **Move to Folder** (`data-testid='move-agent-to-folder-trigger'`) - submenu of left-nav folders.
+- **Move to Folder** (`data-testid='move-agent-to-folder-trigger'`) - submenu (`data-testid='move-agent-to-folder-menu'`) listing only the left-nav folders the agent can move to (`move-agent-to-folder-<id>`, or `move-agent-to-no-folder-item` for "Your Agents"); the folder it is in is left out, so nothing is marked as selected. **New Folder** (`move-agent-to-new-folder-item`) is always offered.
 - **Delete Agent** (`data-testid='delete-agent-item'`) - owners only; opens the confirm dialog.
 - **Leave Agent** (`data-testid='leave-agent-item'`) - non-owners in auth mode.
 

--- a/src/renderer/components/agents/agent-context-menu.test.tsx
+++ b/src/renderer/components/agents/agent-context-menu.test.tsx
@@ -58,8 +58,7 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 const { menuClose } = vi.hoisted(() => ({
   menuClose: { current: null as null | ((event: { preventDefault: () => void }) => void) },
 }))
-vi.mock('@renderer/components/ui/context-menu', async () => {
-  const React = await import('react')
+vi.mock('@renderer/components/ui/context-menu', () => {
   return {
     ContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -73,32 +72,11 @@ vi.mock('@renderer/components/ui/context-menu', async () => {
     ContextMenuSeparator: () => <hr />,
     ContextMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     ContextMenuSubTrigger: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
-    ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    // Radix routes the selection through context; the stub hands each item its
-    // own value so a click reports the same thing the real menu would.
-    ContextMenuRadioGroup: ({ children, value, onValueChange }: any) => (
-      <div>
-        {React.Children.map(children, (child) =>
-          React.isValidElement<{ value: string }>(child)
-            ? React.cloneElement(child as never, {
-                onClick: () => onValueChange?.(child.props.value),
-                'aria-checked': child.props.value === value,
-              })
-            : child
-        )}
-      </div>
-    ),
-    // aria-checked is spread in from the group above; the literal default is
-    // there so the role is never rendered without its required attribute.
-    ContextMenuRadioItem: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-      <button type="button" role="menuitemradio" aria-checked={false} onClick={onClick} {...props}>
-        {children}
-      </button>
-    ),
+    ContextMenuSubContent: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
   }
 })
 
-import { act, render, screen, cleanup, waitFor } from '@testing-library/react'
+import { act, render, screen, cleanup, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AgentContextMenu } from './agent-context-menu'
 
@@ -149,26 +127,29 @@ describe('moving an agent into a left-nav folder', () => {
     return typeof arg === 'function' ? arg(settings) : arg
   }
 
-  it('lists every folder plus the default "Your Agents" option', () => {
+  it('lists every folder the agent is not in, and leaves out "Your Agents" while it is there', () => {
     mockUserSettings.mockReturnValue({ agentFolders: FOLDERS, agentFolderAssignments: {} })
     render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
 
-    expect(screen.getByTestId('move-agent-to-no-folder-item')).toHaveTextContent('Your Agents')
-    expect(screen.getByTestId('move-agent-to-no-folder-item')).toHaveAttribute('aria-checked', 'true')
+    // Only destinations are offered, so nothing is marked as current.
+    expect(screen.queryByTestId('move-agent-to-no-folder-item')).not.toBeInTheDocument()
     expect(screen.getByTestId('move-agent-to-folder-f1')).toHaveTextContent('Work')
     expect(screen.getByTestId('move-agent-to-folder-f2')).toHaveTextContent('Personal')
+    // The destinations are set off from New Folder below them.
+    const submenu = screen.getByTestId('move-agent-to-folder-menu')
+    expect(within(submenu).getByRole('separator')).toBeInTheDocument()
   })
 
-  it('does not write anything when the current folder is re-selected', async () => {
+  it('leaves out the folder the agent is in and offers "Your Agents" instead', () => {
     mockUserSettings.mockReturnValue({
       agentFolders: FOLDERS,
       agentFolderAssignments: { sales: 'f1' },
     })
     render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
 
-    await userEvent.click(screen.getByTestId('move-agent-to-folder-f1'))
-
-    expect(mockUpdateSettings).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('move-agent-to-folder-f1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('move-agent-to-folder-f2')).toHaveTextContent('Personal')
+    expect(screen.getByTestId('move-agent-to-no-folder-item')).toHaveTextContent('Your Agents')
   })
 
   it('files the agent at the end of the folder and keeps agentOrder canonical', async () => {
@@ -191,18 +172,6 @@ describe('moving an agent into a left-nav folder', () => {
       'agent-folder::f2',
     ])
     expect(patch.agentFolders).toEqual(FOLDERS)
-  })
-
-  it('marks the folder the agent is currently in', () => {
-    mockUserSettings.mockReturnValue({
-      agentFolders: FOLDERS,
-      agentFolderAssignments: { sales: 'f2' },
-    })
-    render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
-
-    expect(screen.getByTestId('move-agent-to-folder-f2')).toHaveAttribute('aria-checked', 'true')
-    expect(screen.getByTestId('move-agent-to-folder-f1')).toHaveAttribute('aria-checked', 'false')
-    expect(screen.getByTestId('move-agent-to-no-folder-item')).toHaveAttribute('aria-checked', 'false')
   })
 
   it('preserves other agents\u2019 assignments when filing this one', async () => {
@@ -250,15 +219,16 @@ describe('moving an agent into a left-nav folder', () => {
 
   it('reads an assignment naming a deleted folder as the default folder', () => {
     // The sidebar renders such an agent under "Your Agents", so the menu has
-    // to agree and mark "Your Agents" as where it is.
+    // to agree: that is where it is, so it is not offered as a destination.
     mockUserSettings.mockReturnValue({
       agentFolders: FOLDERS,
       agentFolderAssignments: { sales: 'gone' },
     })
     render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
 
-    expect(screen.getByTestId('move-agent-to-no-folder-item')).toHaveAttribute('aria-checked', 'true')
-    expect(screen.getByTestId('move-agent-to-folder-f1')).toHaveAttribute('aria-checked', 'false')
+    expect(screen.queryByTestId('move-agent-to-no-folder-item')).not.toBeInTheDocument()
+    expect(screen.getByTestId('move-agent-to-folder-f1')).toBeInTheDocument()
+    expect(screen.getByTestId('move-agent-to-folder-f2')).toBeInTheDocument()
   })
 
   it('creates a named folder and files the agent into it in one write', async () => {
@@ -301,12 +271,16 @@ describe('moving an agent into a left-nav folder', () => {
     expect(mockUpdateSettings).not.toHaveBeenCalled()
   })
 
-  it('offers the folder submenu with no folders defined yet', () => {
+  it('offers only New Folder when there is nowhere to move the agent yet', () => {
+    // No folders and the agent in the default one: the destination list is
+    // empty, so New Folder stands alone with no rule above it.
     mockUserSettings.mockReturnValue(undefined)
     render(<AgentContextMenu agent={AGENT}><span>row</span></AgentContextMenu>)
 
-    expect(screen.getByTestId('move-agent-to-no-folder-item')).toBeInTheDocument()
-    expect(screen.getByTestId('move-agent-to-new-folder-item')).toBeInTheDocument()
+    const submenu = screen.getByTestId('move-agent-to-folder-menu')
+    expect(within(submenu).queryByTestId('move-agent-to-no-folder-item')).not.toBeInTheDocument()
+    expect(within(submenu).queryByRole('separator')).not.toBeInTheDocument()
+    expect(within(submenu).getByTestId('move-agent-to-new-folder-item')).toBeInTheDocument()
   })
 })
 

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -5,8 +5,6 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
-  ContextMenuRadioGroup,
-  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuSub,
   ContextMenuSubContent,
@@ -145,13 +143,20 @@ export function AgentContextMenu({
   const { data: allAgents } = useAgents()
   const updateSettings = useUpdateUserSettings()
   const folders = useMemo(() => sanitizeFolders(userSettings?.agentFolders), [userSettings?.agentFolders])
-  const currentFolderId = userSettings?.agentFolderAssignments?.[agent.slug]
+  const assignedFolderId = userSettings?.agentFolderAssignments?.[agent.slug]
   // An assignment naming a folder that no longer exists reads as the default
   // folder, the same way the sidebar renders it.
-  const selectedFolderValue =
-    currentFolderId && folders.some((f) => f.id === currentFolderId)
-      ? currentFolderId
+  const currentFolderId =
+    assignedFolderId && folders.some((f) => f.id === assignedFolderId)
+      ? assignedFolderId
       : ROOT_FOLDER_ID
+  // The submenu offers only where the agent can go. Leaving out the folder it
+  // is already in means there is no current value to mark, so the list is
+  // plain items rather than a radio group.
+  const destinations: Array<{ id: string; name: string }> = [
+    { id: ROOT_FOLDER_ID, name: ROOT_FOLDER_NAME },
+    ...folders,
+  ].filter((folder) => folder.id !== currentFolderId)
 
   // Filing writes the whole canonical tree — the same shape a drag writes —
   // so the two filing paths leave identical settings and the flat agentOrder
@@ -172,22 +177,18 @@ export function AgentContextMenu({
     [allAgents]
   )
 
-  const handleMoveToFolder = useCallback((value: string) => {
-    // Radix reports a selection even when the checked item is re-picked; the
-    // agent is already there, so there is nothing to write (and nothing to
-    // move to the folder's end).
-    if (value === selectedFolderValue) return
+  const handleMoveToFolder = useCallback((folderId: string) => {
     updateSettings.mutate((current) =>
       sectionsToSettings(
         applyTreeOperation(buildSections(current), {
           kind: 'placeAgent',
           slug: agent.slug,
-          folderId: value,
+          folderId,
           index: Number.MAX_SAFE_INTEGER,
         })
       )
     )
-  }, [agent.slug, buildSections, selectedFolderValue, updateSettings])
+  }, [agent.slug, buildSections, updateSettings])
 
   const handleCreateFolderWithAgent = useCallback(() => {
     const name = newFolderName.trim()
@@ -340,28 +341,23 @@ export function AgentContextMenu({
               <FolderInput className="h-4 w-4 mr-2" />
               Move to Folder
             </ContextMenuSubTrigger>
-            <ContextMenuSubContent className="rounded-xl p-2">
-              <ContextMenuRadioGroup
-                value={selectedFolderValue}
-                onValueChange={handleMoveToFolder}
-              >
-                <ContextMenuRadioItem
-                  value={ROOT_FOLDER_ID}
-                  data-testid="move-agent-to-no-folder-item"
+            <ContextMenuSubContent className="rounded-xl p-2" data-testid="move-agent-to-folder-menu">
+              {destinations.map((folder) => (
+                <ContextMenuItem
+                  key={folder.id}
+                  onClick={() => handleMoveToFolder(folder.id)}
+                  data-testid={
+                    folder.id === ROOT_FOLDER_ID
+                      ? 'move-agent-to-no-folder-item'
+                      : `move-agent-to-folder-${folder.id}`
+                  }
                 >
-                  {ROOT_FOLDER_NAME}
-                </ContextMenuRadioItem>
-                {folders.map((folder) => (
-                  <ContextMenuRadioItem
-                    key={folder.id}
-                    value={folder.id}
-                    data-testid={`move-agent-to-folder-${folder.id}`}
-                  >
-                    {folder.name}
-                  </ContextMenuRadioItem>
-                ))}
-              </ContextMenuRadioGroup>
-              <ContextMenuSeparator className="mx-1" />
+                  {folder.name}
+                </ContextMenuItem>
+              ))}
+              {/* With nowhere to go (no folders, agent already in the default
+                  one) the list is empty, so no rule sits above New Folder. */}
+              {destinations.length > 0 && <ContextMenuSeparator className="mx-1" />}
               <ContextMenuItem
                 // Secondary to the destinations above: muted until focused.
                 className="text-muted-foreground"

--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -6,6 +6,7 @@ import { useState, type ReactNode } from 'react'
 import { AgentHome } from './agent-home'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import type { ApiAgent } from '@renderer/hooks/use-agents'
+import type { AgentHomeAction } from '@renderer/context/nav-transient-context'
 import { useDraftsStore } from '@renderer/context/drafts-context'
 import {
   newSessionCarryoverKey,
@@ -113,13 +114,17 @@ vi.mock('@renderer/hooks/use-scheduled-tasks', () => ({
 // intro-morph test can flip justCreatedSlug and assert the clear.
 let mockJustCreatedSlug: string | null = null
 const mockSetJustCreatedSlug = vi.fn()
+// A parked "Export Agent" / "Agent Directory" from a menu elsewhere. Seeded
+// at mount by the hand-off test, which asserts it is consumed.
+let mockPendingAgentHomeAction: AgentHomeAction | null = null
+const mockSetPendingAgentHomeAction = vi.fn()
 
 vi.mock('@renderer/context/nav-transient-context', () => ({
   useNavTransient: () => ({
     justCreatedSlug: mockJustCreatedSlug,
     setJustCreatedSlug: mockSetJustCreatedSlug,
-    pendingAgentHomeAction: null,
-    setPendingAgentHomeAction: vi.fn(),
+    pendingAgentHomeAction: mockPendingAgentHomeAction,
+    setPendingAgentHomeAction: mockSetPendingAgentHomeAction,
   }),
   NavTransientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
@@ -250,6 +255,7 @@ describe('AgentHome', () => {
     capturedComposerOptions = undefined
     mockSessionsData = []
     mockJustCreatedSlug = null
+    mockPendingAgentHomeAction = null
   })
 
   // --- Rendering ---
@@ -411,6 +417,28 @@ describe('AgentHome', () => {
   })
 
   // --- Send button disabled state ---
+
+  it('runs a parked Export Agent only after the composer has taken its mount focus', async () => {
+    // "Export Agent" from a menu away from this page parks the action and
+    // navigates here. The composer autofocuses on the frame after it mounts,
+    // and the Share popover is non-modal, so opening it before that frame let
+    // the focus land outside it and dismiss it — the flaky sidebar export.
+    mockCanAdminAgent = true
+    mockPendingAgentHomeAction = { slug: testAgent.slug, action: 'export' }
+    renderWithProviders(<AgentHome agent={testAgent} onSessionCreated={onSessionCreated} />)
+
+    // Consumed at mount, but not opened in the same tick.
+    expect(mockSetPendingAgentHomeAction).toHaveBeenCalledWith(null)
+    expect(screen.queryByTestId('agent-export-pane')).not.toBeInTheDocument()
+
+    const pane = await screen.findByTestId('agent-export-pane')
+    // Let the composer's autofocus frame (and a spare) fire: the popover must
+    // still be open, i.e. it opened after that focus rather than before it.
+    await act(
+      () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+    )
+    expect(pane).toBeInTheDocument()
+  })
 
   it('send button is disabled when canSubmit is false', () => {
     mockComposer.canSubmit = false

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -141,12 +141,25 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   // "Export Agent" / "Agent Directory" chosen from a menu away from this page
   // (sidebar row, home card, breadcrumb) navigates here with the action
   // parked in NavTransient; run it now that its surface is mounted.
+  //
+  // Not synchronously, though: the composer below focuses itself on the
+  // animation frame after it mounts (see MarkdownComposerEditor's autoFocus),
+  // and the Share popover is non-modal, so if it opens before that frame the
+  // composer's focus lands outside it and Radix dismisses it as an outside
+  // interaction. Whether the popover or the focus came first depended on how
+  // this page mounted, which made "Export Agent" from the sidebar flaky.
+  // Frame callbacks run in the order they were requested, so deferring the
+  // action by one frame always puts it after that autofocus. No cleanup on
+  // purpose: clearing the parked action re-runs this effect, and cancelling
+  // the frame there would drop the action.
   useEffect(() => {
     if (pendingAgentHomeAction?.slug !== agent.slug) return
     const { action } = pendingAgentHomeAction
     setPendingAgentHomeAction(null)
-    if (action === 'export') openExport()
-    else openDirectory()
+    requestAnimationFrame(() => {
+      if (action === 'export') openExport()
+      else openDirectory()
+    })
   }, [pendingAgentHomeAction, agent.slug, setPendingAgentHomeAction, openExport, openDirectory])
   const handleOpenSettings = useCallback((tab?: string) => {
     if (tab === 'system-prompt') setSystemPromptOpen(true)

--- a/src/renderer/components/sessions/session-context-menu.test.tsx
+++ b/src/renderer/components/sessions/session-context-menu.test.tsx
@@ -358,7 +358,7 @@ describe('Fork Session item', () => {
 
   it('shows the item for anyone who can use the agent', () => {
     renderMenu()
-    expect(screen.getByTestId('fork-session-item')).toHaveTextContent('Fork')
+    expect(screen.getByTestId('fork-session-item')).toHaveTextContent('Fork Session')
   })
 
   it('hides the item without canUseAgent', () => {

--- a/src/renderer/components/sessions/session-context-menu.tsx
+++ b/src/renderer/components/sessions/session-context-menu.tsx
@@ -196,7 +196,7 @@ export function SessionContextMenu({
               }}
             >
               <Pencil className="h-4 w-4 mr-2" />
-              Rename
+              Rename Session
             </ContextMenuItem>
           )}
           {canUse && (
@@ -206,7 +206,7 @@ export function SessionContextMenu({
               onClick={handleFork}
             >
               <Split className="h-4 w-4 mr-2" />
-              Fork
+              Fork Session
             </ContextMenuItem>
           )}
           {/* Not permission-gated, unlike rename/delete: a mark is scoped to


### PR DESCRIPTION
Three small edits to the agent and session menus, plus a fix for the flaky "Export Agent" hand-off from the sidebar.

## Menu edits

- **Move to Folder lists only destinations.** The submenu offered every folder with the current one marked as selected. It now leaves the agent's current folder out (including "Your Agents" while the agent is there), so the list is plain items with no radio indicator or inset. The separator above **New Folder** only renders when there is at least one destination; with no folders yet, New Folder stands alone.
- **Session menu labels** say **Rename Session** and **Fork Session**, matching the agent menu's *Rename Agent* / *Export Agent* / *Delete Agent*.

Test ids are unchanged, so the folder e2e specs still pass as they are; `.qagent/features/agent-settings.md` describes the new submenu shape.

## Fix: "Export Agent" from the sidebar was flaky

Choosing **Export Agent** from a menu away from the agent home parks the action in `NavTransient` and navigates there; the home runs it on mount by opening the Share popover on its Export pane.

The composer (`MarkdownComposerEditor`) focuses itself on the animation frame after it mounts, and the Share popover is non-modal. When the popover opened before that frame, the composer's focus landed outside it and Radix dismissed it as an outside interaction. Which came first depended on how the page mounted, so it was reproducible by where you started:

| Sidebar → Export Agent, starting from | before | after |
|---|---|---|
| another agent's home | 0 / 4 | 5 / 5 |
| one of the agent's session pages | 0 / 4 | 5 / 5 |
| the home page | 4 / 4 | 5 / 5 |

(Playwright loop against the mock server; a capture-phase focus/popover recorder showed the popover mounting, the composer taking focus 2 ms later, and the popover unmounting.)

`AgentHome` now runs the parked action one animation frame later. Frame callbacks fire in request order, so it always follows the composer's autofocus. The effect deliberately has no cleanup: clearing the parked action re-runs it, and cancelling the frame there would drop the action.

## Tests

- `agent-context-menu.test.tsx`: destinations exclude the current folder, "Your Agents" is offered only when the agent is in a folder, a deleted-folder assignment reads as the default folder, and the separator appears only with destinations.
- `session-context-menu.test.tsx`: asserts the full "Fork Session" label.
- `agent-home.test.tsx`: seeds a parked export at mount; the popover must not open in the same tick, then open, then survive the composer's autofocus frame. Fails against the synchronous version.
- `npm run typecheck` and eslint clean; the `agent-folders` e2e context-menu spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
