### PR TITLE
fix(triggers): record the minting member and tear down upstream as it (SUP-765)

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -1039,6 +1039,7 @@ describe('GET /:id/webhook-triggers', () => {
     lastSessionId: null,
     createdBySessionId: null,
     createdByUserId: 'owner-private-id',
+    mintedByMemberId: 'sub_member-private-id',
     model: null,
     effort: null,
     speed: null,
@@ -1059,6 +1060,7 @@ describe('GET /:id/webhook-triggers', () => {
     expect(body[0]).not.toHaveProperty('composioTriggerId')
     expect(body[0]).not.toHaveProperty('connectedAccountId')
     expect(body[0]).not.toHaveProperty('createdByUserId')
+    expect(body[0]).not.toHaveProperty('mintedByMemberId')
     expect(JSON.stringify(body)).not.toContain('private-capability')
   })
 

--- a/src/api/routes/webhook-triggers.test.ts
+++ b/src/api/routes/webhook-triggers.test.ts
@@ -77,6 +77,7 @@ const trigger: WebhookTrigger = {
   lastSessionId: null,
   createdBySessionId: null,
   createdByUserId: 'owner-private-id',
+  mintedByMemberId: 'sub_member-private-id',
   model: null,
   effort: null,
   speed: null,
@@ -110,6 +111,7 @@ describe('webhook trigger response access', () => {
     expect(body).not.toHaveProperty('composioTriggerId')
     expect(body).not.toHaveProperty('connectedAccountId')
     expect(body).not.toHaveProperty('createdByUserId')
+    expect(body).not.toHaveProperty('mintedByMemberId')
     expect(JSON.stringify(body)).not.toContain('private-capability')
   })
 
@@ -140,5 +142,6 @@ describe('webhook trigger response access', () => {
     expect(body).not.toHaveProperty('composioTriggerId')
     expect(body).not.toHaveProperty('connectedAccountId')
     expect(body).not.toHaveProperty('createdByUserId')
+    expect(body).not.toHaveProperty('mintedByMemberId')
   })
 })

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -117,12 +117,15 @@ const mockCreateWebhookTrigger = vi.fn<MockFn>(() => Promise.resolve('trigger_ne
 const mockListActiveWebhookTriggers = vi.fn<MockFn>(() => Promise.resolve([]))
 const mockCancelWebhookTriggerWithCleanup = vi.fn<MockFn>(() => Promise.resolve(true))
 const mockGetWebhookTrigger = vi.fn<MockFn>(() => Promise.resolve(null))
+const mockUpdateWebhookTriggerName = vi.fn<MockFn>(() => Promise.resolve())
+const mockResolvePlatformMemberForCandidates = vi.fn<MockFn>(() => null)
 vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
   createWebhookTrigger: (...args: unknown[]) => mockCreateWebhookTrigger(...args),
   listActiveWebhookTriggers: (...args: unknown[]) => mockListActiveWebhookTriggers(...args),
   cancelWebhookTriggerWithCleanup: (...args: unknown[]) => mockCancelWebhookTriggerWithCleanup(...args),
   getWebhookTrigger: (...args: unknown[]) => mockGetWebhookTrigger(...args),
-  resolvePlatformMemberForCandidates: () => null,
+  updateWebhookTriggerName: (...args: unknown[]) => mockUpdateWebhookTriggerName(...args),
+  resolvePlatformMemberForCandidates: (...args: unknown[]) => mockResolvePlatformMemberForCandidates(...args),
 }))
 
 const mockCreatePlatformWebhookEndpoint = vi.fn<MockFn>()
