### PR TITLE
Home card menu: Compact View switch, option icons, Arrange last

### DIFF
--- a/e2e/specs/home-cards.spec.ts
+++ b/e2e/specs/home-cards.spec.ts
@@ -91,11 +91,11 @@ test.describe('home card arrangement', () => {
     await expect(widget.getByRole('button', { name: `Options for ${agent.name}` })).toHaveCount(0)
     await widget.getByRole('link', { name: `Open ${agent.name}` }).focus()
     await page.keyboard.press('Shift+F10')
-    await expect(page.getByRole('menuitemcheckbox', { name: 'Expanded' })).toBeVisible()
+    await expect(page.getByRole('menuitemcheckbox', { name: 'Compact View' })).toBeVisible()
     await page.keyboard.press('Escape')
     // Wait out the Radix menu teardown: it holds pointer-events:none on <body>
     // slightly past close, which would swallow the pointerdown of the drag.
-    await expect(page.getByRole('menuitemcheckbox', { name: 'Expanded' })).not.toBeVisible()
+    await expect(page.getByRole('menuitemcheckbox', { name: 'Compact View' })).not.toBeVisible()
     await page.waitForFunction(() => document.body.style.pointerEvents !== 'none')
 
     // Outside Arrange mode, desktop still supports direct pointer reordering.
@@ -123,9 +123,9 @@ test.describe('home card arrangement', () => {
     // through its overlay to the unified agent context menu.
     await widget.click({ button: 'right', position: { x: 30, y: 30 } })
     await expect(page.getByTestId('move-agent-to-folder-trigger')).toBeVisible()
-    const expanded = page.getByRole('menuitemcheckbox', { name: 'Expanded' })
-    await expect(expanded).toBeVisible()
-    await expanded.click()
+    const compactView = page.getByRole('menuitemcheckbox', { name: 'Compact View' })
+    await expect(compactView).toBeVisible()
+    await compactView.click()
     // Changing the card size remounts its context-menu trigger, so reopen the
     // unified menu on the newly rendered card before toggling the app row.
     await widget.click({ button: 'right', position: { x: 30, y: 30 } })

--- a/src/renderer/components/agents/agent-context-menu.tsx
+++ b/src/renderer/components/agents/agent-context-menu.tsx
@@ -39,7 +39,7 @@ import { apiFetch } from '@renderer/lib/api'
 import {
   Trash2,
   LogOut,
-  Move,
+  LayoutPanelTop,
   FolderInput,
   Pencil,
   Plus,
@@ -310,6 +310,7 @@ export function AgentContextMenu({
             action()
           }}
         >
+          {additionalOptions}
           {onArrange && (
             <ContextMenuItem
               onClick={() => {
@@ -317,11 +318,10 @@ export function AgentContextMenu({
               }}
               data-testid="arrange-agent-cards-item"
             >
-              <Move className="h-4 w-4 mr-2" />
+              <LayoutPanelTop className="h-4 w-4 mr-2" />
               Arrange
             </ContextMenuItem>
           )}
-          {additionalOptions}
           {(onArrange || additionalOptions) && <ContextMenuSeparator className="mx-1" />}
           {isOwner && (
             <ContextMenuItem onClick={handleRenameItem} data-testid="rename-agent-item">

--- a/src/renderer/components/home/home-page.test.tsx
+++ b/src/renderer/components/home/home-page.test.tsx
@@ -456,7 +456,7 @@ describe('HomePage AgentCard', () => {
     renderWithProviders(<HomePage />)
 
     expect(screen.queryByRole('button', { name: 'Options for Test Agent' })).not.toBeInTheDocument()
-    expect(screen.getByRole('switch', { name: 'Expanded' })).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Compact View' })).toBeInTheDocument()
     expect(document.querySelector('button button')).toBeNull()
     const contextMenuEvent = vi.fn()
     screen.getByTestId('agent-context-trigger').addEventListener('contextmenu', contextMenuEvent)
@@ -489,7 +489,7 @@ describe('HomePage AgentCard', () => {
     })
     renderWithProviders(<HomePage />)
 
-    screen.getByRole('switch', { name: 'Expanded' }).click()
+    screen.getByRole('switch', { name: 'Compact View' }).click()
 
     const layoutCall = mockUpdateSettingsMutate.mock.calls.find(
       ([data]) => data && typeof data === 'object' && 'homeGridLayout' in data
@@ -512,7 +512,7 @@ describe('HomePage AgentCard', () => {
     })
     renderWithProviders(<HomePage />)
 
-    screen.getByRole('switch', { name: 'Expanded' }).click()
+    screen.getByRole('switch', { name: 'Compact View' }).click()
 
     const layoutCall = mockUpdateSettingsMutate.mock.calls.find(
       ([data]) => data && typeof data === 'object' && 'homeGridLayout' in data
@@ -533,9 +533,10 @@ describe('HomePage AgentCard', () => {
     })
     renderWithProviders(<HomePage />)
 
-    screen.getByRole('switch', { name: 'Expanded' }).click()
+    screen.getByRole('switch', { name: 'Compact View' }).click()
 
-    expect(screen.getByRole('switch', { name: 'Expanded' })).toHaveAttribute('aria-checked', 'true')
+    // Save failed, so the card is still Wide: Compact stays off.
+    expect(screen.getByRole('switch', { name: 'Compact View' })).toHaveAttribute('aria-checked', 'false')
     expect(mockToastError).toHaveBeenCalledWith('Failed to save the home layout', {
       description: 'offline',
     })
@@ -680,10 +681,11 @@ describe('HomePage AgentCard', () => {
     mockAgentsData.mockReturnValue({ data: [makeAgent()], isLoading: false })
     renderWithProviders(<HomePage />)
 
-    // With no mobile map yet, the phone inherits the desktop card size.
-    const expanded = screen.getByRole('switch', { name: 'Expanded' })
-    expect(expanded).toHaveAttribute('aria-checked', 'true')
-    expanded.click()
+    // With no mobile map yet, the phone inherits the desktop card size (Wide,
+    // so Compact is off).
+    const compact = screen.getByRole('switch', { name: 'Compact View' })
+    expect(compact).toHaveAttribute('aria-checked', 'false')
+    compact.click()
 
     expect(mockUpdateSettingsMutate).toHaveBeenCalledWith(
       {

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -36,7 +36,7 @@ import { DashboardCard } from './dashboard-card'
 import { HomeEmptyClouds } from './home-empty-clouds'
 import { PwaInstallBanner } from './pwa-install-banner'
 import { isElectron, getPlatform } from '@renderer/lib/env'
-import { Plus, Loader2, Search, Power, Square, Check, ArrowRight, LayoutGrid, Waypoints, MoreVertical, Move, Sparkle } from 'lucide-react'
+import { Plus, Loader2, Search, Power, Square, Check, ArrowRight, LayoutGrid, LayoutPanelTop, Minimize, Waypoints, MoreVertical, Sparkle, SquareMousePointer } from 'lucide-react'
 import { useSearch } from '@renderer/context/search-context'
 import { cn } from '@shared/lib/utils/cn'
 import type { ApiAgent } from '@shared/lib/types/api'
@@ -747,7 +747,7 @@ function HomeArrangeMenu({
           }}
           className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
         >
-          <Move className="h-4 w-4" />
+          <LayoutPanelTop className="h-4 w-4" />
           Arrange
         </button>
       </PopoverContent>
@@ -1201,12 +1201,13 @@ export function HomePage() {
                       additionalOptions={
                         <>
                           <ContextMenuSwitchItem
-                            checked={size === 'W'}
+                            checked={size === 'S'}
                             onCheckedChange={() => {
                               onResize(size === 'W' ? 'S' : 'W')
                             }}
                           >
-                            Expanded
+                            <Minimize className="h-4 w-4 mr-2" />
+                            Compact View
                           </ContextMenuSwitchItem>
                           {agentsWithApp.has(agent.slug) && (
                             <ContextMenuSwitchItem
@@ -1215,6 +1216,7 @@ export function HomePage() {
                                 toggleAppCard(agent.slug)
                               }}
                             >
+                              <SquareMousePointer className="h-4 w-4 mr-2" />
                               Show app
                             </ContextMenuSwitchItem>
                           )}

--- a/src/renderer/components/ui/context-menu.tsx
+++ b/src/renderer/components/ui/context-menu.tsx
@@ -247,13 +247,15 @@ const ContextMenuSwitchItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center justify-between gap-3 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
     {...props}
   >
-    <span>{children}</span>
+    {/* Same left edge as ContextMenuItem so a leading icon (h-4 w-4 mr-2) lines
+        up with the icons on plain items. */}
+    <span className="flex items-center">{children}</span>
     <span
       aria-hidden="true"
       className={cn(


### PR DESCRIPTION
## Summary

Small cleanup of the home card's right-click menu.

- **"Expanded" → "Compact View".** The size switch is now on when the card is the Small (1×1) tile and off for the Standard (2×1) card, with a Minimize icon. Same two sizes, inverted semantics.
- **"Show app" gets the app icon** (SquareMousePointer), the one the sidebar, search dialog, and dashboard card already use for dashboard apps.
- **Arrange uses LayoutPanelTop** in both the card menu and the header's "Agent layout options" kebab, and moves to the bottom of the card-options section: Compact View, Show app, Arrange.
- `ContextMenuSwitchItem` now shares `ContextMenuItem`'s left edge instead of the 32px checkbox indent, so a leading icon lines up with the icons on plain items. Nothing else used the old indent.

## Screenshots

Card context menu:

| Light | Dark |
| --- | --- |
| ![Card context menu (light)](https://github.com/user-attachments/assets/08faf61b-3ffc-423e-97ad-6219c158b543) | ![Card context menu (dark)](https://github.com/user-attachments/assets/cb4b2edf-ad1e-4771-a268-82e52bd9f699) |

Header layout menu (light):

![Header layout menu](https://github.com/user-attachments/assets/18236470-81c6-432f-b029-178b2a64cbea)

## Testing

- `eslint` + `tsc --noEmit` clean
- `home-page.test.tsx`, `context-menu.test.tsx`, `agent-context-menu.test.tsx` pass (52 tests); the home-page assertions were updated for the inverted switch
- Screenshots from the mock web instance; verified in the Electron dev app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
