### PR TITLE
Hide the CLI's synthetic "No response requested." placeholder

### DIFF
--- a/e2e/specs/stop-session.spec.ts
+++ b/e2e/specs/stop-session.spec.ts
@@ -104,6 +104,9 @@ test.describe('Stop button interrupts the working agent', () => {
     await sessionPage.waitForUserMessageCount(5)
     await sessionPage.expectUserMessage('please work slowly for the stop test', 1)
     await sessionPage.expectInterruptMarker(2)
+    // The CLI's synthetic "No response requested." stand-in after the abort
+    // is transcript noise and never renders.
+    await expect(page.getByText('No response requested.')).toHaveCount(0)
   })
 
   test('stopping with a queued message rescues its text into the composer for resend', async ({ page }) => {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -534,6 +534,51 @@ describe('MessagePersister', () => {
       await expect(call?.[2]?.responseTranscriptEndOffset).resolves.toBe(12_345)
     })
 
+    it('ignores the synthetic "No response requested." placeholder as a response candidate', async () => {
+      mockStat.mockResolvedValueOnce({ size: 12_345 })
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'capabilities',
+        session_state_events: true,
+      })
+      mockClient._sendMessage({
+        type: 'assistant',
+        uuid: 'real-entry',
+        message: {
+          id: 'msg-real',
+          content: [{ type: 'text', text: 'Real answer.' }],
+        },
+      })
+      // The CLI's stand-in after an interrupt: a newer assistant message id,
+      // but nothing the model said. It must not replace the real answer.
+      mockClient._sendMessage({
+        type: 'assistant',
+        uuid: 'synthetic-entry',
+        isApiErrorMessage: false,
+        message: {
+          id: 'msg-synthetic',
+          model: '<synthetic>',
+          content: [{ type: 'text', text: 'No response requested.' }],
+        },
+      })
+      mockClient._sendMessage({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      })
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'session_state_changed',
+        state: 'idle',
+      })
+
+      const call = vi.mocked(notificationManager.triggerSessionComplete).mock.calls.at(-1)
+      expect(call?.[2]?.responseText).toBe('Real answer.')
+    })
+
     it('dispatches completion without waiting for the transcript stat', async () => {
       let resolveStat: ((value: { size: number }) => void) | undefined
       mockStat.mockImplementationOnce(

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -86,6 +86,7 @@ import { resolveAppFromWindowRef } from '@shared/lib/computer-use/executor'
 import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp, type ComputerUsePermissionLevel } from '@shared/lib/computer-use/types'
 import { getAgentSessionsDir, getSessionJsonlPath } from '@shared/lib/utils/file-storage'
 import { makeThinkingBlockId } from '@shared/lib/utils/thinking-block-id'
+import { isSyntheticPlaceholderMessage } from '@shared/lib/utils/synthetic-message'
 import { WorkflowJournalTailer } from './workflow-journal-tailer'
 import { SubagentCapture } from './subagent-capture'
 import * as fs from 'fs'
@@ -1849,6 +1850,10 @@ class MessagePersister {
 
     switch (content.type) {
       case 'assistant': {
+        // The CLI's "No response requested." stand-in for a turn with no model
+        // output. The transform hides it, so it must not become the
+        // notification body or trigger a refetch either.
+        if (isSyntheticPlaceholderMessage(content)) break
         if (state.resetAssistantBeforeNextTurnOutput) {
           this.resetSessionCompleteResponse(state)
           state.resetAssistantBeforeNextTurnOutput = false

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -3097,6 +3097,18 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
         message: { content: '[Request interrupted by user]' },
         timestamp: new Date().toISOString(),
       })
+      // ...followed by the CLI's synthetic "No response requested." assistant
+      // stand-in (model "<synthetic>"). The app hides it; mirroring it here
+      // keeps E2E honest about the post-interrupt transcript shape.
+      this.writeJsonlEntry(sessionId, {
+        type: 'assistant',
+        message: {
+          model: '<synthetic>',
+          content: [{ type: 'text', text: 'No response requested.' }],
+        },
+        isApiErrorMessage: false,
+        timestamp: new Date().toISOString(),
+      })
     }
 
     // Queued steering messages die with the turn — the real CLI never picks

--- a/src/shared/lib/services/session-service.ts
+++ b/src/shared/lib/services/session-service.ts
@@ -37,6 +37,7 @@ import {
   isTaskNotificationMessage,
   type TransformedItem,
 } from '@shared/lib/utils/message-transform'
+import { isSyntheticPlaceholderMessage } from '@shared/lib/utils/synthetic-message'
 import { findDeltaWindowStart } from '@shared/lib/messages-delta'
 import {
   sortSessionsByActivity,
@@ -1147,6 +1148,7 @@ interface DisplayCountState {
 function countsAsDisplayStart(entry: JsonlEntry, state: DisplayCountState): boolean {
   if (!isMessageOrSystemDisplayEntry(entry)) return false
   if ('isMeta' in entry && entry.isMeta) return false
+  if (isSyntheticPlaceholderMessage(entry)) return false
 
   if (entry.type === 'system') {
     const sys = entry as JsonlSystemEntry
@@ -1236,6 +1238,7 @@ function classifyExtensionRow(
   if (normalized === undefined) return 'filtered'
   if (!isMessageOrSystemDisplayEntry(normalized)) return 'filtered'
   if ('isMeta' in normalized && normalized.isMeta) return 'filtered'
+  if (isSyntheticPlaceholderMessage(normalized)) return 'filtered'
   if (normalized.type === 'system') {
     const sys = normalized as JsonlSystemEntry
     // Mirror countsAsDisplayStart's synthetic-copy tracking so the copy of an

--- a/src/shared/lib/types/agent.ts
+++ b/src/shared/lib/types/agent.ts
@@ -177,6 +177,9 @@ export interface JsonlMessageEntry {
       cache_read_input_tokens?: number
     }
   }
+  // Set by the CLI on synthetic assistant entries that carry an API error
+  // text ("API Error: 529 Overloaded ..."). See utils/synthetic-message.ts.
+  isApiErrorMessage?: boolean
   // Tool result specific fields (present when type is 'user' with tool_result content)
   toolUseResult?: {
     stdout: string

--- a/src/shared/lib/utils/message-transform.test.ts
+++ b/src/shared/lib/utils/message-transform.test.ts
@@ -690,6 +690,32 @@ describe('transformMessages', () => {
   // ============================================================================
 
   describe('edge cases', () => {
+    it('drops the synthetic "No response requested." placeholder but keeps synthetic API errors', () => {
+      const placeholder = createAssistantMessage('a-synth', 'msg-synth', [
+        { type: 'text', text: 'No response requested.' },
+      ])
+      placeholder.message.model = '<synthetic>'
+      placeholder.isApiErrorMessage = false
+      const apiError = createAssistantMessage('a-err', 'msg-err', [
+        { type: 'text', text: 'API Error: 529 Overloaded.' },
+      ])
+      apiError.message.model = '<synthetic>'
+      apiError.isApiErrorMessage = true
+
+      const result = transformMessages([
+        createUserMessage('u1', 'hello'),
+        createUserMessage('u2', '[Request interrupted by user]'),
+        placeholder,
+        apiError,
+      ])
+
+      expect(result.map((item) => asMessage(item).content.text)).toEqual([
+        'hello',
+        '[Request interrupted by user]',
+        'API Error: 529 Overloaded.',
+      ])
+    })
+
     it('handles empty entries array', () => {
       const result = transformMessages([])
       expect(result).toEqual([])

--- a/src/shared/lib/utils/message-transform.ts
+++ b/src/shared/lib/utils/message-transform.ts
@@ -8,6 +8,7 @@
 import { ContentBlock, JsonlMessageEntry, JsonlSystemEntry } from '@shared/lib/types/agent'
 import type { ProviderErrorPresentation } from '@shared/lib/llm-provider/error-presentation'
 import { makeThinkingBlockId } from '@shared/lib/utils/thinking-block-id'
+import { isSyntheticPlaceholderMessage } from '@shared/lib/utils/synthetic-message'
 
 export interface TransformedThinkingBlock {
   /** Stable live↔persisted identity when the SDK message id is available. */
@@ -271,6 +272,9 @@ export function transformMessages(entries: (JsonlMessageEntry | JsonlSystemEntry
     if (skipIndices.has(i)) continue
     const entry = entries[i]
     if (entry.type === 'user' || entry.type === 'assistant') {
+      // "No response requested." and friends: the CLI's stand-in for a turn
+      // that produced no model output. Nothing to show.
+      if (isSyntheticPlaceholderMessage(entry)) continue
       const uuid = (entry as JsonlMessageEntry).uuid
       if (uuid) {
         if (seenUuids.has(uuid)) continue

--- a/src/shared/lib/utils/synthetic-message.test.ts
+++ b/src/shared/lib/utils/synthetic-message.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { isSyntheticPlaceholderMessage } from './synthetic-message'
+
+describe('isSyntheticPlaceholderMessage', () => {
+  it('matches a synthetic assistant placeholder', () => {
+    expect(isSyntheticPlaceholderMessage({
+      type: 'assistant',
+      message: { model: '<synthetic>' },
+      isApiErrorMessage: false,
+    })).toBe(true)
+    expect(isSyntheticPlaceholderMessage({
+      type: 'assistant',
+      message: { model: '<synthetic>' },
+    })).toBe(true)
+  })
+
+  it('keeps synthetic API errors', () => {
+    expect(isSyntheticPlaceholderMessage({
+      type: 'assistant',
+      message: { model: '<synthetic>' },
+      isApiErrorMessage: true,
+    })).toBe(false)
+  })
+
+  it('ignores real model output and non-assistant entries', () => {
+    expect(isSyntheticPlaceholderMessage({ type: 'assistant', message: { model: 'claude-opus-5' } })).toBe(false)
+    expect(isSyntheticPlaceholderMessage({ type: 'assistant', message: {} })).toBe(false)
+    expect(isSyntheticPlaceholderMessage({ type: 'assistant', message: null })).toBe(false)
+    expect(isSyntheticPlaceholderMessage({ type: 'assistant' })).toBe(false)
+    expect(isSyntheticPlaceholderMessage({ type: 'user', message: { model: '<synthetic>' } })).toBe(false)
+  })
+})

--- a/src/shared/lib/utils/synthetic-message.test.ts
+++ b/src/shared/lib/utils/synthetic-message.test.ts
@@ -14,11 +14,16 @@ describe('isSyntheticPlaceholderMessage', () => {
     })).toBe(true)
   })
 
-  it('keeps synthetic API errors', () => {
+  it('keeps synthetic API errors, flagged on the JSONL entry or coded on the live frame', () => {
     expect(isSyntheticPlaceholderMessage({
       type: 'assistant',
       message: { model: '<synthetic>' },
       isApiErrorMessage: true,
+    })).toBe(false)
+    expect(isSyntheticPlaceholderMessage({
+      type: 'assistant',
+      message: { model: '<synthetic>' },
+      error: 'model_not_found',
     })).toBe(false)
   })
 

--- a/src/shared/lib/utils/synthetic-message.ts
+++ b/src/shared/lib/utils/synthetic-message.ts
@@ -6,10 +6,12 @@
  * - Placeholders such as "No response requested." — pure transcript noise,
  *   nothing the model said, nothing the person needs to see.
  * - API errors ("API Error: 529 Overloaded ...") — also synthetic, but
- *   flagged `isApiErrorMessage: true` and rendered as an error card.
+ *   rendered as an error card. The persisted JSONL entry flags them with
+ *   `isApiErrorMessage: true`; the live SDK frame carries the code in
+ *   `error` instead (e.g. "model_not_found"). Either marks an error.
  *
- * Only the first kind is hidden. Match on the model tag and the flag, never
- * on the placeholder text.
+ * Only the first kind is hidden. Match on the model tag and the error
+ * markers, never on the placeholder text.
  */
 export const SYNTHETIC_MODEL = '<synthetic>'
 
@@ -17,6 +19,7 @@ export interface SyntheticCandidate {
   type?: unknown
   message?: { model?: unknown } | null
   isApiErrorMessage?: unknown
+  error?: unknown
 }
 
 /** True for a CLI-authored assistant placeholder that stands in for a missing response. */
@@ -24,6 +27,7 @@ export function isSyntheticPlaceholderMessage(entry: SyntheticCandidate): boolea
   return (
     entry.type === 'assistant' &&
     entry.message?.model === SYNTHETIC_MODEL &&
-    entry.isApiErrorMessage !== true
+    entry.isApiErrorMessage !== true &&
+    !entry.error
   )
 }

--- a/src/shared/lib/utils/synthetic-message.ts
+++ b/src/shared/lib/utils/synthetic-message.ts
@@ -1,0 +1,29 @@
+/**
+ * The CLI writes assistant entries of its own when a turn ends without a
+ * model response, for example right after an interrupt. They carry
+ * `message.model: "<synthetic>"`. Two kinds exist:
+ *
+ * - Placeholders such as "No response requested." — pure transcript noise,
+ *   nothing the model said, nothing the person needs to see.
+ * - API errors ("API Error: 529 Overloaded ...") — also synthetic, but
+ *   flagged `isApiErrorMessage: true` and rendered as an error card.
+ *
+ * Only the first kind is hidden. Match on the model tag and the flag, never
+ * on the placeholder text.
+ */
+export const SYNTHETIC_MODEL = '<synthetic>'
+
+export interface SyntheticCandidate {
+  type?: unknown
+  message?: { model?: unknown } | null
+  isApiErrorMessage?: unknown
+}
+
+/** True for a CLI-authored assistant placeholder that stands in for a missing response. */
+export function isSyntheticPlaceholderMessage(entry: SyntheticCandidate): boolean {
+  return (
+    entry.type === 'assistant' &&
+    entry.message?.model === SYNTHETIC_MODEL &&
+    entry.isApiErrorMessage !== true
+  )
+}


### PR DESCRIPTION
When a turn ends with no model output, most often right after the user presses stop, the CLI writes a stand-in assistant entry tagged `model: "<synthetic>"` with the text "No response requested." It rendered as a real assistant bubble under every stopped turn. In the datawizz transcript sample it appears 330 times.

**The discriminator.** Synthetic entries come in two kinds. The placeholder is `model: "<synthetic>"` with `isApiErrorMessage: false`. API errors ("API Error: 529 Overloaded ...") are also synthetic but carry `isApiErrorMessage: true` and must keep their error card. The new `isSyntheticPlaceholderMessage` in `src/shared/lib/utils/synthetic-message.ts` matches on the tag and the flag, never on the text.

**Where it is applied**, one line each:
- `transformMessages` drops the entry before uuid dedup and assistant merging.
- `message-persister.ts` skips it as a completion-notification candidate, so a stopped turn's notification body stays the last real answer instead of "No response requested."
- `session-service.ts` treats it as a non-display row in both paging predicates, so it never counts toward a page window.
- `JsonlMessageEntry` gains the optional `isApiErrorMessage` field the CLI already writes.

**Mock.** The E2E mock now writes the same synthetic entry after its interrupt marker, so the stop-session specs exercise the filter end to end. One explicit assertion confirms the text never renders.

Tests: unit coverage for the predicate, the transform, and the persister candidate. Stop-session and thinking-display E2E specs pass against the mock.

Not in scope: hiding the interrupt marker that the MCP-add restart produces. That is the follow-up, and the right fix there is the SDK's `setMcpServers`, which avoids the restart entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpyNpJVwWwEWpW8xkjcawc
