### PR TITLE
ci: name the failing unit tests on the run page

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,16 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      # vitest.config.ts switches to CI reporters when GITHUB_ACTIONS is set:
+      # dot output, a GitHub annotation per failure, and the JSON report the
+      # next step turns into a run-page summary. A red run names the failing
+      # tests without expanding this step's log at all.
       - name: Run unit tests with coverage
         run: npx vitest run --coverage
+
+      - name: Unit test summary
+        if: always()
+        run: npx tsx scripts/summarize-vitest-failures.ts
 
       - name: Coverage summary
         if: always()

--- a/scripts/summarize-vitest-failures.ts
+++ b/scripts/summarize-vitest-failures.ts
@@ -1,0 +1,162 @@
+import { appendFileSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { vitestReportSchema, type VitestReport } from './vitest-report-schema'
+
+// Renders vitest's JSON report as a GitHub Actions step summary, so a failing
+// unit-test job says what broke on the run page itself instead of only at the
+// bottom of a several-thousand-line step log.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const reportPath = path.resolve(repoRoot, process.argv[2] ?? 'test-results/unit/vitest-results.json')
+
+const MAX_FAILURES_LISTED = 40
+const MAX_MESSAGE_LINES = 16
+const MAX_MESSAGE_CHARS = 2_000
+const MAX_STACK_FRAMES = 4
+
+// Built from a char code so the ESC byte never appears literally in this file.
+const ESC = String.fromCharCode(27)
+const ANSI_PATTERN = new RegExp(`${ESC}\\[[0-9;]*m`, 'g')
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, '')
+}
+
+function relative(file: string): string {
+  const rel = path.relative(repoRoot, file)
+  return rel.startsWith('..') ? file : rel
+}
+
+// vitest hands the JSON reporter `error.stack`: the assertion message, then a
+// stack that is nearly all vitest-runner frames. Keep the message and only the
+// frames inside this repo — the full stack and the value diff are still in the
+// step log and in the annotation the github-actions reporter emits.
+function trimMessage(message: string): string {
+  const lines = stripAnsi(message).trimEnd().split('\n')
+  const kept: string[] = []
+  let projectFrames = 0
+
+  for (const line of lines) {
+    const frame = line.match(/^\s+at\s+(?:.*\()?(?:file:\/\/)?(\/[^)]+)\)?$/)
+    if (!frame) {
+      if (projectFrames === 0) kept.push(line)
+      continue
+    }
+    const location = relative(frame[1].replace(/^file:\/\//, ''))
+    if (location.startsWith('/') || location.startsWith('node_modules/')) continue
+    if (projectFrames >= MAX_STACK_FRAMES) continue
+    kept.push(`    at ${location}`)
+    projectFrames += 1
+  }
+
+  const body = (kept.length > 0 ? kept : lines).slice(0, MAX_MESSAGE_LINES)
+  return body.join('\n').trimEnd().slice(0, MAX_MESSAGE_CHARS)
+}
+
+function emit(markdown: string): void {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY
+  if (summaryPath) {
+    appendFileSync(summaryPath, `${markdown}\n`)
+  } else {
+    process.stdout.write(`${markdown}\n`)
+  }
+}
+
+type ReadResult =
+  | { kind: 'ok'; report: VitestReport }
+  | { kind: 'missing' }
+  | { kind: 'unreadable'; detail: string }
+
+function readReport(): ReadResult {
+  let raw: string
+  try {
+    raw = readFileSync(reportPath, 'utf-8')
+  } catch {
+    return { kind: 'missing' }
+  }
+  try {
+    return { kind: 'ok', report: vitestReportSchema.parse(JSON.parse(raw)) }
+  } catch (error) {
+    return { kind: 'unreadable', detail: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+const result = readReport()
+
+// Never fail this step on a bad report: the test step's own exit code already
+// decides the job, and a summary that throws would bury the real failure.
+if (result.kind !== 'ok') {
+  const why =
+    result.kind === 'missing'
+      ? 'the run most likely crashed before writing one'
+      : `it could not be parsed: ${result.detail}`
+  emit(
+    [
+      '## Unit tests',
+      '',
+      `No usable vitest report at \`${relative(reportPath)}\` — ${why}.`,
+      'Open the step log for the raw output.',
+    ].join('\n')
+  )
+  process.exit(0)
+}
+
+const report = result.report
+
+const counts = `**${report.numPassedTests} passed** · **${report.numFailedTests} failed** · ${report.numPendingTests} skipped · ${report.numTotalTests} total`
+
+if (report.success && report.numFailedTests === 0) {
+  emit(['## Unit tests — all green', '', counts].join('\n'))
+  process.exit(0)
+}
+
+const lines: string[] = ['## Unit tests failed', '', counts, '']
+let listed = 0
+let omitted = 0
+
+for (const file of report.testResults) {
+  const failures = file.assertionResults.filter((assertion) => assertion.status === 'failed')
+
+  // A file that never produced an assertion but still failed blew up on import
+  // or in a top-level hook; its only diagnostic is the file-level message.
+  if (failures.length === 0) {
+    if (file.status !== 'failed') continue
+    lines.push(`### \`${relative(file.name)}\``, '', 'The test file failed before any test ran.', '')
+    if (file.message.trim()) {
+      lines.push('```', trimMessage(file.message), '```', '')
+    }
+    listed += 1
+    continue
+  }
+
+  // Past the cap, count the rest rather than emitting a header with nothing
+  // under it.
+  if (listed >= MAX_FAILURES_LISTED) {
+    omitted += failures.length
+    continue
+  }
+
+  lines.push(`### \`${relative(file.name)}\``, '')
+  for (const failure of failures) {
+    if (listed >= MAX_FAILURES_LISTED) {
+      omitted += 1
+      continue
+    }
+    const name = [...failure.ancestorTitles, failure.title].filter(Boolean).join(' > ') || failure.fullName
+    const where = failure.location ? ` — line ${failure.location.line}` : ''
+    lines.push(`- **${name}**${where}`)
+    const message = failure.failureMessages.map(trimMessage).filter(Boolean).join('\n')
+    if (message) {
+      lines.push('', '```', message, '```')
+    }
+    listed += 1
+  }
+  lines.push('')
+}
+
+if (omitted > 0) {
+  lines.push(`_...and ${omitted} more failing test(s). See the step log for the full output._`)
+}
+
+emit(lines.join('\n'))

--- a/scripts/vitest-report-schema.ts
+++ b/scripts/vitest-report-schema.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+// The subset of vitest's `json` reporter output (jest-compatible shape) that the
+// CI failure summary reads back. Unknown keys are stripped, not rejected, so a
+// vitest upgrade that adds fields does not break the summary step.
+export const vitestAssertionResultSchema = z.object({
+  ancestorTitles: z.array(z.string()).default([]),
+  fullName: z.string().default(''),
+  title: z.string().default(''),
+  status: z.string(),
+  duration: z.number().nullish(),
+  failureMessages: z.array(z.string()).default([]),
+  location: z
+    .object({
+      line: z.number(),
+      column: z.number(),
+    })
+    .nullish(),
+})
+
+export const vitestFileResultSchema = z.object({
+  name: z.string(),
+  status: z.string(),
+  // Set when the file itself blew up (an import threw, a top-level hook failed)
+  // and no assertion ever ran.
+  message: z.string().default(''),
+  assertionResults: z.array(vitestAssertionResultSchema).default([]),
+})
+
+export const vitestReportSchema = z.object({
+  success: z.boolean().default(false),
+  numTotalTests: z.number().default(0),
+  numPassedTests: z.number().default(0),
+  numFailedTests: z.number().default(0),
+  numPendingTests: z.number().default(0),
+  numTotalTestSuites: z.number().default(0),
+  testResults: z.array(vitestFileResultSchema).default([]),
+})
+
+export type VitestAssertionResult = z.infer<typeof vitestAssertionResultSchema>
+export type VitestFileResult = z.infer<typeof vitestFileResultSchema>
+export type VitestReport = z.infer<typeof vitestReportSchema>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,15 @@ import { readFileSync } from 'fs'
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'))
 
+// CI reads a red run off the run page, not out of the step log, so GitHub
+// Actions gets its own reporting setup: `dot` instead of the per-file default
+// (this suite is ~670 files), an annotation per failure, and a JSON report that
+// the workflow's "Unit test summary" step renders into the run summary. The
+// coverage table goes too — vitest-coverage-report-action already posts those
+// numbers on the PR, so in the log it is several hundred lines of noise between
+// the failures and the end of the step.
+const isGithubActions = process.env.GITHUB_ACTIONS === 'true'
+
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
@@ -20,9 +29,11 @@ export default defineConfig({
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     setupFiles: ['src/renderer/test/setup.ts'],
     testTimeout: 15_000,
+    reporters: isGithubActions ? ['dot', 'github-actions', 'json'] : ['default'],
+    outputFile: { json: 'test-results/unit/vitest-results.json' },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json-summary', 'json'],
+      reporter: isGithubActions ? ['json-summary', 'json'] : ['text', 'json-summary', 'json'],
       include: ['src/**/*.ts', 'src/**/*.tsx'],
       exclude: ['src/**/*.test.ts', 'src/**/*.d.ts', 'src/main/**'],
     },


### PR DESCRIPTION
## The problem

Finding out what broke in the `unit-tests` job means expanding the step log and scrolling past ~670 files of per-file reporter output and a several-hundred-line coverage table to reach the failures near the bottom.

## The change

Under `GITHUB_ACTIONS`, `vitest.config.ts` switches reporters to `dot` + `github-actions` + `json`, and drops the `text` coverage reporter (`vitest-coverage-report-action` already posts those numbers on the PR, so in the log it is pure noise between the failures and the end of the step).

That buys two places to read a red run without expanding anything:

**1. Annotations** — one per failure, at the top of the run page and inline on the PR diff:

```
::error file=src/api/cache-headers.test.ts,title=cache-headers > sets max-age,line=12,column=20::AssertionError: expected 'no-store' to be 'max-age=60'…
```

**2. A job summary** — `scripts/summarize-vitest-failures.ts` renders the JSON report into `$GITHUB_STEP_SUMMARY`:

> ## Unit tests failed
>
> **10920 passed** · **1 failed** · 45 skipped · 10967 total
>
> ### `src/api/cache-headers.test.ts`
> - **cacheHeaders > sets max-age** — line 12
> ```
> AssertionError: expected 'no-store' to be 'max-age=60'
>     at src/api/cache-headers.test.ts:12:20
> ```

The summary strips ANSI, drops the vitest-runner stack frames (keeping up to 4 in-repo ones), handles files that died on import before any test ran, and caps at 40 failures. It never fails the job — the test step's exit code already decides that, and a summary that threw on a missing or malformed report would bury the real failure.

`scripts/vitest-report-schema.ts` is the Zod schema for the report, `.parse()`d at the read boundary per CLAUDE.md.

Local runs are untouched: default reporter, coverage table still printed.

## Verification

- Full suite in CI mode: 661 files / 10921 passed in 80s, JSON report written, no coverage table, summary renders "all green".
- A deliberately failing test: annotation emitted, summary lists it with the trimmed stack.
- Missing report and malformed report: both emit an explanatory summary and exit 0.
- `npm run typecheck` and `npm run lint` clean (`scripts/` isn't in the lint globs, so eslint was run on the two new files directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNzvyZ2qowzyP38JadUmPU
