### PR TITLE
Flip the agent to running on session_active echoes

### DIFF
--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -165,6 +165,28 @@ describe('useMessageStream', () => {
     expect(result.current.activeStartTime).not.toBeNull()
   })
 
+  it('session_active echoes running + active into the agent and session caches', async () => {
+    const { useMessageStream } = await getHookModule()
+    const wrapper = createWrapper()
+    const agent = { slug: 'agent-1', name: 'Agent', status: 'stopped', hasActiveSessions: false }
+    const session = { id: 'session-1', agentSlug: 'agent-1', isActive: false }
+    wrapper.queryClient.setQueryData(['agents'], [agent])
+    wrapper.queryClient.setQueryData(['agents', 'agent-1'], agent)
+    wrapper.queryClient.setQueryData(['sessions', 'agent-1'], [session])
+    renderHook(() => useMessageStream('session-1', 'agent-1'), { wrapper })
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: false })
+      MockEventSource.instances[0].simulateMessage({ type: 'session_active' })
+    })
+
+    expect(wrapper.queryClient.getQueryData(['agents', 'agent-1'])).toMatchObject({
+      status: 'running',
+      hasActiveSessions: true,
+    })
+    expect(wrapper.queryClient.getQueryData(['sessions', 'agent-1'])).toMatchObject([{ isActive: true }])
+  })
+
   it('handles streaming: stream_start → stream_delta → stream_end', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -7,6 +7,7 @@ import type { SlashCommandInfo } from '@shared/lib/container/types'
 import type { ApiMessage, ApiMessageOrBoundary } from '@shared/lib/types/api'
 import type { WorkflowAgentNode } from '@shared/lib/workflows/workflow-schemas'
 import { isBlockingUserInputToolName } from '@shared/lib/tool-definitions/user-input-tools'
+import { applySessionActivityStatus } from '@renderer/lib/agent-cache'
 import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
 import {
   providerErrorPresentationSchema,
@@ -484,6 +485,13 @@ function getOrCreateEventSource(
       else if (data.type === 'session_active') {
         // Session became active - user sent a message
         if (data.sessionId && data.sessionId !== sessionId) return
+        // Echo the flip into the session/agent caches from THIS stream too.
+        // The global notifications stream normally carries it, but that
+        // stream can be silently stale while this one (opened with the view)
+        // is live — and then the sidebar/header would show a sleeping agent
+        // streaming tokens until the next refetch. Idempotent with the global
+        // handler's echo: identical patches leave the caches untouched.
+        applySessionActivityStatus(queryClient, agentSlug, sessionId, { isActive: true })
         // This frame carries TWO meanings: a genuinely new turn, and a
         // queued/steering message accepted into a turn that is already running
         // (`queuedMidTurn`). Deciding reset-vs-preserve field by field produced a

--- a/src/renderer/lib/agent-cache.test.ts
+++ b/src/renderer/lib/agent-cache.test.ts
@@ -249,6 +249,38 @@ describe('targeted agent cache updates', () => {
       expect(client.getQueryData<ApiAgent[]>(['agents'])?.[0].hasActiveSessions).toBe(true)
       expect(client.getQueryData<ApiAgent[]>(['agents'])?.[0].hasSessionsAwaitingInput).toBeUndefined()
     })
+
+    it('an active raise also asserts the container is running in every agent cache', () => {
+      const client = seededSessionClient([session('sess-1', { isActive: false })])
+
+      applySessionActivityStatus(client, 'agent-a', 'sess-1', { isActive: true })
+
+      expect(client.getQueryData<ApiAgent[]>(['agents'])?.[0].status).toBe('running')
+      expect(client.getQueryData<ApiAgent>(['agents', 'agent-a'])?.status).toBe('running')
+      expect(client.getQueryData<ApiAgent>(['agents', 'agent-a-display'])?.status).toBe('running')
+      expect(client.getQueryData<ApiAgent[]>(['agents'])?.[1].status).toBe('stopped')
+    })
+
+    it('an awaiting raise asserts running; clears never lower the container status', () => {
+      const client = seededSessionClient([session('sess-1', { isActive: false })])
+
+      applySessionActivityStatus(client, 'agent-a', 'sess-1', { isAwaitingInput: true })
+      expect(client.getQueryData<ApiAgent>(['agents', 'agent-a'])?.status).toBe('running')
+
+      applySessionActivityStatus(client, 'agent-a', 'sess-1', { isActive: false, isAwaitingInput: false })
+      expect(client.getQueryData<ApiAgent>(['agents', 'agent-a'])?.status).toBe('running')
+    })
+
+    it('a raise on an already-running agent keeps the agent reference', () => {
+      const client = seededSessionClient([session('sess-1')])
+      updateAgentRuntimeCache(client, 'agent-a', 'running', 3456)
+      applySessionActivityStatus(client, 'agent-a', 'sess-1', { isActive: true })
+      const before = client.getQueryData<ApiAgent>(['agents', 'agent-a'])
+
+      applySessionActivityStatus(client, 'agent-a', 'sess-1', { isActive: true })
+
+      expect(client.getQueryData<ApiAgent>(['agents', 'agent-a'])).toBe(before)
+    })
   })
 
   it('invalidates only the matching agent artifact queries, including its display alias', () => {

--- a/src/renderer/lib/agent-cache.ts
+++ b/src/renderer/lib/agent-cache.ts
@@ -260,16 +260,27 @@ export function applySessionActivityStatus(
     }
     agentPatch[agentFlag] = value
   }
+  // A session can only be working or blocked on input inside a running
+  // container, so a raise is also proof of the runtime state. Assert it with
+  // the same event: the activity label short-circuits to "sleeping" while the
+  // container reads 'stopped', so a session that visibly streams tokens would
+  // otherwise keep the header pill and agent row asleep until the separate
+  // agent_status_changed event lands (or is missed on a stalled global
+  // stream) or the next agents refetch. Never lowers — idle/error say nothing
+  // about whether the container is still up.
+  if (patch.isActive === true || patch.isAwaitingInput === true) {
+    agentPatch.status = 'running'
+  }
   if (Object.keys(agentPatch).length > 0) {
     // Identity-preserving on purpose: a no-op patch (e.g. session_active for
     // an already-working agent — the common case) must return the same agent
     // reference, or every event rebuilds the agents array and pays a full
     // deep-compare in structural sharing.
     updateMatchingAgents(queryClient, agentSlug, (agent) => {
-      const rollupChanged = SESSION_ROLLUP_FLAGS.some(([, agentFlag]) => (
-        agentPatch[agentFlag] !== undefined && (agent[agentFlag] ?? false) !== agentPatch[agentFlag]
+      const agentChanged = (Object.keys(agentPatch) as (keyof ApiAgent)[]).some((key) => (
+        (agent[key] ?? false) !== agentPatch[key]
       ))
-      return rollupChanged ? { ...agent, ...agentPatch } : agent
+      return agentChanged ? { ...agent, ...agentPatch } : agent
     })
   }
   return changed


### PR DESCRIPTION
## Summary

Sending a message into an existing session of a sleeping agent left the header pill and sidebar agent row showing "sleeping" while the session was visibly streaming tokens, resolving only many seconds later.

`getAgentActivityStatus` short-circuits to `sleeping` whenever the cached container status is `stopped`, so the optimistic `isActive` echo from #915 could never turn the label over by itself. It waited on the separate `agent_status_changed` event, which is lost when the global notifications stream is silently stale, or on the 60s agents refetch.

## Changes

- `applySessionActivityStatus` now also patches `status: 'running'` into every cached agent projection when the patch raises `isActive` or `isAwaitingInput`. A session can only be working or blocked on input inside a running container, so this is a fact, not a guess. Clears never lower the status, so a failed start is never masked.
- The per-session stream's `session_active` handler applies the same echo. That stream is opened with the view and stays live when the global one has gone quiet, which is the case this fixes.
- Tests for the raise, the no-lower rule, reference stability on an already-running agent, and the session-stream echo.

## Test plan

- [x] `npm run typecheck`, eslint on changed files
- [x] `agent-cache`, `use-message-stream`, `global-notification-handler`, `app-sidebar` unit tests
- [ ] Manual: sleep an agent, send a message in an existing session, confirm header + sidebar flip to working as soon as the turn starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McqP1UKA5ykZtLYqvbV5BA
