### PR TITLE
feat(errors): placement/component keys on errorPresentation + composer placement (SUP-725)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -206,7 +206,7 @@ import { Readable, pipeline } from 'stream'
 import { pipeline as streamPipeline } from 'stream/promises'
 import pLimit from 'p-limit'
 import * as path from 'path'
-import { PROVIDER_ERROR_CODES, type ApiAgent } from '@shared/lib/types/api'
+import type { ApiAgent } from '@shared/lib/types/api'
 import type { SessionInfo, SessionMetadataMap } from '@shared/lib/types/agent'
 import { toPublicChatIntegration } from '@shared/lib/chat-integrations/public'
 import { toPublicWebhookTrigger } from '@shared/lib/webhook-triggers/public'
@@ -2191,8 +2191,9 @@ const messagesListQuerySchema = z
 function attachProviderErrorPresentations(transformed: TransformedItem[]): void {
   for (const item of transformed) {
     // Holes serialize as null (JSON.stringify / streamJsonArrayResponse); skip so this walk does not 500.
-    if (!item || item.type !== 'assistant' || !item.apiError || !PROVIDER_ERROR_CODES.has(item.apiError)) continue
-    item.errorPresentation = getActiveLlmProvider().parseErrorResponse(undefined, item.content.text)
+    if (!item || item.type !== 'assistant' || !item.apiError) continue
+    item.errorPresentation =
+      getActiveLlmProvider().presentationForTurnError(undefined, item.content.text, item.apiError) ?? undefined
   }
 }
 

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -115,8 +115,7 @@ export function SessionChatColumn({
             </PendingRequestStack>
           </div>
         ) : (
-          <>
-            <ProviderErrorPlacement placement="composer" sessionId={sessionId} agentSlug={agentSlug} />
+          <ProviderErrorPlacement placement="composer" sessionId={sessionId} agentSlug={agentSlug}>
             {pendingWakeAt && pendingWakeTaskId && !isActive && (
               <PendingWakeBanner
                 sessionId={sessionId}
@@ -193,7 +192,7 @@ export function SessionChatColumn({
                 <span>New line</span>
               </span>
             </div>
-          </>
+          </ProviderErrorPlacement>
         )
       }
     />

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -6,6 +6,7 @@ import { PendingRequestErrorBoundary } from '@renderer/components/messages/pendi
 import { usePendingRequests } from '@renderer/components/messages/use-pending-requests'
 import { StaleSessionNotice } from '@renderer/components/messages/stale-session-notice'
 import { PendingWakeBanner } from '@renderer/components/messages/pending-wake-banner'
+import { ProviderErrorPlacement } from '@renderer/components/provider-error/provider-error-placement'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useScreenWakeLock } from '@renderer/hooks/use-screen-wake-lock'
 import { useFileDeliveryWatcher } from '@renderer/hooks/use-file-delivery-watcher'
@@ -115,6 +116,7 @@ export function SessionChatColumn({
           </div>
         ) : (
           <>
+            <ProviderErrorPlacement placement="composer" sessionId={sessionId} agentSlug={agentSlug} />
             {pendingWakeAt && pendingWakeTaskId && !isActive && (
               <PendingWakeBanner
                 sessionId={sessionId}

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -138,6 +138,14 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByRole('link', { name: /raise spend limit/i })).toBeInTheDocument()
   })
 
+  it('renders nothing for a provider error routed to the composer placement', () => {
+    mockStreamState.error = 'API Error: 402 insufficient balance'
+    mockStreamState.apiErrorCode = 'billing_error'
+    mockStreamState.errorPresentation = { severity: 'error', message: '**Routed**', icon: 'info', placement: 'composer' }
+    const { container } = render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(container.innerHTML).toBe('')
+  })
+
   it('shows generic error alert when no apiErrorCode', () => {
     mockStreamState.error = 'The agent process was terminated unexpectedly.'
     mockStreamState.apiErrorCode = null

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -138,6 +138,14 @@ describe('AgentActivityIndicator', () => {
     expect(screen.getByRole('link', { name: /raise spend limit/i })).toBeInTheDocument()
   })
 
+  it('shows the provider card for a generic SDK code when a presentation is attached', () => {
+    mockStreamState.error = 'API Error: 402'
+    mockStreamState.apiErrorCode = 'unknown'
+    mockStreamState.errorPresentation = { severity: 'error', message: '**Attached**', icon: 'info' }
+    render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Attached')
+  })
+
   it('renders nothing for a provider error routed to the composer placement', () => {
     mockStreamState.error = 'API Error: 402 insufficient balance'
     mockStreamState.apiErrorCode = 'billing_error'

--- a/src/renderer/components/messages/agent-activity-indicator.test.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.test.tsx
@@ -126,7 +126,7 @@ describe('AgentActivityIndicator', () => {
     platformAuth.connected = true
     mockStreamState.error = 'API Error: Request rejected (429) · A spend cap for this workspace was reached. It resets within 30 days. Ask a workspace admin to raise it.'
     mockStreamState.apiErrorCode = 'rate_limit'
-    // Presentation is authored server-side by PlatformLlmProvider.parseErrorResponse
+    // Presentation is authored server-side by PlatformLlmProvider.presentationForTurnError
     // and arrives on the session_error event.
     mockStreamState.errorPresentation = parsePlatformErrorResponse(429, mockStreamState.error)
     render(<AgentActivityIndicator sessionId="s-1" agentSlug="agent-1" />)

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -4,7 +4,7 @@ import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
 import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-requests'
 import { apiFetch } from '@renderer/lib/api'
-import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
+import { resolveProviderError } from '@renderer/components/provider-error/provider-error-registry'
 import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 import { isTurnStartingUserMessage } from './pending-message'
 import { useCallback, useMemo, useState } from 'react'
@@ -247,10 +247,13 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
   // Show error if present
   if (error) {
     const isProviderError = apiErrorCode != null && PROVIDER_ERROR_CODES.has(apiErrorCode)
+    const providerError = resolveProviderError(errorPresentation)
+    // Routed to another placement (e.g. composer): ProviderErrorPlacement renders it there.
+    if (isProviderError && providerError.placement !== 'inline') return null
     return (
       <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
         {isProviderError ? (
-          <ProviderErrorCard message={error} presentation={errorPresentation ?? undefined} />
+          <providerError.Component message={error} presentation={errorPresentation ?? undefined} />
         ) : (
           <ActivityErrorCard message={error} />
         )}

--- a/src/renderer/components/messages/agent-activity-indicator.tsx
+++ b/src/renderer/components/messages/agent-activity-indicator.tsx
@@ -5,7 +5,7 @@ import { useElapsedTimer } from '@renderer/hooks/use-elapsed-timer'
 import { usePendingUserRequests } from '@renderer/hooks/use-pending-user-requests'
 import { apiFetch } from '@renderer/lib/api'
 import { resolveProviderError } from '@renderer/components/provider-error/provider-error-registry'
-import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
+import { isProviderFacingError } from '@shared/lib/types/api'
 import { isTurnStartingUserMessage } from './pending-message'
 import { useCallback, useMemo, useState } from 'react'
 
@@ -246,7 +246,7 @@ export function AgentActivityIndicator({ sessionId, agentSlug }: AgentActivityIn
 
   // Show error if present
   if (error) {
-    const isProviderError = apiErrorCode != null && PROVIDER_ERROR_CODES.has(apiErrorCode)
+    const isProviderError = isProviderFacingError(apiErrorCode, errorPresentation)
     const providerError = resolveProviderError(errorPresentation)
     // Routed to another placement (e.g. composer): ProviderErrorPlacement renders it there.
     if (isProviderError && providerError.placement !== 'inline') return null

--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -477,6 +477,16 @@ describe('MessageItem', () => {
       expect(screen.getByRole('link', { name: /raise spend limit/i })).toBeInTheDocument()
     })
 
+    it('renders the provider card for a generic SDK code when a presentation is attached', () => {
+      const msg = createAssistantMessage({
+        content: { text: 'API Error: 402' },
+        apiError: 'unknown',
+        errorPresentation: { severity: 'error', message: '**Attached**', icon: 'info' },
+      })
+      render(<MessageItem message={msg} />)
+      expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Attached')
+    })
+
     it('renders nothing in the stream for a provider error routed to the composer placement', () => {
       const msg = createAssistantMessage({
         content: { text: 'API Error: 402 insufficient balance' },

--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -487,14 +487,24 @@ describe('MessageItem', () => {
       expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Attached')
     })
 
-    it('renders nothing in the stream for a provider error routed to the composer placement', () => {
+    it('renders nothing in the stream while its composer-routed error is shown by the placement', () => {
       const msg = createAssistantMessage({
         content: { text: 'API Error: 402 insufficient balance' },
         apiError: 'billing_error',
         errorPresentation: { severity: 'error', message: '**Routed**', icon: 'info', placement: 'composer' },
       })
-      const { container } = render(<MessageItem message={msg} />)
+      const { container } = render(<MessageItem message={msg} suppressInlineError />)
       expect(container.innerHTML).toBe('')
+    })
+
+    it('keeps a composer-routed error in the transcript as the default card once it is no longer current', () => {
+      const msg = createAssistantMessage({
+        content: { text: 'API Error: 402 insufficient balance' },
+        apiError: 'billing_error',
+        errorPresentation: { severity: 'error', message: '**Routed**', icon: 'info', placement: 'composer' },
+      })
+      render(<MessageItem message={msg} />)
+      expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Routed')
     })
 
     it('still renders the inline card when placement is explicitly inline', () => {

--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -477,6 +477,26 @@ describe('MessageItem', () => {
       expect(screen.getByRole('link', { name: /raise spend limit/i })).toBeInTheDocument()
     })
 
+    it('renders nothing in the stream for a provider error routed to the composer placement', () => {
+      const msg = createAssistantMessage({
+        content: { text: 'API Error: 402 insufficient balance' },
+        apiError: 'billing_error',
+        errorPresentation: { severity: 'error', message: '**Routed**', icon: 'info', placement: 'composer' },
+      })
+      const { container } = render(<MessageItem message={msg} />)
+      expect(container.innerHTML).toBe('')
+    })
+
+    it('still renders the inline card when placement is explicitly inline', () => {
+      const msg = createAssistantMessage({
+        content: { text: 'API Error: 429' },
+        apiError: 'rate_limit',
+        errorPresentation: { severity: 'error', message: '**Explicit inline**', icon: 'info', placement: 'inline' },
+      })
+      render(<MessageItem message={msg} />)
+      expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Explicit inline')
+    })
+
     it('falls back to the generic provider banner when no presentation is attached', () => {
       const msg = createAssistantMessage({
         content: {

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@shared/lib/utils/cn'
 import { useState, useCallback, useRef, useLayoutEffect, useMemo, memo, type ReactNode } from 'react'
 import { Check, Copy, Link2 } from 'lucide-react'
-import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
+import { resolveProviderError } from '@renderer/components/provider-error/provider-error-registry'
 import { ToolCallItem } from './tool-call-item'
 import { ThinkingBlockItem } from './thinking-block-item'
 import { SubAgentBlock } from './subagent-block'
@@ -366,20 +366,25 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
 
   // Detect assistant messages that failed due to an LLM provider error (from SDK metadata)
   const isProviderErrorMessage = isAssistant && !!message.apiError && PROVIDER_ERROR_CODES.has(message.apiError)
+  // Errors routed to another placement (e.g. composer) are rendered there, not in the stream.
+  const providerError = resolveProviderError(message.errorPresentation)
+  const showInlineError = isProviderErrorMessage && providerError.placement === 'inline'
+  const hasInlineText = hasText && !(isProviderErrorMessage && !showInlineError)
 
   // Don't render assistant messages that have no text, no tool calls, and no
   // thinking (and aren't streaming). These are transient empty entries from
   // partially-persisted JSONL that will be filled in on the next refetch.
-  if (isAssistant && !hasText && toolCalls.length === 0 && thinking.length === 0 && !isStreaming) {
+  if (isAssistant && !hasInlineText && toolCalls.length === 0 && thinking.length === 0 && !isStreaming) {
     return null
   }
 
   // Skip rendering the text bubble for:
   // - assistant messages with only tool calls (no text) unless streaming
+  // - assistant provider errors routed to another placement
   // - user messages that only had attached files (text was fully stripped)
   const showMessageBubble = isUser
     ? (hasText || attachedFiles.length === 0)
-    : (hasText || isStreaming)
+    : (hasInlineText || isStreaming)
 
   return (
     <div
@@ -440,8 +445,8 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
               )}
 
               {/* LLM provider error display */}
-              {hasText && !CustomUserRender && isProviderErrorMessage && (
-                <ProviderErrorCard message={text} presentation={message.errorPresentation} />
+              {hasText && !CustomUserRender && showInlineError && (
+                <providerError.Component message={text} presentation={message.errorPresentation} />
               )}
 
               {/* Text content */}

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -2,6 +2,7 @@ import { cn } from '@shared/lib/utils/cn'
 import { useState, useCallback, useRef, useLayoutEffect, useMemo, memo, type ReactNode } from 'react'
 import { Check, Copy, Link2 } from 'lucide-react'
 import { resolveProviderError } from '@renderer/components/provider-error/provider-error-registry'
+import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
 import { ToolCallItem } from './tool-call-item'
 import { ThinkingBlockItem } from './thinking-block-item'
 import { SubAgentBlock } from './subagent-block'
@@ -291,6 +292,9 @@ interface MessageItemProps {
   revealedToolCallIds?: ReadonlySet<string>
   /** Container-local image paths verified against image-bearing tool results. */
   embeddedImageAliases?: EmbeddedImageAliases
+  /** This row's provider error is the session's current one and a `ProviderErrorPlacement`
+   *  renders it elsewhere (e.g. composer). Skip the inline card so it does not show twice. */
+  suppressInlineError?: boolean
 }
 
 function resolveSubagentRun(
@@ -315,7 +319,7 @@ function resolveSubagentRun(
   }
 }
 
-function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSessionActive, activeSubagents, completedSubagents, onRemoveMessage, onRemoveToolCall, readOnly, workDetailClassName, revealedToolCallIds, embeddedImageAliases }: MessageItemProps) {
+function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSessionActive, activeSubagents, completedSubagents, onRemoveMessage, onRemoveToolCall, readOnly, workDetailClassName, revealedToolCallIds, embeddedImageAliases, suppressInlineError }: MessageItemProps) {
   useRenderTracker('MessageItem')
   const isUser = message.type === 'user'
   const isAssistant = message.type === 'assistant'
@@ -366,9 +370,11 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
 
   // Detect assistant messages that failed due to an LLM provider error (from SDK metadata)
   const isProviderErrorMessage = isAssistant && !!message.apiError && isProviderFacingError(message.apiError, message.errorPresentation)
-  // Errors routed to another placement (e.g. composer) are rendered there, not in the stream.
+  // Only the session's current error is skipped here (its placement renders it). Older rows
+  // routed elsewhere stay in the transcript as the default inline card.
+  const showInlineError = isProviderErrorMessage && !suppressInlineError
   const providerError = resolveProviderError(message.errorPresentation)
-  const showInlineError = isProviderErrorMessage && providerError.placement === 'inline'
+  const InlineErrorComponent = providerError.placement === 'inline' ? providerError.Component : ProviderErrorCard
   const hasInlineText = hasText && !(isProviderErrorMessage && !showInlineError)
 
   // Don't render assistant messages that have no text, no tool calls, and no
@@ -446,7 +452,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
 
               {/* LLM provider error display */}
               {hasText && !CustomUserRender && showInlineError && (
-                <providerError.Component message={text} presentation={message.errorPresentation} />
+                <InlineErrorComponent message={text} presentation={message.errorPresentation} />
               )}
 
               {/* Text content */}

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -16,7 +16,7 @@ import { classifyUserText } from './user-message-kinds'
 import ReactMarkdown, { type Components, type Options as ReactMarkdownOptions } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { splitStreamingMarkdown } from './split-streaming-markdown'
-import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
+import { isProviderFacingError } from '@shared/lib/types/api'
 import type { ApiMessage, ApiToolCall } from '@shared/lib/types/api'
 import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
 import { useRenderTracker } from '@renderer/lib/perf'
@@ -365,7 +365,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
   const streamingSplit = isStreaming && text ? splitStreamingMarkdown(text) : null
 
   // Detect assistant messages that failed due to an LLM provider error (from SDK metadata)
-  const isProviderErrorMessage = isAssistant && !!message.apiError && PROVIDER_ERROR_CODES.has(message.apiError)
+  const isProviderErrorMessage = isAssistant && !!message.apiError && isProviderFacingError(message.apiError, message.errorPresentation)
   // Errors routed to another placement (e.g. composer) are rendered there, not in the stream.
   const providerError = resolveProviderError(message.errorPresentation)
   const showInlineError = isProviderErrorMessage && providerError.placement === 'inline'

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2162,6 +2162,19 @@ describe('MessageList', () => {
       expect(screen.queryByTestId('provider-error-card')).not.toBeInTheDocument()
     })
 
+    it('renders no card while the live error and its persisted row coexist', () => {
+      mockMessagesData.data = [createUserMessage({ content: { text: 'summarize' } }), routedError()]
+      Object.assign(mockStreamState, {
+        streamingMessage: 'API Error: 402 insufficient balance',
+        error: 'API Error: 402 insufficient balance',
+        apiErrorCode: 'billing_error',
+        errorPresentation: routed,
+      })
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByTestId('provider-error-card')).not.toBeInTheDocument()
+      expect(screen.queryByText(/API Error: 402/)).not.toBeInTheDocument()
+    })
+
     it('still renders the streaming row inline when the live error is not routed away', () => {
       mockMessagesData.data = [createUserMessage()]
       Object.assign(mockStreamState, {

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2148,6 +2148,31 @@ describe('MessageList', () => {
       renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
       expect(screen.getAllByTestId('provider-error-card')).toHaveLength(1)
     })
+
+    it('renders neither raw text nor a card for the streaming row while the live error is routed', () => {
+      mockMessagesData.data = [createUserMessage({ content: { text: 'summarize' } })]
+      Object.assign(mockStreamState, {
+        streamingMessage: 'API Error: 402 {"error":"insufficient_balance"}',
+        error: 'API Error: 402 {"error":"insufficient_balance"}',
+        apiErrorCode: 'unknown',
+        errorPresentation: routed,
+      })
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByText(/API Error: 402/)).not.toBeInTheDocument()
+      expect(screen.queryByTestId('provider-error-card')).not.toBeInTheDocument()
+    })
+
+    it('still renders the streaming row inline when the live error is not routed away', () => {
+      mockMessagesData.data = [createUserMessage()]
+      Object.assign(mockStreamState, {
+        streamingMessage: 'API Error: 429 rate limited',
+        error: 'API Error: 429 rate limited',
+        apiErrorCode: 'rate_limit',
+        errorPresentation: { severity: 'error', message: '**Inline 429**', icon: 'info' },
+      })
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Inline 429')
+    })
   })
 
   describe('peer user message (SSE)', () => {

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -9,6 +9,7 @@ import { TranscriptNotFoundError } from '@renderer/hooks/use-messages'
 import { useDraft } from '@renderer/context/drafts-context'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import { createUserMessage, createAssistantMessage, createToolCall, createCompactBoundary } from '@renderer/test/factories'
+import type { ProviderErrorPresentation } from '@shared/lib/llm-provider/error-presentation'
 import type { ApiMessageOrBoundary } from '@shared/lib/types/api'
 
 // Mock useMessages
@@ -68,6 +69,9 @@ const mockStreamState = {
   peerUserMessages: [] as Array<{ uuid: string; receivedAt: number; content: string; sender: { id: string; name?: string; email?: string }; queued?: boolean }>,
   discardedCommandUuids: [] as string[],
   thinkingBlocks: [] as Array<{ id: number; persistedId?: string; text: string; startedAt: number; endedAt: number | null }>,
+  error: null as string | null,
+  apiErrorCode: null as string | null,
+  errorPresentation: null as ProviderErrorPresentation | null,
 }
 
 const mockClearCompacting = vi.fn()
@@ -81,6 +85,10 @@ vi.mock('@renderer/hooks/use-message-stream', () => ({
   removePeerUserMessage: (...args: unknown[]) => mockRemovePeerUserMessage(...args),
   clearPeerUserMessages: (...args: unknown[]) => mockClearPeerUserMessages(...args),
   consumeDiscardedCommand: (...args: unknown[]) => mockConsumeDiscardedCommand(...args),
+}))
+
+vi.mock('@renderer/hooks/use-platform-auth', () => ({
+  usePlatformAuthStatus: () => ({ data: { connected: false, platformBaseUrl: null, orgId: null } }),
 }))
 
 // Mock useUser — default no user, override per test
@@ -178,6 +186,9 @@ describe('MessageList', () => {
       peerUserMessages: [],
       discardedCommandUuids: [],
       thinkingBlocks: [],
+      error: null,
+      apiErrorCode: null,
+      errorPresentation: null,
     })
   })
 
@@ -2107,6 +2118,36 @@ describe('MessageList', () => {
 
     // The file should still render (deferred position, after streaming content)
     expect(screen.getByText('deferred.csv')).toBeInTheDocument()
+  })
+
+  describe('provider error routed to the composer', () => {
+    const routed: ProviderErrorPresentation = { severity: 'error', message: '**Routed 402**', icon: 'info', placement: 'composer' }
+    const routedError = () =>
+      createAssistantMessage({ content: { text: 'API Error: 402 insufficient balance' }, apiError: 'billing_error', errorPresentation: routed })
+
+    it('skips the inline card only while the row is the current error', () => {
+      mockMessagesData.data = [createUserMessage({ content: { text: 'summarize' } }), routedError()]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.queryByTestId('provider-error-card')).not.toBeInTheDocument()
+    })
+
+    it('keeps the routed row in the transcript once a normal reply follows', () => {
+      mockMessagesData.data = [
+        createUserMessage({ content: { text: 'summarize' } }),
+        routedError(),
+        createUserMessage({ content: { text: 'try again' } }),
+        createAssistantMessage({ content: { text: 'Here you go' } }),
+      ]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Routed 402')
+      expect(screen.getByText('Here you go')).toBeInTheDocument()
+    })
+
+    it('keeps an older routed row while a newer one is current', () => {
+      mockMessagesData.data = [createUserMessage(), routedError(), createUserMessage(), routedError()]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getAllByTestId('provider-error-card')).toHaveLength(1)
+    })
   })
 
   describe('peer user message (SSE)', () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -13,6 +13,7 @@ import {
 import { isTurnStartingUserMessage, type PendingMessage } from './pending-message'
 import { classifyUserMessage, classifyUserText } from './user-message-kinds'
 import { MessageItem } from './message-item'
+import { currentProviderErrorId } from '@renderer/components/provider-error/provider-error-placement'
 import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
 import { ThinkingBlockItem } from './thinking-block-item'
 import { SubAgentBlock } from './subagent-block'
@@ -236,7 +237,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     isCompacting,
     activeSubagents,
     completedSubagents,
+    error: streamError,
     apiErrorCode,
+    errorPresentation,
     typingUser,
     peerUserMessages,
     discardedCommandUuids,
@@ -470,6 +473,12 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       boundaryCountRef.current = boundaryCount
     }
   }, [isCompacting, boundaryCount, sessionId])
+
+  // The one persisted row whose provider error a ProviderErrorPlacement is showing right now.
+  const currentErrorMessageId = useMemo(
+    () => currentProviderErrorId({ isActive, error: streamError, apiErrorCode, errorPresentation }, messages),
+    [isActive, streamError, apiErrorCode, errorPresentation, messages],
+  )
 
   // Check if streaming message is already in persisted messages (prevents double-render)
   const isStreamingMessagePersisted = useMemo(() => {
@@ -1174,6 +1183,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
                           : undefined
                       }
                       embeddedImageAliases={embeddedImageAliases}
+                      suppressInlineError={item.id === currentErrorMessageId}
                     />
                   </MessageErrorBoundary>
                   {turnDeliveredFiles.has(item.id) && item.id !== deferredElapsedMessageId && (

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -13,7 +13,7 @@ import {
 import { isTurnStartingUserMessage, type PendingMessage } from './pending-message'
 import { classifyUserMessage, classifyUserText } from './user-message-kinds'
 import { MessageItem } from './message-item'
-import { currentProviderErrorId } from '@renderer/components/provider-error/provider-error-placement'
+import { currentRoutedProviderError } from '@renderer/components/provider-error/provider-error-placement'
 import { ToolCallItem, StreamingToolCallItem } from './tool-call-item'
 import { ThinkingBlockItem } from './thinking-block-item'
 import { SubAgentBlock } from './subagent-block'
@@ -474,9 +474,9 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     }
   }, [isCompacting, boundaryCount, sessionId])
 
-  // The one persisted row whose provider error a ProviderErrorPlacement is showing right now.
-  const currentErrorMessageId = useMemo(
-    () => currentProviderErrorId({ isActive, error: streamError, apiErrorCode, errorPresentation }, messages),
+  // The one row (streaming or persisted) whose provider error a ProviderErrorPlacement shows right now.
+  const currentRoutedError = useMemo(
+    () => currentRoutedProviderError({ isActive, error: streamError, apiErrorCode, errorPresentation }, messages),
     [isActive, streamError, apiErrorCode, errorPresentation, messages],
   )
 
@@ -1183,7 +1183,7 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
                           : undefined
                       }
                       embeddedImageAliases={embeddedImageAliases}
-                      suppressInlineError={item.id === currentErrorMessageId}
+                      suppressInlineError={item.id === currentRoutedError?.messageId}
                     />
                   </MessageErrorBoundary>
                   {turnDeliveredFiles.has(item.id) && item.id !== deferredElapsedMessageId && (
@@ -1296,8 +1296,10 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
                 toolCalls: [],
                 createdAt: new Date(),
                 ...(apiErrorCode && { apiError: apiErrorCode }),
+                ...(errorPresentation && { errorPresentation }),
               }}
               isStreaming={isStreaming}
+              suppressInlineError={currentRoutedError?.live === true}
               agentSlug={agentSlug}
               sessionId={sessionId}
               embeddedImageAliases={embeddedImageAliases}

--- a/src/renderer/components/provider-error/provider-error-placement.test.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.test.tsx
@@ -46,14 +46,25 @@ function errorMessage(presentation?: ProviderErrorPresentation) {
 }
 
 describe('currentProviderError', () => {
-  it('prefers the live error', () => {
+  it('prefers the live error and reports the persisted row it was written into', () => {
     const live = { isActive: false, error: 'live 429', apiErrorCode: 'rate_limit', errorPresentation: composerError }
-    expect(currentProviderError(live, [errorMessage(inlineError)])).toEqual({
+    const persisted = errorMessage(inlineError)
+    expect(currentProviderError(live, [persisted])).toEqual({
       message: 'live 429',
       presentation: composerError,
       live: true,
-      messageId: null,
+      messageId: persisted.id,
     })
+  })
+
+  it('reports no row for a live error whose persisted row has not arrived yet', () => {
+    const live = { isActive: false, error: 'live 429', apiErrorCode: 'rate_limit', errorPresentation: composerError }
+    expect(currentProviderError(live, [createUserMessage()])?.messageId).toBeNull()
+  })
+
+  it('does not bind a live error to a persisted normal reply', () => {
+    const live = { isActive: false, error: 'live 429', apiErrorCode: 'rate_limit', errorPresentation: composerError }
+    expect(currentProviderError(live, [createAssistantMessage()])?.messageId).toBeNull()
   })
 
   it('accepts a live error with a generic SDK code when a presentation is attached', () => {
@@ -113,7 +124,13 @@ describe('currentRoutedProviderError', () => {
 
   it('is the live error (no persisted row yet) while it is routed to the composer', () => {
     const live = { isActive: false, error: 'API Error: 402', apiErrorCode: 'billing_error', errorPresentation: composerError }
-    expect(currentRoutedProviderError(live, [errorMessage(composerError)])).toMatchObject({ live: true, messageId: null })
+    expect(currentRoutedProviderError(live, [createUserMessage()])).toMatchObject({ live: true, messageId: null })
+  })
+
+  it('is the live error plus its persisted row once that row has arrived', () => {
+    const live = { isActive: false, error: 'API Error: 402', apiErrorCode: 'billing_error', errorPresentation: composerError }
+    const msg = errorMessage(composerError)
+    expect(currentRoutedProviderError(live, [createUserMessage(), msg])).toMatchObject({ live: true, messageId: msg.id })
   })
 
   it('is null for an inline error, which the transcript renders itself', () => {

--- a/src/renderer/components/provider-error/provider-error-placement.test.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProviderErrorPresentation } from '@shared/lib/llm-provider/error-presentation'
+import type { ApiMessageOrBoundary } from '@shared/lib/types/api'
+import { createAssistantMessage, createCompactBoundary, createUserMessage } from '@renderer/test/factories'
+
+import { currentProviderError, ProviderErrorPlacement } from './provider-error-placement'
+
+const mockStreamState = {
+  isActive: false,
+  error: null as string | null,
+  apiErrorCode: null as string | null,
+  errorPresentation: null as ProviderErrorPresentation | null,
+}
+vi.mock('@renderer/hooks/use-message-stream', () => ({
+  useMessageStream: () => mockStreamState,
+}))
+
+const mockMessages: ApiMessageOrBoundary[] = []
+vi.mock('@renderer/hooks/use-messages', () => ({
+  useMessages: () => ({ data: mockMessages }),
+}))
+
+vi.mock('@renderer/hooks/use-platform-auth', () => ({
+  usePlatformAuthStatus: () => ({ data: { connected: false, platformBaseUrl: null, orgId: null } }),
+}))
+
+const composerError: ProviderErrorPresentation = {
+  severity: 'warning',
+  message: '**Routed:** shown above the composer',
+  icon: 'info',
+  placement: 'composer',
+}
+const inlineError: ProviderErrorPresentation = { severity: 'error', message: '**Inline**', icon: 'info' }
+
+const idle = { isActive: false, error: null, apiErrorCode: null, errorPresentation: null }
+
+function errorMessage(presentation?: ProviderErrorPresentation) {
+  return createAssistantMessage({
+    content: { text: 'API Error: 402 insufficient balance' },
+    apiError: 'billing_error',
+    errorPresentation: presentation,
+  })
+}
+
+describe('currentProviderError', () => {
+  it('prefers the live error', () => {
+    const live = { isActive: false, error: 'live 429', apiErrorCode: 'rate_limit', errorPresentation: composerError }
+    expect(currentProviderError(live, [errorMessage(inlineError)])).toEqual({
+      message: 'live 429',
+      presentation: composerError,
+    })
+  })
+
+  it('ignores a live error that is not a provider error', () => {
+    const live = { isActive: false, error: 'container died', apiErrorCode: null, errorPresentation: null }
+    expect(currentProviderError(live, [])).toBeNull()
+  })
+
+  it('falls back to the last assistant message when it is a provider error', () => {
+    const msg = errorMessage(composerError)
+    expect(currentProviderError(idle, [createUserMessage(), msg])).toEqual({
+      message: msg.content.text,
+      presentation: composerError,
+    })
+  })
+
+  it('skips compact boundaries and trailing user messages when scanning back', () => {
+    const msg = errorMessage(composerError)
+    expect(currentProviderError(idle, [msg, createCompactBoundary(), createUserMessage()])).not.toBeNull()
+  })
+
+  it('expires once a normal assistant reply follows', () => {
+    expect(currentProviderError(idle, [errorMessage(composerError), createUserMessage(), createAssistantMessage()])).toBeNull()
+  })
+
+  it('returns null while the agent is working again', () => {
+    expect(currentProviderError({ ...idle, isActive: true }, [errorMessage(composerError)])).toBeNull()
+  })
+
+  it('returns null for an assistant error that is not a provider error', () => {
+    const msg = createAssistantMessage({ content: { text: 'too long' }, apiError: 'max_output_tokens' })
+    expect(currentProviderError(idle, [msg])).toBeNull()
+  })
+
+  it('returns null with no messages', () => {
+    expect(currentProviderError(idle, undefined)).toBeNull()
+    expect(currentProviderError(idle, [])).toBeNull()
+  })
+})
+
+describe('ProviderErrorPlacement', () => {
+  beforeEach(() => {
+    Object.assign(mockStreamState, idle)
+    mockMessages.length = 0
+  })
+
+  it('renders nothing when there is no current error', () => {
+    const { container } = render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing for an error whose placement is inline', () => {
+    mockStreamState.error = 'API rate limit exceeded'
+    mockStreamState.apiErrorCode = 'rate_limit'
+    mockStreamState.errorPresentation = inlineError
+    const { container } = render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing for an error with no presentation (placement defaults to inline)', () => {
+    mockStreamState.error = 'API rate limit exceeded'
+    mockStreamState.apiErrorCode = 'rate_limit'
+    const { container } = render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the default component for a live error routed to composer', () => {
+    mockStreamState.error = 'API Error: 402'
+    mockStreamState.apiErrorCode = 'billing_error'
+    mockStreamState.errorPresentation = composerError
+    render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
+    expect(screen.getByTestId('provider-error-placement-composer')).toBeInTheDocument()
+    expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Routed: shown above the composer')
+  })
+
+  it('renders a persisted error routed to composer once the session is idle', () => {
+    mockMessages.push(createUserMessage(), errorMessage(composerError))
+    render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
+    expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Routed: shown above the composer')
+  })
+
+  it('renders an inline-routed error only in the inline placement', () => {
+    mockMessages.push(errorMessage(inlineError))
+    render(<ProviderErrorPlacement placement="inline" sessionId="s" agentSlug="a" />)
+    expect(screen.getByTestId('provider-error-placement-inline')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/provider-error/provider-error-placement.test.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.test.tsx
@@ -6,7 +6,7 @@ import type { ProviderErrorPresentation } from '@shared/lib/llm-provider/error-p
 import type { ApiMessageOrBoundary } from '@shared/lib/types/api'
 import { createAssistantMessage, createCompactBoundary, createUserMessage } from '@renderer/test/factories'
 
-import { currentProviderError, ProviderErrorPlacement } from './provider-error-placement'
+import { currentProviderError, currentProviderErrorId, ProviderErrorPlacement } from './provider-error-placement'
 
 const mockStreamState = {
   isActive: false,
@@ -52,17 +52,18 @@ describe('currentProviderError', () => {
       message: 'live 429',
       presentation: composerError,
       live: true,
+      messageId: null,
     })
   })
 
   it('accepts a live error with a generic SDK code when a presentation is attached', () => {
     const live = { isActive: false, error: 'API Error: 402', apiErrorCode: 'unknown', errorPresentation: composerError }
-    expect(currentProviderError(live, [])).toEqual({ message: 'API Error: 402', presentation: composerError, live: true })
+    expect(currentProviderError(live, [])).toEqual({ message: 'API Error: 402', presentation: composerError, live: true, messageId: null })
   })
 
   it('accepts a persisted error with a generic SDK code when a presentation is attached', () => {
     const msg = createAssistantMessage({ content: { text: 'API Error: 402' }, apiError: 'unknown', errorPresentation: composerError })
-    expect(currentProviderError(idle, [msg])).toEqual({ message: 'API Error: 402', presentation: composerError, live: false })
+    expect(currentProviderError(idle, [msg])).toEqual({ message: 'API Error: 402', presentation: composerError, live: false, messageId: msg.id })
   })
 
   it('ignores a live error that is not a provider error', () => {
@@ -76,6 +77,7 @@ describe('currentProviderError', () => {
       message: msg.content.text,
       presentation: composerError,
       live: false,
+      messageId: msg.id,
     })
   })
 
@@ -100,6 +102,27 @@ describe('currentProviderError', () => {
   it('returns null with no messages', () => {
     expect(currentProviderError(idle, undefined)).toBeNull()
     expect(currentProviderError(idle, [])).toBeNull()
+  })
+})
+
+describe('currentProviderErrorId', () => {
+  it('is the id of the persisted row a composer placement is showing', () => {
+    const msg = errorMessage(composerError)
+    expect(currentProviderErrorId(idle, [createUserMessage(), msg])).toBe(msg.id)
+  })
+
+  it('is null for a live error (no persisted row yet)', () => {
+    const live = { isActive: false, error: 'API Error: 402', apiErrorCode: 'billing_error', errorPresentation: composerError }
+    expect(currentProviderErrorId(live, [errorMessage(composerError)])).toBeNull()
+  })
+
+  it('is null for an inline error, which the transcript renders itself', () => {
+    expect(currentProviderErrorId(idle, [errorMessage(inlineError)])).toBeNull()
+    expect(currentProviderErrorId(idle, [errorMessage()])).toBeNull()
+  })
+
+  it('is null once a normal reply follows, so the old routed row returns to the transcript', () => {
+    expect(currentProviderErrorId(idle, [errorMessage(composerError), createUserMessage(), createAssistantMessage()])).toBeNull()
   })
 })
 

--- a/src/renderer/components/provider-error/provider-error-placement.test.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.test.tsx
@@ -54,6 +54,16 @@ describe('currentProviderError', () => {
     })
   })
 
+  it('accepts a live error with a generic SDK code when a presentation is attached', () => {
+    const live = { isActive: false, error: 'API Error: 402', apiErrorCode: 'unknown', errorPresentation: composerError }
+    expect(currentProviderError(live, [])).toEqual({ message: 'API Error: 402', presentation: composerError })
+  })
+
+  it('accepts a persisted error with a generic SDK code when a presentation is attached', () => {
+    const msg = createAssistantMessage({ content: { text: 'API Error: 402' }, apiError: 'unknown', errorPresentation: composerError })
+    expect(currentProviderError(idle, [msg])).toEqual({ message: 'API Error: 402', presentation: composerError })
+  })
+
   it('ignores a live error that is not a provider error', () => {
     const live = { isActive: false, error: 'container died', apiErrorCode: null, errorPresentation: null }
     expect(currentProviderError(live, [])).toBeNull()

--- a/src/renderer/components/provider-error/provider-error-placement.test.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@renderer/hooks/use-platform-auth', () => ({
 
 const composerError: ProviderErrorPresentation = {
   severity: 'warning',
-  message: '**Routed:** shown above the composer',
+  message: '**Routed:** replaces the composer',
   icon: 'info',
   placement: 'composer',
 }
@@ -107,44 +107,60 @@ describe('ProviderErrorPlacement', () => {
     mockMessages.length = 0
   })
 
-  it('renders nothing when there is no current error', () => {
-    const { container } = render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
-    expect(container.innerHTML).toBe('')
+  const composer = <div data-testid="composer">composer</div>
+  const mount = (placement: 'composer' | 'inline' = 'composer') =>
+    render(<ProviderErrorPlacement placement={placement} sessionId="s" agentSlug="a">{composer}</ProviderErrorPlacement>)
+
+  it('renders its children untouched when there is no current error', () => {
+    mount()
+    expect(screen.getByTestId('composer')).toBeInTheDocument()
+    expect(screen.queryByTestId('provider-error-placement-composer')).not.toBeInTheDocument()
   })
 
-  it('renders nothing for an error whose placement is inline', () => {
+  it('renders only children for an error whose placement is inline', () => {
     mockStreamState.error = 'API rate limit exceeded'
     mockStreamState.apiErrorCode = 'rate_limit'
     mockStreamState.errorPresentation = inlineError
-    const { container } = render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
-    expect(container.innerHTML).toBe('')
+    mount()
+    expect(screen.getByTestId('composer')).toBeInTheDocument()
+    expect(screen.queryByTestId('provider-error-card')).not.toBeInTheDocument()
   })
 
-  it('renders nothing for an error with no presentation (placement defaults to inline)', () => {
+  it('renders only children for an error with no presentation (placement defaults to inline)', () => {
     mockStreamState.error = 'API rate limit exceeded'
     mockStreamState.apiErrorCode = 'rate_limit'
-    const { container } = render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
-    expect(container.innerHTML).toBe('')
+    mount()
+    expect(screen.getByTestId('composer')).toBeInTheDocument()
+    expect(screen.queryByTestId('provider-error-card')).not.toBeInTheDocument()
   })
 
-  it('renders the default component for a live error routed to composer', () => {
+  it('renders the component in place of children for a live error routed to composer', () => {
     mockStreamState.error = 'API Error: 402'
     mockStreamState.apiErrorCode = 'billing_error'
     mockStreamState.errorPresentation = composerError
-    render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
+    mount()
     expect(screen.getByTestId('provider-error-placement-composer')).toBeInTheDocument()
-    expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Routed: shown above the composer')
+    expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Routed: replaces the composer')
+  })
+
+  it('hands the displaced children to the component (the default card renders them back)', () => {
+    mockStreamState.error = 'API Error: 402'
+    mockStreamState.apiErrorCode = 'billing_error'
+    mockStreamState.errorPresentation = composerError
+    mount()
+    const placement = screen.getByTestId('provider-error-placement-composer')
+    expect(placement).toContainElement(screen.getByTestId('composer'))
   })
 
   it('renders a persisted error routed to composer once the session is idle', () => {
     mockMessages.push(createUserMessage(), errorMessage(composerError))
-    render(<ProviderErrorPlacement placement="composer" sessionId="s" agentSlug="a" />)
-    expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Routed: shown above the composer')
+    mount()
+    expect(screen.getByTestId('provider-error-card')).toHaveTextContent('Routed: replaces the composer')
   })
 
   it('renders an inline-routed error only in the inline placement', () => {
     mockMessages.push(errorMessage(inlineError))
-    render(<ProviderErrorPlacement placement="inline" sessionId="s" agentSlug="a" />)
+    mount('inline')
     expect(screen.getByTestId('provider-error-placement-inline')).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/provider-error/provider-error-placement.test.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.test.tsx
@@ -51,17 +51,18 @@ describe('currentProviderError', () => {
     expect(currentProviderError(live, [errorMessage(inlineError)])).toEqual({
       message: 'live 429',
       presentation: composerError,
+      live: true,
     })
   })
 
   it('accepts a live error with a generic SDK code when a presentation is attached', () => {
     const live = { isActive: false, error: 'API Error: 402', apiErrorCode: 'unknown', errorPresentation: composerError }
-    expect(currentProviderError(live, [])).toEqual({ message: 'API Error: 402', presentation: composerError })
+    expect(currentProviderError(live, [])).toEqual({ message: 'API Error: 402', presentation: composerError, live: true })
   })
 
   it('accepts a persisted error with a generic SDK code when a presentation is attached', () => {
     const msg = createAssistantMessage({ content: { text: 'API Error: 402' }, apiError: 'unknown', errorPresentation: composerError })
-    expect(currentProviderError(idle, [msg])).toEqual({ message: 'API Error: 402', presentation: composerError })
+    expect(currentProviderError(idle, [msg])).toEqual({ message: 'API Error: 402', presentation: composerError, live: false })
   })
 
   it('ignores a live error that is not a provider error', () => {
@@ -74,6 +75,7 @@ describe('currentProviderError', () => {
     expect(currentProviderError(idle, [createUserMessage(), msg])).toEqual({
       message: msg.content.text,
       presentation: composerError,
+      live: false,
     })
   })
 

--- a/src/renderer/components/provider-error/provider-error-placement.test.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.test.tsx
@@ -6,7 +6,7 @@ import type { ProviderErrorPresentation } from '@shared/lib/llm-provider/error-p
 import type { ApiMessageOrBoundary } from '@shared/lib/types/api'
 import { createAssistantMessage, createCompactBoundary, createUserMessage } from '@renderer/test/factories'
 
-import { currentProviderError, currentProviderErrorId, ProviderErrorPlacement } from './provider-error-placement'
+import { currentProviderError, currentRoutedProviderError, ProviderErrorPlacement } from './provider-error-placement'
 
 const mockStreamState = {
   isActive: false,
@@ -105,24 +105,26 @@ describe('currentProviderError', () => {
   })
 })
 
-describe('currentProviderErrorId', () => {
-  it('is the id of the persisted row a composer placement is showing', () => {
+describe('currentRoutedProviderError', () => {
+  it('is the persisted row a composer placement is showing', () => {
     const msg = errorMessage(composerError)
-    expect(currentProviderErrorId(idle, [createUserMessage(), msg])).toBe(msg.id)
+    expect(currentRoutedProviderError(idle, [createUserMessage(), msg])?.messageId).toBe(msg.id)
   })
 
-  it('is null for a live error (no persisted row yet)', () => {
+  it('is the live error (no persisted row yet) while it is routed to the composer', () => {
     const live = { isActive: false, error: 'API Error: 402', apiErrorCode: 'billing_error', errorPresentation: composerError }
-    expect(currentProviderErrorId(live, [errorMessage(composerError)])).toBeNull()
+    expect(currentRoutedProviderError(live, [errorMessage(composerError)])).toMatchObject({ live: true, messageId: null })
   })
 
   it('is null for an inline error, which the transcript renders itself', () => {
-    expect(currentProviderErrorId(idle, [errorMessage(inlineError)])).toBeNull()
-    expect(currentProviderErrorId(idle, [errorMessage()])).toBeNull()
+    expect(currentRoutedProviderError(idle, [errorMessage(inlineError)])).toBeNull()
+    expect(currentRoutedProviderError(idle, [errorMessage()])).toBeNull()
+    const live = { isActive: false, error: 'API Error: 429', apiErrorCode: 'rate_limit', errorPresentation: inlineError }
+    expect(currentRoutedProviderError(live, [])).toBeNull()
   })
 
   it('is null once a normal reply follows, so the old routed row returns to the transcript', () => {
-    expect(currentProviderErrorId(idle, [errorMessage(composerError), createUserMessage(), createAssistantMessage()])).toBeNull()
+    expect(currentRoutedProviderError(idle, [errorMessage(composerError), createUserMessage(), createAssistantMessage()])).toBeNull()
   })
 })
 

--- a/src/renderer/components/provider-error/provider-error-placement.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.tsx
@@ -13,6 +13,7 @@ import { resolveProviderError } from './provider-error-registry'
 export interface CurrentProviderError {
   message: string
   presentation?: ProviderErrorPresentation
+  live: boolean
 }
 
 interface LiveErrorState {
@@ -29,7 +30,7 @@ export function currentProviderError(
   messages: readonly ApiMessageOrBoundary[] | undefined,
 ): CurrentProviderError | null {
   if (live.error && isProviderFacingError(live.apiErrorCode, live.errorPresentation)) {
-    return { message: live.error, presentation: live.errorPresentation ?? undefined }
+    return { message: live.error, presentation: live.errorPresentation ?? undefined, live: true }
   }
   if (live.isActive || !messages) return null
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -37,7 +38,9 @@ export function currentProviderError(
     if (item.type !== 'assistant') continue
     const isProviderError =
       !!item.apiError && isProviderFacingError(item.apiError, item.errorPresentation) && !!item.content.text
-    return isProviderError ? { message: item.content.text, presentation: item.errorPresentation } : null
+    return isProviderError
+      ? { message: item.content.text, presentation: item.errorPresentation, live: false }
+      : null
   }
   return null
 }
@@ -64,7 +67,7 @@ export function ProviderErrorPlacement({ placement, sessionId, agentSlug, childr
   if (!current || !resolved || resolved.placement !== placement) return <>{children}</>
   return (
     <div data-testid={`provider-error-placement-${placement}`}>
-      <resolved.Component message={current.message} presentation={current.presentation}>
+      <resolved.Component message={current.message} presentation={current.presentation} live={current.live}>
         {children}
       </resolved.Component>
     </div>

--- a/src/renderer/components/provider-error/provider-error-placement.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react'
+
+import type {
+  ProviderErrorPlacement as Placement,
+  ProviderErrorPresentation,
+} from '@shared/lib/llm-provider/error-presentation'
+import { PROVIDER_ERROR_CODES, type ApiMessageOrBoundary } from '@shared/lib/types/api'
+import { useMessageStream } from '@renderer/hooks/use-message-stream'
+import { useMessages } from '@renderer/hooks/use-messages'
+
+import { resolveProviderError } from './provider-error-registry'
+
+export interface CurrentProviderError {
+  message: string
+  presentation?: ProviderErrorPresentation
+}
+
+interface LiveErrorState {
+  isActive: boolean
+  error: string | null
+  apiErrorCode: string | null
+  errorPresentation: ProviderErrorPresentation | null
+}
+
+// Live error wins. Otherwise the last assistant message, if it is a provider
+// error and the agent is not working again. A normal reply after it expires it.
+export function currentProviderError(
+  live: LiveErrorState,
+  messages: readonly ApiMessageOrBoundary[] | undefined,
+): CurrentProviderError | null {
+  if (live.error && live.apiErrorCode && PROVIDER_ERROR_CODES.has(live.apiErrorCode)) {
+    return { message: live.error, presentation: live.errorPresentation ?? undefined }
+  }
+  if (live.isActive || !messages) return null
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (item.type !== 'assistant') continue
+    const isProviderError = !!item.apiError && PROVIDER_ERROR_CODES.has(item.apiError) && !!item.content.text
+    return isProviderError ? { message: item.content.text, presentation: item.errorPresentation } : null
+  }
+  return null
+}
+
+interface ProviderErrorPlacementProps {
+  placement: Placement
+  sessionId: string
+  agentSlug: string
+}
+
+// Renders the session's current provider error iff its presentation targets this placement.
+export function ProviderErrorPlacement({ placement, sessionId, agentSlug }: ProviderErrorPlacementProps) {
+  const { isActive, error, apiErrorCode, errorPresentation } = useMessageStream(sessionId, agentSlug)
+  const { data: messages } = useMessages(sessionId, agentSlug)
+  const current = useMemo(
+    () => currentProviderError({ isActive, error, apiErrorCode, errorPresentation }, messages),
+    [isActive, error, apiErrorCode, errorPresentation, messages],
+  )
+  if (!current) return null
+  const resolved = resolveProviderError(current.presentation)
+  if (resolved.placement !== placement) return null
+  return (
+    <div className="px-4 pb-2" data-testid={`provider-error-placement-${placement}`}>
+      <resolved.Component message={current.message} presentation={current.presentation} />
+    </div>
+  )
+}

--- a/src/renderer/components/provider-error/provider-error-placement.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.tsx
@@ -48,16 +48,16 @@ export function currentProviderError(
   return null
 }
 
-// Id of the persisted row whose error a ProviderErrorPlacement renders right now, so the
-// transcript skips only that row's inline card. Inline-routed errors live in the
-// transcript itself, so they never qualify; older routed rows keep their inline card.
-export function currentProviderErrorId(
+// The current error only when a ProviderErrorPlacement renders it (placement other than
+// inline), so the transcript skips that one row's inline card. Inline errors live in the
+// transcript itself and never qualify; older routed rows keep their inline card.
+export function currentRoutedProviderError(
   live: LiveErrorState,
   messages: readonly ApiMessageOrBoundary[] | undefined,
-): string | null {
+): CurrentProviderError | null {
   const current = currentProviderError(live, messages)
   if (!current || resolveProviderError(current.presentation).placement === 'inline') return null
-  return current.messageId
+  return current
 }
 
 interface ProviderErrorPlacementProps {

--- a/src/renderer/components/provider-error/provider-error-placement.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.tsx
@@ -4,7 +4,7 @@ import type {
   ProviderErrorPlacement as Placement,
   ProviderErrorPresentation,
 } from '@shared/lib/llm-provider/error-presentation'
-import { PROVIDER_ERROR_CODES, type ApiMessageOrBoundary } from '@shared/lib/types/api'
+import { isProviderFacingError, type ApiMessageOrBoundary } from '@shared/lib/types/api'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useMessages } from '@renderer/hooks/use-messages'
 
@@ -28,14 +28,15 @@ export function currentProviderError(
   live: LiveErrorState,
   messages: readonly ApiMessageOrBoundary[] | undefined,
 ): CurrentProviderError | null {
-  if (live.error && live.apiErrorCode && PROVIDER_ERROR_CODES.has(live.apiErrorCode)) {
+  if (live.error && isProviderFacingError(live.apiErrorCode, live.errorPresentation)) {
     return { message: live.error, presentation: live.errorPresentation ?? undefined }
   }
   if (live.isActive || !messages) return null
   for (let i = messages.length - 1; i >= 0; i--) {
     const item = messages[i]
     if (item.type !== 'assistant') continue
-    const isProviderError = !!item.apiError && PROVIDER_ERROR_CODES.has(item.apiError) && !!item.content.text
+    const isProviderError =
+      !!item.apiError && isProviderFacingError(item.apiError, item.errorPresentation) && !!item.content.text
     return isProviderError ? { message: item.content.text, presentation: item.errorPresentation } : null
   }
   return null

--- a/src/renderer/components/provider-error/provider-error-placement.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, type ReactNode } from 'react'
 
 import type {
   ProviderErrorPlacement as Placement,
@@ -46,22 +46,27 @@ interface ProviderErrorPlacementProps {
   placement: Placement
   sessionId: string
   agentSlug: string
+  /** What normally lives here (e.g. the composer). Displaced while an error targets this placement. */
+  children?: ReactNode
 }
 
-// Renders the session's current provider error iff its presentation targets this placement.
-export function ProviderErrorPlacement({ placement, sessionId, agentSlug }: ProviderErrorPlacementProps) {
+// Renders children, or the session's current provider error in their place when
+// its presentation targets this placement. The component gets the displaced
+// children and renders them back once it is resolved.
+export function ProviderErrorPlacement({ placement, sessionId, agentSlug, children }: ProviderErrorPlacementProps) {
   const { isActive, error, apiErrorCode, errorPresentation } = useMessageStream(sessionId, agentSlug)
   const { data: messages } = useMessages(sessionId, agentSlug)
   const current = useMemo(
     () => currentProviderError({ isActive, error, apiErrorCode, errorPresentation }, messages),
     [isActive, error, apiErrorCode, errorPresentation, messages],
   )
-  if (!current) return null
-  const resolved = resolveProviderError(current.presentation)
-  if (resolved.placement !== placement) return null
+  const resolved = current ? resolveProviderError(current.presentation) : null
+  if (!current || !resolved || resolved.placement !== placement) return <>{children}</>
   return (
-    <div className="px-4 pb-2" data-testid={`provider-error-placement-${placement}`}>
-      <resolved.Component message={current.message} presentation={current.presentation} />
+    <div data-testid={`provider-error-placement-${placement}`}>
+      <resolved.Component message={current.message} presentation={current.presentation}>
+        {children}
+      </resolved.Component>
     </div>
   )
 }

--- a/src/renderer/components/provider-error/provider-error-placement.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.tsx
@@ -14,6 +14,8 @@ export interface CurrentProviderError {
   message: string
   presentation?: ProviderErrorPresentation
   live: boolean
+  /** Persisted row this error comes from; null for the live turn error. */
+  messageId: string | null
 }
 
 interface LiveErrorState {
@@ -30,26 +32,40 @@ export function currentProviderError(
   messages: readonly ApiMessageOrBoundary[] | undefined,
 ): CurrentProviderError | null {
   if (live.error && isProviderFacingError(live.apiErrorCode, live.errorPresentation)) {
-    return { message: live.error, presentation: live.errorPresentation ?? undefined, live: true }
+    return { message: live.error, presentation: live.errorPresentation ?? undefined, live: true, messageId: null }
   }
   if (live.isActive || !messages) return null
+  // `messages` is the trailing page, newest last (same contract message-list relies on).
   for (let i = messages.length - 1; i >= 0; i--) {
     const item = messages[i]
     if (item.type !== 'assistant') continue
     const isProviderError =
       !!item.apiError && isProviderFacingError(item.apiError, item.errorPresentation) && !!item.content.text
     return isProviderError
-      ? { message: item.content.text, presentation: item.errorPresentation, live: false }
+      ? { message: item.content.text, presentation: item.errorPresentation, live: false, messageId: item.id }
       : null
   }
   return null
+}
+
+// Id of the persisted row whose error a ProviderErrorPlacement renders right now, so the
+// transcript skips only that row's inline card. Inline-routed errors live in the
+// transcript itself, so they never qualify; older routed rows keep their inline card.
+export function currentProviderErrorId(
+  live: LiveErrorState,
+  messages: readonly ApiMessageOrBoundary[] | undefined,
+): string | null {
+  const current = currentProviderError(live, messages)
+  if (!current || resolveProviderError(current.presentation).placement === 'inline') return null
+  return current.messageId
 }
 
 interface ProviderErrorPlacementProps {
   placement: Placement
   sessionId: string
   agentSlug: string
-  /** What normally lives here (e.g. the composer). Displaced while an error targets this placement. */
+  /** Everything that normally lives here, displaced while an error targets this placement. At
+   *  `composer` that is the composer plus its banners (pending wake, stale session), not just the input. */
   children?: ReactNode
 }
 

--- a/src/renderer/components/provider-error/provider-error-placement.tsx
+++ b/src/renderer/components/provider-error/provider-error-placement.tsx
@@ -25,27 +25,45 @@ interface LiveErrorState {
   errorPresentation: ProviderErrorPresentation | null
 }
 
-// Live error wins. Otherwise the last assistant message, if it is a provider
-// error and the agent is not working again. A normal reply after it expires it.
-export function currentProviderError(
-  live: LiveErrorState,
-  messages: readonly ApiMessageOrBoundary[] | undefined,
-): CurrentProviderError | null {
-  if (live.error && isProviderFacingError(live.apiErrorCode, live.errorPresentation)) {
-    return { message: live.error, presentation: live.errorPresentation ?? undefined, live: true, messageId: null }
-  }
-  if (live.isActive || !messages) return null
+interface PersistedProviderError {
+  id: string
+  text: string
+  presentation?: ProviderErrorPresentation
+}
+
+// The last assistant row, if it is a provider error. A normal reply after it expires it.
+function lastAssistantProviderError(messages: readonly ApiMessageOrBoundary[] | undefined): PersistedProviderError | null {
+  if (!messages) return null
   // `messages` is the trailing page, newest last (same contract message-list relies on).
   for (let i = messages.length - 1; i >= 0; i--) {
     const item = messages[i]
     if (item.type !== 'assistant') continue
     const isProviderError =
       !!item.apiError && isProviderFacingError(item.apiError, item.errorPresentation) && !!item.content.text
-    return isProviderError
-      ? { message: item.content.text, presentation: item.errorPresentation, live: false, messageId: item.id }
-      : null
+    return isProviderError ? { id: item.id, text: item.content.text, presentation: item.errorPresentation } : null
   }
   return null
+}
+
+// Live error wins. Otherwise the last assistant message, if it is a provider
+// error and the agent is not working again.
+// The live error stays set after its row is persisted (until the next stream_start), so
+// the live variant still reports that row's id and the transcript suppresses both copies.
+export function currentProviderError(
+  live: LiveErrorState,
+  messages: readonly ApiMessageOrBoundary[] | undefined,
+): CurrentProviderError | null {
+  const persisted = lastAssistantProviderError(messages)
+  if (live.error && isProviderFacingError(live.apiErrorCode, live.errorPresentation)) {
+    return {
+      message: live.error,
+      presentation: live.errorPresentation ?? undefined,
+      live: true,
+      messageId: persisted?.id ?? null,
+    }
+  }
+  if (live.isActive || !persisted) return null
+  return { message: persisted.text, presentation: persisted.presentation, live: false, messageId: persisted.id }
 }
 
 // The current error only when a ProviderErrorPlacement renders it (placement other than

--- a/src/renderer/components/provider-error/provider-error-registry.test.ts
+++ b/src/renderer/components/provider-error/provider-error-registry.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
+
+import { resolveProviderError } from './provider-error-registry'
+
+const base = { severity: 'error' as const, message: 'x', icon: 'info' }
+
+describe('resolveProviderError', () => {
+  it('returns the default component at inline when there is no presentation', () => {
+    expect(resolveProviderError(undefined)).toEqual({ Component: ProviderErrorCard, placement: 'inline' })
+    expect(resolveProviderError(null)).toEqual({ Component: ProviderErrorCard, placement: 'inline' })
+  })
+
+  it('returns the default component when component is unset', () => {
+    expect(resolveProviderError(base).Component).toBe(ProviderErrorCard)
+  })
+
+  it('falls back to the default component for an unregistered key', () => {
+    expect(resolveProviderError({ ...base, component: 'not-registered' }).Component).toBe(ProviderErrorCard)
+  })
+
+  it('passes placement through', () => {
+    expect(resolveProviderError({ ...base, placement: 'composer' }).placement).toBe('composer')
+  })
+})

--- a/src/renderer/components/provider-error/provider-error-registry.ts
+++ b/src/renderer/components/provider-error/provider-error-registry.ts
@@ -12,6 +12,8 @@ export interface ProviderErrorComponentProps {
   presentation?: ProviderErrorPresentation
   /** Content this error displaced (the composer, at `composer`). Render it to give it back. */
   children?: ReactNode
+  /** True when this is the in-flight turn error, not a persisted history row. */
+  live?: boolean
 }
 
 export const DEFAULT_ERROR_COMPONENT = 'default'

--- a/src/renderer/components/provider-error/provider-error-registry.ts
+++ b/src/renderer/components/provider-error/provider-error-registry.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react'
+import type { ComponentType, ReactNode } from 'react'
 
 import {
   errorPlacement,
@@ -10,6 +10,8 @@ import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
 export interface ProviderErrorComponentProps {
   message: string
   presentation?: ProviderErrorPresentation
+  /** Content this error displaced (the composer, at `composer`). Render it to give it back. */
+  children?: ReactNode
 }
 
 export const DEFAULT_ERROR_COMPONENT = 'default'

--- a/src/renderer/components/provider-error/provider-error-registry.ts
+++ b/src/renderer/components/provider-error/provider-error-registry.ts
@@ -1,0 +1,34 @@
+import type { ComponentType } from 'react'
+
+import {
+  errorPlacement,
+  type ProviderErrorPlacement,
+  type ProviderErrorPresentation,
+} from '@shared/lib/llm-provider/error-presentation'
+import { ProviderErrorCard } from '@renderer/components/ui/provider-error-card'
+
+export interface ProviderErrorComponentProps {
+  message: string
+  presentation?: ProviderErrorPresentation
+}
+
+export const DEFAULT_ERROR_COMPONENT = 'default'
+
+// `errorPresentation.component` → component. Adding an error component = one row here.
+const REGISTRY: Record<string, ComponentType<ProviderErrorComponentProps>> = {
+  [DEFAULT_ERROR_COMPONENT]: ProviderErrorCard,
+}
+
+export interface ResolvedProviderError {
+  Component: ComponentType<ProviderErrorComponentProps>
+  placement: ProviderErrorPlacement
+}
+
+// Unknown keys fall back to the default so an older client never drops a server-authored error.
+export function resolveProviderError(presentation: ProviderErrorPresentation | null | undefined): ResolvedProviderError {
+  const key = presentation?.component ?? DEFAULT_ERROR_COMPONENT
+  return {
+    Component: REGISTRY[key] ?? REGISTRY[DEFAULT_ERROR_COMPONENT],
+    placement: errorPlacement(presentation),
+  }
+}

--- a/src/renderer/components/ui/provider-error-card.tsx
+++ b/src/renderer/components/ui/provider-error-card.tsx
@@ -85,7 +85,7 @@ export function ProviderErrorView({
 }
 
 // `presentation` is authored server-side by the active LLM provider's
-// parseErrorResponse. Without one (older server, missed event) the card falls
+// presentationForTurnError. Without one (older server, missed event) the card falls
 // back to the provider-agnostic default banner built from the raw message.
 export function ProviderErrorCard({
   message,

--- a/src/renderer/components/ui/provider-error-card.tsx
+++ b/src/renderer/components/ui/provider-error-card.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, type ReactNode } from 'react'
 import type { Components } from 'react-markdown'
 import ReactMarkdown from 'react-markdown'
 import { CircleDollarSign, Info, TriangleAlert, type LucideIcon } from 'lucide-react'
@@ -90,10 +90,13 @@ export function ProviderErrorView({
 export function ProviderErrorCard({
   message,
   presentation,
+  children,
   'data-testid': testId,
 }: {
   message: string
   presentation?: ProviderErrorPresentation
+  /** Displaced content (see ProviderErrorComponentProps). The default card never withholds it. */
+  children?: ReactNode
   'data-testid'?: string
 }) {
   const base = useMemo(
@@ -102,10 +105,13 @@ export function ProviderErrorCard({
   )
   const resolved = useResolvedErrorPresentation(base)
   return (
-    <ProviderErrorView
-      presentation={resolved}
-      rawMessage={message}
-      data-testid={testId}
-    />
+    <>
+      <ProviderErrorView
+        presentation={resolved}
+        rawMessage={message}
+        data-testid={testId}
+      />
+      {children}
+    </>
   )
 }

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -81,7 +81,6 @@ import { trackServerEvent } from '@shared/lib/analytics/server-analytics'
 import { VALID_SCRIPT_TYPES, getAgentCapabilitySettings } from '@shared/lib/config/settings'
 import { sessionCapabilityGrantsResponseSchema } from '@shared/lib/config/capability-policy-schema'
 import { getActiveLlmProvider, getModelContextWindow } from '@shared/lib/llm-provider'
-import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
 import { resolveAppFromWindowRef } from '@shared/lib/computer-use/executor'
 import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp, type ComputerUsePermissionLevel } from '@shared/lib/computer-use/types'
@@ -2491,10 +2490,11 @@ class MessagePersister {
           // The active provider owns the copy for its own upstream errors
           // (severity, icon, markdown message + CTA link). Sent alongside the
           // raw error so the UI never re-derives provider-specific copy.
-          const errorPresentation =
-            apiErrorCode && PROVIDER_ERROR_CODES.has(apiErrorCode)
-              ? getActiveLlmProvider().parseErrorResponse(apiErrorStatus ?? undefined, errorMessage)
-              : null
+          const errorPresentation = getActiveLlmProvider().presentationForTurnError(
+            apiErrorStatus ?? undefined,
+            errorMessage,
+            apiErrorCode,
+          )
           console.error(
             `[MessagePersister] Session ${sessionId} error:`,
             errorMessage,

--- a/src/shared/lib/llm-provider/anthropic-provider.test.ts
+++ b/src/shared/lib/llm-provider/anthropic-provider.test.ts
@@ -4,11 +4,12 @@ vi.mock('@anthropic-ai/sdk', () => ({ default: class {} }))
 
 import { AnthropicLlmProvider } from './anthropic-provider'
 
-describe('parseErrorResponse', () => {
+describe('presentationForTurnError', () => {
   it('does not special-case a platform spend-cap body', () => {
-    const parsed = new AnthropicLlmProvider().parseErrorResponse(
+    const parsed = new AnthropicLlmProvider().presentationForTurnError(
       429,
       'A spend cap for this workspace was reached. It resets within 30 days.',
+      'rate_limit',
     )
     expect(parsed).toEqual({
       severity: 'error',

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -4,7 +4,7 @@ import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
 import type { CatalogDefaultModels } from './model-catalog-defaults'
 import type { LlmProviderId } from './provider-types'
 import { defaultParseErrorResponse, type ProviderErrorPresentation } from './error-presentation'
-import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
+import { PROVIDER_ERROR_CODES, isUpstreamApiErrorCode } from '@shared/lib/types/api'
 
 export { LLM_PROVIDER_IDS } from './provider-types'
 export type { LlmProviderId } from './provider-types'
@@ -158,26 +158,19 @@ export abstract class BaseLlmProvider {
     throw new Error(`${this.name} does not support model search`)
   }
 
-  /**
-   * Banner presentation for an upstream HTTP error. Providers customize copy by
-   * overriding parseErrorResponseOverride, not this method.
-   */
-  parseErrorResponse(status: number | undefined, body: unknown): ProviderErrorPresentation {
-    return this.parseErrorResponseOverride(status, body) ?? defaultParseErrorResponse(status, body)
-  }
-
-  // Presentation for a failed turn. Classes this provider recognizes always get
-  // one, even under a generic SDK code (the CLI tags some upstream denials as
-  // `unknown`); everything else only when the SDK code marks a provider error.
+  // Presentation for a failed turn, or null when it is not a provider error.
+  // Only consulted for upstream API failures: classes this provider recognizes
+  // get one under any upstream code (the CLI tags some denials `unknown`);
+  // the generic banner only under a code that marks a provider error.
   presentationForTurnError(
     status: number | undefined,
     body: unknown,
     apiErrorCode: string | null | undefined,
   ): ProviderErrorPresentation | null {
+    if (!isUpstreamApiErrorCode(apiErrorCode)) return null
     const specialized = this.parseErrorResponseOverride(status, body)
     if (specialized) return specialized
-    if (apiErrorCode && PROVIDER_ERROR_CODES.has(apiErrorCode)) return defaultParseErrorResponse(status, body)
-    return null
+    return PROVIDER_ERROR_CODES.has(apiErrorCode) ? defaultParseErrorResponse(status, body) : null
   }
 
   /**

--- a/src/shared/lib/llm-provider/base-llm-provider.ts
+++ b/src/shared/lib/llm-provider/base-llm-provider.ts
@@ -4,6 +4,7 @@ import type { ModelDefinition, ModelSearchResult } from './model-catalog-schema'
 import type { CatalogDefaultModels } from './model-catalog-defaults'
 import type { LlmProviderId } from './provider-types'
 import { defaultParseErrorResponse, type ProviderErrorPresentation } from './error-presentation'
+import { PROVIDER_ERROR_CODES } from '@shared/lib/types/api'
 
 export { LLM_PROVIDER_IDS } from './provider-types'
 export type { LlmProviderId } from './provider-types'
@@ -163,6 +164,20 @@ export abstract class BaseLlmProvider {
    */
   parseErrorResponse(status: number | undefined, body: unknown): ProviderErrorPresentation {
     return this.parseErrorResponseOverride(status, body) ?? defaultParseErrorResponse(status, body)
+  }
+
+  // Presentation for a failed turn. Classes this provider recognizes always get
+  // one, even under a generic SDK code (the CLI tags some upstream denials as
+  // `unknown`); everything else only when the SDK code marks a provider error.
+  presentationForTurnError(
+    status: number | undefined,
+    body: unknown,
+    apiErrorCode: string | null | undefined,
+  ): ProviderErrorPresentation | null {
+    const specialized = this.parseErrorResponseOverride(status, body)
+    if (specialized) return specialized
+    if (apiErrorCode && PROVIDER_ERROR_CODES.has(apiErrorCode)) return defaultParseErrorResponse(status, body)
+    return null
   }
 
   /**

--- a/src/shared/lib/llm-provider/error-presentation.test.ts
+++ b/src/shared/lib/llm-provider/error-presentation.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 import {
   defaultParseErrorResponse,
+  errorPlacement,
   extractErrorMessage,
   inferErrorStatus,
+  providerErrorPresentationSchema,
   resolvePresentationMarkdown,
 } from './error-presentation'
 import { parsePlatformErrorResponse } from './platform-error-presentation'
@@ -44,6 +46,44 @@ describe('inferErrorStatus', () => {
 
   it('returns undefined when no status is present', () => {
     expect(inferErrorStatus('Invalid API key')).toBeUndefined()
+  })
+})
+
+describe('providerErrorPresentationSchema', () => {
+  const base = { severity: 'error', message: 'x', icon: 'info' }
+
+  it('accepts the three original keys with placement and component unset', () => {
+    const parsed = providerErrorPresentationSchema.parse(base)
+    expect(parsed.placement).toBeUndefined()
+    expect(parsed.component).toBeUndefined()
+  })
+
+  it('accepts placement and component', () => {
+    expect(providerErrorPresentationSchema.parse({ ...base, placement: 'composer', component: 'paywall' })).toEqual({
+      ...base,
+      placement: 'composer',
+      component: 'paywall',
+    })
+  })
+
+  it('accepts a component key the renderer has never heard of', () => {
+    expect(providerErrorPresentationSchema.safeParse({ ...base, component: 'not-registered' }).success).toBe(true)
+  })
+
+  it('rejects an unknown placement', () => {
+    expect(providerErrorPresentationSchema.safeParse({ ...base, placement: 'sidebar' }).success).toBe(false)
+  })
+})
+
+describe('errorPlacement', () => {
+  it('defaults to inline when the presentation is missing or has no placement', () => {
+    expect(errorPlacement(undefined)).toBe('inline')
+    expect(errorPlacement(null)).toBe('inline')
+    expect(errorPlacement({ severity: 'error', message: 'x', icon: 'info' })).toBe('inline')
+  })
+
+  it('returns the placement when set', () => {
+    expect(errorPlacement({ severity: 'error', message: 'x', icon: 'info', placement: 'composer' })).toBe('composer')
   })
 })
 

--- a/src/shared/lib/llm-provider/error-presentation.ts
+++ b/src/shared/lib/llm-provider/error-presentation.ts
@@ -1,15 +1,28 @@
 import { z } from 'zod'
 
+export const providerErrorPlacementSchema = z.enum(['inline', 'composer'])
+
 export const providerErrorPresentationSchema = z.object({
   severity: z.enum(['error', 'warning']),
   /** Markdown. Providers that need a CTA put a link in the message. */
   message: z.string(),
   /** Lucide icon name, e.g. `info`, `circle-dollar-sign`. */
   icon: z.string(),
+  /** Where the renderer shows it. Unset = `inline` (a row in the chat stream). */
+  placement: providerErrorPlacementSchema.optional(),
+  /** Renderer component-registry key. Unset or unknown = the default card. */
+  component: z.string().optional(),
 })
 
 export type ProviderErrorPresentation = z.infer<typeof providerErrorPresentationSchema>
 export type ProviderErrorSeverity = ProviderErrorPresentation['severity']
+export type ProviderErrorPlacement = z.infer<typeof providerErrorPlacementSchema>
+
+export const DEFAULT_ERROR_PLACEMENT: ProviderErrorPlacement = 'inline'
+
+export function errorPlacement(presentation: ProviderErrorPresentation | null | undefined): ProviderErrorPlacement {
+  return presentation?.placement ?? DEFAULT_ERROR_PLACEMENT
+}
 
 export function extractErrorMessage(body: unknown): string {
   if (typeof body === 'string') {

--- a/src/shared/lib/llm-provider/error-presentation.ts
+++ b/src/shared/lib/llm-provider/error-presentation.ts
@@ -8,7 +8,7 @@ export const providerErrorPresentationSchema = z.object({
   message: z.string(),
   /** Lucide icon name, e.g. `info`, `circle-dollar-sign`. */
   icon: z.string(),
-  /** Where the renderer shows it. Unset = `inline` (a row in the chat stream). */
+  /** Where the renderer shows it. `inline` (default) = a row in the chat stream; `composer` = in place of the composer. */
   placement: providerErrorPlacementSchema.optional(),
   /** Renderer component-registry key. Unset or unknown = the default card. */
   component: z.string().optional(),

--- a/src/shared/lib/llm-provider/index.ts
+++ b/src/shared/lib/llm-provider/index.ts
@@ -4,11 +4,13 @@ export type { LlmProviderId } from './provider-types'
 export type { ModelPurpose, ProviderDefaultModelOption } from './base-llm-provider'
 export {
   defaultParseErrorResponse,
+  errorPlacement,
   extractErrorMessage,
   inferErrorStatus,
   resolvePresentationMarkdown,
 } from './error-presentation'
 export type {
+  ProviderErrorPlacement,
   ProviderErrorPresentation,
   ProviderErrorSeverity,
 } from './error-presentation'

--- a/src/shared/lib/llm-provider/platform-provider.test.ts
+++ b/src/shared/lib/llm-provider/platform-provider.test.ts
@@ -59,11 +59,15 @@ describe('getContainerEnvVars agent identity', () => {
   })
 })
 
-describe('parseErrorResponse', () => {
+describe('presentationForTurnError', () => {
+  const SPEND_CAP = 'A spend cap for this workspace was reached. It resets within 30 days.'
+  const INSUFFICIENT = 'API Error: 402 insufficient balance — top up to continue.'
+
   it('returns warning markdown for a workspace spend cap', () => {
-    const parsed = provider.parseErrorResponse(
+    const parsed = provider.presentationForTurnError(
       429,
       'A spend cap for this workspace was reached. It resets within 30 days. Ask a workspace admin to raise it.',
+      'rate_limit',
     )
     expect(parsed).toEqual({
       severity: 'warning',
@@ -74,14 +78,10 @@ describe('parseErrorResponse', () => {
   })
 
   it('falls back to the generic banner for a non-spend 429', () => {
-    const parsed = provider.parseErrorResponse(429, 'Rate limit exceeded. Slow down and retry shortly.')
-    expect(parsed.severity).toBe('error')
-    expect(parsed.message).toContain('**LLM Provider Error:**')
+    const parsed = provider.presentationForTurnError(429, 'Rate limit exceeded. Slow down and retry shortly.', 'rate_limit')
+    expect(parsed?.severity).toBe('error')
+    expect(parsed?.message).toContain('**LLM Provider Error:**')
   })
-})
-
-describe('presentationForTurnError', () => {
-  const SPEND_CAP = 'A spend cap for this workspace was reached. It resets within 30 days.'
 
   it('attaches a recognized class even when the SDK code is generic', () => {
     const parsed = provider.presentationForTurnError(429, SPEND_CAP, 'unknown')
@@ -96,6 +96,15 @@ describe('presentationForTurnError', () => {
   it('returns null for an unrecognized error with a non-provider SDK code', () => {
     expect(provider.presentationForTurnError(undefined, 'Output too long', 'max_output_tokens')).toBeNull()
     expect(provider.presentationForTurnError(undefined, 'Output too long', null)).toBeNull()
+  })
+
+  it('does not let a recognized class claim a max_output_tokens failure', () => {
+    expect(provider.presentationForTurnError(undefined, SPEND_CAP, 'max_output_tokens')).toBeNull()
+  })
+
+  it('does not let a recognized class claim a turn that failed without an API error', () => {
+    expect(provider.presentationForTurnError(undefined, INSUFFICIENT, null)).toBeNull()
+    expect(provider.presentationForTurnError(undefined, INSUFFICIENT, undefined)).toBeNull()
   })
 })
 

--- a/src/shared/lib/llm-provider/platform-provider.test.ts
+++ b/src/shared/lib/llm-provider/platform-provider.test.ts
@@ -80,6 +80,25 @@ describe('parseErrorResponse', () => {
   })
 })
 
+describe('presentationForTurnError', () => {
+  const SPEND_CAP = 'A spend cap for this workspace was reached. It resets within 30 days.'
+
+  it('attaches a recognized class even when the SDK code is generic', () => {
+    const parsed = provider.presentationForTurnError(429, SPEND_CAP, 'unknown')
+    expect(parsed?.message).toContain('**Spend Limit Reached:**')
+  })
+
+  it('attaches the generic banner when the SDK code marks a provider error', () => {
+    const parsed = provider.presentationForTurnError(500, 'Overloaded', 'server_error')
+    expect(parsed?.message).toContain('**LLM Provider Error:**')
+  })
+
+  it('returns null for an unrecognized error with a non-provider SDK code', () => {
+    expect(provider.presentationForTurnError(undefined, 'Output too long', 'max_output_tokens')).toBeNull()
+    expect(provider.presentationForTurnError(undefined, 'Output too long', null)).toBeNull()
+  })
+})
+
 describe('sanitizeAgentName', () => {
   it('collapses runs of control chars and spaces to a single space', () => {
     expect(sanitizeAgentName('a\r\n\r\nb   c')).toBe('a b c')

--- a/src/shared/lib/types/api.test.ts
+++ b/src/shared/lib/types/api.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from 'vitest'
 
-import { isProviderFacingError } from './api'
+import { isProviderFacingError, isUpstreamApiErrorCode } from './api'
 
 const presentation = { severity: 'error' as const, message: 'x', icon: 'info' }
+
+describe('isUpstreamApiErrorCode', () => {
+  it('is true for any SDK code that marks an upstream API failure, including unknown', () => {
+    expect(isUpstreamApiErrorCode('rate_limit')).toBe(true)
+    expect(isUpstreamApiErrorCode('unknown')).toBe(true)
+    expect(isUpstreamApiErrorCode('overloaded')).toBe(true)
+  })
+
+  it('is false for max_output_tokens and for no code at all', () => {
+    expect(isUpstreamApiErrorCode('max_output_tokens')).toBe(false)
+    expect(isUpstreamApiErrorCode(null)).toBe(false)
+    expect(isUpstreamApiErrorCode(undefined)).toBe(false)
+  })
+})
 
 describe('isProviderFacingError', () => {
   it('is true for a provider SDK code without a presentation', () => {

--- a/src/shared/lib/types/api.test.ts
+++ b/src/shared/lib/types/api.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { isProviderFacingError } from './api'
+
+const presentation = { severity: 'error' as const, message: 'x', icon: 'info' }
+
+describe('isProviderFacingError', () => {
+  it('is true for a provider SDK code without a presentation', () => {
+    expect(isProviderFacingError('rate_limit')).toBe(true)
+    expect(isProviderFacingError('billing_error', null)).toBe(true)
+  })
+
+  it('is true whenever a presentation is attached, regardless of the SDK code', () => {
+    expect(isProviderFacingError('unknown', presentation)).toBe(true)
+    expect(isProviderFacingError(null, presentation)).toBe(true)
+  })
+
+  it('is false for a non-provider SDK code with no presentation', () => {
+    expect(isProviderFacingError('max_output_tokens')).toBe(false)
+    expect(isProviderFacingError(null)).toBe(false)
+    expect(isProviderFacingError(undefined, null)).toBe(false)
+  })
+})

--- a/src/shared/lib/types/api.test.ts
+++ b/src/shared/lib/types/api.test.ts
@@ -1,8 +1,44 @@
 import { describe, expect, it } from 'vitest'
 
-import { isProviderFacingError, isUpstreamApiErrorCode } from './api'
+import { isProviderFacingError, isUpstreamApiErrorCode, NON_UPSTREAM_ERROR_CODES, PROVIDER_ERROR_CODES } from './api'
 
 const presentation = { severity: 'error' as const, message: 'x', icon: 'info' }
+
+// `SDKAssistantMessageError` from @anthropic-ai/claude-agent-sdk (agent-container pin). The host
+// cannot import the SDK types, so the enum is pinned here; update on an SDK bump.
+const SDK_ASSISTANT_ERROR_CODES = [
+  'authentication_failed',
+  'oauth_org_not_allowed',
+  'account_on_hold',
+  'billing_error',
+  'rate_limit',
+  'overloaded',
+  'invalid_request',
+  'model_not_found',
+  'server_error',
+  'unknown',
+  'max_output_tokens',
+] as const
+
+// Upstream codes with no generic banner; provider-facing only when a presentation is attached.
+const UPSTREAM_WITHOUT_BANNER = ['oauth_org_not_allowed', 'account_on_hold', 'overloaded', 'model_not_found', 'unknown']
+
+describe('SDK error code classification', () => {
+  it('keeps NON_UPSTREAM_ERROR_CODES and PROVIDER_ERROR_CODES disjoint', () => {
+    for (const code of NON_UPSTREAM_ERROR_CODES) expect(PROVIDER_ERROR_CODES.has(code)).toBe(false)
+  })
+
+  it('classifies every SDK code exactly once (drift here must be a deliberate choice)', () => {
+    const classified = [...NON_UPSTREAM_ERROR_CODES, ...PROVIDER_ERROR_CODES, ...UPSTREAM_WITHOUT_BANNER].sort()
+    expect(classified).toEqual([...SDK_ASSISTANT_ERROR_CODES].sort())
+  })
+
+  it('treats every code outside NON_UPSTREAM_ERROR_CODES as upstream', () => {
+    for (const code of SDK_ASSISTANT_ERROR_CODES) {
+      expect(isUpstreamApiErrorCode(code)).toBe(!NON_UPSTREAM_ERROR_CODES.has(code))
+    }
+  })
+})
 
 describe('isUpstreamApiErrorCode', () => {
   it('is true for any SDK code that marks an upstream API failure, including unknown', () => {

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -236,6 +236,17 @@ export const PROVIDER_ERROR_CODES = new Set([
   'server_error',
 ])
 
+// The server only attaches a presentation when the active provider recognized
+// the error, so its presence outranks a generic SDK code (the CLI tags some
+// upstream denials, e.g. a 402, as `unknown`).
+export function isProviderFacingError(
+  apiErrorCode: string | null | undefined,
+  presentation?: ProviderErrorPresentation | null,
+): boolean {
+  if (presentation) return true
+  return typeof apiErrorCode === 'string' && PROVIDER_ERROR_CODES.has(apiErrorCode)
+}
+
 /**
  * Compact boundary marker in API response
  */

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -236,6 +236,16 @@ export const PROVIDER_ERROR_CODES = new Set([
   'server_error',
 ])
 
+// SDK codes for turn failures that are not an upstream API error. A provider
+// override must never claim these, whatever the error text happens to contain.
+export const NON_UPSTREAM_ERROR_CODES = new Set(['max_output_tokens'])
+
+// True when the SDK reported that the upstream API call itself failed (any
+// code, including `unknown`). Null = the turn failed for a non-API reason.
+export function isUpstreamApiErrorCode(apiErrorCode: string | null | undefined): apiErrorCode is string {
+  return typeof apiErrorCode === 'string' && !NON_UPSTREAM_ERROR_CODES.has(apiErrorCode)
+}
+
 // The server only attaches a presentation when the active provider recognized
 // the error, so its presence outranks a generic SDK code (the CLI tags some
 // upstream denials, e.g. a 402, as `unknown`).

--- a/src/shared/lib/types/api.ts
+++ b/src/shared/lib/types/api.ts
@@ -224,10 +224,8 @@ export interface ApiMessage {
   }
 }
 
-/**
- * SDK error codes that indicate an external LLM provider issue
- * (as opposed to application-level errors like max_output_tokens).
- */
+// SDK codes split: NON_UPSTREAM = not an API error; PROVIDER = upstream with a generic banner; the
+// rest of the enum is upstream, provider-facing only with a presentation. api.test.ts pins the enum.
 export const PROVIDER_ERROR_CODES = new Set([
   'authentication_failed',
   'billing_error',
@@ -236,12 +234,10 @@ export const PROVIDER_ERROR_CODES = new Set([
   'server_error',
 ])
 
-// SDK codes for turn failures that are not an upstream API error. A provider
-// override must never claim these, whatever the error text happens to contain.
 export const NON_UPSTREAM_ERROR_CODES = new Set(['max_output_tokens'])
 
-// True when the SDK reported that the upstream API call itself failed (any
-// code, including `unknown`). Null = the turn failed for a non-API reason.
+// Upstream = any code not in NON_UPSTREAM (so `unknown`, `overloaded`, … count).
+// Null = the turn failed for a non-API reason (container died, tool failure).
 export function isUpstreamApiErrorCode(apiErrorCode: string | null | undefined): apiErrorCode is string {
   return typeof apiErrorCode === 'string' && !NON_UPSTREAM_ERROR_CODES.has(apiErrorCode)
 }


### PR DESCRIPTION
## Why

**Bug:** a platform 402 ("insufficient balance") shows the plain red error card instead of the provider card with the billing link. The CLI tags that denial `apiErrorCode: 'unknown'`, which is not in `PROVIDER_ERROR_CODES`, so the server never asked the platform provider for a presentation.

Repro: exhaust a staging workspace's balance, send a message, observe the generic `ActivityErrorCard` rather than the "Insufficient Balance" card.

**Groundwork:** a provider error can only render one way today: the default `ProviderErrorCard`, inline in the chat stream. #914 needed a paywall above the composer and had to hard-wire that into `message-item`, `session-chat-column` and the composer itself. This PR adds the generic hooks so an error class can pick *where* it renders and *which* component renders it, with no paywall knowledge in the core files.

## What changed

### The fix (user-visible)

- `BaseLlmProvider.presentationForTurnError(status, body, apiErrorCode)` replaces `parseErrorResponse` as the single entry point. It asks the provider override first, so a class the provider recognizes gets its presentation under any upstream SDK code (including `unknown`); the generic banner still only attaches under a `PROVIDER_ERROR_CODES` code.
- It is only consulted for upstream API failures. When the SDK reported no error code (container died, tool failure) or reported `max_output_tokens`, it returns `null` before the override runs. Those are the two paths that returned `null` on `main`; the widening is limited to real upstream codes outside `PROVIDER_ERROR_CODES`. This matters because the platform override matches on free text (`insufficient balance`, `spend cap`), and without the guard it would run on every failed turn.
- `isUpstreamApiErrorCode()` / `NON_UPSTREAM_ERROR_CODES` in `api.ts` hold that rule. `isProviderFacingError()` lets the renderer trust an attached presentation over the SDK code.
- `message-persister` and `agents.ts` call `presentationForTurnError`. `parseErrorResponse` had no callers left and is removed.

**Reviewer focus:** `parsePlatformErrorResponse`'s text patterns are now reached for `unknown`/`overloaded`/`model_not_found`/… turns, not only the five provider codes. Tests cover the two guarded paths (`max_output_tokens` + spend-cap text → null; no code + insufficient-balance text → null).

### Placement / component keys (no behavior change until #962)

- `errorPresentation` gains two optional keys: `placement` (`inline` | `composer`, default `inline`; `composer` renders **in place of** the composer, not above it) and `component` (registry key, default `default`). Older clients/servers are unaffected.
- `renderer/components/provider-error/`
  - `provider-error-registry.ts`: `component` key → React component. Adding a component = one row.
  - `provider-error-placement.tsx`: renders the session's current provider error iff its placement matches. Wraps the footer in `session-chat-column` at `composer`: no error → children (the composer) render as-is; a composer-routed error renders its component instead, and the component gets the displaced children so it can hand the composer back once resolved.
- `message-item` / `agent-activity-indicator` skip errors whose placement is not `inline`, so nothing renders twice.

No copy or styling changes; the platform provider recognizes the same classes as before. No dismiss.

## Stack

1. this PR
2. #962 — paywall as a registered component

Supersedes #914 / #931.

Made with [Cursor](https://cursor.com)
