### PR TITLE
Home cards: keep the sessions list clear of the status chip

### DIFF
--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -121,7 +121,7 @@ function AgentCardPowerButton({ agent }: { agent: ApiAgent }) {
     // Frosted status chip with a white-bordered stop/power button inside. It's a
     // flex item in the card's control row (see AgentCard), so the kebab aligns
     // with it natively.
-    <div className="flex items-center gap-1.5 rounded-md border border-border/50 bg-white/10 py-0.5 pl-1.5 pr-1 text-xs backdrop-blur-sm">
+    <div className="flex items-center gap-1.5 rounded-md border border-border/50 bg-white/10 py-0.5 pl-1.5 pr-0.5 text-xs backdrop-blur-sm">
       <span className="leading-none text-muted-foreground">{label}</span>
       <button
         type="button"

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -323,9 +323,12 @@ function AgentCardSessions({
                 </span>
               </button>
               {st === 'unread' || st === 'awaiting' ? (
-                <>
-                  <span className="shrink-0 text-muted-foreground tabular-nums">{right}</span>
-                  <span className="flex shrink-0 items-center gap-0.5 opacity-60 transition-opacity group-hover/row:opacity-100 group-focus-within/row:opacity-100">
+                /* Time stamp sits flush right; the action buttons are collapsed
+                   to zero width until the row is hovered/focused, then expand
+                   and slide in from the right, nudging the stamp left. */
+                <span className="flex shrink-0 items-center">
+                  <span className="text-muted-foreground tabular-nums">{right}</span>
+                  <span className="flex max-w-0 translate-x-1 items-center gap-0.5 overflow-hidden opacity-0 transition-all duration-200 ease-out group-hover/row:max-w-16 group-hover/row:translate-x-0 group-hover/row:pl-1.5 group-hover/row:opacity-100 group-focus-within/row:max-w-16 group-focus-within/row:translate-x-0 group-focus-within/row:pl-1.5 group-focus-within/row:opacity-100">
                     {st === 'unread' && (
                       <button
                         type="button"
@@ -353,7 +356,7 @@ function AgentCardSessions({
                       <ArrowRight className="h-3.5 w-3.5" />
                     </button>
                   </span>
-                </>
+                </span>
               ) : (
                 <span className="shrink-0 text-muted-foreground tabular-nums">{right}</span>
               )}
@@ -670,8 +673,9 @@ function AgentCard({
         ) : (
           /* Wide: same glance-tile footing as Small — halftone fills the card,
              title in the bottom-left corner — with the notifications + health
-             carousel overlaid on top. The content reserves bottom space (pb-11)
-             so it clears the title pill. */
+             carousel overlaid on top. The content reserves top space (pt-5) so
+             it clears the status chip and bottom space (pb-11) so it clears
+             the title pill. */
           <>
             <div className="absolute inset-0">
               <AgentCardMatrix
@@ -682,7 +686,7 @@ function AgentCard({
                 className="h-full"
               />
             </div>
-            <div className="pointer-events-none relative z-30 flex min-h-0 flex-1 flex-col gap-1.5 pb-11">
+            <div className="pointer-events-none relative z-30 flex min-h-0 flex-1 flex-col gap-1.5 pt-5 pb-11">
               {/* Notifications sit directly above the cron/webhook carousel
                   (bottom-aligned); any slack opens up above them. Scrolls when
                   the list overflows. */}

--- a/src/renderer/components/home/widget-grid.tsx
+++ b/src/renderer/components/home/widget-grid.tsx
@@ -39,6 +39,9 @@ export function widgetSizeKey(w: number, h: number): WidgetSizeKey {
 
 const GAP = 16 // px between cells
 const TARGET_CELL = 232 // desired cell+gap size — drives the column count
+// Rows are a bit taller than cells are wide, so a Wide card fits three session
+// rows + the health carousel between the status chip and the title pill.
+const CELL_EXTRA_H = 24
 
 export interface Placed extends GridRect {
   id: string
@@ -196,12 +199,14 @@ export function WidgetBoard({
     return items.map((it) => map.get(it.id)!).filter(Boolean)
   }, [items, cols])
 
-  const unit = cellW + GAP
+  const cellH = cellW + CELL_EXTRA_H
+  const unitX = cellW + GAP
+  const unitY = cellH + GAP
   const pos = (g: GridRect) => ({
-    left: g.x * unit,
-    top: g.y * unit,
+    left: g.x * unitX,
+    top: g.y * unitY,
     width: g.w * cellW + (g.w - 1) * GAP,
-    height: g.h * cellW + (g.h - 1) * GAP,
+    height: g.h * cellH + (g.h - 1) * GAP,
   })
 
   const [drag, setDrag] = useState<DragState | null>(null)
@@ -259,8 +264,8 @@ export function WidgetBoard({
       const left = ev.clientX - boardRect.left - dx
       const top = ev.clientY - boardRect.top - dy
       const maxX = cols - item.w
-      const tx = Math.max(0, Math.min(maxX, Math.round(left / unit)))
-      const ty = Math.max(0, Math.round(top / unit))
+      const tx = Math.max(0, Math.min(maxX, Math.round(left / unitX)))
+      const ty = Math.max(0, Math.round(top / unitY))
       const moved = placed.map((g) => (g.id === item.id ? { ...g, x: tx, y: ty } : g))
       const preview = resolveLayout(moved, item.id)
       setDrag({ id: item.id, left, top, w: item.w, h: item.h, target: { x: tx, y: ty }, preview })
@@ -313,22 +318,22 @@ export function WidgetBoard({
     }),
     drag ? drag.target.y + drag.h : 0
   )
-  const boardH = rows * unit - GAP + (drag ? unit : 0)
+  const boardH = rows * unitY - GAP + (drag ? unitY : 0)
 
   return (
     <div
       ref={wrapRef}
       className="relative w-full transition-[height] duration-200 ease-out"
-      style={{ height: Math.max(boardH, unit) }}
+      style={{ height: Math.max(boardH, unitY) }}
     >
       {drag && (
         <div
           className="absolute rounded-lg bg-muted/40 transition-[left,top] duration-100"
           style={{
-            left: drag.target.x * unit,
-            top: drag.target.y * unit,
+            left: drag.target.x * unitX,
+            top: drag.target.y * unitY,
             width: drag.w * cellW + (drag.w - 1) * GAP,
-            height: drag.h * cellW + (drag.h - 1) * GAP,
+            height: drag.h * cellH + (drag.h - 1) * GAP,
           }}
         />
       )}


### PR DESCRIPTION
## Summary

On a Wide home card, a full notifications list (three rows) ran up underneath the status chip in the top-right corner. The card was laid out at exactly its capacity, so the only symptom was the overlap.

- **Reserve top space for the chip.** The Wide card's content column now pads 20px on top, so the sessions list can never sit under the status chip.
- **Taller grid rows instead of tighter spacing.** Every widget-grid row is now 24px taller than a cell is wide (one `CELL_EXTRA_H` constant), so three session rows + the health carousel still fit above the title pill at the original row pitch and chip padding. The grid's vertical unit is now separate from the horizontal one for placement, board height, the drag ghost, and the drop-target hit test.
- **Row actions slide in on hover.** The mark-read and open buttons on a notification row are collapsed to zero width when idle, so the time stamp sits flush right on every row. On hover or keyboard focus they expand and slide in from the right over 200ms, nudging the stamp left. Mirrors the reveal already used in the agent permissions view.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Home (light)](https://github.com/user-attachments/assets/d575e563-9dea-4fba-a906-577bdbfde896) | ![Home (dark)](https://github.com/user-attachments/assets/c55646cb-bcc5-4340-b99b-a6a823604f83) |

Hovered notification row (light):

![Wide card with a notification row hovered](https://github.com/user-attachments/assets/09a74ac9-a8f0-4069-93bf-b1e015b4478e)

## Testing

- `eslint` + `tsc --noEmit` clean
- `home-page.test.tsx` + `widget-grid.test.tsx` pass (39 tests)
- Verified in the Electron dev app at the two- and three-column widths; screenshots above are from the mock web instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
