### PR TITLE
Agent home: split the extras card and give every row one height

### DIFF
--- a/.qagent/features/agent-settings.md
+++ b/.qagent/features/agent-settings.md
@@ -27,7 +27,7 @@ three-dot button on the agent home header.
 
 ## Retention rows (agent home card)
 
-Under **Agent Default Model** in the agent home's right-hand card:
+Under **Agent Default Model**, in the pickers' own card (`data-testid='home-preferences-group'`) above the agent home's navigation-rows card:
 - **Session Auto-Delete** (`data-testid='home-session-auto-delete-trigger'`) - dropdown; options plus "Reset to Global Default".
 - **API Log Auto-Delete** (`data-testid='home-api-log-auto-delete-trigger'`) - same dropdown shape.
 

--- a/src/renderer/components/agents/agent-home/home-extras.test.tsx
+++ b/src/renderer/components/agents/agent-home/home-extras.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HomeExtras } from './home-extras'
 
@@ -50,6 +50,18 @@ vi.mock('@renderer/context/user-context', () => ({
 }))
 
 describe('HomeExtras', () => {
+  it('keeps the three pickers in a standalone group, apart from the navigation rows', () => {
+    render(<HomeExtras agentSlug="test-agent" />)
+
+    const group = within(screen.getByTestId('home-preferences-group'))
+    expect(group.getByTestId('home-default-model-card')).toBeInTheDocument()
+    expect(group.getByTestId('home-session-auto-delete-card')).toBeInTheDocument()
+    expect(group.getByTestId('home-api-log-auto-delete-card')).toBeInTheDocument()
+    // The navigation rows are their own card.
+    expect(group.queryByTestId('home-secrets-open-page')).not.toBeInTheDocument()
+    expect(screen.getByTestId('home-secrets-open-page')).toBeInTheDocument()
+  })
+
   it('opens Agent Directory in the built-in folder browser', async () => {
     const user = userEvent.setup()
     render(<HomeExtras agentSlug="test-agent" />)

--- a/src/renderer/components/agents/agent-home/home-extras.tsx
+++ b/src/renderer/components/agents/agent-home/home-extras.tsx
@@ -16,41 +16,53 @@ export function HomeExtras({ agentSlug, onOpenSettings, className }: HomeExtrasP
   const navigate = useNavigate()
   const { openFolder } = useFilePreview()
 
+  // Two cards, spaced by the column like any other pair of cards. Neither has
+  // vertical padding of its own: that would stack onto its first and last
+  // rows and make them read taller than the rest. The three per-agent picker
+  // rows are a standalone group at one height; the navigation rows are one
+  // uniform height too, flush with their card, which clips them to its
+  // rounded corners so the hover fill stays inside.
   return (
-    <div className={cn("rounded-xl border bg-background py-2", className)}>
-      <div className="divide-y divide-border/50">
-        <HomeDefaultModel agentSlug={agentSlug} />
-        <HomeRetention agentSlug={agentSlug} />
-        <ExtrasButton
-          label="Agent-to-agent connections"
-          onClick={() => {
-            void navigate({ to: '/agents/$slug/x-agent-permissions', params: { slug: agentSlug } })
-          }}
-          testId="home-x-agent-permissions-open-page"
-        />
-        <ExtrasButton label="System Prompt" onClick={() => onOpenSettings?.('system-prompt')} />
-        <ExtrasButton
-          label="Agent Directory"
-          onClick={() => openFolder('/workspace', agentSlug)}
-          hoverIcon={<PanelRightOpen className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
-          testId="home-agent-directory-open-browser"
-        />
-        <ExtrasButton
-          label="Secrets"
-          onClick={() => {
-            void navigate({ to: '/agents/$slug/secrets', params: { slug: agentSlug } })
-          }}
-          testId="home-secrets-open-page"
-        />
-        <ExtrasButton
-          label="API Logs"
-          onClick={() => {
-            void navigate({ to: '/agents/$slug/api-logs', params: { slug: agentSlug } })
-          }}
-          testId="home-api-logs-open-page"
-        />
+    <>
+      <div className={cn("rounded-xl border bg-background", className)} data-testid="home-preferences-group">
+        <div className="divide-y divide-border/50">
+          <HomeDefaultModel agentSlug={agentSlug} />
+          <HomeRetention agentSlug={agentSlug} />
+        </div>
       </div>
-    </div>
+      <div className={cn("overflow-hidden rounded-xl border bg-background", className)}>
+        <div className="divide-y divide-border/50">
+          <ExtrasButton
+            label="Agent-to-agent connections"
+            onClick={() => {
+              void navigate({ to: '/agents/$slug/x-agent-permissions', params: { slug: agentSlug } })
+            }}
+            testId="home-x-agent-permissions-open-page"
+          />
+          <ExtrasButton label="System Prompt" onClick={() => onOpenSettings?.('system-prompt')} />
+          <ExtrasButton
+            label="Agent Directory"
+            onClick={() => openFolder('/workspace', agentSlug)}
+            hoverIcon={<PanelRightOpen className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
+            testId="home-agent-directory-open-browser"
+          />
+          <ExtrasButton
+            label="Secrets"
+            onClick={() => {
+              void navigate({ to: '/agents/$slug/secrets', params: { slug: agentSlug } })
+            }}
+            testId="home-secrets-open-page"
+          />
+          <ExtrasButton
+            label="API Logs"
+            onClick={() => {
+              void navigate({ to: '/agents/$slug/api-logs', params: { slug: agentSlug } })
+            }}
+            testId="home-api-logs-open-page"
+          />
+        </div>
+      </div>
+    </>
   )
 }
 
@@ -60,7 +72,10 @@ function ExtrasButton({ label, onClick, hoverIcon, testId }: { label: string; on
       type="button"
       onClick={onClick}
       data-testid={testId}
-      className="group flex w-full items-center justify-between py-3 px-4 text-left hover:bg-muted/50 transition-colors"
+      // min-h-12: every navigation row is the same height, including the last
+      // one, which sits flush with the card's bottom edge. The focus ring is
+      // inset because the card clips its rows to the rounded corners.
+      className="group flex min-h-12 w-full items-center justify-between px-4 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
     >
       <span className="text-sm font-medium text-muted-foreground">{label}</span>
       {hoverIcon ? (


### PR DESCRIPTION
The agent home's right-hand extras card had rows of different heights: `py-3` chevron rows, `py-2` rows around 34px pickers, and the card's own `py-2` stacking onto its first and last rows.

## Change

- **Two cards.** The three per-agent pickers (Agent Default Model, Session Auto-Delete, API Log Auto-Delete) are now a standalone card, separated from the navigation rows' card (Agent-to-agent connections, System Prompt, Agent Directory, Secrets, API Logs) by the column's usual card spacing. No section label.
- **Every row one height.** Neither card has vertical padding of its own, so the pickers are three identical rows and the navigation rows are one uniform height (`min-h-12`, same `px-4`), flush with their card's bottom edge.
- **Clipping and focus.** The navigation card clips its rows to the rounded corners so the hover fill stays inside, and the row buttons get an inset focus ring in place of the browser outline that clip would cut off.

`HomeRetention` and `HomeDefaultModel` are unchanged; only the card composition in `home-extras.tsx` moved.

## Tests

- `home-extras.test.tsx`: the three pickers render inside the standalone group and the navigation rows outside it.
- `.qagent/features/agent-settings.md` notes the pickers' own card.
- `npm run typecheck` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