@@ -142,8 +145,9 @@ vi.mock('@shared/lib/services/webhook-endpoints-client', () => ({
 // access token (NOT on Composio mode — custom endpoints must work with a
 // personal Composio key).
 const mockGetPlatformAccessToken = vi.fn(() => 'opaque_token' as string | null)
+const mockGetStoredPlatformMemberId = vi.fn(() => null as string | null)
 vi.mock('@shared/lib/services/platform-auth-service', () => ({
-  getStoredPlatformMemberId: () => null,
+  getStoredPlatformMemberId: () => mockGetStoredPlatformMemberId(),
   getPlatformAccessToken: () => mockGetPlatformAccessToken(),
 }))
 
@@ -186,6 +190,15 @@ import { messagePersister, redactStreamedToolInput, sessionKeyOf, WaitForIdleTim
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { finalizeAutomationStatus, getSessionMetadata, updateSessionMetadata } from '@shared/lib/services/session-service'
+import { attribution } from '@shared/lib/platform-attribution'
+
+// An org-scoped platform JWT (the mode where every proxy call must carry an
+// acting member); the payload only has to decode, the signature is never checked.
+function buildOrgToken(orgId: string): string {
+  const header = Buffer.from('{"alg":"none"}').toString('base64url')
+  const payload = Buffer.from(JSON.stringify({ orgId })).toString('base64url')
+  return `${header}.${payload}.sig`
+}
 
 describe('redactStreamedToolInput', () => {
   it('masks the secret in create/update_webhook_endpoint streamed input', () => {
@@ -5209,6 +5222,8 @@ describe('MessagePersister', () => {
 
       mockIsPlatformComposioActive.mockReturnValue(true)
       mockGetPlatformAccessToken.mockReturnValue('opaque_token')
+      mockGetStoredPlatformMemberId.mockReturnValue(null)
+      mockResolvePlatformMemberForCandidates.mockReturnValue(null)
       mockContainerClientFetch.mockResolvedValue({ ok: true })
       mockCreateWebhookTrigger.mockResolvedValue('trigger_new_id')
       mockCancelWebhookTriggerWithCleanup.mockResolvedValue(true)
@@ -5317,6 +5332,54 @@ describe('MessagePersister', () => {
             method: 'POST',
             body: expect.stringContaining('not found'),
           }),
+        )
+      })
+
+      // SUP-765: the row must record the member the proxy actually scoped the
+      // subscription to. Tool handlers run off the stream loop with no
+      // guaranteed ALS scope, so the mint has to establish one itself.
+      it('mints under the session member and records it when no ambient attribution is active', async () => {
+        mockGetPlatformAccessToken.mockReturnValue(buildOrgToken('org_test'))
+        mockGetStoredPlatformMemberId.mockReturnValue('sub_session')
+        let mintKey: string | null | undefined
+        mockEnableComposioTrigger.mockImplementation(async () => {
+          mintKey = attribution.current()?.getKey() ?? null
+          return 'composio_trigger_id'
+        })
+
+        simulateToolUse('mcp__user-input__setup_trigger', 'tool-setup-minted', {
+          connected_account_id: 'ca_1',
+          trigger_type: 'GMAIL_NEW_EMAIL',
+          prompt: 'Summarize this email',
+        })
+
+        await flushHandlers('/inputs/tool-setup-minted/resolve')
+
+        expect(mintKey).toBe('member:sub_session')
+        expect(mockCreateWebhookTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({ mintedByMemberId: 'sub_session' }),
+        )
+      })
+
+      it('never mints as the opaque-key placeholder member', async () => {
+        // Nothing resolves: the bearer must stay the bare token, not `token::local`.
+        let mintKey: string | null | undefined
+        mockEnableComposioTrigger.mockImplementation(async () => {
+          mintKey = attribution.current()?.getKey() ?? null
+          return 'composio_trigger_id'
+        })
+
+        simulateToolUse('mcp__user-input__setup_trigger', 'tool-setup-local', {
+          connected_account_id: 'ca_1',
+          trigger_type: 'GMAIL_NEW_EMAIL',
+          prompt: 'Summarize this email',
+        })
+
+        await flushHandlers('/inputs/tool-setup-local/resolve')
+
+        expect(mintKey).toBeNull()
+        expect(mockCreateWebhookTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({ mintedByMemberId: undefined }),
         )
       })
 
@@ -5678,6 +5741,41 @@ describe('MessagePersister', () => {
         expect(JSON.parse(resolveCall[1].body).value).toContain('signature-verified')
       })
 
+      // SUP-765: the endpoint is scoped to whoever minted it, so a PATCH under
+      // the session creator's member 404s at the proxy.
+      it('patches as the recorded minting member, not the trigger creator', async () => {
+        mockGetWebhookTrigger.mockResolvedValue({ ...customTrigger, mintedByMemberId: 'sub_minted' })
+        mockResolvePlatformMemberForCandidates.mockReturnValue({ userId: 'u1', memberId: 'sub_creator' })
+
+        simulateToolUse('mcp__user-input__update_webhook_endpoint', 'tool-upd-minted', {
+          trigger_id: 'trigger_custom_1',
+          name: 'renamed',
+        })
+
+        await flushHandlers('/inputs/tool-upd-minted/resolve')
+        expect(mockUpdatePlatformWebhookEndpoint).toHaveBeenCalledWith(
+          'sub_minted',
+          customTrigger.composioTriggerId,
+          { name: 'renamed' },
+        )
+      })
+
+      it('falls back to the creator member for rows minted before the column existed', async () => {
+        mockResolvePlatformMemberForCandidates.mockReturnValue({ userId: 'u1', memberId: 'sub_creator' })
+
+        simulateToolUse('mcp__user-input__update_webhook_endpoint', 'tool-upd-precolumn', {
+          trigger_id: 'trigger_custom_1',
+          name: 'renamed',
+        })
+
+        await flushHandlers('/inputs/tool-upd-precolumn/resolve')
+        expect(mockUpdatePlatformWebhookEndpoint).toHaveBeenCalledWith(
+          'sub_creator',
+          customTrigger.composioTriggerId,
+          { name: 'renamed' },
+        )
+      })
+
       it('rejects for a non-custom trigger', async () => {
         mockGetWebhookTrigger.mockResolvedValue({ ...customTrigger, kind: 'composio' })
 
@@ -5751,6 +5849,47 @@ describe('MessagePersister', () => {
         mockTestPlatformWebhookFilter.mockClear()
         mockGetWebhookTrigger.mockResolvedValue(customTrigger)
         mockListPlatformWebhookEvents.mockResolvedValue({ filterExp: null, events: [] })
+      })
+
+      // SUP-765: same scoping as update/teardown — a read under the creator's
+      // member 404s for anything minted by someone else.
+      it('reads as the recorded minting member, not the trigger creator', async () => {
+        mockGetWebhookTrigger.mockResolvedValue({ ...customTrigger, mintedByMemberId: 'sub_minted' })
+        mockResolvePlatformMemberForCandidates.mockReturnValue({ userId: 'u1', memberId: 'sub_creator' })
+
+        simulateToolUse('mcp__user-input__inspect_webhook_events', 'tool-insp-minted', {
+          trigger_id: 'trigger_custom_1',
+        })
+
+        await flushHandlers('/inputs/tool-insp-minted/resolve')
+        expect(mockListPlatformWebhookEvents).toHaveBeenCalledWith(
+          'sub_minted',
+          customTrigger.composioTriggerId,
+          undefined,
+        )
+      })
+
+      it('dry-runs a filter as the recorded minting member too', async () => {
+        mockGetWebhookTrigger.mockResolvedValue({ ...customTrigger, mintedByMemberId: 'sub_minted' })
+        mockTestPlatformWebhookFilter.mockResolvedValue({
+          filter_exp: 'body.action == "update"',
+          evaluated: 0,
+          summary: { passed: 0, filtered: 0, error: 0, skipped: 0 },
+          results: [],
+        })
+
+        simulateToolUse('mcp__user-input__inspect_webhook_events', 'tool-insp-minted-filter', {
+          trigger_id: 'trigger_custom_1',
+          test_filter_exp: 'body.action == "update"',
+        })
+
+        await flushHandlers('/inputs/tool-insp-minted-filter/resolve')
+        expect(mockTestPlatformWebhookFilter).toHaveBeenCalledWith(
+          'sub_minted',
+          customTrigger.composioTriggerId,
+          'body.action == "update"',
+          undefined,
+        )
       })
 
       it('lists recent deliveries with filter verdicts and body previews', async () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -55,6 +55,7 @@ import {
   type WebhookEndpointEvent,
 } from '@shared/lib/services/webhook-endpoint-schema'
 import { getPlatformAccessToken, getStoredPlatformMemberId } from '@shared/lib/services/platform-auth-service'
+import { attribution } from '@shared/lib/platform-attribution'
 import {
   getAvailableTriggers,
   enableComposioTrigger,
@@ -4288,6 +4289,10 @@ ${continuation}`
           return
         }
 
+        // The proxy scopes the subscription to the acting member of THIS mint
+        // request (ambient ALS), which is not always the session creator (SUP-765).
+        const mintedByMemberId = attribution.current()?.actingMemberId() ?? undefined
+
         // 1. Enable trigger on Composio via proxy (using Composio's ca_* ID)
         const composioTriggerId = await enableComposioTrigger(
           input.trigger_type,
@@ -4309,6 +4314,7 @@ ${continuation}`
             name: input.name,
             createdBySessionId: sessionId,
             createdByUserId: triggerOwnerId ?? undefined,
+            mintedByMemberId,
             model: input.model,
             effort: input.effort,
             speed: input.speed,
@@ -4401,6 +4407,10 @@ ${continuation}`
         const filterExp = input.filter_exp ?? undefined
 
         const memberId = await this.resolvePlatformMemberForSession(agentSlug, sessionId)
+        // Minted explicitly as `token::memberId` below, so record that when no ALS
+        // attribution is active; never persist the opaque-key 'local' placeholder.
+        const mintedByMemberId =
+          attribution.current()?.actingMemberId() ?? (memberId === 'local' ? undefined : memberId)
 
         // 1. Mint the endpoint on the platform proxy
         const endpoint = await createPlatformWebhookEndpoint(memberId, {
@@ -4425,6 +4435,7 @@ ${continuation}`
             name: input.name.trim(),
             createdBySessionId: sessionId,
             createdByUserId: triggerOwnerId ?? undefined,
+            mintedByMemberId,
             model: input.model,
             effort: input.effort,
             speed: input.speed,

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -55,7 +55,7 @@ import {
   type WebhookEndpointEvent,
 } from '@shared/lib/services/webhook-endpoint-schema'
 import { getPlatformAccessToken, getStoredPlatformMemberId } from '@shared/lib/services/platform-auth-service'
-import { attribution } from '@shared/lib/platform-attribution'
+import { attribution, runWithAttribution } from '@shared/lib/platform-attribution'
 import {
   getAvailableTriggers,
   enableComposioTrigger,
@@ -4291,13 +4291,25 @@ ${continuation}`
 
         // The proxy scopes the subscription to the acting member of THIS mint
         // request (ambient ALS), which is not always the session creator (SUP-765).
-        const mintedByMemberId = attribution.current()?.actingMemberId() ?? undefined
+        // Tool handlers run off the stream loop with no guaranteed ALS scope, so
+        // when none is active mint explicitly under the session's member instead
+        // of letting the call go out as a bare org token with nothing recorded.
+        const sessionMemberId = await this.resolvePlatformMemberForSession(agentSlug, sessionId)
+        const mintAttribution =
+          attribution.current() ??
+          // Never mint as the opaque-key 'local' placeholder — that would send `token::local`.
+          (sessionMemberId === 'local' ? null : attribution.fromMemberId(sessionMemberId))
+        const mintedByMemberId = mintAttribution?.actingMemberId() ?? undefined
 
         // 1. Enable trigger on Composio via proxy (using Composio's ca_* ID)
-        const composioTriggerId = await enableComposioTrigger(
-          input.trigger_type,
-          providerConnectionId,
-          input.trigger_config,
+        // Under mintAttribution so the recorded member is the one the proxy
+        // actually scoped the subscription to, not a guess made after the fact.
+        const composioTriggerId = await runWithAttribution(mintAttribution, () =>
+          enableComposioTrigger(
+            input.trigger_type,
+            providerConnectionId,
+            input.trigger_config,
+          ),
         )
 
         // 2. Save to SQLite (store the local account ID for app-level lookups)
@@ -4567,9 +4579,11 @@ ${continuation}`
           return
         }
 
-        // Creator-first member resolution, matching teardown: the endpoint is
-        // scoped to whoever minted it, not whoever's session runs the update.
+        // Minting-member-first resolution, matching teardown: the endpoint is
+        // scoped to whoever minted it, not to whoever created the session that
+        // runs the update (SUP-765). Pre-column rows fall back to the creator.
         const memberId =
+          trigger.mintedByMemberId ??
           resolvePlatformMemberForCandidates([trigger.createdByUserId])?.memberId ??
           (await this.resolvePlatformMemberForSession(agentSlug, sessionId))
         await updatePlatformWebhookEndpoint(memberId, trigger.composioTriggerId, patch)
@@ -4649,8 +4663,9 @@ ${continuation}`
           return
         }
 
-        // Creator-first member resolution, same as update/teardown.
+        // Minting-member-first resolution, same as update/teardown (SUP-765).
         const memberId =
+          trigger.mintedByMemberId ??
           resolvePlatformMemberForCandidates([trigger.createdByUserId])?.memberId ??
           (await this.resolvePlatformMemberForSession(agentSlug, sessionId))
 

--- a/src/shared/lib/db/migrations/0039_webhook_trigger_minted_by_member.sql
+++ b/src/shared/lib/db/migrations/0039_webhook_trigger_minted_by_member.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `webhook_triggers` ADD `minted_by_member_id` text;

--- a/src/shared/lib/db/migrations/meta/0039_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0039_snapshot.json
@@ -1,0 +1,2979 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8951f2e5-73f8-4f99-9d8d-749ce07fa0a4",
+  "prevId": "4b98a85f-7a32-4af9-bd5e-d37628875f43",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apns_devices": {
+      "name": "apns_devices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'production'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_device_id": {
+          "name": "mobile_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_tag": {
+          "name": "workspace_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ios'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apns_devices_token_unique": {
+          "name": "apns_devices_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "apns_devices_user_id_idx": {
+          "name": "apns_devices_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "apns_devices_mobile_device_id_idx": {
+          "name": "apns_devices_mobile_device_id_idx",
+          "columns": [
+            "mobile_device_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apns_devices_mobile_device_id_mobile_device_id_fk": {
+          "name": "apns_devices_mobile_device_id_mobile_device_id_fk",
+          "tableFrom": "apns_devices",
+          "tableTo": "mobile_device",
+          "columnsFrom": [
+            "mobile_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creation_method": {
+          "name": "creation_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_device_id_idx": {
+          "name": "session_device_id_idx",
+          "columns": [
+            "device_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_device_id_mobile_device_id_fk": {
+          "name": "session_device_id_mobile_device_id_fk",
+          "tableFrom": "session",
+          "tableTo": "mobile_device",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_audit_log_agent_slug_created_at_idx": {
+          "name": "mcp_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_remote_mcp_id_created_at_idx": {
+          "name": "mcp_audit_log_remote_mcp_id_created_at_idx",
+          "columns": [
+            "remote_mcp_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_mcp_agent_idx": {
+          "name": "mcp_audit_log_mcp_agent_idx",
+          "columns": [
+            "remote_mcp_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mobile_device": {
+      "name": "mobile_device",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mobile_device_refresh_token_hash_unique": {
+          "name": "mobile_device_refresh_token_hash_unique",
+          "columns": [
+            "refresh_token_hash"
+          ],
+          "isUnique": true
+        },
+        "mobile_device_user_id_idx": {
+          "name": "mobile_device_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "mobile_device_expires_at_idx": {
+          "name": "mobile_device_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mobile_device_user_id_user_id_fk": {
+          "name": "mobile_device_user_id_user_id_fk",
+          "tableFrom": "mobile_device",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mobile_pairing_token": {
+      "name": "mobile_pairing_token",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mobile_pairing_token_expires_at_idx": {
+          "name": "mobile_pairing_token_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mobile_pairing_token_user_id_user_id_fk": {
+          "name": "mobile_pairing_token_user_id_user_id_fk",
+          "tableFrom": "mobile_pairing_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_audit_log_agent_slug_created_at_idx": {
+          "name": "proxy_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_id_created_at_idx": {
+          "name": "proxy_audit_log_account_id_created_at_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_agent_idx": {
+          "name": "proxy_audit_log_account_agent_idx",
+          "columns": [
+            "account_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keys_p256dh": {
+          "name": "keys_p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keys_auth": {
+          "name": "keys_auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        },
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_vapid_keys": {
+      "name": "push_vapid_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resume_session_id": {
+          "name": "resume_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_tasks_pending_wake_unique": {
+          "name": "scheduled_tasks_pending_wake_unique",
+          "columns": [
+            "resume_session_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending' AND resume_session_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_unread_marks": {
+      "name": "session_unread_marks",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_unread_marks_agent_slug_user_idx": {
+          "name": "session_unread_marks_agent_slug_user_idx",
+          "columns": [
+            "agent_slug",
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_unread_marks_agent_slug_session_id_user_id_pk": {
+          "columns": [
+            "agent_slug",
+            "session_id",
+            "user_id"
+          ],
+          "name": "session_unread_marks_agent_slug_session_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "token_exchange_jti": {
+      "name": "token_exchange_jti",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "token_exchange_jti_expires_at_idx": {
+          "name": "token_exchange_jti_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minted_by_member_id": {
+          "name": "minted_by_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1787774912000,
       "tag": "0038_session_unread_marks_agent_pk",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1788396615359,
+      "tag": "0039_webhook_trigger_minted_by_member",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -594,6 +594,9 @@ export const webhookTriggers = sqliteTable('webhook_triggers', {
   // Ownership
   createdBySessionId: text('created_by_session_id'),
   createdByUserId: text('created_by_user_id'),
+  // Acting platform member the upstream subscription was minted under (SUP-765).
+  // Teardown must delete as this member; the proxy scopes DELETE to it.
+  mintedByMemberId: text('minted_by_member_id'),
 
   // Runtime options (override global defaults when set)
   model: text('model'),

--- a/src/shared/lib/platform-attribution/index.ts
+++ b/src/shared/lib/platform-attribution/index.ts
@@ -41,6 +41,8 @@ export interface Attribution {
   applyTo(headers: Headers): void
   bearerToken(): string
   getKey(): string
+  /** Acting member id for org-scoped tokens; null in opaque-access-key mode. */
+  actingMemberId(): string | null
 }
 
 class PlatformAttribution implements Attribution {
@@ -63,6 +65,10 @@ class PlatformAttribution implements Attribution {
   getKey(): string {
     if (!this.orgScoped) return 'access_key'
     return this.memberId ? `member:${this.memberId}` : 'org'
+  }
+
+  actingMemberId(): string | null {
+    return this.orgScoped ? this.memberId : null
   }
 }
 
@@ -106,6 +112,10 @@ export const attribution = {
   },
   fromResourceCreator(ownerUserId: string | null): Attribution | null {
     return ownerUserId ? buildAttribution(getPlatformAccountIdForUserId(ownerUserId)) : null
+  },
+  // For callers that already hold a member id (e.g. the recorded minting member).
+  fromMemberId(memberId: string): Attribution | null {
+    return buildAttribution(memberId)
   },
   current(): Attribution | null {
     return attributionContext.getStore()?.auth ?? fromCurrentRequest()

--- a/src/shared/lib/scheduler/trigger-manager.custom-webhooks.test.ts
+++ b/src/shared/lib/scheduler/trigger-manager.custom-webhooks.test.ts
@@ -46,7 +46,8 @@ vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
   getWebhookTriggersByComposioId: (...args: unknown[]) => mockGetWebhookTriggersByComposioId(...args),
   markTriggerFired: (...args: unknown[]) => mockMarkTriggerFired(...args),
   markTriggerFailed: vi.fn().mockResolvedValue(undefined),
-  resolvePlatformMemberForCandidates: () => null,
+  resolveTriggerPrincipal: () => null,
+  getConnectedAccountOwnerUserId: () => null,
 }))
 
 vi.mock('@shared/lib/services/session-service', () => ({

--- a/src/shared/lib/scheduler/trigger-manager.test.ts
+++ b/src/shared/lib/scheduler/trigger-manager.test.ts
@@ -47,17 +47,15 @@ const mockGetWebhookTriggersByComposioId = vi.fn()
 const mockMarkTriggerFired = vi.fn().mockResolvedValue(undefined)
 const mockMarkTriggerFailed = vi.fn().mockResolvedValue(undefined)
 const mockGetDistinctMemberIds = vi.fn(() => ['sub_test_member'])
-const mockResolvePlatformMemberForCandidates =
-  vi.fn<(candidates: Array<string | null | undefined>) => { userId: string; memberId: string } | null>(
-    () => null,
-  )
+const mockResolveTriggerPrincipal =
+  vi.fn<(trigger: unknown) => { userId: string; memberId: string } | null>(() => null)
 vi.mock('@shared/lib/services/webhook-trigger-service', () => ({
   getDistinctPlatformMemberIdsForActiveTriggers: () => mockGetDistinctMemberIds(),
   getWebhookTriggersByComposioId: (...args: unknown[]) => mockGetWebhookTriggersByComposioId(...args),
   markTriggerFired: (...args: unknown[]) => mockMarkTriggerFired(...args),
   markTriggerFailed: (...args: unknown[]) => mockMarkTriggerFailed(...args),
-  resolvePlatformMemberForCandidates: (...args: [Array<string | null | undefined>]) =>
-    mockResolvePlatformMemberForCandidates(...args),
+  resolveTriggerPrincipal: (trigger: unknown) => mockResolveTriggerPrincipal(trigger),
+  getConnectedAccountOwnerUserId: () => null,
 }))
 
 const mockRegisterSession = vi.fn().mockResolvedValue(undefined)
@@ -144,7 +142,7 @@ describe('TriggerManager', () => {
     mockGetDistinctMemberIds.mockReturnValue(['sub_test_member'])
     mockGetPlatformAccessToken.mockReturnValue('opaque_test_token')
     mockDecodeOrgIdFromToken.mockReturnValue(null)
-    mockResolvePlatformMemberForCandidates.mockReturnValue(null)
+    mockResolveTriggerPrincipal.mockReturnValue(null)
   })
 
   describe('start', () => {
@@ -336,18 +334,19 @@ describe('TriggerManager', () => {
       })
       mockGetWebhookTriggersByComposioId.mockResolvedValue([trigger])
       // Creator has no platform member; resolution falls back to the owner.
-      mockResolvePlatformMemberForCandidates.mockReturnValue({
+      mockResolveTriggerPrincipal.mockReturnValue({
         userId: 'owner_user',
         memberId: 'sub_owner_member',
       })
 
       await triggerManager.start()
 
-      expect(mockResolvePlatformMemberForCandidates).toHaveBeenCalledWith([
-        'creator_user',
-        // resolveConnectedAccountOwner is read through the db mock (returns null here).
-        null,
-      ])
+      expect(mockResolveTriggerPrincipal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createdByUserId: 'creator_user',
+          connectedAccountId: 'ca_owned',
+        }),
+      )
       expect(mockRunWithOptionalUser).toHaveBeenCalledWith('owner_user', expect.any(Function))
       expect(mockCreateSession).toHaveBeenCalledTimes(1)
 

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -16,15 +16,13 @@ import { messagePersister } from '@shared/lib/container/message-persister'
 import { notificationManager } from '@shared/lib/notifications/notification-manager'
 import { runWithOptionalUser, attribution } from '@shared/lib/platform-attribution'
 import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
-import { db } from '@shared/lib/db'
-import { connectedAccounts } from '@shared/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import {
   getDistinctPlatformMemberIdsForActiveTriggers,
   getWebhookTriggersByComposioId,
   markTriggerFired,
   markTriggerFailed,
-  resolvePlatformMemberForCandidates,
+  resolveTriggerPrincipal,
+  getConnectedAccountOwnerUserId,
 } from '@shared/lib/services/webhook-trigger-service'
 import type { WebhookTrigger } from '@shared/lib/services/webhook-trigger-service'
 import { resolveRuntimeInherit } from '@shared/lib/container/runtime-options'
@@ -41,17 +39,6 @@ import {
   webhookEnvelopeSchema,
   CUSTOM_WEBHOOK_TRIGGER_TYPE,
 } from '@shared/lib/services/webhook-endpoint-schema'
-
-function resolveConnectedAccountOwner(connectedAccountId: string | null): string | null {
-  if (!connectedAccountId) return null
-  const rows = db
-    .select({ userId: connectedAccounts.userId })
-    .from(connectedAccounts)
-    .where(eq(connectedAccounts.id, connectedAccountId))
-    .limit(1)
-    .all()
-  return rows[0]?.userId ?? null
-}
 
 /**
  * Custom-endpoint events carry a request envelope from the public ingest
@@ -327,12 +314,10 @@ class TriggerManager {
     // creator has no platform member (SUP-226). If neither resolves to a
     // platform member (e.g. opaque-key / single-user mode), keep the prior
     // best-effort attribution (creator, else owner).
-    const candidates = [
-      trigger.createdByUserId,
-      resolveConnectedAccountOwner(trigger.connectedAccountId),
-    ]
-    const resolved = resolvePlatformMemberForCandidates(candidates)
-    const ownerUserId = resolved?.userId ?? candidates.find((c) => c) ?? null
+    const ownerUserId =
+      resolveTriggerPrincipal(trigger)?.userId ??
+      trigger.createdByUserId ??
+      getConnectedAccountOwnerUserId(trigger.connectedAccountId)
     await runWithOptionalUser(ownerUserId, () => this.spawnSessionInner(trigger, events))
   }
 

--- a/src/shared/lib/services/agent-cleanup-service.ts
+++ b/src/shared/lib/services/agent-cleanup-service.ts
@@ -13,14 +13,7 @@ import {
   messageAuthor,
 } from '@shared/lib/db/schema'
 import { eq, and, inArray } from 'drizzle-orm'
-import { captureException } from '@shared/lib/error-reporting'
-import { deleteComposioTrigger } from '@shared/lib/composio/triggers'
-import { isPlatformComposioActive } from '@shared/lib/composio/client'
-import { disablePlatformWebhookEndpoint } from '@shared/lib/services/webhook-endpoints-client'
-import {
-  resolvePlatformMemberForCandidates,
-} from '@shared/lib/services/webhook-trigger-service'
-import { getPlatformAccessToken, getStoredPlatformMemberId } from '@shared/lib/services/platform-auth-service'
+import { cancelWebhookTriggerWithCleanup } from '@shared/lib/services/webhook-trigger-service'
 
 export async function cleanupAgentData(agentSlug: string): Promise<void> {
   await cleanupWebhookTriggers(agentSlug)
@@ -42,9 +35,11 @@ export async function cleanupAgentData(agentSlug: string): Promise<void> {
   })
 }
 
+// Delegates per-trigger cancel + upstream teardown to the shared path so the
+// minting-member-attributed delete (SUP-765) applies to agent deletion too.
 async function cleanupWebhookTriggers(agentSlug: string): Promise<void> {
   const triggers = db
-    .select()
+    .select({ id: webhookTriggers.id })
     .from(webhookTriggers)
     .where(
       and(
@@ -54,55 +49,7 @@ async function cleanupWebhookTriggers(agentSlug: string): Promise<void> {
     )
     .all()
 
-  for (const trigger of triggers) {
-    db.update(webhookTriggers)
-      .set({ status: 'cancelled', cancelledAt: new Date() })
-      .where(eq(webhookTriggers.id, trigger.id))
-      .run()
-
-    // Custom endpoints live on the platform proxy regardless of Composio key
-    // mode — gate their teardown on platform auth, not the Composio condition.
-    const canReachUpstream =
-      trigger.kind === 'custom' ? Boolean(getPlatformAccessToken()) : isPlatformComposioActive()
-    if (trigger.composioTriggerId && canReachUpstream) {
-      const remaining = db
-        .select()
-        .from(webhookTriggers)
-        .where(
-          and(
-            eq(webhookTriggers.composioTriggerId, trigger.composioTriggerId),
-            inArray(webhookTriggers.status, ['active', 'paused']),
-          ),
-        )
-        .all().length
-
-      if (remaining === 0) {
-        try {
-          if (trigger.kind === 'custom') {
-            // Disable the platform endpoint so its public URL 404s at the edge.
-            const memberId =
-              resolvePlatformMemberForCandidates([trigger.createdByUserId])?.memberId ??
-              getStoredPlatformMemberId() ??
-              'local'
-            await disablePlatformWebhookEndpoint(memberId, trigger.composioTriggerId)
-          } else {
-            await deleteComposioTrigger(trigger.composioTriggerId)
-          }
-        } catch (error) {
-          console.error('[agent-cleanup] Failed to tear down upstream subscription:', error)
-          // Agent is being deleted; no owner is left to notice a live public
-          // URL. Capture so the orphaned endpoint is diagnosable.
-          captureException(error, {
-            tags: { area: 'webhook-endpoints', op: 'cleanup-disable' },
-            extra: {
-              agentSlug: trigger.agentSlug,
-              triggerId: trigger.id,
-              upstreamId: trigger.composioTriggerId,
-              kind: trigger.kind,
-            },
-          })
-        }
-      }
-    }
+  for (const { id } of triggers) {
+    await cancelWebhookTriggerWithCleanup(id)
   }
 }

--- a/src/shared/lib/services/webhook-endpoints-client.ts
+++ b/src/shared/lib/services/webhook-endpoints-client.ts
@@ -21,6 +21,16 @@ import {
   type WebhookFilterTestResult,
 } from './webhook-endpoint-schema'
 
+export class WebhookEndpointsApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+  ) {
+    super(message)
+    this.name = 'WebhookEndpointsApiError'
+  }
+}
+
 // Org JWTs encode the acting member as `<token>::<memberId>`; opaque keys ignore it.
 function buildBearer(memberId: string): string {
   const token = getPlatformAccessToken()
@@ -52,7 +62,10 @@ async function endpointsFetch(
     // transcript. Mask any `"secret":"…"` value, then cap the length so a
     // full-body echo can't leak wholesale.
     const masked = text.replace(/("secret"\s*:\s*")(?:\\.|[^"\\])*/g, '$1***')
-    throw new Error(`Webhook endpoints API error ${response.status}: ${masked.slice(0, 500)}`)
+    throw new WebhookEndpointsApiError(
+      `Webhook endpoints API error ${response.status}: ${masked.slice(0, 500)}`,
+      response.status,
+    )
   }
 
   // Disable responds with the updated row today, but a bodyless 204 must not

--- a/src/shared/lib/services/webhook-trigger-service.sup226.test.ts
+++ b/src/shared/lib/services/webhook-trigger-service.sup226.test.ts
@@ -176,9 +176,11 @@ describe('SUP-226: getDistinctPlatformMemberIdsForActiveTriggers owner fallback'
   })
 
   // SUP-765: the proxy scopes the subscription (and its events) to the minting
-  // member, so it must win over the creator in the poll set or the trigger
-  // silently never fires.
-  it('polls as the recorded minting member even when the creator resolves elsewhere', async () => {
+  // member, so it must lead the poll set or the trigger silently never fires.
+  // The creator stays in the set behind it: if the minter has since left the
+  // org their poll throws and the loop only logs it, so dropping the SUP-226
+  // fallback here would strand the trigger for good.
+  it('leads with the recorded minting member, keeping the creator as fallback', async () => {
     await insertUser('creator_user')
     await insertPlatformAccount('creator_user', 'sub_creator_member')
 
@@ -191,6 +193,9 @@ describe('SUP-226: getDistinctPlatformMemberIdsForActiveTriggers owner fallback'
       mintedByMemberId: 'sub_minted_member',
     })
 
-    expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual(['sub_minted_member'])
+    expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual([
+      'sub_minted_member',
+      'sub_creator_member',
+    ])
   })
 })

--- a/src/shared/lib/services/webhook-trigger-service.sup226.test.ts
+++ b/src/shared/lib/services/webhook-trigger-service.sup226.test.ts
@@ -38,6 +38,12 @@ vi.mock('../analytics/server-analytics', () => ({
   trackServerEvent: vi.fn(),
 }))
 
+// Hermetic: the stored-member fallback must not read this machine's settings.
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getPlatformAccessToken: () => null,
+  getStoredPlatformMemberId: () => null,
+}))
+
 import {
   createWebhookTrigger,
   getDistinctPlatformMemberIdsForActiveTriggers,
@@ -167,5 +173,24 @@ describe('SUP-226: getDistinctPlatformMemberIdsForActiveTriggers owner fallback'
     })
 
     expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual([])
+  })
+
+  // SUP-765: the proxy scopes the subscription (and its events) to the minting
+  // member, so it must win over the creator in the poll set or the trigger
+  // silently never fires.
+  it('polls as the recorded minting member even when the creator resolves elsewhere', async () => {
+    await insertUser('creator_user')
+    await insertPlatformAccount('creator_user', 'sub_creator_member')
+
+    await createWebhookTrigger({
+      agentSlug: 'agent-1',
+      composioTriggerId: 'ti_1',
+      triggerType: 'GMAIL_NEW_EMAIL',
+      prompt: 'Handle email',
+      createdByUserId: 'creator_user',
+      mintedByMemberId: 'sub_minted_member',
+    })
+
+    expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual(['sub_minted_member'])
   })
 })

--- a/src/shared/lib/services/webhook-trigger-service.sup765.test.ts
+++ b/src/shared/lib/services/webhook-trigger-service.sup765.test.ts
@@ -54,8 +54,10 @@ vi.mock('@shared/lib/services/webhook-endpoints-client', async (importOriginal) 
 })
 
 const mockCaptureException = vi.fn()
+const mockCaptureMessage = vi.fn()
 vi.mock('@shared/lib/error-reporting', () => ({
   captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
 }))
 
 const mockGetPlatformAccessToken = vi.fn()
@@ -71,6 +73,7 @@ import { WebhookEndpointsApiError } from '@shared/lib/services/webhook-endpoints
 import {
   createWebhookTrigger,
   cancelWebhookTriggerWithCleanup,
+  getDistinctPlatformMemberIdsForActiveTriggers,
   getWebhookTrigger,
   resolveTeardownMembers,
   UpstreamOwnerUnresolvedError,
@@ -262,6 +265,34 @@ describe('upstream teardown attribution (SUP-765)', () => {
     expect(deleteAttributionKey).toBe('member:sub_minted')
   })
 
+  // The poll set is the other half of SUP-765: events for the subscription are
+  // claimed as the minting member. But the minter can leave the org, and the
+  // poll loop only logs the resulting failure — so the recorded member leads the
+  // set without evicting the SUP-226 fallbacks that would still find the events.
+  describe('poll set', () => {
+    it('leads with the recorded minting member and keeps the creator fallback', async () => {
+      await insertUser('user-creator')
+      await insertPlatformAccount('user-creator', 'sub_creator')
+      await createComposioTrigger({ createdByUserId: 'user-creator', mintedByMemberId: 'sub_minted' })
+
+      expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual(['sub_minted', 'sub_creator'])
+    })
+
+    it('collapses to one member when the minter is also the creator', async () => {
+      await insertUser('user-creator')
+      await insertPlatformAccount('user-creator', 'sub_creator')
+      await createComposioTrigger({ createdByUserId: 'user-creator', mintedByMemberId: 'sub_creator' })
+
+      expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual(['sub_creator'])
+    })
+
+    it('polls the minting member alone when nothing else resolves', async () => {
+      await createComposioTrigger({ mintedByMemberId: 'sub_minted' })
+
+      expect(getDistinctPlatformMemberIdsForActiveTriggers()).toEqual(['sub_minted'])
+    })
+  })
+
   describe('resolveTeardownMembers', () => {
     it('is known and single when the minting member was recorded', async () => {
       await insertUser('user-creator')
@@ -300,7 +331,10 @@ describe('upstream teardown attribution (SUP-765)', () => {
   // The proxy 404s a cross-member DELETE exactly like a missing subscription,
   // so a 404 only means "gone" when the acting member is known.
   describe('404 handling', () => {
-    it('is silent when the upstream is already gone under the recorded minting member', async () => {
+    // "Already gone" and "the minter left the org, so the subscription is still
+    // live" 404 identically, so the known-member case is reported (at info, not
+    // as an error) rather than swallowed — otherwise the orphan is invisible.
+    it('accepts a 404 under the recorded minting member but reports it as a possible orphan', async () => {
       mockDeleteComposioTrigger.mockRejectedValue(new ComposioTriggerError('Trigger not found', 404))
       const triggerId = await createComposioTrigger({ mintedByMemberId: 'sub_minted' })
 
@@ -308,6 +342,11 @@ describe('upstream teardown attribution (SUP-765)', () => {
 
       expect(mockDeleteComposioTrigger).toHaveBeenCalledTimes(1)
       expect(mockCaptureException).not.toHaveBeenCalled()
+      expect(mockCaptureMessage).toHaveBeenCalledTimes(1)
+      expect(mockCaptureMessage.mock.calls[0][1]).toMatchObject({
+        level: 'info',
+        extra: expect.objectContaining({ memberId: 'sub_minted', upstreamId: 'ti_composio_1' }),
+      })
     })
 
     it('is silent on a 404 in opaque-access-key mode (the proxy ignores members)', async () => {
@@ -318,6 +357,8 @@ describe('upstream teardown attribution (SUP-765)', () => {
       expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
 
       expect(mockCaptureException).not.toHaveBeenCalled()
+      // No member was tried, so a 404 really does mean gone.
+      expect(mockCaptureMessage).not.toHaveBeenCalled()
     })
 
     it('tries the next guessed member after a 404 and stops on the one that succeeds', async () => {

--- a/src/shared/lib/services/webhook-trigger-service.sup765.test.ts
+++ b/src/shared/lib/services/webhook-trigger-service.sup765.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Upstream teardown must run under the member that minted the subscription:
+ * the proxy scopes DELETE to that member, so an ambient deleter identity 404s
+ * on cross-member cleanup and silently orphans the upstream (SUP-765).
+ *
+ * Uses the REAL platform-attribution resolver against seeded rows; only the
+ * upstream clients and token source are mocked.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as path from 'path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '../db/schema'
+
+let testDb: ReturnType<typeof drizzle>
+let testSqlite: InstanceType<typeof Database>
+
+vi.mock('@shared/lib/db', () => ({
+  get db() {
+    return testDb
+  },
+  get sqlite() {
+    return testSqlite
+  },
+}))
+
+vi.mock('../analytics/server-analytics', () => ({
+  trackServerEvent: vi.fn(),
+}))
+
+const mockIsPlatformComposioActive = vi.fn()
+vi.mock('@shared/lib/composio/client', () => ({
+  isPlatformComposioActive: () => mockIsPlatformComposioActive(),
+}))
+
+// Real error classes so a constructor change here fails these tests.
+const mockDeleteComposioTrigger = vi.fn()
+vi.mock('@shared/lib/composio/triggers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/lib/composio/triggers')>()
+  return {
+    ComposioTriggerError: actual.ComposioTriggerError,
+    deleteComposioTrigger: (...args: unknown[]) => mockDeleteComposioTrigger(...args),
+  }
+})
+
+const mockDisableEndpoint = vi.fn()
+vi.mock('@shared/lib/services/webhook-endpoints-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/lib/services/webhook-endpoints-client')>()
+  return {
+    WebhookEndpointsApiError: actual.WebhookEndpointsApiError,
+    disablePlatformWebhookEndpoint: (...args: unknown[]) => mockDisableEndpoint(...args),
+  }
+})
+
+const mockCaptureException = vi.fn()
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+const mockGetPlatformAccessToken = vi.fn()
+const mockGetStoredPlatformMemberId = vi.fn((): string | null => null)
+vi.mock('@shared/lib/services/platform-auth-service', () => ({
+  getPlatformAccessToken: () => mockGetPlatformAccessToken(),
+  getStoredPlatformMemberId: () => mockGetStoredPlatformMemberId(),
+}))
+
+import { attribution } from '@shared/lib/platform-attribution'
+import { ComposioTriggerError } from '@shared/lib/composio/triggers'
+import { WebhookEndpointsApiError } from '@shared/lib/services/webhook-endpoints-client'
+import {
+  createWebhookTrigger,
+  cancelWebhookTriggerWithCleanup,
+  getWebhookTrigger,
+  resolveTeardownMembers,
+  UpstreamOwnerUnresolvedError,
+} from './webhook-trigger-service'
+import { cleanupAgentData } from './agent-cleanup-service'
+
+function buildOrgToken(orgId: string): string {
+  const header = Buffer.from('{"alg":"none"}').toString('base64url')
+  const payload = Buffer.from(JSON.stringify({ orgId })).toString('base64url')
+  return `${header}.${payload}.sig`
+}
+
+const ORG_TOKEN = buildOrgToken('org_test_765')
+const NOW = new Date('2026-09-01T12:00:00.000Z')
+
+async function insertUser(id: string) {
+  await testDb.insert(schema.user).values({
+    id,
+    name: id,
+    email: `${id}@example.com`,
+    createdAt: NOW,
+    updatedAt: NOW,
+  })
+}
+
+async function insertPlatformAccount(userId: string, memberId: string) {
+  await testDb.insert(schema.authAccount).values({
+    id: `acct_${memberId}`,
+    accountId: memberId,
+    providerId: 'platform',
+    userId,
+    createdAt: NOW,
+    updatedAt: NOW,
+  })
+}
+
+async function insertConnectedAccount(id: string, ownerUserId: string | null) {
+  await testDb.insert(schema.connectedAccounts).values({
+    id,
+    providerConnectionId: `pc_${id}`,
+    providerName: 'composio',
+    toolkitSlug: 'googlecalendar',
+    displayName: 'Calendar',
+    status: 'active',
+    userId: ownerUserId,
+    createdAt: NOW,
+    updatedAt: NOW,
+  })
+}
+
+async function createComposioTrigger(params: {
+  agentSlug?: string
+  createdByUserId?: string
+  mintedByMemberId?: string
+  connectedAccountId?: string
+  composioTriggerId?: string
+}) {
+  return createWebhookTrigger({
+    agentSlug: params.agentSlug ?? 'agent-1',
+    composioTriggerId: params.composioTriggerId ?? 'ti_composio_1',
+    connectedAccountId: params.connectedAccountId,
+    triggerType: 'GOOGLECALENDAR_EVENT_CANCELED_DELETED_TRIGGER',
+    prompt: 'Handle it',
+    createdByUserId: params.createdByUserId,
+    mintedByMemberId: params.mintedByMemberId,
+  })
+}
+
+describe('upstream teardown attribution (SUP-765)', () => {
+  // The attribution key active inside the upstream delete call.
+  let deleteAttributionKey: string | null | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deleteAttributionKey = undefined
+    mockIsPlatformComposioActive.mockReturnValue(true)
+    mockGetPlatformAccessToken.mockReturnValue(ORG_TOKEN)
+    mockGetStoredPlatformMemberId.mockReturnValue(null)
+    mockDeleteComposioTrigger.mockImplementation(async () => {
+      deleteAttributionKey = attribution.current()?.getKey() ?? null
+    })
+    mockDisableEndpoint.mockImplementation(async () => {
+      deleteAttributionKey = attribution.current()?.getKey() ?? null
+    })
+
+    testSqlite = new Database(':memory:')
+    // Mirror production (db/index.ts): FK enforcement on, so seeds must be real.
+    testSqlite.pragma('foreign_keys = ON')
+    testDb = drizzle(testSqlite, { schema })
+    migrate(testDb, { migrationsFolder: path.join(process.cwd(), 'src/shared/lib/db/migrations') })
+  })
+
+  afterEach(() => {
+    testSqlite?.close()
+  })
+
+  it('deletes under the recorded minting member, even when the creator resolves elsewhere', async () => {
+    await insertUser('user-creator')
+    await insertPlatformAccount('user-creator', 'sub_creator')
+
+    const triggerId = await createComposioTrigger({
+      createdByUserId: 'user-creator',
+      mintedByMemberId: 'sub_minted',
+    })
+
+    expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+    expect(mockDeleteComposioTrigger).toHaveBeenCalledWith('ti_composio_1')
+    expect(deleteAttributionKey).toBe('member:sub_minted')
+  })
+
+  it('falls back to the creator member for rows minted before the column existed', async () => {
+    await insertUser('user-creator')
+    await insertPlatformAccount('user-creator', 'sub_creator')
+
+    const triggerId = await createComposioTrigger({ createdByUserId: 'user-creator' })
+
+    expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+    expect(deleteAttributionKey).toBe('member:sub_creator')
+  })
+
+  it('falls back to the connected-account owner when the creator has no platform member', async () => {
+    await insertUser('user-creator')
+    await insertUser('user-owner')
+    await insertPlatformAccount('user-owner', 'sub_owner')
+    await insertConnectedAccount('ca_1', 'user-owner')
+
+    const triggerId = await createComposioTrigger({
+      createdByUserId: 'user-creator',
+      connectedAccountId: 'ca_1',
+    })
+
+    expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+    expect(deleteAttributionKey).toBe('member:sub_owner')
+  })
+
+  it('keeps the ambient attribution when nothing resolves', async () => {
+    const triggerId = await createComposioTrigger({})
+
+    expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+    expect(mockDeleteComposioTrigger).toHaveBeenCalledWith('ti_composio_1')
+    // No request scope in this test, so ambient attribution is null.
+    expect(deleteAttributionKey).toBeNull()
+  })
+
+  it('skips member resolution entirely in opaque-access-key mode', async () => {
+    mockGetPlatformAccessToken.mockReturnValue('plat_sa_opaque_key')
+    await insertUser('user-creator')
+    await insertPlatformAccount('user-creator', 'sub_creator')
+
+    const triggerId = await createComposioTrigger({
+      createdByUserId: 'user-creator',
+      mintedByMemberId: 'sub_minted',
+    })
+
+    expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+    // requiresActingMember() is false, so no override — ambient (null here).
+    expect(deleteAttributionKey).toBeNull()
+  })
+
+  it('disables custom endpoints under the recorded minting member too', async () => {
+    const triggerId = await createWebhookTrigger({
+      agentSlug: 'agent-1',
+      kind: 'custom',
+      composioTriggerId: 'whep_1',
+      triggerType: 'CUSTOM_WEBHOOK',
+      prompt: 'Handle it',
+      mintedByMemberId: 'sub_minted',
+    })
+
+    expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+    expect(mockDisableEndpoint).toHaveBeenCalledWith('sub_minted', 'whep_1')
+    expect(deleteAttributionKey).toBe('member:sub_minted')
+  })
+
+  // The SUP-765 incident path: DELETE /api/agents/:id → cleanupAgentData.
+  it('tears down as the minting member when the agent is deleted', async () => {
+    await insertUser('user-creator')
+    await insertPlatformAccount('user-creator', 'sub_creator')
+    const triggerId = await createComposioTrigger({
+      agentSlug: 'doomed-agent',
+      createdByUserId: 'user-creator',
+      mintedByMemberId: 'sub_minted',
+    })
+
+    await cleanupAgentData('doomed-agent')
+
+    expect((await getWebhookTrigger(triggerId))!.status).toBe('cancelled')
+    expect(mockDeleteComposioTrigger).toHaveBeenCalledWith('ti_composio_1')
+    expect(deleteAttributionKey).toBe('member:sub_minted')
+  })
+
+  describe('resolveTeardownMembers', () => {
+    it('is known and single when the minting member was recorded', async () => {
+      await insertUser('user-creator')
+      await insertPlatformAccount('user-creator', 'sub_creator')
+      const triggerId = await createComposioTrigger({ createdByUserId: 'user-creator', mintedByMemberId: 'sub_minted' })
+
+      expect(resolveTeardownMembers((await getWebhookTrigger(triggerId))!)).toEqual({
+        memberIds: ['sub_minted'],
+        known: true,
+      })
+    })
+
+    it('is a guessed creator → owner → stored chain for pre-column rows', async () => {
+      await insertUser('user-creator')
+      await insertPlatformAccount('user-creator', 'sub_creator')
+      await insertUser('user-owner')
+      await insertPlatformAccount('user-owner', 'sub_owner')
+      await insertConnectedAccount('ca_1', 'user-owner')
+      mockGetStoredPlatformMemberId.mockReturnValue('sub_stored')
+      const triggerId = await createComposioTrigger({ createdByUserId: 'user-creator', connectedAccountId: 'ca_1' })
+
+      expect(resolveTeardownMembers((await getWebhookTrigger(triggerId))!)).toEqual({
+        memberIds: ['sub_creator', 'sub_owner', 'sub_stored'],
+        known: false,
+      })
+    })
+
+    it('is known with no members in opaque-access-key mode', async () => {
+      mockGetPlatformAccessToken.mockReturnValue('plat_sa_opaque_key')
+      const triggerId = await createComposioTrigger({ createdByUserId: 'user-creator' })
+
+      expect(resolveTeardownMembers((await getWebhookTrigger(triggerId))!)).toEqual({ memberIds: [], known: true })
+    })
+  })
+
+  // The proxy 404s a cross-member DELETE exactly like a missing subscription,
+  // so a 404 only means "gone" when the acting member is known.
+  describe('404 handling', () => {
+    it('is silent when the upstream is already gone under the recorded minting member', async () => {
+      mockDeleteComposioTrigger.mockRejectedValue(new ComposioTriggerError('Trigger not found', 404))
+      const triggerId = await createComposioTrigger({ mintedByMemberId: 'sub_minted' })
+
+      expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+
+      expect(mockDeleteComposioTrigger).toHaveBeenCalledTimes(1)
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('is silent on a 404 in opaque-access-key mode (the proxy ignores members)', async () => {
+      mockGetPlatformAccessToken.mockReturnValue('plat_sa_opaque_key')
+      mockDeleteComposioTrigger.mockRejectedValue(new ComposioTriggerError('Trigger not found', 404))
+      const triggerId = await createComposioTrigger({ createdByUserId: 'user-creator' })
+
+      expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('tries the next guessed member after a 404 and stops on the one that succeeds', async () => {
+      await insertUser('user-creator')
+      await insertPlatformAccount('user-creator', 'sub_creator')
+      await insertUser('user-owner')
+      await insertPlatformAccount('user-owner', 'sub_owner')
+      await insertConnectedAccount('ca_1', 'user-owner')
+      const keys: Array<string | null> = []
+      mockDeleteComposioTrigger.mockImplementation(async () => {
+        const key = attribution.current()?.getKey() ?? null
+        keys.push(key)
+        if (key !== 'member:sub_owner') throw new ComposioTriggerError('Trigger not found', 404)
+      })
+      const triggerId = await createComposioTrigger({ createdByUserId: 'user-creator', connectedAccountId: 'ca_1' })
+
+      expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+
+      expect(keys).toEqual(['member:sub_creator', 'member:sub_owner'])
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('reports an unresolved owner when every guessed member 404s', async () => {
+      await insertUser('user-creator')
+      await insertPlatformAccount('user-creator', 'sub_creator')
+      mockGetStoredPlatformMemberId.mockReturnValue('sub_stored')
+      mockDeleteComposioTrigger.mockRejectedValue(new ComposioTriggerError('Trigger not found', 404))
+      const triggerId = await createComposioTrigger({ createdByUserId: 'user-creator' })
+
+      expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+
+      expect(mockDeleteComposioTrigger).toHaveBeenCalledTimes(2)
+      expect(mockCaptureException).toHaveBeenCalledTimes(1)
+      expect(mockCaptureException.mock.calls[0][0]).toBeInstanceOf(UpstreamOwnerUnresolvedError)
+    })
+
+    it('stops at the first non-404 failure', async () => {
+      await insertUser('user-creator')
+      await insertPlatformAccount('user-creator', 'sub_creator')
+      mockGetStoredPlatformMemberId.mockReturnValue('sub_stored')
+      mockDeleteComposioTrigger.mockRejectedValue(new ComposioTriggerError('upstream 502', 502))
+      const triggerId = await createComposioTrigger({ createdByUserId: 'user-creator' })
+
+      expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+
+      expect(mockDeleteComposioTrigger).toHaveBeenCalledTimes(1)
+      expect(mockCaptureException).toHaveBeenCalledTimes(1)
+    })
+
+    it('recognises a 404 from any status-carrying error, not one class', async () => {
+      mockDisableEndpoint.mockRejectedValue(new WebhookEndpointsApiError('API error 404', 404))
+      const triggerId = await createWebhookTrigger({
+        agentSlug: 'agent-1',
+        kind: 'custom',
+        composioTriggerId: 'whep_1',
+        triggerType: 'CUSTOM_WEBHOOK',
+        prompt: 'Handle it',
+        mintedByMemberId: 'sub_minted',
+      })
+
+      expect(await cancelWebhookTriggerWithCleanup(triggerId)).toBe(true)
+
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/shared/lib/services/webhook-trigger-service.ts
+++ b/src/shared/lib/services/webhook-trigger-service.ts
@@ -18,6 +18,7 @@ import { captureException } from '@shared/lib/error-reporting'
 import { trackServerEvent } from '../analytics/server-analytics'
 import { deleteComposioTrigger } from '@shared/lib/composio/triggers'
 import { isPlatformComposioActive } from '@shared/lib/composio/client'
+import { attribution, runWithAttribution } from '@shared/lib/platform-attribution'
 import { disablePlatformWebhookEndpoint } from '@shared/lib/services/webhook-endpoints-client'
 import { getPlatformAccessToken, getStoredPlatformMemberId } from '@shared/lib/services/platform-auth-service'
 
@@ -62,6 +63,7 @@ export function resolvePlatformMemberForCandidates(
 export function getDistinctPlatformMemberIdsForActiveTriggers(): string[] {
   const rows = db
     .select({
+      mintedByMemberId: webhookTriggers.mintedByMemberId,
       createdByUserId: webhookTriggers.createdByUserId,
       ownerUserId: connectedAccounts.userId,
     })
@@ -72,9 +74,16 @@ export function getDistinctPlatformMemberIdsForActiveTriggers(): string[] {
 
   const ids = new Set<string>()
   for (const row of rows) {
-    // Prefer the creator, but fall back to the connected-account owner when the
-    // creator has no platform member — otherwise the trigger is silently dropped
-    // from the poll set even though the owner could claim its events (SUP-226).
+    // The recorded minting member is the one the proxy scopes the subscription
+    // (and its events) to, so it must lead the poll set (SUP-765).
+    if (row.mintedByMemberId) {
+      ids.add(row.mintedByMemberId)
+      continue
+    }
+    // Pre-column rows: prefer the creator, but fall back to the connected-account
+    // owner when the creator has no platform member — otherwise the trigger is
+    // silently dropped from the poll set even though the owner could claim its
+    // events (SUP-226).
     const resolved = resolvePlatformMemberForCandidates([row.createdByUserId, row.ownerUserId])
     if (resolved) {
       ids.add(resolved.memberId)
@@ -148,6 +157,8 @@ export interface CreateWebhookTriggerParams {
   name?: string
   createdBySessionId?: string
   createdByUserId?: string
+  /** Acting platform member the upstream subscription was minted under (SUP-765). */
+  mintedByMemberId?: string
   model?: string
   effort?: string
   speed?: string
@@ -174,6 +185,7 @@ export async function createWebhookTrigger(params: CreateWebhookTriggerParams): 
     fireCount: 0,
     createdBySessionId: params.createdBySessionId ?? null,
     createdByUserId: params.createdByUserId ?? null,
+    mintedByMemberId: params.mintedByMemberId ?? null,
     model: params.model ?? null,
     effort: params.effort ?? null,
     speed: params.speed ?? null,
@@ -451,24 +463,12 @@ export async function cancelWebhookTriggerWithCleanup(
   const cancelled = await cancelWebhookTrigger(triggerId)
   if (!cancelled) return false
 
-  // Custom endpoints live on the platform proxy regardless of which Composio
-  // key mode is active — gate their teardown on platform auth, not the
-  // Composio condition, or a user-supplied Composio key would silently leave
-  // the public URL live.
-  const canReachUpstream =
-    trigger.kind === 'custom' ? Boolean(getPlatformAccessToken()) : isPlatformComposioActive()
-  if (trigger.composioTriggerId && canReachUpstream) {
-    const remaining = await countActiveTriggersForComposioId(trigger.composioTriggerId)
+  if (trigger.composioTriggerId && canReachUpstream(trigger.kind)) {
+    const upstreamId = trigger.composioTriggerId
+    const remaining = await countActiveTriggersForComposioId(upstreamId)
     if (remaining === 0) {
       try {
-        if (trigger.kind === 'custom') {
-          await disablePlatformWebhookEndpoint(
-            resolveCleanupMemberId(trigger),
-            trigger.composioTriggerId,
-          )
-        } else {
-          await deleteComposioTrigger(trigger.composioTriggerId)
-        }
+        await tearDownUpstream(trigger, upstreamId)
       } catch (error) {
         console.error('[webhook-trigger-service] Failed to tear down upstream subscription:', error)
         // Silent to the user: the trigger row is already cancelled, but the
@@ -480,7 +480,7 @@ export async function cancelWebhookTriggerWithCleanup(
           extra: {
             triggerId,
             agentSlug: trigger.agentSlug,
-            upstreamId: trigger.composioTriggerId,
+            upstreamId,
             kind: trigger.kind,
           },
         })
@@ -491,14 +491,101 @@ export async function cancelWebhookTriggerWithCleanup(
   return true
 }
 
-/**
- * Member context for platform-endpoint teardown calls. Org JWTs need a real
- * member suffix; opaque platform keys ignore it, so the 'local' placeholder is
- * safe as the final fallback.
- */
-function resolveCleanupMemberId(trigger: WebhookTrigger): string {
-  const resolved = resolvePlatformMemberForCandidates([trigger.createdByUserId])
-  return resolved?.memberId ?? getStoredPlatformMemberId() ?? 'local'
+// Custom endpoints live on the platform proxy regardless of Composio key mode,
+// so gate on platform auth or a user-supplied Composio key leaves the URL live.
+function canReachUpstream(kind: WebhookTrigger['kind']): boolean {
+  return kind === 'custom' ? Boolean(getPlatformAccessToken()) : isPlatformComposioActive()
+}
+
+// One place that speaks both upstream vocabularies (platform endpoint disable
+// vs Composio subscription delete). Callers own attribution.
+async function deleteUpstream(
+  kind: WebhookTrigger['kind'],
+  memberId: string,
+  upstreamId: string,
+): Promise<void> {
+  if (kind === 'custom') await disablePlatformWebhookEndpoint(memberId, upstreamId)
+  else await deleteComposioTrigger(upstreamId)
+}
+
+// Duck-typed so a new upstream client can't silently regress to perpetual retries.
+function isUpstreamNotFound(error: unknown): boolean {
+  return error instanceof Error && (error as { statusCode?: unknown }).statusCode === 404
+}
+
+// The proxy 404s a cross-member DELETE exactly like a missing subscription, so
+// a 404 under a guessed member proves nothing. Thrown so the orphan is reported.
+export class UpstreamOwnerUnresolvedError extends Error {
+  constructor(
+    public readonly upstreamId: string,
+    public readonly triedMemberIds: string[],
+  ) {
+    super(
+      `Upstream ${upstreamId} not found under any candidate member (${triedMemberIds.join(', ') || 'none'}); owner unknown`,
+    )
+    this.name = 'UpstreamOwnerUnresolvedError'
+  }
+}
+
+export interface TeardownMembers {
+  /** Members that may own the upstream, best guess first. Empty = ambient. */
+  memberIds: string[]
+  /** True when the first entry is the recorded minting member, or the proxy ignores members. */
+  known: boolean
+}
+
+// Minting member when recorded (the only guaranteed principal); pre-column rows
+// guess via the SUP-226 chain (creator, owner) then the stored member.
+export function resolveTeardownMembers(trigger: WebhookTrigger): TeardownMembers {
+  if (!attribution.requiresActingMember()) return { memberIds: [], known: true }
+  if (trigger.mintedByMemberId) return { memberIds: [trigger.mintedByMemberId], known: true }
+  const candidates = [
+    resolvePlatformMemberForCandidates([trigger.createdByUserId])?.memberId,
+    resolvePlatformMemberForCandidates([getConnectedAccountOwnerUserId(trigger.connectedAccountId)])?.memberId,
+    getStoredPlatformMemberId(),
+  ]
+  return { memberIds: [...new Set(candidates.filter((m): m is string => Boolean(m)))], known: false }
+}
+
+// Delete as the minting member via ALS (the interceptor overrides explicit auth).
+// 404 = gone only for a known member; guessed members are tried in turn, all-404 throws.
+async function tearDownUpstream(trigger: WebhookTrigger, upstreamId: string): Promise<void> {
+  const { memberIds, known } = resolveTeardownMembers(trigger)
+  const attempts: Array<string | null> = memberIds.length > 0 ? memberIds : [null]
+  for (const memberId of attempts) {
+    try {
+      await runWithAttribution(memberId ? attribution.fromMemberId(memberId) : null, () =>
+        deleteUpstream(trigger.kind, memberId ?? getStoredPlatformMemberId() ?? 'local', upstreamId),
+      )
+      return
+    } catch (error) {
+      if (!isUpstreamNotFound(error)) throw error
+    }
+  }
+  if (known) return
+  throw new UpstreamOwnerUnresolvedError(upstreamId, memberIds)
+}
+
+// SUP-226 candidate order (creator, then connected-account owner), shared by
+// polling and session attribution so the two chains cannot drift.
+export function resolveTriggerPrincipal(
+  trigger: Pick<WebhookTrigger, 'createdByUserId' | 'connectedAccountId'>,
+): { userId: string; memberId: string } | null {
+  return resolvePlatformMemberForCandidates([
+    trigger.createdByUserId,
+    getConnectedAccountOwnerUserId(trigger.connectedAccountId),
+  ])
+}
+
+export function getConnectedAccountOwnerUserId(connectedAccountId: string | null): string | null {
+  if (!connectedAccountId) return null
+  const rows = db
+    .select({ userId: connectedAccounts.userId })
+    .from(connectedAccounts)
+    .where(eq(connectedAccounts.id, connectedAccountId))
+    .limit(1)
+    .all()
+  return rows[0]?.userId ?? null
 }
 
 /**

--- a/src/shared/lib/services/webhook-trigger-service.ts
+++ b/src/shared/lib/services/webhook-trigger-service.ts
@@ -14,7 +14,7 @@ import {
   type NewWebhookTrigger,
 } from '@shared/lib/db/schema'
 import { eq, and, inArray, isNotNull, sql, count, desc } from 'drizzle-orm'
-import { captureException } from '@shared/lib/error-reporting'
+import { captureException, captureMessage } from '@shared/lib/error-reporting'
 import { trackServerEvent } from '../analytics/server-analytics'
 import { deleteComposioTrigger } from '@shared/lib/composio/triggers'
 import { isPlatformComposioActive } from '@shared/lib/composio/client'
@@ -75,15 +75,14 @@ export function getDistinctPlatformMemberIdsForActiveTriggers(): string[] {
   const ids = new Set<string>()
   for (const row of rows) {
     // The recorded minting member is the one the proxy scopes the subscription
-    // (and its events) to, so it must lead the poll set (SUP-765).
-    if (row.mintedByMemberId) {
-      ids.add(row.mintedByMemberId)
-      continue
-    }
-    // Pre-column rows: prefer the creator, but fall back to the connected-account
-    // owner when the creator has no platform member — otherwise the trigger is
-    // silently dropped from the poll set even though the owner could claim its
-    // events (SUP-226).
+    // (and its events) to, so it leads the poll set (SUP-765). It does not
+    // replace the fallbacks below: if that member has since left the org their
+    // poll throws and the loop only logs it, so without the other candidates the
+    // trigger would silently stop firing forever. Duplicates collapse in the Set.
+    if (row.mintedByMemberId) ids.add(row.mintedByMemberId)
+    // Prefer the creator, but fall back to the connected-account owner when the
+    // creator has no platform member — otherwise the trigger is silently dropped
+    // from the poll set even though the owner could claim its events (SUP-226).
     const resolved = resolvePlatformMemberForCandidates([row.createdByUserId, row.ownerUserId])
     if (resolved) {
       ids.add(resolved.memberId)
@@ -562,7 +561,24 @@ async function tearDownUpstream(trigger: WebhookTrigger, upstreamId: string): Pr
       if (!isUpstreamNotFound(error)) throw error
     }
   }
-  if (known) return
+  if (known) {
+    // Normally "already gone" — but a recorded minter who has since left the org
+    // 404s identically while the subscription stays live, which is the SUP-765
+    // failure mode itself. Report it so that orphan is at least diagnosable.
+    // Ambient teardown (no members) is exempt: there the proxy ignores members,
+    // so a 404 really does mean gone.
+    if (memberIds.length > 0) {
+      console.warn(
+        `[WebhookTriggerService] Upstream ${upstreamId} 404'd under its recorded minting member ${memberIds[0]} — already deleted, or that member left the org and the subscription is orphaned`,
+      )
+      captureMessage('Upstream teardown 404 under the recorded minting member', {
+        level: 'info',
+        tags: { area: 'webhook-triggers', op: 'teardown-known-404', kind: trigger.kind },
+        extra: { triggerId: trigger.id, agentSlug: trigger.agentSlug, upstreamId, memberId: memberIds[0] },
+      })
+    }
+    return
+  }
   throw new UpstreamOwnerUnresolvedError(upstreamId, memberIds)
 }
 

--- a/src/shared/lib/webhook-triggers/public.test.ts
+++ b/src/shared/lib/webhook-triggers/public.test.ts
@@ -21,6 +21,7 @@ const trigger: WebhookTrigger = {
   lastSessionId: null,
   createdBySessionId: null,
   createdByUserId: 'owner-private-id',
+  mintedByMemberId: 'sub_member-private-id',
   model: null,
   effort: null,
   speed: null,
@@ -40,6 +41,7 @@ describe('toPublicWebhookTrigger', () => {
       expect(result).not.toHaveProperty('composioTriggerId')
       expect(result).not.toHaveProperty('connectedAccountId')
       expect(result).not.toHaveProperty('createdByUserId')
+      expect(result).not.toHaveProperty('mintedByMemberId')
       expect(result).toMatchObject({ id: 'trigger-1', name: 'Inbound events' })
       expect(serialized).not.toContain('private-capability')
       expect(serialized).not.toContain('private-id')

--- a/src/shared/lib/webhook-triggers/public.ts
+++ b/src/shared/lib/webhook-triggers/public.ts
@@ -3,7 +3,7 @@ import type { AgentRole } from '@shared/lib/types/agent'
 
 type OwnerOnlyWebhookTriggerFields = Pick<
   WebhookTrigger,
-  'triggerConfig' | 'composioTriggerId' | 'connectedAccountId' | 'createdByUserId'
+  'triggerConfig' | 'composioTriggerId' | 'connectedAccountId' | 'createdByUserId' | 'mintedByMemberId'
 >
 
 /**
@@ -29,6 +29,7 @@ export function toPublicWebhookTrigger(
     composioTriggerId: _composioTriggerId,
     connectedAccountId: _connectedAccountId,
     createdByUserId: _createdByUserId,
+    mintedByMemberId: _mintedByMemberId,
     ...publicFields
   } = trigger
 


### PR DESCRIPTION
Split out of #940 as the first, self-contained slice. Follow-ups (poll-loop reconcile + `upstream_deleted_at`, agent-gone path, one-time cleanup script) come as separate PRs.

## Bug

When an agent is deleted by a user who didn't mint its Composio triggers, the upstream subscription teardown silently fails and the trigger is orphaned: Composio keeps sending webhook events forever, and since the local trigger row is cancelled they can never be claimed. They pile up as `pending` and hammer the host with realtime pings on every arrival.

Root cause: teardown ran `deleteComposioTrigger` under the **deleting user's** ambient attribution. The platform proxy's `DELETE /v1/composio/triggers/{id}` scopes ownership to the subscription's Composio `user_id`, i.e. the **minting** member, so a cross-member delete gets 404 "Trigger not found", which the catch block swallowed (Sentry only; UI reported success).

## Repro / evidence (datawizz, Sep 2)

- 4 calendar triggers minted by one member, agent deleted by another member on Aug 18 → Sentry [ELECTRON-AT](https://datawizz.sentry.io/issues/ELECTRON-AT) `ComposioTriggerError: Trigger not found`, culprit `DELETE /api/agents/jp76x5tltm`, timestamp matches all 4 `cancelled_at` rows.
- ~3,400 unclaimable `pending` webhook_events accumulated since; a recurring-meeting deletion fanned out into ~1,500 events at once and amplified a restart into ~10 min of CPU saturation.
- Verified against the staging proxy (from #940): cross-member DELETE → 404 (subscription untouched), minting member → 200.
- Linear: [SUP-765](https://linear.app/datawizz/issue/SUP-765/composio-trigger-teardown-fails-cross-member-upstream-subscription)

## Change

- **Capture the minting principal at mint time.** New `minted_by_member_id` column (migration 0039). Both mint sites in `message-persister.ts` record `attribution.current()?.actingMemberId()`. The custom-endpoint site keeps the explicit `token::memberId` principal when no ALS attribution is active (container stream dispatch), and never persists the opaque-key `'local'` placeholder. `createdByUserId` is the session creator, not necessarily the minter (session created by A, re-subscribed by B, agent calls `setup_trigger`), so it can't be used for this.
- **Tear down as that member.** `cancelWebhookTriggerWithCleanup` runs the upstream delete inside `runWithAttribution(attribution.fromMemberId(minted))`. Pre-column rows fall back to creator → connected-account owner → stored member. Because the proxy 404s a cross-member DELETE exactly like a missing subscription, a 404 is only treated as "gone" when the member is known (recorded, or opaque-key mode). For guessed members each candidate is tried in turn; all-404 raises `UpstreamOwnerUnresolvedError` into Sentry instead of silently succeeding.
- **Agent deletion uses the shared path.** `cleanupWebhookTriggers` (the actual incident path, `DELETE /api/agents/:id`) now delegates to `cancelWebhookTriggerWithCleanup` per trigger instead of its own copy of the last-one-out + teardown logic.
- **Poll set leads with `minted_by_member_id`.** A subscription minted under a non-creator member was correctly torn down but never polled; now the recorded member is the first candidate in `getDistinctPlatformMemberIdsForActiveTriggers`.
- **One principal resolver.** `resolveTriggerPrincipal` / `getConnectedAccountOwnerUserId` exported from the service; the byte-identical copy in `trigger-manager.ts` is removed.
- `WebhookEndpointsApiError` carries `statusCode` so a custom-kind 404 is recognisable by the same duck-typed check as Composio.
- `mintedByMemberId` is stripped from the public trigger shape for non-owner roles.

## Not in this PR (follow-ups)

- Poll-loop reconcile of owed teardowns (`upstream_deleted_at`, attempt counter, migration 0040 + backfill).
- Agent-gone path: `getAgentPresence` + cancel-with-cleanup instead of `markTriggerFailed`; `listAllWebhookTriggersByComposioId`.
- One-time cleanup script for legacy orphans.

## Known open point (carried over from #940, not resolved here)

The Composio mint site records `attribution.current()?.actingMemberId()` only. If a container-dispatched Composio mint ever runs with no ambient attribution, `minted_by_member_id` is stored as `null` and teardown falls back to the guessed creator → owner → stored chain. The #940 position is that such a mint cannot produce a row: with no ALS the request goes out as a bare org JWT and the proxy rejects it (400 on staging). That claim is not independently re-verified in this PR. If we want to close it here, the custom-endpoint pattern (`actingMemberId() ?? (memberId === 'local' ? undefined : memberId)`) applies, but the Composio site has no `memberId` in scope today and would need a `resolvePlatformMemberForSession` call first.

## Test plan

- [x] New `webhook-trigger-service.sup765.test.ts` against the **real** attribution resolver (org-shaped JWT, seeded `user` / `authAccount` / `connectedAccounts` rows, `PRAGMA foreign_keys = ON`): delete under recorded minter; creator fallback; owner fallback; ambient when nothing resolves; opaque-key skips resolution; custom-endpoint disable under minter; agent deletion (`cleanupAgentData`) tears down as minter; `resolveTeardownMembers` shapes; 404 semantics (known-member 404 silent, guessed chain tries next, all-404 → `UpstreamOwnerUnresolvedError`, non-404 stops, duck-typed 404 across error classes).
- [x] `sup226` suite: new "polls as the recorded minting member" case; suite made hermetic against the machine's stored platform member.
- [x] Trigger + route + public-shape suites: 613/613 green.
- [x] `tsc --noEmit` clean; `eslint` clean on touched files (only the pre-existing `_`-destructure warnings in `public.ts`).

Made with [Cursor](https://cursor.com)

