### PR TITLE
Hot-add remote MCP servers to the live query instead of restarting it

### DIFF
--- a/agent-container/src/claude-code-connections.test.ts
+++ b/agent-container/src/claude-code-connections.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type MockQueryCall = { options: Record<string, unknown> }
 type MockMcpStatus = { name: string; status: string }
+type MockSetServersResult = { added: string[]; removed: string[]; errors: Record<string, string> }
 const calls: MockQueryCall[] = []
 
 // Per-test override for the mcpServerStatus() control request. Left null, every
@@ -9,6 +10,17 @@ const calls: MockQueryCall[] = []
 // tests that are not about the handshake gate never wait on it.
 let mcpServerStatusImpl: (() => Promise<MockMcpStatus[]>) | null = null
 let mcpServerStatusCalls = 0
+
+// Per-test override for the setMcpServers() control request. Left null, the
+// call succeeds and reports every named server as added. The SDK 0.3.257
+// behaviour this mirrors: the map is a full replace, already-registered SDK
+// servers are left alone, and the result names added/removed/errored servers.
+let setMcpServersImpl: ((servers: Record<string, unknown>) => Promise<MockSetServersResult>) | null = null
+const setMcpServersCalls: Array<Record<string, unknown>> = []
+
+const UNSUPPORTED = async () => {
+  throw new Error('control request not supported')
+}
 
 function allConnected(): MockMcpStatus[] {
   const servers = (calls[calls.length - 1]?.options.mcpServers ?? {}) as Record<string, unknown>
@@ -31,6 +43,7 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
       interrupt: () => Promise<void>
       setModel: () => Promise<void>
       mcpServerStatus: () => Promise<MockMcpStatus[]>
+      setMcpServers: (servers: Record<string, unknown>) => Promise<MockSetServersResult>
     } = {
       [Symbol.asyncIterator]() {
         return this
@@ -60,6 +73,13 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
         mcpServerStatusCalls++
         return (mcpServerStatusImpl ?? (async () => allConnected()))()
       },
+      setMcpServers(servers) {
+        setMcpServersCalls.push(servers)
+        return (
+          setMcpServersImpl ??
+          (async (s: Record<string, unknown>) => ({ added: Object.keys(s), removed: [], errors: {} }))
+        )(servers)
+      },
     }
     return iterator
   }
