### PR TITLE
Restyle the cron spark chart onto a shared track

### DIFF
--- a/src/renderer/components/activity/activity-spark-chart.test.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { ActivitySparkChart, CronSparkChart } from './activity-spark-chart'
 
 describe('activity spark charts', () => {
@@ -19,7 +19,12 @@ describe('activity spark charts', () => {
     })).toBeInTheDocument()
     expect(screen.getAllByTestId('activity-success-bar')).toHaveLength(3)
     expect(screen.getAllByTestId('activity-failure-bar')).toHaveLength(3)
-    expect(screen.getByText('Jul 8: 3 succeeded, 1 failed')).toBeInTheDocument()
+    expect(screen.queryByTestId('spark-tooltip')).not.toBeInTheDocument()
+    fireEvent.mouseEnter(screen.getAllByTestId('spark-hit')[1])
+    const tip = screen.getByTestId('spark-tooltip')
+    expect(tip).toHaveTextContent('Jul 8')
+    expect(tip).toHaveTextContent('3 Succeeded')
+    expect(tip).toHaveTextContent('1 Failed')
   })
 
   it('keeps an all-zero series visible and truthful', () => {
@@ -71,6 +76,32 @@ describe('activity spark charts', () => {
     expect(runningSlot).toHaveClass('fill-emerald-500', 'animate-pulse')
   })
 
+  it('shows a run detail on column hover and nothing on pre-history slots', () => {
+    render(<CronSparkChart
+      label="Nightly report schedule"
+      data={[
+        { scheduledAt: '2026-07-09T11:00:00.000Z', status: 'succeeded' },
+        { scheduledAt: '2026-07-09T12:00:00.000Z', status: 'failed' },
+      ]}
+    />)
+
+    const bands = screen.getAllByTestId('spark-hit')
+    expect(bands).toHaveLength(14)
+
+    // Newest run is the last band.
+    fireEvent.mouseEnter(bands[13])
+    expect(screen.getByTestId('spark-tooltip')).toHaveTextContent('Failed')
+
+    // Hovering an empty pre-creation slot clears it rather than showing a blank.
+    fireEvent.mouseEnter(bands[0])
+    expect(screen.queryByTestId('spark-tooltip')).not.toBeInTheDocument()
+
+    fireEvent.mouseEnter(bands[12])
+    expect(screen.getByTestId('spark-tooltip')).toHaveTextContent('Succeeded')
+    fireEvent.mouseLeave(screen.getByRole('img'))
+    expect(screen.queryByTestId('spark-tooltip')).not.toBeInTheDocument()
+  })
+
   it('uses one fixed right-aligned slot grid when tasks have different history lengths', () => {
     const { container: longer } = render(<CronSparkChart
       label="Longer history"
@@ -112,13 +143,14 @@ describe('activity spark charts', () => {
     />)
 
     const noHistorySlots = screen.getAllByTestId('cron-slot-no-history')
-    expect(noHistorySlots).toHaveLength(15)
-    expect(noHistorySlots[0]).toHaveClass('fill-none', 'stroke-muted-foreground/20')
-    expect(noHistorySlots[0]).toHaveAttribute('x', '0.5')
-    expect(noHistorySlots[0]).toHaveAttribute('y', '4.5')
-    expect(noHistorySlots[0]).toHaveAttribute('width', '3')
-    expect(noHistorySlots[0]).toHaveAttribute('height', '17')
-    expect(document.querySelectorAll('rect')).toHaveLength(18)
+    expect(noHistorySlots).toHaveLength(11)
+    expect(noHistorySlots[0]).toHaveClass('fill-muted-foreground/10')
+    expect(noHistorySlots[0]).toHaveAttribute('x', '0')
+    // Every slot draws a track; the three with history draw a status bar on top.
+    expect(screen.getAllByTestId('cron-slot-track')).toHaveLength(3)
+    expect(document.querySelectorAll('rect[data-status]')).toHaveLength(3)
+    // 14 tracks + 3 status bars + 14 hit bands.
+    expect(document.querySelectorAll('rect')).toHaveLength(31)
     expect(screen.getByRole('img', {
       name: 'New schedule: 3 planned runs, 1 ran, 1 skipped, and 1 failed.',
     })).toBeInTheDocument()

--- a/src/renderer/components/activity/activity-spark-chart.test.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { ActivitySparkChart, CronSparkChart } from './activity-spark-chart'
 
@@ -100,6 +100,55 @@ describe('activity spark charts', () => {
     expect(screen.getByTestId('spark-tooltip')).toHaveTextContent('Succeeded')
     fireEvent.mouseLeave(screen.getByRole('img'))
     expect(screen.queryByTestId('spark-tooltip')).not.toBeInTheDocument()
+  })
+
+  it('renders the hover card outside the chart, in viewport space, so overflow-hidden rows cannot clip it', () => {
+    const { container } = render(
+      <div style={{ overflow: 'hidden' }}>
+        <CronSparkChart
+          label="Nightly report schedule"
+          data={[{ scheduledAt: '2026-07-09T11:00:00.000Z', status: 'succeeded' }]}
+        />
+      </div>,
+    )
+    const svg = screen.getByRole('img')
+    // Mid-page chart: the card hangs above it, right edges aligned.
+    vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue(
+      { top: 300, right: 900, bottom: 320, left: 824, width: 76, height: 20, x: 824, y: 300, toJSON: () => ({}) },
+    )
+    const bands = screen.getAllByTestId('spark-hit')
+    fireEvent.mouseEnter(bands[13])
+
+    const tip = screen.getByTestId('spark-tooltip')
+    expect(container).not.toContainElement(tip)
+    expect(document.body).toContainElement(tip)
+    expect(tip).toHaveClass('fixed')
+    expect(tip).toHaveStyle({ left: '900px', top: '294px', transform: 'translate(-100%, -100%)' })
+
+    // First row of a page: no room above, so the card flips underneath.
+    vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue(
+      { top: 12, right: 900, bottom: 32, left: 824, width: 76, height: 20, x: 824, y: 12, toJSON: () => ({}) },
+    )
+    fireEvent.mouseEnter(bands[13])
+    expect(screen.getByTestId('spark-tooltip')).toHaveStyle({ top: '38px', transform: 'translateX(-100%)' })
+
+    // A scroll would strand the card where the chart used to be, so it dismisses.
+    fireEvent.scroll(window)
+    expect(screen.queryByTestId('spark-tooltip')).not.toBeInTheDocument()
+  })
+
+  it('keeps hit bands inside the viewBox without overlapping', () => {
+    render(<CronSparkChart label="Bands" data={[]} />)
+    const bands = screen.getAllByTestId('spark-hit')
+    const box = (el: HTMLElement) => {
+      const x = Number(el.getAttribute('x'))
+      return { x, right: x + Number(el.getAttribute('width')) }
+    }
+    expect(box(bands[0]).x).toBe(0)
+    expect(box(bands[13]).right).toBeCloseTo(76, 5)
+    for (let i = 1; i < bands.length; i++) {
+      expect(box(bands[i]).x).toBeCloseTo(box(bands[i - 1]).right, 5)
+    }
   })
 
   it('uses one fixed right-aligned slot grid when tasks have different history lengths', () => {

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -1,4 +1,5 @@
-import { Fragment, useState, type ReactNode } from 'react'
+import { Fragment, useEffect, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import {
   DEFAULT_CRON_ACTIVITY_SLOTS,
   type CronActivityPoint,
@@ -70,17 +71,42 @@ interface SparkChartFrameProps {
   children: ReactNode
 }
 
-function SparkTooltipCard({ title, rows }: SparkTooltipContent) {
-  return (
+/** Viewport-space box of the hovered chart, from getBoundingClientRect. */
+interface SparkAnchor {
+  top: number
+  right: number
+  bottom: number
+}
+
+/** Gap between the card and the chart edge it hangs off. */
+const TOOLTIP_OFFSET = 6
+/**
+ * Room the card needs above the chart before it flips underneath: ~60px tall
+ * at two rows, plus the offset, plus a little slack.
+ */
+const TOOLTIP_FLIP_THRESHOLD = 72
+
+function SparkTooltipCard({ title, rows, anchor }: SparkTooltipContent & { anchor: SparkAnchor }) {
+  // Above the chart unless that would run off the top of the viewport (a chart
+  // in the first row of a page or a scroll container), then below it.
+  const above = anchor.top >= TOOLTIP_FLIP_THRESHOLD
+  const style = above
+    ? { left: anchor.right, top: anchor.top - TOOLTIP_OFFSET, transform: 'translate(-100%, -100%)' }
+    : { left: anchor.right, top: anchor.bottom + TOOLTIP_OFFSET, transform: 'translateX(-100%)' }
+  return createPortal(
     <span
       role="tooltip"
       data-testid="spark-tooltip"
+      // Portalled to <body> and placed in viewport space: the charts live in
+      // overflow-hidden containers (the home carousel, the settings connections
+      // list) that would clip a card positioned within the row.
       // Anchored to the chart, not the hovered column: the card is wider than
       // the whole 76px strip, so pointing it at a 4px bar would only push it
       // past the row's edge — the title says which column it is. Right-aligned
       // because these charts sit at the right of every row they appear in, so
       // the card can only ever grow inwards.
-      className="pointer-events-none absolute bottom-full right-0 z-50 mb-1.5 rounded-lg border bg-popover px-2.5 py-2 text-popover-foreground shadow-lg"
+      className="pointer-events-none fixed z-50 rounded-lg border bg-popover px-2.5 py-2 text-popover-foreground shadow-lg"
+      style={style}
     >
       <span className="mb-1.5 block whitespace-nowrap text-xs font-medium">{title}</span>
       <span className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1">
@@ -96,7 +122,8 @@ function SparkTooltipCard({ title, rows }: SparkTooltipContent) {
           </Fragment>
         ))}
       </span>
-    </span>
+    </span>,
+    document.body,
   )
 }
 
@@ -117,37 +144,56 @@ function SparkChartFrame({
   geometry,
   children,
 }: SparkChartFrameProps) {
-  const [hovered, setHovered] = useState<number | null>(null)
+  const [hover, setHover] = useState<{ index: number; anchor: SparkAnchor } | null>(null)
   const { width, gap, x } = geometry
-  const active = hovered !== null ? columns[hovered] : null
+  const active = hover ? columns[hover.index] : null
+
+  // The anchor is measured on enter, so a scroll while hovering would leave
+  // the card floating where the chart used to be. Dismiss instead; the next
+  // band the cursor crosses re-measures.
+  useEffect(() => {
+    if (!hover) return
+    const dismiss = () => setHover(null)
+    window.addEventListener('scroll', dismiss, { capture: true, passive: true })
+    return () => window.removeEventListener('scroll', dismiss, { capture: true })
+  }, [hover])
 
   return (
     // `flex`, not `inline-flex`: an inline-level wrapper sits in the parent's
     // line box, which adds descender space beneath it and pushes the chart off
     // centre against neighbouring text.
-    <span className={cn('relative flex', className)}>
-      {active ? <SparkTooltipCard {...active} /> : null}
+    <span className={cn('flex', className)}>
+      {active && hover ? <SparkTooltipCard {...active} anchor={hover.anchor} /> : null}
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         role="img"
         aria-label={accessibleLabel}
         className={cn(CHART_SIZE, 'overflow-visible')}
-        onMouseLeave={() => setHovered(null)}
+        onMouseLeave={() => setHover(null)}
       >
         {children}
-        {columns.map((_, index) => (
-          <rect
-            key={`hit-${index}`}
-            data-testid="spark-hit"
-            aria-hidden="true"
-            x={Math.max(0, x(index) - gap / 2)}
-            y={0}
-            width={width + gap}
-            height={HEIGHT}
-            fill="transparent"
-            onMouseEnter={() => setHovered(index)}
-          />
-        ))}
+        {columns.map((_, index) => {
+          // Bands meet halfway across each gap and stop at the chart edges, so
+          // no two overlap and none reaches past the viewBox.
+          const left = Math.max(0, x(index) - gap / 2)
+          const right = Math.min(WIDTH, x(index) + width + gap / 2)
+          return (
+            <rect
+              key={`hit-${index}`}
+              data-testid="spark-hit"
+              aria-hidden="true"
+              x={left}
+              y={0}
+              width={right - left}
+              height={HEIGHT}
+              fill="transparent"
+              onMouseEnter={(event) => {
+                const box = event.currentTarget.ownerSVGElement!.getBoundingClientRect()
+                setHover({ index, anchor: { top: box.top, right: box.right, bottom: box.bottom } })
+              }}
+            />
+          )
+        })}
       </svg>
     </span>
   )

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -1,3 +1,4 @@
+import { Fragment, useState, type ReactNode } from 'react'
 import {
   DEFAULT_CRON_ACTIVITY_SLOTS,
   type CronActivityPoint,
@@ -5,21 +6,164 @@ import {
 } from '@shared/lib/types/activity'
 import { cn } from '@shared/lib/utils/cn'
 
-const WIDTH = 96
-const HEIGHT = 26
-const BAR_GAP = 1.5
+/**
+ * The viewBox matches the rendered footprint exactly, so one unit is one CSS
+ * pixel and nothing is letterboxed by preserveAspectRatio. Width is whatever
+ * the default grid needs at BAR_WIDTH/BAR_GAP (14 * 4 + 13 * 1.54 = 76) rather
+ * than a round container size, so the bars keep their shipped dimensions
+ * instead of being stretched to fill a wider box. See CHART_SIZE.
+ */
+const WIDTH = 76
+const HEIGHT = 20
 
 /**
- * Same footprint as the charts (h-7 w-24) so rows don't shift when the
- * activity query resolves. Rendered while the query is pending; an errored
- * query renders nothing (rows stay usable, width collapses once, no retry churn).
+ * One bar width for every spark chart: a cron strip and a daily chart sit side
+ * by side in the same row, so bars that differed in width read as two different
+ * components. 4x18 matches the shipped cron strip; the gap absorbs any
+ * difference in slot count. Bars only shrink below BAR_WIDTH when even MIN_GAP
+ * would not fit — a cron history longer than the default grid.
+ */
+const BAR_WIDTH = 4
+const MIN_GAP = 1
+
+function slotGeometry(count: number) {
+  const width = count > 0
+    ? Math.min(BAR_WIDTH, Math.max(1, (WIDTH - MIN_GAP * (count - 1)) / count))
+    : BAR_WIDTH
+  const gap = count > 1 ? (WIDTH - width * count) / (count - 1) : 0
+  return { width, gap, radius: Math.min(2, width / 2), x: (index: number) => index * (width + gap) }
+}
+
+/** The one footprint for every spark chart, skeleton included. */
+const CHART_SIZE = 'h-5 w-[76px]'
+
+/**
+ * Both charts sit in the same rows at the same size, so they share one visual
+ * language: every slot draws a faint full-height track covering the whole
+ * window, and status/volume fills it from the bottom. The track is what makes
+ * an empty or short history legible — you can see how much window is unused.
+ */
+const TRACK_INSET = 1
+const TRACK_HEIGHT = HEIGHT - TRACK_INSET * 2
+const TRACK_BASELINE = HEIGHT - TRACK_INSET
+const TRACK_CLASS = 'fill-muted-foreground/10'
+
+interface SparkTooltipRow {
+  /** Tailwind background class for the legend swatch. */
+  swatch: string
+  /** Leading figure; omitted for rows that are just a state (cron slots). */
+  count?: number
+  label: string
+}
+
+interface SparkTooltipContent {
+  title: string
+  rows: SparkTooltipRow[]
+}
+
+interface SparkChartFrameProps {
+  accessibleLabel: string
+  className?: string
+  /** One entry per column, in column order; null suppresses the tooltip. */
+  columns: Array<SparkTooltipContent | null>
+  geometry: ReturnType<typeof slotGeometry>
+  children: ReactNode
+}
+
+function SparkTooltipCard({ title, rows }: SparkTooltipContent) {
+  return (
+    <span
+      role="tooltip"
+      data-testid="spark-tooltip"
+      // Anchored to the chart, not the hovered column: the card is wider than
+      // the whole 76px strip, so pointing it at a 4px bar would only push it
+      // past the row's edge — the title says which column it is. Right-aligned
+      // because these charts sit at the right of every row they appear in, so
+      // the card can only ever grow inwards.
+      className="pointer-events-none absolute bottom-full right-0 z-50 mb-1.5 rounded-lg border bg-popover px-2.5 py-2 text-popover-foreground shadow-lg"
+    >
+      <span className="mb-1.5 block whitespace-nowrap text-xs font-medium">{title}</span>
+      <span className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1">
+        {rows.map((row) => (
+          <Fragment key={row.label}>
+            <span aria-hidden="true" className={cn('h-2.5 w-2.5 shrink-0 rounded-[3px]', row.swatch)} />
+            <span className="whitespace-nowrap text-xs">
+              {row.count === undefined ? null : (
+                <span className="tabular-nums">{row.count} </span>
+              )}
+              <span className="text-muted-foreground">{row.label}</span>
+            </span>
+          </Fragment>
+        ))}
+      </span>
+    </span>
+  )
+}
+
+/**
+ * Shared hover layer for both spark charts.
+ *
+ * Bars are 4px wide, so the hit target is the whole column band (bar + gap),
+ * full height — otherwise hovering a short bar or an empty slot does nothing.
+ * The tooltip is a plain positioned element rather than the Radix one: a single
+ * row can hold several charts and the home page many more, and one Radix
+ * Tooltip (plus Provider) per column would mean hundreds of components for
+ * what is a label following the cursor across at most 14 bands.
+ */
+function SparkChartFrame({
+  accessibleLabel,
+  className,
+  columns,
+  geometry,
+  children,
+}: SparkChartFrameProps) {
+  const [hovered, setHovered] = useState<number | null>(null)
+  const { width, gap, x } = geometry
+  const active = hovered !== null ? columns[hovered] : null
+
+  return (
+    // `flex`, not `inline-flex`: an inline-level wrapper sits in the parent's
+    // line box, which adds descender space beneath it and pushes the chart off
+    // centre against neighbouring text.
+    <span className={cn('relative flex', className)}>
+      {active ? <SparkTooltipCard {...active} /> : null}
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        role="img"
+        aria-label={accessibleLabel}
+        className={cn(CHART_SIZE, 'overflow-visible')}
+        onMouseLeave={() => setHovered(null)}
+      >
+        {children}
+        {columns.map((_, index) => (
+          <rect
+            key={`hit-${index}`}
+            data-testid="spark-hit"
+            aria-hidden="true"
+            x={Math.max(0, x(index) - gap / 2)}
+            y={0}
+            width={width + gap}
+            height={HEIGHT}
+            fill="transparent"
+            onMouseEnter={() => setHovered(index)}
+          />
+        ))}
+      </svg>
+    </span>
+  )
+}
+
+/**
+ * Same footprint as the charts so rows don't shift when the activity query
+ * resolves. Rendered while the query is pending; an errored query renders
+ * nothing (rows stay usable, width collapses once, no retry churn).
  */
 export function ActivitySparkChartSkeleton({ className }: { className?: string }) {
   return (
     <div
       data-testid="activity-chart-skeleton"
       aria-hidden="true"
-      className={cn('h-7 w-24 rounded-sm bg-muted/40 animate-pulse', className)}
+      className={cn(CHART_SIZE, 'rounded-sm bg-muted/40 animate-pulse', className)}
     />
   )
 }
@@ -52,50 +196,55 @@ export function summarizeDailyActivity(data: DailyActivityPoint[]) {
 export function ActivitySparkChart({ label, data, className }: ActivitySparkChartProps) {
   const { succeeded, failed, total } = summarizeDailyActivity(data)
   const max = Math.max(1, ...data.map((point) => point.succeeded + point.failed))
-  const barWidth = data.length > 0
-    ? Math.max(1, (WIDTH - BAR_GAP * (data.length - 1)) / data.length)
-    : WIDTH
+  const geometry = slotGeometry(data.length)
+  const { width: barWidth, radius, x: barX } = geometry
   const accessibleLabel = total === 0
     ? `${label}: no calls over the last ${data.length} ${plural(data.length, 'day')}.`
     : `${label}: ${total} ${plural(total, 'call')} over ${data.length} ${plural(data.length, 'day')}, ${succeeded} succeeded and ${failed} failed.`
+  const columns = data.map((point) => ({
+    title: dayLabel(point.date),
+    rows: [
+      { swatch: 'bg-emerald-500', count: point.succeeded, label: 'Succeeded' },
+      { swatch: 'bg-red-500', count: point.failed, label: 'Failed' },
+    ],
+  }))
 
   return (
-    <svg
-      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      role="img"
-      aria-label={accessibleLabel}
-      className={cn('h-7 w-24 overflow-visible', className)}
+    <SparkChartFrame
+      accessibleLabel={accessibleLabel}
+      className={className}
+      columns={columns}
+      geometry={geometry}
     >
       {data.map((point, index) => {
-        const x = index * (barWidth + BAR_GAP)
-        const successHeight = (point.succeeded / max) * (HEIGHT - 2)
-        const failureHeight = (point.failed / max) * (HEIGHT - 2)
+        const x = barX(index)
+        const successHeight = (point.succeeded / max) * TRACK_HEIGHT
+        const failureHeight = (point.failed / max) * TRACK_HEIGHT
         const zeroHeight = point.succeeded === 0 && point.failed === 0 ? 1 : 0
         return (
           <g key={point.date}>
-            <title>{dayLabel(point.date)}: {point.succeeded} succeeded, {point.failed} failed</title>
             <rect
               data-testid="activity-success-bar"
               x={x}
-              y={HEIGHT - successHeight - zeroHeight}
+              y={TRACK_BASELINE - successHeight - zeroHeight}
               width={barWidth}
               height={successHeight + zeroHeight}
-              rx={Math.min(1.5, barWidth / 2)}
+              rx={radius}
               className={point.succeeded === 0 ? 'fill-muted' : 'fill-emerald-500'}
             />
             <rect
               data-testid="activity-failure-bar"
               x={x}
-              y={HEIGHT - successHeight - failureHeight}
+              y={TRACK_BASELINE - successHeight - failureHeight}
               width={barWidth}
               height={failureHeight}
-              rx={Math.min(1.5, barWidth / 2)}
+              rx={radius}
               className="fill-red-500"
             />
           </g>
         )
       })}
-    </svg>
+    </SparkChartFrame>
   )
 }
 
@@ -108,9 +257,30 @@ interface CronSparkChartProps {
 const CRON_COLORS: Record<CronActivityPoint['status'], string> = {
   succeeded: 'fill-emerald-500',
   running: 'fill-emerald-500 animate-pulse',
-  skipped: 'fill-muted-foreground/25',
+  skipped: 'fill-muted-foreground/40',
   failed: 'fill-red-500',
 }
+
+/** Background (not fill) twins of CRON_COLORS, for the tooltip legend swatch. */
+const CRON_SWATCH: Record<CronActivityPoint['status'], string> = {
+  succeeded: 'bg-emerald-500',
+  running: 'bg-emerald-500',
+  skipped: 'bg-muted-foreground/40',
+  failed: 'bg-red-500',
+}
+
+const CRON_LABEL: Record<CronActivityPoint['status'], string> = {
+  succeeded: 'Succeeded',
+  running: 'Running',
+  skipped: 'Skipped',
+  failed: 'Failed',
+}
+
+/**
+ * A skipped run reads as a centred marker on an otherwise empty track rather
+ * than a full-height grey bar: nothing ran, so nothing should fill the slot.
+ */
+const CRON_SKIPPED_HEIGHT = 3
 
 function cronTimeLabel(value: string): string {
   return new Intl.DateTimeFormat('en-US', {
@@ -128,53 +298,60 @@ export function CronSparkChart({ label, data, className }: CronSparkChartProps) 
   const running = data.filter((point) => point.status === 'running').length
   const skipped = data.filter((point) => point.status === 'skipped').length
   const failed = data.filter((point) => point.status === 'failed').length
-  const width = 4
-  const placeholderStrokeWidth = 1
-  const placeholderInset = placeholderStrokeWidth / 2
   const gridSlots = Math.max(DEFAULT_CRON_ACTIVITY_SLOTS, data.length)
-  const gap = gridSlots > 1 ? Math.max(1, (WIDTH - width * gridSlots) / (gridSlots - 1)) : 0
+  const geometry = slotGeometry(gridSlots)
+  const { width, radius, x: slotX } = geometry
   const firstGridSlot = gridSlots - data.length
   const runningSummary = running > 0 ? `${running} running, ` : ''
   const accessibleLabel = data.length === 0
     ? `${label}: no mature planned runs yet.`
     : `${label}: ${data.length} planned ${plural(data.length, 'run')}, ${succeeded} ran, ${runningSummary}${skipped} skipped, and ${failed} failed.`
+  // Empty leading slots predate the task, so they get no tooltip.
+  const columns = Array.from({ length: gridSlots }, (_, index) => {
+    const point = data[index - firstGridSlot]
+    if (!point) return null
+    return {
+      title: cronTimeLabel(point.scheduledAt),
+      rows: [{ swatch: CRON_SWATCH[point.status], label: CRON_LABEL[point.status] }],
+    }
+  })
 
   return (
-    <svg
-      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      role="img"
-      aria-label={accessibleLabel}
-      className={cn('h-7 w-24 overflow-visible', className)}
+    <SparkChartFrame
+      accessibleLabel={accessibleLabel}
+      className={className}
+      columns={columns}
+      geometry={geometry}
     >
-      {Array.from({ length: firstGridSlot }, (_, index) => (
+      {Array.from({ length: gridSlots }, (_, index) => (
         <rect
-          key={`no-history-${index}`}
-          data-testid="cron-slot-no-history"
+          key={`track-${index}`}
+          data-testid={index < firstGridSlot ? 'cron-slot-no-history' : 'cron-slot-track'}
           aria-hidden="true"
-          x={index * (width + gap) + placeholderInset}
-          y={4 + placeholderInset}
-          width={width - placeholderStrokeWidth}
-          height={18 - placeholderStrokeWidth}
-          rx={2 - placeholderInset}
-          strokeWidth={placeholderStrokeWidth}
-          className="fill-none stroke-muted-foreground/20"
+          x={slotX(index)}
+          y={TRACK_INSET}
+          width={width}
+          height={TRACK_HEIGHT}
+          rx={radius}
+          className={TRACK_CLASS}
         />
       ))}
-      {data.map((point, index) => (
-        <rect
-          key={`${point.scheduledAt}-${index}`}
-          data-testid={`cron-slot-${point.status}`}
-          data-status={point.status}
-          x={(firstGridSlot + index) * (width + gap)}
-          y={4}
-          width={width}
-          height={18}
-          rx={2}
-          className={CRON_COLORS[point.status]}
-        >
-          <title>{cronTimeLabel(point.scheduledAt)}: {point.status}</title>
-        </rect>
-      ))}
-    </svg>
+      {data.map((point, index) => {
+        const isSkipped = point.status === 'skipped'
+        return (
+          <rect
+            key={`${point.scheduledAt}-${index}`}
+            data-testid={`cron-slot-${point.status}`}
+            data-status={point.status}
+            x={slotX(firstGridSlot + index)}
+            y={isSkipped ? (HEIGHT - CRON_SKIPPED_HEIGHT) / 2 : TRACK_INSET}
+            width={width}
+            height={isSkipped ? CRON_SKIPPED_HEIGHT : TRACK_HEIGHT}
+            rx={isSkipped ? Math.min(radius, CRON_SKIPPED_HEIGHT / 2) : radius}
+            className={CRON_COLORS[point.status]}
+          />
+        )
+      })}
+    </SparkChartFrame>
   )
 }

--- a/src/renderer/components/home/home-page.tsx
+++ b/src/renderer/components/home/home-page.tsx
@@ -439,12 +439,12 @@ function AgentHealthCarousel({
     if (s.kind === 'cron') {
       const activity = health?.cronByTaskId[s.id] ?? []
       const succeeded = activity.filter((p) => p.status === 'succeeded').length
-      chart = <CronSparkChart label={s.name} data={activity} className="h-5 w-24" />
+      chart = <CronSparkChart label={s.name} data={activity} />
       metric = `${succeeded}/${activity.length}`
     } else {
       const activity = health?.webhookByTriggerId[s.id] ?? []
       const { total } = summarizeDailyActivity(activity)
-      chart = <ActivitySparkChart label={s.name} data={activity} className="h-5 w-24" />
+      chart = <ActivitySparkChart label={s.name} data={activity} />
       metric = `${total}/${health?.days ?? DEFAULT_ACTIVITY_DAYS}d`
     }
     return (

--- a/src/shared/lib/types/activity.ts
+++ b/src/shared/lib/types/activity.ts
@@ -1,7 +1,13 @@
 export const DEFAULT_ACTIVITY_DAYS = 14
 export const MIN_ACTIVITY_DAYS = 7
 export const MAX_ACTIVITY_DAYS = 30
-export const DEFAULT_CRON_ACTIVITY_SLOTS = 18
+/**
+ * Cron slots track the daily window so the two spark charts render the same
+ * number of bars — they sit side by side in the same rows, and mismatched slot
+ * counts made them read as two different components. Note the unit differs:
+ * this is N scheduled runs (however far back the schedule reaches), not N days.
+ */
+export const DEFAULT_CRON_ACTIVITY_SLOTS = DEFAULT_ACTIVITY_DAYS
 
 export type ActivityOutcome = 'succeeded' | 'failed'
 


### PR DESCRIPTION
Restyles the cron spark chart, and introduces the shared chart system the webhook chart moves onto in the next PR.

## What changed

- **One visual language.** The cron strip and the daily chart sit in the same rows at the same size but spoke different languages — a discrete slot grid vs a continuous bar chart. Both now draw a faint full-height track per slot, with status/volume filling it from the bottom.
- **Empty history is a dim track**, not a hollow stroked placeholder — the strokes were noisy at 76×20.
- **Skipped renders as a centred marker**, not a full-height grey bar. Nothing ran, so nothing should fill the slot; it stays distinguishable from an empty slot, which has no marker.
- **Slot width is derived**, not hard-coded to `4`. The old `Math.max(1, …)` gap clamp meant bars overflowed the viewBox past ~19 slots.
- **Bars keep their shipped 4×18 dimensions.** Rather than stretch them to a round container width, the viewBox is sized to what the default grid needs — `14 * 4 + 13 * 1.54 = 76`. `CHART_SIZE` is now the single footprint, so the home carousel no longer overrides it. (At the old `96×26` viewBox, the carousel's `h-5 w-24` silently letterboxed the chart to 77% and centred it.)
- **Cron slots track the daily window** (`DEFAULT_CRON_ACTIVITY_SLOTS = DEFAULT_ACTIVITY_DAYS`) so both charts render the same number of bars. Note the unit still differs: this is N scheduled runs, not N days.
- **Hover shows the run detail in a small card**, replacing the native SVG `<title>` and its slow unstyled browser tooltip.

## Notes for review

- The hit target is the whole column band, not the 4px bar — otherwise short bars and empty slots are unhoverable.
- The tooltip is a plain positioned element, not a Radix `Tooltip`. One row can hold several charts and the home page many more; one Radix Tooltip (plus Provider) per column would be hundreds of components for a label that follows the cursor across at most 14 bands. `ActivityBarChart` uses recharts, which is far too heavy for a 76px sparkline.
- The card is anchored to the chart's right edge rather than the hovered column: it is wider than the whole 76px strip, so pointing it at a 4px bar would only push it past the row's edge. The title says which column it is.
- Swatches use `rounded-[3px]`, not `rounded-sm` — the Tailwind config replaces the radius scale with `sm: calc(var(--radius) - 4px)`, which renders a 10px swatch as a near-circle.

Stacked: this is the base of a three-PR stack. Merge bottom-up.

## Screenshots

Agent home → Triggers, against the mock instance seeded with cron/webhook activity.

| Before (main) | After |
| --- | --- |
| ![Trigger rows before (light)](https://github.com/user-attachments/assets/3a8bc06d-5c67-4c1c-bdcd-02d2291bad70) | ![Trigger rows after (light)](https://github.com/user-attachments/assets/656dd871-de23-492a-a9e5-bcef47a4ca6d) |

Cron strips go from 18 hollow-placeholder slots to 14 tracked ones, matching the webhook charts' width. The webhook charts keep their existing stacked rendering here — they move onto the track in the next PR. The subtitle wrapping visible in both columns is fixed in #974.

![Trigger rows after (dark)](https://github.com/user-attachments/assets/413c8f9f-792a-4627-85ce-7835852098bc)


## Review follow-ups

- **The hover card is portalled to `<body>` and positioned in viewport space.** It was absolutely positioned inside the chart's frame, and the home carousel slide and the settings connections list are `overflow-hidden`, so there the card was clipped to nothing. It now anchors to the chart's bounding box, flips underneath when the chart sits within ~72px of the viewport top, and dismisses on scroll rather than being left where the chart used to be.
- **Hit bands stop at the chart edges.** The first band was clamped to `x=0` but kept its full width, so neighbours overlapped by half a gap and the last band reached past the viewBox.
- **Note: `DEFAULT_CRON_ACTIVITY_SLOTS` is also the server-side default.** `getAgentActivityStats` uses it when no `cronSlots` is passed and no route passes one, so `/api/activity/agents/:slug` now returns 14 cron points per task instead of 18.

Hover card in the home carousel, which was the clipped case:

![Home carousel hover (light)](https://github.com/user-attachments/assets/1a0fe411-afd9-4118-b93e-285a0313d9f9)
![Home carousel hover (dark)](https://github.com/user-attachments/assets/f193c95d-a15a-4f86-a40b-cc96d9d31e92)
