### PR TITLE
Fix the session-long-sleep wake assertion that has been failing main

### DIFF
--- a/e2e/specs/session-long-sleep.spec.ts
+++ b/e2e/specs/session-long-sleep.spec.ts
@@ -121,6 +121,16 @@ test.describe('Session long sleep (schedule_resume)', () => {
 
     const banner = page.locator('[data-testid="pending-wake-banner"]')
     await expect(banner).toBeVisible({ timeout: 15000 })
+
+    // The pre-sleep answer is the visible final text of the one existing turn.
+    // The wake demotes it to hidden work behind the turn summary — anchor on it
+    // being visible first so the post-wake assertion can't pass against a
+    // transcript that simply hasn't loaded yet.
+    const preSleepAnswer = sessionPage
+      .getAssistantMessages()
+      .filter({ hasText: "I'll pause here and check back in 2 hours." })
+    await expect(preSleepAnswer).toBeVisible({ timeout: 15000 })
+
     await page.locator('[data-testid="pending-wake-wake-now"]').click()
 
     // The wake task is executed against the SAME session (no new session)
@@ -138,11 +148,28 @@ test.describe('Session long sleep (schedule_resume)', () => {
     // Banner clears once the wake is gone
     await expect(banner).not.toBeVisible({ timeout: 15000 })
 
-    // The wake message lands in this session as a system-prefixed turn and the
-    // mock agent responds — the transcript grows in place. This is the last
-    // stop of the longest serial chain in the suite; under load the wake
-    // delivery plus the transcript refetch can exceed 15s.
-    await expect(sessionPage.getAssistantMessages().nth(1)).toBeVisible({ timeout: 25000 })
+    // The wake message lands in this session as a system-prefixed user turn and
+    // the mock agent responds — the transcript grows in place. It does NOT grow
+    // a second *visible* turn: `[SYSTEM]` user messages are hidden from the
+    // transcript by design (user-message-kinds/system.ts), so the resumed work
+    // folds into the one existing turn. The pre-sleep answer is demoted from
+    // final text to hidden work behind the turn summary, and the post-wake
+    // answer takes its place — that swap is the observable proof the wake
+    // landed. Counting top-level assistant bubbles instead would race the fold,
+    // which only happens once the session goes idle.
+    //
+    // This is the last stop of the longest serial chain in the suite; under
+    // load the wake delivery plus the transcript refetch can exceed 15s.
+    await expect(preSleepAnswer).toBeHidden({ timeout: 25000 })
+
+    // Expanding the turn brings the pre-sleep answer back alongside the
+    // post-wake one: both turns' output is in there, in order.
+    await sessionPage.expandLatestCompletedTurn(15000)
+    await expect(preSleepAnswer).toBeVisible()
+    await expect(sessionPage.getAssistantMessages()).toHaveCount(2)
+    await expect(sessionPage.getAssistantMessages().nth(1)).toContainText(
+      'This is a mock response from the E2E test container.'
+    )
   })
 
   test('Cancel clears the pending wake without resuming', async ({ page, request }) => {


### PR DESCRIPTION
## Summary

`session-long-sleep.spec.ts:116 › Wake now resumes the session and clears the wake` is the sole hard failure in `e2e-tests` on `main`, failing all 3 retries roughly half the time and blocking unrelated PRs. Confirmed on runs [33921660402](https://github.com/SkillfulAgents/SuperAgent/actions/runs/33921660402), [33920052118](https://github.com/SkillfulAgents/SuperAgent/actions/runs/33920052118), [33904643896](https://github.com/SkillfulAgents/SuperAgent/actions/runs/33904643896), [33830207056](https://github.com/SkillfulAgents/SuperAgent/actions/runs/33830207056) — and it's what red-flagged #964, which only touches `home-page.tsx`.

## Root cause

The test is asserting something that isn't part of the wake's steady state.

Reading the failed run's Playwright trace, the API returns four messages after the wake:

| # | type | text |
|---|---|---|
| 1 | user | `schedule resume until the review is approved` |
| 2 | assistant | `I'll pause here and check back in 2 hours.` + `schedule_resume` tool call |
| 3 | user | `[SYSTEM] This session is resuming now…` |
| 4 | assistant | `This is a mock response from the E2E test container.` |

Message 3 is hidden from the transcript **by design** — `user-message-kinds/system.ts` marks `[SYSTEM] `-prefixed user turns `hidden: true`, and `message-list.tsx:409` drops them from `visibleMessages`. So the wake never starts a new visible turn. Turn folding (`message-list.tsx:649`) then sees one turn spanning #1 → #4, folds #2 away as work, and leaves **exactly one** `[data-testid="message-assistant"]`. The old `.nth(1)` can never resolve.

It only ever passed by catching the transient window while the session still read as active — the trailing turn is collapsed only when `!isActive` (`message-list.tsx:786`). Under CI load the transcript refetch lands after the session has already gone idle, so that window never exists. #956 changed when `isActive` flips, which is exactly where the failures start.

## The fix

Assert the swap that actually proves the wake landed: the pre-sleep answer is demoted from final text to hidden work behind the turn summary, and expanding the turn shows both answers in order. Anchored on the pre-sleep answer being visible *before* the wake, so it can't pass against a transcript that simply hasn't loaded.

## Testing

- With a `page.reload()` injected to force the CI steady state, the **old** assertion fails 3/3 with the exact CI error (`locator('[data-testid="message-assistant"]').nth(1)` — element(s) not found)
- The **new** assertion passes 3/3 both with and without that reload
- Full spec: 9/9 under `--repeat-each=3`
- `eslint` + `tsc --noEmit` clean

No UI change.

## Noted, not fixed

There's a real UX question underneath: on "Wake now" the previous answer silently folds away and is replaced by the new one, with no transcript marker that a wake happened — only the banner disappearing signals it. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DpbodCWMtRN5hryvkEWH3