@@ -73,12 +93,12 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
 })
 
 vi.mock('./mcp-server', () => ({
-  createUserInputMcpServer: () => ({}),
-  createBrowserMcpServer: () => ({}),
-  createComputerUseMcpServer: () => ({}),
-  createDashboardsMcpServer: () => ({}),
-  createAgentsMcpServer: () => ({}),
-  createChatMcpServer: () => ({}),
+  createUserInputMcpServer: () => ({ type: 'sdk', name: 'user-input' }),
+  createBrowserMcpServer: () => ({ type: 'sdk', name: 'browser' }),
+  createComputerUseMcpServer: () => ({ type: 'sdk', name: 'computer-use' }),
+  createDashboardsMcpServer: () => ({ type: 'sdk', name: 'dashboards' }),
+  createAgentsMcpServer: () => ({ type: 'sdk', name: 'agents' }),
+  createChatMcpServer: () => ({ type: 'sdk', name: 'chat' }),
 }))
 
 vi.mock('./tools/browser', () => ({
@@ -101,13 +121,38 @@ vi.mock('./input-manager', () => ({
 
 import { ClaudeCodeProcess } from './claude-code'
 
-describe('ClaudeCodeProcess runtime connection handling', () => {
+const CALENDAR = JSON.stringify([
+  {
+    id: 'mcp-calendar',
+    name: 'Team Calendar',
+    proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
+    tools: [{ name: 'list_events' }],
+  },
+])
+
+const AUTH_REQUIRED_CALENDAR = JSON.stringify([
+  {
+    id: 'mcp-calendar',
+    name: 'Team Calendar',
+    status: 'auth_required',
+    proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
+    tools: [{ name: 'list_events' }],
+  },
+])
+
+// The in-process servers every query carries. A dynamic set that omits any of
+// them would make the SDK disconnect it — the user-input server in particular
+// is the one the request_remote_mcp tool itself runs inside.
+const SDK_SERVER_NAMES = ['user-input', 'browser', 'dashboards', 'agents', 'chat']
+
+function useRuntimeEnv() {
   let originalRemoteMcps: string | undefined
   let originalConnectedAccounts: string | undefined
-  let claudeProcess: ClaudeCodeProcess | undefined
 
   beforeEach(() => {
     calls.length = 0
+    setMcpServersCalls.length = 0
+    setMcpServersImpl = null
     mcpServerStatusImpl = null
     mcpServerStatusCalls = 0
     originalRemoteMcps = process.env.REMOTE_MCPS
@@ -116,118 +161,223 @@ describe('ClaudeCodeProcess runtime connection handling', () => {
     delete process.env.CONNECTED_ACCOUNTS
   })
 
+  afterEach(() => {
+    if (originalRemoteMcps === undefined) delete process.env.REMOTE_MCPS
+    else process.env.REMOTE_MCPS = originalRemoteMcps
+    if (originalConnectedAccounts === undefined) delete process.env.CONNECTED_ACCOUNTS
+    else process.env.CONNECTED_ACCOUNTS = originalConnectedAccounts
+  })
+}
+
+describe('ClaudeCodeProcess runtime connection handling', () => {
+  let claudeProcess: ClaudeCodeProcess | undefined
+  useRuntimeEnv()
+
+  async function startProcess(sessionId: string): Promise<ClaudeCodeProcess> {
+    claudeProcess = new ClaudeCodeProcess({ sessionId, workingDirectory: '/tmp' })
+    await claudeProcess.start()
+    return claudeProcess
+  }
+
   afterEach(async () => {
     await claudeProcess?.stop()
-    if (originalRemoteMcps === undefined) {
-      delete process.env.REMOTE_MCPS
-    } else {
-      process.env.REMOTE_MCPS = originalRemoteMcps
-    }
-    if (originalConnectedAccounts === undefined) {
-      delete process.env.CONNECTED_ACCOUNTS
-    } else {
-      process.env.CONNECTED_ACCOUNTS = originalConnectedAccounts
-    }
+    claudeProcess = undefined
   })
 
-  it('rebuilds a live query when Agent Settings changes MCPs or connected accounts', async () => {
-    claudeProcess = new ClaudeCodeProcess({
-      sessionId: 'test-runtime-connection-refresh',
-      workingDirectory: '/tmp',
-    })
-
-    await claudeProcess.start()
+  it('applies a remote MCP change to the live query in place, without a re-query', async () => {
+    const claude = await startProcess('test-runtime-mcp-hot-apply')
     expect(calls).toHaveLength(1)
     expect(calls[0].options.mcpServers).not.toHaveProperty('team_calendar')
 
-    process.env.REMOTE_MCPS = JSON.stringify([
-      {
-        id: 'mcp-calendar',
-        name: 'Team Calendar',
-        proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
-        tools: [{ name: 'list_events' }],
-      },
-    ])
+    process.env.REMOTE_MCPS = CALENDAR
+    await claude.sendMessage('List today’s events')
 
-    await claudeProcess.sendMessage('List today’s events')
-
-    expect(calls).toHaveLength(2)
-    expect(calls[1].options.mcpServers).toMatchObject({
+    // Same query, one dynamic set carrying the FULL map: every in-process
+    // server plus the new remote one.
+    expect(calls).toHaveLength(1)
+    expect(setMcpServersCalls).toHaveLength(1)
+    for (const name of SDK_SERVER_NAMES) expect(setMcpServersCalls[0]).toHaveProperty(name)
+    expect(setMcpServersCalls[0]).toMatchObject({
       team_calendar: {
         type: 'http',
         url: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
       },
     })
+    // setMcpServers() only returns once the server has settled, so the
+    // handshake gate (a re-query concern) never polls.
+    expect(mcpServerStatusCalls).toBe(0)
+
+    // The live query now matches the projection: an unchanged follow-up
+    // neither re-applies nor re-queries.
+    await claude.sendMessage('And tomorrow’s?')
+    expect(calls).toHaveLength(1)
+    expect(setMcpServersCalls).toHaveLength(1)
+
+    // Removing the server is the same replace, minus the entry.
+    process.env.REMOTE_MCPS = '[]'
+    await claude.sendMessage('Continue without the calendar')
+    expect(calls).toHaveLength(1)
+    expect(setMcpServersCalls).toHaveLength(2)
+    expect(setMcpServersCalls[1]).not.toHaveProperty('team_calendar')
+    for (const name of SDK_SERVER_NAMES) expect(setMcpServersCalls[1]).toHaveProperty(name)
+  })
+
+  it('carries the refreshed prompt and tool patterns into the next query creation', async () => {
+    const claude = await startProcess('test-runtime-mcp-prompt-refresh')
+
+    process.env.REMOTE_MCPS = CALENDAR
+    await claude.sendMessage('List today’s events')
+    expect(calls).toHaveLength(1)
+
+    // The live query keeps its prompt; an unrelated re-query (effort change)
+    // must be built from the refreshed projection, not the boot-time one.
+    await claude.sendMessage('Now think harder', undefined, { effort: 'max' })
+    expect(calls).toHaveLength(2)
+    expect(calls[1].options.mcpServers).toHaveProperty('team_calendar')
     expect(calls[1].options.allowedTools).toContain('mcp__team_calendar__*')
     expect(calls[1].options.systemPrompt).toContain('Team Calendar')
     expect(calls[1].options.systemPrompt).toContain('list_events')
+    // The rebuild re-read the env itself — no dynamic set on top of it.
+    expect(setMcpServersCalls).toHaveLength(1)
+  })
 
-    process.env.REMOTE_MCPS = '[]'
-    await claudeProcess.sendMessage('Continue without the calendar')
+  it('rides a pending remote MCP change along with a re-query instead of applying it twice', async () => {
+    const claude = await startProcess('test-runtime-mcp-with-requery')
 
-    expect(calls).toHaveLength(3)
-    expect(calls[2].options.mcpServers).not.toHaveProperty('team_calendar')
-    expect(calls[2].options.allowedTools).not.toContain('mcp__team_calendar__*')
-    expect(calls[2].options.systemPrompt).not.toContain('Team Calendar')
+    process.env.REMOTE_MCPS = CALENDAR
+    await claude.sendMessage('List today’s events', undefined, { effort: 'max' })
+
+    expect(calls).toHaveLength(2)
+    expect(calls[1].options.mcpServers).toHaveProperty('team_calendar')
+    expect(setMcpServersCalls).toHaveLength(0)
+    // A rebuilt query races its own handshake, so this path still gates.
+    expect(mcpServerStatusCalls).toBe(1)
+  })
+
+  it('falls back to a re-query when the CLI has no dynamic MCP support', async () => {
+    const claude = await startProcess('test-runtime-mcp-fallback')
+    setMcpServersImpl = UNSUPPORTED
+
+    process.env.REMOTE_MCPS = CALENDAR
+    await claude.sendMessage('List today’s events')
+
+    expect(setMcpServersCalls).toHaveLength(1)
+    expect(calls).toHaveLength(2)
+    expect(calls[1].options.mcpServers).toMatchObject({
+      team_calendar: { type: 'http' },
+    })
+    expect(calls[1].options.systemPrompt).toContain('Team Calendar')
+    expect(mcpServerStatusCalls).toBe(1)
+  })
+
+  it('rebuilds a live query when Agent Settings changes connected accounts', async () => {
+    const claude = await startProcess('test-runtime-connection-refresh')
+    expect(calls).toHaveLength(1)
 
     process.env.CONNECTED_ACCOUNTS = JSON.stringify({
       gmail: [{ name: 'Work Gmail', id: 'account-gmail', status: 'expired' }],
     })
-    await claudeProcess.sendMessage('Check the connected Gmail account')
+    await claude.sendMessage('Check the connected Gmail account')
 
-    expect(calls).toHaveLength(4)
-    expect(calls[3].options.systemPrompt).toContain('Work Gmail')
-    expect(calls[3].options.systemPrompt).toContain('account-gmail')
-    expect(calls[3].options.systemPrompt).toContain('status: `expired`')
-    expect(calls[3].options.systemPrompt).toContain('Make the intended proxy call')
-    expect(calls[3].options.systemPrompt).toContain('Do NOT report them as missing')
+    // Connected accounts reach the model through the prompt alone, and the
+    // prompt is baked at query creation — so this one is still a re-query.
+    expect(calls).toHaveLength(2)
+    expect(setMcpServersCalls).toHaveLength(0)
+    expect(calls[1].options.systemPrompt).toContain('Work Gmail')
+    expect(calls[1].options.systemPrompt).toContain('account-gmail')
+    expect(calls[1].options.systemPrompt).toContain('status: `expired`')
+    expect(calls[1].options.systemPrompt).toContain('Make the intended proxy call')
+    expect(calls[1].options.systemPrompt).toContain('Do NOT report them as missing')
 
     process.env.CONNECTED_ACCOUNTS = '{}'
-    await claudeProcess.sendMessage('Continue without Gmail')
+    await claude.sendMessage('Continue without Gmail')
 
-    expect(calls).toHaveLength(5)
-    expect(calls[4].options.systemPrompt).not.toContain('Work Gmail')
+    expect(calls).toHaveLength(3)
+    expect(calls[2].options.systemPrompt).not.toContain('Work Gmail')
   })
 
   it('treats unset and serialized empty projections as equivalent', async () => {
-    claudeProcess = new ClaudeCodeProcess({
-      sessionId: 'test-empty-runtime-connections',
-      workingDirectory: '/tmp',
-    })
-
-    await claudeProcess.start()
+    const claude = await startProcess('test-empty-runtime-connections')
     process.env.REMOTE_MCPS = '[]'
     process.env.CONNECTED_ACCOUNTS = '{}'
 
-    await claudeProcess.sendMessage('Continue without connections')
+    await claude.sendMessage('Continue without connections')
 
     expect(calls).toHaveLength(1)
+    expect(setMcpServersCalls).toHaveLength(0)
+  })
+})
+
+describe('ClaudeCodeProcess.addRemoteMcpServer', () => {
+  let claudeProcess: ClaudeCodeProcess | undefined
+  useRuntimeEnv()
+
+  async function startProcess(sessionId: string): Promise<ClaudeCodeProcess> {
+    claudeProcess = new ClaudeCodeProcess({ sessionId, workingDirectory: '/tmp' })
+    await claudeProcess.start()
+    return claudeProcess
+  }
+
+  afterEach(async () => {
+    await claudeProcess?.stop()
+    claudeProcess = undefined
+  })
+
+  it('hot-adds the approved server to the live query and resolves once it is connected', async () => {
+    const claude = await startProcess('test-add-mcp-hot')
+    // The host writes the projection before resolving the approval.
+    process.env.REMOTE_MCPS = CALENDAR
+
+    await claude.addRemoteMcpServer('Team Calendar')
+
+    // No interrupt, no re-query: the tool result lands in the same turn.
+    expect(calls).toHaveLength(1)
+    expect(setMcpServersCalls).toHaveLength(1)
+    expect(setMcpServersCalls[0]).toHaveProperty('team_calendar')
+    for (const name of SDK_SERVER_NAMES) expect(setMcpServersCalls[0]).toHaveProperty(name)
+
+    // The live query is in sync with the projection, so the user's next
+    // message does not re-apply the change or restart anything.
+    await claude.sendMessage('Great, list today’s events')
+    expect(calls).toHaveLength(1)
+    expect(setMcpServersCalls).toHaveLength(1)
+  })
+
+  it('rejects when the server registered but failed to connect', async () => {
+    const claude = await startProcess('test-add-mcp-connect-error')
+    process.env.REMOTE_MCPS = CALENDAR
+    setMcpServersImpl = async () => ({
+      added: [],
+      removed: [],
+      errors: { team_calendar: 'fetch failed: ECONNREFUSED' },
+    })
+
+    await expect(claude.addRemoteMcpServer('Team Calendar')).rejects.toThrow(
+      /team_calendar.*failed to connect.*ECONNREFUSED/,
+    )
+    expect(calls).toHaveLength(1)
+  })
+
+  it('falls back to interrupt + continuation when the CLI rejects the dynamic set', async () => {
+    const claude = await startProcess('test-add-mcp-fallback')
+    process.env.REMOTE_MCPS = CALENDAR
+    setMcpServersImpl = UNSUPPORTED
+    const sendSpy = vi.spyOn(claude, 'sendMessage')
+
+    await claude.addRemoteMcpServer('Team Calendar')
+    // The legacy path is deferred so the tool result reaches the CLI first.
+    await vi.waitFor(() => expect(calls).toHaveLength(2))
+
+    expect(calls[1].options.mcpServers).toHaveProperty('team_calendar')
+    expect(sendSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/^\[SYSTEM\] The remote MCP server "Team Calendar" has been fully registered/),
+    )
   })
 })
 
 describe('ClaudeCodeProcess remote MCP handshake gate', () => {
-  let originalRemoteMcps: string | undefined
-  let originalConnectedAccounts: string | undefined
   let claudeProcess: ClaudeCodeProcess | undefined
-
-  const CALENDAR = JSON.stringify([
-    {
-      id: 'mcp-calendar',
-      name: 'Team Calendar',
-      proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
-      tools: [{ name: 'list_events' }],
-    },
-  ])
-
-  const AUTH_REQUIRED_CALENDAR = JSON.stringify([
-    {
-      id: 'mcp-calendar',
-      name: 'Team Calendar',
-      status: 'auth_required',
-      proxyUrl: 'http://host.test/api/mcp-proxy/test-agent/mcp-calendar',
-      tools: [{ name: 'list_events' }],
-    },
-  ])
+  useRuntimeEnv()
 
   async function startProcess(sessionId: string): Promise<ClaudeCodeProcess> {
     claudeProcess = new ClaudeCodeProcess({ sessionId, workingDirectory: '/tmp' })
@@ -236,22 +386,16 @@ describe('ClaudeCodeProcess remote MCP handshake gate', () => {
   }
 
   beforeEach(() => {
-    calls.length = 0
-    mcpServerStatusImpl = null
-    mcpServerStatusCalls = 0
-    originalRemoteMcps = process.env.REMOTE_MCPS
-    originalConnectedAccounts = process.env.CONNECTED_ACCOUNTS
-    delete process.env.REMOTE_MCPS
-    delete process.env.CONNECTED_ACCOUNTS
+    // The gate only guards a REBUILT query (cold restart or re-query), whose
+    // handshake runs concurrently with the first turn. With dynamic MCP
+    // support the live-query path never rebuilds, so these cases pin the
+    // CLI down to the fallback to exercise it.
+    setMcpServersImpl = UNSUPPORTED
   })
 
   afterEach(async () => {
     await claudeProcess?.stop()
     claudeProcess = undefined
-    if (originalRemoteMcps === undefined) delete process.env.REMOTE_MCPS
-    else process.env.REMOTE_MCPS = originalRemoteMcps
-    if (originalConnectedAccounts === undefined) delete process.env.CONNECTED_ACCOUNTS
-    else process.env.CONNECTED_ACCOUNTS = originalConnectedAccounts
   })
 
   it('holds the message until a newly connected server finishes its handshake', async () => {

--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -1,4 +1,14 @@
-import { query, startup, Options, Query, WarmQuery, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query,
+  startup,
+  Options,
+  Query,
+  WarmQuery,
+  SDKMessage,
+  SDKUserMessage,
+  McpServerConfig,
+  McpSetServersResult,
+} from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { UUID } from 'crypto';
 import { EventEmitter } from 'events';
@@ -136,11 +146,17 @@ function parseRemoteMcps(): RemoteMcpConfig[] {
   }
 }
 
-function runtimeConnectionConfigSnapshot(): string {
-  return JSON.stringify([
-    process.env.CONNECTED_ACCOUNTS || '{}',
-    process.env.REMOTE_MCPS || '[]',
-  ])
+// The two runtime connection projections are tracked separately because they
+// take different paths into a live query: connected accounts only reach the
+// model through the system prompt (baked at query creation, so a change needs
+// a re-query), while remote MCP servers can be swapped into the running query
+// with Query.setMcpServers(). Unset and serialized-empty are the same thing.
+function connectedAccountsSnapshot(): string {
+  return process.env.CONNECTED_ACCOUNTS || '{}';
+}
+
+function remoteMcpsSnapshot(): string {
+  return process.env.REMOTE_MCPS || '[]';
 }
 
 /**
@@ -487,9 +503,16 @@ export class ClaudeCodeProcess extends EventEmitter {
   private capabilityPolicies: AgentCapabilityPolicies | undefined;
   // Connection metadata is mutable at runtime when Agent Settings changes.
   // The SDK snapshots MCP servers, allowed tool patterns, and the system prompt
-  // when query() is created, so the next user message must refresh a stale
-  // query before it is delivered.
-  private runtimeConnectionSnapshot = '';
+  // when query() is created. A connected-accounts change must therefore
+  // refresh a stale query before the next message is delivered; a remote-MCP
+  // change is pushed into the live query instead (see applyRemoteMcpServers).
+  private connectedAccountsSnapshot = '';
+  private remoteMcpsSnapshot = '';
+  // The in-process (SDK) MCP servers handed to the live query. Kept so a
+  // dynamic setMcpServers() call can name the same instances: the SDK leaves
+  // an already-registered SDK server untouched, but disconnects any it does
+  // not see in the map.
+  private sdkMcpServerConfigs: Record<string, McpServerConfig> | null = null;
   // Session-scoped review grants ("Allow for this session"). Scoped to the
   // SESSION, not the process: they must survive idle-eviction + resume (the
   // session-manager persists them via the 'capability-grant' event), or the
@@ -581,14 +604,106 @@ export class ClaudeCodeProcess extends EventEmitter {
   }
 
   /**
-   * Interrupt and restart the query after MCP approval.
-   * Called by request_remote_mcp tool after user approval. The env var REMOTE_MCPS
-   * is already updated by the host. We can't inject tools into the running query
-   * mid-stream, so we interrupt the current query and restart. The new query
-   * picks up the MCP server from the env var, and we send a continuation message
-   * so the model proceeds with the original request using the newly available tools.
+   * Regenerate the system prompt from the current runtime env. The live query
+   * keeps the prompt it was created with; the refreshed text is what the NEXT
+   * query creation (cold restart, effort/model re-query) carries.
    */
-  addRemoteMcpServer(name: string): void {
+  private refreshSystemPrompt(): void {
+    this.systemPrompt = generateSystemPrompt(
+      this.availableEnvVars,
+      this.userSystemPrompt,
+      this.modelPromptHints,
+      this.webSearchProvider,
+      this.webFetchProvider,
+      this.capabilityPolicies,
+      this.subagentModels,
+    );
+  }
+
+  /**
+   * Push the current REMOTE_MCPS projection into the live query without a
+   * re-query: Query.setMcpServers() replaces the CLI's dynamic MCP set in
+   * place, connecting servers that are new and disconnecting ones that are
+   * gone, while the turn (and any tool call that is mid-flight) stays alive.
+   *
+   * The map handed over is the FULL set — every in-process SDK server plus
+   * every remote server — because the SDK treats the call as a replace:
+   * an SDK server missing from the map is disconnected, and the CLI drops
+   * dynamic process servers it no longer sees. The start-time servers passed
+   * via --mcp-config count as dynamic on the CLI side, so this is safe to
+   * call on a query that already has remote servers (verified on 0.3.257:
+   * they report scope 'dynamic' and are re-added, not duplicated).
+   *
+   * Throws when there is no live query or the CLI rejects the control
+   * request (older CLI) — callers fall back to the interrupt + re-query path.
+   */
+  private async applyRemoteMcpServers(): Promise<McpSetServersResult> {
+    const queryInstance = this.queryInstance;
+    if (!queryInstance || !this.sdkMcpServerConfigs) {
+      throw new Error('No live query to apply remote MCP servers to');
+    }
+    const remoteMcpConfigs = this.buildRemoteMcpServers();
+    const result = await queryInstance.setMcpServers({
+      ...this.sdkMcpServerConfigs,
+      ...remoteMcpConfigs,
+    });
+    // The live query now matches the projection, so the next send must not
+    // treat it as stale. The prompt still lists the old server set until the
+    // next query creation; the tool result (and the host's projection) name
+    // the new tools, and ToolSearch finds them by name.
+    this.remoteMcpsSnapshot = remoteMcpsSnapshot();
+    this.refreshSystemPrompt();
+    const errors = Object.entries(result.errors ?? {});
+    console.log(
+      `[Session ${this.sessionId}] Applied remote MCP servers in place: added=[${result.added.join(', ')}] removed=[${result.removed.join(', ')}]` +
+        (errors.length ? ` errors=${JSON.stringify(result.errors)}` : ''),
+    );
+    return result;
+  }
+
+  /**
+   * Make an approved remote MCP server's tools available to the running query.
+   * Called by the request_remote_mcp tool after user approval; the host has
+   * already written the server into REMOTE_MCPS. The server is hot-added with
+   * setMcpServers() so the tool result that names its tools lands in the same
+   * turn and the model carries on — no interrupt, no "Stopped" marker, no
+   * continuation message.
+   *
+   * Resolves once the server is connected. Rejects when the server was
+   * registered but failed to connect (the tool reports that to the model
+   * instead of claiming the tools exist). When the CLI has no dynamic MCP
+   * support at all, falls back to the interrupt + re-query path and resolves
+   * immediately — the re-query picks the server up from the env var.
+   */
+  async addRemoteMcpServer(name: string): Promise<void> {
+    const sanitizedName = sanitizeMcpName(name);
+    if (this.queryInstance && this.isProcessing && !this.stopping) {
+      let result: McpSetServersResult;
+      try {
+        result = await this.applyRemoteMcpServers();
+      } catch (err) {
+        console.warn(`[Session ${this.sessionId}] Dynamic MCP set failed for "${sanitizedName}", falling back to re-query:`, err);
+        this.restartForRemoteMcp(name);
+        return;
+      }
+      const error = result.errors?.[sanitizedName];
+      if (error) {
+        throw new Error(`MCP server "${sanitizedName}" was registered but failed to connect: ${error}`);
+      }
+      console.log(`[Session ${this.sessionId}] MCP server "${sanitizedName}" hot-added to the live query`);
+      return;
+    }
+    this.restartForRemoteMcp(name);
+  }
+
+  /**
+   * Legacy path: interrupt and restart the query so it is rebuilt with the
+   * server from REMOTE_MCPS, then send a continuation so the model proceeds
+   * with the original request. Only reached when the live query cannot take a
+   * dynamic MCP set (older CLI, or no query running). Leaves the interrupt
+   * marker in the transcript that the hot path avoids.
+   */
+  private restartForRemoteMcp(name: string): void {
     const sanitizedName = sanitizeMcpName(name);
     console.log(`[ClaudeCodeProcess] MCP server "${sanitizedName}" approved, scheduling interrupt to inject tools`);
 
@@ -739,10 +854,33 @@ export class ClaudeCodeProcess extends EventEmitter {
     return model ? this.modelContextWindows[model] : undefined;
   }
 
+  /**
+   * The in-process MCP servers for one query. Fresh instances per query (the
+   * MCP protocol allows one transport per server instance), remembered on the
+   * process so applyRemoteMcpServers can hand the SAME instances back to
+   * setMcpServers — which skips servers it already has registered.
+   */
+  private buildSdkMcpServers(browserMcpTools: ReturnType<typeof createBrowserTools>): Record<string, McpServerConfig> {
+    const servers: Record<string, McpServerConfig> = {
+      'user-input': createUserInputMcpServer(() => this),
+      'browser': createBrowserMcpServer(browserMcpTools),
+      'dashboards': createDashboardsMcpServer(),
+      'agents': createAgentsMcpServer(() => this.sessionId),
+      'chat': createChatMcpServer(() => this.sessionId),
+      ...((this.webSearchProvider || this.webFetchProvider)
+        ? { 'web': createWebMcpServer({ search: !!this.webSearchProvider, fetch: !!this.webFetchProvider }) }
+        : {}),
+      ...(isComputerUseHost() ? { 'computer-use': createComputerUseMcpServer() } : {}),
+    };
+    this.sdkMcpServerConfigs = servers;
+    return servers;
+  }
+
   private buildQueryOptions(): Options {
     const remoteMcpConfigs = this.buildRemoteMcpServers();
     const remoteMcpToolPatterns = Object.keys(remoteMcpConfigs).map(name => `mcp__${name}__*`);
-    this.runtimeConnectionSnapshot = runtimeConnectionConfigSnapshot();
+    this.connectedAccountsSnapshot = connectedAccountsSnapshot();
+    this.remoteMcpsSnapshot = remoteMcpsSnapshot();
 
     // Browser tools are bound per-session via a getter read on every request:
     // this.sessionId changes when the query (re)starts, and a module-global id
@@ -855,15 +993,7 @@ export class ClaudeCodeProcess extends EventEmitter {
           }),
       }), this.speed),
       mcpServers: {
-        'user-input': createUserInputMcpServer(() => this),
-        'browser': createBrowserMcpServer(browserMcpTools),
-        'dashboards': createDashboardsMcpServer(),
-        'agents': createAgentsMcpServer(() => this.sessionId),
-        'chat': createChatMcpServer(() => this.sessionId),
-        ...((this.webSearchProvider || this.webFetchProvider)
-          ? { 'web': createWebMcpServer({ search: !!this.webSearchProvider, fetch: !!this.webFetchProvider }) }
-          : {}),
-        ...(isComputerUseHost() ? { 'computer-use': createComputerUseMcpServer() } : {}),
+        ...this.buildSdkMcpServers(browserMcpTools),
         ...remoteMcpConfigs,
       },
       agents: {
@@ -1323,20 +1453,13 @@ export class ClaudeCodeProcess extends EventEmitter {
     const effort = options?.effort;
     const speed = options?.speed;
     const model = options?.model;
-    const runtimeConnectionConfigChanged =
-      runtimeConnectionConfigSnapshot() !== this.runtimeConnectionSnapshot;
-    if (runtimeConnectionConfigChanged) {
+    const connectedAccountsChanged =
+      connectedAccountsSnapshot() !== this.connectedAccountsSnapshot;
+    const remoteMcpsChanged = remoteMcpsSnapshot() !== this.remoteMcpsSnapshot;
+    if (connectedAccountsChanged || remoteMcpsChanged) {
       // The prompt's connected-account and remote-MCP sections are generated
       // from runtime env metadata, so refresh them alongside the query config.
-      this.systemPrompt = generateSystemPrompt(
-        this.availableEnvVars,
-        this.userSystemPrompt,
-        this.modelPromptHints,
-        this.webSearchProvider,
-        this.webFetchProvider,
-        this.capabilityPolicies,
-        this.subagentModels,
-      );
+      this.refreshSystemPrompt();
     }
 
     // Treat undefined stored effort as 'high' so pre-existing sessions (created before
@@ -1391,6 +1514,11 @@ export class ClaudeCodeProcess extends EventEmitter {
       this.model = model;
     }
 
+    // Whether the query was rebuilt on this send. A rebuild re-reads REMOTE_MCPS
+    // itself, so a pending remote-MCP change rides along and only needs the
+    // handshake gate below; otherwise it is applied to the live query in place.
+    let queryRebuilt = false;
+
     if (this.stopping || !this.messageQueue || !this.isReady) {
       // Cold session, or a stop in flight (queue closed but not yet nulled —
       // pushing would throw and lose the message): wait the stop out, then
@@ -1400,11 +1528,12 @@ export class ClaudeCodeProcess extends EventEmitter {
         await this.currentStop.catch(() => undefined);
       }
       await this.restart();
+      queryRebuilt = true;
     } else if (
       effortChanged ||
       speedChanged ||
       capabilityBlockChanged ||
-      runtimeConnectionConfigChanged ||
+      connectedAccountsChanged ||
       contextWindowChanged
     ) {
       // Effort can only be set at query creation time — the SDK has no setEffort
@@ -1412,16 +1541,20 @@ export class ClaudeCodeProcess extends EventEmitter {
       // lives in the query env (ANTHROPIC_CUSTOM_HEADERS), which is likewise
       // baked at query creation. The new model (if also changed) is picked up by
       // the same restart. A capability block boundary flip re-queries for the
-      // same reason: the tool lists and system prompt only apply at query creation.
+      // same reason: the tool lists and system prompt only apply at query
+      // creation — and so does a connected-accounts change, which reaches the
+      // model through the prompt alone.
       const reasons: string[] = [];
       if (effortChanged) reasons.push(`effort ${currentEffort} -> ${effort}`);
       if (speedChanged) reasons.push(`speed ${currentSpeed} -> ${speed}`);
       if (capabilityBlockChanged) reasons.push('capability block boundary changed');
-      if (runtimeConnectionConfigChanged) reasons.push('runtime connection configuration changed');
+      if (connectedAccountsChanged) reasons.push('connected accounts changed');
+      if (remoteMcpsChanged) reasons.push('remote MCP servers changed');
       if (contextWindowChanged) reasons.push('model context window changed');
       if (modelChanged) reasons.push(`model -> ${this.model}`);
       console.log(`[Session ${this.sessionId}] Restarting query (${reasons.join(', ')})`);
       await this.interrupt();
+      queryRebuilt = true;
     } else if (modelChanged && this.queryInstance) {
       // Model-only change — use the SDK's dynamic setModel() so the running query
       // is reused and only subsequent turns are served by the new model. No
@@ -1434,14 +1567,31 @@ export class ClaudeCodeProcess extends EventEmitter {
         // the conservative restart path so the new model still takes effect.
         console.warn(`[Session ${this.sessionId}] setModel failed, falling back to restart:`, err);
         await this.interrupt();
+        queryRebuilt = true;
       }
     }
 
-    // Deliberately outside the branch chain above: BOTH the cold-session
-    // restart() and the interrupt() re-query rebuild the query with the new
-    // connection set, so both race the handshake. Effort- or speed-only
-    // re-queries pay nothing because the runtime connection set is unchanged.
-    if (runtimeConnectionConfigChanged) {
+    if (remoteMcpsChanged && !queryRebuilt) {
+      // Agent Settings assigned or removed a remote MCP while the query is
+      // live: swap the server set in place. setMcpServers() returns once the
+      // new servers have finished their handshake (or failed), so there is no
+      // half-connected window to gate on. Only a CLI without the control
+      // request sends us down the re-query path.
+      console.log(`[Session ${this.sessionId}] Applying remote MCP change to the live query`);
+      try {
+        await this.applyRemoteMcpServers();
+      } catch (err) {
+        console.warn(`[Session ${this.sessionId}] Dynamic MCP set failed, falling back to re-query:`, err);
+        await this.interrupt();
+        queryRebuilt = true;
+      }
+    }
+
+    // BOTH the cold-session restart() and the interrupt() re-query rebuild the
+    // query with the new connection set and race its handshake, so a rebuilt
+    // query with a changed remote-MCP set waits here. Effort- or speed-only
+    // re-queries pay nothing because the remote MCP set is unchanged.
+    if (remoteMcpsChanged && queryRebuilt) {
       await this.waitForRemoteMcpsReady();
     }
 

--- a/agent-container/src/tools/request-remote-mcp.test.ts
+++ b/agent-container/src/tools/request-remote-mcp.test.ts
@@ -172,4 +172,42 @@ describe('requestRemoteMcpTool', () => {
 
     expect(injections).toEqual([GRANOLA_MCP.name])
   })
+
+  // The hot-add is awaited: the result that names the tools is only returned
+  // once they can be called, and a server that registered but never connected
+  // is reported as such instead of the model being sent after phantom tools.
+  it('waits for the hot-add and names the live tools in the result', async () => {
+    process.env.REMOTE_MCPS = JSON.stringify([GRANOLA_MCP])
+    let settled = false
+    mockAddRemoteMcpServer.mockImplementation(
+      () => new Promise<void>((resolve) => setTimeout(() => { settled = true; resolve() }, 20)),
+    )
+    const toolUseId = `mcp-test-${Date.now()}-7`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.resolve(toolUseId, GRANOLA_MCP.id)
+
+    const result = await invokeTool()
+
+    expect(settled).toBe(true)
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0].text).toContain('mcp__granola__list_meetings')
+    expect(result.content[0].text).toContain('live in this session now')
+  })
+
+  it('reports a server that was granted but could not connect, as an error', async () => {
+    process.env.REMOTE_MCPS = JSON.stringify([GRANOLA_MCP])
+    mockAddRemoteMcpServer.mockRejectedValueOnce(
+      new Error('MCP server "granola" was registered but failed to connect: ECONNREFUSED'),
+    )
+    const toolUseId = `mcp-test-${Date.now()}-8`
+    inputManager.setCurrentToolUseId(toolUseId)
+    inputManager.resolve(toolUseId, GRANOLA_MCP.id)
+
+    const result = await invokeTool()
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('could not be connected')
+    expect(result.content[0].text).toContain('ECONNREFUSED')
+    expect(result.content[0].text).not.toContain('Use these tools')
+  })
 })

--- a/agent-container/src/tools/request-remote-mcp.ts
+++ b/agent-container/src/tools/request-remote-mcp.ts
@@ -17,7 +17,11 @@ import { sanitizeMcpName } from '../sanitize-mcp-name'
  * tool module doesn't import back into claude-code.ts.
  */
 export interface RemoteMcpInjectionTarget {
-  addRemoteMcpServer(name: string): void
+  /**
+   * Resolves once the approved server's tools are available to the running
+   * query; rejects when the server was registered but could not connect.
+   */
+  addRemoteMcpServer(name: string): Promise<void> | void
 }
 
 /**
@@ -122,12 +126,32 @@ Never ask the user to paste a client secret into the chat. If they want you to l
               const fullToolNames = matchingMcp.tools.map((t) => `mcp__${sanitizedName}__${t.name}`).join(', ')
               return `MCP Server registered as: ${sanitizedName}\nUse these tools: ${fullToolNames}`
             })
-            mcpInfo = `\n\n${mcpBlocks.join('\n\n')}`
+            mcpInfo = `\n\n${mcpBlocks.join('\n\n')}\n\nThe tools are live in this session now (load them with ToolSearch if they are deferred) — continue with the original request.`
 
-            // Trigger interrupt + restart so the new query picks up the MCP from env var.
+            // Hot-add the approved server(s) to the running query. Awaited so
+            // the tool result that names the tools is delivered only once they
+            // can actually be called. A server that registered but failed to
+            // connect rejects, and the model is told instead of being sent
+            // after tools that do not exist.
             const proc = getProcess()
             if (proc) {
-              matchingMcps.forEach((matchingMcp) => proc.addRemoteMcpServer(matchingMcp.name))
+              try {
+                for (const matchingMcp of matchingMcps) {
+                  await proc.addRemoteMcpServer(matchingMcp.name)
+                }
+              } catch (err) {
+                const detail = err instanceof Error ? err.message : String(err)
+                console.error('[request_remote_mcp] Hot-adding the approved MCP server failed:', detail)
+                return {
+                  content: [
+                    {
+                      type: 'text' as const,
+                      text: `Access to the remote MCP server was granted, but it could not be connected to this session: ${detail}. Tell the user the server is assigned but unreachable right now (they can check its connection settings), and do not assume its tools are available.`,
+                    },
+                  ],
+                  isError: true,
+                }
+              }
             } else {
               console.error('[request_remote_mcp] No active ClaudeCodeProcess found')
             }

--- a/e2e/live/mcp-hot-add/compose-video.mjs
+++ b/e2e/live/mcp-hot-add/compose-video.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Fold a live-probe run's recordings into one demo clip.
+ *
+ * Playwright records one video per page, so the OAuth popup (the login page)
+ * lands in its own file. This lays that recording over the main page's
+ * recording, picture-in-picture, from the moment the popup opened — using the
+ * wall-clock marks the spec writes to timing.json — and encodes an mp4.
+ *
+ *   node e2e/live/mcp-hot-add/compose-video.mjs <test-output-dir> [out.mp4]
+ *
+ * Needs ffmpeg on PATH. Prints the output path; exits non-zero if anything is
+ * missing so run.mjs can report it without failing the probe.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const dir = process.argv[2]
+if (!dir || !existsSync(dir)) {
+  console.error('usage: compose-video.mjs <test-output-dir> [out.mp4]')
+  process.exit(2)
+}
+const out = process.argv[3] ?? path.join(dir, 'mcp-hot-add-demo.mp4')
+
+const videos = readdirSync(dir)
+  .filter((f) => f.endsWith('.webm'))
+  .map((f) => path.join(dir, f))
+  .sort((a, b) => statSync(a).mtimeMs - statSync(b).mtimeMs)
+if (videos.length === 0) {
+  console.error(`no .webm recordings in ${dir}`)
+  process.exit(1)
+}
+
+// The main page is created first and lives longest; the popup is the other one.
+const main = videos.find((v) => path.basename(v) === 'video.webm') ?? videos[0]
+const popup = videos.find((v) => v !== main)
+
+const timingFile = path.join(dir, 'timing.json')
+const timing = existsSync(timingFile) ? JSON.parse(readFileSync(timingFile, 'utf8')) : null
+
+const common = ['-c:v', 'libx264', '-preset', 'medium', '-crf', '20', '-pix_fmt', 'yuv420p', '-r', '25', '-movflags', '+faststart', '-an']
+
+if (!popup || !timing?.popupOpenedAt || !timing?.testStartedAt) {
+  // Nothing to overlay (or nothing to align it with): just transcode the main recording.
+  execFileSync('ffmpeg', ['-y', '-loglevel', 'error', '-i', main, ...common, out], { stdio: 'inherit' })
+  console.log(out)
+  process.exit(0)
+}
+
+// The main recording ends when the context closes (right after the test) but
+// starts a few seconds into the test, so its clock runs behind wall-clock by
+// (test duration − video duration). Shift the popup's wall-clock offset by
+// that lag so the overlay appears at the click, not before it.
+const mainDuration = Number(
+  execFileSync('ffprobe', ['-v', 'error', '-show_entries', 'format=duration', '-of', 'csv=p=0', main], { encoding: 'utf8' }).trim(),
+)
+const wallDuration = (timing.endedAt - timing.testStartedAt) / 1000
+const lag = Number.isFinite(mainDuration) && timing.endedAt ? Math.max(0, wallDuration - mainDuration) : 0
+const offsetSeconds = Math.max(0, (timing.popupOpenedAt - timing.testStartedAt) / 1000 - lag)
+
+// The popup was recorded at the full viewport with the login card centred;
+// crop to the card so it stays legible once scaled down. Top-right placement
+// keeps it clear of the request card, which sits above the composer.
+const filter = [
+  `[1:v]crop=760:560:(iw-760)/2:(ih-560)/2,scale=608:-2,setpts=PTS-STARTPTS+${offsetSeconds.toFixed(3)}/TB[pip]`,
+  `[0:v][pip]overlay=x=W-w-32:y=72:eof_action=pass:format=auto[v]`,
+].join(';')
+
+execFileSync(
+  'ffmpeg',
+  ['-y', '-loglevel', 'error', '-i', main, '-i', popup, '-filter_complex', filter, '-map', '[v]', ...common, out],
+  { stdio: 'inherit' },
+)
+console.log(out)

--- a/e2e/live/mcp-hot-add/mcp-hot-add.spec.ts
+++ b/e2e/live/mcp-hot-add/mcp-hot-add.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect, type Page } from '@playwright/test'
+import { mkdir, writeFile } from 'fs/promises'
+import path from 'path'
+import { SessionPage } from '../../pages/session.page'
+import { startMockOAuthMcp, type MockOAuthMcp } from './mock-oauth-mcp'
+
+/**
+ * Live proof that an MCP server requested mid-turn is hot-added to the running
+ * query — the agent carries on in the SAME turn, with no restart, no "Stopped"
+ * marker and no [SYSTEM] continuation message.
+ *
+ * Nothing is mocked on the agent side: a real container runs the real CLI
+ * against the real model. The only stand-in is the MCP server itself, which
+ * is a local OAuth-protected server so the flow includes the human step —
+ * the person signs in on the server's own login page in the OAuth popup.
+ *
+ * Run through e2e/live/mcp-hot-add/run.mjs, which seeds the data dir, boots
+ * the host with the real container, and records the video.
+ */
+test.describe.configure({ mode: 'serial' })
+
+let mock: MockOAuthMcp
+
+test.beforeAll(async () => {
+  mock = await startMockOAuthMcp()
+})
+
+test.afterAll(async () => {
+  await mock?.close()
+})
+
+/**
+ * Human pacing for the recording — long enough to read, short enough to
+ * watch. Every assertion in the spec still waits on real UI state; these
+ * pauses only exist so the video is followable.
+ */
+async function beat(page: Page, ms = 1500) {
+  // eslint-disable-next-line local-rules/no-brittle-playwright-selectors -- deliberate pacing for the demo recording, not a synchronization wait
+  await page.waitForTimeout(ms)
+}
+
+test('agent requests an OAuth MCP, the user signs in, and the agent uses its tools in the same turn', async ({ page, request }) => {
+  // Wall-clock marks for compose-video.mjs, which lays the popup's recording
+  // over the main page's recording at the moment it opened.
+  const timing: Record<string, number> = { testStartedAt: Date.now() }
+  const sessionPage = new SessionPage(page)
+  const agentName = `Rocket Ops ${Date.now().toString(36)}`
+
+  // The agent is created over the API so the recording opens on its home page
+  // rather than on the create-agent chrome.
+  const created = await request.post('/api/agents', {
+    data: { name: agentName, description: 'Live MCP hot-add probe' },
+  })
+  expect(created.ok(), await created.text()).toBeTruthy()
+  const { slug } = (await created.json()) as { slug: string }
+
+  await page.goto(`/agents/${slug}`)
+  const homeInput = page.getByTestId('home-message-input')
+  await expect(homeInput).toBeVisible({ timeout: 30_000 })
+  await beat(page)
+
+  const prompt =
+    `Please get today's launch authorization code from our Rocket Ops mission board. ` +
+    `It is an MCP server at ${mock.mcpUrl} that uses OAuth. ` +
+    `Request access to it if you don't have it yet, then tell me the code.`
+  await homeInput.click()
+  await homeInput.pressSequentially(prompt, { delay: 8 })
+  await beat(page, 800)
+  await page.getByTestId('home-send-button').click()
+
+  await expect(sessionPage.getMessageList()).toBeVisible({ timeout: 30_000 })
+  await expect(page).toHaveURL(/\/sessions\/[^/]+/, { timeout: 30_000 })
+  const sessionId = page.url().match(/\/sessions\/([^/?#]+)/)![1]
+
+  // ── The agent asks for the server ──────────────────────────────────
+  const card = page.getByTestId('remote-mcp-request')
+  await expect(card).toBeVisible({ timeout: 4 * 60_000 })
+  await expect(card).toContainText(mock.mcpUrl)
+  await beat(page, 2000)
+
+  // ── The user connects: OAuth popup → the server's own login page ──
+  const popupPromise = page.waitForEvent('popup')
+  await card.getByRole('button', { name: 'Connect', exact: true }).click()
+  const popup = await popupPromise
+  timing.popupOpenedAt = Date.now()
+  await expect(popup.getByTestId('login-username')).toBeVisible({ timeout: 30_000 })
+  await expect(popup).toHaveTitle(/Rocket Ops/)
+  await beat(popup, 1200)
+  await popup.getByTestId('login-username').pressSequentially(mock.credentials.username, { delay: 40 })
+  await popup.getByTestId('login-password').pressSequentially(mock.credentials.password, { delay: 40 })
+  await beat(popup, 600)
+  await popup.getByTestId('login-submit').click()
+
+  // The callback page hands the result back to the card, which now offers to
+  // grant the freshly connected server to the agent.
+  const allowButton = card.getByRole('button', { name: /Allow Access/ })
+  await expect(allowButton).toBeVisible({ timeout: 60_000 })
+  timing.popupDoneAt = Date.now()
+  expect(mock.tokensIssued).toHaveLength(1)
+  await beat(page, 1500)
+  await allowButton.click()
+  await expect(card).not.toBeVisible({ timeout: 30_000 })
+
+  // ── The agent carries on in the same turn and uses the new tool ───
+  // A freshly connected server's tools default to the "review" policy, so
+  // the agent's first call through the host proxy parks for one more click.
+  // That the card appears at all is the proof: the call was made in the
+  // same turn, seconds after the grant, with no restart in between.
+  await sessionPage.waitForProxyReviewRequest(4 * 60_000)
+  await expect(sessionPage.getProxyReviewRequests().first()).toContainText('get_launch_code')
+  expect(mock.toolCalls).toHaveLength(0)
+  await beat(page, 2000)
+  await sessionPage.allowProxyReview()
+
+  const answer = sessionPage.getAssistantMessages().filter({ hasText: 'RKT-4242-ORBIT' })
+  await expect(answer).toBeVisible({ timeout: 4 * 60_000 })
+  await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 60_000 })
+  await beat(page, 3000)
+
+  // The tool call reached the mock through the host proxy, carrying the token
+  // the login just minted — and only after the OAuth dance completed.
+  const launchCalls = mock.toolCalls.filter((c) => c.name === 'get_launch_code')
+  expect(launchCalls.length).toBeGreaterThanOrEqual(1)
+  expect(launchCalls[0].bearer).toBe(mock.tokensIssued[0])
+  const order = ['register:', 'login:ok', 'token:issued', 'mcp:initialize:ok', 'mcp:tools/call:get_launch_code']
+    .map((prefix) => mock.events.findIndex((e) => e.startsWith(prefix)))
+  expect(order.every((i) => i >= 0)).toBe(true)
+  expect([...order].sort((a, b) => a - b)).toEqual(order)
+
+  // ── No restart artefacts anywhere ──────────────────────────────────
+  await expect(sessionPage.getInterruptMarkers()).toHaveCount(0)
+  await expect(page.getByText('No response requested.')).toHaveCount(0)
+  await expect(page.getByText(/has been fully registered/)).toHaveCount(0)
+
+  // The persisted transcript agrees: one human message, no interrupt marker,
+  // no [SYSTEM] continuation — both tool calls happened in that single turn.
+  const transcriptRes = await request.get(`/api/agents/${slug}/sessions/${sessionId}/messages`)
+  expect(transcriptRes.ok()).toBeTruthy()
+  // ApiMessage shape: the host serves the transcript verbatim — hidden kinds
+  // ([SYSTEM] continuations, interrupt markers) are filtered in the renderer,
+  // so here they would still show up as user entries if they existed.
+  const transcript = (await transcriptRes.json()) as Array<{
+    type: 'user' | 'assistant'
+    content: { text: string }
+    toolCalls: Array<{ name: string }>
+  }>
+  const userTexts = transcript.filter((m) => m.type === 'user').map((m) => m.content.text)
+  expect(userTexts).toHaveLength(1)
+  expect(userTexts[0]).toContain('Rocket Ops mission board')
+
+  const toolNames = transcript
+    .filter((m) => m.type === 'assistant')
+    .flatMap((m) => m.toolCalls.map((t) => t.name))
+  expect(toolNames).toContain('mcp__user-input__request_remote_mcp')
+  expect(toolNames).toContain('mcp__rocket_ops__get_launch_code')
+
+  test.info().annotations.push(
+    { type: 'session', description: `${slug}/${sessionId}` },
+    { type: 'tool calls', description: toolNames.join(' → ') },
+  )
+  timing.endedAt = Date.now()
+  // Playwright creates the output dir lazily, on the first attachment.
+  await mkdir(test.info().outputDir, { recursive: true })
+  await writeFile(path.join(test.info().outputDir, 'timing.json'), JSON.stringify(timing, null, 2))
+})

--- a/e2e/live/mcp-hot-add/mock-oauth-mcp.ts
+++ b/e2e/live/mcp-hot-add/mock-oauth-mcp.ts
@@ -1,0 +1,335 @@
+import * as http from 'http'
+import * as crypto from 'crypto'
+
+/**
+ * A self-contained OAuth-protected MCP server for the live hot-add probe.
+ *
+ * One process plays all three roles the host's OAuth-first connect flow
+ * expects of a real remote MCP:
+ *
+ *  - the MCP resource server (`POST /mcp`, Streamable HTTP, JSON responses)
+ *    that answers 401 + `WWW-Authenticate: Bearer resource_metadata=...`
+ *    until it sees one of its own bearer tokens;
+ *  - RFC 9728 protected-resource metadata and RFC 8414 authorization-server
+ *    metadata under `/.well-known/`;
+ *  - the authorization server itself: RFC 7591 dynamic client registration,
+ *    an HTML login page at `/authorize` (this is the "log in to the MCP" step
+ *    a person sees in the popup), and a PKCE-checked `/token` endpoint.
+ *
+ * Everything is in memory and every request is logged to `events` so a spec
+ * can assert the exact sequence: registration → login → token → tools/call
+ * carrying the issued token.
+ */
+export interface MockOAuthMcp {
+  origin: string
+  mcpUrl: string
+  port: number
+  /** Login the page accepts. */
+  credentials: { username: string; password: string }
+  /** Tool calls the resource server received, in order, with the bearer they carried. */
+  toolCalls: Array<{ name: string; arguments?: Record<string, unknown>; bearer: string | null }>
+  /** Access tokens issued by /token. */
+  tokensIssued: string[]
+  /** Chronological log of notable requests. */
+  events: string[]
+  close: () => Promise<void>
+}
+
+export interface MockOAuthMcpOptions {
+  port?: number
+  serverName?: string
+  username?: string
+  password?: string
+  /** What `get_launch_code` returns — pick something a model cannot guess. */
+  launchCode?: string
+}
+
+const html = (body: string) => `<!doctype html>
+<html><head><meta charset="utf-8"><title>Rocket Ops — Sign in</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; background: #0f172a; color: #e2e8f0; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+  .card { background: #1e293b; padding: 32px 36px; border-radius: 12px; width: 340px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
+  h1 { font-size: 20px; margin: 0 0 4px; } p { margin: 0 0 20px; color: #94a3b8; font-size: 14px; }
+  label { display: block; font-size: 12px; color: #94a3b8; margin: 12px 0 4px; }
+  input { width: 100%; box-sizing: border-box; padding: 10px 12px; border-radius: 8px; border: 1px solid #334155; background: #0f172a; color: #e2e8f0; font-size: 14px; }
+  button { margin-top: 20px; width: 100%; padding: 11px; border: 0; border-radius: 8px; background: #f97316; color: white; font-weight: 600; font-size: 14px; cursor: pointer; }
+  .err { color: #f87171; font-size: 13px; margin-top: 10px; }
+</style></head><body><div class="card">${body}</div></body></html>`
+
+export async function startMockOAuthMcp(options: MockOAuthMcpOptions = {}): Promise<MockOAuthMcp> {
+  const serverName = options.serverName ?? 'Rocket Ops'
+  const credentials = {
+    username: options.username ?? 'mission-control',
+    password: options.password ?? 'liftoff-2026',
+  }
+  const launchCode = options.launchCode ?? 'RKT-4242-ORBIT'
+
+  const clients = new Map<string, { redirectUris: string[] }>()
+  const codes = new Map<string, { clientId: string; redirectUri: string; codeChallenge: string; resource?: string }>()
+  const tokens = new Set<string>()
+  const toolCalls: MockOAuthMcp['toolCalls'] = []
+  const tokensIssued: string[] = []
+  const events: string[] = []
+  let origin = ''
+
+  const tools = [
+    {
+      name: 'get_launch_code',
+      description: `Returns today's launch authorization code for the ${serverName} mission board.`,
+      inputSchema: { type: 'object', properties: {} },
+    },
+    {
+      name: 'list_missions',
+      description: 'Lists the missions currently on the board.',
+      inputSchema: { type: 'object', properties: { status: { type: 'string' } } },
+    },
+  ]
+
+  const readBody = (req: http.IncomingMessage) =>
+    new Promise<string>((resolve) => {
+      let body = ''
+      req.on('data', (chunk) => { body += chunk })
+      req.on('end', () => resolve(body))
+    })
+
+  const json = (res: http.ServerResponse, status: number, payload: unknown, headers: Record<string, string> = {}) => {
+    res.writeHead(status, { 'Content-Type': 'application/json', ...headers })
+    res.end(JSON.stringify(payload))
+  }
+
+  const bearerOf = (req: http.IncomingMessage): string | null => {
+    const auth = req.headers.authorization
+    if (!auth || !/^Bearer\s+/i.test(auth)) return null
+    return auth.replace(/^Bearer\s+/i, '').trim()
+  }
+
+  const server = http.createServer(async (req, res) => {
+    let url: URL
+    try {
+      url = new URL(req.url ?? '/', origin)
+    } catch {
+      res.writeHead(400); res.end(); return
+    }
+    const route = `${req.method} ${url.pathname}`
+
+    // ── MCP resource server ────────────────────────────────────────────
+    if (url.pathname === '/mcp') {
+      if (req.method === 'GET') {
+        // No server-initiated stream: the spec lets a server answer 405 and
+        // clients carry on with request/response.
+        res.writeHead(405); res.end(); return
+      }
+      if (req.method === 'DELETE') { res.writeHead(200); res.end(); return }
+      if (req.method !== 'POST') { res.writeHead(405); res.end(); return }
+
+      const bearer = bearerOf(req)
+      const body = await readBody(req)
+      let rpc: { id?: unknown; method?: string; params?: { name?: string; arguments?: Record<string, unknown> } } = {}
+      try { rpc = JSON.parse(body) } catch { /* fall through with an empty rpc */ }
+
+      if (!bearer || !tokens.has(bearer)) {
+        events.push(`mcp:${rpc.method ?? '?'}:401`)
+        json(res, 401, { error: 'unauthorized' }, {
+          'WWW-Authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+        })
+        return
+      }
+
+      const reply = (result: unknown) => json(res, 200, { jsonrpc: '2.0', id: rpc.id, result })
+      switch (rpc.method) {
+        case 'initialize':
+          events.push('mcp:initialize:ok')
+          reply({ protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: serverName, version: '1.0.0' } })
+          return
+        case 'notifications/initialized':
+          res.writeHead(202); res.end(); return
+        case 'ping':
+          reply({}); return
+        case 'tools/list':
+          events.push('mcp:tools/list')
+          reply({ tools }); return
+        case 'tools/call': {
+          const name = rpc.params?.name ?? ''
+          toolCalls.push({ name, arguments: rpc.params?.arguments, bearer })
+          events.push(`mcp:tools/call:${name}`)
+          if (name === 'get_launch_code') {
+            reply({ content: [{ type: 'text', text: `Launch authorization code for today: ${launchCode}` }] })
+          } else if (name === 'list_missions') {
+            reply({ content: [{ type: 'text', text: 'Missions: Artemis-7 (go), Kestrel-2 (hold)' }] })
+          } else {
+            json(res, 200, { jsonrpc: '2.0', id: rpc.id, error: { code: -32602, message: `Unknown tool ${name}` } })
+          }
+          return
+        }
+        default:
+          json(res, 200, { jsonrpc: '2.0', id: rpc.id, error: { code: -32601, message: 'Method not found' } })
+          return
+      }
+    }
+
+    // ── Discovery metadata ─────────────────────────────────────────────
+    if (route === 'GET /.well-known/oauth-protected-resource') {
+      events.push('discovery:protected-resource')
+      json(res, 200, { resource: origin, authorization_servers: [origin], scopes_supported: ['missions:read'] })
+      return
+    }
+    if (route === 'GET /.well-known/oauth-authorization-server') {
+      events.push('discovery:authorization-server')
+      json(res, 200, {
+        issuer: origin,
+        authorization_endpoint: `${origin}/authorize`,
+        token_endpoint: `${origin}/token`,
+        registration_endpoint: `${origin}/register`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        code_challenge_methods_supported: ['S256'],
+        token_endpoint_auth_methods_supported: ['none'],
+        scopes_supported: ['missions:read'],
+      })
+      return
+    }
+
+    // ── Authorization server ───────────────────────────────────────────
+    if (route === 'POST /register') {
+      let body: { client_name?: string; redirect_uris?: string[] }
+      try {
+        body = JSON.parse(await readBody(req))
+      } catch {
+        json(res, 400, { error: 'invalid_client_metadata' }); return
+      }
+      const clientId = `rocket-${crypto.randomBytes(6).toString('hex')}`
+      clients.set(clientId, { redirectUris: body.redirect_uris ?? [] })
+      events.push(`register:${body.client_name ?? '?'}`)
+      json(res, 201, {
+        client_id: clientId,
+        client_name: body.client_name,
+        redirect_uris: body.redirect_uris,
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+      })
+      return
+    }
+
+    if (route === 'GET /authorize') {
+      const p = url.searchParams
+      const client = clients.get(p.get('client_id') ?? '')
+      const redirectUri = p.get('redirect_uri') ?? ''
+      if (!client || !client.redirectUris.includes(redirectUri)) {
+        events.push('authorize:invalid_redirect_uri')
+        json(res, 400, { error: 'invalid_redirect_uri' })
+        return
+      }
+      if (p.get('response_type') !== 'code' || p.get('code_challenge_method') !== 'S256' || !p.get('code_challenge')) {
+        json(res, 400, { error: 'invalid_request' })
+        return
+      }
+      events.push('authorize:login-page')
+      const hidden = ['client_id', 'redirect_uri', 'state', 'code_challenge', 'resource', 'scope']
+        .map((k) => `<input type="hidden" name="${k}" value="${escapeAttr(p.get(k) ?? '')}">`)
+        .join('')
+      res.writeHead(200, { 'Content-Type': 'text/html' })
+      res.end(html(`
+        <h1>🚀 ${serverName}</h1>
+        <p>Sign in to let <strong>Gamut</strong> read your mission board.</p>
+        <form method="POST" action="/login" data-testid="login-form">
+          ${hidden}
+          <label for="username">Username</label>
+          <input id="username" name="username" autocomplete="off" data-testid="login-username">
+          <label for="password">Password</label>
+          <input id="password" name="password" type="password" data-testid="login-password">
+          <button type="submit" data-testid="login-submit">Sign in &amp; authorize</button>
+        </form>`))
+      return
+    }
+
+    if (route === 'POST /login') {
+      const form = new URLSearchParams(await readBody(req))
+      const clientId = form.get('client_id') ?? ''
+      const redirectUri = form.get('redirect_uri') ?? ''
+      if (form.get('username') !== credentials.username || form.get('password') !== credentials.password) {
+        events.push('login:rejected')
+        res.writeHead(401, { 'Content-Type': 'text/html' })
+        res.end(html(`<h1>🚀 ${serverName}</h1><p class="err" data-testid="login-error">Wrong username or password.</p><a href="javascript:history.back()">Try again</a>`))
+        return
+      }
+      const code = crypto.randomBytes(16).toString('hex')
+      codes.set(code, {
+        clientId,
+        redirectUri,
+        codeChallenge: form.get('code_challenge') ?? '',
+        resource: form.get('resource') ?? undefined,
+      })
+      events.push('login:ok')
+      let back: URL
+      try {
+        back = new URL(redirectUri)
+      } catch {
+        json(res, 400, { error: 'invalid_redirect_uri' }); return
+      }
+      back.searchParams.set('code', code)
+      if (form.get('state')) back.searchParams.set('state', form.get('state')!)
+      res.writeHead(302, { Location: back.toString() })
+      res.end()
+      return
+    }
+
+    if (route === 'POST /token') {
+      const form = new URLSearchParams(await readBody(req))
+      if (form.get('grant_type') !== 'authorization_code') {
+        json(res, 400, { error: 'unsupported_grant_type' }); return
+      }
+      const grant = codes.get(form.get('code') ?? '')
+      codes.delete(form.get('code') ?? '')
+      const verifier = form.get('code_verifier') ?? ''
+      const challenge = crypto.createHash('sha256').update(verifier).digest('base64url')
+      if (!grant || grant.clientId !== form.get('client_id') || grant.redirectUri !== form.get('redirect_uri') || grant.codeChallenge !== challenge) {
+        events.push('token:invalid_grant')
+        json(res, 400, { error: 'invalid_grant', error_description: 'code, client, redirect or PKCE verifier did not match' })
+        return
+      }
+      const accessToken = `rkt_${crypto.randomBytes(18).toString('hex')}`
+      tokens.add(accessToken)
+      tokensIssued.push(accessToken)
+      events.push('token:issued')
+      json(res, 200, {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: `rkt_refresh_${crypto.randomBytes(8).toString('hex')}`,
+        scope: 'missions:read',
+      })
+      return
+    }
+
+    if (route === 'GET /__probe') {
+      json(res, 200, { toolCalls, tokensIssued: tokensIssued.length, events })
+      return
+    }
+
+    res.writeHead(404); res.end()
+  })
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject)
+    server.listen(options.port ?? 0, '127.0.0.1', () => {
+      const address = server.address()
+      const port = typeof address === 'object' && address ? address.port : (options.port ?? 0)
+      origin = `http://127.0.0.1:${port}`
+      resolve({
+        origin,
+        mcpUrl: `${origin}/mcp`,
+        port,
+        credentials,
+        toolCalls,
+        tokensIssued,
+        events,
+        close: () => new Promise<void>((done) => server.close(() => done())),
+      })
+    })
+  })
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+}

--- a/e2e/live/mcp-hot-add/run.mjs
+++ b/e2e/live/mcp-hot-add/run.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * Live probe: a remote MCP requested mid-turn is hot-added without a restart.
+ *
+ * Boots the REAL host against a seeded data dir, which runs the REAL agent
+ * container and the real model, then drives the browser through
+ * `mcp-hot-add.spec.ts`: the agent asks for an OAuth MCP, the person signs in
+ * on the (local, mock) server's login page, grants access, and the agent
+ * finishes the same turn using the new tool. The Playwright run records the
+ * whole thing, so this is also how the demo video is produced.
+ *
+ * Run:
+ *   node e2e/live/mcp-hot-add/run.mjs
+ *   node e2e/live/mcp-hot-add/run.mjs --source=/path/to/data-dir   # install to borrow settings.json from
+ *   node e2e/live/mcp-hot-add/run.mjs --image=superagent-container:mytag
+ *   node e2e/live/mcp-hot-add/run.mjs --keep-data                   # keep the seeded dir (holds API keys!)
+ *
+ * Prerequisites: Docker running, a container image built from THIS checkout
+ * (`docker build -t superagent-container:mcp-hot-add agent-container`), and
+ * a source data dir whose settings.json carries a working LLM key. The source
+ * install is only ever READ; only settings.json, host-container-tokens.json
+ * and tenant-id are copied, never the database.
+ *
+ * The host is started with SUPERAGENT_UNSAFE_ALLOW_LOOPBACK_MCP=1 so the mock
+ * MCP on 127.0.0.1 passes the remote-MCP SSRF policy — the same exception the
+ * Electron app grants a local MCP server.
+ */
+
+import { spawn, spawnSync, execFileSync } from 'node:child_process'
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  copyFileSync,
+  writeFileSync,
+} from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import net from 'node:net'
+import { fileURLToPath } from 'node:url'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(HERE, '../../..')
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const [k, ...v] = a.replace(/^--/, '').split('=')
+    return [k, v.length ? v.join('=') : true]
+  }),
+)
+
+const SOURCE = args.source || process.env.MCP_HOT_ADD_SOURCE_DIR || path.join(os.homedir(), 'Downloads', 'superagent-sdk257')
+const IMAGE = args.image || process.env.MCP_HOT_ADD_IMAGE || 'superagent-container:mcp-hot-add'
+const RUN_DIR = path.join(os.tmpdir(), `mcp-hot-add-${Date.now()}`)
+const MARKER = '.mcp-hot-add-probe'
+// Away from the packaged default (4000), dev:electron's (5000), the Slack
+// suite's (5300) and the restart probe's (5400).
+const CONTAINER_BASE_PORT = 5500
+
+const log = (msg) => console.log(`[mcp-hot-add] ${msg}`)
+
+// Private temp dir: the seeded copy holds real credentials.
+const TARGET = mkdtempSync(path.join(os.tmpdir(), 'mcp-hot-add-data-'))
+
+function seed() {
+  const settingsPath = path.join(SOURCE, 'settings.json')
+  if (!existsSync(settingsPath)) throw new Error(`No settings.json in ${SOURCE}`)
+  const settings = JSON.parse(readFileSync(settingsPath, 'utf8'))
+  settings.container = { ...(settings.container ?? {}), containerRunner: 'docker', agentImage: IMAGE }
+  settings.app = { ...(settings.app ?? {}), setupCompleted: true }
+
+  mkdirSync(TARGET, { recursive: true })
+  writeFileSync(path.join(TARGET, MARKER), 'mcp-hot-add probe scratch dir\n')
+  writeFileSync(path.join(TARGET, 'settings.json'), JSON.stringify(settings, null, 2), { mode: 0o600 })
+  for (const optional of ['tenant-id', 'host-container-tokens.json']) {
+    const from = path.join(SOURCE, optional)
+    if (existsSync(from)) copyFileSync(from, path.join(TARGET, optional))
+  }
+  log(`seeded data dir ${TARGET} (image ${IMAGE}, fresh database)`)
+}
+
+function removeSeededDataDir() {
+  if (!existsSync(path.join(TARGET, MARKER))) return
+  try {
+    rmSync(TARGET, { recursive: true, force: true })
+    log(`removed seeded data dir ${TARGET}`)
+  } catch (err) {
+    log(`could not remove ${TARGET}: ${err.message} — it holds credentials, delete it by hand`)
+  }
+}
+
+async function freePort() {
+  for (let port = 3410; port < 3460; port++) {
+    const ok = await new Promise((resolve) => {
+      const server = net.createServer()
+      server.once('error', () => resolve(false))
+      server.once('listening', () => server.close(() => resolve(true)))
+      server.listen(port, '127.0.0.1')
+    })
+    if (ok) return port
+  }
+  throw new Error('no free port in 3410-3459')
+}
+
+async function waitFor(label, probe, timeoutMs, intervalMs = 1000) {
+  const start = Date.now()
+  for (;;) {
+    let value
+    try { value = await probe() } catch { value = false }
+    if (value) return value
+    if (Date.now() - start > timeoutMs) throw new Error(`Timed out waiting for ${label} (${timeoutMs}ms)`)
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
+async function startApp(port) {
+  const logFile = path.join(RUN_DIR, 'host.log')
+  const out = createWriteStream(logFile, { flags: 'a' })
+  const child = spawn('npx', ['vite', '--port', String(port), '--strictPort'], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      SUPERAGENT_DATA_DIR: TARGET,
+      PORT: String(port),
+      NODE_ENV: 'development',
+      SUPERAGENT_BASE_PORT: String(CONTAINER_BASE_PORT),
+      SUPERAGENT_UNSAFE_ALLOW_LOOPBACK_MCP: '1',
+      SUPERAGENT_TEST_UPDATES: '',
+      E2E_MOCK: '',
+    },
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  child.stdout.pipe(out)
+  child.stderr.pipe(out)
+  let exited = null
+  child.on('exit', (code, signal) => { exited = `exited with code=${code} signal=${signal}` })
+
+  const base = `http://127.0.0.1:${port}`
+  try {
+    await waitFor('host API to answer', async () => {
+      if (exited) throw new Error(`host ${exited} — see ${logFile}`)
+      const res = await fetch(`${base}/api/settings`)
+      return res.ok
+    }, 180_000)
+  } catch (err) {
+    if (!exited) {
+      try { process.kill(-child.pid, 'SIGKILL') } catch { child.kill('SIGKILL') }
+    }
+    throw err
+  }
+  log(`host up on ${base} (pid ${child.pid}, logs → ${logFile})`)
+  return { child, base }
+}
+
+async function stopApp(app) {
+  try { process.kill(-app.child.pid, 'SIGTERM') } catch { app.child.kill('SIGTERM') }
+  await waitFor('host to stop answering', async () => {
+    try { await fetch(`${app.base}/api/agents`); return false } catch { return true }
+  }, 60_000)
+  log('host stopped')
+}
+
+function superagentContainers() {
+  try {
+    return new Set(
+      execFileSync('docker', ['ps', '-a', '--format', '{{.Names}}'], { encoding: 'utf8' })
+        .split('\n')
+        .filter((n) => n.startsWith('superagent-')),
+    )
+  } catch {
+    return new Set()
+  }
+}
+
+/**
+ * Containers this run created: whatever `superagent-*` container appeared
+ * since the host booted. Agent slugs are random, so the name cannot be
+ * predicted — but the seeded install starts with no agents at all, so every
+ * new container is the probe's.
+ */
+function probeContainers(before) {
+  return [...superagentContainers()].filter((name) => !before.has(name))
+}
+
+function captureAndRemoveContainer(name) {
+  try {
+    const id = execFileSync('docker', ['ps', '-aq', '--filter', `name=^${name}$`], { encoding: 'utf8' }).trim()
+    if (!id) return null
+    const logs = execFileSync('docker', ['logs', name], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    const file = path.join(RUN_DIR, `${name}.container.log`)
+    writeFileSync(file, logs)
+    execFileSync('docker', ['rm', '-f', name], { encoding: 'utf8' })
+    log(`captured container log → ${file}, removed ${name}`)
+    return logs
+  } catch (err) {
+    log(`could not capture/remove ${name}: ${err.message}`)
+    return null
+  }
+}
+
+function check(name, ok, detail = '') {
+  console.log(`  ${ok ? '✅' : '❌'} ${name}${detail ? ` — ${detail}` : ''}`)
+  return ok
+}
+
+function listFiles(dir, ext) {
+  const found = []
+  const walk = (d) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, entry.name)
+      if (entry.isDirectory()) walk(p)
+      else if (p.endsWith(ext)) found.push(p)
+    }
+  }
+  if (existsSync(dir)) walk(dir)
+  return found
+}
+
+async function main() {
+  mkdirSync(RUN_DIR, { recursive: true })
+  log(`run dir ${RUN_DIR}`)
+  let app = null
+  let exitCode = 1
+  let before = new Set()
+  try {
+    seed()
+    const port = await freePort()
+    before = superagentContainers()
+    app = await startApp(port)
+
+    const outputDir = path.join(RUN_DIR, 'test-results')
+    const result = spawnSync('npx', ['playwright', 'test', '--config', 'playwright.live-mcp.config.ts'], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        E2E_BASE_URL: app.base,
+        PLAYWRIGHT_OUTPUT_DIR: outputDir,
+      },
+      stdio: 'inherit',
+    })
+    exitCode = result.status ?? 1
+
+    // The container's own log is the proof of WHICH path ran: the hot path
+    // logs "hot-added to the live query", the legacy path logs "scheduling
+    // interrupt to inject tools".
+    console.log('\nContainer-side evidence:')
+    let allOk = exitCode === 0
+    const containers = probeContainers(before)
+    allOk = check('the probe ran one real agent container', containers.length === 1, containers.join(', ')) && allOk
+    for (const name of containers) {
+      const logs = captureAndRemoveContainer(name) ?? ''
+      allOk = check('remote MCP applied to the live query in place', /Applied remote MCP servers in place: added=\[[^\]]*rocket_ops/.test(logs)) && allOk
+      allOk = check('approved server hot-added, no interrupt scheduled', /hot-added to the live query/.test(logs) && !/scheduling interrupt to inject tools/.test(logs)) && allOk
+      allOk = check('query was never restarted after the MCP approval', !/Restarting query after interrupt/.test(logs)) && allOk
+    }
+    if (!allOk) exitCode = exitCode || 1
+
+    const videos = listFiles(outputDir, '.webm')
+    console.log('\nRecordings:')
+    for (const v of videos) console.log(`  ${v}`)
+    // One clip per test output dir: main page with the OAuth popup laid over it.
+    for (const testDir of new Set(videos.map((v) => path.dirname(v)))) {
+      try {
+        const clip = execFileSync('node', [path.join(HERE, 'compose-video.mjs'), testDir], { encoding: 'utf8' }).trim()
+        console.log(`  demo clip → ${clip}`)
+      } catch (err) {
+        log(`could not compose a demo clip for ${testDir}: ${err.message}`)
+      }
+    }
+    console.log(`Host log: ${path.join(RUN_DIR, 'host.log')}`)
+  } catch (err) {
+    console.error(`[mcp-hot-add] FAILED: ${err.message}`)
+    exitCode = 1
+  } finally {
+    if (app) {
+      for (const name of probeContainers(before)) captureAndRemoveContainer(name)
+      await stopApp(app).catch((err) => log(`stop failed: ${err.message}`))
+    }
+    if (args['keep-data']) log(`kept seeded data dir ${TARGET} — it holds API keys, delete it when done`)
+    else removeSeededDataDir()
+  }
+  process.exit(exitCode)
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e:headed": "E2E_MOCK=true playwright test --project=web-chromium --headed",
     "test:e2e:ui": "E2E_MOCK=true playwright test --ui",
     "test:e2e:auth": "npx playwright test --config=playwright.auth.config.ts",
+    "test:live:mcp-hot-add": "node e2e/live/mcp-hot-add/run.mjs",
     "test:e2e:electron": "npm run build:electron && E2E_MOCK=true playwright test --project=electron",
     "test:e2e:perf": "RENDER_TRACKING=true E2E_MOCK=true playwright test --project=web-chromium e2e/specs/render-perf.spec.ts",
     "test:halftone:visual": "E2E_MOCK=true playwright test e2e/specs/halftone-visual.spec.ts --project=web-chromium --workers=1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,8 @@ const configuredWorkers = process.env.PLAYWRIGHT_WORKERS
 
 const webTestIgnore = [
   '**/auth/**',
+  // Real-container probes with their own config (playwright.live-mcp.config.ts).
+  '**/live/**',
   '**/getting-started-wizard.spec.ts',
   // Mutates the global provider API key — quarantined to the wizard config.
   '**/provider-api-key.spec.ts',
@@ -68,7 +70,10 @@ function buildWebServerCommand() {
 
 export default defineConfig({
   testDir: './e2e',
-  testIgnore: ['**/auth/**'],  // Auth tests use separate config (playwright.auth.config.ts)
+  // Auth tests use a separate config (playwright.auth.config.ts); e2e/live
+  // holds probes against the REAL container (playwright.live-mcp.config.ts
+  // and the .mjs harnesses), which the mock host cannot satisfy.
+  testIgnore: ['**/auth/**', '**/live/**'],
   outputDir: playwrightOutputDir,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,

--- a/playwright.docker.config.ts
+++ b/playwright.docker.config.ts
@@ -28,6 +28,7 @@ const configuredWorkers = process.env.PLAYWRIGHT_WORKERS
 
 const webTestIgnore = [
   '**/auth/**',
+  '**/live/**',
   '**/getting-started-wizard.spec.ts',
   // Mutates the global provider API key — quarantined to the wizard config.
   '**/provider-api-key.spec.ts',
@@ -51,7 +52,7 @@ if (process.env.E2E_INCLUDE_A11Y !== 'true') {
 
 export default defineConfig({
   testDir: './e2e',
-  testIgnore: ['**/auth/**'],
+  testIgnore: ['**/auth/**', '**/live/**'],
   outputDir: playwrightOutputDir,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,

--- a/playwright.live-mcp.config.ts
+++ b/playwright.live-mcp.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Live remote-MCP hot-add probe: the REAL container against a mock OAuth MCP.
+ *
+ * No webServer here — `e2e/live/mcp-hot-add/run.mjs` seeds a data dir with
+ * real credentials, boots the host, and points this config at it through
+ * E2E_BASE_URL. Video is always on: the run doubles as the demo recording of
+ * the whole flow (agent asks → user signs in → agent uses the new tools).
+ */
+const baseURL = process.env.E2E_BASE_URL
+if (!baseURL) {
+  throw new Error('E2E_BASE_URL is required — run this through e2e/live/mcp-hot-add/run.mjs')
+}
+
+const viewport = { width: 1440, height: 900 }
+
+export default defineConfig({
+  testDir: './e2e/live/mcp-hot-add',
+  testMatch: ['**/*.spec.ts'],
+  outputDir: process.env.PLAYWRIGHT_OUTPUT_DIR ?? 'test-results/live-mcp-hot-add',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  // One real agent turn with a human-paced OAuth handoff in the middle.
+  timeout: 10 * 60_000,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    viewport,
+    video: { mode: 'on', size: viewport },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'live-chromium',
+      use: { ...devices['Desktop Chrome'], viewport },
+    },
+  ],
+})

--- a/src/shared/lib/mcp/mcp-safe-fetch.test.ts
+++ b/src/shared/lib/mcp/mcp-safe-fetch.test.ts
@@ -110,7 +110,7 @@ describe('mcpSafeFetch pin (live connect)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     originalE2EMock = process.env.E2E_MOCK
-    process.env.E2E_MOCK = '1'
+    process.env.E2E_MOCK = 'true'
     lookupMock.mockResolvedValue({ address: '127.0.0.1', family: 4 })
   })
 

--- a/src/shared/lib/utils/url-safety-dns-ssrf.test.ts
+++ b/src/shared/lib/utils/url-safety-dns-ssrf.test.ts
@@ -57,7 +57,7 @@ describe('validateMcpDiscoveryUrl DNS resolve (SSRF)', () => {
   })
 
   it('allows localhost under E2E_MOCK even when DNS returns loopback', async () => {
-    process.env.E2E_MOCK = '1'
+    process.env.E2E_MOCK = 'true'
     lookupMock.mockResolvedValue({ address: '127.0.0.1', family: 4 })
 
     const parsed = await validateMcpDiscoveryUrl('http://localhost:3100/mcp')

--- a/src/shared/lib/utils/url-safety.test.ts
+++ b/src/shared/lib/utils/url-safety.test.ts
@@ -22,6 +22,52 @@ describe('validateMcpDiscoveryUrl localhost policy', () => {
     await expect(validateMcpDiscoveryUrl('http://127.0.0.1:8899')).resolves.toBeInstanceOf(URL)
   })
 
+  describe('outside Electron', () => {
+    const saved: Record<string, string | undefined> = {}
+    const KEYS = ['E2E_MOCK', 'SUPERAGENT_UNSAFE_ALLOW_LOOPBACK_MCP'] as const
+
+    afterEach(() => {
+      for (const key of KEYS) {
+        if (saved[key] === undefined) delete process.env[key]
+        else process.env[key] = saved[key]
+      }
+    })
+
+    function setEnv(values: Partial<Record<(typeof KEYS)[number], string>>) {
+      for (const key of KEYS) {
+        saved[key] = process.env[key]
+        if (values[key] === undefined) delete process.env[key]
+        else process.env[key] = values[key]
+      }
+    }
+
+    it('rejects loopback by default', async () => {
+      setEnv({})
+      await expect(validateMcpDiscoveryUrl('http://127.0.0.1:8899')).rejects.toThrow(/private or loopback/)
+    })
+
+    it('allows loopback for a mock E2E run or an opted-in live harness', async () => {
+      setEnv({ E2E_MOCK: 'true' })
+      await expect(validateMcpDiscoveryUrl('http://127.0.0.1:8899')).resolves.toBeInstanceOf(URL)
+      setEnv({ SUPERAGENT_UNSAFE_ALLOW_LOOPBACK_MCP: '1' })
+      await expect(validateMcpDiscoveryUrl('http://localhost:8899')).resolves.toBeInstanceOf(URL)
+    })
+
+    it('reads both switches by exact value, never by presence', async () => {
+      // A string env var is truthy even when it says "no": the switches must
+      // not open up for E2E_MOCK=false or ...=0.
+      setEnv({ E2E_MOCK: 'false' })
+      await expect(validateMcpDiscoveryUrl('http://127.0.0.1:8899')).rejects.toThrow(/private or loopback/)
+      setEnv({ SUPERAGENT_UNSAFE_ALLOW_LOOPBACK_MCP: '0' })
+      await expect(validateMcpDiscoveryUrl('http://127.0.0.1:8899')).rejects.toThrow(/private or loopback/)
+    })
+
+    it('never widens the exception past loopback', async () => {
+      setEnv({ SUPERAGENT_UNSAFE_ALLOW_LOOPBACK_MCP: '1' })
+      await expect(validateMcpDiscoveryUrl('http://192.168.0.10:8899')).rejects.toThrow(/private or loopback/)
+    })
+  })
+
   it('rejects loopback when the caller explicitly disallows it, even on Electron', async () => {
     // The default exception exists for user-configured local targets. A caller
     // following a remotely supplied URL opts out, and that must win.

--- a/src/shared/lib/utils/url-safety.ts
+++ b/src/shared/lib/utils/url-safety.ts
@@ -128,9 +128,21 @@ export function tryParseUrl(input: string, base?: string | URL): URL | null {
   }
 }
 
+/**
+ * Loopback MCP servers are allowed for a user running one locally — but only
+ * where "locally" is demonstrable: the Electron main process, a mock E2E run,
+ * or a live harness that explicitly opts in. The harness switch exists for
+ * `e2e/live/*` runs that drive the REAL container from the web dev server
+ * against a mock MCP on this machine (the mock container path is E2E_MOCK).
+ * It is an exact-value check, like the others: env vars are strings, so a
+ * presence test would also open this up for `...=0` or `E2E_MOCK=false`.
+ * Never set it on a deployment.
+ */
 function allowsLocalhostMcpException(hostname: string): boolean {
   const isElectron = process.type === 'browser'
-  return Boolean((isElectron || process.env.E2E_MOCK) && isLocalhostHost(hostname))
+  const e2eMock = process.env.E2E_MOCK === 'true'
+  const liveHarness = process.env.SUPERAGENT_UNSAFE_ALLOW_LOOPBACK_MCP === '1'
+  return (isElectron || e2eMock || liveHarness) && isLocalhostHost(hostname)
 }
 
 export interface DiscoveryHostPolicy {


### PR DESCRIPTION
## Demo

Real container, real CLI, Opus 5, recorded by the live probe below. The agent asks for the Rocket Ops MCP → the user signs in on the server's OAuth login page (popup, top right) → Allow Access → the agent calls `mcp__rocket_ops__get_launch_code` in the same turn → proxy review → answer. No "Stopped" marker, no continuation message.

https://github.com/user-attachments/assets/b6c19a27-bd58-4dfd-8e89-77917f1a8aa7

## Summary

Approving a remote MCP mid-session no longer restarts the query. The container now pushes the new server into the **live** query with the Agent SDK's `Query.setMcpServers()`, so the model gets its tool result naming the new tools and carries on in the same turn — no interrupt, no "Stopped" marker, no `[SYSTEM] … fully registered` continuation.

Two paths use it:

- **Mid-turn approval** (`request_remote_mcp`): the tool now awaits `addRemoteMcpServer()`, which hot-adds the server and resolves once it is connected. A server that registered but failed to connect makes the tool return an error result instead of telling the model the tools exist.
- **Agent Settings sync**: when `REMOTE_MCPS` changes between turns, `sendMessage` applies it in place. A connected-accounts change still re-queries (it only reaches the model through the system prompt, which is baked at query creation), so the two projections are now tracked separately.

The legacy interrupt + continuation path stays as the fallback for a CLI without the control request.

### Why the full map

`setMcpServers()` is a replace: an in-process SDK server missing from the map is disconnected, and the CLI drops dynamic process servers it no longer sees. The container therefore hands over every in-process server (the same instances the query was created with — the SDK skips ones it already has) plus every remote server from the projection. Verified on SDK 0.3.257 with a standalone probe: start-time `--mcp-config` servers report `scope: "dynamic"`, are re-added rather than duplicated, and can be removed by the same call; a server that is not in `allowedTools` still runs under bypass permissions.

## Live proof (real container, real CLI, real model)

`npm run test:live:mcp-hot-add` boots the host from a seeded data dir with the real container image and drives the browser through the whole flow against a local **OAuth-protected** mock MCP (`e2e/live/mcp-hot-add/`):

1. The agent is asked for the launch code from a "Rocket Ops" MCP it does not have.
2. It calls `request_remote_mcp`; the user clicks **Connect**, signs in on the server's own login page in the OAuth popup (dynamic client registration → PKCE authorize → token), then **Allow Access**.
3. The agent, still in the same turn, runs `ToolSearch` and calls `mcp__rocket_ops__get_launch_code`; the user approves the proxy review; the answer comes back with the code the mock returns.

The spec asserts the mock saw `register → login → token → initialize → tools/call` in that order with the token it minted, that the transcript holds exactly one human message and no interrupt marker or `[SYSTEM]` line, and that both tool calls live in that single turn. The harness then reads the container log for the path that ran:

```
✅ remote MCP applied to the live query in place
✅ approved server hot-added, no interrupt scheduled
✅ query was never restarted after the MCP approval
```

The run records a video; `compose-video.mjs` lays the popup recording over the main one.

### Host change for the probe

The remote-MCP SSRF policy only exempts loopback in Electron or under `E2E_MOCK`. The probe runs the web dev server against a loopback mock, so `url-safety` gains an explicit, exact-value switch `SUPERAGENT_UNSAFE_ALLOW_LOOPBACK_MCP=1` for live harnesses. While there, the `E2E_MOCK` check became exact-value too (it was a presence test, unlike every other `E2E_MOCK` check), with tests for both.

## Tests

- `claude-code-connections.test.ts`: rewritten around the hot path (in-place apply with the full map, no handshake polling, snapshot sync, removal), the re-query fallback, the awaited `addRemoteMcpServer` (resolve / reject on connect error / legacy fallback), and the existing handshake gate pinned to the fallback path it guards.
- `request-remote-mcp.test.ts`: awaits the hot-add before answering; reports a granted-but-unreachable server as an error.
- `url-safety.test.ts`: the loopback switches.
- Container typecheck, host typecheck and lint clean; the live probe above passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpyNpJVwWwEWpW8xkjcawc
