### PR TITLE
chore(deps): bump claude-agent-sdk to 0.3.260 (CLI 2.1.260)

### DIFF
--- a/agent-container/package-lock.json
+++ b/agent-container/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.257",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.260",
         "@anthropic-ai/sdk": "^0.123.0",
         "@hono/node-server": "^1.8.0",
         "hono": "^4.0.0",
@@ -41,22 +41,22 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.257.tgz",
-      "integrity": "sha512-Se55zXv48IYLg/WzoXzpbPLcq86suwDSbRUoNb69l4dkovorqS/47Xuy7MUo/gPNwwcPB4a+aqbXbshU33dcdQ==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.260.tgz",
+      "integrity": "sha512-PmABtP4Rwd6l95itQrqzguv6rS9uACqikPB9g8BPeWRKZOpy3xpEOjJLYauof3BFk2wNZnfhr0Ttx8ttcZzq0w==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.257",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.257",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.257",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.257",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.257",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.257",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.257",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.257"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.260",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.260",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.260",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.260",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.260",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.260",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.260",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.260"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.257.tgz",
-      "integrity": "sha512-ITjFPYB8riu9tbxbrWArokiZ/90w/NDrYbtEvyr3ScilVtu1iupkComxkhvbUxoyT4JRDpKsdw/ZOfwSl/pkpA==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.260.tgz",
+      "integrity": "sha512-0af2gRe6+sk13yYNX2gdDhcO15Kj1qd8B7ZQlv8mDt2lA1xFhTJqIvRwgrCHeCWZryWTmoRgtMoAfJOhQ9yn1g==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.257.tgz",
-      "integrity": "sha512-0s7QoLRnopbMvCqVpgCnvBWg4UNxPUybMZTknkn3HLBMvUjUdHs1QXb77c/yrT1WAPqDTw1Ju+H0esXwWa8/Kg==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.260.tgz",
+      "integrity": "sha512-Tnxzv1//5SBT+IVSfIchpOEsg6tv+FADE1a9fSXYI81317IRMpFCQC9rgqxlRtY1Nh401zRzFvQdTz9QR4pmig==",
       "cpu": [
         "x64"
       ],
@@ -91,11 +91,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.257.tgz",
-      "integrity": "sha512-38tv1s1CaIE6CyEBmJpfKtvwPzrasxPiRT079BEs5aaiLPQ+pmSGF0+Lwy7ot9i6xqr7v5/91TVo5JXHI8Pkpg==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.260.tgz",
+      "integrity": "sha512-sfZVBdAnuflSs+ru7U1DxIgjd9HPDmgvtA8hKZROfgNt8i2CYBfDHe4pLXkk/kS3nlOR+peJnjGVTFHW52s1mQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -104,11 +107,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.257.tgz",
-      "integrity": "sha512-t2WHfKjY4Jjgzfk0lbBUt6EVPQe+wXvXvRmYnK7ICfzZ1jS8CrpDajwBQErKFSMiUqGAutZy3vwDwGziW32cpw==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.260.tgz",
+      "integrity": "sha512-ZLMbeLHVjkq5hmnpWK1Q2qGAztSPrnTtV+ufdPNf9rzYTYEJdLvEHMqmqlFE2VStOrFEpa7feftT3rcbobBJEw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -117,11 +123,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.257.tgz",
-      "integrity": "sha512-0FRyIwV4jEJErdDDoYMC0v9lzuFNz5y0lK2340H5fP02eNXsP3U0htKW/bfRP8Ppei+xc4QUZgdCI6rVzkhXGg==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.260.tgz",
+      "integrity": "sha512-JR6MS8KeETQoxSaNtBFqCFV66QM+gsNeuWjXIhac4wXb19gRGiOcsCjBqQU8kadUYCBUabd6lKN2edwG6ETSXg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -130,11 +139,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.257.tgz",
-      "integrity": "sha512-qSlgAUEpj2JAA+YqMD222iv2W3x8xBDSYwdoaOx20VbaJRjFq8feViI7kcr1C6wVN+ApX4Rxl7YX6gekiBkA2g==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.260.tgz",
+      "integrity": "sha512-JL07je0d2g680Hbu0D9W4hGuZlUeQlhPQac+NPKTJAdJ21bH12JdaMO5QE9RDNIxjd1BaodqMOdTEhjrH1capQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -143,9 +155,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.257.tgz",
-      "integrity": "sha512-7iEwy14lSqaAWvNR3KucBusQs5+hG6uoliYWZ2M2FyaCk5PHYymVf9mrRPtWhaYfNwum/YY13acYIIvnAbz0kA==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.260.tgz",
+      "integrity": "sha512-Fixnzgzxc0W6uGAwlp/zhoKsY+oLwHwE7y57lV8JhbGWHzK2gWPA9Q1s6TrR8A9sKPhmmHy7BrgTUundH2y2cQ==",
       "cpu": [
         "arm64"
       ],
@@ -156,9 +168,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.257",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.257.tgz",
-      "integrity": "sha512-NW0zMjHXFBdu2TcjT9Zo5o/1tJaDy6A7v4Gt/vLVJgaipV/RzAbyRGXZzH37hswyiKrSLGaSoYYP1vUfncbkUQ==",
+      "version": "0.3.260",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.260.tgz",
+      "integrity": "sha512-relNUBdfUSHVYmB04Nle5zJDykdT+FFLwcgz/SJc87Tj68jKT4vRSTeoDrE32kdmwhjFQ15HvmLGib41b9+xTA==",
       "cpu": [
         "x64"
       ],

--- a/agent-container/package.json
+++ b/agent-container/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.257",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.260",
     "@anthropic-ai/sdk": "^0.123.0",
     "@hono/node-server": "^1.8.0",
     "hono": "^4.0.0",


### PR DESCRIPTION
Bumps `agent-container` from `0.3.257` to `0.3.260`, carrying the bundled Claude Code CLI from 2.1.257 to 2.1.260.

## Reviewer note: supply-chain cooldown was overridden

The repo enforces `min-release-age=7` in `.npmrc`, added deliberately in #416. `0.3.260` was one day old at install time, so npm refused it. This was installed with `--min-release-age=0` passed on the command line only, at the maintainer's explicit direction. **`.npmrc` is unchanged** — the control still applies to everyone else.

Worth a second opinion on whether to hold this until 2026-09-10, when 0.3.260 clears the cooldown on its own. Nothing in the three releases fixes a problem we currently have.

## Scope of the change

The lockfile change is confined to the SDK and its eight native-binary optional deps. No other package moved.

The SDK type surface is **purely additive** across this range. There are no removals and no signature changes to any symbol we import: `query`, `startup`, `tool`, `createSdkMcpServer`, `forkSession`, `deleteSession`, `getSessionMessages`, `HookCallback`, `AgentDefinition`, `EffortLevel`, and the message types. The only in-place edits are doc comments.

New optional fields, none of which we use: `permissionPrompts`, `user_message_uuids`, first-frame timing counters, and the `managedMcpServers` managed setting. The new `--permission-prompts none` mode is redundant for us since we already pin `permissionMode: 'bypassPermissions'`.

## Validation

| Check | Result |
|---|---|
| Typecheck | clean |
| Container unit suite | 958 passed, 8 skipped |
| `session-gc.e2e.test.ts` | 2 passed |
| `session-gc-durability.e2e.test.ts` | 5 passed |
| Task-tools escape hatch | all four registered |

The two session-GC files were run in separate vitest invocations, since their zero-process assertions would otherwise see each other's CLI subprocesses. All four CLI-behavior assumptions the idle-eviction reaper depends on still hold under 2.1.260.

For the Task-tools re-verify, note that the drift skill defaults to `claude-opus-4-7`, which sits **below** the gate threshold and would make the check vacuous. Captured on `claude-opus-5` instead, a model we actually ship and that the gate does affect. Reading the real `tools` array from the captured wire payload, `TaskCreate`, `TaskGet`, `TaskList` and `TaskUpdate` are all present among 67 tools, so the undocumented `CLAUDE_CODE_ENABLE_TODO_TOOLS` escape hatch still works. Consider raising the skill's default capture model, since the current default cannot detect the regression it exists to catch.

## Two notes for follow-up

**The `CLAUDE_SDK_CAN_USE_TOOL_SHADOWED` warning is noisy but benign.** Both E2E suites emit it, claiming `canUseTool` will never fire under `bypassPermissions`. It is present in 0.3.257 too, so it is not new here. I verified empirically with a throwaway probe that the callback **does** fire for `AskUserQuestion` under our exact options, so the handler in `claude-code.ts` is live code. The warning is a static startup lint computed from the options, not a description of runtime behavior.

**Preset drift was not assessed.** No prior snapshot existed to diff against, so the porting triage for changes Anthropic made to the `claude_code` preset has no baseline. The capture taken here establishes that baseline for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHv8x3t4KZAEdmsNaR7UtD
